### PR TITLE
Fix payment method cell flicker

### DIFF
--- a/Stripe/STPPaymentMethodTableViewCell.h
+++ b/Stripe/STPPaymentMethodTableViewCell.h
@@ -12,7 +12,7 @@
 
 @interface STPPaymentMethodTableViewCell : UITableViewCell
 
-- (void)configureWithPaymentMethod:(id<STPPaymentMethod>)paymentMethod theme:(STPTheme *)theme;
+- (void)configureWithPaymentMethod:(id<STPPaymentMethod>)paymentMethod selected:(BOOL)selected theme:(STPTheme *)theme;
 - (void)configureForNewCardRowWithTheme:(STPTheme *)theme;
 
 @end

--- a/Stripe/STPPaymentMethodTableViewCell.m
+++ b/Stripe/STPPaymentMethodTableViewCell.m
@@ -66,7 +66,9 @@
     [self setNeedsLayout];
 }
 
-- (void)configureWithPaymentMethod:(id<STPPaymentMethod>)paymentMethod theme:(STPTheme *)theme {
+- (void)configureWithPaymentMethod:(id<STPPaymentMethod>)paymentMethod
+                          selected:(BOOL)selected
+                             theme:(STPTheme *)theme {
     _paymentMethod = paymentMethod;
     _theme = theme;
     self.backgroundColor = [UIColor clearColor];
@@ -75,15 +77,9 @@
     self.titleLabel.font = self.theme.font;
     self.checkmarkIcon.tintColor = self.theme.accentColor;
     self.selected = NO;
-}
-
-- (void)setSelected:(BOOL)selected {
-    [super setSelected:selected];
-    if (self.paymentMethod != nil) {
-        self.checkmarkIcon.hidden = !self.selected;
-        self.leftIcon.tintColor = [self primaryColorForPaymentMethodWithSelectedState:self.selected];
-        self.titleLabel.attributedText = [self buildAttributedStringForPaymentMethod:self.paymentMethod selected:self.selected];
-    }
+    self.checkmarkIcon.hidden = !selected;
+    self.leftIcon.tintColor = [self primaryColorForPaymentMethodWithSelectedState:selected];
+    self.titleLabel.attributedText = [self buildAttributedStringForPaymentMethod:self.paymentMethod selected:selected];
 }
 
 - (UIColor *)primaryColorForPaymentMethodWithSelectedState:(BOOL)isSelected {

--- a/Stripe/STPPaymentMethodsInternalViewController.m
+++ b/Stripe/STPPaymentMethodsInternalViewController.m
@@ -97,8 +97,9 @@ static NSInteger STPPaymentMethodAddCardSection = 1;
     STPPaymentMethodTableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:STPPaymentMethodCellReuseIdentifier forIndexPath:indexPath];
     if (indexPath.section == STPPaymentMethodCardListSection) {
         id<STPPaymentMethod> paymentMethod = [self.paymentMethods stp_boundSafeObjectAtIndex:indexPath.row];
-        [cell configureWithPaymentMethod:paymentMethod theme:self.theme];
-        cell.selected = [paymentMethod isEqual:self.selectedPaymentMethod];
+        [cell configureWithPaymentMethod:paymentMethod
+                                selected:[paymentMethod isEqual:self.selectedPaymentMethod]
+                                   theme:self.theme];
     } else {
         [cell configureForNewCardRowWithTheme:self.theme];
     }


### PR DESCRIPTION
r? @bdorfman-stripe 

The selected payment method cell currently flickers with its highlight color. It's subtle when using the example app's default theming, which I think is why we didn't notice it earlier.

Not using `UITableViewCell`'s `selected` behavior fixes the issue, and seems like a reasonable workaround.

Before:
https://www.dropbox.com/s/18pvcvhtdw1rpur/flicker-before.mov?dl=0

After:
https://www.dropbox.com/s/r6m1mr1u9f7y708/flicker-after.mov?dl=0
