### PR TITLE
Add more STPAddCardViewController tests

### DIFF
--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -457,6 +457,8 @@
 		C135380C1D2C22E5003F6157 /* MockSTPAPIClient.m in Sources */ = {isa = PBXBuildFile; fileRef = C135380A1D2C22E5003F6157 /* MockSTPAPIClient.m */; };
 		C135380F1D2C3E99003F6157 /* MockSTPAddCardViewControllerDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = C135380D1D2C3E99003F6157 /* MockSTPAddCardViewControllerDelegate.h */; };
 		C13538101D2C3E99003F6157 /* MockSTPAddCardViewControllerDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = C135380E1D2C3E99003F6157 /* MockSTPAddCardViewControllerDelegate.m */; };
+		C16A4CDD1D36B19B001F46D2 /* MockSTPCheckoutAPIClient.h in Headers */ = {isa = PBXBuildFile; fileRef = C16A4CDB1D36B19B001F46D2 /* MockSTPCheckoutAPIClient.h */; };
+		C16A4CDE1D36B19B001F46D2 /* MockSTPCheckoutAPIClient.m in Sources */ = {isa = PBXBuildFile; fileRef = C16A4CDC1D36B19B001F46D2 /* MockSTPCheckoutAPIClient.m */; };
 		C16F66AB1CA21BAC006A21B5 /* STPFormTextFieldTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C16F66AA1CA21BAC006A21B5 /* STPFormTextFieldTest.m */; };
 		C1717DB11CC00ED60009CF4A /* STPAddress.h in Headers */ = {isa = PBXBuildFile; fileRef = C1080F471CBECF7B007B2D89 /* STPAddress.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C17A030D1CBEE7A2006C819F /* STPAddressFieldTableViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = C17A030B1CBEE7A2006C819F /* STPAddressFieldTableViewCell.h */; };
@@ -809,6 +811,8 @@
 		C135380A1D2C22E5003F6157 /* MockSTPAPIClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MockSTPAPIClient.m; sourceTree = "<group>"; };
 		C135380D1D2C3E99003F6157 /* MockSTPAddCardViewControllerDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MockSTPAddCardViewControllerDelegate.h; sourceTree = "<group>"; };
 		C135380E1D2C3E99003F6157 /* MockSTPAddCardViewControllerDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MockSTPAddCardViewControllerDelegate.m; sourceTree = "<group>"; };
+		C16A4CDB1D36B19B001F46D2 /* MockSTPCheckoutAPIClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MockSTPCheckoutAPIClient.h; sourceTree = "<group>"; };
+		C16A4CDC1D36B19B001F46D2 /* MockSTPCheckoutAPIClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MockSTPCheckoutAPIClient.m; sourceTree = "<group>"; };
 		C16F66AA1CA21BAC006A21B5 /* STPFormTextFieldTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPFormTextFieldTest.m; sourceTree = "<group>"; };
 		C17A030B1CBEE7A2006C819F /* STPAddressFieldTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPAddressFieldTableViewCell.h; sourceTree = "<group>"; };
 		C17A030C1CBEE7A2006C819F /* STPAddressFieldTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPAddressFieldTableViewCell.m; sourceTree = "<group>"; };
@@ -1161,6 +1165,8 @@
 				C13538071D2C2186003F6157 /* STPAddCardViewControllerTest.m */,
 				C13538091D2C22E5003F6157 /* MockSTPAPIClient.h */,
 				C135380A1D2C22E5003F6157 /* MockSTPAPIClient.m */,
+				C16A4CDB1D36B19B001F46D2 /* MockSTPCheckoutAPIClient.h */,
+				C16A4CDC1D36B19B001F46D2 /* MockSTPCheckoutAPIClient.m */,
 				C135380D1D2C3E99003F6157 /* MockSTPAddCardViewControllerDelegate.h */,
 				C135380E1D2C3E99003F6157 /* MockSTPAddCardViewControllerDelegate.m */,
 			);
@@ -1375,6 +1381,7 @@
 				04633B071CD44F47009D4FB5 /* STPAPIClient+ApplePay.h in Headers */,
 				04BC29BD1CDD535700318357 /* STPSwitchTableViewCell.h in Headers */,
 				049881081CEE695700EA4FFD /* UIViewController+Stripe_Alerts.h in Headers */,
+				C16A4CDD1D36B19B001F46D2 /* MockSTPCheckoutAPIClient.h in Headers */,
 				04CDB5121A5F30A700B854EE /* STPToken.h in Headers */,
 				049952CF1BCF13510088C703 /* STPAPIPostRequest.h in Headers */,
 				049A3FB21CC9FEFC00F57DE7 /* UIToolbar+Stripe_InputAccessory.h in Headers */,
@@ -1883,6 +1890,7 @@
 				04BC29CB1CE40F7500318357 /* STPObscuredCardView.m in Sources */,
 				04B31DD61D08E6E200EF1631 /* STPCustomer.m in Sources */,
 				04A4C3991C4F2C8600B3B290 /* NSString+Stripe_CardBrands.m in Sources */,
+				C16A4CDE1D36B19B001F46D2 /* MockSTPCheckoutAPIClient.m in Sources */,
 				0438EF351B7416BB00D506CC /* STPPaymentCardTextField.m in Sources */,
 				045D71091CEED3AA00F6CD65 /* STPRememberMeEmailCell.m in Sources */,
 				04827D121D2575C6002DB3E8 /* STPImageLibrary.m in Sources */,

--- a/Stripe/STPAddCardViewController.m
+++ b/Stripe/STPAddCardViewController.m
@@ -308,6 +308,9 @@ static NSInteger STPPaymentCardRememberMeSection = 3;
                 if (error) {
                     [strongself handleCheckoutTokenError:error];
                 }
+                else {
+                    self.loading = NO;
+                }
             }];
         }] onFailure:^(NSError *error) {
             [weakself handleCardTokenError:error];
@@ -327,6 +330,9 @@ static NSInteger STPPaymentCardRememberMeSection = 3;
                 [self.delegate addCardViewController:self didCreateToken:token completion:^(NSError * _Nullable error) {
                     if (error) {
                         [self handleCardTokenError:error];
+                    }
+                    else {
+                        self.loading = NO;
                     }
                 }];
             }

--- a/Tests/Tests/MockSTPCheckoutAPIClient.h
+++ b/Tests/Tests/MockSTPCheckoutAPIClient.h
@@ -1,0 +1,17 @@
+//
+//  MockSTPCheckoutAPIClient.h
+//  Stripe
+//
+//  Created by Ben Guo on 7/13/16.
+//  Copyright © 2016 Stripe, Inc. All rights reserved.
+//
+
+#import "STPCheckoutAPIClient.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MockSTPCheckoutAPIClient : STPCheckoutAPIClient
+@property (nonatomic, copy, nullable) STPPromise *(^createTokenWithAccount)(STPCheckoutAccount *checkoutAccount);
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Tests/Tests/MockSTPCheckoutAPIClient.m
+++ b/Tests/Tests/MockSTPCheckoutAPIClient.m
@@ -1,0 +1,18 @@
+//
+//  MockSTPCheckoutAPIClient.m
+//  Stripe
+//
+//  Created by Ben Guo on 7/13/16.
+//  Copyright © 2016 Stripe, Inc. All rights reserved.
+//
+
+#import "MockSTPCheckoutAPIClient.h"
+
+@implementation MockSTPCheckoutAPIClient
+
+- (STPPromise<STPToken *> *)createTokenWithAccount:(STPCheckoutAccount *)account {
+    STPPromise *promise = self.createTokenWithAccount(account);
+    return promise;
+}
+
+@end

--- a/Tests/Tests/STPAddCardViewControllerTest.m
+++ b/Tests/Tests/STPAddCardViewControllerTest.m
@@ -8,13 +8,22 @@
 
 #import <XCTest/XCTest.h>
 #import "MockSTPAPIClient.h"
+#import "MockSTPCheckoutAPIClient.h"
 #import "STPRememberMePaymentCell.h"
 #import "STPCard.h"
 #import "MockSTPAddCardViewControllerDelegate.h"
+#import "STPCheckoutAccount.h"
+
+@interface STPCheckoutAccount (Testing)
+@property(nonatomic, nonnull)STPCard *card;
+@end
 
 @interface STPAddCardViewController (Testing)
 @property(nonatomic)STPRememberMePaymentCell *paymentCell;
 @property(nonatomic)STPAPIClient *apiClient;
+@property(nonatomic)STPCheckoutAPIClient *checkoutAPIClient;
+@property(nonatomic)STPCheckoutAccount *checkoutAccount;
+@property(nonatomic)STPCard *checkoutAccountCard;
 @property(nonatomic)BOOL loading;
 @end
 
@@ -27,6 +36,27 @@
 
 @implementation STPAddCardViewControllerTest
 
+- (STPCardParams *)cardParams {
+    STPCardParams *cardParams = [STPCardParams new];
+    cardParams.number = @"4000000000000002";
+    cardParams.expMonth = 10;
+    cardParams.expYear = 99;
+    cardParams.cvc = @"123";
+    return cardParams;
+}
+
+- (STPCheckoutAccount *)checkoutAccount {
+    STPCheckoutAccount *account = [STPCheckoutAccount new];
+    STPCard *card = [[STPCard alloc] initWithID:@"cc_123"
+                                          brand:STPCardBrandVisa
+                                          last4:@"1234"
+                                       expMonth:10
+                                        expYear:18
+                                        funding:STPCardFundingTypeCredit];
+    account.card = card;
+    return account;
+}
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
 
@@ -35,11 +65,7 @@
     XCTAssertNotNil(sut.view);
     MockSTPAPIClient *mockAPIClient = [MockSTPAPIClient new];
     sut.apiClient = mockAPIClient;
-    STPCardParams *expectedCardParams = [STPCardParams new];
-    expectedCardParams.number = @"4000000000000002";
-    expectedCardParams.expMonth = 10;
-    expectedCardParams.expYear = 99;
-    expectedCardParams.cvc = @"123";
+    STPCardParams *expectedCardParams = [self cardParams];
     sut.paymentCell.paymentField.cardParams = expectedCardParams;
     XCTestExpectation *exp = [self expectationWithDescription:@"createTokenWithCard"];
     mockAPIClient.onCreateTokenWithCard = ^(STPCardParams *cardParams, STPTokenCompletionBlock completion) {
@@ -65,11 +91,7 @@
     sut.apiClient = mockAPIClient;
     MockSTPAddCardViewControllerDelegate *mockDelegate = [MockSTPAddCardViewControllerDelegate new];
     sut.delegate = mockDelegate;
-    STPCardParams *expectedCardParams = [STPCardParams new];
-    expectedCardParams.number = @"4000000000000002";
-    expectedCardParams.expMonth = 10;
-    expectedCardParams.expYear = 99;
-    expectedCardParams.cvc = @"123";
+    STPCardParams *expectedCardParams = [self cardParams];
     sut.paymentCell.paymentField.cardParams = expectedCardParams;
     XCTestExpectation *createTokenExp = [self expectationWithDescription:@"createTokenWithCard"];
     STPToken *expectedToken = [STPToken new];
@@ -86,6 +108,145 @@
         NSError *error = [NSError stp_genericFailedToParseResponseError];
         XCTAssertEqualObjects(token.tokenId, expectedToken.tokenId);
         completion(error);
+        XCTAssertFalse(sut.loading);
+        [didCreateTokenExp fulfill];
+    };
+
+    // tap next button
+    UIBarButtonItem *nextButton = sut.navigationItem.rightBarButtonItem;
+    [nextButton.target performSelector:nextButton.action withObject:nextButton];
+
+    [self waitForExpectationsWithTimeout:2 handler:nil];
+}
+
+- (void)testNextWithCreateTokenSuccessAndDidCreateTokenSuccess {
+    STPAddCardViewController *sut = [STPAddCardViewController new];
+    XCTAssertNotNil(sut.view);
+    MockSTPAPIClient *mockAPIClient = [MockSTPAPIClient new];
+    sut.apiClient = mockAPIClient;
+    MockSTPAddCardViewControllerDelegate *mockDelegate = [MockSTPAddCardViewControllerDelegate new];
+    sut.delegate = mockDelegate;
+    STPCardParams *expectedCardParams = [self cardParams];
+    sut.paymentCell.paymentField.cardParams = expectedCardParams;
+    XCTestExpectation *createTokenExp = [self expectationWithDescription:@"createTokenWithCard"];
+    STPToken *expectedToken = [STPToken new];
+    expectedToken.tokenId = @"tok_123";
+    mockAPIClient.onCreateTokenWithCard = ^(STPCardParams *cardParams, STPTokenCompletionBlock completion) {
+        XCTAssertEqualObjects(cardParams.number, expectedCardParams.number);
+        XCTAssertTrue(sut.loading);
+        completion(expectedToken, nil);
+        [createTokenExp fulfill];
+    };
+    XCTestExpectation *didCreateTokenExp = [self expectationWithDescription:@"didCreateToken"];
+    mockDelegate.onDidCreateToken = ^(STPToken *token, STPErrorBlock completion) {
+        XCTAssertTrue(sut.loading);
+        XCTAssertEqualObjects(token.tokenId, expectedToken.tokenId);
+        completion(nil);
+        XCTAssertFalse(sut.loading);
+        [didCreateTokenExp fulfill];
+    };
+
+    // tap next button
+    UIBarButtonItem *nextButton = sut.navigationItem.rightBarButtonItem;
+    [nextButton.target performSelector:nextButton.action withObject:nextButton];
+
+    [self waitForExpectationsWithTimeout:2 handler:nil];
+}
+
+- (void)testNextWithCheckoutCreateTokenError {
+    STPAddCardViewController *sut = [STPAddCardViewController new];
+    XCTAssertNotNil(sut.view);
+    MockSTPCheckoutAPIClient *mockCheckoutAPIClient = [MockSTPCheckoutAPIClient new];
+    sut.checkoutAPIClient = mockCheckoutAPIClient;
+    STPPromise *promise = [STPPromise new];
+    STPCheckoutAccount *checkoutAccount = [self checkoutAccount];
+    sut.checkoutAccount = checkoutAccount;
+    sut.checkoutAccountCard = checkoutAccount.card;
+    XCTestExpectation *createTokenExp = [self expectationWithDescription:@"createTokenWithCard"];
+    mockCheckoutAPIClient.createTokenWithAccount = ^STPPromise *(STPCheckoutAccount *account) {
+        XCTAssertEqualObjects(account.card, checkoutAccount.card);
+        XCTAssertTrue(sut.loading);
+        [createTokenExp fulfill];
+        return promise;
+    };
+    XCTestExpectation *promiseExp = [self expectationWithDescription:@"onFailure"];
+    [promise fail:[NSError stp_genericFailedToParseResponseError]];
+    [promise onFailure:^(__unused NSError * error) {
+        XCTAssertFalse(sut.loading);
+        [promiseExp fulfill];
+    }];
+
+    // tap next button
+    UIBarButtonItem *nextButton = sut.navigationItem.rightBarButtonItem;
+    [nextButton.target performSelector:nextButton.action withObject:nextButton];
+
+    [self waitForExpectationsWithTimeout:2 handler:nil];
+}
+
+- (void)testNextWithCheckoutCreateTokenSuccessAndDidCreateTokenError {
+    STPAddCardViewController *sut = [STPAddCardViewController new];
+    XCTAssertNotNil(sut.view);
+    MockSTPCheckoutAPIClient *mockCheckoutAPIClient = [MockSTPCheckoutAPIClient new];
+    sut.checkoutAPIClient = mockCheckoutAPIClient;
+    MockSTPAddCardViewControllerDelegate *mockDelegate = [MockSTPAddCardViewControllerDelegate new];
+    sut.delegate = mockDelegate;
+    STPToken *expectedToken = [STPToken new];
+    expectedToken.tokenId = @"tok_123";
+    STPCheckoutAccount *checkoutAccount = [self checkoutAccount];
+    sut.checkoutAccount = checkoutAccount;
+    sut.checkoutAccountCard = checkoutAccount.card;
+    XCTestExpectation *createTokenExp = [self expectationWithDescription:@"createTokenWithCard"];
+    mockCheckoutAPIClient.createTokenWithAccount = ^STPPromise *(STPCheckoutAccount *account) {
+        XCTAssertEqualObjects(account.card, checkoutAccount.card);
+        XCTAssertTrue(sut.loading);
+        STPPromise *promise = [STPPromise new];
+        [promise succeed:expectedToken];
+        [createTokenExp fulfill];
+        return promise;
+    };
+    XCTestExpectation *didCreateTokenExp = [self expectationWithDescription:@"didCreateToken"];
+    mockDelegate.onDidCreateToken = ^(STPToken *token, STPErrorBlock completion) {
+        XCTAssertTrue(sut.loading);
+        NSError *error = [NSError stp_genericFailedToParseResponseError];
+        XCTAssertEqualObjects(token.tokenId, expectedToken.tokenId);
+        completion(error);
+        XCTAssertFalse(sut.loading);
+        [didCreateTokenExp fulfill];
+    };
+
+    // tap next button
+    UIBarButtonItem *nextButton = sut.navigationItem.rightBarButtonItem;
+    [nextButton.target performSelector:nextButton.action withObject:nextButton];
+
+    [self waitForExpectationsWithTimeout:2 handler:nil];
+}
+
+- (void)testNextWithCheckoutCreateTokenSuccessAndDidCreateTokenSuccess {
+    STPAddCardViewController *sut = [STPAddCardViewController new];
+    XCTAssertNotNil(sut.view);
+    MockSTPCheckoutAPIClient *mockCheckoutAPIClient = [MockSTPCheckoutAPIClient new];
+    sut.checkoutAPIClient = mockCheckoutAPIClient;
+    MockSTPAddCardViewControllerDelegate *mockDelegate = [MockSTPAddCardViewControllerDelegate new];
+    sut.delegate = mockDelegate;
+    STPToken *expectedToken = [STPToken new];
+    expectedToken.tokenId = @"tok_123";
+    STPCheckoutAccount *checkoutAccount = [self checkoutAccount];
+    sut.checkoutAccount = checkoutAccount;
+    sut.checkoutAccountCard = checkoutAccount.card;
+    XCTestExpectation *createTokenExp = [self expectationWithDescription:@"createTokenWithCard"];
+    mockCheckoutAPIClient.createTokenWithAccount = ^STPPromise *(STPCheckoutAccount *account) {
+        XCTAssertEqualObjects(account.card, checkoutAccount.card);
+        XCTAssertTrue(sut.loading);
+        STPPromise *promise = [STPPromise new];
+        [promise succeed:expectedToken];
+        [createTokenExp fulfill];
+        return promise;
+    };
+    XCTestExpectation *didCreateTokenExp = [self expectationWithDescription:@"didCreateToken"];
+    mockDelegate.onDidCreateToken = ^(STPToken *token, STPErrorBlock completion) {
+        XCTAssertTrue(sut.loading);
+        XCTAssertEqualObjects(token.tokenId, expectedToken.tokenId);
+        completion(nil);
         XCTAssertFalse(sut.loading);
         [didCreateTokenExp fulfill];
     };


### PR DESCRIPTION
r? @jflinter 

I've also updated the behavior of `addCardViewController:didCreateToken:completion:` so that calling `completion(nil)` resets the view controller's loading state. (#368)



