### PR TITLE
Restore `[STPCard brandFromString:]` Method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 11.x.x 2017-XX-XX
+
+* Restores `[STPCard brandFromString:]` method which was marked as deprecated in a recent version [#801](https://github.com/stripe/stripe-ios/pull/801)
+
 ## 11.3.0 2017-09-13
 * Adds support for creating `STPSourceParams` for P24 source [#779](https://github.com/stripe/stripe-ios/pull/779)
 * Adds support for native app-to-app Alipay redirects [#783](https://github.com/stripe/stripe-ios/pull/783)

--- a/Stripe/PublicHeaders/STPCard.h
+++ b/Stripe/PublicHeaders/STPCard.h
@@ -124,6 +124,23 @@ typedef NS_ENUM(NSInteger, STPCardFundingType) {
  */
 + (NSString *)stringFromBrand:(STPCardBrand)brand;
 
+/**
+ This parses a string representing a card's brand into the appropriate
+ STPCardBrand enum value,
+ i.e. `[STPCard brandFromString:@"American Express"] == STPCardBrandAmex`.
+
+ The string values themselves are specific to Stripe as listed in the Stripe API
+ documentation.
+
+ @see https://stripe.com/docs/api#card_object-brand
+
+ @param string a string representing the card's brand as returned from
+ the Stripe API
+
+ @return an enum value mapped to that string. If the string is unrecognized,
+ returns STPCardBrandUnknown.
+ */
++ (STPCardBrand)brandFromString:(NSString *)string;
 
 #pragma mark - Deprecated methods
 
@@ -195,19 +212,6 @@ typedef NS_ENUM(NSInteger, STPCardFundingType) {
  returns `STPCardFundingTypeOther`.
  */
 + (STPCardFundingType)fundingFromString:(NSString *)string DEPRECATED_ATTRIBUTE;
-
-/**
- This parses a string representing a card's brand into the appropriate 
- STPCardBrand enum value, 
- i.e. `[STPCard brandFromString:@"American Express"] == STPCardBrandAmex`
-
- @param string a string representing the card's brand as returned from 
- the Stripe API
-
- @return an enum value mapped to that string. If the string is unrecognized, 
- returns STPCardBrandUnknown.
- */
-+ (STPCardBrand)brandFromString:(NSString *)string DEPRECATED_ATTRIBUTE;
 
 @end
 

--- a/Stripe/STPCard+Private.h
+++ b/Stripe/STPCard+Private.h
@@ -16,7 +16,6 @@ NS_ASSUME_NONNULL_BEGIN
 + (STPCardFundingType)fundingFromString:(NSString *)string;
 + (nullable NSString *)stringFromFunding:(STPCardFundingType)funding;
 
-+ (STPCardBrand)brandFromString:(NSString *)string;
 + (NSString *)stringFromBrand:(STPCardBrand)brand;
 
 @end

--- a/Stripe/STPCard.m
+++ b/Stripe/STPCard.m
@@ -184,12 +184,11 @@ NS_ASSUME_NONNULL_BEGIN
     card.name = dict[@"name"];
     card.last4 = dict[@"last4"];
     card.dynamicLast4 = dict[@"dynamic_last4"];
+    card.brand = [self.class brandFromString:dict[@"brand"]];
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated"
-    // These are only intended to be deprecated publicly.
+    // This is only intended to be deprecated publicly.
     // When removed from public header, can remove these pragmas
-
-    card.brand = [self.class brandFromString:dict[@"brand"]];
     card.funding = [self.class fundingFromString:dict[@"funding"]];
 #pragma clang diagnostic pop
 

--- a/Stripe/STPSourceCardDetails.m
+++ b/Stripe/STPSourceCardDetails.m
@@ -40,11 +40,11 @@
     self = [super init];
     if (self) {
         _last4 = dict[@"last4"];
+        _brand = [STPCard brandFromString:dict[@"brand"]];
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated"
-        // These are only intended to be deprecated publicly.
+        // This is only intended to be deprecated publicly.
         // When removed from public header, can remove these pragmas
-        _brand = [STPCard brandFromString:dict[@"brand"]];
         _funding = [STPCard fundingFromString:dict[@"funding"]];
 #pragma clang diagnostic pop
         _country = dict[@"country"];

--- a/Tests/Tests/STPCardTest.m
+++ b/Tests/Tests/STPCardTest.m
@@ -32,8 +32,6 @@
 
 #pragma mark - STPCardBrand Tests
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated"
 // These are only intended to be deprecated publicly.
 // When removed from public header, can remove these pragmas
 - (void)testBrandFromString {
@@ -61,7 +59,6 @@
     XCTAssertEqual([STPCard brandFromString:@"garbage"], STPCardBrandUnknown);
     XCTAssertEqual([STPCard brandFromString:@"GARBAGE"], STPCardBrandUnknown);
 }
-#pragma clang diagnostic pop
 
 - (void)testStringFromBrand {
     [self forEachBrand:^(STPCardBrand brand) {


### PR DESCRIPTION
Restoring the `[STPCard brandFromString:]` method which was marked deprecated in a recent version following discussions in https://github.com/stripe/stripe-ios/issues/800