### PR TITLE
[WIP] Fix strong reference cycles for STPRedirectContext, Improve tests

### DIFF
--- a/Stripe/PublicHeaders/STPRedirectContext.h
+++ b/Stripe/PublicHeaders/STPRedirectContext.h
@@ -21,7 +21,7 @@ typedef NS_ENUM(NSUInteger, STPRedirectContextState) {
     STPRedirectContextStateNotStarted,
 
     /**
-      Redirect is in progress.
+     Redirect is in progress.
      */
     STPRedirectContextStateInProgress,
 
@@ -71,6 +71,9 @@ typedef void (^STPRedirectContextCompletionBlock)(NSString *sourceID, NSString *
  You should not use either this class, nor `STPAPIClient`, as a way
  to determine when you should charge the source. Use Stripe webhooks on your
  backend server to listen for source state changes and to make the charge.
+
+ Make sure to maintain a strong reference to `STPRedirectContext`. Otherwise, it
+ will be deallocated.
  */
 NS_EXTENSION_UNAVAILABLE("Redirect based sources are not available in extensions")
 @interface STPRedirectContext : NSObject

--- a/Stripe/STPRedirectContext.m
+++ b/Stripe/STPRedirectContext.m
@@ -100,8 +100,10 @@ typedef void (^STPBoolCompletionBlock)(BOOL success);
 - (void)startRedirectFlowFromViewController:(UIViewController *)presentingViewController {
     FAUXPAS_IGNORED_IN_METHOD(APIAvailability)
 
+    WEAK(self);
     [self performAppRedirectIfPossibleWithCompletion:^(BOOL success) {
         if (!success) {
+            STRONG(self);
             if ([SFSafariViewController class] != nil) {
                 [self startSafariViewControllerRedirectFlowFromViewController:presentingViewController];
             }

--- a/Stripe/STPURLCallbackHandler.m
+++ b/Stripe/STPURLCallbackHandler.m
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface STPURLCallback : NSObject
 @property (nonatomic) NSURLComponents *urlComponents;
-@property (nonatomic) id<STPURLCallbackListener> listener;
+@property (nonatomic, weak) id<STPURLCallbackListener> listener;
 @end
 
 @implementation STPURLCallback

--- a/Tests/Tests/STPRedirectContextTest.m
+++ b/Tests/Tests/STPRedirectContextTest.m
@@ -14,7 +14,16 @@
 #import "STPRedirectContext.h"
 #import "STPURLCallbackHandler.h"
 
-@interface STPRedirectContext (Testing)
+@interface STPSource ()
+@property (nonatomic, readwrite) STPSourceFlow flow;
+@property (nonatomic, readwrite) STPSourceStatus status;
+@end
+
+@interface STPSourceRedirect ()
+@property (nonatomic, nullable) NSURL *returnURL;
+@end
+
+@interface STPRedirectContext ()
 - (void)unsubscribeFromNotifications;
 - (void)dismissPresentedViewController;
 @end
@@ -25,235 +34,272 @@
 
 @implementation STPRedirectContextTest
 
-- (void)testInitWithNonRedirectSourceReturnsNil {
+#pragma mark - Init
+
+- (void)testInitWithSourceCompletion_nonRedirectSource {
+    // Should return `nil` for non-redirect source
     STPSource *source = [STPFixtures cardSource];
-    STPRedirectContext *sut = [[STPRedirectContext alloc] initWithSource:source completion:^(__unused NSString *sourceID, __unused NSString *clientSecret, __unused NSError *error) {
-        XCTFail(@"completion was called");
-    }];
-    XCTAssertNil(sut);
+    STPRedirectContext *context = [[STPRedirectContext alloc] initWithSource:source completion:[self failingCompletionBlock]];
+    XCTAssertNil(context);
 }
 
+- (void)testInitWithSourceCompletion_nonRedirectFlow {
+    // Should return `nil` for source with non-redirect flow
+    NSArray *sourceFlows = @[@(STPSourceFlowNone),
+                             @(STPSourceFlowCodeVerification),
+                             @(STPSourceFlowReceiver),
+                             @(STPSourceFlowUnknown)];
+
+    for (NSNumber *flowNumber in sourceFlows) {
+        STPSource *source = [STPFixtures iDEALSource];
+        source.flow = flowNumber.integerValue;
+
+        STPRedirectContext *context = [[STPRedirectContext alloc] initWithSource:source completion:[self failingCompletionBlock]];
+        XCTAssertNil(context);
+    }
+}
+
+- (void)testInitWithSourceCompletion_statusNotPending {
+    // Should return `nil` for source with non-pending status
+    NSArray *sourceStatuses = @[@(STPSourceStatusChargeable),
+                                @(STPSourceStatusConsumed),
+                                @(STPSourceStatusCanceled),
+                                @(STPSourceStatusFailed),
+                                @(STPSourceStatusUnknown)];
+
+    for (NSNumber *statusNumber in sourceStatuses) {
+        STPSource *source = [STPFixtures iDEALSource];
+        source.status = statusNumber.integerValue;
+
+        STPRedirectContext *context = [[STPRedirectContext alloc] initWithSource:source completion:[self failingCompletionBlock]];
+        XCTAssertNil(context);
+    }
+}
+
+- (void)testInitWithSourceCompletion_missingReturnURL {
+    // Should return `nil` for source with missing return URL
+    STPSource *source = [STPFixtures iDEALSource];
+    source.redirect.returnURL = nil;
+
+    STPRedirectContext *context = [[STPRedirectContext alloc] initWithSource:source completion:[self failingCompletionBlock]];
+    XCTAssertNil(context);
+}
+
+- (void)testInitWithSourceCompletion_validNativeSource {
+    // Should return object for valid redirect source
+    STPSource *source = [STPFixtures iDEALSource];
+    STPRedirectContext *context = [[STPRedirectContext alloc] initWithSource:source completion:[self failingCompletionBlock]];
+    XCTAssert(context);
+}
+
+#pragma mark - startSafariViewControllerRedirectFlowFromViewController
+
 /**
- After starting a SafariViewController redirect flow,
- when the shared URLCallbackHandler is called with a valid URL,
- RedirectContext's completion block and dismiss method should be called.
+ After starting a SFSafariViewController redirect flow,
+ when the STPURLCallbackHandler is called with a valid URL,
+ should execute STPRedirectContext completion block and dismiss SFSafariViewController.
  */
 - (void)testSafariViewControllerRedirectFlow_callbackHandlerCalledValidURL {
-    id mockVC = OCMClassMock([UIViewController class]);
+    XCTestExpectation *expectation = [self expectationWithDescription:@"completion"];
+
     STPSource *source = [STPFixtures iDEALSource];
-    XCTestExpectation *exp = [self expectationWithDescription:@"completion"];
+    id mockVC = OCMClassMock([UIViewController class]);
+    BOOL (^checker)(id) = ^BOOL (id viewController) {
+        if ([viewController isKindOfClass:[SFSafariViewController class]]) {
+            NSURLComponents *urlComponents = [NSURLComponents componentsWithURL:source.redirect.returnURL resolvingAgainstBaseURL:NO];
+            [urlComponents setStp_queryItemsDictionary:@{@"source": source.stripeID, @"client_secret": source.clientSecret}];
+            [[STPURLCallbackHandler shared] handleURLCallback:urlComponents.URL];
+            return YES;
+        }
+        return NO;
+    };
+    OCMStub([mockVC presentViewController:[OCMArg checkWithBlock:checker] animated:YES completion:[OCMArg any]]);
     STPRedirectContext *context = [[STPRedirectContext alloc] initWithSource:source completion:^(NSString *sourceID, NSString *clientSecret, NSError *error) {
         XCTAssertEqualObjects(sourceID, source.stripeID);
         XCTAssertEqualObjects(clientSecret, source.clientSecret);
         XCTAssertNil(error);
-        [exp fulfill];
+        [expectation fulfill];
     }];
     id sut = OCMPartialMock(context);
 
     [sut startSafariViewControllerRedirectFlowFromViewController:mockVC];
 
-    BOOL(^checker)(id) = ^BOOL(id vc) {
-        if ([vc isKindOfClass:[SFSafariViewController class]]) {
-            NSURL *url = source.redirect.returnURL;
-            NSURLComponents *comps = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
-            [comps setStp_queryItemsDictionary:@{@"source": source.stripeID,
-                                                 @"client_secret": source.clientSecret}];
-            [[STPURLCallbackHandler shared] handleURLCallback:comps.URL];
-            return YES;
-        }
-        return NO;
-    };
-    OCMVerify([mockVC presentViewController:[OCMArg checkWithBlock:checker]
-                                   animated:YES
-                                 completion:[OCMArg any]]);
+    OCMVerify([mockVC presentViewController:[OCMArg any] animated:[OCMArg any] completion:[OCMArg any]]);
     OCMVerify([sut unsubscribeFromNotifications]);
     OCMVerify([sut dismissPresentedViewController]);
 
-    [self waitForExpectationsWithTimeout:2 handler:nil];
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
 }
 
 /**
- After starting a SafariViewController redirect flow,
- when the shared URLCallbackHandler is called with an invalid URL,
- RedirectContext's completion block and dismiss method should be called.
+ After starting a SFSafariViewController redirect flow,
+ when the STPURLCallbackHandler is called with an invalid URL,
+ should not execute STPRedirectContext completion block nor dismiss SFSafariViewController.
  */
 - (void)testSafariViewControllerRedirectFlow_callbackHandlerCalledInvalidURL {
-    id mockVC = OCMClassMock([UIViewController class]);
     STPSource *source = [STPFixtures iDEALSource];
-    STPRedirectContext *context = [[STPRedirectContext alloc] initWithSource:source completion:^(__unused NSString *sourceID, __unused NSString *clientSecret, __unused NSError *error) {
-        XCTFail(@"completion called");
-    }];
-    id sut = OCMPartialMock(context);
-
-    [sut startSafariViewControllerRedirectFlowFromViewController:mockVC];
-
-    BOOL(^checker)(id) = ^BOOL(id vc) {
-        if ([vc isKindOfClass:[SFSafariViewController class]]) {
-            NSURL *url = [NSURL URLWithString:@"my-app://some_path"];
-            [[STPURLCallbackHandler shared] handleURLCallback:url];
+    id mockVC = OCMClassMock([UIViewController class]);
+    BOOL(^checker)(id) = ^BOOL(id viewController) {
+        if ([viewController isKindOfClass:[SFSafariViewController class]]) {
+            [[STPURLCallbackHandler shared] handleURLCallback:[NSURL URLWithString:@"my-app://some_path"]];
             return YES;
         }
         return NO;
     };
-    OCMVerify([mockVC presentViewController:[OCMArg checkWithBlock:checker]
-                                   animated:YES
-                                 completion:[OCMArg any]]);
+    OCMStub([mockVC presentViewController:[OCMArg checkWithBlock:checker] animated:[OCMArg any] completion:[OCMArg any]]);
+    STPRedirectContext *context = [[STPRedirectContext alloc] initWithSource:source completion:[self failingCompletionBlock]];
+    id sut = OCMPartialMock(context);
     OCMReject([sut unsubscribeFromNotifications]);
     OCMReject([sut dismissPresentedViewController]);
+
+    [sut startSafariViewControllerRedirectFlowFromViewController:mockVC];
+
+    OCMVerify([mockVC presentViewController:[OCMArg any] animated:YES completion:[OCMArg any]]);
 }
 
 /**
- After starting a SafariViewController redirect flow,
- when SafariViewController finishes, RedirectContext's completion block
- should be called.
+ After starting a SFSafariViewController redirect flow,
+ when SFSafariViewController calls `safariViewControllerDidFinish` because the user tapped "Done",
+ should execute STPRedirectContext completion block.
  */
 - (void)testSafariViewControllerRedirectFlow_didFinish {
-    id mockVC = OCMClassMock([UIViewController class]);
+    XCTestExpectation *expectation = [self expectationWithDescription:@"completion"];
+
     STPSource *source = [STPFixtures iDEALSource];
-    XCTestExpectation *exp = [self expectationWithDescription:@"completion"];
+    id mockVC = OCMClassMock([UIViewController class]);
+    BOOL(^checker)(id) = ^BOOL(id viewController) {
+        if ([viewController isKindOfClass:[SFSafariViewController class]]) {
+            SFSafariViewController *safariViewController = (SFSafariViewController *)viewController;
+            [safariViewController.delegate safariViewControllerDidFinish:safariViewController];
+            return YES;
+        }
+        return NO;
+    };
+    OCMStub([mockVC presentViewController:[OCMArg checkWithBlock:checker] animated:[OCMArg any] completion:[OCMArg any]]);
     STPRedirectContext *context = [[STPRedirectContext alloc] initWithSource:source completion:^(NSString *sourceID, NSString *clientSecret, NSError *error) {
         XCTAssertEqualObjects(sourceID, source.stripeID);
         XCTAssertEqualObjects(clientSecret, source.clientSecret);
         XCTAssertNil(error);
-        [exp fulfill];
+        [expectation fulfill];
     }];
     id sut = OCMPartialMock(context);
+    OCMReject([sut dismissPresentedViewController]);  // The SFSafariViewController dismisses itself when Done is tapped so `dismissPresentedViewController` should not be called
 
     [sut startSafariViewControllerRedirectFlowFromViewController:mockVC];
 
-    BOOL(^checker)(id) = ^BOOL(id vc) {
-        if ([vc isKindOfClass:[SFSafariViewController class]]) {
-            SFSafariViewController *sfvc = (SFSafariViewController *)vc;
-            [sfvc.delegate safariViewControllerDidFinish:sfvc];
+    OCMVerify([mockVC presentViewController:[OCMArg any] animated:YES completion:[OCMArg any]]);
+    OCMVerify([sut unsubscribeFromNotifications]);
+
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
+}
+
+/**
+ After starting a SFSafariViewController redirect flow,
+ when SFSafariViewController calls `didCompleteInitialLoad:NO`,
+ should execute STPRedirectContext completion block with error object and dismiss SFSafariViewController.
+ */
+- (void)testSafariViewControllerRedirectFlow_failedToLoad {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"completion"];
+
+    STPSource *source = [STPFixtures iDEALSource];
+    id mockVC = OCMClassMock([UIViewController class]);
+    BOOL(^checker)(id) = ^BOOL(id viewController) {
+        if ([viewController isKindOfClass:[SFSafariViewController class]]) {
+            SFSafariViewController *safariViewController = (SFSafariViewController *)viewController;
+            [safariViewController.delegate safariViewController:safariViewController didCompleteInitialLoad:NO];
             return YES;
         }
         return NO;
     };
-    OCMVerify([mockVC presentViewController:[OCMArg checkWithBlock:checker]
-                                   animated:YES
-                                 completion:[OCMArg any]]);
-    OCMVerify([sut unsubscribeFromNotifications]);
-    // dismiss should not be called – SafariVC dismisses itself when Done is tapped
-    OCMReject([sut dismissPresentedViewController]);
-
-    [self waitForExpectationsWithTimeout:2 handler:nil];
-}
-
-/**
- After starting a SafariViewController redirect flow,
- when SafariViewController fails to load, RedirectContext's completion block
- and dismiss method should be called.
- */
-- (void)testSafariViewControllerRedirectFlow_failedToLoad {
-    id mockVC = OCMClassMock([UIViewController class]);
-    STPSource *source = [STPFixtures iDEALSource];
-    XCTestExpectation *exp = [self expectationWithDescription:@"completion"];
+    OCMStub([mockVC presentViewController:[OCMArg checkWithBlock:checker] animated:[OCMArg any] completion:[OCMArg any]]);
     STPRedirectContext *context = [[STPRedirectContext alloc] initWithSource:source completion:^(NSString *sourceID, NSString *clientSecret, NSError *error) {
         XCTAssertEqualObjects(sourceID, source.stripeID);
         XCTAssertEqualObjects(clientSecret, source.clientSecret);
-        NSError *expectedError = [NSError stp_genericConnectionError];
-        XCTAssertEqualObjects(error, expectedError);
-        [exp fulfill];
+        XCTAssertEqualObjects(error, [NSError stp_genericConnectionError]);
+        [expectation fulfill];
     }];
     id sut = OCMPartialMock(context);
 
     [sut startSafariViewControllerRedirectFlowFromViewController:mockVC];
 
-    BOOL(^checker)(id) = ^BOOL(id vc) {
-        if ([vc isKindOfClass:[SFSafariViewController class]]) {
-            SFSafariViewController *sfvc = (SFSafariViewController *)vc;
-            [sfvc.delegate safariViewController:sfvc didCompleteInitialLoad:NO];
-            return YES;
-        }
-        return NO;
-    };
-    OCMVerify([mockVC presentViewController:[OCMArg checkWithBlock:checker]
-                                   animated:YES
-                                 completion:[OCMArg any]]);
+    OCMVerify([mockVC presentViewController:[OCMArg any] animated:YES completion:[OCMArg any]]);
     OCMVerify([sut unsubscribeFromNotifications]);
     OCMVerify([sut dismissPresentedViewController]);
 
-    [self waitForExpectationsWithTimeout:2 handler:nil];
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
 }
 
 /**
- After starting a SafariViewController redirect flow,
- when the RedirectContext is cancelled, its dismiss method should be called.
+ After starting a SFSafariViewController redirect flow,
+ when STPRedirectContext `cancel` is called,
+ should dismiss SFSafariViewController.
  */
 - (void)testSafariViewControllerRedirectFlow_cancel {
-    id mockVC = OCMClassMock([UIViewController class]);
     STPSource *source = [STPFixtures iDEALSource];
-    STPRedirectContext *context = [[STPRedirectContext alloc] initWithSource:source completion:^(__unused NSString *sourceID, __unused NSString *clientSecret, __unused NSError *error) {
-        XCTFail(@"completion called");
-    }];
+    id mockVC = OCMClassMock([UIViewController class]);
+    STPRedirectContext *context = [[STPRedirectContext alloc] initWithSource:source completion:[self failingCompletionBlock]];
     id sut = OCMPartialMock(context);
 
     [sut startSafariViewControllerRedirectFlowFromViewController:mockVC];
     [sut cancel];
 
-    OCMVerify([mockVC presentViewController:[OCMArg isKindOfClass:[SFSafariViewController class]]
-                                   animated:YES
-                                 completion:[OCMArg any]]);
+    OCMVerify([mockVC presentViewController:[OCMArg isKindOfClass:[SFSafariViewController class]] animated:YES completion:[OCMArg any]]);
     OCMVerify([sut unsubscribeFromNotifications]);
     OCMVerify([sut dismissPresentedViewController]);
 }
 
 /**
- After starting a SafariViewController redirect flow,
- when the RedirectContext is dealloc'd, its dismiss method should be called.
+ After starting a SFSafariViewControledirler redirect flow,
+ when the STPRedirectContext is deallocated,
+ should stop listening to callbacks (and dismiss SFSafariViewController but not tested due to complexity).
  */
 - (void)testSafariViewControllerRedirectFlow_dealloc {
-    id mockVC = OCMClassMock([UIViewController class]);
     STPSource *source = [STPFixtures iDEALSource];
-    STPRedirectContext *context = [[STPRedirectContext alloc] initWithSource:source completion:^(__unused NSString *sourceID, __unused NSString *clientSecret, __unused NSError *error) {
-        XCTFail(@"completion called");
-    }];
-    id sut = OCMPartialMock(context);
+    UIViewController *viewController = [[UIViewController alloc] init];
+    STPRedirectContext *context = [[STPRedirectContext alloc] initWithSource:source completion:[self failingCompletionBlock]];
 
-    [sut startSafariViewControllerRedirectFlowFromViewController:mockVC];
-    sut = nil;
+    [context startSafariViewControllerRedirectFlowFromViewController:viewController];
+    context = nil;
 
-    OCMVerify([mockVC presentViewController:[OCMArg isKindOfClass:[SFSafariViewController class]]
-                                   animated:YES
-                                 completion:[OCMArg any]]);
-    OCMVerify([sut unsubscribeFromNotifications]);
-    OCMVerify([sut dismissPresentedViewController]);
+    NSURLComponents *urlComponents = [NSURLComponents componentsWithURL:source.redirect.returnURL resolvingAgainstBaseURL:NO];
+    [urlComponents setStp_queryItemsDictionary:@{@"source": source.stripeID, @"client_secret": source.clientSecret}];
+    [[STPURLCallbackHandler shared] handleURLCallback:urlComponents.URL];  // Should do nothing!
 }
 
 /**
- After starting a SafariViewController redirect flow,
- if no action is taken, nothing should be called.
+ After starting a SFSafariViewController redirect flow,
+ when no action is taken,
+ nothing should be called.
  */
 - (void)testSafariViewControllerRedirectFlow_noAction {
-    id mockVC = OCMClassMock([UIViewController class]);
     STPSource *source = [STPFixtures iDEALSource];
-    STPRedirectContext *context = [[STPRedirectContext alloc] initWithSource:source completion:^(__unused NSString *sourceID, __unused NSString *clientSecret, __unused NSError *error) {
-        XCTFail(@"completion called");
-    }];
+    id mockVC = OCMClassMock([UIViewController class]);
+    STPRedirectContext *context = [[STPRedirectContext alloc] initWithSource:source completion:[self failingCompletionBlock]];
     id sut = OCMPartialMock(context);
+    OCMReject([sut unsubscribeFromNotifications]);
+    OCMReject([sut dismissPresentedViewController]);
 
     [sut startSafariViewControllerRedirectFlowFromViewController:mockVC];
 
-    OCMVerify([mockVC presentViewController:[OCMArg isKindOfClass:[SFSafariViewController class]]
-                                   animated:YES
-                                 completion:[OCMArg any]]);
-    OCMReject([sut unsubscribeFromNotifications]);
-    OCMReject([sut dismissPresentedViewController]);
+    OCMVerify([mockVC presentViewController:[OCMArg isKindOfClass:[SFSafariViewController class]] animated:[OCMArg any] completion:[OCMArg any]]);
 }
+
+#pragma mark - startSafariAppRedirectFlow
 
 /**
  After starting a Safari app redirect flow,
- when a WillEnterForeground notification is posted, RedirectContext's completion 
- block and dismiss method should be called.
+ when `UIApplicationWillEnterForegroundNotification` is posted,
+ should execute STPRedirectContext completion block with error object and dismiss just in case.
  */
 - (void)testSafariAppRedirectFlow_foregroundNotification {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"completion"];
+
     STPSource *source = [STPFixtures iDEALSource];
-    XCTestExpectation *exp = [self expectationWithDescription:@"completion"];
     STPRedirectContext *context = [[STPRedirectContext alloc] initWithSource:source completion:^(NSString *sourceID, NSString *clientSecret, NSError *error) {
         XCTAssertEqualObjects(sourceID, source.stripeID);
         XCTAssertEqualObjects(clientSecret, source.clientSecret);
         XCTAssertNil(error);
-        [exp fulfill];
+        [expectation fulfill];
     }];
     id sut = OCMPartialMock(context);
 
@@ -262,67 +308,71 @@
 
     OCMVerify([sut unsubscribeFromNotifications]);
     OCMVerify([sut dismissPresentedViewController]);
-    [self waitForExpectationsWithTimeout:2 handler:nil];
+
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
 }
 
 /**
  After starting a Safari app redirect flow,
- if no notification is posted, nothing should be called.
+ when no notification is posted,
+ nothing should be called.
  */
 - (void)testSafariAppRedirectFlow_noNotification {
     STPSource *source = [STPFixtures iDEALSource];
-    STPRedirectContext *context = [[STPRedirectContext alloc] initWithSource:source completion:^(__unused NSString *sourceID, __unused NSString *clientSecret, __unused NSError *error) {
-        XCTFail(@"completion called");
-    }];
+    STPRedirectContext *context = [[STPRedirectContext alloc] initWithSource:source completion:[self failingCompletionBlock]];
     id sut = OCMPartialMock(context);
-
-    [sut startSafariAppRedirectFlow];
-
     OCMReject([sut unsubscribeFromNotifications]);
     OCMReject([sut dismissPresentedViewController]);
+
+    [sut startSafariAppRedirectFlow];
 }
 
+#pragma mark - startRedirectFlowFromViewController
+
 /**
- If a source type that supports native redirect is used and it contains a native
- url, an app to app redirect should attempt to be initiated.
+ If a source with `STPSourceType` that supports native redirects is used,
+ and `source.details` contains a `native_url`,
+ should attempt to initiate an app to app redirect.
  */
 - (void)testNativeRedirectSupportingSourceFlow_validNativeURL {
     STPSource *source = [STPFixtures alipaySourceWithNativeUrl];
+
     NSURL *sourceURL = [NSURL URLWithString:source.details[@"native_url"]];
 
-    STPRedirectContext *context = [[STPRedirectContext alloc] initWithSource:source
-                                                                  completion:^(__unused NSString *sourceID, __unused NSString *clientSecret, __unused NSError *error) {
-        XCTFail(@"completion called");
-    }];
+    STPRedirectContext *context = [[STPRedirectContext alloc] initWithSource:source completion:[self failingCompletionBlock]];
     id sut = OCMPartialMock(context);
+    OCMReject([sut startSafariViewControllerRedirectFlowFromViewController:[OCMArg any]]);
+    OCMReject([sut startSafariAppRedirectFlow]);
 
     id applicationMock = OCMClassMock([UIApplication class]);
     OCMStub([applicationMock sharedApplication]).andReturn(applicationMock);
-    OCMStub([applicationMock openURL:[OCMArg any]
-                             options:[OCMArg any]
-                   completionHandler:([OCMArg invokeBlockWithArgs:@YES, nil])]);
+    if ([[UIApplication sharedApplication] respondsToSelector:@selector(openURL:options:completionHandler:)]) {
+        OCMStub([applicationMock openURL:[OCMArg any] options:[OCMArg any] completionHandler:([OCMArg invokeBlockWithArgs:@YES, nil])]);
+    }
+    else {
+        OCMStub([applicationMock openURL:[OCMArg any]]).andReturn(YES);
+    }
 
     id mockVC = OCMClassMock([UIViewController class]);
     [context startRedirectFlowFromViewController:mockVC];
 
-    OCMReject([sut startSafariViewControllerRedirectFlowFromViewController:[OCMArg any]]);
-    OCMReject([sut startSafariAppRedirectFlow]);
-    OCMVerify([applicationMock openURL:[OCMArg isEqual:sourceURL]
-                               options:[OCMArg isEqual:@{}]
-                     completionHandler:[OCMArg isNotNil]]);
+    if ([[UIApplication sharedApplication] respondsToSelector:@selector(openURL:options:completionHandler:)]) {
+        OCMVerify([applicationMock openURL:[OCMArg isEqual:sourceURL] options:[OCMArg isEqual:@{}] completionHandler:[OCMArg isNotNil]]);
+    }
+    else {
+        OCMVerify([applicationMock openURL:[OCMArg isEqual:sourceURL]]);
+    }
 }
 
 /**
- If a source type that supports native redirect is used and it does not
- contain a native url, standard web view redirect should be attempted
+ If a source with `STPSourceType` that supports native redirects is used,
+ and `source.details` does not contain a `native_url`,
+ should start a SFSafariViewController redirect flow.
  */
 - (void)testNativeRedirectSupportingSourceFlow_invalidNativeURL {
     STPSource *source = [STPFixtures alipaySource];
 
-    STPRedirectContext *context = [[STPRedirectContext alloc] initWithSource:source
-                                                                  completion:^(__unused NSString *sourceID, __unused NSString *clientSecret, __unused NSError *error) {
-                                                                      XCTFail(@"completion called");
-                                                                  }];
+    STPRedirectContext *context = [[STPRedirectContext alloc] initWithSource:source completion:[self failingCompletionBlock]];
     id sut = OCMPartialMock(context);
 
     id applicationMock = OCMClassMock([UIApplication class]);
@@ -332,12 +382,21 @@
     [context startRedirectFlowFromViewController:mockVC];
 
     OCMVerify([sut startSafariViewControllerRedirectFlowFromViewController:[OCMArg isEqual:mockVC]]);
-    OCMReject([applicationMock openURL:[OCMArg any]
-                               options:[OCMArg any]
-                     completionHandler:[OCMArg any]]);
-    OCMVerify([mockVC presentViewController:[OCMArg isKindOfClass:[SFSafariViewController class]]
-                                   animated:YES
-                                 completion:[OCMArg isNil]]);
+    if ([[UIApplication sharedApplication] respondsToSelector:@selector(openURL:options:completionHandler:)]) {
+        OCMReject([applicationMock openURL:[OCMArg any] options:[OCMArg any] completionHandler:[OCMArg any]]);
+    }
+    else {
+        OCMReject([applicationMock openURL:[OCMArg any]]);
+    }
+    OCMVerify([mockVC presentViewController:[OCMArg isKindOfClass:[SFSafariViewController class]] animated:YES completion:[OCMArg isNil]]);
+}
+
+#pragma mark - Helpers
+
+- (STPRedirectContextCompletionBlock)failingCompletionBlock {
+    return ^(NSString *sourceID, NSString *clientSecret, NSError *error) {
+        XCTFail("Should not have called completion: sourceID=%@, clientSecret=%@, error=%@", sourceID, clientSecret, error);
+    };
 }
 
 @end


### PR DESCRIPTION
Fixing test failures found in: https://github.com/stripe/stripe-ios/pull/802

# Summary

I think the `STPRedirectContext` was failing tests quietly in our previous `Xcode 8, iOS 10.x` testing but shows up when we enable the other Xcode / iOS versions.

1. The first problem is some of the tests were intended to never call the `unsubscribeFromUrlAndForegroundNotifications`. In particular, because the `STPURLCallbackHandler` [held a strong reference](https://github.com/stripe/stripe-ios/pull/804/commits/534ba2875d2c83c161565f1894808e5ae9afeacc#diff-f5b882a2b86c0c0fce5b2f949b1abadaL35), the `STPRedirectContext<STPURLCallbackListener>` ended up staying alive between tests leading to unexpected results.

2. The second problem is the `startRedirectFlowFromViewController` was implicitly [holding a strong reference to itself](https://github.com/stripe/stripe-ios/pull/804/commits/534ba2875d2c83c161565f1894808e5ae9afeacc#diff-fbf1a3bd7e2932d541757062a7d430f4R103) in its completion block. Reproducing this is similar to the first problem, either put a breakpoint in `dealloc` and make sure it's called after every test, or send a valid url scheme to the `STPURLCallbackHandler` and see if any listener picks up.

3. Finally, we needed to [adjust the test cases](https://github.com/stripe/stripe-ios/pull/804/commits/534ba2875d2c83c161565f1894808e5ae9afeacc#diff-30df8fae75ff2f3bb3a3dbc5f5f28493R359) so that they're compatible with all tested iOS versions

I took a broader stroke in the second commit because I was often getting lost/confused when trying to understand the implementation of `STPRedirectContext`. I think some key method renaming is sufficient to solve that but definitely want to avoid introducing new bugs.

The tests are still really tricky to maintain but the implementation itself is good so a refactoring just to simplify tests is probably a bad idea right now.

TODO: Update documentation, add `CHANGELOG` and `MIGRATING` entry to warn about holding a strong reference to `STPRedirectContext` which was not needed before