### PR TITLE
Improve `setup.sh` script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -3,7 +3,10 @@
 echo '▸ Installing dependencies for Stripe iOS Example (Simple)';
 
 cd Example;
-rm Cartfile.resolved;
+
+if [[ -e Cartfile.resolved ]]; then
+  rm Cartfile.resolved;
+fi
 
 if ! command -v carthage > /dev/null; then
   echo ''

--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,17 @@
 #!/bin/bash
 
 echo '▸ Installing dependencies for Stripe iOS Example (Simple)';
+
 cd Example;
 rm Cartfile.resolved;
+
+if ! command -v carthage > /dev/null; then
+  echo ''
+  echo 'ERROR: Please install carthage before running setup.sh:'
+  echo 'https://github.com/Carthage/Carthage#installing-carthage';
+  exit 1;
+fi
+
 carthage bootstrap --platform ios;
+
 echo '▸ Finished installing dependencies for Stripe iOS Example (Simple)';


### PR DESCRIPTION
r? @bdorfman-stripe 
cc @bg-stripe 

## Summary

- Check that `carthage` is installed before attempting to use it. If not, show help doc to installation instructions
- Silence the `rm` error if `Cartfile.resolved` already doesn't exist

Before

```
$ ./setup.sh
▸ Installing dependencies for Stripe iOS Example (Simple)
rm: Cartfile.resolved: No such file or directory
./setup.sh: line 6: carthage: command not found
▸ Finished installing dependencies for Stripe iOS Example (Simple)
```

After

```
$ ./setup.sh
▸ Installing dependencies for Stripe iOS Example (Simple)

ERROR: Please install carthage before running setup.sh:
https://github.com/Carthage/Carthage#installing-carthage
```

## Motivation

Improve initial setup DX

## Testing

- Verified `carthage` still bootstraps if it is installed
- Verified `Cartfile.resolved` still removed if it does exist
