### PR TITLE
[sources-ui] remove address fields from SEPA form

### DIFF
--- a/Stripe/PublicHeaders/STPAddress.h
+++ b/Stripe/PublicHeaders/STPAddress.h
@@ -108,7 +108,6 @@ typedef NS_ENUM(NSUInteger, STPBillingAddressFields) {
 
 - (BOOL)containsRequiredFields:(STPBillingAddressFields)requiredFields;
 - (BOOL)containsRequiredShippingAddressFields:(PKAddressField)requiredFields;
-- (BOOL)containsRequiredSEPADebitFields;
 
 + (PKAddressField)applePayAddressFieldsFromBillingAddressFields:(STPBillingAddressFields)billingAddressFields;
 

--- a/Stripe/STPAddress.m
+++ b/Stripe/STPAddress.m
@@ -272,13 +272,6 @@ NSString *stringIfHasContentsElseNil(NSString *string);
     return containsFields;
 }
 
-- (BOOL)containsRequiredSEPADebitFields {
-    return (self.city.length > 0
-            && self.country.length > 0
-            && [STPPostalCodeValidator stringIsValidSEPAPostalCode:self.postalCode
-                                                       countryCode:self.country]);
-}
-
 - (BOOL)hasValidPostalAddress {
     return (self.line1.length > 0 
             && self.city.length > 0 

--- a/Stripe/STPAddressViewModel.h
+++ b/Stripe/STPAddressViewModel.h
@@ -30,7 +30,6 @@
 
 - (instancetype)initWithRequiredBillingFields:(STPBillingAddressFields)requiredBillingAddressFields;
 - (instancetype)initWithRequiredShippingFields:(PKAddressField)requiredShippingAddressFields;
-- (instancetype)initWithSEPADebitFields;
 - (STPAddressFieldTableViewCell *)cellAtIndex:(NSInteger)index;
 
 @end

--- a/Stripe/STPAddressViewModel.m
+++ b/Stripe/STPAddressViewModel.m
@@ -13,7 +13,6 @@
 typedef NS_ENUM(NSUInteger, STPAddressType) {
     STPAddressTypeBilling,
     STPAddressTypeShipping,
-    STPAddressTypeSEPADebit,
 };
 
 @interface STPAddressViewModel()<STPAddressFieldTableViewCellDelegate>
@@ -99,20 +98,6 @@ typedef NS_ENUM(NSUInteger, STPAddressType) {
     return self;
 }
 
-- (instancetype)initWithSEPADebitFields {
-    self = [super init];
-    if (self) {
-        _addressType = STPAddressTypeSEPADebit;
-        _addressCells = @[
-                          [[STPAddressFieldTableViewCell alloc] initWithType:STPAddressFieldTypeCity contents:@"" lastInList:NO delegate:self],
-                          // Postal code cell will be added later if necessary
-                          [[STPAddressFieldTableViewCell alloc] initWithType:STPAddressFieldTypeSEPACountry contents:_addressFieldTableViewCountryCode lastInList:YES delegate:self],
-                          ];
-        [self commonInit];
-    }
-    return self;
-}
-
 - (void)commonInit {
     _addressFieldTableViewCountryCode = [[NSLocale autoupdatingCurrentLocale] objectForKey:NSLocaleCountryCode];
     [self updatePostalCodeFieldIfNecessary];
@@ -123,9 +108,6 @@ typedef NS_ENUM(NSUInteger, STPAddressType) {
         return;
     }
     STPPostalCodeType postalCodeType = [STPPostalCodeValidator postalCodeTypeForCountryCode:_addressFieldTableViewCountryCode];
-    if (self.addressType == STPAddressTypeSEPADebit) {
-        postalCodeType = [STPPostalCodeValidator postalCodeTypeForSEPACountryCode:_addressFieldTableViewCountryCode];
-    }
     BOOL shouldBeShowingPostalCode = (postalCodeType != STPCountryPostalCodeTypeNotRequired);
     // Add postal code field
     if (shouldBeShowingPostalCode && !self.showingPostalCodeCell) {
@@ -183,8 +165,6 @@ typedef NS_ENUM(NSUInteger, STPAddressType) {
             }
         case STPAddressTypeShipping:
             return @(STPAddressFieldTypeState);
-        case STPAddressTypeSEPADebit:
-            return @(STPAddressFieldTypeCity);
     }
 }
 
@@ -195,8 +175,6 @@ typedef NS_ENUM(NSUInteger, STPAddressType) {
                     (self.requiredBillingAddressFields == STPBillingAddressFieldsZip));
         case STPAddressTypeShipping:
             return ((self.requiredShippingAddressFields & PKAddressFieldPostalAddress) == PKAddressFieldPostalAddress);
-        case STPAddressTypeSEPADebit:
-            return YES;
     }
 }
 
@@ -226,8 +204,6 @@ typedef NS_ENUM(NSUInteger, STPAddressType) {
             return [self.address containsRequiredFields:self.requiredBillingAddressFields];
         case STPAddressTypeShipping:
             return [self.address containsRequiredShippingAddressFields:self.requiredShippingAddressFields];
-        case STPAddressTypeSEPADebit:
-            return [self.address containsRequiredSEPADebitFields];
         default:
             return YES;
     }

--- a/Stripe/STPPostalCodeValidator.h
+++ b/Stripe/STPPostalCodeValidator.h
@@ -22,10 +22,4 @@ typedef NS_ENUM(NSInteger, STPPostalCodeType) {
                     countryCode:(nullable NSString *)countryCode;
 + (STPPostalCodeType)postalCodeTypeForCountryCode:(nullable NSString *)countryCode;
 
-/// We use a separate validation path for SEPA postal codes, where Ireland
-/// is the only country that doesn't require a postal code.
-+ (BOOL)stringIsValidSEPAPostalCode:(nullable NSString *)string
-                        countryCode:(nullable NSString *)countryCode;
-+ (STPPostalCodeType)postalCodeTypeForSEPACountryCode:(nullable NSString *)countryCode;
-
 @end

--- a/Stripe/STPPostalCodeValidator.m
+++ b/Stripe/STPPostalCodeValidator.m
@@ -30,12 +30,6 @@
                                     type:[self postalCodeTypeForCountryCode:countryCode]];
 }
 
-+ (BOOL)stringIsValidSEPAPostalCode:(nullable NSString *)string
-                        countryCode:(nullable NSString *)countryCode {
-    return [self stringIsValidPostalCode:string
-                                    type:[self postalCodeTypeForSEPACountryCode:countryCode]];
-}
-
 + (STPPostalCodeType)postalCodeTypeForCountryCode:(NSString *)countryCode {
     if ([countryCode isEqualToString:@"US"]) {
         return STPCountryPostalCodeTypeNumericOnly;
@@ -46,15 +40,6 @@
     else {
         return STPCountryPostalCodeTypeAlphanumeric;
     }
-}
-
-+ (STPPostalCodeType)postalCodeTypeForSEPACountryCode:(nullable NSString *)countryCode {
-    STPPostalCodeType type = STPCountryPostalCodeTypeAlphanumeric;
-    NSArray *sepaCountriesWithNoPostalCodes = @[@"IE"];
-    if ([sepaCountriesWithNoPostalCodes containsObject:countryCode]) {
-        type = STPCountryPostalCodeTypeNotRequired;
-    }
-    return type;
 }
 
 + (NSArray *)countriesWithNoPostalCodes {

--- a/Tests/Tests/STPAddSourceViewControllerTest.m
+++ b/Tests/Tests/STPAddSourceViewControllerTest.m
@@ -56,7 +56,6 @@
 
 - (STPUserInformation *)buildUserInfoForSEPATests {
     STPUserInformation *info = [STPUserInformation new];
-    info.billingAddress = [STPFixtures sepaAddress];
     return info;
 }
 
@@ -85,12 +84,6 @@
             [sourceParams.owner[@"address"][@"line2"] isEqualToString:address.line2] &&
             [sourceParams.owner[@"address"][@"city"] isEqualToString:address.city] &&
             [sourceParams.owner[@"address"][@"state"] isEqualToString:address.state] &&
-            [sourceParams.owner[@"address"][@"country"] isEqualToString:address.country] &&
-            [sourceParams.owner[@"address"][@"postal_code"] isEqualToString:address.postalCode]);
-}
-
-- (BOOL)sourceParams:(STPSourceParams *)sourceParams matchSEPAAddress:(STPAddress *)address {
-    return ([sourceParams.owner[@"address"][@"city"] isEqualToString:address.city] &&
             [sourceParams.owner[@"address"][@"country"] isEqualToString:address.country] &&
             [sourceParams.owner[@"address"][@"postal_code"] isEqualToString:address.postalCode]);
 }
@@ -266,7 +259,6 @@
         [invocation getArgument:&completion atIndex:3];
         XCTAssertEqualObjects(sourceParams.additionalAPIParameters[@"sepa_debit"][@"iban"], sut.ibanCell.contents);
         XCTAssertEqualObjects(sourceParams.owner[@"name"], sut.nameCell.contents);
-        XCTAssertTrue([self sourceParams:sourceParams matchSEPAAddress:userInfo.billingAddress]);
         XCTAssertEqualObjects(sourceParams.metadata, sourceInfo.metadata);
         XCTAssertTrue(sut.loading);
         NSError *error = [NSError stp_genericFailedToParseResponseError];
@@ -307,7 +299,6 @@
         [invocation getArgument:&completion atIndex:3];
         XCTAssertEqualObjects(sourceParams.additionalAPIParameters[@"sepa_debit"][@"iban"], sut.ibanCell.contents);
         XCTAssertEqualObjects(sourceParams.owner[@"name"], sut.nameCell.contents);
-        XCTAssertTrue([self sourceParams:sourceParams matchSEPAAddress:userInfo.billingAddress]);
         XCTAssertEqualObjects(sourceParams.metadata, sourceInfo.metadata);
         XCTAssertTrue(sut.loading);
         completion(expectedSource, nil);
@@ -361,7 +352,6 @@
         [invocation getArgument:&completion atIndex:3];
         XCTAssertEqualObjects(sourceParams.additionalAPIParameters[@"sepa_debit"][@"iban"], sut.ibanCell.contents);
         XCTAssertEqualObjects(sourceParams.owner[@"name"], sut.nameCell.contents);
-        XCTAssertTrue([self sourceParams:sourceParams matchSEPAAddress:userInfo.billingAddress]);
         XCTAssertEqualObjects(sourceParams.metadata, sourceInfo.metadata);
         XCTAssertTrue(sut.loading);
         completion(expectedSource, nil);
@@ -387,19 +377,6 @@
     [nextButton.target performSelector:nextButton.action withObject:nextButton];
 
     [self waitForExpectationsWithTimeout:2 handler:nil];
-}
-
-- (void)testSettingIBANUpdatesCountry {
-    STPUserInformation *userInfo = [STPUserInformation new];
-    STPAddress *address = [STPAddress new];
-    address.country = @"DE";
-    userInfo.billingAddress = address;
-    STPAddSourceViewController *sut = [self buildAddSourceViewControllerWithType:STPSourceTypeSEPADebit];
-    sut.prefilledInformation = userInfo;
-    XCTAssertNotNil(sut.view);
-    XCTAssertEqualObjects(sut.addressViewModel.address.country, @"DE");
-    sut.ibanCell.contents = @"GB82WEST12345698765432";
-    XCTAssertEqualObjects(sut.addressViewModel.address.country, @"GB");
 }
 
 #pragma clang diagnostic pop

--- a/Tests/Tests/STPAddressViewModelTest.m
+++ b/Tests/Tests/STPAddressViewModelTest.m
@@ -84,22 +84,6 @@
     }
 }
 
-- (void)testInitWithSEPADebitFields {
-    STPAddressViewModel *sut = [[STPAddressViewModel alloc] initWithSEPADebitFields];
-    XCTAssertTrue([sut.addressCells count] == 3);
-    NSArray *types = @[
-                       @(STPAddressFieldTypeCity),
-                       @(STPAddressFieldTypeZip),
-                       @(STPAddressFieldTypeSEPACountry),
-                       ];
-    NSUInteger count = sut.addressCells.count;
-    for (NSUInteger i = 0; i < count; i++) {
-        STPAddressFieldTableViewCell *cell = sut.addressCells[i];
-        XCTAssertEqual(cell.type, [types[i] integerValue]);
-        XCTAssertEqual(cell.lastInList, (i == count - 1));
-    }
-}
-
 - (void)testGetAddress {
     STPAddressViewModel *sut = [[STPAddressViewModel alloc] initWithRequiredShippingFields:(PKAddressField)(PKAddressFieldPostalAddress|PKAddressFieldEmail|PKAddressFieldPhone)];
     sut.addressCells[0].contents = @"foo@example.com";

--- a/Tests/Tests/STPFixtures.h
+++ b/Tests/Tests/STPFixtures.h
@@ -83,9 +83,4 @@
  */
 + (STPSource *)sepaDebitSource;
 
-/**
- An Address object for creating a SEPA source.
- */
-+ (STPAddress *)sepaAddress;
-
 @end

--- a/Tests/Tests/STPFixtures.m
+++ b/Tests/Tests/STPFixtures.m
@@ -128,15 +128,6 @@
     return paymentContext;
 }
 
-+ (STPAddress *)sepaAddress {
-    STPAddress *address = [STPAddress new];
-    address.line1 = @"Nollendorfstraße 27";
-    address.city = @"Berlin";
-    address.postalCode = @"10777";
-    address.country = @"DE";
-    return address;
-}
-
 + (STPSource *)sepaDebitSource {
     return [STPSource decodedObjectFromAPIResponse:[STPTestUtils jsonNamed:@"SEPADebitSource"]];
 }

--- a/Tests/Tests/STPPostalCodeValidatorTest.m
+++ b/Tests/Tests/STPPostalCodeValidatorTest.m
@@ -61,10 +61,4 @@
     }   
 }
 
-- (void)testStringIsValidSEPAPostalCode {
-    XCTAssertTrue([STPPostalCodeValidator stringIsValidSEPAPostalCode:nil countryCode:@"IE"]);
-    XCTAssertFalse([STPPostalCodeValidator stringIsValidSEPAPostalCode:@"" countryCode:@"DE"]);
-    XCTAssertTrue([STPPostalCodeValidator stringIsValidSEPAPostalCode:@"100077" countryCode:@"DE"]);
-}
-
 @end


### PR DESCRIPTION
r? @bdorfman-stripe 

Since address params are now optional, we can remove the address fields from the SEPA form.

<img src="https://cloud.githubusercontent.com/assets/23086960/25922686/19aee0a4-35a8-11e7-9cb4-6b10f0573d46.png" width="400px">
