### PR TITLE
[WIP] Run travis on multiple xcode versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,7 @@ matrix:
       - TEST_TYPE=analyzer
 
 before_install:
-- SIMULATOR_ID=$(xcrun instruments -s | grep -o $SIMULATOR_NAME \[.*\]" | grep -o
+- SIMULATOR_ID=$(xcrun instruments -s | grep -o "$SIMULATOR_NAME \[.*\]" | grep -o
   "\[.*\]" | sed "s/^\[\(.*\)\]$/\1/")
 script:
 - open -a "simulator" --args -CurrentDeviceUDID $SIMULATOR_ID

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: objective-c
-osx_image: xcode8.3
+osx_image:
+  - xcode8.3
+  - xcode9
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: objective-c
-osx_image:
-  - xcode8.3
-  - xcode9
+os: osx
+osx_image: xcode8.3
 branches:
   only:
     - master
@@ -19,8 +18,32 @@ env:
   global:
     secure: gZMOaHQIeG7nplBCuH7EKf9o6Ez2rtoSskrv3nOTziSxFfZq322MrxvkidDpEN7AKWYQm27FO+tCzgq0slXb578lQ9P5ySDwEdExKtk/jMtKsBsf3cr4dzSMiqV5D5TbsH2jE9HQlpYUoJeoMBicR2XsTmd7wiu2jAzNBFqGfiY=
 
+matrix:
+  include:
+  - osx_image: xcode8.3
+    env: SIMULATOR_NAME='iPhone 6 (10.3)'
+  - osx_image: xcode9
+    env:
+      - SIMULATOR_NAME='iPhone 6 (10.3)'
+      - DESTINATIONS_ONLY=1 #Only run tests that have different simulator destination options
+  - osx_image: xcode9
+    env: SIMULATOR_NAME='iPhone 6 (11.0)'
+  exclude:
+  - osx_image: xcode9
+    env:
+      - DESTINATIONS_ONLY=1
+      - TEST_TYPE=lint
+  - osx_image: xcode9
+    env:
+      - DESTINATIONS_ONLY=1
+      - TEST_TYPE=analyzer
+  - osx_image: xcode9
+    env:
+      - DESTINATIONS_ONLY=1
+      - TEST_TYPE=documentation
+
 before_install:
-- SIMULATOR_ID=$(xcrun instruments -s | grep -o "iPhone 6 (10.3) \[.*\]" | grep -o
+- SIMULATOR_ID=$(xcrun instruments -s | grep -o $SIMULATOR_NAME \[.*\]" | grep -o
   "\[.*\]" | sed "s/^\[\(.*\)\]$/\1/")
 script:
 - open -a "simulator" --args -CurrentDeviceUDID $SIMULATOR_ID
@@ -29,10 +52,10 @@ script:
 - "./ci_scripts/check_category_linking.rb"
 - "./ci_scripts/check_resource_bundle.rb"
 - '[ "$TEST_TYPE" != lint ] || ./ci_scripts/check_fauxpas.sh'
-- '[ "$TEST_TYPE" != tests ] || travis_retry ./ci_scripts/run_tests.sh'
+- '[ "$TEST_TYPE" != tests ] || travis_retry ./ci_scripts/run_tests.sh "$SIMULATOR_ID"'
 - '[ "$TEST_TYPE" != analyzer ] || ./ci_scripts/run_analyzer.sh'
-- '[ "$TEST_TYPE" != installation_cocoapods ] || ./Tests/installation_tests/cocoapods/without_frameworks/test.sh'
-- '[ "$TEST_TYPE" != installation_cocoapods_frameworks ] || ./Tests/installation_tests/cocoapods/with_frameworks/test.sh'
-- '[ "$TEST_TYPE" != installation_manual ] || travis_retry ./Tests/installation_tests/manual_installation/test.sh'
-- '[ "$TEST_TYPE" != installation_carthage ] || ./Tests/installation_tests/carthage/test.sh'
+- '[ "$TEST_TYPE" != installation_cocoapods ] || ./Tests/installation_tests/cocoapods/without_frameworks/test.sh "$SIMULATOR_ID"'
+- '[ "$TEST_TYPE" != installation_cocoapods_frameworks ] || ./Tests/installation_tests/cocoapods/with_frameworks/test.sh "$SIMULATOR_ID"'
+- '[ "$TEST_TYPE" != installation_manual ] || travis_retry ./Tests/installation_tests/manual_installation/test.sh "$SIMULATOR_ID"'
+- '[ "$TEST_TYPE" != installation_carthage ] || ./Tests/installation_tests/carthage/test.sh "$SIMULATOR_ID"'
 - '[ "$TEST_TYPE" != documentation ] || ./ci_scripts/check_documentation.sh'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,7 @@ branches:
 
 matrix:
   include:
-    ## Xcode 8, iOS 10. No static analyzer or docs
-  - osx_image: xcode8.3
+  - osx_image: xcode8.3 ## Xcode 8, iOS 10. No static analyzer or docs
     env:
       - SIMULATOR_NAME='iPhone 6 (10.3)'
       - TEST_TYPE=installation_manual
@@ -27,16 +26,15 @@ matrix:
     env:
       - SIMULATOR_NAME='iPhone 6 (10.3)'
       - TEST_TYPE=installation_cocoapods_frameworks
-- osx_image: xcode8.3
-  env:
-    - SIMULATOR_NAME='iPhone 6 (10.3)'
-    - TEST_TYPE=tests
+  - osx_image: xcode8.3
+    env:
+      - SIMULATOR_NAME='iPhone 6 (10.3)'
+      - TEST_TYPE=tests
   - osx_image: xcode8.3 ## TODO: Move fauxpas to Xcode11 image when it updates
     env:
       - SIMULATOR_NAME='iPhone 6 (10.3)'
       - TEST_TYPE=lint
-    ## Xcode 9, iOS 10. No analyzer, docs, or linting
-  - osx_image: xcode9
+  - osx_image: xcode9 ## Xcode 9, iOS 10. No analyzer, docs, or linting
     env:
       - SIMULATOR_NAME='iPhone 6 (10.3)'
       - TEST_TYPE=installation_manual
@@ -52,13 +50,11 @@ matrix:
     env:
       - SIMULATOR_NAME='iPhone 6 (10.3)'
       - TEST_TYPE=installation_cocoapods_frameworks
-- osx_image: xcode9
-  env:
-    - SIMULATOR_NAME='iPhone 6 (10.3)'
-    - TEST_TYPE=tests
-
-    ## Xcode 9, iOS 11. No linting (fauxpas currently only does xcode 8.3 linting)
   - osx_image: xcode9
+    env:
+      - SIMULATOR_NAME='iPhone 6 (10.3)'
+      - TEST_TYPE=tests
+  - osx_image: xcode9 ## Xcode 9, iOS 11. No linting (fauxpas currently only does xcode 8.3 linting)
     env:
       - SIMULATOR_NAME='iPhone 6 (11.0)'
       - TEST_TYPE=installation_manual

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,6 @@ osx_image: xcode8.3
 branches:
   only:
     - master
-env:
-  matrix:
-  - TEST_TYPE=installation_manual
-  - TEST_TYPE=installation_carthage
-  - TEST_TYPE=installation_cocoapods
-  - TEST_TYPE=installation_cocoapods_frameworks
-  - TEST_TYPE=lint
-  - TEST_TYPE=tests
-  - TEST_TYPE=analyzer
-  - TEST_TYPE=documentation
 
   global:
     secure: gZMOaHQIeG7nplBCuH7EKf9o6Ez2rtoSskrv3nOTziSxFfZq322MrxvkidDpEN7AKWYQm27FO+tCzgq0slXb578lQ9P5ySDwEdExKtk/jMtKsBsf3cr4dzSMiqV5D5TbsH2jE9HQlpYUoJeoMBicR2XsTmd7wiu2jAzNBFqGfiY=
@@ -21,25 +11,34 @@ env:
 matrix:
   include:
   - osx_image: xcode8.3
-    env: SIMULATOR_NAME='iPhone 6 (10.3)'
+    env:
+      - SIMULATOR_NAME='iPhone 6 (10.3)'
+      - TEST_TYPE=installation_manual
+      - TEST_TYPE=installation_carthage
+      - TEST_TYPE=installation_cocoapods
+      - TEST_TYPE=installation_cocoapods_frameworks
+      - TEST_TYPE=lint
+      - TEST_TYPE=tests
+      - TEST_TYPE=analyzer
+      - TEST_TYPE=documentation
   - osx_image: xcode9
     env:
       - SIMULATOR_NAME='iPhone 6 (10.3)'
-      - DESTINATIONS_ONLY=1 #Only run tests that have different simulator destination options
-  - osx_image: xcode9
-    env: SIMULATOR_NAME='iPhone 6 (11.0)'
-  exclude:
+      - TEST_TYPE=installation_manual
+      - TEST_TYPE=installation_carthage
+      - TEST_TYPE=installation_cocoapods
+      - TEST_TYPE=installation_cocoapods_frameworks
+      - TEST_TYPE=tests
   - osx_image: xcode9
     env:
-      - DESTINATIONS_ONLY=1
+      - SIMULATOR_NAME='iPhone 6 (11.0)'
+      - TEST_TYPE=installation_manual
+      - TEST_TYPE=installation_carthage
+      - TEST_TYPE=installation_cocoapods
+      - TEST_TYPE=installation_cocoapods_frameworks
       - TEST_TYPE=lint
-  - osx_image: xcode9
-    env:
-      - DESTINATIONS_ONLY=1
+      - TEST_TYPE=tests
       - TEST_TYPE=analyzer
-  - osx_image: xcode9
-    env:
-      - DESTINATIONS_ONLY=1
       - TEST_TYPE=documentation
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,36 +10,78 @@ branches:
 
 matrix:
   include:
+    ## Xcode 8, iOS 10. No static analyzer or docs
   - osx_image: xcode8.3
     env:
       - SIMULATOR_NAME='iPhone 6 (10.3)'
       - TEST_TYPE=installation_manual
+  - osx_image: xcode8.3
+    env:
+      - SIMULATOR_NAME='iPhone 6 (10.3)'
       - TEST_TYPE=installation_carthage
+  - osx_image: xcode8.3
+    env:
+      - SIMULATOR_NAME='iPhone 6 (10.3)'
       - TEST_TYPE=installation_cocoapods
+  - osx_image: xcode8.3
+    env:
+      - SIMULATOR_NAME='iPhone 6 (10.3)'
       - TEST_TYPE=installation_cocoapods_frameworks
+- osx_image: xcode8.3
+  env:
+    - SIMULATOR_NAME='iPhone 6 (10.3)'
+    - TEST_TYPE=tests
+  - osx_image: xcode8.3 ## TODO: Move fauxpas to Xcode11 image when it updates
+    env:
+      - SIMULATOR_NAME='iPhone 6 (10.3)'
       - TEST_TYPE=lint
-      - TEST_TYPE=tests
-      - TEST_TYPE=analyzer
-      - TEST_TYPE=documentation
+    ## Xcode 9, iOS 10. No analyzer, docs, or linting
   - osx_image: xcode9
     env:
       - SIMULATOR_NAME='iPhone 6 (10.3)'
       - TEST_TYPE=installation_manual
+  - osx_image: xcode9
+    env:
+      - SIMULATOR_NAME='iPhone 6 (10.3)'
       - TEST_TYPE=installation_carthage
+  - osx_image: xcode9
+    env:
+      - SIMULATOR_NAME='iPhone 6 (10.3)'
       - TEST_TYPE=installation_cocoapods
+  - osx_image: xcode9
+    env:
+      - SIMULATOR_NAME='iPhone 6 (10.3)'
       - TEST_TYPE=installation_cocoapods_frameworks
-      - TEST_TYPE=tests
+- osx_image: xcode9
+  env:
+    - SIMULATOR_NAME='iPhone 6 (10.3)'
+    - TEST_TYPE=tests
+
+    ## Xcode 9, iOS 11. No linting (fauxpas currently only does xcode 8.3 linting)
   - osx_image: xcode9
     env:
       - SIMULATOR_NAME='iPhone 6 (11.0)'
       - TEST_TYPE=installation_manual
+  - osx_image: xcode9
+    env:
+      - SIMULATOR_NAME='iPhone 6 (11.0)'
       - TEST_TYPE=installation_carthage
+  - osx_image: xcode9
+    env:
+      - SIMULATOR_NAME='iPhone 6 (11.0)'
       - TEST_TYPE=installation_cocoapods
+  - osx_image: xcode9
+    env:
+      - SIMULATOR_NAME='iPhone 6 (11.0)'
       - TEST_TYPE=installation_cocoapods_frameworks
-      - TEST_TYPE=lint
+  - osx_image: xcode9
+    env:
+      - SIMULATOR_NAME='iPhone 6 (11.0)'
       - TEST_TYPE=tests
+  - osx_image: xcode9
+    env:
+      - SIMULATOR_NAME='iPhone 6 (11.0)'
       - TEST_TYPE=analyzer
-      - TEST_TYPE=documentation
 
 before_install:
 - SIMULATOR_ID=$(xcrun instruments -s | grep -o $SIMULATOR_NAME \[.*\]" | grep -o

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,54 +34,53 @@ matrix:
     env:
       - SIMULATOR_NAME='iPhone 6 (10.3)'
       - TEST_TYPE=lint
-  - osx_image: xcode9 ## Xcode 9, iOS 10. No analyzer, docs, or linting
+  - osx_image: xcode9.2 ## Xcode 9, iOS 10. No analyzer, docs, or linting
     env:
       - SIMULATOR_NAME='iPhone 6 (10.3)'
       - TEST_TYPE=installation_manual
-  - osx_image: xcode9
+  - osx_image: xcode9.2
     env:
       - SIMULATOR_NAME='iPhone 6 (10.3)'
       - TEST_TYPE=installation_carthage
-  - osx_image: xcode9
+  - osx_image: xcode9.2
     env:
       - SIMULATOR_NAME='iPhone 6 (10.3)'
       - TEST_TYPE=installation_cocoapods
-  - osx_image: xcode9
+  - osx_image: xcode9.2
     env:
       - SIMULATOR_NAME='iPhone 6 (10.3)'
       - TEST_TYPE=installation_cocoapods_frameworks
-  - osx_image: xcode9
+  - osx_image: xcode9.2
     env:
       - SIMULATOR_NAME='iPhone 6 (10.3)'
       - TEST_TYPE=tests
-  - osx_image: xcode9 ## Xcode 9, iOS 11. No linting (fauxpas currently only does xcode 8.3 linting)
+  - osx_image: xcode9.2 ## Xcode 9, iOS 11. No linting (fauxpas currently only does xcode 8.3 linting)
     env:
-      - SIMULATOR_NAME='iPhone 6 (11.0)'
+      - SIMULATOR_NAME='iPhone 6 (11.2)'
       - TEST_TYPE=installation_manual
-  - osx_image: xcode9
+  - osx_image: xcode9.2
     env:
-      - SIMULATOR_NAME='iPhone 6 (11.0)'
+      - SIMULATOR_NAME='iPhone 6 (11.2)'
       - TEST_TYPE=installation_carthage
-  - osx_image: xcode9
+  - osx_image: xcode9.2
     env:
-      - SIMULATOR_NAME='iPhone 6 (11.0)'
+      - SIMULATOR_NAME='iPhone 6 (11.2)'
       - TEST_TYPE=installation_cocoapods
-  - osx_image: xcode9
+  - osx_image: xcode9.2
     env:
-      - SIMULATOR_NAME='iPhone 6 (11.0)'
+      - SIMULATOR_NAME='iPhone 6 (11.2)'
       - TEST_TYPE=installation_cocoapods_frameworks
-  - osx_image: xcode9
+  - osx_image: xcode9.2
     env:
-      - SIMULATOR_NAME='iPhone 6 (11.0)'
+      - SIMULATOR_NAME='iPhone 6 (11.2)'
       - TEST_TYPE=tests
-  - osx_image: xcode9
+  - osx_image: xcode9.2
     env:
-      - SIMULATOR_NAME='iPhone 6 (11.0)'
+      - SIMULATOR_NAME='iPhone 6 (11.2)'
       - TEST_TYPE=analyzer
 
 before_install:
-- SIMULATOR_ID=$(xcrun instruments -s | grep -o "$SIMULATOR_NAME \[.*\]" | grep -o
-  "\[.*\]" | sed "s/^\[\(.*\)\]$/\1/")
+- SIMULATOR_ID=$(xcrun instruments -s | grep -o "$SIMULATOR_NAME \[.*\]" | grep -o "\[.*\]" | sed "s/^\[\(.*\)\]$/\1/")
 script:
 - open -a "simulator" --args -CurrentDeviceUDID $SIMULATOR_ID
 - "./ci_scripts/check_version.rb"
@@ -89,10 +88,10 @@ script:
 - "./ci_scripts/check_category_linking.rb"
 - "./ci_scripts/check_resource_bundle.rb"
 - '[ "$TEST_TYPE" != lint ] || ./ci_scripts/check_fauxpas.sh'
-- '[ "$TEST_TYPE" != tests ] || travis_retry ./ci_scripts/run_tests.sh "$SIMULATOR_ID"'
+- '[ "$TEST_TYPE" != tests ] || travis_retry ./ci_scripts/run_tests.sh' "$SIMULATOR_ID"
 - '[ "$TEST_TYPE" != analyzer ] || ./ci_scripts/run_analyzer.sh'
-- '[ "$TEST_TYPE" != installation_cocoapods ] || ./Tests/installation_tests/cocoapods/without_frameworks/test.sh "$SIMULATOR_ID"'
-- '[ "$TEST_TYPE" != installation_cocoapods_frameworks ] || ./Tests/installation_tests/cocoapods/with_frameworks/test.sh "$SIMULATOR_ID"'
-- '[ "$TEST_TYPE" != installation_manual ] || travis_retry ./Tests/installation_tests/manual_installation/test.sh "$SIMULATOR_ID"'
-- '[ "$TEST_TYPE" != installation_carthage ] || ./Tests/installation_tests/carthage/test.sh "$SIMULATOR_ID"'
+- '[ "$TEST_TYPE" != installation_cocoapods ] || ./Tests/installation_tests/cocoapods/without_frameworks/test.sh' "$SIMULATOR_ID"
+- '[ "$TEST_TYPE" != installation_cocoapods_frameworks ] || ./Tests/installation_tests/cocoapods/with_frameworks/test.sh' "$SIMULATOR_ID"
+- '[ "$TEST_TYPE" != installation_manual ] || travis_retry ./Tests/installation_tests/manual_installation/test.sh' "$SIMULATOR_ID"
+- '[ "$TEST_TYPE" != installation_carthage ] || ./Tests/installation_tests/carthage/test.sh' "$SIMULATOR_ID"
 - '[ "$TEST_TYPE" != documentation ] || ./ci_scripts/check_documentation.sh'

--- a/Tests/installation_tests/carthage/test.sh
+++ b/Tests/installation_tests/carthage/test.sh
@@ -56,7 +56,7 @@ xcodebuild clean build \
   -project "${script_dir}/CarthageTest.xcodeproj" \
   -scheme "CarthageTest" \
   -sdk "iphonesimulator" \
-  -destination "platform=iOS Simulator,name=iPhone 6,OS=10.3.1" \
+  -destination "platform=iOS Simulator,name=iPhone 6,id=$1" \
   | xcpretty
 
 xcodebuild_exit_code="${PIPESTATUS[0]}"

--- a/Tests/installation_tests/cocoapods/without_frameworks/test.sh
+++ b/Tests/installation_tests/cocoapods/without_frameworks/test.sh
@@ -65,7 +65,7 @@ xcodebuild clean build \
   -workspace "CocoapodsTest.xcworkspace" \
   -scheme "CocoapodsTest" \
   -sdk "iphonesimulator" \
-  -destination "platform=iOS Simulator,name=iPhone 6,OS=10.3.1" \
+  -destination "platform=iOS Simulator,name=iPhone 6,id=$1" \
   | xcpretty
 
 xcodebuild_exit_code="${PIPESTATUS[0]}"

--- a/Tests/installation_tests/manual_installation/test.sh
+++ b/Tests/installation_tests/manual_installation/test.sh
@@ -49,7 +49,7 @@ xcodebuild clean build-for-testing \
   -project "${script_dir}/ManualInstallationTest.xcodeproj" \
   -scheme "ManualInstallationTest" \
   -sdk "iphonesimulator" \
-  -destination "platform=iOS Simulator,name=iPhone 6,OS=10.3.1" \
+  -destination "platform=iOS Simulator,name=iPhone 6,id=$1" \
   | xcpretty
 
 xcodebuild_build_exit_code="${PIPESTATUS[0]}"
@@ -62,7 +62,7 @@ xcodebuild test-without-building \
   -project "${script_dir}/ManualInstallationTest.xcodeproj" \
   -scheme "ManualInstallationTest" \
   -sdk "iphonesimulator" \
-  -destination "platform=iOS Simulator,name=iPhone 6,OS=10.3.1" \
+  -destination "platform=iOS Simulator,name=iPhone 6,id=$1" \
   | xcpretty
 
 xcodebuild_test_exit_code="${PIPESTATUS[0]}"

--- a/ci_scripts/run_tests.sh
+++ b/ci_scripts/run_tests.sh
@@ -4,7 +4,7 @@ carthage bootstrap --platform ios --configuration Release --no-use-binaries
 cd Example; carthage bootstrap --platform ios; cd ..
 
 gem install xcpretty --no-ri --no-rdoc
-xcodebuild clean build build-for-testing -workspace Stripe.xcworkspace -scheme "StripeiOS" -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.3.1' | xcpretty -c
-xcodebuild test-without-building -workspace Stripe.xcworkspace -scheme "StripeiOS" -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.3.1' | xcpretty -c
-xcodebuild build -workspace Stripe.xcworkspace -scheme "Standard Integration (Swift)" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.3.1'  | xcpretty -c
-xcodebuild build -workspace Stripe.xcworkspace -scheme "Custom Integration (ObjC)" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.3.1' | xcpretty -c
+xcodebuild clean build build-for-testing -workspace Stripe.xcworkspace -scheme "StripeiOS" -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,id="$1"' | xcpretty -c
+xcodebuild test-without-building -workspace Stripe.xcworkspace -scheme "StripeiOS" -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,id="$1"' | xcpretty -c
+xcodebuild build -workspace Stripe.xcworkspace -scheme "Standard Integration (Swift)" -sdk iphonesimulator -destination 'platform=iOS Simulator,id="$1"'  | xcpretty -c
+xcodebuild build -workspace Stripe.xcworkspace -scheme "Custom Integration (ObjC)" -sdk iphonesimulator -destination 'platform=iOS Simulator,id="$1"' | xcpretty -c


### PR DESCRIPTION
A little unclear how travis's `osx_image` property behaves and if you can have it matrix like this, but hopefully this will run our tests on both xcode8 and xcode9 (still both on iOS 10.3 though)