### PR TITLE
Update check header script

### DIFF
--- a/ci_scripts/check_public_headers.rb
+++ b/ci_scripts/check_public_headers.rb
@@ -18,6 +18,12 @@ end.compact.map do |match|
 end + ["Stripe.h"]).sort
 contents_of_public_headers_dir = Dir.glob("Stripe/PublicHeaders/*.h").map { |h| File.basename(h) }.sort
 
+duplicate_dot_h_imports = contents_of_stripe_dot_h.select{ |e| contents_of_stripe_dot_h.count(e) > 1 }.uniq
+
+if !duplicate_dot_h_imports.empty?
+  abort("There are duplicate imports in Stripe.h. Likely culprits: #{duplicate_dot_h_imports}.")
+end
+
 if contents_of_public_headers_dir != contents_of_stripe_dot_h
 	likely_culprits = ([contents_of_stripe_dot_h - contents_of_public_headers_dir] + [contents_of_public_headers_dir - contents_of_stripe_dot_h]).uniq
 	abort("The contents of Stripe/PublicHeaders do not match what is #imported in Stripe/PublicHeaders/Stripe.h. Likely culprits: #{likely_culprits}.")


### PR DESCRIPTION
Now warns if the same file is imported multiple times in Stripe.h

Previously this would cause the script to fail, but would return no objects in "likely culprits" because it was uniqued. Now you get a sensible error message.

r? @bg-stripe 