### PR TITLE
Force sdk to use same localization as main bundle.

### DIFF
--- a/Stripe/STPBundleLocator.m
+++ b/Stripe/STPBundleLocator.m
@@ -28,22 +28,27 @@
      4. main bundle (for people dragging all our files into their project)
      **/
     
-    NSBundle *ourBundle = [NSBundle bundleWithPath:@"Stripe.bundle"];
+    static NSBundle *ourBundle;
     
-    if (ourBundle == nil) {
-        // This might be the same as the previous check if not using a dynamic framework
-        NSString *path = [[NSBundle bundleForClass:[STPBundleLocatorInternal class]] pathForResource:@"Stripe" ofType:@"bundle"];
-        ourBundle = [NSBundle bundleWithPath:path];
-    }
-    
-    if (ourBundle == nil) {
-        // This will be the same as mainBundle if not using a dynamic framwork
-        ourBundle = [NSBundle bundleForClass:[STPBundleLocatorInternal class]];
-    }
-    
-    if (ourBundle == nil) {
-        ourBundle = [NSBundle mainBundle];
-    }
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        ourBundle = [NSBundle bundleWithPath:@"Stripe.bundle"];
+        if (ourBundle == nil) {
+            // This might be the same as the previous check if not using a dynamic framework
+            NSString *path = [[NSBundle bundleForClass:[STPBundleLocatorInternal class]] pathForResource:@"Stripe" ofType:@"bundle"];
+            ourBundle = [NSBundle bundleWithPath:path];
+        }
+        
+        if (ourBundle == nil) {
+            // This will be the same as mainBundle if not using a dynamic framework
+            ourBundle = [NSBundle bundleForClass:[STPBundleLocatorInternal class]];
+        }
+        
+        if (ourBundle == nil) {
+            ourBundle = [NSBundle mainBundle];
+        }
+    });
+
     return ourBundle;
 }
 

--- a/Stripe/STPLocalizationUtils.m
+++ b/Stripe/STPLocalizationUtils.m
@@ -12,9 +12,39 @@
 @implementation STPLocalizationUtils
 
 + (NSString *)localizedStripeStringForKey:(NSString *)key {
-    NSBundle *bundle = [STPBundleLocator stripeResourcesBundle];
 
-    return [bundle localizedStringForKey:key value:nil table:nil];
+    /**
+     If the main app has a localization that we do not support, we want to switch
+     to pulling strings from the main bundle instead of our own bundle so that
+     users can add translations for our strings without having to fork the sdk.
+     
+     At launch, NSBundles' store what language(s) the user requests that they
+     actually have translations for in `preferredLocalizations`. 
+     
+     We compare our framework's resource bundle to the main app's bundle, and
+     if their language choice doesn't match up we switch to pulling strings
+     from the main bundle instead.
+     
+     This also prevents language mismatches. E.g. the user lists portuguese and
+     then spanish as their preferred languages. The main app supports both so all its
+     strings are in pt, but we support spanish so our bundle marks es as our
+     preferred language and our strings are in es.
+     */
+    
+    static BOOL useMainBundle = NO;
+    
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        if (![[STPBundleLocator stripeResourcesBundle].preferredLocalizations.firstObject isEqualToString:[NSBundle mainBundle].preferredLocalizations.firstObject]) {
+            useMainBundle = YES;
+        }
+    });
+    
+    NSBundle *bundle = useMainBundle ? [NSBundle mainBundle] : [STPBundleLocator stripeResourcesBundle];
+
+    NSString *translation = [bundle localizedStringForKey:key value:nil table:nil];
+    
+    return translation;
 }
 
 @end


### PR DESCRIPTION
If the language supported by the main app's bundle is different than the language supported by our bundle, switch to pulling strings from the main bundle.
This lets users of the sdk fill in their own sdk localizations for languages we don't support in their main strings files instead of having to fork us.
It also prevents edge cases where the sdk could possibly use a different localization than the app (i think iOS actually prevents this, at least on iOS 10, but I don't like to rely on undocumented Foundation behavior).