### PR TITLE
Fix success case

### DIFF
--- a/Stripe/Checkout/STPCheckoutViewController.m
+++ b/Stripe/Checkout/STPCheckoutViewController.m
@@ -142,10 +142,11 @@
         [self.checkoutDelegate checkoutController:self
                                    didCreateToken:token
                                        completion:^(STPBackendChargeResult status, NSError *error) {
+                                           self.backendChargeSuccessful = (status == STPBackendChargeResultSuccess);
+
                                            if (status == STPBackendChargeResultSuccess) {
                                                [adapter evaluateJavaScript:payload[@"success"]];
                                            } else {
-                                               self.backendChargeSuccessful = (status == STPBackendChargeResultSuccess);
                                                self.backendChargeError = error;
                                                NSString *encodedError = @"";
                                                if (error.localizedDescription) {

--- a/Stripe/STPCard.m
+++ b/Stripe/STPCard.m
@@ -226,7 +226,7 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated"
 #pragma clang diagnostic ignored "-Wunreachable-code"
-    NSString *identifier = (&NSCalendarIdentifierGregorian != nil) ? NSCalendarIdentifierGregorian : NSGregorianCalendar;
+    NSString *identifier = (true) ? NSCalendarIdentifierGregorian : NSGregorianCalendar;
 #pragma clang diagnostic pop
     return [[NSCalendar alloc] initWithCalendarIdentifier:identifier];
 }


### PR DESCRIPTION
In case the callback returns success, we need to set `self.backendChargeSuccessful` to `YES`. If we don't do this, the `STPCheckoutEventFinish` will never call the finish delegate method with a success status.