### PR TITLE
Status bar color improvements

### DIFF
--- a/Stripe/PublicHeaders/STPTheme.h
+++ b/Stripe/PublicHeaders/STPTheme.h
@@ -76,6 +76,19 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, copy, null_resettable)UIFont  *emphasisFont;
 
 /**
+ *  The navigation bar style to use for any view controllers presented modally
+ *  by the SDK. The default value will be determined based on the brightness
+ *  of the theme's `primaryBackgroundColor`.
+ */
+@property(nonatomic)UIBarStyle barStyle;
+
+/**
+ *  A Boolean value indicating whether the navigation bar for any view controllers
+ *  presented modally by the SDK should be translucent. The default value is NO.
+ */
+@property(nonatomic)BOOL translucentNavigationBar;
+
+/**
  *  This font is automatically derived from the font, with a slightly lower point size, and will be used for supplementary labels.
  */
 @property(nonatomic, readonly)UIFont  *smallFont;

--- a/Stripe/STPPaymentMethodTableViewCell.m
+++ b/Stripe/STPPaymentMethodTableViewCell.m
@@ -54,6 +54,8 @@
 
 - (void)configureForNewCardRowWithTheme:(STPTheme *)theme {
     _theme = theme;
+    self.backgroundColor = [UIColor clearColor];
+    self.contentView.backgroundColor = self.theme.secondaryBackgroundColor;
     self.leftIcon.image = [STPImageLibrary addIcon];
     self.leftIcon.tintColor = self.theme.accentColor;
     self.titleLabel.font = self.theme.font;

--- a/Stripe/STPTheme.m
+++ b/Stripe/STPTheme.m
@@ -7,6 +7,7 @@
 //
 
 #import "STPTheme.h"
+#import "STPColorUtils.h"
 
 @interface STPTheme()
 @end
@@ -60,6 +61,10 @@ static UIFont  *STPThemeDefaultMediumFont;
         _errorColor = STPThemeDefaultErrorColor;
         _font = STPThemeDefaultFont;
         _emphasisFont = STPThemeDefaultMediumFont;
+        _translucentNavigationBar = NO;
+        // This is a sentinel value (the equivalent of nil).
+        // If unset, we return the default computed bar style
+        _barStyle = -1;
     }
     return self;
 }
@@ -124,6 +129,25 @@ static UIFont  *STPThemeDefaultMediumFont;
 
 - (UIFont *)largeFont {
     return [self.font fontWithSize:self.font.pointSize + 15];
+}
+
+- (UIBarStyle)barStyleForColor:(UIColor *)color {
+    if ([STPColorUtils colorIsBright:color]) {
+        return UIBarStyleDefault;
+    }
+    else {
+        return UIBarStyleBlack;
+    }
+}
+
+- (UIBarStyle)barStyle {
+    UIBarStyle defaultStyle = [self barStyleForColor:self.primaryBackgroundColor];
+    if (_barStyle < 0) {
+        return defaultStyle;
+    }
+    else {
+        return _barStyle;
+    }
 }
 
 - (id)copyWithZone:(__unused NSZone *)zone {

--- a/Stripe/UINavigationBar+Stripe_Theme.m
+++ b/Stripe/UINavigationBar+Stripe_Theme.m
@@ -19,14 +19,8 @@ static NSInteger const STPNavigationBarHairlineViewTag = 787473;
     [self stp_artificialHairlineView].backgroundColor = theme.tertiaryBackgroundColor;
     self.barTintColor = theme.primaryBackgroundColor;
     self.tintColor = theme.accentColor;
-
-    if ([STPColorUtils colorIsBright:theme.secondaryBackgroundColor]) {
-        self.barStyle = UIBarStyleDefault;
-    }
-    else {
-        self.barStyle = UIBarStyleBlack;
-    }
-
+    self.barStyle = theme.barStyle;
+    self.translucent = theme.translucentNavigationBar;
     self.titleTextAttributes = @{
                                  NSFontAttributeName: theme.emphasisFont,
                                  NSForegroundColorAttributeName: theme.primaryForegroundColor,

--- a/Stripe/UINavigationBar+Stripe_Theme.m
+++ b/Stripe/UINavigationBar+Stripe_Theme.m
@@ -17,7 +17,7 @@ static NSInteger const STPNavigationBarHairlineViewTag = 787473;
 - (void)stp_setTheme:(STPTheme *)theme {
     [self stp_hairlineImageView].hidden = YES;
     [self stp_artificialHairlineView].backgroundColor = theme.tertiaryBackgroundColor;
-    self.barTintColor = theme.secondaryBackgroundColor;
+    self.barTintColor = theme.primaryBackgroundColor;
     self.tintColor = theme.accentColor;
 
     if ([STPColorUtils colorIsBright:theme.secondaryBackgroundColor]) {


### PR DESCRIPTION
r? @bdorfman 
cc @phred 

This PR fixes a few visual bugs:
- the "Add new card" cell wasn't using the theme's background color
- Navigation bars were using `secondaryBackgroundColor`, rather than `primary`
- Navigation bars were defaulting to `translucent=YES`

I've also added two new properties to `STPTheme`, `barStyle` and `translucentNavigationBar`. 

