### PR TITLE
Add nullabillity annotations to Objective-C headers

### DIFF
--- a/Example/OSXExample/ExampleWindowController.m
+++ b/Example/OSXExample/ExampleWindowController.m
@@ -17,8 +17,7 @@
 @implementation ExampleWindowController
 
 - (IBAction)beginPayment:(id)sender {
-    STPCheckoutOptions *options = [STPCheckoutOptions new];
-    options.publishableKey = [Stripe defaultPublishableKey];
+    STPCheckoutOptions *options = [[STPCheckoutOptions alloc] initWithPublishableKey:[Stripe defaultPublishableKey]];
     options.purchaseDescription = @"Tasty Llama food";
     options.purchaseAmount = 1000;
     options.purchaseLabel = @"Pay {{amount}} for that food";

--- a/Example/Stripe iOS Example (Custom)/ViewController.m
+++ b/Example/Stripe iOS Example (Custom)/ViewController.m
@@ -139,8 +139,7 @@
 #pragma mark - Stripe Checkout
 
 - (IBAction)beginStripeCheckout:(id)sender {
-    STPCheckoutOptions *options = [[STPCheckoutOptions alloc] init];
-    options.publishableKey = [Stripe defaultPublishableKey];
+    STPCheckoutOptions *options = [[STPCheckoutOptions alloc] initWithPublishableKey:[Stripe defaultPublishableKey]];
     options.purchaseDescription = @"Cool Shirt";
     options.purchaseAmount = 1000; // this is in cents
     options.logoColor = [UIColor purpleColor];

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The Stripe iOS SDK make it easy to collect your users' credit card details insid
 We also offer [seamless integration](https://stripe.com/applepay) with [Apple Pay](https://apple.com/apple-pay) that will allow you to securely collect payments from your customers in a way that prevents them from having to re-enter their credit card information.
 
 ## Requirements
-Our SDK is compatible with iOS apps supporting iOS6 and above. It requires XCode 6.1 and the iOS8 SDK to build the source.
+Our SDK is compatible with iOS apps supporting iOS6 and above. It requires Xcode 6.3+ and the iOS8 SDK to build the source.
 
 ## Integration
 

--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -34,6 +34,10 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		042983321AF424A700B8AD2C /* STPNullabilityMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 042983311AF41B2600B8AD2C /* STPNullabilityMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		042983331AF424AA00B8AD2C /* STPNullabilityMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 042983311AF41B2600B8AD2C /* STPNullabilityMacros.h */; };
+		042983351AF424CE00B8AD2C /* STPNullabilityMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 042983311AF41B2600B8AD2C /* STPNullabilityMacros.h */; };
+		042983361AF424CF00B8AD2C /* STPNullabilityMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 042983311AF41B2600B8AD2C /* STPNullabilityMacros.h */; };
 		04415C561A6605B5001225ED /* STPAPIClient+ApplePay.m in Sources */ = {isa = PBXBuildFile; fileRef = 04CDB4AB1A5F30A700B854EE /* STPAPIClient+ApplePay.m */; };
 		04415C571A6605B5001225ED /* Stripe+ApplePay.m in Sources */ = {isa = PBXBuildFile; fileRef = 04CDB4AD1A5F30A700B854EE /* Stripe+ApplePay.m */; };
 		04415C591A6605B5001225ED /* STPCheckoutOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 04CDB4B21A5F30A700B854EE /* STPCheckoutOptions.m */; };
@@ -281,6 +285,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		042983311AF41B2600B8AD2C /* STPNullabilityMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPNullabilityMacros.h; sourceTree = "<group>"; };
 		04365D2C1A4CF86C00A3E1D4 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 		045E7C031A5F41DE004751EF /* StripeiOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "StripeiOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		047E67A81A65E769001D7493 /* libStripe.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libStripe.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -468,6 +473,7 @@
 				04CDB4CD1A5F30A700B854EE /* STPToken.m */,
 				04CDB4CE1A5F30A700B854EE /* StripeError.h */,
 				04CDB4CF1A5F30A700B854EE /* StripeError.m */,
+				042983311AF41B2600B8AD2C /* STPNullabilityMacros.h */,
 			);
 			name = Stripe;
 			path = Tests/../Stripe;
@@ -610,6 +616,7 @@
 				047E67D51A65E7BC001D7493 /* STPIOSCheckoutWebViewAdapter.h in Headers */,
 				047E67D61A65E7BC001D7493 /* STPOSXCheckoutWebViewAdapter.h in Headers */,
 				047E67D71A65E7BC001D7493 /* STPStrictURLProtocol.h in Headers */,
+				042983361AF424CF00B8AD2C /* STPNullabilityMacros.h in Headers */,
 				047E67D91A65E7BC001D7493 /* STPFormEncoder.h in Headers */,
 				047E67DA1A65E7BC001D7493 /* STPAPIConnection.h in Headers */,
 			);
@@ -620,6 +627,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				049E84D91A605EF0000B66CD /* Stripe.h in Headers */,
+				042983351AF424CE00B8AD2C /* STPNullabilityMacros.h in Headers */,
 				049E84DA1A605EF0000B66CD /* STPAPIClient+ApplePay.h in Headers */,
 				049E84DB1A605EF0000B66CD /* Stripe+ApplePay.h in Headers */,
 				049E84DD1A605EF0000B66CD /* STPCheckoutOptions.h in Headers */,
@@ -654,6 +662,7 @@
 				04CDB4D81A5F30A700B854EE /* Stripe+ApplePay.h in Headers */,
 				04CDB5161A5F30A700B854EE /* StripeError.h in Headers */,
 				04CDB4D41A5F30A700B854EE /* STPAPIClient+ApplePay.h in Headers */,
+				042983321AF424A700B8AD2C /* STPNullabilityMacros.h in Headers */,
 				04CDB4E01A5F30A700B854EE /* STPCheckoutOptions.h in Headers */,
 				04CDB5021A5F30A700B854EE /* STPFormEncoder.h in Headers */,
 				04CDB4E81A5F30A700B854EE /* STPCheckoutDelegate.h in Headers */,
@@ -686,6 +695,7 @@
 				04D12C361A5F55D10010446E /* STPIOSCheckoutWebViewAdapter.h in Headers */,
 				04D12C371A5F55D10010446E /* STPOSXCheckoutWebViewAdapter.h in Headers */,
 				04D12C381A5F55D10010446E /* STPStrictURLProtocol.h in Headers */,
+				042983331AF424AA00B8AD2C /* STPNullabilityMacros.h in Headers */,
 				04D12C3A1A5F55D10010446E /* STPFormEncoder.h in Headers */,
 				04D12C3B1A5F55D10010446E /* STPAPIConnection.h in Headers */,
 			);

--- a/Stripe/Checkout/STPCheckoutDelegate.h
+++ b/Stripe/Checkout/STPCheckoutDelegate.h
@@ -7,11 +7,14 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "STPNullabilityMacros.h"
 
 @protocol STPCheckoutWebViewAdapter;
 @protocol STPCheckoutDelegate<NSObject>
-- (void)checkoutAdapterDidStartLoad:(id<STPCheckoutWebViewAdapter>)adapter;
-- (void)checkoutAdapterDidFinishLoad:(id<STPCheckoutWebViewAdapter>)adapter;
-- (void)checkoutAdapter:(id<STPCheckoutWebViewAdapter>)adapter didTriggerEvent:(NSString *)event withPayload:(NSDictionary *)payload;
-- (void)checkoutAdapter:(id<STPCheckoutWebViewAdapter>)adapter didError:(NSError *)error;
+- (void)checkoutAdapterDidStartLoad:(stp_nonnull id<STPCheckoutWebViewAdapter>)adapter;
+- (void)checkoutAdapterDidFinishLoad:(stp_nonnull id<STPCheckoutWebViewAdapter>)adapter;
+- (void)checkoutAdapter:(stp_nonnull id<STPCheckoutWebViewAdapter>)adapter
+        didTriggerEvent:(stp_nonnull NSString *)event
+            withPayload:(stp_nonnull NSDictionary *)payload;
+- (void)checkoutAdapter:(stp_nonnull id<STPCheckoutWebViewAdapter>)adapter didError:(stp_nonnull NSError *)error;
 @end

--- a/Stripe/Checkout/STPCheckoutInternalUIWebViewController.h
+++ b/Stripe/Checkout/STPCheckoutInternalUIWebViewController.h
@@ -6,28 +6,23 @@
 //  Copyright (c) 2015 Stripe, Inc. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
-
 #if TARGET_OS_IPHONE
 
+#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
+
 #import "STPCheckoutDelegate.h"
 #import "STPCheckoutViewController.h"
+#import "STPNullabilityMacros.h"
 
 @interface STPCheckoutInternalUIWebViewController : UIViewController<STPCheckoutDelegate, UIScrollViewDelegate>
 
-- (instancetype)initWithCheckoutViewController:(STPCheckoutViewController *)checkoutViewController;
+- (stp_nonnull instancetype)initWithCheckoutViewController:(stp_nonnull STPCheckoutViewController *)checkoutViewController;
 
-@property (weak, nonatomic, readonly) STPCheckoutViewController *checkoutController;
-@property (weak, nonatomic) UIView *webView;
-@property (nonatomic) STPIOSCheckoutWebViewAdapter *adapter;
-@property (weak, nonatomic) UIActivityIndicatorView *activityIndicator;
-@property (nonatomic) STPCheckoutOptions *options;
-@property (nonatomic) NSURL *logoURL;
-@property (nonatomic) NSURL *url;
-@property (nonatomic, weak) id<STPCheckoutViewControllerDelegate> delegate;
-@property (nonatomic) BOOL backendChargeSuccessful;
-@property (nonatomic) NSError *backendChargeError;
+@property (weak, nonatomic, readonly, stp_nonnull) STPCheckoutViewController *checkoutController;
+@property (weak, nonatomic, readonly, stp_nullable) UIView *webView;
+@property (nonatomic, stp_nonnull) STPCheckoutOptions *options;
+@property (nonatomic, weak, stp_nullable) id<STPCheckoutViewControllerDelegate> delegate;
 
 @end
 

--- a/Stripe/Checkout/STPCheckoutInternalUIWebViewController.m
+++ b/Stripe/Checkout/STPCheckoutInternalUIWebViewController.m
@@ -24,6 +24,13 @@
 
 @interface STPCheckoutInternalUIWebViewController ()
 @property (nonatomic) BOOL statusBarHidden;
+@property (weak, nonatomic, stp_nullable) UIView *webView;
+@property (nonatomic, stp_nullable) STPIOSCheckoutWebViewAdapter *adapter;
+@property (nonatomic, stp_nullable) NSURL *logoURL;
+@property (nonatomic, stp_nonnull) NSURL *url;
+@property (weak, nonatomic, stp_nullable) UIActivityIndicatorView *activityIndicator;
+@property (nonatomic) BOOL backendChargeSuccessful;
+@property (nonatomic, stp_nullable) NSError *backendChargeError;
 @end
 
 @implementation STPCheckoutInternalUIWebViewController
@@ -34,6 +41,8 @@
         if ([self respondsToSelector:@selector(setEdgesForExtendedLayout:)]) {
             self.edgesForExtendedLayout = UIRectEdgeNone;
         }
+        self.options = checkoutViewController.options;
+        self.url = [NSURL URLWithString:checkoutURLString];
         UIBarButtonItem *cancelItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancel:)];
         self.navigationItem.leftBarButtonItem = cancelItem;
         _checkoutController = checkoutViewController;
@@ -52,8 +61,6 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-
-    self.url = [NSURL URLWithString:checkoutURLString];
 
     if (self.options.logoImage && !self.options.logoURL) {
         NSURL *url = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:[[NSUUID UUID] UUIDString]]];

--- a/Stripe/Checkout/STPCheckoutInternalUIWebViewController.m
+++ b/Stripe/Checkout/STPCheckoutInternalUIWebViewController.m
@@ -41,8 +41,8 @@
         if ([self respondsToSelector:@selector(setEdgesForExtendedLayout:)]) {
             self.edgesForExtendedLayout = UIRectEdgeNone;
         }
-        self.options = checkoutViewController.options;
-        self.url = [NSURL URLWithString:checkoutURLString];
+        _options = checkoutViewController.options;
+        _url = [NSURL URLWithString:checkoutURLString];
         UIBarButtonItem *cancelItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancel:)];
         self.navigationItem.leftBarButtonItem = cancelItem;
         _checkoutController = checkoutViewController;

--- a/Stripe/Checkout/STPCheckoutOptions.m
+++ b/Stripe/Checkout/STPCheckoutOptions.m
@@ -11,14 +11,18 @@
 
 @implementation STPCheckoutOptions
 
-- (instancetype)init {
+- (instancetype)initWithPublishableKey:(NSString *)publishableKey {
     self = [super init];
     if (self) {
-        _publishableKey = [Stripe defaultPublishableKey];
+        _publishableKey = publishableKey;
         _companyName = [[NSBundle mainBundle] infoDictionary][@"CFBundleDisplayName"];
         _purchaseCurrency = @"USD";
     }
     return self;
+}
+
+- (instancetype)init {
+    return [self initWithPublishableKey:[Stripe defaultPublishableKey]];
 }
 
 - (NSString *)stringifiedJSONRepresentation {

--- a/Stripe/Checkout/STPCheckoutWebViewAdapter.h
+++ b/Stripe/Checkout/STPCheckoutWebViewAdapter.h
@@ -7,7 +7,6 @@
 //
 
 #import <Foundation/Foundation.h>
-
 #if TARGET_OS_IPHONE
 #define STP_VIEW_CLASS UIView
 #import <UIKit/UIKit.h>
@@ -16,25 +15,29 @@
 #import <AppKit/AppKit.h>
 #endif
 
-static NSString *const checkoutOptionsGlobal = @"StripeCheckoutOptions";
-static NSString *const checkoutRedirectPrefix = @"/-/";
-static NSString *const checkoutUserAgent = @"Stripe";
-static NSString *const checkoutRPCScheme = @"stripecheckout";
+#import "STPNullabilityMacros.h"
 
-static NSString *const checkoutHost = @"checkout.stripe.com";
-static NSString *const checkoutURLString = @"https://checkout.stripe.com/v3/ios/index.html";
+static NSString * __stp_nonnull const checkoutOptionsGlobal = @"StripeCheckoutOptions";
+static NSString * __stp_nonnull const checkoutRedirectPrefix = @"/-/";
+static NSString * __stp_nonnull const checkoutUserAgent = @"Stripe";
+static NSString * __stp_nonnull const checkoutRPCScheme = @"stripecheckout";
 
-static NSString *const STPCheckoutEventOpen = @"CheckoutDidOpen";
-static NSString *const STPCheckoutEventTokenize = @"CheckoutDidTokenize";
-static NSString *const STPCheckoutEventCancel = @"CheckoutDidCancel";
-static NSString *const STPCheckoutEventFinish = @"CheckoutDidFinish";
-static NSString *const STPCheckoutEventError = @"CheckoutDidError";
+static NSString * __stp_nonnull const checkoutHost = @"checkout.stripe.com";
+static NSString * __stp_nonnull const checkoutURLString = @"https://checkout.stripe.com/v3/ios/index.html";
+
+static NSString * __stp_nonnull const STPCheckoutEventOpen = @"CheckoutDidOpen";
+static NSString * __stp_nonnull const STPCheckoutEventTokenize = @"CheckoutDidTokenize";
+static NSString * __stp_nonnull const STPCheckoutEventCancel = @"CheckoutDidCancel";
+static NSString * __stp_nonnull const STPCheckoutEventFinish = @"CheckoutDidFinish";
+static NSString * __stp_nonnull const STPCheckoutEventError = @"CheckoutDidError";
 
 @protocol STPCheckoutDelegate;
 @protocol STPCheckoutWebViewAdapter<NSObject>
-@property (nonatomic, weak) id<STPCheckoutDelegate> delegate;
-@property (nonatomic, readonly) STP_VIEW_CLASS *webView;
-- (void)loadRequest:(NSURLRequest *)request;
-- (NSString *)evaluateJavaScript:(NSString *)js;
+
+@property (nonatomic, weak, stp_nullable) id<STPCheckoutDelegate> delegate;
+@property (nonatomic, readonly, stp_nullable) STP_VIEW_CLASS *webView;
+- (void)loadRequest:(stp_nonnull NSURLRequest *)request;
+- (stp_nullable NSString *)evaluateJavaScript:(stp_nonnull NSString *)js;
 - (void)cleanup;
+
 @end

--- a/Stripe/Checkout/STPColorUtils.h
+++ b/Stripe/Checkout/STPColorUtils.h
@@ -15,11 +15,13 @@
 #define STP_COLOR_CLASS NSColor
 #endif
 
+#import "STPNullabilityMacros.h"
+
 @interface STPColorUtils : NSObject
 
-+ (BOOL)colorIsLight:(STP_COLOR_CLASS *)color;
++ (BOOL)colorIsLight:(stp_nonnull STP_COLOR_CLASS *)color;
 
-+ (STP_COLOR_CLASS *)colorForHexCode:(NSString *)hexCode;
-+ (NSString *)hexCodeForColor:(STP_COLOR_CLASS *)color;
++ (stp_nonnull STP_COLOR_CLASS *)colorForHexCode:(stp_nonnull NSString *)hexCode;
++ (stp_nonnull NSString *)hexCodeForColor:(stp_nonnull STP_COLOR_CLASS *)color;
 
 @end

--- a/Stripe/Checkout/STPIOSCheckoutWebViewAdapter.h
+++ b/Stripe/Checkout/STPIOSCheckoutWebViewAdapter.h
@@ -6,15 +6,16 @@
 //  Copyright (c) 2015 Stripe, Inc. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
-
 #if TARGET_OS_IPHONE
 
+#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
+
 #import "STPCheckoutWebViewAdapter.h"
+#import "STPNullabilityMacros.h"
 
 @interface STPIOSCheckoutWebViewAdapter : NSObject<STPCheckoutWebViewAdapter, UIWebViewDelegate>
-@property (nonatomic) UIWebView *webView;
+@property (nonatomic, stp_nullable) UIWebView *webView;
 @end
 
 #endif

--- a/Stripe/Checkout/STPIOSCheckoutWebViewAdapter.m
+++ b/Stripe/Checkout/STPIOSCheckoutWebViewAdapter.m
@@ -73,7 +73,7 @@
         if ([url.scheme isEqualToString:checkoutRPCScheme]) {
             NSString *event = url.host;
             NSString *path = [url.path componentsSeparatedByString:@"/"][1];
-            NSDictionary *payload = nil;
+            NSDictionary *payload = @{};
             if (path != nil) {
                 payload = [NSJSONSerialization JSONObjectWithData:[path dataUsingEncoding:NSUTF8StringEncoding] options:0 error:nil];
             }

--- a/Stripe/Checkout/STPOSXCheckoutWebViewAdapter.h
+++ b/Stripe/Checkout/STPOSXCheckoutWebViewAdapter.h
@@ -6,15 +6,16 @@
 //  Copyright (c) 2015 Stripe, Inc. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
-
 #if !TARGET_OS_IPHONE
 
-#import "STPCheckoutWebViewAdapter.h"
+#import <Foundation/Foundation.h>
 #import <WebKit/WebKit.h>
 
+#import "STPCheckoutWebViewAdapter.h"
+#import "STPNullabilityMacros.h"
+
 @interface STPOSXCheckoutWebViewAdapter : NSObject<STPCheckoutWebViewAdapter>
-@property (nonatomic) WebView *webView;
+@property (nonatomic, stp_nullable) WebView *webView;
 @end
 
 #endif

--- a/Stripe/Checkout/STPOSXCheckoutWebViewAdapter.m
+++ b/Stripe/Checkout/STPOSXCheckoutWebViewAdapter.m
@@ -104,7 +104,7 @@ decisionListener:(id<WebPolicyDecisionListener>)listener {
             if ([url.scheme isEqualToString:checkoutRPCScheme]) {
                 NSString *event = url.host;
                 NSString *path = [url.path componentsSeparatedByString:@"/"][1];
-                NSDictionary *payload = nil;
+                NSDictionary *payload = @{};
                 if (path != nil) {
                     payload = [NSJSONSerialization JSONObjectWithData:[path dataUsingEncoding:NSUTF8StringEncoding] options:0 error:nil];
                 }

--- a/Stripe/Checkout/STPStrictURLProtocol.h
+++ b/Stripe/Checkout/STPStrictURLProtocol.h
@@ -8,11 +8,13 @@
 
 #import <Foundation/Foundation.h>
 
-static NSString *const STPStrictURLProtocolRequestKey = @"STPStrictURLProtocolRequestKey";
+#import "STPNullabilityMacros.h"
+
+static NSString * __stp_nonnull const STPStrictURLProtocolRequestKey = @"STPStrictURLProtocolRequestKey";
 
 /**
  *  This URL protocol treats any non-20x or 30x response from checkout as an error (unlike the default UIWebView behavior, which e.g. displays a 404 page).
  */
 @interface STPStrictURLProtocol : NSURLProtocol
-@property (nonatomic, strong) NSURLConnection *connection;
+@property (nonatomic, strong, stp_nullable) NSURLConnection *connection;
 @end

--- a/Stripe/PublicHeaders/ApplePay/STPAPIClient+ApplePay.h
+++ b/Stripe/PublicHeaders/ApplePay/STPAPIClient+ApplePay.h
@@ -5,8 +5,11 @@
 //  Created by Jack Flintermann on 12/19/14.
 //
 
-#import "STPAPIClient.h"
+#import <Foundation/Foundation.h>
 #import <PassKit/PassKit.h>
+
+#import "STPAPIClient.h"
+#import "STPNullabilityMacros.h"
 
 @interface STPAPIClient (ApplePay)
 
@@ -16,9 +19,9 @@
  *  @param payment     The user's encrypted payment information as returned from a PKPaymentAuthorizationViewController. Cannot be nil.
  *  @param completion  The callback to run with the returned Stripe token (and any errors that may have occurred).
  */
-- (void)createTokenWithPayment:(PKPayment *)payment completion:(STPCompletionBlock)completion;
+- (void)createTokenWithPayment:(stp_nonnull PKPayment *)payment completion:(stp_nonnull STPCompletionBlock)completion;
 
 // Form-encodes a PKPayment object for POSTing to the Stripe API. This method is used internally by STPAPIClient; you should not use it in your own code.
-+ (NSData *)formEncodedDataForPayment:(PKPayment *)payment;
++ (stp_nonnull NSData *)formEncodedDataForPayment:(stp_nonnull PKPayment *)payment;
 
 @end

--- a/Stripe/PublicHeaders/ApplePay/Stripe+ApplePay.h
+++ b/Stripe/PublicHeaders/ApplePay/Stripe+ApplePay.h
@@ -5,9 +5,12 @@
 //  Created by Jack Flintermann on 9/17/14.
 //
 
+#import <Foundation/Foundation.h>
 #import <PassKit/PassKit.h>
+
 #import "Stripe.h"
 #import "STPAPIClient+ApplePay.h"
+#import "STPNullabilityMacros.h"
 
 @class Stripe;
 
@@ -22,7 +25,7 @@
  *
  *  @return whether or not the user is currently able to pay with Apple Pay.
  */
-+ (BOOL)canSubmitPaymentRequest:(PKPaymentRequest *)paymentRequest;
++ (BOOL)canSubmitPaymentRequest:(stp_nullable PKPaymentRequest *)paymentRequest;
 
 /**
  *  A convenience method to return a PKPaymentRequest with sane default values. You will still need to configure the paymentSummaryItems property to indicate
@@ -31,9 +34,9 @@
  *
  *  @param merchantIdentifier Your Apple Merchant ID, as obtained at https://developer.apple.com/account/ios/identifiers/merchant/merchantCreate.action
  *
- *  @return a PKPaymentRequest with proper default values.
+ *  @return a PKPaymentRequest with proper default values. Returns nil if running on < iOS8.
  */
-+ (PKPaymentRequest *)paymentRequestWithMerchantIdentifier:(NSString *)merchantIdentifier;
++ (stp_nullable PKPaymentRequest *)paymentRequestWithMerchantIdentifier:(stp_nonnull NSString *)merchantIdentifier;
 
 #pragma mark - deprecated methods
 
@@ -45,7 +48,7 @@
  *  @param handler Code to run when the token has been returned (along with any errors encountered).
  *  @deprecated use [[STPAPIClient sharedClient] createTokenWithPayment:completion:] instead.
  */
-+ (void)createTokenWithPayment:(PKPayment *)payment completion:(STPCompletionBlock)handler __attribute__((deprecated));
++ (void)createTokenWithPayment:(stp_nonnull PKPayment *)payment completion:(stp_nonnull STPCompletionBlock)handler __attribute__((deprecated));
 
 /**
  *  Securely convert your user's Apple Pay payment information into a Stripe token, which you can then safely store on your server and use to charge the user.
@@ -56,6 +59,6 @@
  *  @param handler Code to run when the token has been returned (along with any errors encountered).
  *  @deprecated use [[STPAPIClient sharedClient] createTokenWithPayment:completion:] instead.
  */
-+ (void)createTokenWithPayment:(PKPayment *)payment operationQueue:(NSOperationQueue *)queue completion:(STPCompletionBlock)handler __attribute__((deprecated));
++ (void)createTokenWithPayment:(stp_nonnull PKPayment *)payment operationQueue:(stp_nonnull NSOperationQueue *)queue completion:(stp_nonnull STPCompletionBlock)handler __attribute__((deprecated));
 
 @end

--- a/Stripe/PublicHeaders/Checkout/STPCheckoutOptions.h
+++ b/Stripe/PublicHeaders/Checkout/STPCheckoutOptions.h
@@ -12,18 +12,22 @@
 #import <AppKit/AppKit.h>
 #endif
 
+#import "STPNullabilityMacros.h"
+
 /**
  *  This class represents a configurable set of options that you can pass to an STPCheckoutViewController to control the appearance of
  * Stripe Checkout. For more information on how these properties behave, see https://stripe.com/docs/checkout#integration-custom
  */
 @interface STPCheckoutOptions : NSObject<NSCopying>
 
+-(stp_nonnull instancetype)initWithPublishableKey:(stp_nonnull NSString *)publishableKey;
+
 #pragma mark - Required options
 
 /**
  *  The Stripe publishable key to use for your Checkout requests. Defaults to [Stripe defaultPublishableKey]. Required.
  */
-@property (nonatomic, copy) NSString *publishableKey;
+@property (nonatomic, copy, stp_nonnull) NSString *publishableKey;
 
 #pragma mark - Strongly recommended options
 
@@ -31,15 +35,15 @@
  *  This can be an external image URL that will load in the header of Stripe Checkout. This takes precedent over the logoImage property. The recommended minimum
  * size for this image is 128x128px.
  */
-@property (nonatomic, copy) NSURL *logoURL;
+@property (nonatomic, copy, stp_nullable) NSURL *logoURL;
 
 /**
  *  You can also specify a local UIImage to be used as the Checkout logo header (see logoURL).
  */
 #if TARGET_OS_IPHONE
-@property (nonatomic) UIImage *logoImage;
+@property (nonatomic, stp_nullable) UIImage *logoImage;
 #else
-@property (nonatomic) NSImage *logoImage;
+@property (nonatomic, stp_nullable) NSImage *logoImage;
 #endif
 
 /**
@@ -47,20 +51,20 @@
  * auto-detect the background color of the image you point to and use that as the header color.
  */
 #if TARGET_OS_IPHONE
-@property (nonatomic, copy) UIColor *logoColor;
+@property (nonatomic, copy, stp_nullable) UIColor *logoColor;
 #else
-@property (nonatomic, copy) NSColor *logoColor;
+@property (nonatomic, copy, stp_nullable) NSColor *logoColor;
 #endif
 
 /**
  *  The name of your company or website. Displayed in the header. Defaults to your app's name.
  */
-@property (nonatomic, copy) NSString *companyName;
+@property (nonatomic, copy, stp_nullable) NSString *companyName;
 
 /**
  *  A description of the product or service being purchased. Appears in the header.
  */
-@property (nonatomic, copy) NSString *purchaseDescription;
+@property (nonatomic, copy, stp_nullable) NSString *purchaseDescription;
 
 /**
  *  The amount (in cents) that's shown to the user. Note that this is for display purposes only; you will still have to explicitly specify the amount when you
@@ -72,7 +76,7 @@
 /**
  *  If you already know the email address of your user, you can provide it to Checkout to be pre-filled.
  */
-@property (nonatomic, copy) NSString *customerEmail;
+@property (nonatomic, copy, stp_nullable) NSString *customerEmail;
 
 #pragma mark - Additional options
 
@@ -80,33 +84,33 @@
  *  The label of the payment button in the Checkout form (e.g. “Subscribe”, “Pay {{amount}}”, etc.). If you include {{amount}}, it will be replaced by the
  * provided amount. Otherwise, the amount will be appended to the end of your label. Defaults to "Pay {{amount}}".
  */
-@property (nonatomic, copy) NSString *purchaseLabel;
+@property (nonatomic, copy, stp_nullable) NSString *purchaseLabel;
 
 /**
  *  The currency of the amount (3-letter ISO code). The default is "USD".
  */
-@property (nonatomic, copy) NSString *purchaseCurrency;
+@property (nonatomic, copy, stp_nonnull) NSString *purchaseCurrency;
 
 /**
  *  Specify whether to include the option to "Remember Me" for future purchases (true or false). The default is true.
  */
-@property (nonatomic, copy) NSNumber *enableRememberMe;
+@property (nonatomic, copy, stp_nullable) NSNumber *enableRememberMe;
 
 /**
  *  Specify whether Checkout should validate your user's billing ZIP code (true or false). The default is false.
  */
-@property (nonatomic, copy) NSNumber *enablePostalCode;
+@property (nonatomic, copy, stp_nullable) NSNumber *enablePostalCode;
 
 /**
  *  Specify whether Checkout should require the user to enter their billing address. The default is false.
  */
-@property (nonatomic, copy) NSNumber *requireBillingAddress;
+@property (nonatomic, copy, stp_nullable) NSNumber *requireBillingAddress;
 
 /**
  *  Used internally by Stripe Checkout.
  *
  *  @return a JSON string representing the options.
  */
-- (NSString *)stringifiedJSONRepresentation;
+- (stp_nonnull NSString *)stringifiedJSONRepresentation;
 
 @end

--- a/Stripe/PublicHeaders/Checkout/STPCheckoutViewController.h
+++ b/Stripe/PublicHeaders/Checkout/STPCheckoutViewController.h
@@ -6,12 +6,13 @@
 //
 
 #import <Foundation/Foundation.h>
-
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
 #else
 #import <AppKit/AppKit.h>
 #endif
+
+#import "STPNullabilityMacros.h"
 
 typedef NS_ENUM(NSInteger, STPPaymentStatus) {
     STPPaymentStatusSuccess,       // The transaction was a success.
@@ -39,13 +40,13 @@ typedef NS_ENUM(NSInteger, STPPaymentStatus) {
  *  @param options A configuration object that describes how to display Stripe Checkout.
  *
  */
-- (instancetype)initWithOptions:(STPCheckoutOptions *)options NS_DESIGNATED_INITIALIZER;
-@property (nonatomic, readonly, copy) STPCheckoutOptions *options;
+- (stp_nonnull instancetype)initWithOptions:(stp_nonnull STPCheckoutOptions *)options NS_DESIGNATED_INITIALIZER;
+@property (nonatomic, readonly, copy, stp_nonnull) STPCheckoutOptions *options;
 
 /**
  *  Note: you must set a delegate before showing an STPViewController.
  */
-@property (nonatomic, weak) id<STPCheckoutViewControllerDelegate> checkoutDelegate;
+@property (nonatomic, weak, stp_nullable) id<STPCheckoutViewControllerDelegate> checkoutDelegate;
 
 @end
 
@@ -60,7 +61,7 @@ typedef NS_ENUM(NSInteger, STPPaymentStatus) {
  *state, for example.
  *  @param error      the returned error, if it exists. Can be nil.
  */
-- (void)checkoutController:(STPCheckoutViewController *)controller didFinishWithStatus:(STPPaymentStatus)status error:(NSError *)error;
+- (void)checkoutController:(stp_nonnull STPCheckoutViewController *)controller didFinishWithStatus:(STPPaymentStatus)status error:(stp_nullable NSError *)error;
 
 /**
  *  Use these options to inform Stripe Checkout of the success or failure of your backend charge.
@@ -70,7 +71,7 @@ typedef NS_ENUM(NSInteger, STPBackendChargeResult) {
     STPBackendChargeResultFailure, // Passing this value will display an "error" animation in the payment button.
 };
 
-typedef void (^STPTokenSubmissionHandler)(STPBackendChargeResult status, NSError *error);
+typedef void (^STPTokenSubmissionHandler)(STPBackendChargeResult status, NSError * __stp_nullable error);
 
 /**
  *  After the user has provided valid credit card information and pressed the "pay" button, Checkout will communicate with Stripe and obtain a tokenized version
@@ -84,6 +85,8 @@ typedef void (^STPTokenSubmissionHandler)(STPBackendChargeResult status, NSError
  *  @param token      a Stripe token
  *  @param completion call this function with STPBackendChargeResultSuccess/Failure when you're done charging your user
  */
-- (void)checkoutController:(STPCheckoutViewController *)controller didCreateToken:(STPToken *)token completion:(STPTokenSubmissionHandler)completion;
+- (void)checkoutController:(stp_nonnull STPCheckoutViewController *)controller
+            didCreateToken:(stp_nonnull STPToken *)token
+                completion:(stp_nonnull STPTokenSubmissionHandler)completion;
 
 @end

--- a/Stripe/PublicHeaders/STPAPIClient.h
+++ b/Stripe/PublicHeaders/STPAPIClient.h
@@ -7,8 +7,9 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "STPNullabilityMacros.h"
 
-static NSString *const STPSDKVersion = @"3.1.0";
+static NSString *const __stp_nonnull STPSDKVersion = @"3.1.0";
 
 @class STPBankAccount, STPCard, STPToken;
 
@@ -18,7 +19,7 @@ static NSString *const STPSDKVersion = @"3.1.0";
  *  @param token The Stripe token from the response. Will be nil if an error occurs. @see STPToken
  *  @param error The error returned from the response, or nil in one occurs. @see StripeError.h for possible values.
  */
-typedef void (^STPCompletionBlock)(STPToken *token, NSError *error);
+typedef void (^STPCompletionBlock)(STPToken * __stp_nullable token, NSError * __stp_nullable error);
 
 /**
  A top-level class that imports the rest of the Stripe SDK. This class used to contain several methods to create Stripe tokens, but those are now deprecated in
@@ -33,10 +34,10 @@ typedef void (^STPCompletionBlock)(STPToken *token, NSError *error);
  *  @param   publishableKey Your publishable key, obtained from https://stripe.com/account/apikeys
  *  @warning Make sure not to ship your test API keys to the App Store! This will log a warning if you use your test key in a release build.
  */
-+ (void)setDefaultPublishableKey:(NSString *)publishableKey;
++ (void)setDefaultPublishableKey:(stp_nonnull NSString *)publishableKey;
 
 /// The current default publishable key.
-+ (NSString *)defaultPublishableKey;
++ (stp_nullable NSString *)defaultPublishableKey;
 @end
 
 /// A client for making connections to the Stripe API.
@@ -45,18 +46,18 @@ typedef void (^STPCompletionBlock)(STPToken *token, NSError *error);
 /**
  *  A shared singleton API client. Its API key will be initially equal to [Stripe defaultPublishableKey].
  */
-+ (instancetype)sharedClient;
-- (instancetype)initWithPublishableKey:(NSString *)publishableKey NS_DESIGNATED_INITIALIZER;
++ (stp_nonnull instancetype)sharedClient;
+- (stp_nonnull instancetype)initWithPublishableKey:(stp_nonnull NSString *)publishableKey NS_DESIGNATED_INITIALIZER;
 
 /**
  *  @see [Stripe setDefaultPublishableKey:]
  */
-@property (nonatomic, copy) NSString *publishableKey;
+@property (nonatomic, copy, stp_nullable) NSString *publishableKey;
 
 /**
  *  The operation queue on which to run the url connection and delegate methods. Cannot be nil. @see NSURLConnection
  */
-@property (nonatomic) NSOperationQueue *operationQueue;
+@property (nonatomic, stp_nonnull) NSOperationQueue *operationQueue;
 
 @end
 
@@ -70,7 +71,7 @@ typedef void (^STPCompletionBlock)(STPToken *token, NSError *error);
  *  @param bankAccount The user's bank account details. Cannot be nil. @see https://stripe.com/docs/api#create_bank_account_token
  *  @param completion  The callback to run with the returned Stripe token (and any errors that may have occurred).
  */
-- (void)createTokenWithBankAccount:(STPBankAccount *)bankAccount completion:(STPCompletionBlock)completion;
+- (void)createTokenWithBankAccount:(stp_nonnull STPBankAccount *)bankAccount completion:(__stp_nullable STPCompletionBlock)completion;
 
 @end
 
@@ -84,14 +85,14 @@ typedef void (^STPCompletionBlock)(STPToken *token, NSError *error);
  *  @param card        The user's card details. Cannot be nil. @see https://stripe.com/docs/api#create_card_token
  *  @param completion  The callback to run with the returned Stripe token (and any errors that may have occurred).
  */
-- (void)createTokenWithCard:(STPCard *)card completion:(STPCompletionBlock)completion;
+- (void)createTokenWithCard:(stp_nonnull STPCard *)card completion:(stp_nullable STPCompletionBlock)completion;
 
 @end
 
 // These methods are used internally and exposed here only for the sake of writing tests more easily. You should not use them in your own application.
 @interface STPAPIClient (PrivateMethods)
 
-- (void)createTokenWithData:(NSData *)data completion:(STPCompletionBlock)completion;
+- (void)createTokenWithData:(stp_nonnull NSData *)data completion:(stp_nullable STPCompletionBlock)completion;
 
 @end
 
@@ -109,7 +110,7 @@ typedef void (^STPCompletionBlock)(STPToken *token, NSError *error);
  *  @param handler Code to run when the user's card has been turned into a Stripe token.
  *  @deprecated    Use STPAPIClient instead.
  */
-+ (void)createTokenWithCard:(STPCard *)card completion:(STPCompletionBlock)handler __attribute__((deprecated));
++ (void)createTokenWithCard:(stp_nonnull STPCard *)card completion:(stp_nullable STPCompletionBlock)handler __attribute__((deprecated));
 
 /**
  *  Securely convert your user's credit card details into a Stripe token, which you can then safely store on your server and use to charge the user. The URL
@@ -120,7 +121,7 @@ typedef void (^STPCompletionBlock)(STPToken *token, NSError *error);
  *  @param handler        Code to run when the user's card has been turned into a Stripe token.
  *  @deprecated           Use STPAPIClient instead.
  */
-+ (void)createTokenWithCard:(STPCard *)card publishableKey:(NSString *)publishableKey completion:(STPCompletionBlock)handler __attribute__((deprecated));
++ (void)createTokenWithCard:(stp_nonnull STPCard *)card publishableKey:(stp_nonnull NSString *)publishableKey completion:(stp_nullable STPCompletionBlock)handler __attribute__((deprecated));
 
 /**
  *  Securely convert your user's credit card details into a Stripe token, which you can then safely store on your server and use to charge the user.
@@ -130,7 +131,7 @@ typedef void (^STPCompletionBlock)(STPToken *token, NSError *error);
  *  @param handler Code to run when the user's card has been turned into a Stripe token.
  *  @deprecated    Use STPAPIClient instead.
  */
-+ (void)createTokenWithCard:(STPCard *)card operationQueue:(NSOperationQueue *)queue completion:(STPCompletionBlock)handler __attribute__((deprecated));
++ (void)createTokenWithCard:(stp_nonnull STPCard *)card operationQueue:(stp_nonnull NSOperationQueue *)queue completion:(stp_nullable STPCompletionBlock)handler __attribute__((deprecated));
 
 /**
  *  Securely convert your user's credit card details into a Stripe token, which you can then safely store on your server and use to charge the user.
@@ -141,10 +142,10 @@ typedef void (^STPCompletionBlock)(STPToken *token, NSError *error);
  *  @param handler        Code to run when the user's card has been turned into a Stripe token.
  *  @deprecated           Use STPAPIClient instead.
  */
-+ (void)createTokenWithCard:(STPCard *)card
-             publishableKey:(NSString *)publishableKey
-             operationQueue:(NSOperationQueue *)queue
-                 completion:(STPCompletionBlock)handler __attribute__((deprecated));
++ (void)createTokenWithCard:(stp_nonnull STPCard *)card
+             publishableKey:(stp_nonnull NSString *)publishableKey
+             operationQueue:(stp_nonnull NSOperationQueue *)queue
+                 completion:(stp_nullable STPCompletionBlock)handler __attribute__((deprecated));
 
 /**
  *  Securely convert your user's credit card details into a Stripe token, which you can then safely store on your server and use to charge the user. The URL
@@ -154,7 +155,7 @@ typedef void (^STPCompletionBlock)(STPToken *token, NSError *error);
  *  @param handler     Code to run when the user's card has been turned into a Stripe token.
  *  @deprecated        Use STPAPIClient instead.
  */
-+ (void)createTokenWithBankAccount:(STPBankAccount *)bankAccount completion:(STPCompletionBlock)handler __attribute__((deprecated));
++ (void)createTokenWithBankAccount:(stp_nonnull STPBankAccount *)bankAccount completion:(stp_nullable STPCompletionBlock)handler __attribute__((deprecated));
 
 /**
  *  Securely convert your user's credit card details into a Stripe token, which you can then safely store on your server and use to charge the user. The URL
@@ -165,9 +166,9 @@ typedef void (^STPCompletionBlock)(STPToken *token, NSError *error);
  *  @param handler        Code to run when the user's card has been turned into a Stripe token.
  *  @deprecated           Use STPAPIClient instead.
  */
-+ (void)createTokenWithBankAccount:(STPBankAccount *)bankAccount
-                    publishableKey:(NSString *)publishableKey
-                        completion:(STPCompletionBlock)handler __attribute__((deprecated));
++ (void)createTokenWithBankAccount:(stp_nonnull STPBankAccount *)bankAccount
+                    publishableKey:(stp_nonnull NSString *)publishableKey
+                        completion:(stp_nullable STPCompletionBlock)handler __attribute__((deprecated));
 
 /**
  *  Securely convert your user's credit card details into a Stripe token, which you can then safely store on your server and use to charge the user. The URL
@@ -178,9 +179,9 @@ typedef void (^STPCompletionBlock)(STPToken *token, NSError *error);
  *  @param handler     Code to run when the user's card has been turned into a Stripe token.
  *  @deprecated        Use STPAPIClient instead.
  */
-+ (void)createTokenWithBankAccount:(STPBankAccount *)bankAccount
-                    operationQueue:(NSOperationQueue *)queue
-                        completion:(STPCompletionBlock)handler __attribute__((deprecated));
++ (void)createTokenWithBankAccount:(stp_nonnull STPBankAccount *)bankAccount
+                    operationQueue:(stp_nonnull NSOperationQueue *)queue
+                        completion:(stp_nullable STPCompletionBlock)handler __attribute__((deprecated));
 
 /**
  *  Securely convert your user's credit card details into a Stripe token, which you can then safely store on your server and use to charge the user. The URL
@@ -192,9 +193,9 @@ typedef void (^STPCompletionBlock)(STPToken *token, NSError *error);
  *  @param handler        Code to run when the user's card has been turned into a Stripe token.
  *  @deprecated           Use STPAPIClient instead.
  */
-+ (void)createTokenWithBankAccount:(STPBankAccount *)bankAccount
-                    publishableKey:(NSString *)publishableKey
-                    operationQueue:(NSOperationQueue *)queue
-                        completion:(STPCompletionBlock)handler __attribute__((deprecated));
++ (void)createTokenWithBankAccount:(stp_nonnull STPBankAccount *)bankAccount
+                    publishableKey:(stp_nonnull NSString *)publishableKey
+                    operationQueue:(stp_nonnull NSOperationQueue *)queue
+                        completion:(stp_nullable STPCompletionBlock)handler __attribute__((deprecated));
 
 @end

--- a/Stripe/PublicHeaders/STPBankAccount.h
+++ b/Stripe/PublicHeaders/STPBankAccount.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "STPNullabilityMacros.h"
 
 /**
  *  Representation of a user's credit card details. You can assemble these with information that your user enters and
@@ -17,43 +18,43 @@
 /**
  *  The account number for the bank account. Currently must be a checking account.
  */
-@property (nonatomic, copy) NSString *accountNumber;
+@property (nonatomic, copy, stp_nullable) NSString *accountNumber;
 
 /**
  *  The routing number for the bank account. This should be the ACH routing number, not the wire routing number.
  */
-@property (nonatomic, copy) NSString *routingNumber;
+@property (nonatomic, copy, stp_nullable) NSString *routingNumber;
 
 /**
  *  The country the bank account is in. Currently, only US is supported.
  */
-@property (nonatomic, copy) NSString *country;
+@property (nonatomic, copy, stp_nullable) NSString *country;
 
 #pragma mark - These fields are only present on objects returned from the Stripe API.
 /**
  *  The Stripe ID for the bank account.
  */
-@property (nonatomic, readonly) NSString *bankAccountId;
+@property (nonatomic, readonly, stp_nullable) NSString *bankAccountId;
 
 /**
  *  The last 4 digits of the account number.
  */
-@property (nonatomic, readonly) NSString *last4;
+@property (nonatomic, readonly, stp_nullable) NSString *last4;
 
 /**
  *  The name of the bank that owns the account.
  */
-@property (nonatomic, readonly) NSString *bankName;
+@property (nonatomic, readonly, stp_nullable) NSString *bankName;
 
 /**
  *  A proxy for the account number, this uniquely identifies the account and can be used to compare equality of different bank accounts.
  */
-@property (nonatomic, readonly) NSString *fingerprint;
+@property (nonatomic, readonly, stp_nullable) NSString *fingerprint;
 
 /**
  *  The default currency for the bank account.
  */
-@property (nonatomic, readonly) NSString *currency;
+@property (nonatomic, readonly, stp_nullable) NSString *currency;
 
 /**
  *  Whether or not the bank account has been validated via microdeposits or other means.
@@ -71,6 +72,6 @@
 // This method is used internally by Stripe to deserialize API responses and exposed here for convenience and testing purposes only. You should not use it in your own code.
 @interface STPBankAccount (PrivateMethods)
 
-- (instancetype)initWithAttributeDictionary:(NSDictionary *)attributeDictionary;
+- (stp_nonnull instancetype)initWithAttributeDictionary:(stp_nonnull NSDictionary *)attributeDictionary;
 
 @end

--- a/Stripe/PublicHeaders/STPCard.h
+++ b/Stripe/PublicHeaders/STPCard.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "STPNullabilityMacros.h"
 
 typedef NS_ENUM(NSInteger, STPCardFundingType) {
     STPCardFundingTypeDebit,
@@ -34,12 +35,12 @@ typedef NS_ENUM(NSInteger, STPCardBrand) {
 /**
  *  The card's number. This will be nil for cards retrieved from the Stripe API.
  */
-@property (nonatomic, copy) NSString *number;
+@property (nonatomic, copy, stp_nullable) NSString *number;
 
 /**
  *  The last 4 digits of the card. Unlike number, this will be present on cards retrieved from the Stripe API.
  */
-@property (nonatomic, readonly) NSString *last4;
+@property (nonatomic, readonly, stp_nullable) NSString *last4;
 
 /**
  *  The card's expiration month.
@@ -54,27 +55,27 @@ typedef NS_ENUM(NSInteger, STPCardBrand) {
 /**
  *  The card's security code, found on the back. This will be nil for cards retrieved from the Stripe API.
  */
-@property (nonatomic, copy) NSString *cvc;
+@property (nonatomic, copy, stp_nullable) NSString *cvc;
 
 /**
  *  The cardholder's name.
  */
-@property (nonatomic, copy) NSString *name;
+@property (nonatomic, copy, stp_nullable) NSString *name;
 
 /**
  *  The cardholder's address.
  */
-@property (nonatomic, copy) NSString *addressLine1;
-@property (nonatomic, copy) NSString *addressLine2;
-@property (nonatomic, copy) NSString *addressCity;
-@property (nonatomic, copy) NSString *addressState;
-@property (nonatomic, copy) NSString *addressZip;
-@property (nonatomic, copy) NSString *addressCountry;
+@property (nonatomic, copy, stp_nullable) NSString *addressLine1;
+@property (nonatomic, copy, stp_nullable) NSString *addressLine2;
+@property (nonatomic, copy, stp_nullable) NSString *addressCity;
+@property (nonatomic, copy, stp_nullable) NSString *addressState;
+@property (nonatomic, copy, stp_nullable) NSString *addressZip;
+@property (nonatomic, copy, stp_nullable) NSString *addressCountry;
 
 /**
  *  The Stripe ID for the card.
  */
-@property (nonatomic, readonly) NSString *cardId;
+@property (nonatomic, readonly, stp_nullable) NSString *cardId;
 
 /**
  *  The issuer of the card.
@@ -86,7 +87,7 @@ typedef NS_ENUM(NSInteger, STPCardBrand) {
  *  Can be one of "Visa", "American Express", "MasterCard", "Discover", "JCB", "Diners Club", or "Unknown"
  *  @deprecated use "brand" instead.
  */
-@property (nonatomic, readonly) NSString *type __attribute__((deprecated));
+@property (nonatomic, readonly, stp_nonnull) NSString *type __attribute__((deprecated));
 
 /**
  *  The funding source for the card (credit, debit, prepaid, or other)
@@ -96,20 +97,24 @@ typedef NS_ENUM(NSInteger, STPCardBrand) {
 /**
  *  A proxy for the card's number, this uniquely identifies the credit card and can be used to compare different cards.
  */
-@property (nonatomic, readonly) NSString *fingerprint;
+@property (nonatomic, readonly, stp_nullable) NSString *fingerprint;
 
 /**
  *  Two-letter ISO code representing the issuing country of the card.
  */
-@property (nonatomic, readonly) NSString *country;
+@property (nonatomic, readonly, stp_nullable) NSString *country;
 
 // These validation methods work as described in
 // http://developer.apple.com/library/mac/#documentation/Cocoa/Conceptual/KeyValueCoding/Articles/Validation.html#//apple_ref/doc/uid/20002173-CJBDBHCB
 
-- (BOOL)validateNumber:(id *)ioValue error:(NSError **)outError;
-- (BOOL)validateCvc:(id *)ioValue error:(NSError **)outError;
-- (BOOL)validateExpMonth:(id *)ioValue error:(NSError **)outError;
-- (BOOL)validateExpYear:(id *)ioValue error:(NSError **)outError;
+- (BOOL)validateNumber:(__stp_nullable id * __stp_nullable )ioValue
+                 error:(NSError * __stp_nullable * __stp_nullable )outError;
+- (BOOL)validateCvc:(__stp_nullable id * __stp_nullable )ioValue
+              error:(NSError * __stp_nullable * __stp_nullable )outError;
+- (BOOL)validateExpMonth:(__stp_nullable  id * __stp_nullable )ioValue
+                   error:(NSError * __stp_nullable * __stp_nullable )outError;
+- (BOOL)validateExpYear:(__stp_nullable id * __stp_nullable)ioValue
+                  error:(NSError * __stp_nullable * __stp_nullable )outError;
 
 /**
  *  This validates a fully populated card to check for all errors, including ones that come about
@@ -122,12 +127,12 @@ typedef NS_ENUM(NSInteger, STPCardBrand) {
  *
  *  @return whether or not the card is valid.
  */
-- (BOOL)validateCardReturningError:(NSError **)outError;
+- (BOOL)validateCardReturningError:(NSError * __stp_nullable * __stp_nullable)outError;
 
 @end
 
 // This method is used internally by Stripe to deserialize API responses and exposed here for convenience and testing purposes only. You should not use it in
 // your own code.
 @interface STPCard (PrivateMethods)
-- (instancetype)initWithAttributeDictionary:(NSDictionary *)attributeDictionary;
+- (stp_nonnull instancetype)initWithAttributeDictionary:(stp_nonnull NSDictionary *)attributeDictionary;
 @end

--- a/Stripe/PublicHeaders/STPToken.h
+++ b/Stripe/PublicHeaders/STPToken.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "STPNullabilityMacros.h"
 
 @class STPCard;
 @class STPBankAccount;
@@ -17,10 +18,15 @@
 @interface STPToken : NSObject
 
 /**
+ *  You cannot directly instantiate an STPToken. You should only use one that has been returned from an STPAPIClient callback.
+ */
+- (stp_nonnull instancetype) init __attribute__((unavailable("You cannot directly instantiate an STPToken. You should only use one that has been returned from an STPAPIClient callback.")));
+
+/**
  *  The value of the token. You can store this value on your server and use it to make charges and customers. @see
  * https://stripe.com/docs/mobile/ios#sending-tokens
  */
-@property (nonatomic, readonly) NSString *tokenId;
+@property (nonatomic, readonly, stp_nonnull) NSString *tokenId;
 
 /**
  *  Whether or not this token was created in livemode. Will be YES if you used your Live Publishable Key, and NO if you used your Test Publishable Key.
@@ -31,19 +37,19 @@
  *  The credit card details that were used to create the token. Will only be set if the token was created via a credit card or Apple Pay, otherwise it will be
  * nil.
  */
-@property (nonatomic, readonly) STPCard *card;
+@property (nonatomic, readonly, stp_nullable) STPCard *card;
 
 /**
  *  The bank account details that were used to create the token. Will only be set if the token was created with a bank account, otherwise it will be nil.
  */
-@property (nonatomic, readonly) STPBankAccount *bankAccount;
+@property (nonatomic, readonly, stp_nullable) STPBankAccount *bankAccount;
 
 /**
  *  When the token was created.
  */
-@property (nonatomic, readonly) NSDate *created;
+@property (nonatomic, readonly, stp_nullable) NSDate *created;
 
-typedef void (^STPCardServerResponseCallback)(NSURLResponse *response, NSData *data, NSError *error);
+typedef void (^STPCardServerResponseCallback)(NSURLResponse * __stp_nullable response, NSData * __stp_nullable data, NSError * __stp_nullable error);
 
 /**
  *  Form-encode the token and post those parameters to your backend URL.
@@ -53,7 +59,7 @@ typedef void (^STPCardServerResponseCallback)(NSURLResponse *response, NSData *d
  *  @param handler code to execute with your server's response
  *  @deprecated    you should write your own networking code to talk to your server.
  */
-- (void)postToURL:(NSURL *)url withParams:(NSDictionary *)params completion:(STPCardServerResponseCallback)handler __attribute((deprecated));
+- (void)postToURL:(stp_nonnull NSURL *)url withParams:(stp_nullable NSDictionary *)params completion:(stp_nullable STPCardServerResponseCallback)handler __attribute((deprecated));
 
 @end
 
@@ -61,6 +67,6 @@ typedef void (^STPCardServerResponseCallback)(NSURLResponse *response, NSData *d
 // your own code.
 @interface STPToken (PrivateMethods)
 
-- (instancetype)initWithAttributeDictionary:(NSDictionary *)attributeDictionary;
+- (stp_nonnull instancetype)initWithAttributeDictionary:(stp_nonnull NSDictionary *)attributeDictionary;
 
 @end

--- a/Stripe/PublicHeaders/Stripe.h
+++ b/Stripe/PublicHeaders/Stripe.h
@@ -13,6 +13,7 @@
 #import "STPToken.h"
 #import "STPCheckoutOptions.h"
 #import "STPCheckoutViewController.h"
+#import "STPNullabilityMacros.h"
 
 #if __has_include("Stripe+ApplePay.h") && TARGET_OS_IPHONE
 #import "Stripe+ApplePay.h"

--- a/Stripe/PublicHeaders/StripeError.h
+++ b/Stripe/PublicHeaders/StripeError.h
@@ -7,11 +7,12 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "STPNullabilityMacros.h"
 
 /**
  *  All Stripe iOS errors will be under this domain.
  */
-FOUNDATION_EXPORT NSString *const StripeDomain;
+FOUNDATION_EXPORT NSString * __stp_nonnull const StripeDomain;
 
 typedef NS_ENUM(NSInteger, STPErrorCode) {
     STPConnectionError = 40,     // Trouble connecting to Stripe.
@@ -25,29 +26,29 @@ typedef NS_ENUM(NSInteger, STPErrorCode) {
 
 // A developer-friendly error message that explains what went wrong. You probably
 // shouldn't show this to your users, but might want to use it yourself.
-FOUNDATION_EXPORT NSString *const STPErrorMessageKey;
+FOUNDATION_EXPORT NSString * __stp_nonnull const STPErrorMessageKey;
 
 // What went wrong with your STPCard (e.g., STPInvalidCVC. See below for full list).
-FOUNDATION_EXPORT NSString *const STPCardErrorCodeKey;
+FOUNDATION_EXPORT NSString * __stp_nonnull const STPCardErrorCodeKey;
 
 // Which parameter on the STPCard had an error (e.g., "cvc"). Useful for marking up the
 // right UI element.
-FOUNDATION_EXPORT NSString *const STPErrorParameterKey;
+FOUNDATION_EXPORT NSString * __stp_nonnull const STPErrorParameterKey;
 
 #pragma mark STPCardErrorCodeKeys
 
 // (Usually determined locally:)
-FOUNDATION_EXPORT NSString *const STPInvalidNumber;
-FOUNDATION_EXPORT NSString *const STPInvalidExpMonth;
-FOUNDATION_EXPORT NSString *const STPInvalidExpYear;
-FOUNDATION_EXPORT NSString *const STPInvalidCVC;
+FOUNDATION_EXPORT NSString * __stp_nonnull const STPInvalidNumber;
+FOUNDATION_EXPORT NSString * __stp_nonnull const STPInvalidExpMonth;
+FOUNDATION_EXPORT NSString * __stp_nonnull const STPInvalidExpYear;
+FOUNDATION_EXPORT NSString * __stp_nonnull const STPInvalidCVC;
 
 // (Usually sent from the server:)
-FOUNDATION_EXPORT NSString *const STPIncorrectNumber;
-FOUNDATION_EXPORT NSString *const STPExpiredCard;
-FOUNDATION_EXPORT NSString *const STPCardDeclined;
-FOUNDATION_EXPORT NSString *const STPProcessingError;
-FOUNDATION_EXPORT NSString *const STPIncorrectCVC;
+FOUNDATION_EXPORT NSString * __stp_nonnull const STPIncorrectNumber;
+FOUNDATION_EXPORT NSString * __stp_nonnull const STPExpiredCard;
+FOUNDATION_EXPORT NSString * __stp_nonnull const STPCardDeclined;
+FOUNDATION_EXPORT NSString * __stp_nonnull const STPProcessingError;
+FOUNDATION_EXPORT NSString * __stp_nonnull const STPIncorrectCVC;
 
 #pragma mark Strings
 

--- a/Stripe/STPAPIConnection.h
+++ b/Stripe/STPAPIConnection.h
@@ -7,21 +7,22 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "STPNullabilityMacros.h"
 
-typedef void (^STPAPIConnectionCompletionBlock)(NSURLResponse *response, NSData *body, NSError *requestError);
+typedef void (^STPAPIConnectionCompletionBlock)(NSURLResponse * __stp_nullable response, NSData * __stp_nullable body, NSError * __stp_nullable requestError);
 
 // Like NSURLConnection but verifies that the server isn't using a revoked certificate.
 @interface STPAPIConnection : NSObject<NSURLConnectionDelegate, NSURLConnectionDataDelegate>
 
-- (instancetype)initWithRequest:(NSURLRequest *)request;
-- (void)runOnOperationQueue:(NSOperationQueue *)queue completion:(STPAPIConnectionCompletionBlock)handler;
+- (stp_nonnull instancetype)initWithRequest:(stp_nonnull NSURLRequest *)request;
+- (void)runOnOperationQueue:(stp_nonnull NSOperationQueue *)queue completion:(stp_nullable STPAPIConnectionCompletionBlock)handler;
 
 @property (nonatomic) BOOL started;
-@property (nonatomic, copy) NSURLRequest *request;
-@property (nonatomic, strong) NSURLConnection *connection;
-@property (nonatomic, strong) NSMutableData *receivedData;
-@property (nonatomic, strong) NSURLResponse *receivedResponse;
-@property (nonatomic, strong) NSError *overrideError; // Replaces the request's error
-@property (nonatomic, copy) STPAPIConnectionCompletionBlock completionBlock;
+@property (nonatomic, copy, stp_nonnull) NSURLRequest *request;
+@property (nonatomic, strong, stp_nullable) NSURLConnection *connection;
+@property (nonatomic, strong, stp_nullable) NSMutableData *receivedData;
+@property (nonatomic, strong, stp_nullable) NSURLResponse *receivedResponse;
+@property (nonatomic, strong, stp_nullable) NSError *overrideError; // Replaces the request's error
+@property (nonatomic, copy, stp_nullable) STPAPIConnectionCompletionBlock completionBlock;
 
 @end

--- a/Stripe/STPFormEncoder.h
+++ b/Stripe/STPFormEncoder.h
@@ -7,17 +7,18 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "STPNullabilityMacros.h"
 
 @class STPBankAccount, STPCard;
 
 @interface STPFormEncoder : NSObject
 
-+ (NSData *)formEncodedDataForBankAccount:(STPBankAccount *)bankAccount;
++ (stp_nonnull NSData *)formEncodedDataForBankAccount:(stp_nonnull STPBankAccount *)bankAccount;
 
-+ (NSData *)formEncodedDataForCard:(STPCard *)card;
++ (stp_nonnull NSData *)formEncodedDataForCard:(stp_nonnull STPCard *)card;
 
-+ (NSString *)stringByURLEncoding:(NSString *)string;
++ (stp_nonnull NSString *)stringByURLEncoding:(stp_nonnull NSString *)string;
 
-+ (NSString *)stringByReplacingSnakeCaseWithCamelCase:(NSString *)input;
++ (stp_nonnull NSString *)stringByReplacingSnakeCaseWithCamelCase:(stp_nonnull NSString *)input;
 
 @end

--- a/Stripe/STPNullabilityMacros.h
+++ b/Stripe/STPNullabilityMacros.h
@@ -1,0 +1,36 @@
+//
+//  STPNullabilityMacros.h
+//  Stripe
+//
+//  Created by Jack Flintermann on 5/1/15.
+//  Copyright (c) 2015 Stripe, Inc. All rights reserved.
+//
+//  Based on https://gist.github.com/steipete/d9f519858fe5fb5533eb
+
+
+#ifndef Stripe_STPNullabilityMacros_h
+#define Stripe_STPNullabilityMacros_h
+
+#if __has_feature(nullability)
+#define STP_ASSUME_NONNULL_BEGIN _Pragma("clang assume_nonnull begin")
+#define STP_ASSUME_NONNULL_END _Pragma("clang assume_nonnull end")
+#define stp_nullable nullable
+#define stp_nonnull nonnull
+#define stp_null_unspecified null_unspecified
+#define stp_null_resettable null_resettable
+#define __stp_nullable __nullable
+#define __stp_nonnull __nonnull
+#define __stp_null_unspecified __null_unspecified
+#else
+#define STP_ASSUME_NONNULL_BEGIN
+#define STP_ASSUME_NONNULL_END
+#define stp_nullable
+#define stp_nonnull
+#define stp_null_unspecified
+#define stp_null_resettable
+#define __stp_nullable
+#define __stp_nonnull
+#define __stp_null_unspecified
+#endif
+
+#endif

--- a/Stripe/STPNullabilityMacros.h
+++ b/Stripe/STPNullabilityMacros.h
@@ -7,9 +7,7 @@
 //
 //  Based on https://gist.github.com/steipete/d9f519858fe5fb5533eb
 
-
-#ifndef Stripe_STPNullabilityMacros_h
-#define Stripe_STPNullabilityMacros_h
+#pragma once
 
 #if __has_feature(nullability)
 #define STP_ASSUME_NONNULL_BEGIN _Pragma("clang assume_nonnull begin")
@@ -31,6 +29,4 @@
 #define __stp_nullable
 #define __stp_nonnull
 #define __stp_null_unspecified
-#endif
-
 #endif

--- a/Stripe/STPToken.m
+++ b/Stripe/STPToken.m
@@ -16,7 +16,7 @@
     self = [super init];
 
     if (self) {
-        _tokenId = attributeDictionary[@"id"];
+        _tokenId = attributeDictionary[@"id"] ?: @"";
         _livemode = [attributeDictionary[@"livemode"] boolValue];
         _created = [NSDate dateWithTimeIntervalSince1970:[attributeDictionary[@"created"] doubleValue]];
 

--- a/ci_scripts/FauxPasConfig/main.fauxpas.json
+++ b/ci_scripts/FauxPasConfig/main.fauxpas.json
@@ -537,13 +537,13 @@
         // Options for rule: Reserved identifier name
         "ReservedIdentifierNaming": {
             // Check for identifier names reserved by the C standard (Boolean)
-            //"checkCStandard": true
+            //"checkCStandard": true,
             // Check for identifier names reserved by the POSIX standard
             // (Boolean)
-            //"checkPOSIXStandard": true
+            //"checkPOSIXStandard": true,
             // Regexes for ignored file paths (Array of regular expression
             // strings)
-            //"ignoredFileRegexes": null
+            "ignoredFileRegexes": ["STPNullabilityMacros.h"]
         },
         // Options for rule: Reserved symbol prefix
         "ReservedPrefix": {


### PR DESCRIPTION
This will improve our Swift interoperability. The `STPNullabilityMacros.h` shim is necessary for building on Travis CI, as they aren't running the latest Xcode/clang yet.

r? @raycmorgan