### PR TITLE
Add missing Foundation.h import to STPAPIConnection.h

### DIFF
--- a/Stripe/STPAPIConnection.h
+++ b/Stripe/STPAPIConnection.h
@@ -5,6 +5,8 @@
 //  Created by Phil Cohen on 4/9/14.
 //
 
+#import <Foundation/Foundation.h>
+
 typedef void (^APIConnectionCompletionBlock)(NSURLResponse *response, NSData *body, NSError *requestError);
 
 // Like NSURLConnection but verifies that the server isn't using a revoked certificate.


### PR DESCRIPTION
Added stripe-ios manually to an Xcode 6 project and got a bunch of compile errors.  This fixed them.
