### PR TITLE
[ApplePay] Take name and address from shippingAddress if present

### DIFF
--- a/Stripe/ApplePay/STPAPIClient+ApplePay.m
+++ b/Stripe/ApplePay/STPAPIClient+ApplePay.m
@@ -17,6 +17,52 @@
     [self createTokenWithData:[self.class formEncodedDataForPayment:payment] completion:completion];
 }
 
++ (NSString * _Nonnull)queryStringForAddress:(ABRecordRef _Nullable)addressRef characterSet:(NSCharacterSet * _Nonnull)set {
+    NSMutableDictionary *params = [NSMutableDictionary dictionary];
+    __block NSString *queryString = [NSString string];
+
+    NSString *firstName = (__bridge_transfer NSString*)ABRecordCopyValue(addressRef, kABPersonFirstNameProperty);
+    NSString *lastName = (__bridge_transfer NSString*)ABRecordCopyValue(addressRef, kABPersonLastNameProperty);
+    if (firstName.length && lastName.length) {
+        params[@"name"] = [NSString stringWithFormat:@"%@ %@", firstName, lastName];
+    }
+
+    ABMultiValueRef addressValues = ABRecordCopyValue(addressRef, kABPersonAddressProperty);
+    if (addressValues != NULL) {
+        if (ABMultiValueGetCount(addressValues) > 0) {
+            CFDictionaryRef dict = ABMultiValueCopyValueAtIndex(addressValues, 0);
+            NSString *line1 = CFDictionaryGetValue(dict, kABPersonAddressStreetKey);
+            if (line1) {
+                params[@"address_line1"] = line1;
+            }
+            NSString *city = CFDictionaryGetValue(dict, kABPersonAddressCityKey);
+            if (city) {
+                params[@"address_city"] = city;
+            }
+            NSString *state = CFDictionaryGetValue(dict, kABPersonAddressStateKey);
+            if (state) {
+                params[@"address_state"] = state;
+            }
+            NSString *zip = CFDictionaryGetValue(dict, kABPersonAddressZIPKey);
+            if (zip) {
+                params[@"address_zip"] = zip;
+            }
+            NSString *country = CFDictionaryGetValue(dict, kABPersonAddressCountryKey);
+            if (country) {
+                params[@"address_country"] = country;
+            }
+            CFRelease(dict);
+            [params enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSString *obj, __unused BOOL *stop) {
+                NSString *param = [NSString stringWithFormat:@"&card[%@]=%@", key, [obj stringByAddingPercentEncodingWithAllowedCharacters:set]];
+                queryString = [queryString stringByAppendingString:param];
+            }];
+        }
+        CFRelease(addressValues);
+    }
+
+    return queryString;
+}
+
 + (NSData *)formEncodedDataForPayment:(PKPayment *)payment {
     NSCAssert(payment != nil, @"Cannot create a token with a nil payment.");
     NSMutableCharacterSet *set = [[NSCharacterSet URLQueryAllowedCharacterSet] mutableCopy];
@@ -26,46 +72,11 @@
     __block NSString *payloadString = [@"pk_token=" stringByAppendingString:paymentString];
 
     if (payment.billingAddress) {
-        NSMutableDictionary *params = [NSMutableDictionary dictionary];
-        
-        NSString *firstName = (__bridge_transfer NSString*)ABRecordCopyValue(payment.billingAddress, kABPersonFirstNameProperty);
-        NSString *lastName = (__bridge_transfer NSString*)ABRecordCopyValue(payment.billingAddress, kABPersonLastNameProperty);
-        if (firstName.length && lastName.length) {
-            params[@"name"] = [NSString stringWithFormat:@"%@ %@", firstName, lastName];
-        }
-        
-        ABMultiValueRef addressValues = ABRecordCopyValue(payment.billingAddress, kABPersonAddressProperty);
-        if (addressValues != NULL) {
-            if (ABMultiValueGetCount(addressValues) > 0) {
-                CFDictionaryRef dict = ABMultiValueCopyValueAtIndex(addressValues, 0);
-                NSString *line1 = CFDictionaryGetValue(dict, kABPersonAddressStreetKey);
-                if (line1) {
-                    params[@"address_line1"] = line1;
-                }
-                NSString *city = CFDictionaryGetValue(dict, kABPersonAddressCityKey);
-                if (city) {
-                    params[@"address_city"] = city;
-                }
-                NSString *state = CFDictionaryGetValue(dict, kABPersonAddressStateKey);
-                if (state) {
-                    params[@"address_state"] = state;
-                }
-                NSString *zip = CFDictionaryGetValue(dict, kABPersonAddressZIPKey);
-                if (zip) {
-                    params[@"address_zip"] = zip;
-                }
-                NSString *country = CFDictionaryGetValue(dict, kABPersonAddressCountryKey);
-                if (country) {
-                    params[@"address_country"] = country;
-                }
-                CFRelease(dict);
-                [params enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSString *obj, __unused BOOL *stop) {
-                    NSString *param = [NSString stringWithFormat:@"&card[%@]=%@", key, [obj stringByAddingPercentEncodingWithAllowedCharacters:set]];
-                    payloadString = [payloadString stringByAppendingString:param];
-                }];
-            }
-            CFRelease(addressValues);
-        }
+        NSString *addressString = [self queryStringForAddress:payment.billingAddress characterSet:set];
+        payloadString = [payloadString stringByAppendingString:addressString];
+    } else if (payment.shippingAddress) {
+        NSString *addressString = [self queryStringForAddress:payment.shippingAddress characterSet:set];
+        payloadString = [payloadString stringByAppendingString:addressString];
     }
 
     if (payment.token.paymentInstrumentName) {


### PR DESCRIPTION
At present if a PKPayment object contains a shippingAddress but no billingAddress then no name/address details are extracted and passed along to Stripe.

This means that when looking on the Stripe dashboard at ApplePay charges with no billingAddress that the name/address fields are empty which is still valid.

This diff changes the behaviour so that:
* If billingAddress and shippingAddress exist then we take the billingAddress
* If billingAddress is set and shippingAddress is not set then we take the billingAddress
* If shippingAddress is set and billingAddress is not set then we take the shippingAddress
* If neither are set then we don't do anything

I tested this and checked the generated URL (from the `formEncodedDataForPayment` method) and checked that only one copy of the name/address data was present when both shipping & billing were set.