### PR TITLE
Fix shipping methods state bug

### DIFF
--- a/Stripe/STPPaymentContext.m
+++ b/Stripe/STPPaymentContext.m
@@ -426,6 +426,8 @@ typedef NS_ENUM(NSUInteger, STPPaymentContextState) {
         if (self.state == STPPaymentContextStateRequestingPayment) {
             self.state = STPPaymentContextStateNone;
             [self requestPayment];
+        } else {
+            self.state = STPPaymentContextStateNone;
         }
     }];
 }


### PR DESCRIPTION
r? @bdorfman-stripe 

To reproduce:
- Tap the shipping row
- Enter a shipping address / method
- PaymentContext's state hasn't been reset, so you get stuck