### PR TITLE
Remove skipsReloadingInputViews, a workaround for a Travis CI crash while testing

### DIFF
--- a/Stripe/STPFormTextField.m
+++ b/Stripe/STPFormTextField.m
@@ -73,20 +73,11 @@ typedef NSAttributedString* (^STPFormTextTransformationBlock)(NSAttributedString
 @interface STPFormTextField()
 @property (nonatomic) STPTextFieldDelegateProxy *delegateProxy;
 @property (nonatomic, copy) STPFormTextTransformationBlock textFormattingBlock;
-// This property only exists to disable keyboard loading in Travis CI due to a crash that occurs while trying to load the keyboard. Don't use it outside of tests.
-@property (nonatomic) BOOL skipsReloadingInputViews;
 @end
 
 @implementation STPFormTextField
 
 @synthesize placeholderColor = _placeholderColor;
-
-- (void)reloadInputViews {
-    if (self.skipsReloadingInputViews) {
-        return;
-    }
-    [super reloadInputViews];
-}
 
 + (NSDictionary *)attributesForAttributedString:(NSAttributedString *)attributedString {
     if (attributedString.length == 0) {

--- a/Tests/Tests/STPPaymentCardTextFieldTest.m
+++ b/Tests/Tests/STPPaymentCardTextFieldTest.m
@@ -14,10 +14,6 @@
 #import "STPFormTextField.h"
 #import "STPPaymentCardTextFieldViewModel.h"
 
-@interface STPFormTextField(Testing)
-@property (nonatomic) BOOL skipsReloadingInputViews;
-@end
-
 @interface STPPaymentCardTextField (Testing)
 @property (nonatomic, readwrite, weak) UIImageView *brandImageView;
 @property (nonatomic, readwrite, weak) STPFormTextField *numberField;
@@ -366,9 +362,6 @@
     [super setUp];
     self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
     STPPaymentCardTextField *textField = [[STPPaymentCardTextField alloc] initWithFrame:self.window.bounds];
-    textField.numberField.skipsReloadingInputViews = YES;
-    textField.expirationField.skipsReloadingInputViews = YES;
-    textField.cvcField.skipsReloadingInputViews = YES;
     [self.window addSubview:textField];
     XCTAssertTrue([textField.numberField canBecomeFirstResponder], @"text field cannot become first responder");
     self.sut = textField;


### PR DESCRIPTION
## Summary

Found this code, want to see if it's still needed.

## Motivation

Code cleanup

## Testing

Ran unit tests locally, looking to see how the Travis CI build does.