### PR TITLE
Add paymentCountry and update Apple Pay helpers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+== 11.0.0 2017-XX-XX
+* We've added a `paymentCountry` property to `STPPaymentContext`. This affects the countryCode of Apple Pay payments, and defaults to "US". You should set this to the country your Stripe account is in.
+* `paymentRequestWithMerchantIdentifier:` has been deprecated. See MIGRATING.md
+
 == 10.1.0 2017-05-05
 * Adds STPRedirectContext, a helper class for handling redirect sources.
 * STPAPIClient now supports tokenizing a PII number and uploading images.

--- a/Example/Stripe iOS Example (Custom)/ApplePayExampleViewController.m
+++ b/Example/Stripe iOS Example (Custom)/ApplePayExampleViewController.m
@@ -63,7 +63,9 @@
 
 - (PKPaymentRequest *)buildPaymentRequest {
     if ([PKPaymentRequest class]) {
-        PKPaymentRequest *paymentRequest = [Stripe paymentRequestWithMerchantIdentifier:AppleMerchantId];
+        PKPaymentRequest *paymentRequest = [Stripe paymentRequestWithMerchantIdentifier:AppleMerchantId
+                                                                                country:@"US"
+                                                                               currency:@"USD"];
         [paymentRequest setRequiredShippingAddressFields:PKAddressFieldPostalAddress];
         [paymentRequest setRequiredBillingAddressFields:PKAddressFieldPostalAddress];
         paymentRequest.shippingMethods = [self.shippingManager defaultShippingMethods];

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,5 +1,9 @@
 ## Migration Guides
 
+### Migrating from versions < 11.0.0
+- `paymentRequestWithMerchantIdentifier:` has been deprecated. You should instead use `paymentRequestWithMerchantIdentifier:country:currency:`. Apple Pay is now available in many countries and currencies, and you should use the appropriate values for your business.
+- We've added a `paymentCountry` property to `STPPaymentContext`. This affects the countryCode of Apple Pay payments, and defaults to "US". You should set this to the country your Stripe account is in.
+
 ### Migrating from versions < 10.1.0
 
 - STPPaymentMethodsViewControllerDelegate now has a separate `paymentMethodsViewControllerDidCancel:` callback, differentiating from successful method selections. You should make sure to also dismiss the view controller in that callback.

--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -481,6 +481,7 @@
 		C19D09931EAEAE5E00A4AB3E /* STPTelemetryClientTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C19D09911EAEAE5200A4AB3E /* STPTelemetryClientTest.m */; };
 		C1A06F101E1D8A7F004DCA06 /* STPCard+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = C1A06F0F1E1D8A6E004DCA06 /* STPCard+Private.h */; };
 		C1A06F111E1D8A7F004DCA06 /* STPCard+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = C1A06F0F1E1D8A6E004DCA06 /* STPCard+Private.h */; };
+		C1AED1561EE0C8C6008BEFBF /* STPApplePayTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C1AED1551EE0C8C6008BEFBF /* STPApplePayTest.m */; };
 		C1B630BB1D1D860100A05285 /* stp_card_amex.png in Resources */ = {isa = PBXBuildFile; fileRef = 0438EF891B741C2800D506CC /* stp_card_amex.png */; };
 		C1B630BC1D1D860100A05285 /* stp_card_amex@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 0438EF8A1B741C2800D506CC /* stp_card_amex@2x.png */; };
 		C1B630BD1D1D860100A05285 /* stp_card_amex@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 0438EF8B1B741C2800D506CC /* stp_card_amex@3x.png */; };
@@ -1052,6 +1053,7 @@
 		C19D098E1EAEAE4000A4AB3E /* STPTelemetryClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPTelemetryClient.m; sourceTree = "<group>"; };
 		C19D09911EAEAE5200A4AB3E /* STPTelemetryClientTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPTelemetryClientTest.m; sourceTree = "<group>"; };
 		C1A06F0F1E1D8A6E004DCA06 /* STPCard+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCard+Private.h"; sourceTree = "<group>"; };
+		C1AED1551EE0C8C6008BEFBF /* STPApplePayTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPApplePayTest.m; sourceTree = "<group>"; };
 		C1B630B31D1D817900A05285 /* Stripe.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Stripe.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		C1B630B51D1D817900A05285 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C1BD9B1E1E390A2700CEE925 /* STPSourceParamsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPSourceParamsTest.m; sourceTree = "<group>"; };
@@ -1472,6 +1474,7 @@
 				C12711091DBA7E490087840D /* STPAddressViewModelTest.m */,
 				C124A1841CCAB750007D42EE /* STPAnalyticsClientTest.m */,
 				04CDB51E1A5F3A9300B854EE /* STPAPIClientTest.m */,
+				C1AED1551EE0C8C6008BEFBF /* STPApplePayTest.m */,
 				04CDB5231A5F3A9300B854EE /* STPBankAccountTest.m */,
 				045D71301CF514BB00F6CD65 /* STPBinRangeTest.m */,
 				04CDB5251A5F3A9300B854EE /* STPCardTest.m */,
@@ -2593,6 +2596,7 @@
 				045D71311CF514BB00F6CD65 /* STPBinRangeTest.m in Sources */,
 				C15B02731EA176090026E606 /* StripeErrorTest.m in Sources */,
 				C1EF044E1DD2397C00FBF452 /* STPShippingMethodsViewControllerLocalizationTests.m in Sources */,
+				C1AED1561EE0C8C6008BEFBF /* STPApplePayTest.m in Sources */,
 				04415C681A6605B5001225ED /* STPFormEncoderTest.m in Sources */,
 				C1CFCB751ED5E12400BE45DF /* STPFileTest.m in Sources */,
 				C11810991CC6D46D0022FB55 /* NSDecimalNumber+StripeTest.m in Sources */,

--- a/Stripe/PublicHeaders/STPAPIClient.h
+++ b/Stripe/PublicHeaders/STPAPIClient.h
@@ -159,15 +159,42 @@ static NSString *const STPSDKVersion = @"10.1.0";
 + (BOOL)deviceSupportsApplePay;
 
 /**
- *  A convenience method to return a `PKPaymentRequest` with sane default values. You will still need to configure the `paymentSummaryItems` property to indicate
- *what the user is purchasing, as well as the optional `requiredShippingAddressFields`, `requiredBillingAddressFields`, and `shippingMethods` properties to indicate
- *what contact information your application requires.
+ *  A convenience method to build a `PKPaymentRequest` with sane default values.
+ *  You will still need to configure the `paymentSummaryItems` property to indicate
+ *  what the user is purchasing, as well as the optional `requiredShippingAddressFields`,
+ *  `requiredBillingAddressFields`, and `shippingMethods` properties to indicate
+ *  what contact information your application requires.
+ *  Note that this method sets the payment request's countryCode to "US" and its
+ *  currencyCode to "USD".
  *
- *  @param merchantIdentifier Your Apple Merchant ID, as obtained at https://developer.apple.com/account/ios/identifiers/merchant/merchantCreate.action
+ *  @param merchantIdentifier Your Apple Merchant ID.
+ *
+ *  @return a `PKPaymentRequest` with proper default values. Returns nil if running on < iOS8.
+ *  @deprecated Use `paymentRequestWithMerchantIdentifier:country:currency:` instead.
+ *  Apple Pay is available in many countries and currencies, and you should use
+ *  the appropriate values for your business.
+ */
++ (PKPaymentRequest *)paymentRequestWithMerchantIdentifier:(NSString *)merchantIdentifier NS_AVAILABLE_IOS(8_0) __attribute__((deprecated));
+
+/**
+ *  A convenience method to build a `PKPaymentRequest` with sane default values.
+ *  You will still need to configure the `paymentSummaryItems` property to indicate
+ *  what the user is purchasing, as well as the optional `requiredShippingAddressFields`,
+ *  `requiredBillingAddressFields`, and `shippingMethods` properties to indicate
+ *  what contact information your application requires.
+ *
+ *  @param merchantIdentifier Your Apple Merchant ID.
+ *  @param countryCode        The two-letter code for the country where the payment 
+ *  will be processed. This should be the country of your Stripe account.
+ *  @param currencyCode       The three-letter code for the currency used by this 
+ *  payment request. Apple Pay interprets the amounts provided by the summary items 
+ *  attached to this request as amounts in this currency.
  *
  *  @return a `PKPaymentRequest` with proper default values. Returns nil if running on < iOS8.
  */
-+ (PKPaymentRequest *)paymentRequestWithMerchantIdentifier:(NSString *)merchantIdentifier NS_AVAILABLE_IOS(8_0);
++ (PKPaymentRequest *)paymentRequestWithMerchantIdentifier:(NSString *)merchantIdentifier
+                                                   country:(NSString *)countryCode
+                                                  currency:(NSString *)currencyCode NS_AVAILABLE_IOS(8_0);
 
 @end
 

--- a/Stripe/PublicHeaders/STPPaymentContext.h
+++ b/Stripe/PublicHeaders/STPPaymentContext.h
@@ -111,27 +111,51 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly, nullable)STPAddress *shippingAddress;
 
 /**
- *  The amount of money you're requesting from the user, in the smallest currency unit for the selected currency. For example, to indicate $10 USD, use 1000 (i.e. 1000 cents). For more information see https://stripe.com/docs/api#charge_object-amount . This value must be present and greater than zero in order for Apple Pay to be automatically enabled.
+ *  The amount of money you're requesting from the user, in the smallest currency 
+ *  unit for the selected currency. For example, to indicate $10 USD, use 1000 
+ *  (i.e. 1000 cents). For more information, see https://stripe.com/docs/api#charge_object-amount
  *
- *  @note You should only set either this or `paymentSummaryItems`, not both. The other will be automatically calculated on demand using your `paymentCurrency`. 
+ *  @note This value must be present and greater than zero in order for Apple Pay
+ *  to be automatically enabled.
+ *
+ *  @note You should only set either this or `paymentSummaryItems`, not both.
+ *  The other will be automatically calculated on demand using your `paymentCurrency`.
  */
 @property(nonatomic)NSInteger paymentAmount;
 
 /**
- *  The three-letter currency code for the currency of the payment (i.e. USD, GBP, JPY, etc). Defaults to USD.
+ *  The three-letter currency code for the currency of the payment (i.e. USD, GBP, 
+ *  JPY, etc). Defaults to "USD".
  *
- *  @note Changing this property may change the return value of `paymentAmount` or `paymentSummaryItems` (whichever one you didn't directly set yourself).
+ *  @note Changing this property may change the return value of `paymentAmount` 
+ *  or `paymentSummaryItems` (whichever one you didn't directly set yourself).
  */
 @property(nonatomic, copy)NSString *paymentCurrency;
 
 /**
- *  If you support Apple Pay, you can optionally set the PKPaymentSummaryItems you want to display here instead of using `paymentAmount`. Note that the grand total (the amount of the last summary item) must be greater than zero.
- *  If not set, a single summary item will be automatically generated using `paymentAmount` and your configuration's `companyName`.
+ *  The two-letter country code for the country where the payment will be processed.
+ *  You should set this to the country your Stripe account is in. Defaults to "US".
+ *
+ *  @note Changing this property will change the `countryCode` of your Apple Pay
+ *  payment requests.
+ *  @see PKPaymentRequest for more information.
+ */
+@property(nonatomic, copy)NSString *paymentCountry;
+
+/**
+ *  If you support Apple Pay, you can optionally set the PKPaymentSummaryItems 
+ *  you want to display here instead of using `paymentAmount`. Note that the 
+ *  grand total (the amount of the last summary item) must be greater than zero.
+ *  If not set, a single summary item will be automatically generated using 
+ *  `paymentAmount` and your configuration's `companyName`.
  *  @see PKPaymentRequest for more information
  *
- *  @note You should only set either this or `paymentAmount`, not both. The other will be automatically calculated on demand using your `paymentCurrency.`
+ *  @note You should only set either this or `paymentAmount`, not both. 
+ *  The other will be automatically calculated on demand using your `paymentCurrency.`
  *
- *  @warning `PKPaymentSummaryItem` is only available in iOS8+. If you support iOS 7 you should do a runtime availability check before accessing or setting this property. 
+ *  @warning `PKPaymentSummaryItem` is only available in iOS8+. If you support 
+ *  iOS 7 you should do a runtime availability check before accessing or setting 
+ *  this property.
  */
 @property(nonatomic, copy)NSArray<PKPaymentSummaryItem *> *paymentSummaryItems NS_AVAILABLE_IOS(8_0);
 

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -369,12 +369,18 @@ static NSString *const stripeAPIVersion = @"2015-10-12";
 }
 
 + (PKPaymentRequest *)paymentRequestWithMerchantIdentifier:(NSString *)merchantIdentifier {
+    return [self paymentRequestWithMerchantIdentifier:merchantIdentifier country:@"US" currency:@"USD"];
+}
+
++ (PKPaymentRequest *)paymentRequestWithMerchantIdentifier:(NSString *)merchantIdentifier
+                                                   country:(NSString *)countryCode
+                                                  currency:(NSString *)currencyCode {
     PKPaymentRequest *paymentRequest = [PKPaymentRequest new];
     [paymentRequest setMerchantIdentifier:merchantIdentifier];
     [paymentRequest setSupportedNetworks:[self supportedPKPaymentNetworks]];
     [paymentRequest setMerchantCapabilities:PKMerchantCapability3DS];
-    [paymentRequest setCountryCode:@"US"];
-    [paymentRequest setCurrencyCode:@"USD"];
+    [paymentRequest setCountryCode:countryCode];
+    [paymentRequest setCurrencyCode:currencyCode];
     return paymentRequest;
 }
 

--- a/Stripe/STPPaymentContext.m
+++ b/Stripe/STPPaymentContext.m
@@ -86,6 +86,7 @@ typedef NS_ENUM(NSUInteger, STPPaymentContextState) {
         _didAppearPromise = [STPVoidPromise new];
         _apiClient = [[STPAPIClient alloc] initWithPublishableKey:configuration.publishableKey];
         _paymentCurrency = @"USD";
+        _paymentCountry = @"US";
         _paymentAmountModel = [[STPPaymentContextAmountModel alloc] initWithAmount:0];
         _modalPresentationStyle = UIModalPresentationFullScreen;
         _state = STPPaymentContextStateNone;
@@ -571,7 +572,7 @@ typedef NS_ENUM(NSUInteger, STPPaymentContextState) {
     if (!self.configuration.appleMerchantIdentifier || !self.paymentAmount) {
         return nil;
     }
-    PKPaymentRequest *paymentRequest = [Stripe paymentRequestWithMerchantIdentifier:self.configuration.appleMerchantIdentifier];
+    PKPaymentRequest *paymentRequest = [Stripe paymentRequestWithMerchantIdentifier:self.configuration.appleMerchantIdentifier country:self.paymentCountry currency:self.paymentCurrency];
 
     NSArray<PKPaymentSummaryItem *> *summaryItems = self.paymentSummaryItems;
     paymentRequest.paymentSummaryItems = summaryItems;

--- a/Tests/Tests/STPApplePayFunctionalTest.m
+++ b/Tests/Tests/STPApplePayFunctionalTest.m
@@ -40,27 +40,4 @@
     [self waitForExpectationsWithTimeout:5.0f handler:nil];
 }
 
-- (void)testCanSubmitPaymentRequestReturnsYES {
-    PKPaymentRequest *request = [[PKPaymentRequest alloc] init];
-    request.merchantIdentifier = @"foo";
-    request.paymentSummaryItems = @[[PKPaymentSummaryItem summaryItemWithLabel:@"bar" amount:[NSDecimalNumber decimalNumberWithString:@"1.00"]]];
-
-    XCTAssertTrue([Stripe canSubmitPaymentRequest:request]);
-}
-
-- (void)testCanSubmitPaymentRequestReturnsNOIfTotalIsZero {
-    PKPaymentRequest *request = [[PKPaymentRequest alloc] init];
-    request.merchantIdentifier = @"foo";
-    request.paymentSummaryItems = @[[PKPaymentSummaryItem summaryItemWithLabel:@"bar" amount:[NSDecimalNumber decimalNumberWithString:@"0.00"]]];
-
-    XCTAssertFalse([Stripe canSubmitPaymentRequest:request]);
-}
-
-- (void)testCanSubmitPaymentRequestReturnsNOIfMerchantIdentifierIsNil {
-    PKPaymentRequest *request = [[PKPaymentRequest alloc] init];
-    request.paymentSummaryItems = @[[PKPaymentSummaryItem summaryItemWithLabel:@"bar" amount:[NSDecimalNumber decimalNumberWithString:@"1.00"]]];
-
-    XCTAssertFalse([Stripe canSubmitPaymentRequest:request]);
-}
-
 @end

--- a/Tests/Tests/STPApplePayTest.m
+++ b/Tests/Tests/STPApplePayTest.m
@@ -1,0 +1,51 @@
+//
+//  STPApplePayTest.m
+//  Stripe
+//
+//  Created by Ben Guo on 6/1/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "STPAPIClient.h"
+
+@interface STPApplePayTest : XCTestCase
+
+@end
+
+@implementation STPApplePayTest
+
+- (void)testPaymentRequestWithMerchantIdentifierCountryCurrency {
+    PKPaymentRequest *paymentRequest = [Stripe paymentRequestWithMerchantIdentifier:@"foo" country:@"GB" currency:@"GBP"];
+    XCTAssertEqualObjects(paymentRequest.merchantIdentifier, @"foo");
+    NSSet *expectedNetworks = [NSSet setWithArray:@[PKPaymentNetworkAmex, PKPaymentNetworkMasterCard, PKPaymentNetworkVisa, PKPaymentNetworkDiscover]];
+    XCTAssertEqualObjects([NSSet setWithArray:paymentRequest.supportedNetworks], expectedNetworks);
+    XCTAssertEqual(paymentRequest.merchantCapabilities, PKMerchantCapability3DS);
+    XCTAssertEqualObjects(paymentRequest.countryCode, @"GB");
+    XCTAssertEqualObjects(paymentRequest.currencyCode, @"GBP");
+}
+
+- (void)testCanSubmitPaymentRequestReturnsYES {
+    PKPaymentRequest *request = [[PKPaymentRequest alloc] init];
+    request.merchantIdentifier = @"foo";
+    request.paymentSummaryItems = @[[PKPaymentSummaryItem summaryItemWithLabel:@"bar" amount:[NSDecimalNumber decimalNumberWithString:@"1.00"]]];
+
+    XCTAssertTrue([Stripe canSubmitPaymentRequest:request]);
+}
+
+- (void)testCanSubmitPaymentRequestReturnsNOIfTotalIsZero {
+    PKPaymentRequest *request = [[PKPaymentRequest alloc] init];
+    request.merchantIdentifier = @"foo";
+    request.paymentSummaryItems = @[[PKPaymentSummaryItem summaryItemWithLabel:@"bar" amount:[NSDecimalNumber decimalNumberWithString:@"0.00"]]];
+
+    XCTAssertFalse([Stripe canSubmitPaymentRequest:request]);
+}
+
+- (void)testCanSubmitPaymentRequestReturnsNOIfMerchantIdentifierIsNil {
+    PKPaymentRequest *request = [[PKPaymentRequest alloc] init];
+    request.paymentSummaryItems = @[[PKPaymentSummaryItem summaryItemWithLabel:@"bar" amount:[NSDecimalNumber decimalNumberWithString:@"1.00"]]];
+
+    XCTAssertFalse([Stripe canSubmitPaymentRequest:request]);
+}
+
+@end


### PR DESCRIPTION
r? @bdorfman-stripe 
Follow-up to #690 

- Deprecated `paymentRequestWithMerchantIdentifier:` in favor of a new variant that allows setting  country and currency.
- Added a `paymentCountry` property to `PaymentContext` that determines the `PKPaymentRequest`s countryCode.
- Per discussion, we're not going to constrain `supportedNetworks` based on country.