### PR TITLE
Change status and scroll style from bg color

### DIFF
--- a/Stripe/STPAddCardViewController.m
+++ b/Stripe/STPAddCardViewController.m
@@ -36,10 +36,11 @@
 #import "UIViewController+Stripe_NavigationItemProxy.h"
 #import "STPRememberMePaymentCell.h"
 #import "STPAnalyticsClient.h"
+#import "STPColorUtils.h"
 
 @interface STPAddCardViewController ()<STPPaymentCardTextFieldDelegate, STPAddressViewModelDelegate, STPAddressFieldTableViewCellDelegate, STPSwitchTableViewCellDelegate, UITableViewDelegate, UITableViewDataSource, STPSMSCodeViewControllerDelegate, STPRememberMePaymentCellDelegate>
 @property(nonatomic)STPPaymentConfiguration *configuration;
-@property(nonatomic) STPTheme *theme;
+@property(nonatomic)STPTheme *theme;
 @property(nonatomic)STPAPIClient *apiClient;
 @property(nonatomic, weak)UITableView *tableView;
 @property(nonatomic, weak)UIImageView *cardImageView;
@@ -183,6 +184,11 @@ static NSInteger STPPaymentCardRememberMeSection = 3;
     self.tableView.allowsSelection = NO;
     self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone; // handle this with fake separator views for flexibility
     self.tableView.backgroundColor = self.theme.primaryBackgroundColor;
+    if ([STPColorUtils colorIsBright:self.theme.primaryBackgroundColor]) {
+        self.tableView.indicatorStyle = UIScrollViewIndicatorStyleBlack;
+    } else {
+        self.tableView.indicatorStyle = UIScrollViewIndicatorStyleWhite;
+    }
     
     self.cardImageView.tintColor = self.theme.accentColor;
     self.activityIndicator.tintColor = self.theme.accentColor;
@@ -196,6 +202,13 @@ static NSInteger STPPaymentCardRememberMeSection = 3;
     self.rememberMeCell.theme = self.theme;
     self.rememberMePhoneCell.theme = self.theme;
     self.rememberMeTermsView.theme = self.theme;
+    [self setNeedsStatusBarAppearanceUpdate];
+}
+
+- (UIStatusBarStyle)preferredStatusBarStyle {
+    return ([STPColorUtils colorIsBright:self.theme.primaryBackgroundColor] 
+            ? UIStatusBarStyleDefault
+            : UIStatusBarStyleLightContent);
 }
 
 - (void)viewDidLayoutSubviews {

--- a/Stripe/STPColorUtils.h
+++ b/Stripe/STPColorUtils.h
@@ -14,4 +14,6 @@
 
 + (UIColor *)brighterColor:(UIColor *)color1 color2:(UIColor *)color2;
 
++ (BOOL)colorIsBright:(UIColor *)color;
+
 @end

--- a/Stripe/STPColorUtils.m
+++ b/Stripe/STPColorUtils.m
@@ -22,4 +22,8 @@
     return brightness1 >= brightness2 ? color1 : color2;
 }
 
++ (BOOL)colorIsBright:(UIColor *)color {
+    return [self perceivedBrightnessForColor:color] > 0.3;
+}
+
 @end

--- a/Stripe/STPPaymentMethodsInternalViewController.m
+++ b/Stripe/STPPaymentMethodsInternalViewController.m
@@ -13,6 +13,7 @@
 #import "NSString+Stripe_CardBrands.h"
 #import "UITableViewCell+Stripe_Borders.h"
 #import "UINavigationController+Stripe_Completion.h"
+#import "STPColorUtils.h"
 
 static NSString *const STPPaymentMethodCellReuseIdentifier = @"STPPaymentMethodCellReuseIdentifier";
 static NSInteger STPPaymentMethodCardListSection = 0;
@@ -77,6 +78,12 @@ static NSInteger STPPaymentMethodAddCardSection = 1;
     self.tableView.backgroundColor = self.theme.primaryBackgroundColor;
     self.tableView.tintColor = self.theme.accentColor;
     self.cardImageView.tintColor = self.theme.accentColor;
+    
+    if ([STPColorUtils colorIsBright:self.theme.primaryBackgroundColor]) {
+        self.tableView.indicatorStyle = UIScrollViewIndicatorStyleBlack;
+    } else {
+        self.tableView.indicatorStyle = UIScrollViewIndicatorStyleWhite;
+    }
 }
 
 - (void)viewDidLayoutSubviews {

--- a/Stripe/STPPaymentMethodsViewController.m
+++ b/Stripe/STPPaymentMethodsViewController.m
@@ -23,11 +23,12 @@
 #import "STPPaymentMethodsInternalViewController.h"
 #import "UIViewController+Stripe_NavigationItemProxy.h"
 #import "STPTheme.h"
+#import "STPColorUtils.h"
 
 @interface STPPaymentMethodsViewController()<STPPaymentMethodsInternalViewControllerDelegate, STPAddCardViewControllerDelegate>
 
 @property(nonatomic)STPPaymentConfiguration *configuration;
-@property(nonatomic) STPTheme *theme;
+@property(nonatomic)STPTheme *theme;
 @property(nonatomic)id<STPBackendAPIAdapter> apiAdapter;
 @property(nonatomic)STPAPIClient *apiClient;
 @property(nonatomic)STPPromise<STPPaymentMethodTuple *> *loadingPromise;
@@ -150,6 +151,13 @@
     [self.cancelItem stp_setTheme:self.theme];
     self.activityIndicator.tintColor = self.theme.accentColor;
     self.view.backgroundColor = self.theme.primaryBackgroundColor;
+    [self setNeedsStatusBarAppearanceUpdate];
+}
+
+- (UIStatusBarStyle)preferredStatusBarStyle {
+    return ([STPColorUtils colorIsBright:self.theme.primaryBackgroundColor] 
+            ? UIStatusBarStyleDefault
+            : UIStatusBarStyleLightContent);
 }
 
 - (void)cancel:(__unused id)sender {

--- a/Stripe/STPSMSCodeViewController.m
+++ b/Stripe/STPSMSCodeViewController.m
@@ -15,6 +15,7 @@
 #import "UIBarButtonItem+Stripe.h"
 #import "UIViewController+Stripe_KeyboardAvoiding.h"
 #import "STPPhoneNumberValidator.h"
+#import "STPColorUtils.h"
 
 @interface STPSMSCodeViewController()<STPSMSCodeTextFieldDelegate>
 
@@ -134,6 +135,18 @@
     self.smsSentLabel.font = self.theme.smallFont;
     self.smsSentLabel.textColor = self.theme.secondaryForegroundColor;
     self.activityIndicator.tintColor = self.theme.accentColor;
+    if ([STPColorUtils colorIsBright:self.theme.primaryBackgroundColor]) {
+        self.scrollView.indicatorStyle = UIScrollViewIndicatorStyleBlack;
+    } else {
+        self.scrollView.indicatorStyle = UIScrollViewIndicatorStyleWhite;
+    }
+    [self setNeedsStatusBarAppearanceUpdate];
+}
+
+- (UIStatusBarStyle)preferredStatusBarStyle {
+    return ([STPColorUtils colorIsBright:self.theme.primaryBackgroundColor] 
+            ? UIStatusBarStyleDefault
+            : UIStatusBarStyleLightContent);
 }
 
 - (void)viewDidLayoutSubviews {

--- a/Stripe/UINavigationBar+Stripe_Theme.m
+++ b/Stripe/UINavigationBar+Stripe_Theme.m
@@ -8,6 +8,7 @@
 
 #import "UINavigationBar+Stripe_Theme.h"
 #import "STPTheme.h"
+#import "STPColorUtils.h"
 
 static NSInteger const STPNavigationBarHairlineViewTag = 787473;
 
@@ -18,6 +19,14 @@ static NSInteger const STPNavigationBarHairlineViewTag = 787473;
     [self stp_artificialHairlineView].backgroundColor = theme.tertiaryBackgroundColor;
     self.barTintColor = theme.secondaryBackgroundColor;
     self.tintColor = theme.accentColor;
+
+    if ([STPColorUtils colorIsBright:theme.secondaryBackgroundColor]) {
+        self.barStyle = UIBarStyleDefault;
+    }
+    else {
+        self.barStyle = UIBarStyleBlack;
+    }
+
     self.titleTextAttributes = @{
                                  NSFontAttributeName: theme.emphasisFont,
                                  NSForegroundColorAttributeName: theme.primaryForegroundColor,


### PR DESCRIPTION
## Summary

Automatically change the preferred status bar style and scroll view indicator style based on the colors of the set STPTheme

This sets the status bar style of any STPTheme'd UINavigationBars and UIScrollViews. Additionally it sets the preferredStatusBarStyle for the sdk's view controllers for use by user-controlled UINavigationBars

## Motivation

When using darker background colors, the status bar and scroll indicators could be hard to see or completely invisible.

## Testing

Tested using the different themes included in the example app.

