### PR TITLE
update Apple Pay helpers with variants that allow specifying a country

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+== 11.0.0 2017-XX-XX
+* We've made some updates to our Apple Pay helper methods. If you're accepting Apple Pay outside the US, be sure to use the methods that accept a country parameter, as a different set of payment networks may be available in your country.
+
 == 10.1.0 2017-05-05
 * Adds STPRedirectContext, a helper class for handling redirect sources.
 * STPAPIClient now supports tokenizing a PII number and uploading images.

--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -377,6 +377,7 @@
 		C1080F491CBECF7B007B2D89 /* STPAddress.h in Headers */ = {isa = PBXBuildFile; fileRef = C1080F471CBECF7B007B2D89 /* STPAddress.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C1080F4A1CBECF7B007B2D89 /* STPAddress.m in Sources */ = {isa = PBXBuildFile; fileRef = C1080F481CBECF7B007B2D89 /* STPAddress.m */; };
 		C1080F4C1CBED48A007B2D89 /* STPAddressTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C1080F4B1CBED48A007B2D89 /* STPAddressTests.m */; };
+		C10C34221EDE1CB800F1B78C /* Stripe+ApplePayTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C10C34211EDE1CB800F1B78C /* Stripe+ApplePayTest.m */; };
 		C11810861CC6AF4C0022FB55 /* STPPaymentMethod.h in Headers */ = {isa = PBXBuildFile; fileRef = C11810851CC6AF4C0022FB55 /* STPPaymentMethod.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C11810891CC6B00D0022FB55 /* STPApplePayPaymentMethod.h in Headers */ = {isa = PBXBuildFile; fileRef = C11810871CC6B00D0022FB55 /* STPApplePayPaymentMethod.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C118108A1CC6B00D0022FB55 /* STPApplePayPaymentMethod.m in Sources */ = {isa = PBXBuildFile; fileRef = C11810881CC6B00D0022FB55 /* STPApplePayPaymentMethod.m */; };
@@ -986,6 +987,7 @@
 		C1080F471CBECF7B007B2D89 /* STPAddress.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = STPAddress.h; path = PublicHeaders/STPAddress.h; sourceTree = "<group>"; };
 		C1080F481CBECF7B007B2D89 /* STPAddress.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPAddress.m; sourceTree = "<group>"; };
 		C1080F4B1CBED48A007B2D89 /* STPAddressTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPAddressTests.m; sourceTree = "<group>"; };
+		C10C34211EDE1CB800F1B78C /* Stripe+ApplePayTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "Stripe+ApplePayTest.m"; sourceTree = "<group>"; };
 		C11810851CC6AF4C0022FB55 /* STPPaymentMethod.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = STPPaymentMethod.h; path = PublicHeaders/STPPaymentMethod.h; sourceTree = "<group>"; };
 		C11810871CC6B00D0022FB55 /* STPApplePayPaymentMethod.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = STPApplePayPaymentMethod.h; path = PublicHeaders/STPApplePayPaymentMethod.h; sourceTree = "<group>"; };
 		C11810881CC6B00D0022FB55 /* STPApplePayPaymentMethod.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPApplePayPaymentMethod.m; sourceTree = "<group>"; };
@@ -1478,6 +1480,7 @@
 				04CDB5271A5F3A9300B854EE /* STPTokenTest.m */,
 				04A4C3931C4F276100B3B290 /* STPUIVCStripeParentViewControllerTests.m */,
 				C15B02721EA176090026E606 /* StripeErrorTest.m */,
+				C10C34211EDE1CB800F1B78C /* Stripe+ApplePayTest.m */,
 				F1D3A25E1EB015B30095BFA9 /* UIImage+StripeTests.m */,
 				F1122A7D1DFB84E000A8B1AF /* UINavigationBar+StripeTest.m */,
 			);
@@ -2575,6 +2578,7 @@
 				C1EEDCC81CA2172700A54582 /* NSString+StripeTest.m in Sources */,
 				04415C6A1A6605B5001225ED /* STPApplePayFunctionalTest.m in Sources */,
 				F1D3A25F1EB015B30095BFA9 /* UIImage+StripeTests.m in Sources */,
+				C10C34221EDE1CB800F1B78C /* Stripe+ApplePayTest.m in Sources */,
 				04415C6B1A6605B5001225ED /* STPBankAccountFunctionalTest.m in Sources */,
 				04415C6C1A6605B5001225ED /* STPBankAccountTest.m in Sources */,
 				C19D09931EAEAE5E00A4AB3E /* STPTelemetryClientTest.m in Sources */,

--- a/Stripe/PublicHeaders/STPAPIClient.h
+++ b/Stripe/PublicHeaders/STPAPIClient.h
@@ -142,32 +142,91 @@ static NSString *const STPSDKVersion = @"10.1.0";
 
 /**
  *  Convenience methods for working with Apple Pay.
+ *  If you're accepting Apple Pay outside the US, be sure to use the variants 
+ *  that accept a country parameter, as a different set of payment networks may
+ *  be available in your country.
  */
 @interface Stripe(ApplePay)
 
 /**
- *  Whether or not this device is capable of using Apple Pay. This checks both whether the user is running an iPhone 6/6+ or later, iPad Air 2 or later, or iPad
- *mini 3 or later, as well as whether or not they have stored any cards in Apple Pay on their device.
+ *  The payment networks that Stripe supports in the given country. 
+ *  You should use this method to set the `supportedNetworks` property of your 
+ *  `PKPaymentRequest`.
  *
- *  @param paymentRequest The return value of this method depends on the `supportedNetworks` property of this payment request, which by default should be
- *`@[PKPaymentNetworkAmex, PKPaymentNetworkMasterCard, PKPaymentNetworkVisa, PKPaymentNetworkDiscover]`.
+ *  @param countryCode  Your two-letter ISO 3166 country code.
+ *  @return an array of supported PKPaymentNetworks for the given country.
+ */
++ (NSArray<NSString *> *)supportedPaymentNetworksForCountry:(NSString *)countryCode;
+
+/**
+ *  Validates the given payment request. This method checks if the payment request 
+ *  is properly configured, and whether or not the device supports Apple Pay.
+ *
+ *  @param paymentRequest The payment request to validate. You should use
+ *  the `supportedPaymentNetworksForCountry:` method to set the `supportedNetworks`
+ *  property of your payment request.
  *
  *  @return whether or not the user is currently able to pay with Apple Pay.
  */
 + (BOOL)canSubmitPaymentRequest:(PKPaymentRequest *)paymentRequest NS_AVAILABLE_IOS(8_0);
 
+/**
+ *  Whether or not this device is capable of using Apple Pay. 
+ *  This method checks whether Apple Pay is available on the user's hardware,
+ *  as well as whether or not the device has any saved Apple Pay cards from
+ *  supported payment networks.
+ *
+ *  Note that this method assumes you are accepting Apple Pay within the US.
+ *  If you are accepting Apple Pay payments outside the US, you should use
+ *  `deviceSupportsApplePayInCountry:`.
+ *
+ *  @return whether or not the device supports Apple Pay.
+ */
 + (BOOL)deviceSupportsApplePay;
 
 /**
- *  A convenience method to return a `PKPaymentRequest` with sane default values. You will still need to configure the `paymentSummaryItems` property to indicate
- *what the user is purchasing, as well as the optional `requiredShippingAddressFields`, `requiredBillingAddressFields`, and `shippingMethods` properties to indicate
- *what contact information your application requires.
+ *  Whether or not this device is capable of using Apple Pay in the given country.
+ *  This method checks whether Apple Pay is available on the user's hardware,
+ *  as well as whether or not the device has any saved Apple Pay cards from
+ *  supported payment networks.
  *
- *  @param merchantIdentifier Your Apple Merchant ID, as obtained at https://developer.apple.com/account/ios/identifiers/merchant/merchantCreate.action
+ *  @param countryCode  Your two-letter ISO 3166 country code.
+ *
+ *  @return whether or not the device supports Apple Pay.
+ */
++ (BOOL)deviceSupportsApplePayInCountry:(NSString *)countryCode;
+
+/**
+ *  A convenience method to return a `PKPaymentRequest` with sane default values. 
+ *  You will still need to configure the `paymentSummaryItems` property to indicate
+ *  what the user is purchasing, as well as the optional `requiredShippingAddressFields`, 
+ *  `requiredBillingAddressFields`, and `shippingMethods` properties to indicate
+ *  what contact information your application requires.
+ *
+ *  Note that this method assumes you are accepting Apple Pay within the US.
+ *  If you are accepting Apple Pay payments outside the US, you should use
+ *  `paymentRequestWithMerchantIdentifier:country:`.
+ *
+ *  @param merchantIdentifier Your Apple Merchant ID.
  *
  *  @return a `PKPaymentRequest` with proper default values. Returns nil if running on < iOS8.
  */
 + (PKPaymentRequest *)paymentRequestWithMerchantIdentifier:(NSString *)merchantIdentifier NS_AVAILABLE_IOS(8_0);
+
+/**
+ *  A convenience method to return a `PKPaymentRequest` with sane default values
+ *  for the given country. The payment request's currency will be set to "USD".
+ *  You will still need to configure the `paymentSummaryItems` property to indicate
+ *  what the user is purchasing, as well as the optional `requiredShippingAddressFields`,
+ *  `requiredBillingAddressFields`, and `shippingMethods` properties to indicate
+ *  what contact information your application requires.
+ *
+ *  @param merchantIdentifier Your Apple Merchant ID.
+ *  @param countryCode        Your two-letter ISO 3166 country code.
+ *
+ *  @return a `PKPaymentRequest` with proper default values. Returns nil if running on < iOS8.
+ */
++ (PKPaymentRequest *)paymentRequestWithMerchantIdentifier:(NSString *)merchantIdentifier country:(NSString *)countryCode NS_AVAILABLE_IOS(8_0);
 
 @end
 

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -344,7 +344,8 @@ static NSString *const stripeAPIVersion = @"2015-10-12";
 @implementation Stripe (ApplePay)
 
 + (BOOL)canSubmitPaymentRequest:(PKPaymentRequest *)paymentRequest {
-    if (![self deviceSupportsApplePay]) {
+    BOOL deviceSupportsApplePay = [self deviceSupportsApplePayInCountry:paymentRequest.countryCode];
+    if (!deviceSupportsApplePay) {
         return NO;
     }
     if (paymentRequest == nil) {
@@ -356,24 +357,33 @@ static NSString *const stripeAPIVersion = @"2015-10-12";
     return [[[paymentRequest.paymentSummaryItems lastObject] amount] floatValue] > 0;
 }
 
-+ (NSArray<NSString *> *)supportedPKPaymentNetworks {
++ (NSArray<NSString *> *)supportedPaymentNetworksForCountry:(NSString *)countryCode {
     NSArray *supportedNetworks = @[PKPaymentNetworkAmex, PKPaymentNetworkMasterCard, PKPaymentNetworkVisa];
-    if ((&PKPaymentNetworkDiscover) != NULL) {
+    if ((&PKPaymentNetworkDiscover) != NULL && [countryCode isEqualToString:@"US"]) {
         supportedNetworks = [supportedNetworks arrayByAddingObject:PKPaymentNetworkDiscover];
     }
     return supportedNetworks;
 }
 
 + (BOOL)deviceSupportsApplePay {
-    return [PKPaymentAuthorizationViewController class] && [PKPaymentAuthorizationViewController canMakePaymentsUsingNetworks:[self supportedPKPaymentNetworks]];
+    return [self deviceSupportsApplePayInCountry:@"US"];
+}
+
++ (BOOL)deviceSupportsApplePayInCountry:(NSString *)countryCode {
+    NSArray<NSString *> *supportedNetworks = [self supportedPaymentNetworksForCountry:countryCode];
+    return [PKPaymentAuthorizationViewController class] && [PKPaymentAuthorizationViewController canMakePaymentsUsingNetworks:supportedNetworks];
 }
 
 + (PKPaymentRequest *)paymentRequestWithMerchantIdentifier:(NSString *)merchantIdentifier {
+    return [self paymentRequestWithMerchantIdentifier:merchantIdentifier country:@"US"];
+}
+
++ (PKPaymentRequest *)paymentRequestWithMerchantIdentifier:(NSString *)merchantIdentifier country:(NSString *)countryCode {
     PKPaymentRequest *paymentRequest = [PKPaymentRequest new];
     [paymentRequest setMerchantIdentifier:merchantIdentifier];
-    [paymentRequest setSupportedNetworks:[self supportedPKPaymentNetworks]];
+    [paymentRequest setSupportedNetworks:[self supportedPaymentNetworksForCountry:countryCode]];
     [paymentRequest setMerchantCapabilities:PKMerchantCapability3DS];
-    [paymentRequest setCountryCode:@"US"];
+    [paymentRequest setCountryCode:countryCode];
     [paymentRequest setCurrencyCode:@"USD"];
     return paymentRequest;
 }

--- a/Tests/Tests/STPApplePayFunctionalTest.m
+++ b/Tests/Tests/STPApplePayFunctionalTest.m
@@ -40,27 +40,6 @@
     [self waitForExpectationsWithTimeout:5.0f handler:nil];
 }
 
-- (void)testCanSubmitPaymentRequestReturnsYES {
-    PKPaymentRequest *request = [[PKPaymentRequest alloc] init];
-    request.merchantIdentifier = @"foo";
-    request.paymentSummaryItems = @[[PKPaymentSummaryItem summaryItemWithLabel:@"bar" amount:[NSDecimalNumber decimalNumberWithString:@"1.00"]]];
 
-    XCTAssertTrue([Stripe canSubmitPaymentRequest:request]);
-}
-
-- (void)testCanSubmitPaymentRequestReturnsNOIfTotalIsZero {
-    PKPaymentRequest *request = [[PKPaymentRequest alloc] init];
-    request.merchantIdentifier = @"foo";
-    request.paymentSummaryItems = @[[PKPaymentSummaryItem summaryItemWithLabel:@"bar" amount:[NSDecimalNumber decimalNumberWithString:@"0.00"]]];
-
-    XCTAssertFalse([Stripe canSubmitPaymentRequest:request]);
-}
-
-- (void)testCanSubmitPaymentRequestReturnsNOIfMerchantIdentifierIsNil {
-    PKPaymentRequest *request = [[PKPaymentRequest alloc] init];
-    request.paymentSummaryItems = @[[PKPaymentSummaryItem summaryItemWithLabel:@"bar" amount:[NSDecimalNumber decimalNumberWithString:@"1.00"]]];
-
-    XCTAssertFalse([Stripe canSubmitPaymentRequest:request]);
-}
 
 @end

--- a/Tests/Tests/Stripe+ApplePayTest.m
+++ b/Tests/Tests/Stripe+ApplePayTest.m
@@ -1,0 +1,82 @@
+//
+//  Stripe+ApplePayTest.m
+//  Stripe
+//
+//  Created by Ben Guo on 5/30/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import <PassKit/PassKit.h>
+#import <OCMock/OCMock.h>
+#import "STPAPIClient.h"
+
+@interface Stripe_ApplePayTest : XCTestCase
+
+@end
+
+@implementation Stripe_ApplePayTest
+
+- (void)testCanSubmitPaymentRequest_valid {
+    PKPaymentRequest *request = [[PKPaymentRequest alloc] init];
+    request.merchantIdentifier = @"foo";
+    request.paymentSummaryItems = @[[PKPaymentSummaryItem summaryItemWithLabel:@"bar" amount:[NSDecimalNumber decimalNumberWithString:@"1.00"]]];
+
+    XCTAssertTrue([Stripe canSubmitPaymentRequest:request]);
+}
+
+- (void)testCanSubmitPaymentRequest_zeroTotal {
+    PKPaymentRequest *request = [[PKPaymentRequest alloc] init];
+    request.merchantIdentifier = @"foo";
+    request.paymentSummaryItems = @[[PKPaymentSummaryItem summaryItemWithLabel:@"bar" amount:[NSDecimalNumber decimalNumberWithString:@"0.00"]]];
+
+    XCTAssertFalse([Stripe canSubmitPaymentRequest:request]);
+}
+
+- (void)testCanSubmitPaymentRequest_nilMerchantIdentifier {
+    PKPaymentRequest *request = [[PKPaymentRequest alloc] init];
+    request.paymentSummaryItems = @[[PKPaymentSummaryItem summaryItemWithLabel:@"bar" amount:[NSDecimalNumber decimalNumberWithString:@"1.00"]]];
+
+    XCTAssertFalse([Stripe canSubmitPaymentRequest:request]);
+}
+
+- (void)testSupportedPKPaymentNetworksForCountry_US {
+    NSSet<NSSet *> *networks = [NSSet setWithArray:[Stripe supportedPaymentNetworksForCountry:@"US"]];
+    NSSet<NSSet *> *expectedNetworks = [NSSet setWithArray:@[
+                                                     PKPaymentNetworkAmex,
+                                                     PKPaymentNetworkMasterCard,
+                                                     PKPaymentNetworkVisa,
+                                                     PKPaymentNetworkDiscover,
+                                                     ]];
+    XCTAssertEqualObjects(networks, expectedNetworks);
+}
+
+- (void)testSupportedPKPaymentNetworksForCountry_notUS {
+    NSSet<NSSet *> *networks = [NSSet setWithArray:[Stripe supportedPaymentNetworksForCountry:@"GB"]];
+    NSSet<NSSet *> *expectedNetworks = [NSSet setWithArray:@[
+                                                     PKPaymentNetworkAmex,
+                                                     PKPaymentNetworkMasterCard,
+                                                     PKPaymentNetworkVisa,
+                                                     ]];
+    XCTAssertEqualObjects(networks, expectedNetworks);
+}
+
+- (void)testPaymentRequestWithMerchantIdentifier {
+    PKPaymentRequest *paymentRequest = [Stripe paymentRequestWithMerchantIdentifier:@"foo"];
+    XCTAssertEqualObjects(paymentRequest.merchantIdentifier, @"foo");
+    XCTAssertEqualObjects(paymentRequest.supportedNetworks, [Stripe supportedPaymentNetworksForCountry:@"US"]);
+    XCTAssertEqual(paymentRequest.merchantCapabilities, PKMerchantCapability3DS);
+    XCTAssertEqualObjects(paymentRequest.countryCode, @"US");
+    XCTAssertEqualObjects(paymentRequest.currencyCode, @"USD");
+}
+
+- (void)testPaymentRequestWithMerchantIdentifierCountry {
+    PKPaymentRequest *paymentRequest = [Stripe paymentRequestWithMerchantIdentifier:@"foo" country:@"GB"];
+    XCTAssertEqualObjects(paymentRequest.merchantIdentifier, @"foo");
+    XCTAssertEqualObjects(paymentRequest.supportedNetworks, [Stripe supportedPaymentNetworksForCountry:@"GB"]);
+    XCTAssertEqual(paymentRequest.merchantCapabilities, PKMerchantCapability3DS);
+    XCTAssertEqualObjects(paymentRequest.countryCode, @"GB");
+    XCTAssertEqualObjects(paymentRequest.currencyCode, @"USD");
+}
+
+@end


### PR DESCRIPTION
r? @bdorfman-stripe 
cc @jack-stripe @mrmcduff-stripe 

This adds 3 new methods, and fleshes out our docs.
- `Stripe.supportedPaymentNetworksForCountry("GB")`
- `Stripe.deviceSupportsApplePayInCountry("GB")`
- `Stripe.paymentRequestWithMerchantIdentifier("merchant.com.foo", country: "GB")`
