### PR TITLE
Fix/apple pay failure issue

### DIFF
--- a/Example/Stripe iOS Example (Simple)/ViewController.swift
+++ b/Example/Stripe iOS Example (Simple)/ViewController.swift
@@ -84,10 +84,15 @@ class ViewController: UIViewController, STPCheckoutViewControllerDelegate, PKPay
                             completion(PKPaymentAuthorizationStatus.Success)
                             return
                         }
+                        else {
+                            completion(PKPaymentAuthorizationStatus.Failure)
+                        }
                     })
                 }
             }
-            completion(PKPaymentAuthorizationStatus.Failure)
+            else {
+                completion(PKPaymentAuthorizationStatus.Failure)
+            }
         })
     }
     

--- a/Example/Stripe iOS Example (Simple)/ViewController.swift
+++ b/Example/Stripe iOS Example (Simple)/ViewController.swift
@@ -82,7 +82,6 @@ class ViewController: UIViewController, STPCheckoutViewControllerDelegate, PKPay
                     self.createBackendChargeWithToken(token, completion: { (result, error) -> Void in
                         if result == STPBackendChargeResult.Success {
                             completion(PKPaymentAuthorizationStatus.Success)
-                            return
                         }
                         else {
                             completion(PKPaymentAuthorizationStatus.Failure)


### PR DESCRIPTION
… completed

Because the backend charge is asynchronous, completion was called with failure before the backend could respond with success (or failure).
