### PR TITLE
Fix nav bar theming in Payment Methods example

### DIFF
--- a/Example/UI Examples.xcodeproj/xcshareddata/xcschemes/UI Examples.xcscheme
+++ b/Example/UI Examples.xcodeproj/xcshareddata/xcschemes/UI Examples.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "C1140CBC1F1EC0FC002084AB"
-               BuildableName = "UI Examples.app"
+               BuildableName = "Stripe UI Examples.app"
                BlueprintName = "UI Examples"
                ReferencedContainer = "container:UI Examples.xcodeproj">
             </BuildableReference>
@@ -33,7 +33,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "C1140CBC1F1EC0FC002084AB"
-            BuildableName = "UI Examples.app"
+            BuildableName = "Stripe UI Examples.app"
             BlueprintName = "UI Examples"
             ReferencedContainer = "container:UI Examples.xcodeproj">
          </BuildableReference>
@@ -56,7 +56,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "C1140CBC1F1EC0FC002084AB"
-            BuildableName = "UI Examples.app"
+            BuildableName = "Stripe UI Examples.app"
             BlueprintName = "UI Examples"
             ReferencedContainer = "container:UI Examples.xcodeproj">
          </BuildableReference>
@@ -75,7 +75,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "C1140CBC1F1EC0FC002084AB"
-            BuildableName = "UI Examples.app"
+            BuildableName = "Stripe UI Examples.app"
             BlueprintName = "UI Examples"
             ReferencedContainer = "container:UI Examples.xcodeproj">
          </BuildableReference>

--- a/Example/UI Examples/BrowseViewController.swift
+++ b/Example/UI Examples/BrowseViewController.swift
@@ -101,6 +101,7 @@ class BrowseViewController: UITableViewController, STPAddCardViewControllerDeleg
                                                                  customerContext: self.customerContext,
                                                                  delegate: self)
             let navigationController = UINavigationController(rootViewController: viewController)
+            navigationController.navigationBar.stp_theme = theme
             present(navigationController, animated: true, completion: nil)
         case .STPShippingInfoViewController:
             let config = STPPaymentConfiguration()


### PR DESCRIPTION
Just noticed we weren't setting the theme in the PaymentMethodsVC example. The shared scheme also had an stale value for `BuildableName` (Not sure why it didn't appear when I was working on #741 , I think it only updates when building to a device for the first time).

r? @joeydong-stripe 