### PR TITLE
Add property on STPPaymentCardTextField for card brand

### DIFF
--- a/Stripe/PublicHeaders/STPPaymentCardTextField.h
+++ b/Stripe/PublicHeaders/STPPaymentCardTextField.h
@@ -264,6 +264,11 @@
  */
 @property(nonatomic, strong, readwrite, nonnull) STPCardParams *cardParams;
 
+/**
+ *  Convenience property for reading the enterred card's brand
+ */
+@property(nonatomic, readonly) STPCardBrand cardBrand;
+
 - (void)commonInit;
 
 @end

--- a/Stripe/STPPaymentCardTextField.m
+++ b/Stripe/STPPaymentCardTextField.m
@@ -462,6 +462,10 @@ CGFloat const STPPaymentCardTextFieldDefaultPadding = 13;
     [self updateCVCPlaceholder];
 }
 
+- (STPCardBrand)cardBrand {
+    return self.viewModel.brand;
+}
+
 - (void)setText:(NSString *)text inField:(STPCardFieldType)field {
     NSString *nonNilText = text ?: @"";
     STPFormTextField *textField = nil;


### PR DESCRIPTION
## Summary

Add property on STPPaymentCardTextField for card brand.

## Motivation
There are cases that I want to know the user's card brand. For example, I want to identify when a user enters an Amex card, because its CVV length could be 4 digits, and I want to handle the UI differently.

## Testing
This property builds on the brand property in STPPaymentCardTextFieldViewModel, and returns the same value.
