### PR TITLE
Bar button items inherit from bar theme if applicable

### DIFF
--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -488,6 +488,7 @@
 		C1FEE5961CBFF11400A7632B /* STPPostalCodeValidator.h in Headers */ = {isa = PBXBuildFile; fileRef = C1FEE5941CBFF11400A7632B /* STPPostalCodeValidator.h */; };
 		C1FEE5971CBFF11400A7632B /* STPPostalCodeValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = C1FEE5951CBFF11400A7632B /* STPPostalCodeValidator.m */; };
 		C1FEE5991CBFF24000A7632B /* STPPostalCodeValidatorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C1FEE5981CBFF24000A7632B /* STPPostalCodeValidatorTest.m */; };
+		F1122A7E1DFB84E000A8B1AF /* UINavigationBar+StripeTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F1122A7D1DFB84E000A8B1AF /* UINavigationBar+StripeTest.m */; };
 		F116E94B1D83404D0026A52A /* AddressBook.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04B94BC71A47B78A00092C46 /* AddressBook.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		F116E94C1D83405E0026A52A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 11C74B9B164043050071C2CA /* Foundation.framework */; };
 		F116E94D1D8340640026A52A /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A0D74F918F6106100966D7B /* Security.framework */; };
@@ -941,6 +942,7 @@
 		C1FEE5941CBFF11400A7632B /* STPPostalCodeValidator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPPostalCodeValidator.h; sourceTree = "<group>"; };
 		C1FEE5951CBFF11400A7632B /* STPPostalCodeValidator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPPostalCodeValidator.m; sourceTree = "<group>"; };
 		C1FEE5981CBFF24000A7632B /* STPPostalCodeValidatorTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPPostalCodeValidatorTest.m; sourceTree = "<group>"; };
+		F1122A7D1DFB84E000A8B1AF /* UINavigationBar+StripeTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UINavigationBar+StripeTest.m"; sourceTree = "<group>"; };
 		F12829D81D7747E4008B10D6 /* STPBundleLocator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPBundleLocator.h; sourceTree = "<group>"; };
 		F12829D91D7747E4008B10D6 /* STPBundleLocator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPBundleLocator.m; sourceTree = "<group>"; };
 		F12C8DBE1D63DE9F00ADA0D7 /* STPPaymentContextAmountModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPPaymentContextAmountModel.h; sourceTree = "<group>"; };
@@ -1404,6 +1406,7 @@
 				F1D96F981DC7DCDE00477E64 /* STPLocalizationUtils+STPTestAdditions.h */,
 				F1D96F991DC7DCDE00477E64 /* STPLocalizationUtils+STPTestAdditions.m */,
 				C1D23FB71D37FE0F002FD83C /* JSON */,
+				F1122A7D1DFB84E000A8B1AF /* UINavigationBar+StripeTest.m */,
 			);
 			name = StripeTests;
 			path = Tests/Tests;
@@ -2064,6 +2067,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F1122A7E1DFB84E000A8B1AF /* UINavigationBar+StripeTest.m in Sources */,
 				04A4C3941C4F276100B3B290 /* STPUIVCStripeParentViewControllerTests.m in Sources */,
 				C13538101D2C3E99003F6157 /* MockSTPAddCardViewControllerDelegate.m in Sources */,
 				04A488361CA34DC600506E53 /* STPEmailAddressValidatorTest.m in Sources */,

--- a/Stripe/PublicHeaders/UINavigationBar+Stripe_Theme.h
+++ b/Stripe/PublicHeaders/UINavigationBar+Stripe_Theme.h
@@ -21,7 +21,11 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @param theme the theme to use to style the navigation bar. @see STPTheme.h
  */
-- (void)stp_setTheme:(STPTheme *)theme;
+- (void)stp_setTheme:(STPTheme *)theme __attribute__((deprecated));
+
+
+
+@property (nonatomic, nullable, retain) STPTheme *stp_theme;
 
 @end
 

--- a/Stripe/PublicHeaders/UINavigationBar+Stripe_Theme.h
+++ b/Stripe/PublicHeaders/UINavigationBar+Stripe_Theme.h
@@ -20,11 +20,16 @@ NS_ASSUME_NONNULL_BEGIN
  *  Sets the navigation bar's appearance to the desired theme. This will affect the bar's `tintColor` and `barTintColor` properties, as well as the color of the single-pixel line at the bottom of the navbar.
  *
  *  @param theme the theme to use to style the navigation bar. @see STPTheme.h
+ *  @deprecated Use the `stp_theme` property instead
  */
 - (void)stp_setTheme:(STPTheme *)theme __attribute__((deprecated));
 
-
-
+/**
+ *  Sets the navigation bar's appearance to the desired theme. This will affect the bar's `tintColor` and `barTintColor` properties, as well as the color of the single-pixel line at the bottom of the navbar.
+ *  Stripe view controllers will use their navigation bar's theme for their UIBarButtonItems instead of their own theme if it is not nil.
+ *
+ *  @see STPTheme.h
+ */
 @property (nonatomic, nullable, retain) STPTheme *stp_theme;
 
 @end

--- a/Stripe/STPAddCardViewController.m
+++ b/Stripe/STPAddCardViewController.m
@@ -193,8 +193,9 @@ typedef NS_ENUM(NSUInteger, STPPaymentCardSection) {
 
 - (void)updateAppearance {
     self.view.backgroundColor = self.theme.primaryBackgroundColor;
-    [self.doneItem stp_setTheme:self.theme];
-    [self.backItem stp_setTheme:self.theme];
+    STPTheme *navBarTheme = self.navigationController.navigationBar.stp_theme ?: self.theme;
+    [self.doneItem stp_setTheme:navBarTheme];
+    [self.backItem stp_setTheme:navBarTheme];
     self.tableView.allowsSelection = NO;
     self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone; // handle this with fake separator views for flexibility
     self.tableView.backgroundColor = self.theme.primaryBackgroundColor;
@@ -509,7 +510,7 @@ typedef NS_ENUM(NSUInteger, STPPaymentCardSection) {
             codeViewController.theme = self.theme;
             codeViewController.delegate = self;
             UINavigationController *nav = [[UINavigationController alloc] initWithRootViewController:codeViewController];
-            [nav.navigationBar stp_setTheme:self.theme];
+            nav.navigationBar.stp_theme = self.theme;
             nav.modalPresentationStyle = UIModalPresentationFormSheet;
             [self presentViewController:nav animated:YES completion:nil];
         }] onCompletion:^(__unused id value, NSError *error) {

--- a/Stripe/STPPaymentContext.m
+++ b/Stripe/STPPaymentContext.m
@@ -236,7 +236,7 @@
         self.paymentMethodsViewController = paymentMethodsViewController;
         paymentMethodsViewController.prefilledInformation = self.prefilledInformation;
         UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:paymentMethodsViewController];
-        [navigationController.navigationBar stp_setTheme:self.theme];
+        navigationController.navigationBar.stp_theme = self.theme;
         navigationController.modalPresentationStyle = self.modalPresentationStyle;
         [self.hostViewController presentViewController:navigationController animated:YES completion:nil];
     }];
@@ -305,7 +305,7 @@
         STRONG(self);
         STPShippingAddressViewController *addressViewController = [[STPShippingAddressViewController alloc] initWithPaymentContext:self];
         UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:addressViewController];
-        [navigationController.navigationBar stp_setTheme:self.theme];
+        navigationController.navigationBar.stp_theme = self.theme;
         navigationController.modalPresentationStyle = self.modalPresentationStyle;
         [self.hostViewController presentViewController:navigationController animated:YES completion:nil];
     }];
@@ -408,7 +408,7 @@
             addCardViewController.delegate = self;
             addCardViewController.prefilledInformation = self.prefilledInformation;
             UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:addCardViewController];
-            [navigationController.navigationBar stp_setTheme:self.theme];
+            navigationController.navigationBar.stp_theme = self.theme;
             navigationController.modalPresentationStyle = self.modalPresentationStyle;
             [self.hostViewController presentViewController:navigationController animated:YES completion:nil];
         }
@@ -418,7 +418,7 @@
             STPShippingAddressViewController *addressViewController = [[STPShippingAddressViewController alloc] initWithPaymentContext:self];
             self.isMidShippingInRequestPayment = YES;
             UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:addressViewController];
-            [navigationController.navigationBar stp_setTheme:self.theme];
+            navigationController.navigationBar.stp_theme = self.theme;
             navigationController.modalPresentationStyle = self.modalPresentationStyle;
             [self.hostViewController presentViewController:navigationController animated:YES completion:nil];
         }

--- a/Stripe/STPPaymentMethodsViewController.m
+++ b/Stripe/STPPaymentMethodsViewController.m
@@ -162,9 +162,11 @@
 }
 
 - (void)updateAppearance {
-    [self.navigationItem.backBarButtonItem stp_setTheme:self.theme];
-    [self.backItem stp_setTheme:self.theme];
-    [self.cancelItem stp_setTheme:self.theme];
+    STPTheme *navBarTheme = self.navigationController.navigationBar.stp_theme ?: self.theme;
+    [self.navigationItem.backBarButtonItem stp_setTheme:navBarTheme];
+    [self.backItem stp_setTheme:navBarTheme];
+    [self.cancelItem stp_setTheme:navBarTheme];
+
     self.activityIndicator.tintColor = self.theme.accentColor;
     self.view.backgroundColor = self.theme.primaryBackgroundColor;
     [self setNeedsStatusBarAppearanceUpdate];

--- a/Stripe/STPSMSCodeViewController.m
+++ b/Stripe/STPSMSCodeViewController.m
@@ -18,6 +18,7 @@
 #import "STPColorUtils.h"
 #import "STPWeakStrongMacros.h"
 #import "STPLocalizationUtils.h"
+#import "UINavigationBar+Stripe_Theme.h"
 
 @interface STPSMSCodeViewController()<STPSMSCodeTextFieldDelegate>
 
@@ -159,8 +160,9 @@
 }
 
 - (void)updateAppearance {
-    [self.navigationItem.leftBarButtonItem stp_setTheme:self.theme];
-    [self.navigationItem.rightBarButtonItem stp_setTheme:self.theme];
+    STPTheme *navBarTheme = self.navigationController.navigationBar.stp_theme ?: self.theme;
+    [self.navigationItem.leftBarButtonItem stp_setTheme:navBarTheme];
+    [self.navigationItem.rightBarButtonItem stp_setTheme:navBarTheme];
     self.view.backgroundColor = self.theme.primaryBackgroundColor;
     self.topLabel.font = self.theme.smallFont;
     self.topLabel.textColor = self.theme.secondaryForegroundColor;

--- a/Stripe/STPShippingAddressViewController.m
+++ b/Stripe/STPShippingAddressViewController.m
@@ -143,9 +143,11 @@
 
 - (void)updateAppearance {
     self.view.backgroundColor = self.theme.primaryBackgroundColor;
-    [self.nextItem stp_setTheme:self.theme];
-    [self.cancelItem stp_setTheme:self.theme];
-    [self.backItem stp_setTheme:self.theme];
+    STPTheme *navBarTheme = self.navigationController.navigationBar.stp_theme ?: self.theme;
+    [self.nextItem stp_setTheme:navBarTheme];
+    [self.cancelItem stp_setTheme:navBarTheme];
+    [self.backItem stp_setTheme:navBarTheme];
+    
     self.tableView.allowsSelection = NO;
     self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
     self.tableView.backgroundColor = self.theme.primaryBackgroundColor;

--- a/Stripe/STPShippingMethodsViewController.m
+++ b/Stripe/STPShippingMethodsViewController.m
@@ -15,6 +15,7 @@
 #import "UITableViewCell+Stripe_Borders.h"
 #import "NSArray+Stripe_BoundSafe.h"
 #import "STPShippingMethodTableViewCell.h"
+#import "UINavigationBar+Stripe_Theme.h"
 
 static NSString *const STPShippingMethodCellReuseIdentifier = @"STPShippingMethodCellReuseIdentifier";
 
@@ -75,7 +76,8 @@ static NSString *const STPShippingMethodCellReuseIdentifier = @"STPShippingMetho
 
 - (void)updateAppearance {
     self.view.backgroundColor = self.theme.primaryBackgroundColor;
-    [self.doneItem stp_setTheme:self.theme];
+    STPTheme *navBarTheme = self.navigationController.navigationBar.stp_theme ?: self.theme;
+    [self.doneItem stp_setTheme:navBarTheme];
     self.tableView.allowsSelection = YES;
     self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
     self.tableView.backgroundColor = self.theme.primaryBackgroundColor;

--- a/Stripe/UINavigationBar+Stripe_Theme.m
+++ b/Stripe/UINavigationBar+Stripe_Theme.m
@@ -9,13 +9,26 @@
 #import "UINavigationBar+Stripe_Theme.h"
 #import "STPTheme.h"
 #import "STPColorUtils.h"
+#import <objc/runtime.h>
 
 static NSInteger const STPNavigationBarHairlineViewTag = 787473;
 
 @implementation UINavigationBar (Stripe_Theme)
 
-- (void)stp_setTheme:(STPTheme *)theme {
-    [self stp_hairlineImageView].hidden = YES;
+
+- (STPTheme *)stp_theme {
+    return objc_getAssociatedObject(self, @selector(stp_theme));
+}
+
+- (void)setStp_theme:(STPTheme *)theme {
+    objc_setAssociatedObject(self, @selector(stp_theme), theme, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+    [self stp_hairlineImageView].hidden = (theme != nil);
+
+    if (!theme) {
+        return;
+    }
+
     [self stp_artificialHairlineView].backgroundColor = theme.tertiaryBackgroundColor;
     self.barTintColor = theme.primaryBackgroundColor;
     self.tintColor = theme.accentColor;
@@ -25,6 +38,11 @@ static NSInteger const STPNavigationBarHairlineViewTag = 787473;
                                  NSFontAttributeName: theme.emphasisFont,
                                  NSForegroundColorAttributeName: theme.primaryForegroundColor,
                                  };
+}
+
+
+- (void)stp_setTheme:(STPTheme *)theme {
+    [self setStp_theme:theme];
 }
 
 - (UIView *)stp_artificialHairlineView {

--- a/Tests/Tests/UINavigationBar+StripeTest.m
+++ b/Tests/Tests/UINavigationBar+StripeTest.m
@@ -1,0 +1,64 @@
+//
+//  UINavigationBar+StripeTest.m
+//  Stripe
+//
+//  Created by Brian Dorfman on 12/9/16.
+//  Copyright © 2016 Stripe, Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import <Stripe/Stripe.h>
+#import "TestSTPBackendAPIAdapter.h"
+
+@interface UINavigationBar_StripeTest : XCTestCase <STPPaymentMethodsViewControllerDelegate>
+
+@end
+
+@implementation UINavigationBar_StripeTest
+
+- (void)setUp {
+    [super setUp];
+    [STPPaymentConfiguration sharedConfiguration].publishableKey = @"pk_test";
+}
+
+- (void)paymentMethodsViewController:(__unused STPPaymentMethodsViewController *)paymentMethodsViewController didSelectPaymentMethod:(__unused id<STPPaymentMethod>)paymentMethod {
+
+}
+
+- (void)paymentMethodsViewControllerDidFinish:(__unused STPPaymentMethodsViewController *)paymentMethodsViewController {
+
+}
+
+- (void)paymentMethodsViewController:(__unused STPPaymentMethodsViewController *)paymentMethodsViewController didFailToLoadWithError:(__unused NSError *)error {
+
+}
+
+- (void)testVCUsesNavigationBarColor {
+    STPPaymentMethodsViewController *paymentMethodsVC = [[STPPaymentMethodsViewController alloc] initWithConfiguration:[STPPaymentConfiguration sharedConfiguration]
+                                                                                                                 theme:[STPTheme defaultTheme]
+                                                                                                            apiAdapter:[TestSTPBackendAPIAdapter new]
+                                                                                                              delegate:self];
+    STPTheme *navTheme = [STPTheme new];
+    navTheme.accentColor = [UIColor purpleColor];
+
+    UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:paymentMethodsVC];
+    navController.navigationBar.stp_theme = navTheme;
+    __unused UIView *view = paymentMethodsVC.view;
+    XCTAssertEqualObjects(paymentMethodsVC.navigationItem.backBarButtonItem.tintColor, [UIColor purpleColor]);
+}
+
+- (void)testVCDoesNotUseNavigationBarColor {
+
+    STPPaymentMethodsViewController *paymentMethodsVC = [[STPPaymentMethodsViewController alloc] initWithConfiguration:[STPPaymentConfiguration sharedConfiguration]
+                                                                                                                 theme:[STPTheme defaultTheme]
+                                                                                                            apiAdapter:[TestSTPBackendAPIAdapter new]
+                                                                                                              delegate:self];
+
+    __unused UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:paymentMethodsVC];
+    __unused UIView *view = paymentMethodsVC.view;
+    XCTAssertEqualObjects(paymentMethodsVC.navigationItem.backBarButtonItem.tintColor, [STPTheme defaultTheme].accentColor);
+}
+
+
+@end


### PR DESCRIPTION
If your UINavigationBar has an stp_theme, use that theme for bar button styling instead of the view controller theme.

Adds support for the use case described in https://github.com/stripe/stripe-ios/issues/480

r? @jack-stripe