### PR TITLE
Add unit tests for STPRedirectContext

### DIFF
--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -433,6 +433,7 @@
 		C1363BBA1D7633D800EB82B4 /* STPPaymentMethodTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = C1363BB61D7633D800EB82B4 /* STPPaymentMethodTableViewCell.m */; };
 		C14FC71D1E9569AD003E268D /* STPMocks.h in Headers */ = {isa = PBXBuildFile; fileRef = C14FC71B1E9569AD003E268D /* STPMocks.h */; };
 		C14FC71E1E9569AD003E268D /* STPMocks.m in Sources */ = {isa = PBXBuildFile; fileRef = C14FC71C1E9569AD003E268D /* STPMocks.m */; };
+		C144568F1E96DC3300A55C2C /* STPRedirectContextTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C144568E1E96DC3300A55C2C /* STPRedirectContextTest.m */; };
 		C158AB3F1E1EE98900348D01 /* STPSectionHeaderView.h in Headers */ = {isa = PBXBuildFile; fileRef = C158AB3D1E1EE98900348D01 /* STPSectionHeaderView.h */; };
 		C158AB401E1EE98900348D01 /* STPSectionHeaderView.m in Sources */ = {isa = PBXBuildFile; fileRef = C158AB3E1E1EE98900348D01 /* STPSectionHeaderView.m */; };
 		C15993231D8807930047950D /* stp_shipping_form.png in Resources */ = {isa = PBXBuildFile; fileRef = C15993201D8807930047950D /* stp_shipping_form.png */; };
@@ -1061,6 +1062,7 @@
 		C1363BB61D7633D800EB82B4 /* STPPaymentMethodTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodTableViewCell.m; sourceTree = "<group>"; };
 		C14FC71B1E9569AD003E268D /* STPMocks.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPMocks.h; sourceTree = "<group>"; };
 		C14FC71C1E9569AD003E268D /* STPMocks.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPMocks.m; sourceTree = "<group>"; };
+		C144568E1E96DC3300A55C2C /* STPRedirectContextTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPRedirectContextTest.m; sourceTree = "<group>"; };
 		C158AB3D1E1EE98900348D01 /* STPSectionHeaderView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPSectionHeaderView.h; sourceTree = "<group>"; };
 		C158AB3E1E1EE98900348D01 /* STPSectionHeaderView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPSectionHeaderView.m; sourceTree = "<group>"; };
 		C15993201D8807930047950D /* stp_shipping_form.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_shipping_form.png; sourceTree = "<group>"; };
@@ -1679,6 +1681,7 @@
 				C1BF02321E8B28AE00FE9F51 /* STPPaymentMethodTupleTest.m */,
 				C1EEDCC91CA2186300A54582 /* STPPhoneNumberValidatorTest.m */,
 				C1FEE5981CBFF24000A7632B /* STPPostalCodeValidatorTest.m */,
+				C144568E1E96DC3300A55C2C /* STPRedirectContextTest.m */,
 				C1BF02331E8B28AE00FE9F51 /* STPSourceInfoViewControllerTest.m */,
 				C1BD9B1E1E390A2700CEE925 /* STPSourceParamsTest.m */,
 				C17D24ED1E37DBAC005CB188 /* STPSourceTest.m */,
@@ -2513,6 +2516,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C144568F1E96DC3300A55C2C /* STPRedirectContextTest.m in Sources */,
 				F1122A7E1DFB84E000A8B1AF /* UINavigationBar+StripeTest.m in Sources */,
 				04A4C3941C4F276100B3B290 /* STPUIVCStripeParentViewControllerTests.m in Sources */,
 				04A488361CA34DC600506E53 /* STPEmailAddressValidatorTest.m in Sources */,

--- a/Tests/Tests/STPRedirectContextTest.m
+++ b/Tests/Tests/STPRedirectContextTest.m
@@ -1,0 +1,273 @@
+//
+//  STPRedirectContextTest.m
+//  Stripe
+//
+//  Created by Ben Guo on 4/6/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import <SafariServices/SafariServices.h>
+#import <XCTest/XCTest.h>
+#import "NSURLComponents+Stripe.h"
+#import "STPFixtures.h"
+#import "STPRedirectContext.h"
+#import "STPURLCallbackHandler.h"
+
+@interface STPRedirectContext (Testing)
+- (void)unsubscribeFromNotificationsAndDismissPresentedViewControllers;
+@end
+
+@interface STPRedirectContextTest : XCTestCase
+
+@end
+
+@implementation STPRedirectContextTest
+
+- (void)testInitWithNonRedirectSourceReturnsNil {
+    STPSource *source = [STPFixtures cardSource];
+    STPRedirectContext *sut = [[STPRedirectContext alloc] initWithSource:source completion:^(__unused NSString *sourceID, __unused NSString *clientSecret, __unused NSError *error) {
+        XCTFail(@"completion was called");
+    }];
+    XCTAssertNil(sut);
+}
+
+/**
+ After starting a SafariViewController redirect flow,
+ when the shared URLCallbackHandler is called with a valid URL,
+ RedirectContext's completion block and dismiss method should be called.
+ */
+- (void)testSafariViewControllerRedirectFlow_callbackHandlerCalledValidURL {
+    id mockVC = OCMClassMock([UIViewController class]);
+    STPSource *source = [STPFixtures iDEALSource];
+    XCTestExpectation *exp = [self expectationWithDescription:@"completion"];
+    STPRedirectContext *context = [[STPRedirectContext alloc] initWithSource:source completion:^(NSString *sourceID, NSString *clientSecret, NSError *error) {
+        XCTAssertEqualObjects(sourceID, source.stripeID);
+        XCTAssertEqualObjects(clientSecret, source.clientSecret);
+        XCTAssertNil(error);
+        [exp fulfill];
+    }];
+    id sut = OCMPartialMock(context);
+
+    [sut startSafariViewControllerRedirectFlowFromViewController:mockVC];
+
+    BOOL(^checker)(id) = ^BOOL(id vc) {
+        if ([vc isKindOfClass:[SFSafariViewController class]]) {
+            NSURL *url = source.redirect.returnURL;
+            NSURLComponents *comps = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
+            [comps setStp_queryItemsDictionary:@{@"source": source.stripeID,
+                                                 @"client_secret": source.clientSecret}];
+            [[STPURLCallbackHandler shared] handleURLCallback:comps.URL];
+            return YES;
+        }
+        return NO;
+    };
+    OCMVerify([mockVC presentViewController:[OCMArg checkWithBlock:checker]
+                                   animated:YES
+                                 completion:[OCMArg any]]);
+    OCMVerify([sut unsubscribeFromNotificationsAndDismissPresentedViewControllers]);
+
+    [self waitForExpectationsWithTimeout:2 handler:nil];
+}
+
+/**
+ After starting a SafariViewController redirect flow,
+ when the shared URLCallbackHandler is called with an invalid URL,
+ RedirectContext's completion block and dismiss method should be called.
+ */
+- (void)testSafariViewControllerRedirectFlow_callbackHandlerCalledInvalidURL {
+    id mockVC = OCMClassMock([UIViewController class]);
+    STPSource *source = [STPFixtures iDEALSource];
+    STPRedirectContext *context = [[STPRedirectContext alloc] initWithSource:source completion:^(__unused NSString *sourceID, __unused NSString *clientSecret, __unused NSError *error) {
+        XCTFail(@"completion called");
+    }];
+    id sut = OCMPartialMock(context);
+
+    [sut startSafariViewControllerRedirectFlowFromViewController:mockVC];
+
+    BOOL(^checker)(id) = ^BOOL(id vc) {
+        if ([vc isKindOfClass:[SFSafariViewController class]]) {
+            NSURL *url = [NSURL URLWithString:@"my-app://some_path"];
+            [[STPURLCallbackHandler shared] handleURLCallback:url];
+            return YES;
+        }
+        return NO;
+    };
+    OCMVerify([mockVC presentViewController:[OCMArg checkWithBlock:checker]
+                                   animated:YES
+                                 completion:[OCMArg any]]);
+    OCMReject([sut unsubscribeFromNotificationsAndDismissPresentedViewControllers]);
+}
+
+/**
+ After starting a SafariViewController redirect flow,
+ when SafariViewController finishes, RedirectContext's completion block
+ and dismiss method should be called.
+ */
+- (void)testSafariViewControllerRedirectFlow_didFinish {
+    id mockVC = OCMClassMock([UIViewController class]);
+    STPSource *source = [STPFixtures iDEALSource];
+    XCTestExpectation *exp = [self expectationWithDescription:@"completion"];
+    STPRedirectContext *context = [[STPRedirectContext alloc] initWithSource:source completion:^(NSString *sourceID, NSString *clientSecret, NSError *error) {
+        XCTAssertEqualObjects(sourceID, source.stripeID);
+        XCTAssertEqualObjects(clientSecret, source.clientSecret);
+        XCTAssertNil(error);
+        [exp fulfill];
+    }];
+    id sut = OCMPartialMock(context);
+
+    [sut startSafariViewControllerRedirectFlowFromViewController:mockVC];
+
+    BOOL(^checker)(id) = ^BOOL(id vc) {
+        if ([vc isKindOfClass:[SFSafariViewController class]]) {
+            SFSafariViewController *sfvc = (SFSafariViewController *)vc;
+            [sfvc.delegate safariViewControllerDidFinish:sfvc];
+            return YES;
+        }
+        return NO;
+    };
+    OCMVerify([mockVC presentViewController:[OCMArg checkWithBlock:checker]
+                                   animated:YES
+                                 completion:[OCMArg any]]);
+    OCMVerify([sut unsubscribeFromNotificationsAndDismissPresentedViewControllers]);
+
+    [self waitForExpectationsWithTimeout:2 handler:nil];
+}
+
+/**
+ After starting a SafariViewController redirect flow,
+ when SafariViewController fails to load, RedirectContext's completion block
+ and dismiss method should be called.
+ */
+- (void)testSafariViewControllerRedirectFlow_failedToLoad {
+    id mockVC = OCMClassMock([UIViewController class]);
+    STPSource *source = [STPFixtures iDEALSource];
+    XCTestExpectation *exp = [self expectationWithDescription:@"completion"];
+    STPRedirectContext *context = [[STPRedirectContext alloc] initWithSource:source completion:^(NSString *sourceID, NSString *clientSecret, NSError *error) {
+        XCTAssertEqualObjects(sourceID, source.stripeID);
+        XCTAssertEqualObjects(clientSecret, source.clientSecret);
+        NSError *expectedError = [NSError stp_genericConnectionError];
+        XCTAssertEqualObjects(error, expectedError);
+        [exp fulfill];
+    }];
+    id sut = OCMPartialMock(context);
+
+    [sut startSafariViewControllerRedirectFlowFromViewController:mockVC];
+
+    BOOL(^checker)(id) = ^BOOL(id vc) {
+        if ([vc isKindOfClass:[SFSafariViewController class]]) {
+            SFSafariViewController *sfvc = (SFSafariViewController *)vc;
+            [sfvc.delegate safariViewController:sfvc didCompleteInitialLoad:NO];
+            return YES;
+        }
+        return NO;
+    };
+    OCMVerify([mockVC presentViewController:[OCMArg checkWithBlock:checker]
+                                   animated:YES
+                                 completion:[OCMArg any]]);
+    OCMVerify([sut unsubscribeFromNotificationsAndDismissPresentedViewControllers]);
+
+    [self waitForExpectationsWithTimeout:2 handler:nil];
+}
+
+/**
+ After starting a SafariViewController redirect flow,
+ when the RedirectContext is cancelled, its dismiss method should be called.
+ */
+- (void)testSafariViewControllerRedirectFlow_cancel {
+    id mockVC = OCMClassMock([UIViewController class]);
+    STPSource *source = [STPFixtures iDEALSource];
+    STPRedirectContext *context = [[STPRedirectContext alloc] initWithSource:source completion:^(__unused NSString *sourceID, __unused NSString *clientSecret, __unused NSError *error) {
+        XCTFail(@"completion called");
+    }];
+    id sut = OCMPartialMock(context);
+
+    [sut startSafariViewControllerRedirectFlowFromViewController:mockVC];
+    [sut cancel];
+
+    OCMVerify([mockVC presentViewController:[OCMArg isKindOfClass:[SFSafariViewController class]]
+                                   animated:YES
+                                 completion:[OCMArg any]]);
+    OCMVerify([sut unsubscribeFromNotificationsAndDismissPresentedViewControllers]);
+}
+
+/**
+ After starting a SafariViewController redirect flow,
+ when the RedirectContext is dealloc'd, its dismiss method should be called.
+ */
+- (void)testSafariViewControllerRedirectFlow_dealloc {
+    id mockVC = OCMClassMock([UIViewController class]);
+    STPSource *source = [STPFixtures iDEALSource];
+    STPRedirectContext *context = [[STPRedirectContext alloc] initWithSource:source completion:^(__unused NSString *sourceID, __unused NSString *clientSecret, __unused NSError *error) {
+        XCTFail(@"completion called");
+    }];
+    id sut = OCMPartialMock(context);
+
+    [sut startSafariViewControllerRedirectFlowFromViewController:mockVC];
+    sut = nil;
+
+    OCMVerify([mockVC presentViewController:[OCMArg isKindOfClass:[SFSafariViewController class]]
+                                   animated:YES
+                                 completion:[OCMArg any]]);
+    OCMVerify([sut unsubscribeFromNotificationsAndDismissPresentedViewControllers]);
+}
+
+/**
+ After starting a SafariViewController redirect flow,
+ if no action is taken, nothing should be called.
+ */
+- (void)testSafariViewControllerRedirectFlow_noAction {
+    id mockVC = OCMClassMock([UIViewController class]);
+    STPSource *source = [STPFixtures iDEALSource];
+    STPRedirectContext *context = [[STPRedirectContext alloc] initWithSource:source completion:^(__unused NSString *sourceID, __unused NSString *clientSecret, __unused NSError *error) {
+        XCTFail(@"completion called");
+    }];
+    id sut = OCMPartialMock(context);
+
+    [sut startSafariViewControllerRedirectFlowFromViewController:mockVC];
+
+    OCMVerify([mockVC presentViewController:[OCMArg isKindOfClass:[SFSafariViewController class]]
+                                   animated:YES
+                                 completion:[OCMArg any]]);
+    OCMReject([sut unsubscribeFromNotificationsAndDismissPresentedViewControllers]);
+}
+
+/**
+ After starting a Safari app redirect flow,
+ when a WillEnterForeground notification is posted, RedirectContext's completion 
+ block and dismiss method should be called.
+ */
+- (void)testSafariAppRedirectFlow_foregroundNotification {
+    STPSource *source = [STPFixtures iDEALSource];
+    XCTestExpectation *exp = [self expectationWithDescription:@"completion"];
+    STPRedirectContext *context = [[STPRedirectContext alloc] initWithSource:source completion:^(NSString *sourceID, NSString *clientSecret, NSError *error) {
+        XCTAssertEqualObjects(sourceID, source.stripeID);
+        XCTAssertEqualObjects(clientSecret, source.clientSecret);
+        XCTAssertNil(error);
+        [exp fulfill];
+    }];
+    id sut = OCMPartialMock(context);
+
+    [sut startSafariAppRedirectFlow];
+    [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationWillEnterForegroundNotification object:nil];
+
+    OCMVerify([sut unsubscribeFromNotificationsAndDismissPresentedViewControllers]);
+    [self waitForExpectationsWithTimeout:2 handler:nil];
+}
+
+/**
+ After starting a Safari app redirect flow,
+ if no notification is posted, nothing should be called.
+ */
+- (void)testSafariAppRedirectFlow_noNotification {
+    STPSource *source = [STPFixtures iDEALSource];
+    STPRedirectContext *context = [[STPRedirectContext alloc] initWithSource:source completion:^(__unused NSString *sourceID, __unused NSString *clientSecret, __unused NSError *error) {
+        XCTFail(@"completion called");
+    }];
+    id sut = OCMPartialMock(context);
+
+    [sut startSafariAppRedirectFlow];
+
+    OCMReject([sut unsubscribeFromNotificationsAndDismissPresentedViewControllers]);
+}
+
+@end


### PR DESCRIPTION
r? @bdorfman-stripe 

Learned some things while writing these. I initially wanted to verify that `dismiss` was called on the view controller presenting `SFSafariVC`, i.e.

```
OCMVerify([mockVC dismissViewControllerAnimated:YES completion:[OCMArg any]]);
```

but ran into some issues. Our unit tests aren't embedded in an application, which means we can't actually present a remote view controller (we get an error about the presenting view controller not being in the window hierarchy). To get around this, I started going down the route of mocking `SFSafariVC` and stubbing `presentingViewController`, but in the end decided that the approach here is cleaner. We partially mock `STPRedirectContext` and verify that an internal method, `unsubscribeFromNotifications...` is called. It's generally not great to leak the internals of the subject under test, but I think it's acceptable in this case.
