### PR TITLE
Add STPAdditionalSourceInfo

### DIFF
--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -464,6 +464,10 @@
 		C18937DB1E8F2A5300CC8827 /* STPRedirectContext.h in Headers */ = {isa = PBXBuildFile; fileRef = C18937D91E8F2A4E00CC8827 /* STPRedirectContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C1A06F101E1D8A7F004DCA06 /* STPCard+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = C1A06F0F1E1D8A6E004DCA06 /* STPCard+Private.h */; };
 		C1A06F111E1D8A7F004DCA06 /* STPCard+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = C1A06F0F1E1D8A6E004DCA06 /* STPCard+Private.h */; };
+		C1B2E3521E9D3AAF00FAB0EA /* STPAdditionalSourceInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = C1B2E34F1E9D3AAF00FAB0EA /* STPAdditionalSourceInfo.m */; };
+		C1B2E3531E9D3AAF00FAB0EA /* STPAdditionalSourceInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = C1B2E34F1E9D3AAF00FAB0EA /* STPAdditionalSourceInfo.m */; };
+		C1B2E3551E9D3AD700FAB0EA /* STPAdditionalSourceInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = C1B2E3541E9D3AD700FAB0EA /* STPAdditionalSourceInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C1B2E3561E9D3AD700FAB0EA /* STPAdditionalSourceInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = C1B2E3541E9D3AD700FAB0EA /* STPAdditionalSourceInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C1B3DD491E54EE2A00E19587 /* STPIBANTableViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = C1B3DD471E54EE2A00E19587 /* STPIBANTableViewCell.h */; };
 		C1B3DD4A1E54EE2A00E19587 /* STPIBANTableViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = C1B3DD471E54EE2A00E19587 /* STPIBANTableViewCell.h */; };
 		C1B3DD4B1E54EE2A00E19587 /* STPIBANTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = C1B3DD481E54EE2A00E19587 /* STPIBANTableViewCell.m */; };
@@ -1043,6 +1047,8 @@
 		C188801F1E68D40300FB169F /* STPSourceInfoDataSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPSourceInfoDataSource.m; sourceTree = "<group>"; };
 		C18937D91E8F2A4E00CC8827 /* STPRedirectContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = STPRedirectContext.h; path = PublicHeaders/STPRedirectContext.h; sourceTree = "<group>"; };
 		C1A06F0F1E1D8A6E004DCA06 /* STPCard+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCard+Private.h"; sourceTree = "<group>"; };
+		C1B2E34F1E9D3AAF00FAB0EA /* STPAdditionalSourceInfo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPAdditionalSourceInfo.m; sourceTree = "<group>"; };
+		C1B2E3541E9D3AD700FAB0EA /* STPAdditionalSourceInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = STPAdditionalSourceInfo.h; path = PublicHeaders/STPAdditionalSourceInfo.h; sourceTree = "<group>"; };
 		C1B3DD471E54EE2A00E19587 /* STPIBANTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPIBANTableViewCell.h; sourceTree = "<group>"; };
 		C1B3DD481E54EE2A00E19587 /* STPIBANTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPIBANTableViewCell.m; sourceTree = "<group>"; };
 		C1B630B31D1D817900A05285 /* Stripe.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Stripe.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1430,6 +1436,8 @@
 				04827D0F1D2575C6002DB3E8 /* STPImageLibrary.m */,
 				04B31DF71D11AC6400EF1631 /* STPUserInformation.h */,
 				04B31DF81D11AC6400EF1631 /* STPUserInformation.m */,
+				C1B2E3541E9D3AD700FAB0EA /* STPAdditionalSourceInfo.h */,
+				C1B2E34F1E9D3AAF00FAB0EA /* STPAdditionalSourceInfo.m */,
 				049880FA1CED5A2300EA4FFD /* STPPaymentConfiguration.h */,
 				04B31DD81D09A4DC00EF1631 /* STPPaymentConfiguration+Private.h */,
 				049880FB1CED5A2300EA4FFD /* STPPaymentConfiguration.m */,
@@ -1868,6 +1876,7 @@
 				04827D111D2575C6002DB3E8 /* STPImageLibrary.h in Headers */,
 				0451CC451C49AE1C003B2CA6 /* STPPaymentResult.h in Headers */,
 				F19491DF1E5F6B8C001E1FC2 /* STPSourceCardDetails.h in Headers */,
+				C1B2E3561E9D3AD700FAB0EA /* STPAdditionalSourceInfo.h in Headers */,
 				C12655391CAA238E006F7265 /* STPAddCardViewController.h in Headers */,
 				04F94DAD1D229F4E004FC826 /* STPColorUtils.h in Headers */,
 				04F94D9B1D229E76004FC826 /* STPTheme.h in Headers */,
@@ -2038,6 +2047,7 @@
 				C17F28B81E4CD13A0073408B /* STPSourceInfoViewController.h in Headers */,
 				F19491E71E60DD9C001E1FC2 /* STPSourceSEPADebitDetails.h in Headers */,
 				04A488421CA3580700506E53 /* UINavigationController+Stripe_Completion.h in Headers */,
+				C1B2E3551E9D3AD700FAB0EA /* STPAdditionalSourceInfo.h in Headers */,
 				F1DEB8991E2074480066B8E8 /* STPCoreViewController.h in Headers */,
 				04A4883C1CA3568800506E53 /* STPBlocks.h in Headers */,
 				C1BB223E1E4E1EF000E72B8E /* STPIDEALBankSelectorDataSource.h in Headers */,
@@ -2496,6 +2506,7 @@
 				04F94DAC1D229F42004FC826 /* UIBarButtonItem+Stripe.m in Sources */,
 				F1DEB88D1E2047CA0066B8E8 /* STPCoreTableViewController.m in Sources */,
 				F1C7B8D41DBECF2400D9F6F0 /* STPDispatchFunctions.m in Sources */,
+				C1B2E3531E9D3AAF00FAB0EA /* STPAdditionalSourceInfo.m in Sources */,
 				04633B141CD45215009D4FB5 /* PKPayment+Stripe.m in Sources */,
 				C1BB22411E4E1EF000E72B8E /* STPIDEALBankSelectorDataSource.m in Sources */,
 				04633AFF1CD129C0009D4FB5 /* NSString+Stripe.m in Sources */,
@@ -2679,6 +2690,7 @@
 				04CDE5B81BC1F1F100548833 /* STPCardParams.m in Sources */,
 				0451CC461C49AE1C003B2CA6 /* STPPaymentResult.m in Sources */,
 				04E39F551CECF7A100AF3B96 /* STPPaymentMethodTuple.m in Sources */,
+				C1B2E3521E9D3AAF00FAB0EA /* STPAdditionalSourceInfo.m in Sources */,
 				C11810961CC6C4700022FB55 /* PKPaymentAuthorizationViewController+Stripe_Blocks.m in Sources */,
 				0439B9891C454F97005A1ED5 /* STPPaymentMethodsViewController.m in Sources */,
 				04A488441CA3580700506E53 /* UINavigationController+Stripe_Completion.m in Sources */,

--- a/Stripe/PublicHeaders/STPAddSourceViewController.h
+++ b/Stripe/PublicHeaders/STPAddSourceViewController.h
@@ -34,9 +34,16 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, weak)id<STPAddSourceViewControllerDelegate>delegate;
 
 /**
- *  You can set this property to pre-fill any information you've already collected from your user. @see STPUserInformation.h
+ *  You can set this property to pre-fill any information you've already collected from your user. @see STPUserInformation
  */
 @property(nonatomic)STPUserInformation *prefilledInformation;
+
+/**
+ *  You can set this property to specify any additional information you'd
+ *  like to attach when creating a source, e.g. metadata.
+ *  @see STPAdditionalSourceInfo
+ */
+@property(nonatomic)STPAdditionalSourceInfo *sourceInformation;
 
 @end
 

--- a/Stripe/PublicHeaders/STPAdditionalSourceInfo.h
+++ b/Stripe/PublicHeaders/STPAdditionalSourceInfo.h
@@ -28,9 +28,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, copy, nullable)NSDictionary<NSString *, NSString *>*metadata;
 
 /**
- *  Some payment methods, like SOFORT, allow setting a custom statement descriptor.
- *  By default, your Stripe account’s statement descriptor is used (you can review 
- *  this in the Dashboard at https://dashboard.stripe.com/account).
+ *  Bancontact, Giropay, iDEAL, and SOFORT payments allow specifying a custom
+ *  statement descriptor. By default, your Stripe account’s statement descriptor
+ *  is used. You can review this in the Dashboard at https://dashboard.stripe.com/account
  */
 @property(nonatomic, copy, nullable)NSString *statementDescriptor;
 

--- a/Stripe/PublicHeaders/STPAdditionalSourceInfo.h
+++ b/Stripe/PublicHeaders/STPAdditionalSourceInfo.h
@@ -11,13 +11,12 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- You can use this class to specify additional information for the SDK to use
- when creating sources.
+ You can use this class to specify additional information to use when creating sources.
  */
 @interface STPAdditionalSourceInfo : NSObject<NSCopying>
 
 /**
- *  Metadata associated with your user. This will be attached to any Source
+ *  Metadata associated with your user. This will be attached to any source
  *  objects created by `STPPaymentContext`, `STPAddSourceViewController`, etc.
  *  You should consider storing any order information (e.g., order number) here.
  *  For payment methods that require additional user action, your backend will

--- a/Stripe/PublicHeaders/STPAdditionalSourceInfo.h
+++ b/Stripe/PublicHeaders/STPAdditionalSourceInfo.h
@@ -1,0 +1,40 @@
+//
+//  STPAdditionalSourceInfo.h
+//  Stripe
+//
+//  Created by Ben Guo on 4/11/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ You can use this class to specify additional information for the SDK to use
+ when creating sources.
+ */
+@interface STPAdditionalSourceInfo : NSObject<NSCopying>
+
+/**
+ *  Metadata associated with your user. This will be attached to any Source
+ *  objects created by `STPPaymentContext`, `STPAddSourceViewController`, etc.
+ *  You should consider storing any order information (e.g., order number) here.
+ *  For payment methods that require additional user action, your backend will
+ *  need to listen to the `source.chargeable` webhook to create a charge request.
+ *  You can retrieve this metadata from the webhook event, and use it to fulfill
+ *  your customer's order.
+ *  https://stripe.com/docs/sources#best-practices
+ */
+@property(nonatomic, copy, nullable)NSDictionary<NSString *, NSString *>*metadata;
+
+/**
+ *  Some payment methods, like SOFORT, allow setting a custom statement descriptor.
+ *  By default, your Stripe account’s statement descriptor is used (you can review 
+ *  this in the Dashboard at https://dashboard.stripe.com/account).
+ */
+@property(nonatomic, copy, nullable)NSString *statementDescriptor;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Stripe/PublicHeaders/STPPaymentConfiguration.h
+++ b/Stripe/PublicHeaders/STPPaymentConfiguration.h
@@ -158,7 +158,7 @@ typedef NS_ENUM(NSUInteger, STPThreeDSecureSupportType) {
  *  For payment methods that redirect a user to authorize a payment, the SDK
  *  will poll the source for up to this amount of time after the user returns to
  *  the app in order to determine the status of the payment. The default is 10
- *  seconds.
+ *  seconds. Timeouts are capped at 5 minutes.
  */
 @property (nonatomic) NSTimeInterval pollingTimeout;
 

--- a/Stripe/PublicHeaders/STPPaymentConfiguration.h
+++ b/Stripe/PublicHeaders/STPPaymentConfiguration.h
@@ -153,6 +153,15 @@ typedef NS_ENUM(NSUInteger, STPThreeDSecureSupportType) {
  */
 @property (nonatomic, assign) STPThreeDSecureSupportType threeDSecureSupportType NS_EXTENSION_UNAVAILABLE("Redirect based sources are not available in extensions");
 
+
+/**
+ *  For payment methods that redirect a user to authorize a payment, the SDK
+ *  will poll the source for up to this amount of time after the user returns to
+ *  the app in order to determine the status of the payment. The default is 10
+ *  seconds.
+ */
+@property (nonatomic) NSTimeInterval pollingTimeout;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Stripe/PublicHeaders/STPPaymentContext.h
+++ b/Stripe/PublicHeaders/STPPaymentContext.h
@@ -11,6 +11,7 @@
 #import <PassKit/PassKit.h>
 
 #import "STPAddress.h"
+#import "STPAdditionalSourceInfo.h"
 #import "STPBlocks.h"
 #import "STPPaymentConfiguration.h"
 #import "STPPaymentMethod.h"
@@ -69,6 +70,13 @@ NS_ASSUME_NONNULL_BEGIN
  *  If you've already collected some information from your user, you can set it here and it'll be automatically filled out when possible/appropriate in any UI that the payment context creates.
  */
 @property(nonatomic, strong, nullable)STPUserInformation *prefilledInformation;
+
+/**
+ *  If you would like to specify additional information to use when the SDK creates
+ *  sources (e.g. metadata, statement descriptor, or details about a specific
+ *  payment method), you can set it here.
+ */
+@property(nonatomic, strong, nullable)STPAdditionalSourceInfo *sourceInformation;
 
 /**
  *  The view controller that any additional UI will be presented on. If you have a "checkout view controller" in your app, that should be used as the host view controller.

--- a/Stripe/PublicHeaders/STPPaymentContext.h
+++ b/Stripe/PublicHeaders/STPPaymentContext.h
@@ -72,9 +72,10 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, strong, nullable)STPUserInformation *prefilledInformation;
 
 /**
- *  If you would like to specify additional information to use when the SDK creates
- *  sources (e.g. metadata, statement descriptor, or details about a specific
- *  payment method), you can set it here.
+ *  If you would like to specify additional information for PaymentContext to
+ *  attach to sources it creates (e.g. metadata) you can set it here.
+ *  You should consider storing any order information (e.g. order number) as
+ *  metadata here.
  */
 @property(nonatomic, strong, nullable)STPAdditionalSourceInfo *sourceInformation;
 

--- a/Stripe/PublicHeaders/STPPaymentMethodsViewController.h
+++ b/Stripe/PublicHeaders/STPPaymentMethodsViewController.h
@@ -8,6 +8,7 @@
 
 #import <UIKit/UIKit.h>
 
+#import "STPAdditionalSourceInfo.h"
 #import "STPBackendAPIAdapter.h"
 #import "STPCoreViewController.h"
 #import "STPPaymentConfiguration.h"
@@ -53,6 +54,13 @@ NS_ASSUME_NONNULL_BEGIN
 *  If you've already collected some information from your user, you can set it here and it'll be automatically filled out when possible/appropriate in any UI that the payment context creates.
 */
 @property(nonatomic, strong, nullable)STPUserInformation *prefilledInformation;
+
+/**
+ *  You can set this property to specify any additional information you'd
+ *  like to attach when creating a source, e.g. metadata.
+ *  @see STPAdditionalSourceInfo
+ */
+@property(nonatomic, strong, nullable)STPAdditionalSourceInfo *sourceInformation;
 
 /**
  *  If you're pushing `STPPaymentMethodsViewController` onto an existing `UINavigationController`'s stack, you should use this method to dismiss it, since it may have pushed an additional add card view controller onto the navigation controller's stack.

--- a/Stripe/PublicHeaders/STPSourceInfoViewController.h
+++ b/Stripe/PublicHeaders/STPSourceInfoViewController.h
@@ -37,13 +37,15 @@ typedef void (^STPSourceInfoCompletionBlock)(STPSourceParams * _Nullable sourceP
  *  @param amount                 The amount of the source.
  *  @param configuration          The configuration to use. This determines the source's returnURL.
  *  @param prefilledInformation   Use this to provide any information you've already collected from your user.
+ *  @param sourceInformation      Use this to specify any additional information about the source.
  *  @param theme                  The theme to use to inform the view controller's visual appearance. @see STPTheme
  *  @param completion             The completion block called when the user submits the forms or cancels.
  */
 - (nullable instancetype)initWithSourceType:(STPSourceType)type
                                      amount:(NSInteger)amount
                               configuration:(STPPaymentConfiguration *)configuration
-                       prefilledInformation:(STPUserInformation *)prefilledInformation
+                       prefilledInformation:(nullable STPUserInformation *)prefilledInformation
+                          sourceInformation:(nullable STPAdditionalSourceInfo *)sourceInformation
                                       theme:(STPTheme *)theme
                                  completion:(STPSourceInfoCompletionBlock)completion;
 

--- a/Stripe/PublicHeaders/STPUserInformation.h
+++ b/Stripe/PublicHeaders/STPUserInformation.h
@@ -31,8 +31,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, copy, nullable)NSString *phone;
 
 /**
- *  The user's billing address. When set, the add card form will be filled with this address.
- *  The user will also have the option to fill their shipping address using this address.
+ *  The user's billing address. If set, address fields will be prefilled with 
+ *  this information when your customer adds a new source.
  */
 @property(nonatomic, copy, nullable)STPAddress *billingAddress;
 
@@ -41,18 +41,6 @@ NS_ASSUME_NONNULL_BEGIN
  *  https://stripe.com/docs/sources/ideal#optional-specifying-the-customers-bank
  */
 @property(nonatomic, copy, nullable)NSString *idealBank;
-
-/**
- *  Metadata associated with your user. This will be attached to any Source
- *  objects created by `STPPaymentContext`, `STPAddSourceViewController`, etc.
- *  You should consider storing any order information (e.g., order number) here.
- *  For payment methods that require additional user action, your backend will
- *  need to listen to the `source.chargeable` webhook to create a charge request.
- *  You can retrieve this metadata from the webhook event, and use it to fulfill
- *  your customer's order.
- *  https://stripe.com/docs/sources#best-practices
- */
-@property(nonatomic, copy, nullable)NSDictionary<NSString *, NSString *>*metadata;
 
 @end
 

--- a/Stripe/PublicHeaders/Stripe.h
+++ b/Stripe/PublicHeaders/Stripe.h
@@ -10,6 +10,7 @@
 #import "STPAPIClient.h"
 #import "STPAPIResponseDecodable.h"
 #import "STPAddCardViewController.h"
+#import "STPAdditionalSourceInfo.h"
 #import "STPAddSourceViewController.h"
 #import "STPAddress.h"
 #import "STPBackendAPIAdapter.h"

--- a/Stripe/STPAddSourceViewController.m
+++ b/Stripe/STPAddSourceViewController.m
@@ -272,8 +272,8 @@ typedef NS_ENUM(NSUInteger, STPAddSourceSection) {
                                                postalCode:address.postalCode
                                                   country:address.country];
     }
-    if (self.prefilledInformation.metadata) {
-        params.metadata = self.prefilledInformation.metadata;
+    if (self.sourceInformation.metadata) {
+        params.metadata = self.sourceInformation.metadata;
     }
     [self.apiClient createSourceWithParams:params completion:^(STPSource *source, NSError *sourceError) {
         if (sourceError) {

--- a/Stripe/STPAdditionalSourceInfo.m
+++ b/Stripe/STPAdditionalSourceInfo.m
@@ -1,0 +1,20 @@
+//
+//  STPAdditionalSourceInfo.m
+//  Stripe
+//
+//  Created by Ben Guo on 4/11/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import "STPAdditionalSourceInfo.h"
+
+@implementation STPAdditionalSourceInfo
+
+- (id)copyWithZone:(__unused NSZone *)zone {
+    STPAdditionalSourceInfo *copy = [self.class new];
+    copy.metadata = self.metadata;
+    copy.statementDescriptor = self.statementDescriptor;
+    return copy;
+}
+
+@end

--- a/Stripe/STPIDEALSourceInfoDataSource.m
+++ b/Stripe/STPIDEALSourceInfoDataSource.m
@@ -47,7 +47,7 @@
     params.owner = owner;
     NSMutableDictionary *idealDict = [NSMutableDictionary new];
     if (additionalParams[@"ideal"]) {
-        idealDict = additionalParams[@"ideal"];
+        idealDict = [additionalParams[@"ideal"] mutableCopy];
     }
     NSInteger selectedRow = self.selectorDataSource.selectedRow;
     NSString *selectedBank = [self.selectorDataSource selectorValueForRow:selectedRow];

--- a/Stripe/STPPaymentConfiguration.m
+++ b/Stripe/STPPaymentConfiguration.m
@@ -47,6 +47,7 @@
         _shippingType = STPShippingTypeShipping;
         self.returnURLBlock = ^NSURL *() { return  nil; };
         self.threeDSecureSupportTypeBlock = ^STPThreeDSecureSupportType() { return STPThreeDSecureSupportTypeDisabled; };
+        _pollingTimeout = 10;
     }
     return self;
 }
@@ -60,6 +61,10 @@
     copy.shippingType = self.shippingType;
     copy.companyName = self.companyName;
     copy.appleMerchantIdentifier = self.appleMerchantIdentifier;
+    copy.useSourcesForCards = self.useSourcesForCards;
+    copy.returnURLBlock = self.returnURLBlock;
+    copy.threeDSecureSupportTypeBlock = self.threeDSecureSupportTypeBlock;
+    copy.pollingTimeout = self.pollingTimeout;
     return copy;
 }
 
@@ -108,7 +113,7 @@
                 else {
                     [apiClient startPollingSourceWithId:sourceId
                                            clientSecret:sourceClientSecret
-                                                timeout:10 //TODO: Add this timeout as a property on STPConfiguration?
+                                                timeout:self.pollingTimeout
                                              completion:^(STPSource * _Nullable polledSource, NSError * _Nullable pollerError) {
                                                  completion(polledSource, pollerError);
                                              }];

--- a/Stripe/STPPaymentContext.m
+++ b/Stripe/STPPaymentContext.m
@@ -255,7 +255,6 @@
             self.state = state;
             STPPaymentMethodsViewController *paymentMethodsViewController = [[STPPaymentMethodsViewController alloc] initWithPaymentContext:self];
             self.paymentMethodsViewController = paymentMethodsViewController;
-            paymentMethodsViewController.prefilledInformation = self.prefilledInformation;
             UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:paymentMethodsViewController];
             navigationController.navigationBar.stp_theme = self.theme;
             navigationController.modalPresentationStyle = self.modalPresentationStyle;
@@ -281,7 +280,6 @@
 
             STPPaymentMethodsViewController *paymentMethodsViewController = [[STPPaymentMethodsViewController alloc] initWithPaymentContext:self];
             self.paymentMethodsViewController = paymentMethodsViewController;
-            paymentMethodsViewController.prefilledInformation = self.prefilledInformation;
             [navigationController pushViewController:paymentMethodsViewController animated:YES];
         }
     }];
@@ -829,8 +827,8 @@
     STPSourceInfoCompletionBlock completion = ^(STPSourceParams * _Nullable sourceParams) {
         STPVoidBlock vcCompletion = ^() {
             if (sourceParams) {
-                if (self.prefilledInformation.metadata) {
-                    sourceParams.metadata = self.prefilledInformation.metadata;
+                if (self.sourceInformation.metadata) {
+                    sourceParams.metadata = self.sourceInformation.metadata;
                 }
                 [self.apiClient createSourceWithParams:sourceParams completion:^(STPSource * _Nullable source, NSError * _Nullable error) {
                     if (source) {
@@ -864,9 +862,9 @@
                                                                                                  amount:self.paymentAmount
                                                                                           configuration:self.configuration
                                                                                    prefilledInformation:self.prefilledInformation
+                                                                                      sourceInformation:self.sourceInformation
                                                                                                   theme:self.theme
                                                                                              completion:completion];
-
     if (sourceInfoVC) {
         self.state = STPPaymentContextStateRequestingPayment;
 

--- a/Stripe/STPPaymentMethodsInternalViewController.h
+++ b/Stripe/STPPaymentMethodsInternalViewController.h
@@ -26,6 +26,7 @@
 - (instancetype)initWithConfiguration:(STPPaymentConfiguration *)configuration
                                 theme:(STPTheme *)theme
                  prefilledInformation:(STPUserInformation *)prefilledInformation
+                    sourceInformation:(STPAdditionalSourceInfo *)sourceInformation
                       shippingAddress:(STPAddress *)shippingAddress
                    paymentMethodTuple:(STPPaymentMethodTuple *)tuple
                              delegate:(id<STPPaymentMethodsInternalViewControllerDelegate>)delegate;

--- a/Stripe/STPPaymentMethodsInternalViewController.m
+++ b/Stripe/STPPaymentMethodsInternalViewController.m
@@ -29,6 +29,7 @@ static NSInteger STPPaymentMethodNewPaymentsSection = 1;
 
 @property (nonatomic) STPPaymentConfiguration *configuration;
 @property (nonatomic) STPUserInformation *prefilledInformation;
+@property (nonatomic) STPAdditionalSourceInfo *sourceInformation;
 @property (nonatomic) STPAddress *shippingAddress;
 @property (nonatomic) NSArray<id<STPPaymentMethod>> *savedPaymentMethods;
 @property (nonatomic) NSArray<STPPaymentMethodType *> *availablePaymentTypes;
@@ -43,6 +44,7 @@ static NSInteger STPPaymentMethodNewPaymentsSection = 1;
 - (instancetype)initWithConfiguration:(STPPaymentConfiguration *)configuration
                                 theme:(STPTheme *)theme
                  prefilledInformation:(STPUserInformation *)prefilledInformation
+                    sourceInformation:(STPAdditionalSourceInfo *)sourceInformation
                       shippingAddress:(STPAddress *)shippingAddress
                    paymentMethodTuple:(STPPaymentMethodTuple *)tuple
                              delegate:(id<STPPaymentMethodsInternalViewControllerDelegate>)delegate {
@@ -50,6 +52,7 @@ static NSInteger STPPaymentMethodNewPaymentsSection = 1;
     if (self) {
         _configuration = configuration;
         _prefilledInformation = prefilledInformation;
+        _sourceInformation = sourceInformation;
         _shippingAddress = shippingAddress;
         _savedPaymentMethods = tuple.savedPaymentMethods;
         _availablePaymentTypes = tuple.availablePaymentTypes;
@@ -142,6 +145,7 @@ static NSInteger STPPaymentMethodNewPaymentsSection = 1;
             if (addSourceViewController) {
                 addSourceViewController.delegate = self;
                 addSourceViewController.prefilledInformation = self.prefilledInformation;
+                addSourceViewController.sourceInformation = self.sourceInformation;
                 addSourceViewController.shippingAddress = self.shippingAddress;
                 [self.navigationController pushViewController:addSourceViewController
                                                      animated:YES];

--- a/Stripe/STPPaymentMethodsViewController.m
+++ b/Stripe/STPPaymentMethodsViewController.m
@@ -50,12 +50,15 @@
 @implementation STPPaymentMethodsViewController
 
 - (instancetype)initWithPaymentContext:(STPPaymentContext *)paymentContext {
-    return [self initWithConfiguration:paymentContext.configuration
-                            apiAdapter:paymentContext.apiAdapter
-                        loadingPromise:paymentContext.currentValuePromise
-                                 theme:paymentContext.theme
-                       shippingAddress:paymentContext.shippingAddress
-                              delegate:paymentContext];
+    STPPaymentMethodsViewController *instance = [self initWithConfiguration:paymentContext.configuration
+                                                                 apiAdapter:paymentContext.apiAdapter
+                                                             loadingPromise:paymentContext.currentValuePromise
+                                                                      theme:paymentContext.theme
+                                                            shippingAddress:paymentContext.shippingAddress
+                                                                   delegate:paymentContext];
+    instance.prefilledInformation = paymentContext.prefilledInformation;
+    instance.sourceInformation = paymentContext.sourceInformation;
+    return instance;
 }
 
 - (instancetype)initWithConfiguration:(STPPaymentConfiguration *)configuration
@@ -127,6 +130,7 @@
                                                                                                                        theme:self.theme];
                 addSourceViewController.delegate = self;
                 addSourceViewController.prefilledInformation = self.prefilledInformation;
+                addSourceViewController.sourceInformation = self.sourceInformation;
                 addSourceViewController.shippingAddress = self.shippingAddress;
                 internal = addSourceViewController;
             }
@@ -135,6 +139,7 @@
             internal = [[STPPaymentMethodsInternalViewController alloc] initWithConfiguration:self.configuration
                                                                                         theme:self.theme
                                                                          prefilledInformation:self.prefilledInformation
+                                                                            sourceInformation:self.sourceInformation
                                                                               shippingAddress:self.shippingAddress
                                                                            paymentMethodTuple:tuple
                                                                                      delegate:self];

--- a/Stripe/STPSofortSourceInfoDataSource.m
+++ b/Stripe/STPSofortSourceInfoDataSource.m
@@ -48,7 +48,7 @@
     }
     NSMutableDictionary *sofortDict = [NSMutableDictionary new];
     if (additionalParams[@"sofort"]) {
-        sofortDict = additionalParams[@"sofort"];
+        sofortDict = [additionalParams[@"sofort"] mutableCopy];
     }
     NSInteger selectedRow = self.selectorDataSource.selectedRow;
     NSString *selectedCountry = [self.selectorDataSource selectorValueForRow:selectedRow];
@@ -57,7 +57,6 @@
         additionalParams[@"sofort"] = sofortDict;
         params.additionalAPIParameters = additionalParams;
     }
-
     NSString *country = params.additionalAPIParameters[@"sofort"][@"country"];
     if (country.length > 0) {
         return params;

--- a/Stripe/STPSourceParams.m
+++ b/Stripe/STPSourceParams.m
@@ -226,6 +226,7 @@
 
 - (id)copyWithZone:(__unused NSZone *)zone {
     STPSourceParams *copy = [self.class new];
+    copy.additionalAPIParameters = self.additionalAPIParameters;
     copy.type = self.type;
     copy.amount = self.amount;
     copy.currency = self.currency;

--- a/Stripe/STPUserInformation.m
+++ b/Stripe/STPUserInformation.m
@@ -22,7 +22,6 @@
     copy.phone = self.phone;
     copy.billingAddress = self.billingAddress;
     copy.idealBank = self.idealBank;
-    copy.metadata = self.metadata;
     return copy;
 }
 

--- a/Tests/Tests/STPPaymentContextRequestPaymentTest.m
+++ b/Tests/Tests/STPPaymentContextRequestPaymentTest.m
@@ -15,6 +15,7 @@
 #import "STPFormEncoder.h"
 #import "STPMocks.h"
 #import "STPPaymentContext+Private.h"
+#import "STPSourceInfoDataSource.h"
 
 @interface STPPaymentContext (Testing)
 @property(nonatomic)id<STPPaymentMethod> selectedPaymentMethod;
@@ -23,12 +24,16 @@
 @end
 
 @interface STPSourceInfoViewController (Testing)
+@property(nonatomic)STPSourceInfoDataSource *dataSource;
 @property(nonatomic, copy)STPSourceInfoCompletionBlock completion;
 @end
 
 @interface STPPaymentContextRequestPaymentTest : XCTestCase
 
 @end
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
 
 /**
  These tests cover STPPaymentContext's requestPayment method
@@ -116,6 +121,17 @@
     config.returnURL = [NSURL URLWithString:@"test://redirect"];
     STPPaymentContext *sut = [self buildPaymentContextWithCustomer:customer
                                                      configuration:config];
+    sut.paymentAmount = 1099;
+    STPUserInformation *userInfo = [STPUserInformation new];
+    userInfo.idealBank = @"ing";
+    STPAddress *address = [STPAddress new];
+    address.name = @"Jenny Rosen";
+    userInfo.billingAddress = address;
+    sut.prefilledInformation = userInfo;
+    STPAdditionalSourceInfo *sourceInfo = [STPAdditionalSourceInfo new];
+    sourceInfo.metadata = @{@"foo": @"bar"};
+    sourceInfo.statementDescriptor = @"ORDER 123";
+    sut.sourceInformation = sourceInfo;
     id mockVC = [STPMocks hostViewController];
     sut.hostViewController = mockVC;
     id mockAPIClient = OCMClassMock([STPAPIClient class]);
@@ -123,7 +139,8 @@
     sut.selectedPaymentMethod = [STPPaymentMethodType ideal];
     XCTAssertEqual(sut.state, STPPaymentContextStateNone);
 
-    STPSourceParams *expectedParams = [STPSourceParams idealParamsWithAmount:1099 name:@"Jenny Rosen" returnURL:@"test://redirect" statementDescriptor:nil bank:nil];
+    STPSourceParams *expectedParams = [STPSourceParams idealParamsWithAmount:1099 name:@"Jenny Rosen" returnURL:@"test://redirect" statementDescriptor:@"ORDER 123" bank:@"ing"];
+    expectedParams.metadata = @{@"foo": @"bar"};
 
     __block NSInteger call = 0;
     BOOL (^checker)() = ^BOOL(id vc) {
@@ -134,7 +151,11 @@
                 UINavigationController *nc = (UINavigationController *)vc;
                 if ([nc.topViewController isKindOfClass:[STPSourceInfoViewController class]]) {
                     STPSourceInfoViewController *sourceInfoVC = (STPSourceInfoViewController *)nc.topViewController;
-                    sourceInfoVC.completion(expectedParams);
+                    // Because iDEAL always requires the user to verify their
+                    // bank, sourceInfoVC.completeSourceParams will be nil.
+                    // As a workaround, we get completeSourceParams from sourceInfoVC's
+                    // internal data source.
+                    sourceInfoVC.completion(sourceInfoVC.dataSource.completeSourceParams);
                     call++;
                     return YES;
                 };
@@ -170,6 +191,7 @@
 
     [self waitForExpectationsWithTimeout:2 handler:nil];
 }
+
 
 /**
  When selectedPaymentMethod is ApplePay, PKPaymentAuthVC should be presented.
@@ -309,5 +331,7 @@
     [sut requestPayment];
     [self waitForExpectationsWithTimeout:2 handler:nil];
 }
+
+#pragma clang diagnostic pop
 
 @end

--- a/Tests/Tests/STPSourceInfoViewControllerTest.m
+++ b/Tests/Tests/STPSourceInfoViewControllerTest.m
@@ -33,10 +33,14 @@ NSString * const kReturnURLString = @"testscheme://stripe";
     STPPaymentConfiguration *config = [STPFixtures paymentConfiguration];
     config.returnURL = [NSURL URLWithString:kReturnURLString];
     NSInteger amount = 100;
+    STPAdditionalSourceInfo *sourceInfo = [STPAdditionalSourceInfo new];
+    sourceInfo.metadata = @{@"foo": @"bar"};
+    sourceInfo.statementDescriptor = @"ORDER 123";
     STPSourceInfoViewController *sut = [[STPSourceInfoViewController alloc] initWithSourceType:type
                                                                                         amount:amount
                                                                                  configuration:config
                                                                           prefilledInformation:info
+                                                                             sourceInformation:sourceInfo
                                                                                          theme:theme
                                                                                     completion:completion];
     UINavigationController *navController = [UINavigationController new];
@@ -78,6 +82,7 @@ NSString * const kReturnURLString = @"testscheme://stripe";
     XCTAssertNotNil(sut.completeSourceParams);
     XCTAssertEqualObjects(sut.completeSourceParams.owner[@"name"], nameCell.contents);
     XCTAssertEqualObjects(sut.completeSourceParams.redirect[@"return_url"], kReturnURLString);
+    XCTAssertEqualObjects(sut.completeSourceParams.additionalAPIParameters[@"bancontact"][@"statement_descriptor"], @"ORDER 123");
 }
 
 - (void)testInitWithSourceParams_giropay {
@@ -104,6 +109,7 @@ NSString * const kReturnURLString = @"testscheme://stripe";
     XCTAssertNotNil(sut.completeSourceParams);
     XCTAssertEqualObjects(sut.completeSourceParams.owner[@"name"], nameCell.contents);
     XCTAssertEqualObjects(sut.completeSourceParams.redirect[@"return_url"], kReturnURLString);
+    XCTAssertEqualObjects(sut.completeSourceParams.additionalAPIParameters[@"giropay"][@"statement_descriptor"], @"ORDER 123");
 }
 
 #pragma clang diagnostic push
@@ -125,7 +131,9 @@ NSString * const kReturnURLString = @"testscheme://stripe";
                                                   XCTAssertNotNil(sourceParams);
                                                   XCTAssertEqualObjects(sourceParams.owner[@"name"], expectedName);
                                                   NSDictionary *idealDict = sourceParams.additionalAPIParameters[@"ideal"];
-                                                  XCTAssertEqualObjects(idealDict, @{@"bank": expectedBank});
+                                                  NSDictionary *expectedDict = @{@"bank": expectedBank,
+                                                                                 @"statement_descriptor": @"ORDER 123"};
+                                                  XCTAssertEqualObjects(idealDict, expectedDict);
                                                   XCTAssertEqualObjects(sourceParams.redirect[@"return_url"], kReturnURLString);
                                                   [exp fulfill];
                                               }];
@@ -180,7 +188,9 @@ NSString * const kReturnURLString = @"testscheme://stripe";
     [selectorDataSource selectRowWithValue:@"AT"];
     XCTAssertNotNil(sut.completeSourceParams);
     NSDictionary *sofortDict = sut.completeSourceParams.additionalAPIParameters[@"sofort"];
-    XCTAssertEqualObjects(sofortDict, @{@"country": @"AT"});
+    NSDictionary *expectedDict = @{@"country": @"AT",
+                                   @"statement_descriptor": @"ORDER 123"};
+    XCTAssertEqualObjects(sofortDict, expectedDict);
     XCTAssertEqualObjects(sut.completeSourceParams.redirect[@"return_url"], kReturnURLString);
 
     // Test initializing with a non-Sofort country


### PR DESCRIPTION
r? @bdorfman-stripe 

- moves `metadata` to from UserInformation to AdditionalSourceInfo
- adds `pollingTimeout` to PaymentConfiguration
- updates the iDEAL `requestPayment` test to verify UserInfo / AdditionalSourceInfo get used correctly