### PR TITLE
Always assert when validating publishable key

### DIFF
--- a/Stripe/BuildConfigurations/StripeiOS-Release.xcconfig
+++ b/Stripe/BuildConfigurations/StripeiOS-Release.xcconfig
@@ -7,6 +7,4 @@
 
 #include "StripeiOS-Shared.xcconfig"
 
-//********************************************//
-//* Currently no build settings in this file *//
-//********************************************//
+ENABLE_NS_ASSERTIONS = YES


### PR DESCRIPTION
Since the framework target blocks assertions in release mode, framework users may see confusing exceptions rather than the intended assertions (see #280).

I've added a new macro that always raises, and replaced the asserts in `validateKey`. There are likely other asserts that shouldn't get blocked, but this should fix #280.


