### PR TITLE
Improve Swift error bridging

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,5 +1,9 @@
 ## Migration Guides
 
+### Migrating from versions < 10.0
+
+- `STPErrorCode` and `STPCardErrorCode` are now first class Swift enums (before, their types were `Int` and `String`, respectively)
+
 ### Migrating from versions < 9.0
 
 Version 9.0 drops support for iOS 7.x and Xcode 7.x. If you need to support iOS or Xcode versions below 8.0, the last compatible Stripe SDK release is version 8.0.7.

--- a/Stripe/PublicHeaders/StripeError.h
+++ b/Stripe/PublicHeaders/StripeError.h
@@ -13,10 +13,12 @@
  */
 FOUNDATION_EXPORT NSString * __nonnull const StripeDomain;
 
+#define STP_ERROR_ENUM(_type, _name, _domain) \
+typedef enum _name: _type _name; \
+enum __attribute__((ns_error_domain(_domain))) _name: _type
+
 #if __has_attribute(ns_error_domain)
-// NS_ERROR_ENUM has not been defined yet: https://twitter.com/bjhomer/status/775571745197535232
-typedef enum STPError: NSInteger STPErrorCode;
-enum __attribute__((ns_error_domain(StripeDomain))) STPErrorCode: NSInteger {
+STP_ERROR_ENUM(NSInteger, STPErrorCode, StripeDomain) {
 #else
 typedef NS_ENUM(NSInteger, STPErrorCode) {
 #endif


### PR DESCRIPTION
r? @bdorfman-stripe 

Made a slight modification to #473 , adding an `STP_ERROR_ENUM` macro (the proposed `NS_ERROR_ENUM` macro still doesn't exist, but we can use our own for now).

Also to summarize the changes in practice:

```swift
// before
let errorCode: STPErrorCode = STPErrorCode.STPCardError // this is an Int
let cardErrorCode: String = STPCardDeclined // this is a String
```

```swift
// after
let errorCode: STPErrorCode = .STPCardError      // this is an enum(rawValue: Int)
let cardErrorCode: STPCardErrorCode = .declined  // this is an enum(rawValue: String)
```


