### PR TITLE
Improve jazzy version check to support multiple local installed versions

### DIFF
--- a/ci_scripts/build_documentation.sh
+++ b/ci_scripts/build_documentation.sh
@@ -10,10 +10,10 @@ if ! command -v jazzy > /dev/null; then
 fi
 
 # Verify jazzy is up to date
-jazzy_version_local="$(gem search ^jazzy$ --local --no-verbose)"
-jazzy_version_remote="$(gem search ^jazzy$ --remote --no-verbose)"
+jazzy_version_remote="$(gem search ^jazzy$ --remote --no-verbose | grep --only-matching --extended-regexp "[0-9\.]+")"
+jazzy_version_installed="$(gem search ^jazzy$ --installed --no-verbose --version "${jazzy_version_remote}")"
 
-if [[ "${jazzy_version_local}" != "${jazzy_version_remote}" ]]; then
+if [[ "${jazzy_version_installed}" != "true" ]]; then
   echo "ERROR: Please update jazzy before running build_documentation.sh:"
   echo "\`gem update jazzy\`"
   exit 1

--- a/ci_scripts/build_documentation.sh
+++ b/ci_scripts/build_documentation.sh
@@ -10,10 +10,10 @@ if ! command -v jazzy > /dev/null; then
 fi
 
 # Verify jazzy is up to date
+jazzy_version_local="$(jazzy --version | grep --only-matching --extended-regexp "[0-9\.]+")"
 jazzy_version_remote="$(gem search ^jazzy$ --remote --no-verbose | grep --only-matching --extended-regexp "[0-9\.]+")"
-jazzy_version_installed="$(gem search ^jazzy$ --installed --no-verbose --version "${jazzy_version_remote}")"
 
-if [[ "${jazzy_version_installed}" != "true" ]]; then
+if [[ "${jazzy_version_local}" != "${jazzy_version_remote}" ]]; then
   echo "ERROR: Please update jazzy before running build_documentation.sh:"
   echo "\`gem update jazzy\`"
   exit 1


### PR DESCRIPTION
The output of `gem search —local` includes all historic versions
installed which does not compare nicely with `gem search —remote`

r? @bdorfman-stripe 
cc @bg-stripe 