### PR TITLE
Add unit tests for STPPaymentMethodsVC

### DIFF
--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -371,6 +371,7 @@
 		04F94DD31D22A23F004FC826 /* NSBundle+Stripe_AppName.h in Headers */ = {isa = PBXBuildFile; fileRef = 049A3F971CC76A2400F57DE7 /* NSBundle+Stripe_AppName.h */; };
 		04F94DD41D22A242004FC826 /* NSBundle+Stripe_AppName.m in Sources */ = {isa = PBXBuildFile; fileRef = 049A3F981CC76A2400F57DE7 /* NSBundle+Stripe_AppName.m */; };
 		04FCFA191BD59A8C00297732 /* STPCategoryLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 04FCFA171BD59A8C00297732 /* STPCategoryLoader.h */; };
+		C107A3891E9C2F2600496C3B /* STPPaymentMethodsViewControllerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C107A3881E9C2F2600496C3B /* STPPaymentMethodsViewControllerTest.m */; };
 		C1080F491CBECF7B007B2D89 /* STPAddress.h in Headers */ = {isa = PBXBuildFile; fileRef = C1080F471CBECF7B007B2D89 /* STPAddress.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C1080F4A1CBECF7B007B2D89 /* STPAddress.m in Sources */ = {isa = PBXBuildFile; fileRef = C1080F481CBECF7B007B2D89 /* STPAddress.m */; };
 		C1080F4C1CBED48A007B2D89 /* STPAddressTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C1080F4B1CBED48A007B2D89 /* STPAddressTests.m */; };
@@ -1024,6 +1025,7 @@
 		04FCFA171BD59A8C00297732 /* STPCategoryLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPCategoryLoader.h; sourceTree = "<group>"; };
 		11C74B9B164043050071C2CA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		4A0D74F918F6106100966D7B /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
+		C107A3881E9C2F2600496C3B /* STPPaymentMethodsViewControllerTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodsViewControllerTest.m; sourceTree = "<group>"; };
 		C1080F471CBECF7B007B2D89 /* STPAddress.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = STPAddress.h; path = PublicHeaders/STPAddress.h; sourceTree = "<group>"; };
 		C1080F481CBECF7B007B2D89 /* STPAddress.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPAddress.m; sourceTree = "<group>"; };
 		C1080F4B1CBED48A007B2D89 /* STPAddressTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPAddressTests.m; sourceTree = "<group>"; };
@@ -1677,6 +1679,7 @@
 				F14C872E1D4FCDBA00C7CC6A /* STPPaymentContextApplePayTest.m */,
 				C11E9CC11E9539B7003F0304 /* STPPaymentContextRequestPaymentTest.m */,
 				C1BF02321E8B28AE00FE9F51 /* STPPaymentMethodTupleTest.m */,
+				C107A3881E9C2F2600496C3B /* STPPaymentMethodsViewControllerTest.m */,
 				C1EEDCC91CA2186300A54582 /* STPPhoneNumberValidatorTest.m */,
 				C1FEE5981CBFF24000A7632B /* STPPostalCodeValidatorTest.m */,
 				C1BF02331E8B28AE00FE9F51 /* STPSourceInfoViewControllerTest.m */,
@@ -2545,6 +2548,7 @@
 				F1D777C01D81DD520076FA19 /* STPStringUtilsTest.m in Sources */,
 				C1FEE5991CBFF24000A7632B /* STPPostalCodeValidatorTest.m in Sources */,
 				C1BF02381E8B28C100FE9F51 /* STPPaymentMethodTupleTest.m in Sources */,
+				C107A3891E9C2F2600496C3B /* STPPaymentMethodsViewControllerTest.m in Sources */,
 				C11E9CC21E9539B7003F0304 /* STPPaymentContextRequestPaymentTest.m in Sources */,
 				C13538081D2C2186003F6157 /* STPAddCardViewControllerTest.m in Sources */,
 				04415C671A6605B5001225ED /* STPAPIClientTest.m in Sources */,

--- a/Stripe/STPPaymentMethodsViewController.m
+++ b/Stripe/STPPaymentMethodsViewController.m
@@ -228,8 +228,6 @@
 }
 
 - (void)addCardViewControllerDidCancel:(__unused STPAddCardViewController *)addCardViewController {
-    // Add card is only our direct delegate if there are no other payment methods possible
-    // and we skipped directly to this screen. In this case, a cancel from it is the same as a cancel to us.
     [self.delegate paymentMethodsViewControllerDidCancel:self];
 }
 
@@ -240,7 +238,7 @@
 }
 
 - (void)addSourceViewControllerDidCancel:(__unused STPAddSourceViewController *)addSourceViewController {
-    [self.delegate paymentMethodsViewControllerDidFinish:self];
+    [self.delegate paymentMethodsViewControllerDidCancel:self];
 }
 
 - (void)addSourceViewController:(__unused STPAddSourceViewController *)addSourceViewController

--- a/Stripe/STPPaymentMethodsViewController.m
+++ b/Stripe/STPPaymentMethodsViewController.m
@@ -228,6 +228,8 @@
 }
 
 - (void)addCardViewControllerDidCancel:(__unused STPAddCardViewController *)addCardViewController {
+    // AddCardVC is only our direct delegate if there are no other payment methods possible
+    // and we skipped directly to this screen. In this case, a cancel from it is the same as a cancel to us.
     [self.delegate paymentMethodsViewControllerDidCancel:self];
 }
 
@@ -238,6 +240,8 @@
 }
 
 - (void)addSourceViewControllerDidCancel:(__unused STPAddSourceViewController *)addSourceViewController {
+    // AddSourceVC is only our direct delegate if there are no other payment methods possible
+    // and we skipped directly to this screen. In this case, a cancel from it is the same as a cancel to us.
     [self.delegate paymentMethodsViewControllerDidCancel:self];
 }
 

--- a/Tests/Tests/STPPaymentMethodsViewControllerTest.m
+++ b/Tests/Tests/STPPaymentMethodsViewControllerTest.m
@@ -1,0 +1,237 @@
+//
+//  STPPaymentMethodsViewControllerTest.m
+//  Stripe
+//
+//  Created by Ben Guo on 4/10/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import <OCMock/OCMock.h>
+#import "STPFixtures.h"
+#import "STPMocks.h"
+#import "STPPaymentMethodsInternalViewController.h"
+
+@interface STPPaymentMethodsViewController (Testing)
+@property(nonatomic, weak)UIViewController *internalViewController;
+@end
+
+@interface STPPaymentMethodsViewControllerTest : XCTestCase
+
+@end
+
+@implementation STPPaymentMethodsViewControllerTest
+
+- (STPPaymentMethodsViewController *)buildViewControllerWithCustomer:(STPCustomer *)customer
+                                                       configuration:(STPPaymentConfiguration *)config
+                                                            delegate:(id<STPPaymentMethodsViewControllerDelegate>)delegate {
+    STPTheme *theme = [STPTheme defaultTheme];
+    id<STPBackendAPIAdapter> mockAPIAdapter = [STPMocks staticAPIAdapterWithCustomer:customer];
+    STPPaymentMethodsViewController *vc = [[STPPaymentMethodsViewController alloc] initWithConfiguration:config
+                                                                                                   theme:theme
+                                                                                              apiAdapter:mockAPIAdapter
+                                                                                                delegate:delegate];
+    if (vc) {
+        XCTAssertNotNil(vc.view);
+    }
+    return vc;
+}
+
+/**
+ When the customer has no sources and the configuration doesn't use sources,
+ STPAddCardViewController should be shown.
+ */
+- (void)testInitWithNoSourcesAndUseSourcesOff {
+    STPCustomer *customer = [STPFixtures customerWithNoSources];
+    STPPaymentConfiguration *config = [STPFixtures paymentConfiguration];
+    config.useSourcesForCards = NO;
+    id<STPPaymentMethodsViewControllerDelegate>delegate = OCMProtocolMock(@protocol(STPPaymentMethodsViewControllerDelegate));
+    STPPaymentMethodsViewController *sut = [self buildViewControllerWithCustomer:customer
+                                                                   configuration:config
+                                                                        delegate:delegate];
+    XCTAssertTrue([sut.internalViewController isKindOfClass:[STPAddCardViewController class]]);
+}
+
+/**
+ When the customer has no sources and the configuration uses sources,
+ STPAddSourceViewController should be shown.
+ */
+- (void)testInitWithNoSourcesAndUseSourcesOn {
+    STPCustomer *customer = [STPFixtures customerWithNoSources];
+    STPPaymentConfiguration *config = [STPFixtures paymentConfiguration];
+    config.useSourcesForCards = YES;
+    id<STPPaymentMethodsViewControllerDelegate>delegate = OCMProtocolMock(@protocol(STPPaymentMethodsViewControllerDelegate));
+    STPPaymentMethodsViewController *sut = [self buildViewControllerWithCustomer:customer
+                                                                   configuration:config
+                                                                        delegate:delegate];
+    XCTAssertTrue([sut.internalViewController isKindOfClass:[STPAddSourceViewController class]]);
+}
+
+/**
+ When the customer has no sources and the configuration uses sources,
+ STPPaymentMethodsInternalVC should be shown.
+ */
+- (void)testInitWithSingleCardSource {
+    STPCustomer *customer = [STPFixtures customerWithSingleCardTokenSource];
+    STPPaymentConfiguration *config = [STPFixtures paymentConfiguration];
+    id<STPPaymentMethodsViewControllerDelegate>delegate = OCMProtocolMock(@protocol(STPPaymentMethodsViewControllerDelegate));
+    STPPaymentMethodsViewController *sut = [self buildViewControllerWithCustomer:customer
+                                                                   configuration:config
+                                                                        delegate:delegate];
+    XCTAssertTrue([sut.internalViewController isKindOfClass:[STPPaymentMethodsInternalViewController class]]);
+}
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+
+/**
+ Tapping cancel in an internal AddCard view controller should result in a call to
+ didCancel:
+ */
+- (void)testAddCardCancelForwardsToDelegate {
+    STPCustomer *customer = [STPFixtures customerWithNoSources];
+    STPPaymentConfiguration *config = [STPFixtures paymentConfiguration];
+    config.useSourcesForCards = NO;
+    id<STPPaymentMethodsViewControllerDelegate>delegate = OCMProtocolMock(@protocol(STPPaymentMethodsViewControllerDelegate));
+    STPPaymentMethodsViewController *sut = [self buildViewControllerWithCustomer:customer
+                                                                   configuration:config
+                                                                        delegate:delegate];
+    XCTAssertTrue([sut.internalViewController isKindOfClass:[STPAddCardViewController class]]);
+    UIBarButtonItem *cancelButton = sut.internalViewController.navigationItem.leftBarButtonItem;
+    [cancelButton.target performSelector:cancelButton.action withObject:cancelButton];
+
+    OCMVerify([delegate paymentMethodsViewControllerDidCancel:[OCMArg any]]);
+}
+
+/**
+ Tapping cancel in an internal AddSource view controller should result in a call to
+ didCancel:
+ */
+- (void)testAddSourceCancelForwardsToDelegate {
+    STPCustomer *customer = [STPFixtures customerWithNoSources];
+    STPPaymentConfiguration *config = [STPFixtures paymentConfiguration];
+    config.useSourcesForCards = YES;
+    id<STPPaymentMethodsViewControllerDelegate>delegate = OCMProtocolMock(@protocol(STPPaymentMethodsViewControllerDelegate));
+    STPPaymentMethodsViewController *sut = [self buildViewControllerWithCustomer:customer
+                                                                   configuration:config
+                                                                        delegate:delegate];
+    XCTAssertTrue([sut.internalViewController isKindOfClass:[STPAddSourceViewController class]]);
+    UIBarButtonItem *cancelButton = sut.internalViewController.navigationItem.leftBarButtonItem;
+    [cancelButton.target performSelector:cancelButton.action withObject:cancelButton];
+
+    OCMVerify([delegate paymentMethodsViewControllerDidCancel:[OCMArg any]]);
+}
+
+/**
+ Tapping cancel in an internal PaymentMethodsInternal view controller should
+ result in a call to didCancel:
+ */
+- (void)testInternalCancelForwardsToDelegate {
+    STPCustomer *customer = [STPFixtures customerWithSingleCardTokenSource];
+    STPPaymentConfiguration *config = [STPFixtures paymentConfiguration];
+    id<STPPaymentMethodsViewControllerDelegate>delegate = OCMProtocolMock(@protocol(STPPaymentMethodsViewControllerDelegate));
+    STPPaymentMethodsViewController *sut = [self buildViewControllerWithCustomer:customer
+                                                                   configuration:config
+                                                                        delegate:delegate];
+    XCTAssertTrue([sut.internalViewController isKindOfClass:[STPPaymentMethodsInternalViewController class]]);
+    UIBarButtonItem *cancelButton = sut.internalViewController.navigationItem.leftBarButtonItem;
+    [cancelButton.target performSelector:cancelButton.action withObject:cancelButton];
+
+    OCMVerify([delegate paymentMethodsViewControllerDidCancel:[OCMArg any]]);
+}
+
+/**
+ When an AddSource view controller creates a source, it should be attached to the
+ customer and the correct delegate methods should be called.
+ */
+- (void)testAddSourceAttachesToCustomerAndFinishes {
+    STPTheme *theme = [STPTheme defaultTheme];
+    STPPaymentConfiguration *config = [STPFixtures paymentConfiguration];
+    config.useSourcesForCards = YES;
+    STPCustomer *customer = [STPFixtures customerWithNoSources];
+    id<STPBackendAPIAdapter> mockAPIAdapter = [STPMocks staticAPIAdapterWithCustomer:customer];
+    id<STPPaymentMethodsViewControllerDelegate>delegate = OCMProtocolMock(@protocol(STPPaymentMethodsViewControllerDelegate));
+    STPPaymentMethodsViewController *sut = [[STPPaymentMethodsViewController alloc] initWithConfiguration:config
+                                                                                                   theme:theme
+                                                                                              apiAdapter:mockAPIAdapter
+                                                                                                delegate:delegate];
+    XCTAssertNotNil(sut.view);
+    XCTAssertTrue([sut.internalViewController isKindOfClass:[STPAddSourceViewController class]]);
+
+    OCMStub([mockAPIAdapter attachSourceToCustomer:[OCMArg any] completion:[OCMArg any]])
+    .andDo(^(NSInvocation *invocation){
+        STPErrorBlock completion;
+        [invocation getArgument:&completion atIndex:3];
+        completion(nil);
+    });
+
+    STPAddSourceViewController *internal = (STPAddSourceViewController *)sut.internalViewController;
+    XCTestExpectation *exp = [self expectationWithDescription:@"completion"];
+    STPSource *expectedSource = [STPFixtures sepaDebitSource];
+    [internal.delegate addSourceViewController:internal didCreateSource:expectedSource completion:^(NSError *error) {
+        XCTAssertNil(error);
+        [exp fulfill];
+    }];
+
+    BOOL (^checker)() = ^BOOL(id obj) {
+        STPSource *source = (STPSource *)obj;
+        return source.stripeID == expectedSource.stripeID;
+    };
+    OCMVerify([mockAPIAdapter attachSourceToCustomer:[OCMArg checkWithBlock:checker] completion:[OCMArg any]]);
+    OCMVerify([mockAPIAdapter selectDefaultCustomerSource:[OCMArg checkWithBlock:checker] completion:[OCMArg any]]);
+    OCMVerify([delegate paymentMethodsViewController:[OCMArg any] didSelectPaymentMethod:[OCMArg checkWithBlock:checker]]);
+    OCMVerify([delegate paymentMethodsViewControllerDidFinish:[OCMArg any]]);
+    [self waitForExpectationsWithTimeout:2 handler:nil];
+}
+
+/**
+ When an AddCard view controller creates a source, it should be attached to the
+ customer and the correct delegate methods should be called.
+ */
+- (void)testAddCardAttachesToCustomerAndFinishes {
+    STPTheme *theme = [STPTheme defaultTheme];
+    STPPaymentConfiguration *config = [STPFixtures paymentConfiguration];
+    config.useSourcesForCards = NO;
+    STPCustomer *customer = [STPFixtures customerWithNoSources];
+    id<STPBackendAPIAdapter> mockAPIAdapter = [STPMocks staticAPIAdapterWithCustomer:customer];
+    id<STPPaymentMethodsViewControllerDelegate>delegate = OCMProtocolMock(@protocol(STPPaymentMethodsViewControllerDelegate));
+    STPPaymentMethodsViewController *sut = [[STPPaymentMethodsViewController alloc] initWithConfiguration:config
+                                                                                                    theme:theme
+                                                                                               apiAdapter:mockAPIAdapter
+                                                                                                 delegate:delegate];
+    XCTAssertNotNil(sut.view);
+    XCTAssertTrue([sut.internalViewController isKindOfClass:[STPAddCardViewController class]]);
+
+    OCMStub([mockAPIAdapter attachSourceToCustomer:[OCMArg any] completion:[OCMArg any]])
+    .andDo(^(NSInvocation *invocation){
+        STPErrorBlock completion;
+        [invocation getArgument:&completion atIndex:3];
+        completion(nil);
+    });
+
+    STPAddCardViewController *internal = (STPAddCardViewController *)sut.internalViewController;
+    XCTestExpectation *exp = [self expectationWithDescription:@"completion"];
+    STPToken *expectedToken = [STPFixtures cardToken];
+    [internal.delegate addCardViewController:internal didCreateToken:expectedToken completion:^(NSError *error) {
+        XCTAssertNil(error);
+        [exp fulfill];
+    }];
+
+    BOOL (^tokenChecker)() = ^BOOL(id obj) {
+        STPToken *token = (STPToken *)obj;
+        return token.stripeID == expectedToken.stripeID;
+    };
+    BOOL (^cardChecker)() = ^BOOL(id obj) {
+        STPCard *card = (STPCard *)obj;
+        return card.stripeID == expectedToken.card.stripeID;
+    };
+    OCMVerify([mockAPIAdapter attachSourceToCustomer:[OCMArg checkWithBlock:tokenChecker] completion:[OCMArg any]]);
+    OCMVerify([mockAPIAdapter selectDefaultCustomerSource:[OCMArg checkWithBlock:cardChecker] completion:[OCMArg any]]);
+    OCMVerify([delegate paymentMethodsViewController:[OCMArg any] didSelectPaymentMethod:[OCMArg checkWithBlock:cardChecker]]);
+    OCMVerify([delegate paymentMethodsViewControllerDidFinish:[OCMArg any]]);
+    [self waitForExpectationsWithTimeout:2 handler:nil];
+}
+
+#pragma clang diagnostic pop
+
+@end


### PR DESCRIPTION
r? @bdorfman-stripe 

Caught a bug while writing these (da8f06c) – we were calling the wrong delegate method when canceling AddSourceVC.