### PR TITLE
Fix sms code entry using certain custom keyboards

### DIFF
--- a/Stripe/STPAddressFieldTableViewCell.m
+++ b/Stripe/STPAddressFieldTableViewCell.m
@@ -105,7 +105,7 @@
                 }
                 
                 self.textField.placeholder = NSLocalizedString(@"12345", nil);
-                self.textField.keyboardType = UIKeyboardTypeNumberPad;
+                self.textField.keyboardType = UIKeyboardTypePhonePad;
                 self.textField.preservesContentsOnPaste = NO;
                 self.textField.selectionEnabled = NO;
                 if (!lastInList) {

--- a/Stripe/STPObscuredCardView.m
+++ b/Stripe/STPObscuredCardView.m
@@ -32,19 +32,19 @@
         
         UITextField *last4Field = [UITextField new];
         last4Field.delegate = self;
-        last4Field.keyboardType = UIKeyboardTypeNumberPad;
+        last4Field.keyboardType = UIKeyboardTypePhonePad;
         [self addSubview:last4Field];
         _last4Field = last4Field;
         
         UITextField *expField = [UITextField new];
         expField.delegate = self;
-        expField.keyboardType = UIKeyboardTypeNumberPad;
+        expField.keyboardType = UIKeyboardTypePhonePad;
         [self addSubview:expField];
         _expField = expField;
         
         UITextField *cvcField = [UITextField new];
         cvcField.delegate = self;
-        cvcField.keyboardType = UIKeyboardTypeNumberPad;
+        cvcField.keyboardType = UIKeyboardTypePhonePad;
         cvcField.secureTextEntry = YES;
         [self addSubview:cvcField];
         _cvcField = cvcField;

--- a/Stripe/STPPaymentCardTextField.m
+++ b/Stripe/STPPaymentCardTextField.m
@@ -536,7 +536,7 @@ CGFloat const STPPaymentCardTextFieldDefaultPadding = 13;
 - (STPFormTextField *)buildTextField {
     STPFormTextField *textField = [[STPFormTextField alloc] initWithFrame:CGRectZero];
     textField.backgroundColor = [UIColor clearColor];
-    textField.keyboardType = UIKeyboardTypeNumberPad;
+    textField.keyboardType = UIKeyboardTypePhonePad;
     textField.font = self.font;
     textField.defaultColor = self.textColor;
     textField.errorColor = self.textErrorColor;

--- a/Stripe/STPSMSCodeTextField.m
+++ b/Stripe/STPSMSCodeTextField.m
@@ -71,7 +71,7 @@
             for (NSInteger i=0; i < 3; i++) {
                 STPCodeInternalTextField *textField = [STPCodeInternalTextField new];
                 textField.delegate = self;
-                textField.keyboardType = UIKeyboardTypeNumberPad;
+                textField.keyboardType = UIKeyboardTypePhonePad;
                 textField.internalDelegate = self;
                 textField.textAlignment = NSTextAlignmentCenter;
                 [textFields addObject:textField];


### PR DESCRIPTION
r? @jflinter 

tl;dr, When the delete key is pressed, some custom keyboards will call `textDocumentProxy.insertText("")` if the field is empty, rather than `textDocumentProxy.deleteBackward()`. This seems entirely at the discretion of the developer, so we should support both possibilities.

I tested entering SMS codes with a few custom keyboards:
- Using the system number pad or Swype, when the delete key is pressed, `deleteBackward` is called.
- Using Gboard or SwiftKey, `deleteBackward` is not called – instead, `shouldChangeCharactersInRange:` is called with an empty string.

A more heavy-handed solution would be to use `UIKeyboardTypePhonePad`, but that doesn't seem ideal.

> Your custom keyboard is also ineligible to type into so-called phone pad objects, such as the phone number fields in Contacts. These input objects are exclusively for strings built from a small set of alphanumeric characters specified by telecommunications carriers and are identified by having one or another of the following two keyboard type traits: UIKeyboardTypePhonePad, UIKeyboardTypeNamePhonePad

https://developer.apple.com/library/prerelease/content/documentation/General/Conceptual/ExtensibilityPG/CustomKeyboard.html