### PR TITLE
Remove some keys from resources plist

### DIFF
--- a/ci_scripts/export_builds.sh
+++ b/ci_scripts/export_builds.sh
@@ -30,6 +30,9 @@ fi
 echo "building static framework..."
 xcodebuild build -workspace Stripe.xcworkspace -scheme StripeiOSStaticFramework -configuration Release OBJROOT=$BUILDDIR SYMROOT=$BUILDDIR | xcpretty -c
 cd $BUILDDIR/Release-iphonesimulator
+plutil -remove DTSDKName Stripe.bundle/Info.plist
+plutil -remove DTPlatformName Stripe.bundle/Info.plist
+plutil -remove CFBundleSupportedPlatforms Stripe.bundle/Info.plist
 mv Stripe.bundle Stripe.framework
 ditto -ck --rsrc --sequesterRsrc --keepParent Stripe.framework StripeiOS-Static.zip
 rm -rf Stripe.framework


### PR DESCRIPTION
Need to remove keys in plist that reference being built for the simulator as ITMS has started rejecting apps with those, even though it is a non-binary resource bundle.