### PR TITLE
Fix error parsing

### DIFF
--- a/Stripe/STPAPIRequest.m
+++ b/Stripe/STPAPIRequest.m
@@ -164,13 +164,12 @@ static NSString * const JSONKeyObject = @"object";
             }
         }
     }
-    if (!deserializerClass) {
-        // No deserializer for response body
-        return safeCompletion(nil, [NSError stp_genericFailedToParseResponseError]);
-    }
 
-    // Generate response object
-    id<STPAPIResponseDecodable> responseObject = [deserializerClass decodedObjectFromAPIResponse:jsonDictionary];
+    id<STPAPIResponseDecodable> responseObject = nil;
+    if (deserializerClass) {
+        // Generate response object
+        responseObject = [deserializerClass decodedObjectFromAPIResponse:jsonDictionary];
+    }
 
     if (!responseObject) {
         // Failed to parse response


### PR DESCRIPTION
We incorrectly return a generic parse error instead of the actual api error for any api request which had multiple possible deserializers. This fixes this case so it continues through to the same error handling logic as single deserializer requests and adds a test to catch this mistake.