### PR TITLE
Expose card icons through UIImage category

### DIFF
--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -334,6 +334,10 @@
 		04F3BB401BA89B1200DE235E /* PKPayment+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = 04F3BB3C1BA89B1200DE235E /* PKPayment+Stripe.m */; };
 		04FCFA191BD59A8C00297732 /* STPCategoryLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 04FCFA171BD59A8C00297732 /* STPCategoryLoader.h */; };
 		04FCFA1A1BD59A8C00297732 /* STPCategoryLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = 04FCFA181BD59A8C00297732 /* STPCategoryLoader.m */; };
+		C1718D561C3B2E5B002A7CB3 /* UIImage+Stripe.h in Headers */ = {isa = PBXBuildFile; fileRef = C1718D541C3B2E5B002A7CB3 /* UIImage+Stripe.h */; };
+		C1718D571C3B2E5B002A7CB3 /* UIImage+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = C1718D551C3B2E5B002A7CB3 /* UIImage+Stripe.m */; };
+		C1718D581C3B2E60002A7CB3 /* UIImage+Stripe.h in Headers */ = {isa = PBXBuildFile; fileRef = C1718D541C3B2E5B002A7CB3 /* UIImage+Stripe.h */; };
+		C181DD721C3B34E300DEB9FE /* UIImage+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = C1718D551C3B2E5B002A7CB3 /* UIImage+Stripe.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -519,6 +523,8 @@
 		04FCFA181BD59A8C00297732 /* STPCategoryLoader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPCategoryLoader.m; sourceTree = "<group>"; };
 		11C74B9B164043050071C2CA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		4A0D74F918F6106100966D7B /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
+		C1718D541C3B2E5B002A7CB3 /* UIImage+Stripe.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIImage+Stripe.h"; path = "UI/UIImage+Stripe.h"; sourceTree = "<group>"; };
+		C1718D551C3B2E5B002A7CB3 /* UIImage+Stripe.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIImage+Stripe.m"; path = "UI/UIImage+Stripe.m"; sourceTree = "<group>"; };
 		FAFC12C516E5767F0066297F /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
@@ -578,6 +584,8 @@
 				0438EF271B7416BB00D506CC /* STPFormTextField.m */,
 				0438EF2A1B7416BB00D506CC /* STPPaymentCardTextFieldViewModel.h */,
 				0438EF2B1B7416BB00D506CC /* STPPaymentCardTextFieldViewModel.m */,
+				C1718D541C3B2E5B002A7CB3 /* UIImage+Stripe.h */,
+				C1718D551C3B2E5B002A7CB3 /* UIImage+Stripe.m */,
 			);
 			name = UI;
 			sourceTree = "<group>";
@@ -877,6 +885,7 @@
 				049E84EC1A605EF0000B66CD /* StripeError.h in Headers */,
 				049E84DF1A605EF0000B66CD /* STPCheckoutDelegate.h in Headers */,
 				049E84E01A605EF0000B66CD /* STPCheckoutInternalUIWebViewController.h in Headers */,
+				C1718D581C3B2E60002A7CB3 /* UIImage+Stripe.h in Headers */,
 				04F3BB3E1BA89B1200DE235E /* PKPayment+Stripe.h in Headers */,
 				04FCFA191BD59A8C00297732 /* STPCategoryLoader.h in Headers */,
 				049E84E11A605EF0000B66CD /* STPCheckoutWebViewAdapter.h in Headers */,
@@ -905,6 +914,7 @@
 				0438EF2C1B7416BB00D506CC /* STPFormTextField.h in Headers */,
 				04CDB50A1A5F30A700B854EE /* STPBankAccount.h in Headers */,
 				049952D21BCF13DD0088C703 /* STPAPIClient+Private.h in Headers */,
+				C1718D561C3B2E5B002A7CB3 /* UIImage+Stripe.h in Headers */,
 				04CDB5121A5F30A700B854EE /* STPToken.h in Headers */,
 				049952CF1BCF13510088C703 /* STPAPIPostRequest.h in Headers */,
 				04CDB4D81A5F30A700B854EE /* Stripe+ApplePay.h in Headers */,
@@ -1311,6 +1321,7 @@
 				049E84C71A605DE0000B66CD /* STPCheckoutInternalUIWebViewController.m in Sources */,
 				049E84C81A605DE0000B66CD /* STPColorUtils.m in Sources */,
 				049E84C91A605DE0000B66CD /* STPIOSCheckoutWebViewAdapter.m in Sources */,
+				C181DD721C3B34E300DEB9FE /* UIImage+Stripe.m in Sources */,
 				049E84CB1A605DE0000B66CD /* STPStrictURLProtocol.m in Sources */,
 				0438EF371B7416BB00D506CC /* STPPaymentCardTextField.m in Sources */,
 				049E84CC1A605DE0000B66CD /* STPAPIClient.m in Sources */,
@@ -1338,6 +1349,7 @@
 				04CDB5001A5F30A700B854EE /* STPAPIClient.m in Sources */,
 				04CDB50C1A5F30A700B854EE /* STPBankAccount.m in Sources */,
 				04CDB5181A5F30A700B854EE /* StripeError.m in Sources */,
+				C1718D571C3B2E5B002A7CB3 /* UIImage+Stripe.m in Sources */,
 				04CDB4E21A5F30A700B854EE /* STPCheckoutOptions.m in Sources */,
 				04CDB4EB1A5F30A700B854EE /* STPCheckoutInternalUIWebViewController.m in Sources */,
 				04CDB4FC1A5F30A700B854EE /* STPStrictURLProtocol.m in Sources */,

--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -337,6 +337,7 @@
 		C1718D561C3B2E5B002A7CB3 /* UIImage+Stripe.h in Headers */ = {isa = PBXBuildFile; fileRef = C1718D541C3B2E5B002A7CB3 /* UIImage+Stripe.h */; };
 		C1718D571C3B2E5B002A7CB3 /* UIImage+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = C1718D551C3B2E5B002A7CB3 /* UIImage+Stripe.m */; };
 		C1718D581C3B2E60002A7CB3 /* UIImage+Stripe.h in Headers */ = {isa = PBXBuildFile; fileRef = C1718D541C3B2E5B002A7CB3 /* UIImage+Stripe.h */; };
+		C178CD451C45607D00851C69 /* UIImage+StripeTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C178CD441C45607D00851C69 /* UIImage+StripeTest.m */; };
 		C181DD721C3B34E300DEB9FE /* UIImage+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = C1718D551C3B2E5B002A7CB3 /* UIImage+Stripe.m */; };
 /* End PBXBuildFile section */
 
@@ -525,6 +526,7 @@
 		4A0D74F918F6106100966D7B /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		C1718D541C3B2E5B002A7CB3 /* UIImage+Stripe.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIImage+Stripe.h"; path = "UI/UIImage+Stripe.h"; sourceTree = "<group>"; };
 		C1718D551C3B2E5B002A7CB3 /* UIImage+Stripe.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIImage+Stripe.m"; path = "UI/UIImage+Stripe.m"; sourceTree = "<group>"; };
+		C178CD441C45607D00851C69 /* UIImage+StripeTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImage+StripeTest.m"; sourceTree = "<group>"; };
 		FAFC12C516E5767F0066297F /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
@@ -750,6 +752,7 @@
 				04CDB5261A5F3A9300B854EE /* STPCertTest.m */,
 				04CDB5271A5F3A9300B854EE /* STPTokenTest.m */,
 				04CB86B81BA89CD400E4F61E /* PKPayment+StripeTest.m */,
+				C178CD441C45607D00851C69 /* UIImage+StripeTest.m */,
 				04CDB5611A5F3D2000B854EE /* Supporting Files */,
 			);
 			name = StripeTests;
@@ -1285,6 +1288,7 @@
 				0438EF301B7416BB00D506CC /* STPFormTextField.m in Sources */,
 				04415C5C1A6605B5001225ED /* STPColorUtils.m in Sources */,
 				04415C5D1A6605B5001225ED /* STPIOSCheckoutWebViewAdapter.m in Sources */,
+				C178CD451C45607D00851C69 /* UIImage+StripeTest.m in Sources */,
 				0438EF4C1B741B0100D506CC /* STPCardValidatorTest.m in Sources */,
 				04415C5F1A6605B5001225ED /* STPStrictURLProtocol.m in Sources */,
 				04415C611A6605B5001225ED /* STPFormEncoder.m in Sources */,

--- a/Stripe/STPCategoryLoader.m
+++ b/Stripe/STPCategoryLoader.m
@@ -13,6 +13,7 @@
 #import "NSDictionary+Stripe.h"
 #import "Stripe+ApplePay.h"
 #import "STPAPIClient+ApplePay.h"
+#import "UIImage+Stripe.h"
 
 @implementation STPCategoryLoader
 
@@ -21,6 +22,7 @@
     linkDictionaryCategory();
     linkStripeApplePayCategory();
     linkSTPAPIClientApplePayCategory();
+    linkUIImageCategory();
 }
 
 @end

--- a/Stripe/UI/STPPaymentCardTextField.m
+++ b/Stripe/UI/STPPaymentCardTextField.m
@@ -13,6 +13,7 @@
 #import "STPPaymentCardTextFieldViewModel.h"
 #import "STPFormTextField.h"
 #import "STPCardValidator.h"
+#import "UIImage+Stripe.h"
 
 #define FAUXPAS_IGNORED_IN_METHOD(...)
 
@@ -634,11 +635,11 @@ typedef void (^STPNumberShrunkCompletionBlock)(BOOL completed);
 }
 
 + (UIImage *)cvcImageForCardBrand:(STPCardBrand)cardBrand {
-    return [STPPaymentCardTextFieldViewModel cvcImageForCardBrand:cardBrand];
+    return [UIImage stp_cvcImageForCardBrand:cardBrand];
 }
 
 + (UIImage *)brandImageForCardBrand:(STPCardBrand)cardBrand {
-    return [STPPaymentCardTextFieldViewModel brandImageForCardBrand:cardBrand];
+    return [UIImage stp_brandImageForCardBrand:cardBrand];
 }
 
 - (UIImage *)brandImageForFieldType:(STPCardFieldType)fieldType {

--- a/Stripe/UI/STPPaymentCardTextFieldViewModel.h
+++ b/Stripe/UI/STPPaymentCardTextFieldViewModel.h
@@ -34,7 +34,4 @@ typedef NS_ENUM(NSInteger, STPCardFieldType) {
 
 - (STPCardValidationState)validationStateForField:(STPCardFieldType)fieldType;
 
-+ (nullable UIImage *)brandImageForCardBrand:(STPCardBrand)brand;
-+ (nullable UIImage *)cvcImageForCardBrand:(STPCardBrand)brand;
-
 @end

--- a/Stripe/UI/STPPaymentCardTextFieldViewModel.m
+++ b/Stripe/UI/STPPaymentCardTextFieldViewModel.m
@@ -99,51 +99,6 @@
     }
 }
 
-+ (UIImage *)brandImageForCardBrand:(STPCardBrand)brand {
-    FAUXPAS_IGNORED_IN_METHOD(APIAvailability);
-    NSString *imageName;
-    BOOL templateSupported = [[UIImage new] respondsToSelector:@selector(imageWithRenderingMode:)];
-    switch (brand) {
-        case STPCardBrandAmex:
-            imageName = @"stp_card_amex";
-            break;
-        case STPCardBrandDinersClub:
-            imageName = @"stp_card_diners";
-            break;
-        case STPCardBrandDiscover:
-            imageName = @"stp_card_discover";
-            break;
-        case STPCardBrandJCB:
-            imageName = @"stp_card_jcb";
-            break;
-        case STPCardBrandMasterCard:
-            imageName = @"stp_card_mastercard";
-            break;
-        case STPCardBrandUnknown:
-            imageName = templateSupported ? @"stp_card_placeholder_template" : @"stp_card_placeholder";
-            break;
-        case STPCardBrandVisa:
-            imageName = @"stp_card_visa";
-    }
-    UIImage *image = [self.class safeImageNamed:imageName];
-    if (brand == STPCardBrandUnknown && templateSupported) {
-        image = [image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
-    }
-    return image;
-}
-
-+ (UIImage *)cvcImageForCardBrand:(STPCardBrand)brand {
-    NSString *imageName = brand == STPCardBrandAmex ? @"stp_card_cvc_amex" : @"stp_card_cvc";
-    return [self.class safeImageNamed:imageName];
-}
-
-+ (UIImage *)safeImageNamed:(NSString *)imageName {
-    if ([[UIImage class] respondsToSelector:@selector(imageNamed:inBundle:compatibleWithTraitCollection:)]) {
-        return [UIImage imageNamed:imageName inBundle:[NSBundle bundleForClass:[self class]] compatibleWithTraitCollection:nil];
-    }
-    return [UIImage imageNamed:imageName];
-}
-
 - (BOOL)isValid {
     return ([self validationStateForField:STPCardFieldTypeNumber] == STPCardValidationStateValid &&
             [self validationStateForField:STPCardFieldTypeExpiration] == STPCardValidationStateValid &&

--- a/Stripe/UI/UIImage+Stripe.h
+++ b/Stripe/UI/UIImage+Stripe.h
@@ -7,6 +7,7 @@
 //
 
 #import <UIKit/UIKit.h>
+#import "STPCardBrand.h"
 
 @interface UIImage (Stripe)
 
@@ -17,6 +18,10 @@
 + (nonnull UIImage *)stp_masterCardCardImage;
 + (nonnull UIImage *)stp_visaCardImage;
 + (nonnull UIImage *)stp_unknownCardCardImage;
+
++ (nullable UIImage *)stp_brandImageForCardBrand:(STPCardBrand)brand;
++ (nullable UIImage *)stp_cvcImageForCardBrand:(STPCardBrand)brand;
++ (nullable UIImage *)stp_safeImageNamed:(nonnull NSString *)imageName;
 
 @end
 

--- a/Stripe/UI/UIImage+Stripe.h
+++ b/Stripe/UI/UIImage+Stripe.h
@@ -1,0 +1,23 @@
+//
+//  UIImage+Stripe.h
+//  Stripe
+//
+//  Created by Ben Guo on 1/4/16.
+//  Copyright © 2016 Stripe, Inc. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface UIImage (Stripe)
+
++ (nonnull UIImage *)stp_amexCardImage;
++ (nonnull UIImage *)stp_dinersClubCardImage;
++ (nonnull UIImage *)stp_discoverCardImage;
++ (nonnull UIImage *)stp_jcbCardImage;
++ (nonnull UIImage *)stp_masterCardCardImage;
++ (nonnull UIImage *)stp_visaCardImage;
++ (nonnull UIImage *)stp_unknownCardCardImage;
+
+@end
+
+void linkUIImageCategory(void);

--- a/Stripe/UI/UIImage+Stripe.m
+++ b/Stripe/UI/UIImage+Stripe.m
@@ -1,0 +1,44 @@
+//
+//  UIImage+Stripe.m
+//  Stripe
+//
+//  Created by Ben Guo on 1/4/16.
+//  Copyright © 2016 Stripe, Inc. All rights reserved.
+//
+
+#import "UIImage+Stripe.h"
+#import "STPPaymentCardTextFieldViewModel.h"
+
+@implementation UIImage (Stripe)
+
++ (UIImage *)stp_amexCardImage {
+    return [STPPaymentCardTextFieldViewModel brandImageForCardBrand:STPCardBrandAmex];
+}
+
++ (UIImage *)stp_dinersClubCardImage {
+    return [STPPaymentCardTextFieldViewModel brandImageForCardBrand:STPCardBrandDinersClub];
+}
+
++ (UIImage *)stp_discoverCardImage {
+    return [STPPaymentCardTextFieldViewModel brandImageForCardBrand:STPCardBrandDiscover];
+}
+
++ (UIImage *)stp_jcbCardImage {
+    return [STPPaymentCardTextFieldViewModel brandImageForCardBrand:STPCardBrandJCB];
+}
+
++ (UIImage *)stp_masterCardCardImage {
+    return [STPPaymentCardTextFieldViewModel brandImageForCardBrand:STPCardBrandMasterCard];
+}
+
++ (UIImage *)stp_visaCardImage {
+    return [STPPaymentCardTextFieldViewModel brandImageForCardBrand:STPCardBrandVisa];
+}
+
++ (UIImage *)stp_unknownCardCardImage {
+    return [STPPaymentCardTextFieldViewModel brandImageForCardBrand:STPCardBrandUnknown];
+}
+
+@end
+
+void linkUIImageCategory(void){}

--- a/Stripe/UI/UIImage+Stripe.m
+++ b/Stripe/UI/UIImage+Stripe.m
@@ -7,36 +7,88 @@
 //
 
 #import "UIImage+Stripe.h"
-#import "STPPaymentCardTextFieldViewModel.h"
+
+#define FAUXPAS_IGNORED_IN_METHOD(...)
+
+// Dummy class for locating the framework bundle
+@interface STPBundleLocator : NSObject
+@end
+@implementation STPBundleLocator
+@end
 
 @implementation UIImage (Stripe)
 
 + (UIImage *)stp_amexCardImage {
-    return [STPPaymentCardTextFieldViewModel brandImageForCardBrand:STPCardBrandAmex];
+    return [UIImage stp_brandImageForCardBrand:STPCardBrandAmex];
 }
 
 + (UIImage *)stp_dinersClubCardImage {
-    return [STPPaymentCardTextFieldViewModel brandImageForCardBrand:STPCardBrandDinersClub];
+    return [UIImage stp_brandImageForCardBrand:STPCardBrandDinersClub];
 }
 
 + (UIImage *)stp_discoverCardImage {
-    return [STPPaymentCardTextFieldViewModel brandImageForCardBrand:STPCardBrandDiscover];
+    return [UIImage stp_brandImageForCardBrand:STPCardBrandDiscover];
 }
 
 + (UIImage *)stp_jcbCardImage {
-    return [STPPaymentCardTextFieldViewModel brandImageForCardBrand:STPCardBrandJCB];
+    return [UIImage stp_brandImageForCardBrand:STPCardBrandJCB];
 }
 
 + (UIImage *)stp_masterCardCardImage {
-    return [STPPaymentCardTextFieldViewModel brandImageForCardBrand:STPCardBrandMasterCard];
+    return [UIImage stp_brandImageForCardBrand:STPCardBrandMasterCard];
 }
 
 + (UIImage *)stp_visaCardImage {
-    return [STPPaymentCardTextFieldViewModel brandImageForCardBrand:STPCardBrandVisa];
+    return [UIImage stp_brandImageForCardBrand:STPCardBrandVisa];
 }
 
 + (UIImage *)stp_unknownCardCardImage {
-    return [STPPaymentCardTextFieldViewModel brandImageForCardBrand:STPCardBrandUnknown];
+    return [UIImage stp_brandImageForCardBrand:STPCardBrandUnknown];
+}
+
++ (UIImage *)stp_brandImageForCardBrand:(STPCardBrand)brand {
+    FAUXPAS_IGNORED_IN_METHOD(APIAvailability);
+    NSString *imageName;
+    BOOL templateSupported = [[UIImage new] respondsToSelector:@selector(imageWithRenderingMode:)];
+    switch (brand) {
+        case STPCardBrandAmex:
+            imageName = @"stp_card_amex";
+            break;
+        case STPCardBrandDinersClub:
+            imageName = @"stp_card_diners";
+            break;
+        case STPCardBrandDiscover:
+            imageName = @"stp_card_discover";
+            break;
+        case STPCardBrandJCB:
+            imageName = @"stp_card_jcb";
+            break;
+        case STPCardBrandMasterCard:
+            imageName = @"stp_card_mastercard";
+            break;
+        case STPCardBrandUnknown:
+            imageName = templateSupported ? @"stp_card_placeholder_template" : @"stp_card_placeholder";
+            break;
+        case STPCardBrandVisa:
+            imageName = @"stp_card_visa";
+    }
+    UIImage *image = [UIImage stp_safeImageNamed:imageName];
+    if (brand == STPCardBrandUnknown && templateSupported) {
+        image = [image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+    }
+    return image;
+}
+
++ (UIImage *)stp_cvcImageForCardBrand:(STPCardBrand)brand {
+    NSString *imageName = brand == STPCardBrandAmex ? @"stp_card_cvc_amex" : @"stp_card_cvc";
+    return [UIImage stp_safeImageNamed:imageName];
+}
+
++ (UIImage *)stp_safeImageNamed:(NSString *)imageName {
+    if ([[UIImage class] respondsToSelector:@selector(imageNamed:inBundle:compatibleWithTraitCollection:)]) {
+        return [UIImage imageNamed:imageName inBundle:[NSBundle bundleForClass:[STPBundleLocator class]] compatibleWithTraitCollection:nil];
+    }
+    return [UIImage imageNamed:imageName];
 }
 
 @end

--- a/Tests/Tests/UIImage+StripeTest.m
+++ b/Tests/Tests/UIImage+StripeTest.m
@@ -1,0 +1,62 @@
+//
+//  UIImage+StripeTest.m
+//  Stripe
+//
+//  Created by Ben Guo on 1/12/16.
+//  Copyright © 2016 Stripe, Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "UIImage+Stripe.h"
+
+@interface UIImage_StripeTest : XCTestCase
+@property NSArray<NSNumber *> *cardBrands;
+@end
+
+@implementation UIImage_StripeTest
+
+- (void)setUp {
+    self.cardBrands = @[
+                        @(STPCardBrandAmex),
+                        @(STPCardBrandDinersClub),
+                        @(STPCardBrandDiscover),
+                        @(STPCardBrandJCB),
+                        @(STPCardBrandMasterCard),
+                        @(STPCardBrandUnknown),
+                        @(STPCardBrandVisa),
+                        ];
+}
+
+- (void)testCardIconMethods {
+    UIImage *image = nil;
+    image = [UIImage stp_amexCardImage];
+    XCTAssertNotNil(image);
+    image = [UIImage stp_dinersClubCardImage];
+    XCTAssertNotNil(image);
+    image = [UIImage stp_discoverCardImage];
+    XCTAssertNotNil(image);
+    image = [UIImage stp_jcbCardImage];
+    XCTAssertNotNil(image);
+    image = [UIImage stp_masterCardCardImage];
+    XCTAssertNotNil(image);
+    image = [UIImage stp_visaCardImage];
+    XCTAssertNotNil(image);
+    image = [UIImage stp_unknownCardCardImage];
+    XCTAssertNotNil(image);
+}
+
+- (void)testBrandImageForCardBrand {
+    for (NSNumber *brand in self.cardBrands) {
+        UIImage *image = [UIImage stp_brandImageForCardBrand:[brand integerValue]];
+        XCTAssertNotNil(image);
+    }
+}
+
+- (void)testCVCImageForCardBrand {
+    for (NSNumber *brand in self.cardBrands) {
+        UIImage *image = [UIImage stp_cvcImageForCardBrand:[brand integerValue]];
+        XCTAssertNotNil(image);
+    }
+}
+
+@end


### PR DESCRIPTION
r? @jflinter 

replaces https://github.com/stripe/stripe-ios/pull/288

It doesn't look like the SDK already has a UIImage category?