### PR TITLE
Remove escaping note from docs

### DIFF
--- a/Stripe/PublicHeaders/STPAddCardViewController.h
+++ b/Stripe/PublicHeaders/STPAddCardViewController.h
@@ -75,8 +75,6 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param addCardViewController the view controller that successfully created a token
  *  @param token                 the Stripe token that was created. @see STPToken
  *  @param completion            call this callback when you're done sending the token to your backend
- *
- *  @note If you are on Swift 3, you must declare the completion block as `@escaping` or Xcode will give you a protocol conformance error. https://bugs.swift.org/browse/SR-2597
  */
 - (void)addCardViewController:(STPAddCardViewController *)addCardViewController
                didCreateToken:(STPToken *)token

--- a/Stripe/PublicHeaders/STPBackendAPIAdapter.h
+++ b/Stripe/PublicHeaders/STPBackendAPIAdapter.h
@@ -36,8 +36,6 @@ typedef void (^STPCustomerCompletionBlock)(STPCustomer * __nullable customer, NS
  *
  *  @see STPCard
  *  @param completion call this callback when you're done fetching and parsing the above information from your backend. For example, `completion(customer, nil)` (if your call succeeds) or `completion(nil, error)` if an error is returned.
- *
- *  @note If you are on Swift 3, you must declare the completion block as `@escaping` or Xcode will give you a protocol conformance error. https://bugs.swift.org/browse/SR-2597
  */
 - (void)retrieveCustomer:(STPCustomerCompletionBlock)completion;
 
@@ -46,8 +44,6 @@ typedef void (^STPCustomerCompletionBlock)(STPCustomer * __nullable customer, NS
  *
  *  @param source     a valid payment source, such as a card token.
  *  @param completion call this callback when you're done adding the token to the customer on your backend. For example, `completion(nil)` (if your call succeeds) or `completion(error)` if an error is returned.
- *
- *  @note If you are on Swift 3, you must declare the completion block as `@escaping` or Xcode will give you a protocol conformance error. https://bugs.swift.org/browse/SR-2597
  */
 - (void)attachSourceToCustomer:(id<STPSource>)source completion:(STPErrorBlock)completion;
 
@@ -56,8 +52,6 @@ typedef void (^STPCustomerCompletionBlock)(STPCustomer * __nullable customer, NS
  *
  *  @param source     The newly-selected default source for the user.
  *  @param completion call this callback when you're done selecting the new default source for the customer on your backend. For example, `completion(nil)` (if your call succeeds) or `completion(error)` if an error is returned.
- *
- *  @note If you are on Swift 3, you must declare the completion block as `@escaping` or Xcode will give you a protocol conformance error. https://bugs.swift.org/browse/SR-2597
  */
 - (void)selectDefaultCustomerSource:(id<STPSource>)source completion:(STPErrorBlock)completion;
 

--- a/Stripe/PublicHeaders/STPPaymentContext.h
+++ b/Stripe/PublicHeaders/STPPaymentContext.h
@@ -206,8 +206,6 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param paymentContext The context that succeeded
  *  @param paymentResult  Information associated with the payment that you can pass to your server. You should go to your backend API with this payment result and make a charge to complete the payment, passing `paymentResult.source.stripeID` as the `source` parameter to the create charge method and your customer's ID as the `customer` parameter (see stripe.com/docs/api#charge_create for more info). Once that's done call the `completion` block with any error that occurred (or none, if the charge succeeded). @see STPPaymentResult.h
  *  @param completion     Call this block when you're done creating a charge (or subscription, etc) on your backend. If it succeeded, call `completion(nil)`. If it failed with an error, call `completion(error)`.
- *
- *  @note If you are on Swift 3, you must declare the completion block as `@escaping` or Xcode will give you a protocol conformance error. https://bugs.swift.org/browse/SR-2597
  */
 - (void)paymentContext:(STPPaymentContext *)paymentContext
 didCreatePaymentResult:(STPPaymentResult *)paymentResult


### PR DESCRIPTION
r? @bdorfman-stripe 

This bug has since been fixed (https://github.com/apple/swift/pull/4905)
