### PR TITLE
Always recreate loadingPromise when calling retryLoading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Pre-built view controllers now layout properly on iPhone X in landscape orientation, respecting `safeAreaInsets`.
 * `STPPaymentContext` now has a `largeTitleDisplayMode` property, which you can use to control the title display mode in the navigation bar of our pre-built view controllers.
 * Fixes a bug where `STPPaymentContext`'s `retryLoading` method would not re-retrieve the customer object, even after calling `STPCustomerContext`'s `clearCachedCustomer` method.
+* `STPPaymentContext`'s `retryLoading` method will now always attempt to retrieve a new customer object, regardless of whether a cached customer object is available. Previously, this method was only intended for recovery from a loading error; if a customer had already been retrieved, `retryLoading` would do nothing.
 
 ## 11.5.0 2017-11-09
 * Adds a new helper method to `STPSourceParams` for creating reusable Alipay sources. [#811](https://github.com/stripe/stripe-ios/pull/811)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * See MIGRATING.md for more information on any of the previously mentioned breaking API changes.
 * Pre-built view controllers now layout properly on iPhone X in landscape orientation, respecting `safeAreaInsets`.
 * `STPPaymentContext` now has a `largeTitleDisplayMode` property, which you can use to control the title display mode in the navigation bar of our pre-built view controllers.
+* Fixes a bug where `STPPaymentContext`'s `retryLoading` method would not re-retrieve the customer object, even after calling `STPCustomerContext`'s `clearCachedCustomer` method.
 
 ## 11.5.0 2017-11-09
 * Adds a new helper method to `STPSourceParams` for creating reusable Alipay sources. [#811](https://github.com/stripe/stripe-ios/pull/811)

--- a/Stripe/STPPaymentContext.m
+++ b/Stripe/STPPaymentContext.m
@@ -112,9 +112,6 @@ typedef NS_ENUM(NSUInteger, STPPaymentContextState) {
 }
 
 - (void)retryLoading {
-    if (self.loadingPromise && self.loadingPromise.value) {
-        return;
-    }
     WEAK(self);
     self.loadingPromise = [[[STPPromise<STPPaymentMethodTuple *> new] onSuccess:^(STPPaymentMethodTuple *tuple) {
         STRONG(self);

--- a/Stripe/STPPaymentContext.m
+++ b/Stripe/STPPaymentContext.m
@@ -112,6 +112,11 @@ typedef NS_ENUM(NSUInteger, STPPaymentContextState) {
 }
 
 - (void)retryLoading {
+    // Clear any cached customer object before refetching
+    if ([self.apiAdapter isKindOfClass:[STPCustomerContext class]]) {
+        STPCustomerContext *customerContext = (STPCustomerContext *)self.apiAdapter;
+        [customerContext clearCachedCustomer];
+    }
     WEAK(self);
     self.loadingPromise = [[[STPPromise<STPPaymentMethodTuple *> new] onSuccess:^(STPPaymentMethodTuple *tuple) {
         STRONG(self);


### PR DESCRIPTION
r? @danj-stripe 

Calling `retryLoading` currently does nothing if the promise has been completed with a value. The method was initially intended for use when PaymentContext's initial load fails, but you would also expect it to be useful for triggering a refresh of the stored customer object:

```
customerContext.clearCachedCustomer()
paymentContext.retryLoading()
paymentContext.presentPaymentMethodsViewController()
```

I can't think of any unintended side effects from this change. The method is only called once internally, in the `STPPaymentContext` initialization path. Apps that use this method to recover from initial loading errors won't be affected by the change.