### PR TITLE
Add support for deleting sources from `STPPaymentMethodViewController`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 == X.X.X 2017-XX-XX
-* Adds an option to allow users to delete payment methods from the `STPPaymentMethodsViewController`. Disabled by default but can enabled using the `canDeletePaymentMethods` property.
+* Adds an option to allow users to delete payment methods from the `STPPaymentMethodsViewController`. Enabled by default but can disabled using the `canDeletePaymentMethods` property of `STPPaymentConfiguration`.
+  * Screenshots: https://user-images.githubusercontent.com/28276156/28131357-7a353474-66ee-11e7-846c-b38277d111fd.png
 
 == 11.1.0 2017-07-12
 * Adds stripeAccount property to `STPAPIClient`, set this to perform API requests on behalf of a connected account

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,10 @@
+== X.X.X 2017-XX-XX
+* Adds an option to allow users to delete payment methods from the `STPPaymentMethodsViewController`. Disabled by default but can enabled using the `canDeletePaymentMethods` property.
+
 == 11.1.0 2017-07-12
-* Added stripeAccount property to `STPAPIClient`, set this to perform API requests on behalf of a connected account
-* Fixed the `routingNumber` property of `STPBankAccount` so that it is populated when the information is available
-* Added iOS Objective-C Style Guide
+* Adds stripeAccount property to `STPAPIClient`, set this to perform API requests on behalf of a connected account
+* Fixes the `routingNumber` property of `STPBankAccount` so that it is populated when the information is available
+* Adds iOS Objective-C Style Guide
 
 == 11.0.0 2017-06-27
 * We've greatly simplified the integration for `STPPaymentContext`. See MIGRATING.md.

--- a/Stripe/PublicHeaders/STPPaymentConfiguration.h
+++ b/Stripe/PublicHeaders/STPPaymentConfiguration.h
@@ -70,6 +70,20 @@ NS_ASSUME_NONNULL_BEGIN
  *  The Apple Merchant Identifier to use during Apple Pay transactions. To create one of these, see our guide at https://stripe.com/docs/mobile/apple-pay . You must set this to a valid identifier in order to automatically enable Apple Pay.
  */
 @property(nonatomic, nullable, copy)NSString *appleMerchantIdentifier;
+
+/**
+ Determines whether or not the user is able to delete payment methods
+ 
+ This is only relevant to the `STPPaymentMethodsViewController` which, if enabled, will allow the
+ user to delete payment methods by tapping the "Edit" button in the navigation bar or by swiping
+ left on a payment method and tapping "Delete". Currently, the user is not allowed to delete the
+ selected payment method but this may change in the future.
+
+ Default value is YES but will only work if `STPPaymentMethodsViewController` is initialized with
+ a `STPCustomerContext` either through the `STPPaymentContext` or directly as an init parameter.
+ */
+@property (nonatomic, assign, readwrite) BOOL canDeletePaymentMethods;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Stripe/PublicHeaders/STPPaymentMethodsViewController.h
+++ b/Stripe/PublicHeaders/STPPaymentMethodsViewController.h
@@ -75,6 +75,17 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, strong, nullable)STPUserInformation *prefilledInformation;
 
 /**
+ Determines whether or not the user is able to delete payment methods using this view controller
+
+ The user can tap the "Edit" button or swipe left on a payment method to delete it if enabled.
+
+ Currently, the user is not allowed to delete the selected payment method but this may change in the future.
+
+ Default is NO.
+ */
+@property (nonatomic, assign, readwrite) BOOL canDeletePaymentMethods;
+
+/**
  *  If you're pushing `STPPaymentMethodsViewController` onto an existing `UINavigationController`'s stack, you should use this method to dismiss it, since it may have pushed an additional add card view controller onto the navigation controller's stack.
  *
  *  @param completion The callback to run after the view controller is dismissed. You may specify nil for this parameter.

--- a/Stripe/PublicHeaders/STPPaymentMethodsViewController.h
+++ b/Stripe/PublicHeaders/STPPaymentMethodsViewController.h
@@ -75,17 +75,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, strong, nullable)STPUserInformation *prefilledInformation;
 
 /**
- Determines whether or not the user is able to delete payment methods using this view controller
-
- The user can tap the "Edit" button or swipe left on a payment method to delete it if enabled.
-
- Currently, the user is not allowed to delete the selected payment method but this may change in the future.
-
- Default is NO.
- */
-@property (nonatomic, assign, readwrite) BOOL canDeletePaymentMethods;
-
-/**
  *  If you're pushing `STPPaymentMethodsViewController` onto an existing `UINavigationController`'s stack, you should use this method to dismiss it, since it may have pushed an additional add card view controller onto the navigation controller's stack.
  *
  *  @param completion The callback to run after the view controller is dismissed. You may specify nil for this parameter.

--- a/Stripe/STPAPIClient+Private.h
+++ b/Stripe/STPAPIClient+Private.h
@@ -30,31 +30,48 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface STPAPIClient (SourcesPrivate)
 
-- (NSURLSessionDataTask *)retrieveSourceWithId:(NSString *)identifier clientSecret:(NSString *)secret responseCompletion:(STPAPIResponseBlock)completion;
+- (NSURLSessionDataTask *)retrieveSourceWithId:(NSString *)identifier
+                                  clientSecret:(NSString *)secret
+                            responseCompletion:(STPAPIResponseBlock)completion;
 
 @end
 
 @interface STPAPIClient (Customers)
 
 /**
- https://stripe.com/docs/api#retrieve_customer
+ Retrieve a customer
+
+ @see https://stripe.com/docs/api#retrieve_customer
  */
 + (void)retrieveCustomerUsingKey:(STPEphemeralKey *)ephemeralKey
                       completion:(STPCustomerCompletionBlock)completion;
 
 /**
- https://stripe.com/docs/api#create_card
+ Add a source to a customer
+
+ @see https://stripe.com/docs/api#create_card
  */
 + (void)addSource:(NSString *)sourceID
 toCustomerUsingKey:(STPEphemeralKey *)ephemeralKey
        completion:(STPSourceProtocolCompletionBlock)completion;
 
 /**
- https://stripe.com/docs/api#update_customer
+ Update a customer with parameters
+
+ @see https://stripe.com/docs/api#update_customer
  */
 + (void)updateCustomerWithParameters:(NSDictionary *)parameters
                             usingKey:(STPEphemeralKey *)ephemeralKey
                           completion:(STPCustomerCompletionBlock)completion;
+
+/**
+ Delete a source from a customer
+
+ @see https://stripe.com/docs/api#delete_card
+ */
++ (void)deleteSource:(NSString *)sourceID
+fromCustomerUsingKey:(STPEphemeralKey *)ephemeralKey
+          completion:(STPSourceProtocolCompletionBlock)completion;
 
 @end
 

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -540,4 +540,16 @@ toCustomerUsingKey:(STPEphemeralKey *)ephemeralKey
                                              }];
 }
 
++ (void)deleteSource:(NSString *)sourceID fromCustomerUsingKey:(STPEphemeralKey *)ephemeralKey completion:(STPSourceProtocolCompletionBlock)completion {
+    STPAPIClient *client = [self apiClientWithEphemeralKey:ephemeralKey];
+    NSString *endpoint = [NSString stringWithFormat:@"%@/%@/%@/%@", APIEndpointCustomers, ephemeralKey.customerID, APIEndpointSources, sourceID];
+    [STPAPIRequest<STPSourceProtocol> deleteWithAPIClient:client
+                                                 endpoint:endpoint
+                                               parameters:nil
+                                            deserializers:@[[STPCard new], [STPSource new]]
+                                               completion:^(id object, __unused NSHTTPURLResponse *response, NSError *error) {
+                                                   completion(object, error);
+                                               }];
+}
+
 @end

--- a/Stripe/STPCustomerContext+Private.h
+++ b/Stripe/STPCustomerContext+Private.h
@@ -17,6 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface STPCustomerContext (Private)
 
 - (void)updateCustomerWithShippingAddress:(STPAddress *)shipping completion:(nullable STPErrorBlock)completion;
+- (void)detachSourceFromCustomer:(id<STPSourceProtocol>)source completion:(nullable STPErrorBlock)completion;
 
 @end
 

--- a/Stripe/STPPaymentConfiguration.m
+++ b/Stripe/STPPaymentConfiguration.m
@@ -39,6 +39,7 @@
         _verifyPrefilledShippingAddress = YES;
         _companyName = [NSBundle stp_applicationName];
         _shippingType = STPShippingTypeShipping;
+        _canDeletePaymentMethods = YES;
     }
     return self;
 }
@@ -53,6 +54,7 @@
     copy.shippingType = self.shippingType;
     copy.companyName = self.companyName;
     copy.appleMerchantIdentifier = self.appleMerchantIdentifier;
+    copy.canDeletePaymentMethods = self.canDeletePaymentMethods;
     return copy;
 }
 

--- a/Stripe/STPPaymentContext+Private.h
+++ b/Stripe/STPPaymentContext+Private.h
@@ -16,7 +16,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface STPPaymentContext (Private)<STPPaymentMethodsViewControllerDelegate, STPShippingAddressViewControllerDelegate>
 
-@property(nonatomic, readonly)STPPromise<STPPaymentMethodTuple *> *currentValuePromise;
+@property (nonatomic, readonly) STPPromise<STPPaymentMethodTuple *> *currentValuePromise;
+
+- (void)removePaymentMethod:(id<STPPaymentMethod>)paymentMethodToRemove;
 
 @end
 

--- a/Stripe/STPPaymentContext.m
+++ b/Stripe/STPPaymentContext.m
@@ -272,6 +272,18 @@ typedef NS_ENUM(NSUInteger, STPPaymentContextState) {
     }
 }
 
+- (void)removePaymentMethod:(id<STPPaymentMethod>)paymentMethodToRemove {
+    // Remove payment method from cached representation
+    NSMutableArray *paymentMethods = [self.paymentMethods mutableCopy];
+    [paymentMethods removeObject:paymentMethodToRemove];
+    self.paymentMethods = paymentMethods;
+
+    // Elect new selected payment method if needed
+    if ([self.selectedPaymentMethod isEqual:paymentMethodToRemove]) {
+        self.selectedPaymentMethod = self.paymentMethods.firstObject;
+    }
+}
+
 #pragma mark - Payment Methods
 
 - (void)presentPaymentMethodsViewController {

--- a/Stripe/STPPaymentMethodTableViewCell.h
+++ b/Stripe/STPPaymentMethodTableViewCell.h
@@ -7,12 +7,20 @@
 //
 
 #import <UIKit/UIKit.h>
-#import "STPPaymentMethod.h"
-#import "STPTheme.h"
+
+@class STPTheme;
+
+@protocol STPPaymentMethod;
+
+NS_ASSUME_NONNULL_BEGIN
 
 @interface STPPaymentMethodTableViewCell : UITableViewCell
 
-- (void)configureWithPaymentMethod:(id<STPPaymentMethod>)paymentMethod selected:(BOOL)selected theme:(STPTheme *)theme;
+- (instancetype)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(nullable NSString *)reuseIdentifier;
+
 - (void)configureForNewCardRowWithTheme:(STPTheme *)theme;
+- (void)configureWithPaymentMethod:(id<STPPaymentMethod>)paymentMethod theme:(STPTheme *)theme selected:(BOOL)selected;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Stripe/STPPaymentMethodTableViewCell.h
+++ b/Stripe/STPPaymentMethodTableViewCell.h
@@ -16,8 +16,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface STPPaymentMethodTableViewCell : UITableViewCell
 
-- (instancetype)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(nullable NSString *)reuseIdentifier;
-
 - (void)configureForNewCardRowWithTheme:(STPTheme *)theme;
 - (void)configureWithPaymentMethod:(id<STPPaymentMethod>)paymentMethod theme:(STPTheme *)theme selected:(BOOL)selected;
 

--- a/Stripe/STPPaymentMethodTableViewCell.m
+++ b/Stripe/STPPaymentMethodTableViewCell.m
@@ -12,28 +12,38 @@
 #import "STPCard.h"
 #import "STPImageLibrary+Private.h"
 #import "STPLocalizationUtils.h"
+#import "STPPaymentMethod.h"
+#import "STPTheme.h"
 
 @interface STPPaymentMethodTableViewCell ()
-@property(nonatomic) id<STPPaymentMethod> paymentMethod;
-@property(nonatomic) STPTheme *theme;
-@property(nonatomic, weak) UIImageView *leftIcon;
-@property(nonatomic, weak) UILabel *titleLabel;
-@property(nonatomic, weak) UIImageView *checkmarkIcon;
+
+@property (nonatomic, strong, nullable, readwrite) id<STPPaymentMethod> paymentMethod;
+@property (nonatomic, strong, readwrite) STPTheme *theme;
+
+@property (nonatomic, strong, readwrite) UIImageView *leftIcon;
+@property (nonatomic, strong, readwrite) UILabel *titleLabel;
+@property (nonatomic, strong, readwrite) UIImageView *checkmarkIcon;
+
 @end
 
 @implementation STPPaymentMethodTableViewCell
 
-- (instancetype)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier {
+- (instancetype)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(nullable NSString *)reuseIdentifier {
     self = [super initWithStyle:style reuseIdentifier:reuseIdentifier];
     if (self) {
+        // Left icon
         UIImageView *leftIcon = [[UIImageView alloc] init];
         _leftIcon = leftIcon;
+        [self.contentView addSubview:leftIcon];
+
+        // Title label
         UILabel *titleLabel = [UILabel new];
         _titleLabel = titleLabel;
+        [self.contentView addSubview:titleLabel];
+
+        // Checkmark icon
         UIImageView *checkmarkIcon = [[UIImageView alloc] initWithImage:[STPImageLibrary checkmarkIcon]];
         _checkmarkIcon = checkmarkIcon;
-        [self.contentView addSubview:leftIcon];
-        [self.contentView addSubview:titleLabel];
         [self.contentView addSubview:checkmarkIcon];
     }
     return self;
@@ -41,77 +51,102 @@
 
 - (void)layoutSubviews {
     [super layoutSubviews];
+
     CGFloat midY = CGRectGetMidY(self.bounds);
+    CGFloat padding = 15.0;
+    CGFloat iconWidth = 26.0;
+
+    // Left icon
     [self.leftIcon sizeToFit];
-    CGFloat padding = 15.0f;
-    CGFloat iconWidth = 26.0f;
-    self.leftIcon.center = CGPointMake(padding + iconWidth/2.0f, midY);
+    self.leftIcon.center = CGPointMake(padding + (iconWidth / 2.0f), midY);
+
+    // Title label
     [self.titleLabel sizeToFit];
-    self.titleLabel.center = CGPointMake(padding*2.0f + iconWidth + CGRectGetMidX(self.titleLabel.bounds), midY);
-    self.checkmarkIcon.frame = CGRectMake(0, 0, 14.0f, 14.0f);
+    self.titleLabel.center = CGPointMake(padding + iconWidth + padding + CGRectGetMidX(self.titleLabel.bounds), midY);
+
+    // Checkmark icon
+    self.checkmarkIcon.frame = CGRectMake(0.0, 0.0, 14.0f, 14.0f);
     self.checkmarkIcon.center = CGPointMake(CGRectGetWidth(self.bounds) - padding - CGRectGetMidX(self.checkmarkIcon.bounds), midY);
 }
 
 - (void)configureForNewCardRowWithTheme:(STPTheme *)theme {
-    _theme = theme;
-    self.backgroundColor = [UIColor clearColor];
-    self.contentView.backgroundColor = self.theme.secondaryBackgroundColor;
+    self.paymentMethod = nil;
+    self.theme = theme;
+
+    self.backgroundColor = theme.secondaryBackgroundColor;
+
+    // Left icon
     self.leftIcon.image = [STPImageLibrary addIcon];
-    self.leftIcon.tintColor = self.theme.accentColor;
-    self.titleLabel.font = self.theme.font;
-    self.titleLabel.textColor = self.theme.accentColor;
-    self.titleLabel.text = STPLocalizedString(@"Add New Card…", 
-                                              @"Button to add a new credit card.");
+    self.leftIcon.tintColor = theme.accentColor;
+
+    // Title label
+    self.titleLabel.font = theme.font;
+    self.titleLabel.textColor = theme.accentColor;
+    self.titleLabel.text = STPLocalizedString(@"Add New Card…", @"Button to add a new credit card.");
+
+    // Checkmark icon
     self.checkmarkIcon.hidden = YES;
+
     [self setNeedsLayout];
 }
 
-- (void)configureWithPaymentMethod:(id<STPPaymentMethod>)paymentMethod
-                          selected:(BOOL)selected
-                             theme:(STPTheme *)theme {
-    _paymentMethod = paymentMethod;
-    _theme = theme;
-    self.backgroundColor = [UIColor clearColor];
-    self.contentView.backgroundColor = self.theme.secondaryBackgroundColor;
+- (void)configureWithPaymentMethod:(id<STPPaymentMethod>)paymentMethod theme:(STPTheme *)theme selected:(BOOL)selected {
+    self.paymentMethod = paymentMethod;
+    self.theme = theme;
+
+    self.backgroundColor = theme.secondaryBackgroundColor;
+
+    // Left icon
     self.leftIcon.image = paymentMethod.templateImage;
-    self.titleLabel.font = self.theme.font;
-    self.checkmarkIcon.tintColor = self.theme.accentColor;
-    self.selected = NO;
+    self.leftIcon.tintColor = [self primaryColorForPaymentMethodWithSelected:selected];
+
+    // Title label
+    self.titleLabel.font = theme.font;
+    self.titleLabel.attributedText = [self buildAttributedStringWithPaymentMethod:paymentMethod selected:selected];
+
+    // Checkmark icon
+    self.checkmarkIcon.tintColor = theme.accentColor;
     self.checkmarkIcon.hidden = !selected;
-    self.leftIcon.tintColor = [self primaryColorForPaymentMethodWithSelectedState:selected];
-    self.titleLabel.attributedText = [self buildAttributedStringForPaymentMethod:self.paymentMethod selected:selected];
+
+    [self setNeedsLayout];
 }
 
-- (UIColor *)primaryColorForPaymentMethodWithSelectedState:(BOOL)isSelected {
-    return isSelected ? self.theme.accentColor : [self.theme.primaryForegroundColor colorWithAlphaComponent:0.6f];
+- (UIColor *)primaryColorForPaymentMethodWithSelected:(BOOL)selected {
+    return selected ? self.theme.accentColor : [self.theme.primaryForegroundColor colorWithAlphaComponent:0.6f];
 }
 
-- (NSAttributedString *)buildAttributedStringForPaymentMethod:(id<STPPaymentMethod>)paymentMethod
-                                                     selected:(BOOL)selected {
+- (NSAttributedString *)buildAttributedStringWithPaymentMethod:(id<STPPaymentMethod>)paymentMethod selected:(BOOL)selected {
     if ([paymentMethod isKindOfClass:[STPCard class]]) {
-        return [self buildAttributedStringForCard:(STPCard *)paymentMethod selected:selected];
-    } else if ([paymentMethod isKindOfClass:[STPApplePayPaymentMethod class]]) {
-        NSString *label = STPLocalizedString(@"Apple Pay", 
-                                             @"Text for Apple Pay payment method");
-        UIColor *primaryColor = [self primaryColorForPaymentMethodWithSelectedState:selected];
+        return [self buildAttributedStringWithCard:(STPCard *)paymentMethod selected:selected];
+    }
+
+    if ([paymentMethod isKindOfClass:[STPApplePayPaymentMethod class]]) {
+        NSString *label = STPLocalizedString(@"Apple Pay", @"Text for Apple Pay payment method");
+        UIColor *primaryColor = [self primaryColorForPaymentMethodWithSelected:selected];
         return [[NSAttributedString alloc] initWithString:label attributes:@{NSForegroundColorAttributeName: primaryColor}];
     }
+
+    // Unrecognized payment method
     return nil;
 }
 
-- (NSAttributedString *)buildAttributedStringForCard:(STPCard *)card selected:(BOOL)selected {
-    NSString *template = STPLocalizedString(@"%@ Ending In %@", @"{card brand} ending in {last4}");
+- (NSAttributedString *)buildAttributedStringWithCard:(STPCard *)card selected:(BOOL)selected {
+    NSString *format = STPLocalizedString(@"%@ Ending In %@", @"{card brand} ending in {last4}");
     NSString *brandString = [STPCard stringFromBrand:card.brand];
-    NSString *label = [NSString stringWithFormat:template, brandString, card.last4];
+    NSString *label = [NSString stringWithFormat:format, brandString, card.last4];
+
     UIColor *primaryColor = selected ? self.theme.accentColor : self.theme.primaryForegroundColor;
     UIColor *secondaryColor = [primaryColor colorWithAlphaComponent:0.6f];
-    NSMutableAttributedString *attributedString = [[NSMutableAttributedString alloc] initWithString:label attributes:@{
-                                                                                                                       NSForegroundColorAttributeName: secondaryColor,
-                                                                                                                       NSFontAttributeName: self.theme.font}];
+
+    NSDictionary *attributes = @{NSForegroundColorAttributeName: secondaryColor,
+                                 NSFontAttributeName: self.theme.font};
+
+    NSMutableAttributedString *attributedString = [[NSMutableAttributedString alloc] initWithString:label attributes:attributes];
     [attributedString addAttribute:NSForegroundColorAttributeName value:primaryColor range:[label rangeOfString:brandString]];
     [attributedString addAttribute:NSForegroundColorAttributeName value:primaryColor range:[label rangeOfString:card.last4]];
     [attributedString addAttribute:NSFontAttributeName value:self.theme.emphasisFont range:[label rangeOfString:brandString]];
     [attributedString addAttribute:NSFontAttributeName value:self.theme.emphasisFont range:[label rangeOfString:card.last4]];
+
     return [attributedString copy];
 }
 

--- a/Stripe/STPPaymentMethodsInternalViewController.h
+++ b/Stripe/STPPaymentMethodsInternalViewController.h
@@ -6,30 +6,38 @@
 //  Copyright © 2016 Stripe, Inc. All rights reserved.
 //
 
-#import "STPAddress.h"
 #import "STPCoreTableViewController.h"
-#import "STPPaymentConfiguration+Private.h"
-#import "STPPaymentConfiguration.h"
-#import "STPPaymentMethodTuple.h"
+#import "STPBlocks.h"
+
+@class STPAddress, STPCustomerContext, STPPaymentConfiguration, STPPaymentMethodTuple, STPToken, STPUserInformation;
+
+@protocol STPPaymentMethod;
+
+NS_ASSUME_NONNULL_BEGIN
 
 @protocol STPPaymentMethodsInternalViewControllerDelegate
 
 - (void)internalViewControllerDidSelectPaymentMethod:(id<STPPaymentMethod>)paymentMethod;
-- (void)internalViewControllerDidCreateToken:(STPToken *)token
-                                  completion:(STPErrorBlock)completion;
+- (void)internalViewControllerDidDeletePaymentMethod:(id<STPPaymentMethod>)paymentMethod;
+- (void)internalViewControllerDidCreateToken:(STPToken *)token completion:(STPErrorBlock)completion;
 - (void)internalViewControllerDidCancel;
 
 @end
 
 @interface STPPaymentMethodsInternalViewController : STPCoreTableViewController
 
+@property (nonatomic, assign, readwrite) BOOL canDeletePaymentMethods;
+
 - (instancetype)initWithConfiguration:(STPPaymentConfiguration *)configuration
+                      customerContext:(nullable STPCustomerContext *)customerContext
                                 theme:(STPTheme *)theme
-                 prefilledInformation:(STPUserInformation *)prefilledInformation
-                      shippingAddress:(STPAddress *)shippingAddress
+                 prefilledInformation:(nullable STPUserInformation *)prefilledInformation
+                      shippingAddress:(nullable STPAddress *)shippingAddress
                    paymentMethodTuple:(STPPaymentMethodTuple *)tuple
                              delegate:(id<STPPaymentMethodsInternalViewControllerDelegate>)delegate;
 
 - (void)updateWithPaymentMethodTuple:(STPPaymentMethodTuple *)tuple;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Stripe/STPPaymentMethodsInternalViewController.h
+++ b/Stripe/STPPaymentMethodsInternalViewController.h
@@ -26,8 +26,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface STPPaymentMethodsInternalViewController : STPCoreTableViewController
 
-@property (nonatomic, assign, readwrite) BOOL canDeletePaymentMethods;
-
 - (instancetype)initWithConfiguration:(STPPaymentConfiguration *)configuration
                       customerContext:(nullable STPCustomerContext *)customerContext
                                 theme:(STPTheme *)theme

--- a/Stripe/STPPaymentMethodsInternalViewController.m
+++ b/Stripe/STPPaymentMethodsInternalViewController.m
@@ -123,7 +123,7 @@ static NSInteger const PaymentMethodSectionAddCard = 1;
 }
 
 - (BOOL)isPaymentMethodDetachable:(id<STPPaymentMethod>)paymentMethod {
-    if (!self.canDeletePaymentMethods) {
+    if (!self.configuration.canDeletePaymentMethods) {
         // Feature is disabled
         return NO;
     }
@@ -164,14 +164,6 @@ static NSInteger const PaymentMethodSectionAddCard = 1;
     // Reload card list section
     NSMutableIndexSet *sections = [NSMutableIndexSet indexSetWithIndex:PaymentMethodSectionCardList];
     [self.tableView reloadSections:sections withRowAnimation:UITableViewRowAnimationAutomatic];
-}
-
-- (void)setCanDeletePaymentMethods:(BOOL)canDeletePaymentMethods {
-    _canDeletePaymentMethods = canDeletePaymentMethods;
-
-    // Reload related components
-    [self reloadRightBarButtonItemWithTableViewIsEditing:self.tableView.isEditing animated:NO];
-    [self.tableView reloadData];
 }
 
 #pragma mark - Button Handlers
@@ -346,7 +338,7 @@ static NSInteger const PaymentMethodSectionAddCard = 1;
     [self reloadRightBarButtonItemWithTableViewIsEditing:YES animated:YES];
 }
 
-- (void)tableView:(__unused UITableView *)tableView didEndEditingRowAtIndexPath:(__unused NSIndexPath *)indexPath {
+- (void)tableView:(UITableView *)tableView didEndEditingRowAtIndexPath:(__unused NSIndexPath *)indexPath {
     [self reloadRightBarButtonItemWithTableViewIsEditing:tableView.isEditing animated:YES];
 }
 

--- a/Stripe/STPPaymentMethodsInternalViewController.m
+++ b/Stripe/STPPaymentMethodsInternalViewController.m
@@ -9,125 +9,315 @@
 #import "STPPaymentMethodsInternalViewController.h"
 
 #import "NSArray+Stripe_BoundSafe.h"
+#import "STPAddCardViewController.h"
 #import "STPAddCardViewController+Private.h"
-#import "STPColorUtils.h"
+#import "STPCoreTableViewController.h"
 #import "STPCoreTableViewController+Private.h"
-#import "STPImageLibrary+Private.h"
+#import "STPCustomerContext.h"
+#import "STPCustomerContext+Private.h"
 #import "STPImageLibrary.h"
+#import "STPImageLibrary+Private.h"
 #import "STPLocalizationUtils.h"
 #import "STPPaymentMethodTableViewCell.h"
-#import "UINavigationController+Stripe_Completion.h"
+#import "STPPaymentMethodTuple.h"
+#import "STPSourceProtocol.h"
 #import "UITableViewCell+Stripe_Borders.h"
+#import "UIViewController+Stripe_NavigationItemProxy.h"
 
-static NSString *const STPPaymentMethodCellReuseIdentifier = @"STPPaymentMethodCellReuseIdentifier";
-static NSInteger STPPaymentMethodCardListSection = 0;
-static NSInteger STPPaymentMethodAddCardSection = 1;
+static NSString * const PaymentMethodCellReuseIdentifier = @"PaymentMethodCellReuseIdentifier";
 
-@interface STPPaymentMethodsInternalViewController()<UITableViewDataSource, UITableViewDelegate, STPAddCardViewControllerDelegate>
+static NSInteger const PaymentMethodSectionCardList = 0;
+static NSInteger const PaymentMethodSectionAddCard = 1;
 
-@property(nonatomic)STPPaymentConfiguration *configuration;
-@property(nonatomic)STPUserInformation *prefilledInformation;
-@property(nonatomic)STPAddress *shippingAddress;
-@property(nonatomic)NSArray<id<STPPaymentMethod>> *paymentMethods;
-@property(nonatomic)id<STPPaymentMethod> selectedPaymentMethod;
-@property(nonatomic, weak)id<STPPaymentMethodsInternalViewControllerDelegate> delegate;
-@property(nonatomic, weak)UIImageView *cardImageView;
+@interface STPPaymentMethodsInternalViewController () <UITableViewDataSource, UITableViewDelegate, STPAddCardViewControllerDelegate>
+
+@property (nonatomic, strong, readwrite) STPPaymentConfiguration *configuration;
+@property (nonatomic, strong, nullable, readwrite) STPCustomerContext *customerContext;
+@property (nonatomic, strong, nullable, readwrite) STPUserInformation *prefilledInformation;
+@property (nonatomic, strong, nullable, readwrite) STPAddress *shippingAddress;
+@property (nonatomic, strong, readwrite) NSArray<id<STPPaymentMethod>> *paymentMethods;
+@property (nonatomic, strong, nullable, readwrite) id<STPPaymentMethod> selectedPaymentMethod;
+@property (nonatomic, weak, nullable, readwrite) id<STPPaymentMethodsInternalViewControllerDelegate> delegate;
+
+@property (nonatomic, strong, readwrite) UIImageView *cardImageView;
 
 @end
 
 @implementation STPPaymentMethodsInternalViewController
 
 - (instancetype)initWithConfiguration:(STPPaymentConfiguration *)configuration
+                      customerContext:(nullable STPCustomerContext *)customerContext
                                 theme:(STPTheme *)theme
-                 prefilledInformation:(STPUserInformation *)prefilledInformation
-                      shippingAddress:(STPAddress *)shippingAddress
+                 prefilledInformation:(nullable STPUserInformation *)prefilledInformation
+                      shippingAddress:(nullable STPAddress *)shippingAddress
                    paymentMethodTuple:(STPPaymentMethodTuple *)tuple
                              delegate:(id<STPPaymentMethodsInternalViewControllerDelegate>)delegate {
     self = [super initWithTheme:theme];
     if (self) {
         _configuration = configuration;
+        _customerContext = customerContext;
         _prefilledInformation = prefilledInformation;
         _shippingAddress = shippingAddress;
         _paymentMethods = tuple.paymentMethods;
         _selectedPaymentMethod = tuple.selectedPaymentMethod;
         _delegate = delegate;
+
+        self.title = STPLocalizedString(@"Payment Method", @"Title for Payment Method screen");
     }
-    self.title = STPLocalizedString(@"Payment Method", @"Title for Payment Method screen");
     return self;
 }
 
 - (void)createAndSetupViews {
     [super createAndSetupViews];
 
-    self.tableView.allowsMultipleSelectionDuringEditing = NO;
+    // Table view
+    [self.tableView registerClass:[STPPaymentMethodTableViewCell class] forCellReuseIdentifier:PaymentMethodCellReuseIdentifier];
+
     self.tableView.dataSource = self;
     self.tableView.delegate = self;
-    [self.tableView registerClass:[STPPaymentMethodTableViewCell class] forCellReuseIdentifier:STPPaymentMethodCellReuseIdentifier];
-    self.tableView.separatorInset = UIEdgeInsetsMake(0, 18, 0, 0);
-    
+
+    // Table header view
     UIImageView *cardImageView = [[UIImageView alloc] initWithImage:[STPImageLibrary largeCardFrontImage]];
     cardImageView.contentMode = UIViewContentModeCenter;
-    cardImageView.frame = CGRectMake(0, 0, self.view.bounds.size.width, cardImageView.bounds.size.height + (57 * 2));
+    cardImageView.frame = CGRectMake(0.0, 0.0, self.view.bounds.size.width, cardImageView.bounds.size.height + (57.0f * 2.0f));
+    cardImageView.image = [STPImageLibrary largeCardFrontImage];
+    cardImageView.tintColor = self.theme.accentColor;
     self.cardImageView = cardImageView;
-    self.tableView.tableHeaderView = cardImageView;
-    
-    self.cardImageView.image = [STPImageLibrary largeCardFrontImage];
 
-    self.cardImageView.tintColor = self.theme.accentColor;
+    self.tableView.tableHeaderView = cardImageView;
+
+    // Table view editing state
+    [self.tableView setEditing:NO animated:NO];
+    [self reloadRightBarButtonItemWithTableViewIsEditing:self.tableView.isEditing animated:NO];
 }
+
+- (void)reloadRightBarButtonItemWithTableViewIsEditing:(BOOL)tableViewIsEditing animated:(BOOL)animated {
+    UIBarButtonItem *barButtonItem;
+
+    if (!tableViewIsEditing) {
+        if ([self isAnyPaymentMethodDetachable]) {
+            // Show edit button
+            barButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemEdit target:self action:@selector(handleEditButtonTapped:)];
+        }
+        else {
+            // Show no button
+            barButtonItem = nil;
+        }
+    }
+    else {
+        // Show done button
+        barButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(handleDoneButtonTapped:)];
+    }
+
+    [self.stp_navigationItemProxy setRightBarButtonItem:barButtonItem animated:animated];
+}
+
+- (BOOL)isAnyPaymentMethodDetachable {
+    for (id<STPPaymentMethod> paymentMethod in self.paymentMethods) {
+        if ([self isPaymentMethodDetachable:paymentMethod]) {
+            return YES;
+        }
+    }
+
+    return NO;
+}
+
+- (BOOL)isPaymentMethodDetachable:(id<STPPaymentMethod>)paymentMethod {
+    if (!self.canDeletePaymentMethods) {
+        // Feature is disabled
+        return NO;
+    }
+
+    if (!self.customerContext) {
+        // Cannot detach payment methods without customer context
+        return NO;
+    }
+
+    if (!paymentMethod) {
+        // Cannot detach non-existent payment method
+        return NO;
+    }
+
+    if (paymentMethod == self.selectedPaymentMethod) {
+        // Cannot detach selected payment method
+        return NO;
+    }
+
+    if (![paymentMethod conformsToProtocol:@protocol(STPSourceProtocol)]) {
+        // Cannot detach non-source payment method
+        return NO;
+    }
+
+    // Payment method can be deleted from customer
+    return YES;
+}
+
+- (void)updateWithPaymentMethodTuple:(STPPaymentMethodTuple *)tuple {
+    if ([self.paymentMethods isEqualToArray:tuple.paymentMethods] &&
+        [self.selectedPaymentMethod isEqual:tuple.selectedPaymentMethod]) {
+        return;
+    }
+
+    self.paymentMethods = tuple.paymentMethods;
+    self.selectedPaymentMethod = tuple.selectedPaymentMethod;
+
+    // Reload card list section
+    NSMutableIndexSet *sections = [NSMutableIndexSet indexSetWithIndex:PaymentMethodSectionCardList];
+    [self.tableView reloadSections:sections withRowAnimation:UITableViewRowAnimationAutomatic];
+}
+
+- (void)setCanDeletePaymentMethods:(BOOL)canDeletePaymentMethods {
+    _canDeletePaymentMethods = canDeletePaymentMethods;
+
+    // Reload related components
+    [self reloadRightBarButtonItemWithTableViewIsEditing:self.tableView.isEditing animated:NO];
+    [self.tableView reloadData];
+}
+
+#pragma mark - Button Handlers
 
 - (void)handleBackOrCancelTapped:(__unused id)sender {
     [self.delegate internalViewControllerDidCancel];
 }
+
+- (void)handleEditButtonTapped:(__unused id)sender {
+    [self.tableView setEditing:YES animated:YES];
+    [self reloadRightBarButtonItemWithTableViewIsEditing:self.tableView.isEditing animated:YES];
+}
+
+- (void)handleDoneButtonTapped:(__unused id)sender {
+    [self.tableView setEditing:NO animated:YES];
+    [self reloadRightBarButtonItemWithTableViewIsEditing:self.tableView.isEditing animated:YES];
+}
+
+#pragma mark - UITableViewDataSource
 
 - (NSInteger)numberOfSectionsInTableView:(__unused UITableView *)tableView {
     return 2;
 }
 
 - (NSInteger)tableView:(__unused UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
-    if (section == STPPaymentMethodCardListSection) {
+    if (section == PaymentMethodSectionCardList) {
         return self.paymentMethods.count;
-    } else if (section == STPPaymentMethodAddCardSection) {
+    }
+
+    if (section == PaymentMethodSectionAddCard) {
         return 1;
     }
+
     return 0;
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
-    STPPaymentMethodTableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:STPPaymentMethodCellReuseIdentifier forIndexPath:indexPath];
-    if (indexPath.section == STPPaymentMethodCardListSection) {
+    STPPaymentMethodTableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:PaymentMethodCellReuseIdentifier forIndexPath:indexPath];
+
+    if (indexPath.section == PaymentMethodSectionCardList) {
         id<STPPaymentMethod> paymentMethod = [self.paymentMethods stp_boundSafeObjectAtIndex:indexPath.row];
-        [cell configureWithPaymentMethod:paymentMethod
-                                selected:[paymentMethod isEqual:self.selectedPaymentMethod]
-                                   theme:self.theme];
-    } else {
+        BOOL selected = [paymentMethod isEqual:self.selectedPaymentMethod];
+
+        [cell configureWithPaymentMethod:paymentMethod theme:self.theme selected:selected];
+    }
+    else {
         [cell configureForNewCardRowWithTheme:self.theme];
     }
+
     return cell;
 }
 
+- (BOOL)tableView:(__unused UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath {
+    if (indexPath.section == PaymentMethodSectionCardList) {
+        id<STPPaymentMethod> paymentMethod = [self.paymentMethods stp_boundSafeObjectAtIndex:indexPath.row];
+
+        if ([self isPaymentMethodDetachable:paymentMethod]) {
+            return YES;
+        }
+    }
+
+    return NO;
+}
+
+- (void)tableView:(UITableView *)tableView commitEditingStyle:(UITableViewCellEditingStyle)editingStyle forRowAtIndexPath:(NSIndexPath *)indexPath {
+    if (indexPath.section == PaymentMethodSectionCardList) {
+        if (editingStyle != UITableViewCellEditingStyleDelete) {
+            // Showed the user a non-delete option when we shouldn't have
+            [tableView reloadData];
+            return;
+        }
+
+        if (!(indexPath.row < (NSInteger)self.paymentMethods.count)) {
+            // Data source and table view out of sync for some reason
+            [tableView reloadData];
+            return;
+        }
+
+        id<STPPaymentMethod> paymentMethodToDelete = [self.paymentMethods stp_boundSafeObjectAtIndex:indexPath.row];
+
+        if (![self isPaymentMethodDetachable:paymentMethodToDelete]) {
+            // Showed the user a delete option for a payment method when we shouldn't have
+            [tableView reloadData];
+            return;
+        }
+
+        if (![paymentMethodToDelete conformsToProtocol:@protocol(STPSourceProtocol)]) {
+            // Showed the user a delete option for a payment method when we shouldn't have
+            [tableView reloadData];
+            return;
+        }
+
+        id<STPSourceProtocol> source = (id<STPSourceProtocol>)paymentMethodToDelete;
+
+        // Kickoff request to delete source from customer
+        [self.customerContext detachSourceFromCustomer:source completion:nil];
+
+        // Optimistically remove payment method from data source
+        NSMutableArray *paymentMethods = [self.paymentMethods mutableCopy];
+        [paymentMethods removeObjectAtIndex:indexPath.row];
+        self.paymentMethods = paymentMethods;
+
+        // Perform deletion animation for single row
+        [tableView deleteRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
+
+        // Reload right bar button item text
+        [self reloadRightBarButtonItemWithTableViewIsEditing:tableView.isEditing animated:YES];
+
+        // Notify delegate
+        [self.delegate internalViewControllerDidDeletePaymentMethod:paymentMethodToDelete];
+    }
+}
+
+#pragma mark - UITableViewDelegate
+
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
-    if (indexPath.section == STPPaymentMethodCardListSection) {
+    if (indexPath.section == PaymentMethodSectionCardList) {
+        // Update data source
         id<STPPaymentMethod> paymentMethod = [self.paymentMethods stp_boundSafeObjectAtIndex:indexPath.row];
         self.selectedPaymentMethod = paymentMethod;
-        [tableView reloadSections:[NSIndexSet indexSetWithIndex:STPPaymentMethodCardListSection] withRowAnimation:UITableViewRowAnimationFade];
+
+        // Perform selection animation
+        [tableView reloadSections:[NSIndexSet indexSetWithIndex:PaymentMethodSectionCardList] withRowAnimation:UITableViewRowAnimationFade];
+
+        // Notify delegate
         [self.delegate internalViewControllerDidSelectPaymentMethod:paymentMethod];
-    } else if (indexPath.section == STPPaymentMethodAddCardSection) {
+    }
+    else if (indexPath.section == PaymentMethodSectionAddCard) {
         STPAddCardViewController *paymentCardViewController = [[STPAddCardViewController alloc] initWithConfiguration:self.configuration theme:self.theme];
         paymentCardViewController.delegate = self;
         paymentCardViewController.prefilledInformation = self.prefilledInformation;
         paymentCardViewController.shippingAddress = self.shippingAddress;
+
         [self.navigationController pushViewController:paymentCardViewController animated:YES];
     }
+
     [tableView deselectRowAtIndexPath:indexPath animated:YES];
 }
 
 - (void)tableView:(UITableView *)tableView willDisplayCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath {
-    BOOL topRow = (indexPath.row == 0);
-    BOOL bottomRow = ([self tableView:tableView numberOfRowsInSection:indexPath.section] - 1 == indexPath.row);
+    BOOL isTopRow = (indexPath.row == 0);
+    BOOL isBottomRow = ([self tableView:tableView numberOfRowsInSection:indexPath.section] - 1 == indexPath.row);
+
     [cell stp_setBorderColor:self.theme.tertiaryBackgroundColor];
-    [cell stp_setTopBorderHidden:!topRow];
-    [cell stp_setBottomBorderHidden:!bottomRow];
+    [cell stp_setTopBorderHidden:!isTopRow];
+    [cell stp_setBottomBorderHidden:!isBottomRow];
     [cell stp_setFakeSeparatorColor:self.theme.quaternaryBackgroundColor];
     [cell stp_setFakeSeparatorLeftInset:15.0f];
 }
@@ -136,6 +326,7 @@ static NSInteger STPPaymentMethodAddCardSection = 1;
     if ([self tableView:tableView numberOfRowsInSection:section] == 0) {
         return 0.01f;
     }
+
     return 27.0f;
 }
 
@@ -143,24 +334,29 @@ static NSInteger STPPaymentMethodAddCardSection = 1;
     return 0.01f;
 }
 
-- (void)updateWithPaymentMethodTuple:(STPPaymentMethodTuple *)tuple {
-    if ([self.paymentMethods isEqualToArray:tuple.paymentMethods] &&
-        [self.selectedPaymentMethod isEqual:tuple.selectedPaymentMethod]) {
-        return;
+- (UITableViewCellEditingStyle)tableView:(__unused UITableView *)tableView editingStyleForRowAtIndexPath:(NSIndexPath *)indexPath {
+    if (indexPath.section == PaymentMethodSectionCardList) {
+        return UITableViewCellEditingStyleDelete;
     }
-    self.paymentMethods = tuple.paymentMethods;
-    self.selectedPaymentMethod = tuple.selectedPaymentMethod;
-    NSMutableIndexSet *sections = [NSMutableIndexSet indexSetWithIndex:STPPaymentMethodCardListSection];
-    [self.tableView reloadSections:sections withRowAnimation:UITableViewRowAnimationAutomatic];
+
+    return UITableViewCellEditingStyleNone;
 }
+
+- (void)tableView:(__unused UITableView *)tableView willBeginEditingRowAtIndexPath:(__unused NSIndexPath *)indexPath {
+    [self reloadRightBarButtonItemWithTableViewIsEditing:YES animated:YES];
+}
+
+- (void)tableView:(__unused UITableView *)tableView didEndEditingRowAtIndexPath:(__unused NSIndexPath *)indexPath {
+    [self reloadRightBarButtonItemWithTableViewIsEditing:tableView.isEditing animated:YES];
+}
+
+#pragma mark - STPAddCardViewControllerDelegate
 
 - (void)addCardViewControllerDidCancel:(__unused STPAddCardViewController *)addCardViewController {
     [self.navigationController popViewControllerAnimated:YES];
 }
 
-- (void)addCardViewController:(__unused STPAddCardViewController *)addCardViewController
-               didCreateToken:(STPToken *)token
-                   completion:(STPErrorBlock)completion {
+- (void)addCardViewController:(__unused STPAddCardViewController *)addCardViewController didCreateToken:(STPToken *)token completion:(STPErrorBlock)completion {
     [self.delegate internalViewControllerDidCreateToken:token completion:completion];
 }
 

--- a/Stripe/STPPaymentMethodsViewController.m
+++ b/Stripe/STPPaymentMethodsViewController.m
@@ -128,15 +128,13 @@
         if (tuple.paymentMethods.count > 0) {
             STPCustomerContext *customerContext = ([self.apiAdapter isKindOfClass:[STPCustomerContext class]]) ? (STPCustomerContext *)self.apiAdapter : nil;
 
-            STPPaymentMethodsInternalViewController *paymentMethodsInternalViewController = [[STPPaymentMethodsInternalViewController alloc] initWithConfiguration:self.configuration
-                                                                                                                                                   customerContext:customerContext
-                                                                                                                                                             theme:self.theme
-                                                                                                                                              prefilledInformation:self.prefilledInformation
-                                                                                                                                                   shippingAddress:self.shippingAddress
-                                                                                                                                                paymentMethodTuple:tuple
-                                                                                                                                                          delegate:self];
-            paymentMethodsInternalViewController.canDeletePaymentMethods = self.canDeletePaymentMethods;
-            internal = paymentMethodsInternalViewController;
+            internal = [[STPPaymentMethodsInternalViewController alloc] initWithConfiguration:self.configuration
+                                                                              customerContext:customerContext
+                                                                                        theme:self.theme
+                                                                         prefilledInformation:self.prefilledInformation
+                                                                              shippingAddress:self.shippingAddress
+                                                                           paymentMethodTuple:tuple
+                                                                                     delegate:self];
         } else {
             STPAddCardViewController *addCardViewController = [[STPAddCardViewController alloc] initWithConfiguration:self.configuration theme:self.theme];
             addCardViewController.delegate = self;
@@ -176,16 +174,6 @@
     [super updateAppearance];
 
     self.activityIndicator.tintColor = self.theme.accentColor;
-}
-
-- (void)setCanDeletePaymentMethods:(BOOL)canDeletePaymentMethods {
-    _canDeletePaymentMethods = canDeletePaymentMethods;
-
-    // Forward change if needed
-    if ([self.internalViewController isKindOfClass:[STPPaymentMethodsInternalViewController class]]) {
-        STPPaymentMethodsInternalViewController *paymentMethodsVC = (STPPaymentMethodsInternalViewController *)self.internalViewController;
-        paymentMethodsVC.canDeletePaymentMethods = canDeletePaymentMethods;
-    }
 }
 
 - (void)finishWithPaymentMethod:(id<STPPaymentMethod>)paymentMethod {

--- a/Stripe/UITableViewCell+Stripe_Borders.m
+++ b/Stripe/UITableViewCell+Stripe_Borders.m
@@ -15,7 +15,7 @@ static NSInteger const STPTableViewCellFakeSeparatorTag = 787475;
 @implementation UITableViewCell (Stripe_Borders)
 
 - (UIView *)stp_topBorderView {
-    UIView *view = [self.contentView viewWithTag:STPTableViewCellTopBorderTag];
+    UIView *view = [self viewWithTag:STPTableViewCellTopBorderTag];
     if (!view) {
         view = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.bounds.size.width, 0.5f)];
         view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleBottomMargin;
@@ -23,13 +23,13 @@ static NSInteger const STPTableViewCellFakeSeparatorTag = 787475;
         view.backgroundColor = self.backgroundColor;
         view.hidden = YES;
         view.accessibilityIdentifier = @"stp_topBorderView";
-        [self.contentView addSubview:view];
+        [self addSubview:view];
     }
     return view;
 }
 
 - (UIView *)stp_bottomBorderView {
-    UIView *view = [self.contentView viewWithTag:STPTableViewCellBottomBorderTag];
+    UIView *view = [self viewWithTag:STPTableViewCellBottomBorderTag];
     if (!view) {
         view = [[UIView alloc] initWithFrame:CGRectMake(0, self.bounds.size.height - 0.5f, self.bounds.size.width, 0.5f)];
         view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleTopMargin;
@@ -37,20 +37,20 @@ static NSInteger const STPTableViewCellFakeSeparatorTag = 787475;
         view.backgroundColor = self.backgroundColor;
         view.hidden = YES;
         view.accessibilityIdentifier = @"stp_bottomBorderView";
-        [self.contentView addSubview:view];
+        [self addSubview:view];
     }
     return view;
 }
 
 - (UIView *)stp_fakeSeparatorView {
-    UIView *view = [self.contentView viewWithTag:STPTableViewCellFakeSeparatorTag];
+    UIView *view = [self viewWithTag:STPTableViewCellFakeSeparatorTag];
     if (!view) {
         view = [[UIView alloc] initWithFrame:CGRectMake(0, self.bounds.size.height - 0.5f, self.bounds.size.width, 0.5f)];
         view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleTopMargin;
         view.tag = STPTableViewCellFakeSeparatorTag;
         view.backgroundColor = self.backgroundColor;
         view.accessibilityIdentifier = @"stp_fakeSeparatorView";
-        [self.contentView addSubview:view];
+        [self addSubview:view];
     }
     return view;
 }


### PR DESCRIPTION
# Summary

![artboard](https://user-images.githubusercontent.com/28276156/28131357-7a353474-66ee-11e7-846c-b38277d111fd.png)

Adds support for allowing users to delete payment methods using the `STPPaymentMethodsViewController`. This is currently restricted so that the "selected" payment method cannot be deleted.

r? @bg-stripe 
cc @bdorfman-stripe 