### PR TITLE
Fix apple pay button in "Custom" example

### DIFF
--- a/Example/Stripe iOS Example (Custom)/ViewController.m
+++ b/Example/Stripe iOS Example (Custom)/ViewController.m
@@ -171,7 +171,7 @@
     NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
     NSURLSession *session = [NSURLSession sessionWithConfiguration:config];
     
-    NSString *urlString = [BackendChargeURLString stringByAppendingPathComponent:@"charge"];
+    NSString *urlString = [BackendChargeURLString stringByAppendingPathComponent:@"charge_custom"];
     NSURL *url = [NSURL URLWithString:urlString];
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url];
     request.HTTPMethod = @"POST";

--- a/Example/Stripe iOS Example (Custom)/ViewController.m
+++ b/Example/Stripe iOS Example (Custom)/ViewController.m
@@ -47,6 +47,8 @@
 - (BOOL)applePayEnabled {
     if ([PKPaymentRequest class]) {
         PKPaymentRequest *paymentRequest = [Stripe paymentRequestWithMerchantIdentifier:AppleMerchantId];
+        paymentRequest.shippingMethods = [self.shippingManager defaultShippingMethods];
+        paymentRequest.paymentSummaryItems = [self summaryItemsForShippingMethod:paymentRequest.shippingMethods.firstObject];
         return [Stripe canSubmitPaymentRequest:paymentRequest];
     }
     return NO;
@@ -59,11 +61,11 @@
     NSString *merchantId = AppleMerchantId;
 
     PKPaymentRequest *paymentRequest = [Stripe paymentRequestWithMerchantIdentifier:merchantId];
+    [paymentRequest setRequiredShippingAddressFields:PKAddressFieldPostalAddress];
+    [paymentRequest setRequiredBillingAddressFields:PKAddressFieldPostalAddress];
+    paymentRequest.shippingMethods = [self.shippingManager defaultShippingMethods];
+    paymentRequest.paymentSummaryItems = [self summaryItemsForShippingMethod:paymentRequest.shippingMethods.firstObject];
     if ([Stripe canSubmitPaymentRequest:paymentRequest]) {
-        [paymentRequest setRequiredShippingAddressFields:PKAddressFieldPostalAddress];
-        [paymentRequest setRequiredBillingAddressFields:PKAddressFieldPostalAddress];
-        paymentRequest.shippingMethods = [self.shippingManager defaultShippingMethods];
-        paymentRequest.paymentSummaryItems = [self summaryItemsForShippingMethod:paymentRequest.shippingMethods.firstObject];
         PKPaymentAuthorizationViewController *auth = [[PKPaymentAuthorizationViewController alloc] initWithPaymentRequest:paymentRequest];
         auth.delegate = self;
         if (auth) {
@@ -171,7 +173,7 @@
     NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
     NSURLSession *session = [NSURLSession sessionWithConfiguration:config];
     
-    NSString *urlString = [BackendChargeURLString stringByAppendingPathComponent:@"charge_custom"];
+    NSString *urlString = [BackendChargeURLString stringByAppendingPathComponent:@"charge"];
     NSURL *url = [NSURL URLWithString:urlString];
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url];
     request.HTTPMethod = @"POST";


### PR DESCRIPTION
r? @bdorfman 

I noticed the Apple Pay button never gets enabled in the "Custom" example app, since we don't set `paymentSummaryItems` before calling `canSubmitPaymentRequest`.

