### PR TITLE
iOS < 6.0 support.

### DIFF
--- a/Stripe/Vendor/PaymentKit/PKView.m
+++ b/Stripe/Vendor/PaymentKit/PKView.m
@@ -84,8 +84,7 @@
     
     UIImageView *backgroundImageView = [[UIImageView alloc] initWithFrame:self.bounds];
     backgroundImageView.image = [[UIImage imageNamed:@"textfield"]
-                                 resizableImageWithCapInsets:UIEdgeInsetsMake(0, 8, 0, 8)
-                                 resizingMode:UIImageResizingModeStretch];
+                                 resizableImageWithCapInsets:UIEdgeInsetsMake(0, 8, 0, 8)];
     [self addSubview:backgroundImageView];
     
     self.innerView = [[UIView alloc] initWithFrame:CGRectMake(40, 12, self.frame.size.width - 40, 20)];


### PR DESCRIPTION
Last changes on the stripe-ios repo broke iOS < 6.0 compatibility. As far as I can see there is no point of using a UIImageResizingModeStretch in this case. I tried the iOS 5.0 method (Not supporting resizingMode) and the background looks exactly the same.
