### PR TITLE
Support native redirects

### DIFF
--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -644,6 +644,7 @@
 		F15675401DB544D3004468E3 /* STPAddCardViewControllerLocalizationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F156753F1DB544D3004468E3 /* STPAddCardViewControllerLocalizationTests.m */; };
 		F15AC18E1DBA9CA90009EADE /* FBSnapshotTestCase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F15AC18D1DBA9CA90009EADE /* FBSnapshotTestCase.framework */; };
 		F15AC1901DBA9CC60009EADE /* FBSnapshotTestCase.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = F15AC18D1DBA9CA90009EADE /* FBSnapshotTestCase.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		F16AA26F1F5A0F1700207FFF /* AlipaySource.json in Resources */ = {isa = PBXBuildFile; fileRef = F16AA26D1F5A05A100207FFF /* AlipaySource.json */; };
 		F1852F931D80B6EC00367C86 /* STPStringUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = F1852F911D80B6EC00367C86 /* STPStringUtils.h */; };
 		F1852F941D80B6EC00367C86 /* STPStringUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = F1852F911D80B6EC00367C86 /* STPStringUtils.h */; };
 		F1852F951D80B6EC00367C86 /* STPStringUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = F1852F921D80B6EC00367C86 /* STPStringUtils.m */; };
@@ -1159,6 +1160,7 @@
 		F15232301EA93E6800D65C67 /* Contacts.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Contacts.framework; path = System/Library/Frameworks/Contacts.framework; sourceTree = SDKROOT; };
 		F156753F1DB544D3004468E3 /* STPAddCardViewControllerLocalizationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPAddCardViewControllerLocalizationTests.m; sourceTree = "<group>"; };
 		F15AC18D1DBA9CA90009EADE /* FBSnapshotTestCase.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FBSnapshotTestCase.framework; path = Carthage/Build/iOS/FBSnapshotTestCase.framework; sourceTree = "<group>"; };
+		F16AA26D1F5A05A100207FFF /* AlipaySource.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = AlipaySource.json; sourceTree = "<group>"; };
 		F1852F911D80B6EC00367C86 /* STPStringUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPStringUtils.h; sourceTree = "<group>"; };
 		F1852F921D80B6EC00367C86 /* STPStringUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPStringUtils.m; sourceTree = "<group>"; };
 		F19491D81E5F606F001E1FC2 /* STPSourceCardDetails.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPSourceCardDetails.m; sourceTree = "<group>"; };
@@ -1471,6 +1473,7 @@
 				F1BA241C1E57BE5700E4A1CF /* CardSource.json */,
 				F152322E1EA9344000D65C67 /* iDEALSource.json */,
 				8BD2133D1F045D31007F6FD1 /* SEPADebitSource.json */,
+				F16AA26D1F5A05A100207FFF /* AlipaySource.json */,
 			);
 			name = Source;
 			sourceTree = "<group>";
@@ -2406,6 +2409,7 @@
 				8BD213391F0457A1007F6FD1 /* FileUpload.json in Resources */,
 				C1CFCB7A1ED5F88D00BE45DF /* stp_test_upload_image.jpeg in Resources */,
 				F152322F1EA9344600D65C67 /* iDEALSource.json in Resources */,
+				F16AA26F1F5A0F1700207FFF /* AlipaySource.json in Resources */,
 				8BD2133C1F0458F5007F6FD1 /* BitcoinSource.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Stripe/PublicHeaders/STPRedirectContext.h
+++ b/Stripe/PublicHeaders/STPRedirectContext.h
@@ -125,6 +125,10 @@ NS_EXTENSION_UNAVAILABLE("Redirect based sources are not available in extensions
  over the redirect method, you can use 
  `startSafariViewControllerRedirectFlowFromViewController` 
  or `startSafariAppRedirectFlow`
+ 
+ If the source supports a native app, and that app is is installed on the user's
+ device, this call will do a direct app-to-app redirect instead of showing
+ a web url. 
 
  @note This method does nothing if the context is not in the 
  `STPRedirectContextStateNotStarted` state.

--- a/Stripe/STPRedirectContext.m
+++ b/Stripe/STPRedirectContext.m
@@ -31,22 +31,6 @@ typedef void (^STPBoolCompletionBlock)(BOOL success);
 
 @implementation STPRedirectContext
 
-
-- (nullable NSURL *)nativeRedirectURLForSource:(STPSource *)source {
-    NSString *nativeUrlString = nil;
-    switch (source.type) {
-        case STPSourceTypeAlipay:
-            nativeUrlString = source.details[@"native_url"];
-            break;
-        default:
-            // All other sources have no native url support
-            break;
-    }
-
-    NSURL *nativeUrl = nativeUrlString ? [NSURL URLWithString:nativeUrlString] : nil;
-    return nativeUrl;
-}
-
 - (nullable instancetype)initWithSource:(STPSource *)source
                              completion:(STPRedirectContextCompletionBlock)completion {
 
@@ -234,6 +218,21 @@ typedef void (^STPBoolCompletionBlock)(BOOL success);
         [self.safariVC.presentingViewController dismissViewControllerAnimated:YES
                                                                    completion:nil];
     }
+}
+
+- (nullable NSURL *)nativeRedirectURLForSource:(STPSource *)source {
+    NSString *nativeUrlString = nil;
+    switch (source.type) {
+        case STPSourceTypeAlipay:
+            nativeUrlString = source.details[@"native_url"];
+            break;
+        default:
+            // All other sources have no native url support
+            break;
+    }
+
+    NSURL *nativeUrl = nativeUrlString ? [NSURL URLWithString:nativeUrlString] : nil;
+    return nativeUrl;
 }
 
 @end

--- a/Stripe/STPRedirectContext.m
+++ b/Stripe/STPRedirectContext.m
@@ -35,6 +35,7 @@ typedef void (^STPBoolCompletionBlock)(BOOL success);
                              completion:(STPRedirectContextCompletionBlock)completion {
 
     if (source.flow != STPSourceFlowRedirect
+        || source.status != STPSourceStatusPending
         || source.redirect.returnURL == nil
         || (source.redirect.url == nil
             && [self nativeRedirectURLForSource:source] == nil)) {
@@ -227,7 +228,7 @@ typedef void (^STPBoolCompletionBlock)(BOOL success);
             nativeUrlString = source.details[@"native_url"];
             break;
         default:
-            // All other sources have no native url support
+            // All other sources currently have no native url support
             break;
     }
 

--- a/Stripe/STPSourceParams.m
+++ b/Stripe/STPSourceParams.m
@@ -9,6 +9,7 @@
 #import "STPSourceParams.h"
 #import "STPSourceParams+Private.h"
 
+#import "NSBundle+Stripe_AppName.h"
 #import "STPCardParams.h"
 #import "STPFormEncoder.h"
 #import "STPSource+Private.h"
@@ -256,6 +257,17 @@
     params.amount = @(amount);
     params.currency = currency;
     params.redirect = @{ @"return_url": returnURL };
+
+    NSString *bundleID = [[NSBundle mainBundle] bundleIdentifier];
+    NSString *versionKey = [NSBundle stp_applicationVersion];
+    if (bundleID && versionKey) {
+        params.additionalAPIParameters = @{
+                                           @"alipay": @{
+                                                   @"app_bundle_id": bundleID,
+                                                   @"app_version_key": versionKey,
+                                                   },
+                                           };
+    }
     return params;
 }
 

--- a/Tests/Tests/AlipaySource.json
+++ b/Tests/Tests/AlipaySource.json
@@ -1,0 +1,33 @@
+{
+    "id": "src_123",
+    "object": "source",
+    "amount": 1099,
+    "client_secret": "src_client_secret_123",
+    "created": 1445277809,
+    "currency": "usd",
+    "flow": "redirect",
+    "livemode": true,
+    "owner": {
+	       "address": null,
+	       "email": null,
+	       "name": null,
+	       "phone": null,
+	       "verified_address": null,
+	       "verified_email": null,
+	       "verified_name": null,
+	       "verified_phone": null,
+    },
+    "redirect": {
+	       "return_url": "https://shop.foo.com/crtABC",
+	       "status": "pending",
+	       "url": "https://pay.stripe.com/redirect/src_123?client_secret=src_client_secret_123"
+    },
+    "statement_descriptor": null,
+    "status": "pending",
+    "type": "alipay",
+    "usage": "single_use",
+    "alipay": {
+        "statement_descriptor": null,
+        "native_url": null
+    }
+}

--- a/Tests/Tests/STPFixtures.h
+++ b/Tests/Tests/STPFixtures.h
@@ -60,7 +60,7 @@
 + (STPSource *)alipaySource;
 
 /**
- A Source object with type Alipay
+ A Source object with type Alipay and a native redirect url
  */
 + (STPSource *)alipaySourceWithNativeUrl;
 

--- a/Tests/Tests/STPFixtures.h
+++ b/Tests/Tests/STPFixtures.h
@@ -55,6 +55,16 @@
 + (STPSource *)iDEALSource;
 
 /**
+ A Source object with type Alipay
+ */
++ (STPSource *)alipaySource;
+
+/**
+ A Source object with type Alipay
+ */
++ (STPSource *)alipaySourceWithNativeUrl;
+
+/**
  A PaymentConfiguration object with a fake publishable key. Use this to avoid
  triggering our asserts when publishable key is nil or invalid. All other values
  are at their original defaults.

--- a/Tests/Tests/STPFixtures.m
+++ b/Tests/Tests/STPFixtures.m
@@ -71,6 +71,18 @@
     return [STPSource decodedObjectFromAPIResponse:[STPTestUtils jsonNamed:@"iDEALSource"]];
 }
 
++ (STPSource *)alipaySource {
+    return [STPSource decodedObjectFromAPIResponse:[STPTestUtils jsonNamed:@"AlipaySource"]];
+}
+
++ (STPSource *)alipaySourceWithNativeUrl {
+    NSMutableDictionary *dictionary = [STPTestUtils jsonNamed:@"AlipaySource"].mutableCopy;
+    NSMutableDictionary *detailsDictionary = ((NSDictionary *)dictionary[@"alipay"]).mutableCopy;
+    detailsDictionary[@"native_url"] = @"alipay://test";
+    dictionary[@"alipay"] = detailsDictionary;
+    return [STPSource decodedObjectFromAPIResponse:dictionary];
+}
+
 + (STPPaymentConfiguration *)paymentConfiguration {
     STPPaymentConfiguration *config = [STPPaymentConfiguration new];
     config.publishableKey = @"pk_fake_publishable_key";

--- a/Tests/Tests/STPRedirectContextTest.m
+++ b/Tests/Tests/STPRedirectContextTest.m
@@ -288,6 +288,7 @@
  */
 - (void)testNativeRedirectSupportingSourceFlow_validNativeURL {
     STPSource *source = [STPFixtures alipaySourceWithNativeUrl];
+    NSURL *sourceURL = [NSURL URLWithString:source.details[@"native_url"]];
 
     STPRedirectContext *context = [[STPRedirectContext alloc] initWithSource:source
                                                                   completion:^(__unused NSString *sourceID, __unused NSString *clientSecret, __unused NSError *error) {
@@ -297,15 +298,18 @@
 
     id applicationMock = OCMClassMock([UIApplication class]);
     OCMStub([applicationMock sharedApplication]).andReturn(applicationMock);
+    OCMStub([applicationMock openURL:[OCMArg any]
+                             options:[OCMArg any]
+                   completionHandler:([OCMArg invokeBlockWithArgs:@YES, nil])]);
 
     id mockVC = OCMClassMock([UIViewController class]);
     [context startRedirectFlowFromViewController:mockVC];
 
     OCMReject([sut startSafariViewControllerRedirectFlowFromViewController:[OCMArg any]]);
     OCMReject([sut startSafariAppRedirectFlow]);
-    OCMVerify([applicationMock openURL:[OCMArg any]
-                               options:[OCMArg any]
-                     completionHandler:[OCMArg any]]);
+    OCMVerify([applicationMock openURL:[OCMArg isEqual:sourceURL]
+                               options:[OCMArg isEqual:@{}]
+                     completionHandler:[OCMArg isNotNil]]);
 }
 
 /**
@@ -327,13 +331,13 @@
     id mockVC = OCMClassMock([UIViewController class]);
     [context startRedirectFlowFromViewController:mockVC];
 
-    OCMVerify([sut startSafariViewControllerRedirectFlowFromViewController:[OCMArg any]]);
+    OCMVerify([sut startSafariViewControllerRedirectFlowFromViewController:[OCMArg isEqual:mockVC]]);
     OCMReject([applicationMock openURL:[OCMArg any]
                                options:[OCMArg any]
                      completionHandler:[OCMArg any]]);
     OCMVerify([mockVC presentViewController:[OCMArg isKindOfClass:[SFSafariViewController class]]
                                    animated:YES
-                                 completion:[OCMArg any]]);
+                                 completion:[OCMArg isNil]]);
 }
 
 @end


### PR DESCRIPTION
Not going to merge immediately because I think there's still some question about where in the source return data the native url for Alipay is going to be, but this is a general framework for dealing with sources that support native redirects going forward.