### PR TITLE
Add source object parsing to STPCustomer

### DIFF
--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -453,9 +453,9 @@
 		C1717DB11CC00ED60009CF4A /* STPAddress.h in Headers */ = {isa = PBXBuildFile; fileRef = C1080F471CBECF7B007B2D89 /* STPAddress.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C17A030D1CBEE7A2006C819F /* STPAddressFieldTableViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = C17A030B1CBEE7A2006C819F /* STPAddressFieldTableViewCell.h */; };
 		C17A030E1CBEE7A2006C819F /* STPAddressFieldTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = C17A030C1CBEE7A2006C819F /* STPAddressFieldTableViewCell.m */; };
+		C17D24EE1E37DBAC005CB188 /* STPSourceTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C17D24ED1E37DBAC005CB188 /* STPSourceTest.m */; };
 		C1A06F101E1D8A7F004DCA06 /* STPCard+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = C1A06F0F1E1D8A6E004DCA06 /* STPCard+Private.h */; };
 		C1A06F111E1D8A7F004DCA06 /* STPCard+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = C1A06F0F1E1D8A6E004DCA06 /* STPCard+Private.h */; };
-		C17D24EE1E37DBAC005CB188 /* STPSourceTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C17D24ED1E37DBAC005CB188 /* STPSourceTest.m */; };
 		C1B630BB1D1D860100A05285 /* stp_card_amex.png in Resources */ = {isa = PBXBuildFile; fileRef = 0438EF891B741C2800D506CC /* stp_card_amex.png */; };
 		C1B630BC1D1D860100A05285 /* stp_card_amex@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 0438EF8A1B741C2800D506CC /* stp_card_amex@2x.png */; };
 		C1B630BD1D1D860100A05285 /* stp_card_amex@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 0438EF8B1B741C2800D506CC /* stp_card_amex@3x.png */; };
@@ -602,6 +602,8 @@
 		F1852F951D80B6EC00367C86 /* STPStringUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = F1852F921D80B6EC00367C86 /* STPStringUtils.m */; };
 		F1852F961D80B6EC00367C86 /* STPStringUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = F1852F921D80B6EC00367C86 /* STPStringUtils.m */; };
 		F1B980941DB550E60075332E /* STPPaymentMethodsViewControllerLocalizationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F1B980931DB550E60075332E /* STPPaymentMethodsViewControllerLocalizationTests.m */; };
+		F1BA241E1E57BE5E00E4A1CF /* CardSource.json in Resources */ = {isa = PBXBuildFile; fileRef = F1BA241C1E57BE5700E4A1CF /* CardSource.json */; };
+		F1BA24211E57BECA00E4A1CF /* 3DSSource.json in Resources */ = {isa = PBXBuildFile; fileRef = F1BA241F1E57BEC600E4A1CF /* 3DSSource.json */; };
 		F1C578F11D651AB200912EAE /* stp_card_applepay.png in Resources */ = {isa = PBXBuildFile; fileRef = F1C578F01D651AB200912EAE /* stp_card_applepay.png */; };
 		F1C7B8D31DBECF2400D9F6F0 /* STPDispatchFunctions.m in Sources */ = {isa = PBXBuildFile; fileRef = F1C7B8D11DBECF2400D9F6F0 /* STPDispatchFunctions.m */; };
 		F1C7B8D41DBECF2400D9F6F0 /* STPDispatchFunctions.m in Sources */ = {isa = PBXBuildFile; fileRef = F1C7B8D11DBECF2400D9F6F0 /* STPDispatchFunctions.m */; };
@@ -968,8 +970,8 @@
 		C16F66AA1CA21BAC006A21B5 /* STPFormTextFieldTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPFormTextFieldTest.m; sourceTree = "<group>"; };
 		C17A030B1CBEE7A2006C819F /* STPAddressFieldTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPAddressFieldTableViewCell.h; sourceTree = "<group>"; };
 		C17A030C1CBEE7A2006C819F /* STPAddressFieldTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPAddressFieldTableViewCell.m; sourceTree = "<group>"; };
-		C1A06F0F1E1D8A6E004DCA06 /* STPCard+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCard+Private.h"; sourceTree = "<group>"; };
 		C17D24ED1E37DBAC005CB188 /* STPSourceTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPSourceTest.m; sourceTree = "<group>"; };
+		C1A06F0F1E1D8A6E004DCA06 /* STPCard+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCard+Private.h"; sourceTree = "<group>"; };
 		C1B630B31D1D817900A05285 /* Stripe.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Stripe.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		C1B630B51D1D817900A05285 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C1BD9B1E1E390A2700CEE925 /* STPSourceParamsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPSourceParamsTest.m; sourceTree = "<group>"; };
@@ -1040,6 +1042,8 @@
 		F1852F911D80B6EC00367C86 /* STPStringUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPStringUtils.h; sourceTree = "<group>"; };
 		F1852F921D80B6EC00367C86 /* STPStringUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPStringUtils.m; sourceTree = "<group>"; };
 		F1B980931DB550E60075332E /* STPPaymentMethodsViewControllerLocalizationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodsViewControllerLocalizationTests.m; sourceTree = "<group>"; };
+		F1BA241C1E57BE5700E4A1CF /* CardSource.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = CardSource.json; sourceTree = "<group>"; };
+		F1BA241F1E57BEC600E4A1CF /* 3DSSource.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = 3DSSource.json; sourceTree = "<group>"; };
 		F1C578F01D651AB200912EAE /* stp_card_applepay.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_applepay.png; sourceTree = "<group>"; };
 		F1C7B8D11DBECF2400D9F6F0 /* STPDispatchFunctions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPDispatchFunctions.m; sourceTree = "<group>"; };
 		F1C7B8D21DBECF2400D9F6F0 /* STPDispatchFunctions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPDispatchFunctions.h; sourceTree = "<group>"; };
@@ -1491,6 +1495,8 @@
 			children = (
 				C1D23FB31D37FE0B002FD83C /* Card.json */,
 				C1D23FB41D37FE0B002FD83C /* Customer.json */,
+				F1BA241C1E57BE5700E4A1CF /* CardSource.json */,
+				F1BA241F1E57BEC600E4A1CF /* 3DSSource.json */,
 			);
 			name = JSON;
 			sourceTree = "<group>";
@@ -2000,6 +2006,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				F1343BEA1D652CAD00F102D8 /* Customer.json in Resources */,
+				F1BA24211E57BECA00E4A1CF /* 3DSSource.json in Resources */,
+				F1BA241E1E57BE5E00E4A1CF /* CardSource.json in Resources */,
 				F1343BE91D652CAB00F102D8 /* Card.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Stripe/STPCustomer.m
+++ b/Stripe/STPCustomer.m
@@ -9,6 +9,7 @@
 #import "STPCustomer.h"
 
 #import "STPCard.h"
+#import "STPSource.h"
 #import "StripeError.h"
 
 @interface STPCustomer()
@@ -82,12 +83,23 @@
             for (id contents in json[@"sources"][@"data"]) {
                 if ([contents isKindOfClass:[NSDictionary class]]) {
                     // eventually support other source types
-                    STPCard *card = [STPCard decodedObjectFromAPIResponse:contents];
-                    // ignore apple pay cards from the response
-                    if (card && !card.isApplePayCard) {
-                        [sources addObject:card];
-                        if (defaultSourceId && [card.stripeID isEqualToString:defaultSourceId]) {
-                            customer.defaultSource = card;
+                    if ([contents[@"object"] isEqualToString:@"card"]) {
+                        STPCard *card = [STPCard decodedObjectFromAPIResponse:contents];
+                        // ignore apple pay cards from the response
+                        if (card && !card.isApplePayCard) {
+                            [sources addObject:card];
+                            if (defaultSourceId && [card.stripeID isEqualToString:defaultSourceId]) {
+                                customer.defaultSource = card;
+                            }
+                        }
+                    }
+                    else if ([contents[@"object"] isEqualToString:@"source"]) {
+                        STPSource *source = [STPSource decodedObjectFromAPIResponse:contents];
+                        if (source) {
+                            [sources addObject:source];
+                            if (defaultSourceId && [source.stripeID isEqualToString:defaultSourceId]) {
+                                customer.defaultSource = source;
+                            }
                         }
                     }
                 }

--- a/Tests/Tests/3DSSource.json
+++ b/Tests/Tests/3DSSource.json
@@ -1,0 +1,34 @@
+{
+    "id": "src_456",
+    "object": "source",
+    "amount": 1099,
+    "client_secret": "src_client_secret_456",
+    "created": 1483663790,
+    "currency": "eur",
+    "flow": "redirect",
+    "livemode": false,
+    "metadata": {},
+    "owner": {
+        "address": null,
+        "email": null,
+        "name": null,
+        "phone": null,
+        "verified_address": null,
+        "verified_email": null,
+        "verified_name": null,
+        "verified_phone": null
+    },
+    "redirect": {
+        "return_url": "exampleappschema://stripe_callback",
+        "status": "pending",
+        "url": "https://hooks.stripe.com/redirect/authenticate/src_19YlvWAHEMiOZZp1QQlOD79v?client_secret=src_client_secret_kBwCSm6Xz5MQETiJ43hUH8qv"
+    },
+    "status": "pending",
+    "type": "three_d_secure",
+    "usage": "single_use",
+    "three_d_secure": {
+        "card": "src_123",
+        "customer": null,
+        "authenticated": false
+    }
+}

--- a/Tests/Tests/CardSource.json
+++ b/Tests/Tests/CardSource.json
@@ -1,0 +1,36 @@
+{
+    "id": "src_123",
+    "object": "source",
+    "amount": null,
+    "client_secret": "src_client_secret_123",
+    "created": 1483575790,
+    "currency": null,
+    "flow": "none",
+    "livemode": false,
+    "metadata": {},
+    "owner": {
+        "address": null,
+        "email": null,
+        "name": null,
+        "phone": null,
+        "verified_address": null,
+        "verified_email": null,
+        "verified_name": null,
+        "verified_phone": null
+    },
+    "status": "chargeable",
+    "type": "card",
+    "usage": "reusable",
+    "card": {
+        "exp_month": 12,
+        "exp_year": 2018,
+        "brand": "Visa",
+        "country": "US",
+        "cvc_check": "unchecked",
+        "funding": "credit",
+        "last4": "4242",
+        "three_d_secure": "not_supported",
+        "address_line1_check": null,
+        "address_zip_check": null
+    }
+}

--- a/Tests/Tests/STPCustomerDeserializerTest.m
+++ b/Tests/Tests/STPCustomerDeserializerTest.m
@@ -56,16 +56,23 @@
 - (void)testInitWithJSONResponse_validJSON {
     NSMutableDictionary *card1 = [[STPTestUtils jsonNamed:@"Card"] mutableCopy];
     card1[@"id"] = @"card_123";
+
     NSMutableDictionary *card2 = [[STPTestUtils jsonNamed:@"Card"] mutableCopy];
     card2[@"id"] = @"card_456";
+
     NSMutableDictionary *applePayCard1 = [[STPTestUtils jsonNamed:@"Card"] mutableCopy];
     applePayCard1[@"id"] = @"card_apple_pay1";
     applePayCard1[@"tokenization_method"] = @"apple_pay";
+
     NSMutableDictionary *applePayCard2 = [applePayCard1 mutableCopy];
     applePayCard2[@"id"] = @"card_apple_pay2";
+
+    NSDictionary *cardSource = [STPTestUtils jsonNamed:@"CardSource"];
+    NSDictionary *threeDSSource = [STPTestUtils jsonNamed:@"3DSSource"];
+
     NSMutableDictionary *customer = [[STPTestUtils jsonNamed:@"Customer"] mutableCopy];
     NSMutableDictionary *sources = [customer[@"sources"] mutableCopy];
-    sources[@"data"] = @[applePayCard1, card1, applePayCard2, card2];
+    sources[@"data"] = @[applePayCard1, card1, applePayCard2, card2, cardSource, threeDSSource];
     customer[@"default_source"] = card1[@"id"];
     customer[@"sources"] = sources;
 
@@ -73,10 +80,12 @@
     XCTAssertNotNil(sut.customer);
     XCTAssertNil(sut.error);
     XCTAssertEqualObjects(sut.customer.stripeID, customer[@"id"]);
-    XCTAssertTrue(sut.customer.sources.count == 2);
+    XCTAssertTrue(sut.customer.sources.count == 4);
     XCTAssertEqualObjects(sut.customer.sources[0].stripeID, card1[@"id"]);
     XCTAssertEqualObjects(sut.customer.sources[1].stripeID, card2[@"id"]);
     XCTAssertEqualObjects(sut.customer.defaultSource.stripeID, card1[@"id"]);
+    XCTAssertEqualObjects(sut.customer.sources[2].stripeID, cardSource[@"id"]);
+    XCTAssertEqualObjects(sut.customer.sources[3].stripeID, threeDSSource[@"id"]);
 }
 
 @end


### PR DESCRIPTION
All STPPaymentContext stuff that reads from Customer already checks to see if the source is an STPCard (and skips it if not) so I think this change should be ok.

Merge target is bg-sources because I need STPSource and it's not in master yet. Can change if it gets merged.