### PR TITLE
If your key or backendurl is missing, fail in init

### DIFF
--- a/Example/Stripe iOS Example (Simple)/CheckoutViewController.swift
+++ b/Example/Stripe iOS Example (Simple)/CheckoutViewController.swift
@@ -60,6 +60,13 @@ class CheckoutViewController: UIViewController, STPPaymentContextDelegate {
     }
 
     init(product: String, price: Int, settings: Settings) {
+
+        let stripePublishableKey = self.stripePublishableKey
+        let backendBaseURL = self.backendBaseURL
+
+        assert(stripePublishableKey.hasPrefix("pk_"), "You must set your Stripe publishable key at the top of CheckoutViewController.swift to run this app.")
+        assert(backendBaseURL != nil, "You must set your backend base url at the top of CheckoutViewController.swift to run this app.")
+
         self.product = product
         self.productImage.text = product
         self.theme = settings.theme


### PR DESCRIPTION
As discussed in person the other week, added a nicer failure for people who run the example app without filling in their deets

r? @jack-stripe