### PR TITLE
Mass Style Tune Up

### DIFF
--- a/Stripe/Fabric.h
+++ b/Stripe/Fabric.h
@@ -9,41 +9,41 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- *  Fabric Base. Coordinates configuration and starts all provided kits.
+ Fabric Base. Coordinates configuration and starts all provided kits.
  */
 @interface Fabric : NSObject
 
 /**
- * Initialize Fabric and all provided kits. Call this method within your App Delegate's `application:didFinishLaunchingWithOptions:` and provide the kits you wish to use.
- *
- * For example, in Objective-C:
- *
- *      `[Fabric with:@[[Crashlytics class], [Twitter class], [Digits class], [MoPub class]]];`
- *
- * Swift:
- *
- *      `Fabric.with([Crashlytics.self(), Twitter.self(), Digits.self(), MoPub.self()])`
- *
- * Only the first call to this method is honored. Subsequent calls are no-ops.
- *
- * @param kitClasses An array of kit Class objects
- *
- * @return Returns the shared Fabric instance. In most cases this can be ignored.
+ Initialize Fabric and all provided kits. Call this method within your App Delegate's `application:didFinishLaunchingWithOptions:` and provide the kits you wish to use.
+
+ For example, in Objective-C:
+
+     `[Fabric with:@[[Crashlytics class], [Twitter class], [Digits class], [MoPub class]]];`
+
+ Swift:
+
+     `Fabric.with([Crashlytics.self(), Twitter.self(), Digits.self(), MoPub.self()])`
+
+ Only the first call to this method is honored. Subsequent calls are no-ops.
+
+ @param kitClasses An array of kit Class objects
+
+ @return Returns the shared Fabric instance. In most cases this can be ignored.
  */
 + (instancetype)with:(NSArray *)kitClasses;
 
 /**
- *  Returns the Fabric singleton object.
+ Returns the Fabric singleton object.
  */
 + (instancetype)sharedSDK;
 
 /**
- *  This BOOL enables or disables debug logging, such as kit version information. The default value is NO.
+ This BOOL enables or disables debug logging, such as kit version information. The default value is NO.
  */
 @property (nonatomic, assign) BOOL debug;
 
 /**
- *  Unavailable. Use `+sharedSDK` to retrieve the shared Fabric instance.
+ Unavailable. Use `+sharedSDK` to retrieve the shared Fabric instance.
  */
 - (id)init __attribute__((unavailable("Use +sharedSDK to retrieve the shared Fabric instance.")));
 

--- a/Stripe/PublicHeaders/STPAPIClient+ApplePay.h
+++ b/Stripe/PublicHeaders/STPAPIClient+ApplePay.h
@@ -14,24 +14,24 @@
 FAUXPAS_IGNORED_IN_FILE(APIAvailability)
 
 /**
- *  STPAPIClient extensions to create Stripe tokens from Apple Pay PKPayment objects.
+ STPAPIClient extensions to create Stripe tokens from Apple Pay PKPayment objects.
  */
 @interface STPAPIClient (ApplePay)
 
 /**
- *  Converts a PKPayment object into a Stripe token using the Stripe API.
- *
- *  @param payment     The user's encrypted payment information as returned from a PKPaymentAuthorizationViewController. Cannot be nil.
- *  @param completion  The callback to run with the returned Stripe token (and any errors that may have occurred).
+ Converts a PKPayment object into a Stripe token using the Stripe API.
+
+ @param payment     The user's encrypted payment information as returned from a PKPaymentAuthorizationViewController. Cannot be nil.
+ @param completion  The callback to run with the returned Stripe token (and any errors that may have occurred).
  */
 - (void)createTokenWithPayment:(nonnull PKPayment *)payment
                     completion:(nonnull STPTokenCompletionBlock)completion;
 
 /**
- *  Converts a PKPayment object into a Stripe source using the Stripe API.
- *
- *  @param payment     The user's encrypted payment information as returned from a PKPaymentAuthorizationViewController. Cannot be nil.
- *  @param completion  The callback to run with the returned Stripe source (and any errors that may have occurred).
+ Converts a PKPayment object into a Stripe source using the Stripe API.
+
+ @param payment     The user's encrypted payment information as returned from a PKPaymentAuthorizationViewController. Cannot be nil.
+ @param completion  The callback to run with the returned Stripe source (and any errors that may have occurred).
  */
 - (void)createSourceWithPayment:(nonnull PKPayment *)payment
                      completion:(nonnull STPSourceCompletionBlock)completion;

--- a/Stripe/PublicHeaders/STPAPIResponseDecodable.h
+++ b/Stripe/PublicHeaders/STPAPIResponseDecodable.h
@@ -23,6 +23,6 @@
 /**
  The raw JSON response used to create the object. This can be useful for using beta features that haven't yet been made into properties in the SDK.
  */
-@property(nonatomic, readonly, nonnull, copy)NSDictionary *allResponseFields;
+@property (nonatomic, readonly, nonnull, copy) NSDictionary *allResponseFields;
 
 @end

--- a/Stripe/PublicHeaders/STPAPIResponseDecodable.h
+++ b/Stripe/PublicHeaders/STPAPIResponseDecodable.h
@@ -11,17 +11,17 @@
 @protocol STPAPIResponseDecodable <NSObject>
 
 /**
- * These fields are required to be present in the API response. If any of them are nil, `decodedObjectFromAPIResponse` should also return nil.
+ These fields are required to be present in the API response. If any of them are nil, `decodedObjectFromAPIResponse` should also return nil.
  */
 + (nonnull NSArray *)requiredFields;
 
 /**
- * Parses an response from the Stripe API (in JSON format; represented as an `NSDictionary`) into an instance of the class. Returns nil if the object could not be decoded (i.e. if one of its `requiredFields` is nil).
+ Parses an response from the Stripe API (in JSON format; represented as an `NSDictionary`) into an instance of the class. Returns nil if the object could not be decoded (i.e. if one of its `requiredFields` is nil).
  */
 + (nullable instancetype)decodedObjectFromAPIResponse:(nullable NSDictionary *)response;
 
 /**
- * The raw JSON response used to create the object. This can be useful for using beta features that haven't yet been made into properties in the SDK.
+ The raw JSON response used to create the object. This can be useful for using beta features that haven't yet been made into properties in the SDK.
  */
 @property(nonatomic, readonly, nonnull, copy)NSDictionary *allResponseFields;
 

--- a/Stripe/PublicHeaders/STPAddCardViewController.h
+++ b/Stripe/PublicHeaders/STPAddCardViewController.h
@@ -43,17 +43,17 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  The view controller's delegate. This must be set before showing the view controller in order for it to work properly. @see STPAddCardViewControllerDelegate
  */
-@property(nonatomic, weak, nullable)id<STPAddCardViewControllerDelegate>delegate;
+@property (nonatomic, weak, nullable) id<STPAddCardViewControllerDelegate>delegate;
 
 /**
  You can set this property to pre-fill any information you've already collected from your user. @see STPUserInformation.h
  */
-@property(nonatomic, strong, nullable)STPUserInformation *prefilledInformation;
+@property (nonatomic, strong, nullable) STPUserInformation *prefilledInformation;
 
 /**
  If you're using the token generated from STPAddCardViewController to make a Managed Account, you should set this property to the currency that account will use. Otherwise, you should leave it empty. For more information, see https://stripe.com/docs/api#create_card_token-card-currency
  */
-@property(nonatomic, copy, nullable)NSString *managedAccountCurrency;
+@property (nonatomic, copy, nullable) NSString *managedAccountCurrency;
 
 @end
 

--- a/Stripe/PublicHeaders/STPAddCardViewController.h
+++ b/Stripe/PublicHeaders/STPAddCardViewController.h
@@ -27,26 +27,26 @@ NS_ASSUME_NONNULL_BEGIN
 @interface STPAddCardViewController : STPCoreTableViewController
 
 /**
- *  A convenience initializer; equivalent to calling `initWithConfiguration:[STPPaymentConfiguration sharedConfiguration] theme:[STPTheme defaultTheme]`.
+ A convenience initializer; equivalent to calling `initWithConfiguration:[STPPaymentConfiguration sharedConfiguration] theme:[STPTheme defaultTheme]`.
  */
 - (instancetype)init;
 
 /**
- *  Initializes a new `STPAddCardViewController` with the provided configuration and theme. Don't forget to set the `delegate` property after initialization.
- *
- *  @param configuration The configuration to use (this determines the Stripe publishable key to use, the required billing address fields, whether or not to use SMS autofill, etc). @see STPPaymentConfiguration
- *  @param theme         The theme to use to inform the view controller's visual appearance. @see STPTheme
+ Initializes a new `STPAddCardViewController` with the provided configuration and theme. Don't forget to set the `delegate` property after initialization.
+
+ @param configuration The configuration to use (this determines the Stripe publishable key to use, the required billing address fields, whether or not to use SMS autofill, etc). @see STPPaymentConfiguration
+ @param theme         The theme to use to inform the view controller's visual appearance. @see STPTheme
  */
 - (instancetype)initWithConfiguration:(STPPaymentConfiguration *)configuration
                                 theme:(STPTheme *)theme;
 
 /**
- *  The view controller's delegate. This must be set before showing the view controller in order for it to work properly. @see STPAddCardViewControllerDelegate
+ The view controller's delegate. This must be set before showing the view controller in order for it to work properly. @see STPAddCardViewControllerDelegate
  */
 @property(nonatomic, weak, nullable)id<STPAddCardViewControllerDelegate>delegate;
 
 /**
- *  You can set this property to pre-fill any information you've already collected from your user. @see STPUserInformation.h
+ You can set this property to pre-fill any information you've already collected from your user. @see STPUserInformation.h
  */
 @property(nonatomic, strong, nullable)STPUserInformation *prefilledInformation;
 
@@ -58,23 +58,23 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 /**
- *  An `STPAddCardViewControllerDelegate` is notified when an `STPAddCardViewController` successfully creates a card token or is cancelled. It has internal error-handling logic, so there's no error case to deal with.
+ An `STPAddCardViewControllerDelegate` is notified when an `STPAddCardViewController` successfully creates a card token or is cancelled. It has internal error-handling logic, so there's no error case to deal with.
  */
 @protocol STPAddCardViewControllerDelegate <NSObject>
 
 /**
- *  Called when the user cancels adding a card. You should dismiss (or pop) the view controller at this point.
- *
- *  @param addCardViewController the view controller that has been cancelled
+ Called when the user cancels adding a card. You should dismiss (or pop) the view controller at this point.
+
+ @param addCardViewController the view controller that has been cancelled
  */
 - (void)addCardViewControllerDidCancel:(STPAddCardViewController *)addCardViewController;
 
 /**
- *  This is called when the user successfully adds a card and tokenizes it with Stripe. You should send the token to your backend to store it on a customer, and then call the provided `completion` block when that call is finished. If an error occurred while talking to your backend, call `completion(error)`, otherwise, dismiss (or pop) the view controller.
- *
- *  @param addCardViewController the view controller that successfully created a token
- *  @param token                 the Stripe token that was created. @see STPToken
- *  @param completion            call this callback when you're done sending the token to your backend
+ This is called when the user successfully adds a card and tokenizes it with Stripe. You should send the token to your backend to store it on a customer, and then call the provided `completion` block when that call is finished. If an error occurred while talking to your backend, call `completion(error)`, otherwise, dismiss (or pop) the view controller.
+
+ @param addCardViewController the view controller that successfully created a token
+ @param token                 the Stripe token that was created. @see STPToken
+ @param completion            call this callback when you're done sending the token to your backend
  */
 - (void)addCardViewController:(STPAddCardViewController *)addCardViewController
                didCreateToken:(STPToken *)token

--- a/Stripe/PublicHeaders/STPAddress.h
+++ b/Stripe/PublicHeaders/STPAddress.h
@@ -24,86 +24,86 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- *  What set of billing address information you need to collect from your user.
- *
- *  @note If the user is from a country that does not use zip/postal codes,
- *  the user may not be asked for one regardless of this setting.
+ What set of billing address information you need to collect from your user.
+
+ @note If the user is from a country that does not use zip/postal codes,
+ the user may not be asked for one regardless of this setting.
  */
 typedef NS_ENUM(NSUInteger, STPBillingAddressFields) {
     /**
-     *  No billing address information
+     No billing address information
      */
     STPBillingAddressFieldsNone,
     /**
-     *  Just request the user's billing ZIP code
+     Just request the user's billing ZIP code
      */
     STPBillingAddressFieldsZip,
     /**
-     *  Request the user's full billing address
+     Request the user's full billing address
      */
     STPBillingAddressFieldsFull,
 };
 
 /**
- *  STPAddress Contains an address as represented by the Stripe API.
+ STPAddress Contains an address as represented by the Stripe API.
  */
 @interface STPAddress : NSObject<STPAPIResponseDecodable>
 
 /**
- *  The user's full name (e.g. "Jane Doe")
+ The user's full name (e.g. "Jane Doe")
  */
 @property (nonatomic, copy, nullable) NSString *name;
 
 /**
- *  The first line of the user's street address (e.g. "123 Fake St")
+ The first line of the user's street address (e.g. "123 Fake St")
  */
 @property (nonatomic, copy, nullable) NSString *line1;
 
 /**
- *  The apartment, floor number, etc of the user's street address (e.g. "Apartment 1A")
+ The apartment, floor number, etc of the user's street address (e.g. "Apartment 1A")
  */
 @property (nonatomic, copy, nullable) NSString *line2;
 
 /**
- *  The city in which the user resides (e.g. "San Francisco")
+ The city in which the user resides (e.g. "San Francisco")
  */
 @property (nonatomic, copy, nullable) NSString *city;
 
 /**
- *  The state in which the user resides (e.g. "CA")
+ The state in which the user resides (e.g. "CA")
  */
 @property (nonatomic, copy, nullable) NSString *state;
 
 /**
- *  The postal code in which the user resides (e.g. "90210")
+ The postal code in which the user resides (e.g. "90210")
  */
 @property (nonatomic, copy, nullable) NSString *postalCode;
 
 /**
- *  The ISO country code of the address (e.g. "US")
+ The ISO country code of the address (e.g. "US")
  */
 @property (nonatomic, copy, nullable) NSString *country;
 
 /**
- *  The phone number of the address (e.g. "8885551212")
+ The phone number of the address (e.g. "8885551212")
  */
 @property (nonatomic, copy, nullable) NSString *phone;
 
 /**
- *  The email of the address (e.g. "jane@doe.com")
+ The email of the address (e.g. "jane@doe.com")
  */
 @property (nonatomic, copy, nullable) NSString *email;
 
 /**
- *  When creating a charge on your backend, you can attach shipping information
- *  to prevent fraud on a physical good. You can use this method to turn your user's
- *  shipping address and selected shipping method into a hash suitable for attaching 
- *  to a charge. You should pass this to your backend, and use it as the `shipping`
- *  parameter when creating a charge.
- *  @see https://stripe.com/docs/api#create_charge-shipping
- *
- *  @param address  The user's shipping address. If nil, this method will return nil.
- *  @param method   The user's selected shipping method. May be nil.
+ When creating a charge on your backend, you can attach shipping information
+ to prevent fraud on a physical good. You can use this method to turn your user's
+ shipping address and selected shipping method into a hash suitable for attaching 
+ to a charge. You should pass this to your backend, and use it as the `shipping`
+ parameter when creating a charge.
+ @see https://stripe.com/docs/api#create_charge-shipping
+
+ @param address  The user's shipping address. If nil, this method will return nil.
+ @param method   The user's selected shipping method. May be nil.
  */
 + (nullable NSDictionary *)shippingInfoForChargeWithAddress:(nullable STPAddress *)address
                                              shippingMethod:(nullable PKShippingMethod *)method;

--- a/Stripe/PublicHeaders/STPApplePayPaymentMethod.h
+++ b/Stripe/PublicHeaders/STPApplePayPaymentMethod.h
@@ -10,12 +10,12 @@
 #import "STPPaymentMethod.h"
 
 /**
- *  An empty class representing that the user wishes to pay via Apple Pay. This can be checked on an `STPPaymentContext`, e.g.
- *
- * `if ([paymentContext.selectedPaymentMethod isKindOfClass:[STPApplePayPaymentMethod class]]) {
- *  // don't ask the user for their card number; they want to pay with apple pay.
- *  }`
- *
+ An empty class representing that the user wishes to pay via Apple Pay. This can be checked on an `STPPaymentContext`, e.g.
+
+ `if ([paymentContext.selectedPaymentMethod isKindOfClass:[STPApplePayPaymentMethod class]]) {
+ // don't ask the user for their card number; they want to pay with apple pay.
+ }`
+
  */
 @interface STPApplePayPaymentMethod : NSObject <STPPaymentMethod>
 @end

--- a/Stripe/PublicHeaders/STPBackendAPIAdapter.h
+++ b/Stripe/PublicHeaders/STPBackendAPIAdapter.h
@@ -19,37 +19,37 @@ NS_ASSUME_NONNULL_BEGIN
 @class STPCard, STPToken;
 
 /**
- *  You should make your application's API client conform to this interface in order to use it with an `STPPaymentContext`. It provides a "bridge" from the prebuilt UI we expose (such as `STPPaymentMethodsViewController`) to your backend to fetch the information it needs to power those views. To read about how to implement this protocol, see https://stripe.com/docs/mobile/ios/standard#prepare-your-api . To see examples of implementing these APIs, see MyAPIClient.swift in our example project and https://github.com/stripe/example-ios-backend .
- *
- *  @deprecated Use `STPCustomerContext`.
- *  Instead of providing your own backend API adapter, you can now create an
- *  `STPCustomerContext`, which will manage retrieving and updating a
- *  Stripe customer for you. @see STPCustomerContext.h
+ You should make your application's API client conform to this interface in order to use it with an `STPPaymentContext`. It provides a "bridge" from the prebuilt UI we expose (such as `STPPaymentMethodsViewController`) to your backend to fetch the information it needs to power those views. To read about how to implement this protocol, see https://stripe.com/docs/mobile/ios/standard#prepare-your-api . To see examples of implementing these APIs, see MyAPIClient.swift in our example project and https://github.com/stripe/example-ios-backend .
+
+ @deprecated Use `STPCustomerContext`.
+ Instead of providing your own backend API adapter, you can now create an
+ `STPCustomerContext`, which will manage retrieving and updating a
+ Stripe customer for you. @see STPCustomerContext.h
  */
 __attribute__((deprecated))
 @protocol STPBackendAPIAdapter<NSObject>
 
 /**
- *  Retrieve the cards to be displayed inside a payment context. On your backend, retrieve the Stripe customer associated with your currently logged-in user (see https://stripe.com/docs/api#retrieve_customer ), and return the raw JSON response from the Stripe API. (For an example Ruby implementation of this API, see https://github.com/stripe/example-ios-backend/blob/master/web.rb#L40 ). Back in your iOS app, after you've called this API, deserialize your API response into an `STPCustomer` object (you can use the `STPCustomerDeserializer` class to do this). See MyAPIClient.swift in our example project to see this in action.
- *
- *  @see STPCard
- *  @param completion call this callback when you're done fetching and parsing the above information from your backend. For example, `completion(customer, nil)` (if your call succeeds) or `completion(nil, error)` if an error is returned.
+ Retrieve the cards to be displayed inside a payment context. On your backend, retrieve the Stripe customer associated with your currently logged-in user (see https://stripe.com/docs/api#retrieve_customer ), and return the raw JSON response from the Stripe API. (For an example Ruby implementation of this API, see https://github.com/stripe/example-ios-backend/blob/master/web.rb#L40 ). Back in your iOS app, after you've called this API, deserialize your API response into an `STPCustomer` object (you can use the `STPCustomerDeserializer` class to do this). See MyAPIClient.swift in our example project to see this in action.
+
+ @see STPCard
+ @param completion call this callback when you're done fetching and parsing the above information from your backend. For example, `completion(customer, nil)` (if your call succeeds) or `completion(nil, error)` if an error is returned.
  */
 - (void)retrieveCustomer:(nullable STPCustomerCompletionBlock)completion;
 
 /**
- *  Adds a payment source to a customer. On your backend, retrieve the Stripe customer associated with your logged-in user. Then, call the Update Customer method on that customer as described at https://stripe.com/docs/api#update_customer (for an example Ruby implementation of this API, see https://github.com/stripe/example-ios-backend/blob/master/web.rb#L60 ). If this API call succeeds, call `completion(nil)`. Otherwise, call `completion(error)` with the error that occurred.
- *
- *  @param source     a valid payment source, such as a card token.
- *  @param completion call this callback when you're done adding the token to the customer on your backend. For example, `completion(nil)` (if your call succeeds) or `completion(error)` if an error is returned.
+ Adds a payment source to a customer. On your backend, retrieve the Stripe customer associated with your logged-in user. Then, call the Update Customer method on that customer as described at https://stripe.com/docs/api#update_customer (for an example Ruby implementation of this API, see https://github.com/stripe/example-ios-backend/blob/master/web.rb#L60 ). If this API call succeeds, call `completion(nil)`. Otherwise, call `completion(error)` with the error that occurred.
+
+ @param source     a valid payment source, such as a card token.
+ @param completion call this callback when you're done adding the token to the customer on your backend. For example, `completion(nil)` (if your call succeeds) or `completion(error)` if an error is returned.
  */
 - (void)attachSourceToCustomer:(id<STPSourceProtocol>)source completion:(STPErrorBlock)completion;
 
 /**
- *  Change a customer's `default_source` to be the provided card. On your backend, retrieve the Stripe customer associated with your logged-in user. Then, call the Customer Update method as described at https://stripe.com/docs/api#update_customer , specifying default_source to be the value of source.stripeID (for an example Ruby implementation of this API, see https://github.com/stripe/example-ios-backend/blob/master/web.rb#L82 ). If this API call succeeds, call `completion(nil)`. Otherwise, call `completion(error)` with the error that occurred.
- *
- *  @param source     The newly-selected default source for the user.
- *  @param completion call this callback when you're done selecting the new default source for the customer on your backend. For example, `completion(nil)` (if your call succeeds) or `completion(error)` if an error is returned.
+ Change a customer's `default_source` to be the provided card. On your backend, retrieve the Stripe customer associated with your logged-in user. Then, call the Customer Update method as described at https://stripe.com/docs/api#update_customer , specifying default_source to be the value of source.stripeID (for an example Ruby implementation of this API, see https://github.com/stripe/example-ios-backend/blob/master/web.rb#L82 ). If this API call succeeds, call `completion(nil)`. Otherwise, call `completion(error)` with the error that occurred.
+
+ @param source     The newly-selected default source for the user.
+ @param completion call this callback when you're done selecting the new default source for the customer on your backend. For example, `completion(nil)` (if your call succeeds) or `completion(error)` if an error is returned.
  */
 - (void)selectDefaultCustomerSource:(id<STPSourceProtocol>)source completion:(STPErrorBlock)completion;
 

--- a/Stripe/PublicHeaders/STPBankAccount.h
+++ b/Stripe/PublicHeaders/STPBankAccount.h
@@ -19,64 +19,64 @@ typedef NS_ENUM(NSInteger, STPBankAccountStatus) {
 };
 
 /**
- *  Representation of a user's bank account details that have been tokenized with the Stripe API
- *
- *  @see https://stripe.com/docs/api#bank_accounts
+ Representation of a user's bank account details that have been tokenized with the Stripe API
+
+ @see https://stripe.com/docs/api#bank_accounts
  */
 @interface STPBankAccount : STPBankAccountParams<STPAPIResponseDecodable>
 
 /**
- *  The last 4 digits of the bank account's account number.
+ The last 4 digits of the bank account's account number.
  */
 - (nonnull NSString *)last4;
 
 /**
- *  The routing number for the bank account. This should be the ACH routing number, not the wire routing number.
+ The routing number for the bank account. This should be the ACH routing number, not the wire routing number.
  */
 @property (nonatomic, copy, nonnull) NSString *routingNumber;
 
 /**
- *  Two-letter ISO code representing the country the bank account is located in.
+ Two-letter ISO code representing the country the bank account is located in.
  */
 @property (nonatomic, copy, nullable) NSString *country;
 
 /**
- *  The default currency for the bank account.
+ The default currency for the bank account.
  */
 @property (nonatomic, copy, nullable) NSString *currency;
 
 /**
- *  The Stripe ID for the bank account.
+ The Stripe ID for the bank account.
  */
 @property (nonatomic, readonly, nonnull) NSString *bankAccountId;
 
 /**
- *  The last 4 digits of the account number.
+ The last 4 digits of the account number.
  */
 @property (nonatomic, readonly, nullable) NSString *last4;
 
 /**
- *  The name of the bank that owns the account.
+ The name of the bank that owns the account.
  */
 @property (nonatomic, readonly, nullable) NSString *bankName;
 
 /**
- *  The name of the person or business that owns the bank account.
+ The name of the person or business that owns the bank account.
  */
 @property(nonatomic, copy, nullable) NSString *accountHolderName;
 
 /**
- *  The type of entity that holds the account.
+ The type of entity that holds the account.
  */
 @property(nonatomic) STPBankAccountHolderType accountHolderType;
 
 /**
- *  A proxy for the account number, this uniquely identifies the account and can be used to compare equality of different bank accounts.
+ A proxy for the account number, this uniquely identifies the account and can be used to compare equality of different bank accounts.
  */
 @property (nonatomic, readonly, nullable) NSString *fingerprint;
 
 /**
- *  The validation status of the bank account. @see STPBankAccountStatus
+ The validation status of the bank account. @see STPBankAccountStatus
  */
 @property (nonatomic, readonly) STPBankAccountStatus status;
 

--- a/Stripe/PublicHeaders/STPBankAccount.h
+++ b/Stripe/PublicHeaders/STPBankAccount.h
@@ -63,12 +63,12 @@ typedef NS_ENUM(NSInteger, STPBankAccountStatus) {
 /**
  The name of the person or business that owns the bank account.
  */
-@property(nonatomic, copy, nullable) NSString *accountHolderName;
+@property (nonatomic, copy, nullable) NSString *accountHolderName;
 
 /**
  The type of entity that holds the account.
  */
-@property(nonatomic) STPBankAccountHolderType accountHolderType;
+@property (nonatomic) STPBankAccountHolderType accountHolderType;
 
 /**
  A proxy for the account number, this uniquely identifies the account and can be used to compare equality of different bank accounts.

--- a/Stripe/PublicHeaders/STPBankAccountParams.h
+++ b/Stripe/PublicHeaders/STPBankAccountParams.h
@@ -51,11 +51,11 @@ typedef NS_ENUM(NSInteger, STPBankAccountHolderType) {
 /**
  The name of the person or business that owns the bank account.
  */
-@property(nonatomic, copy, nullable) NSString *accountHolderName;
+@property (nonatomic, copy, nullable) NSString *accountHolderName;
 
 /**
  The type of entity that holds the account. Defaults to STPBankAccountHolderTypeIndividual.
  */
-@property(nonatomic) STPBankAccountHolderType accountHolderType;
+@property (nonatomic) STPBankAccountHolderType accountHolderType;
 
 @end

--- a/Stripe/PublicHeaders/STPBankAccountParams.h
+++ b/Stripe/PublicHeaders/STPBankAccountParams.h
@@ -16,45 +16,45 @@ typedef NS_ENUM(NSInteger, STPBankAccountHolderType) {
 };
 
 /**
- *  Representation of a user's bank account details. You can assemble these with information that your user enters and
- *  then create Stripe tokens with them using an STPAPIClient.
- *
- *  @see https://stripe.com/docs/api#create_bank_account_token
+ Representation of a user's bank account details. You can assemble these with information that your user enters and
+ then create Stripe tokens with them using an STPAPIClient.
+
+ @see https://stripe.com/docs/api#create_bank_account_token
  */
 @interface STPBankAccountParams : NSObject<STPFormEncodable>
 
 /**
- *  The account number for the bank account. Currently must be a checking account.
+ The account number for the bank account. Currently must be a checking account.
  */
 @property (nonatomic, copy, nullable) NSString *accountNumber;
 
 /**
- *  The last 4 digits of the bank account's account number, if it's been set, otherwise nil.
+ The last 4 digits of the bank account's account number, if it's been set, otherwise nil.
  */
 - (nullable NSString *)last4;
 
 /**
- *  The routing number for the bank account. This should be the ACH routing number, not the wire routing number.
+ The routing number for the bank account. This should be the ACH routing number, not the wire routing number.
  */
 @property (nonatomic, copy, nullable) NSString *routingNumber;
 
 /**
- *  Two-letter ISO code representing the country the bank account is located in.
+ Two-letter ISO code representing the country the bank account is located in.
  */
 @property (nonatomic, copy, nullable) NSString *country;
 
 /**
- *  The default currency for the bank account.
+ The default currency for the bank account.
  */
 @property (nonatomic, copy, nullable) NSString *currency;
 
 /**
- *  The name of the person or business that owns the bank account.
+ The name of the person or business that owns the bank account.
  */
 @property(nonatomic, copy, nullable) NSString *accountHolderName;
 
 /**
- *  The type of entity that holds the account. Defaults to STPBankAccountHolderTypeIndividual.
+ The type of entity that holds the account. Defaults to STPBankAccountHolderTypeIndividual.
  */
 @property(nonatomic) STPBankAccountHolderType accountHolderType;
 

--- a/Stripe/PublicHeaders/STPBlocks.h
+++ b/Stripe/PublicHeaders/STPBlocks.h
@@ -16,119 +16,119 @@
 @protocol STPSourceProtocol;
 
 /**
- *  These values control the labels used in the shipping info collection form.
+ These values control the labels used in the shipping info collection form.
  */
 typedef NS_ENUM(NSUInteger, STPShippingType) {
     /**
-     *  Shipping the purchase to the provided address using a third-party
-     *  shipping company.
+     Shipping the purchase to the provided address using a third-party
+     shipping company.
      */
     STPShippingTypeShipping,
     /**
-     *  Delivering the purchase by the seller.
+     Delivering the purchase by the seller.
      */
     STPShippingTypeDelivery,
 };
 
 /**
- *  An enum representing the status of a shipping address validation.
+ An enum representing the status of a shipping address validation.
  */
 typedef NS_ENUM(NSUInteger, STPShippingStatus) {
     /**
-     *  The shipping address is valid.
+     The shipping address is valid.
      */
     STPShippingStatusValid,
     /**
-     *  The shipping address is invalid.
+     The shipping address is invalid.
      */
     STPShippingStatusInvalid,
 };
 
 /**
- *  An enum representing the status of a payment requested from the user.
+ An enum representing the status of a payment requested from the user.
  */
 typedef NS_ENUM(NSUInteger, STPPaymentStatus) {
     /**
-     *  The payment succeeded.
+     The payment succeeded.
      */
     STPPaymentStatusSuccess,
     /**
-     *  The payment failed due to an unforeseen error, such as the user's Internet connection being offline.
+     The payment failed due to an unforeseen error, such as the user's Internet connection being offline.
      */
     STPPaymentStatusError,
     /**
-     *  The user cancelled the payment (for example, by hitting "cancel" in the Apple Pay dialog).
+     The user cancelled the payment (for example, by hitting "cancel" in the Apple Pay dialog).
      */
     STPPaymentStatusUserCancellation,
 };
 
 /**
- *  An empty block, called with no arguments, returning nothing.
+ An empty block, called with no arguments, returning nothing.
  */
 typedef void (^STPVoidBlock)();
 
 /**
- *  A block that may optionally be called with an error.
- *
- *  @param error The error that occurred, if any.
+ A block that may optionally be called with an error.
+
+ @param error The error that occurred, if any.
  */
 typedef void (^STPErrorBlock)(NSError * __nullable error);
 
 /**
- *  A callback to be run with a JSON response.
- *
- *  @param jsonResponse  The JSON response, or nil if an error occured.
- *  @param error         The error that occurred, if any.
+ A callback to be run with a JSON response.
+
+ @param jsonResponse  The JSON response, or nil if an error occured.
+ @param error         The error that occurred, if any.
  */
 typedef void (^STPJSONResponseCompletionBlock)(NSDictionary * __nullable jsonResponse, NSError * __nullable error);
 
 /**
- *  A callback to be run with a token response from the Stripe API.
- *
- *  @param token The Stripe token from the response. Will be nil if an error occurs. @see STPToken
- *  @param error The error returned from the response, or nil in one occurs. @see StripeError.h for possible values.
+ A callback to be run with a token response from the Stripe API.
+
+ @param token The Stripe token from the response. Will be nil if an error occurs. @see STPToken
+ @param error The error returned from the response, or nil in one occurs. @see StripeError.h for possible values.
  */
 typedef void (^STPTokenCompletionBlock)(STPToken * __nullable token, NSError * __nullable error);
 
 /**
- *  A callback to be run with a source response from the Stripe API.
- *
- *  @param source The Stripe source from the response. Will be nil if an error occurs. @see STPSource
- *  @param error The error returned from the response, or nil in one occurs. @see StripeError.h for possible values.
+ A callback to be run with a source response from the Stripe API.
+
+ @param source The Stripe source from the response. Will be nil if an error occurs. @see STPSource
+ @param error The error returned from the response, or nil in one occurs. @see StripeError.h for possible values.
  */
 typedef void (^STPSourceCompletionBlock)(STPSource * __nullable source, NSError * __nullable error);
 
 /**
- *  A callback to be run with a source or card response from the Stripe API.
- *
- *  @param source The Stripe source from the response. Will be nil if an error occurs. @see STPSourceProtocol
- *  @param error The error returned from the response, or nil in one occurs. @see StripeError.h for possible values.
+ A callback to be run with a source or card response from the Stripe API.
+
+ @param source The Stripe source from the response. Will be nil if an error occurs. @see STPSourceProtocol
+ @param error The error returned from the response, or nil in one occurs. @see StripeError.h for possible values.
  */
 typedef void (^STPSourceProtocolCompletionBlock)(id<STPSourceProtocol> __nullable source, NSError * __nullable error);
 
 /**
- *  A callback to be run with a validation result and shipping methods for a 
- *  shipping address.
- *
- *  @param status An enum representing whether the shipping address is valid.
- *  @param shippingValidationError If the shipping address is invalid, an error describing the issue with the address. If no error is given and the address is invalid, the default error message will be used.
- *  @param shippingMethods The shipping methods available for the address.
- *  @param selectedShippingMethod The default selected shipping method for the address.
+ A callback to be run with a validation result and shipping methods for a 
+ shipping address.
+
+ @param status An enum representing whether the shipping address is valid.
+ @param shippingValidationError If the shipping address is invalid, an error describing the issue with the address. If no error is given and the address is invalid, the default error message will be used.
+ @param shippingMethods The shipping methods available for the address.
+ @param selectedShippingMethod The default selected shipping method for the address.
  */
 typedef void (^STPShippingMethodsCompletionBlock)(STPShippingStatus status, NSError * __nullable shippingValidationError, NSArray<PKShippingMethod *>* __nullable shippingMethods, PKShippingMethod * __nullable selectedShippingMethod);
 
 /**
- *  A callback to be run with a file response from the Stripe API.
- *
- *  @param file The Stripe file from the response. Will be nil if an error occurs. @see STPFile
- *  @param error The error returned from the response, or nil in none occurs. @see StripeError.h for possible values.
+ A callback to be run with a file response from the Stripe API.
+
+ @param file The Stripe file from the response. Will be nil if an error occurs. @see STPFile
+ @param error The error returned from the response, or nil in none occurs. @see StripeError.h for possible values.
  */
 typedef void (^STPFileCompletionBlock)(STPFile * __nullable file, NSError * __nullable error);
 
 /**
- *  A callback to be run with a customer response from the Stripe API.
- *
- *  @param customer     The Stripe customer from the response, or nil if an error occurred. @see STPCustomer
- *  @param error        The error returned from the response, or nil in none occurs.
+ A callback to be run with a customer response from the Stripe API.
+
+ @param customer     The Stripe customer from the response, or nil if an error occurred. @see STPCustomer
+ @param error        The error returned from the response, or nil in none occurs.
  */
 typedef void (^STPCustomerCompletionBlock)(STPCustomer * __nullable customer, NSError * __nullable error);

--- a/Stripe/PublicHeaders/STPCard.h
+++ b/Stripe/PublicHeaders/STPCard.h
@@ -112,7 +112,7 @@ typedef NS_ENUM(NSInteger, STPCardFundingType) {
 /**
  The cardholder's address.
  */
-@property(nonatomic, copy, nullable) STPAddress *address;
+@property (nonatomic, copy, nullable) STPAddress *address;
 
 /**
  The cardholder's address.

--- a/Stripe/PublicHeaders/STPCard.h
+++ b/Stripe/PublicHeaders/STPCard.h
@@ -17,7 +17,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- *  The various funding sources for a payment card.
+ The various funding sources for a payment card.
  */
 typedef NS_ENUM(NSInteger, STPCardFundingType) {
     STPCardFundingTypeDebit,
@@ -27,23 +27,23 @@ typedef NS_ENUM(NSInteger, STPCardFundingType) {
 };
 
 /**
- *  Representation of a user's credit card details that have been tokenized with the Stripe API
- *
- *  @see https://stripe.com/docs/api#cards
+ Representation of a user's credit card details that have been tokenized with the Stripe API
+
+ @see https://stripe.com/docs/api#cards
  */
 @interface STPCard : STPCardParams<STPAPIResponseDecodable, STPPaymentMethod, STPSourceProtocol>
 
 /**
- *  Create an STPCard from a Stripe API response.
- *
- *  @param cardID   The Stripe ID of the card, e.g. `card_185iQx4JYtv6MPZKfcuXwkOx`
- *  @param brand    The brand of the card (e.g. "Visa". To obtain this enum value from a string, use `[STPCardBrand brandFromString:string]`;
- *  @param last4    The last 4 digits of the card, e.g. 4242
- *  @param expMonth The card's expiration month, 1-indexed (i.e. 1 = January)
- *  @param expYear  The card's expiration year
- *  @param funding  The card's funding type (credit, debit, or prepaid). To obtain this enum value from a string, use `[STPCardBrand fundingFromString:string]`.
- *
- *  @return an STPCard instance populated with the provided values.
+ Create an STPCard from a Stripe API response.
+
+ @param cardID   The Stripe ID of the card, e.g. `card_185iQx4JYtv6MPZKfcuXwkOx`
+ @param brand    The brand of the card (e.g. "Visa". To obtain this enum value from a string, use `[STPCardBrand brandFromString:string]`;
+ @param last4    The last 4 digits of the card, e.g. 4242
+ @param expMonth The card's expiration month, 1-indexed (i.e. 1 = January)
+ @param expYear  The card's expiration year
+ @param funding  The card's funding type (credit, debit, or prepaid). To obtain this enum value from a string, use `[STPCardBrand fundingFromString:string]`.
+
+ @return an STPCard instance populated with the provided values.
  */
 - (instancetype)initWithID:(NSString *)cardID
                      brand:(STPCardBrand)brand
@@ -53,69 +53,69 @@ typedef NS_ENUM(NSInteger, STPCardFundingType) {
                    funding:(STPCardFundingType)funding;
 
 /**
- *  This parses a string representing a card's brand into the appropriate STPCardBrand enum value, i.e. `[STPCard brandFromString:@"American Express"] == STPCardBrandAmex`
- *
- *  @param string a string representing the card's brand as returned from the Stripe API
- *
- *  @return an enum value mapped to that string. If the string is unrecognized, returns STPCardBrandUnknown.
+ This parses a string representing a card's brand into the appropriate STPCardBrand enum value, i.e. `[STPCard brandFromString:@"American Express"] == STPCardBrandAmex`
+
+ @param string a string representing the card's brand as returned from the Stripe API
+
+ @return an enum value mapped to that string. If the string is unrecognized, returns STPCardBrandUnknown.
  */
 + (STPCardBrand)brandFromString:(NSString *)string;
 
 /**
- *  Returns a string representation for the provided card brand; i.e. `[NSString stringFromBrand:STPCardBrandVisa] ==  @"Visa"`.
- *
- *  @param brand the brand you want to convert to a string
- *
- *  @return A string representing the brand, suitable for displaying to a user.
+ Returns a string representation for the provided card brand; i.e. `[NSString stringFromBrand:STPCardBrandVisa] ==  @"Visa"`.
+
+ @param brand the brand you want to convert to a string
+
+ @return A string representing the brand, suitable for displaying to a user.
  */
 + (NSString *)stringFromBrand:(STPCardBrand)brand;
 
 /**
- *  This parses a string representing a card's funding type into the appropriate `STPCardFundingType` enum value, i.e. `[STPCard fundingFromString:@"prepaid"] == STPCardFundingTypePrepaid`.
- *
- *  @param string a string representing the card's funding type as returned from the Stripe API
- *
- *  @return an enum value mapped to that string. If the string is unrecognized, returns `STPCardFundingTypeOther`.
+ This parses a string representing a card's funding type into the appropriate `STPCardFundingType` enum value, i.e. `[STPCard fundingFromString:@"prepaid"] == STPCardFundingTypePrepaid`.
+
+ @param string a string representing the card's funding type as returned from the Stripe API
+
+ @return an enum value mapped to that string. If the string is unrecognized, returns `STPCardFundingTypeOther`.
  */
 + (STPCardFundingType)fundingFromString:(NSString *)string;
 
 /**
- *  The last 4 digits of the card.
+ The last 4 digits of the card.
  */
 @property (nonatomic, readonly) NSString *last4;
 
 /**
- *  For cards made with Apple Pay, this refers to the last 4 digits of the "Device Account Number" for the tokenized card. For regular cards, it will be nil.
+ For cards made with Apple Pay, this refers to the last 4 digits of the "Device Account Number" for the tokenized card. For regular cards, it will be nil.
  */
 @property (nonatomic, readonly, nullable) NSString *dynamicLast4;
 
 /**
- *  Whether or not the card originated from Apple Pay.
+ Whether or not the card originated from Apple Pay.
  */
 @property (nonatomic, readonly) BOOL isApplePayCard;
 
 /**
- *  The card's expiration month. 1-indexed (i.e. 1 == January)
+ The card's expiration month. 1-indexed (i.e. 1 == January)
  */
 @property (nonatomic) NSUInteger expMonth;
 
 /**
- *  The card's expiration year.
+ The card's expiration year.
  */
 @property (nonatomic) NSUInteger expYear;
 
 /**
- *  The cardholder's name.
+ The cardholder's name.
  */
 @property (nonatomic, copy, nullable) NSString *name;
 
 /**
- *  The cardholder's address.
+ The cardholder's address.
  */
 @property(nonatomic, copy, nullable) STPAddress *address;
 
 /**
- *  The cardholder's address.
+ The cardholder's address.
  */
 @property (nonatomic, copy, nullable) NSString *addressLine1;
 @property (nonatomic, copy, nullable) NSString *addressLine2;
@@ -125,27 +125,27 @@ typedef NS_ENUM(NSInteger, STPCardFundingType) {
 @property (nonatomic, copy, nullable) NSString *addressCountry;
 
 /**
- *  The Stripe ID for the card.
+ The Stripe ID for the card.
  */
 @property (nonatomic, readonly, nullable) NSString *cardId;
 
 /**
- *  The issuer of the card.
+ The issuer of the card.
  */
 @property (nonatomic, readonly) STPCardBrand brand;
 
 /**
- *  The funding source for the card (credit, debit, prepaid, or other)
+ The funding source for the card (credit, debit, prepaid, or other)
  */
 @property (nonatomic, readonly) STPCardFundingType funding;
 
 /**
- *  Two-letter ISO code representing the issuing country of the card.
+ Two-letter ISO code representing the issuing country of the card.
  */
 @property (nonatomic, readonly, nullable) NSString *country;
 
 /**
- *  This is only applicable when tokenizing debit cards to issue payouts to managed accounts. You should not set it otherwise. The card can then be used as a transfer destination for funds in this currency.
+ This is only applicable when tokenizing debit cards to issue payouts to managed accounts. You should not set it otherwise. The card can then be used as a transfer destination for funds in this currency.
  */
 @property (nonatomic, copy, nullable) NSString *currency;
 

--- a/Stripe/PublicHeaders/STPCardBrand.h
+++ b/Stripe/PublicHeaders/STPCardBrand.h
@@ -9,7 +9,7 @@
 #import <Foundation/Foundation.h>
 
 /**
- *  The various card brands to which a payment card can belong.
+ The various card brands to which a payment card can belong.
  */
 typedef NS_ENUM(NSInteger, STPCardBrand) {
     STPCardBrandVisa,

--- a/Stripe/PublicHeaders/STPCardParams.h
+++ b/Stripe/PublicHeaders/STPCardParams.h
@@ -14,45 +14,45 @@
 #endif
 
 /**
- *  Representation of a user's credit card details. You can assemble these with information that your user enters and
- *  then create Stripe tokens with them using an STPAPIClient.
- *
- *  @see https://stripe.com/docs/api#cards
+ Representation of a user's credit card details. You can assemble these with information that your user enters and
+ then create Stripe tokens with them using an STPAPIClient.
+
+ @see https://stripe.com/docs/api#cards
  */
 @interface STPCardParams : NSObject<STPFormEncodable>
 
 /**
- *  The card's number.
+ The card's number.
  */
 @property (nonatomic, copy, nullable) NSString *number;
 
 /**
- *  The last 4 digits of the card's number, if it's been set, otherwise nil.
+ The last 4 digits of the card's number, if it's been set, otherwise nil.
  */
 - (nullable NSString *)last4;
 
 /**
- *  The card's expiration month.
+ The card's expiration month.
  */
 @property (nonatomic) NSUInteger expMonth;
 
 /**
- *  The card's expiration year.
+ The card's expiration year.
  */
 @property (nonatomic) NSUInteger expYear;
 
 /**
- *  The card's security code, found on the back.
+ The card's security code, found on the back.
  */
 @property (nonatomic, copy, nullable) NSString *cvc;
 
 /**
- *  The cardholder's name.
+ The cardholder's name.
  */
 @property (nonatomic, copy, nullable) NSString *name;
 
 /**
- *  The cardholder's address.
+ The cardholder's address.
  */
 @property(nonatomic, copy, nonnull) STPAddress *address;
 
@@ -64,7 +64,7 @@
 @property (nonatomic, copy, nullable) NSString *addressCountry;
 
 /**
- *  Three-letter ISO currency code representing the currency paid out to the bank account. This is only applicable when tokenizing debit cards to issue payouts to managed accounts. You should not set it otherwise. The card can then be used as a transfer destination for funds in this currency.
+ Three-letter ISO currency code representing the currency paid out to the bank account. This is only applicable when tokenizing debit cards to issue payouts to managed accounts. You should not set it otherwise. The card can then be used as a transfer destination for funds in this currency.
  */
 @property (nonatomic, copy, nullable) NSString *currency;
 

--- a/Stripe/PublicHeaders/STPCardParams.h
+++ b/Stripe/PublicHeaders/STPCardParams.h
@@ -54,7 +54,7 @@
 /**
  The cardholder's address.
  */
-@property(nonatomic, copy, nonnull) STPAddress *address;
+@property (nonatomic, copy, nonnull) STPAddress *address;
 
 @property (nonatomic, copy, nullable) NSString *addressLine1;
 @property (nonatomic, copy, nullable) NSString *addressLine2;

--- a/Stripe/PublicHeaders/STPCardValidator.h
+++ b/Stripe/PublicHeaders/STPCardValidator.h
@@ -15,92 +15,92 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- *  This class contains static methods to validate card numbers, expiration dates, and CVCs. For a list of test card numbers to use with this code, see https://stripe.com/docs/testing
+ This class contains static methods to validate card numbers, expiration dates, and CVCs. For a list of test card numbers to use with this code, see https://stripe.com/docs/testing
  */
 @interface STPCardValidator : NSObject
 
 /**
- *  Returns a copy of the passed string with all non-numeric characters removed.
+ Returns a copy of the passed string with all non-numeric characters removed.
  */
 + (NSString *)sanitizedNumericStringForString:(NSString *)string;
 
 /**
- *  Whether or not the target string contains only numeric characters.
+ Whether or not the target string contains only numeric characters.
  */
 + (BOOL)stringIsNumeric:(NSString *)string;
 
 /**
- *  Validates a card number, passed as a string. This will return STPCardValidationStateInvalid for numbers that are too short or long, contain invalid characters, do not pass Luhn validation, or (optionally) do not match a number format issued by a major card brand.
- *
- *  @param cardNumber The card number to validate. Ex. @"4242424242424242"
- *  @param validatingCardBrand Whether or not to enforce that the number appears to be issued by a major card brand (or could be). For example, no issuing card network currently issues card numbers beginning with the digit 9; if an otherwise correct-length and luhn-valid card number beginning with 9 (example: 9999999999999995) were passed to this method, it would return STPCardValidationStateInvalid if this parameter were YES and STPCardValidationStateValid if this parameter were NO. If unsure, you should use YES for this value.
- *
- *  @return STPCardValidationStateValid if the number is valid, STPCardValidationStateInvalid if the number is invalid, or STPCardValidationStateIncomplete if the number is a substring of a valid card (e.g. @"4242").
+ Validates a card number, passed as a string. This will return STPCardValidationStateInvalid for numbers that are too short or long, contain invalid characters, do not pass Luhn validation, or (optionally) do not match a number format issued by a major card brand.
+
+ @param cardNumber The card number to validate. Ex. @"4242424242424242"
+ @param validatingCardBrand Whether or not to enforce that the number appears to be issued by a major card brand (or could be). For example, no issuing card network currently issues card numbers beginning with the digit 9; if an otherwise correct-length and luhn-valid card number beginning with 9 (example: 9999999999999995) were passed to this method, it would return STPCardValidationStateInvalid if this parameter were YES and STPCardValidationStateValid if this parameter were NO. If unsure, you should use YES for this value.
+
+ @return STPCardValidationStateValid if the number is valid, STPCardValidationStateInvalid if the number is invalid, or STPCardValidationStateIncomplete if the number is a substring of a valid card (e.g. @"4242").
  */
 + (STPCardValidationState)validationStateForNumber:(nullable NSString *)cardNumber
                                validatingCardBrand:(BOOL)validatingCardBrand;
 
 /**
- *  The card brand for a card number or substring thereof.
- *
- *  @param cardNumber A card number, or partial card number. For example, @"4242", @"5555555555554444", or @"123".
- *
- *  @return The brand for that card number. The example parameters would return STPCardBrandVisa, STPCardBrandMasterCard, and STPCardBrandUnknown, respectively.
+ The card brand for a card number or substring thereof.
+
+ @param cardNumber A card number, or partial card number. For example, @"4242", @"5555555555554444", or @"123".
+
+ @return The brand for that card number. The example parameters would return STPCardBrandVisa, STPCardBrandMasterCard, and STPCardBrandUnknown, respectively.
  */
 + (STPCardBrand)brandForNumber:(NSString *)cardNumber;
 
 /**
- *  The possible number lengths for cards associated with a card brand. For example, Discover card numbers contain 16 characters, while American Express cards contain 15 characters.
+ The possible number lengths for cards associated with a card brand. For example, Discover card numbers contain 16 characters, while American Express cards contain 15 characters.
  */
 + (NSSet<NSNumber *>*)lengthsForCardBrand:(STPCardBrand)brand;
 + (NSInteger)maxLengthForCardBrand:(STPCardBrand)brand;
 
 /**
- *  The length of the final grouping of digits to use when formatting a card number for display. For example, Visa cards display their final 4 numbers, e.g. "4242", while American Express cards display their final 5 digits, e.g. "10005".
+ The length of the final grouping of digits to use when formatting a card number for display. For example, Visa cards display their final 4 numbers, e.g. "4242", while American Express cards display their final 5 digits, e.g. "10005".
  */
 + (NSInteger)fragmentLengthForCardBrand:(STPCardBrand)brand;
 
 /**
- *  Validates an expiration month, passed as an (optionally 0-padded) string. Example valid values are "3", "12", and "08". Example invalid values are "99", "a", and "00". Incomplete values include "0" and "1".
- *
- *  @param expirationMonth A string representing a 2-digit expiration month for a payment card.
- *
- *  @return STPCardValidationStateValid if the month is valid, STPCardValidationStateInvalid if the month is invalid, or STPCardValidationStateIncomplete if the month is a substring of a valid month (e.g. @"0" or @"1").
+ Validates an expiration month, passed as an (optionally 0-padded) string. Example valid values are "3", "12", and "08". Example invalid values are "99", "a", and "00". Incomplete values include "0" and "1".
+
+ @param expirationMonth A string representing a 2-digit expiration month for a payment card.
+
+ @return STPCardValidationStateValid if the month is valid, STPCardValidationStateInvalid if the month is invalid, or STPCardValidationStateIncomplete if the month is a substring of a valid month (e.g. @"0" or @"1").
  */
 + (STPCardValidationState)validationStateForExpirationMonth:(NSString *)expirationMonth;
 
 /**
- *  Validates an expiration year, passed as a string representing the final 2 digits of the year. This considers the period between the current year until 2099 as valid times. An example valid year value would be "16" (assuming the current year, as determined by [NSDate date], is 2015). Will return STPCardValidationStateInvalid for a month/year combination that is earlier than the current date (i.e. @"15" and @"04" in October 2015). Example invalid year values are "00", "a", and "13". Any 1-digit year string will return STPCardValidationStateIncomplete.
- *
- *  @param expirationYear A string representing a 2-digit expiration year for a payment card.
- *  @param expirationMonth A string representing a valid 2-digit expiration month for a payment card. If the month is invalid (see -validationStateForExpirationMonth), this will return STPCardValidationStateInvalid.
- *
- *  @return STPCardValidationStateValid if the year is valid, STPCardValidationStateInvalid if the year is invalid, or STPCardValidationStateIncomplete if the year is a substring of a valid year (e.g. @"1" or @"2").
+ Validates an expiration year, passed as a string representing the final 2 digits of the year. This considers the period between the current year until 2099 as valid times. An example valid year value would be "16" (assuming the current year, as determined by [NSDate date], is 2015). Will return STPCardValidationStateInvalid for a month/year combination that is earlier than the current date (i.e. @"15" and @"04" in October 2015). Example invalid year values are "00", "a", and "13". Any 1-digit year string will return STPCardValidationStateIncomplete.
+
+ @param expirationYear A string representing a 2-digit expiration year for a payment card.
+ @param expirationMonth A string representing a valid 2-digit expiration month for a payment card. If the month is invalid (see -validationStateForExpirationMonth), this will return STPCardValidationStateInvalid.
+
+ @return STPCardValidationStateValid if the year is valid, STPCardValidationStateInvalid if the year is invalid, or STPCardValidationStateIncomplete if the year is a substring of a valid year (e.g. @"1" or @"2").
  */
 + (STPCardValidationState)validationStateForExpirationYear:(NSString *)expirationYear
                                                    inMonth:(NSString *)expirationMonth;
 
 /**
- *  The max CVC length for a card brand (for context, American Express CVCs are 4 digits, while all others are 3).
+ The max CVC length for a card brand (for context, American Express CVCs are 4 digits, while all others are 3).
  */
 + (NSUInteger)maxCVCLengthForCardBrand:(STPCardBrand)brand;
 
 /**
- *  Validates a card's CVC, passed as a numeric string, for the given card brand.
- *
- *  @param cvc   the CVC to validate
- *  @param brand the card brand (can be determined from the card's number using +brandForNumber)
- *
- *  @return Whether the CVC represents a valid CVC for that card brand. For example, would return STPCardValidationStateValid for @"123" and STPCardBrandVisa, STPCardValidationStateValid for @"1234" and STPCardBrandAmericanExpress, STPCardValidationStateIncomplete for @"12" and STPCardBrandVisa, and STPCardValidationStateInvalid for @"12345" and any brand.
+ Validates a card's CVC, passed as a numeric string, for the given card brand.
+
+ @param cvc   the CVC to validate
+ @param brand the card brand (can be determined from the card's number using +brandForNumber)
+
+ @return Whether the CVC represents a valid CVC for that card brand. For example, would return STPCardValidationStateValid for @"123" and STPCardBrandVisa, STPCardValidationStateValid for @"1234" and STPCardBrandAmericanExpress, STPCardValidationStateIncomplete for @"12" and STPCardBrandVisa, and STPCardValidationStateInvalid for @"12345" and any brand.
  */
 + (STPCardValidationState)validationStateForCVC:(NSString *)cvc cardBrand:(STPCardBrand)brand;
 
 /**
- *  Validates the given card details.
- *
- *  @param card the card details to validate.
- * 
- *  @return STPCardValidationStateValid if all fields are valid, STPCardValidationStateInvalid if any field is invalid, or STPCardValidationStateIncomplete if all fields are either incomplete or valid.
+ Validates the given card details.
+
+ @param card the card details to validate.
+
+ @return STPCardValidationStateValid if all fields are valid, STPCardValidationStateInvalid if any field is invalid, or STPCardValidationStateIncomplete if all fields are either incomplete or valid.
  */
 + (STPCardValidationState)validationStateForCard:(STPCardParams *)card;
 

--- a/Stripe/PublicHeaders/STPCustomer.h
+++ b/Stripe/PublicHeaders/STPCustomer.h
@@ -40,22 +40,22 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  The Stripe ID of the customer, e.g. `cus_1234`
  */
-@property(nonatomic, readonly, copy)NSString *stripeID;
+@property (nonatomic, readonly, copy) NSString *stripeID;
 
 /**
  The default source used to charge the customer.
  */
-@property(nonatomic, readonly, nullable) id<STPSourceProtocol> defaultSource;
+@property (nonatomic, readonly, nullable) id<STPSourceProtocol> defaultSource;
 
 /**
  The available payment sources the customer has (this may be an empty array).
  */
-@property(nonatomic, readonly) NSArray<id<STPSourceProtocol>> *sources;
+@property (nonatomic, readonly) NSArray<id<STPSourceProtocol>> *sources;
 
 /**
  The customer's shipping address.
  */
-@property(nonatomic, readonly, nullable) STPAddress *shippingAddress;
+@property (nonatomic, readonly, nullable) STPAddress *shippingAddress;
 
 @end
 
@@ -91,12 +91,12 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  If a customer was successfully parsed from the response, it will be set here. Otherwise, this value wil be nil (and the `error` property will explain what went wrong).
  */
-@property(nonatomic, readonly, nullable)STPCustomer *customer;
+@property (nonatomic, readonly, nullable) STPCustomer *customer;
 
 /**
  If the deserializer failed to parse a customer, this property will explain why (and the `customer` property will be nil).
  */
-@property(nonatomic, readonly, nullable)NSError *error;
+@property (nonatomic, readonly, nullable) NSError *error;
 
 @end
 

--- a/Stripe/PublicHeaders/STPCustomer.h
+++ b/Stripe/PublicHeaders/STPCustomer.h
@@ -15,45 +15,45 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- *  An `STPCustomer` represents a deserialized Customer object from the Stripe API.
- *  You shouldn't need to instantiate an `STPCustomer` – you should instead use
- *  `STPCustomerContext` to manage retrieving and updating a customer.
+ An `STPCustomer` represents a deserialized Customer object from the Stripe API.
+ You shouldn't need to instantiate an `STPCustomer` – you should instead use
+ `STPCustomerContext` to manage retrieving and updating a customer.
  */
 @interface STPCustomer : NSObject <STPAPIResponseDecodable>
 
 /**
- *  Initialize a customer object with the provided values.
- *
- *  @param stripeID      The ID of the customer, e.g. `cus_abc`
- *  @param defaultSource The default source of the customer, such as an `STPCard` object. Can be nil.
- *  @param sources       All of the customer's payment sources. This might be an empty array.
- *
- *  @return an instance of STPCustomer
- *
- *  @deprecated Use `STPCustomerContext` to manage retrieving and updating a 
- *  Customer. You will no longer need to initialize an `STPCustomer`.
+ Initialize a customer object with the provided values.
+
+ @param stripeID      The ID of the customer, e.g. `cus_abc`
+ @param defaultSource The default source of the customer, such as an `STPCard` object. Can be nil.
+ @param sources       All of the customer's payment sources. This might be an empty array.
+
+ @return an instance of STPCustomer
+
+ @deprecated Use `STPCustomerContext` to manage retrieving and updating a 
+ Customer. You will no longer need to initialize an `STPCustomer`.
  */
 + (instancetype)customerWithStripeID:(NSString *)stripeID
                        defaultSource:(nullable id<STPSourceProtocol>)defaultSource
                              sources:(NSArray<id<STPSourceProtocol>> *)sources __attribute__((deprecated));
 
 /**
- *  The Stripe ID of the customer, e.g. `cus_1234`
+ The Stripe ID of the customer, e.g. `cus_1234`
  */
 @property(nonatomic, readonly, copy)NSString *stripeID;
 
 /**
- *  The default source used to charge the customer.
+ The default source used to charge the customer.
  */
 @property(nonatomic, readonly, nullable) id<STPSourceProtocol> defaultSource;
 
 /**
- *  The available payment sources the customer has (this may be an empty array).
+ The available payment sources the customer has (this may be an empty array).
  */
 @property(nonatomic, readonly) NSArray<id<STPSourceProtocol>> *sources;
 
 /**
- *  The customer's shipping address.
+ The customer's shipping address.
  */
 @property(nonatomic, readonly, nullable) STPAddress *shippingAddress;
 
@@ -65,36 +65,36 @@ NS_ASSUME_NONNULL_BEGIN
 @interface STPCustomerDeserializer : NSObject
 
 /**
- *  Initialize a customer deserializer. The `data`, `urlResponse`, and `error` parameters are intended to be passed from an `NSURLSessionDataTask` callback. After it has been initialized, you can inspect the `error` and `customer` properties to see if the deserialization was successful. If `error` is nil, `customer` will be non-nil (and vice versa).
- *
- *  @param data        An `NSData` object representing encoded JSON for a Customer object
- *  @param urlResponse The URL response obtained from the `NSURLSessionTask`
- *  @param error       Any error that occurred from the URL session task (if this is non-nil, the `error` property will be set to this value after initialization).
- *
- *  @deprecated Use `STPCustomerContext` to manage retrieving and updating a
- *  Customer. You will no longer need to deserialize an `STPCustomer`.
+ Initialize a customer deserializer. The `data`, `urlResponse`, and `error` parameters are intended to be passed from an `NSURLSessionDataTask` callback. After it has been initialized, you can inspect the `error` and `customer` properties to see if the deserialization was successful. If `error` is nil, `customer` will be non-nil (and vice versa).
+
+ @param data        An `NSData` object representing encoded JSON for a Customer object
+ @param urlResponse The URL response obtained from the `NSURLSessionTask`
+ @param error       Any error that occurred from the URL session task (if this is non-nil, the `error` property will be set to this value after initialization).
+
+ @deprecated Use `STPCustomerContext` to manage retrieving and updating a
+ Customer. You will no longer need to deserialize an `STPCustomer`.
  */
 - (instancetype)initWithData:(nullable NSData *)data
                  urlResponse:(nullable NSURLResponse *)urlResponse
                        error:(nullable NSError *)error __attribute__((deprecated));
 
 /**
- *  Initializes a customer deserializer with a JSON dictionary. This JSON should be in the exact same format as what the Stripe API returns. If it's successfully parsed, the `customer` parameter will be present after initialization; otherwise `error` will be present.
- *
- *  @param json a JSON dictionary.
- *
- *  @deprecated Use `STPCustomerContext` to manage retrieving and updating a
- *  Customer. You will no longer need to deserialize an `STPCustomer`.
+ Initializes a customer deserializer with a JSON dictionary. This JSON should be in the exact same format as what the Stripe API returns. If it's successfully parsed, the `customer` parameter will be present after initialization; otherwise `error` will be present.
+
+ @param json a JSON dictionary.
+
+ @deprecated Use `STPCustomerContext` to manage retrieving and updating a
+ Customer. You will no longer need to deserialize an `STPCustomer`.
  */
 - (instancetype)initWithJSONResponse:(id)json __attribute__((deprecated));
 
 /**
- *  If a customer was successfully parsed from the response, it will be set here. Otherwise, this value wil be nil (and the `error` property will explain what went wrong).
+ If a customer was successfully parsed from the response, it will be set here. Otherwise, this value wil be nil (and the `error` property will explain what went wrong).
  */
 @property(nonatomic, readonly, nullable)STPCustomer *customer;
 
 /**
- *  If the deserializer failed to parse a customer, this property will explain why (and the `customer` property will be nil).
+ If the deserializer failed to parse a customer, this property will explain why (and the `customer` property will be nil).
  */
 @property(nonatomic, readonly, nullable)NSError *error;
 

--- a/Stripe/PublicHeaders/STPFile.h
+++ b/Stripe/PublicHeaders/STPFile.h
@@ -20,33 +20,33 @@ typedef NS_ENUM(NSInteger, STPFilePurpose) {
 @interface STPFile : NSObject <STPAPIResponseDecodable>
 
 /**
- *  The token for this file.
+ The token for this file.
  */
 @property (nonatomic, readonly) NSString *fileId;
 
 /**
- * The date this file was created.
+ The date this file was created.
  */
 @property (nonatomic, readonly) NSDate *created;
 
 /**
- * The purpose of this file. This can be either an identifing document or an evidence dispute. 
- * @see https://stripe.com/docs/file-upload
+ The purpose of this file. This can be either an identifing document or an evidence dispute. 
+ @see https://stripe.com/docs/file-upload
  */
 @property (nonatomic, readonly) STPFilePurpose purpose;
 
 /**
- * The file size in bytes.
+ The file size in bytes.
  */
 @property (nonatomic, readonly) NSNumber *size;
 
 /**
- * The file type. This can be "jpg", "png", or "pdf".
+ The file type. This can be "jpg", "png", or "pdf".
  */
 @property (nonatomic, readonly) NSString *type;
 
 /**
- * Returns the string value for a purpose.
+ Returns the string value for a purpose.
  */
 + (nullable NSString *)stringFromPurpose:(STPFilePurpose)purpose;
 

--- a/Stripe/PublicHeaders/STPFormEncodable.h
+++ b/Stripe/PublicHeaders/STPFormEncodable.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
     cardParams.additionalAPIParameters = @{@"test_field": @"example_value"};
     [[STPAPIClient sharedClient] createTokenWithCard:cardParams completion:...];
  */
-@property(nonatomic, readwrite, copy)NSDictionary *additionalAPIParameters;
+@property (nonatomic, readwrite, copy) NSDictionary *additionalAPIParameters;
 
 @end
 

--- a/Stripe/PublicHeaders/STPFormEncodable.h
+++ b/Stripe/PublicHeaders/STPFormEncodable.h
@@ -11,22 +11,22 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- * Objects conforming to STPFormEncodable can be automatically converted to a form-encoded string, which can then be used when making requests to the Stripe API.
+ Objects conforming to STPFormEncodable can be automatically converted to a form-encoded string, which can then be used when making requests to the Stripe API.
  */
 @protocol STPFormEncodable <NSObject>
 
 /**
- * The root object name to be used when converting this object to a form-encoded string. For example, if this returns @"card", then the form-encoded output will resemble @"card[foo]=bar" (where 'foo' and 'bar' are specified by `propertyNamesToFormFieldNamesMapping` below.
+ The root object name to be used when converting this object to a form-encoded string. For example, if this returns @"card", then the form-encoded output will resemble @"card[foo]=bar" (where 'foo' and 'bar' are specified by `propertyNamesToFormFieldNamesMapping` below.
  */
 + (nullable NSString *)rootObjectName;
 
 /**
- * This maps properties on an object that is being form-encoded into parameter names in the Stripe API. For example, STPCardParams has a field called `expMonth`, but the Stripe API expects a field called `exp_month`. This dictionary represents a mapping from the former to the latter (in other words, [STPCardParams propertyNamesToFormFieldNamesMapping][@"expMonth"] == @"exp_month".)
+ This maps properties on an object that is being form-encoded into parameter names in the Stripe API. For example, STPCardParams has a field called `expMonth`, but the Stripe API expects a field called `exp_month`. This dictionary represents a mapping from the former to the latter (in other words, [STPCardParams propertyNamesToFormFieldNamesMapping][@"expMonth"] == @"exp_month".)
  */
 + (NSDictionary *)propertyNamesToFormFieldNamesMapping;
 
 /**
- * You can use this property to add additional fields to an API request that are not explicitly defined by the object's interface. This can be useful when using beta features that haven't been added to the Stripe SDK yet. For example, if the /v1/tokens API began to accept a beta field called "test_field", you might do the following:
+ You can use this property to add additional fields to an API request that are not explicitly defined by the object's interface. This can be useful when using beta features that haven't been added to the Stripe SDK yet. For example, if the /v1/tokens API began to accept a beta field called "test_field", you might do the following:
     STPCardParams *cardParams = [STPCardParams new];
     // add card values
     cardParams.additionalAPIParameters = @{@"test_field": @"example_value"};

--- a/Stripe/PublicHeaders/STPImageLibrary.h
+++ b/Stripe/PublicHeaders/STPImageLibrary.h
@@ -13,68 +13,68 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- *  This class lets you access card icons used by the Stripe SDK. All icons are 32 x 20 points.
+ This class lets you access card icons used by the Stripe SDK. All icons are 32 x 20 points.
  */
 @interface STPImageLibrary : NSObject
 
 /**
- *  An icon representing Apple Pay.
+ An icon representing Apple Pay.
  */
 + (UIImage *)applePayCardImage;
 
 /**
- *  An icon representing American Express.
+ An icon representing American Express.
  */
 + (UIImage *)amexCardImage;
 
 /**
- *  An icon representing Diners Club.
+ An icon representing Diners Club.
  */
 + (UIImage *)dinersClubCardImage;
 
 /**
- *  An icon representing Discover.
+ An icon representing Discover.
  */
 + (UIImage *)discoverCardImage;
 
 /**
- *  An icon representing JCB.
+ An icon representing JCB.
  */
 + (UIImage *)jcbCardImage;
 
 /**
- *  An icon representing MasterCard.
+ An icon representing MasterCard.
  */
 + (UIImage *)masterCardCardImage;
 
 /**
- *  An icon representing Visa.
+ An icon representing Visa.
  */
 + (UIImage *)visaCardImage;
 
 /**
- *  An icon to use when the type of the card is unknown.
+ An icon to use when the type of the card is unknown.
  */
 + (UIImage *)unknownCardCardImage;
 
 /**
- *  This returns the appropriate icon for the specified card brand.
+ This returns the appropriate icon for the specified card brand.
  */
 + (UIImage *)brandImageForCardBrand:(STPCardBrand)brand;
 
 /**
- *  This returns the appropriate icon for the specified card brand as a 
- *  single color template that can be tinted
+ This returns the appropriate icon for the specified card brand as a 
+ single color template that can be tinted
  */
 + (UIImage *)templatedBrandImageForCardBrand:(STPCardBrand)brand;
 
 /**
- *  This returns a small icon indicating the CVC location for the given card brand.
+ This returns a small icon indicating the CVC location for the given card brand.
  */
 + (UIImage *)cvcImageForCardBrand:(STPCardBrand)brand;
 
 /**
- *  This returns a small icon indicating a card number error for the given card brand.
+ This returns a small icon indicating a card number error for the given card brand.
  */
 + (UIImage *)errorImageForCardBrand:(STPCardBrand)brand;
 

--- a/Stripe/PublicHeaders/STPPaymentActivityIndicatorView.h
+++ b/Stripe/PublicHeaders/STPPaymentActivityIndicatorView.h
@@ -9,23 +9,23 @@
 #import <UIKit/UIKit.h>
 
 /**
- *  This class can be used wherever you'd use a `UIActivityIndicatorView` and is intended to have a similar API. It renders as a spinning circle with a gap in it, similar to what you see in the App Store app or in the Apple Pay dialog when making a purchase. To change its color, set the `tintColor` property.
+ This class can be used wherever you'd use a `UIActivityIndicatorView` and is intended to have a similar API. It renders as a spinning circle with a gap in it, similar to what you see in the App Store app or in the Apple Pay dialog when making a purchase. To change its color, set the `tintColor` property.
  */
 @interface STPPaymentActivityIndicatorView : UIView
 
 /**
- *  Tell the view to start or stop spinning. If `hidesWhenStopped` is true, it will fade in/out if animated is true.
+ Tell the view to start or stop spinning. If `hidesWhenStopped` is true, it will fade in/out if animated is true.
  */
 - (void)setAnimating:(BOOL)animating
             animated:(BOOL)animated;
 
 /**
- *  Whether or not the view is animating.
+ Whether or not the view is animating.
  */
 @property(nonatomic)BOOL animating;
 
 /**
- *  If true, the view will hide when it is not spinning. Default is true.
+ If true, the view will hide when it is not spinning. Default is true.
  */
 @property(nonatomic)BOOL hidesWhenStopped;
 

--- a/Stripe/PublicHeaders/STPPaymentActivityIndicatorView.h
+++ b/Stripe/PublicHeaders/STPPaymentActivityIndicatorView.h
@@ -22,11 +22,11 @@
 /**
  Whether or not the view is animating.
  */
-@property(nonatomic)BOOL animating;
+@property (nonatomic) BOOL animating;
 
 /**
  If true, the view will hide when it is not spinning. Default is true.
  */
-@property(nonatomic)BOOL hidesWhenStopped;
+@property (nonatomic) BOOL hidesWhenStopped;
 
 @end

--- a/Stripe/PublicHeaders/STPPaymentCardTextField.h
+++ b/Stripe/PublicHeaders/STPPaymentCardTextField.h
@@ -26,21 +26,21 @@ IB_DESIGNABLE
 /**
  @see STPPaymentCardTextFieldDelegate
  */
-@property(nonatomic, weak, nullable) IBOutlet id<STPPaymentCardTextFieldDelegate> delegate;
+@property (nonatomic, weak, nullable) IBOutlet id<STPPaymentCardTextFieldDelegate> delegate;
 
 /**
  The font used in each child field. Default is [UIFont systemFontOfSize:18]. 
  
  Set this property to nil to reset to the default.
  */
-@property(nonatomic, copy, null_resettable) UIFont *font UI_APPEARANCE_SELECTOR;
+@property (nonatomic, copy, null_resettable) UIFont *font UI_APPEARANCE_SELECTOR;
 
 /**
  The text color to be used when entering valid text. Default is [UIColor blackColor]. 
  
  Set this property to nil to reset to the default.
  */
-@property(nonatomic, copy, null_resettable) UIColor *textColor UI_APPEARANCE_SELECTOR;
+@property (nonatomic, copy, null_resettable) UIColor *textColor UI_APPEARANCE_SELECTOR;
 
 /**
  The text color to be used when the user has entered invalid information, 
@@ -48,7 +48,7 @@ IB_DESIGNABLE
  
  Default is [UIColor redColor]. Set this property to nil to reset to the default.
  */
-@property(nonatomic, copy, null_resettable) UIColor *textErrorColor UI_APPEARANCE_SELECTOR;
+@property (nonatomic, copy, null_resettable) UIColor *textErrorColor UI_APPEARANCE_SELECTOR;
 
 /**
  The text placeholder color used in each child field.
@@ -57,7 +57,7 @@ IB_DESIGNABLE
 
  Default is [UIColor lightGreyColor]. Set this property to nil to reset to the default. 
  */
-@property(nonatomic, copy, null_resettable) UIColor *placeholderColor UI_APPEARANCE_SELECTOR;
+@property (nonatomic, copy, null_resettable) UIColor *placeholderColor UI_APPEARANCE_SELECTOR;
 
 /**
  The placeholder for the card number field. 
@@ -67,23 +67,23 @@ IB_DESIGNABLE
  If this is set to something that resembles a card number, it will automatically 
  format it as such (in other words, you don't need to add spaces to this string).
  */
-@property(nonatomic, copy, nullable) IBInspectable NSString *numberPlaceholder;
+@property (nonatomic, copy, nullable) IBInspectable NSString *numberPlaceholder;
 
 /**
  The placeholder for the expiration field. Defaults to @"MM/YY".
  */
-@property(nonatomic, copy, nullable) IBInspectable NSString *expirationPlaceholder;
+@property (nonatomic, copy, nullable) IBInspectable NSString *expirationPlaceholder;
 
 /**
  The placeholder for the cvc field. Defaults to @"CVC".
  */
-@property(nonatomic, copy, nullable) IBInspectable NSString *cvcPlaceholder;
+@property (nonatomic, copy, nullable) IBInspectable NSString *cvcPlaceholder;
 
 /**
  The placeholder for the postal code field. Defaults to @"ZIP" for United States
  or @"Postal" for all other country codes.
  */
-@property(nonatomic, copy, nullable) IBInspectable NSString *postalCodePlaceholder;
+@property (nonatomic, copy, nullable) IBInspectable NSString *postalCodePlaceholder;
 
 /**
  The cursor color for the field. 
@@ -91,7 +91,7 @@ IB_DESIGNABLE
  This is a proxy for the view's tintColor property, exposed for clarity only 
  (in other words, calling setCursorColor is identical to calling setTintColor).
  */
-@property(nonatomic, copy, null_resettable) UIColor *cursorColor UI_APPEARANCE_SELECTOR;
+@property (nonatomic, copy, null_resettable) UIColor *cursorColor UI_APPEARANCE_SELECTOR;
 
 /**
  The border color for the field.
@@ -100,38 +100,38 @@ IB_DESIGNABLE
 
  Default is [UIColor lightGreyColor].
  */
-@property(nonatomic, copy, nullable) UIColor *borderColor UI_APPEARANCE_SELECTOR;
+@property (nonatomic, copy, nullable) UIColor *borderColor UI_APPEARANCE_SELECTOR;
 
 /**
  The width of the field's border. 
  
  Default is 1.0.
  */
-@property(nonatomic, assign) CGFloat borderWidth UI_APPEARANCE_SELECTOR;
+@property (nonatomic, assign) CGFloat borderWidth UI_APPEARANCE_SELECTOR;
 
 /**
  The corner radius for the field's border.
  
  Default is 5.0.
  */
-@property(nonatomic, assign) CGFloat cornerRadius UI_APPEARANCE_SELECTOR;
+@property (nonatomic, assign) CGFloat cornerRadius UI_APPEARANCE_SELECTOR;
 
 /**
  The keyboard appearance for the field.
  
  Default is UIKeyboardAppearanceDefault.
  */
-@property(nonatomic, assign) UIKeyboardAppearance keyboardAppearance UI_APPEARANCE_SELECTOR;
+@property (nonatomic, assign) UIKeyboardAppearance keyboardAppearance UI_APPEARANCE_SELECTOR;
 
 /**
  This behaves identically to setting the inputView for each child text field.
  */
-@property(nonatomic, strong, nullable) UIView *inputView;
+@property (nonatomic, strong, nullable) UIView *inputView;
 
 /**
  This behaves identically to setting the inputAccessoryView for each child text field.
  */
-@property(nonatomic, strong, nullable) UIView *inputAccessoryView;
+@property (nonatomic, strong, nullable) UIView *inputAccessoryView;
 
 /**
 The curent brand image displayed in the receiver.
@@ -144,7 +144,7 @@ The curent brand image displayed in the receiver.
 
  @see STPCardValidator
  */
-@property(nonatomic, readonly) BOOL isValid;
+@property (nonatomic, readonly) BOOL isValid;
 
 /**
  Enable/disable selecting or editing the field. Useful when submitting card details to Stripe.
@@ -157,7 +157,7 @@ The curent brand image displayed in the receiver.
  May or may not be valid, unless `isValid` is true, in which case it is guaranteed
  to be valid.
  */
-@property(nonatomic, readonly, nullable) NSString *cardNumber;
+@property (nonatomic, readonly, nullable) NSString *cardNumber;
 
 /**
  The current expiration month displayed by the field (1 = January, etc). 
@@ -165,7 +165,7 @@ The curent brand image displayed in the receiver.
  May or may not be valid, unless `isValid` is true, in which case it is
  guaranteed to be valid.
  */
-@property(nonatomic, readonly) NSUInteger expirationMonth;
+@property (nonatomic, readonly) NSUInteger expirationMonth;
 
 /**
  The current expiration month displayed by the field, as a string. T
@@ -173,7 +173,7 @@ The curent brand image displayed in the receiver.
  This may or may not be a valid entry (i.e. "0") unless `isValid` is true. 
  It may be also 0-prefixed (i.e. "01" for January).
  */
-@property(nonatomic, readonly, nullable) NSString *formattedExpirationMonth;
+@property (nonatomic, readonly, nullable) NSString *formattedExpirationMonth;
 
 /**
  The current expiration year displayed by the field, modulo 100 
@@ -182,7 +182,7 @@ The curent brand image displayed in the receiver.
  May or may not be valid, unless `isValid` is true, in which case it is 
  guaranteed to be valid.
  */
-@property(nonatomic, readonly) NSUInteger expirationYear;
+@property (nonatomic, readonly) NSUInteger expirationYear;
 
 /**
  The current expiration year displayed by the field, as a string. 
@@ -190,7 +190,7 @@ The curent brand image displayed in the receiver.
  This is a 2-digit year (i.e. "15"), and may or may not be a valid entry
  unless `isValid` is true.
  */
-@property(nonatomic, readonly, nullable) NSString *formattedExpirationYear;
+@property (nonatomic, readonly, nullable) NSString *formattedExpirationYear;
 
 /**
  The current card CVC displayed by the field. 
@@ -198,12 +198,12 @@ The curent brand image displayed in the receiver.
  May or may not be valid, unless `isValid` is true, in which case it 
  is guaranteed to be valid.
  */
-@property(nonatomic, readonly, nullable) NSString *cvc;
+@property (nonatomic, readonly, nullable) NSString *cvc;
 
 /**
  The current card ZIP or postal code displayed by the field.
  */
-@property(nonatomic, readonly, nullable) NSString *postalCode;
+@property (nonatomic, readonly, nullable) NSString *postalCode;
 
 /**
  Controls if a postal code entry field can be displayed to the user.
@@ -214,7 +214,7 @@ The curent brand image displayed in the receiver.
  value. Some country codes may result in no postal code entry being shown if
  those countries do not commonly use postal codes.
  */
-@property(nonatomic, assign, readwrite) BOOL postalCodeEntryEnabled;
+@property (nonatomic, assign, readwrite) BOOL postalCodeEntryEnabled;
 
 
 /**
@@ -228,7 +228,7 @@ The curent brand image displayed in the receiver.
 
  By default this will fetch the user's current country code from NSLocale.
  */
-@property(nonatomic, copy, nullable) NSString *countryCode;
+@property (nonatomic, copy, nullable) NSString *countryCode;
 
 /**
  Convenience property for creating an STPCardParams from the currently entered information
@@ -236,7 +236,7 @@ The curent brand image displayed in the receiver.
  to scan your user's credit card with a camera, you can assemble that data into an STPCardParams
  object and set this property to that object to prefill the fields you've collected.
  */
-@property(nonatomic, strong, readwrite, nonnull) STPCardParams *cardParams;
+@property (nonatomic, strong, readwrite, nonnull) STPCardParams *cardParams;
 
 /**
  Causes the text field to begin editing. Presents the keyboard.

--- a/Stripe/PublicHeaders/STPPaymentContext.h
+++ b/Stripe/PublicHeaders/STPPaymentContext.h
@@ -59,232 +59,232 @@ NS_ASSUME_NONNULL_BEGIN
                                   theme:(STPTheme *)theme;
 
 /**
- *  This is a convenience initializer; it is equivalent to calling `initWithAPIAdapter:apiAdapter configuration:[STPPaymentConfiguration sharedConfiguration] theme:[STPTheme defaultTheme]`.
- *
- *  @deprecated Use `initWithCustomerContext:`.
- *  Instead of providing your own backend API adapter, you can now create an
- *  `STPCustomerContext`, which will manage retrieving and updating a
- *  Stripe customer for you. @see STPCustomerContext.h
+ This is a convenience initializer; it is equivalent to calling `initWithAPIAdapter:apiAdapter configuration:[STPPaymentConfiguration sharedConfiguration] theme:[STPTheme defaultTheme]`.
+
+ @deprecated Use `initWithCustomerContext:`.
+ Instead of providing your own backend API adapter, you can now create an
+ `STPCustomerContext`, which will manage retrieving and updating a
+ Stripe customer for you. @see STPCustomerContext.h
  */
 - (instancetype)initWithAPIAdapter:(id<STPBackendAPIAdapter>)apiAdapter __attribute__((deprecated));
 
 /**
- *  Initializes a new Payment Context with the provided API adapter and configuration. After this class is initialized, you should also make sure to set its `delegate` and `hostViewController` properties.
- *
- *  @param apiAdapter    The API adapter the payment context will use to fetch and modify its contents. You need to make a class conforming to this protocol that talks to your server. @see STPBackendAPIAdapter.h
- *  @param configuration The configuration for the payment context to use. This lets you set your Stripe publishable API key, required billing address fields, etc. @see STPPaymentConfiguration.h
- *  @param theme         The theme describing the visual appearance of all UI that the payment context automatically creates for you. @see STPTheme.h
- *
- *  @return the newly-instantiated payment context
- *
- *  @deprecated Use `initWithCustomerContext:configuration:theme:`.
- *  Instead of providing your own backend API adapter, you can now create an
- *  `STPCustomerContext`, which will manage retrieving and updating a
- *  Stripe customer for you. @see STPCustomerContext.h
+ Initializes a new Payment Context with the provided API adapter and configuration. After this class is initialized, you should also make sure to set its `delegate` and `hostViewController` properties.
+
+ @param apiAdapter    The API adapter the payment context will use to fetch and modify its contents. You need to make a class conforming to this protocol that talks to your server. @see STPBackendAPIAdapter.h
+ @param configuration The configuration for the payment context to use. This lets you set your Stripe publishable API key, required billing address fields, etc. @see STPPaymentConfiguration.h
+ @param theme         The theme describing the visual appearance of all UI that the payment context automatically creates for you. @see STPTheme.h
+
+ @return the newly-instantiated payment context
+
+ @deprecated Use `initWithCustomerContext:configuration:theme:`.
+ Instead of providing your own backend API adapter, you can now create an
+ `STPCustomerContext`, which will manage retrieving and updating a
+ Stripe customer for you. @see STPCustomerContext.h
  */
 - (instancetype)initWithAPIAdapter:(id<STPBackendAPIAdapter>)apiAdapter
                      configuration:(STPPaymentConfiguration *)configuration
                              theme:(STPTheme *)theme __attribute__((deprecated));
 
 /**
- *  The API adapter the payment context will use to fetch and modify its contents. You need to make a class conforming to this protocol that talks to your server. @see STPBackendAPIAdapter.h
- *
- *  @deprecated Use `customerContext`.
- *  Instead of providing your own backend API adapter, you can now  create an
- *  `STPCustomerContext`, which will manage retrieving and updating a
- *  Stripe customer for you. @see STPCustomerContext.h
+ The API adapter the payment context will use to fetch and modify its contents. You need to make a class conforming to this protocol that talks to your server. @see STPBackendAPIAdapter.h
+
+ @deprecated Use `customerContext`.
+ Instead of providing your own backend API adapter, you can now  create an
+ `STPCustomerContext`, which will manage retrieving and updating a
+ Stripe customer for you. @see STPCustomerContext.h
  */
 @property(nonatomic, readonly)id<STPBackendAPIAdapter> apiAdapter __attribute__((deprecated));
 
 /**
- *  The configuration for the payment context to use internally. @see STPPaymentConfiguration.h
+ The configuration for the payment context to use internally. @see STPPaymentConfiguration.h
  */
 @property(nonatomic, readonly)STPPaymentConfiguration *configuration;
 
 /**
- *  The visual appearance that will be used by any views that the context generates. @see STPTheme.h
+ The visual appearance that will be used by any views that the context generates. @see STPTheme.h
  */
 @property(nonatomic, readonly)STPTheme *theme;
 
 /**
- *  If you've already collected some information from your user, you can set it here and it'll be automatically filled out when possible/appropriate in any UI that the payment context creates.
+ If you've already collected some information from your user, you can set it here and it'll be automatically filled out when possible/appropriate in any UI that the payment context creates.
  */
 @property(nonatomic, strong, nullable)STPUserInformation *prefilledInformation;
 
 /**
- *  The view controller that any additional UI will be presented on. If you have a "checkout view controller" in your app, that should be used as the host view controller.
+ The view controller that any additional UI will be presented on. If you have a "checkout view controller" in your app, that should be used as the host view controller.
  */
 @property(nonatomic, weak, nullable)UIViewController *hostViewController;
 
 /**
- *  This delegate will be notified when the payment context's contents change. @see STPPaymentContextDelegate
+ This delegate will be notified when the payment context's contents change. @see STPPaymentContextDelegate
  */
 @property(nonatomic, weak, nullable)id<STPPaymentContextDelegate> delegate;
 
 /**
- *  Whether or not the payment context is currently loading information from the network.
+ Whether or not the payment context is currently loading information from the network.
  */
 @property(nonatomic, readonly)BOOL loading;
 
 /**
- *  The user's currently selected payment method. May be nil.
+ The user's currently selected payment method. May be nil.
  */
 @property(nonatomic, readonly, nullable)id<STPPaymentMethod> selectedPaymentMethod;
 
 /**
- *  The available payment methods the user can choose between. May be nil.
+ The available payment methods the user can choose between. May be nil.
  */
 @property(nonatomic, readonly, nullable)NSArray<id<STPPaymentMethod>> *paymentMethods;
 
 /**
- *  The user's currently selected shipping method. May be nil.
+ The user's currently selected shipping method. May be nil.
  */
 @property(nonatomic, readonly, nullable)PKShippingMethod *selectedShippingMethod;
 
 /**
- *  An array of STPShippingMethod objects that describe the supported shipping methods. May be nil.
+ An array of STPShippingMethod objects that describe the supported shipping methods. May be nil.
  */
 @property(nonatomic, readonly, nullable)NSArray<PKShippingMethod *> *shippingMethods;
 
 /**
- *  The user's shipping address. May be nil.
- *  If you've already collected a shipping address from your user, you may
- *  prefill it by setting a shippingAddress in PaymentContext's prefilledInformation.
- *  When your user enters a new shipping address, PaymentContext will save it to 
- *  the current customer object. When PaymentContext loads, if you haven't
- *  manually set a prefilled value, any shipping information saved on the customer 
- *  will be used to prefill the shipping address form. Note that because your
- *  customer's email may not be the same as the email provided with their shipping
- *  info, PaymentContext will not prefill the shipping form's email using your 
- *  customer's email.
- *
- *  You should not rely on the shipping information stored on the Stripe customer 
- *  for order fulfillment, as your user may change this information if they make 
- *  multiple purchases. We recommend adding shipping information when you create
- *  a charge (which can also help prevent fraud), or saving it to your own
- *  database. https://stripe.com/docs/api#create_charge-shipping
- *
- *  Note: by default, your user will still be prompted to verify a prefilled 
- *  shipping address. To change this behavior, you can set 
- *  `verifyPrefilledShippingAddress` to NO in your `STPPaymentConfiguration`.
+ The user's shipping address. May be nil.
+ If you've already collected a shipping address from your user, you may
+ prefill it by setting a shippingAddress in PaymentContext's prefilledInformation.
+ When your user enters a new shipping address, PaymentContext will save it to 
+ the current customer object. When PaymentContext loads, if you haven't
+ manually set a prefilled value, any shipping information saved on the customer 
+ will be used to prefill the shipping address form. Note that because your
+ customer's email may not be the same as the email provided with their shipping
+ info, PaymentContext will not prefill the shipping form's email using your 
+ customer's email.
+
+ You should not rely on the shipping information stored on the Stripe customer 
+ for order fulfillment, as your user may change this information if they make 
+ multiple purchases. We recommend adding shipping information when you create
+ a charge (which can also help prevent fraud), or saving it to your own
+ database. https://stripe.com/docs/api#create_charge-shipping
+
+ Note: by default, your user will still be prompted to verify a prefilled 
+ shipping address. To change this behavior, you can set 
+ `verifyPrefilledShippingAddress` to NO in your `STPPaymentConfiguration`.
  */
 @property(nonatomic, readonly, nullable)STPAddress *shippingAddress;
 
 /**
- *  The amount of money you're requesting from the user, in the smallest currency 
- *  unit for the selected currency. For example, to indicate $10 USD, use 1000 
- *  (i.e. 1000 cents). For more information, see https://stripe.com/docs/api#charge_object-amount
- *
- *  @note This value must be present and greater than zero in order for Apple Pay
- *  to be automatically enabled.
- *
- *  @note You should only set either this or `paymentSummaryItems`, not both.
- *  The other will be automatically calculated on demand using your `paymentCurrency`.
+ The amount of money you're requesting from the user, in the smallest currency 
+ unit for the selected currency. For example, to indicate $10 USD, use 1000 
+ (i.e. 1000 cents). For more information, see https://stripe.com/docs/api#charge_object-amount
+
+ @note This value must be present and greater than zero in order for Apple Pay
+ to be automatically enabled.
+
+ @note You should only set either this or `paymentSummaryItems`, not both.
+ The other will be automatically calculated on demand using your `paymentCurrency`.
  */
 @property(nonatomic)NSInteger paymentAmount;
 
 /**
- *  The three-letter currency code for the currency of the payment (i.e. USD, GBP, 
- *  JPY, etc). Defaults to "USD".
- *
- *  @note Changing this property may change the return value of `paymentAmount` 
- *  or `paymentSummaryItems` (whichever one you didn't directly set yourself).
+ The three-letter currency code for the currency of the payment (i.e. USD, GBP, 
+ JPY, etc). Defaults to "USD".
+
+ @note Changing this property may change the return value of `paymentAmount` 
+ or `paymentSummaryItems` (whichever one you didn't directly set yourself).
  */
 @property(nonatomic, copy)NSString *paymentCurrency;
 
 /**
- *  The two-letter country code for the country where the payment will be processed.
- *  You should set this to the country your Stripe account is in. Defaults to "US".
- *
- *  @note Changing this property will change the `countryCode` of your Apple Pay
- *  payment requests.
- *  @see PKPaymentRequest for more information.
+ The two-letter country code for the country where the payment will be processed.
+ You should set this to the country your Stripe account is in. Defaults to "US".
+
+ @note Changing this property will change the `countryCode` of your Apple Pay
+ payment requests.
+ @see PKPaymentRequest for more information.
  */
 @property(nonatomic, copy)NSString *paymentCountry;
 
 /**
- *  If you support Apple Pay, you can optionally set the PKPaymentSummaryItems 
- *  you want to display here instead of using `paymentAmount`. Note that the 
- *  grand total (the amount of the last summary item) must be greater than zero.
- *  If not set, a single summary item will be automatically generated using 
- *  `paymentAmount` and your configuration's `companyName`.
- *  @see PKPaymentRequest for more information
- *
- *  @note You should only set either this or `paymentAmount`, not both. 
- *  The other will be automatically calculated on demand using your `paymentCurrency.`
+ If you support Apple Pay, you can optionally set the PKPaymentSummaryItems 
+ you want to display here instead of using `paymentAmount`. Note that the 
+ grand total (the amount of the last summary item) must be greater than zero.
+ If not set, a single summary item will be automatically generated using 
+ `paymentAmount` and your configuration's `companyName`.
+ @see PKPaymentRequest for more information
+
+ @note You should only set either this or `paymentAmount`, not both. 
+ The other will be automatically calculated on demand using your `paymentCurrency.`
  */
 @property(nonatomic, copy)NSArray<PKPaymentSummaryItem *> *paymentSummaryItems;
 
 /**
- *  The presentation style used for all view controllers presented modally by the context.
- *  Since custom transition styles are not supported, you should set this to either
- *  `UIModalPresentationFullScreen`, `UIModalPresentationPageSheet`, or `UIModalPresentationFormSheet`.
- *  The default value is `UIModalPresentationFullScreen`.
+ The presentation style used for all view controllers presented modally by the context.
+ Since custom transition styles are not supported, you should set this to either
+ `UIModalPresentationFullScreen`, `UIModalPresentationPageSheet`, or `UIModalPresentationFormSheet`.
+ The default value is `UIModalPresentationFullScreen`.
  */
 @property(nonatomic, assign) UIModalPresentationStyle modalPresentationStyle;
 
 /**
- *  If `paymentContext:didFailToLoadWithError:` is called on your delegate, you
- *  can in turn call this method to try loading again (if that hasn't been called, 
- *  calling this will do nothing). If retrying in turn fails, `paymentContext:didFailToLoadWithError:` 
- *  will be called again (and you can again call this to keep retrying, etc).
+ If `paymentContext:didFailToLoadWithError:` is called on your delegate, you
+ can in turn call this method to try loading again (if that hasn't been called, 
+ calling this will do nothing). If retrying in turn fails, `paymentContext:didFailToLoadWithError:` 
+ will be called again (and you can again call this to keep retrying, etc).
  */
 - (void)retryLoading;
 
 /**
- *  This creates, configures, and appropriately presents an `STPPaymentMethodsViewController` 
- *  on top of the payment context's `hostViewController`. It'll be dismissed automatically 
- *  when the user is done selecting their payment method.
- *  
- *  @note This method will do nothing if it is called while STPPaymentContext is 
- *        already showing a view controller or in the middle of requesting a payment.
+ This creates, configures, and appropriately presents an `STPPaymentMethodsViewController` 
+ on top of the payment context's `hostViewController`. It'll be dismissed automatically 
+ when the user is done selecting their payment method.
+
+ @note This method will do nothing if it is called while STPPaymentContext is 
+       already showing a view controller or in the middle of requesting a payment.
  */
 - (void)presentPaymentMethodsViewController;
 
 /**
- *  This creates, configures, and appropriately pushes an `STPPaymentMethodsViewController` 
- *  onto the navigation stack of the context's `hostViewController`. It'll be popped 
- *  automatically when the user is done selecting their payment method.
- *
- *  @note This method will do nothing if it is called while STPPaymentContext is
- *        already showing a view controller or in the middle of requesting a payment.
+ This creates, configures, and appropriately pushes an `STPPaymentMethodsViewController` 
+ onto the navigation stack of the context's `hostViewController`. It'll be popped 
+ automatically when the user is done selecting their payment method.
+
+ @note This method will do nothing if it is called while STPPaymentContext is
+       already showing a view controller or in the middle of requesting a payment.
  */
 - (void)pushPaymentMethodsViewController;
 
 /**
- *  This creates, configures, and appropriately presents a view controller for 
- *  collecting shipping address and shipping method on top of the payment context's 
- *  `hostViewController`. It'll be dismissed automatically when the user is done 
- *  entering their shipping info.
- *
- *  @note This method will do nothing if it is called while STPPaymentContext is
- *        already showing a view controller or in the middle of requesting a payment.
+ This creates, configures, and appropriately presents a view controller for 
+ collecting shipping address and shipping method on top of the payment context's 
+ `hostViewController`. It'll be dismissed automatically when the user is done 
+ entering their shipping info.
+
+ @note This method will do nothing if it is called while STPPaymentContext is
+       already showing a view controller or in the middle of requesting a payment.
  */
 - (void)presentShippingViewController;
 
 /**
- *  This creates, configures, and appropriately pushes a view controller for 
- *  collecting shipping address and shipping method onto the navigation stack of 
- *  the context's `hostViewController`. It'll be popped automatically when the 
- *  user is done entering their shipping info.
- *
- *  @note This method will do nothing if it is called while STPPaymentContext is
- *        already showing a view controller, or in the middle of requesting a payment.
+ This creates, configures, and appropriately pushes a view controller for 
+ collecting shipping address and shipping method onto the navigation stack of 
+ the context's `hostViewController`. It'll be popped automatically when the 
+ user is done entering their shipping info.
+
+ @note This method will do nothing if it is called while STPPaymentContext is
+       already showing a view controller, or in the middle of requesting a payment.
  */
 - (void)pushShippingViewController;
 
 /**
- *  Requests payment from the user. This may need to present some supplemental UI
- *  to the user, in which case it will be presented on the payment context's 
- *  `hostViewController`. For instance, if they've selected Apple Pay as their 
- *  payment method, calling this method will show the payment sheet. If the user
- *  has a card on file, this will use that without presenting any additional UI.
- *  After this is called, the `paymentContext:didCreatePaymentResult:completion:` 
- *  and `paymentContext:didFinishWithStatus:error:` methods will be called on the
- *  context's `delegate`.
- *
- *  @note This method will do nothing if it is called while STPPaymentContext is
- *        already showing a view controller, or in the middle of requesting a payment.
+ Requests payment from the user. This may need to present some supplemental UI
+ to the user, in which case it will be presented on the payment context's 
+ `hostViewController`. For instance, if they've selected Apple Pay as their 
+ payment method, calling this method will show the payment sheet. If the user
+ has a card on file, this will use that without presenting any additional UI.
+ After this is called, the `paymentContext:didCreatePaymentResult:completion:` 
+ and `paymentContext:didFinishWithStatus:error:` methods will be called on the
+ context's `delegate`.
+
+ @note This method will do nothing if it is called while STPPaymentContext is
+       already showing a view controller, or in the middle of requesting a payment.
  */
 - (void)requestPayment;
 
@@ -292,46 +292,46 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 /**
- *  Implement `STPPaymentContextDelegate` to get notified when a payment context changes, finishes, encounters errors, etc. In practice, if your app has a "checkout screen view controller", that is a good candidate to implement this protocol.
+ Implement `STPPaymentContextDelegate` to get notified when a payment context changes, finishes, encounters errors, etc. In practice, if your app has a "checkout screen view controller", that is a good candidate to implement this protocol.
  */
 @protocol STPPaymentContextDelegate <NSObject>
 
 /**
- *  Called when the payment context encounters an error when fetching its initial set of data. A few ways to handle this are:
+ Called when the payment context encounters an error when fetching its initial set of data. A few ways to handle this are:
  - If you're showing the user a checkout page, dismiss the checkout page when this is called and present the error to the user.
  - Present the error to the user using a `UIAlertController` with two buttons: Retry and Cancel. If they cancel, dismiss your UI. If they Retry, call `retryLoading` on the payment context.
  
  To make it harder to get your UI into a bad state, this won't be called until the context's `hostViewController` has finished appearing.
- *
- *  @param paymentContext the payment context that encountered the error
- *  @param error          the error that was encountered
+
+ @param paymentContext the payment context that encountered the error
+ @param error          the error that was encountered
  */
 - (void)paymentContext:(STPPaymentContext *)paymentContext didFailToLoadWithError:(NSError *)error;
 
 /**
- *  This is called every time the contents of the payment context change. When this is called, you should update your app's UI to reflect the current state of the payment context. For example, if you have a checkout page with a "selected payment method" row, you should update its payment method with `paymentContext.selectedPaymentMethod.label`. If that checkout page has a "buy" button, you should enable/disable it depending on the result of `[paymentContext isReadyForPayment]`.
- *
- *  @param paymentContext the payment context that changed
+ This is called every time the contents of the payment context change. When this is called, you should update your app's UI to reflect the current state of the payment context. For example, if you have a checkout page with a "selected payment method" row, you should update its payment method with `paymentContext.selectedPaymentMethod.label`. If that checkout page has a "buy" button, you should enable/disable it depending on the result of `[paymentContext isReadyForPayment]`.
+
+ @param paymentContext the payment context that changed
  */
 - (void)paymentContextDidChange:(STPPaymentContext *)paymentContext;
 
 /**
- *  Inside this method, you should make a call to your backend API to make a charge with that Customer + source, and invoke the `completion` block when that is done.
- *
- *  @param paymentContext The context that succeeded
- *  @param paymentResult  Information associated with the payment that you can pass to your server. You should go to your backend API with this payment result and make a charge to complete the payment, passing `paymentResult.source.stripeID` as the `source` parameter to the create charge method and your customer's ID as the `customer` parameter (see stripe.com/docs/api#charge_create for more info). Once that's done call the `completion` block with any error that occurred (or none, if the charge succeeded). @see STPPaymentResult.h
- *  @param completion     Call this block when you're done creating a charge (or subscription, etc) on your backend. If it succeeded, call `completion(nil)`. If it failed with an error, call `completion(error)`.
+ Inside this method, you should make a call to your backend API to make a charge with that Customer + source, and invoke the `completion` block when that is done.
+
+ @param paymentContext The context that succeeded
+ @param paymentResult  Information associated with the payment that you can pass to your server. You should go to your backend API with this payment result and make a charge to complete the payment, passing `paymentResult.source.stripeID` as the `source` parameter to the create charge method and your customer's ID as the `customer` parameter (see stripe.com/docs/api#charge_create for more info). Once that's done call the `completion` block with any error that occurred (or none, if the charge succeeded). @see STPPaymentResult.h
+ @param completion     Call this block when you're done creating a charge (or subscription, etc) on your backend. If it succeeded, call `completion(nil)`. If it failed with an error, call `completion(error)`.
  */
 - (void)paymentContext:(STPPaymentContext *)paymentContext
 didCreatePaymentResult:(STPPaymentResult *)paymentResult
             completion:(STPErrorBlock)completion;
 
 /**
- *  This is invoked by an `STPPaymentContext` when it is finished. This will be called after the payment is done and all necessary UI has been dismissed. You should inspect the returned `status` and behave appropriately. For example: if it's `STPPaymentStatusSuccess`, show the user a receipt. If it's `STPPaymentStatusError`, inform the user of the error. If it's `STPPaymentStatusUserCanceled`, do nothing.
- *
- *  @param paymentContext The payment context that finished
- *  @param status         The status of the payment - `STPPaymentStatusSuccess` if it succeeded, `STPPaymentStatusError` if it failed with an error (in which case the `error` parameter will be non-nil), `STPPaymentStatusUserCanceled` if the user canceled the payment.
- *  @param error          An error that occurred, if any.
+ This is invoked by an `STPPaymentContext` when it is finished. This will be called after the payment is done and all necessary UI has been dismissed. You should inspect the returned `status` and behave appropriately. For example: if it's `STPPaymentStatusSuccess`, show the user a receipt. If it's `STPPaymentStatusError`, inform the user of the error. If it's `STPPaymentStatusUserCanceled`, do nothing.
+
+ @param paymentContext The payment context that finished
+ @param status         The status of the payment - `STPPaymentStatusSuccess` if it succeeded, `STPPaymentStatusError` if it failed with an error (in which case the `error` parameter will be non-nil), `STPPaymentStatusUserCanceled` if the user canceled the payment.
+ @param error          An error that occurred, if any.
  */
 - (void)paymentContext:(STPPaymentContext *)paymentContext
    didFinishWithStatus:(STPPaymentStatus)status
@@ -339,21 +339,21 @@ didCreatePaymentResult:(STPPaymentResult *)paymentResult
 
 @optional
 /**
- *  Inside this method, you should verify that you can ship to the given address.
- *  You should call the completion block with the results of your validation
- *  and the available shipping methods for the given address. If you don't implement
- *  this method, the user won't be prompted to select a shipping method and all
- *  addresses will be valid.
- *
- *  @note If a user updates their shipping address within the Apple Pay dialog,
- *  this address will be anonymized. For example, in the US, it will only include the
- *  city, state, and zip code. The payment context will have the user's complete
- *  shipping address by the time `paymentContext:didFinishWithStatus:error` is
- *  called.
- *
- *  @param paymentContext  The context that updated its shipping address
- *  @param address The current shipping address
- *  @param completion      Call this block when you're done validating the shipping address and calculating available shipping methods.
+ Inside this method, you should verify that you can ship to the given address.
+ You should call the completion block with the results of your validation
+ and the available shipping methods for the given address. If you don't implement
+ this method, the user won't be prompted to select a shipping method and all
+ addresses will be valid.
+
+ @note If a user updates their shipping address within the Apple Pay dialog,
+ this address will be anonymized. For example, in the US, it will only include the
+ city, state, and zip code. The payment context will have the user's complete
+ shipping address by the time `paymentContext:didFinishWithStatus:error` is
+ called.
+
+ @param paymentContext  The context that updated its shipping address
+ @param address The current shipping address
+ @param completion      Call this block when you're done validating the shipping address and calculating available shipping methods.
  */
 - (void)paymentContext:(STPPaymentContext *)paymentContext
 didUpdateShippingAddress:(STPAddress *)address

--- a/Stripe/PublicHeaders/STPPaymentContext.h
+++ b/Stripe/PublicHeaders/STPPaymentContext.h
@@ -94,57 +94,57 @@ NS_ASSUME_NONNULL_BEGIN
  `STPCustomerContext`, which will manage retrieving and updating a
  Stripe customer for you. @see STPCustomerContext.h
  */
-@property(nonatomic, readonly)id<STPBackendAPIAdapter> apiAdapter __attribute__((deprecated));
+@property (nonatomic, readonly) id<STPBackendAPIAdapter> apiAdapter __attribute__((deprecated));
 
 /**
  The configuration for the payment context to use internally. @see STPPaymentConfiguration.h
  */
-@property(nonatomic, readonly)STPPaymentConfiguration *configuration;
+@property (nonatomic, readonly) STPPaymentConfiguration *configuration;
 
 /**
  The visual appearance that will be used by any views that the context generates. @see STPTheme.h
  */
-@property(nonatomic, readonly)STPTheme *theme;
+@property (nonatomic, readonly) STPTheme *theme;
 
 /**
  If you've already collected some information from your user, you can set it here and it'll be automatically filled out when possible/appropriate in any UI that the payment context creates.
  */
-@property(nonatomic, strong, nullable)STPUserInformation *prefilledInformation;
+@property (nonatomic, strong, nullable) STPUserInformation *prefilledInformation;
 
 /**
  The view controller that any additional UI will be presented on. If you have a "checkout view controller" in your app, that should be used as the host view controller.
  */
-@property(nonatomic, weak, nullable)UIViewController *hostViewController;
+@property (nonatomic, weak, nullable) UIViewController *hostViewController;
 
 /**
  This delegate will be notified when the payment context's contents change. @see STPPaymentContextDelegate
  */
-@property(nonatomic, weak, nullable)id<STPPaymentContextDelegate> delegate;
+@property (nonatomic, weak, nullable) id<STPPaymentContextDelegate> delegate;
 
 /**
  Whether or not the payment context is currently loading information from the network.
  */
-@property(nonatomic, readonly)BOOL loading;
+@property (nonatomic, readonly) BOOL loading;
 
 /**
  The user's currently selected payment method. May be nil.
  */
-@property(nonatomic, readonly, nullable)id<STPPaymentMethod> selectedPaymentMethod;
+@property (nonatomic, readonly, nullable) id<STPPaymentMethod> selectedPaymentMethod;
 
 /**
  The available payment methods the user can choose between. May be nil.
  */
-@property(nonatomic, readonly, nullable)NSArray<id<STPPaymentMethod>> *paymentMethods;
+@property (nonatomic, readonly, nullable) NSArray<id<STPPaymentMethod>> *paymentMethods;
 
 /**
  The user's currently selected shipping method. May be nil.
  */
-@property(nonatomic, readonly, nullable)PKShippingMethod *selectedShippingMethod;
+@property (nonatomic, readonly, nullable) PKShippingMethod *selectedShippingMethod;
 
 /**
  An array of STPShippingMethod objects that describe the supported shipping methods. May be nil.
  */
-@property(nonatomic, readonly, nullable)NSArray<PKShippingMethod *> *shippingMethods;
+@property (nonatomic, readonly, nullable) NSArray<PKShippingMethod *> *shippingMethods;
 
 /**
  The user's shipping address. May be nil.
@@ -168,7 +168,7 @@ NS_ASSUME_NONNULL_BEGIN
  shipping address. To change this behavior, you can set 
  `verifyPrefilledShippingAddress` to NO in your `STPPaymentConfiguration`.
  */
-@property(nonatomic, readonly, nullable)STPAddress *shippingAddress;
+@property (nonatomic, readonly, nullable) STPAddress *shippingAddress;
 
 /**
  The amount of money you're requesting from the user, in the smallest currency 
@@ -181,7 +181,7 @@ NS_ASSUME_NONNULL_BEGIN
  @note You should only set either this or `paymentSummaryItems`, not both.
  The other will be automatically calculated on demand using your `paymentCurrency`.
  */
-@property(nonatomic)NSInteger paymentAmount;
+@property (nonatomic) NSInteger paymentAmount;
 
 /**
  The three-letter currency code for the currency of the payment (i.e. USD, GBP, 
@@ -190,7 +190,7 @@ NS_ASSUME_NONNULL_BEGIN
  @note Changing this property may change the return value of `paymentAmount` 
  or `paymentSummaryItems` (whichever one you didn't directly set yourself).
  */
-@property(nonatomic, copy)NSString *paymentCurrency;
+@property (nonatomic, copy) NSString *paymentCurrency;
 
 /**
  The two-letter country code for the country where the payment will be processed.
@@ -200,7 +200,7 @@ NS_ASSUME_NONNULL_BEGIN
  payment requests.
  @see PKPaymentRequest for more information.
  */
-@property(nonatomic, copy)NSString *paymentCountry;
+@property (nonatomic, copy) NSString *paymentCountry;
 
 /**
  If you support Apple Pay, you can optionally set the PKPaymentSummaryItems 
@@ -213,7 +213,7 @@ NS_ASSUME_NONNULL_BEGIN
  @note You should only set either this or `paymentAmount`, not both. 
  The other will be automatically calculated on demand using your `paymentCurrency.`
  */
-@property(nonatomic, copy)NSArray<PKPaymentSummaryItem *> *paymentSummaryItems;
+@property (nonatomic, copy) NSArray<PKPaymentSummaryItem *> *paymentSummaryItems;
 
 /**
  The presentation style used for all view controllers presented modally by the context.
@@ -221,7 +221,7 @@ NS_ASSUME_NONNULL_BEGIN
  `UIModalPresentationFullScreen`, `UIModalPresentationPageSheet`, or `UIModalPresentationFormSheet`.
  The default value is `UIModalPresentationFullScreen`.
  */
-@property(nonatomic, assign) UIModalPresentationStyle modalPresentationStyle;
+@property (nonatomic, assign) UIModalPresentationStyle modalPresentationStyle;
 
 /**
  If `paymentContext:didFailToLoadWithError:` is called on your delegate, you

--- a/Stripe/PublicHeaders/STPPaymentMethod.h
+++ b/Stripe/PublicHeaders/STPPaymentMethod.h
@@ -9,42 +9,42 @@
 #import <UIKit/UIKit.h>
 
 /**
- *  This represents all of the payment methods available to your user (in addition to card payments, which are always enabled) when configuring an `STPPaymentContext`.
+ This represents all of the payment methods available to your user (in addition to card payments, which are always enabled) when configuring an `STPPaymentContext`.
  */
 typedef NS_OPTIONS(NSUInteger, STPPaymentMethodType) {
     
     /**
-     *  Don't use any payment methods except for cards.
+     Don't use any payment methods except for cards.
      */
     STPPaymentMethodTypeNone = 0,
     
     /**
-     *  The user is allowed to pay with Apple Pay (if it's configured and available on their device).
+     The user is allowed to pay with Apple Pay (if it's configured and available on their device).
      */
     STPPaymentMethodTypeApplePay = 1 << 0,
     /**
-     *  The user can use any available payment method to pay.
+     The user can use any available payment method to pay.
      */
     STPPaymentMethodTypeAll = STPPaymentMethodTypeApplePay
 };
 
 /**
- *  This protocol represents a payment method that a user can select and use to pay. Currently the only classes that conform to it are `STPCard` (which represents that the user wants to pay with a specific card) and `STPApplePayPaymentMethod` (which represents that the user wants to pay with Apple Pay).
+ This protocol represents a payment method that a user can select and use to pay. Currently the only classes that conform to it are `STPCard` (which represents that the user wants to pay with a specific card) and `STPApplePayPaymentMethod` (which represents that the user wants to pay with Apple Pay).
  */
 @protocol STPPaymentMethod <NSObject>
 
 /**
- *  A small (32 x 20 points) logo image representing the payment method. For example, the Visa logo for a Visa card, or the Apple Pay logo.
+ A small (32 x 20 points) logo image representing the payment method. For example, the Visa logo for a Visa card, or the Apple Pay logo.
  */
 @property (nonatomic, readonly) UIImage *image;
 
 /**
- *  A small (32 x 20 points) logo image representing the payment method that can be used as template for tinted icons. 
+ A small (32 x 20 points) logo image representing the payment method that can be used as template for tinted icons. 
  */
 @property (nonatomic, readonly) UIImage *templateImage;
 
 /**
- *  A string describing the payment method, such as "Apple Pay" or "Visa 4242".
+ A string describing the payment method, such as "Apple Pay" or "Visa 4242".
  */
 @property (nonatomic, readonly) NSString *label;
 

--- a/Stripe/PublicHeaders/STPPaymentMethodsViewController.h
+++ b/Stripe/PublicHeaders/STPPaymentMethodsViewController.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface STPPaymentMethodsViewController : STPCoreViewController
 
-@property(nonatomic, weak, readonly)id<STPPaymentMethodsViewControllerDelegate>delegate;
+@property (nonatomic, weak, readonly) id<STPPaymentMethodsViewControllerDelegate>delegate;
 
 /**
  Creates a new payment methods view controller.
@@ -72,7 +72,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 *  If you've already collected some information from your user, you can set it here and it'll be automatically filled out when possible/appropriate in any UI that the payment context creates.
 */
-@property(nonatomic, strong, nullable)STPUserInformation *prefilledInformation;
+@property (nonatomic, strong, nullable) STPUserInformation *prefilledInformation;
 
 /**
  If you're pushing `STPPaymentMethodsViewController` onto an existing `UINavigationController`'s stack, you should use this method to dismiss it, since it may have pushed an additional add card view controller onto the navigation controller's stack.

--- a/Stripe/PublicHeaders/STPPaymentMethodsViewController.h
+++ b/Stripe/PublicHeaders/STPPaymentMethodsViewController.h
@@ -20,18 +20,18 @@ NS_ASSUME_NONNULL_BEGIN
 @class STPPaymentContext, STPPaymentMethodsViewController, STPCustomerContext;
 
 /**
- *  This view controller presents a list of payment method options to the user, which they can select between. They can also add credit cards to the list. It must be displayed inside a `UINavigationController`, so you can either create a `UINavigationController` with an `STPPaymentMethodsViewController` as the `rootViewController` and then present the `UINavigationController`, or push a new `STPPaymentMethodsViewController` onto an existing `UINavigationController`'s stack. You can also have `STPPaymentContext` do this for you automatically, by calling `presentPaymentMethodsViewController` or `pushPaymentMethodsViewController` on it.
+ This view controller presents a list of payment method options to the user, which they can select between. They can also add credit cards to the list. It must be displayed inside a `UINavigationController`, so you can either create a `UINavigationController` with an `STPPaymentMethodsViewController` as the `rootViewController` and then present the `UINavigationController`, or push a new `STPPaymentMethodsViewController` onto an existing `UINavigationController`'s stack. You can also have `STPPaymentContext` do this for you automatically, by calling `presentPaymentMethodsViewController` or `pushPaymentMethodsViewController` on it.
  */
 @interface STPPaymentMethodsViewController : STPCoreViewController
 
 @property(nonatomic, weak, readonly)id<STPPaymentMethodsViewControllerDelegate>delegate;
 
 /**
- *  Creates a new payment methods view controller.
- *
- *  @param paymentContext A payment context to power the view controller's view. The payment context will in turn use its backend API adapter to fetch the information it needs from your application.
- *
- *  @return an initialized view controller.
+ Creates a new payment methods view controller.
+
+ @param paymentContext A payment context to power the view controller's view. The payment context will in turn use its backend API adapter to fetch the information it needs from your application.
+
+ @return an initialized view controller.
  */
 - (instancetype)initWithPaymentContext:(STPPaymentContext *)paymentContext;
 
@@ -52,17 +52,17 @@ NS_ASSUME_NONNULL_BEGIN
                              delegate:(id<STPPaymentMethodsViewControllerDelegate>)delegate;
 
 /**
- *  Initializes a new payment methods view controller without using a payment context.
- *
- *  @param configuration The configuration to use to determine what types of payment method to offer your user. @see STPPaymentConfiguration.h
- *  @param theme         The theme to inform the appearance of the UI. @see STPTheme.h
- *  @param apiAdapter    The API adapter to use to retrieve a customer's stored payment methods and save new ones. @see STPBackendAPIAdapter.h
- *  @param delegate      A delegate that will be notified when the payment methods view controller's selection changes.
- *
- *  @deprecated Use `initWithConfiguration:theme:customerContext:delegate:`.
- *  Instead of providing your own backend API adapter, you can now create an
- *  `STPCustomerContext`, which will manage retrieving and updating a
- *  Stripe customer for you. @see STPCustomerContext.h
+ Initializes a new payment methods view controller without using a payment context.
+
+ @param configuration The configuration to use to determine what types of payment method to offer your user. @see STPPaymentConfiguration.h
+ @param theme         The theme to inform the appearance of the UI. @see STPTheme.h
+ @param apiAdapter    The API adapter to use to retrieve a customer's stored payment methods and save new ones. @see STPBackendAPIAdapter.h
+ @param delegate      A delegate that will be notified when the payment methods view controller's selection changes.
+
+ @deprecated Use `initWithConfiguration:theme:customerContext:delegate:`.
+ Instead of providing your own backend API adapter, you can now create an
+ `STPCustomerContext`, which will manage retrieving and updating a
+ Stripe customer for you. @see STPCustomerContext.h
  */
 - (instancetype)initWithConfiguration:(STPPaymentConfiguration *)configuration
                                 theme:(STPTheme *)theme
@@ -75,49 +75,49 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, strong, nullable)STPUserInformation *prefilledInformation;
 
 /**
- *  If you're pushing `STPPaymentMethodsViewController` onto an existing `UINavigationController`'s stack, you should use this method to dismiss it, since it may have pushed an additional add card view controller onto the navigation controller's stack.
- *
- *  @param completion The callback to run after the view controller is dismissed. You may specify nil for this parameter.
+ If you're pushing `STPPaymentMethodsViewController` onto an existing `UINavigationController`'s stack, you should use this method to dismiss it, since it may have pushed an additional add card view controller onto the navigation controller's stack.
+
+ @param completion The callback to run after the view controller is dismissed. You may specify nil for this parameter.
  */
 - (void)dismissWithCompletion:(nullable STPVoidBlock)completion;
 
 @end
 
 /**
- *  An `STPPaymentMethodsViewControllerDelegate` responds when a user selects a payment method from (or cancels) an `STPPaymentMethodsViewController`. In both of these instances, you should dismiss the view controller (either by popping it off the navigation stack, or dismissing it).
+ An `STPPaymentMethodsViewControllerDelegate` responds when a user selects a payment method from (or cancels) an `STPPaymentMethodsViewController`. In both of these instances, you should dismiss the view controller (either by popping it off the navigation stack, or dismissing it).
  */
 @protocol STPPaymentMethodsViewControllerDelegate <NSObject>
 
 /**
- *  This is called when the view controller encounters an error fetching the user's payment methods from its API adapter. You should dismiss the view controller when this is called.
- *
- *  @param paymentMethodsViewController the view controller in question
- *  @param error                        the error that occurred
+ This is called when the view controller encounters an error fetching the user's payment methods from its API adapter. You should dismiss the view controller when this is called.
+
+ @param paymentMethodsViewController the view controller in question
+ @param error                        the error that occurred
  */
 - (void)paymentMethodsViewController:(STPPaymentMethodsViewController *)paymentMethodsViewController
               didFailToLoadWithError:(NSError *)error;
 
 /**
- *  This is called when the user selects or adds a payment method, so it will often be called immediately after calling `paymentMethodsViewController:didSelectPaymentMethod:`. You should dismiss the view controller when this is called.
- *
- *  @param paymentMethodsViewController the view controller that has finished
+ This is called when the user selects or adds a payment method, so it will often be called immediately after calling `paymentMethodsViewController:didSelectPaymentMethod:`. You should dismiss the view controller when this is called.
+
+ @param paymentMethodsViewController the view controller that has finished
  */
 - (void)paymentMethodsViewControllerDidFinish:(STPPaymentMethodsViewController *)paymentMethodsViewController;
 
 /**
- *  This is called when the user taps "cancel".
- *  You should dismiss the view controller when this is called.
- *
- *  @param paymentMethodsViewController the view controller that has finished
+ This is called when the user taps "cancel".
+ You should dismiss the view controller when this is called.
+
+ @param paymentMethodsViewController the view controller that has finished
  */
 - (void)paymentMethodsViewControllerDidCancel:(STPPaymentMethodsViewController *)paymentMethodsViewController;
 
 @optional
 /**
- *  This is called when the user either makes a selection, or adds a new card. This will be triggered after the view controller loads with the user's current selection (if they have one) and then subsequently when they change their choice. You should use this callback to update any necessary UI in your app that displays the user's currently selected payment method. You should *not* dismiss the view controller at this point, instead do this in `paymentMethodsViewControllerDidFinish:`. `STPPaymentMethodsViewController` will also call the necessary methods on your API adapter, so you don't need to call them directly during this method.
- *
- *  @param paymentMethodsViewController the view controller in question
- *  @param paymentMethod                the selected payment method
+ This is called when the user either makes a selection, or adds a new card. This will be triggered after the view controller loads with the user's current selection (if they have one) and then subsequently when they change their choice. You should use this callback to update any necessary UI in your app that displays the user's currently selected payment method. You should *not* dismiss the view controller at this point, instead do this in `paymentMethodsViewControllerDidFinish:`. `STPPaymentMethodsViewController` will also call the necessary methods on your API adapter, so you don't need to call them directly during this method.
+
+ @param paymentMethodsViewController the view controller in question
+ @param paymentMethod                the selected payment method
  */
 - (void)paymentMethodsViewController:(STPPaymentMethodsViewController *)paymentMethodsViewController
               didSelectPaymentMethod:(id<STPPaymentMethod>)paymentMethod;

--- a/Stripe/PublicHeaders/STPPaymentResult.h
+++ b/Stripe/PublicHeaders/STPPaymentResult.h
@@ -14,17 +14,17 @@ NS_ASSUME_NONNULL_BEGIN
 @class STPAddress;
 
 /**
- *  When you're using `STPPaymentContext` to request your user's payment details, this is the object that will be returned to your application when they've successfully made a payment. It currently just contains a `source`, but in the future will include any relevant metadata as well. You should pass `source.stripeID` to your server, and call the charge creation endpoint. This assumes you are charging a Customer, so you should specify the `customer` parameter to be that customer's ID and the `source` parameter to the value returned here. For more information, see https://stripe.com/docs/api#create_charge
+ When you're using `STPPaymentContext` to request your user's payment details, this is the object that will be returned to your application when they've successfully made a payment. It currently just contains a `source`, but in the future will include any relevant metadata as well. You should pass `source.stripeID` to your server, and call the charge creation endpoint. This assumes you are charging a Customer, so you should specify the `customer` parameter to be that customer's ID and the `source` parameter to the value returned here. For more information, see https://stripe.com/docs/api#create_charge
  */
 @interface STPPaymentResult : NSObject
 
 /**
- *  The returned source that the user has selected. This may come from a variety of different payment methods, such as an Apple Pay payment or a stored credit card. @see STPSource.h
+ The returned source that the user has selected. This may come from a variety of different payment methods, such as an Apple Pay payment or a stored credit card. @see STPSource.h
  */
 @property(nonatomic, readonly)id<STPSourceProtocol> source;
 
 /**
- *  Initializes the payment result with a given source. This is invoked by `STPPaymentContext` internally; you shouldn't have to call it directly.
+ Initializes the payment result with a given source. This is invoked by `STPPaymentContext` internally; you shouldn't have to call it directly.
  */
 - (nonnull instancetype)initWithSource:(id<STPSourceProtocol>)source;
 

--- a/Stripe/PublicHeaders/STPPaymentResult.h
+++ b/Stripe/PublicHeaders/STPPaymentResult.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  The returned source that the user has selected. This may come from a variety of different payment methods, such as an Apple Pay payment or a stored credit card. @see STPSource.h
  */
-@property(nonatomic, readonly)id<STPSourceProtocol> source;
+@property (nonatomic, readonly) id<STPSourceProtocol> source;
 
 /**
  Initializes the payment result with a given source. This is invoked by `STPPaymentContext` internally; you shouldn't have to call it directly.

--- a/Stripe/PublicHeaders/STPRedirectContext.h
+++ b/Stripe/PublicHeaders/STPRedirectContext.h
@@ -42,122 +42,122 @@ typedef NS_ENUM(NSUInteger, STPRedirectContextState) {
 typedef void (^STPRedirectContextCompletionBlock)(NSString *sourceID, NSString *clientSecret, NSError *error);
 
 /**
- *  This is a helper class for handling redirect sources.
- *
- *  Init an instance with the redirect flow source you want to handle,
- *  then choose a redirect method. The context will fire the completion handler
- *  when the redirect completes.
- *
- *  Due to the nature of iOS, very little concrete information can be gained
- *  during this process, as all actions take place in either the Safari app
- *  or the sandboxed SFSafariViewController class. The context attempts to 
- *  detect when the user has completed the necessary redirect action by listening
- *  for both app foregrounds and url callbacks received in the app delegate.
- *  However, it is possible the when the redirect is "completed", the user may
- *  have not actually completed the necessary actions to authorize the charge.
- *
- *  You can use `STPAPIClient` to listen for state changes on the source
- *  object as a way to identify whether the user action succeeded or not.
- *  @see `[STPAPIClient startPollingSourceWithId:clientSecret:timeout:completion:]`
- *
- *  You should not use either this class, nor `STPAPIClient`, as a way
- *  to determine when you should charge the source. Use Stripe webhooks on your
- *  backend server to listen for source state changes and to make the charge.
- *
+ This is a helper class for handling redirect sources.
+
+ Init an instance with the redirect flow source you want to handle,
+ then choose a redirect method. The context will fire the completion handler
+ when the redirect completes.
+
+ Due to the nature of iOS, very little concrete information can be gained
+ during this process, as all actions take place in either the Safari app
+ or the sandboxed SFSafariViewController class. The context attempts to 
+ detect when the user has completed the necessary redirect action by listening
+ for both app foregrounds and url callbacks received in the app delegate.
+ However, it is possible the when the redirect is "completed", the user may
+ have not actually completed the necessary actions to authorize the charge.
+
+ You can use `STPAPIClient` to listen for state changes on the source
+ object as a way to identify whether the user action succeeded or not.
+ @see `[STPAPIClient startPollingSourceWithId:clientSecret:timeout:completion:]`
+
+ You should not use either this class, nor `STPAPIClient`, as a way
+ to determine when you should charge the source. Use Stripe webhooks on your
+ backend server to listen for source state changes and to make the charge.
+
  */
 NS_EXTENSION_UNAVAILABLE("Redirect based sources are not available in extensions")
 @interface STPRedirectContext : NSObject
 
 /**
- *  The current state of the context.
+ The current state of the context.
  */
 @property (nonatomic, readonly) STPRedirectContextState state;
 
 /**
- *  Initializer for context.
- *
- *  @note You must ensure that the returnURL set up in the created source
- *  correctly goes to your app so that users can be returned once
- *  they complete the redirect in the web broswer.
- *
- *  @param source The source that needs user redirect action to be taken.
- *  @param completion A block to fire when the action is believed to have been completed.
- *  @return Nil if the specified source is not a redirect-flow source. Otherwise a new context object.
- *  
- *  @note Firing of the completion block does not necessarily mean the user successfully
- *  performed the redirect action. You can re-fetch the source object using
- *  its id and clientSecret, and poll for status updates on it to determine if
- *  the source was sucessfully made chargeable.
- *  @see `[STPAPIClient startPollingSourceWithId:clientSecret:timeout:completion:]`
+ Initializer for context.
+
+ @note You must ensure that the returnURL set up in the created source
+ correctly goes to your app so that users can be returned once
+ they complete the redirect in the web broswer.
+
+ @param source The source that needs user redirect action to be taken.
+ @param completion A block to fire when the action is believed to have been completed.
+ @return Nil if the specified source is not a redirect-flow source. Otherwise a new context object.
+
+ @note Firing of the completion block does not necessarily mean the user successfully
+ performed the redirect action. You can re-fetch the source object using
+ its id and clientSecret, and poll for status updates on it to determine if
+ the source was sucessfully made chargeable.
+ @see `[STPAPIClient startPollingSourceWithId:clientSecret:timeout:completion:]`
  */
 - (nullable instancetype)initWithSource:(STPSource *)source
                              completion:(STPRedirectContextCompletionBlock)completion;
 
 
 /**
- * Use `initWithSource:completion:`
+ Use `initWithSource:completion:`
  */
 - (instancetype)init NS_UNAVAILABLE;
 
 
 /**
- *  Starts a redirect flow.
- *
- *  You must ensure that your app delegate listens for  the `returnURL` that you
- *  set on your source object, and forwards it to the Stripe SDK so that the
- *  context can be notified when the redirect is completed and dismiss the
- *  view controller. See `[Stripe handleStripeURLCallbackWithURL:]`
- *
- *  The context will listen for both received URLs and app open notifications
- *  and fire its completion block when either the URL is received, or the next
- *  time the app is foregrounded.
+ Starts a redirect flow.
 
- *  If the app is running on iOS 9+ it will initiate the flow by presenting
- *  a SFSafariViewController instance from the pass in view controller.
- *  Otherwise, if the app is running on iOS 8 it will initiate the flow by
- *  bouncing the user out to the Safari app. If you want more manual control 
- *  over the redirect method, you can use `startSafariViewControllerRedirectFlowFromViewController`
- *  or `startSafariAppRedirectFlow`
- *
- *  @note This method does nothing if the context is not in the `STPRedirectContextStateNotStarted` state.
- *
- *  @param presentingViewController The view controller to present the Safari view controller from.
+ You must ensure that your app delegate listens for  the `returnURL` that you
+ set on your source object, and forwards it to the Stripe SDK so that the
+ context can be notified when the redirect is completed and dismiss the
+ view controller. See `[Stripe handleStripeURLCallbackWithURL:]`
+
+ The context will listen for both received URLs and app open notifications
+ and fire its completion block when either the URL is received, or the next
+ time the app is foregrounded.
+
+ If the app is running on iOS 9+ it will initiate the flow by presenting
+ a SFSafariViewController instance from the pass in view controller.
+ Otherwise, if the app is running on iOS 8 it will initiate the flow by
+ bouncing the user out to the Safari app. If you want more manual control 
+ over the redirect method, you can use `startSafariViewControllerRedirectFlowFromViewController`
+ or `startSafariAppRedirectFlow`
+
+ @note This method does nothing if the context is not in the `STPRedirectContextStateNotStarted` state.
+
+ @param presentingViewController The view controller to present the Safari view controller from.
  */
 - (void)startRedirectFlowFromViewController:(UIViewController *)presentingViewController;
 
 /**
- *  Starts a redirect flow by presenting an SFSafariViewController in your app
- *  from the passed in view controller.
- *
- *  You must ensure that your app delegate listens for  the `returnURL` that you
- *  set on your source object, and forwards it to the Stripe SDK so that the
- *  context can be notified when the redirect is completed and dismiss the
- *  view controller. See `[Stripe handleStripeURLCallbackWithURL:]`
- *
- *  The context will listen for both received URLs and app open notifications 
- *  and fire its completion block when either the URL is received, or the next
- *  time the app is foregrounded.
- *
- *  @note This method does nothing if the context is not in the `STPRedirectContextStateNotStarted` state.
- *
- *  @param presentingViewController The view controller to present the Safari view controller from.
+ Starts a redirect flow by presenting an SFSafariViewController in your app
+ from the passed in view controller.
+
+ You must ensure that your app delegate listens for  the `returnURL` that you
+ set on your source object, and forwards it to the Stripe SDK so that the
+ context can be notified when the redirect is completed and dismiss the
+ view controller. See `[Stripe handleStripeURLCallbackWithURL:]`
+
+ The context will listen for both received URLs and app open notifications 
+ and fire its completion block when either the URL is received, or the next
+ time the app is foregrounded.
+
+ @note This method does nothing if the context is not in the `STPRedirectContextStateNotStarted` state.
+
+ @param presentingViewController The view controller to present the Safari view controller from.
  */
 - (void)startSafariViewControllerRedirectFlowFromViewController:(UIViewController *)presentingViewController NS_AVAILABLE_IOS(9_0);
 
 /**
- *  Starts a redirect flow by calling `openURL` to bounce the user out to
- *  the Safari app.
- *
- *  The context will listen for app open notifications and fire its completion
- *  block the next time the user re-opens the app (either manually or via url)
- *
- *  @note This method does nothing if the context is not in the `STPRedirectContextStateNotStarted` state.
+ Starts a redirect flow by calling `openURL` to bounce the user out to
+ the Safari app.
+
+ The context will listen for app open notifications and fire its completion
+ block the next time the user re-opens the app (either manually or via url)
+
+ @note This method does nothing if the context is not in the `STPRedirectContextStateNotStarted` state.
  */
 - (void)startSafariAppRedirectFlow;
 
 /**
- *  Dismisses any presented views and stops listening for any
- *  app opens or callbacks. The completion block will not be fired.
+ Dismisses any presented views and stops listening for any
+ app opens or callbacks. The completion block will not be fired.
  */
 - (void)cancel;
 

--- a/Stripe/PublicHeaders/STPShippingAddressViewController.h
+++ b/Stripe/PublicHeaders/STPShippingAddressViewController.h
@@ -21,26 +21,26 @@ NS_ASSUME_NONNULL_BEGIN
 @interface STPShippingAddressViewController : STPCoreTableViewController
 
 /**
- *  A convenience initializer; equivalent to calling `initWithConfiguration:[STPPaymentConfiguration sharedConfiguration] theme:[STPTheme defaultTheme] currency:nil shippingAddress:nil selectedShippingMethod:nil prefilledInformation:nil`.
+ A convenience initializer; equivalent to calling `initWithConfiguration:[STPPaymentConfiguration sharedConfiguration] theme:[STPTheme defaultTheme] currency:nil shippingAddress:nil selectedShippingMethod:nil prefilledInformation:nil`.
  */
 - (instancetype)init;
 
 /**
- *  Initializes a new `STPShippingAddressViewController` with the given payment context and sets the payment context as its delegate.
- *
- *  @param paymentContext The payment context to use.
+ Initializes a new `STPShippingAddressViewController` with the given payment context and sets the payment context as its delegate.
+
+ @param paymentContext The payment context to use.
  */
 - (instancetype)initWithPaymentContext:(STPPaymentContext *)paymentContext;
 
 /**
- *  Initializes a new `STPShippingAddressCardViewController` with the provided parameters.
- *
- *  @param configuration             The configuration to use (this determines the required shipping address fields and shipping type). @see STPPaymentConfiguration
- *  @param theme                     The theme to use to inform the view controller's visual appearance. @see STPTheme
- *  @param currency                  The currency to use when displaying amounts for shipping methods. The default is USD.
- *  @param shippingAddress           If set, the shipping address view controller will be pre-filled with this address. @see STPAddress
- *  @param selectedShippingMethod    If set, the shipping methods view controller will use this method as the selected shipping method. If `selectedShippingMethod` is nil, the first shipping method in the array of methods returned by your delegate will be selected.
- *  @param prefilledInformation      If set, the shipping address view controller will be pre-filled with this information. @see STPUserInformation
+ Initializes a new `STPShippingAddressCardViewController` with the provided parameters.
+
+ @param configuration             The configuration to use (this determines the required shipping address fields and shipping type). @see STPPaymentConfiguration
+ @param theme                     The theme to use to inform the view controller's visual appearance. @see STPTheme
+ @param currency                  The currency to use when displaying amounts for shipping methods. The default is USD.
+ @param shippingAddress           If set, the shipping address view controller will be pre-filled with this address. @see STPAddress
+ @param selectedShippingMethod    If set, the shipping methods view controller will use this method as the selected shipping method. If `selectedShippingMethod` is nil, the first shipping method in the array of methods returned by your delegate will be selected.
+ @param prefilledInformation      If set, the shipping address view controller will be pre-filled with this information. @see STPUserInformation
  */
 - (instancetype)initWithConfiguration:(STPPaymentConfiguration *)configuration
                                 theme:(STPTheme *)theme
@@ -50,48 +50,48 @@ NS_ASSUME_NONNULL_BEGIN
                  prefilledInformation:(nullable STPUserInformation *)prefilledInformation;
 
 /**
- *  The view controller's delegate. This must be set before showing the view controller in order for it to work properly. @see STPShippingAddressViewControllerDelegate
+ The view controller's delegate. This must be set before showing the view controller in order for it to work properly. @see STPShippingAddressViewControllerDelegate
  */
 @property(nonatomic, weak) id<STPShippingAddressViewControllerDelegate> delegate;
 
 /**
- *  If you're pushing `STPShippingAddressViewController` onto an existing `UINavigationController`'s stack, you should use this method to dismiss it, since it may have pushed an additional shipping method view controller onto the navigation controller's stack.
- *
- *  @param completion The callback to run after the view controller is dismissed. You may specify nil for this parameter.
+ If you're pushing `STPShippingAddressViewController` onto an existing `UINavigationController`'s stack, you should use this method to dismiss it, since it may have pushed an additional shipping method view controller onto the navigation controller's stack.
+
+ @param completion The callback to run after the view controller is dismissed. You may specify nil for this parameter.
  */
 - (void)dismissWithCompletion:(nullable STPVoidBlock)completion;
 
 @end
 
 /**
- *  An `STPShippingAddressViewControllerDelegate` is notified when an `STPShippingAddressViewController` receives an address, completes with an address, or is cancelled.
+ An `STPShippingAddressViewControllerDelegate` is notified when an `STPShippingAddressViewController` receives an address, completes with an address, or is cancelled.
  */
 @protocol STPShippingAddressViewControllerDelegate <NSObject>
 
 /**
- *  Called when the user cancels entering a shipping address. You should dismiss (or pop) the view controller at this point.
- *
- *  @param addressViewController the view controller that has been cancelled
+ Called when the user cancels entering a shipping address. You should dismiss (or pop) the view controller at this point.
+
+ @param addressViewController the view controller that has been cancelled
  */
 - (void)shippingAddressViewControllerDidCancel:(STPShippingAddressViewController *)addressViewController;
 
 /**
- *  This is called when the user enters a shipping address and taps next. You should validate the address and determine what shipping methods are available, and call the `completion` block when finished. If an error occurrs, call the `completion` block with the error. Otherwise, call the `completion` block with a nil error and an array of available shipping methods. If you don't need to collect a shipping method, you may pass an empty array.
- *
- *  @param addressViewController the view controller where the address was entered
- *  @param address               the address that was entered. @see STPAddress
- *  @param completion            call this callback when you're done validating the address and determining available shipping methods.
+ This is called when the user enters a shipping address and taps next. You should validate the address and determine what shipping methods are available, and call the `completion` block when finished. If an error occurrs, call the `completion` block with the error. Otherwise, call the `completion` block with a nil error and an array of available shipping methods. If you don't need to collect a shipping method, you may pass an empty array.
+
+ @param addressViewController the view controller where the address was entered
+ @param address               the address that was entered. @see STPAddress
+ @param completion            call this callback when you're done validating the address and determining available shipping methods.
  */
 - (void)shippingAddressViewController:(STPShippingAddressViewController *)addressViewController
                       didEnterAddress:(STPAddress *)address
                            completion:(STPShippingMethodsCompletionBlock)completion;
 
 /**
- *  This is called when the user selects a shipping method. If no shipping methods are given, or if the shipping type doesn't require a shipping method, this will be called after the user has a shipping address and your validation has succeeded. After updating your app with the user's shipping info, you should dismiss (or pop) the view controller. Note that if `shippingMethod` is non-nil, there will be an additional shipping methods view controller on the navigation controller's stack.
- *
- *  @param addressViewController the view controller where the address was entered
- *  @param address               the address that was entered. @see STPAddress
- *  @param method        the shipping method that was selected.
+ This is called when the user selects a shipping method. If no shipping methods are given, or if the shipping type doesn't require a shipping method, this will be called after the user has a shipping address and your validation has succeeded. After updating your app with the user's shipping info, you should dismiss (or pop) the view controller. Note that if `shippingMethod` is non-nil, there will be an additional shipping methods view controller on the navigation controller's stack.
+
+ @param addressViewController the view controller where the address was entered
+ @param address               the address that was entered. @see STPAddress
+ @param method        the shipping method that was selected.
  */
 - (void)shippingAddressViewController:(STPShippingAddressViewController *)addressViewController
                  didFinishWithAddress:(STPAddress *)address

--- a/Stripe/PublicHeaders/STPShippingAddressViewController.h
+++ b/Stripe/PublicHeaders/STPShippingAddressViewController.h
@@ -52,7 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  The view controller's delegate. This must be set before showing the view controller in order for it to work properly. @see STPShippingAddressViewControllerDelegate
  */
-@property(nonatomic, weak) id<STPShippingAddressViewControllerDelegate> delegate;
+@property (nonatomic, weak) id<STPShippingAddressViewControllerDelegate> delegate;
 
 /**
  If you're pushing `STPShippingAddressViewController` onto an existing `UINavigationController`'s stack, you should use this method to dismiss it, since it may have pushed an additional shipping method view controller onto the navigation controller's stack.

--- a/Stripe/PublicHeaders/STPSource.h
+++ b/Stripe/PublicHeaders/STPSource.h
@@ -17,7 +17,7 @@
 #import "STPSourceVerification.h"
 
 /**
- *  Authentication flows for a Source
+ Authentication flows for a Source
  */
 typedef NS_ENUM(NSInteger, STPSourceFlow) {
     // No action is required from your customer.
@@ -33,7 +33,7 @@ typedef NS_ENUM(NSInteger, STPSourceFlow) {
 };
 
 /**
- *  Usage types for a Source
+ Usage types for a Source
  */
 typedef NS_ENUM(NSInteger, STPSourceUsage) {
     // The source can be reused.
@@ -45,7 +45,7 @@ typedef NS_ENUM(NSInteger, STPSourceUsage) {
 };
 
 /**
- *  Status types for a Source
+ Status types for a Source
  */
 typedef NS_ENUM(NSInteger, STPSourceStatus) {
     // The source has been created and is awaiting customer action.
@@ -63,7 +63,7 @@ typedef NS_ENUM(NSInteger, STPSourceStatus) {
 };
 
 /**
- *  Types for a Source
+ Types for a Source
  */
 typedef NS_ENUM(NSInteger, STPSourceType) {
     STPSourceTypeBancontact,
@@ -81,99 +81,99 @@ typedef NS_ENUM(NSInteger, STPSourceType) {
 @class STPSourceOwner, STPSourceReceiver, STPSourceRedirect, STPSourceVerification;
 
 /**
- *  Representation of a customer's payment instrument created with the Stripe API. @see https://stripe.com/docs/api#sources
+ Representation of a customer's payment instrument created with the Stripe API. @see https://stripe.com/docs/api#sources
  */
 @interface STPSource : NSObject<STPAPIResponseDecodable, STPSourceProtocol>
 
 /**
- *  You cannot directly instantiate an `STPSource`. You should only use one that has been returned from an `STPAPIClient` callback.
+ You cannot directly instantiate an `STPSource`. You should only use one that has been returned from an `STPAPIClient` callback.
  */
 - (nonnull instancetype) init __attribute__((unavailable("You cannot directly instantiate an STPSource. You should only use one that has been returned from an STPAPIClient callback.")));
 
 /**
- *  The amount associated with the source.
+ The amount associated with the source.
  */
 @property (nonatomic, readonly, nullable) NSNumber *amount;
 
 /**
- *  The client secret of the source. Used for client-side polling using a publishable key.
+ The client secret of the source. Used for client-side polling using a publishable key.
  */
 @property (nonatomic, readonly, nullable) NSString *clientSecret;
 
 /**
- *  When the source was created.
+ When the source was created.
  */
 @property (nonatomic, readonly, nullable) NSDate *created;
 
 /**
- *  The currency associated with the source.
+ The currency associated with the source.
  */
 @property (nonatomic, readonly, nullable) NSString *currency;
 
 /**
- *  The authentication flow of the source.
+ The authentication flow of the source.
  */
 @property (nonatomic, readonly) STPSourceFlow flow;
 
 /**
- *  Whether or not this source was created in livemode.
+ Whether or not this source was created in livemode.
  */
 @property (nonatomic, readonly) BOOL livemode;
 
 /**
- *  A set of key/value pairs associated with the source object.
+ A set of key/value pairs associated with the source object.
  */
 @property (nonatomic, readonly, nullable) NSDictionary *metadata;
 
 /**
- *  Information about the owner of the payment instrument.
+ Information about the owner of the payment instrument.
  */
 @property (nonatomic, readonly, nullable) STPSourceOwner *owner;
 
 /**
- *  Information related to the receiver flow. Present if the source is a receiver.
+ Information related to the receiver flow. Present if the source is a receiver.
  */
 @property (nonatomic, readonly, nullable) STPSourceReceiver *receiver;
 
 /**
- *  Information related to the redirect flow. Present if the source is authenticated by a redirect.
+ Information related to the redirect flow. Present if the source is authenticated by a redirect.
  */
 @property (nonatomic, readonly, nullable) STPSourceRedirect *redirect;
 
 /**
- *  The status of the source.
+ The status of the source.
  */
 @property (nonatomic, readonly) STPSourceStatus status;
 
 /**
- *  The type of the source.
+ The type of the source.
  */
 @property (nonatomic, readonly) STPSourceType type;
 
 /**
- *   Whether this source should be reusable or not.
+  Whether this source should be reusable or not.
  */
 @property (nonatomic, readonly) STPSourceUsage usage;
 
 /**
- *  Information related to the verification flow. Present if the source is authenticated by a verification.
+ Information related to the verification flow. Present if the source is authenticated by a verification.
  */
 @property (nonatomic, readonly, nullable) STPSourceVerification *verification;
 
 /**
- *  Information about the source specific to its type
+ Information about the source specific to its type
  */
 @property (nonatomic, readonly, nullable) NSDictionary *details;
 
 /**
- *  If this is a card source, this property provides typed access to the
- *  contents of the `details` dictionary.
+ If this is a card source, this property provides typed access to the
+ contents of the `details` dictionary.
  */
 @property (nonatomic, readonly, nullable) STPSourceCardDetails *cardDetails;
 
 /**
- *  If this is a SEPA Debit source, this property provides typed access to the
- *  contents of the `details` dictionary.
+ If this is a SEPA Debit source, this property provides typed access to the
+ contents of the `details` dictionary.
  */
 @property (nonatomic, readonly, nullable) STPSourceSEPADebitDetails *sepaDebitDetails;
 

--- a/Stripe/PublicHeaders/STPSourceCardDetails.h
+++ b/Stripe/PublicHeaders/STPSourceCardDetails.h
@@ -21,49 +21,49 @@ typedef NS_ENUM(NSInteger, STPSourceCard3DSecureStatus) {
 };
 
 /**
- *  This class provides typed access to the contents of an STPSource `details`
- *  dictionary for card sources.
+ This class provides typed access to the contents of an STPSource `details`
+ dictionary for card sources.
  */
 @interface STPSourceCardDetails : NSObject <STPAPIResponseDecodable>
 
 /**
- *  You cannot directly instantiate an `STPSourceCardDetails`. You should only 
- *  use one that is part of an existing `STPSource` object.
+ You cannot directly instantiate an `STPSourceCardDetails`. You should only 
+ use one that is part of an existing `STPSource` object.
  */
 - (nonnull instancetype) init __attribute__((unavailable("You cannot directly instantiate an STPSourceCardDetails. You should only use one that is part of an existing STPSource object.")));
 
 /**
- *  The last 4 digits of the card.
+ The last 4 digits of the card.
  */
 @property (nonatomic, readonly, nullable) NSString *last4;
 
 /**
- *  The card's expiration month. 1-indexed (i.e. 1 == January)
+ The card's expiration month. 1-indexed (i.e. 1 == January)
  */
 @property (nonatomic, readonly) NSUInteger expMonth;
 
 /**
- *  The card's expiration year.
+ The card's expiration year.
  */
 @property (nonatomic, readonly) NSUInteger expYear;
 
 /**
- *  The issuer of the card.
+ The issuer of the card.
  */
 @property (nonatomic, readonly) STPCardBrand brand;
 
 /**
- *  The funding source for the card (credit, debit, prepaid, or other)
+ The funding source for the card (credit, debit, prepaid, or other)
  */
 @property (nonatomic, readonly) STPCardFundingType funding;
 
 /**
- *  Two-letter ISO code representing the issuing country of the card.
+ Two-letter ISO code representing the issuing country of the card.
  */
 @property (nonatomic, readonly, nullable) NSString *country;
 
 /**
- *  Whether 3D Secure is supported or required by the card.
+ Whether 3D Secure is supported or required by the card.
  */
 @property (nonatomic, readonly) STPSourceCard3DSecureStatus threeDSecure;
 

--- a/Stripe/PublicHeaders/STPSourceOwner.h
+++ b/Stripe/PublicHeaders/STPSourceOwner.h
@@ -13,52 +13,52 @@
 @class STPAddress;
 
 /**
- *  Information about a source's owner.
+ Information about a source's owner.
  */
 @interface STPSourceOwner : NSObject<STPAPIResponseDecodable>
 
 /**
- *  You cannot directly instantiate an `STPSourceOwner`. You should only use one that is part of an existing `STPSource` object.
+ You cannot directly instantiate an `STPSourceOwner`. You should only use one that is part of an existing `STPSource` object.
  */
 - (nonnull instancetype) init __attribute__((unavailable("You cannot directly instantiate an STPSourceOwner. You should only use one that is part of an existing STPSource object.")));
 
 /**
- *  Owner's address.
+ Owner's address.
  */
 @property (nonatomic, readonly, nullable) STPAddress *address;
 
 /**
- *  Owner's email address.
+ Owner's email address.
  */
 @property (nonatomic, readonly, nullable) NSString *email;
 
 /**
- *  Owner's full name.
+ Owner's full name.
  */
 @property (nonatomic, readonly, nullable) NSString *name;
 
 /**
- *  Owner's phone number.
+ Owner's phone number.
  */
 @property (nonatomic, readonly, nullable) NSString *phone;
 
 /**
- *  Verified owner's address.
+ Verified owner's address.
  */
 @property (nonatomic, readonly, nullable) STPAddress *verifiedAddress;
 
 /**
- *  Verified owner's email address.
+ Verified owner's email address.
  */
 @property (nonatomic, readonly, nullable) NSString *verifiedEmail;
 
 /**
- *  Verified owner's full name.
+ Verified owner's full name.
  */
 @property (nonatomic, readonly, nullable) NSString *verifiedName;
 
 /**
- *  Verified owner's phone number.
+ Verified owner's phone number.
  */
 @property (nonatomic, readonly, nullable) NSString *verifiedPhone;
 

--- a/Stripe/PublicHeaders/STPSourceProtocol.h
+++ b/Stripe/PublicHeaders/STPSourceProtocol.h
@@ -10,13 +10,13 @@
 #import <UIKit/UIKit.h>
 
 /**
- *  Objects conforming to this protocol can be attached to a Stripe Customer object as a payment source.
- *  @see https://stripe.com/docs/api#customer_object-sources
+ Objects conforming to this protocol can be attached to a Stripe Customer object as a payment source.
+ @see https://stripe.com/docs/api#customer_object-sources
  */
 @protocol STPSourceProtocol <NSObject>
 
 /**
- *  The stripe ID of the source.
+ The stripe ID of the source.
  */
 @property(nonatomic, readonly, copy, nonnull)NSString *stripeID;
 

--- a/Stripe/PublicHeaders/STPSourceProtocol.h
+++ b/Stripe/PublicHeaders/STPSourceProtocol.h
@@ -18,6 +18,6 @@
 /**
  The stripe ID of the source.
  */
-@property(nonatomic, readonly, copy, nonnull)NSString *stripeID;
+@property (nonatomic, readonly, copy, nonnull) NSString *stripeID;
 
 @end

--- a/Stripe/PublicHeaders/STPSourceReceiver.h
+++ b/Stripe/PublicHeaders/STPSourceReceiver.h
@@ -10,32 +10,32 @@
 #import "STPAPIResponseDecodable.h"
 
 /**
- *  Information related to a source's receiver flow.
+ Information related to a source's receiver flow.
  */
 @interface STPSourceReceiver : NSObject<STPAPIResponseDecodable>
 
 /**
- *  You cannot directly instantiate an `STPSourceReceiver`. You should only use one that is part of an existing `STPSource` object.
+ You cannot directly instantiate an `STPSourceReceiver`. You should only use one that is part of an existing `STPSource` object.
  */
 - (nonnull instancetype) init __attribute__((unavailable("You cannot directly instantiate an STPSourceReceiver. You should only use one that is part of an existing STPSource object.")));
 
 /**
- *  The address of the receiver source. This is the value that should be communicated to the customer to send their funds to.
+ The address of the receiver source. This is the value that should be communicated to the customer to send their funds to.
  */
 @property (nonatomic, readonly, nullable) NSString *address;
 
 /**
- *  The total amount charged by you.
+ The total amount charged by you.
  */
 @property (nonatomic, readonly, nullable) NSNumber *amountCharged;
 
 /**
- *  The total amount received by the receiver source.
+ The total amount received by the receiver source.
  */
 @property (nonatomic, readonly, nullable) NSNumber *amountReceived;
 
 /**
- *  The total amount that was returned to the customer.
+ The total amount that was returned to the customer.
  */
 @property (nonatomic, readonly, nullable) NSNumber *amountReturned;
 

--- a/Stripe/PublicHeaders/STPSourceRedirect.h
+++ b/Stripe/PublicHeaders/STPSourceRedirect.h
@@ -10,7 +10,7 @@
 #import "STPAPIResponseDecodable.h"
 
 /**
- *  Redirect status types for a Source
+ Redirect status types for a Source
  */
 typedef NS_ENUM(NSInteger, STPSourceRedirectStatus) {
     STPSourceRedirectStatusPending,
@@ -20,27 +20,27 @@ typedef NS_ENUM(NSInteger, STPSourceRedirectStatus) {
 };
 
 /**
- *  Information related to a source's redirect flow.
+ Information related to a source's redirect flow.
  */
 @interface STPSourceRedirect : NSObject<STPAPIResponseDecodable>
 
 /**
- *  You cannot directly instantiate an `STPSourceRedirect`. You should only use one that is part of an existing `STPSource` object.
+ You cannot directly instantiate an `STPSourceRedirect`. You should only use one that is part of an existing `STPSource` object.
  */
 - (nonnull instancetype) init __attribute__((unavailable("You cannot directly instantiate an STPSourceRedirect. You should only use one that is part of an existing STPSource object.")));
 
 /**
- *  The URL you provide to redirect the customer to after they authenticated their payment.
+ The URL you provide to redirect the customer to after they authenticated their payment.
  */
 @property (nonatomic, readonly, nullable) NSURL *returnURL;
 
 /**
- *  The status of the redirect.
+ The status of the redirect.
  */
 @property (nonatomic, readonly) STPSourceRedirectStatus status;
 
 /**
- *  The URL provided to you to redirect a customer to as part of a redirect authentication flow.
+ The URL provided to you to redirect a customer to as part of a redirect authentication flow.
  */
 @property (nonatomic, readonly, nullable) NSURL *url;
 

--- a/Stripe/PublicHeaders/STPSourceSEPADebitDetails.h
+++ b/Stripe/PublicHeaders/STPSourceSEPADebitDetails.h
@@ -13,44 +13,44 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- *  This class provides typed access to the contents of an STPSource `details`
- *  dictionary for SEPA Debit sources.
+ This class provides typed access to the contents of an STPSource `details`
+ dictionary for SEPA Debit sources.
  */
 @interface STPSourceSEPADebitDetails : NSObject <STPAPIResponseDecodable>
 
 /**
- *  You cannot directly instantiate an `STPSourceSEPADebitDetails`. 
- *  You should only use one that is part of an existing `STPSource` object.
+ You cannot directly instantiate an `STPSourceSEPADebitDetails`. 
+ You should only use one that is part of an existing `STPSource` object.
  */
 - (nonnull instancetype) init __attribute__((unavailable("You cannot directly instantiate an STPSourceSEPADebitDetails. You should only use one that is part of an existing STPSource object.")));
 
 /**
- *  The last 4 digits of the account number.
+ The last 4 digits of the account number.
  */
 @property (nonatomic, readonly, nullable) NSString *last4;
 
 /**
- *  The account's bank code.
+ The account's bank code.
  */
 @property (nonatomic, readonly, nullable) NSString *bankCode;
 
 /**
- *  Two-letter ISO code representing the country of the bank account.
+ Two-letter ISO code representing the country of the bank account.
  */
 @property (nonatomic, readonly, nullable) NSString *country;
 
 /**
- *  The account's fingerprint.
+ The account's fingerprint.
  */
 @property (nonatomic, readonly, nullable) NSString *fingerprint;
 
 /**
- *  The reference of the mandate accepted by your customer.
+ The reference of the mandate accepted by your customer.
  */
 @property (nonatomic, readonly, nullable) NSString *mandateReference;
 
 /**
- *  The details of the mandate accepted by your customer.
+ The details of the mandate accepted by your customer.
  */
 @property (nonatomic, readonly, nullable) NSURL *mandateURL;
 

--- a/Stripe/PublicHeaders/STPSourceVerification.h
+++ b/Stripe/PublicHeaders/STPSourceVerification.h
@@ -10,7 +10,7 @@
 #import "STPAPIResponseDecodable.h"
 
 /**
- *  Verification status types for a Source
+ Verification status types for a Source
  */
 typedef NS_ENUM(NSInteger, STPSourceVerificationStatus) {
     STPSourceVerificationStatusPending,
@@ -20,22 +20,22 @@ typedef NS_ENUM(NSInteger, STPSourceVerificationStatus) {
 };
 
 /**
- *  Information related to a source's verification flow.
+ Information related to a source's verification flow.
  */
 @interface STPSourceVerification : NSObject<STPAPIResponseDecodable>
 
 /**
- *  You cannot directly instantiate an `STPSourceVerification`. You should only use one that is part of an existing `STPSource` object.
+ You cannot directly instantiate an `STPSourceVerification`. You should only use one that is part of an existing `STPSource` object.
  */
 - (nonnull instancetype) init __attribute__((unavailable("You cannot directly instantiate an STPSourceVerification. You should only use one that is part of an existing STPSource object.")));
 
 /**
- *  The number of attempts remaining to authenticate the source object with a verification code.
+ The number of attempts remaining to authenticate the source object with a verification code.
  */
 @property (nonatomic, readonly, nullable) NSNumber *attemptsRemaining;
 
 /**
- *  The status of the verification.
+ The status of the verification.
  */
 @property (nonatomic, readonly) STPSourceVerificationStatus status;
 

--- a/Stripe/PublicHeaders/STPTheme.h
+++ b/Stripe/PublicHeaders/STPTheme.h
@@ -23,80 +23,80 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  The primary background color of the theme. This will be used as the `backgroundColor` for any views with this theme.
  */
-@property(nonatomic, copy, null_resettable)UIColor *primaryBackgroundColor;
+@property (nonatomic, copy, null_resettable) UIColor *primaryBackgroundColor;
 
 /**
  The secondary background color of this theme. This will be used as the `backgroundColor` for any supplemental views inside a view with this theme - for example, a `UITableView` will set it's cells' background color to this value.
  */
-@property(nonatomic, copy, null_resettable)UIColor *secondaryBackgroundColor;
+@property (nonatomic, copy, null_resettable) UIColor *secondaryBackgroundColor;
 
 /**
  This color is automatically derived by reducing the alpha of the `primaryBackgroundColor` and is used as a section border color in table view cells.
  */
-@property(nonatomic, readonly)UIColor *tertiaryBackgroundColor;
+@property (nonatomic, readonly) UIColor *tertiaryBackgroundColor;
 
 /**
  This color is automatically derived by reducing the brightness of the `primaryBackgroundColor` and is used as a separator color in table view cells.
  */
-@property(nonatomic, readonly)UIColor *quaternaryBackgroundColor;
+@property (nonatomic, readonly) UIColor *quaternaryBackgroundColor;
 
 /**
  The primary foreground color of this theme. This will be used as the text color for any important labels in a view with this theme (such as the text color for a text field that the user needs to fill out).
  */
-@property(nonatomic, copy, null_resettable)UIColor *primaryForegroundColor;
+@property (nonatomic, copy, null_resettable) UIColor *primaryForegroundColor;
 
 /**
  The secondary foreground color of this theme. This will be used as the text color for any supplementary labels in a view with this theme (such as the placeholder color for a text field that the user needs to fill out).
  */
-@property(nonatomic, copy, null_resettable)UIColor *secondaryForegroundColor;
+@property (nonatomic, copy, null_resettable) UIColor *secondaryForegroundColor;
 
 /**
  This color is automatically derived from the `secondaryForegroundColor` with a lower alpha component, used for disabled text.
  */
-@property(nonatomic, readonly)UIColor *tertiaryForegroundColor;
+@property (nonatomic, readonly) UIColor *tertiaryForegroundColor;
 
 /**
  The accent color of this theme - it will be used for any buttons and other elements on a view that are important to highlight.
  */
-@property(nonatomic, copy, null_resettable)UIColor *accentColor;
+@property (nonatomic, copy, null_resettable) UIColor *accentColor;
 
 /**
  The error color of this theme - it will be used for rendering any error messages or views.
  */
-@property(nonatomic, copy, null_resettable)UIColor *errorColor;
+@property (nonatomic, copy, null_resettable) UIColor *errorColor;
 
 /**
  The font to be used for all views using this theme. Make sure to select an appropriate size.
  */
-@property(nonatomic, copy, null_resettable)UIFont  *font;
+@property (nonatomic, copy, null_resettable) UIFont  *font;
 
 /**
  The medium-weight font to be used for all bold text in views using this theme. Make sure to select an appropriate size.
  */
-@property(nonatomic, copy, null_resettable)UIFont  *emphasisFont;
+@property (nonatomic, copy, null_resettable) UIFont  *emphasisFont;
 
 /**
  The navigation bar style to use for any view controllers presented modally
  by the SDK. The default value will be determined based on the brightness
  of the theme's `secondaryBackgroundColor`.
  */
-@property(nonatomic)UIBarStyle barStyle;
+@property (nonatomic) UIBarStyle barStyle;
 
 /**
  A Boolean value indicating whether the navigation bar for any view controllers
  presented modally by the SDK should be translucent. The default value is NO.
  */
-@property(nonatomic)BOOL translucentNavigationBar;
+@property (nonatomic) BOOL translucentNavigationBar;
 
 /**
  This font is automatically derived from the font, with a slightly lower point size, and will be used for supplementary labels.
  */
-@property(nonatomic, readonly)UIFont  *smallFont;
+@property (nonatomic, readonly) UIFont  *smallFont;
 
 /**
  This font is automatically derived from the font, with a larger point size, and will be used for large labels such as SMS code entry.
  */
-@property(nonatomic, readonly)UIFont  *largeFont;
+@property (nonatomic, readonly) UIFont  *largeFont;
 
 @end
 

--- a/Stripe/PublicHeaders/STPTheme.h
+++ b/Stripe/PublicHeaders/STPTheme.h
@@ -16,85 +16,85 @@ NS_ASSUME_NONNULL_BEGIN
 @interface STPTheme : NSObject<NSCopying>
 
 /**
- *  The default theme used by all Stripe UI. All themable UI classes, such as `STPAddCardViewController`, have one initializer that takes a `theme` and one that does not. If you use the one that does not, the default theme will be used to customize that view controller's appearance.
+ The default theme used by all Stripe UI. All themable UI classes, such as `STPAddCardViewController`, have one initializer that takes a `theme` and one that does not. If you use the one that does not, the default theme will be used to customize that view controller's appearance.
  */
 + (STPTheme *)defaultTheme;
 
 /**
- *  The primary background color of the theme. This will be used as the `backgroundColor` for any views with this theme.
+ The primary background color of the theme. This will be used as the `backgroundColor` for any views with this theme.
  */
 @property(nonatomic, copy, null_resettable)UIColor *primaryBackgroundColor;
 
 /**
- *  The secondary background color of this theme. This will be used as the `backgroundColor` for any supplemental views inside a view with this theme - for example, a `UITableView` will set it's cells' background color to this value.
+ The secondary background color of this theme. This will be used as the `backgroundColor` for any supplemental views inside a view with this theme - for example, a `UITableView` will set it's cells' background color to this value.
  */
 @property(nonatomic, copy, null_resettable)UIColor *secondaryBackgroundColor;
 
 /**
- *  This color is automatically derived by reducing the alpha of the `primaryBackgroundColor` and is used as a section border color in table view cells.
+ This color is automatically derived by reducing the alpha of the `primaryBackgroundColor` and is used as a section border color in table view cells.
  */
 @property(nonatomic, readonly)UIColor *tertiaryBackgroundColor;
 
 /**
- *  This color is automatically derived by reducing the brightness of the `primaryBackgroundColor` and is used as a separator color in table view cells.
+ This color is automatically derived by reducing the brightness of the `primaryBackgroundColor` and is used as a separator color in table view cells.
  */
 @property(nonatomic, readonly)UIColor *quaternaryBackgroundColor;
 
 /**
- *  The primary foreground color of this theme. This will be used as the text color for any important labels in a view with this theme (such as the text color for a text field that the user needs to fill out).
+ The primary foreground color of this theme. This will be used as the text color for any important labels in a view with this theme (such as the text color for a text field that the user needs to fill out).
  */
 @property(nonatomic, copy, null_resettable)UIColor *primaryForegroundColor;
 
 /**
- *  The secondary foreground color of this theme. This will be used as the text color for any supplementary labels in a view with this theme (such as the placeholder color for a text field that the user needs to fill out).
+ The secondary foreground color of this theme. This will be used as the text color for any supplementary labels in a view with this theme (such as the placeholder color for a text field that the user needs to fill out).
  */
 @property(nonatomic, copy, null_resettable)UIColor *secondaryForegroundColor;
 
 /**
- *  This color is automatically derived from the `secondaryForegroundColor` with a lower alpha component, used for disabled text.
+ This color is automatically derived from the `secondaryForegroundColor` with a lower alpha component, used for disabled text.
  */
 @property(nonatomic, readonly)UIColor *tertiaryForegroundColor;
 
 /**
- *  The accent color of this theme - it will be used for any buttons and other elements on a view that are important to highlight.
+ The accent color of this theme - it will be used for any buttons and other elements on a view that are important to highlight.
  */
 @property(nonatomic, copy, null_resettable)UIColor *accentColor;
 
 /**
- *  The error color of this theme - it will be used for rendering any error messages or views.
+ The error color of this theme - it will be used for rendering any error messages or views.
  */
 @property(nonatomic, copy, null_resettable)UIColor *errorColor;
 
 /**
- *  The font to be used for all views using this theme. Make sure to select an appropriate size.
+ The font to be used for all views using this theme. Make sure to select an appropriate size.
  */
 @property(nonatomic, copy, null_resettable)UIFont  *font;
 
 /**
- *  The medium-weight font to be used for all bold text in views using this theme. Make sure to select an appropriate size.
+ The medium-weight font to be used for all bold text in views using this theme. Make sure to select an appropriate size.
  */
 @property(nonatomic, copy, null_resettable)UIFont  *emphasisFont;
 
 /**
- *  The navigation bar style to use for any view controllers presented modally
- *  by the SDK. The default value will be determined based on the brightness
- *  of the theme's `secondaryBackgroundColor`.
+ The navigation bar style to use for any view controllers presented modally
+ by the SDK. The default value will be determined based on the brightness
+ of the theme's `secondaryBackgroundColor`.
  */
 @property(nonatomic)UIBarStyle barStyle;
 
 /**
- *  A Boolean value indicating whether the navigation bar for any view controllers
- *  presented modally by the SDK should be translucent. The default value is NO.
+ A Boolean value indicating whether the navigation bar for any view controllers
+ presented modally by the SDK should be translucent. The default value is NO.
  */
 @property(nonatomic)BOOL translucentNavigationBar;
 
 /**
- *  This font is automatically derived from the font, with a slightly lower point size, and will be used for supplementary labels.
+ This font is automatically derived from the font, with a slightly lower point size, and will be used for supplementary labels.
  */
 @property(nonatomic, readonly)UIFont  *smallFont;
 
 /**
- *  This font is automatically derived from the font, with a larger point size, and will be used for large labels such as SMS code entry.
+ This font is automatically derived from the font, with a larger point size, and will be used for large labels such as SMS code entry.
  */
 @property(nonatomic, readonly)UIFont  *largeFont;
 

--- a/Stripe/PublicHeaders/STPToken.h
+++ b/Stripe/PublicHeaders/STPToken.h
@@ -14,39 +14,39 @@
 @class STPBankAccount;
 
 /**
- *  A token returned from submitting payment details to the Stripe API. You should not have to instantiate one of these directly.
+ A token returned from submitting payment details to the Stripe API. You should not have to instantiate one of these directly.
  */
 @interface STPToken : NSObject<STPAPIResponseDecodable, STPSourceProtocol>
 
 /**
- *  You cannot directly instantiate an `STPToken`. You should only use one that has been returned from an `STPAPIClient` callback.
+ You cannot directly instantiate an `STPToken`. You should only use one that has been returned from an `STPAPIClient` callback.
  */
 - (nonnull instancetype) init __attribute__((unavailable("You cannot directly instantiate an STPToken. You should only use one that has been returned from an STPAPIClient callback.")));
 
 /**
- *  The value of the token. You can store this value on your server and use it to make charges and customers. 
- *  @see https://stripe.com/docs/charges
+ The value of the token. You can store this value on your server and use it to make charges and customers. 
+ @see https://stripe.com/docs/charges
  */
 @property (nonatomic, readonly, nonnull) NSString *tokenId;
 
 /**
- *  Whether or not this token was created in livemode. Will be YES if you used your Live Publishable Key, and NO if you used your Test Publishable Key.
+ Whether or not this token was created in livemode. Will be YES if you used your Live Publishable Key, and NO if you used your Test Publishable Key.
  */
 @property (nonatomic, readonly) BOOL livemode;
 
 /**
- *  The credit card details that were used to create the token. Will only be set if the token was created via a credit card or Apple Pay, otherwise it will be
- * nil.
+ The credit card details that were used to create the token. Will only be set if the token was created via a credit card or Apple Pay, otherwise it will be
+ nil.
  */
 @property (nonatomic, readonly, nullable) STPCard *card;
 
 /**
- *  The bank account details that were used to create the token. Will only be set if the token was created with a bank account, otherwise it will be nil.
+ The bank account details that were used to create the token. Will only be set if the token was created with a bank account, otherwise it will be nil.
  */
 @property (nonatomic, readonly, nullable) STPBankAccount *bankAccount;
 
 /**
- *  When the token was created.
+ When the token was created.
  */
 @property (nonatomic, readonly, nullable) NSDate *created;
 

--- a/Stripe/PublicHeaders/STPUserInformation.h
+++ b/Stripe/PublicHeaders/STPUserInformation.h
@@ -12,24 +12,24 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- *  You can use this class to specify information that you've already collected 
- *  from your user. You can then set the `prefilledInformation` property on 
- *  `STPPaymentContext`, `STPAddCardViewController`, etc and it will pre-fill 
- *  this information whenever possible.
+ You can use this class to specify information that you've already collected 
+ from your user. You can then set the `prefilledInformation` property on 
+ `STPPaymentContext`, `STPAddCardViewController`, etc and it will pre-fill 
+ this information whenever possible.
  */
 @interface STPUserInformation : NSObject<NSCopying>
 
 /**
- *  The user's billing address. When set, the add card form will be filled with 
- *  this address. The user will also have the option to fill their shipping address 
- *  using this address.
+ The user's billing address. When set, the add card form will be filled with 
+ this address. The user will also have the option to fill their shipping address 
+ using this address.
  */
 @property(nonatomic, strong, nullable)STPAddress *billingAddress;
 
 /**
- *  The user's shipping address. When set, the shipping address form will be filled
- *  with this address. The user will also have the option to fill their billing
- *  address using this address.
+ The user's shipping address. When set, the shipping address form will be filled
+ with this address. The user will also have the option to fill their billing
+ address using this address.
  */
 @property(nonatomic, strong, nullable)STPAddress *shippingAddress;
 

--- a/Stripe/PublicHeaders/STPUserInformation.h
+++ b/Stripe/PublicHeaders/STPUserInformation.h
@@ -24,14 +24,14 @@ NS_ASSUME_NONNULL_BEGIN
  this address. The user will also have the option to fill their shipping address 
  using this address.
  */
-@property(nonatomic, strong, nullable)STPAddress *billingAddress;
+@property (nonatomic, strong, nullable) STPAddress *billingAddress;
 
 /**
  The user's shipping address. When set, the shipping address form will be filled
  with this address. The user will also have the option to fill their billing
  address using this address.
  */
-@property(nonatomic, strong, nullable)STPAddress *shippingAddress;
+@property (nonatomic, strong, nullable) STPAddress *shippingAddress;
 
 @end
 

--- a/Stripe/PublicHeaders/StripeError.h
+++ b/Stripe/PublicHeaders/StripeError.h
@@ -9,7 +9,7 @@
 #import <Foundation/Foundation.h>
 
 /**
- *  All Stripe iOS errors will be under this domain.
+ All Stripe iOS errors will be under this domain.
  */
 FOUNDATION_EXPORT NSString * __nonnull const StripeDomain;
 

--- a/Stripe/PublicHeaders/UINavigationBar+Stripe_Theme.h
+++ b/Stripe/PublicHeaders/UINavigationBar+Stripe_Theme.h
@@ -12,23 +12,23 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- *  This allows quickly setting the appearance of a `UINavigationBar` to match your application. This is useful if you're presenting an `STPAddCardViewController` or `STPPaymentMethodsViewController` inside a `UINavigationController`.
+ This allows quickly setting the appearance of a `UINavigationBar` to match your application. This is useful if you're presenting an `STPAddCardViewController` or `STPPaymentMethodsViewController` inside a `UINavigationController`.
  */
 @interface UINavigationBar (Stripe_Theme)
 
 /**
- *  Sets the navigation bar's appearance to the desired theme. This will affect the bar's `tintColor` and `barTintColor` properties, as well as the color of the single-pixel line at the bottom of the navbar.
- *
- *  @param theme the theme to use to style the navigation bar. @see STPTheme.h
- *  @deprecated Use the `stp_theme` property instead
+ Sets the navigation bar's appearance to the desired theme. This will affect the bar's `tintColor` and `barTintColor` properties, as well as the color of the single-pixel line at the bottom of the navbar.
+
+ @param theme the theme to use to style the navigation bar. @see STPTheme.h
+ @deprecated Use the `stp_theme` property instead
  */
 - (void)stp_setTheme:(STPTheme *)theme __attribute__((deprecated));
 
 /**
- *  Sets the navigation bar's appearance to the desired theme. This will affect the bar's `tintColor` and `barTintColor` properties, as well as the color of the single-pixel line at the bottom of the navbar.
- *  Stripe view controllers will use their navigation bar's theme for their UIBarButtonItems instead of their own theme if it is not nil.
- *
- *  @see STPTheme.h
+ Sets the navigation bar's appearance to the desired theme. This will affect the bar's `tintColor` and `barTintColor` properties, as well as the color of the single-pixel line at the bottom of the navbar.
+ Stripe view controllers will use their navigation bar's theme for their UIBarButtonItems instead of their own theme if it is not nil.
+
+ @see STPTheme.h
  */
 @property (nonatomic, nullable, strong) STPTheme *stp_theme;
 

--- a/Stripe/STPAddCardViewController+Private.h
+++ b/Stripe/STPAddCardViewController+Private.h
@@ -13,7 +13,7 @@
 
 @interface STPAddCardViewController (Private)
 
-@property(nonatomic)STPAddress *shippingAddress;
+@property (nonatomic) STPAddress *shippingAddress;
 
 - (void)commonInitWithConfiguration:(STPPaymentConfiguration *)configuration;
 

--- a/Stripe/STPAddCardViewController.m
+++ b/Stripe/STPAddCardViewController.m
@@ -46,22 +46,22 @@
     UITableViewDelegate,
     UITableViewDataSource>
 
-@property(nonatomic)STPPaymentConfiguration *configuration;
-@property(nonatomic)STPAddress *shippingAddress;
-@property(nonatomic)BOOL hasUsedShippingAddress;
-@property(nonatomic)STPAPIClient *apiClient;
-@property(nonatomic, weak)UIImageView *cardImageView;
-@property(nonatomic)UIBarButtonItem *doneItem;
-@property(nonatomic)STPSectionHeaderView *cardHeaderView;
-@property(nonatomic)STPCardIOProxy *cardIOProxy;
-@property(nonatomic)STPSectionHeaderView *addressHeaderView;
-@property(nonatomic)STPPaymentCardTextFieldCell *paymentCell;
-@property(nonatomic)BOOL loading;
-@property(nonatomic)STPPaymentActivityIndicatorView *activityIndicator;
-@property(nonatomic, weak)STPPaymentActivityIndicatorView *lookupActivityIndicator;
-@property(nonatomic)STPAddressViewModel *addressViewModel;
-@property(nonatomic)UIToolbar *inputAccessoryToolbar;
-@property(nonatomic)BOOL lookupSucceeded;
+@property (nonatomic) STPPaymentConfiguration *configuration;
+@property (nonatomic) STPAddress *shippingAddress;
+@property (nonatomic) BOOL hasUsedShippingAddress;
+@property (nonatomic) STPAPIClient *apiClient;
+@property (nonatomic, weak) UIImageView *cardImageView;
+@property (nonatomic) UIBarButtonItem *doneItem;
+@property (nonatomic) STPSectionHeaderView *cardHeaderView;
+@property (nonatomic) STPCardIOProxy *cardIOProxy;
+@property (nonatomic) STPSectionHeaderView *addressHeaderView;
+@property (nonatomic) STPPaymentCardTextFieldCell *paymentCell;
+@property (nonatomic) BOOL loading;
+@property (nonatomic) STPPaymentActivityIndicatorView *activityIndicator;
+@property (nonatomic, weak) STPPaymentActivityIndicatorView *lookupActivityIndicator;
+@property (nonatomic) STPAddressViewModel *addressViewModel;
+@property (nonatomic) UIToolbar *inputAccessoryToolbar;
+@property (nonatomic) BOOL lookupSucceeded;
 @end
 
 static NSString *const STPPaymentCardCellReuseIdentifier = @"STPPaymentCardCellReuseIdentifier";

--- a/Stripe/STPAddressFieldTableViewCell.h
+++ b/Stripe/STPAddressFieldTableViewCell.h
@@ -45,12 +45,12 @@ typedef NS_ENUM(NSInteger, STPAddressFieldType) {
                   lastInList:(BOOL)lastInList
                     delegate:(id<STPAddressFieldTableViewCellDelegate>)delegate;
 
-@property(nonatomic)STPAddressFieldType type;
-@property(nonatomic, copy) NSString *caption;
-@property(nonatomic, weak, readonly) STPFormTextField *textField;
-@property(nonatomic, copy) NSString *contents;
-@property(nonatomic)STPTheme *theme;
-@property(nonatomic, assign) BOOL lastInList;
+@property (nonatomic) STPAddressFieldType type;
+@property (nonatomic, copy) NSString *caption;
+@property (nonatomic, weak, readonly) STPFormTextField *textField;
+@property (nonatomic, copy) NSString *contents;
+@property (nonatomic) STPTheme *theme;
+@property (nonatomic, assign) BOOL lastInList;
 
 - (void)delegateCountryCodeDidChange:(NSString *)countryCode;
 

--- a/Stripe/STPAddressFieldTableViewCell.m
+++ b/Stripe/STPAddressFieldTableViewCell.m
@@ -16,12 +16,12 @@
 
 @interface STPAddressFieldTableViewCell() <STPFormTextFieldDelegate, UIPickerViewDelegate, UIPickerViewDataSource>
 
-@property(nonatomic, weak) STPFormTextField *textField;
-@property(nonatomic) UIToolbar *inputAccessoryToolbar;
-@property(nonatomic) UIPickerView *countryPickerView;
-@property(nonatomic, strong) NSArray *countryCodes;
-@property(nonatomic, weak)id<STPAddressFieldTableViewCellDelegate>delegate;
-@property(nonatomic, strong) NSString *ourCountryCode;
+@property (nonatomic, weak) STPFormTextField *textField;
+@property (nonatomic) UIToolbar *inputAccessoryToolbar;
+@property (nonatomic) UIPickerView *countryPickerView;
+@property (nonatomic, strong) NSArray *countryCodes;
+@property (nonatomic, weak) id<STPAddressFieldTableViewCellDelegate>delegate;
+@property (nonatomic, strong) NSString *ourCountryCode;
 @end
 
 @implementation STPAddressFieldTableViewCell

--- a/Stripe/STPAddressViewModel.h
+++ b/Stripe/STPAddressViewModel.h
@@ -22,11 +22,11 @@
 
 @interface STPAddressViewModel : NSObject
 
-@property(nonatomic, readonly) NSArray<STPAddressFieldTableViewCell *> *addressCells;
-@property(nonatomic, weak) id<STPAddressViewModelDelegate>delegate;
-@property(nonatomic) UIResponder *previousField;
-@property(nonatomic)STPAddress *address;
-@property(nonatomic, readonly)BOOL isValid;
+@property (nonatomic, readonly) NSArray<STPAddressFieldTableViewCell *> *addressCells;
+@property (nonatomic, weak) id<STPAddressViewModelDelegate>delegate;
+@property (nonatomic) UIResponder *previousField;
+@property (nonatomic) STPAddress *address;
+@property (nonatomic, readonly) BOOL isValid;
 
 - (instancetype)initWithRequiredBillingFields:(STPBillingAddressFields)requiredBillingAddressFields;
 - (instancetype)initWithRequiredShippingFields:(PKAddressField)requiredShippingAddressFields;

--- a/Stripe/STPAddressViewModel.m
+++ b/Stripe/STPAddressViewModel.m
@@ -16,12 +16,12 @@
 #import <CoreLocation/CoreLocation.h>
 
 @interface STPAddressViewModel()<STPAddressFieldTableViewCellDelegate>
-@property(nonatomic)BOOL isBillingAddress;
-@property(nonatomic)STPBillingAddressFields requiredBillingAddressFields;
-@property(nonatomic)PKAddressField requiredShippingAddressFields;
-@property(nonatomic)NSArray<STPAddressFieldTableViewCell *> *addressCells;
-@property(nonatomic)BOOL showingPostalCodeCell;
-@property(nonatomic)BOOL geocodeInProgress;
+@property (nonatomic) BOOL isBillingAddress;
+@property (nonatomic) STPBillingAddressFields requiredBillingAddressFields;
+@property (nonatomic) PKAddressField requiredShippingAddressFields;
+@property (nonatomic) NSArray<STPAddressFieldTableViewCell *> *addressCells;
+@property (nonatomic) BOOL showingPostalCodeCell;
+@property (nonatomic) BOOL geocodeInProgress;
 @end
 
 @implementation STPAddressViewModel

--- a/Stripe/STPBINRange.h
+++ b/Stripe/STPBINRange.h
@@ -13,8 +13,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface STPBINRange : NSObject
 
-@property(nonatomic, readonly)NSUInteger length;
-@property(nonatomic, readonly)STPCardBrand brand;
+@property (nonatomic, readonly) NSUInteger length;
+@property (nonatomic, readonly) STPCardBrand brand;
 
 + (NSArray<STPBINRange *> *)allRanges;
 + (NSArray<STPBINRange *> *)binRangesForNumber:(NSString *)number;

--- a/Stripe/STPBINRange.m
+++ b/Stripe/STPBINRange.m
@@ -11,10 +11,10 @@
 
 @interface STPBINRange()
 
-@property(nonatomic)NSUInteger length;
-@property(nonatomic)NSString *qRangeLow;
-@property(nonatomic)NSString *qRangeHigh;
-@property(nonatomic)STPCardBrand brand;
+@property (nonatomic) NSUInteger length;
+@property (nonatomic) NSString *qRangeLow;
+@property (nonatomic) NSString *qRangeHigh;
+@property (nonatomic) STPCardBrand brand;
 
 - (BOOL)matchesNumber:(NSString *)number;
 

--- a/Stripe/STPBundleLocator.m
+++ b/Stripe/STPBundleLocator.m
@@ -9,8 +9,8 @@
 #import "STPBundleLocator.h"
 
 /**
- * Using a private class to ensure that it can't be subclassed, which may
- * change the result of `bundleForClass`
+ Using a private class to ensure that it can't be subclassed, which may
+ change the result of `bundleForClass`
  */
 @interface STPBundleLocatorInternal : NSObject
 @end

--- a/Stripe/STPCardTuple.h
+++ b/Stripe/STPCardTuple.h
@@ -17,8 +17,8 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)tupleWithSelectedCard:(nullable STPCard *)selectedCard
                                 cards:(nullable NSArray<STPCard *>*)cards;
 
-@property(nonatomic, readonly, nullable)STPCard *selectedCard;
-@property(nonatomic, readonly)NSArray<STPCard *> *cards;
+@property (nonatomic, readonly, nullable) STPCard *selectedCard;
+@property (nonatomic, readonly) NSArray<STPCard *> *cards;
 
 @end
 

--- a/Stripe/STPCardTuple.m
+++ b/Stripe/STPCardTuple.m
@@ -10,8 +10,8 @@
 
 @interface STPCardTuple()
 
-@property(nonatomic, nullable)STPCard *selectedCard;
-@property(nonatomic)NSArray<STPCard *> *cards;
+@property (nonatomic, nullable) STPCard *selectedCard;
+@property (nonatomic) NSArray<STPCard *> *cards;
 
 @end
 

--- a/Stripe/STPCoreTableViewController+Private.h
+++ b/Stripe/STPCoreTableViewController+Private.h
@@ -23,5 +23,5 @@
  This points to the same object as `STPCoreScrollViewController`'s `scrollView`
  property but with the type cast to `UITableView`
  */
-@property(nonatomic, nullable, readonly) UITableView *tableView;
+@property (nonatomic, nullable, readonly) UITableView *tableView;
 @end

--- a/Stripe/STPCoreViewController+Private.h
+++ b/Stripe/STPCoreViewController+Private.h
@@ -21,8 +21,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface STPCoreViewController ()
 
 @property (nonatomic) STPTheme *theme;
-@property(nonatomic) UIBarButtonItem *cancelItem;
-@property(nonatomic) UIBarButtonItem *backItem;
+@property (nonatomic) UIBarButtonItem *cancelItem;
+@property (nonatomic) UIBarButtonItem *backItem;
 
 /**
  All designated initializers funnel through this method to do their setup

--- a/Stripe/STPCustomer.m
+++ b/Stripe/STPCustomer.m
@@ -16,10 +16,10 @@
 
 @interface STPCustomer()
 
-@property(nonatomic, copy)NSString *stripeID;
-@property(nonatomic) id<STPSourceProtocol> defaultSource;
-@property(nonatomic) NSArray<id<STPSourceProtocol>> *sources;
-@property(nonatomic) STPAddress *shippingAddress;
+@property (nonatomic, copy) NSString *stripeID;
+@property (nonatomic) id<STPSourceProtocol> defaultSource;
+@property (nonatomic) NSArray<id<STPSourceProtocol>> *sources;
+@property (nonatomic) STPAddress *shippingAddress;
 @property (nonatomic, readwrite, nonnull, copy) NSDictionary *allResponseFields;
 
 @end
@@ -125,8 +125,8 @@
  */
 @interface STPCustomerDeserializer()
 
-@property(nonatomic, nullable)STPCustomer *customer;
-@property(nonatomic, nullable)NSError *error;
+@property (nonatomic, nullable) STPCustomer *customer;
+@property (nonatomic, nullable) NSError *error;
 
 @end
 

--- a/Stripe/STPDelegateProxy.h
+++ b/Stripe/STPDelegateProxy.h
@@ -10,7 +10,7 @@
 
 @interface STPDelegateProxy<__covariant DelegateType:NSObject<NSObject> *> : NSObject
 
-@property(nonatomic, weak)DelegateType delegate;
+@property (nonatomic, weak) DelegateType delegate;
 - (instancetype)init;
 
 @end

--- a/Stripe/STPFormTextField.h
+++ b/Stripe/STPFormTextField.h
@@ -27,14 +27,14 @@ typedef NS_ENUM(NSInteger, STPFormTextFieldAutoFormattingBehavior) {
 
 @interface STPFormTextField : UITextField
 
-@property(nonatomic, readwrite, nullable) UIColor *defaultColor;
-@property(nonatomic, readwrite, nullable) UIColor *errorColor;
-@property(nonatomic, readwrite, nullable) UIColor *placeholderColor;
+@property (nonatomic, readwrite, nullable) UIColor *defaultColor;
+@property (nonatomic, readwrite, nullable) UIColor *errorColor;
+@property (nonatomic, readwrite, nullable) UIColor *placeholderColor;
 
-@property(nonatomic, readwrite, assign)BOOL selectionEnabled; // defaults to NO
-@property(nonatomic, readwrite, assign)BOOL preservesContentsOnPaste; // defaults to NO
-@property(nonatomic, readwrite, assign)STPFormTextFieldAutoFormattingBehavior autoFormattingBehavior;
-@property(nonatomic, readwrite, assign)BOOL validText;
-@property(nonatomic, readwrite, weak, nullable)id<STPFormTextFieldDelegate>formDelegate;
+@property (nonatomic, readwrite, assign) BOOL selectionEnabled; // defaults to NO
+@property (nonatomic, readwrite, assign) BOOL preservesContentsOnPaste; // defaults to NO
+@property (nonatomic, readwrite, assign) STPFormTextFieldAutoFormattingBehavior autoFormattingBehavior;
+@property (nonatomic, readwrite, assign) BOOL validText;
+@property (nonatomic, readwrite, weak, nullable) id<STPFormTextFieldDelegate>formDelegate;
 
 @end

--- a/Stripe/STPFormTextField.m
+++ b/Stripe/STPFormTextField.m
@@ -18,8 +18,8 @@
 #define FAUXPAS_IGNORED_ON_LINE(...)
 
 @interface STPTextFieldDelegateProxy : STPDelegateProxy<UITextFieldDelegate>
-@property(nonatomic, assign)STPFormTextFieldAutoFormattingBehavior autoformattingBehavior;
-@property(nonatomic, assign)BOOL selectionEnabled;
+@property (nonatomic, assign) STPFormTextFieldAutoFormattingBehavior autoformattingBehavior;
+@property (nonatomic, assign) BOOL selectionEnabled;
 @end
 
 @implementation STPTextFieldDelegateProxy
@@ -74,10 +74,10 @@
 typedef NSAttributedString* (^STPFormTextTransformationBlock)(NSAttributedString *inputText);
 
 @interface STPFormTextField()
-@property(nonatomic)STPTextFieldDelegateProxy *delegateProxy;
-@property(nonatomic, copy)STPFormTextTransformationBlock textFormattingBlock;
+@property (nonatomic) STPTextFieldDelegateProxy *delegateProxy;
+@property (nonatomic, copy) STPFormTextTransformationBlock textFormattingBlock;
 // This property only exists to disable keyboard loading in Travis CI due to a crash that occurs while trying to load the keyboard. Don't use it outside of tests.
-@property(nonatomic)BOOL skipsReloadingInputViews;
+@property (nonatomic) BOOL skipsReloadingInputViews;
 @end
 
 @implementation STPFormTextField

--- a/Stripe/STPMultipartFormDataEncoder.h
+++ b/Stripe/STPMultipartFormDataEncoder.h
@@ -13,18 +13,18 @@ NS_ASSUME_NONNULL_BEGIN
 @class STPMultipartFormDataPart;
 
 /**
- * Encoder class to generate the HTTP body data for a multipart/form-data request.
- * @see https://www.w3.org/TR/html401/interact/forms.html#h-17.13.4
+ Encoder class to generate the HTTP body data for a multipart/form-data request.
+ @see https://www.w3.org/TR/html401/interact/forms.html#h-17.13.4
  */
 @interface STPMultipartFormDataEncoder : NSObject
 
 /**
- * Generates the HTTP body data from an array of parts.
+ Generates the HTTP body data from an array of parts.
  */
 + (NSData *)multipartFormDataForParts:(NSArray<STPMultipartFormDataPart *> *)parts boundary:(NSString *)boundary;
 
 /**
- * Generates a unique boundary string to be used between parts.
+ Generates a unique boundary string to be used between parts.
  */
 + (NSString *)generateBoundary;
 

--- a/Stripe/STPMultipartFormDataPart.h
+++ b/Stripe/STPMultipartFormDataPart.h
@@ -11,33 +11,33 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- * Represents a single part of a multipart/form-data upload.
- * @see https://www.w3.org/TR/html401/interact/forms.html#h-17.13.4
+ Represents a single part of a multipart/form-data upload.
+ @see https://www.w3.org/TR/html401/interact/forms.html#h-17.13.4
  */
 @interface STPMultipartFormDataPart : NSObject
 
 /**
- * The data for this part.
+ The data for this part.
  */
 @property (nonatomic, copy) NSData *data;
 
 /**
- * The name for this part.
+ The name for this part.
  */
 @property (nonatomic, copy) NSString *name;
 
 /**
- * The filename for this part. As a rule of thumb, this can be ommitted when the data is just an encoded string. However, this is typically required for other types of binary file data (like images).
+ The filename for this part. As a rule of thumb, this can be ommitted when the data is just an encoded string. However, this is typically required for other types of binary file data (like images).
  */
 @property (nonatomic, copy, nullable) NSString *filename;
 
 /**
- * The content type for this part. When omitted, the multipart/form-data standard assumes text/plain.
+ The content type for this part. When omitted, the multipart/form-data standard assumes text/plain.
  */
 @property (nonatomic, copy, nullable) NSString *contentType;
 
 /**
- * Returns the fully-composed data for this part.
+ Returns the fully-composed data for this part.
  */
 - (NSData *)composedData;
 

--- a/Stripe/STPPaymentActivityIndicatorView.m
+++ b/Stripe/STPPaymentActivityIndicatorView.m
@@ -10,7 +10,7 @@
 
 @interface STPPaymentActivityIndicatorView()
 
-@property(nonatomic, weak)CAShapeLayer *indicatorLayer;
+@property (nonatomic, weak) CAShapeLayer *indicatorLayer;
 
 @end
 

--- a/Stripe/STPPaymentCardTextField.m
+++ b/Stripe/STPPaymentCardTextField.m
@@ -23,38 +23,38 @@
 
 @interface STPPaymentCardTextField()<STPFormTextFieldDelegate>
 
-@property(nonatomic, readwrite, weak) UIImageView *brandImageView;
-@property(nonatomic, readwrite, weak) UIView *fieldsView;
-@property(nonatomic, readwrite, weak) STPFormTextField *numberField;
-@property(nonatomic, readwrite, weak) STPFormTextField *expirationField;
-@property(nonatomic, readwrite, weak) STPFormTextField *cvcField;
-@property(nonatomic, readwrite, weak) STPFormTextField *postalCodeField;
-@property(nonatomic, readwrite, strong) STPPaymentCardTextFieldViewModel *viewModel;
-@property(nonatomic, readwrite, strong) STPCardParams *internalCardParams;
-@property(nonatomic, strong) NSArray<STPFormTextField *> *allFields;
-@property(nonatomic, readwrite, strong) STPFormTextField *sizingField;
-@property(nonatomic, readwrite, strong) UILabel *sizingLabel;
+@property (nonatomic, readwrite, weak) UIImageView *brandImageView;
+@property (nonatomic, readwrite, weak) UIView *fieldsView;
+@property (nonatomic, readwrite, weak) STPFormTextField *numberField;
+@property (nonatomic, readwrite, weak) STPFormTextField *expirationField;
+@property (nonatomic, readwrite, weak) STPFormTextField *cvcField;
+@property (nonatomic, readwrite, weak) STPFormTextField *postalCodeField;
+@property (nonatomic, readwrite, strong) STPPaymentCardTextFieldViewModel *viewModel;
+@property (nonatomic, readwrite, strong) STPCardParams *internalCardParams;
+@property (nonatomic, strong) NSArray<STPFormTextField *> *allFields;
+@property (nonatomic, readwrite, strong) STPFormTextField *sizingField;
+@property (nonatomic, readwrite, strong) UILabel *sizingLabel;
 
 /*
  These track the input parameters to the brand image setter so that we can
  later perform proper transition animations when new values are set
  */
-@property(nonatomic, assign) STPCardFieldType currentBrandImageFieldType;
-@property(nonatomic, assign) STPCardBrand currentBrandImageBrand;
+@property (nonatomic, assign) STPCardFieldType currentBrandImageFieldType;
+@property (nonatomic, assign) STPCardBrand currentBrandImageBrand;
 
 /**
  This is a number-wrapped STPCardFieldType (or nil) that layout uses
  to determine how it should move/animate its subviews so that the chosen
  text field is fully visible.
  */
-@property(nonatomic, copy) NSNumber *focusedTextFieldForLayout;
+@property (nonatomic, copy) NSNumber *focusedTextFieldForLayout;
 
 /*
  Creating and measuring the size of attributed strings is expensive so
  cache the values here.
  */
-@property(nonatomic, strong) NSMutableDictionary<NSString *, NSNumber *> *textToWidthCache;
-@property(nonatomic, strong) NSMutableDictionary<NSString *, NSNumber *> *numberToWidthCache;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, NSNumber *> *textToWidthCache;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, NSNumber *> *numberToWidthCache;
 
 /**
  These bits lets us track beginEditing and endEditing for payment text field
@@ -73,9 +73,9 @@
  pair (shouldBegin/didBegin or shouldEnd/didEnd) then we are transitioning
  into/out of our subviews from/to outside of ourselves
  */
-@property(nonatomic, assign) BOOL isMidSubviewEditingTransitionInternal;
-@property(nonatomic, assign) BOOL receivedUnmatchedShouldBeginEditing;
-@property(nonatomic, assign) BOOL receivedUnmatchedShouldEndEditing;
+@property (nonatomic, assign) BOOL isMidSubviewEditingTransitionInternal;
+@property (nonatomic, assign) BOOL receivedUnmatchedShouldBeginEditing;
+@property (nonatomic, assign) BOOL receivedUnmatchedShouldEndEditing;
 
 @end
 

--- a/Stripe/STPPaymentCardTextFieldCell.h
+++ b/Stripe/STPPaymentCardTextFieldCell.h
@@ -15,9 +15,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface STPPaymentCardTextFieldCell : UITableViewCell
 
-@property(nonatomic, weak, readonly)STPPaymentCardTextField *paymentField;
-@property(nonatomic, copy)STPTheme *theme;
-@property(nonatomic, weak)UIView *inputAccessoryView;
+@property (nonatomic, weak, readonly) STPPaymentCardTextField *paymentField;
+@property (nonatomic, copy) STPTheme *theme;
+@property (nonatomic, weak) UIView *inputAccessoryView;
 
 - (BOOL)isEmpty;
 

--- a/Stripe/STPPaymentCardTextFieldCell.m
+++ b/Stripe/STPPaymentCardTextFieldCell.m
@@ -10,7 +10,7 @@
 
 @interface STPPaymentCardTextFieldCell()
 
-@property(nonatomic, weak)STPPaymentCardTextField *paymentField;
+@property (nonatomic, weak) STPPaymentCardTextField *paymentField;
 
 @end
 

--- a/Stripe/STPPaymentCardTextFieldViewModel.h
+++ b/Stripe/STPPaymentCardTextFieldViewModel.h
@@ -22,16 +22,16 @@ typedef NS_ENUM(NSInteger, STPCardFieldType) {
 
 @interface STPPaymentCardTextFieldViewModel : NSObject
 
-@property(nonatomic, readwrite, copy, nullable) NSString *cardNumber;
-@property(nonatomic, readwrite, copy, nullable)NSString *rawExpiration;
-@property(nonatomic, readonly, nullable) NSString *expirationMonth;
-@property(nonatomic, readonly, nullable) NSString *expirationYear;
-@property(nonatomic, readwrite, copy, nullable) NSString *cvc;
-@property(nonatomic, readwrite, assign) BOOL postalCodeRequired;
-@property(nonatomic, readwrite, copy, nullable) NSString *postalCode;
-@property(nonatomic, readwrite, copy, nullable) NSString *postalCodeCountryCode;
-@property(nonatomic, readonly) STPCardBrand brand;
-@property(nonatomic, readonly) BOOL isValid;
+@property (nonatomic, readwrite, copy, nullable) NSString *cardNumber;
+@property (nonatomic, readwrite, copy, nullable) NSString *rawExpiration;
+@property (nonatomic, readonly, nullable) NSString *expirationMonth;
+@property (nonatomic, readonly, nullable) NSString *expirationYear;
+@property (nonatomic, readwrite, copy, nullable) NSString *cvc;
+@property (nonatomic, readwrite, assign) BOOL postalCodeRequired;
+@property (nonatomic, readwrite, copy, nullable) NSString *postalCode;
+@property (nonatomic, readwrite, copy, nullable) NSString *postalCodeCountryCode;
+@property (nonatomic, readonly) STPCardBrand brand;
+@property (nonatomic, readonly) BOOL isValid;
 
 - (nonnull NSString *)defaultPlaceholder;
 

--- a/Stripe/STPPaymentContext.m
+++ b/Stripe/STPPaymentContext.m
@@ -43,30 +43,30 @@ typedef NS_ENUM(NSUInteger, STPPaymentContextState) {
 
 @interface STPPaymentContext()<STPPaymentMethodsViewControllerDelegate, STPShippingAddressViewControllerDelegate>
 
-@property(nonatomic)STPPaymentConfiguration *configuration;
-@property(nonatomic)STPTheme *theme;
+@property (nonatomic) STPPaymentConfiguration *configuration;
+@property (nonatomic) STPTheme *theme;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated"
-@property(nonatomic)id<STPBackendAPIAdapter> apiAdapter;
+@property (nonatomic) id<STPBackendAPIAdapter> apiAdapter;
 #pragma clang diagnostic pop
-@property(nonatomic)STPAPIClient *apiClient;
-@property(nonatomic)STPPromise<STPPaymentMethodTuple *> *loadingPromise;
+@property (nonatomic) STPAPIClient *apiClient;
+@property (nonatomic) STPPromise<STPPaymentMethodTuple *> *loadingPromise;
 
 // these wrap hostViewController's promises because the hostVC is nil at init-time
-@property(nonatomic)STPVoidPromise *willAppearPromise;
-@property(nonatomic)STPVoidPromise *didAppearPromise;
+@property (nonatomic) STPVoidPromise *willAppearPromise;
+@property (nonatomic) STPVoidPromise *didAppearPromise;
 
-@property(nonatomic, weak)STPPaymentMethodsViewController *paymentMethodsViewController;
-@property(nonatomic)id<STPPaymentMethod> selectedPaymentMethod;
-@property(nonatomic)NSArray<id<STPPaymentMethod>> *paymentMethods;
-@property(nonatomic)STPAddress *shippingAddress;
-@property(nonatomic)PKShippingMethod *selectedShippingMethod;
-@property(nonatomic)NSArray<PKShippingMethod *> *shippingMethods;
+@property (nonatomic, weak) STPPaymentMethodsViewController *paymentMethodsViewController;
+@property (nonatomic) id<STPPaymentMethod> selectedPaymentMethod;
+@property (nonatomic) NSArray<id<STPPaymentMethod>> *paymentMethods;
+@property (nonatomic) STPAddress *shippingAddress;
+@property (nonatomic) PKShippingMethod *selectedShippingMethod;
+@property (nonatomic) NSArray<PKShippingMethod *> *shippingMethods;
 
-@property(nonatomic, assign) STPPaymentContextState state;
+@property (nonatomic, assign) STPPaymentContextState state;
 
-@property(nonatomic)STPPaymentContextAmountModel *paymentAmountModel;
-@property(nonatomic)BOOL shippingAddressNeedsVerification;
+@property (nonatomic) STPPaymentContextAmountModel *paymentAmountModel;
+@property (nonatomic) BOOL shippingAddressNeedsVerification;
 
 @end
 

--- a/Stripe/STPPaymentMethodTuple.h
+++ b/Stripe/STPPaymentMethodTuple.h
@@ -20,8 +20,8 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)tupleWithCardTuple:(STPCardTuple *)cardTuple
                    applePayEnabled:(BOOL)applePayEnabled;
 
-@property(nonatomic, nullable, readonly)id<STPPaymentMethod> selectedPaymentMethod;
-@property(nonatomic, readonly)NSArray<id<STPPaymentMethod>> *paymentMethods;
+@property (nonatomic, nullable, readonly) id<STPPaymentMethod> selectedPaymentMethod;
+@property (nonatomic, readonly) NSArray<id<STPPaymentMethod>> *paymentMethods;
 
 @end
 

--- a/Stripe/STPPaymentMethodTuple.m
+++ b/Stripe/STPPaymentMethodTuple.m
@@ -12,8 +12,8 @@
 
 @interface STPPaymentMethodTuple()
 
-@property(nonatomic)id<STPPaymentMethod> selectedPaymentMethod;
-@property(nonatomic)NSArray<id<STPPaymentMethod>> *paymentMethods;
+@property (nonatomic) id<STPPaymentMethod> selectedPaymentMethod;
+@property (nonatomic) NSArray<id<STPPaymentMethod>> *paymentMethods;
 
 @end
 

--- a/Stripe/STPPaymentMethodsViewController.m
+++ b/Stripe/STPPaymentMethodsViewController.m
@@ -33,17 +33,17 @@
 
 @interface STPPaymentMethodsViewController()<STPPaymentMethodsInternalViewControllerDelegate, STPAddCardViewControllerDelegate>
 
-@property(nonatomic)STPPaymentConfiguration *configuration;
-@property(nonatomic)STPAddress *shippingAddress;
+@property (nonatomic) STPPaymentConfiguration *configuration;
+@property (nonatomic) STPAddress *shippingAddress;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated"
-@property(nonatomic)id<STPBackendAPIAdapter> apiAdapter;
+@property (nonatomic) id<STPBackendAPIAdapter> apiAdapter;
 #pragma clang diagnostic pop
-@property(nonatomic)STPAPIClient *apiClient;
-@property(nonatomic)STPPromise<STPPaymentMethodTuple *> *loadingPromise;
-@property(nonatomic, weak)STPPaymentActivityIndicatorView *activityIndicator;
-@property(nonatomic, weak)UIViewController *internalViewController;
-@property(nonatomic)BOOL loading;
+@property (nonatomic) STPAPIClient *apiClient;
+@property (nonatomic) STPPromise<STPPaymentMethodTuple *> *loadingPromise;
+@property (nonatomic, weak) STPPaymentActivityIndicatorView *activityIndicator;
+@property (nonatomic, weak) UIViewController *internalViewController;
+@property (nonatomic) BOOL loading;
 
 @end
 

--- a/Stripe/STPPaymentResult.m
+++ b/Stripe/STPPaymentResult.m
@@ -9,7 +9,7 @@
 #import "STPPaymentResult.h"
 
 @interface STPPaymentResult()
-@property(nonatomic)id<STPSourceProtocol> source;
+@property (nonatomic) id<STPSourceProtocol> source;
 @end
 
 @implementation STPPaymentResult

--- a/Stripe/STPPromise.h
+++ b/Stripe/STPPromise.h
@@ -21,9 +21,9 @@ typedef void (^STPPromiseCompletionBlock)(__nullable T value,  NSError * _Nullab
 typedef id _Nonnull (^STPPromiseMapBlock)(T value);
 typedef STPPromise* _Nonnull (^STPPromiseFlatMapBlock)(T value);
 
-@property(atomic, readonly)BOOL completed;
-@property(atomic, readonly)T value;
-@property(atomic, readonly)NSError *error;
+@property (atomic, readonly) BOOL completed;
+@property (atomic, readonly) T value;
+@property (atomic, readonly) NSError *error;
 
 + (instancetype)promiseWithError:(NSError *)error;
 + (instancetype)promiseWithValue:(T)value;

--- a/Stripe/STPPromise.m
+++ b/Stripe/STPPromise.m
@@ -13,10 +13,10 @@
 
 @interface STPPromise<T>()
 
-@property(atomic)T value;
-@property(atomic)NSError *error;
-@property(atomic)NSArray<STPPromiseValueBlock> *successCallbacks;
-@property(atomic)NSArray<STPPromiseErrorBlock> *errorCallbacks;
+@property (atomic) T value;
+@property (atomic) NSError *error;
+@property (atomic) NSArray<STPPromiseValueBlock> *successCallbacks;
+@property (atomic) NSArray<STPPromiseErrorBlock> *errorCallbacks;
 
 @end
 

--- a/Stripe/STPSectionHeaderView.h
+++ b/Stripe/STPSectionHeaderView.h
@@ -11,9 +11,9 @@
 
 @interface STPSectionHeaderView : UIView
 
-@property(nonatomic, nonnull)STPTheme *theme;
-@property(nonatomic, copy, nullable)NSString *title;
-@property(nonatomic, nullable, weak)UIButton *button;
-@property(nonatomic)BOOL buttonHidden;
+@property (nonatomic, nonnull) STPTheme *theme;
+@property (nonatomic, copy, nullable) NSString *title;
+@property (nonatomic, nullable, weak) UIButton *button;
+@property (nonatomic) BOOL buttonHidden;
 
 @end

--- a/Stripe/STPSectionHeaderView.m
+++ b/Stripe/STPSectionHeaderView.m
@@ -9,8 +9,8 @@
 #import "STPSectionHeaderView.h"
 
 @interface STPSectionHeaderView()
-@property(nonatomic, weak)UILabel *label;
-@property(nonatomic)UIEdgeInsets buttonInsets;
+@property (nonatomic, weak) UILabel *label;
+@property (nonatomic) UIEdgeInsets buttonInsets;
 @end
 
 @implementation STPSectionHeaderView

--- a/Stripe/STPShippingAddressViewController.m
+++ b/Stripe/STPShippingAddressViewController.m
@@ -28,17 +28,17 @@
 #import "UIViewController+Stripe_ParentViewController.h"
 
 @interface STPShippingAddressViewController ()<STPAddressViewModelDelegate, UITableViewDelegate, UITableViewDataSource, STPShippingMethodsViewControllerDelegate>
-@property(nonatomic)STPPaymentConfiguration *configuration;
-@property(nonatomic)NSString *currency;
-@property(nonatomic)PKShippingMethod *selectedShippingMethod;
-@property(nonatomic, weak)UIImageView *imageView;
-@property(nonatomic)UIBarButtonItem *nextItem;
-@property(nonatomic)BOOL loading;
-@property(nonatomic)STPPaymentActivityIndicatorView *activityIndicator;
-@property(nonatomic)STPAddressViewModel *addressViewModel;
-@property(nonatomic)STPAddress *billingAddress;
-@property(nonatomic)BOOL hasUsedBillingAddress;
-@property(nonatomic)STPSectionHeaderView *addressHeaderView;
+@property (nonatomic) STPPaymentConfiguration *configuration;
+@property (nonatomic) NSString *currency;
+@property (nonatomic) PKShippingMethod *selectedShippingMethod;
+@property (nonatomic, weak) UIImageView *imageView;
+@property (nonatomic) UIBarButtonItem *nextItem;
+@property (nonatomic) BOOL loading;
+@property (nonatomic) STPPaymentActivityIndicatorView *activityIndicator;
+@property (nonatomic) STPAddressViewModel *addressViewModel;
+@property (nonatomic) STPAddress *billingAddress;
+@property (nonatomic) BOOL hasUsedBillingAddress;
+@property (nonatomic) STPSectionHeaderView *addressHeaderView;
 @end
 
 @implementation STPShippingAddressViewController

--- a/Stripe/STPShippingMethodTableViewCell.h
+++ b/Stripe/STPShippingMethodTableViewCell.h
@@ -13,7 +13,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface STPShippingMethodTableViewCell : UITableViewCell
-@property(nonatomic)STPTheme *theme;
+@property (nonatomic) STPTheme *theme;
 - (void)setShippingMethod:(PKShippingMethod *)method currency:(NSString *)currency;
 @end
 

--- a/Stripe/STPShippingMethodTableViewCell.m
+++ b/Stripe/STPShippingMethodTableViewCell.m
@@ -13,12 +13,12 @@
 #import "STPLocalizationUtils.h"
 
 @interface STPShippingMethodTableViewCell ()
-@property(nonatomic, weak) UILabel *titleLabel;
-@property(nonatomic, weak) UILabel *subtitleLabel;
-@property(nonatomic, weak) UILabel *amountLabel;
-@property(nonatomic, weak) UIImageView *checkmarkIcon;
-@property(nonatomic)PKShippingMethod *shippingMethod;
-@property(nonatomic) NSNumberFormatter *numberFormatter;
+@property (nonatomic, weak) UILabel *titleLabel;
+@property (nonatomic, weak) UILabel *subtitleLabel;
+@property (nonatomic, weak) UILabel *amountLabel;
+@property (nonatomic, weak) UIImageView *checkmarkIcon;
+@property (nonatomic) PKShippingMethod *shippingMethod;
+@property (nonatomic) NSNumberFormatter *numberFormatter;
 @end
 
 @implementation STPShippingMethodTableViewCell

--- a/Stripe/STPShippingMethodsViewController.h
+++ b/Stripe/STPShippingMethodsViewController.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
                                currency:(NSString *)currency
                                   theme:(STPTheme *)theme;
 
-@property(nonatomic, weak) id<STPShippingMethodsViewControllerDelegate> delegate;
+@property (nonatomic, weak) id<STPShippingMethodsViewControllerDelegate> delegate;
 
 @end
 

--- a/Stripe/STPShippingMethodsViewController.m
+++ b/Stripe/STPShippingMethodsViewController.m
@@ -22,11 +22,11 @@
 static NSString *const STPShippingMethodCellReuseIdentifier = @"STPShippingMethodCellReuseIdentifier";
 
 @interface STPShippingMethodsViewController () <UITableViewDataSource, UITableViewDelegate>
-@property(nonatomic)NSArray<PKShippingMethod *>*shippingMethods;
-@property(nonatomic)PKShippingMethod *selectedShippingMethod;
-@property(nonatomic)NSString *currency;
-@property(nonatomic, weak)UIImageView *imageView;
-@property(nonatomic)UIBarButtonItem *doneItem;
+@property (nonatomic) NSArray<PKShippingMethod *>*shippingMethods;
+@property (nonatomic) PKShippingMethod *selectedShippingMethod;
+@property (nonatomic) NSString *currency;
+@property (nonatomic, weak) UIImageView *imageView;
+@property (nonatomic) UIBarButtonItem *doneItem;
 @end
 
 @implementation STPShippingMethodsViewController

--- a/Stripe/STPStringUtils.h
+++ b/Stripe/STPStringUtils.h
@@ -13,41 +13,41 @@ typedef void(^STPTaggedSubstringsCompletionBlock)(NSString *string, NSDictionary
 
 @interface STPStringUtils : NSObject
 /**
- *  Takes a string with the named html-style tags, removes the tags,
- *  and then calls the completion block with the modified string and the range 
- *  in it that the tag would have enclosed.
- *  
- *  E.g. Passing in @"Test <b>string</b>" with tag @"b" would call completion
- *  with @"Test string" and NSMakeRange(5,6).
- *  
- *  Completion is always called, location of range is NSNotFound with the unmodified
- *  string if a match could not be found.
- *
- *  @param string     The string with tagged substrings.
- *  @param tag        The tag to search for.
- *  @param completion The string with the named tag removed and the range of the
- *                    substring it covered.
+ Takes a string with the named html-style tags, removes the tags,
+ and then calls the completion block with the modified string and the range 
+ in it that the tag would have enclosed.
+
+ E.g. Passing in @"Test <b>string</b>" with tag @"b" would call completion
+ with @"Test string" and NSMakeRange(5,6).
+
+ Completion is always called, location of range is NSNotFound with the unmodified
+ string if a match could not be found.
+
+ @param string     The string with tagged substrings.
+ @param tag        The tag to search for.
+ @param completion The string with the named tag removed and the range of the
+                   substring it covered.
  */
 + (void)parseRangeFromString:(NSString *)string
                      withTag:(NSString *)tag
                   completion:(STPTaggedSubstringCompletionBlock)completion;
 
 /**
- *  Like `parseRangeFromString:withTag:completion:` but you can pass in a set
- *  of unique tags to get the ranges for and it will return you the mapping.
- *  
- *  E.g. Passing @"<a>Test</a> <b>string</b>" with the tag set [a, b]
- *  will get you a completion block dictionary that looks like
- *  @{ @"a" : NSMakeRange(0,4),
- *     @"b" : NSMakeRange(5,6) }
- *
- *  @param string     The string with tagged substrings.
- *  @param tags       The tags to search for.
- *  @param completion The string with the named tags removed and the ranges of the
- *                    substrings they covered (wrapped in NSValue)
- * 
- *  @warning Doesn't currently support overlapping tag ranges because that's
- *           complicated and we don't need it at the moment.
+ Like `parseRangeFromString:withTag:completion:` but you can pass in a set
+ of unique tags to get the ranges for and it will return you the mapping.
+
+ E.g. Passing @"<a>Test</a> <b>string</b>" with the tag set [a, b]
+ will get you a completion block dictionary that looks like
+ @{ @"a" : NSMakeRange(0,4),
+    @"b" : NSMakeRange(5,6) }
+
+ @param string     The string with tagged substrings.
+ @param tags       The tags to search for.
+ @param completion The string with the named tags removed and the ranges of the
+                   substrings they covered (wrapped in NSValue)
+
+ @warning Doesn't currently support overlapping tag ranges because that's
+          complicated and we don't need it at the moment.
  */
 + (void)parseRangesFromString:(NSString *)string
                      withTags:(NSSet<NSString *> *)tags

--- a/Stripe/STPSwitchTableViewCell.h
+++ b/Stripe/STPSwitchTableViewCell.h
@@ -20,8 +20,8 @@
 
 @interface STPSwitchTableViewCell : UITableViewCell
 
-@property(nonatomic)BOOL on;
-@property(nonatomic)STPTheme *theme;
+@property (nonatomic) BOOL on;
+@property (nonatomic) STPTheme *theme;
 
 - (void)configureWithLabel:(NSString *)label
                   delegate:(id<STPSwitchTableViewCellDelegate>)delegate;

--- a/Stripe/STPSwitchTableViewCell.m
+++ b/Stripe/STPSwitchTableViewCell.m
@@ -11,9 +11,9 @@
 
 @interface STPSwitchTableViewCell()
 
-@property(nonatomic, weak)UILabel *captionLabel;
-@property(nonatomic, weak)UISwitch *switchView;
-@property(nonatomic, weak)id<STPSwitchTableViewCellDelegate> delegate;
+@property (nonatomic, weak) UILabel *captionLabel;
+@property (nonatomic, weak) UISwitch *switchView;
+@property (nonatomic, weak) id<STPSwitchTableViewCellDelegate> delegate;
 
 @end
 

--- a/Stripe/STPTheme.m
+++ b/Stripe/STPTheme.m
@@ -10,7 +10,7 @@
 #import "STPColorUtils.h"
 
 @interface STPTheme()
-@property(nonatomic)NSNumber *internalBarStyle;
+@property (nonatomic) NSNumber *internalBarStyle;
 @end
 
 static UIColor *STPThemeDefaultPrimaryBackgroundColor;

--- a/Stripe/STPWeakStrongMacros.h
+++ b/Stripe/STPWeakStrongMacros.h
@@ -7,8 +7,8 @@
 //
 
 /*
- * Based on @weakify() and @strongify() from
- * https://github.com/jspahrsummers/libextc
+ Based on @weakify() and @strongify() from
+ https://github.com/jspahrsummers/libextc
  */
 
 #define WEAK(var) __weak typeof(var) weak_##var = var;

--- a/Stripe/UIViewController+Stripe_KeyboardAvoiding.m
+++ b/Stripe/UIViewController+Stripe_KeyboardAvoiding.m
@@ -14,11 +14,11 @@ NS_ASSUME_NONNULL_BEGIN
 // This is a private class that is only a UIViewController subclass by virtue of the fact
 // that that makes it easier to attach to another UIViewController as a child.
 @interface STPKeyboardDetectingViewController : UIViewController
-@property(nonatomic, assign)CGRect lastKeyboardFrame;
-@property(nonatomic, weak)UIView *lastResponder;
-@property(nonatomic, nullable, copy)STPKeyboardFrameBlock keyboardFrameBlock;
-@property(nonatomic, weak)UIScrollView *managedScrollView;
-@property(nonatomic, assign)CGFloat currentBottomInsetChange;
+@property (nonatomic, assign) CGRect lastKeyboardFrame;
+@property (nonatomic, weak) UIView *lastResponder;
+@property (nonatomic, nullable, copy) STPKeyboardFrameBlock keyboardFrameBlock;
+@property (nonatomic, weak) UIScrollView *managedScrollView;
+@property (nonatomic, assign) CGFloat currentBottomInsetChange;
 @end
 
 @implementation STPKeyboardDetectingViewController

--- a/Stripe/UIViewController+Stripe_NavigationItemProxy.h
+++ b/Stripe/UIViewController+Stripe_NavigationItemProxy.h
@@ -10,7 +10,7 @@
 
 @interface UIViewController (Stripe_NavigationItemProxy)
 
-@property(nonatomic)UINavigationItem *stp_navigationItemProxy;
+@property (nonatomic) UINavigationItem *stp_navigationItemProxy;
 
 @end
 

--- a/Stripe/UIViewController+Stripe_Promises.h
+++ b/Stripe/UIViewController+Stripe_Promises.h
@@ -14,8 +14,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface UIViewController (Stripe_Promises)
 
-@property(nonatomic, readonly)STPVoidPromise *stp_willAppearPromise;
-@property(nonatomic, readonly)STPVoidPromise *stp_didAppearPromise;
+@property (nonatomic, readonly) STPVoidPromise *stp_willAppearPromise;
+@property (nonatomic, readonly) STPVoidPromise *stp_didAppearPromise;
 
 @end
 

--- a/Tests/Tests/STPAddCardViewControllerLocalizationTests.m
+++ b/Tests/Tests/STPAddCardViewControllerLocalizationTests.m
@@ -24,8 +24,8 @@
 @end
 
 @interface STPAddCardViewController (TestsPrivate)
-@property(nonatomic) UITableView *tableView;
-@property(nonatomic) STPAddressViewModel<STPAddressFieldTableViewCellDelegate> *addressViewModel;
+@property (nonatomic) UITableView *tableView;
+@property (nonatomic) STPAddressViewModel<STPAddressFieldTableViewCellDelegate> *addressViewModel;
 @end
 
 @implementation STPAddCardViewControllerLocalizationTests

--- a/Tests/Tests/STPAddCardViewControllerTest.m
+++ b/Tests/Tests/STPAddCardViewControllerTest.m
@@ -14,9 +14,9 @@
 #import "STPPaymentCardTextFieldCell.h"
 
 @interface STPAddCardViewController (Testing)
-@property(nonatomic)STPPaymentCardTextFieldCell *paymentCell;
-@property(nonatomic)STPAPIClient *apiClient;
-@property(nonatomic)BOOL loading;
+@property (nonatomic) STPPaymentCardTextFieldCell *paymentCell;
+@property (nonatomic) STPAPIClient *apiClient;
+@property (nonatomic) BOOL loading;
 @end
 
 @interface STPToken (Testing)

--- a/Tests/Tests/STPAddressTests.m
+++ b/Tests/Tests/STPAddressTests.m
@@ -354,8 +354,8 @@
     STPAddress *address = [STPAddress new];
     
     /**
-     *  Required fields for full are:
-     *  line1, city, country, state (US only) and a valid postal code (based on country)
+     Required fields for full are:
+     line1, city, country, state (US only) and a valid postal code (based on country)
      */
     
     XCTAssertFalse([address containsRequiredFields:STPBillingAddressFieldsFull]);

--- a/Tests/Tests/STPBinRangeTest.m
+++ b/Tests/Tests/STPBinRangeTest.m
@@ -11,10 +11,10 @@
 
 @interface STPBINRange(Testing)
 
-@property(nonatomic)NSUInteger length;
-@property(nonatomic)NSString *qRangeLow;
-@property(nonatomic)NSString *qRangeHigh;
-@property(nonatomic)STPCardBrand brand;
+@property (nonatomic) NSUInteger length;
+@property (nonatomic) NSString *qRangeLow;
+@property (nonatomic) NSString *qRangeHigh;
+@property (nonatomic) STPCardBrand brand;
 
 - (BOOL)matchesNumber:(NSString *)number;
 

--- a/Tests/Tests/STPFormEncoderTest.m
+++ b/Tests/Tests/STPFormEncoderTest.m
@@ -11,11 +11,11 @@
 #import "STPFormEncodable.h"
 
 @interface STPTestFormEncodableObject : NSObject<STPFormEncodable>
-@property(nonatomic) NSString *testProperty;
-@property(nonatomic) NSString *testIgnoredProperty;
-@property(nonatomic) NSArray *testArrayProperty;
-@property(nonatomic) NSDictionary *testDictionaryProperty;
-@property(nonatomic) STPTestFormEncodableObject *testNestedObjectProperty;
+@property (nonatomic) NSString *testProperty;
+@property (nonatomic) NSString *testIgnoredProperty;
+@property (nonatomic) NSArray *testArrayProperty;
+@property (nonatomic) NSDictionary *testDictionaryProperty;
+@property (nonatomic) STPTestFormEncodableObject *testNestedObjectProperty;
 @end
 
 @implementation STPTestFormEncodableObject

--- a/Tests/Tests/STPPaymentCardTextFieldTest.m
+++ b/Tests/Tests/STPPaymentCardTextFieldTest.m
@@ -15,17 +15,17 @@
 #import "STPPaymentCardTextFieldViewModel.h"
 
 @interface STPFormTextField(Testing)
-@property(nonatomic)BOOL skipsReloadingInputViews;
+@property (nonatomic) BOOL skipsReloadingInputViews;
 @end
 
 @interface STPPaymentCardTextField (Testing)
-@property(nonatomic, readwrite, weak)UIImageView *brandImageView;
-@property(nonatomic, readwrite, weak)STPFormTextField *numberField;
-@property(nonatomic, readwrite, weak)STPFormTextField *expirationField;
-@property(nonatomic, readwrite, weak)STPFormTextField *cvcField;
-@property(nonatomic, readonly, weak)STPFormTextField *currentFirstResponderField;
-@property(nonatomic, readwrite, strong)STPPaymentCardTextFieldViewModel *viewModel;
-@property(nonatomic, copy) NSNumber *focusedTextFieldForLayout;
+@property (nonatomic, readwrite, weak) UIImageView *brandImageView;
+@property (nonatomic, readwrite, weak) STPFormTextField *numberField;
+@property (nonatomic, readwrite, weak) STPFormTextField *expirationField;
+@property (nonatomic, readwrite, weak) STPFormTextField *cvcField;
+@property (nonatomic, readonly, weak) STPFormTextField *currentFirstResponderField;
+@property (nonatomic, readwrite, strong) STPPaymentCardTextFieldViewModel *viewModel;
+@property (nonatomic, copy) NSNumber *focusedTextFieldForLayout;
 + (UIImage *)cvcImageForCardBrand:(STPCardBrand)cardBrand;
 + (UIImage *)brandImageForCardBrand:(STPCardBrand)cardBrand;
 @end
@@ -351,8 +351,8 @@
 @end
 
 @interface STPPaymentCardTextFieldUITests : XCTestCase
-@property(nonatomic)UIWindow *window;
-@property(nonatomic)STPPaymentCardTextField *sut;
+@property (nonatomic) UIWindow *window;
+@property (nonatomic) STPPaymentCardTextField *sut;
 @end
 
 @implementation STPPaymentCardTextFieldUITests

--- a/Tests/Tests/STPPaymentCardTextFieldViewModelTest.m
+++ b/Tests/Tests/STPPaymentCardTextFieldViewModelTest.m
@@ -12,7 +12,7 @@
 #import "STPPaymentCardTextFieldViewModel.h"
 
 @interface STPPaymentCardTextFieldViewModelTest : XCTestCase
-@property(nonatomic)STPPaymentCardTextFieldViewModel *viewModel;
+@property (nonatomic) STPPaymentCardTextFieldViewModel *viewModel;
 @end
 
 @implementation STPPaymentCardTextFieldViewModelTest

--- a/Tests/Tests/STPPaymentContextApplePayTest.m
+++ b/Tests/Tests/STPPaymentContextApplePayTest.m
@@ -15,7 +15,7 @@
 #import "STPPaymentContext.h"
 
 @interface STPPaymentContext (Testing)
-@property(nonatomic) PKShippingMethod *selectedShippingMethod;
+@property (nonatomic) PKShippingMethod *selectedShippingMethod;
 - (PKPaymentRequest *)buildPaymentRequest;
 @end
 

--- a/Tests/Tests/STPShippingAddressViewControllerLocalizationTests.m
+++ b/Tests/Tests/STPShippingAddressViewControllerLocalizationTests.m
@@ -17,8 +17,8 @@
 #import "STPLocalizationUtils+STPTestAdditions.h"
 
 @interface STPShippingAddressViewController (TestsPrivate)
-@property(nonatomic) UITableView *tableView;
-@property(nonatomic) STPAddressViewModel<STPAddressFieldTableViewCellDelegate> *addressViewModel;
+@property (nonatomic) UITableView *tableView;
+@property (nonatomic) STPAddressViewModel<STPAddressFieldTableViewCellDelegate> *addressViewModel;
 @end
 
 @interface STPShippingAddressViewControllerLocalizationTests : FBSnapshotTestCase

--- a/Tests/Tests/STPShippingMethodsViewControllerLocalizationTests.m
+++ b/Tests/Tests/STPShippingMethodsViewControllerLocalizationTests.m
@@ -17,7 +17,7 @@
 #import "STPShippingMethodsViewController.h"
 
 @interface STPShippingMethodsViewController (TestsPrivate)
-@property(nonatomic) UITableView *tableView;
+@property (nonatomic) UITableView *tableView;
 @end
 
 @interface STPShippingMethodsViewControllerLocalizationTests : FBSnapshotTestCase


### PR DESCRIPTION
## Summary

Use some regex replacements to:
- remove all leading asterisks from comments
- update property definitions to use one space before and after the parenthesis

## Motivation

Resolve style changes at once instead of dealing with them case by case.

## Testing

Verified tests still pass and documentation is built with minimal changes.

r? @bdorfman-stripe 
cc @bg-stripe 
