### PR TITLE
Make didSelectPaymentMethod delegate method optional

### DIFF
--- a/Stripe/PublicHeaders/STPPaymentMethodsViewController.h
+++ b/Stripe/PublicHeaders/STPPaymentMethodsViewController.h
@@ -69,16 +69,6 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol STPPaymentMethodsViewControllerDelegate <NSObject>
 
 /**
- *  This is called when the user either makes a selection, or adds a new card. This will be triggered after the view controller loads with the user's current selection (if they have one) and then subsequently when they change their choice. You should use this callback to update any necessary UI in your app that displays the user's currently selected payment method. You should *not* dismiss the view controller at this point, instead do this in `paymentMethodsViewControllerDidFinish:`. `STPPaymentMethodsViewController` will also call the necessary methods on your API adapter, so you don't need to call them directly during this method.
- *
- *  @param paymentMethodsViewController the view controller in question
- *  @param paymentMethod                the selected payment method
- */
-- (void)paymentMethodsViewController:(STPPaymentMethodsViewController *)paymentMethodsViewController
-              didSelectPaymentMethod:(id<STPPaymentMethod>)paymentMethod;
-
-
-/**
  *  This is called when the view controller encounters an error fetching the user's payment methods from its API adapter. You should dismiss the view controller when this is called.
  *
  *  @param paymentMethodsViewController the view controller in question
@@ -101,6 +91,16 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param paymentMethodsViewController the view controller that has finished
  */
 - (void)paymentMethodsViewControllerDidCancel:(STPPaymentMethodsViewController *)paymentMethodsViewController;
+
+@optional
+/**
+ *  This is called when the user either makes a selection, or adds a new card. This will be triggered after the view controller loads with the user's current selection (if they have one) and then subsequently when they change their choice. You should use this callback to update any necessary UI in your app that displays the user's currently selected payment method. You should *not* dismiss the view controller at this point, instead do this in `paymentMethodsViewControllerDidFinish:`. `STPPaymentMethodsViewController` will also call the necessary methods on your API adapter, so you don't need to call them directly during this method.
+ *
+ *  @param paymentMethodsViewController the view controller in question
+ *  @param paymentMethod                the selected payment method
+ */
+- (void)paymentMethodsViewController:(STPPaymentMethodsViewController *)paymentMethodsViewController
+              didSelectPaymentMethod:(id<STPPaymentMethod>)paymentMethod;
 
 @end
 

--- a/Stripe/STPPaymentMethodsViewController.m
+++ b/Stripe/STPPaymentMethodsViewController.m
@@ -167,7 +167,9 @@
         [self.apiAdapter selectDefaultCustomerSource:(STPCard *)paymentMethod completion:^(__unused NSError *error) {
         }];
     }
-    [self.delegate paymentMethodsViewController:self didSelectPaymentMethod:paymentMethod];
+    if ([self.delegate respondsToSelector:@selector(paymentMethodsViewController:didSelectPaymentMethod:)]) {
+        [self.delegate paymentMethodsViewController:self didSelectPaymentMethod:paymentMethod];
+    }
     [self.delegate paymentMethodsViewControllerDidFinish:self];
 }
 
@@ -260,8 +262,10 @@
         }] onSuccess:^(STPPaymentMethodTuple *tuple) {
             STRONG(self);
             if (tuple.selectedPaymentMethod) {
-                [self.delegate paymentMethodsViewController:self
+                if ([self.delegate respondsToSelector:@selector(paymentMethodsViewController:didSelectPaymentMethod:)]) {
+                    [self.delegate paymentMethodsViewController:self
                                          didSelectPaymentMethod:tuple.selectedPaymentMethod];
+                }
             }
         }] onFailure:^(NSError *error) {
             STRONG(self);


### PR DESCRIPTION
r? @bdorfman-stripe 

During an IRL session with @irace today, we realized that we should make this method optional – if your settings page just has a "Change Payment Method" button, and you don't display the specific payment method, you won't need to know when a new method is selected.