### PR TITLE
Failing test case for #674

### DIFF
--- a/Tests/Tests/STPCustomerDeserializerTest.m
+++ b/Tests/Tests/STPCustomerDeserializerTest.m
@@ -26,6 +26,14 @@
     XCTAssertEqualObjects(sut.error, error);
 }
 
+- (void)testInitWithData_nil {
+    STPCustomerDeserializer *sut = [[STPCustomerDeserializer alloc] initWithData:nil
+                                                                     urlResponse:nil
+                                                                           error:nil];
+    XCTAssertNil(sut.customer);
+    XCTAssertNotNil(sut.error);
+}
+
 - (void)testInitWithData_invalidData {
     STPCustomerDeserializer *sut = [[STPCustomerDeserializer alloc] initWithData:[NSData new]
                                                                      urlResponse:nil


### PR DESCRIPTION
This adds a test case for `STPCustomerDeserializer` that demonstrates the unhandled `NSInvalidArgumentException` described in #674.