### PR TITLE
Fixed a documentation issue on "STPCard.h".

### DIFF
--- a/Stripe/PublicHeaders/STPCard.h
+++ b/Stripe/PublicHeaders/STPCard.h
@@ -48,7 +48,7 @@ typedef NS_ENUM(NSInteger, STPCardBrand) {
 @property (nonatomic) NSUInteger expMonth;
 
 /**
- *  The card's expiration month.
+ *  The card's expiration year.
  */
 @property (nonatomic) NSUInteger expYear;
 


### PR DESCRIPTION
The comment on the expYear property was copied from expMonth and not updated.