### PR TITLE
Check for US country code not en_US

### DIFF
--- a/Stripe/STPPhoneNumberValidator.m
+++ b/Stripe/STPPhoneNumberValidator.m
@@ -61,7 +61,7 @@
 }
 
 + (BOOL)isUSLocale {
-    return [[[NSLocale autoupdatingCurrentLocale] localeIdentifier] isEqualToString:@"en_US"];
+    return [[[NSLocale autoupdatingCurrentLocale] objectForKey:NSLocaleCountryCode] isEqualToString:@"US"];
 }
 
 @end


### PR DESCRIPTION
For address entry, we just want to check that their region is US, regardless of the set language.