### PR TITLE
Ignore iOS9 deprecation warnings

### DIFF
--- a/Stripe/ApplePay/STPAPIClient+ApplePay.m
+++ b/Stripe/ApplePay/STPAPIClient+ApplePay.m
@@ -17,6 +17,8 @@
     [self createTokenWithData:[self.class formEncodedDataForPayment:payment] completion:completion];
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
 + (NSData *)formEncodedDataForPayment:(PKPayment *)payment {
     NSCAssert(payment != nil, @"Cannot create a token with a nil payment.");
     NSMutableCharacterSet *set = [[NSCharacterSet URLQueryAllowedCharacterSet] mutableCopy];
@@ -89,6 +91,7 @@
 
     return [payloadString dataUsingEncoding:NSUTF8StringEncoding];
 }
+#pragma clang diagnostic pop
 
 @end
 

--- a/Stripe/Checkout/STPStrictURLProtocol.m
+++ b/Stripe/Checkout/STPStrictURLProtocol.m
@@ -22,11 +22,14 @@
     return request;
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
 - (void)startLoading {
     NSMutableURLRequest *newRequest = [self.request mutableCopy];
     [self.class removePropertyForKey:STPStrictURLProtocolRequestKey inRequest:newRequest];
     self.connection = [NSURLConnection connectionWithRequest:[newRequest copy] delegate:self];
 }
+#pragma clang diagnostic pop
 
 - (void)stopLoading {
     [self.connection cancel];

--- a/Tests/installation_tests/cocoapods/without_frameworks/CocoapodsTest.xcodeproj/project.pbxproj
+++ b/Tests/installation_tests/cocoapods/without_frameworks/CocoapodsTest.xcodeproj/project.pbxproj
@@ -155,6 +155,7 @@
 				04E6FC7E1B71486C000C8759 /* Frameworks */,
 				04E6FC7F1B71486C000C8759 /* Resources */,
 				B2A9D9F6678A1B4817096B70 /* Copy Pods Resources */,
+				06C725CF87BC61F53076066A /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -241,6 +242,21 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		06C725CF87BC61F53076066A /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		7E106CBCE9C93E56E8330C33 /* Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -408,6 +424,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = CocoapodsTest/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -419,6 +436,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = CocoapodsTest/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};

--- a/Tests/installation_tests/cocoapods/without_frameworks/Podfile
+++ b/Tests/installation_tests/cocoapods/without_frameworks/Podfile
@@ -1,2 +1,8 @@
 pod 'Stripe', path: '../../../..'
 pod 'Stripe/ApplePay', path: '../../../..'
+
+post_install do |installer|
+  installer.pods_project.build_configurations.each do |config|
+    config.build_settings['GCC_TREAT_WARNINGS_AS_ERRORS'] = "YES"
+  end
+end


### PR DESCRIPTION
r? @jflinter 

I've also updated the deployment target of the cocoapods `without_frameworks` project to 9.2, and added a post_install hook to treat warnings as errors in the pods project.