### PR TITLE
Continue with request when Stripe key authentication fails

### DIFF
--- a/Stripe/STPAPIConnection.m
+++ b/Stripe/STPAPIConnection.m
@@ -99,6 +99,12 @@
         }
 
         [challenge.sender performDefaultHandlingForAuthenticationChallenge:challenge];
+    } else if ([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodDefault]) {
+        // If this is an HTTP Authorization request, just continue. We want to bubble this back through the
+        // request's error handler.
+        [challenge.sender continueWithoutCredentialForAuthenticationChallenge:challenge];
+    } else {
+        [challenge.sender performDefaultHandlingForAuthenticationChallenge:challenge];
     }
 }
 

--- a/StripeTest/STPCertTest.m
+++ b/StripeTest/STPCertTest.m
@@ -33,8 +33,10 @@ typedef NS_ENUM(NSInteger, StripeCertificateFailMethod) {
     [FailableStripe createTokenWithCard:[self dummyCard]
                          publishableKey:EXAMPLE_STRIPE_PUBLISHABLE_KEY
                              completion:^(STPToken *token, NSError *error) {
-                                 XCTAssertNotNil(token, @"Expected token");
-                                 XCTAssertNil(error, @"Expected no error");
+                                 // Note that this API request *will* fail, but it will return error
+                                 // messages from the server and not be blocked by local cert checks
+                                 XCTAssertNil(token, @"Expected no token");
+                                 XCTAssertNotNil(error, @"Expected error");
                                  dispatch_semaphore_signal(semaphore);
                              }];
 


### PR DESCRIPTION
Inside `connection:willSendRequestForAuthenticationChallenge:` we need to handle other `authenticationMethod`s. In particular, if the user supplies a bad Stripe key, currently the request silently fails.

cc @woodrow for the heads up since this is around the SSL stuff (though in no way should impact)
