### PR TITLE
Fix double-view dismissal

### DIFF
--- a/Stripe/STPRedirectContext.m
+++ b/Stripe/STPRedirectContext.m
@@ -133,7 +133,7 @@ NS_ASSUME_NONNULL_BEGIN
     [self unsubscribeFromNotifications];
 
     if (shouldDismissViewController) {
-        [self dimissPresentedViewController];
+        [self dismissPresentedViewController];
     }
 
     self.completion(self.source.stripeID, self.source.clientSecret, error);
@@ -150,7 +150,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)unsubscribeFromNotificationsAndDismissPresentedViewControllers {
     [self unsubscribeFromNotifications];
-    [self dimissPresentedViewController];
+    [self dismissPresentedViewController];
 }
 
 - (void)unsubscribeFromNotifications {
@@ -160,7 +160,7 @@ NS_ASSUME_NONNULL_BEGIN
     [[STPURLCallbackHandler shared] unregisterListener:self];
 }
 
-- (void)dimissPresentedViewController {
+- (void)dismissPresentedViewController {
     if (self.safariVC) {
         [self.safariVC.presentingViewController dismissViewControllerAnimated:YES
                                                                    completion:nil];

--- a/Stripe/STPRedirectContext.m
+++ b/Stripe/STPRedirectContext.m
@@ -90,14 +90,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)safariViewControllerDidFinish:(__unused SFSafariViewController *)controller { FAUXPAS_IGNORED_ON_LINE(APIAvailability)
     stpDispatchToMainThreadIfNecessary(^{
-        [self handleRedirectCompletionWithError:nil];
+        [self handleRedirectCompletionWithError:nil
+                    shouldDismissViewController:NO];
     });
 }
 
 - (void)safariViewController:(__unused SFSafariViewController *)controller didCompleteInitialLoad:(BOOL)didLoadSuccessfully { FAUXPAS_IGNORED_ON_LINE(APIAvailability)
     if (didLoadSuccessfully == NO) {
         stpDispatchToMainThreadIfNecessary(^{
-            [self handleRedirectCompletionWithError:[NSError stp_genericConnectionError]];
+            [self handleRedirectCompletionWithError:[NSError stp_genericConnectionError]
+                        shouldDismissViewController:YES];
         });
     }
 }
@@ -106,24 +108,33 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)handleWillForegroundNotification {
     stpDispatchToMainThreadIfNecessary(^{
-        [self handleRedirectCompletionWithError:nil];
+        [self handleRedirectCompletionWithError:nil
+                    shouldDismissViewController:YES];
     });
 }
 
 - (BOOL)handleURLCallback:(__unused NSURL *)url {
     stpDispatchToMainThreadIfNecessary(^{
-        [self handleRedirectCompletionWithError:nil];
+        [self handleRedirectCompletionWithError:nil
+                    shouldDismissViewController:YES];
     });
     // We handle all returned urls that match what we registered for
     return YES;
 }
 
-- (void)handleRedirectCompletionWithError:(nullable NSError *)error {
+- (void)handleRedirectCompletionWithError:(nullable NSError *)error
+              shouldDismissViewController:(BOOL)shouldDismissViewController {
     if (self.state != STPRedirectContextStateInProgress) {
         return;
     }
-    [self unsubscribeFromNotificationsAndDismissPresentedViewControllers];
+
     _state = STPRedirectContextStateCompleted;
+
+    [self unsubscribeFromNotifications];
+
+    if (shouldDismissViewController) {
+        [self dimissPresentedViewController];
+    }
 
     self.completion(self.source.stripeID, self.source.clientSecret, error);
 }
@@ -138,18 +149,21 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)unsubscribeFromNotificationsAndDismissPresentedViewControllers {
+    [self unsubscribeFromNotifications];
+    [self dimissPresentedViewController];
+}
+
+- (void)unsubscribeFromNotifications {
     [[NSNotificationCenter defaultCenter] removeObserver:self
                                                     name:UIApplicationWillEnterForegroundNotification
                                                   object:nil];
     [[STPURLCallbackHandler shared] unregisterListener:self];
+}
 
+- (void)dimissPresentedViewController {
     if (self.safariVC) {
         [self.safariVC.presentingViewController dismissViewControllerAnimated:YES
-                                                                   completion:^{
-                                                                       stpDispatchToMainThreadIfNecessary(^{
-                                                                           [self handleRedirectCompletionWithError:nil];
-                                                                       });
-                                                                   }];
+                                                                   completion:nil];
     }
 }
 

--- a/Tests/Tests/STPRedirectContextTest.m
+++ b/Tests/Tests/STPRedirectContextTest.m
@@ -14,7 +14,8 @@
 #import "STPURLCallbackHandler.h"
 
 @interface STPRedirectContext (Testing)
-- (void)unsubscribeFromNotificationsAndDismissPresentedViewControllers;
+- (void)unsubscribeFromNotifications;
+- (void)dismissPresentedViewController;
 @end
 
 @interface STPRedirectContextTest : XCTestCase
@@ -64,7 +65,8 @@
     OCMVerify([mockVC presentViewController:[OCMArg checkWithBlock:checker]
                                    animated:YES
                                  completion:[OCMArg any]]);
-    OCMVerify([sut unsubscribeFromNotificationsAndDismissPresentedViewControllers]);
+    OCMVerify([sut unsubscribeFromNotifications]);
+    OCMVerify([sut dismissPresentedViewController]);
 
     [self waitForExpectationsWithTimeout:2 handler:nil];
 }
@@ -95,13 +97,14 @@
     OCMVerify([mockVC presentViewController:[OCMArg checkWithBlock:checker]
                                    animated:YES
                                  completion:[OCMArg any]]);
-    OCMReject([sut unsubscribeFromNotificationsAndDismissPresentedViewControllers]);
+    OCMReject([sut unsubscribeFromNotifications]);
+    OCMReject([sut dismissPresentedViewController]);
 }
 
 /**
  After starting a SafariViewController redirect flow,
  when SafariViewController finishes, RedirectContext's completion block
- and dismiss method should be called.
+ should be called.
  */
 - (void)testSafariViewControllerRedirectFlow_didFinish {
     id mockVC = OCMClassMock([UIViewController class]);
@@ -128,7 +131,9 @@
     OCMVerify([mockVC presentViewController:[OCMArg checkWithBlock:checker]
                                    animated:YES
                                  completion:[OCMArg any]]);
-    OCMVerify([sut unsubscribeFromNotificationsAndDismissPresentedViewControllers]);
+    OCMVerify([sut unsubscribeFromNotifications]);
+    // dismiss should not be called – SafariVC dismisses itself when Done is tapped
+    OCMReject([sut dismissPresentedViewController]);
 
     [self waitForExpectationsWithTimeout:2 handler:nil];
 }
@@ -164,7 +169,8 @@
     OCMVerify([mockVC presentViewController:[OCMArg checkWithBlock:checker]
                                    animated:YES
                                  completion:[OCMArg any]]);
-    OCMVerify([sut unsubscribeFromNotificationsAndDismissPresentedViewControllers]);
+    OCMVerify([sut unsubscribeFromNotifications]);
+    OCMVerify([sut dismissPresentedViewController]);
 
     [self waitForExpectationsWithTimeout:2 handler:nil];
 }
@@ -187,7 +193,8 @@
     OCMVerify([mockVC presentViewController:[OCMArg isKindOfClass:[SFSafariViewController class]]
                                    animated:YES
                                  completion:[OCMArg any]]);
-    OCMVerify([sut unsubscribeFromNotificationsAndDismissPresentedViewControllers]);
+    OCMVerify([sut unsubscribeFromNotifications]);
+    OCMVerify([sut dismissPresentedViewController]);
 }
 
 /**
@@ -208,7 +215,8 @@
     OCMVerify([mockVC presentViewController:[OCMArg isKindOfClass:[SFSafariViewController class]]
                                    animated:YES
                                  completion:[OCMArg any]]);
-    OCMVerify([sut unsubscribeFromNotificationsAndDismissPresentedViewControllers]);
+    OCMVerify([sut unsubscribeFromNotifications]);
+    OCMVerify([sut dismissPresentedViewController]);
 }
 
 /**
@@ -228,7 +236,8 @@
     OCMVerify([mockVC presentViewController:[OCMArg isKindOfClass:[SFSafariViewController class]]
                                    animated:YES
                                  completion:[OCMArg any]]);
-    OCMReject([sut unsubscribeFromNotificationsAndDismissPresentedViewControllers]);
+    OCMReject([sut unsubscribeFromNotifications]);
+    OCMReject([sut dismissPresentedViewController]);
 }
 
 /**
@@ -250,7 +259,8 @@
     [sut startSafariAppRedirectFlow];
     [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationWillEnterForegroundNotification object:nil];
 
-    OCMVerify([sut unsubscribeFromNotificationsAndDismissPresentedViewControllers]);
+    OCMVerify([sut unsubscribeFromNotifications]);
+    OCMVerify([sut dismissPresentedViewController]);
     [self waitForExpectationsWithTimeout:2 handler:nil];
 }
 
@@ -267,7 +277,8 @@
 
     [sut startSafariAppRedirectFlow];
 
-    OCMReject([sut unsubscribeFromNotificationsAndDismissPresentedViewControllers]);
+    OCMReject([sut unsubscribeFromNotifications]);
+    OCMReject([sut dismissPresentedViewController]);
 }
 
 @end


### PR DESCRIPTION
Hitting the done button in SFSafariVC makes it dismiss itself, so we don't want to manually dismiss it in that case because that will cause two dismissals to be fired and that can cascade to dismiss other view controllers. Instead, only dismiss in the other completion cases.

Also remove an uncessary completion block in the dismiss logic.

Fixes https://github.com/stripe/stripe-ios/issues/717