### PR TITLE
Update JSON key for default source in Test file

### DIFF
--- a/Tests/Tests/STPCustomerDeserializerTest.m
+++ b/Tests/Tests/STPCustomerDeserializerTest.m
@@ -66,7 +66,7 @@
     NSMutableDictionary *customer = [[STPTestUtils jsonNamed:@"Customer"] mutableCopy];
     NSMutableDictionary *sources = [customer[@"sources"] mutableCopy];
     sources[@"data"] = @[applePayCard1, card1, applePayCard2, card2];
-    customer[@"default_source"] = card1[@"id"];
+    customer[@"defaultSource"] = card1[@"id"];
     customer[@"sources"] = sources;
 
     STPCustomerDeserializer *sut = [[STPCustomerDeserializer alloc] initWithJSONResponse:customer];


### PR DESCRIPTION
Changed JSON key for default source from "default_source" to "defaultSource"

The application would not be able parse the default source id because the JSON key in the server response did not match the JSON key used in the NSDictionary.  This change allows the code to properly test default source id.