### PR TITLE
Use generic error if polling completes with no error and no source

### DIFF
--- a/Stripe/PublicHeaders/StripeError.h
+++ b/Stripe/PublicHeaders/StripeError.h
@@ -69,6 +69,7 @@ FOUNDATION_EXPORT STPCardErrorCode __nonnull const STPIncorrectCVC;
 @interface NSError(Stripe)
 
 + (nullable NSError *)stp_errorFromStripeResponse:(nullable NSDictionary *)jsonDictionary;
++ (nonnull NSError *)stp_genericConnectionError;
 + (nonnull NSError *)stp_genericFailedToParseResponseError;
 - (BOOL)stp_isUnknownCheckoutError;
 - (BOOL)stp_isURLSessionCancellationError;

--- a/Stripe/STPSourcePoller.m
+++ b/Stripe/STPSourcePoller.m
@@ -6,10 +6,12 @@
 //  Copyright © 2017 Stripe, Inc. All rights reserved.
 //
 
+#import "STPSourcePoller.h"
+
 #import "STPAPIClient+Private.h"
 #import "STPAPIRequest.h"
 #import "STPSource.h"
-#import "STPSourcePoller.h"
+#import "StripeError.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -196,7 +198,11 @@ static NSTimeInterval const MaxRetries = 5;
                                      error:(nullable NSError *)error {
     if (!self.pollingStopped) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            self.completion(source, error);
+            if (!error && !source) {
+                self.completion(nil, [NSError stp_genericConnectionError]);
+            } else {
+                self.completion(source, error);
+            }
         });
         [self stopPolling];
     }

--- a/Stripe/StripeError.m
+++ b/Stripe/StripeError.m
@@ -94,6 +94,14 @@ NSString *const STPIncorrectCVC = @"com.stripe.lib:IncorrectCVC";
     return [[self alloc] initWithDomain:StripeDomain code:STPAPIError userInfo:userInfo];
 }
 
++ (nonnull NSError *)stp_genericConnectionError {
+    NSDictionary *userInfo = @{
+                               NSLocalizedDescriptionKey: [self stp_unexpectedErrorMessage],
+                               STPErrorMessageKey: @"There was an error connecting to Stripe."
+                               };
+    return [[self alloc] initWithDomain:StripeDomain code:STPConnectionError userInfo:userInfo];
+}
+
 - (BOOL)stp_isUnknownCheckoutError {
     return self.code == STPCheckoutUnknownError;
 }


### PR DESCRIPTION
r? @bdorfman-stripe 

As discussed yesterday