### PR TITLE
Add support for simulated cards in iOS9

### DIFF
--- a/Example/Stripe iOS Example (Custom)/ViewController.m
+++ b/Example/Stripe iOS Example (Custom)/ViewController.m
@@ -6,8 +6,8 @@
 //  Copyright (c) 2014 Stripe. All rights reserved.
 //
 
-#import <Stripe/Stripe.h>
 #import <AFNetworking/AFNetworking.h>
+#import <Stripe/Stripe.h>
 
 #import "ViewController.h"
 #import "PaymentViewController.h"

--- a/Example/Stripe iOS Example (Custom)/ViewController.m
+++ b/Example/Stripe iOS Example (Custom)/ViewController.m
@@ -7,6 +7,7 @@
 //
 
 #import <Stripe/Stripe.h>
+#import <AFNetworking/AFNetworking.h>
 
 #import "ViewController.h"
 #import "PaymentViewController.h"
@@ -180,29 +181,29 @@
 #pragma mark - STPBackendCharging
 
 - (void)createBackendChargeWithToken:(STPToken *)token completion:(STPTokenSubmissionHandler)completion {
-//    NSDictionary *chargeParams = @{ @"stripeToken": token.tokenId, @"amount": @"1000" };
-//
-//    if (!BackendChargeURLString) {
-//        NSError *error = [NSError
-//            errorWithDomain:StripeDomain
-//                       code:STPInvalidRequestError
-//                   userInfo:@{
-//                       NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Good news! Stripe turned your credit card into a token: %@ \nYou can follow the "
-//                                                                             @"instructions in the README to set up an example backend, or use this "
-//                                                                             @"token to manually create charges at dashboard.stripe.com .",
-//                                                                             token.tokenId]
-//                   }];
-//        completion(STPBackendChargeResultFailure, error);
-//        return;
-//    }
-//
-//    // This passes the token off to our payment backend, which will then actually complete charging the card using your Stripe account's secret key
-//    AFHTTPRequestOperationManager *manager = [AFHTTPRequestOperationManager manager];
-//    manager.responseSerializer = [AFHTTPResponseSerializer serializer];
-//    [manager POST:[BackendChargeURLString stringByAppendingString:@"/charge"]
-//        parameters:chargeParams
-//        success:^(AFHTTPRequestOperation *operation, id responseObject) { completion(STPBackendChargeResultSuccess, nil); }
-//        failure:^(AFHTTPRequestOperation *operation, NSError *error) { completion(STPBackendChargeResultFailure, error); }];
+    NSDictionary *chargeParams = @{ @"stripeToken": token.tokenId, @"amount": @"1000" };
+
+    if (!BackendChargeURLString) {
+        NSError *error = [NSError
+            errorWithDomain:StripeDomain
+                       code:STPInvalidRequestError
+                   userInfo:@{
+                       NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Good news! Stripe turned your credit card into a token: %@ \nYou can follow the "
+                                                                             @"instructions in the README to set up an example backend, or use this "
+                                                                             @"token to manually create charges at dashboard.stripe.com .",
+                                                                             token.tokenId]
+                   }];
+        completion(STPBackendChargeResultFailure, error);
+        return;
+    }
+
+    // This passes the token off to our payment backend, which will then actually complete charging the card using your Stripe account's secret key
+    AFHTTPRequestOperationManager *manager = [AFHTTPRequestOperationManager manager];
+    manager.responseSerializer = [AFHTTPResponseSerializer serializer];
+    [manager POST:[BackendChargeURLString stringByAppendingString:@"/charge"]
+        parameters:chargeParams
+        success:^(AFHTTPRequestOperation *operation, id responseObject) { completion(STPBackendChargeResultSuccess, nil); }
+        failure:^(AFHTTPRequestOperation *operation, NSError *error) { completion(STPBackendChargeResultFailure, error); }];
 }
 
 @end

--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -230,6 +230,7 @@
 		04D12C461A5F55FA0010446E /* STPCardTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 04CDB5251A5F3A9300B854EE /* STPCardTest.m */; };
 		04D12C471A5F55FA0010446E /* STPCertTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 04CDB5261A5F3A9300B854EE /* STPCertTest.m */; };
 		04D12C481A5F55FA0010446E /* STPTokenTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 04CDB5271A5F3A9300B854EE /* STPTokenTest.m */; };
+		C105BBE01B4AE90400C7339D /* PKPayment+StripeTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C105BBDF1B4AE90400C7339D /* PKPayment+StripeTest.m */; };
 		C14C19D61B46193A005DC2A1 /* PKPayment+Stripe.h in Headers */ = {isa = PBXBuildFile; fileRef = C14C19D41B46193A005DC2A1 /* PKPayment+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C14C19D81B46193A005DC2A1 /* PKPayment+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = C14C19D51B46193A005DC2A1 /* PKPayment+Stripe.m */; };
 		C14C19DA1B46194D005DC2A1 /* PKPayment+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = C14C19D51B46193A005DC2A1 /* PKPayment+Stripe.m */; };
@@ -368,6 +369,7 @@
 		04F39F241AEF2AFE005B926E /* StripeOSXTests-Shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "StripeOSXTests-Shared.xcconfig"; sourceTree = "<group>"; };
 		11C74B9B164043050071C2CA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		4A0D74F918F6106100966D7B /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
+		C105BBDF1B4AE90400C7339D /* PKPayment+StripeTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "PKPayment+StripeTest.m"; sourceTree = "<group>"; };
 		C14C19D41B46193A005DC2A1 /* PKPayment+Stripe.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PKPayment+Stripe.h"; sourceTree = "<group>"; };
 		C14C19D51B46193A005DC2A1 /* PKPayment+Stripe.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "PKPayment+Stripe.m"; sourceTree = "<group>"; };
 		FAFC12C516E5767F0066297F /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
@@ -502,6 +504,7 @@
 				04CDB5251A5F3A9300B854EE /* STPCardTest.m */,
 				04CDB5261A5F3A9300B854EE /* STPCertTest.m */,
 				04CDB5271A5F3A9300B854EE /* STPTokenTest.m */,
+				C105BBDF1B4AE90400C7339D /* PKPayment+StripeTest.m */,
 				04CDB5611A5F3D2000B854EE /* Supporting Files */,
 			);
 			name = StripeTests;
@@ -986,6 +989,7 @@
 			files = (
 				04415C561A6605B5001225ED /* STPAPIClient+ApplePay.m in Sources */,
 				04415C571A6605B5001225ED /* Stripe+ApplePay.m in Sources */,
+				C105BBE01B4AE90400C7339D /* PKPayment+StripeTest.m in Sources */,
 				04415C591A6605B5001225ED /* STPCheckoutOptions.m in Sources */,
 				04415C5A1A6605B5001225ED /* STPCheckoutViewController.m in Sources */,
 				C14C19DA1B46194D005DC2A1 /* PKPayment+Stripe.m in Sources */,

--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -230,6 +230,12 @@
 		04D12C461A5F55FA0010446E /* STPCardTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 04CDB5251A5F3A9300B854EE /* STPCardTest.m */; };
 		04D12C471A5F55FA0010446E /* STPCertTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 04CDB5261A5F3A9300B854EE /* STPCertTest.m */; };
 		04D12C481A5F55FA0010446E /* STPTokenTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 04CDB5271A5F3A9300B854EE /* STPTokenTest.m */; };
+		C14C19D61B46193A005DC2A1 /* PKPayment+Stripe.h in Headers */ = {isa = PBXBuildFile; fileRef = C14C19D41B46193A005DC2A1 /* PKPayment+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C14C19D81B46193A005DC2A1 /* PKPayment+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = C14C19D51B46193A005DC2A1 /* PKPayment+Stripe.m */; };
+		C14C19DA1B46194D005DC2A1 /* PKPayment+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = C14C19D51B46193A005DC2A1 /* PKPayment+Stripe.m */; };
+		C14C19DB1B46194E005DC2A1 /* PKPayment+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = C14C19D51B46193A005DC2A1 /* PKPayment+Stripe.m */; };
+		C14C19DC1B46195B005DC2A1 /* PKPayment+Stripe.h in Headers */ = {isa = PBXBuildFile; fileRef = C14C19D41B46193A005DC2A1 /* PKPayment+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C14C19DD1B46195C005DC2A1 /* PKPayment+Stripe.h in Headers */ = {isa = PBXBuildFile; fileRef = C14C19D41B46193A005DC2A1 /* PKPayment+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -362,6 +368,8 @@
 		04F39F241AEF2AFE005B926E /* StripeOSXTests-Shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "StripeOSXTests-Shared.xcconfig"; sourceTree = "<group>"; };
 		11C74B9B164043050071C2CA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		4A0D74F918F6106100966D7B /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
+		C14C19D41B46193A005DC2A1 /* PKPayment+Stripe.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PKPayment+Stripe.h"; sourceTree = "<group>"; };
+		C14C19D51B46193A005DC2A1 /* PKPayment+Stripe.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "PKPayment+Stripe.m"; sourceTree = "<group>"; };
 		FAFC12C516E5767F0066297F /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
@@ -422,6 +430,8 @@
 		04CDB4B01A5F30A700B854EE /* ApplePay */ = {
 			isa = PBXGroup;
 			children = (
+				C14C19D41B46193A005DC2A1 /* PKPayment+Stripe.h */,
+				C14C19D51B46193A005DC2A1 /* PKPayment+Stripe.m */,
 				04CDB4AA1A5F30A700B854EE /* STPAPIClient+ApplePay.h */,
 				04CDB4AB1A5F30A700B854EE /* STPAPIClient+ApplePay.m */,
 				04CDB4AC1A5F30A700B854EE /* Stripe+ApplePay.h */,
@@ -583,6 +593,7 @@
 				04415C771A6605D9001225ED /* STPCheckoutViewController.h in Headers */,
 				04415C7F1A6605D9001225ED /* STPAPIClient.h in Headers */,
 				04415C821A6605D9001225ED /* STPBankAccount.h in Headers */,
+				C14C19DC1B46195B005DC2A1 /* PKPayment+Stripe.h in Headers */,
 				04415C831A6605D9001225ED /* STPCard.h in Headers */,
 				04415C841A6605D9001225ED /* STPToken.h in Headers */,
 				0429833A1AFB27AD00B8AD2C /* STPNullabilityMacros.h in Headers */,
@@ -635,6 +646,7 @@
 				049E84DE1A605EF0000B66CD /* STPCheckoutViewController.h in Headers */,
 				049E84E61A605EF0000B66CD /* STPAPIClient.h in Headers */,
 				049E84E91A605EF0000B66CD /* STPBankAccount.h in Headers */,
+				C14C19DD1B46195C005DC2A1 /* PKPayment+Stripe.h in Headers */,
 				049E84EA1A605EF0000B66CD /* STPCard.h in Headers */,
 				049E84EB1A605EF0000B66CD /* STPToken.h in Headers */,
 				0429833C1AFB27B400B8AD2C /* STPNullabilityMacros.h in Headers */,
@@ -662,6 +674,7 @@
 				04CDB50A1A5F30A700B854EE /* STPBankAccount.h in Headers */,
 				04CDB5121A5F30A700B854EE /* STPToken.h in Headers */,
 				04CDB4D81A5F30A700B854EE /* Stripe+ApplePay.h in Headers */,
+				C14C19D61B46193A005DC2A1 /* PKPayment+Stripe.h in Headers */,
 				04CDB5161A5F30A700B854EE /* StripeError.h in Headers */,
 				04CDB4D41A5F30A700B854EE /* STPAPIClient+ApplePay.h in Headers */,
 				042983391AFB27A900B8AD2C /* STPNullabilityMacros.h in Headers */,
@@ -975,6 +988,7 @@
 				04415C571A6605B5001225ED /* Stripe+ApplePay.m in Sources */,
 				04415C591A6605B5001225ED /* STPCheckoutOptions.m in Sources */,
 				04415C5A1A6605B5001225ED /* STPCheckoutViewController.m in Sources */,
+				C14C19DA1B46194D005DC2A1 /* PKPayment+Stripe.m in Sources */,
 				04415C5B1A6605B5001225ED /* STPCheckoutInternalUIWebViewController.m in Sources */,
 				04415C5C1A6605B5001225ED /* STPColorUtils.m in Sources */,
 				04415C5D1A6605B5001225ED /* STPIOSCheckoutWebViewAdapter.m in Sources */,
@@ -1031,6 +1045,7 @@
 				049E84C71A605DE0000B66CD /* STPCheckoutInternalUIWebViewController.m in Sources */,
 				049E84C81A605DE0000B66CD /* STPColorUtils.m in Sources */,
 				049E84C91A605DE0000B66CD /* STPIOSCheckoutWebViewAdapter.m in Sources */,
+				C14C19DB1B46194E005DC2A1 /* PKPayment+Stripe.m in Sources */,
 				049E84CA1A605DE0000B66CD /* STPOSXCheckoutWebViewAdapter.m in Sources */,
 				049E84CB1A605DE0000B66CD /* STPStrictURLProtocol.m in Sources */,
 				049E84CC1A605DE0000B66CD /* STPAPIClient.m in Sources */,
@@ -1054,6 +1069,7 @@
 				04CDB4E21A5F30A700B854EE /* STPCheckoutOptions.m in Sources */,
 				04CDB5081A5F30A700B854EE /* STPAPIConnection.m in Sources */,
 				04CDB4F81A5F30A700B854EE /* STPOSXCheckoutWebViewAdapter.m in Sources */,
+				C14C19D81B46193A005DC2A1 /* PKPayment+Stripe.m in Sources */,
 				04CDB4EB1A5F30A700B854EE /* STPCheckoutInternalUIWebViewController.m in Sources */,
 				04CDB4FC1A5F30A700B854EE /* STPStrictURLProtocol.m in Sources */,
 				04CDB5041A5F30A700B854EE /* STPFormEncoder.m in Sources */,

--- a/Stripe/ApplePay/PKPayment+Stripe.h
+++ b/Stripe/ApplePay/PKPayment+Stripe.h
@@ -1,0 +1,18 @@
+//
+//  PKPayment+Stripe.h
+//  Stripe
+//
+//  Created by Ben Guo on 7/2/15.
+//
+
+#import <PassKit/PassKit.h>
+
+@interface PKPayment (Stripe)
+
+/// Returns true if the instance is a payment from the simulator.
+- (BOOL)isSimulated;
+
+/// Sets the instance's transaction identifier to the expected ApplePayStubs format.
+- (void)setFakeTransactionIdentifierWithRequest:(PKPaymentRequest *)request;
+
+@end

--- a/Stripe/ApplePay/PKPayment+Stripe.h
+++ b/Stripe/ApplePay/PKPayment+Stripe.h
@@ -5,14 +5,14 @@
 //  Created by Ben Guo on 7/2/15.
 //
 
-#import <PassKit/PassKit.h>
+@import PassKit;
 
 @interface PKPayment (Stripe)
 
 /// Returns true if the instance is a payment from the simulator.
 - (BOOL)isSimulated;
 
-/// Sets the instance's transaction identifier to the expected ApplePayStubs format.
-- (void)setFakeTransactionIdentifierWithRequest:(PKPaymentRequest *)request;
+/// Sets the simulated instance's transaction identifier to the expected ~-separated format.
+- (void)setFakeTransactionIdentifier;
 
 @end

--- a/Stripe/ApplePay/PKPayment+Stripe.h
+++ b/Stripe/ApplePay/PKPayment+Stripe.h
@@ -12,7 +12,7 @@
 /// Returns true if the instance is a payment from the simulator.
 - (BOOL)isSimulated;
 
-/// Sets the simulated instance's transaction identifier to the expected ~-separated format.
-- (void)setFakeTransactionIdentifier;
+/// Returns a fake transaction identifier with the expected ~-separated format.
++ (NSString *)testTransactionIdentifier;
 
 @end

--- a/Stripe/ApplePay/PKPayment+Stripe.h
+++ b/Stripe/ApplePay/PKPayment+Stripe.h
@@ -10,9 +10,9 @@
 @interface PKPayment (Stripe)
 
 /// Returns true if the instance is a payment from the simulator.
-- (BOOL)isSimulated;
+- (BOOL)stp_isSimulated;
 
 /// Returns a fake transaction identifier with the expected ~-separated format.
-+ (NSString *)testTransactionIdentifier;
++ (NSString *)stp_testTransactionIdentifier;
 
 @end

--- a/Stripe/ApplePay/PKPayment+Stripe.m
+++ b/Stripe/ApplePay/PKPayment+Stripe.m
@@ -13,31 +13,21 @@
     return [self.token.transactionIdentifier isEqualToString:@"Simulated Identifier"];
 }
 
-- (void)setFakeTransactionIdentifier {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wundeclared-selector"
++ (NSString *)testTransactionIdentifier {
+    NSString *uuid = [[NSUUID UUID] UUIDString];
+    uuid = [uuid stringByReplacingOccurrencesOfString:@"~" withString:@""
+                                              options:0
+                                                range:NSMakeRange(0, uuid.length)];
 
-    PKPaymentToken *token = [PKPaymentToken new];
-    if ([token respondsToSelector:@selector(setTransactionIdentifier:)]) {
-        NSString *uuid = [[NSUUID UUID] UUIDString];
-        uuid = [uuid stringByReplacingOccurrencesOfString:@"~" withString:@""
-                                                  options:0
-                                                    range:NSMakeRange(0, uuid.length)];
-        
-        // Simulated cards don't have enough info yet. For now, use a fake Visa number
-        NSString *number = @"4242424242424242";
+    // Simulated cards don't have enough info yet. For now, use a fake Visa number
+    NSString *number = @"4242424242424242";
 
-        // Without the original PKPaymentRequest, we'll need to use fake data here.
-        NSDecimalNumber *amount = [NSDecimalNumber decimalNumberWithString:@"20.00"];
-        NSString *cents = [@([[amount decimalNumberByMultiplyingByPowerOf10:2] integerValue]) stringValue];
-        NSString *currency = @"USD";
-        NSString *identifier = [@[@"ApplePayStubs", number, cents, currency, uuid] componentsJoinedByString:@"~"];
-        [token performSelector:@selector(setTransactionIdentifier:) withObject:identifier];
-    }
-    if ([self respondsToSelector:@selector(setToken:)]) {
-        [self performSelector:@selector(setToken:) withObject:token];
-    }
-#pragma clang diagnostic pop
+    // Without the original PKPaymentRequest, we'll need to use fake data here.
+    NSDecimalNumber *amount = [NSDecimalNumber decimalNumberWithString:@"0"];
+    NSString *cents = [@([[amount decimalNumberByMultiplyingByPowerOf10:2] integerValue]) stringValue];
+    NSString *currency = @"USD";
+    NSString *identifier = [@[@"ApplePayStubs", number, cents, currency, uuid] componentsJoinedByString:@"~"];
+    return identifier;
 }
 
 @end

--- a/Stripe/ApplePay/PKPayment+Stripe.m
+++ b/Stripe/ApplePay/PKPayment+Stripe.m
@@ -9,11 +9,11 @@
 
 @implementation PKPayment (Stripe)
 
-- (BOOL)isSimulated {
+- (BOOL)stp_isSimulated {
     return [self.token.transactionIdentifier isEqualToString:@"Simulated Identifier"];
 }
 
-+ (NSString *)testTransactionIdentifier {
++ (NSString *)stp_testTransactionIdentifier {
     NSString *uuid = [[NSUUID UUID] UUIDString];
     uuid = [uuid stringByReplacingOccurrencesOfString:@"~" withString:@""
                                               options:0

--- a/Stripe/ApplePay/PKPayment+Stripe.m
+++ b/Stripe/ApplePay/PKPayment+Stripe.m
@@ -13,11 +13,12 @@
     return [self.token.transactionIdentifier isEqualToString:@"Simulated Identifier"];
 }
 
-- (void)setFakeTransactionIdentifierWithRequest:(PKPaymentRequest *)request {
+- (void)setFakeTransactionIdentifier {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wundeclared-selector"
-    
-    if ([self.token respondsToSelector:@selector(setTransactionIdentifier:)]) {
+
+    PKPaymentToken *token = [PKPaymentToken new];
+    if ([token respondsToSelector:@selector(setTransactionIdentifier:)]) {
         NSString *uuid = [[NSUUID UUID] UUIDString];
         uuid = [uuid stringByReplacingOccurrencesOfString:@"~" withString:@""
                                                   options:0
@@ -25,14 +26,17 @@
         
         // Simulated cards don't have enough info yet. For now, use a fake Visa number
         NSString *number = @"4242424242424242";
-        PKPaymentSummaryItem *lastSummaryItem = [request.paymentSummaryItems lastObject];
-        NSDecimalNumber *amount = lastSummaryItem.amount;
+
+        // Without the original PKPaymentRequest, we'll need to use fake data here.
+        NSDecimalNumber *amount = [NSDecimalNumber decimalNumberWithString:@"20.00"];
         NSString *cents = [@([[amount decimalNumberByMultiplyingByPowerOf10:2] integerValue]) stringValue];
-        NSString *currency = request.currencyCode;
+        NSString *currency = @"USD";
         NSString *identifier = [@[@"ApplePayStubs", number, cents, currency, uuid] componentsJoinedByString:@"~"];
-        [self.token performSelector:@selector(setTransactionIdentifier:) withObject:identifier];
+        [token performSelector:@selector(setTransactionIdentifier:) withObject:identifier];
     }
-    
+    if ([self respondsToSelector:@selector(setToken:)]) {
+        [self performSelector:@selector(setToken:) withObject:token];
+    }
 #pragma clang diagnostic pop
 }
 

--- a/Stripe/ApplePay/PKPayment+Stripe.m
+++ b/Stripe/ApplePay/PKPayment+Stripe.m
@@ -1,0 +1,39 @@
+//
+//  PKPayment+Stripe.m
+//  Stripe
+//
+//  Created by Ben Guo on 7/2/15.
+//
+
+#import "PKPayment+Stripe.h"
+
+@implementation PKPayment (Stripe)
+
+- (BOOL)isSimulated {
+    return [self.token.transactionIdentifier isEqualToString:@"Simulated Identifier"];
+}
+
+- (void)setFakeTransactionIdentifierWithRequest:(PKPaymentRequest *)request {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
+    
+    if ([self.token respondsToSelector:@selector(setTransactionIdentifier:)]) {
+        NSString *uuid = [[NSUUID UUID] UUIDString];
+        uuid = [uuid stringByReplacingOccurrencesOfString:@"~" withString:@""
+                                                  options:0
+                                                    range:NSMakeRange(0, uuid.length)];
+        
+        // Simulated cards don't have enough info yet. For now, use a fake Visa number
+        NSString *number = @"4242424242424242";
+        PKPaymentSummaryItem *lastSummaryItem = [request.paymentSummaryItems lastObject];
+        NSDecimalNumber *amount = lastSummaryItem.amount;
+        NSString *cents = [@([[amount decimalNumberByMultiplyingByPowerOf10:2] integerValue]) stringValue];
+        NSString *currency = request.currencyCode;
+        NSString *identifier = [@[@"ApplePayStubs", number, cents, currency, uuid] componentsJoinedByString:@"~"];
+        [self.token performSelector:@selector(setTransactionIdentifier:) withObject:identifier];
+    }
+    
+#pragma clang diagnostic pop
+}
+
+@end

--- a/Stripe/ApplePay/STPAPIClient+ApplePay.m
+++ b/Stripe/ApplePay/STPAPIClient+ApplePay.m
@@ -79,8 +79,8 @@
 
     if (payment.token.transactionIdentifier) {
         NSString *transactionIdentifier = payment.token.transactionIdentifier;
-        if ([payment isSimulated]) {
-            transactionIdentifier = [PKPayment testTransactionIdentifier];
+        if ([payment stp_isSimulated]) {
+            transactionIdentifier = [PKPayment stp_testTransactionIdentifier];
         }
         NSString *param = [NSString stringWithFormat:@"&pk_token_transaction_id=%@", transactionIdentifier];
         payloadString = [payloadString stringByAppendingString:param];

--- a/Stripe/ApplePay/STPAPIClient+ApplePay.m
+++ b/Stripe/ApplePay/STPAPIClient+ApplePay.m
@@ -5,8 +5,10 @@
 //  Created by Jack Flintermann on 12/19/14.
 //
 
+@import AddressBook;
+
 #import "STPAPIClient+ApplePay.h"
-#import <AddressBook/AddressBook.h>
+#import "PKPayment+Stripe.m"
 
 @implementation STPAPIClient (ApplePay)
 
@@ -21,6 +23,10 @@
     NSString *paymentString =
         [[[NSString alloc] initWithData:payment.token.paymentData encoding:NSUTF8StringEncoding] stringByAddingPercentEncodingWithAllowedCharacters:set];
     __block NSString *payloadString = [@"pk_token=" stringByAppendingString:paymentString];
+
+    if ([payment isSimulated]) {
+        [payment setFakeTransactionIdentifier];
+    }
 
     if (payment.billingAddress) {
         NSMutableDictionary *params = [NSMutableDictionary dictionary];

--- a/Stripe/ApplePay/STPAPIClient+ApplePay.m
+++ b/Stripe/ApplePay/STPAPIClient+ApplePay.m
@@ -24,10 +24,6 @@
         [[[NSString alloc] initWithData:payment.token.paymentData encoding:NSUTF8StringEncoding] stringByAddingPercentEncodingWithAllowedCharacters:set];
     __block NSString *payloadString = [@"pk_token=" stringByAppendingString:paymentString];
 
-    if ([payment isSimulated]) {
-        [payment setFakeTransactionIdentifier];
-    }
-
     if (payment.billingAddress) {
         NSMutableDictionary *params = [NSMutableDictionary dictionary];
         
@@ -82,7 +78,11 @@
     }
 
     if (payment.token.transactionIdentifier) {
-        NSString *param = [NSString stringWithFormat:@"&pk_token_transaction_id=%@", payment.token.transactionIdentifier];
+        NSString *transactionIdentifier = payment.token.transactionIdentifier;
+        if ([payment isSimulated]) {
+            transactionIdentifier = [PKPayment testTransactionIdentifier];
+        }
+        NSString *param = [NSString stringWithFormat:@"&pk_token_transaction_id=%@", transactionIdentifier];
         payloadString = [payloadString stringByAppendingString:param];
     }
 

--- a/Stripe/PublicHeaders/Stripe.h
+++ b/Stripe/PublicHeaders/Stripe.h
@@ -20,5 +20,6 @@
 
 #if __has_include("Stripe+ApplePay.h") && TARGET_OS_IPHONE
 #import "Stripe+ApplePay.h"
+#import "PKPayment+Stripe.h"
 #import "STPAPIClient+ApplePay.h"
 #endif

--- a/Tests/Tests/PKPayment+StripeTest.m
+++ b/Tests/Tests/PKPayment+StripeTest.m
@@ -6,8 +6,9 @@
 //  Copyright © 2015 Stripe, Inc. All rights reserved.
 //
 
-#import <XCTest/XCTest.h>
-#import <PassKit/PassKit.h>
+@import XCTest;
+@import PassKit;
+
 #import "PKPayment+Stripe.h"
 
 @interface PKPayment_StripeTest : XCTestCase
@@ -30,7 +31,7 @@
     [payment performSelector:@selector(setToken:) withObject:paymentToken];
 #pragma clang diagnostic pop
 
-    XCTAssertTrue([payment isSimulated]);
+    XCTAssertTrue([payment stp_isSimulated]);
 }
 
 - (void)testTestTransactionIdentifier
@@ -38,8 +39,8 @@
     if (![PKPayment class]) {
         return;
     }
-    NSString *identifier = [PKPayment testTransactionIdentifier];
-    XCTAssertTrue([identifier containsString:@"ApplePayStubs~4242424242424242~2000~USD~"]);
+    NSString *identifier = [PKPayment stp_testTransactionIdentifier];
+    XCTAssertTrue([identifier containsString:@"ApplePayStubs~4242424242424242~0~USD~"]);
 }
 
 @end

--- a/Tests/Tests/PKPayment+StripeTest.m
+++ b/Tests/Tests/PKPayment+StripeTest.m
@@ -1,0 +1,46 @@
+//
+//  PKPayment+StripeTest.m
+//  Stripe
+//
+//  Created by Ben Guo on 7/6/15.
+//  Copyright © 2015 Stripe, Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import <PassKit/PassKit.h>
+#import "PKPayment+Stripe.h"
+
+@interface PKPayment_StripeTest : XCTestCase
+
+@end
+
+@implementation PKPayment_StripeTest
+
+- (void)testIsSimulated
+{
+    if (![PKPayment class]) {
+        return;
+    }
+    PKPayment *payment = [PKPayment new];
+    PKPaymentToken *paymentToken = [PKPaymentToken new];
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
+    [paymentToken performSelector:@selector(setTransactionIdentifier:) withObject:@"Simulated Identifier"];
+    [payment performSelector:@selector(setToken:) withObject:paymentToken];
+#pragma clang diagnostic pop
+
+    XCTAssertTrue([payment isSimulated]);
+}
+
+- (void)testSetFakeTransactionIdentifier
+{
+    if (![PKPayment class]) {
+        return;
+    }
+    PKPayment *payment = [PKPayment new];
+    [payment setFakeTransactionIdentifier];
+    XCTAssertTrue([payment.token.transactionIdentifier containsString:@"ApplePayStubs~4242424242424242~2000~USD~"]);
+}
+
+@end

--- a/Tests/Tests/PKPayment+StripeTest.m
+++ b/Tests/Tests/PKPayment+StripeTest.m
@@ -33,14 +33,13 @@
     XCTAssertTrue([payment isSimulated]);
 }
 
-- (void)testSetFakeTransactionIdentifier
+- (void)testTestTransactionIdentifier
 {
     if (![PKPayment class]) {
         return;
     }
-    PKPayment *payment = [PKPayment new];
-    [payment setFakeTransactionIdentifier];
-    XCTAssertTrue([payment.token.transactionIdentifier containsString:@"ApplePayStubs~4242424242424242~2000~USD~"]);
+    NSString *identifier = [PKPayment testTransactionIdentifier];
+    XCTAssertTrue([identifier containsString:@"ApplePayStubs~4242424242424242~2000~USD~"]);
 }
 
 @end

--- a/Tests/Tests/STPApplePayTest.m
+++ b/Tests/Tests/STPApplePayTest.m
@@ -6,10 +6,11 @@
 //  Copyright (c) 2014 Stripe, Inc. All rights reserved.
 //
 
+@import XCTest;
+@import PassKit;
+
 #import "STPAPIClient.h"
 #import "STPAPIClient+ApplePay.h"
-#import <XCTest/XCTest.h>
-#import <PassKit/PassKit.h>
 
 @interface STPApplePayTest : XCTestCase
 
@@ -105,15 +106,8 @@
     [client createTokenWithPayment:payment
                         completion:^(STPToken *token, NSError *error) {
                             [expectation fulfill];
-                            XCTAssertNil(token, @"token should be nil");
-                            XCTAssertNotNil(error, @"error should not be nil");
-
-                            // Since we can't actually generate a new cryptogram in a CI environment, we should just post a blob of expired token data and
-                            // make sure we get the "too long since tokenization" error. This at least asserts that our blob has been correctly formatted and
-                            // can be decrypted by the backend.
-                            XCTAssert([error.localizedDescription rangeOfString:@"too long"].location != NSNotFound,
-                                      @"Error is unrelated to 24-hour expiry: %@",
-                                      error.localizedDescription);
+                            XCTAssertNotNil(token, @"token should not be nil");
+                            XCTAssertNil(error, @"error should be nil");
                         }];
     [self waitForExpectationsWithTimeout:5.0f handler:nil];
 }

--- a/Tests/Tests/STPApplePayTest.m
+++ b/Tests/Tests/STPApplePayTest.m
@@ -13,16 +13,13 @@
 
 @interface STPApplePayTest : XCTestCase
 
+@property (nonatomic, strong) NSData *tokenData;
+
 @end
 
 @implementation STPApplePayTest
 
-- (void)testCreateTokenWithPayment {
-    if (![PKPayment class]) {
-        return;
-    }
-    PKPayment *payment = [PKPayment new];
-    PKPaymentToken *paymentToken = [PKPaymentToken new];
+- (void)setUp {
     NSString *tokenDataString = @"{\"version\":\"EC_v1\",\"data\":\"lF8RBjPvhc2GuhjEh7qFNijDJjxD/ApmGdQhgn8tpJcJDOwn2E1BkOfSvnhrR8BUGT6+zeBx8OocvalHZ5ba/WA/"
         @"tDxGhcEcOMp8sIJrXMVcJ6WqT5P1ZY+utmdORhxyH4nUw2wuEY4lAE7/GtEU/RNDhaKx/"
         @"m93l0oLlk84qD1ynTA5JP3gjkdX+RK23iCAZDScXCcCU0OnYlJV8sDyf3+8hIo0gpN43AxoY6N1xAsVbGsO4ZjSCahaXbgt0egFug3s7Fyt9W4uzu07SKKCA2+"
@@ -54,11 +51,51 @@
         @"\"header\":{\"transactionId\":\"a530c7d68b6a69791d8864df2646c8aa3d09d33b56d8f8162ab23e1b26afe5e9\",\"ephemeralPublicKey\":"
         @"\"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEhKpIc6wTNQGy39bHM0a0qziDb20jMBFZT9XKSdjGULpDGRdyil6MLwMyIf3lQxaV/"
         @"P7CQztw28IvYozvKvjBPQ==\",\"publicKeyHash\":\"yRcyn7njT6JL3AY9nmg0KD/xm/ch7gW1sGl2OuEucZY=\"}}";
-    NSData *data = [tokenDataString dataUsingEncoding:NSUTF8StringEncoding];
+    self.tokenData = [tokenDataString dataUsingEncoding:NSUTF8StringEncoding];
+}
+
+- (void)testCreateTokenWithPayment {
+    if (![PKPayment class]) {
+        return;
+    }
+    PKPayment *payment = [PKPayment new];
+    PKPaymentToken *paymentToken = [PKPaymentToken new];
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wundeclared-selector"
-    [paymentToken performSelector:@selector(setPaymentData:) withObject:data];
+    [paymentToken performSelector:@selector(setPaymentData:) withObject:self.tokenData];
+    [payment performSelector:@selector(setToken:) withObject:paymentToken];
+#pragma clang diagnostic pop
+
+    STPAPIClient *client = [[STPAPIClient alloc] initWithPublishableKey:@"pk_test_vOo1umqsYxSrP5UXfOeL3ecm"];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Bank account creation"];
+    [client createTokenWithPayment:payment
+                        completion:^(STPToken *token, NSError *error) {
+                            [expectation fulfill];
+                            XCTAssertNil(token, @"token should be nil");
+                            XCTAssertNotNil(error, @"error should not be nil");
+
+                            // Since we can't actually generate a new cryptogram in a CI environment, we should just post a blob of expired token data and
+                            // make sure we get the "too long since tokenization" error. This at least asserts that our blob has been correctly formatted and
+                            // can be decrypted by the backend.
+                            XCTAssert([error.localizedDescription rangeOfString:@"too long"].location != NSNotFound,
+                                      @"Error is unrelated to 24-hour expiry: %@",
+                                      error.localizedDescription);
+                        }];
+    [self waitForExpectationsWithTimeout:5.0f handler:nil];
+}
+
+- (void)testCreateTokenWithSimulatedPayment {
+    if (![PKPayment class]) {
+        return;
+    }
+    PKPayment *payment = [PKPayment new];
+    PKPaymentToken *paymentToken = [PKPaymentToken new];
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
+    [paymentToken performSelector:@selector(setTransactionIdentifier:) withObject:@"Simulated Identifier"];
     [payment performSelector:@selector(setToken:) withObject:paymentToken];
 #pragma clang diagnostic pop
 


### PR DESCRIPTION
r? @jflinter 

Note that the data in the `PKPayment` is, by necessity, mostly fake. 
`ApplePayStubs~4242424242424242~2000~USD~[UUID]`

Our SDK doesn't have access to the user's original `PKPaymentRequest` (since we're no longer stubbing the entire flow), and I'm not sure whether it's worth making the simulated PKPayment look more like a real PKPayment. If we decide that we do want the payment to look more real, I'm sure we could come up with a lurky workaround (e.g. swizzling `PKPaymentAuthorizationViewController`'s initializer).

In addition to the tests in this PR, I've manually verified that the Apple Pay flow works as expected in the simulator.

cc @raycmorgan 