### PR TITLE
Support for cardnumber only

### DIFF
--- a/Stripe/STPView.h
+++ b/Stripe/STPView.h
@@ -17,7 +17,9 @@ typedef void (^STPTokenBlock)(STPToken* token, NSError* error);
 
 @protocol STPViewDelegate <NSObject>
 @optional
-- (void) stripeView:(STPView*)view withCard:(PKCard *)card isValid:(BOOL)valid;
+- (void) stripeView:(STPView *)view withCard:(PKCard *)card isValid:(BOOL)valid;
+- (BOOL) stripeView:(STPView *)view willShowMetaWithCard:(PKCard *)card;
+- (void) stripeView:(STPView *)view withCard:(PKCard *)card cardNumberIsValid:(BOOL)valid;
 @end
 
 @interface STPView : UIView <PKViewDelegate>

--- a/Stripe/STPView.m
+++ b/Stripe/STPView.m
@@ -41,13 +41,6 @@
     return self;
 }
 
-- (void)paymentView:(PKView*)paymentView withCard:(PKCard *)card isValid:(BOOL)valid
-{
-    if ([self.delegate respondsToSelector:@selector(stripeView:withCard:isValid:)]) {
-        [self.delegate stripeView:self withCard:card isValid:valid];
-    }
-}
-
 - (void)pendingHandler:(BOOL)isPending
 {
     pending = isPending;
@@ -87,5 +80,29 @@
                  }];
 
 }
+
+#pragma mark - PKViewDelegate
+
+- (BOOL) paymentView:(PKView *)paymentView shouldShowMetaViewWithCard:(PKCard *)card {
+    if ([self.delegate respondsToSelector:@selector(stripeView:willShowMetaWithCard:)]) {
+        return [self.delegate stripeView:self willShowMetaWithCard:card];
+    } else {
+        return YES;
+    }
+}
+
+- (void)paymentView:(PKView *)paymentView withCard:(PKCard *)card cardNumberIsValid:(BOOL)valid {
+    if ([self.delegate respondsToSelector:@selector(stripeView:withCard:cardNumberIsValid:)]) {
+        [self.delegate stripeView:self withCard:card cardNumberIsValid:valid];
+    }
+}
+
+- (void)paymentView:(PKView*)paymentView withCard:(PKCard *)card isValid:(BOOL)valid
+{
+    if ([self.delegate respondsToSelector:@selector(stripeView:withCard:isValid:)]) {
+        [self.delegate stripeView:self withCard:card isValid:valid];
+    }
+}
+
 
 @end


### PR DESCRIPTION
Using optional protocols the user can now choose to only receive the
cardnumber from the user.
