### PR TITLE
Update export_builds to produce fat framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/*
+Carthage/*
 Tests/build/*
 Tests/installation_tests/cocoapods/**/Podfile.lock
 Tests/installation_tests/cocoapods/**/Pods

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ Carthage/*
 Tests/build/*
 Tests/installation_tests/cocoapods/**/Podfile.lock
 Tests/installation_tests/cocoapods/**/Pods
+Tests/installation_tests/cocoapods/**/build
 Tests/installation_tests/manual_installation/build
 Tests/installation_tests/manual_installation/ManualInstallationTest/Frameworks/Stripe.framework
 Tests/installation_tests/manual_installation/ManualInstallationTest/Frameworks/Stripe.bundle

--- a/ci_scripts/export_builds.sh
+++ b/ci_scripts/export_builds.sh
@@ -1,15 +1,15 @@
 PROJECTDIR="$(cd $(dirname $0)/..; pwd)"
 BUILDDIR="${PROJECTDIR}/build"
+CARTHAGEDIR="${PROJECTDIR}/Carthage/Build/iOS"
 rm -rf $BUILDDIR
 mkdir $BUILDDIR
 cd $PROJECTDIR
 
 # Dynamic framework
-xcodebuild build -workspace Stripe.xcworkspace -scheme StripeiOS -configuration Release OBJROOT=$BUILDDIR SYMROOT=$BUILDDIR | xcpretty -c
-cd $BUILDDIR/Release-iphoneos
+carthage build --no-skip-current --platform iOS --configuration Release
+cd $CARTHAGEDIR
 ditto -ck --rsrc --sequesterRsrc --keepParent Stripe.framework Stripe.framework.zip
-rm -rf Stripe.framework
-cp Stripe.framework.zip $BUILDDIR
+mv Stripe.framework.zip $BUILDDIR
 cd -
 
 # Static framework


### PR DESCRIPTION
r? @jflinter 

The dynamic frameworks we've been attaching to recent releases aren't fat frameworks, and can't be used on the simulator. Since `carthage` treats these attachments as prebuilt binaries, this was also affecting all carthage users (I've updated `Stripe.framework.zip` on the latest release to a fat framework, so this is no longer an issue).

It seems pretty reasonable to just use `carthage build` here, but we could also substitute the raw `xcodebuild`/`lipo` commands.