### PR TITLE
Further improve UI/NSImage handling in checkout

### DIFF
--- a/Stripe/Checkout/STPCheckoutInternalUIWebViewController.m
+++ b/Stripe/Checkout/STPCheckoutInternalUIWebViewController.m
@@ -26,7 +26,6 @@
 @property (nonatomic) BOOL statusBarHidden;
 @property (weak, nonatomic, stp_nullable) UIView *webView;
 @property (nonatomic, stp_nullable) STPIOSCheckoutWebViewAdapter *adapter;
-@property (nonatomic, stp_nullable) NSURL *logoURL;
 @property (nonatomic, stp_nonnull) NSURL *url;
 @property (weak, nonatomic, stp_nullable) UIActivityIndicatorView *activityIndicator;
 @property (nonatomic) BOOL backendChargeSuccessful;
@@ -61,15 +60,6 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-
-    if (self.options.logoImage && !self.options.logoURL) {
-        NSString *base64 = [UIImagePNGRepresentation(self.options.logoImage) base64Encoding];
-        if (base64) {
-            NSString *dataURLString = [NSString stringWithFormat:@"data:png;base64,%@", base64];
-            self.logoURL = self.options.logoURL = [NSURL URLWithString:dataURLString];
-        }
-    }
-
     self.adapter = [[STPIOSCheckoutWebViewAdapter alloc] init];
     self.adapter.delegate = self;
     UIWebView *webView = self.adapter.webView;
@@ -128,9 +118,6 @@
 
 - (void)cleanup {
     [self.adapter cleanup];
-    if (self.logoURL) {
-        [[NSFileManager defaultManager] removeItemAtURL:self.logoURL error:nil];
-    }
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle {

--- a/Stripe/Checkout/STPCheckoutOptions.m
+++ b/Stripe/Checkout/STPCheckoutOptions.m
@@ -67,6 +67,23 @@
     return [[NSString alloc] initWithData:[NSJSONSerialization dataWithJSONObject:values options:0 error:nil] encoding:NSUTF8StringEncoding];
 }
 
+- (void)setLogoImage:(STP_IMAGE_CLASS * __stp_nullable)logoImage {
+    _logoImage = logoImage;
+#if TARGET_OS_IPHONE
+    NSString *base64 = [UIImagePNGRepresentation(logoImage) base64Encoding];
+#else
+    NSData *imageData = [logoImage TIFFRepresentation];
+    NSBitmapImageRep *imageRep = [NSBitmapImageRep imageRepWithData:imageData];
+    imageData = [imageRep representationUsingType:NSPNGFileType
+                                       properties:@{NSImageCompressionFactor: @1.0}];
+    NSString *base64 = [imageData base64EncodedStringWithOptions:0];
+#endif
+    if (base64) {
+        NSString *dataURLString = [NSString stringWithFormat:@"data:png;base64,%@", base64];
+        self.logoURL = [NSURL URLWithString:dataURLString];
+    }
+}
+
 #pragma mark - NSCopying
 
 - (id)copyWithZone:(__unused NSZone *)zone {

--- a/Stripe/Checkout/STPCheckoutViewController.m
+++ b/Stripe/Checkout/STPCheckoutViewController.m
@@ -86,11 +86,11 @@
 @implementation STPCheckoutViewController
 
 - (instancetype)initWithNibName:(__unused NSString *)nibNameOrNil bundle:(__unused NSBundle *)nibBundleOrNil {
-    return [self initWithOptions:nil];
+    return [self initWithOptions:[[STPCheckoutOptions alloc] init]];
 }
 
 - (instancetype)initWithCoder:(__unused NSCoder *)coder {
-    return [self initWithOptions:nil];
+    return [self initWithOptions:[[STPCheckoutOptions alloc] init]];
 }
 
 - (instancetype)initWithOptions:(STPCheckoutOptions *)options {

--- a/Stripe/PublicHeaders/Checkout/STPCheckoutOptions.h
+++ b/Stripe/PublicHeaders/Checkout/STPCheckoutOptions.h
@@ -8,8 +8,10 @@
 #import <Foundation/Foundation.h>
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
+#define STP_IMAGE_CLASS UIImage
 #else
 #import <AppKit/AppKit.h>
+#define STP_IMAGE_CLASS NSImage
 #endif
 
 #import "STPNullabilityMacros.h"
@@ -40,11 +42,7 @@
 /**
  *  You can also specify a local UIImage to be used as the Checkout logo header (see logoURL).
  */
-#if TARGET_OS_IPHONE
-@property (nonatomic, stp_nullable) UIImage *logoImage;
-#else
-@property (nonatomic, stp_nullable) NSImage *logoImage;
-#endif
+@property (nonatomic, stp_nullable) STP_IMAGE_CLASS *logoImage;
 
 /**
  *  This specifies the color of the header shown in Stripe Checkout. If you specify a logoURL (but not a logoImage) and leave this property nil, Checkout will


### PR DESCRIPTION
#146 fixes UIImage handling in checkout, but now that we're doing it with a `data:` URI and there's no temporary-file state to clean up, we can move all of this logic to `STPCheckoutOptions` where it belongs. (It'll also be way easier to test, when we finally get around to it).

This also fixes the issue for OSX, which is much easier now that everything lives in `STPCheckoutOptions`.

r? @jamesreggio 