### PR TITLE
Brand image refactor

### DIFF
--- a/Stripe/PublicHeaders/UI/STPPaymentCardTextField.h
+++ b/Stripe/PublicHeaders/UI/STPPaymentCardTextField.h
@@ -137,7 +137,7 @@
  *  Returns the cvc image used for a card brand.
  *  Override this method in a subclass if you would like to provide custom images.
  *  @param cardBrand The brand of card entered.
- *  @return The cvc image for used for a card brand.
+ *  @return The cvc image used for a card brand.
  */
 + (nullable UIImage *)cvcImageForCardBrand:(STPCardBrand)cardBrand;
 
@@ -145,7 +145,7 @@
  *  Returns the brand image used for a card brand.
  *  Override this method in a subclass if you would like to provide custom images.
  *  @param cardBrand The brand of card entered.
- *  @return The brand image for used for a card brand.
+ *  @return The brand image used for a card brand.
  */
 + (nullable UIImage *)brandImageForCardBrand:(STPCardBrand)cardBrand;
 

--- a/Stripe/PublicHeaders/UI/STPPaymentCardTextField.h
+++ b/Stripe/PublicHeaders/UI/STPPaymentCardTextField.h
@@ -135,6 +135,7 @@
 
 /**
  *  Returns the cvc image used for a card brand.
+ *  Override this method in a subclass if you would like to provide custom images.
  *  @param cardBrand The brand of card entered.
  *  @return The cvc image for used for a card brand.
  */
@@ -142,6 +143,7 @@
 
 /**
  *  Returns the brand image used for a card brand.
+ *  Override this method in a subclass if you would like to provide custom images.
  *  @param cardBrand The brand of card entered.
  *  @return The brand image for used for a card brand.
  */

--- a/Stripe/PublicHeaders/UI/STPPaymentCardTextField.h
+++ b/Stripe/PublicHeaders/UI/STPPaymentCardTextField.h
@@ -139,7 +139,7 @@
  *  @param cardBrand The brand of card entered.
  *  @return The cvc image for used for a card brand.
  */
-- (nullable UIImage *)cvcImageForCardBrand:(STPCardBrand)cardBrand;
++ (nullable UIImage *)cvcImageForCardBrand:(STPCardBrand)cardBrand;
 
 /**
  *  Returns the brand image used for a card brand.
@@ -147,7 +147,7 @@
  *  @param cardBrand The brand of card entered.
  *  @return The brand image for used for a card brand.
  */
-- (nullable UIImage *)brandImageForCardBrand:(STPCardBrand)cardBrand;
++ (nullable UIImage *)brandImageForCardBrand:(STPCardBrand)cardBrand;
 
 /**
  *  Returns the rectangle in which the receiver draws its brand image.

--- a/Stripe/UI/STPPaymentCardTextField.m
+++ b/Stripe/UI/STPPaymentCardTextField.m
@@ -82,7 +82,7 @@ CGFloat const STPPaymentCardTextFieldDefaultPadding = 10;
     _viewModel = [STPPaymentCardTextFieldViewModel new];
     _sizingField = [self buildTextField];
     
-    UIImageView *brandImageView = [[UIImageView alloc] initWithImage:[self brandImageForFieldType:STPCardFieldTypeNumber]];
+    UIImageView *brandImageView = [[UIImageView alloc] initWithImage:self.brandImage];
     brandImageView.contentMode = UIViewContentModeCenter;
     brandImageView.backgroundColor = [UIColor clearColor];
     if ([brandImageView respondsToSelector:@selector(setTintColor:)]) {

--- a/Stripe/UI/STPPaymentCardTextField.m
+++ b/Stripe/UI/STPPaymentCardTextField.m
@@ -405,7 +405,7 @@ CGFloat const STPPaymentCardTextFieldDefaultPadding = 10;
 
 - (CGSize)intrinsicContentSize {
     
-    CGSize imageSize = self.viewModel.brandImage.size;
+    CGSize imageSize = self.brandImage.size;
     
     self.sizingField.text = self.viewModel.defaultPlaceholder;
     CGFloat textHeight = [self.sizingField measureTextSize].height;
@@ -629,7 +629,7 @@ typedef void (^STPNumberShrunkCompletionBlock)(BOOL completed);
 }
 
 - (UIImage *)brandImageForCardBrand:(STPCardBrand)cardBrand {
-    return self.viewModel.brandImage;
+    return [self.viewModel.class brandImageForCardBrand:cardBrand];
 }
 #pragma clang diagnostic pop
 

--- a/Stripe/UI/STPPaymentCardTextField.m
+++ b/Stripe/UI/STPPaymentCardTextField.m
@@ -622,20 +622,20 @@ typedef void (^STPNumberShrunkCompletionBlock)(BOOL completed);
     }
 }
 
-- (UIImage *)cvcImageForCardBrand:(STPCardBrand)cardBrand {
-    return [self.viewModel.class cvcImageForCardBrand:cardBrand];
++ (UIImage *)cvcImageForCardBrand:(STPCardBrand)cardBrand {
+    return [STPPaymentCardTextFieldViewModel cvcImageForCardBrand:cardBrand];
 }
 
-- (UIImage *)brandImageForCardBrand:(STPCardBrand)cardBrand {
-    return [self.viewModel.class brandImageForCardBrand:cardBrand];
++ (UIImage *)brandImageForCardBrand:(STPCardBrand)cardBrand {
+    return [STPPaymentCardTextFieldViewModel brandImageForCardBrand:cardBrand];
 }
 
 - (UIImage *)brandImageForFieldType:(STPCardFieldType)fieldType {
     if (fieldType == STPCardFieldTypeCVC) {
-        return [self cvcImageForCardBrand:self.viewModel.brand];
+        return [self.class cvcImageForCardBrand:self.viewModel.brand];
     }
 
-    return [self brandImageForCardBrand:self.viewModel.brand];
+    return [self.class brandImageForCardBrand:self.viewModel.brand];
 }
 
 - (void)updateImageForFieldType:(STPCardFieldType)fieldType {

--- a/Stripe/UI/STPPaymentCardTextField.m
+++ b/Stripe/UI/STPPaymentCardTextField.m
@@ -622,8 +622,6 @@ typedef void (^STPNumberShrunkCompletionBlock)(BOOL completed);
     }
 }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
 - (UIImage *)cvcImageForCardBrand:(STPCardBrand)cardBrand {
     return [self.viewModel.class cvcImageForCardBrand:cardBrand];
 }
@@ -631,7 +629,6 @@ typedef void (^STPNumberShrunkCompletionBlock)(BOOL completed);
 - (UIImage *)brandImageForCardBrand:(STPCardBrand)cardBrand {
     return [self.viewModel.class brandImageForCardBrand:cardBrand];
 }
-#pragma clang diagnostic pop
 
 - (UIImage *)brandImageForFieldType:(STPCardFieldType)fieldType {
     if (fieldType == STPCardFieldTypeCVC) {

--- a/Stripe/UI/STPPaymentCardTextField.m
+++ b/Stripe/UI/STPPaymentCardTextField.m
@@ -625,7 +625,7 @@ typedef void (^STPNumberShrunkCompletionBlock)(BOOL completed);
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-parameter"
 - (UIImage *)cvcImageForCardBrand:(STPCardBrand)cardBrand {
-    return self.viewModel.cvcImage;
+    return [self.viewModel.class cvcImageForCardBrand:cardBrand];
 }
 
 - (UIImage *)brandImageForCardBrand:(STPCardBrand)cardBrand {

--- a/Stripe/UI/STPPaymentCardTextFieldViewModel.h
+++ b/Stripe/UI/STPPaymentCardTextFieldViewModel.h
@@ -33,7 +33,8 @@ typedef NS_ENUM(NSInteger, STPCardFieldType) {
 - (BOOL)isValid;
 
 - (STPCardValidationState)validationStateForField:(STPCardFieldType)fieldType;
-- (nullable UIImage *)brandImage;
 - (nullable UIImage *)cvcImage;
+
++ (nullable UIImage *)brandImageForCardBrand:(STPCardBrand)brand;
 
 @end

--- a/Stripe/UI/STPPaymentCardTextFieldViewModel.h
+++ b/Stripe/UI/STPPaymentCardTextFieldViewModel.h
@@ -33,8 +33,8 @@ typedef NS_ENUM(NSInteger, STPCardFieldType) {
 - (BOOL)isValid;
 
 - (STPCardValidationState)validationStateForField:(STPCardFieldType)fieldType;
-- (nullable UIImage *)cvcImage;
 
 + (nullable UIImage *)brandImageForCardBrand:(STPCardBrand)brand;
++ (nullable UIImage *)cvcImageForCardBrand:(STPCardBrand)brand;
 
 @end

--- a/Stripe/UI/STPPaymentCardTextFieldViewModel.m
+++ b/Stripe/UI/STPPaymentCardTextFieldViewModel.m
@@ -132,8 +132,8 @@
     return image;
 }
 
-- (UIImage *)cvcImage {
-    NSString *imageName = self.brand == STPCardBrandAmex ? @"stp_card_cvc_amex" : @"stp_card_cvc";
++ (UIImage *)cvcImageForCardBrand:(STPCardBrand)brand {
+    NSString *imageName = brand == STPCardBrandAmex ? @"stp_card_cvc_amex" : @"stp_card_cvc";
     return [self.class safeImageNamed:imageName];
 }
 

--- a/Stripe/UI/STPPaymentCardTextFieldViewModel.m
+++ b/Stripe/UI/STPPaymentCardTextFieldViewModel.m
@@ -132,10 +132,6 @@
     return image;
 }
 
-- (UIImage *)brandImage {
-    return [self.class brandImageForCardBrand:self.brand];
-}
-
 - (UIImage *)cvcImage {
     NSString *imageName = self.brand == STPCardBrandAmex ? @"stp_card_cvc_amex" : @"stp_card_cvc";
     return [self.class safeImageNamed:imageName];

--- a/Stripe/UI/STPPaymentCardTextFieldViewModel.m
+++ b/Stripe/UI/STPPaymentCardTextFieldViewModel.m
@@ -99,11 +99,11 @@
     }
 }
 
-- (UIImage *)brandImage {
++ (UIImage *)brandImageForCardBrand:(STPCardBrand)brand {
     FAUXPAS_IGNORED_IN_METHOD(APIAvailability);
     NSString *imageName;
     BOOL templateSupported = [[UIImage new] respondsToSelector:@selector(imageWithRenderingMode:)];
-    switch (self.brand) {
+    switch (brand) {
         case STPCardBrandAmex:
             imageName = @"stp_card_amex";
             break;
@@ -126,10 +126,14 @@
             imageName = @"stp_card_visa";
     }
     UIImage *image = [self.class safeImageNamed:imageName];
-    if (self.brand == STPCardBrandUnknown && templateSupported) {
+    if (brand == STPCardBrandUnknown && templateSupported) {
         image = [image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
     }
     return image;
+}
+
+- (UIImage *)brandImage {
+    return [self.class brandImageForCardBrand:self.brand];
 }
 
 - (UIImage *)cvcImage {


### PR DESCRIPTION
This pull request aims to correct the broken behavior introduced in #271 as well as close the request in #263.

#271 introduced new methods designs as hooks to allow a subclass which can provide different images for the card brands and CVC:

```objective-c
- (nullable UIImage *)brandImageForCardBrand:(STPCardBrand)cardBrand;
- (nullable UIImage *)cvcImageForCardBrand:(STPCardBrand)cardBrand;
```

However, the default implementation of those methods was broken by ignoring the passed parameter. #271 included [clang diagnostics ignore statements](https://github.com/stripe/stripe-ios/pull/271/files#diff-99f20d71748625ddadd9cce04c247f88R593) to suppress compiler warnings about the ignored parameters. This pull requests fixes the implementation of those methods.

As part of the refactor, `STPPaymentCardTextFieldViewModel` now provides class methods to retrieve `UIImage`s included in the Stripe library for each card brand. These class methods should solve #263.