### PR TITLE
Use 10.3.1 simulator for tests

### DIFF
--- a/Tests/installation_tests/carthage/test.sh
+++ b/Tests/installation_tests/carthage/test.sh
@@ -21,4 +21,4 @@ echo "git \"$GIT_REPO\" \"$GIT_BRANCH\"" > "$TESTDIR/Cartfile"
 
 carthage bootstrap --platform ios --configuration Debug --no-use-binaries
 
-xcodebuild build -project "${TESTDIR}/CarthageTest.xcodeproj" -scheme CarthageTest -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.3' | xcpretty -c
+xcodebuild build -project "${TESTDIR}/CarthageTest.xcodeproj" -scheme CarthageTest -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.3.1' | xcpretty -c

--- a/Tests/installation_tests/cocoapods/with_frameworks/test.sh
+++ b/Tests/installation_tests/cocoapods/with_frameworks/test.sh
@@ -12,4 +12,4 @@ gem update cocoapods --no-ri --no-rdoc
 
 rm -rf Pods
 rm -f Podfile.lock
-pod install --no-repo-update && xcodebuild build -workspace CocoapodsTest.xcworkspace -scheme CocoapodsTest -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.3' | xcpretty -c
+pod install --no-repo-update && xcodebuild build -workspace CocoapodsTest.xcworkspace -scheme CocoapodsTest -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.3.1' | xcpretty -c

--- a/Tests/installation_tests/cocoapods/without_frameworks/test.sh
+++ b/Tests/installation_tests/cocoapods/without_frameworks/test.sh
@@ -12,4 +12,4 @@ gem update cocoapods --no-ri --no-rdoc
 
 rm -rf Pods
 rm -f Podfile.lock
-pod install --no-repo-update && xcodebuild build -workspace CocoapodsTest.xcworkspace -scheme CocoapodsTest -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.3' | xcpretty -c
+pod install --no-repo-update && xcodebuild build -workspace CocoapodsTest.xcworkspace -scheme CocoapodsTest -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.3.1' | xcpretty -c

--- a/Tests/installation_tests/manual_installation/test.sh
+++ b/Tests/installation_tests/manual_installation/test.sh
@@ -22,5 +22,5 @@ mkdir $FRAMEWORKDIR
 cp $BUILDDIR/StripeiOS-Static.zip $FRAMEWORKDIR
 ditto -xk $FRAMEWORKDIR/StripeiOS-Static.zip $FRAMEWORKDIR
 
-xcodebuild clean build-for-testing -project "${TESTDIR}/ManualInstallationTest.xcodeproj" -scheme ManualInstallationTest -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.3' | xcpretty -c
-xcodebuild test-without-building -project "${TESTDIR}/ManualInstallationTest.xcodeproj" -scheme ManualInstallationTest -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.3' | xcpretty -c
+xcodebuild clean build-for-testing -project "${TESTDIR}/ManualInstallationTest.xcodeproj" -scheme ManualInstallationTest -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.3.1' | xcpretty -c
+xcodebuild test-without-building -project "${TESTDIR}/ManualInstallationTest.xcodeproj" -scheme ManualInstallationTest -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.3.1' | xcpretty -c

--- a/ci_scripts/run_tests.sh
+++ b/ci_scripts/run_tests.sh
@@ -4,7 +4,7 @@ carthage bootstrap --platform ios --configuration Release --no-use-binaries
 cd Example; carthage bootstrap --platform ios; cd ..
 
 gem install xcpretty --no-ri --no-rdoc
-xcodebuild clean build build-for-testing -workspace Stripe.xcworkspace -scheme "StripeiOS" -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.3' | xcpretty -c
-xcodebuild test-without-building -workspace Stripe.xcworkspace -scheme "StripeiOS" -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.3' | xcpretty -c
-xcodebuild build -workspace Stripe.xcworkspace -scheme "Stripe iOS Example (Simple)" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.3'  | xcpretty -c
-xcodebuild build -workspace Stripe.xcworkspace -scheme "Stripe iOS Example (Custom)" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.3' | xcpretty -c
+xcodebuild clean build build-for-testing -workspace Stripe.xcworkspace -scheme "StripeiOS" -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.3.1' | xcpretty -c
+xcodebuild test-without-building -workspace Stripe.xcworkspace -scheme "StripeiOS" -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.3.1' | xcpretty -c
+xcodebuild build -workspace Stripe.xcworkspace -scheme "Stripe iOS Example (Simple)" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.3.1'  | xcpretty -c
+xcodebuild build -workspace Stripe.xcworkspace -scheme "Stripe iOS Example (Custom)" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.3.1' | xcpretty -c


### PR DESCRIPTION
r? @bdorfman-stripe 

Tests are failing [0] because there's isn't a 10.3 simulator. It seems like this was caused by the Xcode 8.3.3 update [1]. I'll file an issue with travis, but for now we can just use the 10.3.1 simulator.

[0] https://travis-ci.org/stripe/stripe-ios/jobs/240876722
[1] https://forums.developer.apple.com/thread/79083