### PR TITLE
Have payment card confirm to UIKeyInput

### DIFF
--- a/Stripe/PublicHeaders/STPPaymentCardTextField.h
+++ b/Stripe/PublicHeaders/STPPaymentCardTextField.h
@@ -65,7 +65,7 @@
 /**
  *  STPPaymentCardTextField is a text field with similar properties to UITextField, but specialized for collecting credit/debit card information. It manages multiple UITextFields under the hood to collect this information. It's designed to fit on a single line, and from a design perspective can be used anywhere a UITextField would be appropriate.
  */
-@interface STPPaymentCardTextField : UIControl
+@interface STPPaymentCardTextField : UIControl <UIKeyInput>
 
 /**
  *  @see STPPaymentCardTextFieldDelegate

--- a/Stripe/STPFormTextField.m
+++ b/Stripe/STPFormTextField.m
@@ -155,6 +155,10 @@ typedef NSAttributedString* (^STPFormTextTransformationBlock)(NSAttributedString
     self.delegate = formDelegate;
 }
 
+- (void)insertText:(NSString *)text {
+    [self setText:[self.text stringByAppendingString:text]];
+}
+
 - (void)deleteBackward {
     [super deleteBackward];
     if (self.text.length == 0) {

--- a/Stripe/STPPaymentCardTextField.m
+++ b/Stripe/STPPaymentCardTextField.m
@@ -769,6 +769,20 @@ typedef void (^STPNumberShrunkCompletionBlock)(BOOL completed);
     [self sendActionsForControlEvents:UIControlEventValueChanged];
 }
 
+#pragma mark UIKeyInput
+
+- (BOOL)hasText {
+    return self.numberField.hasText || self.expirationField.hasText || self.cvcField.hasText;
+}
+
+- (void)insertText:(NSString *)text {
+    [self.currentFirstResponderField insertText:text];
+}
+
+- (void)deleteBackward {
+    [self.currentFirstResponderField deleteBackward];
+}
+
 @end
 
 #pragma clang diagnostic push


### PR DESCRIPTION
## Summary

Allows sending custom keys to payment card view and apply same validation logic as if key was entered through a regular keyboard by updating payment card view to confirm to UIKeyInput protocol (hasText, insertText, deleteBackward methods)

## Motivation

I've made a custom keyboard but I'm using the great `STPPaymentCardTextField` for entering card, exp month/year and cvc. However since these text fields are private I can't (beautifully) send a key event to the `STPPaymentCardTextField` view and have it apply validation logic as if I entered a digit from the system keyboard.

With this change I can simply get my reference to the `STPPaymentCardTextField` and perform `insertText` and `deleteBackward` effectively cleaning up my code so I don't need to use `stp_findFirstResponder` in connection with subview iterations and `conformsToProtocol:@protocol(UIKeyInput)` checks :)

## Testing

I did standard boundary tests and ensured to implement protocol by calling already existing methods.