### PR TITLE
Fix an STPURLCallbackListener retain cycle.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ env:
   - TEST_TYPE=installation_carthage
   - TEST_TYPE=installation_cocoapods
   - TEST_TYPE=installation_cocoapods_frameworks
-  - TEST_TYPE=lint
+# Fauxpas 1.7.2 does not build our project correctly https://bitbucket.org/ali_rantakari/faux-pas/issues/117/unrecoverable-compiler-error-translation
+#  - TEST_TYPE=lint
   - TEST_TYPE=tests
   - TEST_TYPE=analyzer
   - TEST_TYPE=documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 12.0.0 2017-12-XX
+* `STPRedirectContext` will no longer retain itself for the duration of the redirect, you must explicitly maintain a reference to it yourself. If you 
+
 ## 11.5.0 2017-11-09
 * Adds a new helper method to `STPSourceParams` for creating reusable Alipay sources. [#811](https://github.com/stripe/stripe-ios/pull/811)
 * Silences spurious availability warnings when using Xcode9 [#823](https://github.com/stripe/stripe-ios/pull/823)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 12.0.0 2017-12-XX
-* `STPRedirectContext` will no longer retain itself for the duration of the redirect, you must explicitly maintain a reference to it yourself. If you 
+* `STPRedirectContext` will no longer retain itself for the duration of the redirect, you must explicitly maintain a reference to it yourself.
 
 ## 11.5.0 2017-11-09
 * Adds a new helper method to `STPSourceParams` for creating reusable Alipay sources. [#811](https://github.com/stripe/stripe-ios/pull/811)

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,5 +1,8 @@
 ## Migration Guides
 
+### Migrating from versions < 12.0.0
+* `STPRedirectContext` will no longer retain itself for the duration of the redirect. If you were relying on this functionality, you must change your code to explicitly maintain a reference to it.
+
 ### Migrating from versions < 11.4.0
 * The `STPBackendAPIAdapter` protocol and all associated methods are no longer deprecated. We still recommend using `STPCustomerContext` to update a Stripe customer object on your behalf, rather than using your own implementation of `STPBackendAPIAdapter`.
 

--- a/Stripe/PublicHeaders/STPRedirectContext.h
+++ b/Stripe/PublicHeaders/STPRedirectContext.h
@@ -52,7 +52,7 @@ typedef void (^STPRedirectContextCompletionBlock)(NSString *sourceID, NSString *
 /**
  This is a helper class for handling redirect sources.
 
- Init an instance with the redirect flow source you want to handle,
+ Init and retain an instance with the redirect flow source you want to handle,
  then choose a redirect method. The context will fire the completion handler
  when the redirect completes.
 
@@ -64,13 +64,12 @@ typedef void (^STPRedirectContextCompletionBlock)(NSString *sourceID, NSString *
  However, it is possible the when the redirect is "completed", the user may
  have not actually completed the necessary actions to authorize the charge.
 
- You can use `STPAPIClient` to listen for state changes on the source
- object as a way to identify whether the user action succeeded or not.
- @see `[STPAPIClient startPollingSourceWithId:clientSecret:timeout:completion:]`
-
  You should not use either this class, nor `STPAPIClient`, as a way
- to determine when you should charge the source. Use Stripe webhooks on your
- backend server to listen for source state changes and to make the charge.
+ to determine when you should charge the source or to determine if the redirect
+ was successful. Use Stripe webhooks on your backend server to listen for source
+ state changes and to make the charge.
+ 
+ See https://stripe.com/docs/sources/best-practices
  */
 NS_EXTENSION_UNAVAILABLE("Redirect based sources are not available in extensions")
 @interface STPRedirectContext : NSObject

--- a/Stripe/STPRedirectContext.m
+++ b/Stripe/STPRedirectContext.m
@@ -105,8 +105,10 @@ typedef void (^STPBoolCompletionBlock)(BOOL success);
 - (void)startRedirectFlowFromViewController:(UIViewController *)presentingViewController {
     FAUXPAS_IGNORED_IN_METHOD(APIAvailability)
 
+    WEAK(self)
     [self performAppRedirectIfPossibleWithCompletion:^(BOOL success) {
         if (!success) {
+            STRONG(self)
             if ([SFSafariViewController class] != nil) {
                 [self startSafariViewControllerRedirectFlowFromViewController:presentingViewController];
             }

--- a/Stripe/STPURLCallbackHandler.m
+++ b/Stripe/STPURLCallbackHandler.m
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface STPURLCallback : NSObject
 @property (nonatomic) NSURLComponents *urlComponents;
-@property (nonatomic) id<STPURLCallbackListener> listener;
+@property (nonatomic, weak) id<STPURLCallbackListener> listener;
 @end
 
 @implementation STPURLCallback


### PR DESCRIPTION
Previously there was a bug where STPURLCallbackListener retained its listeners, which meant that STPRedirectContext had a retain cycle and would not deallocate while it was actively listening for callbacks. Fixing this is in some ways a breaking API change.
This commit fixes the bug, and also updates the docs to explicitly mention that you need to retain the instances you make.
It also replaces referencing to STPAPIClient source polling (which is deprecated) and instead links to the sources best practices doc.