### PR TITLE
Fix country field bug in shipping form

### DIFF
--- a/Stripe/STPAddressFieldTableViewCell.m
+++ b/Stripe/STPAddressFieldTableViewCell.m
@@ -305,7 +305,11 @@
 
 - (void)setContents:(NSString *)contents {
     _contents = contents;
-    self.textField.text = contents;
+    if (self.type == STPAddressFieldTypeCountry) {
+        [self updateTextFieldsAndCaptions];
+    } else {
+        self.textField.text = contents;
+    }
     if ([self.textField isFirstResponder]) {
         self.textField.validText = [self potentiallyValidContents];
     } else {

--- a/Stripe/STPShippingAddressViewController.m
+++ b/Stripe/STPShippingAddressViewController.m
@@ -75,6 +75,7 @@
         }
         else if (prefilledInformation != nil) {
             STPAddress *prefilledAddress = [STPAddress new];
+            prefilledAddress.country = _addressViewModel.address.country;
             if (self.configuration.requiredShippingAddressFields & PKAddressFieldEmail) {
                 prefilledAddress.email = prefilledInformation.email;
             }

--- a/Tests/Tests/STPAddressViewModelTest.m
+++ b/Tests/Tests/STPAddressViewModelTest.m
@@ -122,6 +122,7 @@
     XCTAssertEqualObjects(sut.addressCells[5].contents, @"NY");
     XCTAssertEqualObjects(sut.addressCells[6].contents, @"10002");
     XCTAssertEqualObjects(sut.addressCells[7].contents, @"US");
+    XCTAssertEqualObjects(sut.addressCells[7].textField.text, @"United States");
     XCTAssertEqualObjects(sut.addressCells[8].contents, @"555-555-5555");
 }
 


### PR DESCRIPTION
r? @bdorfman-stripe 

Fixes #509 

This bug occurs when `STPShippingAddressVC` is passed `prefilledInformation`:
  - We were creating a new address with a `nil` country
  - The address setter wasn't calling `delegateCountryCodeDidChange`

## Testing

I've added a regression assert to `STPAddressViewModelTest`

