### PR TITLE
Fix `STPAddressViewModel.isValid` to use country when `requiredBillingFields = .Zip`

### DIFF
--- a/Stripe/STPAddCardViewController.m
+++ b/Stripe/STPAddCardViewController.m
@@ -124,9 +124,7 @@ typedef NS_ENUM(NSUInteger, STPPaymentCardSection) {
     
     self.inputAccessoryToolbar = [UIToolbar stp_inputAccessoryToolbarWithTarget:self action:@selector(paymentFieldNextTapped)];
     [self.inputAccessoryToolbar stp_setEnabled:NO];
-    if (self.configuration.requiredBillingAddressFields != STPBillingAddressFieldsNone) {
-        paymentCell.inputAccessoryView = self.inputAccessoryToolbar;
-    }
+    [self updateInputAccessoryVisiblity];
     self.tableView.dataSource = self;
     self.tableView.delegate = self;
 
@@ -316,6 +314,14 @@ typedef NS_ENUM(NSUInteger, STPPaymentCardSection) {
                                                                );
 }
 
+- (void)updateInputAccessoryVisiblity {
+    // The inputAccessoryToolbar switches from the paymentCell to the first address field.
+    // It should only be shown when there *is* an address field. This compensates for the lack
+    // of a 'Return' key on the number pad used for paymentCell entry
+    BOOL hasAddressCells = self.addressViewModel.addressCells.count > 0;
+    self.paymentCell.inputAccessoryView = hasAddressCells ? self.inputAccessoryToolbar : nil;
+}
+
 - (void)setCustomFooterView:(UIView *)footerView {
     _customFooterView = footerView;
     [self.stp_willAppearPromise voidOnSuccess:^{
@@ -360,11 +366,13 @@ typedef NS_ENUM(NSUInteger, STPPaymentCardSection) {
 - (void)addressViewModel:(__unused STPAddressViewModel *)addressViewModel addedCellAtIndex:(NSUInteger)index {
     NSIndexPath *indexPath = [NSIndexPath indexPathForRow:index inSection:STPPaymentCardBillingAddressSection];
     [self.tableView insertRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
+    [self updateInputAccessoryVisiblity];
 }
 
 - (void)addressViewModel:(__unused STPAddressViewModel *)addressViewModel removedCellAtIndex:(NSUInteger)index {
     NSIndexPath *indexPath = [NSIndexPath indexPathForRow:index inSection:STPPaymentCardBillingAddressSection];
     [self.tableView deleteRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
+    [self updateInputAccessoryVisiblity];
 }
 
 - (void)addressViewModelDidChange:(__unused STPAddressViewModel *)addressViewModel {

--- a/Stripe/STPAddressViewModel.m
+++ b/Stripe/STPAddressViewModel.m
@@ -338,6 +338,9 @@
                 break;
         }
     }
+    // Prefer to use the contents of STPAddressFieldTypeCountry, but fallback to
+    // `addressFieldTableViewCountryCode` if nil (important for STPBillingAddressFieldsZip)
+    address.country = address.country ?: self.addressFieldTableViewCountryCode;
     return address;
 }
 

--- a/Tests/Tests/STPAddressViewModelTest.m
+++ b/Tests/Tests/STPAddressViewModelTest.m
@@ -18,6 +18,7 @@
 - (void)testInitWithRequiredBillingFields {
     STPAddressViewModel *sut = [[STPAddressViewModel alloc] initWithRequiredBillingFields:STPBillingAddressFieldsNone];
     XCTAssertTrue([sut.addressCells count] == 0);
+    XCTAssertTrue(sut.isValid);
 
     sut = [[STPAddressViewModel alloc] initWithRequiredBillingFields:STPBillingAddressFieldsZip];
     XCTAssertTrue([sut.addressCells count] == 1);
@@ -126,7 +127,29 @@
     XCTAssertEqualObjects(sut.addressCells[8].contents, @"555-555-5555");
 }
 
-- (void)testIsValid {
+- (void)testIsValid_Zip {
+    STPAddressViewModel *sut = [[STPAddressViewModel alloc] initWithRequiredBillingFields:STPBillingAddressFieldsZip];
+
+    STPAddress *address = [STPAddress new];
+
+    address.country = @"US";
+    sut.address = address;
+    XCTAssertEqual(sut.addressCells.count, 1ul);
+    XCTAssertFalse(sut.isValid, @"US addresses have postalCode, require it when requiredBillingFields is .Zip");
+
+    address.postalCode = @"94016";
+    sut.address = address;
+    XCTAssertTrue(sut.isValid);
+
+    address.country = @"MO"; // in Macao, postalCode is optional
+    address.postalCode = nil;
+    sut.address = address;
+    XCTAssertEqual(sut.addressCells.count, 0ul);
+    XCTAssertTrue(sut.isValid, @"in Macao, postalCode is optional, valid without one");
+}
+
+
+- (void)testIsValid_Full {
     STPAddressViewModel *sut = [[STPAddressViewModel alloc] initWithRequiredBillingFields:STPBillingAddressFieldsFull];
     XCTAssertFalse(sut.isValid);
     sut.addressCells[0].contents = @"John Smith";


### PR DESCRIPTION
## Summary

We had a bug, where `STPAddressViewModel` objects that only require the Postal Code did
not use the country when calculating `isValid`, but *did* use the country when deciding
whether or not to show the postal code field.

This resulted in a stuck user: they couldn't add a credit card, because the 
`STPAddCardViewController` was waiting for them to enter a postal code, but didn't allow
them to.

Additionally, in this case we were also incorrectly showing the `inputAccessoryToolbar`
with a 'Next' button that did nothing.

## Motivation

Fixes #840

## Testing

Augmented `STPAddressViewModelTest` to capture this case, and protect against regressions.

Further, manual testing in the Standard Integration app, both US & Macau (req'd postal &
non-req'd postal code), and all three values of `STPBillingAddressFields` (none, zip, full)