### PR TITLE
set text content type for cc and phone numbers

### DIFF
--- a/Stripe/STPFormTextField.m
+++ b/Stripe/STPFormTextField.m
@@ -108,6 +108,9 @@ typedef NSAttributedString* (^STPFormTextTransformationBlock)(NSAttributedString
         case STPFormTextFieldAutoFormattingBehaviorNone:
         case STPFormTextFieldAutoFormattingBehaviorExpiration:
             self.textFormattingBlock = nil;
+            if ([self respondsToSelector:@selector(setTextContentType:)]) {
+                self.textContentType = nil;
+            }
             break;
         case STPFormTextFieldAutoFormattingBehaviorCardNumbers:
             self.textFormattingBlock = ^NSAttributedString *(NSAttributedString *inputString) {
@@ -133,6 +136,9 @@ typedef NSAttributedString* (^STPFormTextTransformationBlock)(NSAttributedString
                 }
                 return [attributedString copy];
             };
+            if ([self respondsToSelector:@selector(setTextContentType:)]) {
+                self.textContentType = UITextContentTypeCreditCardNumber;
+            }
             break;
         case STPFormTextFieldAutoFormattingBehaviorPhoneNumbers: {
             WEAK(self);
@@ -145,6 +151,9 @@ typedef NSAttributedString* (^STPFormTextTransformationBlock)(NSAttributedString
                 NSDictionary *attributes = [[self class] attributesForAttributedString:inputString];
                 return [[NSAttributedString alloc] initWithString:phoneNumber attributes:attributes];
             };
+            if ([self respondsToSelector:@selector(setTextContentType:)]) {
+                self.textContentType = UITextContentTypeTelephoneNumber;
+            }
             break;
         }
     }


### PR DESCRIPTION
## Summary
iOS 10 adds a new [`textContentType`](https://developer.apple.com/reference/uikit/uitextinputtraits/1649656-textcontenttype) property on `UITextInput` that helps the system have 'semantic meaning expected for a text-entry area'.

In the best-case scenario, this can help the system show the right info to fill in as a predictive text input suggestion, and in the average-case scenario, nothing changes (although, the system can now automatically switch to the correct keyboard for us). 

## Motivation

One tap to fill in info is nicer than 11-28 taps (10 for phone number, 16 for cc, hitting return 2x) (US-centric numbers, but, I think the point stands regardless of your locale).

## Testing

I made the changes and ran it in an app that integrates the `stripe-ios` pod. It relies on UIKit behavior and per-user settings, and is rather hard to test otherwise.