### PR TITLE
Fix ordering between implementations and tests

### DIFF
--- a/Stripe/STPCard.m
+++ b/Stripe/STPCard.m
@@ -29,24 +29,6 @@
 
 @dynamic number, cvc, expMonth, expYear, currency, name, address, addressLine1, addressLine2, addressCity, addressState, addressZip, addressCountry;
 
-- (instancetype)initWithID:(NSString *)stripeID
-                     brand:(STPCardBrand)brand
-                     last4:(NSString *)last4
-                  expMonth:(NSUInteger)expMonth
-                   expYear:(NSUInteger)expYear
-                   funding:(STPCardFundingType)funding {
-    self = [super init];
-    if (self) {
-        _cardId = stripeID;
-        _brand = brand;
-        _last4 = last4;
-        self.expMonth = expMonth;
-        self.expYear = expYear;
-        _funding = funding;
-    }
-    return self;
-}
-
 #pragma mark - STPCardBrand
 
 + (STPCardBrand)brandFromString:(NSString *)string {
@@ -114,6 +96,24 @@
 
 #pragma mark -
 
+- (instancetype)initWithID:(NSString *)stripeID
+                     brand:(STPCardBrand)brand
+                     last4:(NSString *)last4
+                  expMonth:(NSUInteger)expMonth
+                   expYear:(NSUInteger)expYear
+                   funding:(STPCardFundingType)funding {
+    self = [super init];
+    if (self) {
+        _cardId = stripeID;
+        _brand = brand;
+        _last4 = last4;
+        self.expMonth = expMonth;
+        self.expYear = expYear;
+        _funding = funding;
+    }
+    return self;
+}
+
 - (instancetype)init {
     self = [super init];
     if (self) {
@@ -130,6 +130,21 @@
 
 - (BOOL)isApplePayCard {
     return [self.allResponseFields[@"tokenization_method"] isEqualToString:@"apple_pay"];
+}
+
+- (STPAddress *)address {
+    if (self.name || self.addressLine1 || self.addressLine2 || self.addressZip || self.addressCity || self.addressState || self.addressCountry) {
+        STPAddress *address = [STPAddress new];
+        address.name = self.name;
+        address.line1 = self.addressLine1;
+        address.line2 = self.addressLine2;
+        address.postalCode = self.addressZip;
+        address.city = self.addressCity;
+        address.state = self.addressState;
+        address.country = self.addressCountry;
+        return address;
+    }
+    return nil;
 }
 
 #pragma mark - Equality
@@ -183,21 +198,6 @@
                        ];
 
     return [NSString stringWithFormat:@"<%@>", [props componentsJoinedByString:@"; "]];
-}
-
-- (STPAddress *)address {
-    if (self.name || self.addressLine1 || self.addressLine2 || self.addressZip || self.addressCity || self.addressState || self.addressCountry) {
-        STPAddress *address = [STPAddress new];
-        address.name = self.name;
-        address.line1 = self.addressLine1;
-        address.line2 = self.addressLine2;
-        address.postalCode = self.addressZip;
-        address.city = self.addressCity;
-        address.state = self.addressState;
-        address.country = self.addressCountry;
-        return address;
-    }
-    return nil;
 }
 
 #pragma mark - STPAPIResponseDecodable

--- a/Tests/Tests/STPBankAccountTest.m
+++ b/Tests/Tests/STPBankAccountTest.m
@@ -78,44 +78,7 @@
     }
 }
 
-#pragma mark - STPAPIResponseDecodable Tests
-
-- (NSDictionary *)completeAttributeDictionary {
-    return @{
-        @"id": @"something",
-        @"last4": @"6789",
-        @"bank_name": @"STRIPE TEST BANK",
-        @"country": @"US",
-        @"fingerprint": @"something",
-        @"currency": @"usd",
-        @"status": @"new",
-        @"account_holder_name": @"John Doe",
-        @"account_holder_type": @"company",
-    };
-}
-
-- (void)testInitializingBankAccountWithAttributeDictionary {
-    NSMutableDictionary *apiResponse = [[self completeAttributeDictionary] mutableCopy];
-    apiResponse[@"foo"] = @"bar";
-    STPBankAccount *bankAccountWithAttributes = [STPBankAccount decodedObjectFromAPIResponse:apiResponse];
-
-    XCTAssertEqualObjects([bankAccountWithAttributes bankAccountId], @"something", @"bankAccountId is set correctly");
-    XCTAssertEqualObjects([bankAccountWithAttributes last4], @"6789", @"last4 is set correctly");
-    XCTAssertEqualObjects([bankAccountWithAttributes bankName], @"STRIPE TEST BANK", @"bankName is set correctly");
-    XCTAssertEqualObjects([bankAccountWithAttributes country], @"US", @"country is set correctly");
-    XCTAssertEqualObjects([bankAccountWithAttributes fingerprint], @"something", @"fingerprint is set correctly");
-    XCTAssertEqualObjects([bankAccountWithAttributes currency], @"usd", @"currency is set correctly");
-    XCTAssertEqual([bankAccountWithAttributes status], STPBankAccountStatusNew);
-    XCTAssertEqualObjects([bankAccountWithAttributes accountHolderName], @"John Doe");
-    XCTAssertEqual([bankAccountWithAttributes accountHolderType], STPBankAccountHolderTypeCompany);
-    
-    NSDictionary *allResponseFields = bankAccountWithAttributes.allResponseFields;
-    XCTAssertEqual(allResponseFields[@"foo"], @"bar");
-    XCTAssertEqual(allResponseFields[@"last4"], @"6789");
-    XCTAssertNil(allResponseFields[@"baz"]);
-}
-
-#pragma mark - Last4 Tests
+#pragma mark -
 
 - (void)testLast4ReturnsAccountNumberLast4WhenNotSet {
     self.bankAccount.accountNumber = @"000123456789";
@@ -147,6 +110,43 @@
     STPBankAccount *bankAccount = [STPBankAccount decodedObjectFromAPIResponse:[self completeAttributeDictionary]];
     bankAccount.routingNumber = @"123456789";
     XCTAssert(bankAccount.description);
+}
+
+#pragma mark - STPAPIResponseDecodable Tests
+
+- (NSDictionary *)completeAttributeDictionary {
+    return @{
+             @"id": @"something",
+             @"last4": @"6789",
+             @"bank_name": @"STRIPE TEST BANK",
+             @"country": @"US",
+             @"fingerprint": @"something",
+             @"currency": @"usd",
+             @"status": @"new",
+             @"account_holder_name": @"John Doe",
+             @"account_holder_type": @"company",
+             };
+}
+
+- (void)testInitializingBankAccountWithAttributeDictionary {
+    NSMutableDictionary *apiResponse = [[self completeAttributeDictionary] mutableCopy];
+    apiResponse[@"foo"] = @"bar";
+    STPBankAccount *bankAccountWithAttributes = [STPBankAccount decodedObjectFromAPIResponse:apiResponse];
+
+    XCTAssertEqualObjects([bankAccountWithAttributes bankAccountId], @"something", @"bankAccountId is set correctly");
+    XCTAssertEqualObjects([bankAccountWithAttributes last4], @"6789", @"last4 is set correctly");
+    XCTAssertEqualObjects([bankAccountWithAttributes bankName], @"STRIPE TEST BANK", @"bankName is set correctly");
+    XCTAssertEqualObjects([bankAccountWithAttributes country], @"US", @"country is set correctly");
+    XCTAssertEqualObjects([bankAccountWithAttributes fingerprint], @"something", @"fingerprint is set correctly");
+    XCTAssertEqualObjects([bankAccountWithAttributes currency], @"usd", @"currency is set correctly");
+    XCTAssertEqual([bankAccountWithAttributes status], STPBankAccountStatusNew);
+    XCTAssertEqualObjects([bankAccountWithAttributes accountHolderName], @"John Doe");
+    XCTAssertEqual([bankAccountWithAttributes accountHolderType], STPBankAccountHolderTypeCompany);
+
+    NSDictionary *allResponseFields = bankAccountWithAttributes.allResponseFields;
+    XCTAssertEqual(allResponseFields[@"foo"], @"bar");
+    XCTAssertEqual(allResponseFields[@"last4"], @"6789");
+    XCTAssertNil(allResponseFields[@"baz"]);
 }
 
 @end

--- a/Tests/Tests/STPCardTest.m
+++ b/Tests/Tests/STPCardTest.m
@@ -149,58 +149,7 @@
     }
 }
 
-#pragma mark - STPAPIResponseDecodable Tests
-
-- (NSDictionary *)completeAttributeDictionary {
-    return @{
-        @"id": @"1",
-        @"exp_month": @"12",
-        @"exp_year": @"2013",
-        @"funding": @"debit",
-        @"name": @"Smerlock Smolmes",
-        @"address_line1": @"221A Baker Street",
-        @"address_city": @"New York",
-        @"address_state": @"NY",
-        @"address_zip": @"12345",
-        @"address_country": @"USA",
-        @"last4": @"1234",
-        @"dynamic_last4": @"5678",
-        @"brand": @"MasterCard",
-        @"country": @"Japan",
-        @"currency": @"usd",
-    };
-}
-
-- (void)testInitializingCardWithAttributeDictionary {
-    NSMutableDictionary *apiResponse = [[self completeAttributeDictionary] mutableCopy];
-    apiResponse[@"foo"] = @"bar";
-    apiResponse[@"nested"] = @{@"baz": @"bang"};
-    
-    
-    STPCard *cardWithAttributes = [STPCard decodedObjectFromAPIResponse:apiResponse];
-    XCTAssertTrue([cardWithAttributes expMonth] == 12, @"expMonth is set correctly");
-    XCTAssertTrue([cardWithAttributes expYear] == 2013, @"expYear is set correctly");
-    XCTAssertEqual([cardWithAttributes funding], STPCardFundingTypeDebit);
-    XCTAssertEqualObjects([cardWithAttributes name], @"Smerlock Smolmes", @"name is set correctly");
-    XCTAssertEqualObjects([cardWithAttributes addressLine1], @"221A Baker Street", @"addressLine1 is set correctly");
-    XCTAssertEqualObjects([cardWithAttributes addressCity], @"New York", @"addressCity is set correctly");
-    XCTAssertEqualObjects([cardWithAttributes addressState], @"NY", @"addressState is set correctly");
-    XCTAssertEqualObjects([cardWithAttributes addressZip], @"12345", @"addressZip is set correctly");
-    XCTAssertEqualObjects([cardWithAttributes addressCountry], @"USA", @"addressCountry is set correctly");
-    XCTAssertEqualObjects([cardWithAttributes last4], @"1234", @"last4 is set correctly");
-    XCTAssertEqualObjects([cardWithAttributes dynamicLast4], @"5678", @"last4 is set correctly");
-    XCTAssertEqual([cardWithAttributes brand], STPCardBrandMasterCard, @"type is set correctly");
-    XCTAssertEqualObjects([cardWithAttributes country], @"Japan", @"country is set correctly");
-    XCTAssertEqualObjects([cardWithAttributes currency], @"usd", @"currency is set correctly");
-    
-    NSDictionary *allResponseFields = cardWithAttributes.allResponseFields;
-    XCTAssertEqual(allResponseFields[@"foo"], @"bar");
-    XCTAssertEqual(allResponseFields[@"last4"], @"1234");
-    XCTAssertEqualObjects(allResponseFields[@"nested"], @{@"baz": @"bang"});
-    XCTAssertNil(allResponseFields[@"baz"]);
-}
-
-#pragma mark - Last4 Tests
+#pragma mark -
 
 - (void)testLast4ReturnsCardNumberLast4WhenNotSet {
     self.card.number = @"4242424242424242";
@@ -215,25 +164,6 @@
     self.card.number = @"123";
     XCTAssertEqualObjects(nil, self.card.last4, @"last4 returns nil when number length is < 3");
 }
-
-#pragma mark - Equality Tests
-
-- (void)testCardEquals {
-    STPCard *card1 = [STPCard decodedObjectFromAPIResponse:[self completeAttributeDictionary]];
-    STPCard *card2 = [STPCard decodedObjectFromAPIResponse:[self completeAttributeDictionary]];
-
-    XCTAssertEqualObjects(card1, card1, @"card should equal itself");
-    XCTAssertEqualObjects(card1, card2, @"cards with equal data should be equal");
-}
-
-#pragma mark - Description Tests
-
-- (void)testDescriptionWorks {
-    STPCard *card = [STPCard decodedObjectFromAPIResponse:[self completeAttributeDictionary]];
-    XCTAssert(card.description);
-}
-
-#pragma mark -
 
 - (void)testAddress {
     NSMutableDictionary *apiResponse = [[self completeAttributeDictionary] mutableCopy];
@@ -253,6 +183,74 @@
     apiResponse[@"address_country"] = nil;
     STPCard *noAddressCard = [STPCard decodedObjectFromAPIResponse:apiResponse];
     XCTAssertNil([noAddressCard address]);
+}
+
+#pragma mark - Equality Tests
+
+- (void)testCardEquals {
+    STPCard *card1 = [STPCard decodedObjectFromAPIResponse:[self completeAttributeDictionary]];
+    STPCard *card2 = [STPCard decodedObjectFromAPIResponse:[self completeAttributeDictionary]];
+
+    XCTAssertEqualObjects(card1, card1, @"card should equal itself");
+    XCTAssertEqualObjects(card1, card2, @"cards with equal data should be equal");
+}
+
+#pragma mark - Description Tests
+
+- (void)testDescriptionWorks {
+    STPCard *card = [STPCard decodedObjectFromAPIResponse:[self completeAttributeDictionary]];
+    XCTAssert(card.description);
+}
+
+#pragma mark - STPAPIResponseDecodable Tests
+
+- (NSDictionary *)completeAttributeDictionary {
+    return @{
+             @"id": @"1",
+             @"exp_month": @"12",
+             @"exp_year": @"2013",
+             @"funding": @"debit",
+             @"name": @"Smerlock Smolmes",
+             @"address_line1": @"221A Baker Street",
+             @"address_city": @"New York",
+             @"address_state": @"NY",
+             @"address_zip": @"12345",
+             @"address_country": @"USA",
+             @"last4": @"1234",
+             @"dynamic_last4": @"5678",
+             @"brand": @"MasterCard",
+             @"country": @"Japan",
+             @"currency": @"usd",
+             };
+}
+
+- (void)testInitializingCardWithAttributeDictionary {
+    NSMutableDictionary *apiResponse = [[self completeAttributeDictionary] mutableCopy];
+    apiResponse[@"foo"] = @"bar";
+    apiResponse[@"nested"] = @{@"baz": @"bang"};
+
+
+    STPCard *cardWithAttributes = [STPCard decodedObjectFromAPIResponse:apiResponse];
+    XCTAssertTrue([cardWithAttributes expMonth] == 12, @"expMonth is set correctly");
+    XCTAssertTrue([cardWithAttributes expYear] == 2013, @"expYear is set correctly");
+    XCTAssertEqual([cardWithAttributes funding], STPCardFundingTypeDebit);
+    XCTAssertEqualObjects([cardWithAttributes name], @"Smerlock Smolmes", @"name is set correctly");
+    XCTAssertEqualObjects([cardWithAttributes addressLine1], @"221A Baker Street", @"addressLine1 is set correctly");
+    XCTAssertEqualObjects([cardWithAttributes addressCity], @"New York", @"addressCity is set correctly");
+    XCTAssertEqualObjects([cardWithAttributes addressState], @"NY", @"addressState is set correctly");
+    XCTAssertEqualObjects([cardWithAttributes addressZip], @"12345", @"addressZip is set correctly");
+    XCTAssertEqualObjects([cardWithAttributes addressCountry], @"USA", @"addressCountry is set correctly");
+    XCTAssertEqualObjects([cardWithAttributes last4], @"1234", @"last4 is set correctly");
+    XCTAssertEqualObjects([cardWithAttributes dynamicLast4], @"5678", @"last4 is set correctly");
+    XCTAssertEqual([cardWithAttributes brand], STPCardBrandMasterCard, @"type is set correctly");
+    XCTAssertEqualObjects([cardWithAttributes country], @"Japan", @"country is set correctly");
+    XCTAssertEqualObjects([cardWithAttributes currency], @"usd", @"currency is set correctly");
+
+    NSDictionary *allResponseFields = cardWithAttributes.allResponseFields;
+    XCTAssertEqual(allResponseFields[@"foo"], @"bar");
+    XCTAssertEqual(allResponseFields[@"last4"], @"1234");
+    XCTAssertEqualObjects(allResponseFields[@"nested"], @{@"baz": @"bang"});
+    XCTAssertNil(allResponseFields[@"baz"]);
 }
 
 @end

--- a/Tests/Tests/STPFileTest.m
+++ b/Tests/Tests/STPFileTest.m
@@ -64,6 +64,16 @@
     }
 }
 
+#pragma mark - Equality Tests
+
+- (void)testFileEquals {
+    STPFile *file1 = [STPFile decodedObjectFromAPIResponse:[self completeAttributeDictionary]];
+    STPFile *file2 = [STPFile decodedObjectFromAPIResponse:[self completeAttributeDictionary]];
+
+    XCTAssertEqualObjects(file1, file1, @"file should equal itself");
+    XCTAssertEqualObjects(file1, file2, @"file with equal data should be equal");
+}
+
 #pragma mark - STPAPIResponseDecodable Tests
 
 - (NSDictionary *)completeAttributeDictionary {
@@ -100,16 +110,6 @@
     apiResponse[@"id"] = nil;
     STPFile *fileWithAttributes = [STPFile decodedObjectFromAPIResponse:apiResponse];
     XCTAssertNil(fileWithAttributes);
-}
-
-#pragma mark - Equality Tests
-
-- (void)testFileEquals {
-    STPFile *file1 = [STPFile decodedObjectFromAPIResponse:[self completeAttributeDictionary]];
-    STPFile *file2 = [STPFile decodedObjectFromAPIResponse:[self completeAttributeDictionary]];
-    
-    XCTAssertEqualObjects(file1, file1, @"file should equal itself");
-    XCTAssertEqualObjects(file1, file2, @"file with equal data should be equal");
 }
 
 @end


### PR DESCRIPTION
## Summary

Doing some alignment to make reading/writing tests easier. I plan to follow this up with more test coverage in a different PR.

Tried to follow this general implementation order:

- Class methods
- Init
- Instance methods
- Protocol implementations

Then tests should be ordered the same as the implementation.

## Motivation

Reduce friction for test coverage.

## Testing

No functional changes.
