### PR TITLE
use secondaryBackgroundColor for navigation bar

### DIFF
--- a/Example/Stripe iOS Example (Simple)/BrowseProductsViewController.swift
+++ b/Example/Stripe iOS Example (Simple)/BrowseProductsViewController.swift
@@ -43,7 +43,7 @@ class BrowseProductsViewController: UITableViewController {
         super.viewDidAppear(animated)
         let theme = self.settingsVC.settings.theme
         self.view.backgroundColor = theme.primaryBackgroundColor
-        self.navigationController?.navigationBar.barTintColor = theme.primaryBackgroundColor
+        self.navigationController?.navigationBar.barTintColor = theme.secondaryBackgroundColor
         self.navigationController?.navigationBar.tintColor = theme.accentColor
         let titleAttributes = [
             NSForegroundColorAttributeName: theme.primaryForegroundColor,

--- a/Stripe/STPAddCardViewController.m
+++ b/Stripe/STPAddCardViewController.m
@@ -224,7 +224,7 @@ typedef NS_ENUM(NSUInteger, STPPaymentCardSection) {
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle {
-    return ([STPColorUtils colorIsBright:self.theme.primaryBackgroundColor] 
+    return ([STPColorUtils colorIsBright:self.theme.secondaryBackgroundColor]
             ? UIStatusBarStyleDefault
             : UIStatusBarStyleLightContent);
 }

--- a/Stripe/STPPaymentMethodsViewController.m
+++ b/Stripe/STPPaymentMethodsViewController.m
@@ -165,7 +165,7 @@
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle {
-    return ([STPColorUtils colorIsBright:self.theme.primaryBackgroundColor] 
+    return ([STPColorUtils colorIsBright:self.theme.secondaryBackgroundColor]
             ? UIStatusBarStyleDefault
             : UIStatusBarStyleLightContent);
 }

--- a/Stripe/STPSMSCodeViewController.m
+++ b/Stripe/STPSMSCodeViewController.m
@@ -187,7 +187,7 @@
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle {
-    return ([STPColorUtils colorIsBright:self.theme.primaryBackgroundColor] 
+    return ([STPColorUtils colorIsBright:self.theme.secondaryBackgroundColor]
             ? UIStatusBarStyleDefault
             : UIStatusBarStyleLightContent);
 }

--- a/Stripe/STPShippingAddressViewController.m
+++ b/Stripe/STPShippingAddressViewController.m
@@ -168,6 +168,12 @@
     [self setNeedsStatusBarAppearanceUpdate];
 }
 
+- (UIStatusBarStyle)preferredStatusBarStyle {
+    return ([STPColorUtils colorIsBright:self.theme.secondaryBackgroundColor]
+            ? UIStatusBarStyleDefault
+            : UIStatusBarStyleLightContent);
+}
+
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
     if (![self stp_isAtRootOfNavigationController]) {

--- a/Stripe/STPShippingMethodsViewController.m
+++ b/Stripe/STPShippingMethodsViewController.m
@@ -94,6 +94,12 @@ static NSString *const STPShippingMethodCellReuseIdentifier = @"STPShippingMetho
     [self setNeedsStatusBarAppearanceUpdate];
 }
 
+- (UIStatusBarStyle)preferredStatusBarStyle {
+    return ([STPColorUtils colorIsBright:self.theme.secondaryBackgroundColor]
+            ? UIStatusBarStyleDefault
+            : UIStatusBarStyleLightContent);
+}
+
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
     [self.tableView reloadData];

--- a/Stripe/STPTheme.m
+++ b/Stripe/STPTheme.m
@@ -146,7 +146,7 @@ static UIFont  *STPThemeDefaultMediumFont;
     if (_internalBarStyle) {
         return [_internalBarStyle integerValue];
     }
-    return [self barStyleForColor:self.primaryBackgroundColor];
+    return [self barStyleForColor:self.secondaryBackgroundColor];
 }
 
 - (id)copyWithZone:(__unused NSZone *)zone {

--- a/Stripe/UINavigationBar+Stripe_Theme.m
+++ b/Stripe/UINavigationBar+Stripe_Theme.m
@@ -30,7 +30,7 @@ static NSInteger const STPNavigationBarHairlineViewTag = 787473;
     }
 
     [self stp_artificialHairlineView].backgroundColor = theme.tertiaryBackgroundColor;
-    self.barTintColor = theme.primaryBackgroundColor;
+    self.barTintColor = theme.secondaryBackgroundColor;
     self.tintColor = theme.accentColor;
     self.barStyle = theme.barStyle;
     self.translucent = theme.translucentNavigationBar;


### PR DESCRIPTION
r? @bdorfman-stripe 

This fixes the navigation bar color issue reported in #527 (introduced in #466). 

I haven't been able to reproduce the status bar color issue, however – we're correctly defining `preferredStatusBarStyle` in STPPaymentMethodsViewController. Maybe their app isn't using `UIViewControllerBasedStatusBarAppearance`? 