### PR TITLE
Change how summaryItems property works.

### DIFF
--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -504,6 +504,12 @@
 		C1FEE5961CBFF11400A7632B /* STPPostalCodeValidator.h in Headers */ = {isa = PBXBuildFile; fileRef = C1FEE5941CBFF11400A7632B /* STPPostalCodeValidator.h */; };
 		C1FEE5971CBFF11400A7632B /* STPPostalCodeValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = C1FEE5951CBFF11400A7632B /* STPPostalCodeValidator.m */; };
 		C1FEE5991CBFF24000A7632B /* STPPostalCodeValidatorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C1FEE5981CBFF24000A7632B /* STPPostalCodeValidatorTest.m */; };
+		F12C8DC01D63DE9F00ADA0D7 /* STPPaymentContextAmountModel.h in Headers */ = {isa = PBXBuildFile; fileRef = F12C8DBE1D63DE9F00ADA0D7 /* STPPaymentContextAmountModel.h */; };
+		F12C8DC11D63DE9F00ADA0D7 /* STPPaymentContextAmountModel.h in Headers */ = {isa = PBXBuildFile; fileRef = F12C8DBE1D63DE9F00ADA0D7 /* STPPaymentContextAmountModel.h */; };
+		F12C8DC21D63DE9F00ADA0D7 /* STPPaymentContextAmountModel.h in Headers */ = {isa = PBXBuildFile; fileRef = F12C8DBE1D63DE9F00ADA0D7 /* STPPaymentContextAmountModel.h */; };
+		F12C8DC31D63DE9F00ADA0D7 /* STPPaymentContextAmountModel.m in Sources */ = {isa = PBXBuildFile; fileRef = F12C8DBF1D63DE9F00ADA0D7 /* STPPaymentContextAmountModel.m */; };
+		F12C8DC41D63DE9F00ADA0D7 /* STPPaymentContextAmountModel.m in Sources */ = {isa = PBXBuildFile; fileRef = F12C8DBF1D63DE9F00ADA0D7 /* STPPaymentContextAmountModel.m */; };
+		F12C8DC51D63DE9F00ADA0D7 /* STPPaymentContextAmountModel.m in Sources */ = {isa = PBXBuildFile; fileRef = F12C8DBF1D63DE9F00ADA0D7 /* STPPaymentContextAmountModel.m */; };
 		F14C872F1D4FCDBA00C7CC6A /* STPPaymentContextTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F14C872E1D4FCDBA00C7CC6A /* STPPaymentContextTest.m */; };
 		F14C873A1D4FE5B900C7CC6A /* TestSTPBackendAPIAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = F14C87381D4FE5B900C7CC6A /* TestSTPBackendAPIAdapter.h */; };
 		F14C873C1D4FE5BD00C7CC6A /* TestSTPBackendAPIAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = F14C87391D4FE5B900C7CC6A /* TestSTPBackendAPIAdapter.m */; };
@@ -837,6 +843,8 @@
 		C1FEE5941CBFF11400A7632B /* STPPostalCodeValidator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPPostalCodeValidator.h; sourceTree = "<group>"; };
 		C1FEE5951CBFF11400A7632B /* STPPostalCodeValidator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPPostalCodeValidator.m; sourceTree = "<group>"; };
 		C1FEE5981CBFF24000A7632B /* STPPostalCodeValidatorTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPPostalCodeValidatorTest.m; sourceTree = "<group>"; };
+		F12C8DBE1D63DE9F00ADA0D7 /* STPPaymentContextAmountModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPPaymentContextAmountModel.h; sourceTree = "<group>"; };
+		F12C8DBF1D63DE9F00ADA0D7 /* STPPaymentContextAmountModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPPaymentContextAmountModel.m; sourceTree = "<group>"; };
 		F14C872E1D4FCDBA00C7CC6A /* STPPaymentContextTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPPaymentContextTest.m; sourceTree = "<group>"; };
 		F14C87381D4FE5B900C7CC6A /* TestSTPBackendAPIAdapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TestSTPBackendAPIAdapter.h; sourceTree = "<group>"; };
 		F14C87391D4FE5B900C7CC6A /* TestSTPBackendAPIAdapter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TestSTPBackendAPIAdapter.m; sourceTree = "<group>"; };
@@ -1038,6 +1046,8 @@
 				049A3FAD1CC9AA9900F57DE7 /* STPAddressViewModel.m */,
 				049A3F871CC73C7100F57DE7 /* STPPaymentContext.h */,
 				049A3F881CC73C7100F57DE7 /* STPPaymentContext.m */,
+				F12C8DBE1D63DE9F00ADA0D7 /* STPPaymentContextAmountModel.h */,
+				F12C8DBF1D63DE9F00ADA0D7 /* STPPaymentContextAmountModel.m */,
 				04E39F5A1CECFAFD00AF3B96 /* STPPaymentContext+Private.h */,
 				04E39F4E1CECF7A100AF3B96 /* STPCardTuple.h */,
 				04E39F4F1CECF7A100AF3B96 /* STPCardTuple.m */,
@@ -1277,6 +1287,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C135380F1D2C3E99003F6157 /* MockSTPAddCardViewControllerDelegate.h in Headers */,
+				F12C8DC11D63DE9F00ADA0D7 /* STPPaymentContextAmountModel.h in Headers */,
 				C135380B1D2C22E5003F6157 /* MockSTPAPIClient.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1328,6 +1339,7 @@
 				04F94DA81D229F2F004FC826 /* STPPaymentMethodTuple.h in Headers */,
 				0438EF491B74183100D506CC /* STPCardBrand.h in Headers */,
 				04F94DB71D229F7C004FC826 /* STPObscuredCardView.h in Headers */,
+				F12C8DC21D63DE9F00ADA0D7 /* STPPaymentContextAmountModel.h in Headers */,
 				049A3FA91CC96B3B00F57DE7 /* STPBackendAPIAdapter.h in Headers */,
 				049952D61BCF14930088C703 /* STPAPIPostRequest.h in Headers */,
 				04827D111D2575C6002DB3E8 /* STPImageLibrary.h in Headers */,
@@ -1383,6 +1395,7 @@
 			files = (
 				04BC29A91CD9A83600318357 /* STPCheckoutAPIClient.h in Headers */,
 				C11810A71CC6EE840022FB55 /* STPBackendAPIAdapter.h in Headers */,
+				F12C8DC01D63DE9F00ADA0D7 /* STPPaymentContextAmountModel.h in Headers */,
 				0439B9871C454F97005A1ED5 /* STPPaymentMethodsViewController.h in Headers */,
 				04B31DF91D11AC6400EF1631 /* STPUserInformation.h in Headers */,
 				04EBC7531B7533C300A0E6AE /* STPCardValidationState.h in Headers */,
@@ -1788,6 +1801,7 @@
 				0438EF4C1B741B0100D506CC /* STPCardValidatorTest.m in Sources */,
 				04A4C3921C4F263300B3B290 /* STPNSArrayStripeBoundSafeTests.m in Sources */,
 				045A62AB1B8E7259000165CE /* STPPaymentCardTextFieldTest.m in Sources */,
+				F12C8DC41D63DE9F00ADA0D7 /* STPPaymentContextAmountModel.m in Sources */,
 				F14C872F1D4FCDBA00C7CC6A /* STPPaymentContextTest.m in Sources */,
 				F14C873C1D4FE5BD00C7CC6A /* TestSTPBackendAPIAdapter.m in Sources */,
 				0438EF4D1B741B0100D506CC /* STPPaymentCardTextFieldViewModelTest.m in Sources */,
@@ -1856,6 +1870,7 @@
 				049880FF1CED5A2300EA4FFD /* STPPaymentConfiguration.m in Sources */,
 				04F94DB91D229F86004FC826 /* STPApplePayPaymentMethod.m in Sources */,
 				04B31DE91D09D25F00EF1631 /* STPPaymentMethodsInternalViewController.m in Sources */,
+				F12C8DC51D63DE9F00ADA0D7 /* STPPaymentContextAmountModel.m in Sources */,
 				04633B011CD129CB009D4FB5 /* STPPhoneNumberValidator.m in Sources */,
 				04A488451CA3580700506E53 /* UINavigationController+Stripe_Completion.m in Sources */,
 				049E84CF1A605DE0000B66CD /* STPBankAccount.m in Sources */,
@@ -1949,6 +1964,7 @@
 				C118108A1CC6B00D0022FB55 /* STPApplePayPaymentMethod.m in Sources */,
 				04A488341CA34D3000506E53 /* STPEmailAddressValidator.m in Sources */,
 				0433EB4C1BD06313003912B4 /* NSDictionary+Stripe.m in Sources */,
+				F12C8DC31D63DE9F00ADA0D7 /* STPPaymentContextAmountModel.m in Sources */,
 				C124A17E1CCAA0C2007D42EE /* NSMutableURLRequest+Stripe.m in Sources */,
 				04695ADA1C77F9EF00E08063 /* STPDelegateProxy.m in Sources */,
 				045D712E1CF4ED7600F6CD65 /* STPBINRange.m in Sources */,

--- a/Stripe/NSDecimalNumber+Stripe_Currency.h
+++ b/Stripe/NSDecimalNumber+Stripe_Currency.h
@@ -13,6 +13,8 @@
 + (NSDecimalNumber *)stp_decimalNumberWithAmount:(NSInteger)amount
                                         currency:(NSString *)currency;
 
+- (NSInteger)stp_amountWithCurrency:(NSString *)currency;
+
 @end
 
 void linkNSDecimalNumberCurrencyCategory(void);

--- a/Stripe/NSDecimalNumber+Stripe_Currency.m
+++ b/Stripe/NSDecimalNumber+Stripe_Currency.m
@@ -10,16 +10,30 @@
 
 @implementation NSDecimalNumber (Stripe_Currency)
 
++ (NSArray *)stp_currenciesWithNoDecimal {
+    return @[@"bif", @"clp",@"djf",@"gnf",
+             @"jpy",@"kmf",@"krw",@"mga",@"pyg",@"rwf",@"vnd",
+             @"vuv",@"xaf",@"xof", @"xpf"];
+}
+
 + (NSDecimalNumber *)stp_decimalNumberWithAmount:(NSInteger)amount
                                         currency:(NSString *)currency {
-    NSArray *noDecimalCurrencies = @[@"bif", @"clp",@"djf",@"gnf",
-                                     @"jpy",@"kmf",@"krw",@"mga",@"pyg",@"rwf",@"vnd",
-                                     @"vuv",@"xaf",@"xof", @"xpf"];
+    NSArray *noDecimalCurrencies = [self stp_currenciesWithNoDecimal];
     NSDecimalNumber *number = [self decimalNumberWithMantissa:amount exponent:0 isNegative:NO];
     if ([noDecimalCurrencies containsObject:currency.lowercaseString]) {
         return number;
     }
     return [number decimalNumberByMultiplyingByPowerOf10:-2];
+}
+
+- (NSInteger)stp_amountWithCurrency:(NSString *)currency {
+    NSArray *noDecimalCurrencies = [[self class] stp_currenciesWithNoDecimal];
+    
+    NSDecimalNumber *ourNumber = self;
+    if (![noDecimalCurrencies containsObject:currency.lowercaseString]) {
+        ourNumber = [self decimalNumberByMultiplyingByPowerOf10:2];
+    }
+    return (NSInteger)[ourNumber doubleValue];
 }
 
 @end

--- a/Stripe/PublicHeaders/STPPaymentContext.h
+++ b/Stripe/PublicHeaders/STPPaymentContext.h
@@ -95,23 +95,28 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  *  The amount of money you're requesting from the user, in the smallest currency unit for the selected currency. For example, to indicate $10 USD, use 1000 (i.e. 1000 cents). For more information see https://stripe.com/docs/api#charge_object-amount . This value must be present and greater than zero in order for Apple Pay to be automatically enabled.
+ *
+ *  @note You should only set either this or `paymentSummaryItems`, not both. The other will be automatically calculated on demand using your `paymentCurrency`. 
  */
 @property(nonatomic)NSInteger paymentAmount;
 
 /**
  *  The three-letter currency code for the currency of the payment (i.e. USD, GBP, JPY, etc). Defaults to USD.
+ *
+ *  @note Changing this property may change the return value of `paymentAmount` or `paymentSummaryItems` (whichever one you didn't directly set yourself).
  */
 @property(nonatomic, copy)NSString *paymentCurrency;
 
 /**
- *  If you support Apple Pay, you can optionally set the PKPaymentSummaryItems you want to display here.
- *  If nil, a single summary item will be automatically generated using paymentAmount and your companyName.
+ *  If you support Apple Pay, you can optionally set the PKPaymentSummaryItems you want to display here instead of using `paymentAmount`
+ *  If not set, a single summary item will be automatically generated using `paymentAmount` and your companyName.
  *  @see PKPaymentRequest for more information
  *
- *  @warning If you set this array, the last summary item's amount must match the value you set for paymentAmount or an assert will be thrown.
- *  @warning PKPaymentSummaryItem is only available in iOS8+. If you support iOS 7 you should do a runtime availability check before setting this property. 
+ *  @note You should only set either this or `paymentAmount`, not both. The other will be automatically calculated on demand using your `paymentCurrency.`
+ *
+ *  @warning `PKPaymentSummaryItem` is only available in iOS8+. If you support iOS 7 you should do a runtime availability check before accessing or setting this property. 
  */
-@property(nonatomic, copy, nullable)NSArray<PKPaymentSummaryItem *> *paymentSummaryItems; FAUXPAS_IGNORED_ON_LINE(APIAvailability);
+@property(nonatomic, copy)NSArray<PKPaymentSummaryItem *> *paymentSummaryItems; FAUXPAS_IGNORED_ON_LINE(APIAvailability);
 
 /**
  *  If `paymentContext:didFailToLoadWithError:` is called on your delegate, you can in turn call this method to try loading again (if that hasn't been called, calling this will do nothing). If retrying in turn fails, `paymentContext:didFailToLoadWithError:` will be called again (and you can again call this to keep retrying, etc).

--- a/Stripe/STPPaymentContext.m
+++ b/Stripe/STPPaymentContext.m
@@ -8,7 +8,6 @@
 
 #import <PassKit/PassKit.h>
 #import <objc/runtime.h>
-#import "NSDecimalNumber+Stripe_Currency.h"
 #import "PKPaymentAuthorizationViewController+Stripe_Blocks.h"
 #import "UIViewController+Stripe_ParentViewController.h"
 #import "STPPromise.h"
@@ -19,21 +18,9 @@
 #import "UIViewController+Stripe_Alerts.h"
 #import "UINavigationController+Stripe_Completion.h"
 #import "STPPaymentConfiguration+Private.h"
+#import "STPPaymentContextAmountModel.h"
 
 #define FAUXPAS_IGNORED_IN_METHOD(...)
-#define FAUXPAS_IGNORED_IN_CLASS(...)
-
-@interface STPPaymentContextAmountModel : NSObject
-FAUXPAS_IGNORED_IN_CLASS(APIAvailability)
-
-- (instancetype)initWithAmount:(NSInteger)paymentAmount;
-- (instancetype)initWithPaymentSummaryItems:(NSArray<PKPaymentSummaryItem *> *)paymentSummaryItems;
-
-- (NSInteger)paymentAmountWithCurrency:(NSString *)paymentCurrency;
-- (NSArray<PKPaymentSummaryItem *> *)paymentSummaryItemsWithCurrency:(NSString *)paymentCurrency
-                                                         companyName:(NSString *)companyName;
-
-@end
 
 @interface STPPaymentContext()<STPPaymentMethodsViewControllerDelegate, STPAddCardViewControllerDelegate>
 
@@ -383,54 +370,4 @@ static char kSTPPaymentCoordinatorAssociatedObjectKey;
 
 @end
 
-@implementation STPPaymentContextAmountModel {
-    NSInteger _paymentAmount;
-    NSArray<PKPaymentSummaryItem *> *_paymentSummaryItems;
-}
 
-FAUXPAS_IGNORED_IN_CLASS(APIAvailability)
-
-- (instancetype)initWithAmount:(NSInteger)paymentAmount {
-    self = [super init];
-    if (self) {
-        _paymentAmount = paymentAmount;
-        _paymentSummaryItems = nil;
-    }
-    return self;
-}
-
-- (instancetype)initWithPaymentSummaryItems:(NSArray<PKPaymentSummaryItem *> *)paymentSummaryItems {
-    self = [super init];
-    if (self) {
-        _paymentAmount = 0;
-        _paymentSummaryItems = paymentSummaryItems;
-    }
-    return self;
-}
-
-- (NSInteger)paymentAmountWithCurrency:(NSString *)paymentCurrency {
-    if (_paymentSummaryItems == nil) {
-        return _paymentAmount;
-    }
-    else {
-        PKPaymentSummaryItem *lastItem = _paymentSummaryItems.lastObject;
-        return [lastItem.amount stp_amountWithCurrency:paymentCurrency];
-    }
-}
-
-- (NSArray<PKPaymentSummaryItem *> *)paymentSummaryItemsWithCurrency:(NSString *)paymentCurrency
-                                                         companyName:(NSString *)companyName {
-    if (_paymentSummaryItems == nil) {
-        NSDecimalNumber *amount = [NSDecimalNumber stp_decimalNumberWithAmount:_paymentAmount
-                                                                      currency:paymentCurrency];
-        PKPaymentSummaryItem *totalItem = [PKPaymentSummaryItem summaryItemWithLabel:companyName
-                                                                              amount:amount];
-        return @[totalItem];
-
-    }
-    else {
-        return _paymentSummaryItems;
-    }
-}
-
-@end

--- a/Stripe/STPPaymentContextAmountModel.h
+++ b/Stripe/STPPaymentContextAmountModel.h
@@ -1,0 +1,28 @@
+//
+//  STPPaymentContextAmountModel.h
+//  Stripe
+//
+//  Created by Brian Dorfman on 8/16/16.
+//  Copyright © 2016 Stripe, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <PassKit/PassKit.h>
+
+#define FAUXPAS_IGNORED_IN_CLASS(...)
+
+/**
+ Internal model for STPPaymentContext's `paymentAmount` and 
+ `paymentSummaryItems` properties.
+ */
+@interface STPPaymentContextAmountModel : NSObject
+FAUXPAS_IGNORED_IN_CLASS(APIAvailability)
+
+- (instancetype)initWithAmount:(NSInteger)paymentAmount;
+- (instancetype)initWithPaymentSummaryItems:(NSArray<PKPaymentSummaryItem *> *)paymentSummaryItems;
+
+- (NSInteger)paymentAmountWithCurrency:(NSString *)paymentCurrency;
+- (NSArray<PKPaymentSummaryItem *> *)paymentSummaryItemsWithCurrency:(NSString *)paymentCurrency
+                                                         companyName:(NSString *)companyName;
+
+@end

--- a/Stripe/STPPaymentContextAmountModel.m
+++ b/Stripe/STPPaymentContextAmountModel.m
@@ -1,0 +1,63 @@
+//
+//  STPPaymentContextAmountModel.m
+//  Stripe
+//
+//  Created by Brian Dorfman on 8/16/16.
+//  Copyright © 2016 Stripe, Inc. All rights reserved.
+//
+
+#import "STPPaymentContextAmountModel.h"
+
+#import "NSDecimalNumber+Stripe_Currency.h"
+
+@implementation STPPaymentContextAmountModel {
+    NSInteger _paymentAmount;
+    NSArray<PKPaymentSummaryItem *> *_paymentSummaryItems;
+}
+
+FAUXPAS_IGNORED_IN_CLASS(APIAvailability)
+
+- (instancetype)initWithAmount:(NSInteger)paymentAmount {
+    self = [super init];
+    if (self) {
+        _paymentAmount = paymentAmount;
+        _paymentSummaryItems = nil;
+    }
+    return self;
+}
+
+- (instancetype)initWithPaymentSummaryItems:(NSArray<PKPaymentSummaryItem *> *)paymentSummaryItems {
+    self = [super init];
+    if (self) {
+        _paymentAmount = 0;
+        _paymentSummaryItems = paymentSummaryItems;
+    }
+    return self;
+}
+
+- (NSInteger)paymentAmountWithCurrency:(NSString *)paymentCurrency {
+    if (_paymentSummaryItems == nil) {
+        return _paymentAmount;
+    }
+    else {
+        PKPaymentSummaryItem *lastItem = _paymentSummaryItems.lastObject;
+        return [lastItem.amount stp_amountWithCurrency:paymentCurrency];
+    }
+}
+
+- (NSArray<PKPaymentSummaryItem *> *)paymentSummaryItemsWithCurrency:(NSString *)paymentCurrency
+                                                         companyName:(NSString *)companyName {
+    if (_paymentSummaryItems == nil) {
+        NSDecimalNumber *amount = [NSDecimalNumber stp_decimalNumberWithAmount:_paymentAmount
+                                                                      currency:paymentCurrency];
+        PKPaymentSummaryItem *totalItem = [PKPaymentSummaryItem summaryItemWithLabel:companyName
+                                                                              amount:amount];
+        return @[totalItem];
+        
+    }
+    else {
+        return _paymentSummaryItems;
+    }
+}
+
+@end

--- a/Tests/Tests/STPPaymentContextTest.m
+++ b/Tests/Tests/STPPaymentContextTest.m
@@ -79,37 +79,35 @@
 
 - (void)testBuildPaymentRequest_summaryItems {
     STPPaymentContext *context = [[STPPaymentContext alloc] initWithAPIAdapter:[TestSTPBackendAPIAdapter new]];
-    context.paymentAmount = 10000;
     context.paymentSummaryItems = [self testSummaryItems];
     PKPaymentRequest *request = [context buildPaymentRequest];
     
     XCTAssertTrue([request.paymentSummaryItems isEqualToArray:context.paymentSummaryItems]);
 }
 
-- (void)testBuildPaymentRequest_autoGenSummaryItem {
+- (void)testSetPaymentAmount_generateSummaryItems {
     STPPaymentContext *context = [[STPPaymentContext alloc] initWithAPIAdapter:[TestSTPBackendAPIAdapter new]];
     context.paymentAmount = 10000;
-    PKPaymentRequest *request = [context buildPaymentRequest];
-
-    NSDecimalNumber *itemTotalAmount = request.paymentSummaryItems.lastObject.amount;
+    context.paymentCurrency = @"USD";
+    NSDecimalNumber *itemTotalAmount = context.paymentSummaryItems.lastObject.amount;
     NSDecimalNumber *correctTotalAmount = [NSDecimalNumber stp_decimalNumberWithAmount:context.paymentAmount
                                                                               currency:context.paymentCurrency];
     
     XCTAssertTrue([itemTotalAmount isEqualToNumber:correctTotalAmount]);
 }
 
-- (void)testSetPaymentSummaryItems {
+- (void)testSummaryItems_generateAmountDecimalCurrency {
     STPPaymentContext *context = [[STPPaymentContext alloc] initWithAPIAdapter:[TestSTPBackendAPIAdapter new]];
-    context.paymentAmount = 10000;
-    NSArray<PKPaymentSummaryItem *> *items = [self testSummaryItems];
-    XCTAssertNoThrow(context.paymentSummaryItems = items);
+    context.paymentSummaryItems = [self testSummaryItems];
+    context.paymentCurrency = @"USD";
+    XCTAssertTrue(context.paymentAmount == 10000);
 }
 
-- (void)testSetPaymentSummaryItems_throwOnAmountMismatch {
+- (void)testSummaryItems_generateAmountNoDecimalCurrency {
     STPPaymentContext *context = [[STPPaymentContext alloc] initWithAPIAdapter:[TestSTPBackendAPIAdapter new]];
-    context.paymentAmount = 100;
-    NSArray<PKPaymentSummaryItem *> *items = [self testSummaryItems];
-    XCTAssertThrows(context.paymentSummaryItems = items);
+    context.paymentSummaryItems = [self testSummaryItems];
+    context.paymentCurrency = @"JPY";
+    XCTAssertTrue(context.paymentAmount == 100);
 }
 
 @end


### PR DESCRIPTION
After discussing with @jflinter, made changes to the new paymentSummaryItems property so you don't need to also set paymentAmount. Now on payment context, you only set either paymentAmount OR paymentSummaryItems and the other is generated for you based on that + your paymentCurrency.

Updated some tests to reflect this new logic.