### PR TITLE
Added Apple Pay shipping address support to STPPaymentContext

### DIFF
--- a/Stripe/PublicHeaders/STPPaymentContext.h
+++ b/Stripe/PublicHeaders/STPPaymentContext.h
@@ -118,6 +118,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property(nonatomic, copy)NSArray<PKPaymentSummaryItem *> *paymentSummaryItems NS_AVAILABLE_IOS(8_0);
 
+
+/**
+  *  If you support Apple Pay, you can optionally set this field with the required capabilities of an Apple Pay shipping address, that
+     you need in order to process an Apple Pay transaction.
+  */
+@property(nonatomic) PKAddressField requiredShippingAddressFields;
+    
+
 /**
  *  The presentation style used for all view controllers presented modally by the context.
  *  Since custom transition styles are not supported, you should set this to either

--- a/Stripe/STPPaymentContext.m
+++ b/Stripe/STPPaymentContext.m
@@ -348,6 +348,8 @@
     paymentRequest.paymentSummaryItems = summaryItems;
     paymentRequest.requiredBillingAddressFields = [STPAddress applePayAddressFieldsFromBillingAddressFields:self.configuration.requiredBillingAddressFields];
     paymentRequest.currencyCode = self.paymentCurrency.uppercaseString;
+    paymentRequest.requiredShippingAddressFields = self.requiredShippingAddressFields;
+    
     return paymentRequest;
 }
 

--- a/Tests/Tests/STPPaymentContextTest.m
+++ b/Tests/Tests/STPPaymentContextTest.m
@@ -65,6 +65,16 @@
                   @"PKPaymentRequest currency code is not uppercased");
 }
 
+- (void)testBuildPaymentRequest_shippingAddress {
+    STPPaymentContext *context = [[STPPaymentContext alloc] initWithAPIAdapter:[TestSTPBackendAPIAdapter new]];
+    context.paymentAmount = 100;
+    context.requiredShippingAddressFields = PKAddressFieldAll;
+    PKPaymentRequest *request = [context buildPaymentRequest];
+
+    XCTAssertTrue(request.requiredShippingAddressFields == PKAddressFieldAll,
+                  @"PKPaymentRequest required shipping address field is not set to All");
+}
+
 - (NSArray<PKPaymentSummaryItem *> *)testSummaryItems {
     return @[[PKPaymentSummaryItem summaryItemWithLabel:@"First item"
                                                  amount:[NSDecimalNumber decimalNumberWithMantissa:20 exponent:0 isNegative:NO]],


### PR DESCRIPTION
## Summary

Allow STPPaymentContext to display an Apple Pay sheet with a shipping address.

## Motivation

At the moment, if one wishes to use Apple Pay's shipping address with stripe, one can't use the STPPaymentContext (the simple iOS integration). This change allows the user of STPaymentContext to request a shipping address from Apple Pay if necessary:
```
        let paymentContext = STPPaymentContext(apiAdapter: MyAPIClient.sharedClient,
                                               configuration: config,
                                               theme: settings.theme)
        paymentContext.requiredShippingAddressFields = [.postalAddress]
        paymentContext.paymentAmount = price
```
## Testing

Added a unit test to the STPPaymentContextTests.