### PR TITLE
Add IBOutlet to STPView delegate property

### DIFF
--- a/Stripe/STPView.h
+++ b/Stripe/STPView.h
@@ -24,9 +24,9 @@ typedef void (^STPTokenBlock)(STPToken *token, NSError *error);
 
 - (id)initWithFrame:(CGRect)frame andKey:(NSString *)stripeKey;
 
-@property IBOutlet PKView *paymentView;
+@property (nonatomic) PKView *paymentView;
 @property (copy) NSString *key;
-@property (weak) id <STPViewDelegate> delegate;
+@property (weak, nonatomic) IBOutlet id <STPViewDelegate> delegate;
 @property (readonly) BOOL pending;
 
 - (void)createToken:(STPTokenBlock)block;


### PR DESCRIPTION
This allows setting of the delegate in Interface Builder, which
I think is a pretty common pattern for UIView delegate properties.

I also removed the IBOutlet qualifier from the paymentView property,
since it looks like it is not intended to be set in Interface Builder.
