### PR TITLE
Add `jazzy` version check

### DIFF
--- a/ci_scripts/build_documentation.sh
+++ b/ci_scripts/build_documentation.sh
@@ -9,6 +9,16 @@ if ! command -v jazzy > /dev/null; then
   exit 1
 fi
 
+# Verify jazzy is up to date
+jazzy_version_local="$(gem search ^jazzy$ --local --no-verbose)"
+jazzy_version_remote="$(gem search ^jazzy$ --remote --no-verbose)"
+
+if [[ "${jazzy_version_local}" != "${jazzy_version_remote}" ]]; then
+  echo "ERROR: Please update jazzy before running build_documentation.sh:"
+  echo "\`gem update jazzy\`"
+  exit 1
+fi
+
 # Clean destination `stripe-ios/docs/docs/` directory
 echo "Cleaning stripe-ios/docs/docs/ directory..."
 rm -rf "${script_dir}/../docs/docs/"


### PR DESCRIPTION
## Summary

Add check to `build_documentation.sh` that verifies `jazzy` is up-to-date before continuing

## Motivation

Make sure our documentation continues to improve as jazzy updates with better features.

## Testing

Verified `build_documentation.sh` still runs successfully and that the inverse test works.

r? @bg-stripe 
cc @bdorfman-stripe 
