### PR TITLE
[sources-ui] Auto-select Sofort country based on locale

### DIFF
--- a/Stripe/STPBancontactSourceInfoDataSource.m
+++ b/Stripe/STPBancontactSourceInfoDataSource.m
@@ -15,15 +15,14 @@
 
 @implementation STPBancontactSourceInfoDataSource
 
-- (instancetype)initWithSourceParams:(STPSourceParams *)sourceParams {
-    self = [super initWithSourceParams:sourceParams];
+- (instancetype)initWithSourceParams:(STPSourceParams *)sourceParams
+                prefilledInformation:(STPUserInformation *)prefilledInfo {
+    self = [super initWithSourceParams:sourceParams prefilledInformation:prefilledInfo];
     if (self) {
         self.paymentMethodType = [STPPaymentMethodType bancontact];
         STPTextFieldTableViewCell *nameCell = [[STPTextFieldTableViewCell alloc] init];
         nameCell.placeholder = STPLocalizedString(@"Name", @"Caption for Name field on bank info form");
-        if (self.sourceParams.owner) {
-            nameCell.contents = self.sourceParams.owner[@"name"];
-        }
+        nameCell.contents = prefilledInfo.billingAddress.name;
         self.cells = @[nameCell];
     }
     return self;

--- a/Stripe/STPBancontactSourceInfoDataSource.m
+++ b/Stripe/STPBancontactSourceInfoDataSource.m
@@ -21,7 +21,7 @@
     if (self) {
         self.paymentMethodType = [STPPaymentMethodType bancontact];
         STPTextFieldTableViewCell *nameCell = [[STPTextFieldTableViewCell alloc] init];
-        nameCell.placeholder = STPLocalizedString(@"Name", @"Caption for Name field on bank info form");
+        nameCell.placeholder = STPLocalizedString(@"Account Holder Name", @"Caption for Name field on bank info form");
         nameCell.contents = prefilledInfo.billingAddress.name;
         self.cells = @[nameCell];
     }

--- a/Stripe/STPGiropaySourceInfoDataSource.m
+++ b/Stripe/STPGiropaySourceInfoDataSource.m
@@ -15,15 +15,14 @@
 
 @implementation STPGiropaySourceInfoDataSource
 
-- (instancetype)initWithSourceParams:(STPSourceParams *)sourceParams {
-    self = [super initWithSourceParams:sourceParams];
+- (instancetype)initWithSourceParams:(STPSourceParams *)sourceParams
+                prefilledInformation:(STPUserInformation *)prefilledInfo {
+    self = [super initWithSourceParams:sourceParams prefilledInformation:prefilledInfo];
     if (self) {
         self.paymentMethodType = [STPPaymentMethodType giropay];
         STPTextFieldTableViewCell *nameCell = [[STPTextFieldTableViewCell alloc] init];
         nameCell.placeholder = STPLocalizedString(@"Name", @"Caption for Name field on bank info form");
-        if (self.sourceParams.owner) {
-            nameCell.contents = self.sourceParams.owner[@"name"];
-        }
+        nameCell.contents = prefilledInfo.billingAddress.name;
         self.cells = @[nameCell];
     }
     return self;

--- a/Stripe/STPGiropaySourceInfoDataSource.m
+++ b/Stripe/STPGiropaySourceInfoDataSource.m
@@ -21,7 +21,7 @@
     if (self) {
         self.paymentMethodType = [STPPaymentMethodType giropay];
         STPTextFieldTableViewCell *nameCell = [[STPTextFieldTableViewCell alloc] init];
-        nameCell.placeholder = STPLocalizedString(@"Name", @"Caption for Name field on bank info form");
+        nameCell.placeholder = STPLocalizedString(@"Account Holder Name", @"Caption for Name field on bank info form");
         nameCell.contents = prefilledInfo.billingAddress.name;
         self.cells = @[nameCell];
     }

--- a/Stripe/STPIDEALBankSelectorDataSource.m
+++ b/Stripe/STPIDEALBankSelectorDataSource.m
@@ -55,17 +55,18 @@
     return [self.bankNames count];
 }
 
-- (void)selectRowWithValue:(NSString *)value {
+- (BOOL)selectRowWithValue:(NSString *)value {
     if (!value) {
         self.selectedRow = NSNotFound;
-        return;
-    }
-    NSString *name = [[self.bankNameToBankCode allKeysForObject:value] firstObject];
-    if (name) {
-        self.selectedRow = [self.bankNames indexOfObject:name];
     } else {
-        self.selectedRow = NSNotFound;
+        NSString *name = [[self.bankNameToBankCode allKeysForObject:value] firstObject];
+        if (name) {
+            self.selectedRow = [self.bankNames indexOfObject:name];
+        } else {
+            self.selectedRow = NSNotFound;
+        }
     }
+    return self.selectedRow != NSNotFound;
 }
 
 - (NSString *)selectorValueForRow:(NSInteger)row {

--- a/Stripe/STPIDEALSourceInfoDataSource.m
+++ b/Stripe/STPIDEALSourceInfoDataSource.m
@@ -22,7 +22,7 @@
     if (self) {
         self.paymentMethodType = [STPPaymentMethodType ideal];
         STPTextFieldTableViewCell *nameCell = [[STPTextFieldTableViewCell alloc] init];
-        nameCell.placeholder = STPLocalizedString(@"Name", @"Caption for Name field on bank info form");
+        nameCell.placeholder = STPLocalizedString(@"Account Holder Name", @"Caption for Name field on bank info form");
         nameCell.contents = prefilledInfo.billingAddress.name;
         self.cells = @[nameCell];
         self.selectorDataSource = [STPIDEALBankSelectorDataSource new];

--- a/Stripe/STPIDEALSourceInfoDataSource.m
+++ b/Stripe/STPIDEALSourceInfoDataSource.m
@@ -16,21 +16,17 @@
 
 @implementation STPIDEALSourceInfoDataSource
 
-- (instancetype)initWithSourceParams:(STPSourceParams *)sourceParams {
-    self = [super initWithSourceParams:sourceParams];
+- (instancetype)initWithSourceParams:(STPSourceParams *)sourceParams
+                prefilledInformation:(STPUserInformation *)prefilledInfo {
+    self = [super initWithSourceParams:sourceParams prefilledInformation:prefilledInfo];
     if (self) {
         self.paymentMethodType = [STPPaymentMethodType ideal];
         STPTextFieldTableViewCell *nameCell = [[STPTextFieldTableViewCell alloc] init];
         nameCell.placeholder = STPLocalizedString(@"Name", @"Caption for Name field on bank info form");
-        if (self.sourceParams.owner) {
-            nameCell.contents = self.sourceParams.owner[@"name"];
-        }
+        nameCell.contents = prefilledInfo.billingAddress.name;
         self.cells = @[nameCell];
         self.selectorDataSource = [STPIDEALBankSelectorDataSource new];
-        NSDictionary *idealDict = self.sourceParams.additionalAPIParameters[@"ideal"];
-        if (idealDict) {
-            [self.selectorDataSource selectRowWithValue:idealDict[@"bank"]];
-        }
+        [self.selectorDataSource selectRowWithValue:prefilledInfo.idealBank];
     }
     return self;
 }

--- a/Stripe/STPSelectorDataSource.h
+++ b/Stripe/STPSelectorDataSource.h
@@ -20,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSString *)selectorValueForRow:(NSInteger)row;
 - (NSString *)selectorTitleForRow:(NSInteger)row;
 - (nullable UIImage *)selectorImageForRow:(NSInteger)row;
-- (void)selectRowWithValue:(nullable NSString *)value;
+- (BOOL)selectRowWithValue:(nullable NSString *)value;
 
 @end
 

--- a/Stripe/STPSofortCountrySelectorDataSource.m
+++ b/Stripe/STPSofortCountrySelectorDataSource.m
@@ -41,12 +41,13 @@
     return [self.countryCodes count];
 }
 
-- (void)selectRowWithValue:(NSString *)value {
+- (BOOL)selectRowWithValue:(NSString *)value {
     if (!value) {
         self.selectedRow = NSNotFound;
-        return;
+    } else {
+        self.selectedRow = [self.countryCodes indexOfObject:value];
     }
-    self.selectedRow = [self.countryCodes indexOfObject:value];
+    return self.selectedRow != NSNotFound;
 }
 
 - (NSString *)selectorValueForRow:(NSInteger)row {

--- a/Stripe/STPSofortSourceInfoDataSource.h
+++ b/Stripe/STPSofortSourceInfoDataSource.h
@@ -11,4 +11,7 @@
 
 @interface STPSofortSourceInfoDataSource : STPSourceInfoDataSource
 
+- (instancetype)initWithSourceParams:(STPSourceParams *)sourceParams
+                prefilledInformation:(STPUserInformation *)prefilledInfo;
+
 @end

--- a/Stripe/STPSofortSourceInfoDataSource.m
+++ b/Stripe/STPSofortSourceInfoDataSource.m
@@ -16,15 +16,25 @@
 
 @implementation STPSofortSourceInfoDataSource
 
-- (instancetype)initWithSourceParams:(STPSourceParams *)sourceParams {
-    self = [super initWithSourceParams:sourceParams];
+- (instancetype)initWithSourceParams:(STPSourceParams *)sourceParams
+                prefilledInformation:(STPUserInformation *)prefilledInfo {
+    self = [super initWithSourceParams:sourceParams prefilledInformation:prefilledInfo];
     if (self) {
         self.paymentMethodType = [STPPaymentMethodType sofort];
         self.cells = @[];
         self.selectorDataSource = [STPSofortCountrySelectorDataSource new];
-        NSDictionary *sofortDict = self.sourceParams.additionalAPIParameters[@"sofort"];
-        if (sofortDict) {
-            [self.selectorDataSource selectRowWithValue:sofortDict[@"country"]];
+        NSString *country = prefilledInfo.billingAddress.country;
+        BOOL selected = NO;
+        if (country) {
+            selected = [self.selectorDataSource selectRowWithValue:country];
+        }
+        if (!selected) {
+            NSLocale *locale = [NSLocale autoupdatingCurrentLocale];
+            NSString *localeCountry = [locale objectForKey:NSLocaleCountryCode];
+            selected = [self.selectorDataSource selectRowWithValue:localeCountry];
+            if (selected) {
+                self.requiresUserVerification = YES;
+            }
         }
     }
     return self;

--- a/Stripe/STPSourceInfoDataSource.h
+++ b/Stripe/STPSourceInfoDataSource.h
@@ -18,7 +18,14 @@
 @property (nonatomic, copy) NSArray<STPTextFieldTableViewCell *>*cells;
 @property (nonatomic) id<STPSelectorDataSource>selectorDataSource;
 
-- (instancetype)initWithSourceParams:(STPSourceParams *)sourceParams;
+/// If YES, the data source must be verified by the user even if
+/// completedSourceParams is non-nil.
+@property (nonatomic, assign) BOOL requiresUserVerification;
+
+- (instancetype)initWithSourceParams:(STPSourceParams *)sourceParams
+                prefilledInformation:(STPUserInformation *)prefilledInfo;
+
+/// If the data source contains incomplete info, this method will return nil.
 - (STPSourceParams *)completeSourceParams;
 
 @end

--- a/Stripe/STPSourceInfoDataSource.m
+++ b/Stripe/STPSourceInfoDataSource.m
@@ -12,12 +12,14 @@
 
 @implementation STPSourceInfoDataSource
 
-- (instancetype)initWithSourceParams:(STPSourceParams *)sourceParams {
+- (instancetype)initWithSourceParams:(STPSourceParams *)sourceParams
+                prefilledInformation:(__unused STPUserInformation *)prefilledInfo {
     self = [super init];
     if (self) {
         _sourceParams = sourceParams;
         _paymentMethodType = nil;
         _cells = @[];
+        _requiresUserVerification = NO;
     }
     return self;
 }

--- a/Stripe/STPSourceInfoViewController.m
+++ b/Stripe/STPSourceInfoViewController.m
@@ -326,12 +326,14 @@ typedef NS_ENUM(NSUInteger, STPSourceInfoSection) {
     return nil;
 }
 
-- (CGFloat)tableView:(__unused UITableView *)tableView heightForFooterInSection:(NSInteger)section {
+- (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section {
     NSInteger numberOfSections = [tableView numberOfSections];
     if (numberOfSections == 1 || section == STPSourceInfoSelectorSection) {
         return [self.footerView heightForWidth:CGRectGetWidth(self.tableView.frame)];
-    } else {
+    } else if ([self tableView:tableView numberOfRowsInSection:section] == 0) {
         return 0.01f;
+    } else {
+        return 27.0f;
     }
 }
 

--- a/Stripe/STPSourceInfoViewController.m
+++ b/Stripe/STPSourceInfoViewController.m
@@ -123,7 +123,7 @@ typedef NS_ENUM(NSUInteger, STPSourceInfoSection) {
     self.stp_navigationItemProxy.rightBarButtonItem.enabled = NO;
 
     STPSectionHeaderView *firstSectionHeader = [STPSectionHeaderView new];
-    firstSectionHeader.title = STPLocalizedString(@"Account Information", @"Title for bank account information form");
+    firstSectionHeader.title = STPLocalizedString(@"Bank Account Information", @"Title for bank account information form");
     firstSectionHeader.buttonHidden = YES;
     self.firstSectionHeaderView = firstSectionHeader;
 

--- a/Stripe/STPSourceInfoViewController.m
+++ b/Stripe/STPSourceInfoViewController.m
@@ -74,38 +74,23 @@ typedef NS_ENUM(NSUInteger, STPSourceInfoSection) {
         sourceParams.currency = @"eur";
         sourceParams.amount = @(amount);
         // TODO: get returnURL from STPPaymentConfiguration
-        if (prefilledInformation.billingAddress.name &&
-            (type == STPSourceTypeBancontact ||
-             type == STPSourceTypeGiropay ||
-             type == STPSourceTypeIDEAL))
-        {
-            NSMutableDictionary *owner = [NSMutableDictionary new];
-            owner[@"name"] = prefilledInformation.billingAddress.name;
-            sourceParams.owner = owner;
-        }
-        if (prefilledInformation.billingAddress.country && type == STPSourceTypeSofort) {
-            NSMutableDictionary *sofortDict = [NSMutableDictionary new];
-            sofortDict[@"country"] = prefilledInformation.billingAddress.country;
-            sourceParams.additionalAPIParameters = @{@"sofort": sofortDict};
-        }
-        if (prefilledInformation.idealBank && type == STPSourceTypeIDEAL) {
-            NSMutableDictionary *idealDict = [NSMutableDictionary new];
-            idealDict[@"bank"] = prefilledInformation.idealBank;
-            sourceParams.additionalAPIParameters = @{@"ideal": idealDict};
-        }
         switch (type) {
             case STPSourceTypeBancontact: {
-                dataSource = [[STPBancontactSourceInfoDataSource alloc] initWithSourceParams:sourceParams];
+                dataSource = [[STPBancontactSourceInfoDataSource alloc] initWithSourceParams:sourceParams
+                                                                        prefilledInformation:prefilledInformation];
                 break;
             }
             case STPSourceTypeGiropay:
-                dataSource = [[STPGiropaySourceInfoDataSource alloc] initWithSourceParams:sourceParams];
+                dataSource = [[STPGiropaySourceInfoDataSource alloc] initWithSourceParams:sourceParams
+                                                                     prefilledInformation:prefilledInformation];
                 break;
             case STPSourceTypeIDEAL:
-                dataSource = [[STPIDEALSourceInfoDataSource alloc] initWithSourceParams:sourceParams];
+                dataSource = [[STPIDEALSourceInfoDataSource alloc] initWithSourceParams:sourceParams
+                                                                   prefilledInformation:prefilledInformation];
                 break;
             case STPSourceTypeSofort:
-                dataSource = [[STPSofortSourceInfoDataSource alloc] initWithSourceParams:sourceParams];
+                dataSource = [[STPSofortSourceInfoDataSource alloc] initWithSourceParams:sourceParams
+                                                                    prefilledInformation:prefilledInformation];
                 break;
             default:
                 dataSource = [[STPSourceInfoDataSource alloc] init];
@@ -120,7 +105,11 @@ typedef NS_ENUM(NSUInteger, STPSourceInfoSection) {
 }
 
 - (STPSourceParams *)completeSourceParams {
-    return self.dataSource.completeSourceParams;
+    if (self.dataSource.requiresUserVerification) {
+        return nil;
+    } else {
+        return self.dataSource.completeSourceParams;
+    }
 }
 
 - (void)createAndSetupViews {

--- a/Tests/Tests/STPSourceInfoViewControllerTest.m
+++ b/Tests/Tests/STPSourceInfoViewControllerTest.m
@@ -155,6 +155,24 @@
     XCTAssertNotNil(sut.completeSourceParams);
     NSDictionary *sofortDict = sut.completeSourceParams.additionalAPIParameters[@"sofort"];
     XCTAssertEqualObjects(sofortDict, @{@"country": @"AT"});
+
+    // Test initializing with a non-Sofort country
+    address.country = @"US";
+    info.billingAddress = address;
+    sut = [self sutWithType:STPSourceTypeSofort info:info];
+    XCTAssertNil(sut.completeSourceParams);
+}
+
+- (void)testRequiresUserVerification {
+    STPUserInformation *info = [STPUserInformation new];
+    STPAddress *address = [STPAddress new];
+    address.country = @"FR";
+    info.billingAddress = address;
+    STPSourceInfoViewController *sut = [self sutWithType:STPSourceTypeSofort
+                                                    info:info];
+    XCTAssertNotNil(sut.completeSourceParams);
+    sut.dataSource.requiresUserVerification = YES;
+    XCTAssertNil(sut.completeSourceParams);
 }
 
 @end


### PR DESCRIPTION
r? @bdorfman-stripe 

- For the Sofort form, we now automatically select country based on locale, if it hasn't already been set via `prefilledInformation`. If we used locale to select a country, we'll still present the view controller for the user to verify (`completeSourceParams` will be nil).

- I've also done some refactoring, moving the `userInformation` logic into the individual data sources.

- Made some copy updates in c57f67e

- Fixed footer height in b3eabed


