### PR TITLE
[sources-ui] STPSourceInfoViewController

### DIFF
--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -454,10 +454,34 @@
 		C17A030D1CBEE7A2006C819F /* STPAddressFieldTableViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = C17A030B1CBEE7A2006C819F /* STPAddressFieldTableViewCell.h */; };
 		C17A030E1CBEE7A2006C819F /* STPAddressFieldTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = C17A030C1CBEE7A2006C819F /* STPAddressFieldTableViewCell.m */; };
 		C17D24EE1E37DBAC005CB188 /* STPSourceTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C17D24ED1E37DBAC005CB188 /* STPSourceTest.m */; };
+		C17F28B81E4CD13A0073408B /* STPSourceInfoViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = C17F28B61E4CD13A0073408B /* STPSourceInfoViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C17F28B91E4CD13A0073408B /* STPSourceInfoViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = C17F28B61E4CD13A0073408B /* STPSourceInfoViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C17F28BA1E4CD13A0073408B /* STPSourceInfoViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C17F28B71E4CD13A0073408B /* STPSourceInfoViewController.m */; };
+		C17F28BB1E4CD13A0073408B /* STPSourceInfoViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C17F28B71E4CD13A0073408B /* STPSourceInfoViewController.m */; };
 		C180211A1E3A58710089D712 /* STPSourcePoller.h in Headers */ = {isa = PBXBuildFile; fileRef = C18021181E3A58710089D712 /* STPSourcePoller.h */; };
 		C180211B1E3A58710089D712 /* STPSourcePoller.h in Headers */ = {isa = PBXBuildFile; fileRef = C18021181E3A58710089D712 /* STPSourcePoller.h */; };
 		C180211C1E3A58710089D712 /* STPSourcePoller.m in Sources */ = {isa = PBXBuildFile; fileRef = C18021191E3A58710089D712 /* STPSourcePoller.m */; };
 		C180211D1E3A58710089D712 /* STPSourcePoller.m in Sources */ = {isa = PBXBuildFile; fileRef = C18021191E3A58710089D712 /* STPSourcePoller.m */; };
+		C18880081E68CDA700FB169F /* STPBancontactSourceInfoDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = C18880061E68CDA700FB169F /* STPBancontactSourceInfoDataSource.h */; };
+		C18880091E68CDA700FB169F /* STPBancontactSourceInfoDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = C18880061E68CDA700FB169F /* STPBancontactSourceInfoDataSource.h */; };
+		C188800A1E68CDA700FB169F /* STPBancontactSourceInfoDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = C18880071E68CDA700FB169F /* STPBancontactSourceInfoDataSource.m */; };
+		C188800B1E68CDA700FB169F /* STPBancontactSourceInfoDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = C18880071E68CDA700FB169F /* STPBancontactSourceInfoDataSource.m */; };
+		C188800E1E68CDCC00FB169F /* STPGiropaySourceInfoDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = C188800C1E68CDCC00FB169F /* STPGiropaySourceInfoDataSource.h */; };
+		C188800F1E68CDCC00FB169F /* STPGiropaySourceInfoDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = C188800C1E68CDCC00FB169F /* STPGiropaySourceInfoDataSource.h */; };
+		C18880101E68CDCC00FB169F /* STPGiropaySourceInfoDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = C188800D1E68CDCC00FB169F /* STPGiropaySourceInfoDataSource.m */; };
+		C18880111E68CDCC00FB169F /* STPGiropaySourceInfoDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = C188800D1E68CDCC00FB169F /* STPGiropaySourceInfoDataSource.m */; };
+		C18880141E68CDDE00FB169F /* STPIDEALSourceInfoDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = C18880121E68CDDE00FB169F /* STPIDEALSourceInfoDataSource.h */; };
+		C18880151E68CDDE00FB169F /* STPIDEALSourceInfoDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = C18880121E68CDDE00FB169F /* STPIDEALSourceInfoDataSource.h */; };
+		C18880161E68CDDE00FB169F /* STPIDEALSourceInfoDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = C18880131E68CDDE00FB169F /* STPIDEALSourceInfoDataSource.m */; };
+		C18880171E68CDDE00FB169F /* STPIDEALSourceInfoDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = C18880131E68CDDE00FB169F /* STPIDEALSourceInfoDataSource.m */; };
+		C188801A1E68CDEC00FB169F /* STPSofortSourceInfoDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = C18880181E68CDEC00FB169F /* STPSofortSourceInfoDataSource.h */; };
+		C188801B1E68CDEC00FB169F /* STPSofortSourceInfoDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = C18880181E68CDEC00FB169F /* STPSofortSourceInfoDataSource.h */; };
+		C188801C1E68CDEC00FB169F /* STPSofortSourceInfoDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = C18880191E68CDEC00FB169F /* STPSofortSourceInfoDataSource.m */; };
+		C188801D1E68CDEC00FB169F /* STPSofortSourceInfoDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = C18880191E68CDEC00FB169F /* STPSofortSourceInfoDataSource.m */; };
+		C18880201E68D40300FB169F /* STPSourceInfoDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = C188801E1E68D40300FB169F /* STPSourceInfoDataSource.h */; };
+		C18880211E68D40300FB169F /* STPSourceInfoDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = C188801E1E68D40300FB169F /* STPSourceInfoDataSource.h */; };
+		C18880221E68D40300FB169F /* STPSourceInfoDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = C188801F1E68D40300FB169F /* STPSourceInfoDataSource.m */; };
+		C18880231E68D40300FB169F /* STPSourceInfoDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = C188801F1E68D40300FB169F /* STPSourceInfoDataSource.m */; };
 		C1A06F101E1D8A7F004DCA06 /* STPCard+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = C1A06F0F1E1D8A6E004DCA06 /* STPCard+Private.h */; };
 		C1A06F111E1D8A7F004DCA06 /* STPCard+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = C1A06F0F1E1D8A6E004DCA06 /* STPCard+Private.h */; };
 		C1B630BB1D1D860100A05285 /* stp_card_amex.png in Resources */ = {isa = PBXBuildFile; fileRef = 0438EF891B741C2800D506CC /* stp_card_amex.png */; };
@@ -487,6 +511,22 @@
 		C1B630D61D1D860100A05285 /* stp_card_visa.png in Resources */ = {isa = PBXBuildFile; fileRef = 0438EFA11B741C2800D506CC /* stp_card_visa.png */; };
 		C1B630D71D1D860100A05285 /* stp_card_visa@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 0438EFA21B741C2800D506CC /* stp_card_visa@2x.png */; };
 		C1B630D81D1D860100A05285 /* stp_card_visa@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 0438EFA31B741C2800D506CC /* stp_card_visa@3x.png */; };
+		C1BB222A1E4CEB4300E72B8E /* STPTextFieldTableViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = C1BB22281E4CEB4300E72B8E /* STPTextFieldTableViewCell.h */; };
+		C1BB222B1E4CEB4300E72B8E /* STPTextFieldTableViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = C1BB22281E4CEB4300E72B8E /* STPTextFieldTableViewCell.h */; };
+		C1BB222C1E4CEB4300E72B8E /* STPTextFieldTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = C1BB22291E4CEB4300E72B8E /* STPTextFieldTableViewCell.m */; };
+		C1BB222D1E4CEB4300E72B8E /* STPTextFieldTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = C1BB22291E4CEB4300E72B8E /* STPTextFieldTableViewCell.m */; };
+		C1BB22311E4D258600E72B8E /* STPPickerTableViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = C1BB222F1E4D258600E72B8E /* STPPickerTableViewCell.h */; };
+		C1BB22321E4D258600E72B8E /* STPPickerTableViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = C1BB222F1E4D258600E72B8E /* STPPickerTableViewCell.h */; };
+		C1BB22331E4D258600E72B8E /* STPPickerTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = C1BB22301E4D258600E72B8E /* STPPickerTableViewCell.m */; };
+		C1BB22341E4D258600E72B8E /* STPPickerTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = C1BB22301E4D258600E72B8E /* STPPickerTableViewCell.m */; };
+		C1BB22371E4D2D2200E72B8E /* STPCountryPickerDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = C1BB22351E4D2D2200E72B8E /* STPCountryPickerDataSource.h */; };
+		C1BB22381E4D2D2200E72B8E /* STPCountryPickerDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = C1BB22351E4D2D2200E72B8E /* STPCountryPickerDataSource.h */; };
+		C1BB22391E4D2D2200E72B8E /* STPCountryPickerDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = C1BB22361E4D2D2200E72B8E /* STPCountryPickerDataSource.m */; };
+		C1BB223A1E4D2D2200E72B8E /* STPCountryPickerDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = C1BB22361E4D2D2200E72B8E /* STPCountryPickerDataSource.m */; };
+		C1BB223E1E4E1EF000E72B8E /* STPBankPickerDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = C1BB223C1E4E1EF000E72B8E /* STPBankPickerDataSource.h */; };
+		C1BB223F1E4E1EF000E72B8E /* STPBankPickerDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = C1BB223C1E4E1EF000E72B8E /* STPBankPickerDataSource.h */; };
+		C1BB22401E4E1EF000E72B8E /* STPBankPickerDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = C1BB223D1E4E1EF000E72B8E /* STPBankPickerDataSource.m */; };
+		C1BB22411E4E1EF000E72B8E /* STPBankPickerDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = C1BB223D1E4E1EF000E72B8E /* STPBankPickerDataSource.m */; };
 		C1BD9B1F1E390A2700CEE925 /* STPSourceParamsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C1BD9B1E1E390A2700CEE925 /* STPSourceParamsTest.m */; };
 		C1BD9B221E393FFE00CEE925 /* STPSourceReceiver.h in Headers */ = {isa = PBXBuildFile; fileRef = C1BD9B201E393FFE00CEE925 /* STPSourceReceiver.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C1BD9B231E393FFE00CEE925 /* STPSourceReceiver.h in Headers */ = {isa = PBXBuildFile; fileRef = C1BD9B201E393FFE00CEE925 /* STPSourceReceiver.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -516,6 +556,9 @@
 		C1D7B5221E36C32F002181F5 /* STPSource.m in Sources */ = {isa = PBXBuildFile; fileRef = C1D7B51F1E36C32F002181F5 /* STPSource.m */; };
 		C1D7B5231E36C32F002181F5 /* STPSource.m in Sources */ = {isa = PBXBuildFile; fileRef = C1D7B51F1E36C32F002181F5 /* STPSource.m */; };
 		C1D7B5251E36C70D002181F5 /* STPSourceFunctionalTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C1D7B5241E36C70D002181F5 /* STPSourceFunctionalTest.m */; };
+		C1EC6D321E520F3000AF3659 /* STPSourceInfoViewControllerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C1EC6D311E520F3000AF3659 /* STPSourceInfoViewControllerTest.m */; };
+		C1EC6D341E52158300AF3659 /* STPSource+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = C1EC6D331E52158300AF3659 /* STPSource+Private.h */; };
+		C1EC6D351E52158300AF3659 /* STPSource+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = C1EC6D331E52158300AF3659 /* STPSource+Private.h */; };
 		C1EEDCC61CA2126000A54582 /* STPDelegateProxyTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C1EEDCC51CA2126000A54582 /* STPDelegateProxyTest.m */; };
 		C1EEDCC81CA2172700A54582 /* NSString+StripeTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C1EEDCC71CA2172700A54582 /* NSString+StripeTest.m */; };
 		C1EEDCCA1CA2186300A54582 /* STPPhoneNumberValidatorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C1EEDCC91CA2186300A54582 /* STPPhoneNumberValidatorTest.m */; };
@@ -985,11 +1028,31 @@
 		C17A030B1CBEE7A2006C819F /* STPAddressFieldTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPAddressFieldTableViewCell.h; sourceTree = "<group>"; };
 		C17A030C1CBEE7A2006C819F /* STPAddressFieldTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPAddressFieldTableViewCell.m; sourceTree = "<group>"; };
 		C17D24ED1E37DBAC005CB188 /* STPSourceTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPSourceTest.m; sourceTree = "<group>"; };
+		C17F28B61E4CD13A0073408B /* STPSourceInfoViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = STPSourceInfoViewController.h; path = PublicHeaders/STPSourceInfoViewController.h; sourceTree = "<group>"; };
+		C17F28B71E4CD13A0073408B /* STPSourceInfoViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPSourceInfoViewController.m; sourceTree = "<group>"; };
 		C18021181E3A58710089D712 /* STPSourcePoller.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPSourcePoller.h; sourceTree = "<group>"; };
 		C18021191E3A58710089D712 /* STPSourcePoller.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPSourcePoller.m; sourceTree = "<group>"; };
+		C18880061E68CDA700FB169F /* STPBancontactSourceInfoDataSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPBancontactSourceInfoDataSource.h; sourceTree = "<group>"; };
+		C18880071E68CDA700FB169F /* STPBancontactSourceInfoDataSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPBancontactSourceInfoDataSource.m; sourceTree = "<group>"; };
+		C188800C1E68CDCC00FB169F /* STPGiropaySourceInfoDataSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPGiropaySourceInfoDataSource.h; sourceTree = "<group>"; };
+		C188800D1E68CDCC00FB169F /* STPGiropaySourceInfoDataSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPGiropaySourceInfoDataSource.m; sourceTree = "<group>"; };
+		C18880121E68CDDE00FB169F /* STPIDEALSourceInfoDataSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPIDEALSourceInfoDataSource.h; sourceTree = "<group>"; };
+		C18880131E68CDDE00FB169F /* STPIDEALSourceInfoDataSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPIDEALSourceInfoDataSource.m; sourceTree = "<group>"; };
+		C18880181E68CDEC00FB169F /* STPSofortSourceInfoDataSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPSofortSourceInfoDataSource.h; sourceTree = "<group>"; };
+		C18880191E68CDEC00FB169F /* STPSofortSourceInfoDataSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPSofortSourceInfoDataSource.m; sourceTree = "<group>"; };
+		C188801E1E68D40300FB169F /* STPSourceInfoDataSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPSourceInfoDataSource.h; sourceTree = "<group>"; };
+		C188801F1E68D40300FB169F /* STPSourceInfoDataSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPSourceInfoDataSource.m; sourceTree = "<group>"; };
 		C1A06F0F1E1D8A6E004DCA06 /* STPCard+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCard+Private.h"; sourceTree = "<group>"; };
 		C1B630B31D1D817900A05285 /* Stripe.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Stripe.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		C1B630B51D1D817900A05285 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		C1BB22281E4CEB4300E72B8E /* STPTextFieldTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPTextFieldTableViewCell.h; sourceTree = "<group>"; };
+		C1BB22291E4CEB4300E72B8E /* STPTextFieldTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPTextFieldTableViewCell.m; sourceTree = "<group>"; };
+		C1BB222F1E4D258600E72B8E /* STPPickerTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPPickerTableViewCell.h; sourceTree = "<group>"; };
+		C1BB22301E4D258600E72B8E /* STPPickerTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPPickerTableViewCell.m; sourceTree = "<group>"; };
+		C1BB22351E4D2D2200E72B8E /* STPCountryPickerDataSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPCountryPickerDataSource.h; sourceTree = "<group>"; };
+		C1BB22361E4D2D2200E72B8E /* STPCountryPickerDataSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPCountryPickerDataSource.m; sourceTree = "<group>"; };
+		C1BB223C1E4E1EF000E72B8E /* STPBankPickerDataSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPBankPickerDataSource.h; sourceTree = "<group>"; };
+		C1BB223D1E4E1EF000E72B8E /* STPBankPickerDataSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPBankPickerDataSource.m; sourceTree = "<group>"; };
 		C1BD9B1E1E390A2700CEE925 /* STPSourceParamsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPSourceParamsTest.m; sourceTree = "<group>"; };
 		C1BD9B201E393FFE00CEE925 /* STPSourceReceiver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = STPSourceReceiver.h; path = PublicHeaders/STPSourceReceiver.h; sourceTree = "<group>"; };
 		C1BD9B211E393FFE00CEE925 /* STPSourceReceiver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPSourceReceiver.m; sourceTree = "<group>"; };
@@ -1010,6 +1073,8 @@
 		C1D7B51E1E36C32F002181F5 /* STPSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = STPSource.h; path = PublicHeaders/STPSource.h; sourceTree = "<group>"; };
 		C1D7B51F1E36C32F002181F5 /* STPSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPSource.m; sourceTree = "<group>"; };
 		C1D7B5241E36C70D002181F5 /* STPSourceFunctionalTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPSourceFunctionalTest.m; sourceTree = "<group>"; };
+		C1EC6D311E520F3000AF3659 /* STPSourceInfoViewControllerTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPSourceInfoViewControllerTest.m; sourceTree = "<group>"; };
+		C1EC6D331E52158300AF3659 /* STPSource+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "STPSource+Private.h"; sourceTree = "<group>"; };
 		C1EEDCC51CA2126000A54582 /* STPDelegateProxyTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPDelegateProxyTest.m; sourceTree = "<group>"; };
 		C1EEDCC71CA2172700A54582 /* NSString+StripeTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+StripeTest.m"; sourceTree = "<group>"; };
 		C1EEDCC91CA2186300A54582 /* STPPhoneNumberValidatorTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPPhoneNumberValidatorTest.m; sourceTree = "<group>"; };
@@ -1288,6 +1353,7 @@
 				C1D7B51F1E36C32F002181F5 /* STPSource.m */,
 				F19491DD1E5F6B8C001E1FC2 /* STPSourceCardDetails.h */,
 				F19491D81E5F606F001E1FC2 /* STPSourceCardDetails.m */,
+				C1EC6D331E52158300AF3659 /* STPSource+Private.h */,
 				C1BD9B381E39416700CEE925 /* STPSourceOwner.h */,
 				C1BD9B271E39406C00CEE925 /* STPSourceOwner.m */,
 				C1BD9B201E393FFE00CEE925 /* STPSourceReceiver.h */,
@@ -1446,6 +1512,7 @@
 				F1D777BF1D81DD520076FA19 /* STPStringUtilsTest.m */,
 				F1D96F981DC7DCDE00477E64 /* STPLocalizationUtils+STPTestAdditions.h */,
 				F1D96F991DC7DCDE00477E64 /* STPLocalizationUtils+STPTestAdditions.m */,
+				C1EC6D311E520F3000AF3659 /* STPSourceInfoViewControllerTest.m */,
 				C1D23FB71D37FE0F002FD83C /* JSON */,
 				F1122A7D1DFB84E000A8B1AF /* UINavigationBar+StripeTest.m */,
 			);
@@ -1563,6 +1630,18 @@
 				C15993301D8808680047950D /* STPShippingMethodsViewController.m */,
 				04BC29C01CE2A48000318357 /* STPSMSCodeViewController.h */,
 				04BC29C11CE2A48000318357 /* STPSMSCodeViewController.m */,
+				C17F28B61E4CD13A0073408B /* STPSourceInfoViewController.h */,
+				C17F28B71E4CD13A0073408B /* STPSourceInfoViewController.m */,
+				C188801E1E68D40300FB169F /* STPSourceInfoDataSource.h */,
+				C188801F1E68D40300FB169F /* STPSourceInfoDataSource.m */,
+				C18880061E68CDA700FB169F /* STPBancontactSourceInfoDataSource.h */,
+				C18880071E68CDA700FB169F /* STPBancontactSourceInfoDataSource.m */,
+				C188800C1E68CDCC00FB169F /* STPGiropaySourceInfoDataSource.h */,
+				C188800D1E68CDCC00FB169F /* STPGiropaySourceInfoDataSource.m */,
+				C18880121E68CDDE00FB169F /* STPIDEALSourceInfoDataSource.h */,
+				C18880131E68CDDE00FB169F /* STPIDEALSourceInfoDataSource.m */,
+				C18880181E68CDEC00FB169F /* STPSofortSourceInfoDataSource.h */,
+				C18880191E68CDEC00FB169F /* STPSofortSourceInfoDataSource.m */,
 				F1D64B271D8767FC001CDB7C /* STPWebViewController.h */,
 				F1D64B281D8767FC001CDB7C /* STPWebViewController.m */,
 			);
@@ -1637,6 +1716,14 @@
 				C15993321D8808680047950D /* STPShippingMethodTableViewCell.m */,
 				04BC29BB1CDD535700318357 /* STPSwitchTableViewCell.h */,
 				04BC29BC1CDD535700318357 /* STPSwitchTableViewCell.m */,
+				C1BB22281E4CEB4300E72B8E /* STPTextFieldTableViewCell.h */,
+				C1BB22291E4CEB4300E72B8E /* STPTextFieldTableViewCell.m */,
+				C1BB222F1E4D258600E72B8E /* STPPickerTableViewCell.h */,
+				C1BB22301E4D258600E72B8E /* STPPickerTableViewCell.m */,
+				C1BB223C1E4E1EF000E72B8E /* STPBankPickerDataSource.h */,
+				C1BB223D1E4E1EF000E72B8E /* STPBankPickerDataSource.m */,
+				C1BB22351E4D2D2200E72B8E /* STPCountryPickerDataSource.h */,
+				C1BB22361E4D2D2200E72B8E /* STPCountryPickerDataSource.m */,
 			);
 			name = Cells;
 			sourceTree = "<group>";
@@ -1672,6 +1759,7 @@
 				C1C1012E1E57A26F00C7BFAE /* STPSource+Private.h in Headers */,
 				04A488431CA3580700506E53 /* UINavigationController+Stripe_Completion.h in Headers */,
 				C124A1711CCA968B007D42EE /* STPAnalyticsClient.h in Headers */,
+				C18880211E68D40300FB169F /* STPSourceInfoDataSource.h in Headers */,
 				049A3FA81CC963EB00F57DE7 /* STPPaymentMethod.h in Headers */,
 				F1DEB8911E2052150066B8E8 /* STPCoreScrollViewController.h in Headers */,
 				04F94DB51D229F74004FC826 /* STPSMSCodeTextField.h in Headers */,
@@ -1696,6 +1784,7 @@
 				C15993401D88089E0047950D /* STPShippingMethodTableViewCell.h in Headers */,
 				04B31DD51D08E6E200EF1631 /* STPCustomer.h in Headers */,
 				04633AFB1CD1299B009D4FB5 /* NSString+Stripe.h in Headers */,
+				C18880151E68CDDE00FB169F /* STPIDEALSourceInfoDataSource.h in Headers */,
 				04B31E001D131D9000EF1631 /* STPRememberMePaymentCell.h in Headers */,
 				04BFFFDA1D240B13005F2340 /* STPAddCardViewController+Private.h in Headers */,
 				C1717DB11CC00ED60009CF4A /* STPAddress.h in Headers */,
@@ -1704,8 +1793,11 @@
 				04F94DBA1D229F8A004FC826 /* PKPaymentAuthorizationViewController+Stripe_Blocks.h in Headers */,
 				04F94DD31D22A23F004FC826 /* NSBundle+Stripe_AppName.h in Headers */,
 				04F94DC31D22A1F7004FC826 /* STPCheckoutAccount.h in Headers */,
+				C1BB222B1E4CEB4300E72B8E /* STPTextFieldTableViewCell.h in Headers */,
 				F1852F941D80B6EC00367C86 /* STPStringUtils.h in Headers */,
+				C188800F1E68CDCC00FB169F /* STPGiropaySourceInfoDataSource.h in Headers */,
 				049E84EA1A605EF0000B66CD /* STPCard.h in Headers */,
+				C18880091E68CDA700FB169F /* STPBancontactSourceInfoDataSource.h in Headers */,
 				049E84EB1A605EF0000B66CD /* STPToken.h in Headers */,
 				C124A17D1CCAA0C2007D42EE /* NSMutableURLRequest+Stripe.h in Headers */,
 				F1FA6F991E25970F00EB444D /* STPCoreTableViewController+Private.h in Headers */,
@@ -1730,10 +1822,12 @@
 				04F94D9C1D229EAA004FC826 /* PKPayment+Stripe.h in Headers */,
 				04F94DCF1D22A234004FC826 /* NSDecimalNumber+Stripe_Currency.h in Headers */,
 				C1BD9B231E393FFE00CEE925 /* STPSourceReceiver.h in Headers */,
+				C1EC6D351E52158300AF3659 /* STPSource+Private.h in Headers */,
 				049A3FAA1CC96B7C00F57DE7 /* STPApplePayPaymentMethod.h in Headers */,
 				04F94DA51D229F21004FC826 /* STPPaymentContext+Private.h in Headers */,
 				F12829DB1D7747E4008B10D6 /* STPBundleLocator.h in Headers */,
 				04827D161D257764002DB3E8 /* STPImageLibrary+Private.h in Headers */,
+				C1BB223F1E4E1EF000E72B8E /* STPBankPickerDataSource.h in Headers */,
 				049E84EC1A605EF0000B66CD /* StripeError.h in Headers */,
 				046FE9A31CE5608000DA6A7B /* STPPaymentActivityIndicatorView.h in Headers */,
 				F1DEB88B1E2047CA0066B8E8 /* STPCoreTableViewController.h in Headers */,
@@ -1741,12 +1835,14 @@
 				04F94DC71D22A204004FC826 /* STPCheckoutBootstrapResponse.h in Headers */,
 				04793F571D1D9C0200B3C551 /* STPSourceProtocol.h in Headers */,
 				F1D64B2A1D8767FC001CDB7C /* STPWebViewController.h in Headers */,
+				C1BB22321E4D258600E72B8E /* STPPickerTableViewCell.h in Headers */,
 				04F94DB21D229F69004FC826 /* STPSMSCodeViewController.h in Headers */,
 				04F94DC51D22A1FD004FC826 /* STPCheckoutAccountLookup.h in Headers */,
 				04A4883E1CA3568800506E53 /* STPBlocks.h in Headers */,
 				045D71211CEFA57000F6CD65 /* UIViewController+Stripe_Promises.h in Headers */,
 				C159932A1D88084D0047950D /* STPShippingAddressViewController.h in Headers */,
 				049880FD1CED5A2300EA4FFD /* STPPaymentConfiguration.h in Headers */,
+				C1BB22381E4D2D2200E72B8E /* STPCountryPickerDataSource.h in Headers */,
 				049A3F9B1CC7DBCC00F57DE7 /* STPPaymentContext.h in Headers */,
 				F19491E81E60DD9C001E1FC2 /* STPSourceSEPADebitDetails.h in Headers */,
 				04F3BB3E1BA89B1200DE235E /* PKPayment+Stripe.h in Headers */,
@@ -1767,10 +1863,12 @@
 				0426B9771CEBD001006AC8DD /* UINavigationBar+Stripe_Theme.h in Headers */,
 				04CDE5BE1BC1F21500548833 /* STPCardParams.h in Headers */,
 				04F94D9F1D229F09004FC826 /* STPPostalCodeValidator.h in Headers */,
+				C17F28B91E4CD13A0073408B /* STPSourceInfoViewController.h in Headers */,
 				F1C7B8D61DBECF2400D9F6F0 /* STPDispatchFunctions.h in Headers */,
 				C180211B1E3A58710089D712 /* STPSourcePoller.h in Headers */,
 				04F213371BCECB1C001D6F22 /* STPAPIResponseDecodable.h in Headers */,
 				045D712D1CF4ED7600F6CD65 /* STPBINRange.h in Headers */,
+				C188801B1E68CDEC00FB169F /* STPSofortSourceInfoDataSource.h in Headers */,
 				049E84E71A605EF0000B66CD /* STPFormEncoder.h in Headers */,
 				C1D7B51B1E36B8B9002181F5 /* STPSourceParams.h in Headers */,
 				04F94DC11D22A0B0004FC826 /* STPCheckoutAPIVerification.h in Headers */,
@@ -1807,10 +1905,14 @@
 				04CDB50E1A5F30A700B854EE /* STPCard.h in Headers */,
 				C1BD9B391E39416700CEE925 /* STPSourceOwner.h in Headers */,
 				C1080F491CBECF7B007B2D89 /* STPAddress.h in Headers */,
+				C1BB22371E4D2D2200E72B8E /* STPCountryPickerDataSource.h in Headers */,
+				C1BB22311E4D258600E72B8E /* STPPickerTableViewCell.h in Headers */,
+				C188800E1E68CDCC00FB169F /* STPGiropaySourceInfoDataSource.h in Headers */,
 				0438EF2C1B7416BB00D506CC /* STPFormTextField.h in Headers */,
 				C180211A1E3A58710089D712 /* STPSourcePoller.h in Headers */,
 				04E39F5C1CECFAFD00AF3B96 /* STPPaymentContext+Private.h in Headers */,
 				C1FEE5961CBFF11400A7632B /* STPPostalCodeValidator.h in Headers */,
+				C18880201E68D40300FB169F /* STPSourceInfoDataSource.h in Headers */,
 				04633B0C1CD44F6C009D4FB5 /* PKPayment+Stripe.h in Headers */,
 				04B31DFF1D131D9000EF1631 /* STPRememberMePaymentCell.h in Headers */,
 				04CDB50A1A5F30A700B854EE /* STPBankAccount.h in Headers */,
@@ -1834,9 +1936,11 @@
 				F1FA6F981E25970F00EB444D /* STPCoreTableViewController+Private.h in Headers */,
 				F1DEB8901E2052150066B8E8 /* STPCoreScrollViewController.h in Headers */,
 				04E39F521CECF7A100AF3B96 /* STPCardTuple.h in Headers */,
+				C18880081E68CDA700FB169F /* STPBancontactSourceInfoDataSource.h in Headers */,
 				04A488331CA34D3000506E53 /* STPEmailAddressValidator.h in Headers */,
 				04A4C38D1C4F25F900B3B290 /* UIViewController+Stripe_ParentViewController.h in Headers */,
 				0438EF471B74183100D506CC /* STPCardBrand.h in Headers */,
+				C1BB222A1E4CEB4300E72B8E /* STPTextFieldTableViewCell.h in Headers */,
 				04B31DD41D08E6E200EF1631 /* STPCustomer.h in Headers */,
 				F12829DA1D7747E4008B10D6 /* STPBundleLocator.h in Headers */,
 				C11810951CC6C4700022FB55 /* PKPaymentAuthorizationViewController+Stripe_Blocks.h in Headers */,
@@ -1863,6 +1967,7 @@
 				049880FC1CED5A2300EA4FFD /* STPPaymentConfiguration.h in Headers */,
 				F1852F931D80B6EC00367C86 /* STPStringUtils.h in Headers */,
 				049A3FAE1CC9AA9900F57DE7 /* STPAddressViewModel.h in Headers */,
+				C188801A1E68CDEC00FB169F /* STPSofortSourceInfoDataSource.h in Headers */,
 				0426B96E1CEADC98006AC8DD /* STPColorUtils.h in Headers */,
 				04B31DDA1D09A4DC00EF1631 /* STPPaymentConfiguration+Private.h in Headers */,
 				F1D96F961DC7D82400477E64 /* STPLocalizationUtils.h in Headers */,
@@ -1875,17 +1980,20 @@
 				04BC29A41CD8697900318357 /* STPTheme.h in Headers */,
 				04B31DF21D09F0A800EF1631 /* UIViewController+Stripe_NavigationItemProxy.h in Headers */,
 				04CDB4D31A5F30A700B854EE /* Stripe.h in Headers */,
+				C17F28B81E4CD13A0073408B /* STPSourceInfoViewController.h in Headers */,
 				04BC29C61CE2A82300318357 /* STPSMSCodeTextField.h in Headers */,
 				04E39F601CED2C3900AF3B96 /* STPRememberMeTermsView.h in Headers */,
 				F19491E71E60DD9C001E1FC2 /* STPSourceSEPADebitDetails.h in Headers */,
 				04A488421CA3580700506E53 /* UINavigationController+Stripe_Completion.h in Headers */,
 				F1DEB8991E2074480066B8E8 /* STPCoreViewController.h in Headers */,
 				04A4883C1CA3568800506E53 /* STPBlocks.h in Headers */,
+				C1BB223E1E4E1EF000E72B8E /* STPBankPickerDataSource.h in Headers */,
 				F1FA6F921E258F6800EB444D /* STPCoreViewController+Private.h in Headers */,
 				04BC29B51CD9AE0000318357 /* STPCheckoutBootstrapResponse.h in Headers */,
 				045D71201CEFA57000F6CD65 /* UIViewController+Stripe_Promises.h in Headers */,
 				04793F561D1D8DDD00B3C551 /* STPSourceProtocol.h in Headers */,
 				0451CC441C49AE1C003B2CA6 /* STPPaymentResult.h in Headers */,
+				C1EC6D341E52158300AF3659 /* STPSource+Private.h in Headers */,
 				049A3F951CC75B2E00F57DE7 /* STPPromise.h in Headers */,
 				04BC29AD1CD9A88600318357 /* STPCheckoutAPIVerification.h in Headers */,
 				049A3F7E1CC1920A00F57DE7 /* UIViewController+Stripe_KeyboardAvoiding.h in Headers */,
@@ -1893,6 +2001,7 @@
 				C1363BB71D7633D800EB82B4 /* STPPaymentMethodTableViewCell.h in Headers */,
 				04B31DE61D09D25F00EF1631 /* STPPaymentMethodsInternalViewController.h in Headers */,
 				04CDB4FE1A5F30A700B854EE /* STPAPIClient.h in Headers */,
+				C18880141E68CDDE00FB169F /* STPIDEALSourceInfoDataSource.h in Headers */,
 				045D712C1CF4ED7600F6CD65 /* STPBINRange.h in Headers */,
 				C1D7B51A1E36B8B9002181F5 /* STPSourceParams.h in Headers */,
 				04827D101D2575C6002DB3E8 /* STPImageLibrary.h in Headers */,
@@ -2299,6 +2408,7 @@
 				C1080F4C1CBED48A007B2D89 /* STPAddressTests.m in Sources */,
 				F1D96F9B1DC7DCDE00477E64 /* STPLocalizationUtils+STPTestAdditions.m in Sources */,
 				04415C6F1A6605B5001225ED /* STPCertTest.m in Sources */,
+				C1EC6D321E520F3000AF3659 /* STPSourceInfoViewControllerTest.m in Sources */,
 				04415C701A6605B5001225ED /* STPTokenTest.m in Sources */,
 				C135380C1D2C22E5003F6157 /* MockSTPAPIClient.m in Sources */,
 			);
@@ -2325,10 +2435,12 @@
 				F1C7B8D41DBECF2400D9F6F0 /* STPDispatchFunctions.m in Sources */,
 				04F94DB11D229F64004FC826 /* STPRememberMeTermsView.m in Sources */,
 				04633B141CD45215009D4FB5 /* PKPayment+Stripe.m in Sources */,
+				C1BB22411E4E1EF000E72B8E /* STPBankPickerDataSource.m in Sources */,
 				04633AFF1CD129C0009D4FB5 /* NSString+Stripe.m in Sources */,
 				04633B021CD129D0009D4FB5 /* STPDelegateProxy.m in Sources */,
 				04B31DFC1D11AC6400EF1631 /* STPUserInformation.m in Sources */,
 				04A4C38C1C4F25F900B3B290 /* NSArray+Stripe_BoundSafe.m in Sources */,
+				C188800B1E68CDA700FB169F /* STPBancontactSourceInfoDataSource.m in Sources */,
 				04F94DCE1D22A232004FC826 /* UIViewController+Stripe_KeyboardAvoiding.m in Sources */,
 				04B31E021D131D9000EF1631 /* STPRememberMePaymentCell.m in Sources */,
 				C1D7B5231E36C32F002181F5 /* STPSource.m in Sources */,
@@ -2340,7 +2452,9 @@
 				F19491DC1E5F606F001E1FC2 /* STPSourceCardDetails.m in Sources */,
 				04F94DAA1D229F36004FC826 /* STPTheme.m in Sources */,
 				0439B98A1C454F97005A1ED5 /* STPPaymentMethodsViewController.m in Sources */,
+				C188801D1E68CDEC00FB169F /* STPSofortSourceInfoDataSource.m in Sources */,
 				04F94DAE1D229F54004FC826 /* STPColorUtils.m in Sources */,
+				C18880171E68CDDE00FB169F /* STPIDEALSourceInfoDataSource.m in Sources */,
 				C1D7B51D1E36B8B9002181F5 /* STPSourceParams.m in Sources */,
 				04F94DC01D22A0AD004FC826 /* STPCheckoutAPIClient.m in Sources */,
 				C124A1731CCA968B007D42EE /* STPAnalyticsClient.m in Sources */,
@@ -2348,6 +2462,7 @@
 				F1DEB8931E2052150066B8E8 /* STPCoreScrollViewController.m in Sources */,
 				04F94DC81D22A207004FC826 /* STPCheckoutBootstrapResponse.m in Sources */,
 				04F94D9E1D229F05004FC826 /* STPEmailAddressValidator.m in Sources */,
+				C18880111E68CDCC00FB169F /* STPGiropaySourceInfoDataSource.m in Sources */,
 				04F94DC61D22A1FF004FC826 /* STPCheckoutAccountLookup.m in Sources */,
 				04F94DD21D22A23C004FC826 /* STPPromise.m in Sources */,
 				0438EF371B7416BB00D506CC /* STPPaymentCardTextField.m in Sources */,
@@ -2361,11 +2476,14 @@
 				C1BD9B2B1E39406C00CEE925 /* STPSourceOwner.m in Sources */,
 				C1BD9B311E3940A200CEE925 /* STPSourceRedirect.m in Sources */,
 				04B31DE91D09D25F00EF1631 /* STPPaymentMethodsInternalViewController.m in Sources */,
+				C1BB223A1E4D2D2200E72B8E /* STPCountryPickerDataSource.m in Sources */,
 				F12C8DC51D63DE9F00ADA0D7 /* STPPaymentContextAmountModel.m in Sources */,
+				C17F28BB1E4CD13A0073408B /* STPSourceInfoViewController.m in Sources */,
 				04633B011CD129CB009D4FB5 /* STPPhoneNumberValidator.m in Sources */,
 				C159933F1D88089B0047950D /* STPShippingMethodsViewController.m in Sources */,
 				04A488451CA3580700506E53 /* UINavigationController+Stripe_Completion.m in Sources */,
 				049E84CF1A605DE0000B66CD /* STPBankAccount.m in Sources */,
+				C1BB222D1E4CEB4300E72B8E /* STPTextFieldTableViewCell.m in Sources */,
 				049E84D01A605DE0000B66CD /* STPCard.m in Sources */,
 				04F94DA21D229F14004FC826 /* STPAddressFieldTableViewCell.m in Sources */,
 				049A3FB71CCA6B8900F57DE7 /* STPAddress.m in Sources */,
@@ -2375,6 +2493,7 @@
 				0433EB4E1BD06313003912B4 /* NSDictionary+Stripe.m in Sources */,
 				0438EF3D1B7416BB00D506CC /* STPPaymentCardTextFieldViewModel.m in Sources */,
 				04F94DD01D22A236004FC826 /* NSDecimalNumber+Stripe_Currency.m in Sources */,
+				C18880231E68D40300FB169F /* STPSourceInfoDataSource.m in Sources */,
 				F1852F961D80B6EC00367C86 /* STPStringUtils.m in Sources */,
 				04F94DBC1D229F92004FC826 /* UIToolbar+Stripe_InputAccessory.m in Sources */,
 				04F94DB81D229F7F004FC826 /* STPObscuredCardView.m in Sources */,
@@ -2394,6 +2513,7 @@
 				04B31DD71D08E6E200EF1631 /* STPCustomer.m in Sources */,
 				045D710A1CEED3AA00F6CD65 /* STPRememberMeEmailCell.m in Sources */,
 				04F94DA71D229F2A004FC826 /* STPCardTuple.m in Sources */,
+				C1BB22341E4D258600E72B8E /* STPPickerTableViewCell.m in Sources */,
 				049952D81BCF14990088C703 /* STPAPIRequest.m in Sources */,
 				04F94DBE1D229F98004FC826 /* UITableViewCell+Stripe_Borders.m in Sources */,
 				0426B9791CEBD001006AC8DD /* UINavigationBar+Stripe_Theme.m in Sources */,
@@ -2416,6 +2536,7 @@
 				04BC29C31CE2A48000318357 /* STPSMSCodeViewController.m in Sources */,
 				C180211C1E3A58710089D712 /* STPSourcePoller.m in Sources */,
 				C17A030E1CBEE7A2006C819F /* STPAddressFieldTableViewCell.m in Sources */,
+				C18880161E68CDDE00FB169F /* STPIDEALSourceInfoDataSource.m in Sources */,
 				049A3F921CC740FF00F57DE7 /* NSDecimalNumber+Stripe_Currency.m in Sources */,
 				C1080F4A1CBECF7B007B2D89 /* STPAddress.m in Sources */,
 				04B31DE81D09D25F00EF1631 /* STPPaymentMethodsInternalViewController.m in Sources */,
@@ -2430,9 +2551,11 @@
 				04CDB50C1A5F30A700B854EE /* STPBankAccount.m in Sources */,
 				04E39F611CED2C3900AF3B96 /* STPRememberMeTermsView.m in Sources */,
 				049A3F7F1CC1920A00F57DE7 /* UIViewController+Stripe_KeyboardAvoiding.m in Sources */,
+				C188800A1E68CDA700FB169F /* STPBancontactSourceInfoDataSource.m in Sources */,
 				04F416271CA3639500486FB5 /* STPAddCardViewController.m in Sources */,
 				C1FEE5971CBFF11400A7632B /* STPPostalCodeValidator.m in Sources */,
 				04B31DFB1D11AC6400EF1631 /* STPUserInformation.m in Sources */,
+				C188801C1E68CDEC00FB169F /* STPSofortSourceInfoDataSource.m in Sources */,
 				F12829DC1D7747E4008B10D6 /* STPBundleLocator.m in Sources */,
 				04BC29BE1CDD535700318357 /* STPSwitchTableViewCell.m in Sources */,
 				F1DEB88C1E2047CA0066B8E8 /* STPCoreTableViewController.m in Sources */,
@@ -2451,23 +2574,29 @@
 				C1D7B5221E36C32F002181F5 /* STPSource.m in Sources */,
 				049A3F8A1CC73C7100F57DE7 /* STPPaymentContext.m in Sources */,
 				0426B9731CEAE3EB006AC8DD /* UITableViewCell+Stripe_Borders.m in Sources */,
+				C18880221E68D40300FB169F /* STPSourceInfoDataSource.m in Sources */,
+				C1BB22331E4D258600E72B8E /* STPPickerTableViewCell.m in Sources */,
 				C1BD9B241E393FFE00CEE925 /* STPSourceReceiver.m in Sources */,
 				04BC29B21CD9AAA800318357 /* STPCheckoutAccount.m in Sources */,
 				04BC29CB1CE40F7500318357 /* STPObscuredCardView.m in Sources */,
 				04B31DD61D08E6E200EF1631 /* STPCustomer.m in Sources */,
 				0438EF351B7416BB00D506CC /* STPPaymentCardTextField.m in Sources */,
 				045D71091CEED3AA00F6CD65 /* STPRememberMeEmailCell.m in Sources */,
+				C18880101E68CDCC00FB169F /* STPGiropaySourceInfoDataSource.m in Sources */,
 				04827D121D2575C6002DB3E8 /* STPImageLibrary.m in Sources */,
 				F1D64B2B1D8767FC001CDB7C /* STPWebViewController.m in Sources */,
 				04CDB5041A5F30A700B854EE /* STPFormEncoder.m in Sources */,
 				0426B96F1CEADC98006AC8DD /* STPColorUtils.m in Sources */,
 				04E39F531CECF7A100AF3B96 /* STPCardTuple.m in Sources */,
 				C1D7B51C1E36B8B9002181F5 /* STPSourceParams.m in Sources */,
+				C1BB222C1E4CEB4300E72B8E /* STPTextFieldTableViewCell.m in Sources */,
 				049880FE1CED5A2300EA4FFD /* STPPaymentConfiguration.m in Sources */,
 				046FE9A21CE55D1D00DA6A7B /* STPPaymentActivityIndicatorView.m in Sources */,
 				045D71221CEFA57000F6CD65 /* UIViewController+Stripe_Promises.m in Sources */,
 				C124A1721CCA968B007D42EE /* STPAnalyticsClient.m in Sources */,
+				C1BB22401E4E1EF000E72B8E /* STPBankPickerDataSource.m in Sources */,
 				C158AB401E1EE98900348D01 /* STPSectionHeaderView.m in Sources */,
+				C17F28BA1E4CD13A0073408B /* STPSourceInfoViewController.m in Sources */,
 				F148ABC81D5D334B0014FD92 /* STPLocalizationUtils.m in Sources */,
 				04A4C38B1C4F25F900B3B290 /* NSArray+Stripe_BoundSafe.m in Sources */,
 				F19491E41E60DD72001E1FC2 /* STPSourceSEPADebitDetails.m in Sources */,
@@ -2499,6 +2628,7 @@
 				04BC29BA1CDA995000318357 /* STPCheckoutAccountLookup.m in Sources */,
 				049952D01BCF13510088C703 /* STPAPIRequest.m in Sources */,
 				049A3F9A1CC76A2400F57DE7 /* NSBundle+Stripe_AppName.m in Sources */,
+				C1BB22391E4D2D2200E72B8E /* STPCountryPickerDataSource.m in Sources */,
 				049A3F7B1CC18D5300F57DE7 /* UIView+Stripe_FirstResponder.m in Sources */,
 				04CDE5C51BC20AF800548833 /* STPBankAccountParams.m in Sources */,
 				C1BD9B361E3940C400CEE925 /* STPSourceVerification.m in Sources */,

--- a/Stripe/PublicHeaders/STPSourceInfoViewController.h
+++ b/Stripe/PublicHeaders/STPSourceInfoViewController.h
@@ -1,0 +1,86 @@
+//
+//  STPSourceInfoViewController.h
+//  Stripe
+//
+//  Created by Ben Guo on 2/9/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import <Stripe/Stripe.h>
+#import "STPCoreTableViewController.h"
+#import "STPSource.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol STPSourceInfoViewControllerDelegate;
+@class STPSourceParams, STPPaymentConfiguration, STPUserInformation;
+
+/** 
+ *  You can use this view controller to collect information for payment sources
+ *  that require additional information upon creation (e.g. iDEAL, which requires 
+ *  your customer's name and bank.) Note that this view controller renders a right 
+ *  bar button item that submits the form, so it must be shown inside a
+ *  `UINavigationController`.
+ */
+@interface STPSourceInfoViewController : STPCoreTableViewController
+
+/**
+ *  Initializes a new `STPSourceInfoViewController` with the provided parameters. 
+ *  When the user submits the form, the view controller will return an STPSourceParams 
+ *  object its delegate, updated with the information entered by the user. If the 
+ *  given source type is unsupported, this initializer will return nil.
+ *
+ *  @param type                   The type of the source.
+ *  @param amount                 The amount of the source.
+ *  @param configuration          The configuration to use. This determines the source's returnURL.
+ *  @param prefilledInformation   Use this to provide any information you've already collected from your user.
+ *  @param theme                  The theme to use to inform the view controller's visual appearance. @see STPTheme
+ */
+- (nullable instancetype)initWithSourceType:(STPSourceType)type
+                                     amount:(NSInteger)amount
+                              configuration:(STPPaymentConfiguration *)configuration
+                       prefilledInformation:(STPUserInformation *)prefilledInformation
+                                      theme:(STPTheme *)theme;
+
+/**
+ *  You should check this property after initializing `STPSourceInfoViewController`.
+ *  If this property contains an STPSourceParams object, you already have sufficient
+ *  information about the source, and can immediately use this object to create
+ *  a source. Otherwise, if this property is nil, you must present the view controller
+ *  to gather additional info about the source from your user. When the user submits
+ *  the form, you can use the STPSourceParams object returned to your delegate to
+ *  create a source.
+ */
+@property(nullable, nonatomic, readonly) STPSourceParams *completeSourceParams;
+
+/**
+ *  The view controller's delegate. This must be set before showing the view 
+ *  controller in order for it to work properly. @see STPSourceInfoViewControllerDelegate
+ */
+@property(nonatomic, weak) id<STPSourceInfoViewControllerDelegate> delegate;
+
+@end
+
+/**
+ *  An `STPSourceInfoViewControllerDelegate` is notified when a user submits information or cancels in an `STPSourceInfoViewController`.
+ */
+@protocol STPSourceInfoViewControllerDelegate <NSObject>
+
+/**
+ *  This is called when the user cancels entering source information. You should dismiss (or pop) the view controller at this point.
+ *
+ *  @param sourceInfoViewController the view controller that has been cancelled
+ */
+- (void)sourceInfoViewControllerDidCancel:(STPSourceInfoViewController *)sourceInfoViewController;
+
+/**
+ *  This is called when the user finishes entering source information and submits the form. You should use the `STPSourceParams` object returned by this callback to create a source, and dismiss (or pop) the view controller.
+ *
+ *  @param sourceInfoViewController the view controller that has been cancelled
+ */
+- (void)sourceInfoViewController:(STPSourceInfoViewController *)sourceInfoViewController
+       didFinishWithSourceParams:(STPSourceParams *)sourceParams;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Stripe/PublicHeaders/Stripe.h
+++ b/Stripe/PublicHeaders/Stripe.h
@@ -37,6 +37,7 @@
 #import "STPShippingAddressViewController.h"
 #import "STPSource.h"
 #import "STPSourceCardDetails.h"
+#import "STPSourceInfoViewController.h"
 #import "STPSourceOwner.h"
 #import "STPSourceParams.h"
 #import "STPSourceProtocol.h"

--- a/Stripe/STPBancontactSourceInfoDataSource.h
+++ b/Stripe/STPBancontactSourceInfoDataSource.h
@@ -1,0 +1,14 @@
+//
+//  STPBancontactSourceInfoDataSource.h
+//  Stripe
+//
+//  Created by Ben Guo on 3/2/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import <Stripe/Stripe.h>
+#import "STPSourceInfoDataSource.h"
+
+@interface STPBancontactSourceInfoDataSource : STPSourceInfoDataSource
+
+@end

--- a/Stripe/STPBancontactSourceInfoDataSource.m
+++ b/Stripe/STPBancontactSourceInfoDataSource.m
@@ -1,0 +1,47 @@
+//
+//  STPBancontactSourceInfoDataSource.m
+//  Stripe
+//
+//  Created by Ben Guo on 3/2/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import "STPBancontactSourceInfoDataSource.h"
+
+#import "NSArray+Stripe_BoundSafe.h"
+#import "STPLocalizationUtils.h"
+
+@implementation STPBancontactSourceInfoDataSource
+
+- (instancetype)initWithSourceParams:(STPSourceParams *)sourceParams {
+    self = [super initWithSourceParams:sourceParams];
+    if (self) {
+        self.title = STPLocalizedString(@"Bancontact Info", @"Title for form to collect Bancontact account info");
+        STPTextFieldTableViewCell *nameCell = [[STPTextFieldTableViewCell alloc] init];
+        nameCell.placeholder = STPLocalizedString(@"Name", @"Caption for Name field on bank info form");
+        if (self.sourceParams.owner) {
+            nameCell.contents = self.sourceParams.owner[@"name"];
+        }
+        self.cells = @[nameCell];
+    }
+    return self;
+}
+
+- (STPSourceParams *)completeSourceParams {
+    STPSourceParams *params = [self.sourceParams copy];
+    NSMutableDictionary *owner = [NSMutableDictionary new];
+    if (params.owner) {
+        owner = [params.owner mutableCopy];
+    }
+    STPTextFieldTableViewCell *nameCell = [self.cells stp_boundSafeObjectAtIndex:0];
+    owner[@"name"] = nameCell.contents;
+    params.owner = owner;
+
+    NSString *name = params.owner[@"name"];
+    if (name.length > 0) {
+        return params;
+    }
+    return nil;
+}
+
+@end

--- a/Stripe/STPBankPickerDataSource.h
+++ b/Stripe/STPBankPickerDataSource.h
@@ -1,0 +1,21 @@
+//
+//  STPBankPickerDataSource.h
+//  Stripe
+//
+//  Created by Ben Guo on 2/10/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "STPPickerTableViewCell.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface STPBankPickerDataSource : NSObject <STPPickerDataSource>
+
++ (STPBankPickerDataSource *)iDEALBankDataSource;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Stripe/STPBankPickerDataSource.m
+++ b/Stripe/STPBankPickerDataSource.m
@@ -1,0 +1,69 @@
+//
+//  STPBankPickerDataSource.m
+//  Stripe
+//
+//  Created by Ben Guo on 2/10/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import "STPBankPickerDataSource.h"
+
+#import "NSArray+Stripe_BoundSafe.h"
+
+@interface STPBankPickerDataSource()
+
+/// Dictionary mapping bank names to bank codes
+@property (nonatomic) NSDictionary<NSString *,NSString *>*bankNameToBankCode;
+
+/// Sorted array of bank names
+@property (nonatomic) NSArray<NSString *>*bankNames;
+
+@end
+
+@implementation STPBankPickerDataSource
+
++ (STPBankPickerDataSource *)iDEALBankDataSource {
+    STPBankPickerDataSource *dataSource = [[self class] new];
+    dataSource.bankNameToBankCode = @{
+                                      @"ABN AMRO": @"abn_amro",
+                                      @"ASN Bank": @"asn_bank",
+                                      @"Bunq": @"bunq",
+                                      @"ING": @"ing",
+                                      @"Knab": @"knab",
+                                      @"Rabobank": @"rabobank",
+                                      @"RegioBank": @"regiobank",
+                                      @"SNS Bank": @"sns_bank",
+                                      @"Triodos Bank": @"triodos_bank",
+                                      @"Van Lanschot": @"van_lanschot",
+                                      };
+    dataSource.bankNames = [[dataSource.bankNameToBankCode allKeys] sortedArrayUsingSelector:@selector(compare:)];
+    return dataSource;
+}
+
+- (NSInteger)numberOfRowsInPicker {
+    return [self.bankNames count];
+}
+
+- (NSInteger)indexOfPickerValue:(NSString *)value {
+    NSString *name = [[self.bankNameToBankCode allKeysForObject:value] firstObject];
+    if (!name) {
+        return NSNotFound;
+    }
+    return [self.bankNames indexOfObject:name];
+}
+
+- (NSString *)pickerValueForRow:(NSInteger)row {
+    NSString *value;
+    NSString *name = [self.bankNames stp_boundSafeObjectAtIndex:row];
+    if (name) {
+        value = self.bankNameToBankCode[name];
+    }
+    return value ?: @"";
+}
+
+- (NSString *)pickerTitleForRow:(NSInteger)row {
+    NSString *title = [self.bankNames stp_boundSafeObjectAtIndex:row];
+    return title ?: @"";
+}
+
+@end

--- a/Stripe/STPCountryPickerDataSource.h
+++ b/Stripe/STPCountryPickerDataSource.h
@@ -1,0 +1,21 @@
+//
+//  STPCountryPickerDataSource.h
+//  Stripe
+//
+//  Created by Ben Guo on 2/9/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "STPPickerTableViewCell.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface STPCountryPickerDataSource : NSObject <STPPickerDataSource>
+
+- (instancetype)initWithCountryCodes:(NSArray<NSString *>*)countryCodes;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Stripe/STPCountryPickerDataSource.m
+++ b/Stripe/STPCountryPickerDataSource.m
@@ -1,0 +1,80 @@
+//
+//  STPCountryPickerDataSource.m
+//  Stripe
+//
+//  Created by Ben Guo on 2/9/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import "STPCountryPickerDataSource.h"
+
+#import "NSArray+Stripe_BoundSafe.h"
+
+@interface STPCountryPickerDataSource()
+
+@property (nonatomic) NSArray<NSString *>*countryCodes;
+
+@end
+
+@implementation STPCountryPickerDataSource
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        [self commonInitWithCountryCodes:[NSLocale ISOCountryCodes]];
+    }
+    return self;
+}
+
+- (instancetype)initWithCountryCodes:(NSArray<NSString *>*)countryCodes {
+    self = [super init];
+    if (self) {
+        [self commonInitWithCountryCodes:countryCodes];
+    }
+    return self;
+}
+
+- (void)commonInitWithCountryCodes:(NSArray<NSString *>*)countryCodes {
+    NSLocale *locale = [NSLocale autoupdatingCurrentLocale];
+    NSString *countryCode = [locale objectForKey:NSLocaleCountryCode];
+    NSMutableArray *otherCountryCodes = [countryCodes mutableCopy];
+    [otherCountryCodes sortUsingComparator:^NSComparisonResult(NSString *code1, NSString *code2) {
+        NSString *localeID1 = [NSLocale localeIdentifierFromComponents:@{NSLocaleCountryCode: code1}];
+        NSString *localeID2 = [NSLocale localeIdentifierFromComponents:@{NSLocaleCountryCode: code2}];
+        NSString *name1 = [locale displayNameForKey:NSLocaleIdentifier value:localeID1];
+        NSString *name2 = [locale displayNameForKey:NSLocaleIdentifier value:localeID2];
+        return [name1 compare:name2];
+    }];
+    if (countryCodes) {
+        [otherCountryCodes removeObject:countryCode];
+        self.countryCodes = [@[@"", countryCode] arrayByAddingObjectsFromArray:otherCountryCodes];
+    }
+    else {
+        self.countryCodes = [@[@""] arrayByAddingObjectsFromArray:otherCountryCodes];
+    }
+}
+
+- (NSInteger)numberOfRowsInPicker {
+    return [self.countryCodes count];
+}
+
+- (NSInteger)indexOfPickerValue:(NSString *)value {
+    return [self.countryCodes indexOfObject:value];
+}
+
+- (NSString *)pickerValueForRow:(NSInteger)row {
+    NSString *countryCode = [self.countryCodes stp_boundSafeObjectAtIndex:row];
+    return countryCode ?: @"";
+}
+
+- (NSString *)pickerTitleForRow:(NSInteger)row {
+    NSString *displayName;
+    NSString *countryCode = [self.countryCodes stp_boundSafeObjectAtIndex:row];
+    if (countryCode) {
+        NSString *identifier = [NSLocale localeIdentifierFromComponents:@{NSLocaleCountryCode: countryCode}];
+        displayName = [[NSLocale autoupdatingCurrentLocale] displayNameForKey:NSLocaleIdentifier value:identifier];
+    }
+    return displayName ?: @"";
+}
+
+@end

--- a/Stripe/STPGiropaySourceInfoDataSource.h
+++ b/Stripe/STPGiropaySourceInfoDataSource.h
@@ -1,0 +1,14 @@
+//
+//  STPGiropaySourceInfoDataSource.h
+//  Stripe
+//
+//  Created by Ben Guo on 3/2/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import <Stripe/Stripe.h>
+#import "STPSourceInfoDataSource.h"
+
+@interface STPGiropaySourceInfoDataSource : STPSourceInfoDataSource
+
+@end

--- a/Stripe/STPGiropaySourceInfoDataSource.m
+++ b/Stripe/STPGiropaySourceInfoDataSource.m
@@ -1,0 +1,47 @@
+//
+//  STPGiropaySourceInfoDataSource.m
+//  Stripe
+//
+//  Created by Ben Guo on 3/2/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import "STPGiropaySourceInfoDataSource.h"
+
+#import "NSArray+Stripe_BoundSafe.h"
+#import "STPLocalizationUtils.h"
+
+@implementation STPGiropaySourceInfoDataSource
+
+- (instancetype)initWithSourceParams:(STPSourceParams *)sourceParams {
+    self = [super initWithSourceParams:sourceParams];
+    if (self) {
+        self.title = STPLocalizedString(@"Giropay Info", @"Title for form to collect Giropay account info");
+        STPTextFieldTableViewCell *nameCell = [[STPTextFieldTableViewCell alloc] init];
+        nameCell.placeholder = STPLocalizedString(@"Name", @"Caption for Name field on bank info form");
+        if (self.sourceParams.owner) {
+            nameCell.contents = self.sourceParams.owner[@"name"];
+        }
+        self.cells = @[nameCell];
+    }
+    return self;
+}
+
+- (STPSourceParams *)completeSourceParams {
+    STPSourceParams *params = [self.sourceParams copy];
+    NSMutableDictionary *owner = [NSMutableDictionary new];
+    if (params.owner) {
+        owner = [params.owner mutableCopy];
+    }
+    STPTextFieldTableViewCell *nameCell = [self.cells stp_boundSafeObjectAtIndex:0];
+    owner[@"name"] = nameCell.contents;
+    params.owner = owner;
+
+    NSString *name = params.owner[@"name"];
+    if (name.length > 0) {
+        return params;
+    }
+    return nil;
+}
+
+@end

--- a/Stripe/STPIDEALSourceInfoDataSource.h
+++ b/Stripe/STPIDEALSourceInfoDataSource.h
@@ -1,0 +1,15 @@
+//
+//  STPIDEALSourceInfoDataSource.h
+//  Stripe
+//
+//  Created by Ben Guo on 3/2/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import <Stripe/Stripe.h>
+
+#import "STPSourceInfoDataSource.h"
+
+@interface STPIDEALSourceInfoDataSource : STPSourceInfoDataSource
+
+@end

--- a/Stripe/STPIDEALSourceInfoDataSource.m
+++ b/Stripe/STPIDEALSourceInfoDataSource.m
@@ -1,0 +1,69 @@
+//
+//  STPIDEALSourceInfoDataSource.m
+//  Stripe
+//
+//  Created by Ben Guo on 3/2/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import "STPIDEALSourceInfoDataSource.h"
+
+#import "NSArray+Stripe_BoundSafe.h"
+#import "STPLocalizationUtils.h"
+#import "STPPickerTableViewCell.h"
+#import "STPBankPickerDataSource.h"
+
+@implementation STPIDEALSourceInfoDataSource
+
+- (instancetype)initWithSourceParams:(STPSourceParams *)sourceParams {
+    self = [super initWithSourceParams:sourceParams];
+    if (self) {
+        self.title = STPLocalizedString(@"iDEAL Info", @"Title for form to collect iDEAL account info");
+        STPTextFieldTableViewCell *nameCell = [[STPTextFieldTableViewCell alloc] init];
+        nameCell.placeholder = STPLocalizedString(@"Name", @"Caption for Name field on bank info form");
+        if (self.sourceParams.owner) {
+            nameCell.contents = self.sourceParams.owner[@"name"];
+        }
+        STPPickerTableViewCell *bankCell = [[STPPickerTableViewCell alloc] init];
+        bankCell.placeholder = STPLocalizedString(@"Bank", @"Caption for Bank field on bank info form");
+        bankCell.pickerDataSource = [STPBankPickerDataSource iDEALBankDataSource];
+        NSDictionary *idealDict = self.sourceParams.additionalAPIParameters[@"ideal"];
+        if (idealDict) {
+            bankCell.contents = idealDict[@"bank"];
+        }
+        self.cells = @[nameCell, bankCell];
+    }
+    return self;
+}
+
+- (STPSourceParams *)completeSourceParams {
+    STPSourceParams *params = [self.sourceParams copy];
+    NSMutableDictionary *owner = [NSMutableDictionary new];
+    if (params.owner) {
+        owner = [params.owner mutableCopy];
+    }
+    NSMutableDictionary *additionalParams = [NSMutableDictionary new];
+    if (params.additionalAPIParameters) {
+        additionalParams = [params.additionalAPIParameters mutableCopy];
+    }
+    STPTextFieldTableViewCell *nameCell = [self.cells stp_boundSafeObjectAtIndex:0];
+    owner[@"name"] = nameCell.contents;
+    params.owner = owner;
+    NSMutableDictionary *idealDict = [NSMutableDictionary new];
+    if (additionalParams[@"ideal"]) {
+        idealDict = additionalParams[@"ideal"];
+    }
+    STPTextFieldTableViewCell *bankCell = [self.cells stp_boundSafeObjectAtIndex:1];
+    idealDict[@"bank"] = bankCell.contents;
+    additionalParams[@"ideal"] = idealDict;
+    params.additionalAPIParameters = additionalParams;
+
+    NSString *name = params.owner[@"name"];
+    NSString *bank = params.additionalAPIParameters[@"ideal"][@"bank"];
+    if (name.length > 0 && bank.length > 0) {
+        return params;
+    }
+    return nil;
+}
+
+@end

--- a/Stripe/STPPickerTableViewCell.h
+++ b/Stripe/STPPickerTableViewCell.h
@@ -1,0 +1,30 @@
+//
+//  STPPickerTableViewCell.h
+//  Stripe
+//
+//  Created by Ben Guo on 2/9/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import "STPTextFieldTableViewCell.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol STPPickerDataSource;
+
+@interface STPPickerTableViewCell : STPTextFieldTableViewCell
+
+@property(nonatomic) id<STPPickerDataSource> pickerDataSource;
+
+@end
+
+@protocol STPPickerDataSource <NSObject>
+
+- (NSInteger)numberOfRowsInPicker;
+- (NSInteger)indexOfPickerValue:(NSString *)value;
+- (NSString *)pickerValueForRow:(NSInteger)row;
+- (NSString *)pickerTitleForRow:(NSInteger)row;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Stripe/STPPickerTableViewCell.m
+++ b/Stripe/STPPickerTableViewCell.m
@@ -1,0 +1,77 @@
+//
+//  STPPickerTableViewCell.m
+//  Stripe
+//
+//  Created by Ben Guo on 2/9/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import "STPPickerTableViewCell.h"
+
+#import "STPFormTextField.h"
+#import "STPTextFieldTableViewCell.h"
+
+@interface STPPickerTableViewCell() <UIPickerViewDelegate, UIPickerViewDataSource>
+
+@property(nonatomic) UIPickerView *pickerView;
+
+@end
+
+@implementation STPPickerTableViewCell
+
+@synthesize contents = _contents;
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        UIPickerView *pickerView = [UIPickerView new];
+        pickerView.delegate = self;
+        pickerView.dataSource = self;
+        _pickerView = pickerView;
+        self.textField.inputView = pickerView;
+    }
+    return self;
+}
+
+- (void)setContents:(NSString *)contents {
+    _contents = contents;
+    self.textField.validText = self.textValidationBlock(contents, NO);
+    NSInteger index = [self.pickerDataSource indexOfPickerValue:contents];
+    if (index == NSNotFound) {
+        self.textField.text = @"";
+    }
+    else {
+        [self.pickerView selectRow:index inComponent:0 animated:NO];
+        self.textField.text = [self.pickerDataSource pickerTitleForRow:index];
+    }
+}
+
+#pragma mark - UIPickerViewDelegate
+
+- (void)pickerView:(__unused UIPickerView *)pickerView didSelectRow:(NSInteger)row inComponent:(__unused NSInteger)component {
+    if (!self.pickerDataSource) {
+        return;
+    }
+    self.contents = [self.pickerDataSource pickerValueForRow:row];
+    self.textField.text = [self.pickerDataSource pickerTitleForRow:row];
+}
+
+- (NSString *)pickerView:(__unused UIPickerView *)pickerView titleForRow:(NSInteger)row forComponent:(__unused NSInteger)component {
+    if (!self.pickerDataSource) {
+        return @"";
+    }
+    return [self.pickerDataSource pickerTitleForRow:row];
+}
+
+- (NSInteger)numberOfComponentsInPickerView:(__unused UIPickerView *)pickerView {
+    return 1;
+}
+
+- (NSInteger)pickerView:(__unused UIPickerView *)pickerView numberOfRowsInComponent:(__unused NSInteger)component {
+    if (!self.pickerDataSource) {
+        return 0;
+    }
+    return [self.pickerDataSource numberOfRowsInPicker];
+}
+
+@end

--- a/Stripe/STPSofortSourceInfoDataSource.h
+++ b/Stripe/STPSofortSourceInfoDataSource.h
@@ -1,0 +1,14 @@
+//
+//  STPSofortSourceInfoDataSource.h
+//  Stripe
+//
+//  Created by Ben Guo on 3/2/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import <Stripe/Stripe.h>
+#import "STPSourceInfoDataSource.h"
+
+@interface STPSofortSourceInfoDataSource : STPSourceInfoDataSource
+
+@end

--- a/Stripe/STPSofortSourceInfoDataSource.m
+++ b/Stripe/STPSofortSourceInfoDataSource.m
@@ -1,0 +1,57 @@
+//
+//  STPSofortSourceInfoDataSource.m
+//  Stripe
+//
+//  Created by Ben Guo on 3/2/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import "STPSofortSourceInfoDataSource.h"
+
+#import "NSArray+Stripe_BoundSafe.h"
+#import "STPLocalizationUtils.h"
+#import "STPPickerTableViewCell.h"
+#import "STPCountryPickerDataSource.h"
+
+@implementation STPSofortSourceInfoDataSource
+
+- (instancetype)initWithSourceParams:(STPSourceParams *)sourceParams {
+    self = [super initWithSourceParams:sourceParams];
+    if (self) {
+        self.title = STPLocalizedString(@"Sofort Info", @"Title for form to collect Sofort account info");
+        STPPickerTableViewCell *countryCell = [[STPPickerTableViewCell alloc] init];
+        countryCell.placeholder = STPLocalizedString(@"Country", @"Caption for Country field on bank info form");
+        NSArray *sofortCountries = @[@"AT", @"BE", @"FR", @"DE", @"NL"];
+        countryCell.pickerDataSource = [[STPCountryPickerDataSource alloc] initWithCountryCodes:sofortCountries];
+        NSDictionary *sofortDict = self.sourceParams.additionalAPIParameters[@"sofort"];
+        if (sofortDict) {
+            countryCell.contents = sofortDict[@"country"];
+        }
+        self.cells = @[countryCell];
+    }
+    return self;
+}
+
+- (STPSourceParams *)completeSourceParams {
+    STPSourceParams *params = [self.sourceParams copy];
+    NSMutableDictionary *additionalParams = [NSMutableDictionary new];
+    if (params.additionalAPIParameters) {
+        additionalParams = [params.additionalAPIParameters mutableCopy];
+    }
+    NSMutableDictionary *sofortDict = [NSMutableDictionary new];
+    if (additionalParams[@"sofort"]) {
+        sofortDict = additionalParams[@"sofort"];
+    }
+    STPTextFieldTableViewCell *countryCell = [self.cells stp_boundSafeObjectAtIndex:0];
+    sofortDict[@"country"] = countryCell.contents;
+    additionalParams[@"sofort"] = sofortDict;
+    params.additionalAPIParameters = additionalParams;
+
+    NSString *country = params.additionalAPIParameters[@"sofort"][@"country"];
+    if (country.length > 0) {
+        return params;
+    }
+    return nil;
+}
+
+@end

--- a/Stripe/STPSource+Private.h
+++ b/Stripe/STPSource+Private.h
@@ -10,8 +10,7 @@
 
 @interface STPSource (Private)
 + (NSString *)stringFromType:(STPSourceType)type;
++ (STPSourceType)typeFromString:(NSString *)string;
 + (NSString *)stringFromFlow:(STPSourceFlow)flow;
 + (NSString *)stringFromUsage:(STPSourceUsage)usage;
 @end
-
-

--- a/Stripe/STPSourceInfoDataSource.h
+++ b/Stripe/STPSourceInfoDataSource.h
@@ -1,0 +1,21 @@
+//
+//  STPSourceInfoDataSource.h
+//  Stripe
+//
+//  Created by Ben Guo on 3/2/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import <Stripe/Stripe.h>
+#import "STPTextFieldTableViewCell.h"
+
+@interface STPSourceInfoDataSource : NSObject
+
+@property (nonatomic, copy) NSString *title;
+@property (nonatomic) STPSourceParams *sourceParams;
+@property (nonatomic, copy) NSArray<STPTextFieldTableViewCell *>*cells;
+
+- (instancetype)initWithSourceParams:(STPSourceParams *)sourceParams;
+- (STPSourceParams *)completeSourceParams;
+
+@end

--- a/Stripe/STPSourceInfoDataSource.m
+++ b/Stripe/STPSourceInfoDataSource.m
@@ -1,0 +1,27 @@
+//
+//  STPSourceInfoDataSource.m
+//  Stripe
+//
+//  Created by Ben Guo on 3/2/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import "STPSourceInfoDataSource.h"
+
+@implementation STPSourceInfoDataSource
+
+- (instancetype)initWithSourceParams:(STPSourceParams *)sourceParams {
+    self = [super init];
+    if (self) {
+        _sourceParams = sourceParams;
+        _title = @"";
+        _cells = @[];
+    }
+    return self;
+}
+
+- (STPSourceParams *)completeSourceParams {
+    return nil;
+}
+
+@end

--- a/Stripe/STPSourceInfoViewController.m
+++ b/Stripe/STPSourceInfoViewController.m
@@ -1,0 +1,236 @@
+//
+//  STPSourceInfoViewController.m
+//  Stripe
+//
+//  Created by Ben Guo on 2/9/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import "STPSourceInfoViewController.h"
+
+#import "NSArray+Stripe_BoundSafe.h"
+#import "STPBancontactSourceInfoDataSource.h"
+#import "STPBankPickerDataSource.h"
+#import "STPCoreTableViewController+Private.h"
+#import "STPCountryPickerDataSource.h"
+#import "STPGiropaySourceInfoDataSource.h"
+#import "STPIDEALSourceInfoDataSource.h"
+#import "STPLocalizationUtils.h"
+#import "STPPickerTableViewCell.h"
+#import "STPSofortSourceInfoDataSource.h"
+#import "STPSourceParams.h"
+#import "STPSource+Private.h"
+#import "STPTextFieldTableViewCell.h"
+#import "UIBarButtonItem+Stripe.h"
+#import "UINavigationBar+Stripe_Theme.h"
+#import "UITableViewCell+Stripe_Borders.h"
+#import "UIViewController+Stripe_KeyboardAvoiding.h"
+#import "UIViewController+Stripe_NavigationItemProxy.h"
+
+@interface STPSourceInfoViewController () <UITableViewDelegate, UITableViewDataSource, STPTextFieldTableViewCellDelegate>
+
+@property(nonatomic)UIBarButtonItem *doneItem;
+@property(nonatomic)STPSourceInfoDataSource *dataSource;
+
+@end
+
+@implementation STPSourceInfoViewController
+
++ (BOOL)canCollectInfoForSourceType:(STPSourceType)type {
+    switch (type) {
+        case STPSourceTypeBancontact:
+        case STPSourceTypeGiropay:
+        case STPSourceTypeIDEAL:
+        case STPSourceTypeSofort:
+            return YES;
+        default:
+            return NO;
+    }
+}
+
+- (nullable instancetype)initWithSourceType:(STPSourceType)type
+                                     amount:(NSInteger)amount
+                              configuration:(__unused STPPaymentConfiguration *)configuration
+                       prefilledInformation:(STPUserInformation *)prefilledInformation
+                                      theme:(STPTheme *)theme {
+    self = [super initWithTheme:theme];
+    if (![[self class] canCollectInfoForSourceType:type]) {
+        return nil;
+    }
+    if (self) {
+        STPSourceInfoDataSource *dataSource;
+        STPSourceParams *sourceParams = [STPSourceParams new];
+        sourceParams.type = type;
+        sourceParams.currency = @"eur";
+        sourceParams.amount = @(amount);
+        // TODO: get returnURL from STPPaymentConfiguration
+        if (prefilledInformation.billingAddress.name &&
+            (type == STPSourceTypeBancontact ||
+             type == STPSourceTypeGiropay ||
+             type == STPSourceTypeIDEAL))
+        {
+            NSMutableDictionary *owner = [NSMutableDictionary new];
+            owner[@"name"] = prefilledInformation.billingAddress.name;
+            sourceParams.owner = owner;
+        }
+        if (prefilledInformation.billingAddress.country && type == STPSourceTypeSofort) {
+            NSMutableDictionary *sofortDict = [NSMutableDictionary new];
+            sofortDict[@"country"] = prefilledInformation.billingAddress.country;
+            sourceParams.additionalAPIParameters = @{@"sofort": sofortDict};
+        }
+        // TODO: prefill idealBank from STPUserInformation
+        switch (type) {
+            case STPSourceTypeBancontact: {
+                dataSource = [[STPBancontactSourceInfoDataSource alloc] initWithSourceParams:sourceParams];
+                break;
+            }
+            case STPSourceTypeGiropay:
+                dataSource = [[STPGiropaySourceInfoDataSource alloc] initWithSourceParams:sourceParams];
+                break;
+            case STPSourceTypeIDEAL:
+                dataSource = [[STPIDEALSourceInfoDataSource alloc] initWithSourceParams:sourceParams];
+                break;
+            case STPSourceTypeSofort:
+                dataSource = [[STPSofortSourceInfoDataSource alloc] initWithSourceParams:sourceParams];
+                break;
+            default:
+                dataSource = [[STPSourceInfoDataSource alloc] init];
+                break;
+        }
+        _dataSource = dataSource;
+        self.title = dataSource.title;
+    }
+    return self;
+}
+
+- (STPSourceParams *)completeSourceParams {
+    return self.dataSource.completeSourceParams;
+}
+
+- (void)createAndSetupViews {
+    [super createAndSetupViews];
+    UIBarButtonItem *doneItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(nextPressed:)];
+    self.doneItem = doneItem;
+    self.stp_navigationItemProxy.rightBarButtonItem = doneItem;
+    self.stp_navigationItemProxy.rightBarButtonItem.enabled = NO;
+
+    self.tableView.dataSource = self;
+    self.tableView.delegate = self;
+
+    STPTextFieldTableViewCell *lastCell = [self.dataSource.cells lastObject];
+    for (STPTextFieldTableViewCell *cell in self.dataSource.cells) {
+        cell.delegate = self;
+        cell.lastInList = (cell == lastCell);
+    }
+
+    [self.view addGestureRecognizer:[[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(endEditing)]];
+}
+
+- (void)endEditing {
+    [self.view endEditing:NO];
+}
+
+- (void)updateAppearance {
+    [super updateAppearance];
+
+    self.view.backgroundColor = self.theme.primaryBackgroundColor;
+
+    STPTheme *navBarTheme = self.navigationController.navigationBar.stp_theme ?: self.theme;
+    [self.doneItem stp_setTheme:navBarTheme];
+
+    for (STPTextFieldTableViewCell *cell in self.dataSource.cells) {
+        cell.theme = self.theme;
+    }
+
+    self.tableView.allowsSelection = NO;
+    [self setNeedsStatusBarAppearanceUpdate];
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+    [self stp_beginObservingKeyboardAndInsettingScrollView:self.tableView
+                                             onChangeBlock:nil];
+    [[self firstEmptyField] becomeFirstResponder];
+}
+
+- (UIResponder *)firstEmptyField {
+    for (STPTextFieldTableViewCell *cell in self.dataSource.cells) {
+        if (cell.contents.length == 0) {
+            return cell;
+        }
+    }
+    return nil;
+}
+
+- (void)handleBackOrCancelTapped:(__unused id)sender {
+    [self.delegate sourceInfoViewControllerDidCancel:self];
+}
+
+- (void)nextPressed:(__unused id)sender {
+    STPSourceParams *params = [self.dataSource completeSourceParams];
+    [self.delegate sourceInfoViewController:self
+                  didFinishWithSourceParams:params];
+}
+
+- (void)updateDoneButton {
+    self.stp_navigationItemProxy.rightBarButtonItem.enabled = self.validContents;
+}
+
+- (BOOL)validContents {
+    return self.dataSource.completeSourceParams != nil;
+}
+
+- (STPTextFieldTableViewCell *)cellBeforeCell:(STPTextFieldTableViewCell *)cell {
+    NSInteger index = [self.dataSource.cells indexOfObject:cell];
+    return [self.dataSource.cells stp_boundSafeObjectAtIndex:index - 1];
+}
+
+- (STPTextFieldTableViewCell *)cellAfterCell:(STPTextFieldTableViewCell *)cell {
+    NSInteger index = [self.dataSource.cells indexOfObject:cell];
+    return [self.dataSource.cells stp_boundSafeObjectAtIndex:index + 1];
+}
+
+#pragma mark - STPTextFieldTableViewCellDelegate
+
+- (void)textFieldTableViewCellDidUpdateText:(__unused STPTextFieldTableViewCell *)cell {
+    [self updateDoneButton];
+}
+
+- (void)textFieldTableViewCellDidReturn:(STPTextFieldTableViewCell *)cell {
+    [[self cellAfterCell:cell] becomeFirstResponder];
+}
+
+- (void)textFieldTableViewCellDidBackspaceOnEmpty:(STPTextFieldTableViewCell *)cell {
+    [[self cellBeforeCell:cell] becomeFirstResponder];
+}
+
+#pragma mark - UITableView
+
+- (NSInteger)numberOfSectionsInTableView:(__unused UITableView *)tableView {
+    return 1;
+}
+
+- (NSInteger)tableView:(__unused UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+    if (section == 0) {
+        return [self.dataSource.cells count];
+    } else {
+        return 0;
+    }
+}
+
+- (UITableViewCell *)tableView:(__unused UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    UITableViewCell *cell = [self.dataSource.cells stp_boundSafeObjectAtIndex:indexPath.row];
+    return cell;
+}
+
+- (void)tableView:(UITableView *)tableView willDisplayCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath {
+    BOOL topRow = (indexPath.row == 0);
+    BOOL bottomRow = ([self tableView:tableView numberOfRowsInSection:indexPath.section] - 1 == indexPath.row);
+    [cell stp_setBorderColor:self.theme.tertiaryBackgroundColor];
+    [cell stp_setTopBorderHidden:!topRow];
+    [cell stp_setBottomBorderHidden:!bottomRow];
+    [cell stp_setFakeSeparatorColor:self.theme.quaternaryBackgroundColor];
+    [cell stp_setFakeSeparatorLeftInset:15.0f];
+}
+
+@end

--- a/Stripe/STPTextFieldTableViewCell.h
+++ b/Stripe/STPTextFieldTableViewCell.h
@@ -1,0 +1,41 @@
+//
+//  STPTextFieldTableViewCell.h
+//  Stripe
+//
+//  Created by Ben Guo on 2/9/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import "STPFormTextField.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef BOOL (^STPTextValidationBlock)(NSString *contents, BOOL editing);
+
+@class STPTextFieldTableViewCell, STPTheme, STPFormTextField;
+
+@protocol STPTextFieldTableViewCellDelegate <NSObject>
+
+- (void)textFieldTableViewCellDidUpdateText:(STPTextFieldTableViewCell *)cell;
+
+@optional
+- (void)textFieldTableViewCellDidBackspaceOnEmpty:(STPTextFieldTableViewCell *)cell;
+- (void)textFieldTableViewCellDidReturn:(STPTextFieldTableViewCell *)cell;
+
+@end
+
+@interface STPTextFieldTableViewCell : UITableViewCell <STPFormTextFieldDelegate>
+
+@property (nonatomic, copy) STPTextValidationBlock textValidationBlock;
+@property(nonatomic)STPTheme *theme;
+@property(nonatomic, copy) NSString *placeholder;
+@property(nonatomic, copy) NSString *contents;
+@property(nonatomic, weak)id<STPTextFieldTableViewCellDelegate>delegate;
+@property(nonatomic, weak) STPFormTextField *textField;
+@property(nonatomic, assign) BOOL lastInList;
+@property(nonatomic, readonly) BOOL isValid;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Stripe/STPTextFieldTableViewCell.m
+++ b/Stripe/STPTextFieldTableViewCell.m
@@ -1,0 +1,114 @@
+//
+//  STPTextFieldTableViewCell.m
+//  Stripe
+//
+//  Created by Ben Guo on 2/9/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import "STPTextFieldTableViewCell.h"
+
+#import "STPFormTextField.h"
+#import "STPTheme.h"
+
+@interface STPTextFieldTableViewCell()
+
+@end
+
+@implementation STPTextFieldTableViewCell
+
+- (instancetype)init {
+    self = [super initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
+    if (self) {
+        _theme = [STPTheme defaultTheme];
+        STPFormTextField *textField = [[STPFormTextField alloc] init];
+        textField.formDelegate = self;
+        textField.autoFormattingBehavior = STPFormTextFieldAutoFormattingBehaviorNone;
+        textField.selectionEnabled = YES;
+        textField.preservesContentsOnPaste = YES;
+        _textField = textField;
+        _textValidationBlock = ^BOOL(NSString *contents, __unused BOOL editing) {
+            return contents.length > 0;
+        };
+        [self.contentView addSubview:textField];
+        [self updateAppearance];
+    }
+    return self;
+}
+
+- (void)setTheme:(STPTheme *)theme {
+    _theme = theme;
+    [self updateAppearance];
+}
+
+- (void)updateAppearance {
+    self.contentView.backgroundColor = self.theme.secondaryBackgroundColor;
+    self.backgroundColor = [UIColor clearColor];
+    self.textField.placeholderColor = self.theme.tertiaryForegroundColor;
+    self.textField.defaultColor = self.theme.primaryForegroundColor;
+    self.textField.errorColor = self.theme.errorColor;
+    self.textField.font = self.theme.font;
+    [self setNeedsLayout];
+}
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    CGFloat textFieldX = 15;
+    self.textField.frame = CGRectMake(textFieldX, 1, self.bounds.size.width - textFieldX, self.bounds.size.height - 1);
+}
+
+- (BOOL)becomeFirstResponder {
+    return [self.textField becomeFirstResponder];
+}
+
+- (void)setPlaceholder:(NSString *)placeholder {
+    self.textField.placeholder = placeholder;
+}
+
+- (NSString *)placeholder {
+    return self.textField.placeholder;
+}
+
+- (void)setContents:(NSString *)contents {
+    _contents = contents;
+    self.textField.text = contents;
+    if ([self.textField isFirstResponder]) {
+        self.textField.validText = self.textValidationBlock(contents, YES);
+    } else {
+        self.textField.validText = self.textValidationBlock(contents, NO);
+    }
+}
+
+- (void)setLastInList:(BOOL)lastInList {
+    _lastInList = lastInList;
+    self.textField.returnKeyType = lastInList ? UIReturnKeyDone : UIReturnKeyDefault;
+}
+
+- (BOOL)isValid {
+    return self.contents.length > 0;
+}
+
+#pragma mark - STPFormTextFieldDelegate
+
+- (void)formTextFieldTextDidChange:(STPFormTextField *)textField {
+    _contents = textField.text;
+    self.textField.validText = self.textValidationBlock(self.contents, YES);
+    [self.delegate textFieldTableViewCellDidUpdateText:self];
+}
+
+- (BOOL)textFieldShouldReturn:(__unused UITextField *)textField {
+    if ([self.delegate respondsToSelector:@selector(textFieldTableViewCellDidReturn:)]) {
+        [self.delegate textFieldTableViewCellDidReturn:self];
+    }
+    return NO;
+}
+
+- (void)textFieldDidEndEditing:(__unused STPFormTextField *)textField {
+    self.textField.validText = self.textValidationBlock(self.contents, NO);
+}
+
+- (void)formTextFieldDidBackspaceOnEmpty:(__unused STPFormTextField *)formTextField {
+    [self.delegate textFieldTableViewCellDidBackspaceOnEmpty:self];
+}
+
+@end

--- a/Tests/Tests/STPSourceInfoViewControllerTest.m
+++ b/Tests/Tests/STPSourceInfoViewControllerTest.m
@@ -1,0 +1,136 @@
+//
+//  STPSourceInfoViewControllerTest.m
+//  Stripe
+//
+//  Created by Ben Guo on 2/13/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "STPSourceInfoViewController.h"
+#import "STPSourceInfoDataSource.h"
+#import "STPTextFieldTableViewCell.h"
+
+@interface STPSourceInfoViewController ()
+@property(nonatomic)STPSourceInfoDataSource *dataSource;
+@end
+
+@interface STPSourceInfoViewControllerTest : XCTestCase
+
+@end
+
+@implementation STPSourceInfoViewControllerTest
+
+- (STPSourceInfoViewController *)sutWithType:(STPSourceType)type
+                                        info:(STPUserInformation *)info {
+    STPTheme *theme = [STPTheme defaultTheme];
+    STPPaymentConfiguration *config = [STPPaymentConfiguration sharedConfiguration];
+    // TODO: set returnURL and verify in tests
+    NSInteger amount = 100;
+    STPSourceInfoViewController *sut = [[STPSourceInfoViewController alloc] initWithSourceType:type
+                                                                                        amount:amount
+                                                                                 configuration:config
+                                                                          prefilledInformation:info
+                                                                                         theme:theme];
+    UINavigationController *navController = [UINavigationController new];
+    navController.view.frame = CGRectMake(0, 0, 320, 750);
+    [navController pushViewController:sut animated:NO];
+    [navController.view layoutIfNeeded];
+    return sut;
+}
+
+- (void)testInitWithSourceParams_unsupportedType {
+    STPUserInformation *info = [STPUserInformation new];
+    STPSourceInfoViewController *sut = [self sutWithType:STPSourceTypeBitcoin info:info];
+    XCTAssertNil(sut);
+}
+
+- (void)testInitWithSourceParams_bancontact {
+    STPUserInformation *info = [STPUserInformation new];
+    STPAddress *address = [STPAddress new];
+    address.name = @"Jenny Rosen";
+    info.billingAddress = address;
+    STPSourceInfoViewController *sut = [self sutWithType:STPSourceTypeBancontact
+                                                    info:info];
+
+    XCTAssertEqual(sut.dataSource.cells.count, 1U);
+    STPTextFieldTableViewCell *nameCell = [sut.dataSource.cells firstObject];
+    XCTAssertEqualObjects(nameCell.contents, @"Jenny Rosen");
+
+    nameCell.contents = @"";
+    XCTAssertNil(sut.completeSourceParams);
+
+    nameCell.contents = @"John Smith";
+    XCTAssertNotNil(sut.completeSourceParams);
+    XCTAssertEqualObjects(sut.completeSourceParams.owner[@"name"], nameCell.contents);
+}
+
+- (void)testInitWithSourceParams_giropay {
+    STPUserInformation *info = [STPUserInformation new];
+    STPAddress *address = [STPAddress new];
+    address.name = @"Jenny Rosen";
+    info.billingAddress = address;
+    STPSourceInfoViewController *sut = [self sutWithType:STPSourceTypeGiropay
+                                                    info:info];
+
+    XCTAssertEqual(sut.dataSource.cells.count, 1U);
+    STPTextFieldTableViewCell *nameCell = [sut.dataSource.cells firstObject];
+    XCTAssertEqualObjects(nameCell.contents, @"Jenny Rosen");
+
+    nameCell.contents = @"";
+    XCTAssertNil(sut.completeSourceParams);
+
+    nameCell.contents = @"John Smith";
+    XCTAssertNotNil(sut.completeSourceParams);
+    XCTAssertEqualObjects(sut.completeSourceParams.owner[@"name"], nameCell.contents);
+}
+
+- (void)testInitWithSourceParams_iDEAL {
+    STPUserInformation *info = [STPUserInformation new];
+    // TODO: test setting idealBank in STPUserInformation
+    STPAddress *address = [STPAddress new];
+    address.name = @"Jenny Rosen";
+    info.billingAddress = address;
+    STPSourceInfoViewController *sut = [self sutWithType:STPSourceTypeIDEAL
+                                                    info:info];
+
+    XCTAssertEqual(sut.dataSource.cells.count, 2U);
+    STPTextFieldTableViewCell *nameCell = [sut.dataSource.cells firstObject];
+    XCTAssertEqualObjects(nameCell.contents, @"Jenny Rosen");
+    STPTextFieldTableViewCell *bankCell = [sut.dataSource.cells lastObject];
+//    XCTAssertEqualObjects(bankCell.contents, @"bunq");
+
+    nameCell.contents = @"";
+    bankCell.contents = @"";
+    XCTAssertNil(sut.completeSourceParams);
+
+    nameCell.contents = @"John Smith";
+    bankCell.contents = @"rabobank";
+    XCTAssertNotNil(sut.completeSourceParams);
+    XCTAssertEqualObjects(sut.completeSourceParams.owner[@"name"], nameCell.contents);
+    NSDictionary *idealDict = sut.completeSourceParams.additionalAPIParameters[@"ideal"];
+    XCTAssertEqualObjects(idealDict, @{@"bank": @"rabobank"});
+}
+
+- (void)testInitWithSourceParams_sofort {
+    STPUserInformation *info = [STPUserInformation new];
+    STPAddress *address = [STPAddress new];
+    address.country = @"FR";
+    info.billingAddress = address;
+    STPSourceInfoViewController *sut = [self sutWithType:STPSourceTypeSofort
+                                                    info:info];
+
+    XCTAssertEqual(sut.dataSource.cells.count, 1U);
+    STPTextFieldTableViewCell *countryCell = [sut.dataSource.cells firstObject];
+    XCTAssertEqualObjects(countryCell.contents, @"FR");
+
+    countryCell.contents = @"";
+    XCTAssertNil(sut.completeSourceParams);
+
+    countryCell.contents = @"AT";
+    XCTAssertNotNil(sut.completeSourceParams);
+    NSDictionary *sofortDict = sut.completeSourceParams.additionalAPIParameters[@"sofort"];
+    XCTAssertEqualObjects(sofortDict, @{@"country": @"AT"});
+}
+
+@end


### PR DESCRIPTION
re-r? @bdorfman-stripe 

My previous PR (https://github.com/stripe/stripe-ios/pull/555) got corrupted somehow after rebasing, so I had to make a new PR. It's the same one you reviewed already, only I've moved source-specific logic into subclasses of `STPSourceInfoDataSource`.