### PR TITLE
Check for nil self in loadingPromise completion

### DIFF
--- a/Stripe/STPPaymentMethodsViewController.m
+++ b/Stripe/STPPaymentMethodsViewController.m
@@ -113,6 +113,9 @@
     WEAK(self);
     [self.loadingPromise onSuccess:^(STPPaymentMethodTuple *tuple) {
         STRONG(self);
+        if (!self) {
+            return;
+        }
         UIViewController *internal;
         if (tuple.paymentMethods.count > 0) {
             internal = [[STPPaymentMethodsInternalViewController alloc] initWithConfiguration:self.configuration


### PR DESCRIPTION
r? @bdorfman-stripe 
fixes #500 

I was able to reproduce this issue by pointing the example app to an example backend, adding a delay to `retrieveCustomer`, and hitting cancel before the view controller finishes loading. Either `STPPaymentMethodsVC` or `STPAddCardVC` can crash, depending on whether or not the customer has saved cards.