### PR TITLE
[WIP] Increase Test Device Coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,69 @@
 language: objective-c
-osx_image: xcode8.3
 branches:
   only:
     - master
 env:
-  matrix:
-  - TEST_TYPE=installation_manual
-  - TEST_TYPE=installation_carthage
-  - TEST_TYPE=installation_cocoapods
-  - TEST_TYPE=installation_cocoapods_frameworks
-  - TEST_TYPE=lint
-  - TEST_TYPE=tests
-  - TEST_TYPE=analyzer
-  - TEST_TYPE=documentation
-
   global:
     secure: gZMOaHQIeG7nplBCuH7EKf9o6Ez2rtoSskrv3nOTziSxFfZq322MrxvkidDpEN7AKWYQm27FO+tCzgq0slXb578lQ9P5ySDwEdExKtk/jMtKsBsf3cr4dzSMiqV5D5TbsH2jE9HQlpYUoJeoMBicR2XsTmd7wiu2jAzNBFqGfiY=
 
-before_install:
-- SIMULATOR_ID=$(xcrun instruments -s | grep -o "iPhone 6 (10.3) \[.*\]" | grep -o
-  "\[.*\]" | sed "s/^\[\(.*\)\]$/\1/")
+matrix:
+  include:
+  # Xcode 8.3
+  - osx_image: xcode8.3
+    env:
+      - TEST_TYPE=installation_manual
+  - osx_image: xcode8.3
+    env:
+      - TEST_TYPE=installation_carthage
+  - osx_image: xcode8.3
+    env:
+      - TEST_TYPE=installation_cocoapods
+  - osx_image: xcode8.3
+    env:
+      - TEST_TYPE=installation_cocoapods_frameworks
+  - osx_image: xcode8.3
+    env:
+      - TEST_TYPE=lint
+  - osx_image: xcode8.3
+    env:
+      - TEST_TYPE=tests
+  # Not needed
+  # - osx_image: xcode8.3
+  #   env:
+  #     - TEST_TYPE=analyzer
+  # Not needed
+  # - osx_image: xcode8.3
+  #   env:
+  #     - TEST_TYPE=documentation
+
+  # Xcode 9.0
+  - osx_image: xcode9
+    env:
+      - TEST_TYPE=installation_manual
+  - osx_image: xcode9
+    env:
+      - TEST_TYPE=installation_carthage
+  - osx_image: xcode9
+    env:
+      - TEST_TYPE=installation_cocoapods
+  - osx_image: xcode9
+    env:
+      - TEST_TYPE=installation_cocoapods_frameworks
+  # Not supported by FauxPas yet
+  # - osx_image: xcode9
+  #   env:
+  #     - TEST_TYPE=lint
+  - osx_image: xcode9
+    env:
+      - TEST_TYPE=tests
+  - osx_image: xcode9
+    env:
+      - TEST_TYPE=analyzer
+  - osx_image: xcode9
+    env:
+      - TEST_TYPE=documentation
+
 script:
-- open -a "simulator" --args -CurrentDeviceUDID $SIMULATOR_ID
 - "./ci_scripts/check_version.rb"
 - "./ci_scripts/check_public_headers.rb"
 - "./ci_scripts/check_category_linking.rb"

--- a/Tests/installation_tests/carthage/test.sh
+++ b/Tests/installation_tests/carthage/test.sh
@@ -21,6 +21,16 @@ if ! command -v xcpretty > /dev/null; then
   gem install xcpretty --no-ri --no-rdoc || die "Executing \`gem install xcpretty\` failed"
 fi
 
+# Verify carthage is installed
+if ! command -v carthage > /dev/null; then
+  if [[ "${CI}" != "true" ]]; then
+    die "Please install carthage: https://github.com/Carthage/Carthage#installing-carthage"
+  fi
+
+  info "Installing carthage..."
+  brew install carthage || die "Executing \`brew install carthage\` failed"
+fi
+
 # Clean carthage artifacts
 info "Cleaning carthage artifacts..."
 
@@ -56,7 +66,6 @@ xcodebuild clean build \
   -project "${script_dir}/CarthageTest.xcodeproj" \
   -scheme "CarthageTest" \
   -sdk "iphonesimulator" \
-  -destination "platform=iOS Simulator,name=iPhone 6,OS=10.3.1" \
   | xcpretty
 
 xcodebuild_exit_code="${PIPESTATUS[0]}"

--- a/Tests/installation_tests/cocoapods/with_frameworks/test.sh
+++ b/Tests/installation_tests/cocoapods/with_frameworks/test.sh
@@ -65,7 +65,6 @@ xcodebuild clean build \
   -workspace "CocoapodsTest.xcworkspace" \
   -scheme "CocoapodsTest" \
   -sdk "iphonesimulator" \
-  -destination "platform=iOS Simulator,name=iPhone 6,OS=10.3.1" \
   | xcpretty
 
 xcodebuild_exit_code="${PIPESTATUS[0]}"

--- a/Tests/installation_tests/cocoapods/without_frameworks/test.sh
+++ b/Tests/installation_tests/cocoapods/without_frameworks/test.sh
@@ -65,7 +65,6 @@ xcodebuild clean build \
   -workspace "CocoapodsTest.xcworkspace" \
   -scheme "CocoapodsTest" \
   -sdk "iphonesimulator" \
-  -destination "platform=iOS Simulator,name=iPhone 6,OS=10.3.1" \
   | xcpretty
 
 xcodebuild_exit_code="${PIPESTATUS[0]}"

--- a/Tests/installation_tests/manual_installation/test.sh
+++ b/Tests/installation_tests/manual_installation/test.sh
@@ -42,33 +42,31 @@ ditto -xk \
   "${root_dir}/build/StripeiOS-Static.zip" \
   "${framework_dir}"
 
+# Determine xcodebuild simulator destination
+destination=(
+  -destination "platform=iOS Simulator,name=iPhone 6,OS=10.3.1"
+)
+
+if xcodebuild -version | grep -q "Xcode 9"; then
+  destination=(
+    -destination "platform=iOS Simulator,name=iPhone 6,OS=11.0"
+  )
+fi
+
 # Execute xcodebuild
 info "Executing xcodebuild..."
 
-xcodebuild clean build-for-testing \
+xcodebuild clean test \
   -project "${script_dir}/ManualInstallationTest.xcodeproj" \
   -scheme "ManualInstallationTest" \
   -sdk "iphonesimulator" \
-  -destination "platform=iOS Simulator,name=iPhone 6,OS=10.3.1" \
+  "${destination[@]}" \
   | xcpretty
 
 xcodebuild_build_exit_code="${PIPESTATUS[0]}"
 
 if [[ "${xcodebuild_build_exit_code}" != 0 ]]; then
   die "Executing xcodebuild failed with status code: ${xcodebuild_build_exit_code}"
-fi
-
-xcodebuild test-without-building \
-  -project "${script_dir}/ManualInstallationTest.xcodeproj" \
-  -scheme "ManualInstallationTest" \
-  -sdk "iphonesimulator" \
-  -destination "platform=iOS Simulator,name=iPhone 6,OS=10.3.1" \
-  | xcpretty
-
-xcodebuild_test_exit_code="${PIPESTATUS[0]}"
-
-if [[ "${xcodebuild_test_exit_code}" != 0 ]]; then
-  die "Executing xcodebuild failed with status code: ${xcodebuild_test_exit_code}"
 fi
 
 info "All good!"

--- a/ci_scripts/run_tests.sh
+++ b/ci_scripts/run_tests.sh
@@ -1,10 +1,141 @@
-set -euf -o pipefail
+#!/bin/bash
 
-carthage bootstrap --platform ios --configuration Release --no-use-binaries
-cd Example; carthage bootstrap --platform ios; cd ..
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-gem install xcpretty --no-ri --no-rdoc
-xcodebuild clean build build-for-testing -workspace Stripe.xcworkspace -scheme "StripeiOS" -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.3.1' | xcpretty -c
-xcodebuild test-without-building -workspace Stripe.xcworkspace -scheme "StripeiOS" -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.3.1' | xcpretty -c
-xcodebuild build -workspace Stripe.xcworkspace -scheme "Standard Integration (Swift)" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.3.1'  | xcpretty -c
-xcodebuild build -workspace Stripe.xcworkspace -scheme "Custom Integration (ObjC)" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.3.1' | xcpretty -c
+function info {
+  echo "[$(basename "${0}")] [INFO] ${1}"
+}
+
+function die {
+  echo "[$(basename "${0}")] [ERROR] ${1}"
+  exit 1
+}
+
+# Verify xcpretty is installed
+if ! command -v xcpretty > /dev/null; then
+  if [[ "${CI}" != "true" ]]; then
+    die "Please install xcpretty: https://github.com/supermarin/xcpretty#installation"
+  fi
+
+  info "Installing xcpretty..."
+  gem install xcpretty --no-ri --no-rdoc || die "Executing \`gem install xcpretty\` failed"
+fi
+
+# Verify carthage is installed
+if ! command -v carthage > /dev/null; then
+  if [[ "${CI}" != "true" ]]; then
+    die "Please install carthage: https://github.com/Carthage/Carthage#installing-carthage"
+  fi
+
+  info "Installing carthage..."
+  brew install carthage || die "Executing \`brew install carthage\` failed"
+fi
+
+# Execute carthage bootstrap
+info "Executing carthage bootstrap..."
+
+cd "${script_dir}/.." || die "Executing \`cd\` failed"
+
+carthage bootstrap --platform ios --cache-builds
+
+if [[ "$?" != 0 ]]; then
+  die "Executing carthage bootstrap exited with a non-zero status code"
+fi
+
+# Execute carthage bootstrap for example apps
+info "Executing carthage bootstrap for example apps..."
+
+cd "${script_dir}/../Example" || die "Executing \`cd\` failed"
+
+carthage bootstrap --platform ios --cache-builds
+
+if [[ "$?" != 0 ]]; then
+  die "Executing carthage bootstrap for example apps exited with a non-zero status code"
+fi
+
+# Determine xcodebuild simulator destinations
+destinations=(
+  -destination "platform=iOS Simulator,name=iPhone 6,OS=8.4"
+  -destination "platform=iOS Simulator,name=iPhone 6,OS=9.3"
+  -destination "platform=iOS Simulator,name=iPhone 6,OS=10.3.1"
+)
+
+if xcodebuild -version | grep -q "Xcode 9"; then
+  destinations+=("-destination")
+  destinations+=("platform=iOS Simulator,name=iPhone 6,OS=11.0")
+fi
+
+# Execute xcodebuild for test target
+info "Executing xcodebuild for test target..."
+
+cd "${script_dir}/.." || die "Executing \`cd\` failed"
+
+xcodebuild clean build-for-testing \
+  -workspace "Stripe.xcworkspace" \
+  -scheme "StripeiOS" \
+  -configuration "Debug" \
+  -sdk "iphonesimulator" \
+  | xcpretty
+
+xcodebuild_exit_code="${PIPESTATUS[0]}"
+
+if [[ "${xcodebuild_exit_code}" != 0 ]]; then
+  die "Executing xcodebuild failed with status code: ${xcodebuild_exit_code}"
+fi
+
+xcodebuild test-without-building \
+  -workspace "Stripe.xcworkspace" \
+  -scheme "StripeiOS" \
+  -configuration "Debug" \
+  -sdk "iphonesimulator" \
+  "${destinations[@]}"
+  # Multiple destination output not compatible with xcpretty
+
+xcodebuild_exit_code="$?"
+
+if [[ "${xcodebuild_exit_code}" != 0 ]]; then
+  die "Executing xcodebuild failed with status code: ${xcodebuild_exit_code}"
+fi
+
+# Execute xcodebuild for example apps
+info "Executing xcodebuild for example app targets..."
+
+cd "${script_dir}/.." || die "Executing \`cd\` failed"
+
+xcodebuild clean build \
+  -workspace Stripe.xcworkspace \
+  -scheme "UI Examples" \
+  -sdk iphonesimulator \
+  | xcpretty
+
+xcodebuild_exit_code="${PIPESTATUS[0]}"
+
+if [[ "${xcodebuild_exit_code}" != 0 ]]; then
+  die "Executing xcodebuild failed with status code: ${xcodebuild_exit_code}"
+fi
+
+xcodebuild clean build \
+  -workspace Stripe.xcworkspace \
+  -scheme "Standard Integration (Swift)" \
+  -sdk iphonesimulator \
+  | xcpretty
+
+xcodebuild_exit_code="${PIPESTATUS[0]}"
+
+if [[ "${xcodebuild_exit_code}" != 0 ]]; then
+  die "Executing xcodebuild failed with status code: ${xcodebuild_exit_code}"
+fi
+
+xcodebuild clean build \
+  -workspace Stripe.xcworkspace \
+  -scheme "Custom Integration (ObjC)" \
+  -sdk iphonesimulator \
+  | xcpretty
+
+xcodebuild_exit_code="${PIPESTATUS[0]}"
+
+if [[ "${xcodebuild_exit_code}" != 0 ]]; then
+  die "Executing xcodebuild failed with status code: ${xcodebuild_exit_code}"
+fi
+
+info "All good!"


### PR DESCRIPTION
Following up from our learnings in: https://github.com/stripe/stripe-ios/pull/797

# Summary

Adjust our `.travis.yml` and `run_tests.sh` to increase our test coverage. Previously we were testing:

- Xcode 8.x, iOS 10.x

Now we should be testing:

- Xcode 8.x, iOS 8.x
- Xcode 8.x, iOS 9.x
- Xcode 8.x, iOS 10.x
- Xcode 9.x, iOS 8.x
- Xcode 9.x, iOS 9.x
- Xcode 9.x, iOS 10.x
- Xcode 9.x, iOS 11.x

We're targeting the "iPhone 6" because it conveniently supports all of our target iOS versions: iOS 8.x to 11.x. We also removed the `-destination` specifier for `xcodebuild build` (not `xcodebuild test`) commands because it's unnecessary (only the `-sdk` is needed).

As a result, we're discovering a few groups of test case failures that need to be investigated:

- LocalizationTests
  - STPAddCardViewControllerLocalizationTests
  - STPPaymentMethodsViewControllerLocalizationTests
  - STPShippingAddressViewControllerLocalizationTests
- STPAddressTests https://github.com/stripe/stripe-ios/pull/805
- STPApplePayTest (`testPaymentRequestWithMerchantIdentifierCountryCurrency` only)
- STPPaymentCardTextFieldTest (`testIntrinsicContentSize` only)
- STPRedirectContextTest https://github.com/stripe/stripe-ios/pull/804