### PR TITLE
Add muid to card token creation

### DIFF
--- a/Stripe/STPAPIClient+Private.h
+++ b/Stripe/STPAPIClient+Private.h
@@ -18,8 +18,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithPublishableKey:(NSString *)publishableKey
                                baseURL:(NSString *)baseURL;
 
-- (void)createTokenWithData:(NSData *)data
-                 completion:(STPTokenCompletionBlock)completion;
+- (void)createTokenWithParameters:(NSDictionary *)parameters
+                       completion:(STPTokenCompletionBlock)completion;
 
 - (NSURLSessionDataTask *)retrieveSourceWithId:(NSString *)identifier clientSecret:(NSString *)secret responseCompletion:(STPAPIResponseBlock)completion;
 

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -129,15 +129,15 @@ static NSString *const stripeAPIVersion = @"2015-10-12";
     return self.configuration.publishableKey;
 }
 
-- (void)createTokenWithData:(NSData *)data
-                 completion:(STPTokenCompletionBlock)completion {
-    NSCAssert(data != nil, @"'data' is required to create a token");
+- (void)createTokenWithParameters:(NSDictionary *)parameters
+                       completion:(STPTokenCompletionBlock)completion {
+    NSCAssert(parameters != nil, @"'parameters' is required to create a token");
     NSCAssert(completion != nil, @"'completion' is required to use the token that is created");
     NSDate *start = [NSDate date];
     [[STPAnalyticsClient sharedClient] logTokenCreationAttemptWithConfiguration:self.configuration];
     [STPAPIRequest<STPToken *> postWithAPIClient:self
                                         endpoint:tokenEndpoint
-                                        postData:data
+                                      parameters:parameters
                                       serializer:[STPToken new]
                                       completion:^(STPToken *object, NSHTTPURLResponse *response, NSError *error) {
                                           NSDate *end = [NSDate date];
@@ -235,8 +235,8 @@ static NSString *const stripeAPIVersion = @"2015-10-12";
 
 - (void)createTokenWithBankAccount:(STPBankAccountParams *)bankAccount
                         completion:(STPTokenCompletionBlock)completion {
-    NSData *data = [STPFormEncoder formEncodedDataForObject:bankAccount];
-    [self createTokenWithData:data completion:completion];
+    NSDictionary *params = [STPFormEncoder dictionaryForObject:bankAccount];
+    [self createTokenWithParameters:params completion:completion];
 }
 
 @end
@@ -245,8 +245,8 @@ static NSString *const stripeAPIVersion = @"2015-10-12";
 @implementation STPAPIClient (CreditCards)
 
 - (void)createTokenWithCard:(STPCard *)card completion:(STPTokenCompletionBlock)completion {
-    NSData *data = [STPFormEncoder formEncodedDataForObject:card];
-    [self createTokenWithData:data completion:completion];
+    NSDictionary *params = [STPFormEncoder dictionaryForObject:card];
+    [self createTokenWithParameters:params completion:completion];
 }
 
 @end
@@ -294,16 +294,16 @@ static NSString *const stripeAPIVersion = @"2015-10-12";
 
 @implementation STPAPIClient (Sources)
 
-- (void)createSourceWithParams:(STPSourceParams *)params completion:(STPSourceCompletionBlock)completion {
-    NSCAssert(params != nil, @"'params' is required to create a source");
+- (void)createSourceWithParams:(STPSourceParams *)sourceParams completion:(STPSourceCompletionBlock)completion {
+    NSCAssert(sourceParams != nil, @"'params' is required to create a source");
     NSCAssert(completion != nil, @"'completion' is required to use the source that is created");
-    NSString *sourceType = [STPSource stringFromType:params.type];
+    NSString *sourceType = [STPSource stringFromType:sourceParams.type];
     [[STPAnalyticsClient sharedClient] logSourceCreationAttemptWithConfiguration:self.configuration
                                                                       sourceType:sourceType];
-    NSData *data = [STPFormEncoder formEncodedDataForObject:params];
+    NSDictionary *params = [STPFormEncoder dictionaryForObject:sourceParams];
     [STPAPIRequest<STPSource *> postWithAPIClient:self
                                          endpoint:sourcesEndpoint
-                                         postData:data
+                                       parameters:params
                                        serializer:[STPSource new]
                                        completion:^(STPSource *object, __unused NSHTTPURLResponse *response, NSError *error) {
                                            completion(object, error);

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -245,7 +245,8 @@ static NSString *const stripeAPIVersion = @"2015-10-12";
 @implementation STPAPIClient (CreditCards)
 
 - (void)createTokenWithCard:(STPCard *)card completion:(STPTokenCompletionBlock)completion {
-    NSDictionary *params = [STPFormEncoder dictionaryForObject:card];
+    NSMutableDictionary *params = [[STPFormEncoder dictionaryForObject:card] mutableCopy];
+    params[@"muid"] = [STPAnalyticsClient muid];
     [self createTokenWithParameters:params completion:completion];
 }
 

--- a/Stripe/STPAPIRequest.h
+++ b/Stripe/STPAPIRequest.h
@@ -16,7 +16,7 @@ typedef void(^STPAPIResponseBlock)(ResponseType object, NSHTTPURLResponse *respo
 
 + (NSURLSessionDataTask *)postWithAPIClient:(STPAPIClient *)apiClient
                                    endpoint:(NSString *)endpoint
-                                   postData:(NSData *)postData
+                                 parameters:(NSDictionary *)parameters
                                  serializer:(ResponseType)serializer
                                  completion:(STPAPIResponseBlock)completion;
 

--- a/Stripe/STPAPIRequest.m
+++ b/Stripe/STPAPIRequest.m
@@ -6,25 +6,28 @@
 //  Copyright © 2015 Stripe, Inc. All rights reserved.
 //
 
+#import "STPAPIRequest.h"
+
 #import "NSMutableURLRequest+Stripe.h"
 #import "STPAPIClient+Private.h"
 #import "STPAPIClient.h"
 #import "STPDispatchFunctions.h"
-#import "STPAPIRequest.h"
+#import "STPFormEncoder.h"
 #import "StripeError.h"
 
 @implementation STPAPIRequest
 
 + (NSURLSessionDataTask *)postWithAPIClient:(STPAPIClient *)apiClient
                                    endpoint:(NSString *)endpoint
-                                   postData:(NSData *)postData
+                                 parameters:(NSDictionary *)parameters
                                  serializer:(id<STPAPIResponseDecodable>)serializer
                                  completion:(STPAPIResponseBlock)completion {
 
     NSURL *url = [apiClient.apiURL URLByAppendingPathComponent:endpoint];
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url];
     request.HTTPMethod = @"POST";
-    request.HTTPBody = postData;
+    NSString *query = [STPFormEncoder queryStringFromParameters:parameters];
+    request.HTTPBody = [query dataUsingEncoding:NSUTF8StringEncoding];
     
     NSURLSessionDataTask *task = [apiClient.urlSession dataTaskWithRequest:request completionHandler:^(NSData * _Nullable body, NSURLResponse * _Nullable response, NSError * _Nullable error) {
         [[self class] parseResponse:response

--- a/Stripe/STPAnalyticsClient.h
+++ b/Stripe/STPAnalyticsClient.h
@@ -27,6 +27,8 @@ typedef NS_ENUM(NSUInteger, STPAddCardRememberMeUsage) {
 
 + (void)disableAnalytics;
 
++ (NSString *)muid;
+
 - (void)logRememberMeConversion:(STPAddCardRememberMeUsage)selected;
 
 - (void)logTokenCreationAttemptWithConfiguration:(STPPaymentConfiguration *)configuration;

--- a/Stripe/STPAnalyticsClient.m
+++ b/Stripe/STPAnalyticsClient.m
@@ -109,6 +109,10 @@ static BOOL STPAnalyticsCollectionDisabled = NO;
     return @((NSInteger)([date timeIntervalSince1970]*1000));
 }
 
++ (NSString *)muid {
+    return [[[UIDevice currentDevice] identifierForVendor] UUIDString];
+}
+
 - (instancetype)init {
     self = [super init];
     if (self) {

--- a/Stripe/STPFormEncoder.h
+++ b/Stripe/STPFormEncoder.h
@@ -13,8 +13,6 @@
 
 @interface STPFormEncoder : NSObject
 
-+ (nonnull NSData *)formEncodedDataForObject:(nonnull NSObject<STPFormEncodable> *)object;
-
 + (nonnull NSDictionary *)dictionaryForObject:(nonnull NSObject<STPFormEncodable> *)object;
 
 + (nonnull NSString *)stringByURLEncoding:(nonnull NSString *)string;

--- a/Stripe/STPFormEncoder.m
+++ b/Stripe/STPFormEncoder.m
@@ -26,11 +26,6 @@ FOUNDATION_EXPORT NSString * STPQueryStringFromParameters(NSDictionary *paramete
     return [camelCaseParam copy];
 }
 
-+ (nonnull NSData *)formEncodedDataForObject:(nonnull NSObject<STPFormEncodable> *)object {
-    NSDictionary *dict = [self dictionaryForObject:object];
-    return [STPQueryStringFromParameters(dict) dataUsingEncoding:NSUTF8StringEncoding];
-}
-
 + (NSDictionary *)dictionaryForObject:(nonnull NSObject<STPFormEncodable> *)object {
     NSDictionary *keyPairs = [self keyPairDictionaryForObject:object];
     NSString *rootObjectName = [object.class rootObjectName];

--- a/Tests/Tests/STPCertTest.m
+++ b/Tests/Tests/STPCertTest.m
@@ -26,14 +26,14 @@ NSString *const STPExamplePublishableKey = @"bad_key";
 - (void)testNoError {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Token creation"];
     STPAPIClient *client = [[STPAPIClient alloc] initWithPublishableKey:STPExamplePublishableKey];
-    [client createTokenWithData:[NSData new]
-                     completion:^(STPToken *token, NSError *error) {
-                         [expectation fulfill];
-                         // Note that this API request *will* fail, but it will return error
-                         // messages from the server and not be blocked by local cert checks
-                         XCTAssertNil(token, @"Expected no token");
-                         XCTAssertNotNil(error, @"Expected error");
-                     }];
+    [client createTokenWithParameters:@{}
+                           completion:^(STPToken *token, NSError *error) {
+                               [expectation fulfill];
+                               // Note that this API request *will* fail, but it will return error
+                               // messages from the server and not be blocked by local cert checks
+                               XCTAssertNil(token, @"Expected no token");
+                               XCTAssertNotNil(error, @"Expected error");
+                           }];
     [self waitForExpectationsWithTimeout:10.0f handler:nil];
 }
 
@@ -60,12 +60,11 @@ NSString *const STPExamplePublishableKey = @"bad_key";
     XCTestExpectation *expectation = [self expectationWithDescription:@"Token creation"];
     STPAPIClient *client = [[STPAPIClient alloc] initWithPublishableKey:STPExamplePublishableKey];
     client.apiURL = baseURL;
-    [client createTokenWithData:[NSData new]
-                     completion:^(STPToken *token, NSError *error) {
-                         [expectation fulfill];
-                         completion(token, error);
-                     }];
-
+    [client createTokenWithParameters:@{}
+                           completion:^(STPToken *token, NSError *error) {
+                               [expectation fulfill];
+                               completion(token, error);
+                           }];
     [self waitForExpectationsWithTimeout:10.0f handler:nil];
 }
 

--- a/Tests/Tests/STPFormEncoderTest.m
+++ b/Tests/Tests/STPFormEncoderTest.m
@@ -60,8 +60,9 @@
 
 // helper test method
 - (NSString *)encodeObject:(STPTestFormEncodableObject *)object {
-    NSData *encoded = [STPFormEncoder formEncodedDataForObject:object];
-    return [[[NSString alloc] initWithData:encoded encoding:NSUTF8StringEncoding] stringByRemovingPercentEncoding];
+    NSDictionary *dictionary = [STPFormEncoder dictionaryForObject:object];
+    NSString *queryString = [STPFormEncoder queryStringFromParameters:dictionary];
+    return [queryString stringByRemovingPercentEncoding];
 }
 
 - (void)testFormEncoding_emptyObject {


### PR DESCRIPTION
r? @bdorfman-stripe 
cc @matt-stripe 

* I've replaced the data parameter in `createTokenWithData` and `postWithAPIClient` with a dictionary.
* For card tokens, I've added an `muid` parameter to the request.
* I've QA'd this pretty thoroughly, and our existing functional tests cover the change pretty well. I've also verified that the `muid` we send gets saved to the token's external metadata.
