### PR TITLE
Fix spelling of `verification`

### DIFF
--- a/Stripe/PublicHeaders/STPAPIClient.h
+++ b/Stripe/PublicHeaders/STPAPIClient.h
@@ -134,7 +134,7 @@ static NSString *const STPSDKVersion = @"11.2.0";
 
 /**
  Uses the Stripe file upload API to upload an image. This can be used for
- identity veritfication and evidence disputes.
+ identity verification and evidence disputes.
 
  @param image The image to be uploaded. The maximum allowed file size is 4MB
         for identity documents and 8MB for evidence disputes. Cannot be nil.


### PR DESCRIPTION
## Summary

Fix spelling of `verification` in documentation comment.

## Motivation

Saw the typo while reading code.

## Testing

None