### PR TITLE
[WIP] Adding a playground to UI Examples

### DIFF
--- a/Example/Examples.playground/Pages/1. STPPaymentCardTextField.xcplaygroundpage/Contents.swift
+++ b/Example/Examples.playground/Pages/1. STPPaymentCardTextField.xcplaygroundpage/Contents.swift
@@ -1,0 +1,116 @@
+/*:
+ # UI Examples Playground
+ 
+ Switch Xcode to show the assistant editor (cmd-opt-return), and make sure it's showing the timeline, so you
+ can see a live view of the text field as you make changes to its properties.
+ ## Import the Stripe Framework
+ 
+ If this fails, you'll need to build the `UI Examples` application for simulator once.
+ */
+import Stripe
+
+/*:
+ ## Create STPPaymentCardTextField
+ 
+ 
+ */
+// We'll use Auto-layout to size and position the view in the superview, so frame doesn't matter.
+let textField = STPPaymentCardTextField(frame: CGRect.zero)
+textField.translatesAutoresizingMaskIntoConstraints = false
+
+/*:
+ ## Customize STPPaymentCardTextField
+ 
+ You can change the font & colors used
+ */
+// The font used in each child field. Default is [UIFont systemFontOfSize:18].
+textField.font = .systemFont(ofSize: 18.0)
+
+// The text color to be used when entering valid text. Default is [UIColor blackColor].
+textField.textColor = .black
+
+// The text color to be used when the user has entered invalid information, such as an
+// invalid card number.
+textField.textErrorColor = .red
+
+// The text placeholder color used in each child field.
+// This will also set the color of the card placeholder icon.
+textField.placeholderColor = .lightGray
+
+// The cursor color for the field.
+// This is a proxy for the view's tintColor property, exposed for clarity only
+// (in other words, calling setCursorColor is identical to calling setTintColor).
+textField.cursorColor = nil
+
+/*:
+ You can adjust the border.
+ 
+ Note: STPPaymentCardTextField integrates with the UIAppearance protocol for many appearance
+ properties, so you can customize *all* instances in one place. The font/color customization could
+ have also been done via the proxy.
+ */
+let proxy = STPPaymentCardTextField.appearance()
+proxy.borderColor = .lightGray
+proxy.borderWidth = 1.0
+proxy.cornerRadius = 5.0
+
+/*:
+ You can control the placeholder text.
+ */
+textField.numberPlaceholder = "4242424242424242"
+textField.expirationPlaceholder = "MM/YY"
+textField.cvcPlaceholder = "CVC"
+textField.postalCodePlaceholder = "Postal"
+
+/*:
+ You can turn on Postal Code entry, and optionally specify the country.
+ 
+ It's off by default.
+ */
+textField.postalCodeEntryEnabled = false
+textField.countryCode = NSLocale.current.regionCode
+
+/*:
+ There are other customization options available, please see STPPaymentCardTextField.h
+
+ ## Set up STPPaymentCardTextFieldDelegate
+ 
+ There are 5 pairs of `...DidBeginEditing...` and `...DidEndEditing...` methods, one for the whole text
+ field, and one for each of the 4 embedded text fields (card number, expiration, CVC, and postal code).
+ 
+ There is also a single `paymentCardTextFieldDidChange` method for changes in any of the text
+ fields.
+ */
+// This delegate class just logs when the methods are called.
+class MySTPPaymentCardTextFieldDelegate: NSObject, STPPaymentCardTextFieldDelegate {
+    func paymentCardTextFieldDidChange(_ textField: STPPaymentCardTextField) {
+        // You might enable/disable your 'Submit' based on isValid
+        if textField.isValid {
+            print("Valid payment card information entered",
+                  textField.cardNumber!,
+                  textField.expirationMonth, textField.expirationYear,
+                  textField.cvc!,
+                  textField.postalCode)
+        }
+    }
+    
+    func paymentCardTextFieldDidBeginEditing(_ textField: STPPaymentCardTextField) {
+        print(textField, "paymentCardTextFieldDidBeginEditing")
+    }
+    
+    // Implement any other delegate methods you're interested in.
+}
+let myDelegate = MySTPPaymentCardTextFieldDelegate()
+textField.delegate = myDelegate
+
+/*:
+ ## Display STPPaymentCardTextField in the Playground
+ 
+ This is just for demo purposes.
+ */
+let container = ContainerView(textField)
+import PlaygroundSupport
+PlaygroundPage.current.liveView = container
+textField.becomeFirstResponder() // Activate the text field
+
+//: [Next Page: STPAddCardViewController](@next)

--- a/Example/Examples.playground/Pages/1. STPPaymentCardTextField.xcplaygroundpage/Sources/ContainerView.swift
+++ b/Example/Examples.playground/Pages/1. STPPaymentCardTextField.xcplaygroundpage/Sources/ContainerView.swift
@@ -1,0 +1,29 @@
+import UIKit
+
+public class ContainerView: UIView {
+    required public init(_ subview: UIView) {
+        let screen = UIScreen.main.bounds
+        
+        super.init(frame: screen)
+        
+        self.backgroundColor = UIColor.white
+        self.autoresizingMask = [.flexibleHeight, .flexibleWidth]
+        
+        self.addSubview(subview)
+        
+        self.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "|-(margin)-[subview]-(margin)-|",
+                                                           options: [],
+                                                           metrics: ["margin": 30.0],
+                                                           views: ["subview": subview]))
+        self.addConstraint(NSLayoutConstraint(item: self, attribute: .centerY,
+                                              relatedBy: .equal,
+                                              toItem: subview, attribute: .centerY,
+                                              multiplier: 1.0, constant: 0.0))
+        self.setNeedsUpdateConstraints()
+        
+    }
+    
+    required public init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/Example/Examples.playground/Pages/1. STPPaymentCardTextField.xcplaygroundpage/timeline.xctimeline
+++ b/Example/Examples.playground/Pages/1. STPPaymentCardTextField.xcplaygroundpage/timeline.xctimeline
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Timeline
+   version = "3.0">
+   <TimelineItems>
+   </TimelineItems>
+</Timeline>

--- a/Example/Examples.playground/Pages/2. STPAddCardViewController.xcplaygroundpage/Contents.swift
+++ b/Example/Examples.playground/Pages/2. STPAddCardViewController.xcplaygroundpage/Contents.swift
@@ -1,0 +1,101 @@
+/*:
+ [Previous Page: STPPaymentCardTextField](@previous)
+
+ ## Import the Stripe library
+ */
+import Stripe
+
+/*:
+ ## Set up the STPPaymentConfiguration
+
+ As an alternative to configuring the `sharedConfiguration`, you could create one
+ and pass it into the `STPAddCardViewController` initializer.
+
+ This configuration, particularly the `publishableKey`, would make sense to do on
+ application launch.
+ */
+let config = STPPaymentConfiguration.shared()
+
+// Set publishable key
+config.publishableKey = "pk_test_6pRNASCoBOKtIshFeQd4XMUh"
+
+// Request the full billing address
+config.requiredBillingAddressFields = .full
+
+/*:
+ ## Set up the STPTheme.
+
+ As an alternative to configuring the `default` theme, you could create one
+ and pass it into the `STPAddCardViewController` initializer.
+
+ By setting up the default theme at launch time, you ensure all STP view controllers
+ will share the same styling.
+ */
+
+let theme = STPTheme.default()
+
+// Customize the theme a little.
+// These are not recommended choices, and you can find more properties in the documentation.
+theme.accentColor = UIColor.orange
+theme.emphasisFont = UIFont(name: "Copperplate-Bold", size: 24.0)
+theme.font = UIFont(name: "Copperplate", size: 24.0)
+
+/*:
+ ## Implement STPAddCardViewControllerDelegate methods
+
+ This is an example delegate object that just logs when the methods are called.
+ Yours will integrate with your view controller hierarchy and navigation scheme.
+ */
+class MyAddCardVCDelegate: NSObject, STPAddCardViewControllerDelegate {
+    func addCardViewControllerDidCancel(_ vc: STPAddCardViewController) {
+        print(vc, "addCardViewControllerDidCancel:")
+        // VC needs to be dismissed
+    }
+
+    func addCardViewController(_ vc: STPAddCardViewController, didCreateToken token: STPToken, completion: @escaping STPErrorBlock) {
+        print(vc, "addCardViewController:didCreateToken:completion:")
+        print(token)
+
+        // Token needs to be sent to the backend, the completion block called,
+        // and the VC dismissed. This example just waits ~5 seconds.
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .seconds(5)) {
+            completion(nil)
+        }
+    }
+}
+let myDelegate = MyAddCardVCDelegate()
+
+
+/*:
+ ## Create a STPAddCardViewController to display
+ */
+let addCardVC = STPAddCardViewController()
+
+addCardVC.delegate = myDelegate
+
+//: Pre-fill the billing address with information our fake app already knew.
+let billingAddress = STPAddress()
+billingAddress.line1 = "1234 Main Street"
+billingAddress.city = "San Francisco"
+billingAddress.state = "CA"
+billingAddress.postalCode = "94107"
+billingAddress.country = "US"
+
+let prefilledInfo = STPUserInformation()
+prefilledInfo.billingAddress = billingAddress
+addCardVC.prefilledInformation = prefilledInfo
+
+
+/*:
+ ## Display STPAddCardViewController in UINavigationController
+
+ The STPAddCardViewController would be shown as part of your app flow.
+ */
+let navVC = UINavigationController(rootViewController: addCardVC)
+navVC.navigationBar.stp_theme = theme
+
+
+// This shows it as the only view of the playground, for demo purposes
+import PlaygroundSupport
+PlaygroundPage.current.liveView = navVC.view
+

--- a/Example/Examples.playground/Pages/2. STPAddCardViewController.xcplaygroundpage/timeline.xctimeline
+++ b/Example/Examples.playground/Pages/2. STPAddCardViewController.xcplaygroundpage/timeline.xctimeline
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Timeline
+   version = "3.0">
+   <TimelineItems>
+   </TimelineItems>
+</Timeline>

--- a/Example/Examples.playground/contents.xcplayground
+++ b/Example/Examples.playground/contents.xcplayground
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<playground version='6.0' target-platform='ios' display-mode='rendered'>
+    <pages>
+        <page name='1. STPAddCardViewController'/>
+        <page name='2. STPPaymentCardTextField'/>
+        <page name='3. Using Standard Integration'/>
+    </pages>
+</playground>

--- a/Example/UI Examples.xcodeproj/project.pbxproj
+++ b/Example/UI Examples.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		B3134FD41F44E3FA00127EBC /* Examples.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = Examples.playground; sourceTree = "<group>"; };
 		C1140CBD1F1EC0FC002084AB /* Stripe UI Examples.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Stripe UI Examples.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C1140CC01F1EC0FC002084AB /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C1140CC21F1EC0FC002084AB /* BrowseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowseViewController.swift; sourceTree = "<group>"; };
@@ -72,6 +73,7 @@
 		C1140CB41F1EC0FC002084AB = {
 			isa = PBXGroup;
 			children = (
+				B3134FD41F44E3FA00127EBC /* Examples.playground */,
 				C13A00541F1FF7A800825683 /* README.md */,
 				C1140CBF1F1EC0FC002084AB /* UI Examples */,
 				C19A55A71F1EC18600C8AABE /* Frameworks */,


### PR DESCRIPTION
## Summary

Adding a playground to UI Examples

It has pages for STPPaymentCardTextField and STPAddCardViewController, which show off
some of the customization options, and allow users to play with the components directly
inside the playground's timeline.

## Motivation

I have a hypothesis that it'll be an interesting way to allow people to explore the library.

## Testing

Interact with the playground.

If the Stripe framework hasn't been built (new checkout or cleaned build folder), the playground fails in non-obvious ways. It also doesn't appear to recover well.