### PR TITLE
Fix STPCustomerDeserializer exception

### DIFF
--- a/Stripe/STPCustomer.m
+++ b/Stripe/STPCustomer.m
@@ -49,6 +49,11 @@
     if (error) {
         return [self initWithError:error];
     }
+
+    if (data == nil) {
+        return [self initWithError:[NSError stp_genericFailedToParseResponseError]];
+    }
+
     NSError *jsonError;
     id json = [NSJSONSerialization JSONObjectWithData:data options:(NSJSONReadingOptions)kNilOptions error:&jsonError];
     if (!json) {

--- a/Tests/Tests/STPCustomerDeserializerTest.m
+++ b/Tests/Tests/STPCustomerDeserializerTest.m
@@ -26,6 +26,14 @@
     XCTAssertEqualObjects(sut.error, error);
 }
 
+- (void)testInitWithData_nil {
+    STPCustomerDeserializer *sut = [[STPCustomerDeserializer alloc] initWithData:nil
+                                                                     urlResponse:nil
+                                                                           error:nil];
+    XCTAssertNil(sut.customer);
+    XCTAssertNotNil(sut.error);
+}
+
 - (void)testInitWithData_invalidData {
     STPCustomerDeserializer *sut = [[STPCustomerDeserializer alloc] initWithData:[NSData new]
                                                                      urlResponse:nil


### PR DESCRIPTION
Fixes an exception thrown in STPCustomerDeserializer when passing in nil data with nil error, and adds a test for this case.