### PR TITLE
Implementation of the real amount (not $10)

### DIFF
--- a/Example/StripeExample/PaymentViewController.m
+++ b/Example/StripeExample/PaymentViewController.m
@@ -91,12 +91,13 @@
 
 - (void)hasToken:(STPToken *)token {
     [MBProgressHUD showHUDAddedTo:self.view animated:YES];
-
+    NSString *amount = [NSString stringWithFormat:@"%ld00",(long)self.amount.integerValue];
     NSDictionary *chargeParams = @{
         @"token": token.tokenId,
         @"currency": @"usd",
-        @"amount": @"1000", // this is in cents (i.e. $10)
+        @"amount": amount
     };
+
 
     if (!ParseApplicationId || !ParseClientKey) {
         UIAlertView *message =


### PR DESCRIPTION
The amount for the payment was being collected through self.amount, but on the payment flow, it was hardcoded with $10. This is solved on my pull request