### PR TITLE
Adding a minimum deployment target.

### DIFF
--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -1201,6 +1201,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 04F39F101AEF2AFE005B926E /* StripeiOS-Debug.xcconfig */;
 			buildSettings = {
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 			};
 			name = Debug;
 		};
@@ -1208,6 +1209,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 04F39F111AEF2AFE005B926E /* StripeiOS-Release.xcconfig */;
 			buildSettings = {
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
I was trying to deploy a build to iTunes Connect, but I was receiving cryptic error after cryptic error. I couldn't figure out what was going on. I reached out to @codafi and on our third hour, he caught the issue and saved the day. 

![one](http://www.reactiongifs.com/r/tmhnks.gif)

For some reason Xcode would not infer what the minimum deployment target was and since you had nothing set, Xcode was like: 

![two](http://www.reactiongifs.com/r/wuut.gif)

"Glad I could help, but now I'm inconsolable about the state of our tools." — @codafi

So…I've set the minimum deployment target to **8.0**. 

That was painful! :sob: 