### PR TITLE
Treat polling error as PaymentStatusPending

### DIFF
--- a/Stripe/PublicHeaders/STPBlocks.h
+++ b/Stripe/PublicHeaders/STPBlocks.h
@@ -41,26 +41,37 @@ typedef NS_ENUM(NSUInteger, STPShippingStatus) {
 };
 
 /**
- *  An enum representing the status of a payment requested from the user.
+ *  An enum representing the status of a payment requested from the customer.
  */
 typedef NS_ENUM(NSUInteger, STPPaymentStatus) {
     /**
-     *  The payment succeeded.
+     *  The payment succeeded or the user authorized the payment.
+     *  Note that for payment methods that require additional customer action,
+     *  (e.g., redirecting to authorize the payment with their bank), a `Success`
+     *  means the payment has been authorized, but does not necessarily mean the
+     *  customer has been charged. If you are using one of these payment methods,
+     *  your backend should listen to the `source.chargeable` webhook to complete
+     *  the charge.
+     *  @see https://stripe.com/docs/sources#best-practices
      */
     STPPaymentStatusSuccess,
     /**
-     *  The payment failed due to an unforeseen error, such as the user's Internet connection being offline.
+     *  The payment failed due to an unforeseen error, such as the user's
+     *  Internet connection being offline.
      */
     STPPaymentStatusError,
     /**
-     *  The user cancelled the payment (for example, by hitting "cancel" in the Apple Pay dialog).
+     *  The user cancelled the payment (for example, by hitting "cancel"
+     *  in the Apple Pay dialog).
      */
     STPPaymentStatusUserCancellation,
-
     /**
-     * The status of the payment cannot be determined at this time.
-     * E.g. the user payed with a redirect-flow source, and the source
-     * is still in the pending state.
+     *  The status of the payment cannot be determined at this time.
+     *  In general, this means your customer chose to complete their payment using
+     *  a method that requires additional action (e.g., they were redirected to
+     *  authorize the payment with their bank), and the SDK was unable to determine
+     *  the status of the action. In this case, you can simply inform your
+     *  customer that their order was received.
      */
     STPPaymentStatusPending,
 };

--- a/Stripe/PublicHeaders/STPPaymentContext.h
+++ b/Stripe/PublicHeaders/STPPaymentContext.h
@@ -248,10 +248,25 @@ didCreatePaymentResult:(STPPaymentResult *)paymentResult
             completion:(STPErrorBlock)completion;
 
 /**
- *  This is invoked by an `STPPaymentContext` when it is finished. This will be called after the payment is done and all necessary UI has been dismissed. You should inspect the returned `status` and behave appropriately. For example: if it's `STPPaymentStatusSuccess`, show the user a receipt. If it's `STPPaymentStatusError`, inform the user of the error. If it's `STPPaymentStatusUserCanceled`, do nothing.
+ *  This is invoked by an `STPPaymentContext` when it is finished. This will be
+ *  called after the payment is done and all necessary UI has been dismissed.
+ *  You should inspect the returned `status` and behave appropriately.
+ *  For example: if it's `STPPaymentStatusSuccess`, show the user an order
+ *  confirmation. If it's `STPPaymentStatusError`, inform the user of the error.
+ *  If it's `STPPaymentStatusUserCanceled`, do nothing.
  *
- *  @param paymentContext The payment context that finished
- *  @param status         The status of the payment - `STPPaymentStatusSuccess` if it succeeded, `STPPaymentStatusError` if it failed with an error (in which case the `error` parameter will be non-nil), `STPPaymentStatusUserCanceled` if the user canceled the payment.
+ *  If the status is `STPaymentStatusPending`, your customer chose to complete
+ *  their payment using a method that requires additional action (e.g., they
+ *  were redirected to authorize the payment with their bank), and the SDK
+ *  was unable to determine the status of the action. In this case, you may
+ *  want to simply inform the user that their order has been received.
+ *  Once your backend completes the charge, you can notify your customer that
+ *  their order has been fulfilled (e.g., by sending an email or a push
+ *  notification).
+ *  @see https://stripe.com/docs/sources#best-practices
+ *
+ *  @param paymentContext The payment context that finished.
+ *  @param status         The status of the payment.
  *  @param error          An error that occurred, if any.
  */
 - (void)paymentContext:(STPPaymentContext *)paymentContext

--- a/Stripe/STPPaymentContext.m
+++ b/Stripe/STPPaymentContext.m
@@ -568,7 +568,7 @@ typedef NS_ENUM(NSUInteger, STPPaymentContextState) {
     STPSourceCompletionBlock onRedirectCompletion = ^(STPSource *finishedSource, NSError *error) {
         stpDispatchToMainThreadIfNecessary(^{
             if (error) {
-                [self didFinishWithStatus:STPPaymentStatusError error:error];
+                [self didFinishWithStatus:STPPaymentStatusPending error:nil];
             } else {
                 switch (finishedSource.status) {
                     case STPSourceStatusChargeable:


### PR DESCRIPTION
r? @bdorfman-stripe 

We now treat a polling error as `PaymentStatusPending`. Also updated docs with some additional notes about webhooks and the pending status.