### PR TITLE
Expose inputView similar to inputAccessoryView

### DIFF
--- a/Stripe/PublicHeaders/STPPaymentCardTextField.h
+++ b/Stripe/PublicHeaders/STPPaymentCardTextField.h
@@ -134,6 +134,11 @@ IB_DESIGNABLE
 @property(nonatomic, assign) UIKeyboardAppearance keyboardAppearance UI_APPEARANCE_SELECTOR;
 
 /**
+ *  This behaves identically to setting the inputView for each child text field.
+ */
+@property(nonatomic, strong, nullable) UIView *inputView;
+
+/**
  *  This behaves identically to setting the inputAccessoryView for each child text field.
  */
 @property(nonatomic, strong, nullable) UIView *inputAccessoryView;

--- a/Stripe/STPPaymentCardTextField.m
+++ b/Stripe/STPPaymentCardTextField.m
@@ -297,6 +297,14 @@ CGFloat const STPPaymentCardTextFieldDefaultPadding = 13;
     }
 }
 
+- (void)setInputView:(UIView *)inputView {
+    _inputView = inputView;
+
+    for (STPFormTextField *field in [self allFields]) {
+        field.inputView = inputView;
+    }
+}
+
 - (void)setInputAccessoryView:(UIView *)inputAccessoryView {
     _inputAccessoryView = inputAccessoryView;
     


### PR DESCRIPTION
## Summary

Allows inputView to be set on child text fields similar to how it's done on inputAccessoryView.

## Motivation

I need to do a custom keyboard and do not want the standard iOS keyboard to be shown. Overriding inputView with my custom keyboard is exactly what I need.

## Testing

I tested it by building the pod locally and setting the inputView property from my custom implementation.
