### PR TITLE
Redirect helper

### DIFF
--- a/Stripe.podspec
+++ b/Stripe.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.homepage                       = 'https://stripe.com/docs/mobile/ios'
   s.authors                        = { 'Jack Flintermann' => 'jack@stripe.com', 'Stripe' => 'support+github@stripe.com' }
   s.source                         = { :git => 'https://github.com/stripe/stripe-ios.git', :tag => "v#{s.version}" }
-  s.frameworks                     = 'Foundation', 'Security', 'WebKit', 'PassKit', 'AddressBook'
+  s.frameworks                     = 'Foundation', 'Security', 'WebKit', 'PassKit', 'AddressBook', 'SafariServices'
   s.requires_arc                   = true
   s.platform                       = :ios
   s.ios.deployment_target          = '8.0'

--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -594,6 +594,14 @@
 		F11829111E8C5A200056B8C7 /* STPRedirectContext.m in Sources */ = {isa = PBXBuildFile; fileRef = F118290E1E8C5A200056B8C7 /* STPRedirectContext.m */; };
 		F11829121E8C5A200056B8C7 /* STPRedirectContext.m in Sources */ = {isa = PBXBuildFile; fileRef = F118290E1E8C5A200056B8C7 /* STPRedirectContext.m */; };
 		F11829141E8C6C310056B8C7 /* SafariServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F11829131E8C6C310056B8C7 /* SafariServices.framework */; };
+		F11829171E8C7E0F0056B8C7 /* STPURLCallbackHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = F11829151E8C7E0F0056B8C7 /* STPURLCallbackHandler.h */; };
+		F11829181E8C7E0F0056B8C7 /* STPURLCallbackHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = F11829151E8C7E0F0056B8C7 /* STPURLCallbackHandler.h */; };
+		F11829191E8C7E0F0056B8C7 /* STPURLCallbackHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = F11829161E8C7E0F0056B8C7 /* STPURLCallbackHandler.m */; };
+		F118291A1E8C7E0F0056B8C7 /* STPURLCallbackHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = F11829161E8C7E0F0056B8C7 /* STPURLCallbackHandler.m */; };
+		F118291D1E8C7F250056B8C7 /* NSURLComponents+Stripe.h in Headers */ = {isa = PBXBuildFile; fileRef = F118291B1E8C7F250056B8C7 /* NSURLComponents+Stripe.h */; };
+		F118291E1E8C7F250056B8C7 /* NSURLComponents+Stripe.h in Headers */ = {isa = PBXBuildFile; fileRef = F118291B1E8C7F250056B8C7 /* NSURLComponents+Stripe.h */; };
+		F118291F1E8C7F250056B8C7 /* NSURLComponents+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = F118291C1E8C7F250056B8C7 /* NSURLComponents+Stripe.m */; };
+		F11829201E8C7F250056B8C7 /* NSURLComponents+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = F118291C1E8C7F250056B8C7 /* NSURLComponents+Stripe.m */; };
 		F11C96ED1E78A9BB008DB23D /* STPPaymentMethodType.m in Sources */ = {isa = PBXBuildFile; fileRef = F11C96EA1E78A9BB008DB23D /* STPPaymentMethodType.m */; };
 		F11C96EE1E78A9BB008DB23D /* STPPaymentMethodType.m in Sources */ = {isa = PBXBuildFile; fileRef = F11C96EA1E78A9BB008DB23D /* STPPaymentMethodType.m */; };
 		F11C96F21E78CD3A008DB23D /* STPPaymentMethodType+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = F11C96F01E78CD3A008DB23D /* STPPaymentMethodType+Private.h */; };
@@ -1127,6 +1135,10 @@
 		F118290D1E8C5A200056B8C7 /* STPRedirectContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPRedirectContext.h; sourceTree = "<group>"; };
 		F118290E1E8C5A200056B8C7 /* STPRedirectContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPRedirectContext.m; sourceTree = "<group>"; };
 		F11829131E8C6C310056B8C7 /* SafariServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SafariServices.framework; path = System/Library/Frameworks/SafariServices.framework; sourceTree = SDKROOT; };
+		F11829151E8C7E0F0056B8C7 /* STPURLCallbackHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPURLCallbackHandler.h; sourceTree = "<group>"; };
+		F11829161E8C7E0F0056B8C7 /* STPURLCallbackHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPURLCallbackHandler.m; sourceTree = "<group>"; };
+		F118291B1E8C7F250056B8C7 /* NSURLComponents+Stripe.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURLComponents+Stripe.h"; sourceTree = "<group>"; };
+		F118291C1E8C7F250056B8C7 /* NSURLComponents+Stripe.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURLComponents+Stripe.m"; sourceTree = "<group>"; };
 		F11C96EA1E78A9BB008DB23D /* STPPaymentMethodType.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodType.m; sourceTree = "<group>"; };
 		F11C96F01E78CD3A008DB23D /* STPPaymentMethodType+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "STPPaymentMethodType+Private.h"; sourceTree = "<group>"; };
 		F11C96F61E7C82B1008DB23D /* STPCustomer+Stripe_PaymentMethods.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "STPCustomer+Stripe_PaymentMethods.h"; sourceTree = "<group>"; };
@@ -1508,6 +1520,8 @@
 				C158AB3E1E1EE98900348D01 /* STPSectionHeaderView.m */,
 				F118290D1E8C5A200056B8C7 /* STPRedirectContext.h */,
 				F118290E1E8C5A200056B8C7 /* STPRedirectContext.m */,
+				F11829151E8C7E0F0056B8C7 /* STPURLCallbackHandler.h */,
+				F11829161E8C7E0F0056B8C7 /* STPURLCallbackHandler.m */,
 			);
 			name = Stripe;
 			path = Tests/../Stripe;
@@ -1753,6 +1767,8 @@
 				C124A17B1CCAA0C2007D42EE /* NSMutableURLRequest+Stripe.m */,
 				04695AD11C77F9DB00E08063 /* NSString+Stripe.h */,
 				04695AD21C77F9DB00E08063 /* NSString+Stripe.m */,
+				F118291B1E8C7F250056B8C7 /* NSURLComponents+Stripe.h */,
+				F118291C1E8C7F250056B8C7 /* NSURLComponents+Stripe.m */,
 				04633B081CD44F6C009D4FB5 /* PKPayment+Stripe.h */,
 				04633B091CD44F6C009D4FB5 /* PKPayment+Stripe.m */,
 				C11810931CC6C4700022FB55 /* PKPaymentAuthorizationViewController+Stripe_Blocks.h */,
@@ -1856,6 +1872,7 @@
 				04F94DC91D22A20A004FC826 /* STPSwitchTableViewCell.h in Headers */,
 				0433EB4B1BD06313003912B4 /* NSDictionary+Stripe.h in Headers */,
 				04F94DCB1D22A229004FC826 /* UIView+Stripe_FirstResponder.h in Headers */,
+				F118291E1E8C7F250056B8C7 /* NSURLComponents+Stripe.h in Headers */,
 				04F94DD11D22A239004FC826 /* STPPromise.h in Headers */,
 				C1BD9B351E3940C400CEE925 /* STPSourceVerification.h in Headers */,
 				04633B161CD45222009D4FB5 /* STPAPIClient+ApplePay.h in Headers */,
@@ -1868,6 +1885,7 @@
 				C1CE41B31E787499009C4BD0 /* STPAddSourceViewController+Private.h in Headers */,
 				049E84E91A605EF0000B66CD /* STPBankAccount.h in Headers */,
 				C15993401D88089E0047950D /* STPShippingMethodTableViewCell.h in Headers */,
+				F11829181E8C7E0F0056B8C7 /* STPURLCallbackHandler.h in Headers */,
 				04B31DD51D08E6E200EF1631 /* STPCustomer.h in Headers */,
 				04633AFB1CD1299B009D4FB5 /* NSString+Stripe.h in Headers */,
 				C18880151E68CDDE00FB169F /* STPIDEALSourceInfoDataSource.h in Headers */,
@@ -1989,6 +2007,7 @@
 				04EBC7531B7533C300A0E6AE /* STPCardValidationState.h in Headers */,
 				C133C7F21E805EAD005042DF /* STPSelectorDataSource.h in Headers */,
 				045D710E1CEEE30500F6CD65 /* STPAspects.h in Headers */,
+				F11829171E8C7E0F0056B8C7 /* STPURLCallbackHandler.h in Headers */,
 				C158AB3F1E1EE98900348D01 /* STPSectionHeaderView.h in Headers */,
 				04EBC7571B7533C300A0E6AE /* STPCardValidator.h in Headers */,
 				04BC29B91CDA995000318357 /* STPCheckoutAccountLookup.h in Headers */,
@@ -2032,6 +2051,7 @@
 				049952CF1BCF13510088C703 /* STPAPIRequest.h in Headers */,
 				C15993381D8808680047950D /* STPShippingMethodTableViewCell.h in Headers */,
 				049A3FB21CC9FEFC00F57DE7 /* UIToolbar+Stripe_InputAccessory.h in Headers */,
+				F118291D1E8C7F250056B8C7 /* NSURLComponents+Stripe.h in Headers */,
 				F1FA6F981E25970F00EB444D /* STPCoreTableViewController+Private.h in Headers */,
 				F1DEB8901E2052150066B8E8 /* STPCoreScrollViewController.h in Headers */,
 				C18880081E68CDA700FB169F /* STPBancontactSourceInfoDataSource.h in Headers */,
@@ -2609,11 +2629,13 @@
 				04F94DB31D229F6D004FC826 /* STPSMSCodeViewController.m in Sources */,
 				04F94DB41D229F71004FC826 /* STPPaymentActivityIndicatorView.m in Sources */,
 				C1BD9B251E393FFE00CEE925 /* STPSourceReceiver.m in Sources */,
+				F118291A1E8C7E0F0056B8C7 /* STPURLCallbackHandler.m in Sources */,
 				04827D131D2575C6002DB3E8 /* STPImageLibrary.m in Sources */,
 				045D712F1CF4ED7600F6CD65 /* STPBINRange.m in Sources */,
 				F148ABCA1D5D334B0014FD92 /* STPLocalizationUtils.m in Sources */,
 				045D71111CEEE30500F6CD65 /* STPAspects.m in Sources */,
 				04F94DCA1D22A20D004FC826 /* STPSwitchTableViewCell.m in Sources */,
+				F11829201E8C7F250056B8C7 /* NSURLComponents+Stripe.m in Sources */,
 				04CDE5BA1BC1F1F100548833 /* STPCardParams.m in Sources */,
 				0451CC471C49AE1C003B2CA6 /* STPPaymentResult.m in Sources */,
 				049E84D11A605DE0000B66CD /* STPToken.m in Sources */,
@@ -2638,6 +2660,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0438EF431B74170D00D506CC /* STPCardValidator.m in Sources */,
+				F118291F1E8C7F250056B8C7 /* NSURLComponents+Stripe.m in Sources */,
 				F19491DB1E5F606F001E1FC2 /* STPSourceCardDetails.m in Sources */,
 				04BC29AE1CD9A88600318357 /* STPCheckoutAPIVerification.m in Sources */,
 				0426B9781CEBD001006AC8DD /* UINavigationBar+Stripe_Theme.m in Sources */,
@@ -2726,6 +2749,7 @@
 				C124A17E1CCAA0C2007D42EE /* NSMutableURLRequest+Stripe.m in Sources */,
 				04695ADA1C77F9EF00E08063 /* STPDelegateProxy.m in Sources */,
 				045D712E1CF4ED7600F6CD65 /* STPBINRange.m in Sources */,
+				F11829191E8C7E0F0056B8C7 /* STPURLCallbackHandler.m in Sources */,
 				049A3FB31CC9FEFC00F57DE7 /* UIToolbar+Stripe_InputAccessory.m in Sources */,
 				0438EF3B1B7416BB00D506CC /* STPPaymentCardTextFieldViewModel.m in Sources */,
 				C1BD9B301E3940A200CEE925 /* STPSourceRedirect.m in Sources */,

--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -602,6 +602,7 @@
 		F118291E1E8C7F250056B8C7 /* NSURLComponents+Stripe.h in Headers */ = {isa = PBXBuildFile; fileRef = F118291B1E8C7F250056B8C7 /* NSURLComponents+Stripe.h */; };
 		F118291F1E8C7F250056B8C7 /* NSURLComponents+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = F118291C1E8C7F250056B8C7 /* NSURLComponents+Stripe.m */; };
 		F11829201E8C7F250056B8C7 /* NSURLComponents+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = F118291C1E8C7F250056B8C7 /* NSURLComponents+Stripe.m */; };
+		F11829221E8DA0F70056B8C7 /* NSURLComponents+StripeTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F11829211E8DA0F70056B8C7 /* NSURLComponents+StripeTest.m */; };
 		F11C96ED1E78A9BB008DB23D /* STPPaymentMethodType.m in Sources */ = {isa = PBXBuildFile; fileRef = F11C96EA1E78A9BB008DB23D /* STPPaymentMethodType.m */; };
 		F11C96EE1E78A9BB008DB23D /* STPPaymentMethodType.m in Sources */ = {isa = PBXBuildFile; fileRef = F11C96EA1E78A9BB008DB23D /* STPPaymentMethodType.m */; };
 		F11C96F21E78CD3A008DB23D /* STPPaymentMethodType+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = F11C96F01E78CD3A008DB23D /* STPPaymentMethodType+Private.h */; };
@@ -1139,6 +1140,7 @@
 		F11829161E8C7E0F0056B8C7 /* STPURLCallbackHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPURLCallbackHandler.m; sourceTree = "<group>"; };
 		F118291B1E8C7F250056B8C7 /* NSURLComponents+Stripe.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURLComponents+Stripe.h"; sourceTree = "<group>"; };
 		F118291C1E8C7F250056B8C7 /* NSURLComponents+Stripe.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURLComponents+Stripe.m"; sourceTree = "<group>"; };
+		F11829211E8DA0F70056B8C7 /* NSURLComponents+StripeTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURLComponents+StripeTest.m"; sourceTree = "<group>"; };
 		F11C96EA1E78A9BB008DB23D /* STPPaymentMethodType.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodType.m; sourceTree = "<group>"; };
 		F11C96F01E78CD3A008DB23D /* STPPaymentMethodType+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "STPPaymentMethodType+Private.h"; sourceTree = "<group>"; };
 		F11C96F61E7C82B1008DB23D /* STPCustomer+Stripe_PaymentMethods.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "STPCustomer+Stripe_PaymentMethods.h"; sourceTree = "<group>"; };
@@ -1633,6 +1635,7 @@
 				C11810981CC6D46D0022FB55 /* NSDecimalNumber+StripeTest.m */,
 				C124A1801CCAA1BF007D42EE /* NSMutableURLRequest+StripeTest.m */,
 				C1EEDCC71CA2172700A54582 /* NSString+StripeTest.m */,
+				F11829211E8DA0F70056B8C7 /* NSURLComponents+StripeTest.m */,
 				04CB86B81BA89CD400E4F61E /* PKPayment+StripeTest.m */,
 				C13538071D2C2186003F6157 /* STPAddCardViewControllerTest.m */,
 				C1080F4B1CBED48A007B2D89 /* STPAddressTests.m */,
@@ -1657,10 +1660,10 @@
 				C1BF02321E8B28AE00FE9F51 /* STPPaymentMethodTupleTest.m */,
 				C1EEDCC91CA2186300A54582 /* STPPhoneNumberValidatorTest.m */,
 				C1FEE5981CBFF24000A7632B /* STPPostalCodeValidatorTest.m */,
-				F1D777BF1D81DD520076FA19 /* STPStringUtilsTest.m */,
 				C1BF02331E8B28AE00FE9F51 /* STPSourceInfoViewControllerTest.m */,
 				C1BD9B1E1E390A2700CEE925 /* STPSourceParamsTest.m */,
 				C17D24ED1E37DBAC005CB188 /* STPSourceTest.m */,
+				F1D777BF1D81DD520076FA19 /* STPStringUtilsTest.m */,
 				04CDB5271A5F3A9300B854EE /* STPTokenTest.m */,
 				04A4C3931C4F276100B3B290 /* STPUIVCStripeParentViewControllerTests.m */,
 				F1122A7D1DFB84E000A8B1AF /* UINavigationBar+StripeTest.m */,
@@ -2489,6 +2492,7 @@
 				F1122A7E1DFB84E000A8B1AF /* UINavigationBar+StripeTest.m in Sources */,
 				04A4C3941C4F276100B3B290 /* STPUIVCStripeParentViewControllerTests.m in Sources */,
 				04A488361CA34DC600506E53 /* STPEmailAddressValidatorTest.m in Sources */,
+				F11829221E8DA0F70056B8C7 /* NSURLComponents+StripeTest.m in Sources */,
 				C1EEDCCA1CA2186300A54582 /* STPPhoneNumberValidatorTest.m in Sources */,
 				04CB86BA1BA89CE100E4F61E /* PKPayment+StripeTest.m in Sources */,
 				F1B980941DB550E60075332E /* STPPaymentMethodsViewControllerLocalizationTests.m in Sources */,

--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -95,7 +95,7 @@
 		0451CC451C49AE1C003B2CA6 /* STPPaymentResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 0451CC421C49AE1C003B2CA6 /* STPPaymentResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0451CC461C49AE1C003B2CA6 /* STPPaymentResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 0451CC431C49AE1C003B2CA6 /* STPPaymentResult.m */; };
 		0451CC471C49AE1C003B2CA6 /* STPPaymentResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 0451CC431C49AE1C003B2CA6 /* STPPaymentResult.m */; };
-		04533E7D1A6877F400C7E52E /* PassKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04D5BF9019BF958F009521A5 /* PassKit.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		04533E7D1A6877F400C7E52E /* PassKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04D5BF9019BF958F009521A5 /* PassKit.framework */; settings = {ATTRIBUTES = (Required, ); }; };
 		045A62AB1B8E7259000165CE /* STPPaymentCardTextFieldTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 045A62AA1B8E7259000165CE /* STPPaymentCardTextFieldTest.m */; };
 		045D71071CEED3AA00F6CD65 /* STPRememberMeEmailCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 045D71051CEED3AA00F6CD65 /* STPRememberMeEmailCell.h */; };
 		045D71081CEED3AA00F6CD65 /* STPRememberMeEmailCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 045D71051CEED3AA00F6CD65 /* STPRememberMeEmailCell.h */; };
@@ -586,9 +586,14 @@
 		C1FEE5971CBFF11400A7632B /* STPPostalCodeValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = C1FEE5951CBFF11400A7632B /* STPPostalCodeValidator.m */; };
 		C1FEE5991CBFF24000A7632B /* STPPostalCodeValidatorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C1FEE5981CBFF24000A7632B /* STPPostalCodeValidatorTest.m */; };
 		F1122A7E1DFB84E000A8B1AF /* UINavigationBar+StripeTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F1122A7D1DFB84E000A8B1AF /* UINavigationBar+StripeTest.m */; };
-		F116E94B1D83404D0026A52A /* AddressBook.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04B94BC71A47B78A00092C46 /* AddressBook.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		F116E94B1D83404D0026A52A /* AddressBook.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04B94BC71A47B78A00092C46 /* AddressBook.framework */; settings = {ATTRIBUTES = (Required, ); }; };
 		F116E94C1D83405E0026A52A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 11C74B9B164043050071C2CA /* Foundation.framework */; };
 		F116E94D1D8340640026A52A /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A0D74F918F6106100966D7B /* Security.framework */; };
+		F118290F1E8C5A200056B8C7 /* STPRedirectContext.h in Headers */ = {isa = PBXBuildFile; fileRef = F118290D1E8C5A200056B8C7 /* STPRedirectContext.h */; };
+		F11829101E8C5A200056B8C7 /* STPRedirectContext.h in Headers */ = {isa = PBXBuildFile; fileRef = F118290D1E8C5A200056B8C7 /* STPRedirectContext.h */; };
+		F11829111E8C5A200056B8C7 /* STPRedirectContext.m in Sources */ = {isa = PBXBuildFile; fileRef = F118290E1E8C5A200056B8C7 /* STPRedirectContext.m */; };
+		F11829121E8C5A200056B8C7 /* STPRedirectContext.m in Sources */ = {isa = PBXBuildFile; fileRef = F118290E1E8C5A200056B8C7 /* STPRedirectContext.m */; };
+		F11829141E8C6C310056B8C7 /* SafariServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F11829131E8C6C310056B8C7 /* SafariServices.framework */; };
 		F11C96ED1E78A9BB008DB23D /* STPPaymentMethodType.m in Sources */ = {isa = PBXBuildFile; fileRef = F11C96EA1E78A9BB008DB23D /* STPPaymentMethodType.m */; };
 		F11C96EE1E78A9BB008DB23D /* STPPaymentMethodType.m in Sources */ = {isa = PBXBuildFile; fileRef = F11C96EA1E78A9BB008DB23D /* STPPaymentMethodType.m */; };
 		F11C96F21E78CD3A008DB23D /* STPPaymentMethodType+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = F11C96F01E78CD3A008DB23D /* STPPaymentMethodType+Private.h */; };
@@ -1119,6 +1124,9 @@
 		C1FEE5951CBFF11400A7632B /* STPPostalCodeValidator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPPostalCodeValidator.m; sourceTree = "<group>"; };
 		C1FEE5981CBFF24000A7632B /* STPPostalCodeValidatorTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPPostalCodeValidatorTest.m; sourceTree = "<group>"; };
 		F1122A7D1DFB84E000A8B1AF /* UINavigationBar+StripeTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UINavigationBar+StripeTest.m"; sourceTree = "<group>"; };
+		F118290D1E8C5A200056B8C7 /* STPRedirectContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPRedirectContext.h; sourceTree = "<group>"; };
+		F118290E1E8C5A200056B8C7 /* STPRedirectContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPRedirectContext.m; sourceTree = "<group>"; };
+		F11829131E8C6C310056B8C7 /* SafariServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SafariServices.framework; path = System/Library/Frameworks/SafariServices.framework; sourceTree = SDKROOT; };
 		F11C96EA1E78A9BB008DB23D /* STPPaymentMethodType.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodType.m; sourceTree = "<group>"; };
 		F11C96F01E78CD3A008DB23D /* STPPaymentMethodType+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "STPPaymentMethodType+Private.h"; sourceTree = "<group>"; };
 		F11C96F61E7C82B1008DB23D /* STPCustomer+Stripe_PaymentMethods.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "STPCustomer+Stripe_PaymentMethods.h"; sourceTree = "<group>"; };
@@ -1217,6 +1225,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F11829141E8C6C310056B8C7 /* SafariServices.framework in Frameworks */,
 				F1D64B2E1D87686E001CDB7C /* WebKit.framework in Frameworks */,
 				F116E94B1D83404D0026A52A /* AddressBook.framework in Frameworks */,
 				F116E94C1D83405E0026A52A /* Foundation.framework in Frameworks */,
@@ -1497,6 +1506,8 @@
 				F1C7B8D11DBECF2400D9F6F0 /* STPDispatchFunctions.m */,
 				C158AB3D1E1EE98900348D01 /* STPSectionHeaderView.h */,
 				C158AB3E1E1EE98900348D01 /* STPSectionHeaderView.m */,
+				F118290D1E8C5A200056B8C7 /* STPRedirectContext.h */,
+				F118290E1E8C5A200056B8C7 /* STPRedirectContext.m */,
 			);
 			name = Stripe;
 			path = Tests/../Stripe;
@@ -1564,6 +1575,7 @@
 		11C74B9A164043050071C2CA /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				F11829131E8C6C310056B8C7 /* SafariServices.framework */,
 				C11B14961E8AE316000F760C /* OCMock.framework */,
 				F15AC18D1DBA9CA90009EADE /* FBSnapshotTestCase.framework */,
 				F1D64B2D1D87686E001CDB7C /* WebKit.framework */,
@@ -1828,6 +1840,7 @@
 				C159933D1D8808970047950D /* STPShippingMethodsViewController.h in Headers */,
 				04F94DCD1D22A22F004FC826 /* UIViewController+Stripe_KeyboardAvoiding.h in Headers */,
 				C1BD9B3A1E39416700CEE925 /* STPSourceOwner.h in Headers */,
+				F11829101E8C5A200056B8C7 /* STPRedirectContext.h in Headers */,
 				C1C1012E1E57A26F00C7BFAE /* STPSource+Private.h in Headers */,
 				04A488431CA3580700506E53 /* UINavigationController+Stripe_Completion.h in Headers */,
 				C124A1711CCA968B007D42EE /* STPAnalyticsClient.h in Headers */,
@@ -2068,6 +2081,7 @@
 				04CDB4D31A5F30A700B854EE /* Stripe.h in Headers */,
 				C17F28B81E4CD13A0073408B /* STPSourceInfoViewController.h in Headers */,
 				04BC29C61CE2A82300318357 /* STPSMSCodeTextField.h in Headers */,
+				F118290F1E8C5A200056B8C7 /* STPRedirectContext.h in Headers */,
 				04E39F601CED2C3900AF3B96 /* STPRememberMeTermsView.h in Headers */,
 				F19491E71E60DD9C001E1FC2 /* STPSourceSEPADebitDetails.h in Headers */,
 				04A488421CA3580700506E53 /* UINavigationController+Stripe_Completion.h in Headers */,
@@ -2513,6 +2527,7 @@
 				F12829DD1D7747E4008B10D6 /* STPBundleLocator.m in Sources */,
 				04F94DA91D229F32004FC826 /* STPPaymentMethodTuple.m in Sources */,
 				04F94DC41D22A1F9004FC826 /* STPCheckoutAccount.m in Sources */,
+				F11829121E8C5A200056B8C7 /* STPRedirectContext.m in Sources */,
 				04F94DB61D229F77004FC826 /* STPSMSCodeTextField.m in Sources */,
 				F19491E51E60DD72001E1FC2 /* STPSourceSEPADebitDetails.m in Sources */,
 				0438EF311B7416BB00D506CC /* STPFormTextField.m in Sources */,
@@ -2661,6 +2676,7 @@
 				C133C7F81E80627C005042DF /* STPSofortCountrySelectorDataSource.m in Sources */,
 				C15993371D8808680047950D /* STPShippingMethodsViewController.m in Sources */,
 				C1363BB91D7633D800EB82B4 /* STPPaymentMethodTableViewCell.m in Sources */,
+				F11829111E8C5A200056B8C7 /* STPRedirectContext.m in Sources */,
 				C15993331D8808680047950D /* STPShippingAddressViewController.m in Sources */,
 				04633B051CD44F1C009D4FB5 /* STPAPIClient+ApplePay.m in Sources */,
 				F1C7B8D31DBECF2400D9F6F0 /* STPDispatchFunctions.m in Sources */,

--- a/Stripe/NSURLComponents+Stripe.h
+++ b/Stripe/NSURLComponents+Stripe.h
@@ -1,0 +1,37 @@
+//
+//  NSURLComponents+Stripe.h
+//  Stripe
+//
+//  Created by Brian Dorfman on 1/26/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface NSURLComponents (Stripe)
+
+
+/**
+ Returns or sets self.queryItems as a dictionary where all the keys are the item
+ names and the values are the values. When reading, if there are duplicate 
+ names, earlier ones are overwritten by later ones.
+ */
+@property (nonatomic, copy, nullable) NSDictionary<NSString *, NSString *> *stp_queryItemsDictionary;
+
+/**
+ Returns YES if the passed in url matches self in scheme, host, and path,
+ AND all the query items in self are also in the passed 
+ in components (as determined by `stp_queryItemsDictionary`)
+ 
+ This is used for URL routing style matching
+
+ @param rhsComponents The components to match against
+ @return YES if there is a match, NO otherwise.
+ */
+- (BOOL)stp_matchesURLComponents:(NSURLComponents *)rhsComponents;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Stripe/NSURLComponents+Stripe.h
+++ b/Stripe/NSURLComponents+Stripe.h
@@ -34,4 +34,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+void linkNSURLComponentsCategory(void);
+
 NS_ASSUME_NONNULL_END

--- a/Stripe/NSURLComponents+Stripe.m
+++ b/Stripe/NSURLComponents+Stripe.m
@@ -1,0 +1,51 @@
+//
+//  NSURLComponents+Stripe.m
+//  Stripe
+//
+//  Created by Brian Dorfman on 1/26/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import "NSURLComponents+Stripe.h"
+
+@implementation NSURLComponents (Stripe)
+
+- (NSDictionary<NSString *, NSString *> *)stp_queryItemsDictionary {
+    NSMutableDictionary *queryItems = [NSMutableDictionary new];
+
+    for (NSURLQueryItem *queryItem in self.queryItems) {
+        queryItems[queryItem.name] = queryItem.value;
+    }
+
+    return queryItems.copy;
+}
+
+- (void)setStp_queryItemsDictionary:(NSDictionary<NSString *, NSString *> *)stp_queryItemsDictionary {
+    NSMutableArray *queryItems = [NSMutableArray new];
+    [stp_queryItemsDictionary enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull key, NSString * _Nonnull obj, BOOL * __unused _Nonnull stop) {
+        [queryItems addObject:[NSURLQueryItem queryItemWithName:key value:obj]];
+    }];
+
+    self.queryItems = queryItems.copy;
+}
+
+- (BOOL)stp_matchesURLComponents:(NSURLComponents *)rhsComponents {
+    BOOL matches = ([self.scheme isEqualToString:rhsComponents.scheme]
+                    && [self.host isEqualToString:rhsComponents.host]
+                    && [self.path isEqualToString:rhsComponents.path]);
+
+    if (matches) {
+        NSDictionary<NSString *, NSString *> *rhsQueryItems = rhsComponents.stp_queryItemsDictionary;
+
+        for (NSURLQueryItem *queryItem in self.queryItems) {
+            if (![rhsQueryItems[queryItem.name] isEqualToString:queryItem.value]) {
+                matches = NO;
+                break;
+            }
+        }
+    }
+
+    return matches;
+}
+
+@end

--- a/Stripe/NSURLComponents+Stripe.m
+++ b/Stripe/NSURLComponents+Stripe.m
@@ -49,3 +49,5 @@
 }
 
 @end
+
+void linkNSURLComponentsCategory(void){}

--- a/Stripe/PublicHeaders/STPAPIClient.h
+++ b/Stripe/PublicHeaders/STPAPIClient.h
@@ -185,5 +185,25 @@ static NSString *const STPSDKVersion = @"10.0.1";
 
 @end
 
+#pragma mark URL callbacks
+
+@interface Stripe (STPURLCallbackHandlerAdditions)
+
+/**
+ Call this method in your app delegate whenever you receive an openURL for
+ a Stripe callback.
+
+ For convenience, you can pass all URL's you receive in
+ `application:openURL:options:` to this method first, and check the return value
+ to easily determine whether it is a callback URL that Stripe will handle
+ or if your app should process it normally.
+
+ @param url The URL that you received in your app delegate
+
+ @return YES if the URL is expected and will be handled by Stripe. NO otherwise.
+ */
++ (BOOL)handleStripeURLCallbackWithURL:(NSURL *)url;
+
+@end
 
 NS_ASSUME_NONNULL_END

--- a/Stripe/PublicHeaders/STPPaymentContext.h
+++ b/Stripe/PublicHeaders/STPPaymentContext.h
@@ -280,16 +280,6 @@ didCreatePaymentResult:(STPPaymentResult *)paymentResult
 didUpdateShippingAddress:(STPAddress *)address
             completion:(STPShippingMethodsCompletionBlock)completion;
 
-/**
- *  This method is called after the user returns to the app after completing
- *  a redirect-based payment method.
- *
- *  You may want to show some sort of loading UI on screen when this happens,
- *  while payment context polls for updated source information. When source polling
- *  completes, the delegate will receive a call to `paymentContext:didFinishWithStatus:error:`
- */
-- (void)paymentContextDidReturnFromRedirect:(STPPaymentContext *)paymentContext;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Stripe/STPCategoryLoader.m
+++ b/Stripe/STPCategoryLoader.m
@@ -16,6 +16,7 @@
 #import "NSDictionary+Stripe.h"
 #import "NSMutableURLRequest+Stripe.h"
 #import "NSString+Stripe.h"
+#import "NSURLComponents+Stripe.h"
 #import "PKPayment+Stripe.h"
 #import "PKPaymentAuthorizationViewController+Stripe_Blocks.h"
 #import "STPAPIClient+ApplePay.h"
@@ -54,6 +55,7 @@
     linkNSDecimalNumberCurrencyCategory();
     linkNSBundleAppNameCategory();
     linkAspectsCategory();
+    linkNSURLComponentsCategory();
 }
 
 @end

--- a/Stripe/STPPaymentConfiguration+Private.h
+++ b/Stripe/STPPaymentConfiguration+Private.h
@@ -23,7 +23,15 @@ NS_ASSUME_NONNULL_BEGIN
  It handles opening the redirect url, subscribes for foreground notifications, 
  does some polling when the customer comes back, and then returns you the completed source object
  */
-@property (nonatomic, copy, nullable) void (^sourceURLRedirectBlock)(STPAPIClient *apiClient, STPSource *source, STPVoidBlock onRedirectReturn, STPSourceCompletionBlock completion);
+@property (nonatomic, copy, nullable) void (^sourceURLRedirectBlock)(STPAPIClient *apiClient, STPSource *source, UIViewController *presentingViewController, STPSourceCompletionBlock completion);
+
+
+/**
+ Cancels the current source url redirect, if any.
+ 
+ Nullable block to get around app extension restrictions. Non-nil if there is a redirect in progress.
+ */
+@property (nonatomic, copy, nullable) STPVoidBlock cancelSourceURLRedirectBlock;
 
 @end
 

--- a/Stripe/STPPaymentContext.m
+++ b/Stripe/STPPaymentContext.m
@@ -519,12 +519,6 @@ typedef NS_ENUM(NSUInteger, STPPaymentContextState) {
                     break;
                 case STPSourceFlowRedirect: {
 
-                    STPVoidBlock onRedirectReturn = ^ {
-                        if ([self.delegate respondsToSelector:@selector(paymentContextDidReturnFromRedirect:)]) {
-                            [self.delegate paymentContextDidReturnFromRedirect:self];
-                        }
-                    };
-
                     STPSourceCompletionBlock onRedirectCompletion = ^(STPSource *finishedSource, NSError *error) {
                         stpDispatchToMainThreadIfNecessary(^{
                             if (error) {
@@ -569,7 +563,7 @@ typedef NS_ENUM(NSUInteger, STPPaymentContextState) {
 
                     self.configuration.sourceURLRedirectBlock(self.apiClient,
                                                               source,
-                                                              onRedirectReturn,
+                                                              self.hostViewController,
                                                               onRedirectCompletion);
                 }
                     break;

--- a/Stripe/STPPaymentContext.m
+++ b/Stripe/STPPaymentContext.m
@@ -97,6 +97,12 @@ typedef NS_ENUM(NSUInteger, STPPaymentContextState) {
     return self;
 }
 
+- (void)dealloc {
+    if (self.configuration.cancelSourceURLRedirectBlock) {
+        self.configuration.cancelSourceURLRedirectBlock();
+    }
+}
+
 - (void)retryLoading {
     if (self.loadingPromise && self.loadingPromise.value) {
         return;

--- a/Stripe/STPRedirectContext.h
+++ b/Stripe/STPRedirectContext.h
@@ -16,6 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  - STPRedirectContextStateNotStarted: Initialized, but redirect not started
  - STPRedirectContextStateInProgress: Redirect is in progress
+ - STPRedirectContextStateCancelled: Redirect has been cancelled programmatically before completing
  - STPRedirectContextStateCompleted: Redirect has completed.
  */
 typedef NS_ENUM(NSUInteger, STPRedirectContextState) {

--- a/Stripe/STPRedirectContext.h
+++ b/Stripe/STPRedirectContext.h
@@ -61,7 +61,7 @@ typedef void (^STPRedirectContextCompletionBlock)(NSString *sourceId, NSString *
  *
  *  You should not use either this class, nor `STPAPIClient`, as a way
  *  to determine when you should charge the source. Use Stripe webhooks on your
- *  backend server to listen for source state changes and make the charge.
+ *  backend server to listen for source state changes and to make the charge.
  *
  */
 NS_EXTENSION_UNAVAILABLE("Redirect based sources are not available in extensions")

--- a/Stripe/STPRedirectContext.h
+++ b/Stripe/STPRedirectContext.h
@@ -1,0 +1,139 @@
+//
+//  STPRedirectContext.h
+//  Stripe
+//
+//  Created by Brian Dorfman on 3/29/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "STPBlocks.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Possible states for the redirect context to be in
+
+ - STPRedirectContextStateNotStarted: Initialized, but redirect not started
+ - STPRedirectContextStateInProgress: Redirect is in progress
+ - STPRedirectContextStateCompleted: Redirect has completed.
+ */
+typedef NS_ENUM(NSUInteger, STPRedirectContextState) {
+    STPRedirectContextStateNotStarted,
+    STPRedirectContextStateInProgress,
+    STPRedirectContextStateCancelled,
+    STPRedirectContextStateCompleted
+};
+
+/**
+ A callback run when the context believes the redirect action has been completed.
+
+ @param sourceId The stripe id of the source.
+ @param sourceClientSecret The client secret of the source.
+ @param error An error if one occured. Note that a lack of an error does not mean that the action was completed successfully, the presence of one confirms that it was not.
+ Currently the only possible error the context can know about is if SFSafariViewController fails its initial load (like the user has no internet connection, or servers are down).
+ 
+ @note you can use the id and client secret to fetch the source from Stripe's servers
+ and check its status. 
+ @see `[STPAPIClient retrieveSourceWithId:clientSecret:completion]`
+ @see `[STPAPIClient startPollingSourceWithId:clientSecret:timeout:completion:]`
+ */
+typedef void (^STPRedirectContextCompletionBlock)(NSString *sourceId, NSString *sourceClientSecret, NSError *error);
+
+/**
+ *  This is a helper class for handling redirect sources.
+ *
+ *  Init an instance with the redirect flow source you want to handle,
+ *  then choose a redirect method. The context will fire the completion handler
+ *  when the redirect completes.
+ *
+ *  Due to the nature of iOS, very little concrete information can be gained
+ *  during this process, as all actions take place in either the Safari app
+ *  or the sandboxed SFSafariViewController class. The context attempts to 
+ *  detect when the user has completed the necessary redirect action by listening
+ *  for both app foregrounds and url callbacks received in the app delegate.
+ *  However, it is possible the when the redirect is "completed", the user may
+ *  have not actually completed the necessary actions to authorize the charge.
+ *
+ *  You can use `STPAPIClient` to listen for state changes on the source
+ *  object as a way to identify whether the user action succeeded or not.
+ *  @see `[STPAPIClient startPollingSourceWithId:clientSecret:timeout:completion:]`
+ *
+ *  You should not use either this class, nor `STPAPIClient`, as a way
+ *  to determine when you should charge the source. Use Stripe webhooks on your
+ *  backend server to listen for source state changes and make the charge.
+ *
+ */
+NS_EXTENSION_UNAVAILABLE("Redirect based sources are not available in extensions")
+@interface STPRedirectContext : NSObject
+
+/**
+ *  The current state of the context.
+ */
+@property (nonatomic, readonly) STPRedirectContextState state;
+
+/**
+ *  Initializer for context.
+ *
+ *  @note You must ensure that the returnURL set up in the created source
+ *  correctly goes to your app so that users can be returned once
+ *  they complete the redirect in the web broswer.
+ *
+ *  @param source The source that needs user redirect action to be taken.
+ *  @param completion A block to fire when the action is believed to have been completed.
+ *  @return Nil if the specified source is not a redirect-flow source. Otherwise a new context object.
+ *  
+ *  @note Firing of the completion block does not necessarily mean the user successfully
+ *  performed the redirect action. You can re-fetch the source object using
+ *  its id and clientSecret, and poll for status updates on it to determine if
+ *  the source was sucessfully made chargeable.
+ *  @see `[STPAPIClient startPollingSourceWithId:clientSecret:timeout:completion:]`
+ */
+- (nullable instancetype)initWithSource:(STPSource *)source
+                             completion:(STPRedirectContextCompletionBlock)completion;
+
+
+/**
+ * Use `initWithSource:completion:`
+ */
+- (instancetype)init NS_UNAVAILABLE;
+
+/**
+ *  Starts a redirect flow by presenting an SFSafariViewController in your app
+ *  from the passed in view controller.
+ *
+ *  You must ensure that your app delegate listens for  the `returnURL` that you
+ *  set on your source object, and forwards it to the Stripe SDK so that the
+ *  context can be notified when the redirect is completed and dismiss the
+ *  view controller. See `[Stripe handleStripeURLCallback:]`
+ *
+ *  The context will listen for both received URLs and app open notifications 
+ *  and fire its completion block when either the URL is received, or the next
+ *  time the app is foregrounded.
+ *
+ *  @note This method does nothing if the context is not in the `STPRedirectContextStateNotStarted` state.
+ *
+ *  @param presentingViewController The view controller to present the Safari view controller from.
+ */
+- (void)startSafariViewControllerRedirectFlowFromViewController:(UIViewController *)presentingViewController NS_AVAILABLE_IOS(9_0);
+
+/**
+ *  Starts a redirect flow by calling `openURL` to bounce the user out to
+ *  the Safari app.
+ *
+ *  The context will listen for app open notifications and fire its completion
+ *  block the next time the user re-opens the app (either manually or via url)
+ *
+ *  @note This method does nothing if the context is not in the `STPRedirectContextStateNotStarted` state.
+ */
+- (void)startSafariAppRedirectFlow;
+
+/**
+ *  Dismisses any presented views and stops listening for any
+ *  app opens or callbacks. The completion block will not be fired.
+ */
+- (void)cancel;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Stripe/STPURLCallbackHandler.h
+++ b/Stripe/STPURLCallbackHandler.h
@@ -1,0 +1,30 @@
+//
+//  STPURLCallbackHandler.h
+//  Stripe
+//
+//  Created by Brian Dorfman on 10/6/16.
+//  Copyright © 2016 Stripe, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol STPURLCallbackListener <NSObject>
+- (BOOL)handleURLCallback:(NSURL *)url;
+@end
+
+@interface STPURLCallbackHandler : NSObject
+
++ (instancetype)shared;
+
+- (BOOL)handleURLCallback:(NSURL *)url;
+- (void)registerListener:(id<STPURLCallbackListener>)listener
+                  forURL:(NSURL *)url;
+
+- (void)unregisterListener:(id<STPURLCallbackListener>)listener
+                    forURL:(NSURL *)url;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Stripe/STPURLCallbackHandler.h
+++ b/Stripe/STPURLCallbackHandler.h
@@ -24,6 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)unregisterListener:(id<STPURLCallbackListener>)listener
                     forURL:(NSURL *)url;
+- (void)unregisterListener:(id<STPURLCallbackListener>)listener;
 
 @end
 

--- a/Stripe/STPURLCallbackHandler.h
+++ b/Stripe/STPURLCallbackHandler.h
@@ -22,8 +22,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)registerListener:(id<STPURLCallbackListener>)listener
                   forURL:(NSURL *)url;
 
-- (void)unregisterListener:(id<STPURLCallbackListener>)listener
-                    forURL:(NSURL *)url;
 - (void)unregisterListener:(id<STPURLCallbackListener>)listener;
 
 @end

--- a/Stripe/STPURLCallbackHandler.m
+++ b/Stripe/STPURLCallbackHandler.m
@@ -1,0 +1,114 @@
+//
+//  STPURLCallbackHandler.m
+//  Stripe
+//
+//  Created by Brian Dorfman on 10/6/16.
+//  Copyright © 2016 Stripe, Inc. All rights reserved.
+//
+
+#import "STPURLCallbackHandler.h"
+
+#import "STPAPIClient.h"
+
+#import "NSURLComponents+Stripe.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation Stripe (STPURLCallbackHandlerAdditions)
+
++ (BOOL)handleStripeURLCallbackWithURL:(NSURL *)url {
+    if (url) {
+        return [[STPURLCallbackHandler shared] handleURLCallback:url];
+    }
+    else {
+        return NO;
+    }
+}
+
+@end
+
+@interface STPURLCallback : NSObject
+@property (nonatomic) NSURLComponents *urlComponents;
+@property (nonatomic) id<STPURLCallbackListener> listener;
+@end
+
+@implementation STPURLCallback
+@end
+
+@interface STPURLCallbackHandler ()
+@property (nonatomic) NSArray <STPURLCallback *> *callbacks;
+@end
+
+@implementation STPURLCallbackHandler
+
++ (instancetype)shared {
+    static STPURLCallbackHandler *handler;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        handler = [STPURLCallbackHandler new];
+    });
+
+    return handler;
+}
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        self.callbacks = [NSArray new];
+    }
+    return self;
+}
+
+- (BOOL)handleURLCallback:(NSURL *)url {
+
+    NSURLComponents *components = [[NSURLComponents alloc] initWithURL:url
+                                               resolvingAgainstBaseURL:NO];
+
+    BOOL resultsOrred = NO;
+
+    for (STPURLCallback *callback in self.callbacks) {
+        if ([callback.urlComponents stp_matchesURLComponents:components]) {
+            resultsOrred |= [callback.listener handleURLCallback:url];
+        }
+    }
+
+    return resultsOrred;
+}
+
+- (void)registerListener:(id<STPURLCallbackListener>)listener
+                  forURL:(NSURL *)url {
+
+    STPURLCallback *callback = [STPURLCallback new];
+    callback.listener = listener;
+    callback.urlComponents = [[NSURLComponents alloc] initWithURL:url
+                                          resolvingAgainstBaseURL:NO];
+
+    if (callback.listener && callback.urlComponents) {
+        NSMutableArray <STPURLCallback *> *callbacksCopy = self.callbacks.mutableCopy;
+        [callbacksCopy addObject:callback];
+        self.callbacks = callbacksCopy.copy;
+    }
+}
+
+- (void)unregisterListener:(id<STPURLCallbackListener>)listener
+                    forURL:(NSURL *)url {
+    NSURLComponents *components = [[NSURLComponents alloc] initWithURL:url
+                                               resolvingAgainstBaseURL:NO];
+
+    NSMutableArray *callbacksToRemove = [NSMutableArray new];
+
+    for (STPURLCallback *callback in self.callbacks) {
+        if ([callback.urlComponents stp_matchesURLComponents:components]
+            && listener == callback.listener) {
+            [callbacksToRemove addObject:callback];
+        }
+    }
+    NSMutableArray <STPURLCallback *> *callbacksCopy = self.callbacks.mutableCopy;
+    [callbacksCopy removeObjectsInArray:callbacksToRemove];
+    self.callbacks = callbacksCopy.copy;
+
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Stripe/STPURLCallbackHandler.m
+++ b/Stripe/STPURLCallbackHandler.m
@@ -90,24 +90,6 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
-- (void)unregisterListener:(id<STPURLCallbackListener>)listener
-                    forURL:(NSURL *)url {
-    NSURLComponents *components = [[NSURLComponents alloc] initWithURL:url
-                                               resolvingAgainstBaseURL:NO];
-
-    NSMutableArray *callbacksToRemove = [NSMutableArray new];
-
-    for (STPURLCallback *callback in self.callbacks) {
-        if ([callback.urlComponents stp_matchesURLComponents:components]
-            && listener == callback.listener) {
-            [callbacksToRemove addObject:callback];
-        }
-    }
-    NSMutableArray <STPURLCallback *> *callbacksCopy = self.callbacks.mutableCopy;
-    [callbacksCopy removeObjectsInArray:callbacksToRemove];
-    self.callbacks = callbacksCopy.copy;
-}
-
 - (void)unregisterListener:(id<STPURLCallbackListener>)listener {
     NSMutableArray *callbacksToRemove = [NSMutableArray new];
 

--- a/Stripe/STPURLCallbackHandler.m
+++ b/Stripe/STPURLCallbackHandler.m
@@ -106,7 +106,19 @@ NS_ASSUME_NONNULL_BEGIN
     NSMutableArray <STPURLCallback *> *callbacksCopy = self.callbacks.mutableCopy;
     [callbacksCopy removeObjectsInArray:callbacksToRemove];
     self.callbacks = callbacksCopy.copy;
+}
 
+- (void)unregisterListener:(id<STPURLCallbackListener>)listener {
+    NSMutableArray *callbacksToRemove = [NSMutableArray new];
+
+    for (STPURLCallback *callback in self.callbacks) {
+        if (listener == callback.listener) {
+            [callbacksToRemove addObject:callback];
+        }
+    }
+    NSMutableArray <STPURLCallback *> *callbacksCopy = self.callbacks.mutableCopy;
+    [callbacksCopy removeObjectsInArray:callbacksToRemove];
+    self.callbacks = callbacksCopy.copy;
 }
 
 @end

--- a/Tests/Tests/NSURLComponents+StripeTest.m
+++ b/Tests/Tests/NSURLComponents+StripeTest.m
@@ -1,0 +1,74 @@
+//
+//  NSURLComponents+StripeTest.m
+//  Stripe
+//
+//  Created by Brian Dorfman on 1/26/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "NSURLComponents+Stripe.h"
+
+@interface NSURLComponents_StripeTest : XCTestCase
+
+@end
+
+@implementation NSURLComponents_StripeTest
+
+
+- (void)testMatchesURLComponents {
+    NSURLComponents *componentsToMatchAgainst = [NSURLComponents componentsWithString:@"test://foo?one=1"];
+
+
+    XCTAssertTrue([componentsToMatchAgainst stp_matchesURLComponents:[NSURLComponents componentsWithString:@"test://foo?one=1"]]);
+    XCTAssertTrue([componentsToMatchAgainst stp_matchesURLComponents:[NSURLComponents componentsWithString:@"test://foo?one=1&two=2"]]);
+    XCTAssertTrue([componentsToMatchAgainst stp_matchesURLComponents:[NSURLComponents componentsWithString:@"test://foo?two=2&one=1"]]);
+    XCTAssertFalse([componentsToMatchAgainst stp_matchesURLComponents:[NSURLComponents componentsWithString:@"test://foo"]]);
+    XCTAssertFalse([componentsToMatchAgainst stp_matchesURLComponents:[NSURLComponents componentsWithString:@"test://foo?one=one"]]);
+    XCTAssertFalse([componentsToMatchAgainst stp_matchesURLComponents:[NSURLComponents componentsWithString:@"test://bar?one=1"]]);
+    XCTAssertFalse([componentsToMatchAgainst stp_matchesURLComponents:[NSURLComponents componentsWithString:@"foo://foo?one=1"]]);
+
+
+    componentsToMatchAgainst = [NSURLComponents componentsWithString:@"test://"];
+    XCTAssertTrue([componentsToMatchAgainst stp_matchesURLComponents:[NSURLComponents componentsWithString:@"test://"]]);
+    XCTAssertTrue([componentsToMatchAgainst stp_matchesURLComponents:[NSURLComponents componentsWithString:@"test://?one=1"]]);
+}
+
+- (void)testSetQueryItemsDictionary {
+
+    NSURLComponents *components = [NSURLComponents componentsWithString:@"test://foo"];
+    components.stp_queryItemsDictionary = @{@"one": @"1",
+                                            @"two": @"dos",
+                                            };
+
+    // Order is not deterministic so can't just check the final string
+
+    BOOL foundOne = NO;
+    BOOL foundTwo = NO;
+
+    XCTAssertTrue((components.queryItems.count == 2));
+    for (NSURLQueryItem *item in components.queryItems) {
+        if ([item.name isEqualToString:@"one"]) {
+            foundOne = YES;
+            XCTAssertEqualObjects(@"1", item.value);
+        }
+        else if ([item.name isEqualToString:@"two"]) {
+            foundTwo = YES;
+            XCTAssertEqualObjects(@"dos", item.value);
+        }
+    }
+
+    XCTAssertTrue((foundOne && foundTwo));
+}
+
+- (void)testGetQueryItemsDictionary {
+    NSURLComponents *components = [NSURLComponents componentsWithString:@"test://foo?one=1&two=dos"];
+    NSDictionary *queryitems = components.stp_queryItemsDictionary;
+
+    XCTAssertEqualObjects(queryitems[@"one"], @"1");
+    XCTAssertEqualObjects(queryitems[@"two"], @"dos");
+    XCTAssertTrue((queryitems.count == 2));
+}
+
+@end


### PR DESCRIPTION
Adds a helper for doing source redirects. Pass in source and completion block, and it can do either SFSafariVC or openURL/bounce to Safari and call your completion block when done.

Rewrote existing handling to use this class instead.
Copied over some old classes to handle URL stuff that I wrote back in October and never shipped.