### PR TITLE
Introduce STPCardParams

### DIFF
--- a/Example/Stripe iOS Example (Custom)/PaymentViewController.m
+++ b/Example/Stripe iOS Example (Custom)/PaymentViewController.m
@@ -77,12 +77,7 @@
         return;
     }
     [self.activityIndicator startAnimating];
-    STPCard *card = [[STPCard alloc] init];
-    card.number = self.paymentTextField.cardNumber;
-    card.expMonth = self.paymentTextField.expirationMonth;
-    card.expYear = self.paymentTextField.expirationYear;
-    card.cvc = self.paymentTextField.cvc;
-    [[STPAPIClient sharedClient] createTokenWithCard:card
+    [[STPAPIClient sharedClient] createTokenWithCard:self.paymentTextField.card
                                           completion:^(STPToken *token, NSError *error) {
                                               [self.activityIndicator stopAnimating];
                                               if (error) {

--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -324,6 +324,9 @@
 		04F213311BCEAB61001D6F22 /* STPFormEncodable.h in Headers */ = {isa = PBXBuildFile; fileRef = 04F213301BCEAB61001D6F22 /* STPFormEncodable.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		04F213321BCEAB61001D6F22 /* STPFormEncodable.h in Headers */ = {isa = PBXBuildFile; fileRef = 04F213301BCEAB61001D6F22 /* STPFormEncodable.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		04F213331BCEAB61001D6F22 /* STPFormEncodable.h in Headers */ = {isa = PBXBuildFile; fileRef = 04F213301BCEAB61001D6F22 /* STPFormEncodable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		04F213351BCECB1C001D6F22 /* STPAPIResponseDecodable.h in Headers */ = {isa = PBXBuildFile; fileRef = 04F213341BCECB1C001D6F22 /* STPAPIResponseDecodable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		04F213361BCECB1C001D6F22 /* STPAPIResponseDecodable.h in Headers */ = {isa = PBXBuildFile; fileRef = 04F213341BCECB1C001D6F22 /* STPAPIResponseDecodable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		04F213371BCECB1C001D6F22 /* STPAPIResponseDecodable.h in Headers */ = {isa = PBXBuildFile; fileRef = 04F213341BCECB1C001D6F22 /* STPAPIResponseDecodable.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		04F3BB3D1BA89B1200DE235E /* PKPayment+Stripe.h in Headers */ = {isa = PBXBuildFile; fileRef = 04F3BB3B1BA89B1200DE235E /* PKPayment+Stripe.h */; settings = {ASSET_TAGS = (); }; };
 		04F3BB3E1BA89B1200DE235E /* PKPayment+Stripe.h in Headers */ = {isa = PBXBuildFile; fileRef = 04F3BB3B1BA89B1200DE235E /* PKPayment+Stripe.h */; settings = {ASSET_TAGS = (); }; };
 		04F3BB3F1BA89B1200DE235E /* PKPayment+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = 04F3BB3C1BA89B1200DE235E /* PKPayment+Stripe.m */; settings = {ASSET_TAGS = (); }; };
@@ -471,6 +474,7 @@
 		04EBC7511B7533C300A0E6AE /* STPCardValidationState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = STPCardValidationState.h; path = PublicHeaders/STPCardValidationState.h; sourceTree = "<group>"; };
 		04EBC7521B7533C300A0E6AE /* STPCardValidator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = STPCardValidator.h; path = PublicHeaders/STPCardValidator.h; sourceTree = "<group>"; };
 		04F213301BCEAB61001D6F22 /* STPFormEncodable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = STPFormEncodable.h; path = PublicHeaders/STPFormEncodable.h; sourceTree = "<group>"; };
+		04F213341BCECB1C001D6F22 /* STPAPIResponseDecodable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = STPAPIResponseDecodable.h; path = PublicHeaders/STPAPIResponseDecodable.h; sourceTree = "<group>"; };
 		04F39F0A1AEF2AFE005B926E /* Project-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Project-Debug.xcconfig"; sourceTree = "<group>"; };
 		04F39F0B1AEF2AFE005B926E /* Project-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Project-Release.xcconfig"; sourceTree = "<group>"; };
 		04F39F0C1AEF2AFE005B926E /* Project-Shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Project-Shared.xcconfig"; sourceTree = "<group>"; };
@@ -657,6 +661,7 @@
 				04CDB4C91A5F30A700B854EE /* STPBankAccount.m */,
 				0438EF461B74183100D506CC /* STPCardBrand.h */,
 				04F213301BCEAB61001D6F22 /* STPFormEncodable.h */,
+				04F213341BCECB1C001D6F22 /* STPAPIResponseDecodable.h */,
 				04CDE5BB1BC1F21500548833 /* STPCardParams.h */,
 				04CDE5B41BC1F1F100548833 /* STPCardParams.m */,
 				04CDB4CA1A5F30A700B854EE /* STPCard.h */,
@@ -829,6 +834,7 @@
 				04CDE5CB1BC20B1D00548833 /* STPBankAccountParams.h in Headers */,
 				0438EF3A1B7416BB00D506CC /* STPPaymentCardTextFieldViewModel.h in Headers */,
 				04CDE5BE1BC1F21500548833 /* STPCardParams.h in Headers */,
+				04F213371BCECB1C001D6F22 /* STPAPIResponseDecodable.h in Headers */,
 				049E84E31A605EF0000B66CD /* STPIOSCheckoutWebViewAdapter.h in Headers */,
 				049E84E41A605EF0000B66CD /* STPOSXCheckoutWebViewAdapter.h in Headers */,
 				049E84E51A605EF0000B66CD /* STPStrictURLProtocol.h in Headers */,
@@ -865,6 +871,7 @@
 				04CDE5C91BC20B1D00548833 /* STPBankAccountParams.h in Headers */,
 				0438EF381B7416BB00D506CC /* STPPaymentCardTextFieldViewModel.h in Headers */,
 				04CDE5BC1BC1F21500548833 /* STPCardParams.h in Headers */,
+				04F213351BCECB1C001D6F22 /* STPAPIResponseDecodable.h in Headers */,
 				04CDB5061A5F30A700B854EE /* STPAPIConnection.h in Headers */,
 				04CDB4FA1A5F30A700B854EE /* STPStrictURLProtocol.h in Headers */,
 				04CDB4D31A5F30A700B854EE /* Stripe.h in Headers */,
@@ -895,6 +902,7 @@
 				04D12C331A5F55D10010446E /* STPCheckoutInternalUIWebViewController.h in Headers */,
 				04D12C341A5F55D10010446E /* STPCheckoutWebViewAdapter.h in Headers */,
 				04D12C351A5F55D10010446E /* STPColorUtils.h in Headers */,
+				04F213361BCECB1C001D6F22 /* STPAPIResponseDecodable.h in Headers */,
 				04D12C361A5F55D10010446E /* STPIOSCheckoutWebViewAdapter.h in Headers */,
 				04D12C371A5F55D10010446E /* STPOSXCheckoutWebViewAdapter.h in Headers */,
 				04D12C381A5F55D10010446E /* STPStrictURLProtocol.h in Headers */,

--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -263,6 +263,13 @@
 		04CDE5BD1BC1F21500548833 /* STPCardParams.h in Headers */ = {isa = PBXBuildFile; fileRef = 04CDE5BB1BC1F21500548833 /* STPCardParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		04CDE5BE1BC1F21500548833 /* STPCardParams.h in Headers */ = {isa = PBXBuildFile; fileRef = 04CDE5BB1BC1F21500548833 /* STPCardParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		04CDE5BF1BC1FD4500548833 /* STPCardParams.h in Headers */ = {isa = PBXBuildFile; fileRef = 04CDE5BB1BC1F21500548833 /* STPCardParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		04CDE5C51BC20AF800548833 /* STPBankAccountParams.m in Sources */ = {isa = PBXBuildFile; fileRef = 04CDE5C11BC20AF800548833 /* STPBankAccountParams.m */; settings = {ASSET_TAGS = (); }; };
+		04CDE5C61BC20AF800548833 /* STPBankAccountParams.m in Sources */ = {isa = PBXBuildFile; fileRef = 04CDE5C11BC20AF800548833 /* STPBankAccountParams.m */; settings = {ASSET_TAGS = (); }; };
+		04CDE5C71BC20AF800548833 /* STPBankAccountParams.m in Sources */ = {isa = PBXBuildFile; fileRef = 04CDE5C11BC20AF800548833 /* STPBankAccountParams.m */; settings = {ASSET_TAGS = (); }; };
+		04CDE5C91BC20B1D00548833 /* STPBankAccountParams.h in Headers */ = {isa = PBXBuildFile; fileRef = 04CDE5C81BC20B1D00548833 /* STPBankAccountParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		04CDE5CA1BC20B1D00548833 /* STPBankAccountParams.h in Headers */ = {isa = PBXBuildFile; fileRef = 04CDE5C81BC20B1D00548833 /* STPBankAccountParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		04CDE5CB1BC20B1D00548833 /* STPBankAccountParams.h in Headers */ = {isa = PBXBuildFile; fileRef = 04CDE5C81BC20B1D00548833 /* STPBankAccountParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		04CDE5CC1BC20B2600548833 /* STPBankAccountParams.h in Headers */ = {isa = PBXBuildFile; fileRef = 04CDE5C81BC20B1D00548833 /* STPBankAccountParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		04D12C111A5F556D0010446E /* StripeOSX.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04D12C061A5F556D0010446E /* StripeOSX.framework */; };
 		04D12C1F1A5F55AD0010446E /* STPCheckoutOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 04CDB4B21A5F30A700B854EE /* STPCheckoutOptions.m */; };
 		04D12C201A5F55AD0010446E /* STPCheckoutViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 04CDB4B41A5F30A700B854EE /* STPCheckoutViewController.m */; };
@@ -452,6 +459,8 @@
 		04CDB5621A5F3D2000B854EE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		04CDE5B41BC1F1F100548833 /* STPCardParams.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPCardParams.m; sourceTree = "<group>"; };
 		04CDE5BB1BC1F21500548833 /* STPCardParams.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = STPCardParams.h; path = PublicHeaders/STPCardParams.h; sourceTree = "<group>"; };
+		04CDE5C11BC20AF800548833 /* STPBankAccountParams.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPBankAccountParams.m; sourceTree = "<group>"; };
+		04CDE5C81BC20B1D00548833 /* STPBankAccountParams.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = STPBankAccountParams.h; path = PublicHeaders/STPBankAccountParams.h; sourceTree = "<group>"; };
 		04D12C061A5F556D0010446E /* StripeOSX.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripeOSX.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		04D12C101A5F556D0010446E /* StripeOSXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StripeOSXTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		04D5BF9019BF958F009521A5 /* PassKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PassKit.framework; path = System/Library/Frameworks/PassKit.framework; sourceTree = SDKROOT; };
@@ -638,6 +647,8 @@
 				04CDB4C51A5F30A700B854EE /* STPFormEncoder.m */,
 				04CDB4C61A5F30A700B854EE /* STPAPIConnection.h */,
 				04CDB4C71A5F30A700B854EE /* STPAPIConnection.m */,
+				04CDE5C81BC20B1D00548833 /* STPBankAccountParams.h */,
+				04CDE5C11BC20AF800548833 /* STPBankAccountParams.m */,
 				04CDB4C81A5F30A700B854EE /* STPBankAccount.h */,
 				04CDB4C91A5F30A700B854EE /* STPBankAccount.m */,
 				0438EF461B74183100D506CC /* STPCardBrand.h */,
@@ -774,6 +785,7 @@
 				04415C781A6605D9001225ED /* STPCheckoutDelegate.h in Headers */,
 				04415C791A6605D9001225ED /* STPCheckoutInternalUIWebViewController.h in Headers */,
 				04415C7A1A6605D9001225ED /* STPCheckoutWebViewAdapter.h in Headers */,
+				04CDE5CC1BC20B2600548833 /* STPBankAccountParams.h in Headers */,
 				04415C7B1A6605D9001225ED /* STPColorUtils.h in Headers */,
 				0438EF391B7416BB00D506CC /* STPPaymentCardTextFieldViewModel.h in Headers */,
 				04415C7C1A6605D9001225ED /* STPIOSCheckoutWebViewAdapter.h in Headers */,
@@ -808,6 +820,7 @@
 				04F3BB3E1BA89B1200DE235E /* PKPayment+Stripe.h in Headers */,
 				049E84E11A605EF0000B66CD /* STPCheckoutWebViewAdapter.h in Headers */,
 				049E84E21A605EF0000B66CD /* STPColorUtils.h in Headers */,
+				04CDE5CB1BC20B1D00548833 /* STPBankAccountParams.h in Headers */,
 				0438EF3A1B7416BB00D506CC /* STPPaymentCardTextFieldViewModel.h in Headers */,
 				04CDE5BE1BC1F21500548833 /* STPCardParams.h in Headers */,
 				049E84E31A605EF0000B66CD /* STPIOSCheckoutWebViewAdapter.h in Headers */,
@@ -842,6 +855,7 @@
 				04F3BB3D1BA89B1200DE235E /* PKPayment+Stripe.h in Headers */,
 				04CDB4ED1A5F30A700B854EE /* STPCheckoutWebViewAdapter.h in Headers */,
 				04CDB4E91A5F30A700B854EE /* STPCheckoutInternalUIWebViewController.h in Headers */,
+				04CDE5C91BC20B1D00548833 /* STPBankAccountParams.h in Headers */,
 				0438EF381B7416BB00D506CC /* STPPaymentCardTextFieldViewModel.h in Headers */,
 				04CDE5BC1BC1F21500548833 /* STPCardParams.h in Headers */,
 				04CDB5061A5F30A700B854EE /* STPAPIConnection.h in Headers */,
@@ -860,6 +874,7 @@
 				04EBC7551B7533C300A0E6AE /* STPCardValidationState.h in Headers */,
 				04D12C2C1A5F55D10010446E /* Stripe.h in Headers */,
 				04CDE5BD1BC1F21500548833 /* STPCardParams.h in Headers */,
+				04CDE5CA1BC20B1D00548833 /* STPBankAccountParams.h in Headers */,
 				04D12C301A5F55D10010446E /* STPCheckoutOptions.h in Headers */,
 				04D12C311A5F55D10010446E /* STPCheckoutViewController.h in Headers */,
 				04D12C391A5F55D10010446E /* STPAPIClient.h in Headers */,
@@ -1244,6 +1259,7 @@
 				04CDE5BA1BC1F1F100548833 /* STPCardParams.m in Sources */,
 				049E84D11A605DE0000B66CD /* STPToken.m in Sources */,
 				049E84D21A605DE0000B66CD /* StripeError.m in Sources */,
+				04CDE5C71BC20AF800548833 /* STPBankAccountParams.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1273,6 +1289,7 @@
 				04CDE5B81BC1F1F100548833 /* STPCardParams.m in Sources */,
 				04CDB4D61A5F30A700B854EE /* STPAPIClient+ApplePay.m in Sources */,
 				04CDB4E61A5F30A700B854EE /* STPCheckoutViewController.m in Sources */,
+				04CDE5C51BC20AF800548833 /* STPBankAccountParams.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1285,6 +1302,7 @@
 				04D12C211A5F55AD0010446E /* STPCheckoutInternalUIWebViewController.m in Sources */,
 				04D12C221A5F55AD0010446E /* STPColorUtils.m in Sources */,
 				04E32A9B1B7A93FC009C9E35 /* STPCardValidator.m in Sources */,
+				04CDE5C61BC20AF800548833 /* STPBankAccountParams.m in Sources */,
 				04D12C231A5F55AD0010446E /* STPOSXCheckoutWebViewAdapter.m in Sources */,
 				04CDE5B91BC1F1F100548833 /* STPCardParams.m in Sources */,
 				04D12C241A5F55AD0010446E /* STPStrictURLProtocol.m in Sources */,

--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -321,6 +321,9 @@
 		04EBC7581B7533C300A0E6AE /* STPCardValidator.h in Headers */ = {isa = PBXBuildFile; fileRef = 04EBC7521B7533C300A0E6AE /* STPCardValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		04EBC7591B7533C300A0E6AE /* STPCardValidator.h in Headers */ = {isa = PBXBuildFile; fileRef = 04EBC7521B7533C300A0E6AE /* STPCardValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		04EBC75A1B7533C300A0E6AE /* STPCardValidator.h in Headers */ = {isa = PBXBuildFile; fileRef = 04EBC7521B7533C300A0E6AE /* STPCardValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		04F213311BCEAB61001D6F22 /* STPFormEncodable.h in Headers */ = {isa = PBXBuildFile; fileRef = 04F213301BCEAB61001D6F22 /* STPFormEncodable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		04F213321BCEAB61001D6F22 /* STPFormEncodable.h in Headers */ = {isa = PBXBuildFile; fileRef = 04F213301BCEAB61001D6F22 /* STPFormEncodable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		04F213331BCEAB61001D6F22 /* STPFormEncodable.h in Headers */ = {isa = PBXBuildFile; fileRef = 04F213301BCEAB61001D6F22 /* STPFormEncodable.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		04F3BB3D1BA89B1200DE235E /* PKPayment+Stripe.h in Headers */ = {isa = PBXBuildFile; fileRef = 04F3BB3B1BA89B1200DE235E /* PKPayment+Stripe.h */; settings = {ASSET_TAGS = (); }; };
 		04F3BB3E1BA89B1200DE235E /* PKPayment+Stripe.h in Headers */ = {isa = PBXBuildFile; fileRef = 04F3BB3B1BA89B1200DE235E /* PKPayment+Stripe.h */; settings = {ASSET_TAGS = (); }; };
 		04F3BB3F1BA89B1200DE235E /* PKPayment+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = 04F3BB3C1BA89B1200DE235E /* PKPayment+Stripe.m */; settings = {ASSET_TAGS = (); }; };
@@ -467,6 +470,7 @@
 		04E32A9C1B7A9490009C9E35 /* STPPaymentCardTextField.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = STPPaymentCardTextField.h; path = PublicHeaders/UI/STPPaymentCardTextField.h; sourceTree = "<group>"; };
 		04EBC7511B7533C300A0E6AE /* STPCardValidationState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = STPCardValidationState.h; path = PublicHeaders/STPCardValidationState.h; sourceTree = "<group>"; };
 		04EBC7521B7533C300A0E6AE /* STPCardValidator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = STPCardValidator.h; path = PublicHeaders/STPCardValidator.h; sourceTree = "<group>"; };
+		04F213301BCEAB61001D6F22 /* STPFormEncodable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = STPFormEncodable.h; path = PublicHeaders/STPFormEncodable.h; sourceTree = "<group>"; };
 		04F39F0A1AEF2AFE005B926E /* Project-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Project-Debug.xcconfig"; sourceTree = "<group>"; };
 		04F39F0B1AEF2AFE005B926E /* Project-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Project-Release.xcconfig"; sourceTree = "<group>"; };
 		04F39F0C1AEF2AFE005B926E /* Project-Shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Project-Shared.xcconfig"; sourceTree = "<group>"; };
@@ -652,6 +656,7 @@
 				04CDB4C81A5F30A700B854EE /* STPBankAccount.h */,
 				04CDB4C91A5F30A700B854EE /* STPBankAccount.m */,
 				0438EF461B74183100D506CC /* STPCardBrand.h */,
+				04F213301BCEAB61001D6F22 /* STPFormEncodable.h */,
 				04CDE5BB1BC1F21500548833 /* STPCardParams.h */,
 				04CDE5B41BC1F1F100548833 /* STPCardParams.m */,
 				04CDB4CA1A5F30A700B854EE /* STPCard.h */,
@@ -814,6 +819,7 @@
 				049E84EB1A605EF0000B66CD /* STPToken.h in Headers */,
 				04E32AA01B7A9490009C9E35 /* STPPaymentCardTextField.h in Headers */,
 				0438EF491B74183100D506CC /* STPCardBrand.h in Headers */,
+				04F213331BCEAB61001D6F22 /* STPFormEncodable.h in Headers */,
 				049E84EC1A605EF0000B66CD /* StripeError.h in Headers */,
 				049E84DF1A605EF0000B66CD /* STPCheckoutDelegate.h in Headers */,
 				049E84E01A605EF0000B66CD /* STPCheckoutInternalUIWebViewController.h in Headers */,
@@ -849,6 +855,7 @@
 				04CDB5161A5F30A700B854EE /* StripeError.h in Headers */,
 				04CDB4D41A5F30A700B854EE /* STPAPIClient+ApplePay.h in Headers */,
 				04E32A9D1B7A9490009C9E35 /* STPPaymentCardTextField.h in Headers */,
+				04F213311BCEAB61001D6F22 /* STPFormEncodable.h in Headers */,
 				04CDB4E01A5F30A700B854EE /* STPCheckoutOptions.h in Headers */,
 				04CDB5021A5F30A700B854EE /* STPFormEncoder.h in Headers */,
 				04CDB4E81A5F30A700B854EE /* STPCheckoutDelegate.h in Headers */,
@@ -877,6 +884,7 @@
 				04CDE5CA1BC20B1D00548833 /* STPBankAccountParams.h in Headers */,
 				04D12C301A5F55D10010446E /* STPCheckoutOptions.h in Headers */,
 				04D12C311A5F55D10010446E /* STPCheckoutViewController.h in Headers */,
+				04F213321BCEAB61001D6F22 /* STPFormEncodable.h in Headers */,
 				04D12C391A5F55D10010446E /* STPAPIClient.h in Headers */,
 				04D12C3C1A5F55D10010446E /* STPBankAccount.h in Headers */,
 				04D12C3D1A5F55D10010446E /* STPCard.h in Headers */,

--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -256,6 +256,13 @@
 		04CDB5141A5F30A700B854EE /* STPToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 04CDB4CD1A5F30A700B854EE /* STPToken.m */; };
 		04CDB5161A5F30A700B854EE /* StripeError.h in Headers */ = {isa = PBXBuildFile; fileRef = 04CDB4CE1A5F30A700B854EE /* StripeError.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		04CDB5181A5F30A700B854EE /* StripeError.m in Sources */ = {isa = PBXBuildFile; fileRef = 04CDB4CF1A5F30A700B854EE /* StripeError.m */; };
+		04CDE5B81BC1F1F100548833 /* STPCardParams.m in Sources */ = {isa = PBXBuildFile; fileRef = 04CDE5B41BC1F1F100548833 /* STPCardParams.m */; settings = {ASSET_TAGS = (); }; };
+		04CDE5B91BC1F1F100548833 /* STPCardParams.m in Sources */ = {isa = PBXBuildFile; fileRef = 04CDE5B41BC1F1F100548833 /* STPCardParams.m */; settings = {ASSET_TAGS = (); }; };
+		04CDE5BA1BC1F1F100548833 /* STPCardParams.m in Sources */ = {isa = PBXBuildFile; fileRef = 04CDE5B41BC1F1F100548833 /* STPCardParams.m */; settings = {ASSET_TAGS = (); }; };
+		04CDE5BC1BC1F21500548833 /* STPCardParams.h in Headers */ = {isa = PBXBuildFile; fileRef = 04CDE5BB1BC1F21500548833 /* STPCardParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		04CDE5BD1BC1F21500548833 /* STPCardParams.h in Headers */ = {isa = PBXBuildFile; fileRef = 04CDE5BB1BC1F21500548833 /* STPCardParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		04CDE5BE1BC1F21500548833 /* STPCardParams.h in Headers */ = {isa = PBXBuildFile; fileRef = 04CDE5BB1BC1F21500548833 /* STPCardParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		04CDE5BF1BC1FD4500548833 /* STPCardParams.h in Headers */ = {isa = PBXBuildFile; fileRef = 04CDE5BB1BC1F21500548833 /* STPCardParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		04D12C111A5F556D0010446E /* StripeOSX.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04D12C061A5F556D0010446E /* StripeOSX.framework */; };
 		04D12C1F1A5F55AD0010446E /* STPCheckoutOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 04CDB4B21A5F30A700B854EE /* STPCheckoutOptions.m */; };
 		04D12C201A5F55AD0010446E /* STPCheckoutViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 04CDB4B41A5F30A700B854EE /* STPCheckoutViewController.m */; };
@@ -443,6 +450,8 @@
 		04CDB5261A5F3A9300B854EE /* STPCertTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPCertTest.m; sourceTree = "<group>"; };
 		04CDB5271A5F3A9300B854EE /* STPTokenTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPTokenTest.m; sourceTree = "<group>"; };
 		04CDB5621A5F3D2000B854EE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		04CDE5B41BC1F1F100548833 /* STPCardParams.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPCardParams.m; sourceTree = "<group>"; };
+		04CDE5BB1BC1F21500548833 /* STPCardParams.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = STPCardParams.h; path = PublicHeaders/STPCardParams.h; sourceTree = "<group>"; };
 		04D12C061A5F556D0010446E /* StripeOSX.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripeOSX.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		04D12C101A5F556D0010446E /* StripeOSXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StripeOSXTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		04D5BF9019BF958F009521A5 /* PassKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PassKit.framework; path = System/Library/Frameworks/PassKit.framework; sourceTree = SDKROOT; };
@@ -632,6 +641,8 @@
 				04CDB4C81A5F30A700B854EE /* STPBankAccount.h */,
 				04CDB4C91A5F30A700B854EE /* STPBankAccount.m */,
 				0438EF461B74183100D506CC /* STPCardBrand.h */,
+				04CDE5BB1BC1F21500548833 /* STPCardParams.h */,
+				04CDE5B41BC1F1F100548833 /* STPCardParams.m */,
 				04CDB4CA1A5F30A700B854EE /* STPCard.h */,
 				04CDB4CB1A5F30A700B854EE /* STPCard.m */,
 				04EBC7511B7533C300A0E6AE /* STPCardValidationState.h */,
@@ -752,6 +763,7 @@
 				04415C761A6605D9001225ED /* STPCheckoutOptions.h in Headers */,
 				0438EF2D1B7416BB00D506CC /* STPFormTextField.h in Headers */,
 				04415C771A6605D9001225ED /* STPCheckoutViewController.h in Headers */,
+				04CDE5BF1BC1FD4500548833 /* STPCardParams.h in Headers */,
 				04415C7F1A6605D9001225ED /* STPAPIClient.h in Headers */,
 				04415C821A6605D9001225ED /* STPBankAccount.h in Headers */,
 				04415C831A6605D9001225ED /* STPCard.h in Headers */,
@@ -797,6 +809,7 @@
 				049E84E11A605EF0000B66CD /* STPCheckoutWebViewAdapter.h in Headers */,
 				049E84E21A605EF0000B66CD /* STPColorUtils.h in Headers */,
 				0438EF3A1B7416BB00D506CC /* STPPaymentCardTextFieldViewModel.h in Headers */,
+				04CDE5BE1BC1F21500548833 /* STPCardParams.h in Headers */,
 				049E84E31A605EF0000B66CD /* STPIOSCheckoutWebViewAdapter.h in Headers */,
 				049E84E41A605EF0000B66CD /* STPOSXCheckoutWebViewAdapter.h in Headers */,
 				049E84E51A605EF0000B66CD /* STPStrictURLProtocol.h in Headers */,
@@ -830,6 +843,7 @@
 				04CDB4ED1A5F30A700B854EE /* STPCheckoutWebViewAdapter.h in Headers */,
 				04CDB4E91A5F30A700B854EE /* STPCheckoutInternalUIWebViewController.h in Headers */,
 				0438EF381B7416BB00D506CC /* STPPaymentCardTextFieldViewModel.h in Headers */,
+				04CDE5BC1BC1F21500548833 /* STPCardParams.h in Headers */,
 				04CDB5061A5F30A700B854EE /* STPAPIConnection.h in Headers */,
 				04CDB4FA1A5F30A700B854EE /* STPStrictURLProtocol.h in Headers */,
 				04CDB4D31A5F30A700B854EE /* Stripe.h in Headers */,
@@ -845,6 +859,7 @@
 				04EBC7591B7533C300A0E6AE /* STPCardValidator.h in Headers */,
 				04EBC7551B7533C300A0E6AE /* STPCardValidationState.h in Headers */,
 				04D12C2C1A5F55D10010446E /* Stripe.h in Headers */,
+				04CDE5BD1BC1F21500548833 /* STPCardParams.h in Headers */,
 				04D12C301A5F55D10010446E /* STPCheckoutOptions.h in Headers */,
 				04D12C311A5F55D10010446E /* STPCheckoutViewController.h in Headers */,
 				04D12C391A5F55D10010446E /* STPAPIClient.h in Headers */,
@@ -1226,6 +1241,7 @@
 				049E84D01A605DE0000B66CD /* STPCard.m in Sources */,
 				04F3BB401BA89B1200DE235E /* PKPayment+Stripe.m in Sources */,
 				0438EF3D1B7416BB00D506CC /* STPPaymentCardTextFieldViewModel.m in Sources */,
+				04CDE5BA1BC1F1F100548833 /* STPCardParams.m in Sources */,
 				049E84D11A605DE0000B66CD /* STPToken.m in Sources */,
 				049E84D21A605DE0000B66CD /* StripeError.m in Sources */,
 			);
@@ -1254,6 +1270,7 @@
 				04CDB5141A5F30A700B854EE /* STPToken.m in Sources */,
 				04F3BB3F1BA89B1200DE235E /* PKPayment+Stripe.m in Sources */,
 				0438EF3B1B7416BB00D506CC /* STPPaymentCardTextFieldViewModel.m in Sources */,
+				04CDE5B81BC1F1F100548833 /* STPCardParams.m in Sources */,
 				04CDB4D61A5F30A700B854EE /* STPAPIClient+ApplePay.m in Sources */,
 				04CDB4E61A5F30A700B854EE /* STPCheckoutViewController.m in Sources */,
 			);
@@ -1269,6 +1286,7 @@
 				04D12C221A5F55AD0010446E /* STPColorUtils.m in Sources */,
 				04E32A9B1B7A93FC009C9E35 /* STPCardValidator.m in Sources */,
 				04D12C231A5F55AD0010446E /* STPOSXCheckoutWebViewAdapter.m in Sources */,
+				04CDE5B91BC1F1F100548833 /* STPCardParams.m in Sources */,
 				04D12C241A5F55AD0010446E /* STPStrictURLProtocol.m in Sources */,
 				04D12C251A5F55AD0010446E /* STPAPIClient.m in Sources */,
 				04D12C261A5F55AD0010446E /* STPFormEncoder.m in Sources */,

--- a/Stripe/Checkout/STPCheckoutInternalUIWebViewController.m
+++ b/Stripe/Checkout/STPCheckoutInternalUIWebViewController.m
@@ -19,6 +19,7 @@
 #import "StripeError.h"
 #import "STPToken.h"
 #import "STPColorUtils.h"
+#import "STPAPIResponseDecodable.h"
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated"
@@ -156,7 +157,7 @@
     } else if ([event isEqualToString:STPCheckoutEventTokenize]) {
         STPToken *token = nil;
         if (payload != nil && payload[@"token"] != nil) {
-            token = [[STPToken alloc] initWithAttributeDictionary:payload[@"token"]];
+            token = [STPToken decodedObjectFromAPIResponse:payload[@"token"]];
         }
         [self.delegate checkoutController:self.checkoutController
                            didCreateToken:token

--- a/Stripe/Checkout/STPCheckoutViewController.m
+++ b/Stripe/Checkout/STPCheckoutViewController.m
@@ -141,7 +141,7 @@
     } else if ([event isEqualToString:STPCheckoutEventTokenize]) {
         STPToken *token = nil;
         if (payload != nil && payload[@"token"] != nil) {
-            token = [[STPToken alloc] initWithAttributeDictionary:payload[@"token"]];
+            token = [STPToken decodedObjectFromAPIResponse:payload[@"token"]];
         }
         [self.checkoutDelegate checkoutController:self
                                    didCreateToken:token

--- a/Stripe/PublicHeaders/STPAPIClient.h
+++ b/Stripe/PublicHeaders/STPAPIClient.h
@@ -11,7 +11,7 @@
 
 static NSString *const __nonnull STPSDKVersion = @"5.1.4";
 
-@class STPBankAccount, STPCard, STPToken;
+@class STPBankAccount, STPCard, STPCardParams, STPToken;
 
 /**
  *  A callback to be run with the response from the Stripe API.
@@ -80,12 +80,12 @@ typedef void (^STPCompletionBlock)(STPToken * __nullable token, NSError * __null
 @interface STPAPIClient (CreditCards)
 
 /**
- *  Converts an STPCard object into a Stripe token using the Stripe API.
+ *  Converts an STPCardParams object into a Stripe token using the Stripe API.
  *
  *  @param card        The user's card details. Cannot be nil. @see https://stripe.com/docs/api#create_card_token
  *  @param completion  The callback to run with the returned Stripe token (and any errors that may have occurred).
  */
-- (void)createTokenWithCard:(nonnull STPCard *)card completion:(nullable STPCompletionBlock)completion;
+- (void)createTokenWithCard:(nonnull STPCardParams *)card completion:(nullable STPCompletionBlock)completion;
 
 @end
 

--- a/Stripe/PublicHeaders/STPAPIClient.h
+++ b/Stripe/PublicHeaders/STPAPIClient.h
@@ -11,7 +11,7 @@
 
 static NSString *const __nonnull STPSDKVersion = @"5.1.4";
 
-@class STPBankAccount, STPCard, STPCardParams, STPToken;
+@class STPBankAccount, STPBankAccountParams, STPCard, STPCardParams, STPToken;
 
 /**
  *  A callback to be run with the response from the Stripe API.
@@ -71,7 +71,7 @@ typedef void (^STPCompletionBlock)(STPToken * __nullable token, NSError * __null
  *  @param bankAccount The user's bank account details. Cannot be nil. @see https://stripe.com/docs/api#create_bank_account_token
  *  @param completion  The callback to run with the returned Stripe token (and any errors that may have occurred).
  */
-- (void)createTokenWithBankAccount:(nonnull STPBankAccount *)bankAccount completion:(__nullable STPCompletionBlock)completion;
+- (void)createTokenWithBankAccount:(nonnull STPBankAccountParams *)bankAccount completion:(__nullable STPCompletionBlock)completion;
 
 @end
 

--- a/Stripe/PublicHeaders/STPAPIResponseDecodable.h
+++ b/Stripe/PublicHeaders/STPAPIResponseDecodable.h
@@ -1,0 +1,15 @@
+//
+//  STPAPIResponseDecodable.h
+//  Stripe
+//
+//  Created by Jack Flintermann on 10/14/15.
+//  Copyright © 2015 Stripe, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@protocol STPAPIResponseDecodable <NSObject>
+
++ (nullable instancetype)decodedObjectFromAPIResponse:(nonnull NSDictionary *)response;
+
+@end

--- a/Stripe/PublicHeaders/STPBankAccount.h
+++ b/Stripe/PublicHeaders/STPBankAccount.h
@@ -8,11 +8,12 @@
 
 #import <Foundation/Foundation.h>
 #import "STPBankAccountParams.h"
+#import "STPAPIResponseDecodable.h"
 
 /**
  *  Representation of a user's bank account details that have been tokenized with the Stripe API. @see https://stripe.com/docs/api#cards
  */
-@interface STPBankAccount : STPBankAccountParams
+@interface STPBankAccount : STPBankAccountParams<STPAPIResponseDecodable>
 
 /**
  *  The last 4 digits of the bank account's account number.
@@ -69,12 +70,5 @@
 #define DEPRECATED_IN_FAVOR_OF_STPBANKACCOUNTPARAMS __attribute__((deprecated("For collecting your users' bank account details, you should use an STPBankAccountParams object instead of an STPBankAccount.")))
 
 - (void)setAccountNumber:(nullable NSString *)accountNumber DEPRECATED_IN_FAVOR_OF_STPBANKACCOUNTPARAMS;
-
-@end
-
-// This method is used internally by Stripe to deserialize API responses and exposed here for convenience and testing purposes only. You should not use it in your own code.
-@interface STPBankAccount (PrivateMethods)
-
-- (nonnull instancetype)initWithAttributeDictionary:(nonnull NSDictionary *)attributeDictionary;
 
 @end

--- a/Stripe/PublicHeaders/STPBankAccount.h
+++ b/Stripe/PublicHeaders/STPBankAccount.h
@@ -7,19 +7,17 @@
 //
 
 #import <Foundation/Foundation.h>
-
-
-
-/**
- *  Representation of a user's credit card details. You can assemble these with information that your user enters and
- *  then create Stripe tokens with them using an STPAPIClient. @see https://stripe.com/docs/api#create_bank_account_token
- */
-@interface STPBankAccount : NSObject
+#import "STPBankAccountParams.h"
 
 /**
- *  The account number for the bank account. Currently must be a checking account.
+ *  Representation of a user's bank account details that have been tokenized with the Stripe API. @see https://stripe.com/docs/api#cards
  */
-@property (nonatomic, copy, nullable) NSString *accountNumber;
+@interface STPBankAccount : STPBankAccountParams
+
+/**
+ *  The last 4 digits of the bank account's account number, if it's been set, otherwise nil.
+ */
+- (nonnull NSString *)last4;
 
 /**
  *  The routing number for the bank account. This should be the ACH routing number, not the wire routing number.
@@ -36,7 +34,6 @@
  */
 @property (nonatomic, copy, nullable) NSString *currency;
 
-#pragma mark - These fields are only present on objects returned from the Stripe API.
 /**
  *  The Stripe ID for the bank account.
  */
@@ -67,8 +64,13 @@
  */
 @property (nonatomic, readonly) BOOL disabled;
 
-@end
+#pragma mark - deprecated setters for STPBankAccountParams properties
 
+#define DEPRECATED_IN_FAVOR_OF_STPBANKACCOUNTPARAMS __attribute__((deprecated("For collecting your users' bank account details, you should use an STPBankAccountParams object instead of an STPBankAccount.")))
+
+- (void)setAccountNumber:(nullable NSString *)accountNumber DEPRECATED_IN_FAVOR_OF_STPBANKACCOUNTPARAMS;
+
+@end
 
 // This method is used internally by Stripe to deserialize API responses and exposed here for convenience and testing purposes only. You should not use it in your own code.
 @interface STPBankAccount (PrivateMethods)

--- a/Stripe/PublicHeaders/STPBankAccount.h
+++ b/Stripe/PublicHeaders/STPBankAccount.h
@@ -15,7 +15,7 @@
 @interface STPBankAccount : STPBankAccountParams
 
 /**
- *  The last 4 digits of the bank account's account number, if it's been set, otherwise nil.
+ *  The last 4 digits of the bank account's account number.
  */
 - (nonnull NSString *)last4;
 
@@ -25,7 +25,7 @@
 @property (nonatomic, copy, nullable) NSString *routingNumber;
 
 /**
- *  The country the bank account is in.
+ *  Two-letter ISO code representing the country the bank account is located in.
  */
 @property (nonatomic, copy, nullable) NSString *country;
 

--- a/Stripe/PublicHeaders/STPBankAccountParams.h
+++ b/Stripe/PublicHeaders/STPBankAccountParams.h
@@ -7,12 +7,13 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "STPFormEncodable.h"
 
 /**
  *  Representation of a user's bank account details. You can assemble these with information that your user enters and
  *  then create Stripe tokens with them using an STPAPIClient. @see https://stripe.com/docs/api#create_bank_account_token
  */
-@interface STPBankAccountParams : NSObject
+@interface STPBankAccountParams : NSObject<STPFormEncodable>
 
 /**
  *  The account number for the bank account. Currently must be a checking account.

--- a/Stripe/PublicHeaders/STPBankAccountParams.h
+++ b/Stripe/PublicHeaders/STPBankAccountParams.h
@@ -30,7 +30,7 @@
 @property (nonatomic, copy, nullable) NSString *routingNumber;
 
 /**
- *  The country the bank account is in.
+ *  Two-letter ISO code representing the country the bank account is located in.
  */
 @property (nonatomic, copy, nullable) NSString *country;
 

--- a/Stripe/PublicHeaders/STPBankAccountParams.h
+++ b/Stripe/PublicHeaders/STPBankAccountParams.h
@@ -1,0 +1,42 @@
+//
+//  STPBankAccountParams.h
+//  Stripe
+//
+//  Created by Jack Flintermann on 10/4/15.
+//  Copyright © 2015 Stripe, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+/**
+ *  Representation of a user's bank account details. You can assemble these with information that your user enters and
+ *  then create Stripe tokens with them using an STPAPIClient. @see https://stripe.com/docs/api#create_bank_account_token
+ */
+@interface STPBankAccountParams : NSObject
+
+/**
+ *  The account number for the bank account. Currently must be a checking account.
+ */
+@property (nonatomic, copy, nullable) NSString *accountNumber;
+
+/**
+ *  The last 4 digits of the bank account's account number, if it's been set, otherwise nil.
+ */
+- (nullable NSString *)last4;
+
+/**
+ *  The routing number for the bank account. This should be the ACH routing number, not the wire routing number.
+ */
+@property (nonatomic, copy, nullable) NSString *routingNumber;
+
+/**
+ *  The country the bank account is in.
+ */
+@property (nonatomic, copy, nullable) NSString *country;
+
+/**
+ *  The default currency for the bank account.
+ */
+@property (nonatomic, copy, nullable) NSString *currency;
+
+@end

--- a/Stripe/PublicHeaders/STPCard.h
+++ b/Stripe/PublicHeaders/STPCard.h
@@ -9,6 +9,7 @@
 #import <Foundation/Foundation.h>
 
 #import "STPCardBrand.h"
+#import "STPCardParams.h"
 
 /**
  *  The various funding sources for a payment card.
@@ -21,20 +22,19 @@ typedef NS_ENUM(NSInteger, STPCardFundingType) {
 };
 
 /**
- *  Representation of a user's credit card details. You can assemble these with information that your user enters and
- *  then create Stripe tokens with them using an STPAPIClient. @see https://stripe.com/docs/api#cards
+ *  Representation of a user's credit card details that have been tokenized with the Stripe API. @see https://stripe.com/docs/api#cards
  */
-@interface STPCard : NSObject
+@interface STPCard : STPCardParams
 
 /**
  *  The card's number. This will be nil for cards retrieved from the Stripe API.
  */
-@property (nonatomic, copy, nullable) NSString *number;
+
 
 /**
- *  The last 4 digits of the card. Unlike number, this will be present on cards retrieved from the Stripe API.
+ *  The last 4 digits of the card.
  */
-@property (nonatomic, readonly, nullable) NSString *last4;
+@property (nonatomic, readonly, nonnull) NSString *last4;
 
 /**
  *  For cards made with Apple Pay, this refers to the last 4 digits of the "Device Account Number" for the tokenized card. For regular cards, it will be nil.
@@ -50,11 +50,6 @@ typedef NS_ENUM(NSInteger, STPCardFundingType) {
  *  The card's expiration year.
  */
 @property (nonatomic) NSUInteger expYear;
-
-/**
- *  The card's security code, found on the back. This will be nil for cards retrieved from the Stripe API.
- */
-@property (nonatomic, copy, nullable) NSString *cvc;
 
 /**
  *  The cardholder's name.
@@ -109,33 +104,22 @@ typedef NS_ENUM(NSInteger, STPCardFundingType) {
  */
 @property (nonatomic, copy, nullable) NSString *currency;
 
-/**
- *  Validate each field of the card.
- *  @return whether or not that field is valid.
- *  @deprecated use STPCardValidator instead.
- */
-- (BOOL)validateNumber:(__nullable id * __nullable )ioValue
-                 error:(NSError * __nullable * __nullable )outError __attribute__((deprecated("Use STPCardValidator instead.")));
-- (BOOL)validateCvc:(__nullable id * __nullable )ioValue
-              error:(NSError * __nullable * __nullable )outError __attribute__((deprecated("Use STPCardValidator instead.")));
-- (BOOL)validateExpMonth:(__nullable  id * __nullable )ioValue
-                   error:(NSError * __nullable * __nullable )outError __attribute__((deprecated("Use STPCardValidator instead.")));
-- (BOOL)validateExpYear:(__nullable id * __nullable)ioValue
-                  error:(NSError * __nullable * __nullable )outError __attribute__((deprecated("Use STPCardValidator instead.")));
+#pragma mark - deprecated properties
 
-/**
- *  This validates a fully populated card to check for all errors, including ones that come about
- *  from the interaction of more than one property. It will also do all the validations on individual
- *  properties, so if you only want to call one method on your card to validate it after setting all the
- *  properties, call this one
- *
- *  @param outError a pointer to an NSError that, after calling this method, will be populated with an error if the card is not valid. See StripeError.h for
- possible values
- *
- *  @return whether or not the card is valid.
- *  @deprecated use STPCardValidator instead.
- */
-- (BOOL)validateCardReturningError:(NSError * __nullable * __nullable)outError __attribute__((deprecated("Use STPCardValidator instead.")));
+#define DEPRECATED_IN_FAVOR_OF_STPCARDPARAMS __attribute__((deprecated("For collecting your users' credit card details, you should use an STPCardParams object instead of an STPCard.")))
+
+@property (nonatomic, copy, nullable) NSString *number DEPRECATED_IN_FAVOR_OF_STPCARDPARAMS;
+@property (nonatomic, copy, nullable) NSString *cvc DEPRECATED_IN_FAVOR_OF_STPCARDPARAMS;
+- (void)setExpMonth:(NSUInteger)expMonth DEPRECATED_IN_FAVOR_OF_STPCARDPARAMS;
+- (void)setExpYear:(NSUInteger)expYear DEPRECATED_IN_FAVOR_OF_STPCARDPARAMS;
+- (void)setName:(nullable NSString *)name DEPRECATED_IN_FAVOR_OF_STPCARDPARAMS;
+- (void)setAddressLine1:(nullable NSString *)addressLine1 DEPRECATED_IN_FAVOR_OF_STPCARDPARAMS;
+- (void)setAddressLine2:(nullable NSString *)addressLine2 DEPRECATED_IN_FAVOR_OF_STPCARDPARAMS;
+- (void)setAddressCity:(nullable NSString *)addressCity DEPRECATED_IN_FAVOR_OF_STPCARDPARAMS;
+- (void)setAddressState:(nullable NSString *)addressState DEPRECATED_IN_FAVOR_OF_STPCARDPARAMS;
+- (void)setAddressZip:(nullable NSString *)addressZip DEPRECATED_IN_FAVOR_OF_STPCARDPARAMS;
+- (void)setAddressCountry:(nullable NSString *)addressCountry DEPRECATED_IN_FAVOR_OF_STPCARDPARAMS;
+
 
 @end
 

--- a/Stripe/PublicHeaders/STPCard.h
+++ b/Stripe/PublicHeaders/STPCard.h
@@ -10,6 +10,7 @@
 
 #import "STPCardBrand.h"
 #import "STPCardParams.h"
+#import "STPAPIResponseDecodable.h"
 
 /**
  *  The various funding sources for a payment card.
@@ -24,7 +25,7 @@ typedef NS_ENUM(NSInteger, STPCardFundingType) {
 /**
  *  Representation of a user's credit card details that have been tokenized with the Stripe API. @see https://stripe.com/docs/api#cards
  */
-@interface STPCard : STPCardParams
+@interface STPCard : STPCardParams<STPAPIResponseDecodable>
 
 /**
  *  The card's number. This will be nil for cards retrieved from the Stripe API.
@@ -121,10 +122,4 @@ typedef NS_ENUM(NSInteger, STPCardFundingType) {
 - (void)setAddressCountry:(nullable NSString *)addressCountry DEPRECATED_IN_FAVOR_OF_STPCARDPARAMS;
 
 
-@end
-
-// This method is used internally by Stripe to deserialize API responses and exposed here for convenience and testing purposes only. You should not use it in
-// your own code.
-@interface STPCard (PrivateMethods)
-- (nonnull instancetype)initWithAttributeDictionary:(nonnull NSDictionary *)attributeDictionary;
 @end

--- a/Stripe/PublicHeaders/STPCardParams.h
+++ b/Stripe/PublicHeaders/STPCardParams.h
@@ -35,7 +35,7 @@
 @property (nonatomic) NSUInteger expYear;
 
 /**
- *  The card's security code, found on the back. This will be nil for cards retrieved from the Stripe API.
+ *  The card's security code, found on the back.
  */
 @property (nonatomic, copy, nullable) NSString *cvc;
 
@@ -55,7 +55,7 @@
 @property (nonatomic, copy, nullable) NSString *addressCountry;
 
 /**
- *  This is only applicable when tokenizing debit cards to issue payouts to managed accounts. You should not set it otherwise. The card can then be used as a transfer destination for funds in this currency.
+ *  Three-letter ISO currency code representing the currency paid out to the bank account. This is only applicable when tokenizing debit cards to issue payouts to managed accounts. You should not set it otherwise. The card can then be used as a transfer destination for funds in this currency.
  */
 @property (nonatomic, copy, nullable) NSString *currency;
 

--- a/Stripe/PublicHeaders/STPCardParams.h
+++ b/Stripe/PublicHeaders/STPCardParams.h
@@ -1,0 +1,85 @@
+//
+//  STPCardParams.h
+//  Stripe
+//
+//  Created by Jack Flintermann on 10/4/15.
+//  Copyright © 2015 Stripe, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+/**
+ *  Representation of a user's credit card details. You can assemble these with information that your user enters and
+ *  then create Stripe tokens with them using an STPAPIClient. @see https://stripe.com/docs/api#cards
+ */
+@interface STPCardParams : NSObject
+
+/**
+ *  The card's number.
+ */
+@property (nonatomic, copy, nullable) NSString *number;
+
+/**
+ *  The card's expiration month.
+ */
+@property (nonatomic) NSUInteger expMonth;
+
+/**
+ *  The card's expiration year.
+ */
+@property (nonatomic) NSUInteger expYear;
+
+/**
+ *  The card's security code, found on the back. This will be nil for cards retrieved from the Stripe API.
+ */
+@property (nonatomic, copy, nullable) NSString *cvc;
+
+/**
+ *  The cardholder's name.
+ */
+@property (nonatomic, copy, nullable) NSString *name;
+
+/**
+ *  The cardholder's address.
+ */
+@property (nonatomic, copy, nullable) NSString *addressLine1;
+@property (nonatomic, copy, nullable) NSString *addressLine2;
+@property (nonatomic, copy, nullable) NSString *addressCity;
+@property (nonatomic, copy, nullable) NSString *addressState;
+@property (nonatomic, copy, nullable) NSString *addressZip;
+@property (nonatomic, copy, nullable) NSString *addressCountry;
+
+/**
+ *  This is only applicable when tokenizing debit cards to issue payouts to managed accounts. You should not set it otherwise. The card can then be used as a transfer destination for funds in this currency.
+ */
+@property (nonatomic, copy, nullable) NSString *currency;
+
+/**
+ *  Validate each field of the card.
+ *  @return whether or not that field is valid.
+ *  @deprecated use STPCardValidator instead.
+ */
+- (BOOL)validateNumber:(__nullable id * __nullable )ioValue
+                 error:(NSError * __nullable * __nullable )outError __attribute__((deprecated("Use STPCardValidator instead.")));
+- (BOOL)validateCvc:(__nullable id * __nullable )ioValue
+              error:(NSError * __nullable * __nullable )outError __attribute__((deprecated("Use STPCardValidator instead.")));
+- (BOOL)validateExpMonth:(__nullable  id * __nullable )ioValue
+                   error:(NSError * __nullable * __nullable )outError __attribute__((deprecated("Use STPCardValidator instead.")));
+- (BOOL)validateExpYear:(__nullable id * __nullable)ioValue
+                  error:(NSError * __nullable * __nullable )outError __attribute__((deprecated("Use STPCardValidator instead.")));
+
+/**
+ *  This validates a fully populated card to check for all errors, including ones that come about
+ *  from the interaction of more than one property. It will also do all the validations on individual
+ *  properties, so if you only want to call one method on your card to validate it after setting all the
+ *  properties, call this one
+ *
+ *  @param outError a pointer to an NSError that, after calling this method, will be populated with an error if the card is not valid. See StripeError.h for
+ possible values
+ *
+ *  @return whether or not the card is valid.
+ *  @deprecated use STPCardValidator instead.
+ */
+- (BOOL)validateCardReturningError:(NSError * __nullable * __nullable)outError __attribute__((deprecated("Use STPCardValidator instead.")));
+
+@end

--- a/Stripe/PublicHeaders/STPCardParams.h
+++ b/Stripe/PublicHeaders/STPCardParams.h
@@ -20,6 +20,11 @@
 @property (nonatomic, copy, nullable) NSString *number;
 
 /**
+ *  The last 4 digits of the card's number, if it's been set, otherwise nil.
+ */
+- (nullable NSString *)last4;
+
+/**
  *  The card's expiration month.
  */
 @property (nonatomic) NSUInteger expMonth;

--- a/Stripe/PublicHeaders/STPCardParams.h
+++ b/Stripe/PublicHeaders/STPCardParams.h
@@ -7,12 +7,13 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "STPFormEncodable.h"
 
 /**
  *  Representation of a user's credit card details. You can assemble these with information that your user enters and
  *  then create Stripe tokens with them using an STPAPIClient. @see https://stripe.com/docs/api#cards
  */
-@interface STPCardParams : NSObject
+@interface STPCardParams : NSObject<STPFormEncodable>
 
 /**
  *  The card's number.

--- a/Stripe/PublicHeaders/STPFormEncodable.h
+++ b/Stripe/PublicHeaders/STPFormEncodable.h
@@ -1,0 +1,16 @@
+//
+//  STPFormEncodable.h
+//  Stripe
+//
+//  Created by Jack Flintermann on 10/14/15.
+//  Copyright © 2015 Stripe, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@protocol STPFormEncodable <NSObject>
+
+- (NSString *)rootObjectName;
+- (NSDictionary *)propertyNamesToFormFieldNamesMapping;
+
+@end

--- a/Stripe/PublicHeaders/STPToken.h
+++ b/Stripe/PublicHeaders/STPToken.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "STPAPIResponseDecodable.h"
 
 @class STPCard;
 @class STPBankAccount;
@@ -14,7 +15,7 @@
 /**
  *  A token returned from submitting payment details to the Stripe API. You should not have to instantiate one of these directly.
  */
-@interface STPToken : NSObject
+@interface STPToken : NSObject<STPAPIResponseDecodable>
 
 /**
  *  You cannot directly instantiate an STPToken. You should only use one that has been returned from an STPAPIClient callback.
@@ -47,25 +48,5 @@
  *  When the token was created.
  */
 @property (nonatomic, readonly, nullable) NSDate *created;
-
-typedef void (^STPCardServerResponseCallback)(NSURLResponse * __nullable response, NSData * __nullable data, NSError * __nullable error);
-
-/**
- *  Form-encode the token and post those parameters to your backend URL.
- *
- *  @param url     the URL to upload the token details to
- *  @param params  optional parameters to additionally include in the POST body
- *  @param handler code to execute with your server's response
- *  @deprecated    you should write your own networking code to talk to your server.
- */
-- (void)postToURL:(nonnull NSURL *)url withParams:(nullable NSDictionary *)params completion:(nullable STPCardServerResponseCallback)handler __attribute((deprecated));
-
-@end
-
-// This method is used internally by Stripe to deserialize API responses and exposed here for convenience and testing purposes only. You should not use it in
-// your own code.
-@interface STPToken (PrivateMethods)
-
-- (nonnull instancetype)initWithAttributeDictionary:(nonnull NSDictionary *)attributeDictionary;
 
 @end

--- a/Stripe/PublicHeaders/Stripe.h
+++ b/Stripe/PublicHeaders/Stripe.h
@@ -8,6 +8,7 @@
 
 #import "STPAPIClient.h"
 #import "StripeError.h"
+#import "STPBankAccountParams.h"
 #import "STPBankAccount.h"
 #import "STPCardBrand.h"
 #import "STPCardParams.h"

--- a/Stripe/PublicHeaders/Stripe.h
+++ b/Stripe/PublicHeaders/Stripe.h
@@ -10,6 +10,7 @@
 #import "StripeError.h"
 #import "STPBankAccount.h"
 #import "STPCardBrand.h"
+#import "STPCardParams.h"
 #import "STPCard.h"
 #import "STPCardValidationState.h"
 #import "STPCardValidator.h"

--- a/Stripe/PublicHeaders/UI/STPPaymentCardTextField.h
+++ b/Stripe/PublicHeaders/UI/STPPaymentCardTextField.h
@@ -157,7 +157,7 @@
 /**
  *  Convenience method to create a STPCard from the currently entered information. Will return nil if not valid.
  */
-@property(nonatomic, readonly, nullable) STPCard *card;
+@property(nonatomic, readonly, nullable) STPCardParams *card;
 
 @end
 

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -234,7 +234,8 @@ static NSString *STPDefaultPublishableKey;
 @implementation STPAPIClient (BankAccounts)
 
 - (void)createTokenWithBankAccount:(STPBankAccountParams *)bankAccount completion:(STPCompletionBlock)completion {
-    [self createTokenWithData:[STPFormEncoder formEncodedDataForBankAccountParams:bankAccount] completion:completion];
+    NSData *data = [STPFormEncoder formEncodedDataForObject:bankAccount];
+    [self createTokenWithData:data completion:completion];
 }
 
 @end
@@ -243,7 +244,8 @@ static NSString *STPDefaultPublishableKey;
 @implementation STPAPIClient (CreditCards)
 
 - (void)createTokenWithCard:(STPCard *)card completion:(STPCompletionBlock)completion {
-    [self createTokenWithData:[STPFormEncoder formEncodedDataForCardParams:card] completion:completion];
+    NSData *data = [STPFormEncoder formEncodedDataForObject:card];
+    [self createTokenWithData:data completion:completion];
 }
 
 @end

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -243,7 +243,7 @@ static NSString *STPDefaultPublishableKey;
 @implementation STPAPIClient (CreditCards)
 
 - (void)createTokenWithCard:(STPCard *)card completion:(STPCompletionBlock)completion {
-    [self createTokenWithData:[STPFormEncoder formEncodedDataForCard:card] completion:completion];
+    [self createTokenWithData:[STPFormEncoder formEncodedDataForCardParams:card] completion:completion];
 }
 
 @end

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -233,8 +233,8 @@ static NSString *STPDefaultPublishableKey;
 #pragma mark - Bank Accounts
 @implementation STPAPIClient (BankAccounts)
 
-- (void)createTokenWithBankAccount:(STPBankAccount *)bankAccount completion:(STPCompletionBlock)completion {
-    [self createTokenWithData:[STPFormEncoder formEncodedDataForBankAccount:bankAccount] completion:completion];
+- (void)createTokenWithBankAccount:(STPBankAccountParams *)bankAccount completion:(STPCompletionBlock)completion {
+    [self createTokenWithData:[STPFormEncoder formEncodedDataForBankAccountParams:bankAccount] completion:completion];
 }
 
 @end

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -108,7 +108,8 @@ static NSString *STPDefaultPublishableKey;
                                      NSError *error = [[NSError alloc] initWithDomain:StripeDomain code:STPAPIError userInfo:userInfo];
                                      completion(nil, error);
                                  } else if ([(NSHTTPURLResponse *)response statusCode] == 200) {
-                                     completion([[STPToken alloc] initWithAttributeDictionary:jsonDictionary], nil);
+                                     STPToken *token = [STPToken decodedObjectFromAPIResponse:jsonDictionary];
+                                     completion(token, nil);
                                  } else {
                                      completion(nil, [self.class errorFromStripeResponse:jsonDictionary]);
                                  }

--- a/Stripe/STPBankAccount.m
+++ b/Stripe/STPBankAccount.m
@@ -49,31 +49,26 @@
     return [self.bankAccountId isEqualToString:bankAccount.bankAccountId];
 }
 
-@end
+#pragma mark STPAPIResponseDecodable
 
-@implementation STPBankAccount (PrivateMethods)
-
-- (instancetype)initWithAttributeDictionary:(NSDictionary *)attributeDictionary {
-    self = [self init];
-    if (self) {
-        // sanitize NSNull
-        NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
-        [attributeDictionary enumerateKeysAndObjectsUsingBlock:^(id key, id obj, __unused BOOL *stop) {
-            if (obj != [NSNull null]) {
-                dictionary[key] = obj;
-            }
-        }];
-
-        _bankAccountId = dictionary[@"id"];
-        _last4 = dictionary[@"last4"];
-        _bankName = dictionary[@"bank_name"];
-        [self setCountry:dictionary[@"country"]];
-        _fingerprint = dictionary[@"fingerprint"];
-        [self setCurrency:dictionary[@"currency"]];
-        _validated = [dictionary[@"validated"] boolValue];
-        _disabled = [dictionary[@"disabled"] boolValue];
-    }
-    return self;
++ (instancetype)decodedObjectFromAPIResponse:(NSDictionary *)response {
+    STPBankAccount *bankAccount = [STPBankAccount new];
+    NSMutableDictionary *dict = [NSMutableDictionary dictionary];
+    [response enumerateKeysAndObjectsUsingBlock:^(id key, id obj, __unused BOOL *stop) {
+        if (obj != [NSNull null]) {
+            dict[key] = obj;
+        }
+    }];
+    
+    bankAccount.bankAccountId = dict[@"id"];
+    bankAccount.last4 = dict[@"last4"];
+    bankAccount.bankName = dict[@"bank_name"];
+    bankAccount.country = dict[@"country"];
+    bankAccount.fingerprint = dict[@"fingerprint"];
+    bankAccount.currency = dict[@"currency"];
+    bankAccount.validated = [dict[@"validated"] boolValue];
+    bankAccount.disabled = [dict[@"disabled"] boolValue];
+    return bankAccount;
 }
 
 @end

--- a/Stripe/STPBankAccount.m
+++ b/Stripe/STPBankAccount.m
@@ -21,6 +21,12 @@
 
 @implementation STPBankAccount
 
+@synthesize routingNumber, country, currency;
+
+- (void)setAccountNumber:(NSString *)accountNumber {
+    [super setAccountNumber:accountNumber];
+}
+
 #pragma mark - Getters
 
 - (NSString *)last4 {
@@ -40,7 +46,7 @@
 }
 
 - (NSUInteger)hash {
-    return [self.fingerprint hash];
+    return [self.bankAccountId hash];
 }
 
 - (BOOL)isEqualToBankAccount:(STPBankAccount *)bankAccount {
@@ -51,11 +57,8 @@
     if (!bankAccount || ![bankAccount isKindOfClass:self.class]) {
         return NO;
     }
-
-    return [self.accountNumber ?: @"" isEqualToString:bankAccount.accountNumber ?: @""] &&
-           [self.routingNumber ?: @"" isEqualToString:bankAccount.routingNumber ?: @""] &&
-           [self.country ?: @"" isEqualToString:bankAccount.country ?: @""] && [self.last4 ?: @"" isEqualToString:bankAccount.last4 ?: @""] &&
-           [self.bankName ?: @"" isEqualToString:bankAccount.bankName ?: @""] && [self.currency ?: @"" isEqualToString:bankAccount.currency ?: @""];
+    
+    return [self.bankAccountId isEqualToString:bankAccount.bankAccountId];
 }
 
 @end
@@ -76,9 +79,9 @@
         _bankAccountId = dictionary[@"id"];
         _last4 = dictionary[@"last4"];
         _bankName = dictionary[@"bank_name"];
-        _country = dictionary[@"country"];
+        [self setCountry:dictionary[@"country"]];
         _fingerprint = dictionary[@"fingerprint"];
-        _currency = dictionary[@"currency"];
+        [self setCurrency:dictionary[@"currency"]];
         _validated = [dictionary[@"validated"] boolValue];
         _disabled = [dictionary[@"disabled"] boolValue];
     }

--- a/Stripe/STPBankAccount.m
+++ b/Stripe/STPBankAccount.m
@@ -27,18 +27,6 @@
     [super setAccountNumber:accountNumber];
 }
 
-#pragma mark - Getters
-
-- (NSString *)last4 {
-    if (_last4) {
-        return _last4;
-    } else if (self.accountNumber && self.accountNumber.length >= 4) {
-        return [self.accountNumber substringFromIndex:(self.accountNumber.length - 4)];
-    } else {
-        return nil;
-    }
-}
-
 #pragma mark - Equality
 
 - (BOOL)isEqual:(STPBankAccount *)bankAccount {

--- a/Stripe/STPBankAccount.m
+++ b/Stripe/STPBankAccount.m
@@ -56,7 +56,7 @@
 #pragma mark STPAPIResponseDecodable
 
 + (instancetype)decodedObjectFromAPIResponse:(NSDictionary *)response {
-    STPBankAccount *bankAccount = [STPBankAccount new];
+    STPBankAccount *bankAccount = [self new];
     NSMutableDictionary *dict = [NSMutableDictionary dictionary];
     [response enumerateKeysAndObjectsUsingBlock:^(id key, id obj, __unused BOOL *stop) {
         if (obj != [NSNull null]) {

--- a/Stripe/STPBankAccount.m
+++ b/Stripe/STPBankAccount.m
@@ -27,6 +27,10 @@
     [super setAccountNumber:accountNumber];
 }
 
+- (NSString *)last4 {
+    return _last4 ?: [super last4];
+}
+
 #pragma mark - Equality
 
 - (BOOL)isEqual:(STPBankAccount *)bankAccount {

--- a/Stripe/STPBankAccountParams.m
+++ b/Stripe/STPBankAccountParams.m
@@ -1,0 +1,21 @@
+//
+//  STPBankAccountParams.m
+//  Stripe
+//
+//  Created by Jack Flintermann on 10/4/15.
+//  Copyright © 2015 Stripe, Inc. All rights reserved.
+//
+
+#import "STPBankAccountParams.h"
+
+@implementation STPBankAccountParams
+
+- (NSString *)last4 {
+    if (self.accountNumber && self.accountNumber.length >= 4) {
+        return [self.accountNumber substringFromIndex:(self.accountNumber.length - 4)];
+    } else {
+        return nil;
+    }
+}
+
+@end

--- a/Stripe/STPBankAccountParams.m
+++ b/Stripe/STPBankAccountParams.m
@@ -18,4 +18,17 @@
     }
 }
 
+- (NSString *)rootObjectName {
+    return @"bank_account";
+}
+
+- (NSDictionary *)propertyNamesToFormFieldNamesMapping {
+    return @{
+             @"accountNumber": @"account_number",
+             @"routingNumber": @"routing_number",
+             @"country": @"country",
+             @"currency": @"currency",
+             };
+}
+
 @end

--- a/Stripe/STPCard.m
+++ b/Stripe/STPCard.m
@@ -75,70 +75,62 @@
     return [self.cardId isEqualToString:other.cardId];
 }
 
-@end
-
-
-@implementation STPCard(PrivateMethods)
-
-- (instancetype)initWithAttributeDictionary:(NSDictionary *)attributeDictionary {
-    self = [self init];
-    
+#pragma mark STPAPIResponseDecodable
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
++ (instancetype)decodedObjectFromAPIResponse:(NSDictionary *)response {
+    STPCard *card = [STPCard new];
     NSMutableDictionary *dict = [NSMutableDictionary dictionary];
-    
-    [attributeDictionary enumerateKeysAndObjectsUsingBlock:^(id key, id obj, __unused BOOL *stop) {
+    [response enumerateKeysAndObjectsUsingBlock:^(id key, id obj, __unused BOOL *stop) {
         if (obj != [NSNull null]) {
             dict[key] = obj;
         }
     }];
     
-    if (self) {
-        _cardId = dict[@"id"];
-        [super setName:dict[@"name"]];
-        _last4 = dict[@"last4"];
-        _dynamicLast4 = dict[@"dynamic_last4"];
-        NSString *brand = dict[@"brand"] ?: dict[@"type"];
-        if ([brand isEqualToString:@"Visa"]) {
-            _brand = STPCardBrandVisa;
-        } else if ([brand isEqualToString:@"American Express"]) {
-            _brand = STPCardBrandAmex;
-        } else if ([brand isEqualToString:@"MasterCard"]) {
-            _brand = STPCardBrandMasterCard;
-        } else if ([brand isEqualToString:@"Discover"]) {
-            _brand = STPCardBrandDiscover;
-        } else if ([brand isEqualToString:@"JCB"]) {
-            _brand = STPCardBrandJCB;
-        } else if ([brand isEqualToString:@"Diners Club"]) {
-            _brand = STPCardBrandDinersClub;
-        } else {
-            _brand = STPCardBrandUnknown;
-        }
-        NSString *funding = dict[@"funding"];
-        if ([funding.lowercaseString isEqualToString:@"credit"]) {
-            _funding = STPCardFundingTypeCredit;
-        } else if ([funding.lowercaseString isEqualToString:@"debit"]) {
-            _funding = STPCardFundingTypeDebit;
-        } else if ([funding.lowercaseString isEqualToString:@"prepaid"]) {
-            _funding = STPCardFundingTypePrepaid;
-        } else {
-            _funding = STPCardFundingTypeOther;
-        }
-        _fingerprint = dict[@"fingerprint"];
-        _country = dict[@"country"];
-        self.currency = dict[@"currency"];
-        // Support both camelCase and snake_case keys
-        [super setExpMonth:[(dict[@"exp_month"] ?: dict[@"expMonth"])intValue]];
-        [super setExpYear:[(dict[@"exp_year"] ?: dict[@"expYear"])intValue]];
-        [super setAddressLine1:dict[@"address_line1"] ?: dict[@"addressLine1"]];
-        [super setAddressLine2:dict[@"address_line2"] ?: dict[@"addressLine2"]];
-        [super setAddressCity:dict[@"address_city"] ?: dict[@"addressCity"]];
-        [super setAddressState:dict[@"address_state"] ?: dict[@"addressState"]];
-        [super setAddressZip:dict[@"address_zip"] ?: dict[@"addressZip"]];
-        [super setAddressCountry:dict[@"address_country"] ?: dict[@"addressCountry"]];
+    card.cardId = dict[@"id"];
+    card.name = dict[@"name"];
+    card.last4 = dict[@"last4"];
+    card.dynamicLast4 = dict[@"dynamic_last4"];
+    NSString *brand = dict[@"brand"] ?: dict[@"type"];
+    if ([brand isEqualToString:@"Visa"]) {
+        card.brand = STPCardBrandVisa;
+    } else if ([brand isEqualToString:@"American Express"]) {
+        card.brand = STPCardBrandAmex;
+    } else if ([brand isEqualToString:@"MasterCard"]) {
+        card.brand = STPCardBrandMasterCard;
+    } else if ([brand isEqualToString:@"Discover"]) {
+        card.brand = STPCardBrandDiscover;
+    } else if ([brand isEqualToString:@"JCB"]) {
+        card.brand = STPCardBrandJCB;
+    } else if ([brand isEqualToString:@"Diners Club"]) {
+        card.brand = STPCardBrandDinersClub;
+    } else {
+        card.brand = STPCardBrandUnknown;
     }
-    
-    return self;
+    NSString *funding = dict[@"funding"];
+    if ([funding.lowercaseString isEqualToString:@"credit"]) {
+        card.funding = STPCardFundingTypeCredit;
+    } else if ([funding.lowercaseString isEqualToString:@"debit"]) {
+        card.funding = STPCardFundingTypeDebit;
+    } else if ([funding.lowercaseString isEqualToString:@"prepaid"]) {
+        card.funding = STPCardFundingTypePrepaid;
+    } else {
+        card.funding = STPCardFundingTypeOther;
+    }
+    card.fingerprint = dict[@"fingerprint"];
+    card.country = dict[@"country"];
+    card.currency = dict[@"currency"];
+    // Support both camelCase and snake_case keys
+    card.expMonth = [(dict[@"exp_month"] ?: dict[@"expMonth"])intValue];
+    card.expYear = [(dict[@"exp_year"] ?: dict[@"expYear"])intValue];
+    card.addressLine1 = dict[@"address_line1"] ?: dict[@"addressLine1"];
+    card.addressLine2 = dict[@"address_line2"] ?: dict[@"addressLine2"];
+    card.addressCity = dict[@"address_city"] ?: dict[@"addressCity"];
+    card.addressState = dict[@"address_state"] ?: dict[@"addressState"];
+    card.addressZip = dict[@"address_zip"] ?: dict[@"addressZip"];
+    card.addressCountry = dict[@"address_country"] ?: dict[@"addressCountry"];
+    return card;
 }
+#pragma clang diagnostic pop
 
 @end
-
-

--- a/Stripe/STPCard.m
+++ b/Stripe/STPCard.m
@@ -83,7 +83,7 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated"
 + (instancetype)decodedObjectFromAPIResponse:(NSDictionary *)response {
-    STPCard *card = [STPCard new];
+    STPCard *card = [self new];
     NSMutableDictionary *dict = [NSMutableDictionary dictionary];
     [response enumerateKeysAndObjectsUsingBlock:^(id key, id obj, __unused BOOL *stop) {
         if (obj != [NSNull null]) {

--- a/Stripe/STPCard.m
+++ b/Stripe/STPCard.m
@@ -36,6 +36,10 @@
     return self;
 }
 
+- (NSString *)last4 {
+    return _last4 ?: [super last4];
+}
+
 - (NSString *)type {
     switch (self.brand) {
     case STPCardBrandAmex:

--- a/Stripe/STPCardParams.m
+++ b/Stripe/STPCardParams.m
@@ -1,0 +1,164 @@
+//
+//  STPCardParams.m
+//  Stripe
+//
+//  Created by Jack Flintermann on 10/4/15.
+//  Copyright © 2015 Stripe, Inc. All rights reserved.
+//
+
+#import "STPCardParams.h"
+#import "STPCardValidator.h"
+#import "StripeError.h"
+
+@implementation STPCardParams
+
+- (NSString *)last4 {
+    if (self.number && self.number.length >= 4) {
+        return [self.number substringFromIndex:(self.number.length - 4)];
+    } else {
+        return nil;
+    }
+}
+
+- (BOOL)isEqual:(id)other {
+    return [self isEqualToCardParams:other];
+}
+
+- (NSUInteger)hash {
+    return [self.number hash];
+}
+
+- (BOOL)isEqualToCardParams:(STPCardParams *)other {
+    if (self == other) {
+        return YES;
+    }
+    
+    if (!other || ![other isKindOfClass:self.class]) {
+        return NO;
+    }
+    
+    return self.expMonth == other.expMonth && self.expYear == other.expYear && [self.number ?: @"" isEqualToString:other.number ?: @""] &&
+    [self.cvc ?: @"" isEqualToString:other.cvc ?: @""] && [self.name ?: @"" isEqualToString:other.name ?: @""] &&
+    [self.addressLine1 ?: @"" isEqualToString:other.addressLine1 ?: @""] && [self.addressLine2 ?: @"" isEqualToString:other.addressLine2 ?: @""] &&
+    [self.addressCity ?: @"" isEqualToString:other.addressCity ?: @""] && [self.addressState ?: @"" isEqualToString:other.addressState ?: @""] &&
+    [self.addressZip ?: @"" isEqualToString:other.addressZip ?: @""] && [self.addressCountry ?: @"" isEqualToString:other.addressCountry ?: @""];
+}
+
+- (BOOL)validateNumber:(id *)ioValue error:(NSError **)outError {
+    if (*ioValue == nil) {
+        return [self.class handleValidationErrorForParameter:@"number" error:outError];
+    }
+    NSString *ioValueString = (NSString *)*ioValue;
+    
+    if ([STPCardValidator validationStateForNumber:ioValueString validatingCardBrand:NO] != STPCardValidationStateValid) {
+        return [self.class handleValidationErrorForParameter:@"number" error:outError];
+    }
+    return YES;
+}
+
+- (BOOL)validateCvc:(id *)ioValue error:(NSError **)outError {
+    if (*ioValue == nil) {
+        return [self.class handleValidationErrorForParameter:@"number" error:outError];
+    }
+    NSString *ioValueString = (NSString *)*ioValue;
+    
+    STPCardBrand brand = [STPCardValidator brandForNumber:self.number];
+    
+    if ([STPCardValidator validationStateForCVC:ioValueString cardBrand:brand] != STPCardValidationStateValid) {
+        return [self.class handleValidationErrorForParameter:@"cvc" error:outError];
+    }
+    return YES;
+}
+
+- (BOOL)validateExpMonth:(id *)ioValue error:(NSError **)outError {
+    if (*ioValue == nil) {
+        return [self.class handleValidationErrorForParameter:@"expMonth" error:outError];
+    }
+    NSString *ioValueString = [(NSString *)*ioValue stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+    
+    if ([STPCardValidator validationStateForExpirationMonth:ioValueString] != STPCardValidationStateValid) {
+        return [self.class handleValidationErrorForParameter:@"expMonth" error:outError];
+    }
+    return YES;
+}
+
+- (BOOL)validateExpYear:(id *)ioValue error:(NSError **)outError {
+    if (*ioValue == nil) {
+        return [self.class handleValidationErrorForParameter:@"expYear" error:outError];
+    }
+    NSString *ioValueString = [(NSString *)*ioValue stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+    
+    NSString *monthString = [@(self.expMonth) stringValue];
+    if ([STPCardValidator validationStateForExpirationYear:ioValueString inMonth:monthString] != STPCardValidationStateValid) {
+        return [self.class handleValidationErrorForParameter:@"expYear" error:outError];
+    }
+    return YES;
+}
+
+- (BOOL)validateCardReturningError:(NSError **)outError {
+    // Order matters here
+    NSString *numberRef = [self number];
+    NSString *expMonthRef = [NSString stringWithFormat:@"%lu", (unsigned long)[self expMonth]];
+    NSString *expYearRef = [NSString stringWithFormat:@"%lu", (unsigned long)[self expYear]];
+    NSString *cvcRef = [self cvc];
+    
+    // Make sure expMonth, expYear, and number are set.  Validate CVC if it is provided
+    return [self validateNumber:&numberRef error:outError] && [self validateExpYear:&expYearRef error:outError] &&
+    [self validateExpMonth:&expMonthRef error:outError] && (cvcRef == nil || [self validateCvc:&cvcRef error:outError]);
+}
+
+#pragma mark Private Helpers
++ (BOOL)handleValidationErrorForParameter:(NSString *)parameter error:(NSError **)outError {
+    if (outError != nil) {
+        if ([parameter isEqualToString:@"number"]) {
+            *outError = [self createErrorWithMessage:STPCardErrorInvalidNumberUserMessage
+                                           parameter:parameter
+                                       cardErrorCode:STPInvalidNumber
+                                     devErrorMessage:@"Card number must be between 10 and 19 digits long and Luhn valid."];
+        } else if ([parameter isEqualToString:@"cvc"]) {
+            *outError = [self createErrorWithMessage:STPCardErrorInvalidCVCUserMessage
+                                           parameter:parameter
+                                       cardErrorCode:STPInvalidCVC
+                                     devErrorMessage:@"Card CVC must be numeric, 3 digits for Visa, Discover, MasterCard, JCB, and Discover cards, and 3 or 4 "
+                         @"digits for American Express cards."];
+        } else if ([parameter isEqualToString:@"expMonth"]) {
+            *outError = [self createErrorWithMessage:STPCardErrorInvalidExpMonthUserMessage
+                                           parameter:parameter
+                                       cardErrorCode:STPInvalidExpMonth
+                                     devErrorMessage:@"expMonth must be less than 13"];
+        } else if ([parameter isEqualToString:@"expYear"]) {
+            *outError = [self createErrorWithMessage:STPCardErrorInvalidExpYearUserMessage
+                                           parameter:parameter
+                                       cardErrorCode:STPInvalidExpYear
+                                     devErrorMessage:@"expYear must be this year or a year in the future"];
+        } else {
+            // This should not be possible since this is a private method so we
+            // know exactly how it is called.  We use STPAPIError for all errors
+            // that are unexpected within the bindings as well.
+            *outError = [[NSError alloc] initWithDomain:StripeDomain
+                                                   code:STPAPIError
+                                               userInfo:@{
+                                                          NSLocalizedDescriptionKey: STPUnexpectedError,
+                                                          STPErrorMessageKey: @"There was an error within the Stripe client library when trying to generate the "
+                                                          @"proper validation error. Contact support@stripe.com if you see this."
+                                                          }];
+        }
+    }
+    return NO;
+}
+
++ (NSError *)createErrorWithMessage:(NSString *)userMessage
+                          parameter:(NSString *)parameter
+                      cardErrorCode:(NSString *)cardErrorCode
+                    devErrorMessage:(NSString *)devMessage {
+    return [[NSError alloc] initWithDomain:StripeDomain
+                                      code:STPCardError
+                                  userInfo:@{
+                                             NSLocalizedDescriptionKey: userMessage,
+                                             STPErrorParameterKey: parameter,
+                                             STPCardErrorCodeKey: cardErrorCode,
+                                             STPErrorMessageKey: devMessage
+                                             }];
+}
+
+@end

--- a/Stripe/STPCardParams.m
+++ b/Stripe/STPCardParams.m
@@ -20,30 +20,6 @@
     }
 }
 
-- (BOOL)isEqual:(id)other {
-    return [self isEqualToCardParams:other];
-}
-
-- (NSUInteger)hash {
-    return [self.number hash];
-}
-
-- (BOOL)isEqualToCardParams:(STPCardParams *)other {
-    if (self == other) {
-        return YES;
-    }
-    
-    if (!other || ![other isKindOfClass:self.class]) {
-        return NO;
-    }
-    
-    return self.expMonth == other.expMonth && self.expYear == other.expYear && [self.number ?: @"" isEqualToString:other.number ?: @""] &&
-    [self.cvc ?: @"" isEqualToString:other.cvc ?: @""] && [self.name ?: @"" isEqualToString:other.name ?: @""] &&
-    [self.addressLine1 ?: @"" isEqualToString:other.addressLine1 ?: @""] && [self.addressLine2 ?: @"" isEqualToString:other.addressLine2 ?: @""] &&
-    [self.addressCity ?: @"" isEqualToString:other.addressCity ?: @""] && [self.addressState ?: @"" isEqualToString:other.addressState ?: @""] &&
-    [self.addressZip ?: @"" isEqualToString:other.addressZip ?: @""] && [self.addressCountry ?: @"" isEqualToString:other.addressCountry ?: @""];
-}
-
 - (BOOL)validateNumber:(id *)ioValue error:(NSError **)outError {
     if (*ioValue == nil) {
         return [self.class handleValidationErrorForParameter:@"number" error:outError];

--- a/Stripe/STPCardParams.m
+++ b/Stripe/STPCardParams.m
@@ -137,4 +137,27 @@
                                              }];
 }
 
+#pragma mark - STPFormEncodable
+
+- (NSString *)rootObjectName {
+    return @"card";
+}
+
+- (NSDictionary *)propertyNamesToFormFieldNamesMapping {
+    return @{
+             @"number": @"number",
+             @"cvc": @"cvc",
+             @"name": @"name",
+             @"addressLine1": @"address_line1",
+             @"addressLine2": @"address_line2",
+             @"addressCity": @"address_city",
+             @"addressState": @"address_state",
+             @"addressZip": @"address_zip",
+             @"addressCountry": @"address_country",
+             @"expMonth": @"exp_month",
+             @"expYear": @"exp_year",
+             @"currency": @"currency",
+             };
+}
+
 @end

--- a/Stripe/STPFormEncoder.h
+++ b/Stripe/STPFormEncoder.h
@@ -8,11 +8,11 @@
 
 #import <Foundation/Foundation.h>
 
-@class STPBankAccount, STPCardParams;
+@class STPCardParams, STPBankAccountParams;
 
 @interface STPFormEncoder : NSObject
 
-+ (nonnull NSData *)formEncodedDataForBankAccount:(nonnull STPBankAccount *)bankAccount;
++ (nonnull NSData *)formEncodedDataForBankAccountParams:(nonnull STPBankAccountParams *)bankAccount;
 
 + (nonnull NSData *)formEncodedDataForCardParams:(nonnull STPCardParams *)card;
 

--- a/Stripe/STPFormEncoder.h
+++ b/Stripe/STPFormEncoder.h
@@ -8,13 +8,13 @@
 
 #import <Foundation/Foundation.h>
 
-@class STPBankAccount, STPCard;
+@class STPBankAccount, STPCardParams;
 
 @interface STPFormEncoder : NSObject
 
 + (nonnull NSData *)formEncodedDataForBankAccount:(nonnull STPBankAccount *)bankAccount;
 
-+ (nonnull NSData *)formEncodedDataForCard:(nonnull STPCard *)card;
++ (nonnull NSData *)formEncodedDataForCardParams:(nonnull STPCardParams *)card;
 
 + (nonnull NSString *)stringByURLEncoding:(nonnull NSString *)string;
 

--- a/Stripe/STPFormEncoder.h
+++ b/Stripe/STPFormEncoder.h
@@ -9,12 +9,11 @@
 #import <Foundation/Foundation.h>
 
 @class STPCardParams, STPBankAccountParams;
+@protocol STPFormEncodable;
 
 @interface STPFormEncoder : NSObject
 
-+ (nonnull NSData *)formEncodedDataForBankAccountParams:(nonnull STPBankAccountParams *)bankAccount;
-
-+ (nonnull NSData *)formEncodedDataForCardParams:(nonnull STPCardParams *)card;
++ (nonnull NSData *)formEncodedDataForObject:(nonnull NSObject<STPFormEncodable> *)object;
 
 + (nonnull NSString *)stringByURLEncoding:(nonnull NSString *)string;
 

--- a/Stripe/STPFormEncoder.m
+++ b/Stripe/STPFormEncoder.m
@@ -7,12 +7,12 @@
 //
 
 #import "STPFormEncoder.h"
-#import "STPBankAccount.h"
+#import "STPBankAccountParams.h"
 #import "STPCardParams.h"
 
 @implementation STPFormEncoder
 
-+ (NSData *)formEncodedDataForBankAccount:(STPBankAccount *)bankAccount {
++ (NSData *)formEncodedDataForBankAccountParams:(STPBankAccountParams *)bankAccount {
     NSCAssert(bankAccount != nil, @"Cannot create a token with a nil bank account.");
     NSMutableDictionary *params = [NSMutableDictionary dictionary];
     NSMutableArray *parts = [NSMutableArray array];

--- a/Stripe/STPFormEncoder.m
+++ b/Stripe/STPFormEncoder.m
@@ -8,7 +8,7 @@
 
 #import "STPFormEncoder.h"
 #import "STPBankAccount.h"
-#import "STPCard.h"
+#import "STPCardParams.h"
 
 @implementation STPFormEncoder
 
@@ -37,7 +37,7 @@
     return [[parts componentsJoinedByString:@"&"] dataUsingEncoding:NSUTF8StringEncoding];
 }
 
-+ (NSData *)formEncodedDataForCard:(STPCard *)card {
++ (NSData *)formEncodedDataForCardParams:(STPCardParams *)card {
     NSCAssert(card != nil, @"Cannot create a token with a nil card.");
     NSMutableDictionary *params = [NSMutableDictionary dictionary];
     

--- a/Stripe/STPFormEncoder.m
+++ b/Stripe/STPFormEncoder.m
@@ -9,82 +9,16 @@
 #import "STPFormEncoder.h"
 #import "STPBankAccountParams.h"
 #import "STPCardParams.h"
+#import "STPFormEncodable.h"
 
 @implementation STPFormEncoder
 
-+ (NSData *)formEncodedDataForBankAccountParams:(STPBankAccountParams *)bankAccount {
-    NSCAssert(bankAccount != nil, @"Cannot create a token with a nil bank account.");
-    NSMutableDictionary *params = [NSMutableDictionary dictionary];
++ (nonnull NSData *)formEncodedDataForObject:(nonnull NSObject<STPFormEncodable> *)object {
     NSMutableArray *parts = [NSMutableArray array];
-    
-    if (bankAccount.accountNumber) {
-        params[@"account_number"] = bankAccount.accountNumber;
-    }
-    if (bankAccount.routingNumber) {
-        params[@"routing_number"] = bankAccount.routingNumber;
-    }
-    if (bankAccount.country) {
-        params[@"country"] = bankAccount.country;
-    }
-    if (bankAccount.currency) {
-        params[@"currency"] = bankAccount.currency;
-    }
-    
-    [params enumerateKeysAndObjectsUsingBlock:^(id key, id val, __unused BOOL *stop) {
-        [parts addObject:[NSString stringWithFormat:@"bank_account[%@]=%@", key, [self.class stringByURLEncoding:val]]];
+    [[object propertyNamesToFormFieldNamesMapping] enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull propertyName, NSString *  _Nonnull formFieldName, __unused BOOL * _Nonnull stop) {
+        NSString *formFieldValue = [[object valueForKey:propertyName] description];
+        [parts addObject:[NSString stringWithFormat:@"%@[%@]=%@", [object rootObjectName], formFieldName, [self.class stringByURLEncoding:formFieldValue]]];
     }];
-    
-    return [[parts componentsJoinedByString:@"&"] dataUsingEncoding:NSUTF8StringEncoding];
-}
-
-+ (NSData *)formEncodedDataForCardParams:(STPCardParams *)card {
-    NSCAssert(card != nil, @"Cannot create a token with a nil card.");
-    NSMutableDictionary *params = [NSMutableDictionary dictionary];
-    
-    if (card.number) {
-        params[@"number"] = card.number;
-    }
-    if (card.cvc) {
-        params[@"cvc"] = card.cvc;
-    }
-    if (card.name) {
-        params[@"name"] = card.name;
-    }
-    if (card.addressLine1) {
-        params[@"address_line1"] = card.addressLine1;
-    }
-    if (card.addressLine2) {
-        params[@"address_line2"] = card.addressLine2;
-    }
-    if (card.addressCity) {
-        params[@"address_city"] = card.addressCity;
-    }
-    if (card.addressState) {
-        params[@"address_state"] = card.addressState;
-    }
-    if (card.addressZip) {
-        params[@"address_zip"] = card.addressZip;
-    }
-    if (card.addressCountry) {
-        params[@"address_country"] = card.addressCountry;
-    }
-    if (card.expMonth) {
-        params[@"exp_month"] = @(card.expMonth).stringValue;
-    }
-    if (card.expYear) {
-        params[@"exp_year"] = @(card.expYear).stringValue;
-    }
-    if (card.currency) {
-        params[@"currency"] = card.currency;
-    }
-    
-    NSMutableArray *parts = [NSMutableArray array];
-    
-    [params enumerateKeysAndObjectsUsingBlock:^(id key, id val, __unused BOOL *stop) {
-        [parts addObject:[NSString stringWithFormat:@"card[%@]=%@", key, [self.class stringByURLEncoding:val]]];
-        
-    }];
-    
     return [[parts componentsJoinedByString:@"&"] dataUsingEncoding:NSUTF8StringEncoding];
 }
 

--- a/Stripe/STPFormEncoder.m
+++ b/Stripe/STPFormEncoder.m
@@ -17,7 +17,9 @@
     NSMutableArray *parts = [NSMutableArray array];
     [[object propertyNamesToFormFieldNamesMapping] enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull propertyName, NSString *  _Nonnull formFieldName, __unused BOOL * _Nonnull stop) {
         NSString *formFieldValue = [[object valueForKey:propertyName] description];
-        [parts addObject:[NSString stringWithFormat:@"%@[%@]=%@", [object rootObjectName], formFieldName, [self.class stringByURLEncoding:formFieldValue]]];
+        if (formFieldValue) {
+            [parts addObject:[NSString stringWithFormat:@"%@[%@]=%@", [object rootObjectName], formFieldName, [self.class stringByURLEncoding:formFieldValue]]];
+        }
     }];
     return [[parts componentsJoinedByString:@"&"] dataUsingEncoding:NSUTF8StringEncoding];
 }

--- a/Stripe/STPToken.m
+++ b/Stripe/STPToken.m
@@ -59,7 +59,7 @@
 #pragma mark STPAPIResponseDecodable
 
 + (instancetype)decodedObjectFromAPIResponse:(NSDictionary *)response {
-    STPToken *token = [STPToken new];
+    STPToken *token = [self new];
     NSMutableDictionary *dict = [NSMutableDictionary dictionary];
     [response enumerateKeysAndObjectsUsingBlock:^(id key, id obj, __unused BOOL *stop) {
         if (obj != [NSNull null]) {

--- a/Stripe/STPToken.m
+++ b/Stripe/STPToken.m
@@ -10,47 +10,21 @@
 #import "STPCard.h"
 #import "STPBankAccount.h"
 
+@interface STPToken()
+@property (nonatomic, nonnull) NSString *tokenId;
+@property (nonatomic) BOOL livemode;
+@property (nonatomic, nullable) STPCard *card;
+@property (nonatomic, nullable) STPBankAccount *bankAccount;
+@property (nonatomic, nullable) NSDate *created;
+@end
+
 @implementation STPToken
-
-- (instancetype)initWithAttributeDictionary:(NSDictionary *)attributeDictionary {
-    self = [super init];
-
-    if (self) {
-        _tokenId = attributeDictionary[@"id"] ?: @"";
-        _livemode = [attributeDictionary[@"livemode"] boolValue];
-        _created = [NSDate dateWithTimeIntervalSince1970:[attributeDictionary[@"created"] doubleValue]];
-
-        NSDictionary *cardDictionary = attributeDictionary[@"card"];
-        if (cardDictionary) {
-            _card = [[STPCard alloc] initWithAttributeDictionary:cardDictionary];
-        }
-
-        NSDictionary *bankAccountDictionary = attributeDictionary[@"bank_account"];
-        if (bankAccountDictionary) {
-            _bankAccount = [[STPBankAccount alloc] initWithAttributeDictionary:bankAccountDictionary];
-        }
-    }
-
-    return self;
-}
 
 - (NSString *)description {
     NSString *token = self.tokenId ?: @"Unknown token";
     NSString *livemode = self.livemode ? @"live mode" : @"test mode";
 
     return [NSString stringWithFormat:@"%@ (%@)", token, livemode];
-}
-
-- (void)postToURL:(NSURL *)url withParams:(NSMutableDictionary *)params completion:(STPCardServerResponseCallback)handler {
-    NSMutableString *body = [NSMutableString stringWithFormat:@"stripeToken=%@", self.tokenId];
-
-    [params enumerateKeysAndObjectsUsingBlock:^(id key, id obj, __unused BOOL *stop) { [body appendFormat:@"&%@=%@", key, obj]; }];
-
-    NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url];
-    request.HTTPMethod = @"POST";
-    request.HTTPBody = [body dataUsingEncoding:NSUTF8StringEncoding];
-
-    [NSURLConnection sendAsynchronousRequest:request queue:[NSOperationQueue mainQueue] completionHandler:handler];
 }
 
 - (BOOL)isEqual:(id)object {
@@ -80,6 +54,33 @@
 
     return self.livemode == object.livemode && [self.tokenId isEqualToString:object.tokenId] && [self.created isEqualToDate:object.created] &&
            [self.card isEqual:object.card] && [self.tokenId isEqualToString:object.tokenId] && [self.created isEqualToDate:object.created];
+}
+
+#pragma mark STPAPIResponseDecodable
+
++ (instancetype)decodedObjectFromAPIResponse:(NSDictionary *)response {
+    STPToken *token = [STPToken new];
+    NSMutableDictionary *dict = [NSMutableDictionary dictionary];
+    [response enumerateKeysAndObjectsUsingBlock:^(id key, id obj, __unused BOOL *stop) {
+        if (obj != [NSNull null]) {
+            dict[key] = obj;
+        }
+    }];
+    
+    token.tokenId = dict[@"id"] ?: @"";
+    token.livemode = [dict[@"livemode"] boolValue];
+    token.created = [NSDate dateWithTimeIntervalSince1970:[dict[@"created"] doubleValue]];
+    
+    NSDictionary *cardDictionary = dict[@"card"];
+    if (cardDictionary) {
+        token.card = [STPCard decodedObjectFromAPIResponse:cardDictionary];
+    }
+    
+    NSDictionary *bankAccountDictionary = dict[@"bank_account"];
+    if (bankAccountDictionary) {
+        token.bankAccount = [STPBankAccount decodedObjectFromAPIResponse:bankAccountDictionary];
+    }
+    return token;
 }
 
 @end

--- a/Stripe/UI/STPPaymentCardTextField.m
+++ b/Stripe/UI/STPPaymentCardTextField.m
@@ -384,10 +384,10 @@ CGFloat const STPPaymentCardTextFieldDefaultPadding = 10;
     return self.viewModel.cvc;
 }
 
-- (STPCard *)card {
+- (STPCardParams *)card {
     if (!self.isValid) { return nil; }
     
-    STPCard *c = [[STPCard alloc] init];
+    STPCardParams *c = [[STPCardParams alloc] init];
     c.number = self.cardNumber;
     c.expMonth = self.expirationMonth;
     c.expYear = self.expirationYear;

--- a/Tests/Tests/STPBankAccountFunctionalTest.m
+++ b/Tests/Tests/STPBankAccountFunctionalTest.m
@@ -19,7 +19,7 @@
 @implementation STPBankAccountFunctionalTest
 
 - (void)testCreateAndRetreiveBankAccountToken {
-    STPBankAccount *bankAccount = [[STPBankAccount alloc] init];
+    STPBankAccountParams *bankAccount = [[STPBankAccountParams alloc] init];
     bankAccount.accountNumber = @"000123456789";
     bankAccount.routingNumber = @"110000000";
     bankAccount.country = @"US";
@@ -43,7 +43,7 @@
 }
 
 - (void)testInvalidKey {
-    STPBankAccount *bankAccount = [[STPBankAccount alloc] init];
+    STPBankAccountParams *bankAccount = [[STPBankAccountParams alloc] init];
     bankAccount.accountNumber = @"000123456789";
     bankAccount.routingNumber = @"110000000";
     bankAccount.country = @"US";

--- a/Tests/Tests/STPBankAccountTest.m
+++ b/Tests/Tests/STPBankAccountTest.m
@@ -18,7 +18,7 @@
 @implementation STPBankAccountTest
 
 - (void)setUp {
-    _bankAccount = [[STPBankAccount alloc] init];
+    _bankAccount = [[STPBankAccountParams alloc] init];
 }
 
 #pragma mark - initWithAttributeDictionary: Tests
@@ -53,7 +53,7 @@
     NSDictionary *attributes = [self completeAttributeDictionary];
     STPBankAccount *bankAccountWithAttributes = [[STPBankAccount alloc] initWithAttributeDictionary:attributes];
 
-    NSData *encoded = [STPFormEncoder formEncodedDataForBankAccountParams:bankAccountWithAttributes];
+    NSData *encoded = [STPFormEncoder formEncodedDataForObject:bankAccountWithAttributes];
     NSString *formData = [[NSString alloc] initWithData:encoded encoding:NSUTF8StringEncoding];
 
     NSArray *parts = [formData componentsSeparatedByString:@"&"];

--- a/Tests/Tests/STPBankAccountTest.m
+++ b/Tests/Tests/STPBankAccountTest.m
@@ -12,7 +12,7 @@
 #import "STPBankAccount.h"
 
 @interface STPBankAccountTest : XCTestCase
-@property (nonatomic) STPBankAccount *bankAccount;
+@property (nonatomic) STPBankAccountParams *bankAccount;
 @end
 
 @implementation STPBankAccountTest
@@ -53,7 +53,7 @@
     NSDictionary *attributes = [self completeAttributeDictionary];
     STPBankAccount *bankAccountWithAttributes = [[STPBankAccount alloc] initWithAttributeDictionary:attributes];
 
-    NSData *encoded = [STPFormEncoder formEncodedDataForBankAccount:bankAccountWithAttributes];
+    NSData *encoded = [STPFormEncoder formEncodedDataForBankAccountParams:bankAccountWithAttributes];
     NSString *formData = [[NSString alloc] initWithData:encoded encoding:NSUTF8StringEncoding];
 
     NSArray *parts = [formData componentsSeparatedByString:@"&"];
@@ -111,9 +111,6 @@
 
     XCTAssertEqualObjects(bankAccount1, bankAccount1, @"bank account should equal itself");
     XCTAssertEqualObjects(bankAccount1, bankAccount2, @"bank account with equal data should be equal");
-
-    bankAccount1.accountNumber = @"1234";
-    XCTAssertNotEqualObjects(bankAccount1, bankAccount2, @"bank accounts should not match");
 }
 
 @end

--- a/Tests/Tests/STPBankAccountTest.m
+++ b/Tests/Tests/STPBankAccountTest.m
@@ -37,7 +37,7 @@
 }
 
 - (void)testInitializingBankAccountWithAttributeDictionary {
-    STPBankAccount *bankAccountWithAttributes = [[STPBankAccount alloc] initWithAttributeDictionary:[self completeAttributeDictionary]];
+    STPBankAccount *bankAccountWithAttributes = [STPBankAccount decodedObjectFromAPIResponse:[self completeAttributeDictionary]];
 
     XCTAssertEqualObjects([bankAccountWithAttributes bankAccountId], @"something", @"bankAccountId is set correctly");
     XCTAssertEqualObjects([bankAccountWithAttributes last4], @"6789", @"last4 is set correctly");
@@ -51,7 +51,7 @@
 
 - (void)testFormEncode {
     NSDictionary *attributes = [self completeAttributeDictionary];
-    STPBankAccount *bankAccountWithAttributes = [[STPBankAccount alloc] initWithAttributeDictionary:attributes];
+    STPBankAccount *bankAccountWithAttributes = [STPBankAccount decodedObjectFromAPIResponse:attributes];
 
     NSData *encoded = [STPFormEncoder formEncodedDataForObject:bankAccountWithAttributes];
     NSString *formData = [[NSString alloc] initWithData:encoded encoding:NSUTF8StringEncoding];
@@ -106,8 +106,8 @@
 #pragma mark - Equality Tests
 
 - (void)testBankAccountEquals {
-    STPBankAccount *bankAccount1 = [[STPBankAccount alloc] initWithAttributeDictionary:[self completeAttributeDictionary]];
-    STPBankAccount *bankAccount2 = [[STPBankAccount alloc] initWithAttributeDictionary:[self completeAttributeDictionary]];
+    STPBankAccount *bankAccount1 = [STPBankAccount decodedObjectFromAPIResponse:[self completeAttributeDictionary]];
+    STPBankAccount *bankAccount2 = [STPBankAccount decodedObjectFromAPIResponse:[self completeAttributeDictionary]];
 
     XCTAssertEqualObjects(bankAccount1, bankAccount1, @"bank account should equal itself");
     XCTAssertEqualObjects(bankAccount1, bankAccount2, @"bank account with equal data should be equal");

--- a/Tests/Tests/STPBankAccountTest.m
+++ b/Tests/Tests/STPBankAccountTest.m
@@ -18,7 +18,7 @@
 @implementation STPBankAccountTest
 
 - (void)setUp {
-    _bankAccount = [[STPBankAccountParams alloc] init];
+    _bankAccount = [[STPBankAccount alloc] init];
 }
 
 - (NSDictionary *)completeAttributeDictionary {

--- a/Tests/Tests/STPBankAccountTest.m
+++ b/Tests/Tests/STPBankAccountTest.m
@@ -21,8 +21,6 @@
     _bankAccount = [[STPBankAccountParams alloc] init];
 }
 
-#pragma mark - initWithAttributeDictionary: Tests
-
 - (NSDictionary *)completeAttributeDictionary {
     return @{
         @"id": @"something",

--- a/Tests/Tests/STPCardFunctionalTest.m
+++ b/Tests/Tests/STPCardFunctionalTest.m
@@ -16,7 +16,7 @@
 @implementation STPCardFunctionalTest
 
 - (void)testCreateCardToken {
-    STPCard *card = [[STPCard alloc] init];
+    STPCardParams *card = [[STPCardParams alloc] init];
 
     card.number = @"4242 4242 4242 4242";
     card.expMonth = 6;
@@ -44,7 +44,7 @@
 }
 
 - (void)testCardTokenCreationWithInvalidParams {
-    STPCard *card = [[STPCard alloc] init];
+    STPCardParams *card = [[STPCardParams alloc] init];
 
     card.number = @"4242 4242 4242 4241";
     card.expMonth = 6;
@@ -68,7 +68,7 @@
 }
 
 - (void)testInvalidKey {
-    STPCard *card = [[STPCard alloc] init];
+    STPCardParams *card = [[STPCardParams alloc] init];
 
     card.number = @"4242 4242 4242 4242";
     card.expMonth = 6;

--- a/Tests/Tests/STPCardTest.m
+++ b/Tests/Tests/STPCardTest.m
@@ -33,7 +33,6 @@
     return [[self currentDateComponents] year];
 }
 
-#pragma mark -initWithAttributeDictionary: tests
 - (NSDictionary *)completeAttributeDictionary {
     return @{
         @"id": @"1",

--- a/Tests/Tests/STPCardTest.m
+++ b/Tests/Tests/STPCardTest.m
@@ -54,7 +54,7 @@
 }
 
 - (void)testInitializingCardWithAttributeDictionary {
-    STPCard *cardWithAttributes = [[STPCard alloc] initWithAttributeDictionary:[self completeAttributeDictionary]];
+    STPCard *cardWithAttributes = [STPCard decodedObjectFromAPIResponse:[self completeAttributeDictionary]];
 
     XCTAssertTrue([cardWithAttributes expMonth] == 12, @"expMonth is set correctly");
     XCTAssertTrue([cardWithAttributes expYear] == 2013, @"expYear is set correctly");
@@ -73,7 +73,7 @@
 
 - (void)testFormEncode {
     NSDictionary *attributes = [self completeAttributeDictionary];
-    STPCard *cardWithAttributes = [[STPCard alloc] initWithAttributeDictionary:attributes];
+    STPCard *cardWithAttributes = [STPCard decodedObjectFromAPIResponse:attributes];
 
     NSData *encoded = [STPFormEncoder formEncodedDataForObject:cardWithAttributes];
     NSString *formData = [[NSString alloc] initWithData:encoded encoding:NSUTF8StringEncoding];
@@ -127,8 +127,8 @@
 }
 
 - (void)testCardEquals {
-    STPCard *card1 = [[STPCard alloc] initWithAttributeDictionary:[self completeAttributeDictionary]];
-    STPCard *card2 = [[STPCard alloc] initWithAttributeDictionary:[self completeAttributeDictionary]];
+    STPCard *card1 = [STPCard decodedObjectFromAPIResponse:[self completeAttributeDictionary]];
+    STPCard *card2 = [STPCard decodedObjectFromAPIResponse:[self completeAttributeDictionary]];
 
     XCTAssertEqualObjects(card1, card1, @"card should equal itself");
     XCTAssertEqualObjects(card1, card2, @"cards with equal data should be equal");

--- a/Tests/Tests/STPCardTest.m
+++ b/Tests/Tests/STPCardTest.m
@@ -13,13 +13,13 @@
 #import "StripeError.h"
 
 @interface STPCardTest : XCTestCase
-@property (nonatomic) STPCard *card;
+@property (nonatomic) STPCardParams *card;
 @end
 
 @implementation STPCardTest
 
 - (void)setUp {
-    _card = [[STPCard alloc] init];
+    _card = [[STPCardParams alloc] init];
 }
 
 #pragma mark Helpers
@@ -36,10 +36,9 @@
 #pragma mark -initWithAttributeDictionary: tests
 - (NSDictionary *)completeAttributeDictionary {
     return @{
-        @"number": @"4242424242424242",
+        @"id": @"1",
         @"exp_month": @"12",
         @"exp_year": @"2013",
-        @"cvc": @"123",
         @"name": @"Smerlock Smolmes",
         @"address_line1": @"221A Baker Street",
         @"address_city": @"New York",
@@ -57,10 +56,8 @@
 - (void)testInitializingCardWithAttributeDictionary {
     STPCard *cardWithAttributes = [[STPCard alloc] initWithAttributeDictionary:[self completeAttributeDictionary]];
 
-    XCTAssertEqualObjects([cardWithAttributes number], @"4242424242424242", @"number is set correctly");
     XCTAssertTrue([cardWithAttributes expMonth] == 12, @"expMonth is set correctly");
     XCTAssertTrue([cardWithAttributes expYear] == 2013, @"expYear is set correctly");
-    XCTAssertEqualObjects([cardWithAttributes cvc], @"123", @"CVC is set correctly");
     XCTAssertEqualObjects([cardWithAttributes name], @"Smerlock Smolmes", @"name is set correctly");
     XCTAssertEqualObjects([cardWithAttributes addressLine1], @"221A Baker Street", @"addressLine1 is set correctly");
     XCTAssertEqualObjects([cardWithAttributes addressCity], @"New York", @"addressCity is set correctly");
@@ -78,7 +75,7 @@
     NSDictionary *attributes = [self completeAttributeDictionary];
     STPCard *cardWithAttributes = [[STPCard alloc] initWithAttributeDictionary:attributes];
 
-    NSData *encoded = [STPFormEncoder formEncodedDataForCard:cardWithAttributes];
+    NSData *encoded = [STPFormEncoder formEncodedDataForCardParams:cardWithAttributes];
     NSString *formData = [[NSString alloc] initWithData:encoded encoding:NSUTF8StringEncoding];
 
     NSArray *parts = [formData componentsSeparatedByString:@"&"];
@@ -129,54 +126,12 @@
     XCTAssertEqualObjects(nil, self.card.last4, @"last4 returns nil when number length is < 3");
 }
 
-#pragma mark -type tests
-- (void)testBrandReturnsCorrectlyForAmexCard {
-    self.card.number = @"3412123412341234";
-    XCTAssertEqual(STPCardBrandAmex, self.card.brand, @"Correct card brand returned for Amex card");
-}
-
-- (void)testBrandReturnsCorrectlyForDiscoverCard {
-    self.card.number = @"6452123412341234";
-    XCTAssertEqual(STPCardBrandDiscover, self.card.brand, @"Correct card brand returned for Discover card");
-}
-
-- (void)testBrandReturnsCorrectlyForJCBCard {
-    self.card.number = @"3512123412341234";
-    XCTAssertEqual(STPCardBrandJCB, self.card.brand, @"Correct card brand returned for JCB card");
-}
-
-- (void)testBrandReturnsCorrectlyForDinersClubCard {
-    self.card.number = @"3612123412341234";
-    XCTAssertEqual(STPCardBrandDinersClub, self.card.brand, @"Correct card brand returned for Diners Club card");
-}
-
-- (void)testBrandReturnsCorrectlyForVisaCard {
-    self.card.number = @"4123123412341234";
-    XCTAssertEqual(STPCardBrandVisa, self.card.brand, @"Correct card brand returned for Visa card");
-}
-
-- (void)testBrandReturnsCorrectlyForMasterCardCard {
-    self.card.number = @"5123123412341234";
-    XCTAssertEqual(STPCardBrandMasterCard, self.card.brand, @"Correct card brand returned for MasterCard card");
-}
-
-- (void)testTypeReturnsCorrectlyForMasterCardCard {
-    self.card.number = @"5123123412341234";
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated"
-    XCTAssertEqualObjects(@"MasterCard", self.card.type, @"Correct card type returned for MasterCard card");
-#pragma clang diagnostic pop
-}
-
 - (void)testCardEquals {
     STPCard *card1 = [[STPCard alloc] initWithAttributeDictionary:[self completeAttributeDictionary]];
     STPCard *card2 = [[STPCard alloc] initWithAttributeDictionary:[self completeAttributeDictionary]];
 
     XCTAssertEqualObjects(card1, card1, @"card should equal itself");
     XCTAssertEqualObjects(card1, card2, @"cards with equal data should be equal");
-
-    card2.addressCity = @"My Fake City";
-    XCTAssertNotEqualObjects(card1, card2, @"cards should not match");
 }
 
 @end

--- a/Tests/Tests/STPCardTest.m
+++ b/Tests/Tests/STPCardTest.m
@@ -75,7 +75,7 @@
     NSDictionary *attributes = [self completeAttributeDictionary];
     STPCard *cardWithAttributes = [[STPCard alloc] initWithAttributeDictionary:attributes];
 
-    NSData *encoded = [STPFormEncoder formEncodedDataForCardParams:cardWithAttributes];
+    NSData *encoded = [STPFormEncoder formEncodedDataForObject:cardWithAttributes];
     NSString *formData = [[NSString alloc] initWithData:encoded encoding:NSUTF8StringEncoding];
 
     NSArray *parts = [formData componentsSeparatedByString:@"&"];

--- a/Tests/Tests/STPTokenTest.m
+++ b/Tests/Tests/STPTokenTest.m
@@ -17,10 +17,8 @@
 @implementation STPTokenTest
 - (void)testCreatingTokenWithAttributeDictionarySetsAttributes {
     NSDictionary *cardDict = @{
-        @"number": @"4242424242424242",
         @"expMonth": @"12",
         @"expYear": @"2013",
-        @"cvc": @"123",
         @"name": @"Smerlock Smolmes",
         @"addressLine1": @"221A Baker Street",
         @"addressCity": @"New York",
@@ -39,6 +37,5 @@
     XCTAssertEqual([token livemode], NO, @"Generated token has the correct livemode");
 
     XCTAssertEqualWithAccuracy([[token created] timeIntervalSince1970], 1353025450.0, 1.0, @"Generated token has the correct created time");
-    XCTAssertEqualObjects([[token card] number], @"4242424242424242", @"Generated token has the correct card");
 }
 @end

--- a/Tests/Tests/STPTokenTest.m
+++ b/Tests/Tests/STPTokenTest.m
@@ -32,7 +32,7 @@
     };
 
     NSDictionary *tokenDict = @{ @"id": @"id_for_token", @"object": @"token", @"livemode": @NO, @"created": @1353025450.0, @"used": @NO, @"card": cardDict };
-    STPToken *token = [[STPToken alloc] initWithAttributeDictionary:tokenDict];
+    STPToken *token = [STPToken decodedObjectFromAPIResponse:tokenDict];
     XCTAssertEqualObjects([token tokenId], @"id_for_token", @"Generated token has the correct id");
     XCTAssertEqual([token livemode], NO, @"Generated token has the correct livemode");
 


### PR DESCRIPTION
This splits `STPCard`, which was previously used for both creating requests to the Stripe API and serializing responses from it, into `STPCardParams` and `STPCard`, respectively. (Same for `STPBankAccount`.) For compatibility reasons, `STPCard` inherits from `STPCardParams` - this way existing code won't break, although it will trigger deprecation warnings.
r? @benzguo