### PR TITLE
fix bug where PaymentContext gets stuck with shippingType Delivery

### DIFF
--- a/Stripe/PublicHeaders/STPPaymentContext.h
+++ b/Stripe/PublicHeaders/STPPaymentContext.h
@@ -370,9 +370,10 @@ didCreatePaymentResult:(STPPaymentResult *)paymentResult
  Inside this method, you should verify that you can ship to the given address.
  You should call the completion block with the results of your validation
  and the available shipping methods for the given address. If you don't implement
- this method or call the completion block with nil or an empty array of shipping
- method, the user won't be prompted to select a shipping method and all
- addresses will be valid.
+ this method, the user won't be prompted to select a shipping method and all
+ addresses will be valid. If you call the completion block with nil or an
+ empty array of shipping methods, the user won't be prompted to select a
+ shipping method.
 
  @note If a user updates their shipping address within the Apple Pay dialog,
  this address will be anonymized. For example, in the US, it will only include the
@@ -382,7 +383,10 @@ didCreatePaymentResult:(STPPaymentResult *)paymentResult
 
  @param paymentContext  The context that updated its shipping address
  @param address The current shipping address
- @param completion      Call this block when you're done validating the shipping address and calculating available shipping methods.
+ @param completion      Call this block when you're done validating the shipping
+ address and calculating available shipping methods. If you call the completion
+ block with nil or an empty array of shipping methods, the user won't be prompted
+ to select a shipping method.
  */
 - (void)paymentContext:(STPPaymentContext *)paymentContext
 didUpdateShippingAddress:(STPAddress *)address

--- a/Stripe/PublicHeaders/STPPaymentContext.h
+++ b/Stripe/PublicHeaders/STPPaymentContext.h
@@ -370,7 +370,8 @@ didCreatePaymentResult:(STPPaymentResult *)paymentResult
  Inside this method, you should verify that you can ship to the given address.
  You should call the completion block with the results of your validation
  and the available shipping methods for the given address. If you don't implement
- this method, the user won't be prompted to select a shipping method and all
+ this method or call the completion block with nil or an empty array of shipping
+ method, the user won't be prompted to select a shipping method and all
  addresses will be valid.
 
  @note If a user updates their shipping address within the Apple Pay dialog,

--- a/Stripe/PublicHeaders/STPShippingAddressViewController.h
+++ b/Stripe/PublicHeaders/STPShippingAddressViewController.h
@@ -76,7 +76,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)shippingAddressViewControllerDidCancel:(STPShippingAddressViewController *)addressViewController;
 
 /**
- This is called when the user enters a shipping address and taps next. You should validate the address and determine what shipping methods are available, and call the `completion` block when finished. If an error occurrs, call the `completion` block with the error. Otherwise, call the `completion` block with a nil error and an array of available shipping methods. If you don't need to collect a shipping method, you may pass an empty array.
+ This is called when the user enters a shipping address and taps next. You
+ should validate the address and determine what shipping methods are available,
+ and call the `completion` block when finished. If an error occurrs, call
+ the `completion` block with the error. Otherwise, call the `completion`
+ block with a nil error and an array of available shipping methods. If you don't
+ need to collect a shipping method, you may pass an empty array or nil.
 
  @param addressViewController the view controller where the address was entered
  @param address               the address that was entered. @see STPAddress

--- a/Stripe/STPPaymentContext.m
+++ b/Stripe/STPPaymentContext.m
@@ -510,11 +510,8 @@ typedef NS_ENUM(NSUInteger, STPPaymentContextState) {
 - (BOOL)requestPaymentShouldPresentShippingViewController {
     BOOL shippingAddressRequired = self.configuration.requiredShippingAddressFields != STPBillingAddressFieldsNone;
     BOOL shippingAddressIncomplete = ![self.shippingAddress containsRequiredShippingAddressFields:self.configuration.requiredShippingAddressFields];
-    BOOL shippingMethodRequired = (self.configuration.shippingType == STPShippingTypeShipping &&
-                                   [self.delegate respondsToSelector:@selector(paymentContext:didUpdateShippingAddress:completion:)] &&
-                                   !self.selectedShippingMethod);
     BOOL verificationRequired = self.configuration.verifyPrefilledShippingAddress && self.shippingAddressNeedsVerification;
-    return (shippingAddressRequired && (shippingAddressIncomplete || shippingMethodRequired || verificationRequired));
+    return (shippingAddressRequired && (shippingAddressIncomplete || verificationRequired));
 }
 
 - (void)requestPayment {

--- a/Stripe/STPPaymentContext.m
+++ b/Stripe/STPPaymentContext.m
@@ -510,8 +510,20 @@ typedef NS_ENUM(NSUInteger, STPPaymentContextState) {
 - (BOOL)requestPaymentShouldPresentShippingViewController {
     BOOL shippingAddressRequired = self.configuration.requiredShippingAddressFields != STPBillingAddressFieldsNone;
     BOOL shippingAddressIncomplete = ![self.shippingAddress containsRequiredShippingAddressFields:self.configuration.requiredShippingAddressFields];
+    BOOL shippingMethodRequired = (self.configuration.shippingType == STPShippingTypeShipping &&
+                                   [self.delegate respondsToSelector:@selector(paymentContext:didUpdateShippingAddress:completion:)] &&
+                                   !self.selectedShippingMethod);
     BOOL verificationRequired = self.configuration.verifyPrefilledShippingAddress && self.shippingAddressNeedsVerification;
-    return (shippingAddressRequired && (shippingAddressIncomplete || verificationRequired));
+    // true if STPShippingVC should be presented to collect or verify a shipping address
+    BOOL shouldPresentShippingAddress = (shippingAddressRequired && (shippingAddressIncomplete || verificationRequired));
+    // this handles a corner case where STPShippingVC should be presented because:
+    // - shipping address has been pre-filled
+    // - no verification is required, but the user still needs to enter a shipping method
+    BOOL shouldPresentShippingMethods = (shippingAddressRequired &&
+                                         !shippingAddressIncomplete &&
+                                         !verificationRequired &&
+                                         shippingMethodRequired);
+    return (shouldPresentShippingAddress || shouldPresentShippingMethods);
 }
 
 - (void)requestPayment {

--- a/Stripe/STPPaymentContext.m
+++ b/Stripe/STPPaymentContext.m
@@ -510,7 +510,9 @@ typedef NS_ENUM(NSUInteger, STPPaymentContextState) {
 - (BOOL)requestPaymentShouldPresentShippingViewController {
     BOOL shippingAddressRequired = self.configuration.requiredShippingAddressFields != STPBillingAddressFieldsNone;
     BOOL shippingAddressIncomplete = ![self.shippingAddress containsRequiredShippingAddressFields:self.configuration.requiredShippingAddressFields];
-    BOOL shippingMethodRequired = ([self.delegate respondsToSelector:@selector(paymentContext:didUpdateShippingAddress:completion:)] && !self.selectedShippingMethod);
+    BOOL shippingMethodRequired = (self.configuration.shippingType == STPShippingTypeShipping &&
+                                   [self.delegate respondsToSelector:@selector(paymentContext:didUpdateShippingAddress:completion:)] &&
+                                   !self.selectedShippingMethod);
     BOOL verificationRequired = self.configuration.verifyPrefilledShippingAddress && self.shippingAddressNeedsVerification;
     return (shippingAddressRequired && (shippingAddressIncomplete || shippingMethodRequired || verificationRequired));
 }


### PR DESCRIPTION
r? @danj-stripe 

This fixes the bug reported in #839 – shipping method shouldn't be required if `shippingType` is `delivery`.
