### PR TITLE
Fix bug when canceling in PaymentMethodsVC

### DIFF
--- a/Stripe/STPPaymentMethodsInternalViewController.h
+++ b/Stripe/STPPaymentMethodsInternalViewController.h
@@ -17,6 +17,7 @@
 - (void)internalViewControllerDidSelectPaymentMethod:(id<STPPaymentMethod>)paymentMethod;
 - (void)internalViewControllerDidCreateTokenOrSource:(id<STPSourceProtocol>)tokenOrSource
                                           completion:(STPErrorBlock)completion;
+- (void)internalViewControllerDidCancel;
 
 @end
 

--- a/Stripe/STPPaymentMethodsInternalViewController.m
+++ b/Stripe/STPPaymentMethodsInternalViewController.m
@@ -80,6 +80,10 @@ static NSInteger STPPaymentMethodNewPaymentsSection = 1;
     self.cardImageView.tintColor = self.theme.accentColor;
 }
 
+- (void)handleBackOrCancelTapped:(__unused id)sender {
+    [self.delegate internalViewControllerDidCancel];
+}
+
 - (NSInteger)numberOfSectionsInTableView:(__unused UITableView *)tableView {
     return 2;
 }

--- a/Stripe/STPPaymentMethodsViewController.m
+++ b/Stripe/STPPaymentMethodsViewController.m
@@ -168,10 +168,6 @@
     self.activityIndicator.tintColor = self.theme.accentColor;
 }
 
-- (void)handleBackOrCancelTapped:(__unused id)sender {
-    [self.delegate paymentMethodsViewControllerDidCancel:self];
-}
-
 - (void)finishWithPaymentMethod:(id<STPPaymentMethod>)paymentMethod {
     if ([paymentMethod conformsToProtocol:@protocol(STPSourceProtocol)]
         && paymentMethod.paymentMethodType.canBeDefaultSource) {
@@ -212,6 +208,10 @@
             }
         });
     }];
+}
+
+- (void)internalViewControllerDidCancel {
+    [self.delegate paymentMethodsViewControllerDidCancel:self];
 }
 
 - (void)addCardViewControllerDidCancel:(__unused STPAddCardViewController *)addCardViewController {


### PR DESCRIPTION
r? @bdorfman-stripe 

To reproduce in the example app:
- tap the payment row
- add a payment method
- tap the payment row
- tap "Back"
- PaymentContext's state is stuck in `ShowingRequestedViewController`. Tapping the payment or shipping row does nothing

`STPPaymentMethodVC`'s navigation item gets forwarded to its internal view controller, so `handleBackOrCancelTapped` does nothing.