### PR TITLE
Add description implementations

### DIFF
--- a/Stripe/PublicHeaders/STPCard.h
+++ b/Stripe/PublicHeaders/STPCard.h
@@ -78,6 +78,15 @@ typedef NS_ENUM(NSInteger, STPCardFundingType) {
 + (STPCardFundingType)fundingFromString:(NSString *)string;
 
 /**
+ * Returns a string representation for the provided card funding
+ *
+ * @param funding The enum value you want to covert to a string
+ *
+ * @return A string representation of the funding, suitable for displaying to a user
+ */
++ (NSString *)stringFromFunding:(STPCardFundingType)funding;
+
+/**
  *  The last 4 digits of the card.
  */
 @property (nonatomic, readonly) NSString *last4;

--- a/Stripe/PublicHeaders/STPCard.h
+++ b/Stripe/PublicHeaders/STPCard.h
@@ -78,15 +78,6 @@ typedef NS_ENUM(NSInteger, STPCardFundingType) {
 + (STPCardFundingType)fundingFromString:(NSString *)string;
 
 /**
- * Returns a string representation for the provided card funding
- *
- * @param funding The enum value you want to covert to a string
- *
- * @return A string representation of the funding, suitable for displaying to a user
- */
-+ (NSString *)stringFromFunding:(STPCardFundingType)funding;
-
-/**
  *  The last 4 digits of the card.
  */
 @property (nonatomic, readonly) NSString *last4;

--- a/Stripe/STPBankAccount.m
+++ b/Stripe/STPBankAccount.m
@@ -54,7 +54,58 @@
     return [self.bankAccountId isEqualToString:bankAccount.bankAccountId];
 }
 
-#pragma mark STPAPIResponseDecodable
+#pragma mark - Description
+
+- (NSString *)description {
+    NSString *statusDescription;
+
+    switch (self.status) {
+        case STPBankAccountStatusNew:
+            statusDescription = @"new";
+        case STPBankAccountStatusValidated:
+            statusDescription = @"validated";
+        case STPBankAccountStatusVerified:
+            statusDescription = @"verified";
+        case STPBankAccountStatusErrored:
+            statusDescription = @"errored";
+    }
+
+    NSString *accountHolderTypeDescription;
+
+    switch (self.accountHolderType) {
+        case STPBankAccountHolderTypeIndividual:
+            accountHolderTypeDescription = @"individual";
+        case STPBankAccountHolderTypeCompany:
+            accountHolderTypeDescription = @"company";
+    }
+
+    NSArray *descriptionComponents = @[
+                                       // Object
+                                       [NSString stringWithFormat:@"%@: %p", NSStringFromClass([self class]), self],
+
+                                       // Identifier
+                                       [NSString stringWithFormat:@"bankAccountId = %@", self.bankAccountId],
+
+                                       // Basic account details
+                                       [NSString stringWithFormat:@"routingNumber = %@", self.routingNumber],
+                                       [NSString stringWithFormat:@"last4 = %@", self.last4],
+
+                                       // Additional account details
+                                       [NSString stringWithFormat:@"bankName = %@", self.bankName],
+                                       [NSString stringWithFormat:@"country = %@", self.country],
+                                       [NSString stringWithFormat:@"currency = %@", self.currency],
+                                       [NSString stringWithFormat:@"fingerprint = %@", self.fingerprint],
+                                       [NSString stringWithFormat:@"status = %@", statusDescription],
+
+                                       // Owner details
+                                       [NSString stringWithFormat:@"accountHolderName = %@", (self.accountHolderName) ? @"<redacted>" : nil],
+                                       [NSString stringWithFormat:@"accountHolderType = %@", accountHolderTypeDescription],
+                                       ];
+
+    return [NSString stringWithFormat:@"<%@>", [descriptionComponents componentsJoinedByString:@"; "]];
+}
+
+#pragma mark - STPAPIResponseDecodable
 
 + (NSArray *)requiredFields {
     return @[

--- a/Stripe/STPCard.m
+++ b/Stripe/STPCard.m
@@ -97,19 +97,6 @@
     }
 }
 
-+ (NSString *)displayStringFromFunding:(STPCardFundingType)funding {
-    switch (funding) {
-        case STPCardFundingTypeCredit:
-            return @"Credit";
-        case STPCardFundingTypeDebit:
-            return @"Debit";
-        case STPCardFundingTypePrepaid:
-            return @"Prepaid";
-        case STPCardFundingTypeOther:
-            return @"Other";
-    }
-}
-
 - (instancetype)init {
     self = [super init];
     if (self) {
@@ -127,6 +114,8 @@
 - (BOOL)isApplePayCard {
     return [self.allResponseFields[@"tokenization_method"] isEqualToString:@"apple_pay"];
 }
+
+#pragma mark - Equality
 
 - (BOOL)isEqual:(id)other {
     return [self isEqualToCard:other];
@@ -148,12 +137,27 @@
     return [self.cardId isEqualToString:other.cardId];
 }
 
+#pragma mark - Description
+
 - (NSString *)description {
+    NSString *fundingDescription;
+
+    switch (self.funding) {
+        case STPCardFundingTypeCredit:
+            fundingDescription = @"credit";
+        case STPCardFundingTypeDebit:
+            fundingDescription = @"debit";
+        case STPCardFundingTypePrepaid:
+            fundingDescription = @"prepaid";
+        case STPCardFundingTypeOther:
+            fundingDescription = @"other";
+    }
+
     NSArray *descriptionComponents = @[
-                                       // NSObject
+                                       // Object
                                        [NSString stringWithFormat:@"%@: %p", NSStringFromClass([self class]), self],
 
-                                       // Card ID
+                                       // Identifier
                                        [NSString stringWithFormat:@"cardId = %@", self.cardId],
 
                                        // Basic card details
@@ -161,7 +165,7 @@
                                        [NSString stringWithFormat:@"last4 = %@", self.last4],
                                        [NSString stringWithFormat:@"expMonth = %lu", (unsigned long)self.expMonth],
                                        [NSString stringWithFormat:@"expYear = %lu", (unsigned long)self.expYear],
-                                       [NSString stringWithFormat:@"funding = %@", [STPCard displayStringFromFunding:self.funding]],
+                                       [NSString stringWithFormat:@"funding = %@", fundingDescription],
 
                                        // Additional card details
                                        [NSString stringWithFormat:@"country = %@", self.country],
@@ -170,9 +174,10 @@
                                        [NSString stringWithFormat:@"isApplePayCard = %@", (self.isApplePayCard) ? @"YES" : @"NO"],
 
                                        // Cardholder details
-                                       [NSString stringWithFormat:@"name = %@", (self.name.length > 0) ? @"<redacted>" : nil],
+                                       [NSString stringWithFormat:@"name = %@", (self.name) ? @"<redacted>" : nil],
                                        [NSString stringWithFormat:@"address = %@", (self.address) ? @"<redacted>" : nil],
                                        ];
+
     return [NSString stringWithFormat:@"<%@>", [descriptionComponents componentsJoinedByString:@"; "]];
 }
 
@@ -191,7 +196,8 @@
     return nil;
 }
 
-#pragma mark STPAPIResponseDecodable
+#pragma mark - STPAPIResponseDecodable
+
 + (NSArray *)requiredFields {
     return @[@"id", @"last4", @"brand", @"exp_month", @"exp_year"];
 }

--- a/Stripe/STPCard.m
+++ b/Stripe/STPCard.m
@@ -97,7 +97,7 @@
     }
 }
 
-+ (NSString *)stringFromFunding:(STPCardFundingType)funding {
++ (NSString *)displayStringFromFunding:(STPCardFundingType)funding {
     switch (funding) {
         case STPCardFundingTypeCredit:
             return @"Credit";
@@ -149,32 +149,31 @@
 }
 
 - (NSString *)description {
-    NSMutableArray *descriptionParts = [[NSMutableArray alloc] init];
+    NSArray *descriptionComponents = @[
+                                       // NSObject
+                                       [NSString stringWithFormat:@"%@: %p", NSStringFromClass([self class]), self],
 
-    // NSObject
-    [descriptionParts addObject:[NSString stringWithFormat:@"%@: %p", NSStringFromClass([self class]), self]];
+                                       // Card ID
+                                       [NSString stringWithFormat:@"cardId = %@", self.cardId],
 
-    // Card ID
-    [descriptionParts addObject:[NSString stringWithFormat:@"cardId = %@", self.cardId]];
+                                       // Basic card details
+                                       [NSString stringWithFormat:@"brand = %@", [STPCard stringFromBrand:self.brand]],
+                                       [NSString stringWithFormat:@"last4 = %@", self.last4],
+                                       [NSString stringWithFormat:@"expMonth = %lu", (unsigned long)self.expMonth],
+                                       [NSString stringWithFormat:@"expYear = %lu", (unsigned long)self.expYear],
+                                       [NSString stringWithFormat:@"funding = %@", [STPCard displayStringFromFunding:self.funding]],
 
-    // Basic card details
-    [descriptionParts addObject:[NSString stringWithFormat:@"brand = %@", [STPCard stringFromBrand:self.brand]]];
-    [descriptionParts addObject:[NSString stringWithFormat:@"last4 = %@", self.last4]];
-    [descriptionParts addObject:[NSString stringWithFormat:@"expMonth = %lu", (unsigned long)self.expMonth]];
-    [descriptionParts addObject:[NSString stringWithFormat:@"expYear = %lu", (unsigned long)self.expYear]];
-    [descriptionParts addObject:[NSString stringWithFormat:@"funding = %@", [STPCard stringFromFunding:self.funding]]];
+                                       // Additional card details
+                                       [NSString stringWithFormat:@"country = %@", self.country],
+                                       [NSString stringWithFormat:@"currency = %@", self.currency],
+                                       [NSString stringWithFormat:@"dynamicLast4 = %@", self.dynamicLast4],
+                                       [NSString stringWithFormat:@"isApplePayCard = %@", (self.isApplePayCard) ? @"YES" : @"NO"],
 
-    // Additional card details
-    [descriptionParts addObject:[NSString stringWithFormat:@"country = %@", self.country]];
-    [descriptionParts addObject:[NSString stringWithFormat:@"currency = %@", self.currency]];
-    [descriptionParts addObject:[NSString stringWithFormat:@"dynamicLast4 = %@", self.dynamicLast4]];
-    [descriptionParts addObject:[NSString stringWithFormat:@"isApplePayCard = %@", (self.isApplePayCard) ? @"YES" : @"NO"]];
-
-    // Cardholder details
-    [descriptionParts addObject:[NSString stringWithFormat:@"name = %@", (self.name.length > 0) ? @"<redacted>" : nil]];
-    [descriptionParts addObject:[NSString stringWithFormat:@"address = %@", (self.address) ? @"<redacted>" : nil]];
-
-    return [NSString stringWithFormat:@"<%@>", [descriptionParts componentsJoinedByString:@"; "]];
+                                       // Cardholder details
+                                       [NSString stringWithFormat:@"name = %@", (self.name.length > 0) ? @"<redacted>" : nil],
+                                       [NSString stringWithFormat:@"address = %@", (self.address) ? @"<redacted>" : nil],
+                                       ];
+    return [NSString stringWithFormat:@"<%@>", [descriptionComponents componentsJoinedByString:@"; "]];
 }
 
 - (STPAddress *)address {

--- a/Stripe/STPCard.m
+++ b/Stripe/STPCard.m
@@ -148,6 +148,35 @@
     return [self.cardId isEqualToString:other.cardId];
 }
 
+- (NSString *)description {
+    NSMutableArray *descriptionParts = [[NSMutableArray alloc] init];
+
+    // NSObject
+    [descriptionParts addObject:[NSString stringWithFormat:@"%@: %p", NSStringFromClass([self class]), self]];
+
+    // Card ID
+    [descriptionParts addObject:[NSString stringWithFormat:@"cardId = %@", self.cardId]];
+
+    // Basic card details
+    [descriptionParts addObject:[NSString stringWithFormat:@"brand = %@", [STPCard stringFromBrand:self.brand]]];
+    [descriptionParts addObject:[NSString stringWithFormat:@"last4 = %@", self.last4]];
+    [descriptionParts addObject:[NSString stringWithFormat:@"expMonth = %lu", (unsigned long)self.expMonth]];
+    [descriptionParts addObject:[NSString stringWithFormat:@"expYear = %lu", (unsigned long)self.expYear]];
+    [descriptionParts addObject:[NSString stringWithFormat:@"funding = %@", [STPCard stringFromFunding:self.funding]]];
+
+    // Additional card details
+    [descriptionParts addObject:[NSString stringWithFormat:@"country = %@", self.country]];
+    [descriptionParts addObject:[NSString stringWithFormat:@"currency = %@", self.currency]];
+    [descriptionParts addObject:[NSString stringWithFormat:@"dynamicLast4 = %@", self.dynamicLast4]];
+    [descriptionParts addObject:[NSString stringWithFormat:@"isApplePayCard = %@", (self.isApplePayCard) ? @"YES" : @"NO"]];
+
+    // Cardholder details
+    [descriptionParts addObject:[NSString stringWithFormat:@"name = %@", (self.name.length > 0) ? @"<redacted>" : nil]];
+    [descriptionParts addObject:[NSString stringWithFormat:@"address = %@", (self.address) ? @"<redacted>" : nil]];
+
+    return [NSString stringWithFormat:@"<%@>", [descriptionParts componentsJoinedByString:@"; "]];
+}
+
 - (STPAddress *)address {
     if (self.name || self.addressLine1 || self.addressLine2 || self.addressZip || self.addressCity || self.addressState || self.addressCountry) {
         STPAddress *address = [STPAddress new];

--- a/Stripe/STPCard.m
+++ b/Stripe/STPCard.m
@@ -97,6 +97,19 @@
     }
 }
 
++ (NSString *)stringFromFunding:(STPCardFundingType)funding {
+    switch (funding) {
+        case STPCardFundingTypeCredit:
+            return @"Credit";
+        case STPCardFundingTypeDebit:
+            return @"Debit";
+        case STPCardFundingTypePrepaid:
+            return @"Prepaid";
+        case STPCardFundingTypeOther:
+            return @"Other";
+    }
+}
+
 - (instancetype)init {
     self = [super init];
     if (self) {


### PR DESCRIPTION
Wanted to get some early feedback on this before I dive into adding description implementations to a bunch more classes.

- What do you think about the formatting?
  - I think there's a little too much spacing but it's nice that it looks like stock iOS descriptions
- Should we make `[STPCard stringFromFunding:]` public or just keep it private?
- How does the description string building pattern / ordering feel?
- I decided to redact the cardholder details. Are there others we should consider?

Here's what the output would look like:

```
<__NSArrayI 0x6000002454f0>(
<STPCard: 0x600000151930; cardId = card_1AUJxDEOD54MuFwSyKCDbNuU; brand = Visa; last4 = 1881; expMonth = 11; expYear = 2029; funding = Credit; country = CA; currency = (null); dynamicLast4 = (null); isApplePayCard = NO; name = (null); address = (null)>,
<STPCard: 0x600000151b40; cardId = card_1AUJunEOD54MuFwSnU9HEPUO; brand = Visa; last4 = 4242; expMonth = 4; expYear = 2024; funding = Credit; country = US; currency = (null); dynamicLast4 = (null); isApplePayCard = NO; name = (null); address = (null)>,
<STPCard: 0x600000151670; cardId = card_1AVRojEOD54MuFwSxr93QJSx; brand = Visa; last4 = 5556; expMonth = 12; expYear = 2034; funding = Debit; country = US; currency = (null); dynamicLast4 = (null); isApplePayCard = NO; name = <redacted>; address = <redacted>>
)
```

cc @bg-stripe @bdorfman-stripe 