### PR TITLE
Installation test scripts improvements

### DIFF
--- a/Tests/installation_tests/carthage/test.sh
+++ b/Tests/installation_tests/carthage/test.sh
@@ -2,21 +2,34 @@
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Install xcpretty
+function info {
+  echo "[$(basename ${0})] [INFO] ${1}"
+}
+
+function die {
+  echo "[$(basename ${0})] [ERROR] ${1}"
+  exit 1
+}
+
+# Verify xcpretty is installed
 if ! command -v xcpretty > /dev/null; then
-  echo "Installing xcpretty..."
-  gem install xcpretty --no-ri --no-rdoc
+  if [[ "${CI}" != "true" ]]; then
+    die "Please install xcpretty: https://github.com/supermarin/xcpretty#installation"
+  fi
+
+  info "Installing xcpretty..."
+  gem install xcpretty --no-ri --no-rdoc || die "Executing \`gem install xcpretty\` failed"
 fi
 
 # Clean carthage artifacts
-echo "Cleaning carthage artifacts..."
+info "Cleaning carthage artifacts..."
 
 rm -f "${script_dir}/Cartfile"
 rm -f "${script_dir}/Cartfile.resolved"
 rm -rf "${script_dir}/Carthage"
 
 # Generate new Cartfile
-echo "Generating new Cartfile..."
+info "Generating new Cartfile..."
 
 git_repo="$(cd "${script_dir}/../../../" && pwd)"
 git_hash="$(git rev-parse HEAD)"
@@ -24,23 +37,22 @@ git_hash="$(git rev-parse HEAD)"
 echo "git \"${git_repo}\" \"${git_hash}\"" > "${script_dir}/Cartfile"
 
 # Execute carthage bootstrap
-echo "Executing carthage bootstrap..."
+info "Executing carthage bootstrap..."
 
-cd "${script_dir}"
+cd "${script_dir}" || die "Executing \`cd\` failed"
 
 carthage bootstrap --platform ios --configuration Debug --no-use-binaries
 
 carthage_exit_code="$?"
 
 if [[ "${carthage_exit_code}" != 0 ]]; then
-  echo "ERROR: Executing carthage bootstrap failed with status code: ${carthage_exit_code}"
-  exit 1
+  die "Executing carthage bootstrap failed with status code: ${carthage_exit_code}"
 fi
 
 # Execute xcodebuild
-echo "Executing xcodebuild..."
+info "Executing xcodebuild..."
 
-xcodebuild build \
+xcodebuild clean build \
   -project "${script_dir}/CarthageTest.xcodeproj" \
   -scheme "CarthageTest" \
   -sdk "iphonesimulator" \
@@ -50,8 +62,7 @@ xcodebuild build \
 xcodebuild_exit_code="${PIPESTATUS[0]}"
 
 if [[ "${xcodebuild_exit_code}" != 0 ]]; then
-  echo "ERROR: Executing xcodebuild failed with status code: ${xcodebuild_exit_code}"
-  exit 1
+  die "Executing xcodebuild failed with status code: ${xcodebuild_exit_code}"
 fi
 
-echo "All good!"
+info "All good!"

--- a/Tests/installation_tests/cocoapods/with_frameworks/test.sh
+++ b/Tests/installation_tests/cocoapods/with_frameworks/test.sh
@@ -1,15 +1,77 @@
-#!/bin/sh
+#!/bin/bash
 
-# This causes the script to fail if any subscript fails
-set -e
-set -o pipefail
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-echo "Checking test CocoaPods app (with frameworks)..."
-cd $(dirname $0)
+function info {
+  echo "[$(basename ${0})] [INFO] ${1}"
+}
 
-gem install xcpretty --no-ri --no-rdoc
-gem update cocoapods --no-ri --no-rdoc
+function die {
+  echo "[$(basename ${0})] [ERROR] ${1}"
+  exit 1
+}
 
-rm -rf Pods
-rm -f Podfile.lock
-pod install --no-repo-update && xcodebuild build -workspace CocoapodsTest.xcworkspace -scheme CocoapodsTest -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.3.1' | xcpretty -c
+# Verify xcpretty is installed
+if ! command -v xcpretty > /dev/null; then
+  if [[ "${CI}" != "true" ]]; then
+    die "Please install xcpretty: https://github.com/supermarin/xcpretty#installation"
+  fi
+
+  info "Installing xcpretty..."
+  gem install xcpretty --no-ri --no-rdoc || die "Executing \`gem install xcpretty\` failed"
+fi
+
+# Verify cocoapods is installed
+if ! command -v pod > /dev/null; then
+  if [[ "${CI}" != "true" ]]; then
+    die "Please install cocoapods: https://cocoapods.org"
+  fi
+
+  info "Installing cocoapods..."
+  gem install cocoapods --no-ri --no-rdoc || die "Executing \`gem install cocoapods\` failed"
+fi
+
+# Verify cocoapods is up to date
+cocoapods_version_local="$(pod --version | grep --only-matching --extended-regexp "[0-9\.]+")"
+cocoapods_version_remote="$(gem search ^cocoapods$ --remote --no-verbose | grep --only-matching --extended-regexp "[0-9\.]+")"
+
+if [[ "${cocoapods_version_local}" != "${cocoapods_version_remote}" ]]; then
+  if [[ "${CI}" != "true" ]]; then
+    die "Please update cocoapods: \`gem update cocoapods\`"
+  fi
+
+  info "Updating cocoapods..."
+  gem update cocoapods --no-ri --no-rdoc || die "Executing \`gem update cocoapods\` failed"
+fi
+
+# Switch to script directory
+cd "${script_dir}" || die "Executing \`cd\` failed"
+
+# Clean cocoapods artifacts
+info "Cleaning cocoapods artifacts..."
+
+rm -rf "Pods"
+rm -f "Podfile.lock"
+
+# Perform cocoapods installation
+info "Performing pod install..."
+
+pod install --no-repo-update || die "Executing \`pod install\` failed"
+
+# Execute xcodebuild
+info "Executing xcodebuild..."
+
+xcodebuild clean build \
+  -workspace "CocoapodsTest.xcworkspace" \
+  -scheme "CocoapodsTest" \
+  -sdk "iphonesimulator" \
+  -destination "platform=iOS Simulator,name=iPhone 6,OS=10.3.1" \
+  | xcpretty
+
+xcodebuild_exit_code="${PIPESTATUS[0]}"
+
+if [[ "${xcodebuild_exit_code}" != 0 ]]; then
+  die "Executing xcodebuild failed with status code: ${xcodebuild_exit_code}"
+fi
+
+info "All good!"

--- a/Tests/installation_tests/cocoapods/without_frameworks/test.sh
+++ b/Tests/installation_tests/cocoapods/without_frameworks/test.sh
@@ -1,15 +1,77 @@
-#!/bin/sh
+#!/bin/bash
 
-# This causes the script to fail if any subscript fails
-set -e
-set -o pipefail
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-echo "Checking test CocoaPods app..."
-cd $(dirname $0)
+function info {
+  echo "[$(basename ${0})] [INFO] ${1}"
+}
 
-gem install xcpretty --no-ri --no-rdoc
-gem update cocoapods --no-ri --no-rdoc
+function die {
+  echo "[$(basename ${0})] [ERROR] ${1}"
+  exit 1
+}
 
-rm -rf Pods
-rm -f Podfile.lock
-pod install --no-repo-update && xcodebuild build -workspace CocoapodsTest.xcworkspace -scheme CocoapodsTest -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.3.1' | xcpretty -c
+# Verify xcpretty is installed
+if ! command -v xcpretty > /dev/null; then
+  if [[ "${CI}" != "true" ]]; then
+    die "Please install xcpretty: https://github.com/supermarin/xcpretty#installation"
+  fi
+
+  info "Installing xcpretty..."
+  gem install xcpretty --no-ri --no-rdoc || die "Executing \`gem install xcpretty\` failed"
+fi
+
+# Verify cocoapods is installed
+if ! command -v pod > /dev/null; then
+  if [[ "${CI}" != "true" ]]; then
+    die "Please install cocoapods: https://cocoapods.org"
+  fi
+
+  info "Installing cocoapods..."
+  gem install cocoapods --no-ri --no-rdoc || die "Executing \`gem install cocoapods\` failed"
+fi
+
+# Verify cocoapods is up to date
+cocoapods_version_local="$(pod --version | grep --only-matching --extended-regexp "[0-9\.]+")"
+cocoapods_version_remote="$(gem search ^cocoapods$ --remote --no-verbose | grep --only-matching --extended-regexp "[0-9\.]+")"
+
+if [[ "${cocoapods_version_local}" != "${cocoapods_version_remote}" ]]; then
+  if [[ "${CI}" != "true" ]]; then
+    die "Please update cocoapods: \`gem update cocoapods\`"
+  fi
+
+  info "Updating cocoapods..."
+  gem update cocoapods --no-ri --no-rdoc || die "Executing \`gem update cocoapods\` failed"
+fi
+
+# Switch to script directory
+cd "${script_dir}" || die "Executing \`cd\` failed"
+
+# Clean cocoapods artifacts
+info "Cleaning cocoapods artifacts..."
+
+rm -rf "Pods"
+rm -f "Podfile.lock"
+
+# Perform cocoapods installation
+info "Performing pod install..."
+
+pod install --no-repo-update || die "Executing \`pod install\` failed"
+
+# Execute xcodebuild
+info "Executing xcodebuild..."
+
+xcodebuild clean build \
+  -workspace "CocoapodsTest.xcworkspace" \
+  -scheme "CocoapodsTest" \
+  -sdk "iphonesimulator" \
+  -destination "platform=iOS Simulator,name=iPhone 6,OS=10.3.1" \
+  | xcpretty
+
+xcodebuild_exit_code="${PIPESTATUS[0]}"
+
+if [[ "${xcodebuild_exit_code}" != 0 ]]; then
+  die "Executing xcodebuild failed with status code: ${xcodebuild_exit_code}"
+fi
+
+info "All good!"


### PR DESCRIPTION
# Summary

General improvements to our installation test scripts including:
- Use `info` / `die` helper functions to clarify owner of log lines and shorten implementations
- Auto install / update dependencies on CI, otherwise exit with an instruction
- Verify exit code of `cd` steps
- Add `clean` to `xcodebuild` steps in case that improves test reliability
- Improve messaging when steps do fail unexpectedly

r? @bg-stripe 
cc @bdorfman-stripe 