### PR TITLE
set .podspec to specify arc

### DIFF
--- a/Stripe.podspec
+++ b/Stripe.podspec
@@ -9,4 +9,5 @@ Pod::Spec.new do |s|
   s.source_files        = 'Stripe/*.{h,m}'
   s.public_header_files = 'Stripe/*.h'
   s.framework           = 'Foundation'
+  s.requires_arc        = true
 end


### PR DESCRIPTION
Unless I'm mistaken, stripe-ios uses arc. This specifies that in the .podspec.
