### PR TITLE
Configure brand images

### DIFF
--- a/Stripe/PublicHeaders/UI/STPPaymentCardTextField.h
+++ b/Stripe/PublicHeaders/UI/STPPaymentCardTextField.h
@@ -128,6 +128,9 @@
  */
 - (void)clear;
 
+- (nullable UIImage *)cvcImageForCardBrand:(STPCardBrand)cardBrand;
+- (nullable UIImage *)brandImageForCardBrand:(STPCardBrand)cardBrand;
+
 /**
  *  Whether or not the form currently contains a valid card number, expiration date, and CVC.
  *  @see STPCardValidator

--- a/Stripe/PublicHeaders/UI/STPPaymentCardTextField.h
+++ b/Stripe/PublicHeaders/UI/STPPaymentCardTextField.h
@@ -128,7 +128,18 @@
  */
 - (void)clear;
 
+/**
+ *  Returns the cvc image used for a card brand.
+ *  @param cardBrand The brand of card entered.
+ *  @return The cvc image for used for a card brand.
+ */
 - (nullable UIImage *)cvcImageForCardBrand:(STPCardBrand)cardBrand;
+
+/**
+ *  Returns the brand image used for a card brand.
+ *  @param cardBrand The brand of card entered.
+ *  @return The brand image for used for a card brand.
+ */
 - (nullable UIImage *)brandImageForCardBrand:(STPCardBrand)cardBrand;
 
 /**

--- a/Stripe/UI/STPPaymentCardTextField.m
+++ b/Stripe/UI/STPPaymentCardTextField.m
@@ -82,7 +82,7 @@ CGFloat const STPPaymentCardTextFieldDefaultPadding = 10;
     _viewModel = [STPPaymentCardTextFieldViewModel new];
     _sizingField = [self buildTextField];
     
-    UIImageView *brandImageView = [[UIImageView alloc] initWithImage:_viewModel.brandImage];
+    UIImageView *brandImageView = [[UIImageView alloc] initWithImage:[self brandImageForFieldType:STPCardFieldTypeNumber]];
     brandImageView.contentMode = UIViewContentModeCenter;
     brandImageView.backgroundColor = [UIColor clearColor];
     if ([brandImageView respondsToSelector:@selector(setTintColor:)]) {
@@ -589,8 +589,24 @@ typedef void (^STPNumberShrunkCompletionBlock)(BOOL completed);
     return NO;
 }
 
+- (UIImage *)cvcImageForCardBrand:(STPCardBrand)cardBrand {
+    return self.viewModel.cvcImage;
+}
+
+- (UIImage *)brandImageForCardBrand:(STPCardBrand)cardBrand {
+    return self.viewModel.brandImage;
+}
+
+- (UIImage *)brandImageForFieldType:(STPCardFieldType)fieldType {
+    if (fieldType == STPCardFieldTypeCVC) {
+        return [self cvcImageForCardBrand:self.viewModel.brand];
+    }
+
+    return [self brandImageForCardBrand:self.viewModel.brand];
+}
+
 - (void)updateImageForFieldType:(STPCardFieldType)fieldType {
-    UIImage *image = fieldType == STPCardFieldTypeCVC ? self.viewModel.cvcImage : self.viewModel.brandImage;
+    UIImage *image = [self brandImageForFieldType:fieldType];
     if (image != self.brandImageView.image) {
         self.brandImageView.image = image;
         

--- a/Stripe/UI/STPPaymentCardTextField.m
+++ b/Stripe/UI/STPPaymentCardTextField.m
@@ -589,6 +589,8 @@ typedef void (^STPNumberShrunkCompletionBlock)(BOOL completed);
     return NO;
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-parameter"
 - (UIImage *)cvcImageForCardBrand:(STPCardBrand)cardBrand {
     return self.viewModel.cvcImage;
 }
@@ -596,6 +598,7 @@ typedef void (^STPNumberShrunkCompletionBlock)(BOOL completed);
 - (UIImage *)brandImageForCardBrand:(STPCardBrand)cardBrand {
     return self.viewModel.brandImage;
 }
+#pragma clang diagnostic pop
 
 - (UIImage *)brandImageForFieldType:(STPCardFieldType)fieldType {
     if (fieldType == STPCardFieldTypeCVC) {


### PR DESCRIPTION
Useful for apps, like mine, that need to customize the brand images used by the card text field.