### PR TITLE
Fix bugs around `STPPaymentCardTextField becomeFirstResponder`

### DIFF
--- a/Stripe/STPPaymentCardTextField.m
+++ b/Stripe/STPPaymentCardTextField.m
@@ -447,7 +447,7 @@ CGFloat const STPPaymentCardTextFieldMinimumPadding = 10;
 #pragma mark UIResponder & related methods
 
 - (BOOL)isFirstResponder {
-    return [self.currentFirstResponderField isFirstResponder];
+    return self.currentFirstResponderField != nil;
 }
 
 - (BOOL)canBecomeFirstResponder {
@@ -458,31 +458,11 @@ CGFloat const STPPaymentCardTextFieldMinimumPadding = 10;
     return [[self nextFirstResponderField] becomeFirstResponder];
 }
 
-- (STPFormTextField *)nextFirstResponderField {
-    STPFormTextField *currentSubResponder = self.currentFirstResponderField;
-    if (currentSubResponder) {
-        NSUInteger index = [self.allFields indexOfObject:currentSubResponder];
-        if (index != NSNotFound) {
-            index += 1;
-            if (self.allFields.count > index) {
-                STPFormTextField *nextField = self.allFields[index];
-                if (nextField == self.postalCodeField
-                    && !self.postalCodeEntryEnabled) {
-                    return [self firstInvalidSubField];
-                }
-                else {
-                    return nextField;
-                }
-            }
-        }
-        return [self firstInvalidSubField];
-    }
-    else {
-        return [self firstInvalidSubField];
-    }
+- (nonnull STPFormTextField *)nextFirstResponderField {
+    return [self firstInvalidSubField] ?: [self lastSubField];
 }
 
-- (STPFormTextField *)firstInvalidSubField {
+- (nullable STPFormTextField *)firstInvalidSubField {
     if ([self.viewModel validationStateForField:STPCardFieldTypeNumber] != STPCardValidationStateValid) {
         return self.numberField;
     }
@@ -499,6 +479,10 @@ CGFloat const STPPaymentCardTextFieldMinimumPadding = 10;
     else {
         return nil;
     }
+}
+
+- (nonnull STPFormTextField *)lastSubField {
+    return self.postalCodeEntryEnabled ? self.postalCodeField : self.cvcField;
 }
 
 - (STPFormTextField *)currentFirstResponderField {
@@ -1283,6 +1267,7 @@ typedef void (^STPLayoutAnimationCompletionBlock)(BOOL completed);
                 }
             }
 
+            // This is a no-op if this is the last field
             [[self nextFirstResponderField] becomeFirstResponder];
             break;
         }

--- a/Tests/Tests/STPPaymentCardTextFieldTest.m
+++ b/Tests/Tests/STPPaymentCardTextFieldTest.m
@@ -500,22 +500,22 @@
 
     self.sut.numberField.text = @"4242" "4242" "4242" "4242";
 
-    XCTAssertTrue([self.sut becomeFirstResponder]);
     XCTAssertEqual(self.sut.expirationField, self.sut.currentFirstResponderField,
-                   @"Once numberField is valid, becomeFirstResponder should move to the next field (expiration)");
+                   @"Once numberField is valid, firstResponder should move to the next field (expiration)");
 
     XCTAssertTrue([self.sut.cvcField becomeFirstResponder]);
     XCTAssertEqual(self.sut.cvcField, self.sut.currentFirstResponderField,
                    @"We don't block other fields from becoming firstResponder");
 
     XCTAssertTrue([self.sut becomeFirstResponder]);
-    XCTAssertEqual(self.sut.expirationField, self.sut.currentFirstResponderField,
-                   @"Moves firstResponder back to expiration, because it's not valid yet");
+    XCTAssertEqual(self.sut.cvcField, self.sut.currentFirstResponderField,
+                   @"Calling becomeFirstResponder does not change the currentFirstResponder");
 
     self.sut.expirationField.text = @"10/99";
     self.sut.cvcField.text = @"123";
 
     XCTAssertTrue(self.sut.isValid);
+    [self.sut resignFirstResponder];
     XCTAssertTrue([self.sut canBecomeFirstResponder]);
     XCTAssertTrue([self.sut becomeFirstResponder]);
 
@@ -525,11 +525,13 @@
     self.sut.postalCodeEntryEnabled = YES;
     XCTAssertFalse(self.sut.isValid);
 
+    [self.sut resignFirstResponder];
     XCTAssertTrue([self.sut becomeFirstResponder]);
     XCTAssertEqual(self.sut.postalCodeField, self.sut.currentFirstResponderField,
                    @"When postalCodeEntryEnabled=YES, it should become firstResponder after other fields are valid");
 
     self.sut.expirationField.text = @"";
+    [self.sut resignFirstResponder];
     XCTAssertTrue([self.sut becomeFirstResponder]);
     XCTAssertEqual(self.sut.expirationField, self.sut.currentFirstResponderField,
                    @"Moves firstResponder back to expiration, because it's not valid anymore");
@@ -538,6 +540,7 @@
     self.sut.postalCodeField.text = @"90210";
 
     XCTAssertTrue(self.sut.isValid);
+    [self.sut resignFirstResponder];
     XCTAssertTrue([self.sut becomeFirstResponder]);
     XCTAssertEqual(self.sut.postalCodeField, self.sut.currentFirstResponderField,
                    @"When all fields are valid, the last one should be the preferred firstResponder");

--- a/Tests/Tests/STPPaymentCardTextFieldTest.m
+++ b/Tests/Tests/STPPaymentCardTextFieldTest.m
@@ -23,6 +23,7 @@
 @property (nonatomic, readwrite, weak) STPFormTextField *numberField;
 @property (nonatomic, readwrite, weak) STPFormTextField *expirationField;
 @property (nonatomic, readwrite, weak) STPFormTextField *cvcField;
+@property (nonatomic, readwrite, weak) STPFormTextField *postalCodeField;
 @property (nonatomic, readonly, weak) STPFormTextField *currentFirstResponderField;
 @property (nonatomic, readwrite, strong) STPPaymentCardTextFieldViewModel *viewModel;
 @property (nonatomic, copy) NSNumber *focusedTextFieldForLayout;
@@ -394,7 +395,7 @@
     XCTAssertEqualObjects(self.sut.numberField.text, number);
     XCTAssertEqualObjects(self.sut.expirationField.text, @"10/99");
     XCTAssertEqualObjects(self.sut.cvcField.text, cvc);
-    XCTAssertFalse([self.sut isFirstResponder]);
+    XCTAssertFalse([self.sut isFirstResponder], @"after `setCardParams:`, if all fields are valid, should resign firstResponder");
     XCTAssertTrue(self.sut.isValid);
 }
 
@@ -415,7 +416,7 @@
     XCTAssertEqualObjects(self.sut.numberField.text, number);
     XCTAssertEqualObjects(self.sut.expirationField.text, @"10/99");
     XCTAssertEqual(self.sut.cvcField.text.length, (NSUInteger)0);
-    XCTAssertTrue([self.sut.numberField isFirstResponder]);
+    XCTAssertTrue([self.sut.numberField isFirstResponder], @"after `setCardParams:`, when firstResponder becomes valid, first invalid field should become firstResponder");
     XCTAssertFalse(self.sut.isValid);
 }
 
@@ -434,7 +435,7 @@
     XCTAssertEqualObjects(self.sut.numberField.text, number);
     XCTAssertEqual(self.sut.expirationField.text.length, (NSUInteger)0);
     XCTAssertEqual(self.sut.cvcField.text.length, (NSUInteger)0);
-    XCTAssertTrue([self.sut.cvcField isFirstResponder]);
+    XCTAssertTrue([self.sut.cvcField isFirstResponder], @"after `setCardParams:`, if firstResponder is invalid, it should remain firstResponder");
     XCTAssertFalse(self.sut.isValid);
 }
 
@@ -454,7 +455,7 @@
     XCTAssertEqual(self.sut.numberField.text.length, (NSUInteger)0);
     XCTAssertEqual(self.sut.expirationField.text.length, (NSUInteger)0);
     XCTAssertEqual(self.sut.cvcField.text.length, (NSUInteger)0);
-    XCTAssertTrue([self.sut.numberField isFirstResponder]);
+    XCTAssertTrue([self.sut.numberField isFirstResponder], @"after `setCardParams:` that clears the text fields, the first invalid field should become firstResponder");
     XCTAssertFalse(self.sut.isValid);
 }
 
@@ -484,6 +485,62 @@
     self.sut.cvcField.text = @"123";
 
     [self waitForExpectationsWithTimeout:2 handler:nil];
+}
+
+- (void)testBecomeFirstResponder {
+    XCTAssertTrue([self.sut canBecomeFirstResponder]);
+    XCTAssertTrue([self.sut becomeFirstResponder]);
+    XCTAssertTrue(self.sut.isFirstResponder);
+
+    XCTAssertEqual(self.sut.numberField, self.sut.currentFirstResponderField);
+
+    [self.sut becomeFirstResponder];
+    XCTAssertEqual(self.sut.numberField, self.sut.currentFirstResponderField,
+                   @"Repeated calls to becomeFirstResponder should not change the firstResponder");
+
+    self.sut.numberField.text = @"4242" "4242" "4242" "4242";
+
+    XCTAssertTrue([self.sut becomeFirstResponder]);
+    XCTAssertEqual(self.sut.expirationField, self.sut.currentFirstResponderField,
+                   @"Once numberField is valid, becomeFirstResponder should move to the next field (expiration)");
+
+    XCTAssertTrue([self.sut.cvcField becomeFirstResponder]);
+    XCTAssertEqual(self.sut.cvcField, self.sut.currentFirstResponderField,
+                   @"We don't block other fields from becoming firstResponder");
+
+    XCTAssertTrue([self.sut becomeFirstResponder]);
+    XCTAssertEqual(self.sut.expirationField, self.sut.currentFirstResponderField,
+                   @"Moves firstResponder back to expiration, because it's not valid yet");
+
+    self.sut.expirationField.text = @"10/99";
+    self.sut.cvcField.text = @"123";
+
+    XCTAssertTrue(self.sut.isValid);
+    XCTAssertTrue([self.sut canBecomeFirstResponder]);
+    XCTAssertTrue([self.sut becomeFirstResponder]);
+
+    XCTAssertEqual(self.sut.cvcField, self.sut.currentFirstResponderField,
+                   @"When all fields are valid, the last one should be the preferred firstResponder");
+
+    self.sut.postalCodeEntryEnabled = YES;
+    XCTAssertFalse(self.sut.isValid);
+
+    XCTAssertTrue([self.sut becomeFirstResponder]);
+    XCTAssertEqual(self.sut.postalCodeField, self.sut.currentFirstResponderField,
+                   @"When postalCodeEntryEnabled=YES, it should become firstResponder after other fields are valid");
+
+    self.sut.expirationField.text = @"";
+    XCTAssertTrue([self.sut becomeFirstResponder]);
+    XCTAssertEqual(self.sut.expirationField, self.sut.currentFirstResponderField,
+                   @"Moves firstResponder back to expiration, because it's not valid anymore");
+
+    self.sut.expirationField.text = @"10/99";
+    self.sut.postalCodeField.text = @"90210";
+
+    XCTAssertTrue(self.sut.isValid);
+    XCTAssertTrue([self.sut becomeFirstResponder]);
+    XCTAssertEqual(self.sut.postalCodeField, self.sut.currentFirstResponderField,
+                   @"When all fields are valid, the last one should be the preferred firstResponder");
 }
 
 @end


### PR DESCRIPTION
## Summary

Previous implementation of `nextFirstResponderField` would return `nil` if all fields were
valid, which blocked programatic calls to `becomeFirstResponder`.

It *also* used to cycle through the fields every time it was called, which doesn't seem
right. It feels more natural for the default first responder to be either the first
invalid field *or* the last field. This puts the insertion point at the right place
to start deleting.

We *do* want to move to the next field (ignoring whether fields are valid or not) when the user fills the current field with valid text. This matches the web elements behavior, and feels better as they proceed through, instead of jumping around (possibly earlier, possibly to the end)

## Motivation

Fixes #841

## Testing

Manual testing through the Standard Integration. I also added a unit test for this
behavior. Some of the things it verifies:

* becomeFirstResponder should not change the first responder if one of the STPPaymentCardTextField subfields is already first responder
* becomeFirstResponder should take the user to the first invalid field when called
* becomeFirstResponder should make the last sub-field first responder when all the fields are valid