### PR TITLE
Fixes action sheet button index in STPTestPaymentAuthorizationViewController

### DIFF
--- a/Stripe/STPTestPaymentAuthorizationViewController.m
+++ b/Stripe/STPTestPaymentAuthorizationViewController.m
@@ -57,7 +57,7 @@
         return;
     }
     switch (buttonIndex) {
-        case 1:
+        case 0:
             [self makePaymentWithCardNumber:STPSuccessfulChargeCardNumber];
             break;
         default:


### PR DESCRIPTION
This fixes the action sheet button handling in STPTestPaymentAuthorizationViewController to use the correct card numbers when selecting between a successful/failure card number.
