### PR TITLE
Convert all Address Fields (except phone number) to use `STPValidatedTextField` instead of `STPFormTextField`

### DIFF
--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -351,6 +351,7 @@
 		8BE5AE8B1EF8905B0081A33C /* STPCardParamsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BE5AE8A1EF8905B0081A33C /* STPCardParamsTest.m */; };
 		B347DD481FE35423006B3BAC /* STPValidatedTextField.h in Headers */ = {isa = PBXBuildFile; fileRef = B347DD461FE35423006B3BAC /* STPValidatedTextField.h */; };
 		B347DD491FE35423006B3BAC /* STPValidatedTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = B347DD471FE35423006B3BAC /* STPValidatedTextField.m */; };
+		B382D6611FE8BEA0009B56AB /* STPValidatedTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = B347DD471FE35423006B3BAC /* STPValidatedTextField.m */; };
 		C1054F911FE197AE0033C87E /* STPPaymentContextSnapshotTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C1054F901FE197AE0033C87E /* STPPaymentContextSnapshotTests.m */; };
 		C1080F491CBECF7B007B2D89 /* STPAddress.h in Headers */ = {isa = PBXBuildFile; fileRef = C1080F471CBECF7B007B2D89 /* STPAddress.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C1080F4A1CBECF7B007B2D89 /* STPAddress.m in Sources */ = {isa = PBXBuildFile; fileRef = C1080F481CBECF7B007B2D89 /* STPAddress.m */; };
@@ -2733,6 +2734,7 @@
 				04F94DAC1D229F42004FC826 /* UIBarButtonItem+Stripe.m in Sources */,
 				F1DEB88D1E2047CA0066B8E8 /* STPCoreTableViewController.m in Sources */,
 				F1C7B8D41DBECF2400D9F6F0 /* STPDispatchFunctions.m in Sources */,
+				B382D6611FE8BEA0009B56AB /* STPValidatedTextField.m in Sources */,
 				04633B141CD45215009D4FB5 /* PKPayment+Stripe.m in Sources */,
 				04633AFF1CD129C0009D4FB5 /* NSString+Stripe.m in Sources */,
 				04633B021CD129D0009D4FB5 /* STPDelegateProxy.m in Sources */,

--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -349,6 +349,8 @@
 		8BD87B931EFB1C1E00269C2B /* STPSourceVerification+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BD87B911EFB1C1E00269C2B /* STPSourceVerification+Private.h */; };
 		8BD87B951EFB1CB100269C2B /* STPSourceVerificationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BD87B941EFB1CB100269C2B /* STPSourceVerificationTest.m */; };
 		8BE5AE8B1EF8905B0081A33C /* STPCardParamsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BE5AE8A1EF8905B0081A33C /* STPCardParamsTest.m */; };
+		B347DD481FE35423006B3BAC /* STPValidatedTextField.h in Headers */ = {isa = PBXBuildFile; fileRef = B347DD461FE35423006B3BAC /* STPValidatedTextField.h */; };
+		B347DD491FE35423006B3BAC /* STPValidatedTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = B347DD471FE35423006B3BAC /* STPValidatedTextField.m */; };
 		C1054F911FE197AE0033C87E /* STPPaymentContextSnapshotTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C1054F901FE197AE0033C87E /* STPPaymentContextSnapshotTests.m */; };
 		C1080F491CBECF7B007B2D89 /* STPAddress.h in Headers */ = {isa = PBXBuildFile; fileRef = C1080F471CBECF7B007B2D89 /* STPAddress.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C1080F4A1CBECF7B007B2D89 /* STPAddress.m in Sources */ = {isa = PBXBuildFile; fileRef = C1080F481CBECF7B007B2D89 /* STPAddress.m */; };
@@ -994,6 +996,8 @@
 		8BD87B911EFB1C1E00269C2B /* STPSourceVerification+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "STPSourceVerification+Private.h"; sourceTree = "<group>"; };
 		8BD87B941EFB1CB100269C2B /* STPSourceVerificationTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPSourceVerificationTest.m; sourceTree = "<group>"; };
 		8BE5AE8A1EF8905B0081A33C /* STPCardParamsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPCardParamsTest.m; sourceTree = "<group>"; };
+		B347DD461FE35423006B3BAC /* STPValidatedTextField.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPValidatedTextField.h; sourceTree = "<group>"; };
+		B347DD471FE35423006B3BAC /* STPValidatedTextField.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPValidatedTextField.m; sourceTree = "<group>"; };
 		C1054F901FE197AE0033C87E /* STPPaymentContextSnapshotTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentContextSnapshotTests.m; sourceTree = "<group>"; };
 		C1080F471CBECF7B007B2D89 /* STPAddress.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = STPAddress.h; path = PublicHeaders/STPAddress.h; sourceTree = "<group>"; };
 		C1080F481CBECF7B007B2D89 /* STPAddress.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPAddress.m; sourceTree = "<group>"; };
@@ -1932,6 +1936,8 @@
 				0438EF2B1B7416BB00D506CC /* STPPaymentCardTextFieldViewModel.m */,
 				C158AB3D1E1EE98900348D01 /* STPSectionHeaderView.h */,
 				C158AB3E1E1EE98900348D01 /* STPSectionHeaderView.m */,
+				B347DD461FE35423006B3BAC /* STPValidatedTextField.h */,
+				B347DD471FE35423006B3BAC /* STPValidatedTextField.m */,
 			);
 			name = Views;
 			sourceTree = "<group>";
@@ -2195,6 +2201,7 @@
 				C192269C1EBA99F900BED563 /* STPCustomerContext.h in Headers */,
 				04A4C38D1C4F25F900B3B290 /* UIViewController+Stripe_ParentViewController.h in Headers */,
 				0438EF471B74183100D506CC /* STPCardBrand.h in Headers */,
+				B347DD481FE35423006B3BAC /* STPValidatedTextField.h in Headers */,
 				04B31DD41D08E6E200EF1631 /* STPCustomer.h in Headers */,
 				F12829DA1D7747E4008B10D6 /* STPBundleLocator.h in Headers */,
 				C11810951CC6C4700022FB55 /* PKPaymentAuthorizationViewController+Stripe_Blocks.h in Headers */,
@@ -2906,6 +2913,7 @@
 				F1A2F92E1EEB6A70006B0456 /* NSCharacterSet+Stripe.m in Sources */,
 				F1D3A24B1EB012010095BFA9 /* STPFile.m in Sources */,
 				049A3F9A1CC76A2400F57DE7 /* NSBundle+Stripe_AppName.m in Sources */,
+				B347DD491FE35423006B3BAC /* STPValidatedTextField.m in Sources */,
 				049A3F7B1CC18D5300F57DE7 /* UIView+Stripe_FirstResponder.m in Sources */,
 				04CDE5C51BC20AF800548833 /* STPBankAccountParams.m in Sources */,
 				C1BD9B361E3940C400CEE925 /* STPSourceVerification.m in Sources */,

--- a/Stripe/STPAddCardViewController.m
+++ b/Stripe/STPAddCardViewController.m
@@ -118,7 +118,6 @@ typedef NS_ENUM(NSUInteger, STPPaymentCardSection) {
     if (self.prefilledInformation.billingAddress != nil) {
         self.addressViewModel.address = self.prefilledInformation.billingAddress;
     }
-    self.addressViewModel.previousField = paymentCell;
     
     self.activityIndicator = [[STPPaymentActivityIndicatorView alloc] initWithFrame:CGRectMake(0, 0, 20.0f, 20.0f)];
     

--- a/Stripe/STPAddressFieldTableViewCell.h
+++ b/Stripe/STPAddressFieldTableViewCell.h
@@ -46,7 +46,7 @@ typedef NS_ENUM(NSInteger, STPAddressFieldType) {
 
 @property (nonatomic) STPAddressFieldType type;
 @property (nonatomic, copy) NSString *caption;
-@property (nonatomic, weak, readonly) STPFormTextField *textField;
+@property (nonatomic, weak, readonly) STPValidatedTextField *textField;
 @property (nonatomic, copy) NSString *contents;
 @property (nonatomic) STPTheme *theme;
 @property (nonatomic, assign) BOOL lastInList;

--- a/Stripe/STPAddressFieldTableViewCell.h
+++ b/Stripe/STPAddressFieldTableViewCell.h
@@ -29,7 +29,6 @@ typedef NS_ENUM(NSInteger, STPAddressFieldType) {
 @protocol STPAddressFieldTableViewCellDelegate <NSObject>
 
 - (void)addressFieldTableViewCellDidUpdateText:(STPAddressFieldTableViewCell *)cell;
-- (void)addressFieldTableViewCellDidBackspaceOnEmpty:(STPAddressFieldTableViewCell *)cell;
 
 @optional
 - (void)addressFieldTableViewCellDidReturn:(STPAddressFieldTableViewCell *)cell;

--- a/Stripe/STPAddressFieldTableViewCell.m
+++ b/Stripe/STPAddressFieldTableViewCell.m
@@ -139,9 +139,7 @@
             } else {
                 self.textField.keyboardType = UIKeyboardTypeASCIICapable;
             }
-            
-            self.textField.preservesContentsOnPaste = NO;
-            self.textField.selectionEnabled = NO;
+
             if (!self.lastInList) {
                 self.textField.inputAccessoryView = self.inputAccessoryToolbar;
             }

--- a/Stripe/STPAddressFieldTableViewCell.m
+++ b/Stripe/STPAddressFieldTableViewCell.m
@@ -15,7 +15,7 @@
 #import "STPPostalCodeValidator.h"
 #import "UIView+Stripe_SafeAreaBounds.h"
 
-@interface STPAddressFieldTableViewCell() <STPFormTextFieldDelegate, UIPickerViewDelegate, UIPickerViewDataSource>
+@interface STPAddressFieldTableViewCell() <UITextFieldDelegate, UIPickerViewDelegate, UIPickerViewDataSource>
 
 @property (nonatomic, weak) STPFormTextField *textField;
 @property (nonatomic) UIToolbar *inputAccessoryToolbar;
@@ -38,10 +38,13 @@
         _contents = contents;
         
         STPFormTextField *textField = [[STPFormTextField alloc] init];
-        textField.formDelegate = self;
+        textField.delegate = self;
         textField.autoFormattingBehavior = STPFormTextFieldAutoFormattingBehaviorNone;
         textField.selectionEnabled = YES;
         textField.preservesContentsOnPaste = YES;
+        [textField addTarget:self
+                      action:@selector(textFieldTextDidChange:)
+            forControlEvents:UIControlEventEditingChanged];
         _textField = textField;
         [self.contentView addSubview:textField];
         
@@ -267,9 +270,9 @@
     }
 }
 
-#pragma mark - STPFormTextFieldDelegate
+#pragma mark - UITextFieldDelegate
 
-- (void)formTextFieldTextDidChange:(STPFormTextField *)textField {
+- (void)textFieldTextDidChange:(STPValidatedTextField *)textField {
     if (self.type != STPAddressFieldTypeCountry) {
         _contents = textField.text;
         if ([textField isFirstResponder]) {
@@ -367,6 +370,7 @@
     self.ourCountryCode = self.countryCodes[row];
     self.contents = self.ourCountryCode;
     self.textField.text = [self pickerView:pickerView titleForRow:row forComponent:component];
+    [self textFieldTextDidChange:self.textField]; // UIControlEvent not fired for programmatic changes
     if ([self.delegate respondsToSelector:@selector(addressFieldTableViewCountryCode)]) {
         self.delegate.addressFieldTableViewCountryCode = self.ourCountryCode;
     }

--- a/Stripe/STPAddressFieldTableViewCell.m
+++ b/Stripe/STPAddressFieldTableViewCell.m
@@ -295,10 +295,6 @@
     }
 }
 
-- (void)formTextFieldDidBackspaceOnEmpty:(__unused STPFormTextField *)formTextField {
-    [self.delegate addressFieldTableViewCellDidBackspaceOnEmpty:self];
-}
-
 - (void)setCaption:(NSString *)caption {
     self.textField.placeholder = caption;
 }

--- a/Stripe/STPAddressViewModel.h
+++ b/Stripe/STPAddressViewModel.h
@@ -24,7 +24,6 @@
 
 @property (nonatomic, readonly) NSArray<STPAddressFieldTableViewCell *> *addressCells;
 @property (nonatomic, weak) id<STPAddressViewModelDelegate>delegate;
-@property (nonatomic) UIResponder *previousField;
 @property (nonatomic) STPAddress *address;
 @property (nonatomic, readonly) BOOL isValid;
 

--- a/Stripe/STPAddressViewModel.m
+++ b/Stripe/STPAddressViewModel.m
@@ -340,11 +340,6 @@
     return address;
 }
 
-- (STPAddressFieldTableViewCell *)cellBeforeCell:(STPAddressFieldTableViewCell *)cell {
-    NSInteger index = [self.addressCells indexOfObject:cell];
-    return [self.addressCells stp_boundSafeObjectAtIndex:index - 1];
-}
-
 - (STPAddressFieldTableViewCell *)cellAfterCell:(STPAddressFieldTableViewCell *)cell {
     NSInteger index = [self.addressCells indexOfObject:cell];
     return [self.addressCells stp_boundSafeObjectAtIndex:index + 1];

--- a/Stripe/STPAddressViewModel.m
+++ b/Stripe/STPAddressViewModel.m
@@ -240,14 +240,6 @@
     }
 }
 
-- (void)addressFieldTableViewCellDidBackspaceOnEmpty:(STPAddressFieldTableViewCell *)cell {
-    if ([self.addressCells indexOfObject:cell] == 0) {
-        [self.previousField becomeFirstResponder];
-    } else {
-        [[self cellBeforeCell:cell] becomeFirstResponder];
-    }
-}
-
 - (void)addressFieldTableViewCellDidUpdateText:(__unused STPAddressFieldTableViewCell *)cell {
     [self.delegate addressViewModelDidChange:self];
 }

--- a/Stripe/STPFormTextField.h
+++ b/Stripe/STPFormTextField.h
@@ -8,6 +8,8 @@
 
 #import <UIKit/UIKit.h>
 
+#import "STPValidatedTextField.h"
+
 @class STPFormTextField;
 
 typedef NS_ENUM(NSInteger, STPFormTextFieldAutoFormattingBehavior) {
@@ -25,16 +27,11 @@ typedef NS_ENUM(NSInteger, STPFormTextFieldAutoFormattingBehavior) {
 - (void)formTextFieldTextDidChange:(nonnull STPFormTextField *)textField;
 @end
 
-@interface STPFormTextField : UITextField
-
-@property (nonatomic, readwrite, nullable) UIColor *defaultColor;
-@property (nonatomic, readwrite, nullable) UIColor *errorColor;
-@property (nonatomic, readwrite, nullable) UIColor *placeholderColor;
+@interface STPFormTextField : STPValidatedTextField
 
 @property (nonatomic, readwrite, assign) BOOL selectionEnabled; // defaults to NO
 @property (nonatomic, readwrite, assign) BOOL preservesContentsOnPaste; // defaults to NO
 @property (nonatomic, readwrite, assign) STPFormTextFieldAutoFormattingBehavior autoFormattingBehavior;
-@property (nonatomic, readwrite, assign) BOOL validText;
 @property (nonatomic, readwrite, weak, nullable) id<STPFormTextFieldDelegate>formDelegate;
 
 @end

--- a/Stripe/STPFormTextField.m
+++ b/Stripe/STPFormTextField.m
@@ -77,8 +77,6 @@ typedef NSAttributedString* (^STPFormTextTransformationBlock)(NSAttributedString
 
 @implementation STPFormTextField
 
-@synthesize placeholderColor = _placeholderColor;
-
 + (NSDictionary *)attributesForAttributedString:(NSAttributedString *)attributedString {
     if (attributedString.length == 0) {
         return @{};
@@ -189,55 +187,9 @@ typedef NSAttributedString* (^STPFormTextTransformationBlock)(NSAttributedString
     }
 }
 
-- (void)setPlaceholder:(NSString *)placeholder {
-    NSString *nonNilPlaceholder = placeholder ?: @"";
-    NSAttributedString *attributedPlaceholder = [[NSAttributedString alloc] initWithString:nonNilPlaceholder attributes:[self placeholderTextAttributes]];
-    [self setAttributedPlaceholder:attributedPlaceholder];
-}
-
 - (void)setAttributedPlaceholder:(NSAttributedString *)attributedPlaceholder {
     NSAttributedString *transformed = self.textFormattingBlock ? self.textFormattingBlock(attributedPlaceholder) : attributedPlaceholder;
     [super setAttributedPlaceholder:transformed];
-}
-
-- (NSDictionary *)placeholderTextAttributes {
-    NSMutableDictionary *defaultAttributes = [[self defaultTextAttributes] mutableCopy];
-    if (self.placeholderColor) {
-        defaultAttributes[NSForegroundColorAttributeName] = self.placeholderColor;
-    }
-    return [defaultAttributes copy];
-}
-
-- (void)setDefaultColor:(UIColor *)defaultColor {
-    _defaultColor = defaultColor;
-    [self updateColor];
-}
-
-- (void)setErrorColor:(UIColor *)errorColor {
-    _errorColor = errorColor;
-    [self updateColor];
-}
-
-- (void)setValidText:(BOOL)validText {
-    _validText = validText;
-    [self updateColor];
-}
-
-- (void)setPlaceholderColor:(UIColor *)placeholderColor {
-    _placeholderColor = placeholderColor;
-    [self setPlaceholder:self.placeholder]; //explicitly rebuild attributed placeholder
-}
-
-- (void)updateColor {
-    self.textColor = _validText ? self.defaultColor : self.errorColor;
-}
-
-// Workaround for http://www.openradar.appspot.com/19374610
-- (CGRect)editingRectForBounds:(CGRect)bounds {
-    // danj: I still see a small vertical jump between the editingRect & textRect for text fields in
-    // iOS 10.0-10.3 (but not 9.0 or 11.0-11.2). By using the textRect as the editingRect, this prevents
-    // mismatches causing vertical mis-alignments
-    return [self textRectForBounds:bounds];
 }
 
 // Fixes a weird issue related to our custom override of deleteBackwards. This only affects the simulator and iPads with custom keyboards.

--- a/Stripe/STPValidatedTextField.h
+++ b/Stripe/STPValidatedTextField.h
@@ -1,0 +1,30 @@
+//
+//  STPValidatedTextField.h
+//  StripeiOS
+//
+//  Created by Daniel Jackson on 12/14/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+/**
+ A UITextField that changes the text color, based on the validity of
+ its contents.
+
+ This does *not* (currently?) have any logic or hooks for determining whether
+ the contents are valid, that must be done by something else.
+ */
+@interface STPValidatedTextField : UITextField
+
+/// color to use for `text` when `validText` is YES
+@property (nonatomic, readwrite, nullable) UIColor *defaultColor;
+/// color to use for `text` when `validText` is NO
+@property (nonatomic, readwrite, nullable) UIColor *errorColor;
+/// color to use for `placeholderText`, displayed when `text` is empty
+@property (nonatomic, readwrite, nullable) UIColor *placeholderColor;
+
+/// flag to indicate whether the contents are valid or not.
+@property (nonatomic, readwrite, assign) BOOL validText;
+
+@end

--- a/Stripe/STPValidatedTextField.m
+++ b/Stripe/STPValidatedTextField.m
@@ -1,0 +1,66 @@
+//
+//  STPValidatedTextField.m
+//  StripeiOS
+//
+//  Created by Daniel Jackson on 12/14/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import "STPValidatedTextField.h"
+
+@implementation STPValidatedTextField
+
+#pragma mark - Property Overrides
+
+- (void)setDefaultColor:(UIColor *)defaultColor {
+    _defaultColor = defaultColor;
+    [self updateColor];
+}
+
+- (void)setErrorColor:(UIColor *)errorColor {
+    _errorColor = errorColor;
+    [self updateColor];
+}
+
+- (void)setPlaceholderColor:(UIColor *)placeholderColor {
+    _placeholderColor = placeholderColor;
+    // explicitly rebuild attributed placeholder to pick up new color
+    [self setPlaceholder:self.placeholder];
+}
+
+- (void)setValidText:(BOOL)validText {
+    _validText = validText;
+    [self updateColor];
+}
+
+#pragma mark - UITextField overrides
+
+- (void)setPlaceholder:(NSString *)placeholder {
+    NSString *nonNilPlaceholder = placeholder ?: @"";
+    NSAttributedString *attributedPlaceholder = [[NSAttributedString alloc] initWithString:nonNilPlaceholder attributes:[self placeholderTextAttributes]];
+    [self setAttributedPlaceholder:attributedPlaceholder];
+}
+
+// Workaround for http://www.openradar.appspot.com/19374610
+- (CGRect)editingRectForBounds:(CGRect)bounds {
+    // danj: I still see a small vertical jump between the editingRect & textRect for text fields in
+    // iOS 10.0-10.3 (but not 9.0 or 11.0-11.2). By using the textRect as the editingRect, this prevents
+    // mismatches causing vertical mis-alignments
+    return [self textRectForBounds:bounds];
+}
+
+#pragma mark - Private Methods
+
+- (void)updateColor {
+    self.textColor = _validText ? self.defaultColor : self.errorColor;
+}
+
+- (NSDictionary *)placeholderTextAttributes {
+    NSMutableDictionary *defaultAttributes = [[self defaultTextAttributes] mutableCopy];
+    if (self.placeholderColor) {
+        defaultAttributes[NSForegroundColorAttributeName] = self.placeholderColor;
+    }
+    return [defaultAttributes copy];
+}
+
+@end

--- a/Tests/installation_tests/manual_installation/ManualInstallationTest.xcodeproj/project.pbxproj
+++ b/Tests/installation_tests/manual_installation/ManualInstallationTest.xcodeproj/project.pbxproj
@@ -316,7 +316,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -355,7 +355,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
@@ -371,7 +371,6 @@
 					"$(PROJECT_DIR)/ManualInstallationTest/Frameworks",
 				);
 				INFOPLIST_FILE = ManualInstallationTest/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.stripe.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -387,7 +386,6 @@
 					"$(PROJECT_DIR)/ManualInstallationTest/Frameworks",
 				);
 				INFOPLIST_FILE = ManualInstallationTest/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.stripe.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
## Summary

Create `SPTValidatedTextField` and extract default/error/placeholder colors & `validText`
from `STPFormTextField`. This is now the `UITextField` superclass for the SDK, so this
also includes the bugfix for `editingRect` (#860)

Use `UIControlEventEditingChanged` instead of `STPFormTextFieldDelegate` to detect changes
to the address fields.

Change zip/postal code text field to enable selection and preserve contents on paste.

This *removes* several `STPFormTextField`-specific behaviors from these fields:

* Remove 'Go to previous field on delete' behavior.
* The implementation of `textField:shouldChangeCharactersInRange:replacementString:` 
that always returns NO, and uses `setText:` to apply the changes from the user action.
None of these fields had an `autoformattingBehavior`, and they all allowed
selection, so this method was (mostly) trying to replicate standard UITextField behavior.
* Custom `setText:` override that turned the text into an attributed string
and called `setAttributedText:`
* Custom `setAttributedText:` override that fires `UIControlEventEditingChanged` when called.
* Disabled all `UIMenuController` actions except `paste:`

The other parts of `STPFormTextField` were already disabled or not applicable to these
address fields. Things like sanitization, formatting, `selectionEnabled`,
`preservesContentsOnPaste`, etc.


## Motivation

Primary motivation was eliminating `textField:shouldChangeCharactersInRange:replacementString:`
always returning `NO`, because that breaks Japanese (and related) auto-complete views.

This SO post is actually trying *to* disable the autocomplete, we want the opposite:
https://stackoverflow.com/questions/8293648/disable-the-kanji-auto-complete-henkan-for-japanese-keyboards-in-ios

Customer support issue IOS-588

## Testing

Manual testing in the Standard Integration sample app, with a variety of required shipping
and billing address settings. Ensuring that the expected changes to behavior have occurred:
old `STPFormTextField` behaviors were removed. Ensuring that address entry in US & non-US
countries still behaves correctly.

Automated tests continue to pass.