### PR TITLE
fix nil window issue on iOS 8

### DIFF
--- a/Example/Stripe iOS Example (Simple)/AppDelegate.swift
+++ b/Example/Stripe iOS Example (Simple)/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         let rootVC = BrowseProductsViewController()
         let navigationController = UINavigationController(rootViewController: rootVC)
-        let window = UIWindow()
+        let window = UIWindow(frame: UIScreen.main.bounds)
         window.rootViewController = navigationController;
         window.makeKeyAndVisible()
         self.window = window


### PR DESCRIPTION
r? @bdorfman 

While doing some testing, I noticed our example app doesn't respond to touches on an iOS 8 simulator [0]

[0] http://stackoverflow.com/questions/25963101/unexpected-nil-window-in-uiapplicationhandleeventfromqueueevent
