### PR TITLE
Add .cocoapods.yml specifying try project

### DIFF
--- a/.cocoapods.yml
+++ b/.cocoapods.yml
@@ -1,2 +1,2 @@
 try:
-    project: 'Example/Stripe iOS Example (Simple).xcodeproj'
+    project: 'Example/Stripe iOS Example (Simple).xcworkspace'

--- a/.cocoapods.yml
+++ b/.cocoapods.yml
@@ -1,0 +1,2 @@
+try:
+    project: 'Example/Stripe iOS Example (Simple).xcodeproj'

--- a/Example/Stripe iOS Example (Simple).xcworkspace/contents.xcworkspacedata
+++ b/Example/Stripe iOS Example (Simple).xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:../Stripe.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Stripe iOS Example (Simple).xcodeproj">
+   </FileRef>
+</Workspace>


### PR DESCRIPTION
r? @jflinter
Fixes https://github.com/stripe/stripe-ios/issues/203

Currently, `pod try` gives you a very long list of options:
```
Trying Stripe
1: Example/Stripe iOS Example (Custom).xcodeproj
2: Example/Stripe iOS Example (Simple).xcodeproj
3: Tests/installation_tests/carthage/CarthageTest.xcodeproj
4: Tests/installation_tests/manual_installation/ManualInstallationTest.xcodeproj
5: Stripe.xcworkspace
6: Tests/installation_tests/cocoapods/with_frameworks/CocoapodsTest.xcworkspace
7: Tests/installation_tests/cocoapods/without_frameworks/CocoapodsTest.xcworkspace
Which project would you like to open
```

Since `Example/Stripe iOS Example (Simple).xcodeproj` won't compile on its own, I've added a new workspace, `Stripe iOS Example (Simple).xcworkspace`, which includes `Stripe.xcodeproj` and `Stripe iOS Example (Simple).xcodeproj`

`pod try` will use the new workspace.
