### PR TITLE
Guard all escaping completions with dispatch

### DIFF
--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -572,6 +572,10 @@
 		F1852F951D80B6EC00367C86 /* STPStringUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = F1852F921D80B6EC00367C86 /* STPStringUtils.m */; };
 		F1852F961D80B6EC00367C86 /* STPStringUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = F1852F921D80B6EC00367C86 /* STPStringUtils.m */; };
 		F1C578F11D651AB200912EAE /* stp_card_applepay.png in Resources */ = {isa = PBXBuildFile; fileRef = F1C578F01D651AB200912EAE /* stp_card_applepay.png */; };
+		F1C7B8D31DBECF2400D9F6F0 /* STPDispatchFunctions.m in Sources */ = {isa = PBXBuildFile; fileRef = F1C7B8D11DBECF2400D9F6F0 /* STPDispatchFunctions.m */; };
+		F1C7B8D41DBECF2400D9F6F0 /* STPDispatchFunctions.m in Sources */ = {isa = PBXBuildFile; fileRef = F1C7B8D11DBECF2400D9F6F0 /* STPDispatchFunctions.m */; };
+		F1C7B8D51DBECF2400D9F6F0 /* STPDispatchFunctions.h in Headers */ = {isa = PBXBuildFile; fileRef = F1C7B8D21DBECF2400D9F6F0 /* STPDispatchFunctions.h */; };
+		F1C7B8D61DBECF2400D9F6F0 /* STPDispatchFunctions.h in Headers */ = {isa = PBXBuildFile; fileRef = F1C7B8D21DBECF2400D9F6F0 /* STPDispatchFunctions.h */; };
 		F1D64B291D8767FC001CDB7C /* STPWebViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = F1D64B271D8767FC001CDB7C /* STPWebViewController.h */; };
 		F1D64B2A1D8767FC001CDB7C /* STPWebViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = F1D64B271D8767FC001CDB7C /* STPWebViewController.h */; };
 		F1D64B2B1D8767FC001CDB7C /* STPWebViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F1D64B281D8767FC001CDB7C /* STPWebViewController.m */; };
@@ -949,10 +953,12 @@
 		F1852F911D80B6EC00367C86 /* STPStringUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPStringUtils.h; sourceTree = "<group>"; };
 		F1852F921D80B6EC00367C86 /* STPStringUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPStringUtils.m; sourceTree = "<group>"; };
 		F1C578F01D651AB200912EAE /* stp_card_applepay.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_applepay.png; sourceTree = "<group>"; };
+		F1C7B8D11DBECF2400D9F6F0 /* STPDispatchFunctions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPDispatchFunctions.m; sourceTree = "<group>"; };
+		F1C7B8D21DBECF2400D9F6F0 /* STPDispatchFunctions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPDispatchFunctions.h; sourceTree = "<group>"; };
 		F1D64B271D8767FC001CDB7C /* STPWebViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPWebViewController.h; sourceTree = "<group>"; };
 		F1D64B281D8767FC001CDB7C /* STPWebViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPWebViewController.m; sourceTree = "<group>"; };
-		F1D777BF1D81DD520076FA19 /* STPStringUtilsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPStringUtilsTest.m; sourceTree = "<group>"; };
 		F1D64B2D1D87686E001CDB7C /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
+		F1D777BF1D81DD520076FA19 /* STPStringUtilsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPStringUtilsTest.m; sourceTree = "<group>"; };
 		FAFC12C516E5767F0066297F /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
@@ -1293,6 +1299,8 @@
 				F1D64B281D8767FC001CDB7C /* STPWebViewController.m */,
 				F1852F911D80B6EC00367C86 /* STPStringUtils.h */,
 				F1852F921D80B6EC00367C86 /* STPStringUtils.m */,
+				F1C7B8D21DBECF2400D9F6F0 /* STPDispatchFunctions.h */,
+				F1C7B8D11DBECF2400D9F6F0 /* STPDispatchFunctions.m */,
 			);
 			name = Stripe;
 			path = Tests/../Stripe;
@@ -1536,6 +1544,7 @@
 				0426B9771CEBD001006AC8DD /* UINavigationBar+Stripe_Theme.h in Headers */,
 				04CDE5BE1BC1F21500548833 /* STPCardParams.h in Headers */,
 				04F94D9F1D229F09004FC826 /* STPPostalCodeValidator.h in Headers */,
+				F1C7B8D61DBECF2400D9F6F0 /* STPDispatchFunctions.h in Headers */,
 				04F213371BCECB1C001D6F22 /* STPAPIResponseDecodable.h in Headers */,
 				045D712D1CF4ED7600F6CD65 /* STPBINRange.h in Headers */,
 				049E84E71A605EF0000B66CD /* STPFormEncoder.h in Headers */,
@@ -1599,6 +1608,7 @@
 				04F213311BCEAB61001D6F22 /* STPFormEncodable.h in Headers */,
 				04CDB5021A5F30A700B854EE /* STPFormEncoder.h in Headers */,
 				04695ADB1C77F9EF00E08063 /* STPPhoneNumberValidator.h in Headers */,
+				F1C7B8D51DBECF2400D9F6F0 /* STPDispatchFunctions.h in Headers */,
 				0426B9761CEBD001006AC8DD /* UINavigationBar+Stripe_Theme.h in Headers */,
 				04BC29CA1CE40F7500318357 /* STPObscuredCardView.h in Headers */,
 				04E39F581CECF9A800AF3B96 /* STPPaymentMethodsViewController+Private.h in Headers */,
@@ -2052,6 +2062,7 @@
 				04B31DF51D09F0A800EF1631 /* UIViewController+Stripe_NavigationItemProxy.m in Sources */,
 				04633B171CD45437009D4FB5 /* STPCategoryLoader.m in Sources */,
 				04F94DAC1D229F42004FC826 /* UIBarButtonItem+Stripe.m in Sources */,
+				F1C7B8D41DBECF2400D9F6F0 /* STPDispatchFunctions.m in Sources */,
 				04F94DB11D229F64004FC826 /* STPRememberMeTermsView.m in Sources */,
 				04633B141CD45215009D4FB5 /* PKPayment+Stripe.m in Sources */,
 				04633AFF1CD129C0009D4FB5 /* NSString+Stripe.m in Sources */,
@@ -2154,6 +2165,7 @@
 				04CDB5181A5F30A700B854EE /* StripeError.m in Sources */,
 				C1363BB91D7633D800EB82B4 /* STPPaymentMethodTableViewCell.m in Sources */,
 				04633B051CD44F1C009D4FB5 /* STPAPIClient+ApplePay.m in Sources */,
+				F1C7B8D31DBECF2400D9F6F0 /* STPDispatchFunctions.m in Sources */,
 				04B31DF41D09F0A800EF1631 /* UIViewController+Stripe_NavigationItemProxy.m in Sources */,
 				04BC29A51CD8697900318357 /* STPTheme.m in Sources */,
 				049A3F8A1CC73C7100F57DE7 /* STPPaymentContext.m in Sources */,

--- a/Stripe/STPAPIPostRequest.m
+++ b/Stripe/STPAPIPostRequest.m
@@ -10,6 +10,7 @@
 #import "STPAPIClient.h"
 #import "STPAPIClient+Private.h"
 #import "StripeError.h"
+#import "STPDispatchFunctions.h"
 
 @implementation STPAPIPostRequest
 
@@ -36,7 +37,7 @@
         if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
             httpResponse = (NSHTTPURLResponse *)response;
         }
-        dispatch_async(dispatch_get_main_queue(), ^{
+        stpDispatchToMainThreadIfNecessary(^{
             if (returnedError) {
                 completion(nil, httpResponse, returnedError);
             } else {

--- a/Stripe/STPAddCardViewController.m
+++ b/Stripe/STPAddCardViewController.m
@@ -305,12 +305,14 @@ static NSInteger STPPaymentCardRememberMeSection = 3;
         [[[self.checkoutAPIClient createTokenWithAccount:self.checkoutAccount] onSuccess:^(STPToken *token) {
             STRONG(self);
             [self.delegate addCardViewController:self didCreateToken:token completion:^(NSError * _Nullable error) {
-                if (error) {
-                    [self handleCheckoutTokenError:error];
-                }
-                else {
-                    self.loading = NO;
-                }
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    if (error) {
+                        [self handleCheckoutTokenError:error];
+                    }
+                    else {
+                        self.loading = NO;
+                    }
+                });
             }];
         }] onFailure:^(NSError *error) {
             STRONG(self);
@@ -329,12 +331,14 @@ static NSInteger STPPaymentCardRememberMeSection = 3;
                     [self.checkoutAPIClient createAccountWithCardParams:cardParams email:email phone:phone];
                 }
                 [self.delegate addCardViewController:self didCreateToken:token completion:^(NSError * _Nullable error) {
-                    if (error) {
-                        [self handleCardTokenError:error];
-                    }
-                    else {
-                        self.loading = NO;
-                    }
+                    dispatch_async(dispatch_get_main_queue(), ^{
+                        if (error) {
+                            [self handleCardTokenError:error];
+                        }
+                        else {
+                            self.loading = NO;
+                        }
+                    });
                 }];
             }
         }];

--- a/Stripe/STPAddCardViewController.m
+++ b/Stripe/STPAddCardViewController.m
@@ -38,6 +38,7 @@
 #import "STPColorUtils.h"
 #import "STPWeakStrongMacros.h"
 #import "STPLocalizationUtils.h"
+#import "STPDispatchFunctions.h"
 
 @interface STPAddCardViewController ()<STPPaymentCardTextFieldDelegate, STPAddressViewModelDelegate, STPAddressFieldTableViewCellDelegate, STPSwitchTableViewCellDelegate, UITableViewDelegate, UITableViewDataSource, STPSMSCodeViewControllerDelegate, STPRememberMePaymentCellDelegate>
 @property(nonatomic)STPPaymentConfiguration *configuration;
@@ -305,7 +306,7 @@ static NSInteger STPPaymentCardRememberMeSection = 3;
         [[[self.checkoutAPIClient createTokenWithAccount:self.checkoutAccount] onSuccess:^(STPToken *token) {
             STRONG(self);
             [self.delegate addCardViewController:self didCreateToken:token completion:^(NSError * _Nullable error) {
-                dispatch_async(dispatch_get_main_queue(), ^{
+                stpDispatchToMainThreadIfNecessary(^{
                     if (error) {
                         [self handleCheckoutTokenError:error];
                     }
@@ -331,7 +332,7 @@ static NSInteger STPPaymentCardRememberMeSection = 3;
                     [self.checkoutAPIClient createAccountWithCardParams:cardParams email:email phone:phone];
                 }
                 [self.delegate addCardViewController:self didCreateToken:token completion:^(NSError * _Nullable error) {
-                    dispatch_async(dispatch_get_main_queue(), ^{
+                    stpDispatchToMainThreadIfNecessary(^{
                         if (error) {
                             [self handleCardTokenError:error];
                         }

--- a/Stripe/STPDispatchFunctions.h
+++ b/Stripe/STPDispatchFunctions.h
@@ -1,0 +1,11 @@
+//
+//  STPDispatchFunctions.h
+//  Stripe
+//
+//  Created by Brian Dorfman on 10/24/16.
+//  Copyright © 2016 Stripe, Inc. All rights reserved.
+//
+
+#include <Foundation/Foundation.h>
+
+void stpDispatchToMainThreadIfNecessary(dispatch_block_t block);

--- a/Stripe/STPDispatchFunctions.m
+++ b/Stripe/STPDispatchFunctions.m
@@ -1,0 +1,18 @@
+//
+//  STPDispatchFunctions.m
+//  Stripe
+//
+//  Created by Brian Dorfman on 10/24/16.
+//  Copyright © 2016 Stripe, Inc. All rights reserved.
+//
+
+#include "STPDispatchFunctions.h"
+
+void stpDispatchToMainThreadIfNecessary(dispatch_block_t block) {
+    if ([NSThread isMainThread]) {
+        block();
+    }
+    else {
+        dispatch_async(dispatch_get_main_queue(), block);
+    }
+}

--- a/Stripe/STPPaymentContext.m
+++ b/Stripe/STPPaymentContext.m
@@ -19,6 +19,7 @@
 #import "STPPaymentConfiguration+Private.h"
 #import "STPWeakStrongMacros.h"
 #import "STPPaymentContextAmountModel.h"
+#import "STPDispatchFunctions.h"
 
 #define FAUXPAS_IGNORED_IN_METHOD(...)
 
@@ -93,7 +94,7 @@
         }
     }];
     [self.apiAdapter retrieveCustomer:^(STPCustomer * _Nullable customer, NSError * _Nullable error) {
-        dispatch_async(dispatch_get_main_queue(), ^{
+        stpDispatchToMainThreadIfNecessary(^{
             STRONG(self);
             if (!self) {
                 return;
@@ -175,7 +176,7 @@
     }
     if (![_selectedPaymentMethod isEqual:selectedPaymentMethod]) {
         _selectedPaymentMethod = selectedPaymentMethod;
-        dispatch_async(dispatch_get_main_queue(), ^{
+        stpDispatchToMainThreadIfNecessary(^{
             [self.delegate paymentContextDidChange:self];
         });
     }
@@ -293,7 +294,7 @@
         else if ([self.selectedPaymentMethod isKindOfClass:[STPCard class]]) {
             STPPaymentResult *result = [[STPPaymentResult alloc] initWithSource:(STPCard *)self.selectedPaymentMethod];
             [self.delegate paymentContext:self didCreatePaymentResult:result completion:^(NSError * _Nullable error) {
-                dispatch_async(dispatch_get_main_queue(), ^{
+                stpDispatchToMainThreadIfNecessary(^{
                     if (error) {
                         [self.delegate paymentContext:self didFinishWithStatus:STPPaymentStatusError error:error];
                     } else {
@@ -306,7 +307,7 @@
             PKPaymentRequest *paymentRequest = [self buildPaymentRequest];
             STPApplePayTokenHandlerBlock applePayTokenHandler = ^(STPToken *token, STPErrorBlock tokenCompletion) {
                 [self.apiAdapter attachSourceToCustomer:token completion:^(NSError *tokenError) {
-                    dispatch_async(dispatch_get_main_queue(), ^{
+                    stpDispatchToMainThreadIfNecessary(^{
                         if (tokenError) {
                             tokenCompletion(tokenError);
                         } else {
@@ -377,7 +378,7 @@ static char kSTPPaymentCoordinatorAssociatedObjectKey;
                didCreateToken:(STPToken *)token
                    completion:(STPErrorBlock)completion {
     [self.apiAdapter attachSourceToCustomer:token completion:^(NSError *error) {
-        dispatch_async(dispatch_get_main_queue(), ^{
+        stpDispatchToMainThreadIfNecessary(^{
             if (error) {
                 completion(error);
             } else {

--- a/Stripe/STPPaymentMethodsViewController.m
+++ b/Stripe/STPPaymentMethodsViewController.m
@@ -26,6 +26,7 @@
 #import "STPColorUtils.h"
 #import "STPWeakStrongMacros.h"
 #import "STPLocalizationUtils.h"
+#import "STPDispatchFunctions.h"
 
 @interface STPPaymentMethodsViewController()<STPPaymentMethodsInternalViewControllerDelegate, STPAddCardViewControllerDelegate>
 
@@ -60,7 +61,7 @@
                              delegate:(id<STPPaymentMethodsViewControllerDelegate>)delegate {
     STPPromise<STPPaymentMethodTuple *> *promise = [STPPromise new];
     [apiAdapter retrieveCustomer:^(STPCustomer * _Nullable customer, NSError * _Nullable error) {
-        dispatch_async(dispatch_get_main_queue(), ^{
+        stpDispatchToMainThreadIfNecessary(^{
             if (error) {
                 [promise fail:error];
             } else {
@@ -190,7 +191,7 @@
 
 - (void)internalViewControllerDidCreateToken:(STPToken *)token completion:(STPErrorBlock)completion {
     [self.apiAdapter attachSourceToCustomer:token completion:^(NSError * _Nullable error) {
-        dispatch_async(dispatch_get_main_queue(), ^{
+        stpDispatchToMainThreadIfNecessary(^{
             completion(error);
             if (!error) {
                 [self finishWithPaymentMethod:token.card];

--- a/Stripe/STPPaymentMethodsViewController.m
+++ b/Stripe/STPPaymentMethodsViewController.m
@@ -60,25 +60,27 @@
                              delegate:(id<STPPaymentMethodsViewControllerDelegate>)delegate {
     STPPromise<STPPaymentMethodTuple *> *promise = [STPPromise new];
     [apiAdapter retrieveCustomer:^(STPCustomer * _Nullable customer, NSError * _Nullable error) {
-        if (error) {
-            [promise fail:error];
-        } else {
-            STPCard *selectedCard;
-            NSMutableArray<STPCard *> *cards = [NSMutableArray array];
-            for (id<STPSource> source in customer.sources) {
-                if ([source isKindOfClass:[STPCard class]]) {
-                    STPCard *card = (STPCard *)source;
-                    [cards addObject:card];
-                    if ([card.stripeID isEqualToString:customer.defaultSource.stripeID]) {
-                        selectedCard = card;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (error) {
+                [promise fail:error];
+            } else {
+                STPCard *selectedCard;
+                NSMutableArray<STPCard *> *cards = [NSMutableArray array];
+                for (id<STPSource> source in customer.sources) {
+                    if ([source isKindOfClass:[STPCard class]]) {
+                        STPCard *card = (STPCard *)source;
+                        [cards addObject:card];
+                        if ([card.stripeID isEqualToString:customer.defaultSource.stripeID]) {
+                            selectedCard = card;
+                        }
                     }
                 }
+                STPCardTuple *cardTuple = [STPCardTuple tupleWithSelectedCard:selectedCard cards:cards];
+                STPPaymentMethodTuple *tuple = [STPPaymentMethodTuple tupleWithCardTuple:cardTuple
+                                                                         applePayEnabled:configuration.applePayEnabled];
+                [promise succeed:tuple];
             }
-            STPCardTuple *cardTuple = [STPCardTuple tupleWithSelectedCard:selectedCard cards:cards];
-            STPPaymentMethodTuple *tuple = [STPPaymentMethodTuple tupleWithCardTuple:cardTuple
-                                                                     applePayEnabled:configuration.applePayEnabled];
-            [promise succeed:tuple];
-        }
+        });
     }];
     return [self initWithConfiguration:configuration
                             apiAdapter:apiAdapter
@@ -188,10 +190,12 @@
 
 - (void)internalViewControllerDidCreateToken:(STPToken *)token completion:(STPErrorBlock)completion {
     [self.apiAdapter attachSourceToCustomer:token completion:^(NSError * _Nullable error) {
-        completion(error);
-        if (!error) {
-            [self finishWithPaymentMethod:token.card];
-        }
+        dispatch_async(dispatch_get_main_queue(), ^{
+            completion(error);
+            if (!error) {
+                [self finishWithPaymentMethod:token.card];
+            }
+        });
     }];
 }
 


### PR DESCRIPTION
Any delegate method where we pass a completion block that might be called outside of the framework itself, we should make sure to dispatch back to the main thread ourselves inside the completion instead of relying on the user to make sure they are calling it on the correct thread.

I believe this fixes https://github.com/stripe/stripe-ios/issues/477

r? @benzguo 