### PR TITLE
Fix missing cardParam address fields 

### DIFF
--- a/Stripe/STPPaymentCardTextField.m
+++ b/Stripe/STPPaymentCardTextField.m
@@ -36,6 +36,8 @@
 
 @property(nonatomic, assign)BOOL numberFieldShrunk;
 
+@property(nonatomic, readwrite, strong)STPCardParams *internalCardParams;
+
 @end
 
 @implementation STPPaymentCardTextField
@@ -400,15 +402,15 @@ CGFloat const STPPaymentCardTextFieldDefaultPadding = 13;
 }
 
 - (STPCardParams *)cardParams {
-    STPCardParams *c = [[STPCardParams alloc] init];
-    c.number = self.cardNumber;
-    c.expMonth = self.expirationMonth;
-    c.expYear = self.expirationYear;
-    c.cvc = self.cvc;
-    return c;
+    self.internalCardParams.number = self.cardNumber;
+    self.internalCardParams.expMonth = self.expirationMonth;
+    self.internalCardParams.expYear = self.expirationYear;
+    self.internalCardParams.cvc = self.cvc;
+    return self.internalCardParams;
 }
 
 - (void)setCardParams:(STPCardParams *)cardParams {
+    self.internalCardParams = cardParams;
     [self setText:cardParams.number inField:STPCardFieldTypeNumber];
     BOOL expirationPresent = cardParams.expMonth && cardParams.expYear;
     if (expirationPresent) {

--- a/Tests/Tests/STPPaymentCardTextFieldTest.m
+++ b/Tests/Tests/STPPaymentCardTextFieldTest.m
@@ -246,6 +246,28 @@
     XCTAssertFalse(sut.isValid);
 }
 
+- (void)testSetCard_addressFields {
+    STPPaymentCardTextField *sut = [STPPaymentCardTextField new];
+
+    STPCardParams *cardParams = [STPCardParams new];
+    cardParams.name = @"John S";
+    cardParams.addressLine1 = @"123 Main St";
+    cardParams.addressLine2 = @"#3B";
+    cardParams.addressCity = @"San Francisco";
+    cardParams.addressState = @"CA";
+    cardParams.addressZip = @"12345";
+    cardParams.addressCountry = @"US";
+    sut.cardParams = cardParams;
+
+    XCTAssertEqualObjects(sut.cardParams.name, @"John S");
+    XCTAssertEqualObjects(sut.cardParams.addressLine1, @"123 Main St");
+    XCTAssertEqualObjects(sut.cardParams.addressLine2, @"#3B");
+    XCTAssertEqualObjects(sut.cardParams.addressCity, @"San Francisco");
+    XCTAssertEqualObjects(sut.cardParams.addressState, @"CA");
+    XCTAssertEqualObjects(sut.cardParams.addressZip, @"12345");
+    XCTAssertEqualObjects(sut.cardParams.addressCountry, @"US");
+}
+
 - (void)testSettingTextUpdatesViewModelText {
     STPPaymentCardTextField *sut = [STPPaymentCardTextField new];
     sut.numberField.text = @"4242424242424242";


### PR DESCRIPTION
r? @jflinter 

Addresses #349 

We were previously discarding address fields when setting `STPPaymentCardTextField`'s `cardParams`.

Note that this doesn't fully support the usage pattern in #349 – we'd have to do some more work (i.e. KVO) to support chaining.

```swift
paymentTextField.cardParams.addressCity = "San Francisco"
paymentTextField.cardParams.name = "Val"
paymentTextField.cardParams.addressCountry = "US"
```