### PR TITLE
Fix bin range testing.

### DIFF
--- a/Stripe/STPBINRange.m
+++ b/Stripe/STPBINRange.m
@@ -81,11 +81,31 @@
     return STPBINRangeAllRanges;
 }
 
+
+/**
+ Number matching strategy: Truncate the longer of the two numbers (theirs and our
+ bounds) to match the length of the shorter one, then do numerical compare.
+ */
 - (BOOL)matchesNumber:(NSString *)number {
-    NSString *low = [number stringByPaddingToLength:self.qRangeLow.length withString:@"0" startingAtIndex:0];
-    NSString *high = [number stringByPaddingToLength:self.qRangeHigh.length withString:@"0" startingAtIndex:0];
-    
-    return self.qRangeLow.integerValue <= low.integerValue && self.qRangeHigh.integerValue >= high.integerValue;
+
+    BOOL withinLowRange = NO;
+    BOOL withinHighRange = NO;
+
+    if (number.length < self.qRangeLow.length) {
+        withinLowRange = number.integerValue >= [self.qRangeLow substringToIndex:number.length].integerValue;
+    }
+    else {
+        withinLowRange = [number substringToIndex:self.qRangeLow.length].integerValue >= self.qRangeLow.integerValue;
+    }
+
+    if (number.length < self.qRangeHigh.length) {
+        withinHighRange = number.integerValue <= [self.qRangeHigh substringToIndex:number.length].integerValue;
+    }
+    else {
+        withinHighRange = [number substringToIndex:self.qRangeHigh.length].integerValue <= self.qRangeHigh.integerValue;
+    }
+
+    return withinLowRange && withinHighRange;
 }
 
 - (NSComparisonResult)compare:(STPBINRange *)other {

--- a/Tests/Tests/STPBinRangeTest.m
+++ b/Tests/Tests/STPBinRangeTest.m
@@ -37,27 +37,64 @@
     binRange.qRangeHigh = @"167";
     
     XCTAssertFalse([binRange matchesNumber:@"0"]);
-    XCTAssertFalse([binRange matchesNumber:@"1"]);
+    XCTAssertTrue([binRange matchesNumber:@"1"]);
     XCTAssertFalse([binRange matchesNumber:@"2"]);
-    
+
+    XCTAssertFalse([binRange matchesNumber:@"00"]);
+    XCTAssertTrue([binRange matchesNumber:@"13"]);
+    XCTAssertTrue([binRange matchesNumber:@"14"]);
+    XCTAssertTrue([binRange matchesNumber:@"16"]);
+    XCTAssertFalse([binRange matchesNumber:@"20"]);
+
     XCTAssertFalse([binRange matchesNumber:@"133"]);
-    XCTAssert([binRange matchesNumber:@"134"]);
-    XCTAssert([binRange matchesNumber:@"135"]);
-    XCTAssert([binRange matchesNumber:@"167"]);
+    XCTAssertTrue([binRange matchesNumber:@"134"]);
+    XCTAssertTrue([binRange matchesNumber:@"135"]);
+    XCTAssertTrue([binRange matchesNumber:@"167"]);
     XCTAssertFalse([binRange matchesNumber:@"168"]);
     
     XCTAssertFalse([binRange matchesNumber:@"1244"]);
-    XCTAssert([binRange matchesNumber:@"1340"]);
-    XCTAssert([binRange matchesNumber:@"1344"]);
-    XCTAssert([binRange matchesNumber:@"1444"]);
-    XCTAssert([binRange matchesNumber:@"1670"]);
-    XCTAssert([binRange matchesNumber:@"1679"]);
+    XCTAssertTrue([binRange matchesNumber:@"1340"]);
+    XCTAssertTrue([binRange matchesNumber:@"1344"]);
+    XCTAssertTrue([binRange matchesNumber:@"1444"]);
+    XCTAssertTrue([binRange matchesNumber:@"1670"]);
+    XCTAssertTrue([binRange matchesNumber:@"1679"]);
     XCTAssertFalse([binRange matchesNumber:@"1680"]);
-    
+
+    binRange.qRangeLow = @"004";
+    binRange.qRangeHigh = @"017";
+
+    XCTAssertTrue([binRange matchesNumber:@"0"]);
+    XCTAssertFalse([binRange matchesNumber:@"1"]);
+
+    XCTAssertTrue([binRange matchesNumber:@"00"]);
+    XCTAssertTrue([binRange matchesNumber:@"01"]);
+    XCTAssertFalse([binRange matchesNumber:@"10"]);
+    XCTAssertFalse([binRange matchesNumber:@"20"]);
+
+    XCTAssertFalse([binRange matchesNumber:@"000"]);
+    XCTAssertFalse([binRange matchesNumber:@"002"]);
+    XCTAssertTrue([binRange matchesNumber:@"004"]);
+    XCTAssertTrue([binRange matchesNumber:@"009"]);
+    XCTAssertTrue([binRange matchesNumber:@"014"]);
+    XCTAssertTrue([binRange matchesNumber:@"017"]);
+    XCTAssertFalse([binRange matchesNumber:@"019"]);
+    XCTAssertFalse([binRange matchesNumber:@"020"]);
+    XCTAssertFalse([binRange matchesNumber:@"100"]);
+
+    XCTAssertFalse([binRange matchesNumber:@"0000"]);
+    XCTAssertFalse([binRange matchesNumber:@"0021"]);
+    XCTAssertTrue([binRange matchesNumber:@"0044"]);
+    XCTAssertTrue([binRange matchesNumber:@"0098"]);
+    XCTAssertTrue([binRange matchesNumber:@"0143"]);
+    XCTAssertTrue([binRange matchesNumber:@"0173"]);
+    XCTAssertFalse([binRange matchesNumber:@"0195"]);
+    XCTAssertFalse([binRange matchesNumber:@"0202"]);
+    XCTAssertFalse([binRange matchesNumber:@"1004"]);
+
     binRange.qRangeLow = @"";
     binRange.qRangeHigh = @"";
-    XCTAssert([binRange matchesNumber:@""]);
-    XCTAssert([binRange matchesNumber:@"1"]);
+    XCTAssertTrue([binRange matchesNumber:@""]);
+    XCTAssertTrue([binRange matchesNumber:@"1"]);
 }
 
 - (void)testBinRangesForNumber {
@@ -73,7 +110,7 @@
     XCTAssertEqual(binRanges.count, 2U);
     
     binRanges = [STPBINRange binRangesForNumber:@""];
-    XCTAssertEqual(binRanges.count, 1U);
+    XCTAssertEqual(binRanges.count, [STPBINRange allRanges].count);
     
     binRanges = [STPBINRange binRangesForNumber:@"123"];
     XCTAssertEqual(binRanges.count, 1U);
@@ -95,11 +132,11 @@
     }
 }
 
-- (void)testMostSpecifiBinRangeForNumber {
+- (void)testMostSpecificBinRangeForNumber {
     STPBINRange *binRange;
     
     binRange = [STPBINRange mostSpecificBINRangeForNumber:@""];
-    XCTAssertEqual(binRange.brand, STPCardBrandUnknown);
+    XCTAssertNotEqual(binRange.brand, STPCardBrandUnknown);
     
     binRange = [STPBINRange mostSpecificBINRangeForNumber:@"4242424242422"];
     XCTAssertEqual(binRange.brand, STPCardBrandVisa);


### PR DESCRIPTION
Previously partial numbers did not match to any ranges (eg 6 did not match to 622). This meant that the validator sometimes incorrectly said things were invalid when they were in fact incomplete and would also not correctly return `brandForNumber:` for these partial matches (in the case where they could only possibly complete to single brand). I changed this logic so partial numbers match bin ranges correctly and updated tests.

Also added a bunch of tests for hypthetical bin ranges which start with 0, which I expect is the most likely sort of future bug in this type of numeric comparison.

Fixes: https://github.com/stripe/stripe-ios/issues/632
