### PR TITLE
Add description implementations for public models

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+== 10.3.0 2017-XX-XX
+* Fixed nullability annotation for `[STPFile stringFromPurpose:]`. See MIGRATING.md.
+
 == 10.2.0 2017-06-19
 * We've added a `paymentCountry` property to `STPPaymentContext`. This affects the countryCode of Apple Pay payments, and defaults to "US". You should set this to the country your Stripe account is in.
 * `paymentRequestWithMerchantIdentifier:` has been deprecated. See MIGRATING.md

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,5 +1,9 @@
 ## Migration Guides
 
+### Migrating from versions < 10.3.0
+
+- Fixed nullability annotation for `[STPFile stringFromPurpose:]` which returns `nil` for `STPFilePurposeUnknown`. Will return a non-nil value for all other `STPFilePurpose`.
+
 ### Migrating from versions < 10.2.0
 - `paymentRequestWithMerchantIdentifier:` has been deprecated. You should instead use `paymentRequestWithMerchantIdentifier:country:currency:`. Apple Pay is now available in many countries and currencies, and you should use the appropriate values for your business.
 - We've added a `paymentCountry` property to `STPPaymentContext`. This affects the countryCode of Apple Pay payments, and defaults to "US". You should set this to the country your Stripe account is in.

--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -374,7 +374,22 @@
 		04F94DD31D22A23F004FC826 /* NSBundle+Stripe_AppName.h in Headers */ = {isa = PBXBuildFile; fileRef = 049A3F971CC76A2400F57DE7 /* NSBundle+Stripe_AppName.h */; };
 		04F94DD41D22A242004FC826 /* NSBundle+Stripe_AppName.m in Sources */ = {isa = PBXBuildFile; fileRef = 049A3F981CC76A2400F57DE7 /* NSBundle+Stripe_AppName.m */; };
 		04FCFA191BD59A8C00297732 /* STPCategoryLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 04FCFA171BD59A8C00297732 /* STPCategoryLoader.h */; };
+		8B429AD81EF9D4B400F95F34 /* STPBankAccountParams+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B429AD71EF9D4A300F95F34 /* STPBankAccountParams+Private.h */; };
+		8B429AD91EF9D4B500F95F34 /* STPBankAccountParams+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B429AD71EF9D4A300F95F34 /* STPBankAccountParams+Private.h */; };
+		8B429ADB1EF9E18400F95F34 /* STPBankAccount+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B429ADA1EF9E15900F95F34 /* STPBankAccount+Private.h */; };
+		8B429ADC1EF9E18400F95F34 /* STPBankAccount+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B429ADA1EF9E15900F95F34 /* STPBankAccount+Private.h */; };
+		8B429ADE1EF9EFF900F95F34 /* STPFile+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B429ADD1EF9EFF600F95F34 /* STPFile+Private.h */; };
+		8B429ADF1EF9EFFA00F95F34 /* STPFile+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B429ADD1EF9EFF600F95F34 /* STPFile+Private.h */; };
 		8B8DDBB31EF887A4004B141F /* STPBankAccountParamsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B8DDBB21EF887A4004B141F /* STPBankAccountParamsTest.m */; };
+		8BD87B881EFB131700269C2B /* STPSourceCardDetails+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BD87B871EFB131400269C2B /* STPSourceCardDetails+Private.h */; };
+		8BD87B891EFB131800269C2B /* STPSourceCardDetails+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BD87B871EFB131400269C2B /* STPSourceCardDetails+Private.h */; };
+		8BD87B8B1EFB136F00269C2B /* STPSourceCardDetailsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BD87B8A1EFB136F00269C2B /* STPSourceCardDetailsTest.m */; };
+		8BD87B8D1EFB152B00269C2B /* STPSourceRedirect+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BD87B8C1EFB152800269C2B /* STPSourceRedirect+Private.h */; };
+		8BD87B8E1EFB152B00269C2B /* STPSourceRedirect+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BD87B8C1EFB152800269C2B /* STPSourceRedirect+Private.h */; };
+		8BD87B901EFB17AA00269C2B /* STPSourceRedirectTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BD87B8F1EFB17AA00269C2B /* STPSourceRedirectTest.m */; };
+		8BD87B921EFB1C1E00269C2B /* STPSourceVerification+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BD87B911EFB1C1E00269C2B /* STPSourceVerification+Private.h */; };
+		8BD87B931EFB1C1E00269C2B /* STPSourceVerification+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BD87B911EFB1C1E00269C2B /* STPSourceVerification+Private.h */; };
+		8BD87B951EFB1CB100269C2B /* STPSourceVerificationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BD87B941EFB1CB100269C2B /* STPSourceVerificationTest.m */; };
 		8BE5AE8B1EF8905B0081A33C /* STPCardParamsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BE5AE8A1EF8905B0081A33C /* STPCardParamsTest.m */; };
 		C1080F491CBECF7B007B2D89 /* STPAddress.h in Headers */ = {isa = PBXBuildFile; fileRef = C1080F471CBECF7B007B2D89 /* STPAddress.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C1080F4A1CBECF7B007B2D89 /* STPAddress.m in Sources */ = {isa = PBXBuildFile; fileRef = C1080F481CBECF7B007B2D89 /* STPAddress.m */; };
@@ -997,7 +1012,16 @@
 		04FCFA171BD59A8C00297732 /* STPCategoryLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPCategoryLoader.h; sourceTree = "<group>"; };
 		11C74B9B164043050071C2CA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		4A0D74F918F6106100966D7B /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
+		8B429AD71EF9D4A300F95F34 /* STPBankAccountParams+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPBankAccountParams+Private.h"; sourceTree = "<group>"; };
+		8B429ADA1EF9E15900F95F34 /* STPBankAccount+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPBankAccount+Private.h"; sourceTree = "<group>"; };
+		8B429ADD1EF9EFF600F95F34 /* STPFile+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPFile+Private.h"; sourceTree = "<group>"; };
 		8B8DDBB21EF887A4004B141F /* STPBankAccountParamsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPBankAccountParamsTest.m; sourceTree = "<group>"; };
+		8BD87B871EFB131400269C2B /* STPSourceCardDetails+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSourceCardDetails+Private.h"; sourceTree = "<group>"; };
+		8BD87B8A1EFB136F00269C2B /* STPSourceCardDetailsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPSourceCardDetailsTest.m; sourceTree = "<group>"; };
+		8BD87B8C1EFB152800269C2B /* STPSourceRedirect+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSourceRedirect+Private.h"; sourceTree = "<group>"; };
+		8BD87B8F1EFB17AA00269C2B /* STPSourceRedirectTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPSourceRedirectTest.m; sourceTree = "<group>"; };
+		8BD87B911EFB1C1E00269C2B /* STPSourceVerification+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "STPSourceVerification+Private.h"; sourceTree = "<group>"; };
+		8BD87B941EFB1CB100269C2B /* STPSourceVerificationTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPSourceVerificationTest.m; sourceTree = "<group>"; };
 		8BE5AE8A1EF8905B0081A33C /* STPCardParamsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPCardParamsTest.m; sourceTree = "<group>"; };
 		C1080F471CBECF7B007B2D89 /* STPAddress.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = STPAddress.h; path = PublicHeaders/STPAddress.h; sourceTree = "<group>"; };
 		C1080F481CBECF7B007B2D89 /* STPAddress.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPAddress.m; sourceTree = "<group>"; };
@@ -1467,7 +1491,6 @@
 				04CDB5211A5F3A9300B854EE /* STPApplePayFunctionalTest.m */,
 				04CDB5221A5F3A9300B854EE /* STPBankAccountFunctionalTest.m */,
 				04CDB5241A5F3A9300B854EE /* STPCardFunctionalTest.m */,
-				C1CFCB701ED5E11500BE45DF /* STPFileTest.m */,
 				C1CFCB6F1ED5E11500BE45DF /* STPFileFunctionalTest.m */,
 				C1CFCB711ED5E11500BE45DF /* STPPIIFunctionalTest.m */,
 				C1D7B5241E36C70D002181F5 /* STPSourceFunctionalTest.m */,
@@ -1499,6 +1522,7 @@
 				C1D23FAC1D37F81F002FD83C /* STPCustomerTest.m */,
 				C1EEDCC51CA2126000A54582 /* STPDelegateProxyTest.m */,
 				04A488351CA34DC600506E53 /* STPEmailAddressValidatorTest.m */,
+				C1CFCB701ED5E11500BE45DF /* STPFileTest.m */,
 				04CDB51F1A5F3A9300B854EE /* STPFormEncoderTest.m */,
 				C16F66AA1CA21BAC006A21B5 /* STPFormTextFieldTest.m */,
 				04827D171D257A6C002DB3E8 /* STPImageLibraryTest.m */,
@@ -1508,8 +1532,11 @@
 				C1EEDCC91CA2186300A54582 /* STPPhoneNumberValidatorTest.m */,
 				C1FEE5981CBFF24000A7632B /* STPPostalCodeValidatorTest.m */,
 				F152321A1EA92F9D00D65C67 /* STPRedirectContextTest.m */,
+				8BD87B8A1EFB136F00269C2B /* STPSourceCardDetailsTest.m */,
 				C1BD9B1E1E390A2700CEE925 /* STPSourceParamsTest.m */,
+				8BD87B8F1EFB17AA00269C2B /* STPSourceRedirectTest.m */,
 				C17D24ED1E37DBAC005CB188 /* STPSourceTest.m */,
+				8BD87B941EFB1CB100269C2B /* STPSourceVerificationTest.m */,
 				F1D777BF1D81DD520076FA19 /* STPStringUtilsTest.m */,
 				C19D09911EAEAE5200A4AB3E /* STPTelemetryClientTest.m */,
 				04CDB5271A5F3A9300B854EE /* STPTokenTest.m */,
@@ -1645,7 +1672,6 @@
 		F1728CED1EAAA2D9002E0C29 /* API Bindings */ = {
 			isa = PBXGroup;
 			children = (
-				F1D3A2461EB012010095BFA9 /* STPFile.m */,
 				F1728CF51EAAA4A1002E0C29 /* Models */,
 				04CDB4C21A5F30A700B854EE /* STPAPIClient.h */,
 				04CDB4C31A5F30A700B854EE /* STPAPIClient.m */,
@@ -1725,7 +1751,10 @@
 				049952D11BCF13DD0088C703 /* STPAPIClient+Private.h */,
 				049952CD1BCF13510088C703 /* STPAPIRequest.h */,
 				049952CE1BCF13510088C703 /* STPAPIRequest.m */,
+				8B429ADA1EF9E15900F95F34 /* STPBankAccount+Private.h */,
+				8B429AD71EF9D4A300F95F34 /* STPBankAccountParams+Private.h */,
 				C1A06F0F1E1D8A6E004DCA06 /* STPCard+Private.h */,
+				8B429ADD1EF9EFF600F95F34 /* STPFile+Private.h */,
 				04CDB4C41A5F30A700B854EE /* STPFormEncoder.h */,
 				04CDB4C51A5F30A700B854EE /* STPFormEncoder.m */,
 				F1D3A2471EB012010095BFA9 /* STPMultipartFormDataEncoder.h */,
@@ -1733,9 +1762,12 @@
 				F1D3A2491EB012010095BFA9 /* STPMultipartFormDataPart.h */,
 				F1D3A24A1EB012010095BFA9 /* STPMultipartFormDataPart.m */,
 				C1C1012C1E57A26F00C7BFAE /* STPSource+Private.h */,
+				8BD87B871EFB131400269C2B /* STPSourceCardDetails+Private.h */,
 				F1A0197A1EA5733200354301 /* STPSourceParams+Private.h */,
 				C18021181E3A58710089D712 /* STPSourcePoller.h */,
 				C18021191E3A58710089D712 /* STPSourcePoller.m */,
+				8BD87B8C1EFB152800269C2B /* STPSourceRedirect+Private.h */,
+				8BD87B911EFB1C1E00269C2B /* STPSourceVerification+Private.h */,
 			);
 			name = "API Bindings";
 			sourceTree = "<group>";
@@ -1814,6 +1846,7 @@
 				04B31DD21D08E6E200EF1631 /* STPCustomer.h */,
 				04B31DD31D08E6E200EF1631 /* STPCustomer.m */,
 				F1D3A2501EB0120F0095BFA9 /* STPFile.h */,
+				F1D3A2461EB012010095BFA9 /* STPFile.m */,
 				04F213301BCEAB61001D6F22 /* STPFormEncodable.h */,
 				C1D7B51E1E36C32F002181F5 /* STPSource.h */,
 				C1D7B51F1E36C32F002181F5 /* STPSource.m */,
@@ -2011,6 +2044,7 @@
 				C124A17D1CCAA0C2007D42EE /* NSMutableURLRequest+Stripe.h in Headers */,
 				F1FA6F991E25970F00EB444D /* STPCoreTableViewController+Private.h in Headers */,
 				C1BD9B2F1E3940A200CEE925 /* STPSourceRedirect.h in Headers */,
+				8B429AD91EF9D4B500F95F34 /* STPBankAccountParams+Private.h in Headers */,
 				04F94DB01D229F60004FC826 /* STPRememberMeTermsView.h in Headers */,
 				04F94DBF1D22A0AA004FC826 /* STPCheckoutAPIClient.h in Headers */,
 				04E32AA01B7A9490009C9E35 /* STPPaymentCardTextField.h in Headers */,
@@ -2031,10 +2065,12 @@
 				04F213331BCEAB61001D6F22 /* STPFormEncodable.h in Headers */,
 				04F94D9C1D229EAA004FC826 /* PKPayment+Stripe.h in Headers */,
 				04F94DCF1D22A234004FC826 /* NSDecimalNumber+Stripe_Currency.h in Headers */,
+				8BD87B931EFB1C1E00269C2B /* STPSourceVerification+Private.h in Headers */,
 				C1BD9B231E393FFE00CEE925 /* STPSourceReceiver.h in Headers */,
 				049A3FAA1CC96B7C00F57DE7 /* STPApplePayPaymentMethod.h in Headers */,
 				04F94DA51D229F21004FC826 /* STPPaymentContext+Private.h in Headers */,
 				F12829DB1D7747E4008B10D6 /* STPBundleLocator.h in Headers */,
+				8BD87B891EFB131800269C2B /* STPSourceCardDetails+Private.h in Headers */,
 				04827D161D257764002DB3E8 /* STPImageLibrary+Private.h in Headers */,
 				049E84EC1A605EF0000B66CD /* StripeError.h in Headers */,
 				046FE9A31CE5608000DA6A7B /* STPPaymentActivityIndicatorView.h in Headers */,
@@ -2051,6 +2087,7 @@
 				049880FD1CED5A2300EA4FFD /* STPPaymentConfiguration.h in Headers */,
 				049A3F9B1CC7DBCC00F57DE7 /* STPPaymentContext.h in Headers */,
 				F19491E81E60DD9C001E1FC2 /* STPSourceSEPADebitDetails.h in Headers */,
+				8BD87B8E1EFB152B00269C2B /* STPSourceRedirect+Private.h in Headers */,
 				04F3BB3E1BA89B1200DE235E /* PKPayment+Stripe.h in Headers */,
 				04B31DDB1D09A4DC00EF1631 /* STPPaymentConfiguration+Private.h in Headers */,
 				045D710F1CEEE30500F6CD65 /* STPAspects.h in Headers */,
@@ -2067,8 +2104,10 @@
 				04F94DA31D229F18004FC826 /* STPAddressViewModel.h in Headers */,
 				0438EF3A1B7416BB00D506CC /* STPPaymentCardTextFieldViewModel.h in Headers */,
 				04B31DF31D09F0A800EF1631 /* UIViewController+Stripe_NavigationItemProxy.h in Headers */,
+				8B429ADF1EF9EFFA00F95F34 /* STPFile+Private.h in Headers */,
 				0426B9771CEBD001006AC8DD /* UINavigationBar+Stripe_Theme.h in Headers */,
 				04CDE5BE1BC1F21500548833 /* STPCardParams.h in Headers */,
+				8B429ADC1EF9E18400F95F34 /* STPBankAccount+Private.h in Headers */,
 				04F94D9F1D229F09004FC826 /* STPPostalCodeValidator.h in Headers */,
 				F1C7B8D61DBECF2400D9F6F0 /* STPDispatchFunctions.h in Headers */,
 				C180211B1E3A58710089D712 /* STPSourcePoller.h in Headers */,
@@ -2112,6 +2151,7 @@
 				C1BD9B391E39416700CEE925 /* STPSourceOwner.h in Headers */,
 				C1080F491CBECF7B007B2D89 /* STPAddress.h in Headers */,
 				0438EF2C1B7416BB00D506CC /* STPFormTextField.h in Headers */,
+				8B429ADE1EF9EFF900F95F34 /* STPFile+Private.h in Headers */,
 				C180211A1E3A58710089D712 /* STPSourcePoller.h in Headers */,
 				04E39F5C1CECFAFD00AF3B96 /* STPPaymentContext+Private.h in Headers */,
 				C1FEE5961CBFF11400A7632B /* STPPostalCodeValidator.h in Headers */,
@@ -2129,10 +2169,12 @@
 				04BC29B11CD9AAA800318357 /* STPCheckoutAccount.h in Headers */,
 				04827D151D257764002DB3E8 /* STPImageLibrary+Private.h in Headers */,
 				049952D21BCF13DD0088C703 /* STPAPIClient+Private.h in Headers */,
+				8B429AD81EF9D4B400F95F34 /* STPBankAccountParams+Private.h in Headers */,
 				049A3F911CC740FF00F57DE7 /* NSDecimalNumber+Stripe_Currency.h in Headers */,
 				04633B071CD44F47009D4FB5 /* STPAPIClient+ApplePay.h in Headers */,
 				04BC29BD1CDD535700318357 /* STPSwitchTableViewCell.h in Headers */,
 				04CDB5121A5F30A700B854EE /* STPToken.h in Headers */,
+				8BD87B921EFB1C1E00269C2B /* STPSourceVerification+Private.h in Headers */,
 				C1785F5C1EC60B5E00E9CFAC /* STPCardIOProxy.h in Headers */,
 				049952CF1BCF13510088C703 /* STPAPIRequest.h in Headers */,
 				C15993381D8808680047950D /* STPShippingMethodTableViewCell.h in Headers */,
@@ -2183,6 +2225,8 @@
 				C1BD9B2E1E3940A200CEE925 /* STPSourceRedirect.h in Headers */,
 				04BC29A41CD8697900318357 /* STPTheme.h in Headers */,
 				04B31DF21D09F0A800EF1631 /* UIViewController+Stripe_NavigationItemProxy.h in Headers */,
+				8BD87B881EFB131700269C2B /* STPSourceCardDetails+Private.h in Headers */,
+				8BD87B8D1EFB152B00269C2B /* STPSourceRedirect+Private.h in Headers */,
 				04CDB4D31A5F30A700B854EE /* Stripe.h in Headers */,
 				04BC29C61CE2A82300318357 /* STPSMSCodeTextField.h in Headers */,
 				04E39F601CED2C3900AF3B96 /* STPRememberMeTermsView.h in Headers */,
@@ -2210,6 +2254,7 @@
 				04827D101D2575C6002DB3E8 /* STPImageLibrary.h in Headers */,
 				F152322A1EA9306100D65C67 /* NSURLComponents+Stripe.h in Headers */,
 				F1D3A25A1EB014BD0095BFA9 /* UIImage+Stripe.h in Headers */,
+				8B429ADB1EF9E18400F95F34 /* STPBankAccount+Private.h in Headers */,
 				C124A17C1CCAA0C2007D42EE /* NSMutableURLRequest+Stripe.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2607,10 +2652,12 @@
 				C1BD9B1F1E390A2700CEE925 /* STPSourceParamsTest.m in Sources */,
 				C1D7B5251E36C70D002181F5 /* STPSourceFunctionalTest.m in Sources */,
 				0438EF4D1B741B0100D506CC /* STPPaymentCardTextFieldViewModelTest.m in Sources */,
+				8BD87B951EFB1CB100269C2B /* STPSourceVerificationTest.m in Sources */,
 				C124A1811CCAA1BF007D42EE /* NSMutableURLRequest+StripeTest.m in Sources */,
 				C1EEDCC61CA2126000A54582 /* STPDelegateProxyTest.m in Sources */,
 				F1D777C01D81DD520076FA19 /* STPStringUtilsTest.m in Sources */,
 				C1FEE5991CBFF24000A7632B /* STPPostalCodeValidatorTest.m in Sources */,
+				8BD87B8B1EFB136F00269C2B /* STPSourceCardDetailsTest.m in Sources */,
 				C13538081D2C2186003F6157 /* STPAddCardViewControllerTest.m in Sources */,
 				04415C671A6605B5001225ED /* STPAPIClientTest.m in Sources */,
 				045D71311CF514BB00F6CD65 /* STPBinRangeTest.m in Sources */,
@@ -2621,6 +2668,7 @@
 				C1CFCB751ED5E12400BE45DF /* STPFileTest.m in Sources */,
 				C11810991CC6D46D0022FB55 /* NSDecimalNumber+StripeTest.m in Sources */,
 				C1EEDCC81CA2172700A54582 /* NSString+StripeTest.m in Sources */,
+				8BD87B901EFB17AA00269C2B /* STPSourceRedirectTest.m in Sources */,
 				04415C6A1A6605B5001225ED /* STPApplePayFunctionalTest.m in Sources */,
 				8BE5AE8B1EF8905B0081A33C /* STPCardParamsTest.m in Sources */,
 				F1D3A25F1EB015B30095BFA9 /* UIImage+StripeTests.m in Sources */,

--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -374,6 +374,8 @@
 		04F94DD31D22A23F004FC826 /* NSBundle+Stripe_AppName.h in Headers */ = {isa = PBXBuildFile; fileRef = 049A3F971CC76A2400F57DE7 /* NSBundle+Stripe_AppName.h */; };
 		04F94DD41D22A242004FC826 /* NSBundle+Stripe_AppName.m in Sources */ = {isa = PBXBuildFile; fileRef = 049A3F981CC76A2400F57DE7 /* NSBundle+Stripe_AppName.m */; };
 		04FCFA191BD59A8C00297732 /* STPCategoryLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 04FCFA171BD59A8C00297732 /* STPCategoryLoader.h */; };
+		8B8DDBB31EF887A4004B141F /* STPBankAccountParamsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B8DDBB21EF887A4004B141F /* STPBankAccountParamsTest.m */; };
+		8BE5AE8B1EF8905B0081A33C /* STPCardParamsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BE5AE8A1EF8905B0081A33C /* STPCardParamsTest.m */; };
 		C1080F491CBECF7B007B2D89 /* STPAddress.h in Headers */ = {isa = PBXBuildFile; fileRef = C1080F471CBECF7B007B2D89 /* STPAddress.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C1080F4A1CBECF7B007B2D89 /* STPAddress.m in Sources */ = {isa = PBXBuildFile; fileRef = C1080F481CBECF7B007B2D89 /* STPAddress.m */; };
 		C1080F4C1CBED48A007B2D89 /* STPAddressTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C1080F4B1CBED48A007B2D89 /* STPAddressTests.m */; };
@@ -995,6 +997,8 @@
 		04FCFA171BD59A8C00297732 /* STPCategoryLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPCategoryLoader.h; sourceTree = "<group>"; };
 		11C74B9B164043050071C2CA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		4A0D74F918F6106100966D7B /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
+		8B8DDBB21EF887A4004B141F /* STPBankAccountParamsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPBankAccountParamsTest.m; sourceTree = "<group>"; };
+		8BE5AE8A1EF8905B0081A33C /* STPCardParamsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPCardParamsTest.m; sourceTree = "<group>"; };
 		C1080F471CBECF7B007B2D89 /* STPAddress.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = STPAddress.h; path = PublicHeaders/STPAddress.h; sourceTree = "<group>"; };
 		C1080F481CBECF7B007B2D89 /* STPAddress.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPAddress.m; sourceTree = "<group>"; };
 		C1080F4B1CBED48A007B2D89 /* STPAddressTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPAddressTests.m; sourceTree = "<group>"; };
@@ -1485,8 +1489,10 @@
 				C124A1841CCAB750007D42EE /* STPAnalyticsClientTest.m */,
 				04CDB51E1A5F3A9300B854EE /* STPAPIClientTest.m */,
 				C1AED1551EE0C8C6008BEFBF /* STPApplePayTest.m */,
+				8B8DDBB21EF887A4004B141F /* STPBankAccountParamsTest.m */,
 				04CDB5231A5F3A9300B854EE /* STPBankAccountTest.m */,
 				045D71301CF514BB00F6CD65 /* STPBinRangeTest.m */,
+				8BE5AE8A1EF8905B0081A33C /* STPCardParamsTest.m */,
 				04CDB5251A5F3A9300B854EE /* STPCardTest.m */,
 				0438EF4A1B741B0100D506CC /* STPCardValidatorTest.m */,
 				04CDB5261A5F3A9300B854EE /* STPCertTest.m */,
@@ -2616,6 +2622,7 @@
 				C11810991CC6D46D0022FB55 /* NSDecimalNumber+StripeTest.m in Sources */,
 				C1EEDCC81CA2172700A54582 /* NSString+StripeTest.m in Sources */,
 				04415C6A1A6605B5001225ED /* STPApplePayFunctionalTest.m in Sources */,
+				8BE5AE8B1EF8905B0081A33C /* STPCardParamsTest.m in Sources */,
 				F1D3A25F1EB015B30095BFA9 /* UIImage+StripeTests.m in Sources */,
 				04415C6B1A6605B5001225ED /* STPBankAccountFunctionalTest.m in Sources */,
 				04415C6C1A6605B5001225ED /* STPBankAccountTest.m in Sources */,
@@ -2629,6 +2636,7 @@
 				F1D96F9B1DC7DCDE00477E64 /* STPLocalizationUtils+STPTestAdditions.m in Sources */,
 				04415C6F1A6605B5001225ED /* STPCertTest.m in Sources */,
 				04415C701A6605B5001225ED /* STPTokenTest.m in Sources */,
+				8B8DDBB31EF887A4004B141F /* STPBankAccountParamsTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Stripe/PublicHeaders/STPFile.h
+++ b/Stripe/PublicHeaders/STPFile.h
@@ -48,7 +48,7 @@ typedef NS_ENUM(NSInteger, STPFilePurpose) {
 /**
  * Returns the string value for a purpose.
  */
-+ (NSString *)stringFromPurpose:(STPFilePurpose)purpose;
++ (nullable NSString *)stringFromPurpose:(STPFilePurpose)purpose;
 
 @end
 

--- a/Stripe/STPBankAccount+Private.h
+++ b/Stripe/STPBankAccount+Private.h
@@ -1,0 +1,20 @@
+//
+//  STPBankAccount+Private.h
+//  Stripe
+//
+//  Created by Joey Dong on 6/20/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import "STPBankAccount.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface STPBankAccount ()
+
++ (STPBankAccountStatus)statusFromString:(NSString *)string;
++ (NSString *)stringFromStatus:(STPBankAccountStatus)status;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Stripe/STPBankAccount.m
+++ b/Stripe/STPBankAccount.m
@@ -54,7 +54,58 @@
     return [self.bankAccountId isEqualToString:bankAccount.bankAccountId];
 }
 
-#pragma mark STPAPIResponseDecodable
+#pragma mark - Description
+
+- (NSString *)description {
+    NSString *statusDescription;
+
+    switch (self.status) {
+        case STPBankAccountStatusNew:
+            statusDescription = @"new";
+        case STPBankAccountStatusValidated:
+            statusDescription = @"validated";
+        case STPBankAccountStatusVerified:
+            statusDescription = @"verified";
+        case STPBankAccountStatusErrored:
+            statusDescription = @"errored";
+    }
+
+    NSString *accountHolderTypeDescription;
+
+    switch (self.accountHolderType) {
+        case STPBankAccountHolderTypeIndividual:
+            accountHolderTypeDescription = @"individual";
+        case STPBankAccountHolderTypeCompany:
+            accountHolderTypeDescription = @"company";
+    }
+
+    NSArray *props = @[
+                       // Object
+                       [NSString stringWithFormat:@"%@: %p", NSStringFromClass([self class]), self],
+
+                       // Identifier
+                       [NSString stringWithFormat:@"bankAccountId = %@", self.bankAccountId],
+
+                       // Basic account details
+                       [NSString stringWithFormat:@"routingNumber = %@", self.routingNumber],
+                       [NSString stringWithFormat:@"last4 = %@", self.last4],
+
+                       // Additional account details (alphabetical)
+                       [NSString stringWithFormat:@"bankName = %@", self.bankName],
+                       [NSString stringWithFormat:@"country = %@", self.country],
+                       [NSString stringWithFormat:@"currency = %@", self.currency],
+                       [NSString stringWithFormat:@"fingerprint = %@", self.fingerprint],
+                       [NSString stringWithFormat:@"status = %@", statusDescription],
+
+                       // Owner details
+                       [NSString stringWithFormat:@"accountHolderName = %@", (self.accountHolderName) ? @"<redacted>" : nil],
+                       [NSString stringWithFormat:@"accountHolderType = %@", accountHolderTypeDescription],
+                       ];
+
+    return [NSString stringWithFormat:@"<%@>", [props componentsJoinedByString:@"; "]];
+}
+
+#pragma mark - STPAPIResponseDecodable
 
 + (NSArray *)requiredFields {
     return @[

--- a/Stripe/STPBankAccount.m
+++ b/Stripe/STPBankAccount.m
@@ -39,7 +39,8 @@
 }
 
 + (STPBankAccountStatus)statusFromString:(NSString *)string {
-    NSNumber *statusNumber = [self stringToStatusMapping][string];
+    NSString *key = [string lowercaseString];
+    NSNumber *statusNumber = [self stringToStatusMapping][key];
 
     if (statusNumber) {
         return (STPBankAccountStatus)[statusNumber integerValue];

--- a/Stripe/STPBankAccount.m
+++ b/Stripe/STPBankAccount.m
@@ -62,12 +62,16 @@
     switch (self.status) {
         case STPBankAccountStatusNew:
             statusDescription = @"new";
+            break;
         case STPBankAccountStatusValidated:
             statusDescription = @"validated";
+            break;
         case STPBankAccountStatusVerified:
             statusDescription = @"verified";
+            break;
         case STPBankAccountStatusErrored:
             statusDescription = @"errored";
+            break;
     }
 
     NSString *accountHolderTypeDescription;
@@ -75,8 +79,10 @@
     switch (self.accountHolderType) {
         case STPBankAccountHolderTypeIndividual:
             accountHolderTypeDescription = @"individual";
+            break;
         case STPBankAccountHolderTypeCompany:
             accountHolderTypeDescription = @"company";
+            break;
     }
 
     NSArray *props = @[

--- a/Stripe/STPBankAccountParams+Private.h
+++ b/Stripe/STPBankAccountParams+Private.h
@@ -1,0 +1,22 @@
+//
+//  STPBankAccountParams+Private.h
+//  Stripe
+//
+//  Created by Joey Dong on 6/20/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import "STPBankAccountParams.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface STPBankAccountParams ()
+
++ (STPBankAccountHolderType)accountHolderTypeFromString:(NSString *)string;
++ (NSString *)stringFromAccountHolderType:(STPBankAccountHolderType)accountHolderType;
+
+- (NSString *)accountHolderTypeString;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Stripe/STPBankAccountParams.m
+++ b/Stripe/STPBankAccountParams.m
@@ -43,6 +43,31 @@
     }
 }
 
+#pragma mark - Description
+
+- (NSString *)description {
+    NSArray *props = @[
+                       // Object
+                       [NSString stringWithFormat:@"%@: %p", NSStringFromClass([self class]), self],
+
+                       // Basic account details
+                       [NSString stringWithFormat:@"routingNumber = %@", self.routingNumber],
+                       [NSString stringWithFormat:@"last4 = %@", self.last4],
+
+                       // Additional account details (alphabetical)
+                       [NSString stringWithFormat:@"country = %@", self.country],
+                       [NSString stringWithFormat:@"currency = %@", self.currency],
+
+                       // Owner details
+                       [NSString stringWithFormat:@"accountHolderName = %@", (self.accountHolderName) ? @"<redacted>" : nil],
+                       [NSString stringWithFormat:@"accountHolderType = %@", [self accountHolderTypeString]],
+                       ];
+
+    return [NSString stringWithFormat:@"<%@>", [props componentsJoinedByString:@"; "]];
+}
+
+#pragma mark - STPFormEncodable
+
 + (NSString *)rootObjectName {
     return @"bank_account";
 }

--- a/Stripe/STPBankAccountParams.m
+++ b/Stripe/STPBankAccountParams.m
@@ -48,7 +48,8 @@
 }
 
 + (STPBankAccountHolderType)accountHolderTypeFromString:(NSString *)string {
-    NSNumber *accountHolderTypeNumber = [self stringToAccountHolderTypeMapping][string];
+    NSString *key = [string lowercaseString];
+    NSNumber *accountHolderTypeNumber = [self stringToAccountHolderTypeMapping][key];
 
     if (accountHolderTypeNumber) {
         return (STPBankAccountHolderType)[accountHolderTypeNumber integerValue];

--- a/Stripe/STPBankAccountParams.m
+++ b/Stripe/STPBankAccountParams.m
@@ -7,10 +7,14 @@
 //
 
 #import "STPBankAccountParams.h"
+#import "STPBankAccountParams+Private.h"
+
 #define FAUXPAS_IGNORED_ON_LINE(...)
 
-@interface STPBankAccountParams()
-@property(nonatomic, readonly)NSString *accountHolderTypeString;
+@interface STPBankAccountParams ()
+
+@property (nonatomic, readonly) NSString *accountHolderTypeString;
+
 @end
 
 @implementation STPBankAccountParams
@@ -34,13 +38,27 @@
     }
 }
 
-- (NSString *)accountHolderTypeString { FAUXPAS_IGNORED_ON_LINE(UnusedMethod)
-    switch (self.accountHolderType) {
-        case STPBankAccountHolderTypeCompany:
-            return @"company";
-        case STPBankAccountHolderTypeIndividual:
-            return @"individual";
+#pragma mark - STPBankAccountHolderType
+
++ (NSDictionary<NSString *, NSNumber *> *)stringToAccountHolderTypeMapping {
+    return @{
+             @"individual": @(STPBankAccountHolderTypeIndividual),
+             @"company": @(STPBankAccountHolderTypeCompany),
+             };
+}
+
++ (STPBankAccountHolderType)accountHolderTypeFromString:(NSString *)string {
+    NSNumber *accountHolderTypeNumber = [self stringToAccountHolderTypeMapping][string];
+
+    if (accountHolderTypeNumber) {
+        return (STPBankAccountHolderType)[accountHolderTypeNumber integerValue];
     }
+
+    return STPBankAccountHolderTypeIndividual;
+}
+
++ (NSString *)stringFromAccountHolderType:(STPBankAccountHolderType)accountHolderType {
+    return [[[self stringToAccountHolderTypeMapping] allKeysForObject:@(accountHolderType)] firstObject];
 }
 
 #pragma mark - Description
@@ -60,7 +78,7 @@
 
                        // Owner details
                        [NSString stringWithFormat:@"accountHolderName = %@", (self.accountHolderName) ? @"<redacted>" : nil],
-                       [NSString stringWithFormat:@"accountHolderType = %@", [self accountHolderTypeString]],
+                       [NSString stringWithFormat:@"accountHolderType = %@", [self.class stringFromAccountHolderType:self.accountHolderType]],
                        ];
 
     return [NSString stringWithFormat:@"<%@>", [props componentsJoinedByString:@"; "]];
@@ -81,6 +99,10 @@
              @"accountHolderName": @"account_holder_name",
              @"accountHolderTypeString": @"account_holder_type",
              };
+}
+
+- (NSString *)accountHolderTypeString { FAUXPAS_IGNORED_ON_LINE(UnusedMethod)
+    return [self.class stringFromAccountHolderType:self.accountHolderType];
 }
 
 @end

--- a/Stripe/STPCard+Private.h
+++ b/Stripe/STPCard+Private.h
@@ -8,6 +8,15 @@
 
 #import "STPCard.h"
 
-@interface STPCard (Private)
+NS_ASSUME_NONNULL_BEGIN
+
+@interface STPCard ()
+
++ (STPCardFundingType)fundingFromString:(NSString *)string;
++ (NSString *)stringFromFunding:(STPCardFundingType)funding;
+
 - (nullable STPAddress *)address;
+
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Stripe/STPCard+Private.h
+++ b/Stripe/STPCard+Private.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface STPCard ()
 
 + (STPCardFundingType)fundingFromString:(NSString *)string;
-+ (NSString *)stringFromFunding:(STPCardFundingType)funding;
++ (nullable NSString *)stringFromFunding:(STPCardFundingType)funding;
 
 - (nullable STPAddress *)address;
 

--- a/Stripe/STPCard.m
+++ b/Stripe/STPCard.m
@@ -145,12 +145,16 @@
     switch (self.funding) {
         case STPCardFundingTypeCredit:
             fundingDescription = @"credit";
+            break;
         case STPCardFundingTypeDebit:
             fundingDescription = @"debit";
+            break;
         case STPCardFundingTypePrepaid:
             fundingDescription = @"prepaid";
+            break;
         case STPCardFundingTypeOther:
             fundingDescription = @"other";
+            break;
     }
 
     NSArray *props = @[

--- a/Stripe/STPCard.m
+++ b/Stripe/STPCard.m
@@ -94,7 +94,6 @@
              @"credit": @(STPCardFundingTypeCredit),
              @"debit": @(STPCardFundingTypeDebit),
              @"prepaid": @(STPCardFundingTypePrepaid),
-             @"other": @(STPCardFundingTypeOther),
              };
 }
 
@@ -109,7 +108,7 @@
     return STPCardFundingTypeOther;
 }
 
-+ (NSString *)stringFromFunding:(STPCardFundingType)funding {
++ (nullable NSString *)stringFromFunding:(STPCardFundingType)funding {
     return [[[self stringToFundingMapping] allKeysForObject:@(funding)] firstObject];
 }
 
@@ -170,7 +169,7 @@
                        [NSString stringWithFormat:@"last4 = %@", self.last4],
                        [NSString stringWithFormat:@"expMonth = %lu", (unsigned long)self.expMonth],
                        [NSString stringWithFormat:@"expYear = %lu", (unsigned long)self.expYear],
-                       [NSString stringWithFormat:@"funding = %@", [self.class stringFromFunding:self.funding]],
+                       [NSString stringWithFormat:@"funding = %@", ([self.class stringFromFunding:self.funding]) ?: @"unknown"],
 
                        // Additional card details (alphabetical)
                        [NSString stringWithFormat:@"country = %@", self.country],

--- a/Stripe/STPCard.m
+++ b/Stripe/STPCard.m
@@ -115,6 +115,8 @@
     return [self.allResponseFields[@"tokenization_method"] isEqualToString:@"apple_pay"];
 }
 
+#pragma mark - Equality
+
 - (BOOL)isEqual:(id)other {
     return [self isEqualToCard:other];
 }
@@ -135,6 +137,50 @@
     return [self.cardId isEqualToString:other.cardId];
 }
 
+#pragma mark - Description
+
+- (NSString *)description {
+    NSString *fundingDescription;
+
+    switch (self.funding) {
+        case STPCardFundingTypeCredit:
+            fundingDescription = @"credit";
+        case STPCardFundingTypeDebit:
+            fundingDescription = @"debit";
+        case STPCardFundingTypePrepaid:
+            fundingDescription = @"prepaid";
+        case STPCardFundingTypeOther:
+            fundingDescription = @"other";
+    }
+
+    NSArray *props = @[
+                       // Object
+                       [NSString stringWithFormat:@"%@: %p", NSStringFromClass([self class]), self],
+
+                       // Identifier
+                       [NSString stringWithFormat:@"cardId = %@", self.cardId],
+
+                       // Basic card details
+                       [NSString stringWithFormat:@"brand = %@", [STPCard stringFromBrand:self.brand]],
+                       [NSString stringWithFormat:@"last4 = %@", self.last4],
+                       [NSString stringWithFormat:@"expMonth = %lu", (unsigned long)self.expMonth],
+                       [NSString stringWithFormat:@"expYear = %lu", (unsigned long)self.expYear],
+                       [NSString stringWithFormat:@"funding = %@", fundingDescription],
+
+                       // Additional card details (alphabetical)
+                       [NSString stringWithFormat:@"country = %@", self.country],
+                       [NSString stringWithFormat:@"currency = %@", self.currency],
+                       [NSString stringWithFormat:@"dynamicLast4 = %@", self.dynamicLast4],
+                       [NSString stringWithFormat:@"isApplePayCard = %@", (self.isApplePayCard) ? @"YES" : @"NO"],
+
+                       // Cardholder details
+                       [NSString stringWithFormat:@"name = %@", (self.name) ? @"<redacted>" : nil],
+                       [NSString stringWithFormat:@"address = %@", (self.address) ? @"<redacted>" : nil],
+                       ];
+
+    return [NSString stringWithFormat:@"<%@>", [props componentsJoinedByString:@"; "]];
+}
+
 - (STPAddress *)address {
     if (self.name || self.addressLine1 || self.addressLine2 || self.addressZip || self.addressCity || self.addressState || self.addressCountry) {
         STPAddress *address = [STPAddress new];
@@ -150,7 +196,8 @@
     return nil;
 }
 
-#pragma mark STPAPIResponseDecodable
+#pragma mark - STPAPIResponseDecodable
+
 + (NSArray *)requiredFields {
     return @[@"id", @"last4", @"brand", @"exp_month", @"exp_year"];
 }
@@ -185,7 +232,7 @@
     return card;
 }
 
-#pragma mark - STPSource
+#pragma mark - STPSourceProtocol
 
 - (NSString *)stripeID {
     return self.cardId;

--- a/Stripe/STPCardParams.m
+++ b/Stripe/STPCardParams.m
@@ -53,6 +53,30 @@
     self.addressCountry = address.country;
 }
 
+#pragma mark - Description
+
+- (NSString *)description {
+    NSArray *props = @[
+                       // Object
+                       [NSString stringWithFormat:@"%@: %p", NSStringFromClass([self class]), self],
+
+                       // Basic card details
+                       [NSString stringWithFormat:@"last4 = %@", self.last4],
+                       [NSString stringWithFormat:@"expMonth = %lu", (unsigned long)self.expMonth],
+                       [NSString stringWithFormat:@"expYear = %lu", (unsigned long)self.expYear],
+                       [NSString stringWithFormat:@"cvc = %@", (self.cvc) ? @"<redacted>" : nil],
+
+                       // Additional card details (alphabetical)
+                       [NSString stringWithFormat:@"currency = %@", self.currency],
+
+                       // Cardholder details
+                       [NSString stringWithFormat:@"name = %@", (self.name) ? @"<redacted>" : nil],
+                       [NSString stringWithFormat:@"address = %@", (self.address) ? @"<redacted>" : nil],
+                       ];
+
+    return [NSString stringWithFormat:@"<%@>", [props componentsJoinedByString:@"; "]];
+}
+
 #pragma mark - STPFormEncodable
 
 + (NSString *)rootObjectName {

--- a/Stripe/STPCustomer.m
+++ b/Stripe/STPCustomer.m
@@ -33,7 +33,25 @@
     return customer;
 }
 
-#pragma mark STPAPIResponseDecodable
+#pragma mark - Description
+
+- (NSString *)description {
+    NSArray *props = @[
+                       // Object
+                       [NSString stringWithFormat:@"%@: %p", NSStringFromClass([self class]), self],
+
+                       // Identifier
+                       [NSString stringWithFormat:@"stripeID = %@", self.stripeID],
+
+                       // Sources
+                       [NSString stringWithFormat:@"defaultSource = %@", self.defaultSource],
+                       [NSString stringWithFormat:@"sources = %@", self.sources],
+                       ];
+
+    return [NSString stringWithFormat:@"<%@>", [props componentsJoinedByString:@"; "]];
+}
+
+#pragma mark - STPAPIResponseDecodable
 
 + (NSArray *)requiredFields {
     return @[@"id"];

--- a/Stripe/STPFile+Private.h
+++ b/Stripe/STPFile+Private.h
@@ -1,0 +1,19 @@
+//
+//  STPFile+Private.h
+//  Stripe
+//
+//  Created by Joey Dong on 6/20/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import "STPFile.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface STPFile ()
+
++ (STPFilePurpose)purposeFromString:(NSString *)string;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Stripe/STPFile.m
+++ b/Stripe/STPFile.m
@@ -7,6 +7,8 @@
 //
 
 #import "STPFile.h"
+#import "STPFile+Private.h"
+
 #import "NSDictionary+Stripe.h"
 
 @interface STPFile ()
@@ -24,9 +26,9 @@
 
 @implementation STPFile
 
-#pragma mark - Helpers
+#pragma mark - STPFilePurpose
 
-+ (NSDictionary<NSString *,NSNumber *>*)stringToPurpose {
++ (NSDictionary<NSString *,NSNumber *> *)stringToPurposeMapping {
     return @{
              @"dispute_evidence": @(STPFilePurposeDisputeEvidence),
              @"identity_document": @(STPFilePurposeIdentityDocument),
@@ -35,16 +37,17 @@
 
 + (STPFilePurpose)purposeFromString:(NSString *)string {
     NSString *key = [string lowercaseString];
-    NSNumber *value = [self stringToPurpose][key];
-    if (value) {
-        return (STPFilePurpose)[value integerValue];
-    } else {
-        return STPFilePurposeUnknown;
+    NSNumber *purposeNumber = [self stringToPurposeMapping][key];
+
+    if (purposeNumber) {
+        return (STPFilePurpose)[purposeNumber integerValue];
     }
+
+    return STPFilePurposeUnknown;
 }
 
-+ (NSString *)stringFromPurpose:(STPFilePurpose)purpose {
-    return [[[self stringToPurpose] allKeysForObject:@(purpose)] firstObject];
++ (nullable NSString *)stringFromPurpose:(STPFilePurpose)purpose {
+    return [[[self stringToPurposeMapping] allKeysForObject:@(purpose)] firstObject];
 }
 
 #pragma mark - Equality

--- a/Stripe/STPSource+Private.h
+++ b/Stripe/STPSource+Private.h
@@ -8,11 +8,22 @@
 
 #import "STPSource.h"
 
-@interface STPSource (Private)
-+ (NSString *)stringFromType:(STPSourceType)type;
+NS_ASSUME_NONNULL_BEGIN
+
+@interface STPSource ()
+
 + (STPSourceType)typeFromString:(NSString *)string;
-+ (NSString *)stringFromFlow:(STPSourceFlow)flow;
-+ (NSString *)stringFromUsage:(STPSourceUsage)usage;
++ (nullable NSString *)stringFromType:(STPSourceType)type;
+
++ (STPSourceFlow)flowFromString:(NSString *)string;
++ (nullable NSString *)stringFromFlow:(STPSourceFlow)flow;
+
++ (STPSourceStatus)statusFromString:(NSString *)string;
++ (nullable NSString *)stringFromStatus:(STPSourceStatus)status;
+
++ (STPSourceUsage)usageFromString:(NSString *)string;
++ (nullable NSString *)stringFromUsage:(STPSourceUsage)usage;
+
 @end
 
-
+NS_ASSUME_NONNULL_END

--- a/Stripe/STPSource.m
+++ b/Stripe/STPSource.m
@@ -149,7 +149,54 @@
     return [self.stripeID isEqualToString:source.stripeID];
 }
 
-#pragma mark STPAPIResponseDecodable
+#pragma mark - Description
+
+- (NSString *)description {
+    NSString *statusDescription;
+
+    switch (self.status) {
+        case STPSourceStatusPending:
+            statusDescription = @"pending";
+        case STPSourceStatusChargeable:
+            statusDescription = @"chargeable";
+        case STPSourceStatusConsumed:
+            statusDescription = @"consumed";
+        case STPSourceStatusCanceled:
+            statusDescription = @"canceled";
+        case STPSourceStatusFailed:
+            statusDescription = @"failed";
+        case STPSourceStatusUnknown:
+            statusDescription = @"unknown";
+    }
+
+    NSArray *props = @[
+                       // Object
+                       [NSString stringWithFormat:@"%@: %p", NSStringFromClass([self class]), self],
+
+                       // Identifier
+                       [NSString stringWithFormat:@"stripeID = %@", self.stripeID],
+
+                       // Source details (alphabetical)
+                       [NSString stringWithFormat:@"amount = %@", self.amount],
+                       [NSString stringWithFormat:@"clientSecret = %@", (self.clientSecret) ? @"<redacted>" : nil],
+                       [NSString stringWithFormat:@"created = %@", self.created],
+                       [NSString stringWithFormat:@"currency = %@", self.currency],
+                       [NSString stringWithFormat:@"flow = %@", [STPSource stringFromFlow:self.flow]],
+                       [NSString stringWithFormat:@"livemode = %@", (self.livemode) ? @"YES" : @"NO"],
+                       [NSString stringWithFormat:@"metadata = %@", (self.metadata) ? @"<redacted>" : nil],
+                       [NSString stringWithFormat:@"owner = %@", (self.owner) ? @"<redacted>" : nil],
+                       [NSString stringWithFormat:@"receiver = %@", self.receiver],
+                       [NSString stringWithFormat:@"redirect = %@", self.redirect],
+                       [NSString stringWithFormat:@"status = %@", statusDescription],
+                       [NSString stringWithFormat:@"type = %@", [STPSource stringFromType:self.type]],
+                       [NSString stringWithFormat:@"usage = %@", [STPSource stringFromUsage:self.usage]],
+                       [NSString stringWithFormat:@"verification = %@", self.verification],
+                       ];
+
+    return [NSString stringWithFormat:@"<%@>", [props componentsJoinedByString:@"; "]];
+}
+
+#pragma mark - STPAPIResponseDecodable
 
 + (NSArray *)requiredFields {
     return @[@"id", @"livemode", @"status", @"type"];

--- a/Stripe/STPSource.m
+++ b/Stripe/STPSource.m
@@ -6,12 +6,16 @@
 //  Copyright © 2017 Stripe, Inc. All rights reserved.
 //
 
-#import "NSDictionary+Stripe.h"
+
 #import "STPSource.h"
+#import "STPSource+Private.h"
+
 #import "STPSourceOwner.h"
 #import "STPSourceReceiver.h"
 #import "STPSourceRedirect.h"
 #import "STPSourceVerification.h"
+
+#import "NSDictionary+Stripe.h"
 
 @interface STPSource ()
 
@@ -39,7 +43,9 @@
 
 @implementation STPSource
 
-+ (NSDictionary<NSString *,NSNumber *>*)stringToType {
+#pragma mark - STPSourceType
+
++ (NSDictionary<NSString *,NSNumber *> *)stringToTypeMapping {
     return @{
              @"bancontact": @(STPSourceTypeBancontact),
              @"bitcoin": @(STPSourceTypeBitcoin),
@@ -48,83 +54,100 @@
              @"ideal": @(STPSourceTypeIDEAL),
              @"sepa_debit": @(STPSourceTypeSEPADebit),
              @"sofort": @(STPSourceTypeSofort),
-             @"three_d_secure": @(STPSourceTypeThreeDSecure)
+             @"three_d_secure": @(STPSourceTypeThreeDSecure),
              };
 }
 
 + (STPSourceType)typeFromString:(NSString *)string {
     NSString *key = [string lowercaseString];
-    NSNumber *value = [self stringToType][key];
-    if (value) {
-        return (STPSourceType)[value integerValue];
-    } else {
-        return STPSourceTypeUnknown;
+    NSNumber *typeNumber = [self stringToTypeMapping][key];
+
+    if (typeNumber) {
+        return (STPSourceType)[typeNumber integerValue];
     }
+
+    return STPSourceTypeUnknown;
 }
 
-+ (NSString *)stringFromType:(STPSourceType)type {
-    return [[[self stringToType] allKeysForObject:@(type)] firstObject];
++ (nullable NSString *)stringFromType:(STPSourceType)type {
+    return [[[self stringToTypeMapping] allKeysForObject:@(type)] firstObject];
 }
 
-+ (NSDictionary<NSString *,NSNumber *>*)stringToFlow {
+#pragma mark - STPSourceFlow
+
++ (NSDictionary<NSString *,NSNumber *> *)stringToFlowMapping {
     return @{
              @"redirect": @(STPSourceFlowRedirect),
              @"receiver": @(STPSourceFlowReceiver),
              @"code_verification": @(STPSourceFlowCodeVerification),
-             @"none": @(STPSourceFlowNone)
+             @"none": @(STPSourceFlowNone),
              };
 }
 
 + (STPSourceFlow)flowFromString:(NSString *)string {
     NSString *key = [string lowercaseString];
-    NSNumber *value = [self stringToFlow][key];
-    if (value) {
-        return (STPSourceFlow)[value integerValue];
-    } else {
-        return STPSourceFlowUnknown;
+    NSNumber *flowNumber = [self stringToFlowMapping][key];
+
+    if (flowNumber) {
+        return (STPSourceFlow)[flowNumber integerValue];
     }
+
+    return STPSourceFlowUnknown;
 }
 
-+ (NSString *)stringFromFlow:(STPSourceFlow)flow {
-    return [[[self stringToFlow] allKeysForObject:@(flow)] firstObject];
++ (nullable NSString *)stringFromFlow:(STPSourceFlow)flow {
+    return [[[self stringToFlowMapping] allKeysForObject:@(flow)] firstObject];
+}
+
+#pragma mark - STPSourceStatus
+
++ (NSDictionary <NSString *, NSNumber *> *)stringToStatusMapping {
+    return @{
+             @"pending": @(STPSourceStatusPending),
+             @"chargeable": @(STPSourceStatusChargeable),
+             @"consumed": @(STPSourceStatusConsumed),
+             @"canceled": @(STPSourceStatusCanceled),
+             @"failed": @(STPSourceStatusFailed),
+             };
 }
 
 + (STPSourceStatus)statusFromString:(NSString *)string {
-    NSString *status = [string lowercaseString];
-    if ([status isEqualToString:@"pending"]) {
-        return STPSourceStatusPending;
-    } else if ([status isEqualToString:@"chargeable"]) {
-        return STPSourceStatusChargeable;
-    } else if ([status isEqualToString:@"consumed"]) {
-        return STPSourceStatusConsumed;
-    } else if ([status isEqualToString:@"canceled"]) {
-        return STPSourceStatusCanceled;
-    } else if ([status isEqualToString:@"failed"]) {
-        return STPSourceStatusFailed;
-    } else {
-        return STPSourceStatusUnknown;
+    NSString *key = [string lowercaseString];
+    NSNumber *statusNumber = [self stringToStatusMapping][key];
+
+    if (statusNumber) {
+        return (STPSourceStatus)[statusNumber integerValue];
     }
+
+    return STPSourceStatusUnknown;
 }
 
-+ (NSDictionary<NSString *,NSNumber *>*)stringToUsage {
++ (nullable NSString *)stringFromStatus:(STPSourceStatus)status {
+    return [[[self stringToStatusMapping] allKeysForObject:@(status)] firstObject];
+}
+
+#pragma mark - STPSourceUsage
+
++ (NSDictionary<NSString *,NSNumber *> *)stringToUsageMapping {
     return @{
              @"reusable": @(STPSourceUsageReusable),
-             @"single_use": @(STPSourceUsageSingleUse)
+             @"single_use": @(STPSourceUsageSingleUse),
              };
 }
 
 + (STPSourceUsage)usageFromString:(NSString *)string {
     NSString *key = [string lowercaseString];
-    NSNumber *value = [self stringToUsage][key];
-    if (value) {
-        return (STPSourceUsage)[value integerValue];
-    } else {
-        return STPSourceUsageUnknown;
+    NSNumber *usageNumber = [self stringToUsageMapping][key];
+
+    if (usageNumber) {
+        return (STPSourceUsage)[usageNumber integerValue];
     }
+
+    return STPSourceUsageUnknown;
 }
 
-+ (NSString *)stringFromUsage:(STPSourceUsage)usage {
-    return [[[self stringToUsage] allKeysForObject:@(usage)] firstObject];
++ (nullable NSString *)stringFromUsage:(STPSourceUsage)usage {
+    return [[[self stringToUsageMapping] allKeysForObject:@(usage)] firstObject];
 }
 
 #pragma mark - Equality
@@ -152,29 +175,6 @@
 #pragma mark - Description
 
 - (NSString *)description {
-    NSString *statusDescription;
-
-    switch (self.status) {
-        case STPSourceStatusPending:
-            statusDescription = @"pending";
-            break;
-        case STPSourceStatusChargeable:
-            statusDescription = @"chargeable";
-            break;
-        case STPSourceStatusConsumed:
-            statusDescription = @"consumed";
-            break;
-        case STPSourceStatusCanceled:
-            statusDescription = @"canceled";
-            break;
-        case STPSourceStatusFailed:
-            statusDescription = @"failed";
-            break;
-        case STPSourceStatusUnknown:
-            statusDescription = @"unknown";
-            break;
-    }
-
     NSArray *props = @[
                        // Object
                        [NSString stringWithFormat:@"%@: %p", NSStringFromClass([self class]), self],
@@ -187,15 +187,15 @@
                        [NSString stringWithFormat:@"clientSecret = %@", (self.clientSecret) ? @"<redacted>" : nil],
                        [NSString stringWithFormat:@"created = %@", self.created],
                        [NSString stringWithFormat:@"currency = %@", self.currency],
-                       [NSString stringWithFormat:@"flow = %@", [STPSource stringFromFlow:self.flow]],
+                       [NSString stringWithFormat:@"flow = %@", ([self.class stringFromFlow:self.flow]) ?: @"unknown"],
                        [NSString stringWithFormat:@"livemode = %@", (self.livemode) ? @"YES" : @"NO"],
                        [NSString stringWithFormat:@"metadata = %@", (self.metadata) ? @"<redacted>" : nil],
                        [NSString stringWithFormat:@"owner = %@", (self.owner) ? @"<redacted>" : nil],
                        [NSString stringWithFormat:@"receiver = %@", self.receiver],
                        [NSString stringWithFormat:@"redirect = %@", self.redirect],
-                       [NSString stringWithFormat:@"status = %@", statusDescription],
-                       [NSString stringWithFormat:@"type = %@", [STPSource stringFromType:self.type]],
-                       [NSString stringWithFormat:@"usage = %@", [STPSource stringFromUsage:self.usage]],
+                       [NSString stringWithFormat:@"status = %@", ([self.class stringFromStatus:self.status]) ?: @"unknown"],
+                       [NSString stringWithFormat:@"type = %@", ([self.class stringFromType:self.type]) ?: @"unknown"],
+                       [NSString stringWithFormat:@"usage = %@", ([self.class stringFromUsage:self.usage]) ?: @"unknown"],
                        [NSString stringWithFormat:@"verification = %@", self.verification],
                        ];
 

--- a/Stripe/STPSource.m
+++ b/Stripe/STPSource.m
@@ -157,16 +157,22 @@
     switch (self.status) {
         case STPSourceStatusPending:
             statusDescription = @"pending";
+            break;
         case STPSourceStatusChargeable:
             statusDescription = @"chargeable";
+            break;
         case STPSourceStatusConsumed:
             statusDescription = @"consumed";
+            break;
         case STPSourceStatusCanceled:
             statusDescription = @"canceled";
+            break;
         case STPSourceStatusFailed:
             statusDescription = @"failed";
+            break;
         case STPSourceStatusUnknown:
             statusDescription = @"unknown";
+            break;
     }
 
     NSArray *props = @[

--- a/Stripe/STPSourceCardDetails+Private.h
+++ b/Stripe/STPSourceCardDetails+Private.h
@@ -1,0 +1,20 @@
+//
+//  STPSourceCardDetails+Private.h
+//  Stripe
+//
+//  Created by Joey Dong on 6/21/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import "STPSourceCardDetails.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface STPSourceCardDetails ()
+
++ (STPSourceCard3DSecureStatus)threeDSecureStatusFromString:(NSString *)string;
++ (nullable NSString *)stringFromThreeDSecureStatus:(STPSourceCard3DSecureStatus)threeDSecureStatus;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Stripe/STPSourceCardDetails.m
+++ b/Stripe/STPSourceCardDetails.m
@@ -7,16 +7,21 @@
 //
 
 #import "STPSourceCardDetails.h"
+#import "STPSourceCardDetails+Private.h"
 
+#import "STPCard+Private.h"
 #import "NSDictionary+Stripe.h"
 
 @interface STPSourceCardDetails ()
+
 @property (nonatomic, readwrite, nonnull, copy) NSDictionary *allResponseFields;
+
 @end
 
 @implementation STPSourceCardDetails
 
-#pragma mark STPAPIResponseDecodable
+#pragma mark - STPAPIResponseDecodable
+
 + (NSArray *)requiredFields {
     return @[];
 }
@@ -48,56 +53,34 @@
 
 }
 
+#pragma mark - STPSourceCard3DSecureStatus
+
++ (NSDictionary <NSString *, NSNumber *> *)stringToThreeDSecureStatusMapping {
+    return @{
+             @"required": @(STPSourceCard3DSecureStatusRequired),
+             @"optional": @(STPSourceCard3DSecureStatusOptional),
+             @"not_supported": @(STPSourceCard3DSecureStatusNotSupported),
+             };
+}
+
 + (STPSourceCard3DSecureStatus)threeDSecureStatusFromString:(NSString *)string {
-    NSString *brand = [string lowercaseString];
-    if ([brand isEqualToString:@"required"]) {
-        return STPSourceCard3DSecureStatusRequired;
-    } else if ([brand isEqualToString:@"optional"]) {
-        return STPSourceCard3DSecureStatusOptional;
-    } else if ([brand isEqualToString:@"not_supported"]) {
-        return STPSourceCard3DSecureStatusNotSupported;
-    } else {
-        return STPSourceCard3DSecureStatusUnknown;
+    NSString *key = [string lowercaseString];
+    NSNumber *threeDSecureStatusNumber = [self stringToThreeDSecureStatusMapping][key];
+
+    if (threeDSecureStatusNumber) {
+        return (STPSourceCard3DSecureStatus)[threeDSecureStatusNumber integerValue];
     }
+
+    return STPSourceCard3DSecureStatusUnknown;
+}
+
++ (nullable NSString *)stringFromThreeDSecureStatus:(STPSourceCard3DSecureStatus)threeDSecureStatus {
+    return [[[self stringToThreeDSecureStatusMapping] allKeysForObject:@(threeDSecureStatus)] firstObject];
 }
 
 #pragma mark - Description
 
 - (NSString *)description {
-    NSString *fundingDescription;
-
-    switch (self.funding) {
-        case STPCardFundingTypeCredit:
-            fundingDescription = @"credit";
-            break;
-        case STPCardFundingTypeDebit:
-            fundingDescription = @"debit";
-            break;
-        case STPCardFundingTypePrepaid:
-            fundingDescription = @"prepaid";
-            break;
-        case STPCardFundingTypeOther:
-            fundingDescription = @"other";
-            break;
-    }
-
-    NSString *threeDSecureStatusDescription;
-
-    switch (self.threeDSecure) {
-        case STPSourceCard3DSecureStatusRequired:
-            threeDSecureStatusDescription = @"required";
-            break;
-        case STPSourceCard3DSecureStatusOptional:
-            threeDSecureStatusDescription = @"optional";
-            break;
-        case STPSourceCard3DSecureStatusNotSupported:
-            threeDSecureStatusDescription = @"not_supported";
-            break;
-        case STPSourceCard3DSecureStatusUnknown:
-            threeDSecureStatusDescription = @"unknown";
-            break;
-    }
-
     NSArray *props = @[
                        // Object
                        [NSString stringWithFormat:@"%@: %p", NSStringFromClass([self class]), self],
@@ -107,11 +90,11 @@
                        [NSString stringWithFormat:@"last4 = %@", self.last4],
                        [NSString stringWithFormat:@"expMonth = %lu", (unsigned long)self.expMonth],
                        [NSString stringWithFormat:@"expYear = %lu", (unsigned long)self.expYear],
-                       [NSString stringWithFormat:@"funding = %@", fundingDescription],
+                       [NSString stringWithFormat:@"funding = %@", [STPCard stringFromFunding:self.funding]],
 
                        // Additional card details (alphabetical)
                        [NSString stringWithFormat:@"country = %@", self.country],
-                       [NSString stringWithFormat:@"threeDSecure = %@", threeDSecureStatusDescription],
+                       [NSString stringWithFormat:@"threeDSecure = %@", ([self.class stringFromThreeDSecureStatus:self.threeDSecure]) ?: @"unknown"],
                        ];
 
     return [NSString stringWithFormat:@"<%@>", [props componentsJoinedByString:@"; "]];

--- a/Stripe/STPSourceCardDetails.m
+++ b/Stripe/STPSourceCardDetails.m
@@ -61,4 +61,52 @@
     }
 }
 
+#pragma mark - Description
+
+- (NSString *)description {
+    NSString *fundingDescription;
+
+    switch (self.funding) {
+        case STPCardFundingTypeCredit:
+            fundingDescription = @"credit";
+        case STPCardFundingTypeDebit:
+            fundingDescription = @"debit";
+        case STPCardFundingTypePrepaid:
+            fundingDescription = @"prepaid";
+        case STPCardFundingTypeOther:
+            fundingDescription = @"other";
+    }
+
+    NSString *threeDSecureStatusDescription;
+
+    switch (self.threeDSecure) {
+        case STPSourceCard3DSecureStatusRequired:
+            threeDSecureStatusDescription = @"required";
+        case STPSourceCard3DSecureStatusOptional:
+            threeDSecureStatusDescription = @"optional";
+        case STPSourceCard3DSecureStatusNotSupported:
+            threeDSecureStatusDescription = @"not_supported";
+        case STPSourceCard3DSecureStatusUnknown:
+            threeDSecureStatusDescription = @"unknown";
+    }
+
+    NSArray *props = @[
+                       // Object
+                       [NSString stringWithFormat:@"%@: %p", NSStringFromClass([self class]), self],
+
+                       // Basic card details
+                       [NSString stringWithFormat:@"brand = %@", [STPCard stringFromBrand:self.brand]],
+                       [NSString stringWithFormat:@"last4 = %@", self.last4],
+                       [NSString stringWithFormat:@"expMonth = %lu", (unsigned long)self.expMonth],
+                       [NSString stringWithFormat:@"expYear = %lu", (unsigned long)self.expYear],
+                       [NSString stringWithFormat:@"funding = %@", fundingDescription],
+
+                       // Additional card details (alphabetical)
+                       [NSString stringWithFormat:@"country = %@", self.country],
+                       [NSString stringWithFormat:@"threeDSecure = %@", threeDSecureStatusDescription],
+                       ];
+
+    return [NSString stringWithFormat:@"<%@>", [props componentsJoinedByString:@"; "]];
+}
+
 @end

--- a/Stripe/STPSourceCardDetails.m
+++ b/Stripe/STPSourceCardDetails.m
@@ -90,7 +90,7 @@
                        [NSString stringWithFormat:@"last4 = %@", self.last4],
                        [NSString stringWithFormat:@"expMonth = %lu", (unsigned long)self.expMonth],
                        [NSString stringWithFormat:@"expYear = %lu", (unsigned long)self.expYear],
-                       [NSString stringWithFormat:@"funding = %@", [STPCard stringFromFunding:self.funding]],
+                       [NSString stringWithFormat:@"funding = %@", ([STPCard stringFromFunding:self.funding]) ?: @"unknown"],
 
                        // Additional card details (alphabetical)
                        [NSString stringWithFormat:@"country = %@", self.country],

--- a/Stripe/STPSourceCardDetails.m
+++ b/Stripe/STPSourceCardDetails.m
@@ -69,12 +69,16 @@
     switch (self.funding) {
         case STPCardFundingTypeCredit:
             fundingDescription = @"credit";
+            break;
         case STPCardFundingTypeDebit:
             fundingDescription = @"debit";
+            break;
         case STPCardFundingTypePrepaid:
             fundingDescription = @"prepaid";
+            break;
         case STPCardFundingTypeOther:
             fundingDescription = @"other";
+            break;
     }
 
     NSString *threeDSecureStatusDescription;
@@ -82,12 +86,16 @@
     switch (self.threeDSecure) {
         case STPSourceCard3DSecureStatusRequired:
             threeDSecureStatusDescription = @"required";
+            break;
         case STPSourceCard3DSecureStatusOptional:
             threeDSecureStatusDescription = @"optional";
+            break;
         case STPSourceCard3DSecureStatusNotSupported:
             threeDSecureStatusDescription = @"not_supported";
+            break;
         case STPSourceCard3DSecureStatusUnknown:
             threeDSecureStatusDescription = @"unknown";
+            break;
     }
 
     NSArray *props = @[

--- a/Stripe/STPSourceOwner.m
+++ b/Stripe/STPSourceOwner.m
@@ -26,7 +26,7 @@
 
 @implementation STPSourceOwner
 
-#pragma mark STPAPIResponseDecodable
+#pragma mark - STPAPIResponseDecodable
 
 + (NSArray *)requiredFields {
     return @[];

--- a/Stripe/STPSourceParams.m
+++ b/Stripe/STPSourceParams.m
@@ -48,6 +48,33 @@
     return [STPSource stringFromUsage:self.usage];
 }
 
+#pragma mark - Description
+
+- (NSString *)description {
+    NSArray *props = @[
+                       // Object
+                       [NSString stringWithFormat:@"%@: %p", NSStringFromClass([self class]), self],
+
+                       // Basic source details
+                       [NSString stringWithFormat:@"type = %@", [STPSource stringFromType:self.type]],
+                       [NSString stringWithFormat:@"rawTypeString = %@", self.rawTypeString],
+
+                       // Additional source details (alphabetical)
+                       [NSString stringWithFormat:@"amount = %@", self.amount],
+                       [NSString stringWithFormat:@"currency = %@", self.currency],
+                       [NSString stringWithFormat:@"flow = %@", [STPSource stringFromFlow:self.flow]],
+                       [NSString stringWithFormat:@"metadata = %@", (self.metadata) ? @"<redacted>" : nil],
+                       [NSString stringWithFormat:@"owner = %@", (self.owner) ? @"<redacted>" : nil],
+                       [NSString stringWithFormat:@"redirect = %@", self.redirect],
+                       [NSString stringWithFormat:@"token = %@", self.token],
+                       [NSString stringWithFormat:@"usage = %@", [STPSource stringFromUsage:self.usage]],
+                       ];
+
+    return [NSString stringWithFormat:@"<%@>", [props componentsJoinedByString:@"; "]];
+}
+
+#pragma mark - Constructors
+
 + (STPSourceParams *)bancontactParamsWithAmount:(NSUInteger)amount
                                            name:(NSString *)name
                                       returnURL:(NSString *)returnURL

--- a/Stripe/STPSourceParams.m
+++ b/Stripe/STPSourceParams.m
@@ -56,18 +56,18 @@
                        [NSString stringWithFormat:@"%@: %p", NSStringFromClass([self class]), self],
 
                        // Basic source details
-                       [NSString stringWithFormat:@"type = %@", [STPSource stringFromType:self.type]],
+                       [NSString stringWithFormat:@"type = %@", ([STPSource stringFromType:self.type]) ?: @"unknown"],
                        [NSString stringWithFormat:@"rawTypeString = %@", self.rawTypeString],
 
                        // Additional source details (alphabetical)
                        [NSString stringWithFormat:@"amount = %@", self.amount],
                        [NSString stringWithFormat:@"currency = %@", self.currency],
-                       [NSString stringWithFormat:@"flow = %@", [STPSource stringFromFlow:self.flow]],
+                       [NSString stringWithFormat:@"flow = %@", ([STPSource stringFromFlow:self.flow]) ?: @"unknown"],
                        [NSString stringWithFormat:@"metadata = %@", (self.metadata) ? @"<redacted>" : nil],
                        [NSString stringWithFormat:@"owner = %@", (self.owner) ? @"<redacted>" : nil],
                        [NSString stringWithFormat:@"redirect = %@", self.redirect],
                        [NSString stringWithFormat:@"token = %@", self.token],
-                       [NSString stringWithFormat:@"usage = %@", [STPSource stringFromUsage:self.usage]],
+                       [NSString stringWithFormat:@"usage = %@", ([STPSource stringFromUsage:self.usage]) ?: @"unknown"],
                        ];
 
     return [NSString stringWithFormat:@"<%@>", [props componentsJoinedByString:@"; "]];

--- a/Stripe/STPSourceReceiver.m
+++ b/Stripe/STPSourceReceiver.m
@@ -21,7 +21,24 @@
 
 @implementation STPSourceReceiver
 
-#pragma mark STPAPIResponseDecodable
+#pragma mark - Description
+
+- (NSString *)description {
+    NSArray *props = @[
+                       // Object
+                       [NSString stringWithFormat:@"%@: %p", NSStringFromClass([self class]), self],
+
+                       // Details (alphabetical)
+                       [NSString stringWithFormat:@"address = %@", (self.address) ? @"<redacted>" : nil],
+                       [NSString stringWithFormat:@"amountCharged = %@", self.amountCharged],
+                       [NSString stringWithFormat:@"amountReceived = %@", self.amountReceived],
+                       [NSString stringWithFormat:@"amountReturned = %@", self.amountReturned],
+                       ];
+
+    return [NSString stringWithFormat:@"<%@>", [props componentsJoinedByString:@"; "]];
+}
+
+#pragma mark - STPAPIResponseDecodable
 
 + (NSArray *)requiredFields {
     return @[@"address"];

--- a/Stripe/STPSourceRedirect+Private.h
+++ b/Stripe/STPSourceRedirect+Private.h
@@ -1,0 +1,20 @@
+//
+//  STPSourceRedirect+Private.h
+//  Stripe
+//
+//  Created by Joey Dong on 6/21/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import "STPSourceRedirect.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface STPSourceRedirect ()
+
++ (STPSourceRedirectStatus)statusFromString:(NSString *)string;
++ (nullable NSString *)stringFromStatus:(STPSourceRedirectStatus)status;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Stripe/STPSourceRedirect.m
+++ b/Stripe/STPSourceRedirect.m
@@ -6,8 +6,10 @@
 //  Copyright © 2017 Stripe, Inc. All rights reserved.
 //
 
-#import "NSDictionary+Stripe.h"
 #import "STPSourceRedirect.h"
+#import "STPSourceRedirect+Private.h"
+
+#import "NSDictionary+Stripe.h"
 
 @interface STPSourceRedirect ()
 
@@ -20,46 +22,41 @@
 
 @implementation STPSourceRedirect
 
+#pragma mark - STPSourceRedirectStatus
+
++ (NSDictionary <NSString *, NSNumber *> *)stringToStatusMapping {
+    return @{
+             @"pending": @(STPSourceRedirectStatusPending),
+             @"succeeded": @(STPSourceRedirectStatusSucceeded),
+             @"failed": @(STPSourceRedirectStatusFailed),
+             };
+}
+
 + (STPSourceRedirectStatus)statusFromString:(NSString *)string {
-    NSString *status = [string lowercaseString];
-    if ([status isEqualToString:@"pending"]) {
-        return STPSourceRedirectStatusPending;
-    } else if ([status isEqualToString:@"succeeded"]) {
-        return STPSourceRedirectStatusSucceeded;
-    } else if ([status isEqualToString:@"failed"]) {
-        return STPSourceRedirectStatusFailed;
-    } else {
-        return STPSourceRedirectStatusUnknown;
+    NSString *key = [string lowercaseString];
+    NSNumber *statusNumber = [self stringToStatusMapping][key];
+
+    if (statusNumber) {
+        return (STPSourceRedirectStatus)[statusNumber integerValue];
     }
+
+    return STPSourceRedirectStatusUnknown;
+}
+
++ (nullable NSString *)stringFromStatus:(STPSourceRedirectStatus)status {
+    return [[[self stringToStatusMapping] allKeysForObject:@(status)] firstObject];
 }
 
 #pragma mark - Description
 
 - (NSString *)description {
-    NSString *statusDescription;
-
-    switch (self.status) {
-        case STPSourceRedirectStatusPending:
-            statusDescription = @"pending";
-            break;
-        case STPSourceRedirectStatusSucceeded:
-            statusDescription = @"succeeded";
-            break;
-        case STPSourceRedirectStatusFailed:
-            statusDescription = @"failed";
-            break;
-        case STPSourceRedirectStatusUnknown:
-            statusDescription = @"unknown";
-            break;
-    }
-
     NSArray *props = @[
                        // Object
                        [NSString stringWithFormat:@"%@: %p", NSStringFromClass([self class]), self],
 
                        // Details (alphabetical)
                        [NSString stringWithFormat:@"returnURL = %@", self.returnURL],
-                       [NSString stringWithFormat:@"status = %@", statusDescription],
+                       [NSString stringWithFormat:@"status = %@", ([self.class stringFromStatus:self.status]) ?: @"unknown"],
                        [NSString stringWithFormat:@"url = %@", self.url],
                        ];
 

--- a/Stripe/STPSourceRedirect.m
+++ b/Stripe/STPSourceRedirect.m
@@ -41,12 +41,16 @@
     switch (self.status) {
         case STPSourceRedirectStatusPending:
             statusDescription = @"pending";
+            break;
         case STPSourceRedirectStatusSucceeded:
             statusDescription = @"succeeded";
+            break;
         case STPSourceRedirectStatusFailed:
             statusDescription = @"failed";
+            break;
         case STPSourceRedirectStatusUnknown:
             statusDescription = @"unknown";
+            break;
     }
 
     NSArray *props = @[

--- a/Stripe/STPSourceRedirect.m
+++ b/Stripe/STPSourceRedirect.m
@@ -33,7 +33,36 @@
     }
 }
 
-#pragma mark STPAPIResponseDecodable
+#pragma mark - Description
+
+- (NSString *)description {
+    NSString *statusDescription;
+
+    switch (self.status) {
+        case STPSourceRedirectStatusPending:
+            statusDescription = @"pending";
+        case STPSourceRedirectStatusSucceeded:
+            statusDescription = @"succeeded";
+        case STPSourceRedirectStatusFailed:
+            statusDescription = @"failed";
+        case STPSourceRedirectStatusUnknown:
+            statusDescription = @"unknown";
+    }
+
+    NSArray *props = @[
+                       // Object
+                       [NSString stringWithFormat:@"%@: %p", NSStringFromClass([self class]), self],
+
+                       // Details (alphabetical)
+                       [NSString stringWithFormat:@"returnURL = %@", self.returnURL],
+                       [NSString stringWithFormat:@"status = %@", statusDescription],
+                       [NSString stringWithFormat:@"url = %@", self.url],
+                       ];
+
+    return [NSString stringWithFormat:@"<%@>", [props componentsJoinedByString:@"; "]];
+}
+
+#pragma mark - STPAPIResponseDecodable
 
 + (NSArray *)requiredFields {
     return @[@"return_url", @"status", @"url"];

--- a/Stripe/STPSourceSEPADebitDetails.m
+++ b/Stripe/STPSourceSEPADebitDetails.m
@@ -16,6 +16,29 @@
 
 @implementation STPSourceSEPADebitDetails
 
+#pragma mark - Description
+
+- (NSString *)description {
+    NSArray *props = @[
+                       // Object
+                       [NSString stringWithFormat:@"%@: %p", NSStringFromClass([self class]), self],
+
+                       // Basic SEPA debit details
+                       [NSString stringWithFormat:@"last4 = %@", self.last4],
+
+                       // Additional SEPA debit details (alphabetical)
+                       [NSString stringWithFormat:@"bankCode = %@", self.bankCode],
+                       [NSString stringWithFormat:@"country = %@", self.country],
+                       [NSString stringWithFormat:@"fingerprint = %@", self.fingerprint],
+                       [NSString stringWithFormat:@"mandateReference = %@", self.mandateReference],
+                       [NSString stringWithFormat:@"mandateURL = %@", self.mandateURL],
+                       ];
+
+    return [NSString stringWithFormat:@"<%@>", [props componentsJoinedByString:@"; "]];
+}
+
+#pragma mark - STPAPIResponseDecodable
+
 + (NSArray *)requiredFields {
     return @[];
 }

--- a/Stripe/STPSourceVerification+Private.h
+++ b/Stripe/STPSourceVerification+Private.h
@@ -1,0 +1,20 @@
+//
+//  STPSourceVerification+Private.h
+//  Stripe
+//
+//  Created by Joey Dong on 6/21/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import "STPSourceVerification.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface STPSourceVerification ()
+
++ (STPSourceVerificationStatus)statusFromString:(NSString *)string;
++ (nullable NSString *)stringFromStatus:(STPSourceVerificationStatus)status;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Stripe/STPSourceVerification.m
+++ b/Stripe/STPSourceVerification.m
@@ -32,7 +32,35 @@
     }
 }
 
-#pragma mark STPAPIResponseDecodable
+#pragma mark - Description
+
+- (NSString *)description {
+    NSString *statusDescription;
+
+    switch (self.status) {
+        case STPSourceVerificationStatusPending:
+            statusDescription = @"pending";
+        case STPSourceVerificationStatusSucceeded:
+            statusDescription = @"succeeded";
+        case STPSourceVerificationStatusFailed:
+            statusDescription = @"failed";
+        case STPSourceVerificationStatusUnknown:
+            statusDescription = @"unknown";
+    }
+
+    NSArray *props = @[
+                       // Object
+                       [NSString stringWithFormat:@"%@: %p", NSStringFromClass([self class]), self],
+
+                       // Details (alphabetical)
+                       [NSString stringWithFormat:@"attemptsRemaining = %@", self.attemptsRemaining],
+                       [NSString stringWithFormat:@"status = %@", statusDescription],
+                       ];
+
+    return [NSString stringWithFormat:@"<%@>", [props componentsJoinedByString:@"; "]];
+}
+
+#pragma mark - STPAPIResponseDecodable
 
 + (NSArray *)requiredFields {
     return @[@"status"];

--- a/Stripe/STPSourceVerification.m
+++ b/Stripe/STPSourceVerification.m
@@ -40,12 +40,16 @@
     switch (self.status) {
         case STPSourceVerificationStatusPending:
             statusDescription = @"pending";
+            break;
         case STPSourceVerificationStatusSucceeded:
             statusDescription = @"succeeded";
+            break;
         case STPSourceVerificationStatusFailed:
             statusDescription = @"failed";
+            break;
         case STPSourceVerificationStatusUnknown:
             statusDescription = @"unknown";
+            break;
     }
 
     NSArray *props = @[

--- a/Stripe/STPSourceVerification.m
+++ b/Stripe/STPSourceVerification.m
@@ -6,8 +6,10 @@
 //  Copyright © 2017 Stripe, Inc. All rights reserved.
 //
 
-#import "NSDictionary+Stripe.h"
 #import "STPSourceVerification.h"
+#import "STPSourceVerification+Private.h"
+
+#import "NSDictionary+Stripe.h"
 
 @interface STPSourceVerification ()
 
@@ -19,46 +21,41 @@
 
 @implementation STPSourceVerification
 
+#pragma mark - STPSourceVerificationStatus
+
++ (NSDictionary <NSString *, NSNumber *> *)stringToStatusMapping {
+    return @{
+             @"pending": @(STPSourceVerificationStatusPending),
+             @"succeeded": @(STPSourceVerificationStatusSucceeded),
+             @"failed": @(STPSourceVerificationStatusFailed),
+             };
+}
+
 + (STPSourceVerificationStatus)statusFromString:(NSString *)string {
-    NSString *status = [string lowercaseString];
-    if ([status isEqualToString:@"pending"]) {
-        return STPSourceVerificationStatusPending;
-    } else if ([status isEqualToString:@"succeeded"]) {
-        return STPSourceVerificationStatusSucceeded;
-    } else if ([status isEqualToString:@"failed"]) {
-        return STPSourceVerificationStatusFailed;
-    } else {
-        return STPSourceVerificationStatusUnknown;
+    NSString *key = [string lowercaseString];
+    NSNumber *statusNumber = [self stringToStatusMapping][key];
+
+    if (statusNumber) {
+        return (STPSourceVerificationStatus)[statusNumber integerValue];
     }
+
+    return STPSourceVerificationStatusUnknown;
+}
+
++ (nullable NSString *)stringFromStatus:(STPSourceVerificationStatus)status {
+    return [[[self stringToStatusMapping] allKeysForObject:@(status)] firstObject];
 }
 
 #pragma mark - Description
 
 - (NSString *)description {
-    NSString *statusDescription;
-
-    switch (self.status) {
-        case STPSourceVerificationStatusPending:
-            statusDescription = @"pending";
-            break;
-        case STPSourceVerificationStatusSucceeded:
-            statusDescription = @"succeeded";
-            break;
-        case STPSourceVerificationStatusFailed:
-            statusDescription = @"failed";
-            break;
-        case STPSourceVerificationStatusUnknown:
-            statusDescription = @"unknown";
-            break;
-    }
-
     NSArray *props = @[
                        // Object
                        [NSString stringWithFormat:@"%@: %p", NSStringFromClass([self class]), self],
 
                        // Details (alphabetical)
                        [NSString stringWithFormat:@"attemptsRemaining = %@", self.attemptsRemaining],
-                       [NSString stringWithFormat:@"status = %@", statusDescription],
+                       [NSString stringWithFormat:@"status = %@", ([self.class stringFromStatus:self.status]) ?: @"unknown"],
                        ];
 
     return [NSString stringWithFormat:@"<%@>", [props componentsJoinedByString:@"; "]];

--- a/Stripe/STPToken.m
+++ b/Stripe/STPToken.m
@@ -23,6 +23,8 @@
 
 @implementation STPToken
 
+#pragma mark - Description
+
 - (NSString *)description {
     return self.tokenId ?: @"Unknown token";
 }
@@ -32,6 +34,8 @@
     NSString *livemode = self.livemode ? @"live mode" : @"test mode";
     return [NSString stringWithFormat:@"%@ (%@)", token, livemode];
 }
+
+#pragma mark - Equality
 
 - (BOOL)isEqual:(id)object {
     return [self isEqualToToken:object];
@@ -62,13 +66,13 @@
            [self.card isEqual:object.card] && [self.tokenId isEqualToString:object.tokenId] && [self.created isEqualToDate:object.created];
 }
 
-#pragma mark STPSource
+#pragma mark - STPSourceProtocol
 
 - (NSString *)stripeID {
     return self.tokenId;
 }
 
-#pragma mark STPAPIResponseDecodable
+#pragma mark - STPAPIResponseDecodable
 
 + (NSArray *)requiredFields {
     return @[@"id", @"livemode", @"created"];

--- a/Tests/Tests/STPBankAccountParamsTest.m
+++ b/Tests/Tests/STPBankAccountParamsTest.m
@@ -9,12 +9,7 @@
 @import XCTest;
 
 #import "STPBankAccountParams.h"
-
-@interface STPBankAccountParams ()
-
-- (NSString *)accountHolderTypeString;
-
-@end
+#import "STPBankAccountParams+Private.h"
 
 @interface STPBankAccountParamsTest : XCTestCase
 
@@ -51,14 +46,38 @@
     XCTAssertNil(bankAccountParams.last4);
 }
 
-- (void)testAccountHolderTypeString {
-    STPBankAccountParams *bankAccountParams = [[STPBankAccountParams alloc] init];
+#pragma mark - STPBankAccountHolderType Tests
 
-    bankAccountParams.accountHolderType = STPBankAccountHolderTypeIndividual;
-    XCTAssertEqualObjects([bankAccountParams accountHolderTypeString], @"individual");
+- (void)testAccountHolderTypeFromString {
+    XCTAssertEqual([STPBankAccountParams accountHolderTypeFromString:@"individual"], STPBankAccountHolderTypeIndividual);
+    XCTAssertEqual([STPBankAccountParams accountHolderTypeFromString:@"INDIVIDUAL"], STPBankAccountHolderTypeIndividual);
 
-    bankAccountParams.accountHolderType = STPBankAccountHolderTypeCompany;
-    XCTAssertEqualObjects([bankAccountParams accountHolderTypeString], @"company");
+    XCTAssertEqual([STPBankAccountParams accountHolderTypeFromString:@"company"], STPBankAccountHolderTypeCompany);
+    XCTAssertEqual([STPBankAccountParams accountHolderTypeFromString:@"COMPANY"], STPBankAccountHolderTypeIndividual);
+
+    XCTAssertEqual([STPBankAccountParams accountHolderTypeFromString:@"garbage"], STPBankAccountHolderTypeIndividual);
+    XCTAssertEqual([STPBankAccountParams accountHolderTypeFromString:@"GARBAGE"], STPBankAccountHolderTypeIndividual);
+}
+
+- (void)testStringFromAccountHolderType {
+    NSArray<NSNumber *> *values = @[
+                                    @(STPBankAccountHolderTypeIndividual),
+                                    @(STPBankAccountHolderTypeCompany),
+                                    ];
+
+    for (NSNumber *accountHolderTypeNumber in values) {
+        STPBankAccountHolderType accountHolderType = (STPBankAccountHolderType)[accountHolderTypeNumber integerValue];
+        NSString *string = [STPBankAccountParams stringFromAccountHolderType:accountHolderType];
+
+        switch (accountHolderType) {
+            case STPBankAccountHolderTypeIndividual:
+                XCTAssertEqualObjects(string, @"individual");
+                break;
+            case STPBankAccountHolderTypeCompany:
+                XCTAssertEqualObjects(string, @"company");
+                break;
+        }
+    }
 }
 
 #pragma mark - Description Tests
@@ -95,6 +114,16 @@
     }
 
     XCTAssertEqual([[mapping allValues] count], [[NSSet setWithArray:[mapping allValues]] count]);
+}
+
+- (void)testAccountHolderTypeString {
+    STPBankAccountParams *bankAccountParams = [[STPBankAccountParams alloc] init];
+
+    bankAccountParams.accountHolderType = STPBankAccountHolderTypeIndividual;
+    XCTAssertEqualObjects([bankAccountParams accountHolderTypeString], @"individual");
+
+    bankAccountParams.accountHolderType = STPBankAccountHolderTypeCompany;
+    XCTAssertEqualObjects([bankAccountParams accountHolderTypeString], @"company");
 }
 
 @end

--- a/Tests/Tests/STPBankAccountParamsTest.m
+++ b/Tests/Tests/STPBankAccountParamsTest.m
@@ -53,7 +53,7 @@
     XCTAssertEqual([STPBankAccountParams accountHolderTypeFromString:@"INDIVIDUAL"], STPBankAccountHolderTypeIndividual);
 
     XCTAssertEqual([STPBankAccountParams accountHolderTypeFromString:@"company"], STPBankAccountHolderTypeCompany);
-    XCTAssertEqual([STPBankAccountParams accountHolderTypeFromString:@"COMPANY"], STPBankAccountHolderTypeIndividual);
+    XCTAssertEqual([STPBankAccountParams accountHolderTypeFromString:@"COMPANY"], STPBankAccountHolderTypeCompany);
 
     XCTAssertEqual([STPBankAccountParams accountHolderTypeFromString:@"garbage"], STPBankAccountHolderTypeIndividual);
     XCTAssertEqual([STPBankAccountParams accountHolderTypeFromString:@"GARBAGE"], STPBankAccountHolderTypeIndividual);

--- a/Tests/Tests/STPBankAccountParamsTest.m
+++ b/Tests/Tests/STPBankAccountParamsTest.m
@@ -1,0 +1,87 @@
+//
+//  STPBankAccountParamsTest.m
+//  Stripe
+//
+//  Created by Joey Dong on 6/19/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+@import XCTest;
+
+#import "STPBankAccountParams.h"
+
+@interface STPBankAccountParams ()
+
+- (NSString *)accountHolderTypeString;
+
+@end
+
+@interface STPBankAccountParamsTest : XCTestCase
+
+@end
+
+@implementation STPBankAccountParamsTest
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+#pragma mark -
+
+- (void)testLast4ReturnsAccountNumberLast4 {
+    STPBankAccountParams *bankAccountParams = [[STPBankAccountParams alloc] init];
+    bankAccountParams.accountNumber = @"000123456789";
+    XCTAssertEqualObjects(bankAccountParams.last4, @"6789");
+}
+
+- (void)testLast4ReturnsNilWhenNoAccountNumberSet {
+    STPBankAccountParams *bankAccountParams = [[STPBankAccountParams alloc] init];
+    XCTAssertNil(bankAccountParams.last4);
+}
+
+- (void)testLast4ReturnsNilWhenAccountNumberIsLessThanLength4 {
+    STPBankAccountParams *bankAccountParams = [[STPBankAccountParams alloc] init];
+    bankAccountParams.accountNumber = @"123";
+    XCTAssertNil(bankAccountParams.last4);
+}
+
+- (void)testAccountHolderTypeString {
+    STPBankAccountParams *bankAccountParams = [[STPBankAccountParams alloc] init];
+
+    bankAccountParams.accountHolderType = STPBankAccountHolderTypeIndividual;
+    XCTAssertEqualObjects([bankAccountParams accountHolderTypeString], @"individual");
+
+    bankAccountParams.accountHolderType = STPBankAccountHolderTypeCompany;
+    XCTAssertEqualObjects([bankAccountParams accountHolderTypeString], @"company");
+}
+
+#pragma mark - STPFormEncodable Tests
+
+- (void)testRootObjectName {
+    XCTAssertEqualObjects([STPBankAccountParams rootObjectName], @"bank_account");
+}
+
+- (void)testPropertyNamesToFormFieldNamesMapping {
+    STPBankAccountParams *bankAccountParams = [[STPBankAccountParams alloc] init];
+
+    NSDictionary *mapping = [STPBankAccountParams propertyNamesToFormFieldNamesMapping];
+
+    for (NSString *propertyName in [mapping allKeys]) {
+        XCTAssert([bankAccountParams respondsToSelector:NSSelectorFromString(propertyName)]);
+    }
+
+    for (NSString *formFieldName in [mapping allValues]) {
+        XCTAssert([formFieldName isKindOfClass:[NSString class]]);
+        XCTAssert([formFieldName length] > 0);
+    }
+
+    XCTAssertEqual([[mapping allValues] count], [[NSSet setWithArray:[mapping allValues]] count]);
+}
+
+@end

--- a/Tests/Tests/STPBankAccountParamsTest.m
+++ b/Tests/Tests/STPBankAccountParamsTest.m
@@ -61,6 +61,19 @@
     XCTAssertEqualObjects([bankAccountParams accountHolderTypeString], @"company");
 }
 
+#pragma mark - Description Tests
+
+- (void)testDescriptionWorks {
+    STPBankAccountParams *bankAccountParams = [[STPBankAccountParams alloc] init];
+    bankAccountParams.accountNumber = @"000123456789";
+    bankAccountParams.routingNumber = @"123456789";
+    bankAccountParams.country = @"US";
+    bankAccountParams.currency = @"usd";
+    bankAccountParams.accountHolderName = @"John Doe";
+    bankAccountParams.accountHolderType = STPBankAccountHolderTypeCompany;
+    XCTAssert(bankAccountParams.description);
+}
+
 #pragma mark - STPFormEncodable Tests
 
 - (void)testRootObjectName {

--- a/Tests/Tests/STPBankAccountTest.m
+++ b/Tests/Tests/STPBankAccountTest.m
@@ -12,14 +12,24 @@
 #import "STPBankAccount.h"
 
 @interface STPBankAccountTest : XCTestCase
-@property (nonatomic) STPBankAccountParams *bankAccount;
+
+@property (nonatomic) STPBankAccount *bankAccount;
+
 @end
 
 @implementation STPBankAccountTest
 
 - (void)setUp {
+    [super setUp];
     _bankAccount = [[STPBankAccount alloc] init];
 }
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+#pragma mark - STPAPIResponseDecodable Tests
 
 - (NSDictionary *)completeAttributeDictionary {
     return @{
@@ -30,6 +40,8 @@
         @"fingerprint": @"something",
         @"currency": @"usd",
         @"status": @"new",
+        @"account_holder_name": @"John Doe",
+        @"account_holder_type": @"company",
     };
 }
 
@@ -44,7 +56,9 @@
     XCTAssertEqualObjects([bankAccountWithAttributes country], @"US", @"country is set correctly");
     XCTAssertEqualObjects([bankAccountWithAttributes fingerprint], @"something", @"fingerprint is set correctly");
     XCTAssertEqualObjects([bankAccountWithAttributes currency], @"usd", @"currency is set correctly");
-    XCTAssertEqual(bankAccountWithAttributes.status, STPBankAccountStatusNew);
+    XCTAssertEqual([bankAccountWithAttributes status], STPBankAccountStatusNew);
+    XCTAssertEqualObjects([bankAccountWithAttributes accountHolderName], @"John Doe");
+    XCTAssertEqual([bankAccountWithAttributes accountHolderType], STPBankAccountHolderTypeCompany);
     
     NSDictionary *allResponseFields = bankAccountWithAttributes.allResponseFields;
     XCTAssertEqual(allResponseFields[@"foo"], @"bar");

--- a/Tests/Tests/STPBankAccountTest.m
+++ b/Tests/Tests/STPBankAccountTest.m
@@ -10,6 +10,7 @@
 
 #import "STPFormEncoder.h"
 #import "STPBankAccount.h"
+#import "STPBankAccount+Private.h"
 
 @interface STPBankAccountTest : XCTestCase
 
@@ -27,6 +28,54 @@
 - (void)tearDown {
     // Put teardown code here. This method is called after the invocation of each test method in the class.
     [super tearDown];
+}
+
+#pragma mark - STPBankAccountStatus Tests
+
+- (void)testStatusFromString {
+    XCTAssertEqual([STPBankAccount statusFromString:@"new"], STPBankAccountStatusNew);
+    XCTAssertEqual([STPBankAccount statusFromString:@"NEW"], STPBankAccountStatusNew);
+
+    XCTAssertEqual([STPBankAccount statusFromString:@"validated"], STPBankAccountStatusValidated);
+    XCTAssertEqual([STPBankAccount statusFromString:@"VALIDATED"], STPBankAccountStatusNew);
+
+    XCTAssertEqual([STPBankAccount statusFromString:@"verified"], STPBankAccountStatusVerified);
+    XCTAssertEqual([STPBankAccount statusFromString:@"VERIFIED"], STPBankAccountStatusNew);
+
+    XCTAssertEqual([STPBankAccount statusFromString:@"errored"], STPBankAccountStatusErrored);
+    XCTAssertEqual([STPBankAccount statusFromString:@"ERRORED"], STPBankAccountStatusNew);
+
+    XCTAssertEqual([STPBankAccount statusFromString:@"garbage"], STPBankAccountStatusNew);
+    XCTAssertEqual([STPBankAccount statusFromString:@"GARBAGE"], STPBankAccountStatusNew);
+}
+
+- (void)testStringFromStatus {
+    NSArray<NSNumber *> *values = @[
+                                    @(STPBankAccountStatusNew),
+                                    @(STPBankAccountStatusValidated),
+                                    @(STPBankAccountStatusVerified),
+                                    @(STPBankAccountStatusErrored)
+                                    ];
+
+    for (NSNumber *statusNumber in values) {
+        STPBankAccountStatus status = (STPBankAccountStatus)[statusNumber integerValue];
+        NSString *string = [STPBankAccount stringFromStatus:status];
+
+        switch (status) {
+            case STPBankAccountStatusNew:
+                XCTAssertEqualObjects(string, @"new");
+                break;
+            case STPBankAccountStatusValidated:
+                XCTAssertEqualObjects(string, @"validated");
+                break;
+            case STPBankAccountStatusVerified:
+                XCTAssertEqualObjects(string, @"verified");
+                break;
+            case STPBankAccountStatusErrored:
+                XCTAssertEqualObjects(string, @"errored");
+                break;
+        }
+    }
 }
 
 #pragma mark - STPAPIResponseDecodable Tests

--- a/Tests/Tests/STPBankAccountTest.m
+++ b/Tests/Tests/STPBankAccountTest.m
@@ -37,13 +37,13 @@
     XCTAssertEqual([STPBankAccount statusFromString:@"NEW"], STPBankAccountStatusNew);
 
     XCTAssertEqual([STPBankAccount statusFromString:@"validated"], STPBankAccountStatusValidated);
-    XCTAssertEqual([STPBankAccount statusFromString:@"VALIDATED"], STPBankAccountStatusNew);
+    XCTAssertEqual([STPBankAccount statusFromString:@"VALIDATED"], STPBankAccountStatusValidated);
 
     XCTAssertEqual([STPBankAccount statusFromString:@"verified"], STPBankAccountStatusVerified);
-    XCTAssertEqual([STPBankAccount statusFromString:@"VERIFIED"], STPBankAccountStatusNew);
+    XCTAssertEqual([STPBankAccount statusFromString:@"VERIFIED"], STPBankAccountStatusVerified);
 
     XCTAssertEqual([STPBankAccount statusFromString:@"errored"], STPBankAccountStatusErrored);
-    XCTAssertEqual([STPBankAccount statusFromString:@"ERRORED"], STPBankAccountStatusNew);
+    XCTAssertEqual([STPBankAccount statusFromString:@"ERRORED"], STPBankAccountStatusErrored);
 
     XCTAssertEqual([STPBankAccount statusFromString:@"garbage"], STPBankAccountStatusNew);
     XCTAssertEqual([STPBankAccount statusFromString:@"GARBAGE"], STPBankAccountStatusNew);

--- a/Tests/Tests/STPBankAccountTest.m
+++ b/Tests/Tests/STPBankAccountTest.m
@@ -92,4 +92,12 @@
     XCTAssertEqualObjects(bankAccount1, bankAccount2, @"bank account with equal data should be equal");
 }
 
+#pragma mark - Description Tests
+
+- (void)testDescriptionWorks {
+    STPBankAccount *bankAccount = [STPBankAccount decodedObjectFromAPIResponse:[self completeAttributeDictionary]];
+    bankAccount.routingNumber = @"123456789";
+    XCTAssert(bankAccount.description);
+}
+
 @end

--- a/Tests/Tests/STPCardParamsTest.m
+++ b/Tests/Tests/STPCardParamsTest.m
@@ -88,6 +88,25 @@
     XCTAssertEqualObjects(cardParams.addressCountry, @"US");
 }
 
+#pragma mark - Description Tests
+
+- (void)testDescriptionWorks {
+    STPCardParams *cardParams = [[STPCardParams alloc] init];
+    cardParams.number = @"4242424242424242";
+    cardParams.expMonth = 6;
+    cardParams.expYear = 2020;
+    cardParams.cvc = @"123";
+    cardParams.name = @"John Smith";
+    cardParams.addressLine1 = @"55 John St";
+    cardParams.addressLine2 = @"#3B";
+    cardParams.addressCity = @"New York";
+    cardParams.addressState = @"NY";
+    cardParams.addressZip = @"10002";
+    cardParams.addressCountry = @"US";
+    cardParams.currency = @"usd";
+    XCTAssert(cardParams.description);
+}
+
 #pragma mark - STPFormEncodable Tests
 
 - (void)testRootObjectName {

--- a/Tests/Tests/STPCardParamsTest.m
+++ b/Tests/Tests/STPCardParamsTest.m
@@ -1,0 +1,114 @@
+//
+//  STPCardParamsTest.m
+//  Stripe
+//
+//  Created by Joey Dong on 6/19/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+@import XCTest;
+
+#import "STPCardParams.h"
+
+@interface STPCardParamsTest : XCTestCase
+
+@end
+
+@implementation STPCardParamsTest
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+#pragma mark -
+
+- (void)testLast4ReturnsCardNumberLast4 {
+    STPCardParams *cardParams = [[STPCardParams alloc] init];
+    cardParams.number = @"4242424242424242";
+    XCTAssertEqualObjects(cardParams.last4, @"4242");
+}
+
+- (void)testLast4ReturnsNilWhenNoCardNumberSet {
+    STPCardParams *cardParams = [[STPCardParams alloc] init];
+    XCTAssertNil(cardParams.last4);
+}
+
+- (void)testLast4ReturnsNilWhenCardNumberIsLessThanLength4 {
+    STPCardParams *cardParams = [[STPCardParams alloc] init];
+    cardParams.number = @"123";
+    XCTAssertNil(cardParams.last4);
+}
+
+- (void)testAddress {
+    STPCardParams *cardParams = [[STPCardParams alloc] init];
+    cardParams.name = @"John Smith";
+    cardParams.addressLine1 = @"55 John St";
+    cardParams.addressLine2 = @"#3B";
+    cardParams.addressCity = @"New York";
+    cardParams.addressState = @"NY";
+    cardParams.addressZip = @"10002";
+    cardParams.addressCountry = @"US";
+
+    STPAddress *address = cardParams.address;
+
+    XCTAssertEqualObjects(address.name, @"John Smith");
+    XCTAssertEqualObjects(address.line1, @"55 John St");
+    XCTAssertEqualObjects(address.line2, @"#3B");
+    XCTAssertEqualObjects(address.city, @"New York");
+    XCTAssertEqualObjects(address.state, @"NY");
+    XCTAssertEqualObjects(address.postalCode, @"10002");
+    XCTAssertEqualObjects(address.country, @"US");
+}
+
+- (void)testSetAddress {
+    STPAddress *address = [[STPAddress alloc] init];
+    address.name = @"John Smith";
+    address.line1 = @"55 John St";
+    address.line2 = @"#3B";
+    address.city = @"New York";
+    address.state = @"NY";
+    address.postalCode = @"10002";
+    address.country = @"US";
+
+    STPCardParams *cardParams = [[STPCardParams alloc] init];
+    cardParams.address = address;
+
+    XCTAssertEqualObjects(cardParams.name, @"John Smith");
+    XCTAssertEqualObjects(cardParams.addressLine1, @"55 John St");
+    XCTAssertEqualObjects(cardParams.addressLine2, @"#3B");
+    XCTAssertEqualObjects(cardParams.addressCity, @"New York");
+    XCTAssertEqualObjects(cardParams.addressState, @"NY");
+    XCTAssertEqualObjects(cardParams.addressZip, @"10002");
+    XCTAssertEqualObjects(cardParams.addressCountry, @"US");
+}
+
+#pragma mark - STPFormEncodable Tests
+
+- (void)testRootObjectName {
+    XCTAssertEqualObjects([STPCardParams rootObjectName], @"card");
+}
+
+- (void)testPropertyNamesToFormFieldNamesMapping {
+    STPCardParams *cardParams = [[STPCardParams alloc] init];
+
+    NSDictionary *mapping = [STPCardParams propertyNamesToFormFieldNamesMapping];
+
+    for (NSString *propertyName in [mapping allKeys]) {
+        XCTAssert([cardParams respondsToSelector:NSSelectorFromString(propertyName)]);
+    }
+
+    for (NSString *formFieldName in [mapping allValues]) {
+        XCTAssert([formFieldName isKindOfClass:[NSString class]]);
+        XCTAssert([formFieldName length] > 0);
+    }
+
+    XCTAssertEqual([[mapping allValues] count], [[NSSet setWithArray:[mapping allValues]] count]);
+}
+
+@end

--- a/Tests/Tests/STPCardTest.m
+++ b/Tests/Tests/STPCardTest.m
@@ -9,6 +9,7 @@
 @import XCTest;
 
 #import "STPCard.h"
+#import "STPCard+Private.h"
 
 @interface STPCardTest : XCTestCase
 
@@ -27,6 +28,125 @@
     // Put teardown code here. This method is called after the invocation of each test method in the class.
     [super tearDown];
 }
+
+#pragma mark - STPCardBrand Tests
+
+- (void)testBrandFromString {
+    XCTAssertEqual([STPCard brandFromString:@"visa"], STPCardBrandVisa);
+    XCTAssertEqual([STPCard brandFromString:@"VISA"], STPCardBrandVisa);
+
+    XCTAssertEqual([STPCard brandFromString:@"american express"], STPCardBrandAmex);
+    XCTAssertEqual([STPCard brandFromString:@"AMERICAN EXPRESS"], STPCardBrandAmex);
+
+    XCTAssertEqual([STPCard brandFromString:@"mastercard"], STPCardBrandMasterCard);
+    XCTAssertEqual([STPCard brandFromString:@"MASTERCARD"], STPCardBrandMasterCard);
+
+    XCTAssertEqual([STPCard brandFromString:@"discover"], STPCardBrandDiscover);
+    XCTAssertEqual([STPCard brandFromString:@"DISCOVER"], STPCardBrandDiscover);
+
+    XCTAssertEqual([STPCard brandFromString:@"jcb"], STPCardBrandJCB);
+    XCTAssertEqual([STPCard brandFromString:@"JCB"], STPCardBrandJCB);
+
+    XCTAssertEqual([STPCard brandFromString:@"diners club"], STPCardBrandDinersClub);
+    XCTAssertEqual([STPCard brandFromString:@"DINERS CLUB"], STPCardBrandDinersClub);
+
+    XCTAssertEqual([STPCard brandFromString:@"unknown"], STPCardBrandUnknown);
+    XCTAssertEqual([STPCard brandFromString:@"UNKNOWN"], STPCardBrandUnknown);
+    
+    XCTAssertEqual([STPCard brandFromString:@"garbage"], STPCardBrandUnknown);
+    XCTAssertEqual([STPCard brandFromString:@"GARBAGE"], STPCardBrandUnknown);
+}
+
+- (void)testStringFromBrand {
+    NSArray<NSNumber *> *values = @[
+                                    @(STPCardBrandAmex),
+                                    @(STPCardBrandDinersClub),
+                                    @(STPCardBrandDiscover),
+                                    @(STPCardBrandJCB),
+                                    @(STPCardBrandMasterCard),
+                                    @(STPCardBrandVisa),
+                                    @(STPCardBrandUnknown),
+                                    ];
+
+    for (NSNumber *brandNumber in values) {
+        STPCardBrand brand = (STPCardBrand)[brandNumber integerValue];
+        NSString *string = [STPCard stringFromBrand:brand];
+
+        switch (brand) {
+            case STPCardBrandAmex:
+                XCTAssertEqualObjects(string, @"American Express");
+                break;
+            case STPCardBrandDinersClub:
+                XCTAssertEqualObjects(string, @"Diners Club");
+                break;
+            case STPCardBrandDiscover:
+                XCTAssertEqualObjects(string, @"Discover");
+                break;
+            case STPCardBrandJCB:
+                XCTAssertEqualObjects(string, @"JCB");
+                break;
+            case STPCardBrandMasterCard:
+                XCTAssertEqualObjects(string, @"MasterCard");
+                break;
+            case STPCardBrandVisa:
+                XCTAssertEqualObjects(string, @"Visa");
+                break;
+            case STPCardBrandUnknown:
+                XCTAssertEqualObjects(string, @"Unknown");
+                break;
+        }
+    }
+}
+
+#pragma mark - STPCardFundingType Tests
+
+- (void)testFundingFromString {
+    XCTAssertEqual([STPCard fundingFromString:@"credit"], STPCardFundingTypeCredit);
+    XCTAssertEqual([STPCard fundingFromString:@"CREDIT"], STPCardFundingTypeCredit);
+
+    XCTAssertEqual([STPCard fundingFromString:@"debit"], STPCardFundingTypeDebit);
+    XCTAssertEqual([STPCard fundingFromString:@"DEBIT"], STPCardFundingTypeDebit);
+
+    XCTAssertEqual([STPCard fundingFromString:@"prepaid"], STPCardFundingTypePrepaid);
+    XCTAssertEqual([STPCard fundingFromString:@"PREPAID"], STPCardFundingTypePrepaid);
+
+    XCTAssertEqual([STPCard fundingFromString:@"other"], STPCardFundingTypeOther);
+    XCTAssertEqual([STPCard fundingFromString:@"OTHER"], STPCardFundingTypeOther);
+
+    XCTAssertEqual([STPCard fundingFromString:@"garbage"], STPCardFundingTypeOther);
+    XCTAssertEqual([STPCard fundingFromString:@"GARBAGE"], STPCardFundingTypeOther);
+}
+
+- (void)testStringFromFunding {
+    NSArray<NSNumber *> *values = @[
+                                    @(STPCardFundingTypeCredit),
+                                    @(STPCardFundingTypeDebit),
+                                    @(STPCardFundingTypePrepaid),
+                                    @(STPCardFundingTypeOther),
+                                    ];
+
+    for (NSNumber *fundingNumber in values) {
+        STPCardFundingType funding = (STPCardFundingType)[fundingNumber integerValue];
+        NSString *string = [STPCard stringFromFunding:funding];
+
+        switch (funding) {
+            case STPCardFundingTypeCredit:
+                XCTAssertEqualObjects(string, @"credit");
+                break;
+            case STPCardFundingTypeDebit:
+                XCTAssertEqualObjects(string, @"debit");
+                break;
+            case STPCardFundingTypePrepaid:
+                XCTAssertEqualObjects(string, @"prepaid");
+                break;
+            case STPCardFundingTypeOther:
+                XCTAssertEqualObjects(string, @"other");
+                break;
+        }
+    }
+}
+
+#pragma mark - STPAPIResponseDecodable Tests
 
 - (NSDictionary *)completeAttributeDictionary {
     return @{
@@ -47,8 +167,6 @@
         @"currency": @"usd",
     };
 }
-
-#pragma mark - STPAPIResponseDecodable Tests
 
 - (void)testInitializingCardWithAttributeDictionary {
     NSMutableDictionary *apiResponse = [[self completeAttributeDictionary] mutableCopy];

--- a/Tests/Tests/STPCardTest.m
+++ b/Tests/Tests/STPCardTest.m
@@ -105,6 +105,15 @@
     XCTAssertEqualObjects(card1, card2, @"cards with equal data should be equal");
 }
 
+#pragma mark - Description Tests
+
+- (void)testDescriptionWorks {
+    STPCard *card = [STPCard decodedObjectFromAPIResponse:[self completeAttributeDictionary]];
+    XCTAssert(card.description);
+}
+
+#pragma mark -
+
 - (void)testAddress {
     NSMutableDictionary *apiResponse = [[self completeAttributeDictionary] mutableCopy];
     STPCard *card = [STPCard decodedObjectFromAPIResponse:apiResponse];

--- a/Tests/Tests/STPCardTest.m
+++ b/Tests/Tests/STPCardTest.m
@@ -113,6 +113,9 @@
     XCTAssertEqual([STPCard fundingFromString:@"other"], STPCardFundingTypeOther);
     XCTAssertEqual([STPCard fundingFromString:@"OTHER"], STPCardFundingTypeOther);
 
+    XCTAssertEqual([STPCard fundingFromString:@"unknown"], STPCardFundingTypeOther);
+    XCTAssertEqual([STPCard fundingFromString:@"UNKNOWN"], STPCardFundingTypeOther);
+
     XCTAssertEqual([STPCard fundingFromString:@"garbage"], STPCardFundingTypeOther);
     XCTAssertEqual([STPCard fundingFromString:@"GARBAGE"], STPCardFundingTypeOther);
 }
@@ -140,7 +143,7 @@
                 XCTAssertEqualObjects(string, @"prepaid");
                 break;
             case STPCardFundingTypeOther:
-                XCTAssertEqualObjects(string, @"other");
+                XCTAssertNil(string);
                 break;
         }
     }

--- a/Tests/Tests/STPFileTest.m
+++ b/Tests/Tests/STPFileTest.m
@@ -9,6 +9,7 @@
 @import XCTest;
 
 #import "STPFile.h"
+#import "STPFile+Private.h"
 
 @interface STPFileTest : XCTestCase
 
@@ -22,6 +23,49 @@
     _file = [[STPFile alloc] init];
 }
 
+#pragma mark - STPFilePurpose Tests
+
+- (void)testPurposeFromString {
+    XCTAssertEqual([STPFile purposeFromString:@"dispute_evidence"], STPFilePurposeDisputeEvidence);
+    XCTAssertEqual([STPFile purposeFromString:@"DISPUTE_EVIDENCE"], STPFilePurposeDisputeEvidence);
+
+    XCTAssertEqual([STPFile purposeFromString:@"identity_document"], STPFilePurposeIdentityDocument);
+    XCTAssertEqual([STPFile purposeFromString:@"IDENTITY_DOCUMENT"], STPFilePurposeIdentityDocument);
+
+    XCTAssertEqual([STPFile purposeFromString:@"unknown"], STPFilePurposeUnknown);
+    XCTAssertEqual([STPFile purposeFromString:@"UNKNOWN"], STPFilePurposeUnknown);
+
+    XCTAssertEqual([STPFile purposeFromString:@"garbage"], STPFilePurposeUnknown);
+    XCTAssertEqual([STPFile purposeFromString:@"GARBAGE"], STPFilePurposeUnknown);
+}
+
+- (void)testStringFromPurpose {
+    NSArray<NSNumber *> *values = @[
+                                    @(STPFilePurposeDisputeEvidence),
+                                    @(STPFilePurposeIdentityDocument),
+                                    @(STPFilePurposeUnknown),
+                                    ];
+
+    for (NSNumber *purposeNumber in values) {
+        STPFilePurpose purpose = (STPFilePurpose)[purposeNumber integerValue];
+        NSString *string = [STPFile stringFromPurpose:purpose];
+
+        switch (purpose) {
+            case STPFilePurposeDisputeEvidence:
+                XCTAssertEqualObjects(string, @"dispute_evidence");
+                break;
+            case STPFilePurposeIdentityDocument:
+                XCTAssertEqualObjects(string, @"identity_document");
+                break;
+            case STPFilePurposeUnknown:
+                XCTAssertNil(string);
+                break;
+        }
+    }
+}
+
+#pragma mark - STPAPIResponseDecodable Tests
+
 - (NSDictionary *)completeAttributeDictionary {
     return @{
         @"id": @"file_something",
@@ -31,8 +75,6 @@
         @"purpose": @"identity_document",
     };
 }
-
-#pragma mark - Initialization Tests
 
 - (void)testInitializingFileWithAttributeDictionary {
     NSMutableDictionary *apiResponse = [[self completeAttributeDictionary] mutableCopy];

--- a/Tests/Tests/STPSourceCardDetailsTest.m
+++ b/Tests/Tests/STPSourceCardDetailsTest.m
@@ -1,0 +1,79 @@
+//
+//  STPSourceCardDetailsTest.m
+//  Stripe
+//
+//  Created by Joey Dong on 6/21/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+@import XCTest;
+
+#import "STPSourceCardDetails.h"
+#import "STPSourceCardDetails+Private.h"
+
+@interface STPSourceCardDetailsTest : XCTestCase
+
+@end
+
+@implementation STPSourceCardDetailsTest
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+
+#pragma mark - STPSourceCard3DSecureStatus Tests
+
+- (void)testThreeDSecureStatusFromString {
+    XCTAssertEqual([STPSourceCardDetails threeDSecureStatusFromString:@"required"], STPSourceCard3DSecureStatusRequired);
+    XCTAssertEqual([STPSourceCardDetails threeDSecureStatusFromString:@"REQUIRED"], STPSourceCard3DSecureStatusRequired);
+
+    XCTAssertEqual([STPSourceCardDetails threeDSecureStatusFromString:@"optional"], STPSourceCard3DSecureStatusOptional);
+    XCTAssertEqual([STPSourceCardDetails threeDSecureStatusFromString:@"OPTIONAL"], STPSourceCard3DSecureStatusOptional);
+
+    XCTAssertEqual([STPSourceCardDetails threeDSecureStatusFromString:@"not_supported"], STPSourceCard3DSecureStatusNotSupported);
+    XCTAssertEqual([STPSourceCardDetails threeDSecureStatusFromString:@"NOT_SUPPORTED"], STPSourceCard3DSecureStatusNotSupported);
+
+    XCTAssertEqual([STPSourceCardDetails threeDSecureStatusFromString:@"unknown"], STPSourceCard3DSecureStatusUnknown);
+    XCTAssertEqual([STPSourceCardDetails threeDSecureStatusFromString:@"UNKNOWN"], STPSourceCard3DSecureStatusUnknown);
+
+    XCTAssertEqual([STPSourceCardDetails threeDSecureStatusFromString:@"garbage"], STPSourceCard3DSecureStatusUnknown);
+    XCTAssertEqual([STPSourceCardDetails threeDSecureStatusFromString:@"GARBAGE"], STPSourceCard3DSecureStatusUnknown);
+}
+
+- (void)testStringFromThreeDSecureStatus {
+    NSArray<NSNumber *> *values = @[
+                                    @(STPSourceCard3DSecureStatusRequired),
+                                    @(STPSourceCard3DSecureStatusOptional),
+                                    @(STPSourceCard3DSecureStatusNotSupported),
+                                    @(STPSourceCard3DSecureStatusUnknown),
+                                    ];
+
+    for (NSNumber *threeDSecureStatusNumber in values) {
+        STPSourceCard3DSecureStatus threeDSecureStatus = (STPSourceCard3DSecureStatus)[threeDSecureStatusNumber integerValue];
+        NSString *string = [STPSourceCardDetails stringFromThreeDSecureStatus:threeDSecureStatus];
+
+        switch (threeDSecureStatus) {
+            case STPSourceCard3DSecureStatusRequired:
+                XCTAssertEqualObjects(string, @"required");
+                break;
+            case STPSourceCard3DSecureStatusOptional:
+                XCTAssertEqualObjects(string, @"optional");
+                break;
+            case STPSourceCard3DSecureStatusNotSupported:
+                XCTAssertEqualObjects(string, @"not_supported");
+                break;
+            case STPSourceCard3DSecureStatusUnknown:
+                XCTAssertNil(string);
+                break;
+        }
+    }
+}
+
+@end

--- a/Tests/Tests/STPSourceRedirectTest.m
+++ b/Tests/Tests/STPSourceRedirectTest.m
@@ -1,0 +1,78 @@
+//
+//  STPSourceRedirectTest.m
+//  Stripe
+//
+//  Created by Joey Dong on 6/21/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+@import XCTest;
+
+#import "STPSourceRedirect.h"
+#import "STPSourceRedirect+Private.h"
+
+@interface STPSourceRedirectTest : XCTestCase
+
+@end
+
+@implementation STPSourceRedirectTest
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+#pragma mark - STPSourceRedirectStatus Tests
+
+- (void)testStatusFromString {
+    XCTAssertEqual([STPSourceRedirect statusFromString:@"pending"], STPSourceRedirectStatusPending);
+    XCTAssertEqual([STPSourceRedirect statusFromString:@"PENDING"], STPSourceRedirectStatusPending);
+
+    XCTAssertEqual([STPSourceRedirect statusFromString:@"succeeded"], STPSourceRedirectStatusSucceeded);
+    XCTAssertEqual([STPSourceRedirect statusFromString:@"SUCCEEDED"], STPSourceRedirectStatusSucceeded);
+
+    XCTAssertEqual([STPSourceRedirect statusFromString:@"failed"], STPSourceRedirectStatusFailed);
+    XCTAssertEqual([STPSourceRedirect statusFromString:@"FAILED"], STPSourceRedirectStatusFailed);
+
+    XCTAssertEqual([STPSourceRedirect statusFromString:@"unknown"], STPSourceRedirectStatusUnknown);
+    XCTAssertEqual([STPSourceRedirect statusFromString:@"UNKNOWN"], STPSourceRedirectStatusUnknown);
+
+    XCTAssertEqual([STPSourceRedirect statusFromString:@"garbage"], STPSourceRedirectStatusUnknown);
+    XCTAssertEqual([STPSourceRedirect statusFromString:@"GARBAGE"], STPSourceRedirectStatusUnknown);
+}
+
+- (void)testStringFromStatus {
+    NSArray<NSNumber *> *values = @[
+                                    @(STPSourceRedirectStatusPending),
+                                    @(STPSourceRedirectStatusSucceeded),
+                                    @(STPSourceRedirectStatusFailed),
+                                    @(STPSourceRedirectStatusUnknown),
+                                    ];
+
+    for (NSNumber *statusNumber in values) {
+        STPSourceRedirectStatus status = (STPSourceRedirectStatus)[statusNumber integerValue];
+        NSString *string = [STPSourceRedirect stringFromStatus:status];
+
+        switch (status) {
+            case STPSourceRedirectStatusPending:
+                XCTAssertEqualObjects(string, @"pending");
+                break;
+            case STPSourceRedirectStatusSucceeded:
+                XCTAssertEqualObjects(string, @"succeeded");
+                break;
+            case STPSourceRedirectStatusFailed:
+                XCTAssertEqualObjects(string, @"failed");
+                break;
+            case STPSourceRedirectStatusUnknown:
+                XCTAssertNil(string);
+                break;
+        }
+    }
+}
+
+@end

--- a/Tests/Tests/STPSourceTest.m
+++ b/Tests/Tests/STPSourceTest.m
@@ -8,13 +8,258 @@
 
 @import XCTest;
 
-#import "Stripe.h"
+#import "STPSource.h"
+#import "STPSource+Private.h"
 
 @interface STPSourceTest : XCTestCase
 
 @end
 
 @implementation STPSourceTest
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+#pragma mark - STPSourceType Tests
+
+- (void)testTypeFromString {
+    XCTAssertEqual([STPSource typeFromString:@"bancontact"], STPSourceTypeBancontact);
+    XCTAssertEqual([STPSource typeFromString:@"BANCONTACT"], STPSourceTypeBancontact);
+
+    XCTAssertEqual([STPSource typeFromString:@"bitcoin"], STPSourceTypeBitcoin);
+    XCTAssertEqual([STPSource typeFromString:@"BITCOIN"], STPSourceTypeBitcoin);
+
+    XCTAssertEqual([STPSource typeFromString:@"card"], STPSourceTypeCard);
+    XCTAssertEqual([STPSource typeFromString:@"CARD"], STPSourceTypeCard);
+
+    XCTAssertEqual([STPSource typeFromString:@"giropay"], STPSourceTypeGiropay);
+    XCTAssertEqual([STPSource typeFromString:@"GIROPAY"], STPSourceTypeGiropay);
+
+    XCTAssertEqual([STPSource typeFromString:@"ideal"], STPSourceTypeIDEAL);
+    XCTAssertEqual([STPSource typeFromString:@"IDEAL"], STPSourceTypeIDEAL);
+
+    XCTAssertEqual([STPSource typeFromString:@"sepa_debit"], STPSourceTypeSEPADebit);
+    XCTAssertEqual([STPSource typeFromString:@"SEPA_DEBIT"], STPSourceTypeSEPADebit);
+
+    XCTAssertEqual([STPSource typeFromString:@"sofort"], STPSourceTypeSofort);
+    XCTAssertEqual([STPSource typeFromString:@"SOFORT"], STPSourceTypeSofort);
+
+    XCTAssertEqual([STPSource typeFromString:@"three_d_secure"], STPSourceTypeThreeDSecure);
+    XCTAssertEqual([STPSource typeFromString:@"THREE_D_SECURE"], STPSourceTypeThreeDSecure);
+
+    XCTAssertEqual([STPSource typeFromString:@"unknown"], STPSourceTypeUnknown);
+    XCTAssertEqual([STPSource typeFromString:@"UNKNOWN"], STPSourceTypeUnknown);
+
+    XCTAssertEqual([STPSource typeFromString:@"garbage"], STPSourceTypeUnknown);
+    XCTAssertEqual([STPSource typeFromString:@"GARBAGE"], STPSourceTypeUnknown);
+}
+
+- (void)testStringFromType {
+    NSArray<NSNumber *> *values = @[
+                                    @(STPSourceTypeBancontact),
+                                    @(STPSourceTypeBitcoin),
+                                    @(STPSourceTypeCard),
+                                    @(STPSourceTypeGiropay),
+                                    @(STPSourceTypeIDEAL),
+                                    @(STPSourceTypeSEPADebit),
+                                    @(STPSourceTypeSofort),
+                                    @(STPSourceTypeThreeDSecure),
+                                    @(STPSourceTypeUnknown),
+                                    ];
+
+    for (NSNumber *typeNumber in values) {
+        STPSourceType type = (STPSourceType)[typeNumber integerValue];
+        NSString *string = [STPSource stringFromType:type];
+
+        switch (type) {
+            case STPSourceTypeBancontact:
+                XCTAssertEqualObjects(string, @"bancontact");
+                break;
+            case STPSourceTypeBitcoin:
+                XCTAssertEqualObjects(string, @"bitcoin");
+                break;
+            case STPSourceTypeCard:
+                XCTAssertEqualObjects(string, @"card");
+                break;
+            case STPSourceTypeGiropay:
+                XCTAssertEqualObjects(string, @"giropay");
+                break;
+            case STPSourceTypeIDEAL:
+                XCTAssertEqualObjects(string, @"ideal");
+                break;
+            case STPSourceTypeSEPADebit:
+                XCTAssertEqualObjects(string, @"sepa_debit");
+                break;
+            case STPSourceTypeSofort:
+                XCTAssertEqualObjects(string, @"sofort");
+                break;
+            case STPSourceTypeThreeDSecure:
+                XCTAssertEqualObjects(string, @"three_d_secure");
+                break;
+            case STPSourceTypeUnknown:
+                XCTAssertNil(string);
+                break;
+        }
+    }
+}
+
+#pragma mark - STPSourceFlow Tests
+
+- (void)testFlowFromString {
+    XCTAssertEqual([STPSource flowFromString:@"redirect"], STPSourceFlowRedirect);
+    XCTAssertEqual([STPSource flowFromString:@"REDIRECT"], STPSourceFlowRedirect);
+
+    XCTAssertEqual([STPSource flowFromString:@"receiver"], STPSourceFlowReceiver);
+    XCTAssertEqual([STPSource flowFromString:@"RECEIVER"], STPSourceFlowReceiver);
+
+    XCTAssertEqual([STPSource flowFromString:@"code_verification"], STPSourceFlowCodeVerification);
+    XCTAssertEqual([STPSource flowFromString:@"CODE_VERIFICATION"], STPSourceFlowCodeVerification);
+
+    XCTAssertEqual([STPSource flowFromString:@"none"], STPSourceFlowNone);
+    XCTAssertEqual([STPSource flowFromString:@"NONE"], STPSourceFlowNone);
+
+    XCTAssertEqual([STPSource flowFromString:@"garbage"], STPSourceFlowUnknown);
+    XCTAssertEqual([STPSource flowFromString:@"GARBAGE"], STPSourceFlowUnknown);
+}
+
+- (void)testStringFromFlow {
+    NSArray<NSNumber *> *values = @[
+                                    @(STPSourceFlowRedirect),
+                                    @(STPSourceFlowReceiver),
+                                    @(STPSourceFlowCodeVerification),
+                                    @(STPSourceFlowNone),
+                                    @(STPSourceFlowUnknown),
+                                    ];
+
+    for (NSNumber *flowNumber in values) {
+        STPSourceFlow flow = (STPSourceFlow)[flowNumber integerValue];
+        NSString *string = [STPSource stringFromFlow:flow];
+
+        switch (flow) {
+            case STPSourceFlowRedirect:
+                XCTAssertEqualObjects(string, @"redirect");
+                break;
+            case STPSourceFlowReceiver:
+                XCTAssertEqualObjects(string, @"receiver");
+                break;
+            case STPSourceFlowCodeVerification:
+                XCTAssertEqualObjects(string, @"code_verification");
+                break;
+            case STPSourceFlowNone:
+                XCTAssertEqualObjects(string, @"none");
+                break;
+            case STPSourceFlowUnknown:
+                XCTAssertNil(string);
+                break;
+        }
+    }
+}
+
+#pragma mark - STPSourceStatus Tests
+
+- (void)testStatusFromString {
+    XCTAssertEqual([STPSource statusFromString:@"pending"], STPSourceStatusPending);
+    XCTAssertEqual([STPSource statusFromString:@"PENDING"], STPSourceStatusPending);
+
+    XCTAssertEqual([STPSource statusFromString:@"chargeable"], STPSourceStatusChargeable);
+    XCTAssertEqual([STPSource statusFromString:@"CHARGEABLE"], STPSourceStatusChargeable);
+
+    XCTAssertEqual([STPSource statusFromString:@"consumed"], STPSourceStatusConsumed);
+    XCTAssertEqual([STPSource statusFromString:@"CONSUMED"], STPSourceStatusConsumed);
+
+    XCTAssertEqual([STPSource statusFromString:@"canceled"], STPSourceStatusCanceled);
+    XCTAssertEqual([STPSource statusFromString:@"CANCELED"], STPSourceStatusCanceled);
+
+    XCTAssertEqual([STPSource statusFromString:@"failed"], STPSourceStatusFailed);
+    XCTAssertEqual([STPSource statusFromString:@"FAILED"], STPSourceStatusFailed);
+
+    XCTAssertEqual([STPSource statusFromString:@"garbage"], STPSourceStatusUnknown);
+    XCTAssertEqual([STPSource statusFromString:@"GARBAGE"], STPSourceStatusUnknown);
+}
+
+- (void)testStringFromStatus {
+    NSArray<NSNumber *> *values = @[
+                                    @(STPSourceStatusPending),
+                                    @(STPSourceStatusChargeable),
+                                    @(STPSourceStatusConsumed),
+                                    @(STPSourceStatusCanceled),
+                                    @(STPSourceStatusFailed),
+                                    @(STPSourceStatusUnknown),
+                                    ];
+
+    for (NSNumber *statusNumber in values) {
+        STPSourceStatus status = (STPSourceStatus)[statusNumber integerValue];
+        NSString *string = [STPSource stringFromStatus:status];
+
+        switch (status) {
+            case STPSourceStatusPending:
+                XCTAssertEqualObjects(string, @"pending");
+                break;
+            case STPSourceStatusChargeable:
+                XCTAssertEqualObjects(string, @"chargeable");
+                break;
+            case STPSourceStatusConsumed:
+                XCTAssertEqualObjects(string, @"consumed");
+                break;
+            case STPSourceStatusCanceled:
+                XCTAssertEqualObjects(string, @"canceled");
+                break;
+            case STPSourceStatusFailed:
+                XCTAssertEqualObjects(string, @"failed");
+                break;
+            case STPSourceStatusUnknown:
+                XCTAssertNil(string);
+                break;
+        }
+    }
+}
+
+#pragma mark - STPSourceUsage Tests
+
+- (void)testUsageFromString {
+    XCTAssertEqual([STPSource usageFromString:@"reusable"], STPSourceUsageReusable);
+    XCTAssertEqual([STPSource usageFromString:@"REUSABLE"], STPSourceUsageReusable);
+
+    XCTAssertEqual([STPSource usageFromString:@"single_use"], STPSourceUsageSingleUse);
+    XCTAssertEqual([STPSource usageFromString:@"SINGLE_USE"], STPSourceUsageSingleUse);
+
+    XCTAssertEqual([STPSource usageFromString:@"garbage"], STPSourceUsageUnknown);
+    XCTAssertEqual([STPSource usageFromString:@"GARBAGE"], STPSourceUsageUnknown);
+}
+
+- (void)testStringFromUsage {
+    NSArray<NSNumber *> *values = @[
+                                    @(STPSourceUsageReusable),
+                                    @(STPSourceUsageSingleUse),
+                                    @(STPSourceUsageUnknown),
+                                    ];
+
+    for (NSNumber *usageNumber in values) {
+        STPSourceUsage usage = (STPSourceUsage)[usageNumber integerValue];
+        NSString *string = [STPSource stringFromUsage:usage];
+
+        switch (usage) {
+            case STPSourceUsageReusable:
+                XCTAssertEqualObjects(string, @"reusable");
+                break;
+            case STPSourceUsageSingleUse:
+                XCTAssertEqualObjects(string, @"single_use");
+                break;
+            case STPSourceUsageUnknown:
+                XCTAssertNil(string);
+                break;
+        }
+    }
+}
+
+#pragma mark - STPAPIResponseDecodable Tests
 
 - (NSDictionary *)buildTestResponse_ideal {
     NSDictionary *dict = @{

--- a/Tests/Tests/STPSourceVerificationTest.m
+++ b/Tests/Tests/STPSourceVerificationTest.m
@@ -1,0 +1,78 @@
+//
+//  STPSourceVerificationTest.m
+//  Stripe
+//
+//  Created by Joey Dong on 6/21/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+@import XCTest;
+
+#import "STPSourceVerification.h"
+#import "STPSourceVerification+Private.h"
+
+@interface STPSourceVerificationTest : XCTestCase
+
+@end
+
+@implementation STPSourceVerificationTest
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+#pragma mark - STPSourceVerificationStatus Tests
+
+- (void)testStatusFromString {
+    XCTAssertEqual([STPSourceVerification statusFromString:@"pending"], STPSourceVerificationStatusPending);
+    XCTAssertEqual([STPSourceVerification statusFromString:@"pending"], STPSourceVerificationStatusPending);
+
+    XCTAssertEqual([STPSourceVerification statusFromString:@"succeeded"], STPSourceVerificationStatusSucceeded);
+    XCTAssertEqual([STPSourceVerification statusFromString:@"SUCCEEDED"], STPSourceVerificationStatusSucceeded);
+
+    XCTAssertEqual([STPSourceVerification statusFromString:@"failed"], STPSourceVerificationStatusFailed);
+    XCTAssertEqual([STPSourceVerification statusFromString:@"FAILED"], STPSourceVerificationStatusFailed);
+
+    XCTAssertEqual([STPSourceVerification statusFromString:@"unknown"], STPSourceVerificationStatusUnknown);
+    XCTAssertEqual([STPSourceVerification statusFromString:@"UNKNOWN"], STPSourceVerificationStatusUnknown);
+
+    XCTAssertEqual([STPSourceVerification statusFromString:@"garbage"], STPSourceVerificationStatusUnknown);
+    XCTAssertEqual([STPSourceVerification statusFromString:@"GARBAGE"], STPSourceVerificationStatusUnknown);
+}
+
+- (void)testStringFromStatus {
+    NSArray<NSNumber *> *values = @[
+                                    @(STPSourceVerificationStatusPending),
+                                    @(STPSourceVerificationStatusSucceeded),
+                                    @(STPSourceVerificationStatusFailed),
+                                    @(STPSourceVerificationStatusUnknown),
+                                    ];
+
+    for (NSNumber *statusNumber in values) {
+        STPSourceVerificationStatus status = (STPSourceVerificationStatus)[statusNumber integerValue];
+        NSString *string = [STPSourceVerification stringFromStatus:status];
+
+        switch (status) {
+            case STPSourceVerificationStatusPending:
+                XCTAssertEqualObjects(string, @"pending");
+                break;
+            case STPSourceVerificationStatusSucceeded:
+                XCTAssertEqualObjects(string, @"succeeded");
+                break;
+            case STPSourceVerificationStatusFailed:
+                XCTAssertEqualObjects(string, @"failed");
+                break;
+            case STPSourceVerificationStatusUnknown:
+                XCTAssertNil(string);
+                break;
+        }
+    }
+}
+
+@end


### PR DESCRIPTION
## Summary

Adding a bunch of `description` implementations that will make logging and debugging objects produced by the SDK a little easier. Decided to start with the public models because I think that would be the most impactful.

## Motivation

Before:

```
<STPCard: 0x600000151930>
```

After:

```
<STPCard: 0x600000151930; cardId = card_1AUJxDEOD54MuFwSyKCDbNuU; brand = Visa; last4 = 1881; expMonth = 11; expYear = 2029; funding = Credit; country = CA; currency = (null); dynamicLast4 = (null); isApplePayCard = NO; name = (null); address = (null)>
```

## Testing

Updated test coverage but could still use some more improvement in a future PR.

r? @bdorfman-stripe 
cc @bg-stripe 