### PR TITLE
Hotfix for crash (unrecognized selector sent to instance) (Updated STPCard.m)

### DIFF
--- a/Stripe/STPCard.m
+++ b/Stripe/STPCard.m
@@ -198,7 +198,8 @@ NS_ASSUME_NONNULL_BEGIN
     card.currency = dict[@"currency"];
     card.expMonth = [dict[@"exp_month"] intValue];
     card.expYear = [dict[@"exp_year"] intValue];
-    card.metadata = [dict[@"metadata"] stp_dictionaryByRemovingNonStrings];
+    if ([dict[@"metadata"] isKindOfClass: [NSDictionary class]])
+        card.metadata = [dict[@"metadata"] stp_dictionaryByRemovingNonStrings];
 
     card.address.name = card.name;
     card.address.line1 = dict[@"address_line1"];


### PR DESCRIPTION
## Summary

Hotfix for crash (unrecognized selector sent to instance) in 11.4.0 when deserialize STPCustomer #826

## Motivation

Bug described in issue #826

## Testing

Was tested in real project.
