### PR TITLE
Allow subclasses to override layout rectangles

### DIFF
--- a/Stripe/PublicHeaders/UI/STPPaymentCardTextField.h
+++ b/Stripe/PublicHeaders/UI/STPPaymentCardTextField.h
@@ -108,6 +108,11 @@
 @property(nonatomic, strong, nullable) UIView *inputAccessoryView;
 
 /**
+ *  The curent brand image displayed in the receiver.
+ */
+@property (nonatomic, readonly, nullable) UIImage *brandImage;
+
+/**
  *  Causes the text field to begin editing. Presents the keyboard.
  *
  *  @return Whether or not the text field successfully began editing.
@@ -141,6 +146,41 @@
  *  @return The brand image for used for a card brand.
  */
 - (nullable UIImage *)brandImageForCardBrand:(STPCardBrand)cardBrand;
+
+/**
+ *  Returns the rectangle in which the receiver draws its brand image.
+ *  @param bounds The bounding rectangle of the receiver.
+ *  @return the rectangle in which the receiver draws its brand image.
+ */
+- (CGRect)brandImageRectForBounds:(CGRect)bounds;
+
+/**
+ *  Returns the rectangle in which the receiver draws the text fields.
+ *  @param bounds The bounding rectangle of the receiver.
+ *  @return The rectangle in which the receiver draws the text fields.
+ */
+- (CGRect)fieldsRectForBounds:(CGRect)bounds;
+
+/**
+ *  Returns the rectangle in which the receiver draws its number field.
+ *  @param bounds The bounding rectangle of the receiver.
+ *  @return the rectangle in which the receiver draws its number field.
+ */
+- (CGRect)numberFieldRectForBounds:(CGRect)bounds;
+
+/**
+ *  Returns the rectangle in which the receiver draws its cvc field.
+ *  @param bounds The bounding rectangle of the receiver.
+ *  @return the rectangle in which the receiver draws its cvc field.
+ */
+- (CGRect)cvcFieldRectForBounds:(CGRect)bounds;
+
+/**
+ *  Returns the rectangle in which the receiver draws its expiration field.
+ *  @param bounds The bounding rectangle of the receiver.
+ *  @return the rectangle in which the receiver draws its expiration field.
+ */
+- (CGRect)expirationFieldRectForBounds:(CGRect)bounds;
 
 /**
  *  Whether or not the form currently contains a valid card number, expiration date, and CVC.

--- a/Stripe/UI/STPPaymentCardTextField.m
+++ b/Stripe/UI/STPPaymentCardTextField.m
@@ -417,28 +417,53 @@ CGFloat const STPPaymentCardTextFieldDefaultPadding = 10;
     return CGSizeMake(width, height);
 }
 
-- (void)layoutSubviews {
-    [super layoutSubviews];
-    
-    self.brandImageView.frame = CGRectMake(STPPaymentCardTextFieldDefaultPadding, 2, self.brandImageView.image.size.width, self.frame.size.height - 2);
-    self.fieldsView.frame = CGRectMake(CGRectGetMaxX(self.brandImageView.frame), 0, self.bounds.size.width - CGRectGetMaxX(self.brandImageView.frame), self.frame.size.height);
-    
+- (CGRect)brandImageRectForBounds:(CGRect)bounds {
+    return CGRectMake(STPPaymentCardTextFieldDefaultPadding, 2, self.brandImageView.image.size.width, bounds.size.height - 2);
+}
+
+- (CGRect)fieldsRectForBounds:(CGRect)bounds {
+    CGRect brandImageRect = [self brandImageRectForBounds:bounds];
+    return CGRectMake(CGRectGetMaxX(brandImageRect), 0, CGRectGetWidth(bounds) - CGRectGetMaxX(brandImageRect), CGRectGetHeight(bounds));
+}
+
+- (CGRect)numberFieldRectForBounds:(CGRect)bounds {
     CGFloat placeholderWidth = [self widthForCardNumber:self.numberField.placeholder] - 4;
     CGFloat numberWidth = [self widthForCardNumber:self.viewModel.defaultPlaceholder] - 4;
     CGFloat numberFieldWidth = MAX(placeholderWidth, numberWidth);
     CGFloat nonFragmentWidth = [self widthForCardNumber:[self.viewModel numberWithoutLastDigits]] - 8;
     CGFloat numberFieldX = self.numberFieldShrunk ? STPPaymentCardTextFieldDefaultPadding - nonFragmentWidth : 8;
-    self.numberField.frame = CGRectMake(numberFieldX, 0, numberFieldWidth, self.frame.size.height);
-    
+    return CGRectMake(numberFieldX, 0, numberFieldWidth, CGRectGetHeight(bounds));
+}
+
+- (CGRect)cvcFieldRectForBounds:(CGRect)bounds {
+    CGRect fieldsRect = [self fieldsRectForBounds:bounds];
+
     CGFloat cvcWidth = MAX([self widthForText:self.cvcField.placeholder], [self widthForText:@"8888"]);
     CGFloat cvcX = self.numberFieldShrunk ?
-        self.fieldsView.bounds.size.width - cvcWidth - STPPaymentCardTextFieldDefaultPadding / 2  :
-        self.fieldsView.bounds.size.width;
-    self.cvcField.frame = CGRectMake(cvcX, 0, cvcWidth, self.frame.size.height);
-    
+    CGRectGetWidth(fieldsRect) - cvcWidth - STPPaymentCardTextFieldDefaultPadding / 2  :
+    CGRectGetWidth(fieldsRect);
+    return CGRectMake(cvcX, 0, cvcWidth, CGRectGetHeight(bounds));
+}
+
+- (CGRect)expirationFieldRectForBounds:(CGRect)bounds {
+    CGRect numberFieldRect = [self numberFieldRectForBounds:bounds];
+    CGRect cvcRect = [self cvcFieldRectForBounds:bounds];
+
     CGFloat expirationWidth = MAX([self widthForText:self.expirationField.placeholder], [self widthForText:@"88/88"]);
-    CGFloat expirationX = (CGRectGetMaxX(self.numberField.frame) + CGRectGetMinX(self.cvcField.frame) - expirationWidth) / 2;
-    self.expirationField.frame = CGRectMake(expirationX, 0, expirationWidth, self.frame.size.height);
+    CGFloat expirationX = (CGRectGetMaxX(numberFieldRect) + CGRectGetMinX(cvcRect) - expirationWidth) / 2;
+    return CGRectMake(expirationX, 0, expirationWidth, CGRectGetHeight(bounds));
+}
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+
+    CGRect bounds = self.bounds;
+
+    self.brandImageView.frame = [self brandImageRectForBounds:bounds];
+    self.fieldsView.frame = [self fieldsRectForBounds:bounds];
+    self.numberField.frame = [self numberFieldRectForBounds:bounds];
+    self.cvcField.frame = [self cvcFieldRectForBounds:bounds];
+    self.expirationField.frame = [self expirationFieldRectForBounds:bounds];
     
 }
 
@@ -589,6 +614,14 @@ typedef void (^STPNumberShrunkCompletionBlock)(BOOL completed);
     return NO;
 }
 
+- (UIImage *)brandImage {
+    if (self.selectedField) {
+        return [self brandImageForFieldType:self.selectedField.tag];
+    } else {
+        return [self brandImageForFieldType:STPCardFieldTypeNumber];
+    }
+}
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-parameter"
 - (UIImage *)cvcImageForCardBrand:(STPCardBrand)cardBrand {
@@ -619,6 +652,8 @@ typedef void (^STPNumberShrunkCompletionBlock)(BOOL completed);
         transition.type = kCATransitionFade;
         
         [self.brandImageView.layer addAnimation:transition forKey:nil];
+
+        [self setNeedsLayout];
     }
 }
 


### PR DESCRIPTION
This makes it easier for subclasses to alter how the text field lays out it's different subviews. Or to use the exposed information to add other subviews alongside the already existing views.

It's also a common pattern for `UIControl` subclasses. For example:

- [UIButton](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIButton_Class/#//apple_ref/occ/instm/UIButton/backgroundRectForBounds:)
- [UITextField](https://developer.apple.com/library/prerelease/tvos/documentation/UIKit/Reference/UITextField_Class/index.html#//apple_ref/occ/instm/UITextField/textRectForBounds:)