### PR TITLE
Fix addressbook tests for ios11

### DIFF
--- a/Stripe/STPAddress.m
+++ b/Stripe/STPAddress.m
@@ -83,23 +83,23 @@ NSString *stringIfHasContentsElseNil(NSString *string);
             if (ABMultiValueGetCount(addressValues) > 0) {
                 CFDictionaryRef dict = ABMultiValueCopyValueAtIndex(addressValues, 0);
                 NSString *street = CFDictionaryGetValue(dict, kABPersonAddressStreetKey);
-                if (street) {
+                if (street.length > 0) {
                     _line1 = street;
                 }
                 NSString *city = CFDictionaryGetValue(dict, kABPersonAddressCityKey);
-                if (city) {
+                if (city.length > 0) {
                     _city = city;
                 }
                 NSString *state = CFDictionaryGetValue(dict, kABPersonAddressStateKey);
-                if (state) {
+                if (state.length > 0) {
                     _state = state;
                 }
                 NSString *zip = CFDictionaryGetValue(dict, kABPersonAddressZIPKey);
-                if (zip) {
+                if (zip.length > 0) {
                     _postalCode = zip;
                 }
                 NSString *country = CFDictionaryGetValue(dict, kABPersonAddressCountryCodeKey);
-                if (country) {
+                if (country.length > 0) {
                     _country = [country uppercaseString];
                 }
                 if (dict != NULL) {

--- a/Tests/Tests/STPAddressTests.m
+++ b/Tests/Tests/STPAddressTests.m
@@ -284,11 +284,11 @@
     XCTAssertNil(lastName);
     XCTAssertNil(email);
     XCTAssertNil(phone);
-    XCTAssertNil(line1);
-    XCTAssertNil(city);
+    XCTAssertTrue((line1.length == 0));
+    XCTAssertTrue((city.length == 0));
     XCTAssertEqualObjects(state, @"VA");
-    XCTAssertNil(country);
-    XCTAssertNil(postalCode);
+    XCTAssertTrue((country.length == 0));
+    XCTAssertTrue((postalCode.length == 0));
 }
 
 - (void)testPKContactValue {


### PR DESCRIPTION
iOS11 returns empty string (@"") instead of nil for empty address fields. Changed checks and STPAddress logic to accomodate this behavior.