### PR TITLE
Add delegate methods for editing subfields

### DIFF
--- a/Stripe/PublicHeaders/UI/STPPaymentCardTextField.h
+++ b/Stripe/PublicHeaders/UI/STPPaymentCardTextField.h
@@ -29,6 +29,21 @@
  */
 - (void)paymentCardTextFieldDidChange:(nonnull STPPaymentCardTextField *)textField;
 
+/**
+ *  Called when editing begins in the payment card field's number field.
+ */
+- (void)paymentCardTextFieldDidBeginEditingNumber:(nonnull STPPaymentCardTextField *)textField;
+
+/**
+ *  Called when editing begins in the payment card field's CVC field.
+ */
+- (void)paymentCardTextFieldDidBeginEditingCVC:(nonnull STPPaymentCardTextField *)textField;
+
+/**
+ *  Called when editing begins in the payment card field's expiration field.
+ */
+- (void)paymentCardTextFieldDidBeginEditingExpiration:(nonnull STPPaymentCardTextField *)textField;
+
 @end
 
 

--- a/Stripe/UI/STPPaymentCardTextField.m
+++ b/Stripe/UI/STPPaymentCardTextField.m
@@ -555,10 +555,21 @@ typedef void (^STPNumberShrunkCompletionBlock)(BOOL completed);
     switch ((STPCardFieldType)textField.tag) {
         case STPCardFieldTypeNumber:
             [self setNumberFieldShrunk:NO animated:YES completion:nil];
+            if ([self.delegate respondsToSelector:@selector(paymentCardTextFieldDidBeginEditingNumber:)]) {
+                [self.delegate paymentCardTextFieldDidBeginEditingNumber:self];
+            }
             break;
-            
-        default:
+        case STPCardFieldTypeCVC:
             [self setNumberFieldShrunk:YES animated:YES completion:nil];
+            if ([self.delegate respondsToSelector:@selector(paymentCardTextFieldDidBeginEditingCVC:)]) {
+                [self.delegate paymentCardTextFieldDidBeginEditingCVC:self];
+            }
+            break;
+        case STPCardFieldTypeExpiration:
+            [self setNumberFieldShrunk:YES animated:YES completion:nil];
+            if ([self.delegate respondsToSelector:@selector(paymentCardTextFieldDidBeginEditingExpiration:)]) {
+                [self.delegate paymentCardTextFieldDidBeginEditingExpiration:self];
+            }
             break;
     }
     [self updateImageForFieldType:textField.tag];


### PR DESCRIPTION
This PR adds three optional methods to `STPPaymentCardTextFieldDelegate`, called when subfields begin editing.

More context: #266 
cc @pocket7878
