### PR TITLE
Simplify override of editingRectForBounds workaround, removing iOS 8-specific code

### DIFF
--- a/Stripe/STPFormTextField.m
+++ b/Stripe/STPFormTextField.m
@@ -234,19 +234,10 @@ typedef NSAttributedString* (^STPFormTextTransformationBlock)(NSAttributedString
 
 // Workaround for http://www.openradar.appspot.com/19374610
 - (CGRect)editingRectForBounds:(CGRect)bounds {
-    if (UIDevice.currentDevice.systemVersion.integerValue != 8) {
-        return [self textRectForBounds:bounds];
-    }
-    
-    CGFloat const scale = UIScreen.mainScreen.scale;
-    CGFloat const preferred = self.attributedText.size.height;
-    CGFloat const delta = (CGFloat)ceil(preferred) - preferred;
-    CGFloat const adjustment = (CGFloat)floor(delta * scale) / scale;
-    
-    CGRect const textRect = [self textRectForBounds:bounds];
-    CGRect const editingRect = CGRectOffset(textRect, 0.0, adjustment);
-    
-    return editingRect;
+    // danj: I still see a small vertical jump between the editingRect & textRect for text fields in
+    // iOS 10.0-10.3 (but not 9.0 or 11.0-11.2). By using the textRect as the editingRect, this prevents
+    // mismatches causing vertical mis-alignments
+    return [self textRectForBounds:bounds];
 }
 
 // Fixes a weird issue related to our custom override of deleteBackwards. This only affects the simulator and iPads with custom keyboards.


### PR DESCRIPTION
## Summary

Now that we've dropped support for iOS 8, remove the parts of this bugfix that were
specific to iOS 8.
https://stackoverflow.com/a/30676237/1196205

## Motivation

Code cleanup.

## Testing

By going back to v11.5, and removing this block, I was able to reproduce the issue. It's
only a couple pixels, but the text in the UITextField jumps vertically when editing
starts/ends (verified on iPhone 5 simulator). I think it's easiest to see in the simulator,
because you can disable the system software keyboard and *really* see it happening when
everything else on screen is static

That same code, running on iOS 9.0 simulator did not exhibit the bug.

Finally, testing in iOS 10 & 11 showed that 10.0 & 10.3.1 *do* have this bug, but it's
gone again in iOS 11.