### PR TITLE
Allows non-numeric zip/postal codes to be entered

### DIFF
--- a/Stripe/STPAddressFieldTableViewCell.m
+++ b/Stripe/STPAddressFieldTableViewCell.m
@@ -100,12 +100,14 @@
             case STPAddressFieldTypeZip:
                 if ([STPPhoneNumberValidator isUSLocale]) {
                     self.captionLabel.text = NSLocalizedString(@"ZIP Code", nil);
+                    self.textField.placeholder = NSLocalizedString(@"12345", nil);
+                    self.textField.keyboardType = UIKeyboardTypePhonePad;
                 } else {
                     self.captionLabel.text = NSLocalizedString(@"Postal Code", nil);
+                    self.textField.placeholder = NSLocalizedString(@"ABC-1234", nil);
+                    self.textField.keyboardType = UIKeyboardTypeASCIICapable;
                 }
                 
-                self.textField.placeholder = NSLocalizedString(@"12345", nil);
-                self.textField.keyboardType = UIKeyboardTypePhonePad;
                 self.textField.preservesContentsOnPaste = NO;
                 self.textField.selectionEnabled = NO;
                 if (!lastInList) {


### PR DESCRIPTION
## Summary

Allows non-numeric ZIP/Postal codes to be entered

## Motivation

Because we explicitly were not setting the keypad layout based on phone
number locale, it was ~impossible to enter non-numeric zip/postal codes
into the zip code type fields using the Stripe iOS SDK.

## Testing

I verified that this change still compiled, but I'm unsure how to fake locales in the iOS simulator 
