### PR TITLE
add includeApplePaySources to CustomerContext

### DIFF
--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -449,6 +449,8 @@
 		C15B02731EA176090026E606 /* StripeErrorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C15B02721EA176090026E606 /* StripeErrorTest.m */; };
 		C16F66AB1CA21BAC006A21B5 /* STPFormTextFieldTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C16F66AA1CA21BAC006A21B5 /* STPFormTextFieldTest.m */; };
 		C1717DB11CC00ED60009CF4A /* STPAddress.h in Headers */ = {isa = PBXBuildFile; fileRef = C1080F471CBECF7B007B2D89 /* STPAddress.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C175B7941FE834A3009F5A0E /* STPCustomer+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = C175B7931FE834A3009F5A0E /* STPCustomer+Private.h */; };
+		C175B7951FE834A3009F5A0E /* STPCustomer+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = C175B7931FE834A3009F5A0E /* STPCustomer+Private.h */; };
 		C1785F5C1EC60B5E00E9CFAC /* STPCardIOProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = C1785F5A1EC60B5E00E9CFAC /* STPCardIOProxy.h */; };
 		C1785F5D1EC60B5E00E9CFAC /* STPCardIOProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = C1785F5A1EC60B5E00E9CFAC /* STPCardIOProxy.h */; };
 		C1785F5E1EC60B5E00E9CFAC /* STPCardIOProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = C1785F5B1EC60B5E00E9CFAC /* STPCardIOProxy.m */; };
@@ -1052,6 +1054,7 @@
 		C15993321D8808680047950D /* STPShippingMethodTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPShippingMethodTableViewCell.m; sourceTree = "<group>"; };
 		C15B02721EA176090026E606 /* StripeErrorTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = StripeErrorTest.m; sourceTree = "<group>"; };
 		C16F66AA1CA21BAC006A21B5 /* STPFormTextFieldTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPFormTextFieldTest.m; sourceTree = "<group>"; };
+		C175B7931FE834A3009F5A0E /* STPCustomer+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCustomer+Private.h"; sourceTree = "<group>"; };
 		C1785F5A1EC60B5E00E9CFAC /* STPCardIOProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPCardIOProxy.h; sourceTree = "<group>"; };
 		C1785F5B1EC60B5E00E9CFAC /* STPCardIOProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPCardIOProxy.m; sourceTree = "<group>"; };
 		C17A030B1CBEE7A2006C819F /* STPAddressFieldTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPAddressFieldTableViewCell.h; sourceTree = "<group>"; };
@@ -1783,6 +1786,7 @@
 				049952CE1BCF13510088C703 /* STPAPIRequest.m */,
 				8B429AD71EF9D4A300F95F34 /* STPBankAccountParams+Private.h */,
 				C1A06F0F1E1D8A6E004DCA06 /* STPCard+Private.h */,
+				C175B7931FE834A3009F5A0E /* STPCustomer+Private.h */,
 				C113D2171EBB9A36006FACC2 /* STPEphemeralKey.h */,
 				C113D2181EBB9A36006FACC2 /* STPEphemeralKey.m */,
 				C18410741EC2529400178149 /* STPEphemeralKeyManager.h */,
@@ -2108,6 +2112,7 @@
 				C1D7B5211E36C32F002181F5 /* STPSource.h in Headers */,
 				049A3FB41CC9FF0500F57DE7 /* UIToolbar+Stripe_InputAccessory.h in Headers */,
 				04CDE5CB1BC20B1D00548833 /* STPBankAccountParams.h in Headers */,
+				C175B7951FE834A3009F5A0E /* STPCustomer+Private.h in Headers */,
 				F1D3A2521EB012220095BFA9 /* STPFile.h in Headers */,
 				049952D41BCF13DD0088C703 /* STPAPIClient+Private.h in Headers */,
 				04F94DA31D229F18004FC826 /* STPAddressViewModel.h in Headers */,
@@ -2222,6 +2227,7 @@
 				C15608DD1FE08F2E0032AE66 /* UIView+Stripe_SafeAreaBounds.h in Headers */,
 				F1852F931D80B6EC00367C86 /* STPStringUtils.h in Headers */,
 				049A3FAE1CC9AA9900F57DE7 /* STPAddressViewModel.h in Headers */,
+				C175B7941FE834A3009F5A0E /* STPCustomer+Private.h in Headers */,
 				F1D3A2651EBA5BAE0095BFA9 /* STPPaymentCardTextField+Private.h in Headers */,
 				0426B96E1CEADC98006AC8DD /* STPColorUtils.h in Headers */,
 				04B31DDA1D09A4DC00EF1631 /* STPPaymentConfiguration+Private.h in Headers */,

--- a/Stripe/PublicHeaders/STPCustomerContext.h
+++ b/Stripe/PublicHeaders/STPCustomerContext.h
@@ -48,8 +48,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  By default, `STPCustomerContext` will filter Apple Pay sources when it retrieves
- a Customer object. If you are using `STPCustomerContext` to back your own UI and
- would like to disable Apple Pay filtering, set this property to YES.
+ a Customer object. Apple Pay sources should generally not be re-used and
+ shouldn't be offered to customers as a new payment source (Apple Pay sources may
+ only be re-used for subscriptions).
+
+ If you are using `STPCustomerContext` to back your own UI and would like to
+ disable Apple Pay filtering, set this property to YES.
 
  Note: If you are using `STPPaymentContext`, you should not change this property.
  */

--- a/Stripe/PublicHeaders/STPCustomerContext.h
+++ b/Stripe/PublicHeaders/STPCustomerContext.h
@@ -46,6 +46,15 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)clearCachedCustomer;
 
+/**
+ By default, `STPCustomerContext` will filter Apple Pay sources when it retrieves
+ a Customer object. If you are using `STPCustomerContext` to back your own UI and
+ would like to disable Apple Pay filtering, set this property to YES.
+
+ Note: If you are using `STPPaymentContext`, you should not change this property.
+ */
+@property (nonatomic, assign) BOOL includeApplePaySources;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Stripe/STPCustomer+Private.h
+++ b/Stripe/STPCustomer+Private.h
@@ -1,0 +1,26 @@
+//
+//  STPCustomer+Private.h
+//  Stripe
+//
+//  Created by Ben Guo on 12/18/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import "STPCustomer.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface STPCustomer ()
+
+/**
+ Updates the customer's sources and defaultSource with a Customer API response.
+
+ @param response            The Customer API response
+ @param filterApplePay      If YES, Apple Pay sources will be ignored
+ */
+- (void)updateSourcesWithResponse:(NSDictionary *)response
+                filteringApplePay:(BOOL)filterApplePay;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Stripe/STPCustomer+Private.h
+++ b/Stripe/STPCustomer+Private.h
@@ -13,7 +13,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface STPCustomer ()
 
 /**
- Updates the customer's sources and defaultSource with a Customer API response.
+ Replaces the customer's sources and defaultSource with the contents of a
+ Customer API response.
 
  @param response            The Customer API response
  @param filterApplePay      If YES, Apple Pay sources will be ignored

--- a/Stripe/STPCustomer.m
+++ b/Stripe/STPCustomer.m
@@ -18,11 +18,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface STPCustomer()
 
-@property (nonatomic, copy) NSString *stripeID;
-@property (nonatomic) id<STPSourceProtocol> defaultSource;
-@property (nonatomic) NSArray<id<STPSourceProtocol>> *sources;
-@property (nonatomic) STPAddress *shippingAddress;
-@property (nonatomic, readwrite, nonnull, copy) NSDictionary *allResponseFields;
+@property (nonatomic, copy, readwrite) NSString *stripeID;
+@property (nonatomic, strong, nullable, readwrite) id<STPSourceProtocol> defaultSource;
+@property (nonatomic, strong, readwrite) NSArray<id<STPSourceProtocol>> *sources;
+@property (nonatomic, strong, nullable, readwrite) STPAddress *shippingAddress;
+@property (nonatomic, copy, readwrite) NSDictionary *allResponseFields;
 
 @end
 
@@ -97,6 +97,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (![data isKindOfClass:[NSArray class]]) {
         return;
     }
+    self.defaultSource = nil;
     NSString *defaultSourceId;
     if ([response[@"default_source"] isKindOfClass:[NSString class]]) {
         defaultSourceId = response[@"default_source"];
@@ -104,7 +105,7 @@ NS_ASSUME_NONNULL_BEGIN
     NSMutableArray *sources = [NSMutableArray new];
     for (id contents in data) {
         if ([contents isKindOfClass:[NSDictionary class]]) {
-            if ([contents[@"object"] isEqualToString:@"card"]) {
+            if ([contents[@"object"] isEqual:@"card"]) {
                 STPCard *card = [STPCard decodedObjectFromAPIResponse:contents];
                 BOOL includeCard = card != nil;
                 // ignore apple pay cards from the response

--- a/Stripe/STPCustomer.m
+++ b/Stripe/STPCustomer.m
@@ -83,6 +83,8 @@ NS_ASSUME_NONNULL_BEGIN
         shipping.country = shippingDict[@"address"][@"country"];
         customer.shippingAddress = shipping;
     }
+    customer.sources = @[];
+    customer.defaultSource = nil;
     [customer updateSourcesWithResponse:dict filteringApplePay:YES];
     customer.allResponseFields = dict;
     return customer;

--- a/Stripe/STPCustomerContext.m
+++ b/Stripe/STPCustomerContext.m
@@ -9,7 +9,7 @@
 #import "STPCustomerContext.h"
 
 #import "STPAPIClient+Private.h"
-#import "STPCustomer.h"
+#import "STPCustomer+Private.h"
 #import "STPEphemeralKey.h"
 #import "STPEphemeralKeyManager.h"
 #import "STPWeakStrongMacros.h"
@@ -38,6 +38,7 @@ static NSTimeInterval const CachedCustomerMaxAge = 60;
     self = [self init];
     if (self) {
         _keyManager = keyManager;
+        _includeApplePaySources = NO;
         [self retrieveCustomer:nil];
     }
     return self;
@@ -48,6 +49,10 @@ static NSTimeInterval const CachedCustomerMaxAge = 60;
 }
 
 - (void)setCustomer:(STPCustomer *)customer {
+    if (self.includeApplePaySources) {
+        [customer updateSourcesWithResponse:customer.allResponseFields
+                          filteringApplePay:NO];
+    }
     _customer = customer;
     _customerRetrievedDate = (customer) ? [NSDate date] : nil;
 }
@@ -84,7 +89,7 @@ static NSTimeInterval const CachedCustomerMaxAge = 60;
             }
             if (completion) {
                 stpDispatchToMainThreadIfNecessary(^{
-                    completion(customer, error);
+                    completion(self.customer, error);
                 });
             }
         }];

--- a/Stripe/STPCustomerContext.m
+++ b/Stripe/STPCustomerContext.m
@@ -49,12 +49,14 @@ static NSTimeInterval const CachedCustomerMaxAge = 60;
 }
 
 - (void)setCustomer:(STPCustomer *)customer {
-    if (self.includeApplePaySources) {
-        [customer updateSourcesWithResponse:customer.allResponseFields
-                          filteringApplePay:NO];
-    }
     _customer = customer;
     _customerRetrievedDate = (customer) ? [NSDate date] : nil;
+}
+
+- (void)setIncludeApplePaySources:(BOOL)includeApplePaySources {
+    _includeApplePaySources = includeApplePaySources;
+    [self.customer updateSourcesWithResponse:self.customer.allResponseFields
+                           filteringApplePay:!includeApplePaySources];
 }
 
 - (BOOL)shouldUseCachedCustomer {
@@ -85,11 +87,13 @@ static NSTimeInterval const CachedCustomerMaxAge = 60;
         }
         [STPAPIClient retrieveCustomerUsingKey:ephemeralKey completion:^(STPCustomer *customer, NSError *error) {
             if (customer) {
+                [customer updateSourcesWithResponse:self.customer.allResponseFields
+                                  filteringApplePay:!self.includeApplePaySources];
                 self.customer = customer;
             }
             if (completion) {
                 stpDispatchToMainThreadIfNecessary(^{
-                    completion(self.customer, error);
+                    completion(customer, error);
                 });
             }
         }];
@@ -134,6 +138,8 @@ static NSTimeInterval const CachedCustomerMaxAge = 60;
                                           usingKey:ephemeralKey
                                         completion:^(STPCustomer *customer, NSError *error) {
                                             if (customer) {
+                                                [customer updateSourcesWithResponse:self.customer.allResponseFields
+                                                                  filteringApplePay:!self.includeApplePaySources];
                                                 self.customer = customer;
                                             }
                                             if (completion) {
@@ -162,6 +168,8 @@ static NSTimeInterval const CachedCustomerMaxAge = 60;
                                           usingKey:ephemeralKey
                                         completion:^(STPCustomer *customer, NSError *error) {
                                             if (customer) {
+                                                [customer updateSourcesWithResponse:self.customer.allResponseFields
+                                                                  filteringApplePay:!self.includeApplePaySources];
                                                 self.customer = customer;
                                             }
                                             if (completion) {

--- a/Tests/Tests/STPCustomerContextTest.m
+++ b/Tests/Tests/STPCustomerContextTest.m
@@ -304,4 +304,45 @@
     [self waitForExpectationsWithTimeout:2 handler:nil];
 }
 
+#pragma mark - includeApplePaySources
+
+- (void)testFiltersApplePaySourcesByDefault {
+    STPEphemeralKey *customerKey = [STPFixtures ephemeralKey];
+    STPCustomer *expectedCustomer = [STPFixtures customerWithCardAndApplePaySources];
+    [self stubRetrieveCustomerUsingKey:customerKey
+                     returningCustomer:expectedCustomer
+                         expectedCount:2];
+    id mockKeyManager = [self mockKeyManagerWithKey:customerKey];
+    STPCustomerContext *sut = [[STPCustomerContext alloc] initWithKeyManager:mockKeyManager];
+    [sut clearCachedCustomer];
+    XCTestExpectation *exp = [self expectationWithDescription:@"retrieveCustomer"];
+    [sut retrieveCustomer:^(STPCustomer *customer, __unused NSError *error) {
+        XCTAssertEqual(customer.sources.count, (unsigned int)1);
+        XCTAssertNil(customer.defaultSource);
+        [exp fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:2 handler:nil];
+}
+
+- (void)testIncludeApplePaySources {
+    STPEphemeralKey *customerKey = [STPFixtures ephemeralKey];
+    STPCustomer *expectedCustomer = [STPFixtures customerWithCardAndApplePaySources];
+    [self stubRetrieveCustomerUsingKey:customerKey
+                     returningCustomer:expectedCustomer
+                         expectedCount:2];
+    id mockKeyManager = [self mockKeyManagerWithKey:customerKey];
+    STPCustomerContext *sut = [[STPCustomerContext alloc] initWithKeyManager:mockKeyManager];
+    sut.includeApplePaySources = YES;
+    [sut clearCachedCustomer];
+    XCTestExpectation *exp = [self expectationWithDescription:@"retrieveCustomer"];
+    [sut retrieveCustomer:^(STPCustomer *customer, __unused NSError *error) {
+        XCTAssertEqual(customer.sources.count, (unsigned int)2);
+        XCTAssertNotNil(customer.defaultSource);
+        [exp fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:2 handler:nil];
+}
+
 @end

--- a/Tests/Tests/STPCustomerContextTest.m
+++ b/Tests/Tests/STPCustomerContextTest.m
@@ -311,10 +311,9 @@
     STPCustomer *expectedCustomer = [STPFixtures customerWithCardAndApplePaySources];
     [self stubRetrieveCustomerUsingKey:customerKey
                      returningCustomer:expectedCustomer
-                         expectedCount:2];
+                         expectedCount:1];
     id mockKeyManager = [self mockKeyManagerWithKey:customerKey];
     STPCustomerContext *sut = [[STPCustomerContext alloc] initWithKeyManager:mockKeyManager];
-    [sut clearCachedCustomer];
     XCTestExpectation *exp = [self expectationWithDescription:@"retrieveCustomer"];
     [sut retrieveCustomer:^(STPCustomer *customer, __unused NSError *error) {
         XCTAssertEqual(customer.sources.count, (unsigned int)1);
@@ -330,11 +329,10 @@
     STPCustomer *expectedCustomer = [STPFixtures customerWithCardAndApplePaySources];
     [self stubRetrieveCustomerUsingKey:customerKey
                      returningCustomer:expectedCustomer
-                         expectedCount:2];
+                         expectedCount:1];
     id mockKeyManager = [self mockKeyManagerWithKey:customerKey];
     STPCustomerContext *sut = [[STPCustomerContext alloc] initWithKeyManager:mockKeyManager];
     sut.includeApplePaySources = YES;
-    [sut clearCachedCustomer];
     XCTestExpectation *exp = [self expectationWithDescription:@"retrieveCustomer"];
     [sut retrieveCustomer:^(STPCustomer *customer, __unused NSError *error) {
         XCTAssertEqual(customer.sources.count, (unsigned int)2);

--- a/Tests/Tests/STPFixtures.h
+++ b/Tests/Tests/STPFixtures.h
@@ -84,6 +84,12 @@ extern NSString *const STPTestJSONSourceSEPADebit;
 + (STPCustomer *)customerWithCardTokenAndSourceSources;
 
 /**
+ A Customer object with a card source, and apple pay card source, and
+ default_source set to the apple pay source.
+ */
++ (STPCustomer *)customerWithCardAndApplePaySources;
+
+/**
  A customer object with a sources array that includes the listed json sources
  in the order they are listed in the array.
  

--- a/Tests/Tests/STPFixtures.m
+++ b/Tests/Tests/STPFixtures.m
@@ -125,6 +125,25 @@ NSString *const STPTestJSONSourceSEPADebit = @"SEPADebitSource";
 
 }
 
++ (STPCustomer *)customerWithCardAndApplePaySources {
+    NSMutableDictionary *card1 = [[STPTestUtils jsonNamed:STPTestJSONSourceCard] mutableCopy];
+    card1[@"id"] = @"src_apple_pay_123";
+    NSMutableDictionary *cardDict = [card1[@"card"] mutableCopy];
+    cardDict[@"tokenization_method"] = @"apple_pay";
+    card1[@"card"] = cardDict;
+
+    NSMutableDictionary *card2 = [[STPTestUtils jsonNamed:STPTestJSONSourceCard] mutableCopy];
+    card2[@"id"] = @"src_card_456";
+
+    NSMutableDictionary *customer = [[STPTestUtils jsonNamed:STPTestJSONCustomer] mutableCopy];
+    NSMutableDictionary *sources = [customer[@"sources"] mutableCopy];
+    sources[@"data"] = @[card1, card2];
+    customer[@"default_source"] = card1[@"id"];
+    customer[@"sources"] = sources;
+
+    return [STPCustomer decodedObjectFromAPIResponse:customer];
+}
+
 + (STPCustomer *)customerWithSourcesFromJSONKeys:(NSArray<NSString *> *)jsonSourceKeys
                                    defaultSource:(NSString *)jsonKeyForDefaultSource {
     NSMutableArray *sourceJSONDicts = [NSMutableArray new];


### PR DESCRIPTION
r? @danj-stripe 

Addresses #842 by adding a new `includeApplePaySources` property to `CustomerContext`

