### PR TITLE
Mark PKPayment methods as only available in iOS8+

### DIFF
--- a/Stripe/PublicHeaders/STPAPIClient+ApplePay.h
+++ b/Stripe/PublicHeaders/STPAPIClient+ApplePay.h
@@ -25,7 +25,7 @@ FAUXPAS_IGNORED_IN_FILE(APIAvailability)
  *  @param completion  The callback to run with the returned Stripe token (and any errors that may have occurred).
  */
 - (void)createTokenWithPayment:(nonnull PKPayment *)payment
-                    completion:(nonnull STPTokenCompletionBlock)completion;
+                    completion:(nonnull STPTokenCompletionBlock)completion NS_AVAILABLE_IOS(8_0);
 
 @end
 

--- a/Stripe/PublicHeaders/STPAPIClient.h
+++ b/Stripe/PublicHeaders/STPAPIClient.h
@@ -116,7 +116,7 @@ static NSString *const STPSDKVersion = @"8.0.6";
  *
  *  @return whether or not the user is currently able to pay with Apple Pay.
  */
-+ (BOOL)canSubmitPaymentRequest:(PKPaymentRequest *)paymentRequest;
++ (BOOL)canSubmitPaymentRequest:(PKPaymentRequest *)paymentRequest NS_AVAILABLE_IOS(8_0);
 
 + (BOOL)deviceSupportsApplePay;
 
@@ -129,7 +129,7 @@ static NSString *const STPSDKVersion = @"8.0.6";
  *
  *  @return a `PKPaymentRequest` with proper default values. Returns nil if running on < iOS8.
  */
-+ (nullable PKPaymentRequest *)paymentRequestWithMerchantIdentifier:(NSString *)merchantIdentifier;
++ (PKPaymentRequest *)paymentRequestWithMerchantIdentifier:(NSString *)merchantIdentifier NS_AVAILABLE_IOS(8_0);
 
 + (void)createTokenWithPayment:(PKPayment *)payment
                     completion:(STPTokenCompletionBlock)handler __attribute__((deprecated("Use STPAPIClient instead.")));

--- a/Stripe/PublicHeaders/STPPaymentContext.h
+++ b/Stripe/PublicHeaders/STPPaymentContext.h
@@ -116,7 +116,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @warning `PKPaymentSummaryItem` is only available in iOS8+. If you support iOS 7 you should do a runtime availability check before accessing or setting this property. 
  */
-@property(nonatomic, copy)NSArray<PKPaymentSummaryItem *> *paymentSummaryItems; FAUXPAS_IGNORED_ON_LINE(APIAvailability);
+@property(nonatomic, copy)NSArray<PKPaymentSummaryItem *> *paymentSummaryItems NS_AVAILABLE_IOS(8_0);
 
 /**
  *  The presentation style used for all view controllers presented modally by the context.


### PR DESCRIPTION
Should hopefully give better warnings to people supporting iOS7 and will play more nicely with Swift.

Solves https://github.com/stripe/stripe-ios/issues/425