### PR TITLE
Fix deprecated call to `brew cask update` and just call `brew update`

### DIFF
--- a/ci_scripts/check_fauxpas.sh
+++ b/ci_scripts/check_fauxpas.sh
@@ -11,7 +11,7 @@ if which fauxpas ; then
     echo "FausPas already installed; skipping installation"
 else
 	echo "Installing FauxPas..."
-  brew cask update
+  brew update
 	brew cask install fauxpas
 
 	/Applications/FauxPas.app/Contents/Resources/install-cli-tools


### PR DESCRIPTION
See https://github.com/Homebrew/brew/issues/1946

r? @bg-stripe 
cc @bdorfman-stripe 