### PR TITLE
Improve `STPAPIRequest` class

### DIFF
--- a/Stripe/STPAPIRequest.h
+++ b/Stripe/STPAPIRequest.h
@@ -8,6 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import "STPAPIResponseDecodable.h"
+
 @class STPAPIClient;
 
 @interface STPAPIRequest<__covariant ResponseType:id<STPAPIResponseDecodable>> : NSObject
@@ -23,19 +24,25 @@ typedef void(^STPAPIResponseBlock)(ResponseType object, NSHTTPURLResponse *respo
 + (NSURLSessionDataTask *)postWithAPIClient:(STPAPIClient *)apiClient
                                     endpoint:(NSString *)endpoint
                                   parameters:(NSDictionary *)parameters
-                               deserializers:(NSArray<ResponseType>*)deserializers
+                               deserializers:(NSArray<ResponseType> *)deserializers
                                   completion:(STPAPIResponseBlock)completion;
 
 + (NSURLSessionDataTask *)getWithAPIClient:(STPAPIClient *)apiClient
                                   endpoint:(NSString *)endpoint
                                 parameters:(NSDictionary *)parameters
-                              deserializer:(id<STPAPIResponseDecodable>)deserializer
+                              deserializer:(ResponseType)deserializer
                                 completion:(STPAPIResponseBlock)completion;
 
-+ (void)parseResponse:(NSURLResponse *)response
-                body:(NSData *)body
-               error:(NSError *)error
-       deserializers:(NSArray<id<STPAPIResponseDecodable>>*)deserializers
-          completion:(STPAPIResponseBlock)completion;
++ (NSURLSessionDataTask *)deleteWithAPIClient:(STPAPIClient *)apiClient
+                                     endpoint:(NSString *)endpoint
+                                   parameters:(NSDictionary *)parameters
+                                 deserializer:(ResponseType)deserializer
+                                   completion:(STPAPIResponseBlock)completion;
+
++ (NSURLSessionDataTask *)deleteWithAPIClient:(STPAPIClient *)apiClient
+                                     endpoint:(NSString *)endpoint
+                                   parameters:(NSDictionary *)parameters
+                                deserializers:(NSArray<ResponseType> *)deserializer
+                                   completion:(STPAPIResponseBlock)completion;
 
 @end

--- a/Stripe/STPAPIRequest.m
+++ b/Stripe/STPAPIRequest.m
@@ -131,6 +131,11 @@ static NSString * const JSONKeyObject = @"object";
         });
     };
 
+    if (error) {
+        // Forward NSURLSession error
+        return safeCompletion(nil, error);
+    }
+
     if (deserializers.count == 0) {
         // Missing deserializers
         return safeCompletion(nil, [NSError stp_genericFailedToParseResponseError]);
@@ -147,7 +152,7 @@ static NSString * const JSONKeyObject = @"object";
 
     Class deserializerClass = nil;
     if (deserializers.count == 1) {
-        // Legacy deserializers don't always define `stripeObject` method
+        // Some deserializers don't conform to STPInternalAPIResponseDecodable
         deserializerClass = [deserializers.firstObject class];
     }
     else {
@@ -174,11 +179,6 @@ static NSString * const JSONKeyObject = @"object";
         if (parsedError) {
             // Use response body error
             return safeCompletion(nil, parsedError);
-        }
-
-        if (error) {
-            // Use NSURLSession error
-            return safeCompletion(nil, error);
         }
 
         // Use generic error

--- a/Tests/Tests/STPAPIRequestTest.m
+++ b/Tests/Tests/STPAPIRequestTest.m
@@ -411,7 +411,7 @@
     NSDictionary *json = [STPTestUtils jsonNamed:@"CardSource"];
     NSData *body = [NSJSONSerialization dataWithJSONObject:json options:(NSJSONWritingOptions)kNilOptions error:nil];
     NSError *errorParameter = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorUnknown userInfo:nil];
-    NSArray *deserializers = @[[STPCard new]];
+    NSArray *deserializers = @[[STPCard new], [STPSource new]];
 
     [STPAPIRequest parseResponse:httpURLResponse
                             body:body

--- a/Tests/Tests/STPAPIRequestTest.m
+++ b/Tests/Tests/STPAPIRequestTest.m
@@ -17,86 +17,193 @@
 
 @implementation STPAPIRequestTest
 
-- (void)testParseResponseWithMultipleSerializers {
-    XCTestExpectation *exp = [self expectationWithDescription:@"parseResponse"];
+- (void)testParseResponseWithMultipleDeserializers {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"parseResponse"];
+
     NSHTTPURLResponse *httpURLResponse = [[NSHTTPURLResponse alloc] init];
     NSDictionary *json = [STPTestUtils jsonNamed:@"CardSource"];
     NSData *body = [NSJSONSerialization dataWithJSONObject:json options:(NSJSONWritingOptions)kNilOptions error:nil];
+    NSError *errorParameter = nil;
     NSArray *deserializers = @[[STPCard new], [STPSource new]];
-    [STPAPIRequest parseResponse:httpURLResponse body:body error:nil deserializers:deserializers completion:^(id<STPAPIResponseDecodable> object, NSHTTPURLResponse *response, NSError *error) {
-        XCTAssertEqualObjects(object, [STPSource decodedObjectFromAPIResponse:json]);
-        XCTAssertEqualObjects(response, httpURLResponse);
-        XCTAssertNil(error);
-        [exp fulfill];
-    }];
-    [self waitForExpectationsWithTimeout:2 handler:nil];
+
+    [STPAPIRequest parseResponse:httpURLResponse
+                            body:body
+                           error:errorParameter
+                   deserializers:deserializers
+                      completion:^(id<STPAPIResponseDecodable> object, NSHTTPURLResponse *response, NSError *error) {
+                          XCTAssertEqualObjects(object, [STPSource decodedObjectFromAPIResponse:json]);
+                          XCTAssertEqualObjects(response, httpURLResponse);
+                          XCTAssertNil(error);
+                          [expectation fulfill];
+                      }];
+
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
 }
 
-- (void)testParseResponseWithMultipleSerializersNoMatchingObject {
-    XCTestExpectation *exp = [self expectationWithDescription:@"parseResponse"];
+- (void)testParseResponseWithMultipleDeserializersNoMatchingObject {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"parseResponse"];
+
     NSHTTPURLResponse *httpURLResponse = [[NSHTTPURLResponse alloc] init];
     NSDictionary *json = [STPTestUtils jsonNamed:@"CardSource"];
     NSData *body = [NSJSONSerialization dataWithJSONObject:json options:(NSJSONWritingOptions)kNilOptions error:nil];
+    NSError *errorParameter = nil;
     NSArray *deserializers = @[[STPFile new], [STPBankAccount new]];
-    [STPAPIRequest parseResponse:httpURLResponse body:body error:nil deserializers:deserializers completion:^(id<STPAPIResponseDecodable> object, NSHTTPURLResponse *response, NSError *error) {
-        XCTAssertNil(object);
-        XCTAssertEqualObjects(response, httpURLResponse);
-        XCTAssertEqualObjects(error, [NSError stp_genericFailedToParseResponseError]);
-        [exp fulfill];
-    }];
-    [self waitForExpectationsWithTimeout:2 handler:nil];   
+
+    [STPAPIRequest parseResponse:httpURLResponse
+                            body:body
+                           error:errorParameter
+                   deserializers:deserializers
+                      completion:^(id<STPAPIResponseDecodable> object, NSHTTPURLResponse *response, NSError *error) {
+                          XCTAssertNil(object);
+                          XCTAssertEqualObjects(response, httpURLResponse);
+                          XCTAssertEqualObjects(error, [NSError stp_genericFailedToParseResponseError]);
+                          [expectation fulfill];
+                      }];
+
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
 }
 
-- (void)testParseResponseWithOneSerializer {
-    XCTestExpectation *exp = [self expectationWithDescription:@"parseResponse"];
+- (void)testParseResponseWithOneDeserializer {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"parseResponse"];
+
     NSHTTPURLResponse *httpURLResponse = [[NSHTTPURLResponse alloc] init];
     NSDictionary *json = [STPTestUtils jsonNamed:@"Customer"];
     NSData *body = [NSJSONSerialization dataWithJSONObject:json options:(NSJSONWritingOptions)kNilOptions error:nil];
+    NSError *errorParameter = nil;
     NSArray *deserializers = @[[STPCustomer new]];
-    [STPAPIRequest parseResponse:httpURLResponse body:body error:nil deserializers:deserializers completion:^(id<STPAPIResponseDecodable> object, NSHTTPURLResponse *response, NSError *error) {
-        XCTAssertEqualObjects(((STPCustomer *)object).stripeID, json[@"id"]);
-        XCTAssertEqualObjects(response, httpURLResponse);
-        XCTAssertNil(error);
-        [exp fulfill];
-    }];
-    [self waitForExpectationsWithTimeout:2 handler:nil];
+
+    [STPAPIRequest parseResponse:httpURLResponse
+                            body:body
+                           error:errorParameter
+                   deserializers:deserializers
+                      completion:^(id<STPAPIResponseDecodable> object, NSHTTPURLResponse *response, NSError *error) {
+                          XCTAssertEqualObjects(((STPCustomer *)object).stripeID, [STPCustomer decodedObjectFromAPIResponse:json].stripeID);
+                          XCTAssertEqualObjects(response, httpURLResponse);
+                          XCTAssertNil(error);
+                          [expectation fulfill];
+                      }];
+
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
 }
 
-- (void)testParseResponseWithNoSerializers {
-    XCTestExpectation *exp = [self expectationWithDescription:@"parseResponse"];
+- (void)testParseResponseWithNoDeserializers {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"parseResponse"];
+
     NSHTTPURLResponse *httpURLResponse = [[NSHTTPURLResponse alloc] init];
     NSDictionary *json = [STPTestUtils jsonNamed:@"EphemeralKey"];
     NSData *body = [NSJSONSerialization dataWithJSONObject:json options:(NSJSONWritingOptions)kNilOptions error:nil];
+    NSError *errorParameter = nil;
     NSArray *deserializers = @[];
-    [STPAPIRequest parseResponse:httpURLResponse body:body error:nil deserializers:deserializers completion:^(id<STPAPIResponseDecodable> object, NSHTTPURLResponse *response, NSError *error) {
-        XCTAssertNil(object);
-        XCTAssertEqualObjects(response, httpURLResponse);
-        XCTAssertEqualObjects(error, [NSError stp_genericFailedToParseResponseError]);
-        [exp fulfill];
-    }];
-    [self waitForExpectationsWithTimeout:2 handler:nil];
+
+    [STPAPIRequest parseResponse:httpURLResponse
+                            body:body
+                           error:errorParameter
+                   deserializers:deserializers
+                      completion:^(id<STPAPIResponseDecodable> object, NSHTTPURLResponse *response, NSError *error) {
+                          XCTAssertNil(object);
+                          XCTAssertEqualObjects(response, httpURLResponse);
+                          XCTAssertEqualObjects(error, [NSError stp_genericFailedToParseResponseError]);
+                          [expectation fulfill];
+                      }];
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
 }
 
-- (void)testParseResponseWithError {
-    XCTestExpectation *exp = [self expectationWithDescription:@"parseResponse"];
+- (void)testParseResponseWithConnectionError {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"parseResponse"];
+
+    NSHTTPURLResponse *httpURLResponse = [[NSHTTPURLResponse alloc] init];
+    NSDictionary *json = @{};
+    NSData *body = [NSJSONSerialization dataWithJSONObject:json options:(NSJSONWritingOptions)kNilOptions error:nil];
+    NSError *errorParameter = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorNotConnectedToInternet userInfo:nil];
+    NSArray *deserializers = @[[STPCard new]];
+
+    [STPAPIRequest parseResponse:httpURLResponse
+                            body:body
+                           error:errorParameter
+                   deserializers:deserializers
+                      completion:^(id<STPAPIResponseDecodable> object, NSHTTPURLResponse *response, NSError *error) {
+                          XCTAssertNil(object);
+                          XCTAssertEqualObjects(response, httpURLResponse);
+                          XCTAssertEqualObjects(error, errorParameter);
+                          [expectation fulfill];
+                      }];
+
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
+}
+
+- (void)testParseResponseWithReturnedError {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"parseResponse"];
+
     NSHTTPURLResponse *httpURLResponse = [[NSHTTPURLResponse alloc] init];
     NSDictionary *json = @{
                            @"error": @{
                                    @"type": @"invalid_request_error",
                                    @"message": @"Your card number is incorrect.",
-                                   @"code": @"incorrect_number"
+                                   @"code": @"incorrect_number",
                                    }
                            };
-    NSError *expectedError = [NSError stp_errorFromStripeResponse:json];
     NSData *body = [NSJSONSerialization dataWithJSONObject:json options:(NSJSONWritingOptions)kNilOptions error:nil];
+    NSError *errorParameter = nil;
     NSArray *deserializers = @[[STPCard new]];
-    [STPAPIRequest parseResponse:httpURLResponse body:body error:nil deserializers:deserializers completion:^(id<STPAPIResponseDecodable> object, NSHTTPURLResponse *response, NSError *error) {
-        XCTAssertNil(object);
-        XCTAssertEqualObjects(response, httpURLResponse);
-        XCTAssertEqualObjects(error, expectedError);
-        [exp fulfill];
-    }];
-    [self waitForExpectationsWithTimeout:2 handler:nil];
+
+    [STPAPIRequest parseResponse:httpURLResponse
+                            body:body
+                           error:errorParameter
+                   deserializers:deserializers
+                      completion:^(id<STPAPIResponseDecodable> object, NSHTTPURLResponse *response, NSError *error) {
+                          XCTAssertNil(object);
+                          XCTAssertEqualObjects(response, httpURLResponse);
+                          XCTAssertEqualObjects(error, [NSError stp_errorFromStripeResponse:json]);
+                          [expectation fulfill];
+                      }];
+
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
+}
+
+- (void)testParseResponseWithMissingError {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"parseResponse"];
+
+    NSHTTPURLResponse *httpURLResponse = [[NSHTTPURLResponse alloc] init];
+    NSDictionary *json = @{};
+    NSData *body = [NSJSONSerialization dataWithJSONObject:json options:(NSJSONWritingOptions)kNilOptions error:nil];
+    NSError *errorParameter = nil;
+    NSArray *deserializers = @[[STPCard new]];
+
+    [STPAPIRequest parseResponse:httpURLResponse
+                            body:body
+                           error:errorParameter
+                   deserializers:deserializers
+                      completion:^(id<STPAPIResponseDecodable> object, NSHTTPURLResponse *response, NSError *error) {
+                          XCTAssertNil(object);
+                          XCTAssertEqualObjects(response, httpURLResponse);
+                          XCTAssertEqualObjects(error, [NSError stp_genericFailedToParseResponseError]);
+                          [expectation fulfill];
+                      }];
+
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
+}
+
+- (void)testParseResponseWithResponseObjectAndReturnedError {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"parseResponse"];
+
+    NSHTTPURLResponse *httpURLResponse = [[NSHTTPURLResponse alloc] init];
+    NSDictionary *json = [STPTestUtils jsonNamed:@"CardSource"];
+    NSData *body = [NSJSONSerialization dataWithJSONObject:json options:(NSJSONWritingOptions)kNilOptions error:nil];
+    NSError *errorParameter = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorUnknown userInfo:nil];
+    NSArray *deserializers = @[[STPCard new]];
+
+    [STPAPIRequest parseResponse:httpURLResponse
+                            body:body
+                           error:errorParameter
+                   deserializers:deserializers
+                      completion:^(id<STPAPIResponseDecodable> object, NSHTTPURLResponse *response, NSError *error) {
+                          XCTAssertNil(object);
+                          XCTAssertEqualObjects(response, httpURLResponse);
+                          XCTAssertEqualObjects(error, errorParameter);
+                          [expectation fulfill];
+                      }];
+
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
 }
 
 @end

--- a/Tests/Tests/STPAPIRequestTest.m
+++ b/Tests/Tests/STPAPIRequestTest.m
@@ -7,15 +7,168 @@
 //
 
 #import <XCTest/XCTest.h>
+#import <OCMock/OCMock.h>
 #import <Stripe/Stripe.h>
+
 #import "STPAPIRequest.h"
+
+#import "STPAPIClient.h"
+#import "STPAPIClient+Private.h"
 #import "STPTestUtils.h"
+
+@interface STPAPIRequest ()
+
++ (void)parseResponse:(NSURLResponse *)response
+                 body:(NSData *)body
+                error:(NSError *)error
+        deserializers:(NSArray<id<STPAPIResponseDecodable>>*)deserializers
+           completion:(STPAPIResponseBlock)completion;
+
+@end
 
 @interface STPAPIRequestTest : XCTestCase
 
 @end
 
 @implementation STPAPIRequestTest
+
+- (void)testPostWithAPIClient {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
+
+    // Setup mocks
+    NSURLSessionDataTask *dataTaskMock = OCMClassMock([NSURLSessionDataTask class]);
+
+    NSURLSession *urlSessionMock = OCMClassMock([NSURLSession class]);
+    OCMStub([urlSessionMock dataTaskWithRequest:[OCMArg any]
+                              completionHandler:[OCMArg checkWithBlock:^BOOL(void (^completionHandler)(NSData *, NSURLResponse *, NSError *)) {
+        completionHandler((NSData *)@"body", (NSURLResponse *)@"response", (NSError *)@"error");
+        return YES;
+    }]]).andReturn(dataTaskMock);
+
+    STPAPIClient *apiClientMock = OCMClassMock([STPAPIClient class]);
+    OCMStub([apiClientMock apiURL]).andReturn([NSURL URLWithString:@"https://api.stripe.com"]);
+    OCMStub([apiClientMock urlSession]).andReturn(urlSessionMock);
+
+    id apiRequestMock = OCMClassMock([STPAPIRequest class]);
+    OCMStub([apiRequestMock parseResponse:[OCMArg any]
+                                     body:[OCMArg any]
+                                    error:[OCMArg any]
+                            deserializers:[OCMArg any]
+                               completion:[OCMArg checkWithBlock:^BOOL(STPAPIResponseBlock completion) {
+        completion((STPCard *)@"card", (NSHTTPURLResponse *)@"httpURLResponse", (NSError *)@"error");
+        return YES;
+    }]]);
+
+    // Perform request
+    NSString *endpoint = @"endpoint";
+    NSDictionary *parameters = @{@"key": @"value"};
+    STPCard *deserializer = [[STPCard alloc] init];
+
+    NSURLSessionDataTask *task = [STPAPIRequest postWithAPIClient:apiClientMock
+                                                         endpoint:endpoint
+                                                       parameters:parameters
+                                                     deserializer:deserializer
+                                                       completion:^(id<STPAPIResponseDecodable> object, NSHTTPURLResponse *response, NSError *error) {
+                                                           XCTAssertEqualObjects(object, (STPCard *)@"card");
+                                                           XCTAssertEqualObjects(response, (NSHTTPURLResponse *)@"httpURLResponse");
+                                                           XCTAssertEqualObjects(error, (NSError *)@"error");
+                                                           [expectation fulfill];
+                                                       }];
+    XCTAssertEqualObjects(task, dataTaskMock);
+
+    [self waitForExpectationsWithTimeout:2.0 handler:^(NSError *error) {
+        XCTAssertNil(error);
+
+        // Verify mocks
+        OCMVerify([dataTaskMock resume]);
+
+        OCMVerify([urlSessionMock dataTaskWithRequest:[OCMArg checkWithBlock:^BOOL(NSURLRequest *request) {
+            XCTAssertEqualObjects(request.URL, [NSURL URLWithString:@"https://api.stripe.com/endpoint"]);
+            XCTAssertEqualObjects(request.HTTPMethod, @"POST");
+            XCTAssertEqualObjects([[NSString alloc] initWithData:request.HTTPBody encoding:NSUTF8StringEncoding], @"key=value");
+            return YES;
+        }] completionHandler:[OCMArg any]]);
+
+        OCMVerify([apiRequestMock parseResponse:[OCMArg isEqual:@"response"]
+                                           body:[OCMArg isEqual:@"body"]
+                                          error:[OCMArg isEqual:@"error"]
+                                  deserializers:[OCMArg checkWithBlock:^BOOL(NSArray *deserializers) {
+            XCTAssert([deserializers.firstObject isKindOfClass:[STPCard class]]);
+            XCTAssertEqual(deserializers.count, (NSUInteger)1);
+            return YES;
+        }] completion:[OCMArg any]]);
+    }];
+}
+
+- (void)testGetWithAPIClient {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
+
+    // Setup mocks
+    NSURLSessionDataTask *dataTaskMock = OCMClassMock([NSURLSessionDataTask class]);
+
+    NSURLSession *urlSessionMock = OCMClassMock([NSURLSession class]);
+    OCMStub([urlSessionMock dataTaskWithRequest:[OCMArg any]
+                              completionHandler:[OCMArg checkWithBlock:^BOOL(void (^completionHandler)(NSData *, NSURLResponse *, NSError *)) {
+        completionHandler((NSData *)@"body", (NSURLResponse *)@"response", (NSError *)@"error");
+        return YES;
+    }]]).andReturn(dataTaskMock);
+
+    STPAPIClient *apiClientMock = OCMClassMock([STPAPIClient class]);
+    OCMStub([apiClientMock apiURL]).andReturn([NSURL URLWithString:@"https://api.stripe.com"]);
+    OCMStub([apiClientMock urlSession]).andReturn(urlSessionMock);
+
+    id apiRequestMock = OCMClassMock([STPAPIRequest class]);
+    OCMStub([apiRequestMock parseResponse:[OCMArg any]
+                                     body:[OCMArg any]
+                                    error:[OCMArg any]
+                            deserializers:[OCMArg any]
+                               completion:[OCMArg checkWithBlock:^BOOL(STPAPIResponseBlock completion) {
+        completion((STPCard *)@"card", (NSHTTPURLResponse *)@"httpURLResponse", (NSError *)@"error");
+        return YES;
+    }]]);
+
+    // Perform request
+    NSString *endpoint = @"endpoint";
+    NSDictionary *parameters = @{@"key": @"value"};
+    STPCard *deserializer = [[STPCard alloc] init];
+
+    NSURLSessionDataTask *task = [STPAPIRequest getWithAPIClient:apiClientMock
+                                                        endpoint:endpoint
+                                                      parameters:parameters
+                                                    deserializer:deserializer
+                                                      completion:^(id<STPAPIResponseDecodable> object, NSHTTPURLResponse *response, NSError *error) {
+                                                          XCTAssertEqualObjects(object, (STPCard *)@"card");
+                                                          XCTAssertEqualObjects(response, (NSHTTPURLResponse *)@"httpURLResponse");
+                                                          XCTAssertEqualObjects(error, (NSError *)@"error");
+                                                          [expectation fulfill];
+                                                      }];
+    XCTAssertEqualObjects(task, dataTaskMock);
+
+    [self waitForExpectationsWithTimeout:2.0 handler:^(NSError *error) {
+        XCTAssertNil(error);
+
+        // Verify mocks
+        OCMVerify([dataTaskMock resume]);
+
+        OCMVerify([urlSessionMock dataTaskWithRequest:[OCMArg checkWithBlock:^BOOL(NSURLRequest *request) {
+            XCTAssertEqualObjects(request.URL, [NSURL URLWithString:@"https://api.stripe.com/endpoint?key=value"]);
+            XCTAssertEqualObjects(request.HTTPMethod, @"GET");
+            XCTAssertEqualObjects([[NSString alloc] initWithData:request.HTTPBody encoding:NSUTF8StringEncoding], @"");
+            return YES;
+        }] completionHandler:[OCMArg any]]);
+
+        OCMVerify([apiRequestMock parseResponse:[OCMArg isEqual:@"response"]
+                                           body:[OCMArg isEqual:@"body"]
+                                          error:[OCMArg isEqual:@"error"]
+                                  deserializers:[OCMArg checkWithBlock:^BOOL(NSArray *deserializers) {
+            XCTAssert([deserializers.firstObject isKindOfClass:[STPCard class]]);
+            XCTAssertEqual(deserializers.count, (NSUInteger)1);
+            return YES;
+        }] completion:[OCMArg any]]);
+    }];
+}
+
+#pragma mark -
 
 - (void)testParseResponseWithMultipleDeserializers {
     XCTestExpectation *expectation = [self expectationWithDescription:@"parseResponse"];


### PR DESCRIPTION
## Summary & Motivation & Testing

I was in the process of adding support for `DELETE` requests in `STPAPIRequest` and decided to take a few steps back and improve the surrounding implementation first.

In particular, I started by [ensuring 100% test coverage for `[STPAPIRequest parseResponse:...]`](https://github.com/stripe/stripe-ios/commit/15a4bab5e69d380e1e4ef661795fb5cc8bd94c1f) before [untangling it](https://github.com/stripe/stripe-ios/commit/84b9794b31148f92859a7917d8dc5fcacb1863ce).

Then I [added support for making `DELETE` requests](https://github.com/stripe/stripe-ios/commit/44b3250e71f9689dc85e0b352c626691197508df) along with [corresponding test coverage](https://github.com/stripe/stripe-ios/commit/5c026855c9b27cbc2fde32ba06b12f9064071fb2). These tests turned out pretty complicated because of all the side effects. What do you think?

r? @bg-stripe 
cc @bdorfman-stripe 