### PR TITLE
Genericize STPAPIClient methods internally

### DIFF
--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -112,7 +112,6 @@
 		04415C5D1A6605B5001225ED /* STPIOSCheckoutWebViewAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 04CDB4BC1A5F30A700B854EE /* STPIOSCheckoutWebViewAdapter.m */; };
 		04415C5E1A6605B5001225ED /* STPOSXCheckoutWebViewAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 04CDB4BE1A5F30A700B854EE /* STPOSXCheckoutWebViewAdapter.m */; };
 		04415C5F1A6605B5001225ED /* STPStrictURLProtocol.m in Sources */ = {isa = PBXBuildFile; fileRef = 04CDB4C01A5F30A700B854EE /* STPStrictURLProtocol.m */; };
-		04415C601A6605B5001225ED /* STPAPIClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 04CDB4C31A5F30A700B854EE /* STPAPIClient.m */; };
 		04415C611A6605B5001225ED /* STPFormEncoder.m in Sources */ = {isa = PBXBuildFile; fileRef = 04CDB4C51A5F30A700B854EE /* STPFormEncoder.m */; };
 		04415C631A6605B5001225ED /* STPBankAccount.m in Sources */ = {isa = PBXBuildFile; fileRef = 04CDB4C91A5F30A700B854EE /* STPBankAccount.m */; };
 		04415C641A6605B5001225ED /* STPCard.m in Sources */ = {isa = PBXBuildFile; fileRef = 04CDB4CB1A5F30A700B854EE /* STPCard.m */; };
@@ -1211,7 +1210,6 @@
 				0438EF4C1B741B0100D506CC /* STPCardValidatorTest.m in Sources */,
 				04415C5E1A6605B5001225ED /* STPOSXCheckoutWebViewAdapter.m in Sources */,
 				04415C5F1A6605B5001225ED /* STPStrictURLProtocol.m in Sources */,
-				04415C601A6605B5001225ED /* STPAPIClient.m in Sources */,
 				04415C611A6605B5001225ED /* STPFormEncoder.m in Sources */,
 				045A62AB1B8E7259000165CE /* STPPaymentCardTextFieldTest.m in Sources */,
 				04415C631A6605B5001225ED /* STPBankAccount.m in Sources */,

--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -25,6 +25,12 @@
 		042CA1B61B7BD84100AF0DA6 /* stp_card_placeholder_template.png in Resources */ = {isa = PBXBuildFile; fileRef = 042CA1B31B7BD84100AF0DA6 /* stp_card_placeholder_template.png */; };
 		042CA1B71B7BD84100AF0DA6 /* stp_card_placeholder_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 042CA1B41B7BD84100AF0DA6 /* stp_card_placeholder_template@2x.png */; };
 		042CA1B81B7BD84100AF0DA6 /* stp_card_placeholder_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 042CA1B51B7BD84100AF0DA6 /* stp_card_placeholder_template@3x.png */; };
+		0433EB491BD06313003912B4 /* NSDictionary+Stripe.h in Headers */ = {isa = PBXBuildFile; fileRef = 0433EB471BD06313003912B4 /* NSDictionary+Stripe.h */; settings = {ASSET_TAGS = (); }; };
+		0433EB4A1BD06313003912B4 /* NSDictionary+Stripe.h in Headers */ = {isa = PBXBuildFile; fileRef = 0433EB471BD06313003912B4 /* NSDictionary+Stripe.h */; settings = {ASSET_TAGS = (); }; };
+		0433EB4B1BD06313003912B4 /* NSDictionary+Stripe.h in Headers */ = {isa = PBXBuildFile; fileRef = 0433EB471BD06313003912B4 /* NSDictionary+Stripe.h */; settings = {ASSET_TAGS = (); }; };
+		0433EB4C1BD06313003912B4 /* NSDictionary+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = 0433EB481BD06313003912B4 /* NSDictionary+Stripe.m */; settings = {ASSET_TAGS = (); }; };
+		0433EB4D1BD06313003912B4 /* NSDictionary+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = 0433EB481BD06313003912B4 /* NSDictionary+Stripe.m */; settings = {ASSET_TAGS = (); }; };
+		0433EB4E1BD06313003912B4 /* NSDictionary+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = 0433EB481BD06313003912B4 /* NSDictionary+Stripe.m */; settings = {ASSET_TAGS = (); }; };
 		0438EF2C1B7416BB00D506CC /* STPFormTextField.h in Headers */ = {isa = PBXBuildFile; fileRef = 0438EF261B7416BB00D506CC /* STPFormTextField.h */; };
 		0438EF2D1B7416BB00D506CC /* STPFormTextField.h in Headers */ = {isa = PBXBuildFile; fileRef = 0438EF261B7416BB00D506CC /* STPFormTextField.h */; };
 		0438EF2E1B7416BB00D506CC /* STPFormTextField.h in Headers */ = {isa = PBXBuildFile; fileRef = 0438EF261B7416BB00D506CC /* STPFormTextField.h */; };
@@ -375,6 +381,8 @@
 		042CA1B31B7BD84100AF0DA6 /* stp_card_placeholder_template.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_placeholder_template.png; sourceTree = "<group>"; };
 		042CA1B41B7BD84100AF0DA6 /* stp_card_placeholder_template@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_placeholder_template@2x.png"; sourceTree = "<group>"; };
 		042CA1B51B7BD84100AF0DA6 /* stp_card_placeholder_template@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_placeholder_template@3x.png"; sourceTree = "<group>"; };
+		0433EB471BD06313003912B4 /* NSDictionary+Stripe.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDictionary+Stripe.h"; sourceTree = "<group>"; };
+		0433EB481BD06313003912B4 /* NSDictionary+Stripe.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDictionary+Stripe.m"; sourceTree = "<group>"; };
 		04365D2C1A4CF86C00A3E1D4 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 		0438EF261B7416BB00D506CC /* STPFormTextField.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = STPFormTextField.h; path = UI/STPFormTextField.h; sourceTree = "<group>"; };
 		0438EF271B7416BB00D506CC /* STPFormTextField.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = STPFormTextField.m; path = UI/STPFormTextField.m; sourceTree = "<group>"; };
@@ -675,6 +683,8 @@
 				04CDB4CD1A5F30A700B854EE /* STPToken.m */,
 				04CDB4CE1A5F30A700B854EE /* StripeError.h */,
 				04CDB4CF1A5F30A700B854EE /* StripeError.m */,
+				0433EB471BD06313003912B4 /* NSDictionary+Stripe.h */,
+				0433EB481BD06313003912B4 /* NSDictionary+Stripe.m */,
 			);
 			name = Stripe;
 			path = Tests/../Stripe;
@@ -815,6 +825,7 @@
 				04EBC75A1B7533C300A0E6AE /* STPCardValidator.h in Headers */,
 				049E84D91A605EF0000B66CD /* Stripe.h in Headers */,
 				049E84DA1A605EF0000B66CD /* STPAPIClient+ApplePay.h in Headers */,
+				0433EB4B1BD06313003912B4 /* NSDictionary+Stripe.h in Headers */,
 				049E84DB1A605EF0000B66CD /* Stripe+ApplePay.h in Headers */,
 				049E84DD1A605EF0000B66CD /* STPCheckoutOptions.h in Headers */,
 				0438EF2E1B7416BB00D506CC /* STPFormTextField.h in Headers */,
@@ -853,6 +864,7 @@
 				04EBC7571B7533C300A0E6AE /* STPCardValidator.h in Headers */,
 				04CDB4EE1A5F30A700B854EE /* STPColorUtils.h in Headers */,
 				04CDB4F61A5F30A700B854EE /* STPOSXCheckoutWebViewAdapter.h in Headers */,
+				0433EB491BD06313003912B4 /* NSDictionary+Stripe.h in Headers */,
 				04CDB50E1A5F30A700B854EE /* STPCard.h in Headers */,
 				04CDB4E41A5F30A700B854EE /* STPCheckoutViewController.h in Headers */,
 				0438EF2C1B7416BB00D506CC /* STPFormTextField.h in Headers */,
@@ -907,6 +919,7 @@
 				04D12C331A5F55D10010446E /* STPCheckoutInternalUIWebViewController.h in Headers */,
 				04D12C341A5F55D10010446E /* STPCheckoutWebViewAdapter.h in Headers */,
 				04D12C351A5F55D10010446E /* STPColorUtils.h in Headers */,
+				0433EB4A1BD06313003912B4 /* NSDictionary+Stripe.h in Headers */,
 				04F213361BCECB1C001D6F22 /* STPAPIResponseDecodable.h in Headers */,
 				04D12C361A5F55D10010446E /* STPIOSCheckoutWebViewAdapter.h in Headers */,
 				04D12C371A5F55D10010446E /* STPOSXCheckoutWebViewAdapter.h in Headers */,
@@ -1272,6 +1285,7 @@
 				049E84CF1A605DE0000B66CD /* STPBankAccount.m in Sources */,
 				049E84D01A605DE0000B66CD /* STPCard.m in Sources */,
 				04F3BB401BA89B1200DE235E /* PKPayment+Stripe.m in Sources */,
+				0433EB4E1BD06313003912B4 /* NSDictionary+Stripe.m in Sources */,
 				0438EF3D1B7416BB00D506CC /* STPPaymentCardTextFieldViewModel.m in Sources */,
 				04CDE5BA1BC1F1F100548833 /* STPCardParams.m in Sources */,
 				049E84D11A605DE0000B66CD /* STPToken.m in Sources */,
@@ -1302,6 +1316,7 @@
 				04CDB4F01A5F30A700B854EE /* STPColorUtils.m in Sources */,
 				04CDB5141A5F30A700B854EE /* STPToken.m in Sources */,
 				04F3BB3F1BA89B1200DE235E /* PKPayment+Stripe.m in Sources */,
+				0433EB4C1BD06313003912B4 /* NSDictionary+Stripe.m in Sources */,
 				0438EF3B1B7416BB00D506CC /* STPPaymentCardTextFieldViewModel.m in Sources */,
 				04CDE5B81BC1F1F100548833 /* STPCardParams.m in Sources */,
 				04CDB4D61A5F30A700B854EE /* STPAPIClient+ApplePay.m in Sources */,
@@ -1329,6 +1344,7 @@
 				04D12C281A5F55AD0010446E /* STPBankAccount.m in Sources */,
 				04D12C291A5F55AD0010446E /* STPCard.m in Sources */,
 				04D12C2A1A5F55AD0010446E /* STPToken.m in Sources */,
+				0433EB4D1BD06313003912B4 /* NSDictionary+Stripe.m in Sources */,
 				049952D71BCF14980088C703 /* STPAPIPostRequest.m in Sources */,
 				04D12C2B1A5F55AD0010446E /* StripeError.m in Sources */,
 			);

--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -177,6 +177,15 @@
 		045A62C81B8E73AB000165CE /* stp_card_visa@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 0438EFA21B741C2800D506CC /* stp_card_visa@2x.png */; };
 		045A62C91B8E73AB000165CE /* stp_card_visa@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 0438EFA31B741C2800D506CC /* stp_card_visa@3x.png */; };
 		045E7C091A5F41DE004751EF /* Stripe.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04CDB4421A5F2E1800B854EE /* Stripe.framework */; };
+		049952CF1BCF13510088C703 /* STPAPIPostRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 049952CD1BCF13510088C703 /* STPAPIPostRequest.h */; settings = {ASSET_TAGS = (); }; };
+		049952D01BCF13510088C703 /* STPAPIPostRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 049952CE1BCF13510088C703 /* STPAPIPostRequest.m */; settings = {ASSET_TAGS = (); }; };
+		049952D21BCF13DD0088C703 /* STPAPIClient+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 049952D11BCF13DD0088C703 /* STPAPIClient+Private.h */; settings = {ASSET_TAGS = (); }; };
+		049952D31BCF13DD0088C703 /* STPAPIClient+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 049952D11BCF13DD0088C703 /* STPAPIClient+Private.h */; settings = {ASSET_TAGS = (); }; };
+		049952D41BCF13DD0088C703 /* STPAPIClient+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 049952D11BCF13DD0088C703 /* STPAPIClient+Private.h */; settings = {ASSET_TAGS = (); }; };
+		049952D51BCF14920088C703 /* STPAPIPostRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 049952CD1BCF13510088C703 /* STPAPIPostRequest.h */; settings = {ASSET_TAGS = (); }; };
+		049952D61BCF14930088C703 /* STPAPIPostRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 049952CD1BCF13510088C703 /* STPAPIPostRequest.h */; settings = {ASSET_TAGS = (); }; };
+		049952D71BCF14980088C703 /* STPAPIPostRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 049952CE1BCF13510088C703 /* STPAPIPostRequest.m */; settings = {ASSET_TAGS = (); }; };
+		049952D81BCF14990088C703 /* STPAPIPostRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 049952CE1BCF13510088C703 /* STPAPIPostRequest.m */; settings = {ASSET_TAGS = (); }; };
 		049E84C21A605DE0000B66CD /* STPAPIClient+ApplePay.m in Sources */ = {isa = PBXBuildFile; fileRef = 04CDB4AB1A5F30A700B854EE /* STPAPIClient+ApplePay.m */; };
 		049E84C31A605DE0000B66CD /* Stripe+ApplePay.m in Sources */ = {isa = PBXBuildFile; fileRef = 04CDB4AD1A5F30A700B854EE /* Stripe+ApplePay.m */; };
 		049E84C51A605DE0000B66CD /* STPCheckoutOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 04CDB4B21A5F30A700B854EE /* STPCheckoutOptions.m */; };
@@ -405,6 +414,9 @@
 		0438EFA31B741C2800D506CC /* stp_card_visa@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_visa@3x.png"; sourceTree = "<group>"; };
 		045A62AA1B8E7259000165CE /* STPPaymentCardTextFieldTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPPaymentCardTextFieldTest.m; sourceTree = "<group>"; };
 		045E7C031A5F41DE004751EF /* StripeiOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "StripeiOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		049952CD1BCF13510088C703 /* STPAPIPostRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPAPIPostRequest.h; sourceTree = "<group>"; };
+		049952CE1BCF13510088C703 /* STPAPIPostRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPAPIPostRequest.m; sourceTree = "<group>"; };
+		049952D11BCF13DD0088C703 /* STPAPIClient+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "STPAPIClient+Private.h"; sourceTree = "<group>"; };
 		049E84AB1A605D93000B66CD /* libStripe.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libStripe.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		04B94BC71A47B78A00092C46 /* AddressBook.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AddressBook.framework; path = System/Library/Frameworks/AddressBook.framework; sourceTree = SDKROOT; };
 		04CB86B81BA89CD400E4F61E /* PKPayment+StripeTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "PKPayment+StripeTest.m"; sourceTree = "<group>"; };
@@ -640,6 +652,9 @@
 				0438EF251B74162700D506CC /* UI */,
 				04CDB4C21A5F30A700B854EE /* STPAPIClient.h */,
 				04CDB4C31A5F30A700B854EE /* STPAPIClient.m */,
+				049952D11BCF13DD0088C703 /* STPAPIClient+Private.h */,
+				049952CD1BCF13510088C703 /* STPAPIPostRequest.h */,
+				049952CE1BCF13510088C703 /* STPAPIPostRequest.m */,
 				04CDB4C41A5F30A700B854EE /* STPFormEncoder.h */,
 				04CDB4C51A5F30A700B854EE /* STPFormEncoder.m */,
 				04CDE5C81BC20B1D00548833 /* STPBankAccountParams.h */,
@@ -810,6 +825,7 @@
 				049E84EB1A605EF0000B66CD /* STPToken.h in Headers */,
 				04E32AA01B7A9490009C9E35 /* STPPaymentCardTextField.h in Headers */,
 				0438EF491B74183100D506CC /* STPCardBrand.h in Headers */,
+				049952D61BCF14930088C703 /* STPAPIPostRequest.h in Headers */,
 				04F213331BCEAB61001D6F22 /* STPFormEncodable.h in Headers */,
 				049E84EC1A605EF0000B66CD /* StripeError.h in Headers */,
 				049E84DF1A605EF0000B66CD /* STPCheckoutDelegate.h in Headers */,
@@ -818,6 +834,7 @@
 				049E84E11A605EF0000B66CD /* STPCheckoutWebViewAdapter.h in Headers */,
 				049E84E21A605EF0000B66CD /* STPColorUtils.h in Headers */,
 				04CDE5CB1BC20B1D00548833 /* STPBankAccountParams.h in Headers */,
+				049952D41BCF13DD0088C703 /* STPAPIClient+Private.h in Headers */,
 				0438EF3A1B7416BB00D506CC /* STPPaymentCardTextFieldViewModel.h in Headers */,
 				04CDE5BE1BC1F21500548833 /* STPCardParams.h in Headers */,
 				04F213371BCECB1C001D6F22 /* STPAPIResponseDecodable.h in Headers */,
@@ -840,7 +857,9 @@
 				04CDB4E41A5F30A700B854EE /* STPCheckoutViewController.h in Headers */,
 				0438EF2C1B7416BB00D506CC /* STPFormTextField.h in Headers */,
 				04CDB50A1A5F30A700B854EE /* STPBankAccount.h in Headers */,
+				049952D21BCF13DD0088C703 /* STPAPIClient+Private.h in Headers */,
 				04CDB5121A5F30A700B854EE /* STPToken.h in Headers */,
+				049952CF1BCF13510088C703 /* STPAPIPostRequest.h in Headers */,
 				04CDB4D81A5F30A700B854EE /* Stripe+ApplePay.h in Headers */,
 				0438EF471B74183100D506CC /* STPCardBrand.h in Headers */,
 				04CDB5161A5F30A700B854EE /* StripeError.h in Headers */,
@@ -878,9 +897,11 @@
 				04F213321BCEAB61001D6F22 /* STPFormEncodable.h in Headers */,
 				04D12C391A5F55D10010446E /* STPAPIClient.h in Headers */,
 				04D12C3C1A5F55D10010446E /* STPBankAccount.h in Headers */,
+				049952D31BCF13DD0088C703 /* STPAPIClient+Private.h in Headers */,
 				04D12C3D1A5F55D10010446E /* STPCard.h in Headers */,
 				04D12C3E1A5F55D10010446E /* STPToken.h in Headers */,
 				04D12C3F1A5F55D10010446E /* StripeError.h in Headers */,
+				049952D51BCF14920088C703 /* STPAPIPostRequest.h in Headers */,
 				0438EFDB1B7524AA00D506CC /* STPCardBrand.h in Headers */,
 				04D12C321A5F55D10010446E /* STPCheckoutDelegate.h in Headers */,
 				04D12C331A5F55D10010446E /* STPCheckoutInternalUIWebViewController.h in Headers */,
@@ -1255,6 +1276,7 @@
 				04CDE5BA1BC1F1F100548833 /* STPCardParams.m in Sources */,
 				049E84D11A605DE0000B66CD /* STPToken.m in Sources */,
 				049E84D21A605DE0000B66CD /* StripeError.m in Sources */,
+				049952D81BCF14990088C703 /* STPAPIPostRequest.m in Sources */,
 				04CDE5C71BC20AF800548833 /* STPBankAccountParams.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1284,6 +1306,7 @@
 				04CDE5B81BC1F1F100548833 /* STPCardParams.m in Sources */,
 				04CDB4D61A5F30A700B854EE /* STPAPIClient+ApplePay.m in Sources */,
 				04CDB4E61A5F30A700B854EE /* STPCheckoutViewController.m in Sources */,
+				049952D01BCF13510088C703 /* STPAPIPostRequest.m in Sources */,
 				04CDE5C51BC20AF800548833 /* STPBankAccountParams.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1306,6 +1329,7 @@
 				04D12C281A5F55AD0010446E /* STPBankAccount.m in Sources */,
 				04D12C291A5F55AD0010446E /* STPCard.m in Sources */,
 				04D12C2A1A5F55AD0010446E /* STPToken.m in Sources */,
+				049952D71BCF14980088C703 /* STPAPIPostRequest.m in Sources */,
 				04D12C2B1A5F55AD0010446E /* StripeError.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Stripe/ApplePay/STPAPIClient+ApplePay.m
+++ b/Stripe/ApplePay/STPAPIClient+ApplePay.m
@@ -9,6 +9,7 @@
 
 #import "STPAPIClient+ApplePay.h"
 #import "PKPayment+Stripe.h"
+#import "STPAPIClient+Private.h"
 
 @implementation STPAPIClient (ApplePay)
 

--- a/Stripe/ApplePay/STPAPIClient+ApplePay.m
+++ b/Stripe/ApplePay/STPAPIClient+ApplePay.m
@@ -13,7 +13,7 @@
 
 @implementation STPAPIClient (ApplePay)
 
-- (void)createTokenWithPayment:(PKPayment *)payment completion:(STPCompletionBlock)completion {
+- (void)createTokenWithPayment:(PKPayment *)payment completion:(STPTokenCompletionBlock)completion {
     [self createTokenWithData:[self.class formEncodedDataForPayment:payment] completion:completion];
 }
 

--- a/Stripe/NSDictionary+Stripe.h
+++ b/Stripe/NSDictionary+Stripe.h
@@ -1,0 +1,15 @@
+//
+//  NSDictionary+Stripe.h
+//  Stripe
+//
+//  Created by Jack Flintermann on 10/15/15.
+//  Copyright © 2015 Stripe, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSDictionary (Stripe)
+
+- (nullable NSDictionary *)stp_dictionaryByRemovingNullsValidatingRequiredFields:(nonnull NSArray *)requiredFields;
+
+@end

--- a/Stripe/NSDictionary+Stripe.m
+++ b/Stripe/NSDictionary+Stripe.m
@@ -1,0 +1,28 @@
+//
+//  NSDictionary+Stripe.m
+//  Stripe
+//
+//  Created by Jack Flintermann on 10/15/15.
+//  Copyright © 2015 Stripe, Inc. All rights reserved.
+//
+
+#import "NSDictionary+Stripe.h"
+
+@implementation NSDictionary (Stripe)
+
+- (nullable NSDictionary *)stp_dictionaryByRemovingNullsValidatingRequiredFields:(nonnull NSArray *)requiredFields {
+    NSMutableDictionary *dict = [NSMutableDictionary dictionary];
+    [self enumerateKeysAndObjectsUsingBlock:^(id key, id obj, __unused BOOL *stop) {
+        if (obj != [NSNull null]) {
+            dict[key] = obj;
+        }
+    }];
+    for (NSString *key in requiredFields) {
+        if (![[dict allKeys] containsObject:key]) {
+            return nil;
+        }
+    }
+    return [dict copy];
+}
+
+@end

--- a/Stripe/PublicHeaders/ApplePay/STPAPIClient+ApplePay.h
+++ b/Stripe/PublicHeaders/ApplePay/STPAPIClient+ApplePay.h
@@ -19,7 +19,7 @@
  *  @param payment     The user's encrypted payment information as returned from a PKPaymentAuthorizationViewController. Cannot be nil.
  *  @param completion  The callback to run with the returned Stripe token (and any errors that may have occurred).
  */
-- (void)createTokenWithPayment:(nonnull PKPayment *)payment completion:(nonnull STPCompletionBlock)completion;
+- (void)createTokenWithPayment:(nonnull PKPayment *)payment completion:(nonnull STPTokenCompletionBlock)completion;
 
 // Form-encodes a PKPayment object for POSTing to the Stripe API. This method is used internally by STPAPIClient; you should not use it in your own code.
 + (nonnull NSData *)formEncodedDataForPayment:(nonnull PKPayment *)payment;

--- a/Stripe/PublicHeaders/STPAPIClient.h
+++ b/Stripe/PublicHeaders/STPAPIClient.h
@@ -89,13 +89,6 @@ typedef void (^STPCompletionBlock)(STPToken * __nullable token, NSError * __null
 
 @end
 
-// These methods are used internally and exposed here only for the sake of writing tests more easily. You should not use them in your own application.
-@interface STPAPIClient (PrivateMethods)
-
-- (void)createTokenWithData:(nonnull NSData *)data completion:(nullable STPCompletionBlock)completion;
-
-@end
-
 #pragma mark - Deprecated Methods
 // These methods are deprecated. You should instead use STPAPIClient to create tokens.
 // Example: [Stripe createTokenWithCard:card completion:completion];

--- a/Stripe/PublicHeaders/STPAPIClient.h
+++ b/Stripe/PublicHeaders/STPAPIClient.h
@@ -55,7 +55,7 @@ typedef void (^STPCompletionBlock)(STPToken * __nullable token, NSError * __null
 @property (nonatomic, copy, nullable) NSString *publishableKey;
 
 /**
- *  The operation queue on which to run completion blocks passed to the api client. Cannot be nil.
+ *  The operation queue on which to run completion blocks passed to the api client. Defaults to [NSOperationQueue mainQueue].
  */
 @property (nonatomic, nonnull) NSOperationQueue *operationQueue;
 

--- a/Stripe/PublicHeaders/STPAPIClient.h
+++ b/Stripe/PublicHeaders/STPAPIClient.h
@@ -8,18 +8,17 @@
 
 #import <Foundation/Foundation.h>
 
-
 static NSString *const __nonnull STPSDKVersion = @"5.1.4";
 
 @class STPBankAccount, STPBankAccountParams, STPCard, STPCardParams, STPToken;
 
 /**
- *  A callback to be run with the response from the Stripe API.
+ *  A callback to be run with a token response from the Stripe API.
  *
  *  @param token The Stripe token from the response. Will be nil if an error occurs. @see STPToken
  *  @param error The error returned from the response, or nil in one occurs. @see StripeError.h for possible values.
  */
-typedef void (^STPCompletionBlock)(STPToken * __nullable token, NSError * __nullable error);
+typedef void (^STPTokenCompletionBlock)(STPToken * __nullable token, NSError * __nullable error);
 
 /**
  A top-level class that imports the rest of the Stripe SDK. This class used to contain several methods to create Stripe tokens, but those are now deprecated in
@@ -71,7 +70,7 @@ typedef void (^STPCompletionBlock)(STPToken * __nullable token, NSError * __null
  *  @param bankAccount The user's bank account details. Cannot be nil. @see https://stripe.com/docs/api#create_bank_account_token
  *  @param completion  The callback to run with the returned Stripe token (and any errors that may have occurred).
  */
-- (void)createTokenWithBankAccount:(nonnull STPBankAccountParams *)bankAccount completion:(__nullable STPCompletionBlock)completion;
+- (void)createTokenWithBankAccount:(nonnull STPBankAccountParams *)bankAccount completion:(__nullable STPTokenCompletionBlock)completion;
 
 @end
 
@@ -85,11 +84,36 @@ typedef void (^STPCompletionBlock)(STPToken * __nullable token, NSError * __null
  *  @param card        The user's card details. Cannot be nil. @see https://stripe.com/docs/api#create_card_token
  *  @param completion  The callback to run with the returned Stripe token (and any errors that may have occurred).
  */
-- (void)createTokenWithCard:(nonnull STPCardParams *)card completion:(nullable STPCompletionBlock)completion;
+- (void)createTokenWithCard:(nonnull STPCardParams *)card completion:(nullable STPTokenCompletionBlock)completion;
+
+@end
+
+#pragma mark Connected Accounts
+
+@interface STPAPIClient (ConnectedAccounts)
+
+/**
+ *  Converts an STPCardParams object into a Stripe token using the Stripe API.
+ *
+ *  @param card        The user's card details. Cannot be nil. @see https://stripe.com/docs/api#create_card_token
+ *  @param completion  The callback to run with the returned Stripe token (and any errors that may have occurred).
+ */
+- (void)createConnectedAccountWithParams:(nonnull STPConnectedAccountParams *)params
+                              completion:(nonnull STPAccountCompletionBlock)completion;
 
 @end
 
 #pragma mark - Deprecated Methods
+
+/**
+ *  A callback to be run with a token response from the Stripe API.
+ *
+ *  @param token The Stripe token from the response. Will be nil if an error occurs. @see STPToken
+ *  @param error The error returned from the response, or nil in one occurs. @see StripeError.h for possible values.
+ *  @deprecated This has been renamed to STPTokenCompletionBlock.
+ */
+typedef void (^STPCompletionBlock)(STPToken * __nullable token, NSError * __nullable error) __attribute__((deprecated("STPCompletionBlock has been renamed to STPTokenCompletionBlock.")));
+
 // These methods are deprecated. You should instead use STPAPIClient to create tokens.
 // Example: [Stripe createTokenWithCard:card completion:completion];
 // becomes [[STPAPIClient sharedClient] createTokenWithCard:card completion:completion];

--- a/Stripe/PublicHeaders/STPAPIClient.h
+++ b/Stripe/PublicHeaders/STPAPIClient.h
@@ -88,21 +88,6 @@ typedef void (^STPTokenCompletionBlock)(STPToken * __nullable token, NSError * _
 
 @end
 
-#pragma mark Connected Accounts
-
-@interface STPAPIClient (ConnectedAccounts)
-
-/**
- *  Converts an STPCardParams object into a Stripe token using the Stripe API.
- *
- *  @param card        The user's card details. Cannot be nil. @see https://stripe.com/docs/api#create_card_token
- *  @param completion  The callback to run with the returned Stripe token (and any errors that may have occurred).
- */
-- (void)createConnectedAccountWithParams:(nonnull STPConnectedAccountParams *)params
-                              completion:(nonnull STPAccountCompletionBlock)completion;
-
-@end
-
 #pragma mark - Deprecated Methods
 
 /**

--- a/Stripe/PublicHeaders/STPAPIResponseDecodable.h
+++ b/Stripe/PublicHeaders/STPAPIResponseDecodable.h
@@ -10,6 +10,7 @@
 
 @protocol STPAPIResponseDecodable <NSObject>
 
++ (nonnull NSArray *)requiredFields;
 + (nullable instancetype)decodedObjectFromAPIResponse:(nonnull NSDictionary *)response;
 
 @end

--- a/Stripe/PublicHeaders/STPBankAccount.h
+++ b/Stripe/PublicHeaders/STPBankAccount.h
@@ -10,6 +10,13 @@
 #import "STPBankAccountParams.h"
 #import "STPAPIResponseDecodable.h"
 
+typedef NS_ENUM(NSInteger, STPBankAccountStatus) {
+    STPBankAccountStatusNew,
+    STPBankAccountStatusValidated,
+    STPBankAccountStatusVerified,
+    STPBankAccountStatusErrored,
+};
+
 /**
  *  Representation of a user's bank account details that have been tokenized with the Stripe API. @see https://stripe.com/docs/api#cards
  */
@@ -23,7 +30,7 @@
 /**
  *  The routing number for the bank account. This should be the ACH routing number, not the wire routing number.
  */
-@property (nonatomic, copy, nullable) NSString *routingNumber;
+@property (nonatomic, copy, nonnull) NSString *routingNumber;
 
 /**
  *  Two-letter ISO code representing the country the bank account is located in.
@@ -38,7 +45,7 @@
 /**
  *  The Stripe ID for the bank account.
  */
-@property (nonatomic, readonly, nullable) NSString *bankAccountId;
+@property (nonatomic, readonly, nonnull) NSString *bankAccountId;
 
 /**
  *  The last 4 digits of the account number.
@@ -56,14 +63,21 @@
 @property (nonatomic, readonly, nullable) NSString *fingerprint;
 
 /**
- *  Whether or not the bank account has been validated via microdeposits or other means.
+ *  The validation status of the bank account. @see STPBankAccountStatus
  */
-@property (nonatomic, readonly) BOOL validated;
+@property (nonatomic, readonly) STPBankAccountStatus status;
+
+/**
+ *  Whether or not the bank account has been validated via microdeposits or other means.
+ *  @deprecated Use status == STPBankAccountStatusValidated instead.
+ */
+@property (nonatomic, readonly) BOOL validated __attribute__((deprecated("Use status == STPBankAccountStatusValidated instead.")));
 
 /**
  *  Whether or not the bank account is currently disabled.
+ *  @deprecated Use status == STPBankAccountStatusErrored instead.
  */
-@property (nonatomic, readonly) BOOL disabled;
+@property (nonatomic, readonly) BOOL disabled __attribute__((deprecated("Use status == STPBankAccountStatusErrored instead.")));
 
 #pragma mark - deprecated setters for STPBankAccountParams properties
 

--- a/Stripe/PublicHeaders/STPFormEncodable.h
+++ b/Stripe/PublicHeaders/STPFormEncodable.h
@@ -10,7 +10,7 @@
 
 @protocol STPFormEncodable <NSObject>
 
-- (NSString *)rootObjectName;
-- (NSDictionary *)propertyNamesToFormFieldNamesMapping;
++ (NSString *)rootObjectName;
++ (NSDictionary *)propertyNamesToFormFieldNamesMapping;
 
 @end

--- a/Stripe/PublicHeaders/StripeError.h
+++ b/Stripe/PublicHeaders/StripeError.h
@@ -64,7 +64,7 @@ FOUNDATION_EXPORT NSString * __nonnull const STPIncorrectCVC;
 #define STPCardErrorProcessingErrorUserMessage                                                                                                                 \
     NSLocalizedString(@"There was an error processing your card -- try again in a few seconds", @"Error when there is a problem processing the credit card")
 
-@interface STPError : NSError
+@interface NSError(Stripe)
 
 + (nullable NSError *)errorFromStripeResponse:(nullable NSDictionary *)jsonDictionary;
 

--- a/Stripe/PublicHeaders/StripeError.h
+++ b/Stripe/PublicHeaders/StripeError.h
@@ -66,6 +66,6 @@ FOUNDATION_EXPORT NSString * __nonnull const STPIncorrectCVC;
 
 @interface NSError(Stripe)
 
-+ (nullable NSError *)errorFromStripeResponse:(nullable NSDictionary *)jsonDictionary;
++ (nullable NSError *)stp_errorFromStripeResponse:(nullable NSDictionary *)jsonDictionary;
 
 @end

--- a/Stripe/PublicHeaders/StripeError.h
+++ b/Stripe/PublicHeaders/StripeError.h
@@ -63,3 +63,9 @@ FOUNDATION_EXPORT NSString * __nonnull const STPIncorrectCVC;
     NSLocalizedString(@"There was an unexpected error -- try again in a few seconds", @"Unexpected error, such as a 500 from Stripe or a JSON parse error")
 #define STPCardErrorProcessingErrorUserMessage                                                                                                                 \
     NSLocalizedString(@"There was an error processing your card -- try again in a few seconds", @"Error when there is a problem processing the credit card")
+
+@interface STPError : NSError
+
++ (nullable NSError *)errorFromStripeResponse:(nullable NSDictionary *)jsonDictionary;
+
+@end

--- a/Stripe/STPAPIClient+Private.h
+++ b/Stripe/STPAPIClient+Private.h
@@ -10,7 +10,7 @@
 
 @interface STPAPIClient ()<NSURLSessionDelegate>
 
-- (void)createTokenWithData:(nonnull NSData *)data completion:(nullable STPCompletionBlock)completion;
+- (void)createTokenWithData:(nonnull NSData *)data completion:(nullable STPTokenCompletionBlock)completion;
 
 @property (nonatomic, readwrite, nonnull) NSURL *apiURL;
 @property (nonatomic, readwrite, nonnull) NSURLSession *urlSession;

--- a/Stripe/STPAPIClient+Private.h
+++ b/Stripe/STPAPIClient+Private.h
@@ -1,0 +1,16 @@
+//
+//  STPAPIClient+Private.h
+//  Stripe
+//
+//  Created by Jack Flintermann on 10/14/15.
+//  Copyright © 2015 Stripe, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface STPAPIClient ()<NSURLSessionDelegate>
+
+@property (nonatomic, readwrite) NSURL *apiURL;
+@property (nonatomic, readwrite) NSURLSession *urlSession;
+
+@end

--- a/Stripe/STPAPIClient+Private.h
+++ b/Stripe/STPAPIClient+Private.h
@@ -10,7 +10,9 @@
 
 @interface STPAPIClient ()<NSURLSessionDelegate>
 
-@property (nonatomic, readwrite) NSURL *apiURL;
-@property (nonatomic, readwrite) NSURLSession *urlSession;
+- (void)createTokenWithData:(nonnull NSData *)data completion:(nullable STPCompletionBlock)completion;
+
+@property (nonatomic, readwrite, nonnull) NSURL *apiURL;
+@property (nonatomic, readwrite, nonnull) NSURLSession *urlSession;
 
 @end

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -23,9 +23,9 @@
 
 #define FAUXPAS_IGNORED_IN_METHOD(...)
 
-static NSString *const apiURLBase = @"api.stripe.com";
-static NSString *const apiVersion = @"v1";
+static NSString *const apiURLBase = @"api.stripe.com/v1";
 static NSString *const tokenEndpoint = @"tokens";
+static NSString *const stripeAPIVersion = @"2015-10-12";
 static NSString *STPDefaultPublishableKey;
 
 @implementation Stripe
@@ -62,14 +62,14 @@ static NSString *STPDefaultPublishableKey;
     self = [super init];
     if (self) {
         [self.class validateKey:publishableKey];
-        _apiURL = [[NSURL URLWithString:[NSString stringWithFormat:@"https://%@", apiURLBase]] URLByAppendingPathComponent:apiVersion];
+        _apiURL = [NSURL URLWithString:[NSString stringWithFormat:@"https://%@", apiURLBase]];
         _publishableKey = [publishableKey copy];
         _operationQueue = [NSOperationQueue mainQueue];
         NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
         NSString *auth = [@"Bearer " stringByAppendingString:self.publishableKey];
         config.HTTPAdditionalHeaders = @{
                                          @"X-Stripe-User-Agent": [self.class stripeUserAgentDetails],
-                                         @"Stripe-Version": @"2015-10-12",
+                                         @"Stripe-Version": stripeAPIVersion,
                                          @"Authorization": auth,
                                          };
         _urlSession = [NSURLSession sessionWithConfiguration:config delegate:self delegateQueue:_operationQueue];

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -18,6 +18,7 @@
 #import "STPCard.h"
 #import "STPToken.h"
 #import "StripeError.h"
+#import "STPAPIResponseDecodable.h"
 
 #define FAUXPAS_IGNORED_IN_METHOD(...)
 
@@ -43,6 +44,55 @@ static NSString *STPDefaultPublishableKey;
 @property (nonatomic, readwrite) NSURLSession *urlSession;
 @end
 
+@interface STPAPIPostRequest<__covariant ResponseType:id<STPAPIResponseDecodable>> : NSObject
+
++ (void)startWithAPIClient:(STPAPIClient *)apiClient
+                  endpoint:(NSString *)endpoint
+                  postData:(NSData *)postData
+                serializer:(ResponseType)serializer
+                completion:(void (^)(ResponseType object, NSError *error))completion;
+
+@end
+
+@implementation STPAPIPostRequest
+
++ (void)startWithAPIClient:(STPAPIClient *)apiClient
+                  endpoint:(NSString *)endpoint
+                  postData:(NSData *)postData
+                serializer:(id<STPAPIResponseDecodable>)serializer
+                completion:(void (^)(id<STPAPIResponseDecodable>, NSError *))completion {
+    
+    NSURL *url = [apiClient.apiURL URLByAppendingPathComponent:endpoint];
+    NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url];
+    request.HTTPMethod = @"POST";
+    request.HTTPBody = postData;
+    
+    [[apiClient.urlSession dataTaskWithRequest:request completionHandler:^(NSData * _Nullable body, __unused NSURLResponse * _Nullable response, NSError * _Nullable error) {
+        NSDictionary *jsonDictionary = body ? [NSJSONSerialization JSONObjectWithData:body options:0 error:NULL] : nil;
+        id<STPAPIResponseDecodable> responseObject = [[serializer class] decodedObjectFromAPIResponse:jsonDictionary];
+        NSError *returnedError = [STPError errorFromStripeResponse:jsonDictionary] ?: error;
+        if (!responseObject && !returnedError) {
+            NSDictionary *userInfo = @{
+                                       NSLocalizedDescriptionKey: STPUnexpectedError,
+                                       STPErrorMessageKey: @"The response from Stripe failed to get parsed into valid JSON."
+                                       };
+            returnedError = [[NSError alloc] initWithDomain:StripeDomain code:STPAPIError userInfo:userInfo];
+        }
+        if (returnedError) {
+            [apiClient.operationQueue addOperationWithBlock:^{
+                completion(nil, returnedError);
+            }];
+            return;
+        }
+        [apiClient.operationQueue addOperationWithBlock:^{
+            completion(responseObject, nil);
+        }];
+    }] resume];
+
+}
+
+@end
+
 @implementation STPAPIClient
 
 + (instancetype)sharedClient {
@@ -60,14 +110,14 @@ static NSString *STPDefaultPublishableKey;
     self = [super init];
     if (self) {
         [self.class validateKey:publishableKey];
-        _apiURL = [[[NSURL URLWithString:[NSString stringWithFormat:@"https://%@", apiURLBase]] URLByAppendingPathComponent:apiVersion]
-            URLByAppendingPathComponent:tokenEndpoint];
+        _apiURL = [[NSURL URLWithString:[NSString stringWithFormat:@"https://%@", apiURLBase]] URLByAppendingPathComponent:apiVersion];
         _publishableKey = [publishableKey copy];
         _operationQueue = [NSOperationQueue mainQueue];
         NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
         NSString *auth = [@"Bearer " stringByAppendingString:self.publishableKey];
         config.HTTPAdditionalHeaders = @{
                                          @"X-Stripe-User-Agent": [self.class stripeUserAgentDetails],
+                                         @"Stripe-Version": @"2015-10-12",
                                          @"Authorization": auth,
                                          };
         _urlSession = [NSURLSession sessionWithConfiguration:config delegate:self delegateQueue:_operationQueue];
@@ -83,48 +133,11 @@ static NSString *STPDefaultPublishableKey;
 - (void)createTokenWithData:(NSData *)data completion:(STPCompletionBlock)completion {
     NSCAssert(data != nil, @"'data' is required to create a token");
     NSCAssert(completion != nil, @"'completion' is required to use the token that is created");
-    
-    NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:self.apiURL];
-    request.HTTPMethod = @"POST";
-    request.HTTPBody = data;
-    
-    [[self.urlSession dataTaskWithRequest:request completionHandler:^(NSData * _Nullable body, NSURLResponse * _Nullable response, NSError * _Nullable error) {
-        if (error) {
-            // If this is an error that Stripe returned, let's handle it as a StripeDomain error
-            if (body) {
-                NSDictionary *jsonDictionary = [NSJSONSerialization JSONObjectWithData:body options:0 error:NULL];
-                if ([jsonDictionary valueForKey:@"error"] != nil) {
-                    [self.operationQueue addOperationWithBlock:^{
-                        completion(nil, [self.class errorFromStripeResponse:jsonDictionary]);
-                    }];
-                    return;
-                }
-            }
-            [self.operationQueue addOperationWithBlock:^{
-                completion(nil, error);
-            }];
-            return;
-        } else {
-            NSDictionary *jsonDictionary = [NSJSONSerialization JSONObjectWithData:body options:0 error:NULL];
-            if (!jsonDictionary) {
-                NSDictionary *userInfo = @{
-                                           NSLocalizedDescriptionKey: STPUnexpectedError,
-                                           STPErrorMessageKey: @"The response from Stripe failed to get parsed into valid JSON."
-                                           };
-                NSError *jsonError = [[NSError alloc] initWithDomain:StripeDomain code:STPAPIError userInfo:userInfo];
-                completion(nil, jsonError);
-            } else if ([(NSHTTPURLResponse *)response statusCode] == 200) {
-                [self.operationQueue addOperationWithBlock:^{
-                                     STPToken *token = [STPToken decodedObjectFromAPIResponse:jsonDictionary];
-                                     completion(token, nil);
-                }];
-            } else {
-                [self.operationQueue addOperationWithBlock:^{
-                    completion(nil, [self.class errorFromStripeResponse:jsonDictionary]);
-                }];
-            }
-        }
-    }] resume];
+    [STPAPIPostRequest<STPToken *> startWithAPIClient:self
+                                             endpoint:tokenEndpoint
+                                             postData:data
+                                           serializer:[STPToken new]
+                                           completion:completion];
 }
 
 #pragma mark - private helpers
@@ -146,62 +159,6 @@ static NSString *STPDefaultPublishableKey;
 #endif
 }
 #pragma clang diagnostic pop
-
-+ (NSError *)errorFromStripeResponse:(NSDictionary *)jsonDictionary {
-    NSDictionary *errorDictionary = jsonDictionary[@"error"];
-    NSString *type = errorDictionary[@"type"];
-    NSString *devMessage = errorDictionary[@"message"];
-    NSString *parameter = errorDictionary[@"param"];
-    NSInteger code = 0;
-
-    // There should always be a message and type for the error
-    if (devMessage == nil || type == nil) {
-        NSDictionary *userInfo = @{
-            NSLocalizedDescriptionKey: STPUnexpectedError,
-            STPErrorMessageKey: @"Could not interpret the error response that was returned from Stripe."
-        };
-        return [[NSError alloc] initWithDomain:StripeDomain code:STPAPIError userInfo:userInfo];
-    }
-
-    NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
-    userInfo[STPErrorMessageKey] = devMessage;
-
-    if (parameter) {
-        userInfo[STPErrorParameterKey] = [STPFormEncoder stringByReplacingSnakeCaseWithCamelCase:parameter];
-    }
-
-    if ([type isEqualToString:@"api_error"]) {
-        code = STPAPIError;
-        userInfo[NSLocalizedDescriptionKey] = STPUnexpectedError;
-    } else if ([type isEqualToString:@"invalid_request_error"]) {
-        code = STPInvalidRequestError;
-        userInfo[NSLocalizedDescriptionKey] = devMessage;
-    } else if ([type isEqualToString:@"card_error"]) {
-        code = STPCardError;
-        NSDictionary *errorCodes = @{
-            @"incorrect_number": @{@"code": STPIncorrectNumber, @"message": STPCardErrorInvalidNumberUserMessage},
-            @"invalid_number": @{@"code": STPInvalidNumber, @"message": STPCardErrorInvalidNumberUserMessage},
-            @"invalid_expiry_month": @{@"code": STPInvalidExpMonth, @"message": STPCardErrorInvalidExpMonthUserMessage},
-            @"invalid_expiry_year": @{@"code": STPInvalidExpYear, @"message": STPCardErrorInvalidExpYearUserMessage},
-            @"invalid_cvc": @{@"code": STPInvalidCVC, @"message": STPCardErrorInvalidCVCUserMessage},
-            @"expired_card": @{@"code": STPExpiredCard, @"message": STPCardErrorExpiredCardUserMessage},
-            @"incorrect_cvc": @{@"code": STPIncorrectCVC, @"message": STPCardErrorInvalidCVCUserMessage},
-            @"card_declined": @{@"code": STPCardDeclined, @"message": STPCardErrorDeclinedUserMessage},
-            @"processing_error": @{@"code": STPProcessingError, @"message": STPCardErrorProcessingErrorUserMessage},
-        };
-        NSDictionary *codeMapEntry = errorCodes[errorDictionary[@"code"]];
-
-        if (codeMapEntry) {
-            userInfo[STPCardErrorCodeKey] = codeMapEntry[@"code"];
-            userInfo[NSLocalizedDescriptionKey] = codeMapEntry[@"message"];
-        } else {
-            userInfo[STPCardErrorCodeKey] = errorDictionary[@"code"];
-            userInfo[NSLocalizedDescriptionKey] = devMessage;
-        }
-    }
-
-    return [[NSError alloc] initWithDomain:StripeDomain code:code userInfo:userInfo];
-}
 
 #pragma mark Utility methods -
 

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -82,7 +82,7 @@ static NSString *STPDefaultPublishableKey;
     _operationQueue = operationQueue;
 }
 
-- (void)createTokenWithData:(NSData *)data completion:(STPCompletionBlock)completion {
+- (void)createTokenWithData:(NSData *)data completion:(STPTokenCompletionBlock)completion {
     NSCAssert(data != nil, @"'data' is required to create a token");
     NSCAssert(completion != nil, @"'completion' is required to use the token that is created");
     [STPAPIPostRequest<STPToken *> startWithAPIClient:self
@@ -149,7 +149,7 @@ static NSString *STPDefaultPublishableKey;
 #pragma mark - Bank Accounts
 @implementation STPAPIClient (BankAccounts)
 
-- (void)createTokenWithBankAccount:(STPBankAccountParams *)bankAccount completion:(STPCompletionBlock)completion {
+- (void)createTokenWithBankAccount:(STPBankAccountParams *)bankAccount completion:(STPTokenCompletionBlock)completion {
     NSData *data = [STPFormEncoder formEncodedDataForObject:bankAccount];
     [self createTokenWithData:data completion:completion];
 }
@@ -159,7 +159,7 @@ static NSString *STPDefaultPublishableKey;
 #pragma mark - Credit Cards
 @implementation STPAPIClient (CreditCards)
 
-- (void)createTokenWithCard:(STPCard *)card completion:(STPCompletionBlock)completion {
+- (void)createTokenWithCard:(STPCard *)card completion:(STPTokenCompletionBlock)completion {
     NSData *data = [STPFormEncoder formEncodedDataForObject:card];
     [self createTokenWithData:data completion:completion];
 }

--- a/Stripe/STPAPIPostRequest.h
+++ b/Stripe/STPAPIPostRequest.h
@@ -1,0 +1,21 @@
+//
+//  STPAPIPostRequest.h
+//  Stripe
+//
+//  Created by Jack Flintermann on 10/14/15.
+//  Copyright © 2015 Stripe, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "STPAPIResponseDecodable.h"
+@class STPAPIClient;
+
+@interface STPAPIPostRequest<__covariant ResponseType:id<STPAPIResponseDecodable>> : NSObject
+
++ (void)startWithAPIClient:(STPAPIClient *)apiClient
+                  endpoint:(NSString *)endpoint
+                  postData:(NSData *)postData
+                serializer:(ResponseType)serializer
+                completion:(void (^)(ResponseType object, NSError *error))completion;
+
+@end

--- a/Stripe/STPAPIPostRequest.m
+++ b/Stripe/STPAPIPostRequest.m
@@ -1,0 +1,51 @@
+//
+//  STPAPIPostRequest.m
+//  Stripe
+//
+//  Created by Jack Flintermann on 10/14/15.
+//  Copyright © 2015 Stripe, Inc. All rights reserved.
+//
+
+#import "STPAPIPostRequest.h"
+#import "STPAPIClient.h"
+#import "STPAPIClient+Private.h"
+#import "StripeError.h"
+
+@implementation STPAPIPostRequest
+
++ (void)startWithAPIClient:(STPAPIClient *)apiClient
+                  endpoint:(NSString *)endpoint
+                  postData:(NSData *)postData
+                serializer:(id<STPAPIResponseDecodable>)serializer
+                completion:(void (^)(id<STPAPIResponseDecodable>, NSError *))completion {
+    
+    NSURL *url = [apiClient.apiURL URLByAppendingPathComponent:endpoint];
+    NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url];
+    request.HTTPMethod = @"POST";
+    request.HTTPBody = postData;
+    
+    [[apiClient.urlSession dataTaskWithRequest:request completionHandler:^(NSData * _Nullable body, __unused NSURLResponse * _Nullable response, NSError * _Nullable error) {
+        NSDictionary *jsonDictionary = body ? [NSJSONSerialization JSONObjectWithData:body options:0 error:NULL] : nil;
+        id<STPAPIResponseDecodable> responseObject = [[serializer class] decodedObjectFromAPIResponse:jsonDictionary];
+        NSError *returnedError = [STPError errorFromStripeResponse:jsonDictionary] ?: error;
+        if (!responseObject && !returnedError) {
+            NSDictionary *userInfo = @{
+                                       NSLocalizedDescriptionKey: STPUnexpectedError,
+                                       STPErrorMessageKey: @"The response from Stripe failed to get parsed into valid JSON."
+                                       };
+            returnedError = [[NSError alloc] initWithDomain:StripeDomain code:STPAPIError userInfo:userInfo];
+        }
+        if (returnedError) {
+            [apiClient.operationQueue addOperationWithBlock:^{
+                completion(nil, returnedError);
+            }];
+            return;
+        }
+        [apiClient.operationQueue addOperationWithBlock:^{
+            completion(responseObject, nil);
+        }];
+    }] resume];
+    
+}
+
+@end

--- a/Stripe/STPAPIPostRequest.m
+++ b/Stripe/STPAPIPostRequest.m
@@ -27,7 +27,7 @@
     [[apiClient.urlSession dataTaskWithRequest:request completionHandler:^(NSData * _Nullable body, __unused NSURLResponse * _Nullable response, NSError * _Nullable error) {
         NSDictionary *jsonDictionary = body ? [NSJSONSerialization JSONObjectWithData:body options:0 error:NULL] : nil;
         id<STPAPIResponseDecodable> responseObject = [[serializer class] decodedObjectFromAPIResponse:jsonDictionary];
-        NSError *returnedError = [NSError errorFromStripeResponse:jsonDictionary] ?: error;
+        NSError *returnedError = [NSError stp_errorFromStripeResponse:jsonDictionary] ?: error;
         if (!responseObject && !returnedError) {
             NSDictionary *userInfo = @{
                                        NSLocalizedDescriptionKey: STPUnexpectedError,

--- a/Stripe/STPBankAccount.m
+++ b/Stripe/STPBankAccount.m
@@ -7,6 +7,7 @@
 //
 
 #import "STPBankAccount.h"
+#import "NSDictionary+Stripe.h"
 
 @interface STPBankAccount ()
 
@@ -67,19 +68,12 @@
 }
 
 + (instancetype)decodedObjectFromAPIResponse:(NSDictionary *)response {
-    STPBankAccount *bankAccount = [self new];
-    NSMutableDictionary *dict = [NSMutableDictionary dictionary];
-    [response enumerateKeysAndObjectsUsingBlock:^(id key, id obj, __unused BOOL *stop) {
-        if (obj != [NSNull null]) {
-            dict[key] = obj;
-        }
-    }];
-    for (NSString *key in [self requiredFields]) {
-        if (![[dict allKeys] containsObject:key]) {
-            return nil;
-        }
+    NSDictionary *dict = [response stp_dictionaryByRemovingNullsValidatingRequiredFields:[self requiredFields]];
+    if (!dict) {
+        return nil;
     }
     
+    STPBankAccount *bankAccount = [self new];
     bankAccount.bankAccountId = dict[@"id"];
     bankAccount.last4 = dict[@"last4"];
     bankAccount.bankName = dict[@"bank_name"];

--- a/Stripe/STPBankAccountParams.m
+++ b/Stripe/STPBankAccountParams.m
@@ -18,11 +18,11 @@
     }
 }
 
-- (NSString *)rootObjectName {
++ (NSString *)rootObjectName {
     return @"bank_account";
 }
 
-- (NSDictionary *)propertyNamesToFormFieldNamesMapping {
++ (NSDictionary *)propertyNamesToFormFieldNamesMapping {
     return @{
              @"accountNumber": @"account_number",
              @"routingNumber": @"routing_number",

--- a/Stripe/STPCard.m
+++ b/Stripe/STPCard.m
@@ -80,6 +80,10 @@
 }
 
 #pragma mark STPAPIResponseDecodable
++ (NSArray *)requiredFields {
+    return @[@"id", @"last4", @"brand", @"exp_month", @"exp_year"];
+}
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated"
 + (instancetype)decodedObjectFromAPIResponse:(NSDictionary *)response {
@@ -90,12 +94,17 @@
             dict[key] = obj;
         }
     }];
+    for (NSString *key in [self requiredFields]) {
+        if (![[dict allKeys] containsObject:key]) {
+            return nil;
+        }
+    }
     
     card.cardId = dict[@"id"];
     card.name = dict[@"name"];
     card.last4 = dict[@"last4"];
     card.dynamicLast4 = dict[@"dynamic_last4"];
-    NSString *brand = dict[@"brand"] ?: dict[@"type"];
+    NSString *brand = dict[@"brand"];
     if ([brand isEqualToString:@"Visa"]) {
         card.brand = STPCardBrandVisa;
     } else if ([brand isEqualToString:@"American Express"]) {
@@ -124,15 +133,14 @@
     card.fingerprint = dict[@"fingerprint"];
     card.country = dict[@"country"];
     card.currency = dict[@"currency"];
-    // Support both camelCase and snake_case keys
-    card.expMonth = [(dict[@"exp_month"] ?: dict[@"expMonth"])intValue];
-    card.expYear = [(dict[@"exp_year"] ?: dict[@"expYear"])intValue];
-    card.addressLine1 = dict[@"address_line1"] ?: dict[@"addressLine1"];
-    card.addressLine2 = dict[@"address_line2"] ?: dict[@"addressLine2"];
-    card.addressCity = dict[@"address_city"] ?: dict[@"addressCity"];
-    card.addressState = dict[@"address_state"] ?: dict[@"addressState"];
-    card.addressZip = dict[@"address_zip"] ?: dict[@"addressZip"];
-    card.addressCountry = dict[@"address_country"] ?: dict[@"addressCountry"];
+    card.expMonth = [dict[@"exp_month"] intValue];
+    card.expYear = [dict[@"exp_year"] intValue];
+    card.addressLine1 = dict[@"address_line1"];
+    card.addressLine2 = dict[@"address_line2"];
+    card.addressCity = dict[@"address_city"];
+    card.addressState = dict[@"address_state"];
+    card.addressZip = dict[@"address_zip"];
+    card.addressCountry = dict[@"address_country"];
     return card;
 }
 #pragma clang diagnostic pop

--- a/Stripe/STPCard.m
+++ b/Stripe/STPCard.m
@@ -9,6 +9,7 @@
 #import "STPCard.h"
 #import "StripeError.h"
 #import "STPCardValidator.h"
+#import "NSDictionary+Stripe.h"
 
 @interface STPCard ()
 
@@ -87,19 +88,12 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated"
 + (instancetype)decodedObjectFromAPIResponse:(NSDictionary *)response {
-    STPCard *card = [self new];
-    NSMutableDictionary *dict = [NSMutableDictionary dictionary];
-    [response enumerateKeysAndObjectsUsingBlock:^(id key, id obj, __unused BOOL *stop) {
-        if (obj != [NSNull null]) {
-            dict[key] = obj;
-        }
-    }];
-    for (NSString *key in [self requiredFields]) {
-        if (![[dict allKeys] containsObject:key]) {
-            return nil;
-        }
+    NSDictionary *dict = [response stp_dictionaryByRemovingNullsValidatingRequiredFields:[self requiredFields]];
+    if (!dict) {
+        return nil;
     }
     
+    STPCard *card = [self new];
     card.cardId = dict[@"id"];
     card.name = dict[@"name"];
     card.last4 = dict[@"last4"];

--- a/Stripe/STPCardParams.m
+++ b/Stripe/STPCardParams.m
@@ -139,11 +139,11 @@
 
 #pragma mark - STPFormEncodable
 
-- (NSString *)rootObjectName {
++ (NSString *)rootObjectName {
     return @"card";
 }
 
-- (NSDictionary *)propertyNamesToFormFieldNamesMapping {
++ (NSDictionary *)propertyNamesToFormFieldNamesMapping {
     return @{
              @"number": @"number",
              @"cvc": @"cvc",

--- a/Stripe/STPFormEncoder.m
+++ b/Stripe/STPFormEncoder.m
@@ -15,10 +15,10 @@
 
 + (nonnull NSData *)formEncodedDataForObject:(nonnull NSObject<STPFormEncodable> *)object {
     NSMutableArray *parts = [NSMutableArray array];
-    [[object propertyNamesToFormFieldNamesMapping] enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull propertyName, NSString *  _Nonnull formFieldName, __unused BOOL * _Nonnull stop) {
+    [[object.class propertyNamesToFormFieldNamesMapping] enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull propertyName, NSString *  _Nonnull formFieldName, __unused BOOL * _Nonnull stop) {
         NSString *formFieldValue = [[object valueForKey:propertyName] description];
         if (formFieldValue) {
-            [parts addObject:[NSString stringWithFormat:@"%@[%@]=%@", [object rootObjectName], formFieldName, [self.class stringByURLEncoding:formFieldValue]]];
+            [parts addObject:[NSString stringWithFormat:@"%@[%@]=%@", [object.class rootObjectName], formFieldName, [self.class stringByURLEncoding:formFieldValue]]];
         }
     }];
     return [[parts componentsJoinedByString:@"&"] dataUsingEncoding:NSUTF8StringEncoding];

--- a/Stripe/STPToken.m
+++ b/Stripe/STPToken.m
@@ -9,6 +9,7 @@
 #import "STPToken.h"
 #import "STPCard.h"
 #import "STPBankAccount.h"
+#import "NSDictionary+Stripe.h"
 
 @interface STPToken()
 @property (nonatomic, nonnull) NSString *tokenId;
@@ -63,19 +64,12 @@
 }
 
 + (instancetype)decodedObjectFromAPIResponse:(NSDictionary *)response {
-    STPToken *token = [self new];
-    NSMutableDictionary *dict = [NSMutableDictionary dictionary];
-    [response enumerateKeysAndObjectsUsingBlock:^(id key, id obj, __unused BOOL *stop) {
-        if (obj != [NSNull null]) {
-            dict[key] = obj;
-        }
-    }];
-    for (NSString *key in [self requiredFields]) {
-        if (![[dict allKeys] containsObject:key]) {
-            return nil;
-        }
+    NSDictionary *dict = [response stp_dictionaryByRemovingNullsValidatingRequiredFields:[self requiredFields]];
+    if (!dict) {
+        return nil;
     }
     
+    STPToken *token = [self new];
     token.tokenId = dict[@"id"];
     token.livemode = [dict[@"livemode"] boolValue];
     token.created = [NSDate dateWithTimeIntervalSince1970:[dict[@"created"] doubleValue]];

--- a/Stripe/STPToken.m
+++ b/Stripe/STPToken.m
@@ -58,6 +58,10 @@
 
 #pragma mark STPAPIResponseDecodable
 
++ (NSArray *)requiredFields {
+    return @[@"id", @"livemode", @"created"];
+}
+
 + (instancetype)decodedObjectFromAPIResponse:(NSDictionary *)response {
     STPToken *token = [self new];
     NSMutableDictionary *dict = [NSMutableDictionary dictionary];
@@ -66,8 +70,13 @@
             dict[key] = obj;
         }
     }];
+    for (NSString *key in [self requiredFields]) {
+        if (![[dict allKeys] containsObject:key]) {
+            return nil;
+        }
+    }
     
-    token.tokenId = dict[@"id"] ?: @"";
+    token.tokenId = dict[@"id"];
     token.livemode = [dict[@"livemode"] boolValue];
     token.created = [NSDate dateWithTimeIntervalSince1970:[dict[@"created"] doubleValue]];
     

--- a/Stripe/StripeError.m
+++ b/Stripe/StripeError.m
@@ -23,7 +23,7 @@ NSString *const STPCardDeclined = @"com.stripe.lib:CardDeclined";
 NSString *const STPProcessingError = @"com.stripe.lib:ProcessingError";
 NSString *const STPIncorrectCVC = @"com.stripe.lib:IncorrectCVC";
 
-@implementation STPError
+@implementation NSError(Stripe)
 
 + (NSError *)errorFromStripeResponse:(NSDictionary *)jsonDictionary {
     NSDictionary *errorDictionary = jsonDictionary[@"error"];

--- a/Stripe/StripeError.m
+++ b/Stripe/StripeError.m
@@ -7,6 +7,7 @@
 //
 
 #import "StripeError.h"
+#import "STPFormEncoder.h"
 
 NSString *const StripeDomain = @"com.stripe.lib";
 NSString *const STPCardErrorCodeKey = @"com.stripe.lib:CardErrorCodeKey";
@@ -21,3 +22,66 @@ NSString *const STPExpiredCard = @"com.stripe.lib:ExpiredCard";
 NSString *const STPCardDeclined = @"com.stripe.lib:CardDeclined";
 NSString *const STPProcessingError = @"com.stripe.lib:ProcessingError";
 NSString *const STPIncorrectCVC = @"com.stripe.lib:IncorrectCVC";
+
+@implementation STPError
+
++ (NSError *)errorFromStripeResponse:(NSDictionary *)jsonDictionary {
+    NSDictionary *errorDictionary = jsonDictionary[@"error"];
+    if (!errorDictionary) {
+        return nil;
+    }
+    NSString *type = errorDictionary[@"type"];
+    NSString *devMessage = errorDictionary[@"message"];
+    NSString *parameter = errorDictionary[@"param"];
+    NSInteger code = 0;
+    
+    // There should always be a message and type for the error
+    if (devMessage == nil || type == nil) {
+        NSDictionary *userInfo = @{
+                                   NSLocalizedDescriptionKey: STPUnexpectedError,
+                                   STPErrorMessageKey: @"Could not interpret the error response that was returned from Stripe."
+                                   };
+        return [[NSError alloc] initWithDomain:StripeDomain code:STPAPIError userInfo:userInfo];
+    }
+    
+    NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
+    userInfo[STPErrorMessageKey] = devMessage;
+    
+    if (parameter) {
+        userInfo[STPErrorParameterKey] = [STPFormEncoder stringByReplacingSnakeCaseWithCamelCase:parameter];
+    }
+    
+    if ([type isEqualToString:@"api_error"]) {
+        code = STPAPIError;
+        userInfo[NSLocalizedDescriptionKey] = STPUnexpectedError;
+    } else if ([type isEqualToString:@"invalid_request_error"]) {
+        code = STPInvalidRequestError;
+        userInfo[NSLocalizedDescriptionKey] = devMessage;
+    } else if ([type isEqualToString:@"card_error"]) {
+        code = STPCardError;
+        NSDictionary *errorCodes = @{
+                                     @"incorrect_number": @{@"code": STPIncorrectNumber, @"message": STPCardErrorInvalidNumberUserMessage},
+                                     @"invalid_number": @{@"code": STPInvalidNumber, @"message": STPCardErrorInvalidNumberUserMessage},
+                                     @"invalid_expiry_month": @{@"code": STPInvalidExpMonth, @"message": STPCardErrorInvalidExpMonthUserMessage},
+                                     @"invalid_expiry_year": @{@"code": STPInvalidExpYear, @"message": STPCardErrorInvalidExpYearUserMessage},
+                                     @"invalid_cvc": @{@"code": STPInvalidCVC, @"message": STPCardErrorInvalidCVCUserMessage},
+                                     @"expired_card": @{@"code": STPExpiredCard, @"message": STPCardErrorExpiredCardUserMessage},
+                                     @"incorrect_cvc": @{@"code": STPIncorrectCVC, @"message": STPCardErrorInvalidCVCUserMessage},
+                                     @"card_declined": @{@"code": STPCardDeclined, @"message": STPCardErrorDeclinedUserMessage},
+                                     @"processing_error": @{@"code": STPProcessingError, @"message": STPCardErrorProcessingErrorUserMessage},
+                                     };
+        NSDictionary *codeMapEntry = errorCodes[errorDictionary[@"code"]];
+        
+        if (codeMapEntry) {
+            userInfo[STPCardErrorCodeKey] = codeMapEntry[@"code"];
+            userInfo[NSLocalizedDescriptionKey] = codeMapEntry[@"message"];
+        } else {
+            userInfo[STPCardErrorCodeKey] = errorDictionary[@"code"];
+            userInfo[NSLocalizedDescriptionKey] = devMessage;
+        }
+    }
+    
+    return [[NSError alloc] initWithDomain:StripeDomain code:code userInfo:userInfo];
+}
+
+@end

--- a/Stripe/StripeError.m
+++ b/Stripe/StripeError.m
@@ -25,7 +25,7 @@ NSString *const STPIncorrectCVC = @"com.stripe.lib:IncorrectCVC";
 
 @implementation NSError(Stripe)
 
-+ (NSError *)errorFromStripeResponse:(NSDictionary *)jsonDictionary {
++ (NSError *)stp_errorFromStripeResponse:(NSDictionary *)jsonDictionary {
     NSDictionary *errorDictionary = jsonDictionary[@"error"];
     if (!errorDictionary) {
         return nil;

--- a/Tests/Tests/STPBankAccountTest.m
+++ b/Tests/Tests/STPBankAccountTest.m
@@ -29,8 +29,7 @@
         @"country": @"US",
         @"fingerprint": @"something",
         @"currency": @"usd",
-        @"validated": @(NO),
-        @"disabled": @(NO)
+        @"status": @"new",
     };
 }
 
@@ -43,8 +42,7 @@
     XCTAssertEqualObjects([bankAccountWithAttributes country], @"US", @"country is set correctly");
     XCTAssertEqualObjects([bankAccountWithAttributes fingerprint], @"something", @"fingerprint is set correctly");
     XCTAssertEqualObjects([bankAccountWithAttributes currency], @"usd", @"currency is set correctly");
-    XCTAssertEqual([bankAccountWithAttributes validated], NO, @"validated is set correctly");
-    XCTAssertEqual([bankAccountWithAttributes disabled], NO, @"disabled is set correctly");
+    XCTAssertEqual(bankAccountWithAttributes.status, STPBankAccountStatusNew);
 }
 
 - (void)testFormEncode {

--- a/Tests/Tests/STPCardFunctionalTest.m
+++ b/Tests/Tests/STPCardFunctionalTest.m
@@ -60,7 +60,7 @@
 
                          XCTAssertNotNil(error, @"error should not be nil");
                          XCTAssertEqual(error.code, 70);
-                         XCTAssertEqual(error.domain, StripeDomain);
+                         XCTAssertEqualObjects(error.domain, StripeDomain);
                          XCTAssertEqualObjects(error.userInfo[STPErrorParameterKey], @"number");
                          XCTAssertNil(token, @"token should not be nil: %@", token.description);
                      }];

--- a/Tests/Tests/STPCertTest.m
+++ b/Tests/Tests/STPCertTest.m
@@ -56,7 +56,7 @@ NSString *const STPExamplePublishableKey = @"bad_key";
 }
 
 // helper method
-- (void)createTokenWithBaseURL:(NSURL *)baseURL completion:(STPCompletionBlock)completion {
+- (void)createTokenWithBaseURL:(NSURL *)baseURL completion:(STPTokenCompletionBlock)completion {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Token creation"];
     STPAPIClient *client = [[STPAPIClient alloc] initWithPublishableKey:STPExamplePublishableKey];
     client.apiURL = baseURL;

--- a/Tests/Tests/STPCertTest.m
+++ b/Tests/Tests/STPCertTest.m
@@ -9,6 +9,7 @@
 @import XCTest;
 
 #import "STPAPIClient.h"
+#import "STPAPIClient+Private.h"
 #import "Stripe.h"
 
 NSString *const STPExamplePublishableKey = @"bad_key";

--- a/Tests/Tests/STPTokenTest.m
+++ b/Tests/Tests/STPTokenTest.m
@@ -17,16 +17,17 @@
 @implementation STPTokenTest
 - (void)testCreatingTokenWithAttributeDictionarySetsAttributes {
     NSDictionary *cardDict = @{
-        @"expMonth": @"12",
-        @"expYear": @"2013",
+        @"id": @"card_123",
+        @"exp_month": @"12",
+        @"exp_year": @"2013",
         @"name": @"Smerlock Smolmes",
-        @"addressLine1": @"221A Baker Street",
-        @"addressCity": @"New York",
-        @"addressState": @"NY",
-        @"addressZip": @"12345",
-        @"addressCountry": @"USA",
+        @"address_line1": @"221A Baker Street",
+        @"address_city": @"New York",
+        @"address_state": @"NY",
+        @"address_zip": @"12345",
+        @"address_country": @"USA",
         @"last4": @"1234",
-        @"type": @"Smastersmard",
+        @"brand": @"Visa",
         @"fingerprint": @"Fingolfin",
         @"country": @"Japan"
     };

--- a/ci_scripts/FauxPasConfig/main.fauxpas.json
+++ b/ci_scripts/FauxPasConfig/main.fauxpas.json
@@ -89,13 +89,19 @@
             // strings)
             //"ignoredFileRegexes": null
         },
-        // Options for rule: Block-typed declaration without typedef
-        "NonTypedefBlockDeclaration": {
-            // Apply only to function/method arguments (Boolean)
-            //"onlyArguments": true
+        // Options for rule: Associated object on value-like type
+        "AssociatedObjectOnValueType": {
             // Regexes for ignored file paths (Array of regular expression
             // strings)
             //"ignoredFileRegexes": null
+        },
+        // Options for rule: Block-typed declaration without typedef
+        "NonTypedefBlockDeclaration": {
+            // Apply only to function/method arguments (Boolean)
+            //"onlyArguments": true,
+            // Regexes for ignored file paths (Array of regular expression
+            // strings)
+            "ignoredFileRegexes": ["STPAPIPostRequest.*"]
         },
         // Options for rule: Build settings set in Xcode GUI
         "BuildSettingsSetInGUI": {
@@ -126,6 +132,12 @@
         },
         // Options for rule: Code refers to unknown resource
         "UnknownResourceCodeReference": {
+            // Regexes for ignored file paths (Array of regular expression
+            // strings)
+            //"ignoredFileRegexes": null
+        },
+        // Options for rule: Complete NSNotificationCenter detachment
+        "CompleteNotificationCenterDetachment": {
             // Regexes for ignored file paths (Array of regular expression
             // strings)
             //"ignoredFileRegexes": null
@@ -226,6 +238,16 @@
         "ThreadUnsafeInstanceCaching": {
             // The thread-unsafe classes to warn about (Array of strings)
             "classNames": ["NSDateFormatter","NSMutableArray","NSMutableAttributedString","NSMutableCharacterSet","NSMutableData","NSMutableDictionary","NSMutableSet","NSMutableString","NSNumberFormatter"]
+            // Regexes for ignored file paths (Array of regular expression
+            // strings)
+            //"ignoredFileRegexes": null
+        },
+        // Options for rule: Hardcoded self class reference
+        "HardcodedSelfClass": {
+            // Warn only about allocations (Boolean)
+            //"warnOnlyAboutAlloc": false
+            // Check only factory methods (Boolean)
+            //"checkOnlyFactoryMethods": false
             // Regexes for ignored file paths (Array of regular expression
             // strings)
             //"ignoredFileRegexes": null
@@ -495,6 +517,10 @@
             //"workspaceIgnored": false
             // Whether CocoaPods data should be ignored (Boolean)
             //"cocoaPodsIgnored": false
+            // Whether Carthage/Build should be ignored (Boolean)
+            //"carthageBuildIgnored": true
+            // Whether Carthage/Checkouts should be ignored (Boolean)
+            //"carthageCheckoutsIgnored": false
             // Whether user-specific AppCode data should be ignored (Boolean)
             //"appCodeUserDataIgnored": true
             // Regexes for ignored file paths (Array of regular expression
@@ -520,6 +546,9 @@
             // Whether the ‘wrap lines’ setting should be set or not ("wrap" /
             // "nowrap")
             //"wrapLines": null
+            // Whether the ‘class prefix’ project setting should have a value
+            // (Boolean)
+            //"expectClassPrefix": true
             // Regexes for ignored file paths (Array of regular expression
             // strings)
             //"ignoredFileRegexes": null


### PR DESCRIPTION
This uses objective-c generics (!) to DRY up STPAPIClient. It also, notably, adds API versioning to STPAPIClient - it's now locked to "2015-10-12".
r? @benzguo