### PR TITLE
Fix mismatched param declaration

### DIFF
--- a/Stripe/PublicHeaders/STPBlocks.h
+++ b/Stripe/PublicHeaders/STPBlocks.h
@@ -82,7 +82,7 @@ typedef void (^STPTokenCompletionBlock)(STPToken * __nullable token, NSError * _
  *  A callback to be run with a validation result and shipping methods for a 
  *  shipping address.
  *
- *  @param shippingStatus An enum representing whether the shipping address is valid.
+ *  @param status An enum representing whether the shipping address is valid.
  *  @param shippingValidationError If the shipping address is invalid, an error describing the issue with the address. If no error is given and the address is invalid, the default error message will be used.
  *  @param shippingMethods The shipping methods available for the address.
  *  @param selectedShippingMethod The default selected shipping method for the address.

--- a/Stripe/PublicHeaders/STPPaymentContext.h
+++ b/Stripe/PublicHeaders/STPPaymentContext.h
@@ -238,7 +238,7 @@ didCreatePaymentResult:(STPPaymentResult *)paymentResult
  *  called.
  *
  *  @param paymentContext  The context that updated its shipping address
- *  @param shippingAddress The current shipping address
+ *  @param address         The current shipping address
  *  @param completion      Call this block when you're done validating the shipping address and calculating available shipping methods.
  */
 - (void)paymentContext:(STPPaymentContext *)paymentContext

--- a/Stripe/PublicHeaders/STPShippingAddressViewController.h
+++ b/Stripe/PublicHeaders/STPShippingAddressViewController.h
@@ -90,7 +90,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @param addressViewController the view controller where the address was entered
  *  @param address               the address that was entered. @see STPAddress
- *  @param shippingMethod        the shipping method that was selected.
+ *  @param method                the shipping method that was selected.
  */
 - (void)shippingAddressViewController:(STPShippingAddressViewController *)addressViewController
                  didFinishWithAddress:(STPAddress *)address


### PR DESCRIPTION
## Summary

Fix three name mismatch between param declaration and its comment

## Motivation

Keep in sync comments and code is a right thing to do, and in Xcode you can turn on documentation warning and this three mismatch are triggering that.