### PR TITLE
isValid -> KVO observable

### DIFF
--- a/Stripe/STPPaymentCardTextField.m
+++ b/Stripe/STPPaymentCardTextField.m
@@ -48,7 +48,7 @@
 @synthesize borderColor = _borderColor;
 @synthesize borderWidth = _borderWidth;
 @synthesize cornerRadius = _cornerRadius;
-@dynamic enabled, isValid, valid;
+@dynamic enabled;
 
 CGFloat const STPPaymentCardTextFieldDefaultPadding = 13;
 

--- a/Stripe/STPPaymentCardTextField.m
+++ b/Stripe/STPPaymentCardTextField.m
@@ -48,7 +48,7 @@
 @synthesize borderColor = _borderColor;
 @synthesize borderWidth = _borderWidth;
 @synthesize cornerRadius = _cornerRadius;
-@dynamic enabled;
+@dynamic enabled, isValid, valid;
 
 CGFloat const STPPaymentCardTextFieldDefaultPadding = 13;
 
@@ -811,6 +811,14 @@ typedef void (^STPNumberShrunkCompletionBlock)(BOOL completed);
 
 - (void)deleteBackward {
     [self.currentFirstResponderField deleteBackward];
+}
+
++ (NSSet<NSString *> *)keyPathsForValuesAffectingIsValid {
+    return [NSSet setWithArray:@[
+                                 [NSString stringWithFormat:@"%@.%@",
+                                  NSStringFromSelector(@selector(viewModel)),
+                                  NSStringFromSelector(@selector(valid))]
+                                 ]];
 }
 
 @end

--- a/Stripe/STPPaymentCardTextFieldViewModel.h
+++ b/Stripe/STPPaymentCardTextFieldViewModel.h
@@ -26,11 +26,10 @@ typedef NS_ENUM(NSInteger, STPCardFieldType) {
 @property(nonatomic, readonly, nullable)NSString *expirationYear;
 @property(nonatomic, readwrite, copy, nullable)NSString *cvc;
 @property(nonatomic, readonly) STPCardBrand brand;
+@property(nonatomic, getter=isValid, readonly) BOOL valid;
 
 - (nonnull NSString *)defaultPlaceholder;
 - (nullable NSString *)numberWithoutLastDigits;
-
-- (BOOL)isValid;
 
 - (STPCardValidationState)validationStateForField:(STPCardFieldType)fieldType;
 

--- a/Stripe/STPPaymentCardTextFieldViewModel.m
+++ b/Stripe/STPPaymentCardTextFieldViewModel.m
@@ -12,6 +12,7 @@
 #define FAUXPAS_IGNORED_IN_METHOD(...)
 
 @implementation STPPaymentCardTextFieldViewModel
+@dynamic valid;
 
 - (void)setCardNumber:(NSString *)cardNumber {
     NSString *sanitizedNumber = [STPCardValidator sanitizedNumericStringForString:cardNumber];
@@ -100,6 +101,16 @@
         [self.cardNumber substringToIndex:toIndex] :
         [self.defaultPlaceholder stp_safeSubstringToIndex:[self defaultPlaceholder].length - length];
 
+}
+
++ (NSSet<NSString *> *)keyPathsForValuesAffectingValid {
+    return [NSSet setWithArray:@[
+                                 NSStringFromSelector(@selector(cardNumber)),
+                                 NSStringFromSelector(@selector(expirationMonth)),
+                                 NSStringFromSelector(@selector(expirationYear)),
+                                 NSStringFromSelector(@selector(cvc)),
+                                 NSStringFromSelector(@selector(brand))
+                                 ]];
 }
 
 @end

--- a/Stripe/STPPaymentCardTextFieldViewModel.m
+++ b/Stripe/STPPaymentCardTextFieldViewModel.m
@@ -12,7 +12,6 @@
 #define FAUXPAS_IGNORED_IN_METHOD(...)
 
 @implementation STPPaymentCardTextFieldViewModel
-@dynamic valid;
 
 - (void)setCardNumber:(NSString *)cardNumber {
     NSString *sanitizedNumber = [STPCardValidator sanitizedNumericStringForString:cardNumber];


### PR DESCRIPTION
## Summary

Enabled STPPaymentCardTextField and STPPaymentCardTextFieldViewModel isValid properties to be KVO observable.

## Motivation

Before this PR if the user wanted to know when the isValid property changed the only way was to assign a delegate to STPPaymentCardTextField, implement the did change method and check isValid. In some situations KVO observing is faster and leads to better code than delegation.

## Testing

I just tested it by running (Xcode 8.3.1, iOS 10.3 Simulator) and it's working. 