### PR TITLE
Capitalize currency and country codes automatically

### DIFF
--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -414,8 +414,8 @@ static NSString * const FileUploadURL = @"https://uploads.stripe.com/v1/files";
     [paymentRequest setMerchantIdentifier:merchantIdentifier];
     [paymentRequest setSupportedNetworks:[self supportedPKPaymentNetworks]];
     [paymentRequest setMerchantCapabilities:PKMerchantCapability3DS];
-    [paymentRequest setCountryCode:countryCode];
-    [paymentRequest setCurrencyCode:currencyCode];
+    [paymentRequest setCountryCode:countryCode.uppercaseString];
+    [paymentRequest setCurrencyCode:currencyCode.uppercaseString];
     return paymentRequest;
 }
 


### PR DESCRIPTION
Payment context already force-capitalizes the currency code before attempting to create a PKPaymentAuthorizationViewController but this other helper method does not. iOS now returns nil for PKPaymentAuthorizationViewController if the request you create it with has a lowercase currency code so capitalize it automatically for people.

Fixes https://github.com/stripe/stripe-ios/issues/828 (will also update our examples in docs to have "USD" instead so that we are showing the correct thing, even though we will auto fix it for people).