### PR TITLE
Optimize sanitization methods in STPCardValidator

### DIFF
--- a/Tests/Tests/STPCardValidatorTest.m
+++ b/Tests/Tests/STPCardValidatorTest.m
@@ -43,6 +43,8 @@
                        @[@"4242424242424242", @"4242424242424242"],
                        @[@"XXXXXX", @""],
                        @[@"424242424242424X", @"424242424242424"],
+                       @[@"X4242", @"4242"],
+                       @[@"4242 4242 4242 4242", @"4242424242424242"]
                        ];
     for (NSArray *test in tests) {
         XCTAssertEqualObjects([STPCardValidator sanitizedNumericStringForString:test[0]], test[1]);


### PR DESCRIPTION
## Summary

Strings that are already numeric can now be sanitized with zero allocations, and strings that need sanitization will now be sanitized faster. In addition, `+stringIsNumeric:` will never allocate.

This also changes the sanitization methods to only allow ASCII digits. The previous use of `+decimalDigitCharacterSet` allowed any character in the Decimal Digit unicode category, such as Indic and Arabic decimal digits, but AFAIK credit card numbers should always be ASCII digits.

## Motivation

I read the source of `STPCardValidator` and saw the calls to `-componentsSeparatedByCharactersInSet:`. Sanitizing a string should not require creating an intermediate array, and testing if the string is numeric shouldn't require any allocations at all. I want to be able to ditch my own code for string sanitizing in favor of `STPCardValidator`, but I'm not willing to do so if `STPCardValidator` is slower than my code.

## Testing

I ran the existing suite of unit tests (and modified one test to cover more cases). I also wrote a simple benchmark (not included) to test the new implementation of `+sanitizedNumericStringForString:` against the old implementation using the string `@"4242 4242 4242 4242"` and the new implementation was roughly twice as fast (and this is on the slow path for the new implementation).