### PR TITLE
Modify deployment targets

### DIFF
--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -612,6 +612,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 045E7C0C1A5F41DE004751EF /* Build configuration list for PBXNativeTarget "StripeiOS Tests" */;
 			buildPhases = (
+				04E6FC431B702BCC000C8759 /* Lint with FauxPas (if installed) */,
 				045E7BFF1A5F41DE004751EF /* Sources */,
 				045E7C001A5F41DE004751EF /* Frameworks */,
 				045E7C011A5F41DE004751EF /* Resources */,
@@ -842,6 +843,20 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -e\n\n# If we're already inside this script then die\nif [ -n \"$RW_MULTIPLATFORM_BUILD_IN_PROGRESS\" ]; then\nexit 0\nfi\nexport RW_MULTIPLATFORM_BUILD_IN_PROGRESS=1\n\nRW_FRAMEWORK_NAME=\"Stripe\"\nRW_INPUT_STATIC_LIB=\"libStripe.a\"\nRW_FRAMEWORK_LOCATION=\"${BUILT_PRODUCTS_DIR}/${RW_FRAMEWORK_NAME}.framework\"\n\nfunction build_static_library {\n    # Will rebuild the static library as specified\n    #     build_static_library sdk\n    xcrun xcodebuild -project \"${PROJECT_FILE_PATH}\" \\\n    -target \"${TARGET_NAME}\" \\\n    -configuration \"${CONFIGURATION}\" \\\n    -sdk \"${1}\" \\\n    ONLY_ACTIVE_ARCH=NO \\\n    BUILD_DIR=\"${BUILD_DIR}\" \\\n    OBJROOT=\"${OBJROOT}\" \\\n    BUILD_ROOT=\"${BUILD_ROOT}\" \\\n    SYMROOT=\"${SYMROOT}\" $ACTION\n}\n\nfunction make_fat_library {\n    # Will smash 2 static libs together\n    #     make_fat_library in1 in2 out\n    xcrun lipo -create \"${1}\" \"${2}\" -output \"${3}\"\n}\n\n# 1 - Extract the platform (iphoneos/iphonesimulator) from the SDK name\nif [[ \"$SDK_NAME\" =~ ([A-Za-z]+) ]]; then\nRW_SDK_PLATFORM=${BASH_REMATCH[1]}\nelse\necho \"Could not find platform name from SDK_NAME: $SDK_NAME\"\nexit 1\nfi\n\n# 2 - Extract the version from the SDK\nif [[ \"$SDK_NAME\" =~ ([0-9]+.*$) ]]; then\nRW_SDK_VERSION=${BASH_REMATCH[1]}\nelse\necho \"Could not find sdk version from SDK_NAME: $SDK_NAME\"\nexit 1\nfi\n\n# 3 - Determine the other platform\nif [ \"$RW_SDK_PLATFORM\" == \"iphoneos\" ]; then\nRW_OTHER_PLATFORM=iphonesimulator\nelse\nRW_OTHER_PLATFORM=iphoneos\nfi\n\n# 4 - Find the build directory\nif [[ \"$BUILT_PRODUCTS_DIR\" =~ (.*)$RW_SDK_PLATFORM$ ]]; then\nRW_OTHER_BUILT_PRODUCTS_DIR=\"${BASH_REMATCH[1]}${RW_OTHER_PLATFORM}\"\nelse\necho \"Could not find other platform build directory.\"\nexit 1\nfi\n\n# Build the other platform.\nbuild_static_library \"${RW_OTHER_PLATFORM}${RW_SDK_VERSION}\"\n\n# If we're currently building for iphonesimulator, then need to rebuild\n#   to ensure that we get both i386 and x86_64\nif [ \"$RW_SDK_PLATFORM\" == \"iphonesimulator\" ]; then\nbuild_static_library \"${SDK_NAME}\"\nfi\n\n# Join the 2 static libs into 1 and push into the .framework\nmake_fat_library \"${BUILT_PRODUCTS_DIR}/${RW_INPUT_STATIC_LIB}\" \\\n\"${RW_OTHER_BUILT_PRODUCTS_DIR}/${RW_INPUT_STATIC_LIB}\" \\\n\"${RW_FRAMEWORK_LOCATION}/Versions/A/${RW_FRAMEWORK_NAME}\"\n\n# Ensure that the framework is present in both platform's build directories\ncp -a \"${RW_FRAMEWORK_LOCATION}/Versions/A/${RW_FRAMEWORK_NAME}\" \\\n\"${RW_OTHER_BUILT_PRODUCTS_DIR}/${RW_FRAMEWORK_NAME}.framework/Versions/A/${RW_FRAMEWORK_NAME}\"";
+		};
+		04E6FC431B702BCC000C8759 /* Lint with FauxPas (if installed) */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Lint with FauxPas (if installed)";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "[[ ${FAUXPAS_SKIP} == 1 ]] && exit 0\n [[ ${CI} == 1 ]] && exit 0\n \n FAUXPAS_PATH=\"/usr/local/bin/fauxpas\"\n if [[ -f \"${FAUXPAS_PATH}\" ]]; then\n \"${FAUXPAS_PATH}\" check-xcode --configFile \"./ci_scripts/FauxPasConfig/main.fauxpas.json\"\n else\n echo \"warning: Faux Pas was not found at '${FAUXPAS_PATH}'\"\n fi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Stripe/BuildConfigurations/StripeiOS Tests-Debug.xcconfig
+++ b/Stripe/BuildConfigurations/StripeiOS Tests-Debug.xcconfig
@@ -8,23 +8,3 @@
 #include "StripeiOS Tests-Shared.xcconfig"
 
 GCC_PREPROCESSOR_DEFINITIONS = DEBUG=1 $(inherited)
-
-// iOS Deployment Target
-//
-// Code will load on this and later versions of iOS.  Framework APIs that are unavailable
-// in earlier versions will be weak-linked; your code should check for null function
-// pointers or specific system versions before calling newer APIs.
-//
-// iOS 4.3 - Code will not load on systems earlier than 4.3. [4.3]
-// iOS 5.0 - Code will not load on systems earlier than 5.0. [5.0]
-// iOS 5.1 - Code will not load on systems earlier than 5.1. [5.1]
-// iOS 6.0 - Code will not load on systems earlier than 6.0. [6.0]
-// iOS 6.1 - Code will not load on systems earlier than 6.1. [6.1]
-// iOS 7.0 - Code will not load on systems earlier than 7.0. [7.0]
-// iOS 7.1 - Code will not load on systems earlier than 7.1. [7.1]
-// iOS 8.0 - Code will not load on systems earlier than 8.0. [8.0]
-// iOS 8.1 - Code will not load on systems earlier than 8.1. [8.1]
-// iOS 8.2 - Code will not load on systems earlier than 8.2. [8.2]
-// iOS 8.3 - Code will not load on systems earlier than 8.3. [8.3]
-
-IPHONEOS_DEPLOYMENT_TARGET = 6.0

--- a/Stripe/BuildConfigurations/StripeiOS Tests-Release.xcconfig
+++ b/Stripe/BuildConfigurations/StripeiOS Tests-Release.xcconfig
@@ -7,22 +7,6 @@
 
 #include "StripeiOS Tests-Shared.xcconfig"
 
-// iOS Deployment Target
-//
-// Code will load on this and later versions of iOS.  Framework APIs that are unavailable
-// in earlier versions will be weak-linked; your code should check for null function
-// pointers or specific system versions before calling newer APIs.
-//
-// iOS 4.3 - Code will not load on systems earlier than 4.3. [4.3]
-// iOS 5.0 - Code will not load on systems earlier than 5.0. [5.0]
-// iOS 5.1 - Code will not load on systems earlier than 5.1. [5.1]
-// iOS 6.0 - Code will not load on systems earlier than 6.0. [6.0]
-// iOS 6.1 - Code will not load on systems earlier than 6.1. [6.1]
-// iOS 7.0 - Code will not load on systems earlier than 7.0. [7.0]
-// iOS 7.1 - Code will not load on systems earlier than 7.1. [7.1]
-// iOS 8.0 - Code will not load on systems earlier than 8.0. [8.0]
-// iOS 8.1 - Code will not load on systems earlier than 8.1. [8.1]
-// iOS 8.2 - Code will not load on systems earlier than 8.2. [8.2]
-// iOS 8.3 - Code will not load on systems earlier than 8.3. [8.3]
-
-IPHONEOS_DEPLOYMENT_TARGET = 8.0
+//********************************************//
+//* Currently no build settings in this file *//
+//********************************************//

--- a/Stripe/BuildConfigurations/StripeiOS Tests-Shared.xcconfig
+++ b/Stripe/BuildConfigurations/StripeiOS Tests-Shared.xcconfig
@@ -20,6 +20,7 @@ CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR
 
 CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR
 
+IPHONEOS_DEPLOYMENT_TARGET = 6.0 // Target 6.0 in tests so that FauxPas can detect accidental usage of unavailable APIs
 
 // Code Signing Identity
 // 

--- a/Stripe/BuildConfigurations/StripeiOS Tests-Shared.xcconfig
+++ b/Stripe/BuildConfigurations/StripeiOS Tests-Shared.xcconfig
@@ -20,7 +20,9 @@ CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR
 
 CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR
 
-IPHONEOS_DEPLOYMENT_TARGET = 6.0 // Target 6.0 in tests so that FauxPas can detect accidental usage of unavailable APIs
+
+IPHONEOS_DEPLOYMENT_TARGET = 8.0 // Target 6.0 in tests so that FauxPas can detect accidental usage of unavailable APIs
+
 
 // Code Signing Identity
 // 

--- a/Stripe/BuildConfigurations/StripeiOS-Shared.xcconfig
+++ b/Stripe/BuildConfigurations/StripeiOS-Shared.xcconfig
@@ -120,7 +120,7 @@ INSTALL_PATH = $(LOCAL_LIBRARY_DIR)/Frameworks
 // iOS 8.2 - Code will not load on systems earlier than 8.2. [8.2]
 // iOS 8.3 - Code will not load on systems earlier than 8.3. [8.3]
 
-IPHONEOS_DEPLOYMENT_TARGET = 6.0
+IPHONEOS_DEPLOYMENT_TARGET = 8.0
 
 
 // Runpath Search Paths

--- a/Stripe/BuildConfigurations/StripeiOSStatic.xcconfig
+++ b/Stripe/BuildConfigurations/StripeiOSStatic.xcconfig
@@ -69,7 +69,7 @@ GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE
 // iOS 8.2 - Code will not load on systems earlier than 8.2. [8.2]
 // iOS 8.3 - Code will not load on systems earlier than 8.3. [8.3]
 
-IPHONEOS_DEPLOYMENT_TARGET = 8.1
+IPHONEOS_DEPLOYMENT_TARGET = 6.0
 
 
 // Other Linker Flags

--- a/ci_scripts/check_fauxpas.sh
+++ b/ci_scripts/check_fauxpas.sh
@@ -6,4 +6,4 @@ if [[ $CI && "$TRAVIS_SECURE_ENV_VARS" != "true" ]]; then
 fi
 
 echo "Linting with Faux Pas..."
-fauxpas check Stripe.xcodeproj/ --target "StripeiOS" --configFile "./ci_scripts/FauxPasConfig/main.fauxpas.json" --minErrorStatusSeverity Concern && fauxpas check Stripe.xcodeproj/ --target "StripeOSX" --configFile "./ci_scripts/FauxPasConfig/main.fauxpas.json" --minErrorStatusSeverity Concern
+fauxpas check Stripe.xcodeproj/ --target "StripeiOSStatic" --configFile "./ci_scripts/FauxPasConfig/main.fauxpas.json" --minErrorStatusSeverity Concern && fauxpas check Stripe.xcodeproj/ --target "StripeOSX" --configFile "./ci_scripts/FauxPasConfig/main.fauxpas.json" --minErrorStatusSeverity Concern


### PR DESCRIPTION
Previously I was setting the deployment target of `StripeiOS` to 6.0, which is pretty obviously wrong, but was useful for linting the project with FauxPas (as it would then catch any accidental usage of unavailable APIs) and didn't seem to cause any issues. #182 has shown that that assumption was wrong, and that deployment target breaks app store submission. This sets iOS 8.0 as the minimum deployment target for `StripeiOS`, but changes `StripeiOSTests` to use 6.0 so that FauxPas will catch errors there (which kind of semantically makes more sense anyway).

r? @benzguo 