### PR TITLE
Add travis_retry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,9 @@ script:
 - "./ci_scripts/check_public_headers.rb"
 - "./ci_scripts/check_resource_bundle.rb"
 - '[ "$TEST_TYPE" != lint ] || ./ci_scripts/check_fauxpas.sh'
-- '[ "$TEST_TYPE" != tests ] || ./ci_scripts/run_tests.sh'
+- '[ "$TEST_TYPE" != tests ] || travis_retry ./ci_scripts/run_tests.sh'
 - '[ "$TEST_TYPE" != analyzer ] || ./ci_scripts/run_analyzer.sh'
 - '[ "$TEST_TYPE" != installation_cocoapods ] || ./Tests/installation_tests/cocoapods/without_frameworks/test.sh'
 - '[ "$TEST_TYPE" != installation_cocoapods_frameworks ] || ./Tests/installation_tests/cocoapods/with_frameworks/test.sh'
-- '[ "$TEST_TYPE" != installation_manual ] || ./Tests/installation_tests/manual_installation/test.sh'
+- '[ "$TEST_TYPE" != installation_manual ] || travis_retry ./Tests/installation_tests/manual_installation/test.sh'
 - '[ "$TEST_TYPE" != installation_carthage ] || ./Tests/installation_tests/carthage/test.sh'

--- a/Tests/installation_tests/manual_installation/test.sh
+++ b/Tests/installation_tests/manual_installation/test.sh
@@ -22,4 +22,5 @@ mkdir $FRAMEWORKDIR
 cp $BUILDDIR/StripeiOS-Static.zip $FRAMEWORKDIR
 ditto -xk $FRAMEWORKDIR/StripeiOS-Static.zip $FRAMEWORKDIR
 
-xcodebuild test -project "${TESTDIR}/ManualInstallationTest.xcodeproj" -scheme ManualInstallationTest -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.1' | xcpretty -c
+xcodebuild clean build-for-testing -project "${TESTDIR}/ManualInstallationTest.xcodeproj" -scheme ManualInstallationTest -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.1' | xcpretty -c
+xcodebuild test-without-building -project "${TESTDIR}/ManualInstallationTest.xcodeproj" -scheme ManualInstallationTest -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.1' | xcpretty -c

--- a/ci_scripts/run_tests.sh
+++ b/ci_scripts/run_tests.sh
@@ -3,6 +3,7 @@ set -euf -o pipefail
 carthage bootstrap --platform ios --configuration Release --no-use-binaries
 
 gem install xcpretty --no-ri --no-rdoc
-xcodebuild test -workspace Stripe.xcworkspace -scheme "StripeiOS" -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.1' | xcpretty -c
+xcodebuild clean build build-for-testing -workspace Stripe.xcworkspace -scheme "StripeiOS" -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.1' | xcpretty -c
+xcodebuild test-without-building -workspace Stripe.xcworkspace -scheme "StripeiOS" -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.1' | xcpretty -c
 xcodebuild build -workspace Stripe.xcworkspace -scheme "Stripe iOS Example (Simple)" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.1'  | xcpretty -c
 xcodebuild build -workspace Stripe.xcworkspace -scheme "Stripe iOS Example (Custom)" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.1' | xcpretty -c


### PR DESCRIPTION
r? @bdorfman-stripe 

There's some discussion of people running into the same simulator warmup / XCTest timeout issue on Travis here: https://github.com/travis-ci/travis-ci/issues/6422

I think we can start with adding `travis_retry` before the flaking tests. If flakiness continues, we can try separating the build and test commands: http://stackoverflow.com/questions/37922146/xctests-failing-on-physical-device-canceling-tests-due-to-timeout/40790171#40790171
