### PR TITLE
Fix `ci_script/run_analyzer.sh`

### DIFF
--- a/Stripe/STPLocalizationUtils.h
+++ b/Stripe/STPLocalizationUtils.h
@@ -21,3 +21,9 @@
 static inline NSString * _Nonnull STPLocalizedString(NSString* _Nonnull key, NSString * _Nullable __unused comment) {
     return [STPLocalizationUtils localizedStripeStringForKey:key];
 }
+
+/// Use to explicitly ignore static analyzer warning: "User-facing text should use localized string macro"
+__attribute__((annotate("returns_localized_nsstring")))
+static inline NSString * _Nonnull STPNonLocalizedString(NSString * _Nonnull string) {
+    return string;
+}

--- a/Stripe/STPPaymentCardTextField.m
+++ b/Stripe/STPPaymentCardTextField.m
@@ -13,6 +13,7 @@
 #import "STPPaymentCardTextFieldViewModel.h"
 #import "STPWeakStrongMacros.h"
 #import "Stripe.h"
+#import "STPLocalizationUtils.h"
 
 #define FAUXPAS_IGNORED_IN_METHOD(...)
 
@@ -514,7 +515,7 @@ CGFloat const STPPaymentCardTextFieldDefaultPadding = 13;
 - (CGRect)cvcFieldRectForBounds:(CGRect)bounds {
     CGRect fieldsRect = [self fieldsRectForBounds:bounds];
 
-    CGFloat cvcWidth = MAX([self widthForText:self.cvcField.placeholder], [self widthForText:@"8888"]);
+    CGFloat cvcWidth = MAX([self widthForText:self.cvcField.placeholder], [self widthForText:STPNonLocalizedString(@"8888")]);
     CGFloat cvcX = self.numberFieldShrunk ?
     CGRectGetWidth(fieldsRect) - cvcWidth - STPPaymentCardTextFieldDefaultPadding / 2  :
     CGRectGetWidth(fieldsRect);
@@ -525,7 +526,7 @@ CGFloat const STPPaymentCardTextFieldDefaultPadding = 13;
     CGRect numberFieldRect = [self numberFieldRectForBounds:bounds];
     CGRect cvcRect = [self cvcFieldRectForBounds:bounds];
 
-    CGFloat expirationWidth = MAX([self widthForText:self.expirationField.placeholder], [self widthForText:@"88/88"]);
+    CGFloat expirationWidth = MAX([self widthForText:self.expirationField.placeholder], [self widthForText:STPNonLocalizedString(@"88/88")]);
     CGFloat expirationX = (CGRectGetMaxX(numberFieldRect) + CGRectGetMinX(cvcRect) - expirationWidth) / 2;
     return CGRectMake(expirationX, 0, expirationWidth, CGRectGetHeight(bounds));
 }
@@ -789,9 +790,9 @@ typedef void (^STPNumberShrunkCompletionBlock)(BOOL completed);
 
 - (NSString *)defaultCVCPlaceholder {
     if (self.viewModel.brand == STPCardBrandAmex) {
-        return @"CVV";
+        return STPNonLocalizedString(@"CVV");
     } else {
-        return @"CVC";
+        return STPNonLocalizedString(@"CVC");
     }
 }
 

--- a/ci_scripts/run_analyzer.sh
+++ b/ci_scripts/run_analyzer.sh
@@ -1,5 +1,42 @@
-gem install xcpretty --no-ri --no-rdoc
-export PYTHONUSERBASE=~/.local
-easy_install --user scan-build
-export PATH="${HOME}/.local/bin:${PATH}"
-set -o pipefail && scan-build --status-bugs --use-analyzer Xcode xcodebuild analyze -workspace Stripe.xcworkspace -scheme "StripeiOS" -configuration Debug -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO | xcpretty
+#!/bin/sh
+
+log_file="${TMPDIR}/xcodebuild_analyze.log"
+
+# Install xcpretty
+if ! command -v xcpretty > /dev/null; then
+  echo "Installing xcpretty..."
+  gem install xcpretty --no-ri --no-rdoc
+fi
+
+# Reset log file
+echo "Resetting log file..."
+rm -f "${log_file}"
+
+# Run static analyzer
+echo "Running static analyzer..."
+xcodebuild clean analyze \
+  -workspace "Stripe.xcworkspace" \
+  -scheme "StripeiOS" \
+  -configuration "Debug" \
+  -sdk "iphonesimulator" \
+  ONLY_ACTIVE_ARCH=NO \
+  | tee "${log_file}" \
+  | xcpretty
+
+exit_code="${PIPESTATUS[0]}"
+
+if [[ "${exit_code}" != 0 ]]; then
+  echo "ERROR: xcodebuild exited with non-zero status code: ${exit_code}"
+  exit 1
+fi
+
+# Search for warnings in log file
+echo "Searching for static analyzer warnings..."
+grep "warning:" "${log_file}" > "/dev/null"
+
+if [[ "$?" != 1 ]]; then
+  echo "ERROR: Found static analyzer warnings!"
+  exit 1
+fi
+
+echo "All good!"


### PR DESCRIPTION
## Summary

Fixed the script to start exiting with a non-zero status code when static analyzer warnings are found. This should then trigger a build failure.

Added a `STPNonLocalizedString` (open to naming suggestions) helper to explicitly ignore non-localized string warnings in appropriate cases.

## Motivation

Make sure we deal with static analyzer warnings as soon as they appear.

## Testing

Verified `STPPaymentCardTextField` continues to function as expected and that `STPNonLocalizedString` correctly returns the input parameter unchanged.

r? @bdorfman-stripe 