### PR TITLE
Convert to using WEAK/STRONG macros

### DIFF
--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -504,6 +504,7 @@
 		C1FEE5961CBFF11400A7632B /* STPPostalCodeValidator.h in Headers */ = {isa = PBXBuildFile; fileRef = C1FEE5941CBFF11400A7632B /* STPPostalCodeValidator.h */; };
 		C1FEE5971CBFF11400A7632B /* STPPostalCodeValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = C1FEE5951CBFF11400A7632B /* STPPostalCodeValidator.m */; };
 		C1FEE5991CBFF24000A7632B /* STPPostalCodeValidatorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C1FEE5981CBFF24000A7632B /* STPPostalCodeValidatorTest.m */; };
+		F132DFE31D51372A002FF5B7 /* STPWeakStrongMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = F132DFE21D51372A002FF5B7 /* STPWeakStrongMacros.h */; };
 		F14C872F1D4FCDBA00C7CC6A /* STPPaymentContextTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F14C872E1D4FCDBA00C7CC6A /* STPPaymentContextTest.m */; };
 		F14C873A1D4FE5B900C7CC6A /* TestSTPBackendAPIAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = F14C87381D4FE5B900C7CC6A /* TestSTPBackendAPIAdapter.h */; };
 		F14C873C1D4FE5BD00C7CC6A /* TestSTPBackendAPIAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = F14C87391D4FE5B900C7CC6A /* TestSTPBackendAPIAdapter.m */; };
@@ -837,6 +838,7 @@
 		C1FEE5941CBFF11400A7632B /* STPPostalCodeValidator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPPostalCodeValidator.h; sourceTree = "<group>"; };
 		C1FEE5951CBFF11400A7632B /* STPPostalCodeValidator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPPostalCodeValidator.m; sourceTree = "<group>"; };
 		C1FEE5981CBFF24000A7632B /* STPPostalCodeValidatorTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPPostalCodeValidatorTest.m; sourceTree = "<group>"; };
+		F132DFE21D51372A002FF5B7 /* STPWeakStrongMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPWeakStrongMacros.h; sourceTree = "<group>"; };
 		F14C872E1D4FCDBA00C7CC6A /* STPPaymentContextTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPPaymentContextTest.m; sourceTree = "<group>"; };
 		F14C87381D4FE5B900C7CC6A /* TestSTPBackendAPIAdapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TestSTPBackendAPIAdapter.h; sourceTree = "<group>"; };
 		F14C87391D4FE5B900C7CC6A /* TestSTPBackendAPIAdapter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TestSTPBackendAPIAdapter.m; sourceTree = "<group>"; };
@@ -986,6 +988,7 @@
 				045D710B1CEEDC2100F6CD65 /* Vendor */,
 				04CDB4A91A5F30A700B854EE /* Stripe.h */,
 				04A4883B1CA3568800506E53 /* STPBlocks.h */,
+				F132DFE21D51372A002FF5B7 /* STPWeakStrongMacros.h */,
 				04CDB4C21A5F30A700B854EE /* STPAPIClient.h */,
 				04CDB4C31A5F30A700B854EE /* STPAPIClient.m */,
 				04633B081CD44F6C009D4FB5 /* PKPayment+Stripe.h */,
@@ -1464,6 +1467,7 @@
 				0451CC441C49AE1C003B2CA6 /* STPPaymentResult.h in Headers */,
 				049A3F951CC75B2E00F57DE7 /* STPPromise.h in Headers */,
 				04BC29AD1CD9A88600318357 /* STPCheckoutAPIVerification.h in Headers */,
+				F132DFE31D51372A002FF5B7 /* STPWeakStrongMacros.h in Headers */,
 				049A3F7E1CC1920A00F57DE7 /* UIViewController+Stripe_KeyboardAvoiding.h in Headers */,
 				04BFFFD91D240B13005F2340 /* STPAddCardViewController+Private.h in Headers */,
 				04B31DE61D09D25F00EF1631 /* STPPaymentMethodsInternalViewController.h in Headers */,

--- a/Stripe/STPAddCardViewController.m
+++ b/Stripe/STPAddCardViewController.m
@@ -37,6 +37,7 @@
 #import "STPRememberMePaymentCell.h"
 #import "STPAnalyticsClient.h"
 #import "STPColorUtils.h"
+#import "STPWeakStrongMacros.h"
 
 @interface STPAddCardViewController ()<STPPaymentCardTextFieldDelegate, STPAddressViewModelDelegate, STPAddressFieldTableViewCellDelegate, STPSwitchTableViewCellDelegate, UITableViewDelegate, UITableViewDataSource, STPSMSCodeViewControllerDelegate, STPRememberMePaymentCellDelegate>
 @property(nonatomic)STPPaymentConfiguration *configuration;
@@ -167,9 +168,10 @@ static NSInteger STPPaymentCardRememberMeSection = 3;
     
     [self.view addGestureRecognizer:[[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(endEditing)]];
     
-    __weak typeof(self) weakself = self;
+    WEAK(self);
     [self.checkoutAPIClient.bootstrapPromise onCompletion:^(__unused id value, __unused NSError *error) {
-        [weakself reloadRememberMeCellAnimated:YES];
+        STRONG(self);
+        [self reloadRememberMeCellAnimated:YES];
     }];
 }
 
@@ -294,19 +296,20 @@ static NSInteger STPPaymentCardRememberMeSection = 3;
     STPCardParams *cardParams = self.paymentCell.paymentField.cardParams;
     cardParams.address = self.addressViewModel.address;
     if (self.checkoutAccountCard) {
-        __weak typeof(self) weakself = self;
+        WEAK(self);
         [[[self.checkoutAPIClient createTokenWithAccount:self.checkoutAccount] onSuccess:^(STPToken *token) {
-            __strong typeof(weakself) strongself = weakself;
-            [strongself.delegate addCardViewController:strongself didCreateToken:token completion:^(NSError * _Nullable error) {
+            STRONG(self);
+            [self.delegate addCardViewController:self didCreateToken:token completion:^(NSError * _Nullable error) {
                 if (error) {
-                    [strongself handleCheckoutTokenError:error];
+                    [self handleCheckoutTokenError:error];
                 }
                 else {
                     self.loading = NO;
                 }
             }];
         }] onFailure:^(NSError *error) {
-            [weakself handleCardTokenError:error];
+            STRONG(self);
+            [self handleCardTokenError:error];
         }];
     } else if (cardParams) {
         [self.apiClient createTokenWithCard:cardParams completion:^(STPToken *token, NSError *tokenError) {
@@ -437,25 +440,31 @@ static NSInteger STPPaymentCardRememberMeSection = 3;
     if (self.checkoutAccount || self.configuration.smsAutofillDisabled || self.lookupSucceeded) {
         return;
     }
-    __weak typeof(self) weakself = self;
+    WEAK(self);
     if ([STPEmailAddressValidator stringIsValidEmailAddress:email]) {
         [self.emailCell.activityIndicator setAnimating:YES animated:YES];
         [[[[self.stp_didAppearPromise voidFlatMap:^STPPromise * _Nonnull{
-            return [weakself.checkoutAPIClient lookupEmail:email];
+            STRONG(self);
+            return [self.checkoutAPIClient lookupEmail:email];
         }] flatMap:^STPPromise * _Nonnull(STPCheckoutAccountLookup *lookup) {
-            weakself.lookupSucceeded = YES;
-            weakself.checkoutLookup = lookup;
-            return [weakself.checkoutAPIClient sendSMSToAccountWithEmail:lookup.email];
+            STRONG(self);
+            self.lookupSucceeded = YES;
+            self.checkoutLookup = lookup;
+            return [self.checkoutAPIClient sendSMSToAccountWithEmail:lookup.email];
         }] onSuccess:^(STPCheckoutAPIVerification *verification) {
-            STPSMSCodeViewController *codeViewController = [[STPSMSCodeViewController alloc] initWithCheckoutAPIClient:self.checkoutAPIClient verification:verification redactedPhone:self.checkoutLookup.redactedPhone];
+            STRONG(self);
+            STPSMSCodeViewController *codeViewController = [[STPSMSCodeViewController alloc] initWithCheckoutAPIClient:self.checkoutAPIClient 
+                                                                                                          verification:verification 
+                                                                                                         redactedPhone:self.checkoutLookup.redactedPhone];
             codeViewController.theme = self.theme;
             codeViewController.delegate = self;
             UINavigationController *nav = [[UINavigationController alloc] initWithRootViewController:codeViewController];
             [nav.navigationBar stp_setTheme:self.theme];
-            [weakself presentViewController:nav animated:YES completion:nil];
+            [self presentViewController:nav animated:YES completion:nil];
         }] onCompletion:^(__unused id value, NSError *error) {
+            STRONG(self);
             if (![error stp_isURLSessionCancellationError]) {
-                [weakself.emailCell.activityIndicator setAnimating:NO animated:YES];
+                [self.emailCell.activityIndicator setAnimating:NO animated:YES];
             }
         }];
     }

--- a/Stripe/STPFormTextField.m
+++ b/Stripe/STPFormTextField.m
@@ -11,6 +11,7 @@
 #import "STPPhoneNumberValidator.h"
 #import "NSString+Stripe.h"
 #import "STPDelegateProxy.h"
+#import "STPWeakStrongMacros.h"
 
 #define FAUXPAS_IGNORED_IN_METHOD(...)
 
@@ -134,14 +135,14 @@ typedef NSAttributedString* (^STPFormTextTransformationBlock)(NSAttributedString
             };
             break;
         case STPFormTextFieldAutoFormattingBehaviorPhoneNumbers: {
-            __weak id weakself = self;
+            WEAK(self);
             self.textFormattingBlock = ^NSAttributedString *(NSAttributedString *inputString) {
                 if (![STPCardValidator stringIsNumeric:inputString.string]) {
                     return [inputString copy];
                 }
-                __strong id strongself = weakself;
+                STRONG(self);
                 NSString *phoneNumber = [STPPhoneNumberValidator formattedSanitizedPhoneNumberForString:inputString.string];
-                NSDictionary *attributes = [[strongself class] attributesForAttributedString:inputString];
+                NSDictionary *attributes = [[self class] attributesForAttributedString:inputString];
                 return [[NSAttributedString alloc] initWithString:phoneNumber attributes:attributes];
             };
             break;

--- a/Stripe/STPPaymentCardTextField.m
+++ b/Stripe/STPPaymentCardTextField.m
@@ -12,6 +12,7 @@
 #import "STPPaymentCardTextFieldViewModel.h"
 #import "STPFormTextField.h"
 #import "STPImageLibrary.h"
+#import "STPWeakStrongMacros.h"
 
 #define FAUXPAS_IGNORED_IN_METHOD(...)
 
@@ -357,11 +358,11 @@ CGFloat const STPPaymentCardTextFieldDefaultPadding = 13;
     self.viewModel = [STPPaymentCardTextFieldViewModel new];
     [self onChange];
     [self updateImageForFieldType:STPCardFieldTypeNumber];
-    __weak id weakself = self;
+    WEAK(self);
     [self setNumberFieldShrunk:NO animated:YES completion:^(__unused BOOL completed){
-        __strong id strongself = weakself;
-        if ([strongself isFirstResponder]) {
-            [[strongself numberField] becomeFirstResponder];
+        STRONG(self);
+        if ([self isFirstResponder]) {
+            [[self numberField] becomeFirstResponder];
         }
     }];
 }

--- a/Stripe/STPPromise.m
+++ b/Stripe/STPPromise.m
@@ -7,6 +7,7 @@
 //
 
 #import "STPPromise.h"
+#import "STPWeakStrongMacros.h"
 
 @interface STPPromise<T>()
 
@@ -89,11 +90,13 @@
 }
 
 - (void)completeWith:(STPPromise *)promise {
-    __weak typeof(self) weakself = self;
+    WEAK(self);
     [[promise onSuccess:^(id value) {
-        [weakself succeed:value];
+        STRONG(self);
+        [self succeed:value];
     }] onFailure:^(NSError * _Nonnull error) {
-        [weakself fail:error];
+        STRONG(self);
+        [self fail:error];
     }];
 }
 
@@ -180,11 +183,13 @@
 }
 
 - (void)voidCompleteWith:(STPVoidPromise *)promise {
-    __weak typeof(self)weakself = self;
+    WEAK(self);
     [[promise voidOnSuccess:^{
-        [weakself succeed];
+        STRONG(self);
+        [self succeed];
     }] onFailure:^(NSError *error) {
-        [weakself fail:error];
+        STRONG(self);
+        [self fail:error];
     }];
 }
 

--- a/Stripe/STPWeakStrongMacros.h
+++ b/Stripe/STPWeakStrongMacros.h
@@ -1,0 +1,19 @@
+//
+//  STPWeakStrongMacros.h
+//  Stripe
+//
+//  Created by Brian Dorfman on 7/28/16.
+//  Copyright © 2016 Stripe, Inc. All rights reserved.
+//
+
+/*
+ * Based on @weakify() and @strongify() from
+ * https://github.com/jspahrsummers/libextc
+ */
+
+#define WEAK(var) __weak typeof(var) weak_##var = var;
+#define STRONG(var) \
+_Pragma("clang diagnostic push") \
+_Pragma("clang diagnostic ignored \"-Wshadow\"") \
+__strong typeof(var) var = weak_##var; \
+_Pragma("clang diagnostic pop") \


### PR DESCRIPTION
These macros are based off libextc's @weakify and @strongify.
This change also fixes some incorrect self-capturing retain cycles and probably some potential errors with weakself being dealloc'd partway through block execution.