### PR TITLE
Add all the possible file upload purposes

### DIFF
--- a/Stripe/PublicHeaders/STPFile.h
+++ b/Stripe/PublicHeaders/STPFile.h
@@ -11,12 +11,64 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ The purpose of the uploaded file.
+ 
+ @see https://stripe.com/docs/file-upload
+ */
 typedef NS_ENUM(NSInteger, STPFilePurpose) {
+
+    /**
+     Identity document file
+     */
     STPFilePurposeIdentityDocument,
+
+    /**
+     Dispute evidence file
+     */
     STPFilePurposeDisputeEvidence,
+
+    /**
+     Business logo file
+     */
+    STPFilePurposeBusinessLogo,
+
+    /**
+     Incorporation document file
+     */
+    STPFilePurposeIncorporationDocument,
+
+    /**
+     Incorporation article file
+     */
+    STPFilePurposeIncorporationArticle,
+
+    /**
+     Invoice statement file
+     */
+    STPFilePurposeInvoiceStatement,
+
+    /**
+     Payment provider transfer file
+     */
+    STPFilePurposePaymentProviderTransfer,
+
+    /**
+     Product feed file
+     */
+    STPFilePurposeProductFeed,
+
+    /**
+     A file of unknown purpose type
+     */
     STPFilePurposeUnknown,
 };
 
+/**
+ Representation of a file upload object in the Stripe API.
+ 
+ @see https://stripe.com/docs/api#file_uploads
+ */
 @interface STPFile : NSObject <STPAPIResponseDecodable>
 
 /**
@@ -30,7 +82,8 @@ typedef NS_ENUM(NSInteger, STPFilePurpose) {
 @property (nonatomic, readonly) NSDate *created;
 
 /**
- The purpose of this file. This can be either an identifing document or an evidence dispute. 
+ The purpose of this file.
+
  @see https://stripe.com/docs/file-upload
  */
 @property (nonatomic, readonly) STPFilePurpose purpose;
@@ -45,10 +98,12 @@ typedef NS_ENUM(NSInteger, STPFilePurpose) {
  */
 @property (nonatomic, readonly) NSString *type;
 
+#pragma mark - Deprecated methods
+
 /**
  Returns the string value for a purpose.
  */
-+ (nullable NSString *)stringFromPurpose:(STPFilePurpose)purpose;
++ (nullable NSString *)stringFromPurpose:(STPFilePurpose)purpose DEPRECATED_ATTRIBUTE;
 
 @end
 

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -306,6 +306,11 @@ static NSString * const FileUploadURL = @"https://uploads.stripe.com/v1/files";
         case STPFilePurposeDisputeEvidence:
             maxBytes = 8 * 1000000;
             break;
+        default:
+            // TODO: Docs don't state max file size for other types
+            // using same as identity document for now
+            maxBytes = 4 * 1000000;
+            break;
         case STPFilePurposeUnknown:
             maxBytes = 0;
             break;
@@ -319,7 +324,12 @@ static NSString * const FileUploadURL = @"https://uploads.stripe.com/v1/files";
 
     STPMultipartFormDataPart *purposePart = [[STPMultipartFormDataPart alloc] init];
     purposePart.name = @"purpose";
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
+    // Only deprecated publicly. Can remove pragma and move to +Private
+    // in future release
     purposePart.data = [[STPFile stringFromPurpose:purpose] dataUsingEncoding:NSUTF8StringEncoding];
+#pragma clang diagnostic pop
 
     STPMultipartFormDataPart *imagePart = [[STPMultipartFormDataPart alloc] init];
     imagePart.name = @"file";

--- a/Stripe/STPFile+Private.h
+++ b/Stripe/STPFile+Private.h
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface STPFile ()
 
-//
++ (nullable NSString *)stringFromPurpose:(STPFilePurpose)purpose;
 
 @end
 

--- a/Stripe/STPFile.m
+++ b/Stripe/STPFile.m
@@ -11,16 +11,18 @@
 
 #import "NSDictionary+Stripe.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface STPFile ()
 
-@property (nonatomic, readwrite) NSString *fileId;
-@property (nonatomic, readwrite) NSDate *created;
-@property (nonatomic, readwrite) STPFilePurpose purpose;
-@property (nonatomic, readwrite) NSNumber *size;
-@property (nonatomic, readwrite) NSString *type;
-@property (nonatomic, readwrite, copy) NSDictionary *allResponseFields;
+@property (nonatomic, copy, readwrite) NSString *fileId;
+@property (nonatomic, copy, readwrite) NSDate *created;
+@property (nonatomic, assign, readwrite) STPFilePurpose purpose;
+@property (nonatomic, copy, readwrite) NSNumber *size;
+@property (nonatomic, copy, readwrite) NSString *type;
+@property (nonatomic, copy, readwrite, copy) NSDictionary *allResponseFields;
 
-- (BOOL)isEqualToFile:(STPFile *)file;
+- (BOOL)isEqualToFile:(nullable STPFile *)file;
 
 // See STPFile+Private.h
 
@@ -32,8 +34,14 @@
 
 + (NSDictionary<NSString *,NSNumber *> *)stringToPurposeMapping {
     return @{
+             @"business_logo": @(STPFilePurposeBusinessLogo),
              @"dispute_evidence": @(STPFilePurposeDisputeEvidence),
              @"identity_document": @(STPFilePurposeIdentityDocument),
+             @"incorporation_article": @(STPFilePurposeIncorporationArticle),
+             @"incorporation_document": @(STPFilePurposeIncorporationDocument),
+             @"invoice_statement": @(STPFilePurposeInvoiceStatement),
+             @"payment_provider_transfer": @(STPFilePurposePaymentProviderTransfer),
+             @"product_feed": @(STPFilePurposeProductFeed),
              };
 }
 
@@ -54,15 +62,15 @@
 
 #pragma mark - Equality
 
-- (BOOL)isEqual:(STPFile *)file {
-    return [self isEqualToFile:file];
+- (BOOL)isEqual:(nullable id)object {
+    return [self isEqualToFile:object];
 }
 
 - (NSUInteger)hash {
     return [self.fileId hash];
 }
 
-- (BOOL)isEqualToFile:(STPFile *)file {
+- (BOOL)isEqualToFile:(nullable STPFile *)file {
     if (self == file) {
         return YES;
     }
@@ -80,7 +88,7 @@
     return @[@"id", @"created", @"size", @"purpose", @"type"];
 }
 
-+ (instancetype)decodedObjectFromAPIResponse:(NSDictionary *)response {
++ (nullable instancetype)decodedObjectFromAPIResponse:(nullable NSDictionary *)response {
     NSDictionary *dict = [response stp_dictionaryByRemovingNullsValidatingRequiredFields:[self requiredFields]];
     if (!dict) {
         return nil;
@@ -100,3 +108,5 @@
 }
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Tests/Tests/STPFileTest.m
+++ b/Tests/Tests/STPFileTest.m
@@ -34,6 +34,29 @@
     XCTAssertEqual([STPFile purposeFromString:@"identity_document"], STPFilePurposeIdentityDocument);
     XCTAssertEqual([STPFile purposeFromString:@"IDENTITY_DOCUMENT"], STPFilePurposeIdentityDocument);
 
+
+    XCTAssertEqual([STPFile purposeFromString:@"business_logo"], STPFilePurposeBusinessLogo);
+    XCTAssertEqual([STPFile purposeFromString:@"BUSINESS_LOGO"], STPFilePurposeBusinessLogo);
+
+
+    XCTAssertEqual([STPFile purposeFromString:@"incorporation_document"], STPFilePurposeIncorporationDocument);
+    XCTAssertEqual([STPFile purposeFromString:@"INCORPORATION_DOCUMENT"], STPFilePurposeIncorporationDocument);
+
+
+    XCTAssertEqual([STPFile purposeFromString:@"incorporation_article"], STPFilePurposeIncorporationArticle);
+    XCTAssertEqual([STPFile purposeFromString:@"INCORPORATION_ARTICLE"], STPFilePurposeIncorporationArticle);
+
+
+    XCTAssertEqual([STPFile purposeFromString:@"invoice_statement"], STPFilePurposeInvoiceStatement);
+    XCTAssertEqual([STPFile purposeFromString:@"INVOICE_STATEMENT"], STPFilePurposeInvoiceStatement);
+
+
+    XCTAssertEqual([STPFile purposeFromString:@"payment_provider_transfer"], STPFilePurposePaymentProviderTransfer);
+    XCTAssertEqual([STPFile purposeFromString:@"PAYMENT_PROVIDER_TRANSFER"], STPFilePurposePaymentProviderTransfer);
+
+    XCTAssertEqual([STPFile purposeFromString:@"product_feed"], STPFilePurposeProductFeed);
+    XCTAssertEqual([STPFile purposeFromString:@"PRODUCT_FEED"], STPFilePurposeProductFeed);
+
     XCTAssertEqual([STPFile purposeFromString:@"unknown"], STPFilePurposeUnknown);
     XCTAssertEqual([STPFile purposeFromString:@"UNKNOWN"], STPFilePurposeUnknown);
 
@@ -45,12 +68,24 @@
     NSArray<NSNumber *> *values = @[
                                     @(STPFilePurposeDisputeEvidence),
                                     @(STPFilePurposeIdentityDocument),
+                                    @(STPFilePurposeBusinessLogo),
+                                    @(STPFilePurposeIncorporationDocument),
+                                    @(STPFilePurposeIncorporationArticle),
+                                    @(STPFilePurposeInvoiceStatement),
+                                    @(STPFilePurposePaymentProviderTransfer),
+                                    @(STPFilePurposeProductFeed),
                                     @(STPFilePurposeUnknown),
                                     ];
 
     for (NSNumber *purposeNumber in values) {
         STPFilePurpose purpose = (STPFilePurpose)[purposeNumber integerValue];
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
+        // Only deprecated publicly. Can remove pragma and move to +Private
+        // in future release
         NSString *string = [STPFile stringFromPurpose:purpose];
+#pragma clang diagnostic pop
 
         switch (purpose) {
             case STPFilePurposeDisputeEvidence:
@@ -58,6 +93,24 @@
                 break;
             case STPFilePurposeIdentityDocument:
                 XCTAssertEqualObjects(string, @"identity_document");
+                break;
+            case STPFilePurposeBusinessLogo:
+                XCTAssertEqualObjects(string, @"business_logo");
+                break;
+            case STPFilePurposeIncorporationDocument:
+                XCTAssertEqualObjects(string, @"incorporation_document");
+                break;
+            case STPFilePurposeIncorporationArticle:
+                XCTAssertEqualObjects(string, @"incorporation_article");
+                break;
+            case STPFilePurposeInvoiceStatement:
+                XCTAssertEqualObjects(string, @"invoice_statement");
+                break;
+            case STPFilePurposePaymentProviderTransfer:
+                XCTAssertEqualObjects(string, @"payment_provider_transfer");
+                break;
+            case STPFilePurposeProductFeed:
+                XCTAssertEqualObjects(string, @"product_feed");
                 break;
             case STPFilePurposeUnknown:
                 XCTAssertNil(string);


### PR DESCRIPTION
Noticed that the API docs list a whole bunch more possible values for the file upload `purpose` key, so I added them.

The file upload guide doesn't state what the max file size values are for the other types (or really give any guidance on what they're for that I could find). I have an ask open and will update the branch with correct values before merging.