### PR TITLE
[WIP] Autocorrecting Linter

### DIFF
--- a/Tests/linter_tests/linter_tests.rb
+++ b/Tests/linter_tests/linter_tests.rb
@@ -1,0 +1,56 @@
+#!/usr/bin/env ruby
+# encoding: utf-8
+
+require 'optparse'
+
+require_relative 'rules/property_rule'
+
+usage = 'Usage: linter_tests.rb [--force] [directory]'
+
+# Parse options from command line
+options = {}
+
+OptionParser.new do |opts|
+  opts.banner = usage
+
+  opts.on('-f', '--force', 'Force linter to write changes. Will perform dry run by default.') do |force|
+    options[:force] = force
+  end
+end.parse!
+
+# Parse directory argument
+if ARGV.length != 1
+  print "#{usage}\n"
+  exit 1
+end
+
+file_paths = []
+
+Dir.glob(ARGV[0] + '/**/*.h') do |file_path|
+  file_paths.push(file_path)
+end
+
+Dir.glob(ARGV[0] + '/**/*.m') do |file_path|
+  file_paths << file_path
+end
+
+# Apply rules
+file_paths.each do |file_path|
+  file_name = file_path.split('/').last
+  file_lines = File.readlines(file_path).map(&:chomp)
+
+  # Property rule
+  file_lines = Rules::PropertyRule.apply_rule(file_name, file_lines)
+
+  # Apply changes if needed
+  if options[:force]
+    File.open(file_path, 'w') do |file|
+      file.write(file_lines.join("\n") + "\n")
+    end
+  end
+end
+
+# Print summary
+if !options[:force]
+  print "Run linter_tests.rb with `--force` option to autocorrect\n"
+end

--- a/Tests/linter_tests/linter_tests.rb
+++ b/Tests/linter_tests/linter_tests.rb
@@ -4,6 +4,7 @@
 require 'optparse'
 
 require_relative 'rules/property_rule'
+require_relative 'utils/logger'
 
 usage = 'Usage: linter_tests.rb [--force] [directory]'
 
@@ -16,6 +17,10 @@ OptionParser.new do |opts|
   opts.on('-f', '--force', 'Force linter to write changes. Will perform dry run by default.') do |force|
     options[:force] = force
   end
+
+  opts.on('-v', '--verbose', 'Enable logging debug messages.') do |verbose|
+    options[:verbose] = verbose
+  end
 end.parse!
 
 # Parse directory argument
@@ -24,6 +29,10 @@ if ARGV.length != 1
   exit 1
 end
 
+# Configure logger
+Utils::Logger.verbose_mode = options[:verbose]
+
+# Load file paths
 file_paths = []
 
 Dir.glob(ARGV[0] + '/**/*.h') do |file_path|

--- a/Tests/linter_tests/rules/property_rule.rb
+++ b/Tests/linter_tests/rules/property_rule.rb
@@ -9,6 +9,10 @@ module Rules
       file_lines
     end
 
+    # Applies proper property definition spacing up to the type name
+    #
+    # Ex: `@property (nonatomic, strong) NSString *string;`
+    #      ^                             ^
     def self.apply_property_spacing_rule(file_name, file_lines)
       file_lines_corrected = []
 
@@ -42,7 +46,10 @@ module Rules
       file_lines_corrected
     end
 
-    # Lint property attributes ordering
+    # Applies proper property attribute ordering
+    #
+    # Ex:  `@property (strong, nonatomic) NSString *string;`
+    #   => `@property (nonatomic, strong) NSString *string;`
     @ideal_ordering = %w[
       nonatomic
       atomic
@@ -105,6 +112,16 @@ module Rules
       file_lines_corrected
     end
 
+    # Verifies that immutable classes with mutable counterparts are marked with copy
+    @mutable_counterparts_list = %w[
+      NSString
+      NSArray
+      NSDictionary
+    ]
+    def self.apply_property_copy_rule(file_name, file_lines)
+
+    end
+
     # Parse property line into attributes and definition
     #
     # `@property (nonatomic, readwrite) NSString *type;  // Type of transaction`
@@ -116,11 +133,17 @@ module Rules
       matches = /^@property\s*\(([\w,\s]+)\)\s*(.*)$/.match(line)
 
       if matches && matches.length == 3
+        Utils::Logger.log_debug("Property matches: #{matches.inspect}")
+
         {
           attributes: matches[1].strip.split(/\s*,\s*/),
           definition: matches[2],
         }
       else
+        if line.include?('@property')
+          Utils::Logger.log_debug("Skipped property: #{line}")
+        end
+
         nil
       end
     end

--- a/Tests/linter_tests/rules/property_rule.rb
+++ b/Tests/linter_tests/rules/property_rule.rb
@@ -1,0 +1,128 @@
+require_relative '../utils/logger'
+
+module Rules
+  class PropertyRule
+    def self.apply_rule(file_name, file_lines)
+      file_lines = apply_property_spacing_rule(file_name, file_lines)
+      file_lines = apply_property_attributes_ordering_rule(file_name, file_lines)
+
+      file_lines
+    end
+
+    def self.apply_property_spacing_rule(file_name, file_lines)
+      file_lines_corrected = []
+
+      file_lines.each_with_index do |line, idx|
+        property = parse_property(line)
+
+        if property.nil?
+          # Do nothing
+          file_lines_corrected << line
+          next
+        end
+
+        # Determine correct spacing for property
+        attributes_string = property[:attributes].join(', ')
+        line_fixed = "@property (#{attributes_string}) #{property[:definition]}"
+
+        if line == line_fixed
+          # Do nothing
+          file_lines_corrected << line
+          next
+        end
+
+        # Generate corrected line and print info
+        Utils::Logger.log_lint('Fix property spacing', file_name, idx + 1,
+          line: line,
+          line_fixed: line_fixed)
+
+        file_lines_corrected << line_fixed
+      end
+
+      file_lines_corrected
+    end
+
+    # Lint property attributes ordering
+    @ideal_ordering = %w[
+      nonatomic
+      atomic
+      unsafe_unretained
+      weak
+      copy
+      strong
+      assign
+      nonnull
+      nullable
+      null_resettable
+      readonly
+      readwrite
+    ]
+    def self.apply_property_attributes_ordering_rule(file_name, file_lines)
+      file_lines_corrected = []
+
+      file_lines.each_with_index do |line, idx|
+        property = parse_property(line)
+
+        if property.nil?
+          # Do nothing
+          file_lines_corrected << line
+          next
+        end
+
+        # Determine correct ordering for given attributes
+        attributes_actual = property[:attributes]
+        attributes_ordered = []
+
+        @ideal_ordering.each do |attr|
+          attributes_ordered << attr if attributes_actual.include?(attr)
+        end
+
+        if attributes_actual.length != attributes_ordered.length
+          Utils::Logger.log_error('Found attribute(s) missing from ideal_ordering list', line: line)
+          raise RuntimeError
+        end
+
+        if attributes_actual == attributes_ordered
+          # Do nothing
+          file_lines_corrected << line
+          next
+        end
+
+        # Generate corrected line and print info
+        attributes_ordered_string = attributes_ordered.join(', ')
+
+        line_fixed = "@property (#{attributes_ordered_string}) #{property[:definition]}"
+
+        Utils::Logger.log_lint('Fix property attributes ordering', file_name, idx + 1,
+          line: line,
+          line_fixed: line_fixed,
+          attributes_actual: attributes_actual,
+          attributes_ordered: attributes_ordered)
+
+        file_lines_corrected << line_fixed
+      end
+
+      file_lines_corrected
+    end
+
+    # Parse property line into attributes and definition
+    #
+    # `@property (nonatomic, readwrite) NSString *type;  // Type of transaction`
+    #   => {
+    #        attributes: `[nonatomic, readwrite]`,
+    #        definition: `NSString *type;  // Type of transaction`,
+    #      }
+    def self.parse_property(line)
+      matches = /^@property\s*\(([\w,\s]+)\)\s*(.*)$/.match(line)
+
+      if matches && matches.length == 3
+        {
+          attributes: matches[1].strip.split(/\s*,\s*/),
+          definition: matches[2],
+        }
+      else
+        nil
+      end
+    end
+  end
+end

--- a/Tests/linter_tests/tests/property_rule.rb
+++ b/Tests/linter_tests/tests/property_rule.rb
@@ -1,0 +1,53 @@
+require 'test/unit'
+
+require_relative '../rules/property_rule'
+
+class PropertyRuleTest < Test::Unit::TestCase
+  def test_apply_property_spacing_rule_autocorrect_compact
+    # Should autocorrect property spacing (compact style)
+    line = '@property(nonatomic,strong,readwrite)NSString *string; // comment'
+    expected = '@property (nonatomic, strong, readwrite) NSString *string; // comment'
+    result = Rules::PropertyRule.apply_property_spacing_rule('file_name', [line])
+    assert_equal([expected], result)
+  end
+
+  def test_apply_property_spacing_rule_autocorrect_expanded
+    # Should autocorrect property spacing (expanded style)
+    line = '@property    ( nonatomic,   strong  , readwrite  )    NSString *string; // comment'
+    expected = '@property (nonatomic, strong, readwrite) NSString *string; // comment'
+    result = Rules::PropertyRule.apply_property_spacing_rule('file_name', [line])
+    assert_equal([expected], result)
+  end
+
+  def test_apply_property_attributes_ordering_rule_garbage
+    # Should throw on unrecognized property attribute
+    line = '@property (garbage) NSString *string;'
+    assert_raise do
+      Rules::PropertyRule.apply_property_attributes_ordering_rule('file_name', [line])
+    end
+  end
+
+  def test_apply_property_attributes_ordering_rule_autocorrect
+    # Should autocorrect property attribute ordering
+    line = '@property (nonatomic, readwrite, strong) NSString *string;'
+    expected = '@property (nonatomic, strong, readwrite) NSString *string;'
+    result = Rules::PropertyRule.apply_property_attributes_ordering_rule('file_name', [line])
+    assert_equal([expected], result)
+  end
+
+  def test_apply_property_attributes_ordering_rule_autocorrect_comment
+    # Should autocorrect property attribute ordering (line ends with comment)
+    line = '@property (nonatomic, readwrite, strong) NSString *string; // comment'
+    expected = '@property (nonatomic, strong, readwrite) NSString *string; // comment'
+    result = Rules::PropertyRule.apply_property_attributes_ordering_rule('file_name', [line])
+    assert_equal([expected], result)
+  end
+
+  def test_apply_property_attributes_ordering_rule_non_property
+    # Should do nothing for non property line
+    line = 'NSString *string;'
+    expected = 'NSString *string;'
+    result = Rules::PropertyRule.apply_property_attributes_ordering_rule('file_name', [line])
+    assert_equal([expected], result)
+  end
+end

--- a/Tests/linter_tests/tests/run_tests.rb
+++ b/Tests/linter_tests/tests/run_tests.rb
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+# encoding: utf-8
+
+require_relative '../utils/logger'
+Utils::Logger.test_mode = true
+
+require_relative 'property_rule.rb'

--- a/Tests/linter_tests/utils/logger.rb
+++ b/Tests/linter_tests/utils/logger.rb
@@ -1,9 +1,11 @@
 module Utils
   class Logger
     @test_mode = false
+    @verbose_mode = false
 
     class << self
       attr_accessor :test_mode
+      attr_accessor :verbose_mode
     end
 
     def self.log_lint(message, file_name, line_number, context_hash)
@@ -29,6 +31,10 @@ module Utils
       end
 
       log "\n"
+    end
+
+    def self.log_debug(line)
+      print "[DEBUG] #{line}\n" if @verbose_mode
     end
 
     def self.log(line)

--- a/Tests/linter_tests/utils/logger.rb
+++ b/Tests/linter_tests/utils/logger.rb
@@ -1,0 +1,38 @@
+module Utils
+  class Logger
+    @test_mode = false
+
+    class << self
+      attr_accessor :test_mode
+    end
+
+    def self.log_lint(message, file_name, line_number, context_hash)
+      log "[INFO] #{message}:\n"
+      log "[INFO]   #{file_name}:L#{line_number}\n"
+
+      context_hash.each do |key, value|
+        log "[INFO]   #{key}=`#{value}`\n"
+      end
+
+      log "\n"
+    end
+
+    def self.log_error(message, context_hash)
+      if context_hash.nil?
+        log "[ERROR] #{message}\n"
+      else
+        log "[ERROR] #{message}:\n"
+
+        context_hash.each do |key, value|
+          log "[ERROR]   #{key}=`#{value}`\n"
+        end
+      end
+
+      log "\n"
+    end
+
+    def self.log(line)
+      print line unless @test_mode
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Spent some time looking into linting solutions for ObjC but nothing in particular stood out in terms of ease of use and extensibility. Then started going down the path of writing our own so that we can add rules to it as issues come up.

Initially ruled out building this linter on an abstract syntax tree because Xcode uses clang but has many blackbox flags/extensions on it that we can't recreate. The current implementation basically:

- For each header/implementation file
  - For each rule
    - For each line
      - If line matches (regex) a problem
      - Then fix the problem by rewriting the line
      - Else do nothing
 
In the future, we could start piping non-autocorrectable warnings into Xcode using [mayday](https://github.com/marklarr/mayday)

You can test this out by running `./Tests/linter_tests/linter_tests.rb --force Stripe/` which should autocorrect some property attribute ordering violations we currently have in the codebase.

## Motivation

Help us avoid common mistakes / style consistencies through automation.

## Testing

There's a corresponding test suite for the linter itself at `./Tests/linter_tests/tests/run_tests.rb`

wdyt? @bdorfman-stripe , @bg-stripe , @danj-stripe 
