### PR TITLE
Leaked STAPIConnection

### DIFF
--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -24,7 +24,6 @@ static NSString *const apiURLBase = @"api.stripe.com";
 static NSString *const apiVersion = @"v1";
 static NSString *const tokenEndpoint = @"tokens";
 static NSString *STPDefaultPublishableKey;
-static char kAssociatedClientKey;
 
 @implementation Stripe
 
@@ -84,9 +83,6 @@ static char kAssociatedClientKey;
     
     STPAPIConnection *connection = [[STPAPIConnection alloc] initWithRequest:request];
     
-    // use the runtime to ensure we're not dealloc'ed before completion
-    objc_setAssociatedObject(connection, &kAssociatedClientKey, self, OBJC_ASSOCIATION_RETAIN);
-    
     [connection runOnOperationQueue:self.operationQueue
                          completion:^(NSURLResponse *response, NSData *body, NSError *requestError) {
                              if (requestError) {
@@ -115,8 +111,6 @@ static char kAssociatedClientKey;
                                      completion(nil, [self.class errorFromStripeResponse:jsonDictionary]);
                                  }
                              }
-                             // at this point it's safe to be dealloced
-                             objc_setAssociatedObject(connection, &kAssociatedClientKey, nil, OBJC_ASSOCIATION_RETAIN);
                          }];
 }
 

--- a/Stripe/STPAPIConnection.m
+++ b/Stripe/STPAPIConnection.m
@@ -7,7 +7,6 @@
 //
 
 #import "STPAPIConnection.h"
-#import "STPAPIClient.h"
 #import "StripeError.h"
 #import <CommonCrypto/CommonDigest.h>
 


### PR DESCRIPTION
Removing association made from `STAPIConnection` to `STAPIClient`. Referencing `connection` in `STAPIClient.m` line 119 creates a retain cycle on `connection`. This association is actually not necessary because self is already retained by the completion block on line 97 and 115.