### PR TITLE
Add dummy strings files to example app.

### DIFF
--- a/Example/Stripe iOS Example (Simple).xcodeproj/project.pbxproj
+++ b/Example/Stripe iOS Example (Simple).xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		C188F2A61CC1A338003A524B /* MyAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C188F2A51CC1A338003A524B /* MyAPIClient.swift */; };
 		C1B83CBD1CCE6C0700F0790B /* Buttons.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B83CBC1CCE6C0700F0790B /* Buttons.swift */; };
 		C1C154341CD296CB0036AA63 /* Networking.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1C154331CD296CB0036AA63 /* Networking.swift */; };
+		F10C9F6B1DC916BD00A91F7C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = F10C9F691DC916BD00A91F7C /* Localizable.strings */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -48,6 +49,14 @@
 		C188F2A51CC1A338003A524B /* MyAPIClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MyAPIClient.swift; sourceTree = "<group>"; };
 		C1B83CBC1CCE6C0700F0790B /* Buttons.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Buttons.swift; sourceTree = "<group>"; };
 		C1C154331CD296CB0036AA63 /* Networking.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Networking.swift; sourceTree = "<group>"; };
+		F10C9F6A1DC916BD00A91F7C /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = Localizations/de.lproj/Localizable.strings; sourceTree = "<group>"; };
+		F10C9F6C1DC916C200A91F7C /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = Localizations/en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		F10C9F6D1DC916C800A91F7C /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = Localizations/nl.lproj/Localizable.strings; sourceTree = "<group>"; };
+		F10C9F6E1DC916CD00A91F7C /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "Localizations/zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		F1F3832B1DC917110006DA86 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = Localizations/ja.lproj/Localizable.strings; sourceTree = "<group>"; };
+		F1F3832C1DC917170006DA86 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = Localizations/it.lproj/Localizable.strings; sourceTree = "<group>"; };
+		F1F3832D1DC9171C0006DA86 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = Localizations/fr.lproj/Localizable.strings; sourceTree = "<group>"; };
+		F1F3832E1DC917260006DA86 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = Localizations/es.lproj/Localizable.strings; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -65,6 +74,7 @@
 		042CA4131A685E8D00D778E7 /* Stripe iOS Example (Simple) */ = {
 			isa = PBXGroup;
 			children = (
+				F11726811DC913D30058F2A0 /* Localizations */,
 				042CA4141A685E8D00D778E7 /* AppDelegate.swift */,
 				C188F2A51CC1A338003A524B /* MyAPIClient.swift */,
 				C13C24211D14438700F3765E /* SettingsViewController.swift */,
@@ -103,6 +113,14 @@
 				04D076191A69C14700094431 /* Stripe.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		F11726811DC913D30058F2A0 /* Localizations */ = {
+			isa = PBXGroup;
+			children = (
+				F10C9F691DC916BD00A91F7C /* Localizable.strings */,
+			);
+			name = Localizations;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -162,6 +180,13 @@
 			knownRegions = (
 				en,
 				Base,
+				de,
+				nl,
+				"zh-Hans",
+				ja,
+				it,
+				fr,
+				es,
 			);
 			mainGroup = 04823F6F1A6849200098400B;
 			productRefGroup = 04823F791A6849200098400B /* Products */;
@@ -179,6 +204,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				042CA4201A685E8D00D778E7 /* Images.xcassets in Resources */,
+				F10C9F6B1DC916BD00A91F7C /* Localizable.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -218,6 +244,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		F10C9F691DC916BD00A91F7C /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				F10C9F6A1DC916BD00A91F7C /* de */,
+				F10C9F6C1DC916C200A91F7C /* en */,
+				F10C9F6D1DC916C800A91F7C /* nl */,
+				F10C9F6E1DC916CD00A91F7C /* zh-Hans */,
+				F1F3832B1DC917110006DA86 /* ja */,
+				F1F3832C1DC917170006DA86 /* it */,
+				F1F3832D1DC9171C0006DA86 /* fr */,
+				F1F3832E1DC917260006DA86 /* es */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
 		04823F951A6849200098400B /* Debug */ = {

--- a/Example/Stripe iOS Example (Simple)/Localizations/de.lproj/Localizable.strings
+++ b/Example/Stripe iOS Example (Simple)/Localizations/de.lproj/Localizable.strings
@@ -1,0 +1,1 @@
+/* No Localized Strings */

--- a/Example/Stripe iOS Example (Simple)/Localizations/en.lproj/Localizable.strings
+++ b/Example/Stripe iOS Example (Simple)/Localizations/en.lproj/Localizable.strings
@@ -1,0 +1,1 @@
+/* No Localized Strings */

--- a/Example/Stripe iOS Example (Simple)/Localizations/es.lproj/Localizable.strings
+++ b/Example/Stripe iOS Example (Simple)/Localizations/es.lproj/Localizable.strings
@@ -1,0 +1,1 @@
+/* No Localized Strings */

--- a/Example/Stripe iOS Example (Simple)/Localizations/fr.lproj/Localizable.strings
+++ b/Example/Stripe iOS Example (Simple)/Localizations/fr.lproj/Localizable.strings
@@ -1,0 +1,1 @@
+/* No Localized Strings */

--- a/Example/Stripe iOS Example (Simple)/Localizations/it.lproj/Localizable.strings
+++ b/Example/Stripe iOS Example (Simple)/Localizations/it.lproj/Localizable.strings
@@ -1,0 +1,1 @@
+/* No Localized Strings */

--- a/Example/Stripe iOS Example (Simple)/Localizations/ja.lproj/Localizable.strings
+++ b/Example/Stripe iOS Example (Simple)/Localizations/ja.lproj/Localizable.strings
@@ -1,0 +1,1 @@
+/* No Localized Strings */

--- a/Example/Stripe iOS Example (Simple)/Localizations/nl.lproj/Localizable.strings
+++ b/Example/Stripe iOS Example (Simple)/Localizations/nl.lproj/Localizable.strings
@@ -1,0 +1,1 @@
+/* No Localized Strings */

--- a/Example/Stripe iOS Example (Simple)/Localizations/zh-Hans.lproj/Localizable.strings
+++ b/Example/Stripe iOS Example (Simple)/Localizations/zh-Hans.lproj/Localizable.strings
@@ -1,0 +1,1 @@
+/* No Localized Strings */


### PR DESCRIPTION
iOS won't localize linked frameworks unless the parent app is localized in that language. Added empty strings files for all our supported languages to the swift example app so that if you run it in a different language the framework's strings would show translated properly