### PR TITLE
Improve usability for `build_documentation.sh`

### DIFF
--- a/ci_scripts/build_documentation.sh
+++ b/ci_scripts/build_documentation.sh
@@ -1,11 +1,30 @@
 #!/bin/bash
 
-mv docs/index.html .
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-rm -rf docs
+# Verify jazzy is installed
+if ! command -v jazzy > /dev/null; then
+  echo "ERROR: Please install jazzy before running build_documentation.sh:"
+  echo "https://github.com/realm/jazzy#installation"
+  exit 1
+fi
 
+# Clean destination `stripe-ios/docs/docs/` directory
+echo "Cleaning stripe-ios/docs/docs/ directory..."
+rm -rf "${script_dir}/../docs/docs/"
+
+# Execute jazzy
+echo "Executing jazzy..."
 jazzy \
-  --config .jazzy.yaml \
-  --output "docs/docs"
+  --config "${script_dir}/../.jazzy.yaml" \
+  --output "${script_dir}/../docs/docs"
 
-mv index.html docs/index.html
+# Verify jazzy exit code
+jazzy_exit_code="$?"
+
+if [[ "${jazzy_exit_code}" != 0 ]]; then
+  echo "ERROR: Executing jazzy failed with status code: ${jazzy_exit_code}"
+  exit 1
+fi
+
+echo "Successfully built documentation"


### PR DESCRIPTION
## Summary & Motivation

Some minor improvements to make the script easier to use:

- Print help doc if jazzy is not installed
- Support executing from any directory
- Adjust clean step so that saving a copy of `index.html` is unnecessary
- Add informational logs

## Testing

Verified docs still generate successfully and tested various exit branches.

r? @bdorfman-stripe 
cc @bg-stripe 
