### PR TITLE
Improve Stripe error bridging with Swift

### DIFF
--- a/Stripe/PublicHeaders/StripeError.h
+++ b/Stripe/PublicHeaders/StripeError.h
@@ -13,7 +13,8 @@
  */
 FOUNDATION_EXPORT NSString * __nonnull const StripeDomain;
 
-typedef NS_ENUM(NSInteger, STPErrorCode) {
+typedef enum STPError: NSInteger STPErrorCode;
+enum __attribute__((ns_error_domain(StripeDomain))) STPErrorCode: NSInteger {
     STPConnectionError = 40,     // Trouble connecting to Stripe.
     STPInvalidRequestError = 50, // Your request had invalid parameters.
     STPAPIError = 60,            // General-purpose API error (should be rare).

--- a/Stripe/PublicHeaders/StripeError.h
+++ b/Stripe/PublicHeaders/StripeError.h
@@ -13,8 +13,13 @@
  */
 FOUNDATION_EXPORT NSString * __nonnull const StripeDomain;
 
+#if __has_attribute(ns_error_domain)
+// NS_ERROR_ENUM has not been defined yet: https://twitter.com/bjhomer/status/775571745197535232
 typedef enum STPError: NSInteger STPErrorCode;
 enum __attribute__((ns_error_domain(StripeDomain))) STPErrorCode: NSInteger {
+#else
+typedef NS_ENUM(NSInteger, STPErrorCode) {
+#endif
     STPConnectionError = 40,     // Trouble connecting to Stripe.
     STPInvalidRequestError = 50, // Your request had invalid parameters.
     STPAPIError = 60,            // General-purpose API error (should be rare).
@@ -39,7 +44,11 @@ FOUNDATION_EXPORT NSString * __nonnull const STPErrorParameterKey;
 
 #pragma mark STPCardErrorCodeKeys
 
-typedef NSString *STPCardErrorCode NS_STRING_ENUM;
+typedef NSString * STPCardErrorCode
+#ifdef NS_STRING_ENUM
+NS_STRING_ENUM
+#endif
+;
 
 // (Usually determined locally:)
 FOUNDATION_EXPORT STPCardErrorCode __nonnull const STPInvalidNumber;

--- a/Stripe/PublicHeaders/StripeError.h
+++ b/Stripe/PublicHeaders/StripeError.h
@@ -39,18 +39,20 @@ FOUNDATION_EXPORT NSString * __nonnull const STPErrorParameterKey;
 
 #pragma mark STPCardErrorCodeKeys
 
+typedef NSString *STPCardErrorCode NS_STRING_ENUM;
+
 // (Usually determined locally:)
-FOUNDATION_EXPORT NSString * __nonnull const STPInvalidNumber;
-FOUNDATION_EXPORT NSString * __nonnull const STPInvalidExpMonth;
-FOUNDATION_EXPORT NSString * __nonnull const STPInvalidExpYear;
-FOUNDATION_EXPORT NSString * __nonnull const STPInvalidCVC;
+FOUNDATION_EXPORT STPCardErrorCode __nonnull const STPInvalidNumber;
+FOUNDATION_EXPORT STPCardErrorCode __nonnull const STPInvalidExpMonth;
+FOUNDATION_EXPORT STPCardErrorCode __nonnull const STPInvalidExpYear;
+FOUNDATION_EXPORT STPCardErrorCode __nonnull const STPInvalidCVC;
 
 // (Usually sent from the server:)
-FOUNDATION_EXPORT NSString * __nonnull const STPIncorrectNumber;
-FOUNDATION_EXPORT NSString * __nonnull const STPExpiredCard;
-FOUNDATION_EXPORT NSString * __nonnull const STPCardDeclined;
-FOUNDATION_EXPORT NSString * __nonnull const STPProcessingError;
-FOUNDATION_EXPORT NSString * __nonnull const STPIncorrectCVC;
+FOUNDATION_EXPORT STPCardErrorCode __nonnull const STPIncorrectNumber;
+FOUNDATION_EXPORT STPCardErrorCode __nonnull const STPExpiredCard;
+FOUNDATION_EXPORT STPCardErrorCode __nonnull const STPCardDeclined;
+FOUNDATION_EXPORT STPCardErrorCode __nonnull const STPProcessingError;
+FOUNDATION_EXPORT STPCardErrorCode __nonnull const STPIncorrectCVC;
 
 
 @interface NSError(Stripe)


### PR DESCRIPTION
## Summary

With the Swift evolution proposal [Improved NSError Bridging](https://github.com/apple/swift-evolution/blob/master/proposals/0112-nserror-bridging.md) having been implemented we can now directly cast NSErrors coming from Stripe to the `STPError` type that is created by Clang via the import process.
## Motivation

Most of the motivation is covered by the [Swift evolution proposal](https://github.com/apple/swift-evolution/blob/master/proposals/0112-nserror-bridging.md#motivation), particularly number 2. Working with NSError and fetching details out of the userInfo dictionary in Swift is less than ideal due to the amount of casting required.

With this change the Swift generated interface for StripeError.h turns from this:

``` Swift
public let StripeDomain: String

public enum STPErrorCode : Int {
    case STPConnectionError // Trouble connecting to Stripe.
    case STPInvalidRequestError // Your request had invalid parameters.
    case STPAPIError // General-purpose API error (should be rare).
    case STPCardError // Something was wrong with the given card (most common).
    case STPCancellationError // The operation was cancelled.
    case STPCheckoutUnknownError // Checkout failed
    case STPCheckoutTooManyAttemptsError // Too many incorrect code attempts
}

// (Usually determined locally:)
public let STPInvalidNumber: String
public let STPInvalidExpMonth: String
public let STPInvalidExpYear: String
public let STPInvalidCVC: String

// (Usually sent from the server:)
public let STPIncorrectNumber: String
public let STPExpiredCard: String
public let STPCardDeclined: String
public let STPProcessingError: String
public let STPIncorrectCVC: String
```

to this:

``` Swift
public let StripeDomain: String

public struct STPError {
    public init(_nsError: NSError)
    public static var _nsErrorDomain: String { get }

    public enum Code : Int {
        public typealias _ErrorType = STPError
        case STPConnectionError // Trouble connecting to Stripe.
        case STPInvalidRequestError // Your request had invalid parameters.
        case STPAPIError // General-purpose API error (should be rare).
        case STPCardError // Something was wrong with the given card (most common).
        case STPCancellationError // The operation was cancelled.
        case STPCheckoutUnknownError // Checkout failed
        case STPCheckoutTooManyAttemptsError // Too many incorrect code attempts
    }

    public static var STPConnectionError: STPError.Code { get }
    public static var STPInvalidRequestError: STPError.Code { get }
    public static var STPAPIError: STPError.Code { get }
    public static var STPCardError: STPError.Code { get }
    public static var STPCancellationError: STPError.Code { get }
    public static var STPCheckoutUnknownError: STPError.Code { get }
    public static var STPCheckoutTooManyAttemptsError: STPError.Code { get }
}

public struct STPCardErrorCode : RawRepresentable, Equatable, Hashable, Comparable {
    public init(rawValue: String)
}
extension STPCardErrorCode {
    // (Usually determined locally:)
    public static let invalidNumber: STPCardErrorCode
    public static let invalidExpMonth: STPCardErrorCode
    public static let invalidExpYear: STPCardErrorCode
    public static let invalidCVC: STPCardErrorCode

    // (Usually sent from the server:)
    public static let incorrectNumber: STPCardErrorCode
    public static let expiredCard: STPCardErrorCode
    public static let declined: STPCardErrorCode
    public static let processingError: STPCardErrorCode
    public static let incorrectCVC: STPCardErrorCode
}
```

This allows consumers of the library to provide their own extensions to STPError without polluting the NSError class and using the type information allows handling the errors much more Swift-like:

``` Swift
extension STPError {
    var developerMessage: String? {
        return userInfo[STPErrorMessageKey] as? String
    }
    var cardErrorCode: STPCardErrorCode? {
        return userInfo[STPCardErrorCodeKey] as? STPCardErrorCode
    }
    var parameter: String? {
        return userInfo[STPErrorParameterKey] as? String
    }
}

func handleAnErrorThatOccurred(_ error: Error) {
    if let error = error as? STPError {
        switch error.cardErrorCode {
        case .invalidNumber?, .incorrectNumber?:
            () // Highlight the number field...
        case .declined?:
            () // Ask for a different card...
        default:
            ()
        }
    }
}
```

Note that this will break compatibility for Swift users of this library. Any Objective-C code will not be affected.
## Testing

No changes are expected for any Objective-C files. Since this framework is entirely Objective-C, no tests have been added without adding Swift specific tests. Existing tests have been run locally and have passed on Xcode 8.0 (8A218a).
