### PR TITLE
Call evaluate javascript on the main thread

### DIFF
--- a/Stripe/Checkout/STPIOSCheckoutWebViewAdapter.m
+++ b/Stripe/Checkout/STPIOSCheckoutWebViewAdapter.m
@@ -39,7 +39,9 @@
 }
 
 - (void)evaluateJavaScript:(NSString *)js {
-    [self.webView stringByEvaluatingJavaScriptFromString:js];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self.webView stringByEvaluatingJavaScriptFromString:js];
+    });
 }
 
 - (void)cleanup {


### PR DESCRIPTION
When the checkout form completes, the completion handler evaluates some javascript on the webview which can cause it to crash giving the following error message: 

`Tried to obtain the web lock from a thread other than the main thread or the web thread. This may be a result of calling to UIKit from a secondary thread. Crashing now...`

We simply fix this by ensuring the app evaluates the javascript on the main thread.