### PR TITLE
Add Example/Example.xcworkspace

### DIFF
--- a/Example/Example.xcworkspace/contents.xcworkspacedata
+++ b/Example/Example.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+     location = "group:../Stripe.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Stripe iOS Example (Simple).xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Stripe iOS Example (Custom).xcodeproj">
+   </FileRef>
+</Workspace>


### PR DESCRIPTION
fix #203 pod try for Stripe iOS Example (Custom) not working /cc @loudnate 

cocoapods-try opens xcworkspace directly if find "Example.xcworkspace".
https://github.com/CocoaPods/cocoapods-try/blob/master/lib/pod/command/try.rb#L154

```
# my test repo
pod try https://github.com/laiso/stripe-ios.git
 > Git download

Trying Stripe
Opening '/private/var/folders/_y/l8y6vh_d2zq4_bmq6cqrr8vm0000gn/T/CocoaPods/Try/Stripe/Example/Example.xcworkspace'
```
and run Apps with Xcode be successful.

(I have not change Stripe.xcworkspace or other build process)