### PR TITLE
Add unit tests for requestPayment

### DIFF
--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -385,6 +385,7 @@
 		C11810C21CC7DA290022FB55 /* stp_card_form_front@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = C11810BC1CC7DA290022FB55 /* stp_card_form_front@2x.png */; };
 		C11810C31CC7DA290022FB55 /* stp_card_form_front@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = C11810BD1CC7DA290022FB55 /* stp_card_form_front@3x.png */; };
 		C11B14971E8AE316000F760C /* OCMock.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C11B14961E8AE316000F760C /* OCMock.framework */; };
+		C11E9CC21E9539B7003F0304 /* STPPaymentContextRequestPaymentTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C11E9CC11E9539B7003F0304 /* STPPaymentContextRequestPaymentTest.m */; };
 		C12057491D676DD400CFBCB8 /* stp_card_applepay.png in Resources */ = {isa = PBXBuildFile; fileRef = F1C578F01D651AB200912EAE /* stp_card_applepay.png */; };
 		C120574A1D676DD400CFBCB8 /* stp_card_diners_template.png in Resources */ = {isa = PBXBuildFile; fileRef = F1510BA41D5A77F6000731AD /* stp_card_diners_template.png */; };
 		C120574B1D676DD400CFBCB8 /* stp_card_diners_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = F1510BA51D5A77F6000731AD /* stp_card_diners_template@2x.png */; };
@@ -430,6 +431,8 @@
 		C1363BB81D7633D800EB82B4 /* STPPaymentMethodTableViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = C1363BB51D7633D800EB82B4 /* STPPaymentMethodTableViewCell.h */; };
 		C1363BB91D7633D800EB82B4 /* STPPaymentMethodTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = C1363BB61D7633D800EB82B4 /* STPPaymentMethodTableViewCell.m */; };
 		C1363BBA1D7633D800EB82B4 /* STPPaymentMethodTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = C1363BB61D7633D800EB82B4 /* STPPaymentMethodTableViewCell.m */; };
+		C14FC71D1E9569AD003E268D /* STPMocks.h in Headers */ = {isa = PBXBuildFile; fileRef = C14FC71B1E9569AD003E268D /* STPMocks.h */; };
+		C14FC71E1E9569AD003E268D /* STPMocks.m in Sources */ = {isa = PBXBuildFile; fileRef = C14FC71C1E9569AD003E268D /* STPMocks.m */; };
 		C158AB3F1E1EE98900348D01 /* STPSectionHeaderView.h in Headers */ = {isa = PBXBuildFile; fileRef = C158AB3D1E1EE98900348D01 /* STPSectionHeaderView.h */; };
 		C158AB401E1EE98900348D01 /* STPSectionHeaderView.m in Sources */ = {isa = PBXBuildFile; fileRef = C158AB3E1E1EE98900348D01 /* STPSectionHeaderView.m */; };
 		C15993231D8807930047950D /* stp_shipping_form.png in Resources */ = {isa = PBXBuildFile; fileRef = C15993201D8807930047950D /* stp_shipping_form.png */; };
@@ -1036,6 +1039,7 @@
 		C11810BC1CC7DA290022FB55 /* stp_card_form_front@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_form_front@2x.png"; sourceTree = "<group>"; };
 		C11810BD1CC7DA290022FB55 /* stp_card_form_front@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_form_front@3x.png"; sourceTree = "<group>"; };
 		C11B14961E8AE316000F760C /* OCMock.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OCMock.framework; path = Carthage/Build/iOS/OCMock.framework; sourceTree = "<group>"; };
+		C11E9CC11E9539B7003F0304 /* STPPaymentContextRequestPaymentTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPPaymentContextRequestPaymentTest.m; sourceTree = "<group>"; };
 		C124A16E1CCA968B007D42EE /* STPAnalyticsClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPAnalyticsClient.h; sourceTree = "<group>"; };
 		C124A16F1CCA968B007D42EE /* STPAnalyticsClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPAnalyticsClient.m; sourceTree = "<group>"; };
 		C124A17A1CCAA0C2007D42EE /* NSMutableURLRequest+Stripe.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSMutableURLRequest+Stripe.h"; sourceTree = "<group>"; };
@@ -1055,6 +1059,8 @@
 		C1363BAE1D76337400EB82B4 /* stp_icon_checkmark@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_icon_checkmark@3x.png"; sourceTree = "<group>"; };
 		C1363BB51D7633D800EB82B4 /* STPPaymentMethodTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPPaymentMethodTableViewCell.h; sourceTree = "<group>"; };
 		C1363BB61D7633D800EB82B4 /* STPPaymentMethodTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodTableViewCell.m; sourceTree = "<group>"; };
+		C14FC71B1E9569AD003E268D /* STPMocks.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPMocks.h; sourceTree = "<group>"; };
+		C14FC71C1E9569AD003E268D /* STPMocks.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPMocks.m; sourceTree = "<group>"; };
 		C158AB3D1E1EE98900348D01 /* STPSectionHeaderView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPSectionHeaderView.h; sourceTree = "<group>"; };
 		C158AB3E1E1EE98900348D01 /* STPSectionHeaderView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPSectionHeaderView.m; sourceTree = "<group>"; };
 		C15993201D8807930047950D /* stp_shipping_form.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_shipping_form.png; sourceTree = "<group>"; };
@@ -1550,6 +1556,8 @@
 				C18867DA1E8B0C4100A77634 /* STPFixtures.m */,
 				F1D96F981DC7DCDE00477E64 /* STPLocalizationUtils+STPTestAdditions.h */,
 				F1D96F991DC7DCDE00477E64 /* STPLocalizationUtils+STPTestAdditions.m */,
+				C14FC71B1E9569AD003E268D /* STPMocks.h */,
+				C14FC71C1E9569AD003E268D /* STPMocks.m */,
 			);
 			name = StripeTests;
 			path = Tests/Tests;
@@ -1667,6 +1675,7 @@
 				045A62AA1B8E7259000165CE /* STPPaymentCardTextFieldTest.m */,
 				0438EF4B1B741B0100D506CC /* STPPaymentCardTextFieldViewModelTest.m */,
 				F14C872E1D4FCDBA00C7CC6A /* STPPaymentContextApplePayTest.m */,
+				C11E9CC11E9539B7003F0304 /* STPPaymentContextRequestPaymentTest.m */,
 				C1BF02321E8B28AE00FE9F51 /* STPPaymentMethodTupleTest.m */,
 				C1EEDCC91CA2186300A54582 /* STPPhoneNumberValidatorTest.m */,
 				C1FEE5981CBFF24000A7632B /* STPPostalCodeValidatorTest.m */,
@@ -1854,6 +1863,7 @@
 			files = (
 				F1D96F9A1DC7DCDE00477E64 /* STPLocalizationUtils+STPTestAdditions.h in Headers */,
 				F148ABFA1D5E88C40014FD92 /* STPTestUtils.h in Headers */,
+				C14FC71D1E9569AD003E268D /* STPMocks.h in Headers */,
 				C18867DB1E8B0C4100A77634 /* STPFixtures.h in Headers */,
 				F12C8DC11D63DE9F00ADA0D7 /* STPPaymentContextAmountModel.h in Headers */,
 			);
@@ -2528,12 +2538,14 @@
 				F14C872F1D4FCDBA00C7CC6A /* STPPaymentContextApplePayTest.m in Sources */,
 				C1BD9B1F1E390A2700CEE925 /* STPSourceParamsTest.m in Sources */,
 				C1D7B5251E36C70D002181F5 /* STPSourceFunctionalTest.m in Sources */,
+				C14FC71E1E9569AD003E268D /* STPMocks.m in Sources */,
 				0438EF4D1B741B0100D506CC /* STPPaymentCardTextFieldViewModelTest.m in Sources */,
 				C124A1811CCAA1BF007D42EE /* NSMutableURLRequest+StripeTest.m in Sources */,
 				C1EEDCC61CA2126000A54582 /* STPDelegateProxyTest.m in Sources */,
 				F1D777C01D81DD520076FA19 /* STPStringUtilsTest.m in Sources */,
 				C1FEE5991CBFF24000A7632B /* STPPostalCodeValidatorTest.m in Sources */,
 				C1BF02381E8B28C100FE9F51 /* STPPaymentMethodTupleTest.m in Sources */,
+				C11E9CC21E9539B7003F0304 /* STPPaymentContextRequestPaymentTest.m in Sources */,
 				C13538081D2C2186003F6157 /* STPAddCardViewControllerTest.m in Sources */,
 				04415C671A6605B5001225ED /* STPAPIClientTest.m in Sources */,
 				045D71311CF514BB00F6CD65 /* STPBinRangeTest.m in Sources */,

--- a/Stripe/STPPaymentContext+Private.h
+++ b/Stripe/STPPaymentContext+Private.h
@@ -12,6 +12,19 @@
 #import "STPPromise.h"
 #import "STPShippingAddressViewController.h"
 
+/**
+ The current state of the payment context
+
+ - STPPaymentContextStateNone: No view controllers are currently being shown. The payment may or may not have already been completed
+ - STPPaymentContextStateShowingRequestedViewController: The view controller that you requested the context show is being shown (via the push or present payment methods or shipping view controller methods)
+ - STPPaymentContextStateRequestingPayment: The payment context is in the middle of requesting payment. It may be showing some other UI or view controller if more information is necessary to complete the payment.
+ */
+typedef NS_ENUM(NSUInteger, STPPaymentContextState) {
+    STPPaymentContextStateNone,
+    STPPaymentContextStateShowingRequestedViewController,
+    STPPaymentContextStateRequestingPayment,
+};
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface STPPaymentContext (Private)<STPPaymentMethodsViewControllerDelegate, STPShippingAddressViewControllerDelegate>

--- a/Stripe/STPPaymentContext.m
+++ b/Stripe/STPPaymentContext.m
@@ -29,19 +29,6 @@
 
 #define FAUXPAS_IGNORED_IN_METHOD(...)
 
-/**
- The current state of the payment context
-
- - STPPaymentContextStateNone: No view controllers are currently being shown. The payment may or may not have already been completed
- - STPPaymentContextStateShowingRequestedViewController: The view controller that you requested the context show is being shown (via the push or present payment methods or shipping view controller methods)
- - STPPaymentContextStateRequestingPayment: The payment context is in the middle of requesting payment. It may be showing some other UI or view controller if more information is necessary to complete the payment.
- */
-typedef NS_ENUM(NSUInteger, STPPaymentContextState) {
-    STPPaymentContextStateNone,
-    STPPaymentContextStateShowingRequestedViewController,
-    STPPaymentContextStateRequestingPayment,
-};
-
 @interface STPPaymentContext()<STPPaymentMethodsViewControllerDelegate, STPShippingAddressViewControllerDelegate>
 
 @property(nonatomic)STPPaymentConfiguration *configuration;
@@ -484,7 +471,7 @@ typedef NS_ENUM(NSUInteger, STPPaymentContextState) {
         if (!self.selectedPaymentMethod) {
             [self presentPaymentMethodsViewControllerWithNewState:STPPaymentContextStateRequestingPayment];
         }
-        else if (self.configuration.requiredShippingAddressFields != STPBillingAddressFieldsNone &&
+        else if (self.configuration.requiredShippingAddressFields != PKAddressFieldNone &&
                  !self.shippingAddress) {
             [self presentShippingViewControllerWithNewState:STPPaymentContextStateRequestingPayment];
         }

--- a/Tests/Tests/STPFixtures.h
+++ b/Tests/Tests/STPFixtures.h
@@ -33,10 +33,21 @@
 + (STPToken *)cardToken;
 
 /**
+ A Customer object with no attached sources.
+ */
++ (STPCustomer *)customerWithNoSources;
+
+/**
  A Customer object with a single card token in its sources array, and
  default_source set to that card token.
  */
 + (STPCustomer *)customerWithSingleCardTokenSource;
+
+/**
+ A Customer object with a single SEPA Debit source in its sources array, and
+ default_source set to that source.
+ */
++ (STPCustomer *)customerWithSingleSEPADebitSource;
 
 /**
  A Source object with type iDEAL
@@ -59,17 +70,5 @@
  An Address object for creating a SEPA source.
  */
 + (STPAddress *)sepaAddress;
-
-/**
- A stateless API adapter that always retrieves the same customer object.
- */
-+ (id<STPBackendAPIAdapter>)staticAPIAdapter;
-
-/**
- A stateless API adapter that always retrieves the given customer.
- selectDefaultSource and attachSource immediately call their completion blocks
- with nil.
- */
-+ (id<STPBackendAPIAdapter>)staticAPIAdapterWithCustomer:(STPCustomer *)customer;
 
 @end

--- a/Tests/Tests/STPMocks.h
+++ b/Tests/Tests/STPMocks.h
@@ -1,0 +1,32 @@
+//
+//  STPMocks.h
+//  Stripe
+//
+//  Created by Ben Guo on 4/5/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <OCMock/OCMock.h>
+#import <Stripe/Stripe.h>
+
+@interface STPMocks : NSObject
+
+/**
+ A view controller that can be used as a STPPaymentContext's hostViewController.
+ */
++ (id)hostViewController;
+
+/**
+ A stateless API adapter that always retrieves the same customer object.
+ */
++ (id<STPBackendAPIAdapter>)staticAPIAdapter;
+
+/**
+ A stateless API adapter that always retrieves the given customer.
+ selectDefaultSource and attachSource immediately call their completion blocks
+ with nil.
+ */
++ (id<STPBackendAPIAdapter>)staticAPIAdapterWithCustomer:(STPCustomer *)customer;
+
+@end

--- a/Tests/Tests/STPMocks.m
+++ b/Tests/Tests/STPMocks.m
@@ -1,0 +1,44 @@
+//
+//  STPMocks.m
+//  Stripe
+//
+//  Created by Ben Guo on 4/5/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import "STPMocks.h"
+
+#import "STPFixtures.h"
+#import "STPPaymentContext+Private.h"
+#import "UIViewController+Stripe_Promises.h"
+
+@implementation STPMocks
+
++ (id)hostViewController {
+    id mockVC = OCMClassMock([UIViewController class]);
+    STPVoidPromise *didAppearPromise = [STPVoidPromise new];
+    STPVoidPromise *willAppearPromise = [STPVoidPromise new];
+    [didAppearPromise succeed];
+    [willAppearPromise succeed];
+    OCMStub([mockVC stp_didAppearPromise]).andReturn(didAppearPromise);
+    OCMStub([mockVC stp_willAppearPromise]).andReturn(willAppearPromise);
+    return mockVC;
+}
+
++ (id<STPBackendAPIAdapter>)staticAPIAdapter {
+    return [self staticAPIAdapterWithCustomer:[STPFixtures customerWithSingleCardTokenSource]];
+}
+
++ (id<STPBackendAPIAdapter>)staticAPIAdapterWithCustomer:(STPCustomer *)customer {
+    id mockAPIAdapter = OCMProtocolMock(@protocol(STPBackendAPIAdapter));
+    OCMStub([mockAPIAdapter retrieveCustomer:[OCMArg any]]).andDo(^(NSInvocation *invocation){
+        STPCustomerCompletionBlock completion;
+        [invocation getArgument:&completion atIndex:2];
+        completion(customer, nil);
+    });
+    OCMStub([mockAPIAdapter selectDefaultCustomerSource:[OCMArg any] completion:[OCMArg invokeBlock]]);
+    OCMStub([mockAPIAdapter attachSourceToCustomer:[OCMArg any] completion:[OCMArg invokeBlock]]);
+    return mockAPIAdapter;
+}
+
+@end

--- a/Tests/Tests/STPPaymentContextApplePayTest.m
+++ b/Tests/Tests/STPPaymentContextApplePayTest.m
@@ -11,6 +11,7 @@
 #import "NSDecimalNumber+Stripe_Currency.h"
 #import "STPAPIClient.h"
 #import "STPFixtures.h"
+#import "STPMocks.h"
 #import "STPPaymentContext.h"
 
 @interface STPPaymentContext (Testing)
@@ -32,7 +33,7 @@
     STPPaymentConfiguration *config = [STPFixtures paymentConfiguration];
     config.appleMerchantIdentifier = @"fake_merchant_id";
     STPTheme *theme = [STPTheme defaultTheme];
-    id<STPBackendAPIAdapter> mockAPIAdapter = [STPFixtures staticAPIAdapter];
+    id<STPBackendAPIAdapter> mockAPIAdapter = [STPMocks staticAPIAdapter];
     STPPaymentContext *paymentContext = [[STPPaymentContext alloc] initWithAPIAdapter:mockAPIAdapter
                                                                         configuration:config
                                                                                 theme:theme];

--- a/Tests/Tests/STPPaymentContextRequestPaymentTest.m
+++ b/Tests/Tests/STPPaymentContextRequestPaymentTest.m
@@ -1,0 +1,313 @@
+//
+//  STPPaymentContextPaymentMethodsTest.m
+//  Stripe
+//
+//  Created by Ben Guo on 4/5/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import <OCMock/OCMock.h>
+#import <SafariServices/SafariServices.h>
+#import "UIViewController+Stripe_Promises.h"
+#import "STPAPIClient.h"
+#import "STPFixtures.h"
+#import "STPFormEncoder.h"
+#import "STPMocks.h"
+#import "STPPaymentContext+Private.h"
+
+@interface STPPaymentContext (Testing)
+@property(nonatomic)id<STPPaymentMethod> selectedPaymentMethod;
+@property(nonatomic, assign) STPPaymentContextState state;
+@property(nonatomic)STPAPIClient *apiClient;
+@end
+
+@interface STPSourceInfoViewController (Testing)
+@property(nonatomic, copy)STPSourceInfoCompletionBlock completion;
+@end
+
+@interface STPPaymentContextRequestPaymentTest : XCTestCase
+
+@end
+
+/**
+ These tests cover STPPaymentContext's requestPayment method
+ */
+@implementation STPPaymentContextRequestPaymentTest
+
+- (STPPaymentContext *)buildPaymentContextWithCustomer:(STPCustomer *)customer
+                                         configuration:(STPPaymentConfiguration *)config {
+    STPTheme *theme = [STPTheme defaultTheme];
+    id<STPBackendAPIAdapter> mockAPIAdapter = [STPMocks staticAPIAdapterWithCustomer:customer];
+    STPPaymentContext *paymentContext = [[STPPaymentContext alloc] initWithAPIAdapter:mockAPIAdapter
+                                                                        configuration:config
+                                                                                theme:theme];
+    return paymentContext;
+}
+
+/**
+ When selectedPaymentMethod is nil, STPPaymentMethodsVC should be presented.
+ */
+- (void)testRequestPaymentWithNoSelectedPaymentMethod {
+    STPCustomer *customer = [STPFixtures customerWithNoSources];
+    STPPaymentConfiguration *config = [STPFixtures paymentConfiguration];
+    STPPaymentContext *sut = [self buildPaymentContextWithCustomer:customer
+                                                     configuration:config];
+    XCTAssertNil(sut.selectedPaymentMethod);
+    XCTAssertEqual(sut.state, STPPaymentContextStateNone);
+    id mockVC = [STPMocks hostViewController];
+    sut.hostViewController = mockVC;
+
+    [sut requestPayment];
+
+    BOOL (^checker)() = ^BOOL(id vc) {
+        XCTAssertEqual(sut.state, STPPaymentContextStateRequestingPayment);
+        if ([vc isKindOfClass:[UINavigationController class]]) {
+            UINavigationController *nc = (UINavigationController *)vc;
+            return [nc.topViewController isKindOfClass:[STPPaymentMethodsViewController class]];
+        }
+        return NO;
+    };
+    OCMVerify([mockVC presentViewController:[OCMArg checkWithBlock:checker]
+                                   animated:YES
+                                 completion:[OCMArg any]]);
+}
+
+/**
+ When a shipping address is required, STPShippingAddressVC should be presented
+ */
+- (void)testRequestPaymentWithNoShippingAddress {
+    STPCustomer *customer = [STPFixtures customerWithSingleCardTokenSource];
+    STPPaymentConfiguration *config = [STPFixtures paymentConfiguration];
+    config.requiredShippingAddressFields = PKAddressFieldAll;
+    STPPaymentContext *sut = [self buildPaymentContextWithCustomer:customer
+                                                     configuration:config];
+    XCTAssertNotNil(sut.selectedPaymentMethod);
+    XCTAssertNil(sut.shippingAddress);
+    XCTAssertEqual(sut.state, STPPaymentContextStateNone);
+    id mockVC = [STPMocks hostViewController];
+    sut.hostViewController = mockVC;
+
+    [sut requestPayment];
+
+    BOOL (^checker)() = ^BOOL(id vc) {
+        XCTAssertEqual(sut.state, STPPaymentContextStateRequestingPayment);
+        if ([vc isKindOfClass:[UINavigationController class]]) {
+            UINavigationController *nc = (UINavigationController *)vc;
+            return [nc.topViewController isKindOfClass:[STPShippingAddressViewController class]];
+        }
+        return NO;
+    };
+    OCMVerify([mockVC presentViewController:[OCMArg checkWithBlock:checker]
+                                   animated:YES
+                                 completion:[OCMArg any]]);
+}
+
+
+/**
+ When selectedPaymentMethod is iDEAL, STPSourceInfoVC should be presented.
+ When STPSourceInfoVC's completion block is called with iDEAL source params,
+ createSource should be called with those params, after which SFSafariVC
+ should be presented.
+ */
+- (void)testRequestPaymentWithIDEALSourceSelected {
+    STPCustomer *customer = [STPFixtures customerWithNoSources];
+    STPPaymentConfiguration *config = [STPFixtures paymentConfiguration];
+    config.returnURL = [NSURL URLWithString:@"test://redirect"];
+    STPPaymentContext *sut = [self buildPaymentContextWithCustomer:customer
+                                                     configuration:config];
+    id mockVC = [STPMocks hostViewController];
+    sut.hostViewController = mockVC;
+    id mockAPIClient = OCMClassMock([STPAPIClient class]);
+    sut.apiClient = mockAPIClient;
+    sut.selectedPaymentMethod = [STPPaymentMethodType ideal];
+    XCTAssertEqual(sut.state, STPPaymentContextStateNone);
+
+    STPSourceParams *expectedParams = [STPSourceParams idealParamsWithAmount:1099 name:@"Jenny Rosen" returnURL:@"test://redirect" statementDescriptor:nil bank:nil];
+
+    __block NSInteger call = 0;
+    BOOL (^checker)() = ^BOOL(id vc) {
+        XCTAssertEqual(sut.state, STPPaymentContextStateRequestingPayment);
+        // First call should present STPSourceInfoVC
+        if (call == 0) {
+            if ([vc isKindOfClass:[UINavigationController class]]) {
+                UINavigationController *nc = (UINavigationController *)vc;
+                if ([nc.topViewController isKindOfClass:[STPSourceInfoViewController class]]) {
+                    STPSourceInfoViewController *sourceInfoVC = (STPSourceInfoViewController *)nc.topViewController;
+                    sourceInfoVC.completion(expectedParams);
+                    call++;
+                    return YES;
+                };
+            }
+        }
+        // Second call should present SFSafariVC
+        else if (call == 1) {
+            call++;
+            return [vc isKindOfClass:[SFSafariViewController class]];
+        }
+        return NO;
+    };
+    OCMStub([mockVC presentViewController:[OCMArg checkWithBlock:checker]
+                                 animated:YES
+                               completion:[OCMArg any]]);
+
+    STPSource *expectedSource = [STPFixtures iDEALSource];
+    XCTestExpectation *createSourceExp = [self expectationWithDescription:@"createSource"];
+    OCMStub([mockAPIClient createSourceWithParams:[OCMArg any] completion:[OCMArg any]])
+    .andDo(^(NSInvocation *invocation){
+        STPSourceParams *sourceParams;
+        STPSourceCompletionBlock completion;
+        [invocation getArgument:&sourceParams atIndex:2];
+        [invocation getArgument:&completion atIndex:3];
+        NSDictionary *dict = [STPFormEncoder dictionaryForObject:sourceParams];
+        NSDictionary *expectedDict = [STPFormEncoder dictionaryForObject:expectedParams];
+        XCTAssertEqualObjects(dict, expectedDict);
+        completion(expectedSource, nil);
+        [createSourceExp fulfill];
+    });
+
+    [sut requestPayment];
+
+    [self waitForExpectationsWithTimeout:2 handler:nil];
+}
+
+/**
+ When selectedPaymentMethod is ApplePay, PKPaymentAuthVC should be presented.
+ */
+- (void)testRequestPaymentWithApplePaySelected {
+    STPCustomer *customer = [STPFixtures customerWithNoSources];
+    STPPaymentConfiguration *config = [STPFixtures paymentConfiguration];
+    config.appleMerchantIdentifier = @"fake_merchant_id";
+    config.companyName = @"Test Company";
+    STPPaymentContext *sut = [self buildPaymentContextWithCustomer:customer
+                                                     configuration:config];
+    sut.paymentAmount = 150;
+    id mockVC = [STPMocks hostViewController];
+    sut.hostViewController = mockVC;
+    sut.selectedPaymentMethod = [STPPaymentMethodType applePay];
+    XCTAssertEqual(sut.state, STPPaymentContextStateNone);
+
+    [sut requestPayment];
+
+    BOOL (^checker)() = ^BOOL(id vc) {
+        XCTAssertEqual(sut.state, STPPaymentContextStateRequestingPayment);
+        return [vc isKindOfClass:[PKPaymentAuthorizationViewController class]];
+    };
+    OCMVerify([mockVC presentViewController:[OCMArg checkWithBlock:checker]
+                                   animated:YES
+                                 completion:[OCMArg any]]);
+}
+
+/**
+ When selectedPaymentMethod is a legacy STPCard, didCreatePaymentResult should be
+ called with the correct STPPaymentResult.
+ */
+- (void)testRequestPaymentWithSTPCardSelected {
+    STPCustomer *customer = [STPFixtures customerWithSingleCardTokenSource];
+    STPPaymentConfiguration *config = [STPFixtures paymentConfiguration];
+    STPPaymentContext *sut = [self buildPaymentContextWithCustomer:customer
+                                                     configuration:config];
+    XCTAssertTrue([sut.selectedPaymentMethod isKindOfClass:[STPCard class]]);
+    id mockVC = [STPMocks hostViewController];
+    sut.hostViewController = mockVC;
+    id mockDelegate = OCMProtocolMock(@protocol(STPPaymentContextDelegate));
+    sut.delegate = mockDelegate;
+    XCTAssertEqual(sut.state, STPPaymentContextStateNone);
+    XCTestExpectation *exp = [self expectationWithDescription:@"didCreatePaymentResult"];
+    OCMExpect([mockDelegate paymentContext:[OCMArg any] didFinishWithStatus:STPPaymentStatusSuccess error:[OCMArg isNil]])
+    .andDo(^(__unused NSInvocation *invocation){
+        XCTAssertEqual(sut.state, STPPaymentContextStateNone);
+    });
+    OCMStub([mockDelegate paymentContext:[OCMArg any] didCreatePaymentResult:[OCMArg any] completion:[OCMArg any]])
+    .andDo(^(NSInvocation *invocation){
+        XCTAssertEqual(sut.state, STPPaymentContextStateRequestingPayment);
+        STPPaymentResult *result;
+        STPErrorBlock completion;
+        [invocation getArgument:&result atIndex:3];
+        [invocation getArgument:&completion atIndex:4];
+        XCTAssertEqual(result.source, customer.defaultSource);
+        completion(nil);
+        OCMVerifyAll(mockDelegate);
+        [exp fulfill];
+    });
+
+    [sut requestPayment];
+    [self waitForExpectationsWithTimeout:2 handler:nil];
+}
+
+/**
+ When selectedPaymentMethod is a SEPA Debit source, didCreatePaymentResult
+ should be called with the correct STPPaymentResult.
+ */
+- (void)testRequestPaymentWithSEPADebitSourceSelected {
+    STPCustomer *customer = [STPFixtures customerWithSingleSEPADebitSource];
+    STPPaymentConfiguration *config = [STPFixtures paymentConfiguration];
+    config.availablePaymentMethodTypes = @[[STPPaymentMethodType sepaDebit]];
+    STPPaymentContext *sut = [self buildPaymentContextWithCustomer:customer
+                                                     configuration:config];
+    XCTAssertTrue([sut.selectedPaymentMethod isKindOfClass:[STPSource class]]);
+    XCTAssertTrue([sut.selectedPaymentMethod.paymentMethodType isEqual:[STPPaymentMethodType sepaDebit]]);
+    id mockVC = [STPMocks hostViewController];
+    sut.hostViewController = mockVC;
+    id mockDelegate = OCMProtocolMock(@protocol(STPPaymentContextDelegate));
+    sut.delegate = mockDelegate;
+    XCTAssertEqual(sut.state, STPPaymentContextStateNone);
+    XCTestExpectation *exp = [self expectationWithDescription:@"didCreatePaymentResult"];
+    OCMExpect([mockDelegate paymentContext:[OCMArg any] didFinishWithStatus:STPPaymentStatusSuccess error:[OCMArg isNil]])
+    .andDo(^(__unused NSInvocation *invocation){
+        XCTAssertEqual(sut.state, STPPaymentContextStateNone);
+    });
+    OCMStub([mockDelegate paymentContext:[OCMArg any] didCreatePaymentResult:[OCMArg any] completion:[OCMArg any]])
+    .andDo(^(NSInvocation *invocation){
+        XCTAssertEqual(sut.state, STPPaymentContextStateRequestingPayment);
+        STPPaymentResult *result;
+        STPErrorBlock completion;
+        [invocation getArgument:&result atIndex:3];
+        [invocation getArgument:&completion atIndex:4];
+        XCTAssertEqual(result.source, customer.defaultSource);
+        completion(nil);
+        OCMVerifyAll(mockDelegate);
+        [exp fulfill];
+    });
+
+    [sut requestPayment];
+    [self waitForExpectationsWithTimeout:2 handler:nil];
+}
+
+/**
+ When the completion block of didCreatePaymentResult is called with an error,
+ didFinishWithStatus should be called with StatusError and the error.
+ */
+- (void)testDidCreatePaymentResultWithErrorReturnsErrorToDidFinishWithStatus {
+    STPCustomer *customer = [STPFixtures customerWithSingleCardTokenSource];
+    STPPaymentConfiguration *config = [STPFixtures paymentConfiguration];
+    STPPaymentContext *sut = [self buildPaymentContextWithCustomer:customer
+                                                     configuration:config];
+    XCTAssertTrue([sut.selectedPaymentMethod isKindOfClass:[STPCard class]]);
+    id mockVC = [STPMocks hostViewController];
+    sut.hostViewController = mockVC;
+    id mockDelegate = OCMProtocolMock(@protocol(STPPaymentContextDelegate));
+    sut.delegate = mockDelegate;
+    XCTAssertEqual(sut.state, STPPaymentContextStateNone);
+    NSError *expectedError = [[NSError alloc] initWithDomain:@"com.stripe.tests" code:0 userInfo:nil];
+    XCTestExpectation *exp = [self expectationWithDescription:@"didCreatePaymentResult"];
+    OCMExpect([mockDelegate paymentContext:[OCMArg any] didFinishWithStatus:STPPaymentStatusError
+                                     error:[OCMArg isEqual:expectedError]])
+    .andDo(^(__unused NSInvocation *invocation){
+        XCTAssertEqual(sut.state, STPPaymentContextStateNone);
+    });;
+    OCMStub([mockDelegate paymentContext:[OCMArg any] didCreatePaymentResult:[OCMArg any] completion:[OCMArg any]])
+    .andDo(^(NSInvocation *invocation){
+        XCTAssertEqual(sut.state, STPPaymentContextStateRequestingPayment);
+        STPErrorBlock completion;
+        [invocation getArgument:&completion atIndex:4];
+        completion(expectedError);
+        OCMVerifyAll(mockDelegate);
+        [exp fulfill];
+    });
+
+    [sut requestPayment];
+    [self waitForExpectationsWithTimeout:2 handler:nil];
+}
+
+@end

--- a/Tests/Tests/STPPaymentMethodsViewControllerLocalizationTests.m
+++ b/Tests/Tests/STPPaymentMethodsViewControllerLocalizationTests.m
@@ -11,6 +11,7 @@
 
 #import "STPFixtures.h"
 #import "STPLocalizationUtils+STPTestAdditions.h"
+#import "STPMocks.h"
 
 @interface STPPaymentMethodsViewControllerLocalizationTests : FBSnapshotTestCase
 
@@ -32,7 +33,7 @@
                                            [STPPaymentMethodType applePay]];
     config.smsAutofillDisabled = NO;
     STPTheme *theme = [STPTheme defaultTheme];
-    id apiAdapter = [STPFixtures staticAPIAdapter];
+    id apiAdapter = [STPMocks staticAPIAdapter];
     id delegate = OCMProtocolMock(@protocol(STPPaymentMethodsViewControllerDelegate));
     [STPLocalizationUtils overrideLanguageTo:language];
     STPPaymentMethodsViewController *paymentMethodsVC = [[STPPaymentMethodsViewController alloc] initWithConfiguration:config

--- a/Tests/Tests/UINavigationBar+StripeTest.m
+++ b/Tests/Tests/UINavigationBar+StripeTest.m
@@ -10,6 +10,7 @@
 #import <OCMock/OCMock.h>
 #import <Stripe/Stripe.h>
 #import "STPFixtures.h"
+#import "STPMocks.h"
 
 @interface UINavigationBar_StripeTest : XCTestCase
 
@@ -18,7 +19,7 @@
 @implementation UINavigationBar_StripeTest
 
 - (STPPaymentMethodsViewController *)buildPaymentMethodsViewController {
-    id apiAdapter = [STPFixtures staticAPIAdapter];
+    id apiAdapter = [STPMocks staticAPIAdapter];
     STPPaymentConfiguration *config = [STPFixtures paymentConfiguration];
     config.publishableKey = @"pk_test";
     STPTheme *theme = [STPTheme defaultTheme];


### PR DESCRIPTION
r? @bdorfman-stripe 

This adds some unit tests for requestPayment, verifying that we do the right thing for different selected payment methods. I'm especially proud of the iDEAL test, which was tricky – it goes all to way to verifying that SFSafariVC gets presented after completing SourceInfoVC.

Next up, I'm going to add some unit tests for STPRedirectContext.

I'd also like to add some basic tests for PaymentMethodsVC, making sure it chooses the right `internalViewController` for a given configuration.

