### PR TITLE
Handle payment request being concrete source

### DIFF
--- a/Example/Stripe iOS Example (Simple)/CheckoutViewController.swift
+++ b/Example/Stripe iOS Example (Simple)/CheckoutViewController.swift
@@ -192,6 +192,9 @@ class CheckoutViewController: UIViewController, STPPaymentContextDelegate {
             message = "You bought a \(self.product)!"
         case .userCancellation:
             return
+        case .pending:
+            title = "Order received"
+            message = "Item will ship when payment is confirmed."
         }
         let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
         let action = UIAlertAction(title: "OK", style: .default, handler: nil)

--- a/Stripe/PublicHeaders/STPBlocks.h
+++ b/Stripe/PublicHeaders/STPBlocks.h
@@ -56,6 +56,13 @@ typedef NS_ENUM(NSUInteger, STPPaymentStatus) {
      *  The user cancelled the payment (for example, by hitting "cancel" in the Apple Pay dialog).
      */
     STPPaymentStatusUserCancellation,
+
+    /**
+     * The status of the payment cannot be determined at this time.
+     * E.g. the user payed with a redirect-flow source, and the source
+     * is still in the pending state.
+     */
+    STPPaymentStatusPending,
 };
 
 /**

--- a/Stripe/PublicHeaders/STPPaymentConfiguration.h
+++ b/Stripe/PublicHeaders/STPPaymentConfiguration.h
@@ -104,6 +104,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic) BOOL smsAutofillDisabled;
 
+- (void)setReturnURL:(nullable NSURL *)returnURL NS_EXTENSION_UNAVAILABLE("Redirect based sources are not available in extensions");
+- (nullable NSURL *)returnURL;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Stripe/PublicHeaders/STPPaymentContext.h
+++ b/Stripe/PublicHeaders/STPPaymentContext.h
@@ -198,7 +198,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Inside this method, you should make a call to your backend API to make a charge with that Customer + source, and invoke the `completion` block when that is done.
  *
- *  @note This method is not called for redirect-based sources. See `paymentContext:redirectDidReturnForSource:`
+ *  @note This method is not called for redirect-based sources.
  *
  *  @param paymentContext The context that succeeded
  *  @param paymentResult  Information associated with the payment that you can pass to your server. You should go to your backend API with this payment result and make a charge to complete the payment, passing `paymentResult.source.stripeID` as the `source` parameter to the create charge method and your customer's ID as the `customer` parameter (see stripe.com/docs/api#charge_create for more info). Once that's done call the `completion` block with any error that occurred (or none, if the charge succeeded). @see STPPaymentResult.h
@@ -240,6 +240,16 @@ didCreatePaymentResult:(STPPaymentResult *)paymentResult
 - (void)paymentContext:(STPPaymentContext *)paymentContext
 didUpdateShippingAddress:(STPAddress *)address
             completion:(STPShippingMethodsCompletionBlock)completion;
+
+/**
+ *  This method is called after the user returns to the app after completing
+ *  a redirect-based payment method.
+ *
+ *  You may want to show some sort of loading UI on screen when this happens,
+ *  while payment context polls for updated source information. When source polling
+ *  completes, the delegate will receive a call to `paymentContext:didFinishWithStatus:error:`
+ */
+- (void)paymentContextDidReturnFromRedirect:(STPPaymentContext *)paymentContext;
 
 @end
 

--- a/Stripe/PublicHeaders/STPPaymentContext.h
+++ b/Stripe/PublicHeaders/STPPaymentContext.h
@@ -19,7 +19,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class STPPaymentContext, STPAPIClient, STPTheme;
+@class STPPaymentContext, STPTheme;
 @protocol STPBackendAPIAdapter, STPPaymentMethod, STPPaymentContextDelegate;
 
 /**
@@ -197,6 +197,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  *  Inside this method, you should make a call to your backend API to make a charge with that Customer + source, and invoke the `completion` block when that is done.
+ *
+ *  @note This method is not called for redirect-based sources. See `paymentContext:redirectDidReturnForSource:`
  *
  *  @param paymentContext The context that succeeded
  *  @param paymentResult  Information associated with the payment that you can pass to your server. You should go to your backend API with this payment result and make a charge to complete the payment, passing `paymentResult.source.stripeID` as the `source` parameter to the create charge method and your customer's ID as the `customer` parameter (see stripe.com/docs/api#charge_create for more info). Once that's done call the `completion` block with any error that occurred (or none, if the charge succeeded). @see STPPaymentResult.h

--- a/Stripe/STPPaymentConfiguration+Private.h
+++ b/Stripe/STPPaymentConfiguration+Private.h
@@ -8,11 +8,23 @@
 
 #import <Stripe/Stripe.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface STPPaymentConfiguration ()
 
 @property(nonatomic, readonly)BOOL applePayEnabled;
 @property(nonatomic, readwrite) BOOL ineligibleForSmsAutofill;
 @property (nonatomic, copy) NSOrderedSet<STPPaymentMethodType *> *availablePaymentMethodTypesSet;
 
+/**
+ Optional block to get around app extension restrictions
+ It is set by returnURL setter so should exist for anyone using redirect sources with payment context
+ 
+ It handles opening the redirect url, subscribes for foreground notifications, 
+ does some polling when the customer comes back, and then returns you the completed source object
+ */
+@property (nonatomic, copy, nullable) void (^sourceURLRedirectBlock)(STPAPIClient *apiClient, STPSource *source, STPSourceCompletionBlock completion);
+
 @end
 
+NS_ASSUME_NONNULL_END

--- a/Stripe/STPPaymentConfiguration+Private.h
+++ b/Stripe/STPPaymentConfiguration+Private.h
@@ -23,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
  It handles opening the redirect url, subscribes for foreground notifications, 
  does some polling when the customer comes back, and then returns you the completed source object
  */
-@property (nonatomic, copy, nullable) void (^sourceURLRedirectBlock)(STPAPIClient *apiClient, STPSource *source, STPSourceCompletionBlock completion);
+@property (nonatomic, copy, nullable) void (^sourceURLRedirectBlock)(STPAPIClient *apiClient, STPSource *source, STPVoidBlock onRedirectReturn, STPSourceCompletionBlock completion);
 
 @end
 

--- a/Stripe/STPPaymentConfiguration.m
+++ b/Stripe/STPPaymentConfiguration.m
@@ -91,13 +91,18 @@
 
 - (void)setReturnURL:(nullable NSURL *)returnURL {
     _returnURL = returnURL;
-    self.sourceURLRedirectBlock = ^(STPAPIClient *apiClient, STPSource *source, STPSourceCompletionBlock completion) {
+    self.sourceURLRedirectBlock = ^(STPAPIClient *apiClient, STPSource *source, STPVoidBlock onRedirectReturn, STPSourceCompletionBlock completion) {
         if (completion) {
             __block id notificationObserver = nil;
 
             void (^notificationBlock)(NSNotification * _Nonnull note) = ^(NSNotification * __unused _Nonnull note) {
                 [[NSNotificationCenter defaultCenter] removeObserver:notificationObserver];
                 notificationObserver = nil;
+
+                if (onRedirectReturn) {
+                    onRedirectReturn();
+                }
+
                 __block STPSourcePoller *poller = [[STPSourcePoller alloc] initWithAPIClient:apiClient
                                                                                 clientSecret:source.clientSecret
                                                                                     sourceID:source.stripeID

--- a/Stripe/STPPaymentContext.m
+++ b/Stripe/STPPaymentContext.m
@@ -527,10 +527,9 @@
                 case STPSourceFlowUnknown:
                 {
                     // We don't support this type
-                    // TODO: Fill in an apprioriate NSError object
                     [self.delegate paymentContext:self
                               didFinishWithStatus:STPPaymentStatusError
-                                            error:nil];
+                                            error:[NSError stp_genericFailedToParseResponseError]];
                 }
                     break;
             }


### PR DESCRIPTION
If you hit request payment method with a concrete source object, either hit existing callback for flow = none or do redirect and poll if flow == redirect

Might need some new UI or flow to handle the "we need to show a spinner while polling" case? requestPayment is theoretically already async, I'm not sure how we handle that currently (or if we do at all).