### PR TITLE
Example app improvements

### DIFF
--- a/Example/Stripe iOS Example (Simple)/CheckoutViewController.swift
+++ b/Example/Stripe iOS Example (Simple)/CheckoutViewController.swift
@@ -71,8 +71,9 @@ class CheckoutViewController: UIViewController, STPPaymentContextDelegate {
         self.totalRow = CheckoutRowView(title: "Total", detail: "", tappable: false,
                                         theme: settings.theme)
         self.buyButton = BuyButton(enabled: true, theme: settings.theme)
-        MyAPIClient.sharedInit(baseURL: self.backendBaseURL, customerID: self.customerID)
-        
+        MyAPIClient.sharedClient.baseURLString = self.backendBaseURL
+        MyAPIClient.sharedClient.customerID = self.customerID
+
         // This code is included here for the sake of readability, but in your application you should set up your configuration and theme earlier, preferably in your App Delegate.
         let config = STPPaymentConfiguration.sharedConfiguration()
         config.publishableKey = self.stripePublishableKey

--- a/Example/Stripe iOS Example (Simple)/MyAPIClient.swift
+++ b/Example/Stripe iOS Example (Simple)/MyAPIClient.swift
@@ -11,27 +11,17 @@ import Stripe
 
 class MyAPIClient: NSObject, STPBackendAPIAdapter {
 
-    let baseURLString: String?
-    let customerID: String?
+    static let sharedClient = MyAPIClient()
     let session: NSURLSession
-
+    var baseURLString: String? = nil
+    var customerID: String? = nil
     var defaultSource: STPCard? = nil
     var sources: [STPCard] = []
 
-    static var sharedClient = MyAPIClient(baseURL: nil, customerID: nil)
-    static func sharedInit(baseURL baseURL: String?, customerID: String?) {
-        if sharedClient.baseURLString != baseURL || sharedClient.customerID != customerID {
-            sharedClient = MyAPIClient(baseURL: baseURL, customerID: customerID)
-        }
-    }
-
-    /// If no base URL or customerID is given, MyAPIClient will save cards in memory.
-    init(baseURL: String?, customerID: String?) {
+    override init() {
         let configuration = NSURLSessionConfiguration.defaultSessionConfiguration()
         configuration.timeoutIntervalForRequest = 5
         self.session = NSURLSession(configuration: configuration)
-        self.baseURLString = baseURL
-        self.customerID = customerID
         super.init()
     }
 

--- a/Example/Stripe iOS Example (Simple)/MyAPIClient.swift
+++ b/Example/Stripe iOS Example (Simple)/MyAPIClient.swift
@@ -20,7 +20,9 @@ class MyAPIClient: NSObject, STPBackendAPIAdapter {
 
     static var sharedClient = MyAPIClient(baseURL: nil, customerID: nil)
     static func sharedInit(baseURL baseURL: String?, customerID: String?) {
-        sharedClient = MyAPIClient(baseURL: baseURL, customerID: customerID)
+        if sharedClient.baseURLString != baseURL || sharedClient.customerID != customerID {
+            sharedClient = MyAPIClient(baseURL: baseURL, customerID: customerID)
+        }
     }
 
     /// If no base URL or customerID is given, MyAPIClient will save cards in memory.

--- a/Example/Stripe iOS Example (Simple)/MyAPIClient.swift
+++ b/Example/Stripe iOS Example (Simple)/MyAPIClient.swift
@@ -44,8 +44,18 @@ class MyAPIClient: NSObject, STPBackendAPIAdapter {
     }
 
     func completeCharge(result: STPPaymentResult, amount: Int, completion: STPErrorBlock) {
-        guard let baseURLString = baseURLString, baseURL = NSURL(string: baseURLString), customerID = customerID else {
-            completion(nil)
+        guard let baseURLString = baseURLString, baseURL = NSURL(string: baseURLString) else {
+            let error = NSError(domain: StripeDomain, code: 50, userInfo: [
+                NSLocalizedDescriptionKey: "Please set baseURLString to your Heroku URL in CheckoutViewController.swift"
+                ])
+            completion(error)
+            return
+        }
+        guard let customerID = customerID else {
+            let error = NSError(domain: StripeDomain, code: 50, userInfo: [
+                NSLocalizedDescriptionKey: "Please set customerID to a valid Stripe customer ID in CheckoutViewController.swift"
+                ])
+            completion(error)
             return
         }
         let path = "charge"

--- a/Stripe/PublicHeaders/STPAddCardViewController.h
+++ b/Stripe/PublicHeaders/STPAddCardViewController.h
@@ -63,7 +63,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)addCardViewControllerDidCancel:(STPAddCardViewController *)addCardViewController;
 
 /**
- *  This is called when the user successfully adds a card and tokenizes it with Stripe. You should send the token to your backend to store it on a customer, and then call the provided `completion` block when that call is finished. If an error occurred while talking to your backend, call `completion(error)`, otherwise, call `completion(nil)` and then dismiss (or pop) the view controller.
+ *  This is called when the user successfully adds a card and tokenizes it with Stripe. You should send the token to your backend to store it on a customer, and then call the provided `completion` block when that call is finished. If an error occurred while talking to your backend, call `completion(error)`, otherwise, dismiss (or pop) the view controller.
  *
  *  @param addCardViewController the view controller that successfully created a token
  *  @param token                 the Stripe token that was created. @see STPToken


### PR DESCRIPTION
r? @jflinter 

- In-memory card persistence now works
- I've updated `MyAPIClient` to return an error if `completeCharge` is called and `customerID` or `baseURL` aren't set, rather than fake-succeeding.

- Unrelated to the example app: I've tweaked the `STPAddCardViewControllerDelegate` documentation – we advise calling `completion(nil)` if no error occurs, but that actually isn't necessary. [0]

[0] https://github.com/stripe/stripe-ios/blob/master/Stripe/STPAddCardViewController.m#L328-L330