### PR TITLE
[sources-ui] Add network activity notifications

### DIFF
--- a/Example/Stripe iOS Example (Simple)/CheckoutViewController.swift
+++ b/Example/Stripe iOS Example (Simple)/CheckoutViewController.swift
@@ -25,12 +25,12 @@ class CheckoutViewController: UIViewController, STPPaymentContextDelegate {
     // to create an Apple Merchant ID. Replace nil on the line below with it (it looks like merchant.com.yourappname).
     let appleMerchantID: String? = nil
     
-    // These values will be shown to the user when they purchase with Apple Pay.
     let companyName = "Emoji Apparel"
     let paymentCurrency = "usd"
 
-    let paymentContext: STPPaymentContext
-
+    let paymentAmount: Int
+    var paymentContext: STPPaymentContext?
+    let paymentConfiguration: STPPaymentConfiguration
     let theme: STPTheme
     let paymentRow: CheckoutRowView
     let shippingRow: CheckoutRowView
@@ -60,7 +60,6 @@ class CheckoutViewController: UIViewController, STPPaymentContextDelegate {
     }
 
     init(product: String, price: Int, settings: Settings) {
-
         let stripePublishableKey = self.stripePublishableKey
         let backendBaseURL = self.backendBaseURL
 
@@ -70,6 +69,7 @@ class CheckoutViewController: UIViewController, STPPaymentContextDelegate {
         self.product = product
         self.productImage.text = product
         self.theme = settings.theme
+        self.paymentAmount = price
         MyAPIClient.sharedClient.baseURLString = self.backendBaseURL
 
         // This code is included here for the sake of readability, but in your application you should set up your configuration and theme earlier, preferably in your App Delegate.
@@ -82,16 +82,8 @@ class CheckoutViewController: UIViewController, STPPaymentContextDelegate {
         config.shippingType = settings.shippingType
         config.availablePaymentMethodTypes = settings.availablePaymentMethods.array as! [STPPaymentMethodType]
         config.smsAutofillDisabled = !settings.smsAutofillEnabled
+        self.paymentConfiguration = config
         
-        let paymentContext = STPPaymentContext(apiAdapter: MyAPIClient.sharedClient,
-                                               configuration: config,
-                                               theme: settings.theme)
-        let userInformation = STPUserInformation()
-        paymentContext.prefilledInformation = userInformation
-        paymentContext.paymentAmount = price
-        paymentContext.paymentCurrency = self.paymentCurrency
-        self.paymentContext = paymentContext
-
         self.paymentRow = CheckoutRowView(title: "Payment", detail: "Select Payment",
                                           theme: settings.theme)
         var shippingString = "Contact"
@@ -116,8 +108,15 @@ class CheckoutViewController: UIViewController, STPPaymentContextDelegate {
         numberFormatter.usesGroupingSeparator = true
         self.numberFormatter = numberFormatter
         super.init(nibName: nil, bundle: nil)
-        self.paymentContext.delegate = self
-        paymentContext.hostViewController = self
+
+        NotificationCenter.default.addObserver(self, selector: #selector(networkActivityDidBegin),
+                                               name: NSNotification.Name.STPNetworkActivityDidBegin, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(networkActivityDidEnd),
+                                               name: NSNotification.Name.STPNetworkActivityDidEnd, object: nil)
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -126,6 +125,17 @@ class CheckoutViewController: UIViewController, STPPaymentContextDelegate {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        let paymentContext = STPPaymentContext(apiAdapter: MyAPIClient.sharedClient,
+                                               configuration: self.paymentConfiguration,
+                                               theme: self.theme)
+        let userInformation = STPUserInformation()
+        paymentContext.prefilledInformation = userInformation
+        paymentContext.paymentAmount = self.paymentAmount
+        paymentContext.paymentCurrency = self.paymentCurrency
+        paymentContext.delegate = self
+        paymentContext.hostViewController = self
+        self.paymentContext = paymentContext
+
         self.view.backgroundColor = self.theme.primaryBackgroundColor
         var red: CGFloat = 0
         self.theme.primaryBackgroundColor.getRed(&red, green: nil, blue: nil, alpha: nil)
@@ -141,12 +151,14 @@ class CheckoutViewController: UIViewController, STPPaymentContextDelegate {
         self.view.addSubview(self.activityIndicator)
         self.activityIndicator.alpha = 0
         self.buyButton.addTarget(self, action: #selector(didTapBuy), for: .touchUpInside)
-        self.totalRow.detail = self.numberFormatter.string(from: NSNumber(value: Float(self.paymentContext.paymentAmount)/100))!
+        self.totalRow.detail = self.numberFormatter.string(from: NSNumber(value: Float(paymentContext.paymentAmount)/100))!
         self.paymentRow.onTap = { [weak self] _ in
-            self?.paymentContext.pushPaymentMethodsViewController()
+            guard let strongSelf = self else { return }
+            strongSelf.paymentContext?.pushPaymentMethodsViewController()
         }
         self.shippingRow.onTap = { [weak self] _ in
-            self?.paymentContext.pushShippingViewController()
+            guard let strongSelf = self else { return }
+            strongSelf.paymentContext?.pushShippingViewController()
         }
     }
 
@@ -169,13 +181,13 @@ class CheckoutViewController: UIViewController, STPPaymentContextDelegate {
 
     func didTapBuy() {
         self.paymentInProgress = true
-        self.paymentContext.requestPayment()
+        self.paymentContext?.requestPayment()
     }
 
     // MARK: STPPaymentContextDelegate
     
     func paymentContext(_ paymentContext: STPPaymentContext, didCreatePaymentResult paymentResult: STPPaymentResult, completion: @escaping STPErrorBlock) {
-        MyAPIClient.sharedClient.completeCharge(paymentResult, amount: self.paymentContext.paymentAmount,
+        MyAPIClient.sharedClient.completeCharge(paymentResult, amount: paymentContext.paymentAmount,
                                                 completion: completion)
     }
     
@@ -216,7 +228,7 @@ class CheckoutViewController: UIViewController, STPPaymentContextDelegate {
         else {
             self.shippingRow.detail = "Enter \(self.shippingString) Info"
         }
-        self.totalRow.detail = self.numberFormatter.string(from: NSNumber(value: Float(self.paymentContext.paymentAmount)/100))!
+        self.totalRow.detail = self.numberFormatter.string(from: NSNumber(value: Float(paymentContext.paymentAmount)/100))!
     }
 
     func paymentContext(_ paymentContext: STPPaymentContext, didFailToLoadWithError error: Error) {
@@ -231,7 +243,7 @@ class CheckoutViewController: UIViewController, STPPaymentContextDelegate {
             _ = self.navigationController?.popViewController(animated: true)
         })
         let retry = UIAlertAction(title: "Retry", style: .default, handler: { action in
-            self.paymentContext.retryLoading()
+            paymentContext.retryLoading()
         })
         alertController.addAction(cancel)
         alertController.addAction(retry)
@@ -269,6 +281,16 @@ class CheckoutViewController: UIViewController, STPPaymentContextDelegate {
                 completion(.valid, nil, [upsWorldwide, fedEx], fedEx)
             }
         }
+    }
+
+    // MARK: Network activity notifications
+
+    func networkActivityDidBegin() {
+        UIApplication.shared.isNetworkActivityIndicatorVisible = true
+    }
+
+    func networkActivityDidEnd() {
+        UIApplication.shared.isNetworkActivityIndicatorVisible = false
     }
 
 }

--- a/Example/Stripe iOS Example (Simple)/CheckoutViewController.swift
+++ b/Example/Stripe iOS Example (Simple)/CheckoutViewController.swift
@@ -283,14 +283,20 @@ class CheckoutViewController: UIViewController, STPPaymentContextDelegate {
         }
     }
 
-    // MARK: Network activity notifications
+    // MARK: Network activity
+
+    var networkActivityCount: Int = 0 {
+        didSet {
+            UIApplication.shared.isNetworkActivityIndicatorVisible = self.networkActivityCount > 0;
+        }
+    }
 
     func networkActivityDidBegin() {
-        UIApplication.shared.isNetworkActivityIndicatorVisible = true
+        self.networkActivityCount += 1;
     }
 
     func networkActivityDidEnd() {
-        UIApplication.shared.isNetworkActivityIndicatorVisible = false
+        self.networkActivityCount = max(self.networkActivityCount - 1, 0);
     }
 
 }

--- a/Stripe/PublicHeaders/STPAPIClient.h
+++ b/Stripe/PublicHeaders/STPAPIClient.h
@@ -185,5 +185,18 @@ static NSString *const STPSDKVersion = @"10.0.1";
 
 @end
 
+///--------------------
+/// @name Notifications
+///--------------------
+
+/**
+ *  Posted when network activity begins.
+ */
+FOUNDATION_EXPORT NSString *const STPNetworkActivityDidBeginNotification;
+
+/**
+ *  Posted when network activity ends.
+ */
+FOUNDATION_EXPORT NSString *const STPNetworkActivityDidEndNotification;
 
 NS_ASSUME_NONNULL_END

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -39,6 +39,9 @@ static NSString *const tokenEndpoint = @"tokens";
 static NSString *const sourcesEndpoint = @"sources";
 static NSString *const stripeAPIVersion = @"2015-10-12";
 
+NSString *const STPNetworkActivityDidBeginNotification = @"com.stripe.networkactivity.begin";
+NSString *const STPNetworkActivityDidEndNotification = @"com.stripe.networkactivity.end";
+
 @implementation Stripe
 
 + (void)setDefaultPublishableKey:(NSString *)publishableKey {

--- a/Stripe/STPAPIRequest.m
+++ b/Stripe/STPAPIRequest.m
@@ -28,8 +28,14 @@
     request.HTTPMethod = @"POST";
     NSString *query = [STPFormEncoder queryStringFromParameters:parameters];
     request.HTTPBody = [query dataUsingEncoding:NSUTF8StringEncoding];
-    
+
+    stpDispatchToMainThreadIfNecessary(^{
+        [[NSNotificationCenter defaultCenter] postNotificationName:STPNetworkActivityDidBeginNotification object:self];
+    });
     NSURLSessionDataTask *task = [apiClient.urlSession dataTaskWithRequest:request completionHandler:^(NSData * _Nullable body, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+        stpDispatchToMainThreadIfNecessary(^{
+            [[NSNotificationCenter defaultCenter] postNotificationName:STPNetworkActivityDidEndNotification object:self];
+        });
         [[self class] parseResponse:response
                                body:body
                               error:error
@@ -51,7 +57,13 @@
     [request stp_addParametersToURL:parameters];
     request.HTTPMethod = @"GET";
 
+    stpDispatchToMainThreadIfNecessary(^{
+        [[NSNotificationCenter defaultCenter] postNotificationName:STPNetworkActivityDidBeginNotification object:self];
+    });
     NSURLSessionDataTask *task = [apiClient.urlSession dataTaskWithRequest:request completionHandler:^(NSData * _Nullable body, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+        stpDispatchToMainThreadIfNecessary(^{
+            [[NSNotificationCenter defaultCenter] postNotificationName:STPNetworkActivityDidEndNotification object:self];
+        });
         [[self class] parseResponse:response
                                body:body
                               error:error

--- a/Stripe/STPPaymentContext.m
+++ b/Stripe/STPPaymentContext.m
@@ -29,7 +29,6 @@
 
 #define FAUXPAS_IGNORED_IN_METHOD(...)
 
-
 /**
  The current state of the payment context
 
@@ -119,8 +118,12 @@ typedef NS_ENUM(NSUInteger, STPPaymentContextState) {
             }];
         }
     }];
+    stpDispatchToMainThreadIfNecessary(^{
+        [[NSNotificationCenter defaultCenter] postNotificationName:STPNetworkActivityDidBeginNotification object:self];
+    });
     [self.apiAdapter retrieveCustomer:^(STPCustomer * _Nullable customer, NSError * _Nullable error) {
         stpDispatchToMainThreadIfNecessary(^{
+            [[NSNotificationCenter defaultCenter] postNotificationName:STPNetworkActivityDidEndNotification object:self];
             STRONG(self);
             if (!self) {
                 return;
@@ -610,8 +613,12 @@ typedef NS_ENUM(NSUInteger, STPPaymentContextState) {
                 [self.delegate paymentContextDidChange:self];
             };
             STPApplePayTokenHandlerBlock applePayTokenHandler = ^(STPToken *token, STPErrorBlock tokenCompletion) {
+                stpDispatchToMainThreadIfNecessary(^{
+                    [[NSNotificationCenter defaultCenter] postNotificationName:STPNetworkActivityDidBeginNotification object:self];
+                });
                 [self.apiAdapter attachSourceToCustomer:token completion:^(NSError *tokenError) {
                     stpDispatchToMainThreadIfNecessary(^{
+                        [[NSNotificationCenter defaultCenter] postNotificationName:STPNetworkActivityDidEndNotification object:self];
                         if (tokenError) {
                             tokenCompletion(tokenError);
                         } else {


### PR DESCRIPTION
r? @bdorfman-stripe 

This posts notifications whenever we call `backendAPIAdapter` or `apiClient` methods. I haven't modified `STPCheckoutAPIClient`, since we'll likely remove it. I've also modified the example app to initialize PaymentContext in `viewDidLoad`, so we can catch its initial loading notification.