### PR TITLE
Just build pushes to master w/ Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: objective-c
 osx_image: xcode7.3
+branches:
+  only: 
+    - master
 env:
   matrix:
   - TEST_TYPE=installation_manual


### PR DESCRIPTION
We're currently doing a lot of redundant builds - each pull request has 2 Travis checks, "PR" and "Push". We want Travis to build each push, but only to the master branch. This approach is shamelessly stolen from http://stackoverflow.com/questions/31882306/how-to-configure-travis-ci-to-build-pull-requests-merges-to-master-w-o-redunda

r? @bdorfman