### PR TITLE
Update STPSource enums

### DIFF
--- a/Stripe/PublicHeaders/STPSource.h
+++ b/Stripe/PublicHeaders/STPSource.h
@@ -18,10 +18,15 @@
  *  Authentication flows for a Source
  */
 typedef NS_ENUM(NSInteger, STPSourceFlow) {
-    STPSourceFlowRedirect,
-    STPSourceFlowReceiver,
-    STPSourceFlowVerification,
+    // No action is required from your customer.
     STPSourceFlowNone,
+    // Your customer must be redirected to their online banking service (either a website or mobile banking app) to approve the payment.
+    STPSourceFlowRedirect,
+    // Your customer must verify ownership of their account by providing a code that you post to the Stripe API for authentication.
+    STPSourceFlowCodeVerification,
+    // Your customer must push funds to the account information provided.
+    STPSourceFlowReceiver,
+    // The source's flow is unknown. You shouldn't encounter this value.
     STPSourceFlowUnknown
 };
 
@@ -29,8 +34,11 @@ typedef NS_ENUM(NSInteger, STPSourceFlow) {
  *  Usage types for a Source
  */
 typedef NS_ENUM(NSInteger, STPSourceUsage) {
+    // The source can be reused.
     STPSourceUsageReusable,
+    // The source can only be used once.
     STPSourceUsageSingleUse,
+    // The source's usage is unknown. You shouldn't encounter this value.
     STPSourceUsageUnknown
 };
 
@@ -38,10 +46,17 @@ typedef NS_ENUM(NSInteger, STPSourceUsage) {
  *  Status types for a Source
  */
 typedef NS_ENUM(NSInteger, STPSourceStatus) {
+    // The source has been created and is awaiting customer action.
     STPSourceStatusPending,
+    // The source is ready to use. The customer action has been completed or the payment method requires no customer action.
     STPSourceStatusChargeable,
+    // The source has been used. This status only applies to single-use sources.
     STPSourceStatusConsumed,
+    // The source, which was chargeable, has expired because it was not used to make a charge request within a specified amount of time.
     STPSourceStatusCanceled,
+    // Your customer has not taken the required action or revoked your access (e.g., did not authorize the payment with their bank or canceled their mandate acceptance for SEPA direct debits).
+    STPSourceStatusFailed,
+    // The source status is unknown. You shouldn't encounter this value.
     STPSourceStatusUnknown,
 };
 

--- a/Stripe/STPSource.m
+++ b/Stripe/STPSource.m
@@ -68,7 +68,7 @@
     return @{
              @"redirect": @(STPSourceFlowRedirect),
              @"receiver": @(STPSourceFlowReceiver),
-             @"verification": @(STPSourceFlowVerification),
+             @"code_verification": @(STPSourceFlowCodeVerification),
              @"none": @(STPSourceFlowNone)
              };
 }
@@ -97,6 +97,8 @@
         return STPSourceStatusConsumed;
     } else if ([status isEqualToString:@"canceled"]) {
         return STPSourceStatusCanceled;
+    } else if ([status isEqualToString:@"failed"]) {
+        return STPSourceStatusFailed;
     } else {
         return STPSourceStatusUnknown;
     }


### PR DESCRIPTION
r? @bdorfman-stripe 

- Added comments to each enum value
- Changed "verification" to "code_verification" (I think the docs were wrong when I first implemented this)
- Added the "failed" status, which we were missing :/