### PR TITLE
Auto select payment method if only one

### DIFF
--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -667,6 +667,7 @@
 		F15675401DB544D3004468E3 /* STPAddCardViewControllerLocalizationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F156753F1DB544D3004468E3 /* STPAddCardViewControllerLocalizationTests.m */; };
 		F15AC18E1DBA9CA90009EADE /* FBSnapshotTestCase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F15AC18D1DBA9CA90009EADE /* FBSnapshotTestCase.framework */; };
 		F15AC1901DBA9CC60009EADE /* FBSnapshotTestCase.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = F15AC18D1DBA9CA90009EADE /* FBSnapshotTestCase.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		F182941A1E89F6A6008F8E4E /* STPPaymentMethodTupleTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F18294191E89F6A6008F8E4E /* STPPaymentMethodTupleTest.m */; };
 		F1852F931D80B6EC00367C86 /* STPStringUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = F1852F911D80B6EC00367C86 /* STPStringUtils.h */; };
 		F1852F941D80B6EC00367C86 /* STPStringUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = F1852F911D80B6EC00367C86 /* STPStringUtils.h */; };
 		F1852F951D80B6EC00367C86 /* STPStringUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = F1852F921D80B6EC00367C86 /* STPStringUtils.m */; };
@@ -1153,6 +1154,7 @@
 		F1510BBE1D5A8146000731AD /* stp_card_jcb_template@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_jcb_template@3x.png"; sourceTree = "<group>"; };
 		F156753F1DB544D3004468E3 /* STPAddCardViewControllerLocalizationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPAddCardViewControllerLocalizationTests.m; sourceTree = "<group>"; };
 		F15AC18D1DBA9CA90009EADE /* FBSnapshotTestCase.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FBSnapshotTestCase.framework; path = Carthage/Build/iOS/FBSnapshotTestCase.framework; sourceTree = "<group>"; };
+		F18294191E89F6A6008F8E4E /* STPPaymentMethodTupleTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodTupleTest.m; sourceTree = "<group>"; };
 		F1852F911D80B6EC00367C86 /* STPStringUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPStringUtils.h; sourceTree = "<group>"; };
 		F1852F921D80B6EC00367C86 /* STPStringUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPStringUtils.m; sourceTree = "<group>"; };
 		F19491D81E5F606F001E1FC2 /* STPSourceCardDetails.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPSourceCardDetails.m; sourceTree = "<group>"; };
@@ -1553,6 +1555,7 @@
 				C1EC6D311E520F3000AF3659 /* STPSourceInfoViewControllerTest.m */,
 				C1D23FB71D37FE0F002FD83C /* JSON */,
 				F1122A7D1DFB84E000A8B1AF /* UINavigationBar+StripeTest.m */,
+				F18294191E89F6A6008F8E4E /* STPPaymentMethodTupleTest.m */,
 			);
 			name = StripeTests;
 			path = Tests/Tests;
@@ -2444,6 +2447,7 @@
 				F148ABF81D5E88BA0014FD92 /* MockSTPCheckoutAPIClient.m in Sources */,
 				C1E8E2E01E54F974006DC619 /* STPIBANValidatorTest.m in Sources */,
 				C124A1811CCAA1BF007D42EE /* NSMutableURLRequest+StripeTest.m in Sources */,
+				F182941A1E89F6A6008F8E4E /* STPPaymentMethodTupleTest.m in Sources */,
 				C1EEDCC61CA2126000A54582 /* STPDelegateProxyTest.m in Sources */,
 				F1D777C01D81DD520076FA19 /* STPStringUtilsTest.m in Sources */,
 				C1FEE5991CBFF24000A7632B /* STPPostalCodeValidatorTest.m in Sources */,

--- a/Stripe/PublicHeaders/STPPaymentContext.h
+++ b/Stripe/PublicHeaders/STPPaymentContext.h
@@ -89,6 +89,10 @@ NS_ASSUME_NONNULL_BEGIN
  *  The user's currently selected payment method. May be nil.
  */
 @property(nonatomic, readonly, nullable)id<STPPaymentMethod> selectedPaymentMethod;
+/**
+ *  The available payment methods the user can choose between. May be nil.
+ */
+@property(nonatomic, readonly, nullable)NSArray<id<STPPaymentMethod>> *paymentMethods;
 
 /**
  *  The user's currently selected shipping method. May be nil.

--- a/Stripe/STPPaymentContext.m
+++ b/Stripe/STPPaymentContext.m
@@ -194,6 +194,10 @@
     return self.paymentMethodTuple.selectedPaymentMethod;
 }
 
+- (NSArray<id<STPPaymentMethod>> *)paymentMethods {
+    return self.paymentMethodTuple.allPaymentMethods.allObjects;
+}
+
 - (void)setPaymentAmount:(NSInteger)paymentAmount {
     self.paymentAmountModel = [[STPPaymentContextAmountModel alloc] initWithAmount:paymentAmount];
 }

--- a/Stripe/STPPaymentMethodTuple.h
+++ b/Stripe/STPPaymentMethodTuple.h
@@ -18,7 +18,12 @@ NS_ASSUME_NONNULL_BEGIN
                       selectedPaymentMethod:(nullable id<STPPaymentMethod>)selectedPaymentMethod;
 
 /**
- The users currently chosen payment method
+ The users currently chosen payment method.
+ 
+ Must be in one of the other two arrays or will be nil'd.
+ 
+ If there is only one payment method total, it will be automatically set as
+ the selected one.
  */
 @property(nonatomic, nullable, readonly)id<STPPaymentMethod> selectedPaymentMethod;
 
@@ -32,6 +37,11 @@ NS_ASSUME_NONNULL_BEGIN
  Available previously known payment methods (eg saved cards, saved sepa debits)
  */
 @property(nonatomic, readonly)NSArray<id<STPPaymentMethod>> *savedPaymentMethods;
+
+/**
+ Unique set of all payment methods in tuple
+ */
+@property(nonatomic, readonly)NSSet<id<STPPaymentMethod>> *allPaymentMethods;
 
 @end
 

--- a/Stripe/STPPaymentMethodTuple.h
+++ b/Stripe/STPPaymentMethodTuple.h
@@ -23,7 +23,8 @@ NS_ASSUME_NONNULL_BEGIN
  Must be in one of the other two arrays or will be nil'd.
  
  If there is only one payment method total, it will be automatically set as
- the selected one.
+ the selected one if it is allowed to be selected (but not if its a generic
+ type that converts to source at selection like credit cards)
  */
 @property(nonatomic, nullable, readonly)id<STPPaymentMethod> selectedPaymentMethod;
 

--- a/Stripe/STPPaymentMethodTuple.h
+++ b/Stripe/STPPaymentMethodTuple.h
@@ -13,8 +13,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface STPPaymentMethodTuple : NSObject
 
-- (instancetype)initWithSavedPaymentMethods:(NSArray<id<STPPaymentMethod>> *)savedPaymentMethods
-                      availablePaymentTypes:(NSArray<STPPaymentMethodType *> *)availablePaymentTypes
+- (instancetype)initWithSavedPaymentMethods:(nullable NSArray<id<STPPaymentMethod>> *)savedPaymentMethods
+                      availablePaymentTypes:(nullable NSArray<STPPaymentMethodType *> *)availablePaymentTypes
                       selectedPaymentMethod:(nullable id<STPPaymentMethod>)selectedPaymentMethod;
 
 /**

--- a/Stripe/STPPaymentMethodTuple.m
+++ b/Stripe/STPPaymentMethodTuple.m
@@ -8,6 +8,8 @@
 
 #import "STPPaymentMethodTuple.h"
 
+#import "STPPaymentMethodType.h"
+
 @implementation STPPaymentMethodTuple
 
 - (instancetype)initWithSavedPaymentMethods:(NSArray<id<STPPaymentMethod>> *)savedPaymentMethods
@@ -16,7 +18,18 @@
     if ((self = [super init])) {
         _savedPaymentMethods = savedPaymentMethods ? savedPaymentMethods.copy : @[];
         _availablePaymentTypes = availablePaymentTypes ? availablePaymentTypes.copy : @[];
-        _selectedPaymentMethod = selectedPaymentMethod;
+
+        _allPaymentMethods = [NSSet setWithArray:[_savedPaymentMethods arrayByAddingObjectsFromArray:_availablePaymentTypes]];
+
+        if (_allPaymentMethods.count == 1) {
+            _selectedPaymentMethod = _allPaymentMethods.anyObject;
+        }
+        else if ([_allPaymentMethods containsObject:selectedPaymentMethod]) {
+            _selectedPaymentMethod = selectedPaymentMethod;
+        }
+        else {
+            _selectedPaymentMethod = nil;
+        }
     }
     return self;
 }

--- a/Stripe/STPPaymentMethodTuple.m
+++ b/Stripe/STPPaymentMethodTuple.m
@@ -12,8 +12,8 @@
 
 @implementation STPPaymentMethodTuple
 
-- (instancetype)initWithSavedPaymentMethods:(NSArray<id<STPPaymentMethod>> *)savedPaymentMethods
-                      availablePaymentTypes:(NSArray<STPPaymentMethodType *> *)availablePaymentTypes
+- (instancetype)initWithSavedPaymentMethods:(nullable NSArray<id<STPPaymentMethod>> *)savedPaymentMethods
+                      availablePaymentTypes:(nullable NSArray<STPPaymentMethodType *> *)availablePaymentTypes
                       selectedPaymentMethod:(nullable id<STPPaymentMethod>)selectedPaymentMethod {
     if ((self = [super init])) {
         _savedPaymentMethods = savedPaymentMethods ? savedPaymentMethods.copy : @[];
@@ -25,26 +25,18 @@
             _selectedPaymentMethod = selectedPaymentMethod;
         }
         else if (_allPaymentMethods.count == 1) {
-            id<STPPaymentMethod> method = _allPaymentMethods.anyObject;
-
-
-
-            if ([method isKindOfClass:[STPPaymentMethodType class]]) {
-                STPPaymentMethodType *paymentType = (STPPaymentMethodType *)method;
-                if (paymentType.convertsToSourceAtSelection) {
-                    // Can't already be selected
-                    _selectedPaymentMethod = nil;
-                }
-                else {
-                    _selectedPaymentMethod = method;
-                }
-            }
-            else {
-                _selectedPaymentMethod = method;
-            }
+            _selectedPaymentMethod = _allPaymentMethods.anyObject;
         }
         else {
             _selectedPaymentMethod = nil;
+        }
+
+        if ([_selectedPaymentMethod isKindOfClass:[STPPaymentMethodType class]]) {
+            STPPaymentMethodType *paymentType = (STPPaymentMethodType *)_selectedPaymentMethod;
+            if (paymentType.convertsToSourceAtSelection) {
+                // Can't already be selected
+                _selectedPaymentMethod = nil;
+            }
         }
     }
     return self;

--- a/Stripe/STPPaymentMethodTuple.m
+++ b/Stripe/STPPaymentMethodTuple.m
@@ -8,7 +8,7 @@
 
 #import "STPPaymentMethodTuple.h"
 
-#import "STPPaymentMethodType.h"
+#import "STPPaymentMethodType+Private.h"
 
 @implementation STPPaymentMethodTuple
 
@@ -21,11 +21,27 @@
 
         _allPaymentMethods = [NSSet setWithArray:[_savedPaymentMethods arrayByAddingObjectsFromArray:_availablePaymentTypes]];
 
-        if (_allPaymentMethods.count == 1) {
-            _selectedPaymentMethod = _allPaymentMethods.anyObject;
-        }
-        else if ([_allPaymentMethods containsObject:selectedPaymentMethod]) {
+        if ([_allPaymentMethods containsObject:selectedPaymentMethod]) {
             _selectedPaymentMethod = selectedPaymentMethod;
+        }
+        else if (_allPaymentMethods.count == 1) {
+            id<STPPaymentMethod> method = _allPaymentMethods.anyObject;
+
+
+
+            if ([method isKindOfClass:[STPPaymentMethodType class]]) {
+                STPPaymentMethodType *paymentType = (STPPaymentMethodType *)method;
+                if (paymentType.convertsToSourceAtSelection) {
+                    // Can't already be selected
+                    _selectedPaymentMethod = nil;
+                }
+                else {
+                    _selectedPaymentMethod = method;
+                }
+            }
+            else {
+                _selectedPaymentMethod = method;
+            }
         }
         else {
             _selectedPaymentMethod = nil;

--- a/Stripe/STPPaymentMethodType+Private.h
+++ b/Stripe/STPPaymentMethodType+Private.h
@@ -13,11 +13,14 @@
 
 
 /**
- YES if this type needs to get information at selection time 
- 
+ YES if this type immediately gathers info and converts to a token/source
+ at selection time
  ie show Add Card/Source VC when chosen
+ 
+ If YES, this type shouldn't be allowed to be the selectedPaymentMethod
+ (selecting it always generates a source that becomes the selection instead)
  */
-- (BOOL)gathersInfoAtSelection;
+- (BOOL)convertsToSourceAtSelection;
 
 
 /**

--- a/Stripe/STPPaymentMethodType.m
+++ b/Stripe/STPPaymentMethodType.m
@@ -42,7 +42,7 @@
     return STPLocalizedString(@"New Credit Card", @"Label for 'new credit card' payment method field") ;
 }
 
-- (BOOL)gathersInfoAtSelection {
+- (BOOL)convertsToSourceAtSelection {
     return YES;
 }
 
@@ -76,7 +76,7 @@
     return STPLocalizedString(@"New SEPA Debit", @"Label for 'new sepa debit' payment method field") ;;
 }
 
-- (BOOL)gathersInfoAtSelection {
+- (BOOL)convertsToSourceAtSelection {
     return YES;
 }
 
@@ -273,7 +273,7 @@
     return nil;
 }
 
-- (BOOL)gathersInfoAtSelection {
+- (BOOL)convertsToSourceAtSelection {
     return NO;
 }
 

--- a/Stripe/STPPaymentMethodsInternalViewController.m
+++ b/Stripe/STPPaymentMethodsInternalViewController.m
@@ -115,7 +115,7 @@ static NSInteger STPPaymentMethodNewPaymentsSection = 1;
     }
 
     if ([paymentMethod isKindOfClass:[STPPaymentMethodType class]]
-        && [(STPPaymentMethodType *)paymentMethod gathersInfoAtSelection]) {
+        && [(STPPaymentMethodType *)paymentMethod convertsToSourceAtSelection]) {
         // Go to create screen
         STPPaymentMethodType *paymentType = (STPPaymentMethodType *)paymentMethod;
 

--- a/Stripe/STPPaymentMethodsViewController.m
+++ b/Stripe/STPPaymentMethodsViewController.m
@@ -103,7 +103,7 @@
         UIViewController *internal;
         if (tuple.savedPaymentMethods.count == 0
             && tuple.availablePaymentTypes.count == 1
-            && [tuple.availablePaymentTypes firstObject].gathersInfoAtSelection) {
+            && [tuple.availablePaymentTypes firstObject].convertsToSourceAtSelection) {
             // There's only one option, go straight to it if reasonable
 
             STPPaymentMethodType *paymentType = [tuple.availablePaymentTypes firstObject];

--- a/Tests/Tests/STPPaymentMethodTupleTest.m
+++ b/Tests/Tests/STPPaymentMethodTupleTest.m
@@ -1,0 +1,96 @@
+//
+//  STPPaymentMethodTupleTest.m
+//  Stripe
+//
+//  Created by Brian Dorfman on 3/27/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import <Stripe/Stripe.h>
+#import "STPPaymentMethodTuple.h"
+#import "STPTestUtils.h"
+
+@interface STPPaymentMethodTupleTest : XCTestCase
+
+@end
+
+@implementation STPPaymentMethodTupleTest
+
+- (void)testSavedSelectedPaymentMethod {
+
+    STPCard *card = [STPCard decodedObjectFromAPIResponse:[STPTestUtils jsonNamed:@"Card"]];
+    STPSource *source = [STPSource decodedObjectFromAPIResponse:[STPTestUtils jsonNamed:@"CardSource"]];
+
+    STPPaymentMethodTuple *tuple = [[STPPaymentMethodTuple alloc] initWithSavedPaymentMethods:@[card, source]
+                                                                        availablePaymentTypes:@[[STPPaymentMethodType creditCard],
+                                                                                                [STPPaymentMethodType giropay]]
+                                                                        selectedPaymentMethod:source];
+
+    XCTAssertEqualObjects(tuple.selectedPaymentMethod, source);
+}
+
+- (void)testAllowedAvailableSelectedPaymentMethod {
+
+    STPCard *card = [STPCard decodedObjectFromAPIResponse:[STPTestUtils jsonNamed:@"Card"]];
+    STPSource *source = [STPSource decodedObjectFromAPIResponse:[STPTestUtils jsonNamed:@"CardSource"]];
+
+    STPPaymentMethodTuple *tuple = [[STPPaymentMethodTuple alloc] initWithSavedPaymentMethods:@[card, source]
+                                                                        availablePaymentTypes:@[[STPPaymentMethodType creditCard],
+                                                                                                [STPPaymentMethodType giropay]]
+                                                                        selectedPaymentMethod:[STPPaymentMethodType giropay]];
+
+    XCTAssertEqualObjects(tuple.selectedPaymentMethod, [STPPaymentMethodType giropay]);
+}
+
+- (void)testNotAllowedAvailableSelectedPaymentMethod {
+
+    STPCard *card = [STPCard decodedObjectFromAPIResponse:[STPTestUtils jsonNamed:@"Card"]];
+    STPSource *source = [STPSource decodedObjectFromAPIResponse:[STPTestUtils jsonNamed:@"CardSource"]];
+
+    STPPaymentMethodTuple *tuple = [[STPPaymentMethodTuple alloc] initWithSavedPaymentMethods:@[card, source]
+                                                                        availablePaymentTypes:@[[STPPaymentMethodType creditCard],
+                                                                                                [STPPaymentMethodType giropay]]
+                                                                        selectedPaymentMethod:[STPPaymentMethodType creditCard]];
+
+    XCTAssertNil(tuple.selectedPaymentMethod);
+}
+
+- (void)testMissingSelectedPaymentMethod {
+
+    STPCard *card = [STPCard decodedObjectFromAPIResponse:[STPTestUtils jsonNamed:@"Card"]];
+    STPSource *source = [STPSource decodedObjectFromAPIResponse:[STPTestUtils jsonNamed:@"CardSource"]];
+
+    STPPaymentMethodTuple *tuple = [[STPPaymentMethodTuple alloc] initWithSavedPaymentMethods:@[card, source]
+                                                                        availablePaymentTypes:@[[STPPaymentMethodType creditCard],
+                                                                                                [STPPaymentMethodType giropay]]
+                                                                        selectedPaymentMethod:[STPPaymentMethodType sofort]];
+
+    XCTAssertNil(tuple.selectedPaymentMethod);
+}
+
+- (void)testOnlyOneAvailableUnselectablePaymentMethod {
+    STPPaymentMethodTuple *tuple = [[STPPaymentMethodTuple alloc] initWithSavedPaymentMethods:nil
+                                                                        availablePaymentTypes:@[[STPPaymentMethodType creditCard]]
+                                                                        selectedPaymentMethod:nil];
+
+    XCTAssertNil(tuple.selectedPaymentMethod);
+}
+
+- (void)testOnlyOneAvailableNotAllowedPaymentMethod {
+    STPPaymentMethodTuple *tuple = [[STPPaymentMethodTuple alloc] initWithSavedPaymentMethods:nil
+                                                                        availablePaymentTypes:@[[STPPaymentMethodType creditCard]]
+                                                                        selectedPaymentMethod:nil];
+
+    XCTAssertNil(tuple.selectedPaymentMethod);
+}
+
+- (void)testOnlyOneAvailableAllowedPaymentMethod {
+    STPPaymentMethodTuple *tuple = [[STPPaymentMethodTuple alloc] initWithSavedPaymentMethods:nil
+                                                                        availablePaymentTypes:@[[STPPaymentMethodType bancontact]]
+                                                                        selectedPaymentMethod:nil];
+
+    XCTAssertEqualObjects(tuple.selectedPaymentMethod, [STPPaymentMethodType bancontact]);
+}
+
+@end

--- a/Tests/Tests/STPPaymentMethodTupleTest.m
+++ b/Tests/Tests/STPPaymentMethodTupleTest.m
@@ -69,14 +69,6 @@
     XCTAssertNil(tuple.selectedPaymentMethod);
 }
 
-- (void)testOnlyOneAvailableUnselectablePaymentMethod {
-    STPPaymentMethodTuple *tuple = [[STPPaymentMethodTuple alloc] initWithSavedPaymentMethods:nil
-                                                                        availablePaymentTypes:@[[STPPaymentMethodType creditCard]]
-                                                                        selectedPaymentMethod:nil];
-
-    XCTAssertNil(tuple.selectedPaymentMethod);
-}
-
 - (void)testOnlyOneAvailableNotAllowedPaymentMethod {
     STPPaymentMethodTuple *tuple = [[STPPaymentMethodTuple alloc] initWithSavedPaymentMethods:nil
                                                                         availablePaymentTypes:@[[STPPaymentMethodType creditCard]]


### PR DESCRIPTION
Adds back public accessor for available payment methods on context.
Ensures that selected payment method cant be set to something not in the available list, and that if there is only one possible method it is auto-selected.