### PR TITLE
Fix requestPayment logic

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,5 +1,9 @@
 ## Migration Guides
 
+### Migrating from versions < 11.0
+
+- STPPaymentMethodsViewControllerDelegate now has a separate `paymentMethodsViewControllerDidCancel:` callback, differentiating from successful method selections. You should make sure to also dismiss the view controller in that callback.
+
 ### Migrating from versions < 10.0
 
 - Methods deprecated in Version 6.0 have now been removed.

--- a/Stripe/PublicHeaders/STPPaymentContext.h
+++ b/Stripe/PublicHeaders/STPPaymentContext.h
@@ -144,32 +144,67 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, assign) UIModalPresentationStyle modalPresentationStyle;
 
 /**
- *  If `paymentContext:didFailToLoadWithError:` is called on your delegate, you can in turn call this method to try loading again (if that hasn't been called, calling this will do nothing). If retrying in turn fails, `paymentContext:didFailToLoadWithError:` will be called again (and you can again call this to keep retrying, etc).
+ *  If `paymentContext:didFailToLoadWithError:` is called on your delegate, you
+ *  can in turn call this method to try loading again (if that hasn't been called, 
+ *  calling this will do nothing). If retrying in turn fails, `paymentContext:didFailToLoadWithError:` 
+ *  will be called again (and you can again call this to keep retrying, etc).
  */
 - (void)retryLoading;
 
 /**
- *  This creates, configures, and appropriately presents an `STPPaymentMethodsViewController` on top of the payment context's `hostViewController`. It'll be dismissed automatically when the user is done selecting their payment method.
+ *  This creates, configures, and appropriately presents an `STPPaymentMethodsViewController` 
+ *  on top of the payment context's `hostViewController`. It'll be dismissed automatically 
+ *  when the user is done selecting their payment method.
+ *  
+ *  @note This method will do nothing if it is called while STPPaymentContext is 
+ *        already showing a view controller or in the middle of requesting a payment.
  */
 - (void)presentPaymentMethodsViewController;
 
 /**
- *  This creates, configures, and appropriately pushes an `STPPaymentMethodsViewController` onto the navigation stack of the context's `hostViewController`. It'll be popped automatically when the user is done selecting their payment method.
+ *  This creates, configures, and appropriately pushes an `STPPaymentMethodsViewController` 
+ *  onto the navigation stack of the context's `hostViewController`. It'll be popped 
+ *  automatically when the user is done selecting their payment method.
+ *
+ *  @note This method will do nothing if it is called while STPPaymentContext is
+ *        already showing a view controller or in the middle of requesting a payment.
  */
 - (void)pushPaymentMethodsViewController;
 
 /**
- *  This creates, configures, and appropriately presents a view controller for collecting shipping address and shipping method on top of the payment context's `hostViewController`. It'll be dismissed automatically when the user is done entering their shipping info.
+ *  This creates, configures, and appropriately presents a view controller for 
+ *  collecting shipping address and shipping method on top of the payment context's 
+ *  `hostViewController`. It'll be dismissed automatically when the user is done 
+ *  entering their shipping info.
+ *
+ *  @note This method will do nothing if it is called while STPPaymentContext is
+ *        already showing a view controller or in the middle of requesting a payment.
  */
 - (void)presentShippingViewController;
 
 /**
- *  This creates, configures, and appropriately pushes a view controller for collecting shipping address and shipping method onto the navigation stack of the context's `hostViewController`. It'll be popped automatically when the user is done entering their shipping info.
+ *  This creates, configures, and appropriately pushes a view controller for 
+ *  collecting shipping address and shipping method onto the navigation stack of 
+ *  the context's `hostViewController`. It'll be popped automatically when the 
+ *  user is done entering their shipping info.
+ *
+ *  @note This method will do nothing if it is called while STPPaymentContext is
+ *        already showing a view controller, or in the middle of requesting a payment.
  */
 - (void)pushShippingViewController;
 
 /**
- *  Requests payment from the user. This may need to present some supplemental UI to the user, in which case it will be presented on the payment context's `hostViewController`. For instance, if they've selected Apple Pay as their payment method, calling this method will show the payment sheet. If the user has a card on file, this will use that without presenting any additional UI. After this is called, the `paymentContext:didCreatePaymentResult:completion:` and `paymentContext:didFinishWithStatus:error:` methods will be called on the context's `delegate`.
+ *  Requests payment from the user. This may need to present some supplemental UI
+ *  to the user, in which case it will be presented on the payment context's 
+ *  `hostViewController`. For instance, if they've selected Apple Pay as their 
+ *  payment method, calling this method will show the payment sheet. If the user
+ *  has a card on file, this will use that without presenting any additional UI.
+ *  After this is called, the `paymentContext:didCreatePaymentResult:completion:` 
+ *  and `paymentContext:didFinishWithStatus:error:` methods will be called on the
+ *  context's `delegate`.
+ *
+ *  @note This method will do nothing if it is called while STPPaymentContext is
+ *        already showing a view controller, or in the middle of requesting a payment.
  */
 - (void)requestPayment;
 

--- a/Stripe/PublicHeaders/STPPaymentMethodsViewController.h
+++ b/Stripe/PublicHeaders/STPPaymentMethodsViewController.h
@@ -88,11 +88,19 @@ NS_ASSUME_NONNULL_BEGIN
               didFailToLoadWithError:(NSError *)error;
 
 /**
- *  This is called when the user taps "cancel". It's also called after the user directly selects or adds a payment method, so it will often be called immediately after calling `paymentMethodsViewController:didSelectPaymentMethod:`. You should dismiss the view controller when this is called.
+ *  This is called when the user selects or adds a payment method, so it will often be called immediately after calling `paymentMethodsViewController:didSelectPaymentMethod:`. You should dismiss the view controller when this is called.
  *
  *  @param paymentMethodsViewController the view controller that has finished
  */
 - (void)paymentMethodsViewControllerDidFinish:(STPPaymentMethodsViewController *)paymentMethodsViewController;
+
+/**
+ *  This is called when the user taps "cancel".
+ *  You should dismiss the view controller when this is called.
+ *
+ *  @param paymentMethodsViewController the view controller that has finished
+ */
+- (void)paymentMethodsViewControllerDidCancel:(STPPaymentMethodsViewController *)paymentMethodsViewController;
 
 @end
 

--- a/Stripe/STPPaymentContext.m
+++ b/Stripe/STPPaymentContext.m
@@ -383,9 +383,6 @@ typedef NS_ENUM(NSUInteger, STPPaymentContextState) {
             STPShippingAddressViewController *addressViewController = [[STPShippingAddressViewController alloc] initWithPaymentContext:self];
             [navigationController pushViewController:addressViewController animated:YES];
         }
-        else {
-            self.state = STPPaymentContextStateNone;
-        }
     }];
 }
 

--- a/Stripe/STPPaymentContext.m
+++ b/Stripe/STPPaymentContext.m
@@ -406,16 +406,9 @@
             return;
         }
         if (!self.selectedPaymentMethod) {
-            STPAddCardViewController *addCardViewController = [[STPAddCardViewController alloc] initWithConfiguration:self.configuration theme:self.theme];
-            addCardViewController.delegate = self;
-            addCardViewController.prefilledInformation = self.prefilledInformation;
-            addCardViewController.shippingAddress = self.shippingAddress;
-            UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:addCardViewController];
-            navigationController.navigationBar.stp_theme = self.theme;
-            navigationController.modalPresentationStyle = self.modalPresentationStyle;
-            [self.hostViewController presentViewController:navigationController animated:YES completion:nil];
+            [self presentPaymentMethodsViewController];
         }
-        if (self.configuration.requiredShippingAddressFields != STPBillingAddressFieldsNone &&
+        else if (self.configuration.requiredShippingAddressFields != STPBillingAddressFieldsNone &&
             !self.shippingAddress)
         {
             STPShippingAddressViewController *addressViewController = [[STPShippingAddressViewController alloc] initWithPaymentContext:self];

--- a/Stripe/STPPaymentContext.m
+++ b/Stripe/STPPaymentContext.m
@@ -26,7 +26,21 @@
 
 #define FAUXPAS_IGNORED_IN_METHOD(...)
 
-@interface STPPaymentContext()<STPPaymentMethodsViewControllerDelegate, STPAddCardViewControllerDelegate, STPShippingAddressViewControllerDelegate>
+
+/**
+ The current state of the payment context
+
+ - STPPaymentContextStateNone: No view controllers are currently being shown. The payment may or may not have already been completed
+ - STPPaymentContextStateShowingRequestedViewController: The view controller that you requested the context show is being shown (via the push or present payment methods or shipping view controller methods)
+ - STPPaymentContextStateRequestingPayment: The payment context is in the middle of requesting payment. It may be showing some other UI or view controller if more information is necessary to complete the payment.
+ */
+typedef NS_ENUM(NSUInteger, STPPaymentContextState) {
+    STPPaymentContextStateNone,
+    STPPaymentContextStateShowingRequestedViewController,
+    STPPaymentContextStateRequestingPayment,
+};
+
+@interface STPPaymentContext()<STPPaymentMethodsViewControllerDelegate, STPShippingAddressViewControllerDelegate>
 
 @property(nonatomic)STPPaymentConfiguration *configuration;
 @property(nonatomic)STPTheme *theme;
@@ -44,9 +58,8 @@
 @property(nonatomic)STPAddress *shippingAddress;
 @property(nonatomic)PKShippingMethod *selectedShippingMethod;
 @property(nonatomic)NSArray<PKShippingMethod *> *shippingMethods;
-// This property tracks whether we're currently collecting shipping info
-// in the middle of a call to requestPayment
-@property(nonatomic) BOOL isMidShippingInRequestPayment;
+
+@property(nonatomic, assign) STPPaymentContextState state;
 
 @property(nonatomic)STPPaymentContextAmountModel *paymentAmountModel;
 
@@ -75,7 +88,7 @@
         _paymentCurrency = @"USD";
         _paymentAmountModel = [[STPPaymentContextAmountModel alloc] initWithAmount:0];
         _modalPresentationStyle = UIModalPresentationFullScreen;
-        _isMidShippingInRequestPayment = NO;
+        _state = STPPaymentContextStateNone;
         [self retryLoading];
     }
     return self;
@@ -230,17 +243,24 @@
 #pragma mark - Payment Methods
 
 - (void)presentPaymentMethodsViewController {
+    [self presentPaymentMethodsViewControllerWithNewState:STPPaymentContextStateShowingRequestedViewController];
+}
+
+- (void)presentPaymentMethodsViewControllerWithNewState:(STPPaymentContextState)state {
     NSCAssert(self.hostViewController != nil, @"hostViewController must not be nil on STPPaymentContext when calling pushPaymentMethodsViewController on it. Next time, set the hostViewController property first!");
     WEAK(self);
     [self.didAppearPromise voidOnSuccess:^{
         STRONG(self);
-        STPPaymentMethodsViewController *paymentMethodsViewController = [[STPPaymentMethodsViewController alloc] initWithPaymentContext:self];
-        self.paymentMethodsViewController = paymentMethodsViewController;
-        paymentMethodsViewController.prefilledInformation = self.prefilledInformation;
-        UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:paymentMethodsViewController];
-        navigationController.navigationBar.stp_theme = self.theme;
-        navigationController.modalPresentationStyle = self.modalPresentationStyle;
-        [self.hostViewController presentViewController:navigationController animated:YES completion:nil];
+        if (self.state == STPPaymentContextStateNone) {
+            self.state = state;
+            STPPaymentMethodsViewController *paymentMethodsViewController = [[STPPaymentMethodsViewController alloc] initWithPaymentContext:self];
+            self.paymentMethodsViewController = paymentMethodsViewController;
+            paymentMethodsViewController.prefilledInformation = self.prefilledInformation;
+            UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:paymentMethodsViewController];
+            navigationController.navigationBar.stp_theme = self.theme;
+            navigationController.modalPresentationStyle = self.modalPresentationStyle;
+            [self.hostViewController presentViewController:navigationController animated:YES completion:nil];
+        }
     }];
 }
 
@@ -256,10 +276,14 @@
     WEAK(self);
     [self.didAppearPromise voidOnSuccess:^{
         STRONG(self);
-        STPPaymentMethodsViewController *paymentMethodsViewController = [[STPPaymentMethodsViewController alloc] initWithPaymentContext:self];
-        self.paymentMethodsViewController = paymentMethodsViewController;
-        paymentMethodsViewController.prefilledInformation = self.prefilledInformation;
-        [navigationController pushViewController:paymentMethodsViewController animated:YES];
+        if (self.state == STPPaymentContextStateNone) {
+            self.state = STPPaymentContextStateShowingRequestedViewController;
+
+            STPPaymentMethodsViewController *paymentMethodsViewController = [[STPPaymentMethodsViewController alloc] initWithPaymentContext:self];
+            self.paymentMethodsViewController = paymentMethodsViewController;
+            paymentMethodsViewController.prefilledInformation = self.prefilledInformation;
+            [navigationController pushViewController:paymentMethodsViewController animated:YES];
+        }
     }];
 }
 
@@ -269,7 +293,27 @@
 }
 
 - (void)paymentMethodsViewControllerDidFinish:(STPPaymentMethodsViewController *)paymentMethodsViewController {
-    [self appropriatelyDismissPaymentMethodsViewController:paymentMethodsViewController completion:nil];
+    [self appropriatelyDismissPaymentMethodsViewController:paymentMethodsViewController completion:^{
+        if (self.state == STPPaymentContextStateRequestingPayment) {
+            self.state = STPPaymentContextStateNone;
+            [self requestPayment];
+        }
+        else {
+            self.state = STPPaymentContextStateNone;
+        }
+    }];
+}
+
+- (void)paymentMethodsViewControllerDidCancel:(STPPaymentMethodsViewController *)paymentMethodsViewController {
+    [self appropriatelyDismissPaymentMethodsViewController:paymentMethodsViewController completion:^{
+        if (self.state == STPPaymentContextStateRequestingPayment) {
+            [self didFinishWithStatus:STPPaymentStatusUserCancellation
+                                error:nil];
+        }
+        else {
+            self.state = STPPaymentContextStateNone;
+        }
+    }];
 }
 
 - (void)paymentMethodsViewController:(__unused STPPaymentMethodsViewController *)paymentMethodsViewController
@@ -301,15 +345,23 @@
 #pragma mark - Shipping Info
 
 - (void)presentShippingViewController {
+    [self presentShippingViewControllerWithNewState:STPPaymentContextStateShowingRequestedViewController];
+}
+
+- (void)presentShippingViewControllerWithNewState:(STPPaymentContextState)state {
     NSCAssert(self.hostViewController != nil, @"hostViewController must not be nil on STPPaymentContext when calling presentShippingViewController on it. Next time, set the hostViewController property first!");
     WEAK(self);
     [self.didAppearPromise voidOnSuccess:^{
         STRONG(self);
-        STPShippingAddressViewController *addressViewController = [[STPShippingAddressViewController alloc] initWithPaymentContext:self];
-        UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:addressViewController];
-        navigationController.navigationBar.stp_theme = self.theme;
-        navigationController.modalPresentationStyle = self.modalPresentationStyle;
-        [self.hostViewController presentViewController:navigationController animated:YES completion:nil];
+        if (self.state == STPPaymentContextStateNone) {
+            self.state = state;
+
+            STPShippingAddressViewController *addressViewController = [[STPShippingAddressViewController alloc] initWithPaymentContext:self];
+            UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:addressViewController];
+            navigationController.navigationBar.stp_theme = self.theme;
+            navigationController.modalPresentationStyle = self.modalPresentationStyle;
+            [self.hostViewController presentViewController:navigationController animated:YES completion:nil];
+        }
     }];
 }
 
@@ -325,18 +377,26 @@
     WEAK(self);
     [self.didAppearPromise voidOnSuccess:^{
         STRONG(self);
-        STPShippingAddressViewController *addressViewController = [[STPShippingAddressViewController alloc] initWithPaymentContext:self];
-        [navigationController pushViewController:addressViewController animated:YES];
+        if (self.state == STPPaymentContextStateNone) {
+            self.state = STPPaymentContextStateShowingRequestedViewController;
+
+            STPShippingAddressViewController *addressViewController = [[STPShippingAddressViewController alloc] initWithPaymentContext:self];
+            [navigationController pushViewController:addressViewController animated:YES];
+        }
+        else {
+            self.state = STPPaymentContextStateNone;
+        }
     }];
 }
 
 - (void)shippingAddressViewControllerDidCancel:(STPShippingAddressViewController *)addressViewController {
     [self appropriatelyDismissViewController:addressViewController completion:^{
-        if (self.isMidShippingInRequestPayment) {
-            [self.delegate paymentContext:self
-                      didFinishWithStatus:STPPaymentStatusUserCancellation
-                                    error:nil];
-            self.isMidShippingInRequestPayment = NO;
+        if (self.state == STPPaymentContextStateRequestingPayment) {
+            [self didFinishWithStatus:STPPaymentStatusUserCancellation
+                                error:nil];
+        }
+        else {
+            self.state = STPPaymentContextStateNone;
         }
     }];
 }
@@ -366,9 +426,9 @@
     self.selectedShippingMethod = method;
     [self.delegate paymentContextDidChange:self];
     [self appropriatelyDismissViewController:addressViewController completion:^{
-        if (self.isMidShippingInRequestPayment) {
+        if (self.state == STPPaymentContextStateRequestingPayment) {
+            self.state = STPPaymentContextStateNone;
             [self requestPayment];
-            self.isMidShippingInRequestPayment = NO;
         }
     }];
 }
@@ -405,32 +465,34 @@
         if (!self) {
             return;
         }
+
+        if (self.state != STPPaymentContextStateNone) {
+            return;
+        }
+
         if (!self.selectedPaymentMethod) {
-            [self presentPaymentMethodsViewController];
+            [self presentPaymentMethodsViewControllerWithNewState:STPPaymentContextStateRequestingPayment];
         }
         else if (self.configuration.requiredShippingAddressFields != STPBillingAddressFieldsNone &&
-            !self.shippingAddress)
+                 !self.shippingAddress)
         {
-            STPShippingAddressViewController *addressViewController = [[STPShippingAddressViewController alloc] initWithPaymentContext:self];
-            self.isMidShippingInRequestPayment = YES;
-            UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:addressViewController];
-            navigationController.navigationBar.stp_theme = self.theme;
-            navigationController.modalPresentationStyle = self.modalPresentationStyle;
-            [self.hostViewController presentViewController:navigationController animated:YES completion:nil];
+            [self presentShippingViewControllerWithNewState:STPPaymentContextStateRequestingPayment];
         }
         else if ([self.selectedPaymentMethod isKindOfClass:[STPCard class]]) {
+            self.state = STPPaymentContextStateRequestingPayment;
             STPPaymentResult *result = [[STPPaymentResult alloc] initWithSource:(STPCard *)self.selectedPaymentMethod];
             [self.delegate paymentContext:self didCreatePaymentResult:result completion:^(NSError * _Nullable error) {
                 stpDispatchToMainThreadIfNecessary(^{
                     if (error) {
-                        [self.delegate paymentContext:self didFinishWithStatus:STPPaymentStatusError error:error];
+                        [self didFinishWithStatus:STPPaymentStatusError error:error];
                     } else {
-                        [self.delegate paymentContext:self didFinishWithStatus:STPPaymentStatusSuccess error:nil];
+                        [self didFinishWithStatus:STPPaymentStatusSuccess error:nil];
                     }
                 });
             }];
         }
         else if ([self.selectedPaymentMethod isKindOfClass:[STPApplePayPaymentMethod class]]) {
+            self.state = STPPaymentContextStateRequestingPayment;
             PKPaymentRequest *paymentRequest = [self buildPaymentRequest];
             STPShippingAddressSelectionBlock shippingAddressHandler = ^(STPAddress *shippingAddress, STPShippingAddressValidationBlock completion) {
                 // Apple Pay always returns a partial address here, so we won't
@@ -476,26 +538,33 @@
             PKPaymentAuthorizationViewController *paymentAuthVC;
             paymentAuthVC = [PKPaymentAuthorizationViewController
                              stp_controllerWithPaymentRequest:paymentRequest
-                                                    apiClient:self.apiClient
-                                   onShippingAddressSelection:shippingAddressHandler
-                                    onShippingMethodSelection:shippingMethodHandler
-                                       onPaymentAuthorization:paymentHandler
-                                              onTokenCreation:applePayTokenHandler
-                                                     onFinish:^(STPPaymentStatus status, NSError * _Nullable error) {
-                                                         [self.hostViewController dismissViewControllerAnimated:YES completion:^{
-                                                             [self.delegate paymentContext:self
-                                                                           didFinishWithStatus:status
-                                                                                         error:error];
-                                                         }];
-                                                     }];
+                             apiClient:self.apiClient
+                             onShippingAddressSelection:shippingAddressHandler
+                             onShippingMethodSelection:shippingMethodHandler
+                             onPaymentAuthorization:paymentHandler
+                             onTokenCreation:applePayTokenHandler
+                             onFinish:^(STPPaymentStatus status, NSError * _Nullable error) {
+                                 [self.hostViewController dismissViewControllerAnimated:YES completion:^{
+                                     [self didFinishWithStatus:status
+                                                         error:error];
+                                 }];
+                             }];
             [self.hostViewController presentViewController:paymentAuthVC
-                                                      animated:YES
-                                                    completion:nil];
+                                                  animated:YES
+                                                completion:nil];
         }
-    }]onFailure:^(NSError *error) {
+    }] onFailure:^(NSError *error) {
         STRONG(self);
-        [self.delegate paymentContext:self didFinishWithStatus:STPPaymentStatusError error:error];
+        [self didFinishWithStatus:STPPaymentStatusError error:error];
     }];
+}
+
+- (void)didFinishWithStatus:(STPPaymentStatus)status
+                      error:(nullable NSError *)error {
+    self.state = STPPaymentContextStateNone;
+    [self.delegate paymentContext:self
+              didFinishWithStatus:status
+                            error:error];
 }
 
 - (PKPaymentRequest *)buildPaymentRequest {
@@ -504,7 +573,7 @@
         return nil;
     }
     PKPaymentRequest *paymentRequest = [Stripe paymentRequestWithMerchantIdentifier:self.configuration.appleMerchantIdentifier];
-    
+
     NSArray<PKPaymentSummaryItem *> *summaryItems = self.paymentSummaryItems;
     paymentRequest.paymentSummaryItems = summaryItems;
     paymentRequest.requiredBillingAddressFields = [STPAddress applePayAddressFieldsFromBillingAddressFields:self.configuration.requiredBillingAddressFields];
@@ -552,32 +621,6 @@ static char kSTPPaymentCoordinatorAssociatedObjectKey;
 
 - (void)artificiallyRetain:(NSObject *)host {
     objc_setAssociatedObject(host, &kSTPPaymentCoordinatorAssociatedObjectKey, self, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-}
-
-- (void)addCardViewControllerDidCancel:(__unused STPAddCardViewController *)addCardViewController {
-    [self.hostViewController dismissViewControllerAnimated:YES completion:^{
-        [self.delegate paymentContext:self
-                  didFinishWithStatus:STPPaymentStatusUserCancellation
-                                error:nil];
-    }];
-}
-
-- (void)addCardViewController:(__unused STPAddCardViewController *)addCardViewController
-               didCreateToken:(STPToken *)token
-                   completion:(STPErrorBlock)completion {
-    [self.apiAdapter attachSourceToCustomer:token completion:^(NSError *error) {
-        stpDispatchToMainThreadIfNecessary(^{
-            if (error) {
-                completion(error);
-            } else {
-                [self.hostViewController dismissViewControllerAnimated:YES completion:^{
-                    completion(nil);
-                    self.selectedPaymentMethod = token.card;
-                    [self requestPayment];
-                }];
-            }
-        });
-    }];
 }
 
 @end

--- a/Stripe/STPPaymentMethodsViewController.m
+++ b/Stripe/STPPaymentMethodsViewController.m
@@ -163,7 +163,7 @@
 }
 
 - (void)handleBackOrCancelTapped:(__unused id)sender {
-    [self.delegate paymentMethodsViewControllerDidFinish:self];
+    [self.delegate paymentMethodsViewControllerDidCancel:self];
 }
 
 - (void)finishWithPaymentMethod:(id<STPPaymentMethod>)paymentMethod {
@@ -201,7 +201,9 @@
 }
 
 - (void)addCardViewControllerDidCancel:(__unused STPAddCardViewController *)addCardViewController {
-    [self.delegate paymentMethodsViewControllerDidFinish:self];
+    // Add card is only our direct delegate if there are no other payment methods possible
+    // and we skipped directly to this screen. In this case, a cancel from it is the same as a cancel to us.
+    [self.delegate paymentMethodsViewControllerDidCancel:self];
 }
 
 - (void)addCardViewController:(__unused STPAddCardViewController *)addCardViewController

--- a/Tests/Tests/STPPaymentMethodsViewControllerLocalizationTests.m
+++ b/Tests/Tests/STPPaymentMethodsViewControllerLocalizationTests.m
@@ -107,5 +107,8 @@
     
 }
 
+- (void)paymentMethodsViewControllerDidCancel:(__unused STPPaymentMethodsViewController *)paymentMethodsViewController {
+
+}
 
 @end

--- a/Tests/Tests/UINavigationBar+StripeTest.m
+++ b/Tests/Tests/UINavigationBar+StripeTest.m
@@ -34,6 +34,10 @@
 
 }
 
+- (void)paymentMethodsViewControllerDidCancel:(__unused STPPaymentMethodsViewController *)paymentMethodsViewController {
+
+}
+
 - (void)testVCUsesNavigationBarColor {
     STPPaymentMethodsViewController *paymentMethodsVC = [[STPPaymentMethodsViewController alloc] initWithConfiguration:[STPPaymentConfiguration sharedConfiguration]
                                                                                                                  theme:[STPTheme defaultTheme]


### PR DESCRIPTION
If there is no selectedPaymentMethod, we should just call requestPaymentMethodsVC instead. Besides de-duping code, current logic is wrong as it doesn't offer an option to use Apple Pay if its available.

Also seems like there was a missing else statement in this if/else flow. Not sure how this was working correctly tbh, seems like if you had no method and also no shipping info, it would try to push both? And/or set your `isMidShippingInRequestPayment` bit incorrectly.
