### PR TITLE
International address updates

### DIFF
--- a/Stripe/STPAddress.m
+++ b/Stripe/STPAddress.m
@@ -83,12 +83,12 @@
 }
 
 - (BOOL)hasValidPostalAddress {
-    return self.line1.length > 0 &&
-    self.city.length > 0 &&
-    self.state.length > 0 &&
-    self.country.length > 0 &&
-    [STPPostalCodeValidator stringIsValidPostalCode:self.postalCode 
-                                        countryCode:self.country];
+    return (self.line1.length > 0 
+            && self.city.length > 0 
+            && self.country.length > 0 
+            && (self.state.length > 0 || ![self.country isEqualToString:@"US"])  
+            && [STPPostalCodeValidator stringIsValidPostalCode:self.postalCode 
+                                                   countryCode:self.country]);
 }
 
 + (PKAddressField)applePayAddressFieldsFromBillingAddressFields:(STPBillingAddressFields)billingAddressFields {

--- a/Stripe/STPAddressFieldTableViewCell.m
+++ b/Stripe/STPAddressFieldTableViewCell.m
@@ -341,7 +341,8 @@
         case STPAddressFieldTypeEmail:
             return [STPEmailAddressValidator stringIsValidEmailAddress:self.contents];
         case STPAddressFieldTypePhone:
-            return [STPPhoneNumberValidator stringIsValidPhoneNumber:self.contents];
+            return [STPPhoneNumberValidator stringIsValidPhoneNumber:self.contents
+                                                      forCountryCode:self.ourCountryCode];
     }
 }
 
@@ -365,7 +366,8 @@
         case STPAddressFieldTypeEmail:
             return [STPEmailAddressValidator stringIsValidPartialEmailAddress:self.contents];
         case STPAddressFieldTypePhone:
-            return [STPPhoneNumberValidator stringIsValidPartialPhoneNumber:self.contents];
+            return [STPPhoneNumberValidator stringIsValidPartialPhoneNumber:self.contents
+                                                             forCountryCode:self.ourCountryCode];
     }
 }
 

--- a/Stripe/STPPhoneNumberValidator.h
+++ b/Stripe/STPPhoneNumberValidator.h
@@ -12,7 +12,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface STPPhoneNumberValidator : NSObject
 
-+ (BOOL)isUSLocale;
 + (BOOL)stringIsValidPartialPhoneNumber:(NSString *)string;
 + (BOOL)stringIsValidPhoneNumber:(NSString *)string;
 + (BOOL)stringIsValidPartialPhoneNumber:(NSString *)string

--- a/Stripe/STPPhoneNumberValidator.h
+++ b/Stripe/STPPhoneNumberValidator.h
@@ -15,9 +15,17 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL)isUSLocale;
 + (BOOL)stringIsValidPartialPhoneNumber:(NSString *)string;
 + (BOOL)stringIsValidPhoneNumber:(NSString *)string;
++ (BOOL)stringIsValidPartialPhoneNumber:(NSString *)string
+                         forCountryCode:(nullable NSString *)countryCode;
++ (BOOL)stringIsValidPhoneNumber:(NSString *)string
+                  forCountryCode:(nullable NSString *)countryCode;
 
 + (NSString *)formattedSanitizedPhoneNumberForString:(NSString *)string;
++ (NSString *)formattedSanitizedPhoneNumberForString:(NSString *)string
+                                      forCountryCode:(nullable NSString *)countryCode;
 + (NSString *)formattedRedactedPhoneNumberForString:(NSString *)string;
++ (NSString *)formattedRedactedPhoneNumberForString:(NSString *)string
+                                     forCountryCode:(nullable NSString *)countryCode;
 
 @end
 

--- a/Stripe/STPPhoneNumberValidator.m
+++ b/Stripe/STPPhoneNumberValidator.m
@@ -104,8 +104,4 @@
     return string;
 }
 
-+ (BOOL)isUSLocale {
-    return [[[NSLocale autoupdatingCurrentLocale] objectForKey:NSLocaleCountryCode] isEqualToString:@"US"];
-}
-
 @end

--- a/Stripe/STPPhoneNumberValidator.m
+++ b/Stripe/STPPhoneNumberValidator.m
@@ -12,37 +12,80 @@
 
 @implementation STPPhoneNumberValidator
 
-+ (BOOL)stringIsValidPartialPhoneNumber:(NSString *)string {
-    if (![self isUSLocale]) {
-        return YES;
++ (NSString *)countryCodeOrCurrentLocaleCountryFromString:(nullable NSString *)nillableCode {
+    if (!nillableCode) {
+        nillableCode = [[NSLocale autoupdatingCurrentLocale] objectForKey:NSLocaleCountryCode];
     }
-    return [STPCardValidator sanitizedNumericStringForString:string].length <= 10;
+    return nillableCode;
+}
+                                                           
++ (BOOL)stringIsValidPartialPhoneNumber:(NSString *)string {
+    return [self stringIsValidPartialPhoneNumber:string forCountryCode:nil];
 }
 
 + (BOOL)stringIsValidPhoneNumber:(NSString *)string {
-    if (![self isUSLocale]) {
+    return [self stringIsValidPhoneNumber:string forCountryCode:nil];
+}
+
++ (BOOL)stringIsValidPartialPhoneNumber:(NSString *)string
+                         forCountryCode:(nullable NSString *)countryCode {
+    countryCode = [self countryCodeOrCurrentLocaleCountryFromString:countryCode];
+    
+    if ([countryCode isEqualToString:@"US"]) {
+        return [STPCardValidator sanitizedNumericStringForString:string].length <= 10;
+    }
+    else {
         return YES;
     }
-    return [STPCardValidator sanitizedNumericStringForString:string].length == 10;
+}
+
++ (BOOL)stringIsValidPhoneNumber:(NSString *)string 
+                  forCountryCode:(nullable NSString *)countryCode {
+    countryCode = [self countryCodeOrCurrentLocaleCountryFromString:countryCode];
+    
+    if ([countryCode isEqualToString:@"US"]) {
+        return [STPCardValidator sanitizedNumericStringForString:string].length == 10;
+    }
+    else {
+        return YES;
+    }
 }
 
 + (NSString *)formattedSanitizedPhoneNumberForString:(NSString *)string {
+    return [self formattedSanitizedPhoneNumberForString:string
+                                         forCountryCode:nil];
+}
+
++ (NSString *)formattedSanitizedPhoneNumberForString:(NSString *)string 
+                                      forCountryCode:(nullable NSString *)countryCode {
+    countryCode = [self countryCodeOrCurrentLocaleCountryFromString:countryCode];
     NSString *sanitized = [STPCardValidator sanitizedNumericStringForString:string];
-    return [self formattedPhoneNumberForString:sanitized];
+    return [self formattedPhoneNumberForString:sanitized
+                                forCountryCode:countryCode];
 }
 
 + (NSString *)formattedRedactedPhoneNumberForString:(NSString *)string {
+    return [self formattedRedactedPhoneNumberForString:string
+                                        forCountryCode:nil];
+}
+
++ (NSString *)formattedRedactedPhoneNumberForString:(NSString *)string
+                                     forCountryCode:(nullable NSString *)countryCode {
+    countryCode = [self countryCodeOrCurrentLocaleCountryFromString:countryCode];
     NSScanner *scanner = [NSScanner scannerWithString:string];
     NSMutableString *prefix = [NSMutableString stringWithCapacity:string.length];
     [scanner scanUpToString:@"*" intoString:&prefix];
     NSString *number = [string stringByReplacingOccurrencesOfString:prefix withString:@""];
     number = [number stringByReplacingOccurrencesOfString:@"*" withString:@"•"];
-    number = [self formattedPhoneNumberForString:number];
+    number = [self formattedPhoneNumberForString:number
+                                  forCountryCode:countryCode];
     return [NSString stringWithFormat:@"%@ %@", prefix, number];
 }
 
-+ (NSString *)formattedPhoneNumberForString:(NSString *)string {
-    if (![self isUSLocale]) {
++ (NSString *)formattedPhoneNumberForString:(NSString *)string 
+                             forCountryCode:(NSString *)countryCode {
+    
+    if (![countryCode isEqualToString:@"US"]) {
         return string;
     }
     if (string.length >= 6) {

--- a/Stripe/STPPhoneNumberValidator.m
+++ b/Stripe/STPPhoneNumberValidator.m
@@ -13,10 +13,11 @@
 @implementation STPPhoneNumberValidator
 
 + (NSString *)countryCodeOrCurrentLocaleCountryFromString:(nullable NSString *)nillableCode {
-    if (!nillableCode) {
-        nillableCode = [[NSLocale autoupdatingCurrentLocale] objectForKey:NSLocaleCountryCode];
+    NSString *countryCode = nillableCode;
+    if (!countryCode) {
+        countryCode = [[NSLocale autoupdatingCurrentLocale] objectForKey:NSLocaleCountryCode];
     }
-    return nillableCode;
+    return countryCode;
 }
                                                            
 + (BOOL)stringIsValidPartialPhoneNumber:(NSString *)string {
@@ -28,8 +29,8 @@
 }
 
 + (BOOL)stringIsValidPartialPhoneNumber:(NSString *)string
-                         forCountryCode:(nullable NSString *)countryCode {
-    countryCode = [self countryCodeOrCurrentLocaleCountryFromString:countryCode];
+                         forCountryCode:(nullable NSString *)nillableCode {
+    NSString *countryCode = [self countryCodeOrCurrentLocaleCountryFromString:nillableCode];
     
     if ([countryCode isEqualToString:@"US"]) {
         return [STPCardValidator sanitizedNumericStringForString:string].length <= 10;
@@ -40,8 +41,8 @@
 }
 
 + (BOOL)stringIsValidPhoneNumber:(NSString *)string 
-                  forCountryCode:(nullable NSString *)countryCode {
-    countryCode = [self countryCodeOrCurrentLocaleCountryFromString:countryCode];
+                  forCountryCode:(nullable NSString *)nillableCode {
+    NSString *countryCode = [self countryCodeOrCurrentLocaleCountryFromString:nillableCode];
     
     if ([countryCode isEqualToString:@"US"]) {
         return [STPCardValidator sanitizedNumericStringForString:string].length == 10;
@@ -57,8 +58,8 @@
 }
 
 + (NSString *)formattedSanitizedPhoneNumberForString:(NSString *)string 
-                                      forCountryCode:(nullable NSString *)countryCode {
-    countryCode = [self countryCodeOrCurrentLocaleCountryFromString:countryCode];
+                                      forCountryCode:(nullable NSString *)nillableCode {
+    NSString *countryCode = [self countryCodeOrCurrentLocaleCountryFromString:nillableCode];
     NSString *sanitized = [STPCardValidator sanitizedNumericStringForString:string];
     return [self formattedPhoneNumberForString:sanitized
                                 forCountryCode:countryCode];
@@ -70,8 +71,8 @@
 }
 
 + (NSString *)formattedRedactedPhoneNumberForString:(NSString *)string
-                                     forCountryCode:(nullable NSString *)countryCode {
-    countryCode = [self countryCodeOrCurrentLocaleCountryFromString:countryCode];
+                                     forCountryCode:(nullable NSString *)nillableCode {
+    NSString *countryCode = [self countryCodeOrCurrentLocaleCountryFromString:nillableCode];
     NSScanner *scanner = [NSScanner scannerWithString:string];
     NSMutableString *prefix = [NSMutableString stringWithCapacity:string.length];
     [scanner scanUpToString:@"*" intoString:&prefix];

--- a/Tests/Tests/STPPhoneNumberValidatorTest.m
+++ b/Tests/Tests/STPPhoneNumberValidatorTest.m
@@ -9,11 +9,8 @@
 #import <XCTest/XCTest.h>
 #import "STPPhoneNumberValidator.h"
 
-@interface STPNonUSLocalePhoneNumberValidator: STPPhoneNumberValidator
-@end
-@implementation STPNonUSLocalePhoneNumberValidator
-+ (BOOL)isUSLocale { return NO; }
-@end
+static NSString *const kUSCountryCode = @"US";
+static NSString *const kUKCountryCode = @"UK";
 
 @interface STPPhoneNumberValidatorTest : XCTestCase
 
@@ -22,9 +19,9 @@
 @implementation STPPhoneNumberValidatorTest
 
 - (void)testValidPhoneNumbers {
-    XCTAssertTrue([STPPhoneNumberValidator stringIsValidPhoneNumber:@"555-555-5555"]);
-    XCTAssertTrue([STPPhoneNumberValidator stringIsValidPhoneNumber:@"5555555555"]);
-    XCTAssertTrue([STPPhoneNumberValidator stringIsValidPhoneNumber:@"(555) 555-5555"]);
+    XCTAssertTrue([STPPhoneNumberValidator stringIsValidPhoneNumber:@"555-555-5555" forCountryCode:kUSCountryCode]);
+    XCTAssertTrue([STPPhoneNumberValidator stringIsValidPhoneNumber:@"5555555555" forCountryCode:kUSCountryCode]);
+    XCTAssertTrue([STPPhoneNumberValidator stringIsValidPhoneNumber:@"(555) 555-5555" forCountryCode:kUSCountryCode]);
 }
 
 - (void)testInvalidPhoneNumbers {
@@ -42,12 +39,13 @@
     XCTAssertEqualObjects([STPPhoneNumberValidator formattedSanitizedPhoneNumberForString:@"5555555"], @"(555) 555-5");
     XCTAssertEqualObjects([STPPhoneNumberValidator formattedSanitizedPhoneNumberForString:@"5555555555"], @"(555) 555-5555");
     XCTAssertEqualObjects([STPPhoneNumberValidator formattedSanitizedPhoneNumberForString:@"5555555555123"], @"(555) 555-5555");
-    XCTAssertEqualObjects([STPNonUSLocalePhoneNumberValidator formattedSanitizedPhoneNumberForString:@"5555555555123"], @"5555555555123");
+    XCTAssertEqualObjects([STPPhoneNumberValidator formattedSanitizedPhoneNumberForString:@"5555555555123" forCountryCode:kUKCountryCode], 
+                          @"5555555555123");
 }
 
 - (void)testFormattedRedactedPhoneNumberForString {
     XCTAssertEqualObjects([STPPhoneNumberValidator formattedRedactedPhoneNumberForString:@"+1******1234"], @"+1 (•••) •••-1234");
-    XCTAssertEqualObjects([STPNonUSLocalePhoneNumberValidator formattedRedactedPhoneNumberForString:@"+86******1234"], @"+86 ••••••1234");
+    XCTAssertEqualObjects([STPPhoneNumberValidator formattedRedactedPhoneNumberForString:@"+86******1234" forCountryCode:kUKCountryCode], @"+86 ••••••1234");
 }
 
 @end


### PR DESCRIPTION
Changes non-US address forms to not require the State/County field.
Updates phone number validation to use country codes other than from the device's locale.