### PR TITLE
Add UITextContentType values to text fields provided by the SDK.

### DIFF
--- a/Stripe/STPAddressFieldTableViewCell.m
+++ b/Stripe/STPAddressFieldTableViewCell.m
@@ -175,9 +175,7 @@
             break;
         case STPAddressFieldTypeCountry:
             self.textField.keyboardType = UIKeyboardTypeDefault;
-            if (@available(iOS 10.0, *)) {
-                self.textField.textContentType = UITextContentTypeCountryName;
-            }
+            // Don't set textContentType for Country, because we don't want iOS to skip the UIPickerView for input
             self.textField.inputView = self.countryPickerView;
             NSInteger index = [self.countryCodes indexOfObject:self.contents];
             if (index == NSNotFound) {

--- a/Stripe/STPAddressFieldTableViewCell.m
+++ b/Stripe/STPAddressFieldTableViewCell.m
@@ -127,24 +127,43 @@
     switch (self.type) {
         case STPAddressFieldTypeName: 
             self.textField.keyboardType = UIKeyboardTypeDefault;
+            if (@available(iOS 10.0, *)) {
+                self.textField.textContentType = UITextContentTypeName;
+            }
             break;
         case STPAddressFieldTypeLine1: 
             self.textField.keyboardType = UIKeyboardTypeDefault;
+            if (@available(iOS 10.0, *)) {
+                self.textField.textContentType = UITextContentTypeStreetAddressLine1;
+            }
             break;
         case STPAddressFieldTypeLine2: 
             self.textField.keyboardType = UIKeyboardTypeDefault;
+            if (@available(iOS 10.0, *)) {
+                self.textField.textContentType = UITextContentTypeStreetAddressLine2;
+            }
             break;
         case STPAddressFieldTypeCity:
             self.textField.keyboardType = UIKeyboardTypeDefault;
+            if (@available(iOS 10.0, *)) {
+                self.textField.textContentType = UITextContentTypeAddressCity;
+            }
             break;
         case STPAddressFieldTypeState:
             self.textField.keyboardType = UIKeyboardTypeDefault;
+            if (@available(iOS 10.0, *)) {
+                self.textField.textContentType = UITextContentTypeAddressState;
+            }
             break;
         case STPAddressFieldTypeZip:
             if ([self countryCodeIsUnitedStates]) { 
                 self.textField.keyboardType = UIKeyboardTypePhonePad;
             } else {
                 self.textField.keyboardType = UIKeyboardTypeASCIICapable;
+            }
+
+            if (@available(iOS 10.0, *)) {
+                self.textField.textContentType = UITextContentTypePostalCode;
             }
 
             if (!self.lastInList) {
@@ -156,6 +175,9 @@
             break;
         case STPAddressFieldTypeCountry:
             self.textField.keyboardType = UIKeyboardTypeDefault;
+            if (@available(iOS 10.0, *)) {
+                self.textField.textContentType = UITextContentTypeCountryName;
+            }
             self.textField.inputView = self.countryPickerView;
             NSInteger index = [self.countryCodes indexOfObject:self.contents];
             if (index == NSNotFound) {
@@ -169,6 +191,9 @@
             break;
         case STPAddressFieldTypePhone:
             self.textField.keyboardType = UIKeyboardTypePhonePad;
+            if (@available(iOS 10.0, *)) {
+                self.textField.textContentType = UITextContentTypeTelephoneNumber;
+            }
             STPFormTextFieldAutoFormattingBehavior behavior = ([self countryCodeIsUnitedStates] ?
                                                                STPFormTextFieldAutoFormattingBehaviorPhoneNumbers :
                                                                STPFormTextFieldAutoFormattingBehaviorNone);
@@ -180,10 +205,13 @@
                 self.textField.inputAccessoryView = nil;
             }
             break;
-        case STPAddressFieldTypeEmail: 
+        case STPAddressFieldTypeEmail:
             self.textField.autocapitalizationType = UITextAutocapitalizationTypeNone;
             self.textField.autocorrectionType = UITextAutocorrectionTypeNo;
             self.textField.keyboardType = UIKeyboardTypeEmailAddress;
+            if (@available(iOS 10.0, *)) {
+                self.textField.textContentType = UITextContentTypeEmailAddress;
+            }
             break;
             
     }

--- a/Stripe/STPPaymentCardTextField.m
+++ b/Stripe/STPPaymentCardTextField.m
@@ -1118,7 +1118,7 @@ typedef NS_ENUM(NSInteger, STPCardTextFieldState) {
     if (@available(iOS 10, *)) {
         textField.keyboardType = UIKeyboardTypeASCIICapableNumberPad;
     } else {
-        textField.keyboardType = UIKeyboardTypeNumberPad;
+        textField.keyboardType = UIKeyboardTypePhonePad;
     }
     textField.textAlignment = NSTextAlignmentLeft;
     textField.font = self.font;

--- a/Stripe/STPPaymentCardTextField.m
+++ b/Stripe/STPPaymentCardTextField.m
@@ -144,6 +144,11 @@ CGFloat const STPPaymentCardTextFieldMinimumPadding = 10;
     self.brandImageView = brandImageView;
     
     STPFormTextField *numberField = [self buildTextField];
+    if (@available(iOS 10.0, *)) {
+        // This does not offer quick-type suggestions (as iOS 11.2), but does pick
+        // the best keyboard (maybe other, hidden behavior?)
+        numberField.textContentType = UITextContentTypeCreditCardNumber;
+    }
     numberField.autoFormattingBehavior = STPFormTextFieldAutoFormattingBehaviorCardNumbers;
     numberField.tag = STPCardFieldTypeNumber;
     numberField.accessibilityLabel = STPLocalizedString(@"card number", @"accessibility label for text field");
@@ -166,6 +171,9 @@ CGFloat const STPPaymentCardTextFieldMinimumPadding = 10;
     self.cvcField.accessibilityLabel = [self defaultCVCPlaceholder];
 
     STPFormTextField *postalCodeField = [self buildTextField];
+    if (@available(iOS 10.0, *)) {
+        postalCodeField.textContentType = UITextContentTypePostalCode;
+    }
     postalCodeField.tag = STPCardFieldTypePostalCode;
     postalCodeField.alpha = 0;
     self.postalCodeField = postalCodeField;
@@ -1106,7 +1114,12 @@ typedef NS_ENUM(NSInteger, STPCardTextFieldState) {
 - (STPFormTextField *)buildTextField {
     STPFormTextField *textField = [[STPFormTextField alloc] initWithFrame:CGRectZero];
     textField.backgroundColor = [UIColor clearColor];
-    textField.keyboardType = UIKeyboardTypePhonePad;
+    // setCountryCode: updates the postalCodeField keyboardType, this is safe
+    if (@available(iOS 10, *)) {
+        textField.keyboardType = UIKeyboardTypeASCIICapableNumberPad;
+    } else {
+        textField.keyboardType = UIKeyboardTypeNumberPad;
+    }
     textField.textAlignment = NSTextAlignmentLeft;
     textField.font = self.font;
     textField.defaultColor = self.textColor;


### PR DESCRIPTION
## Summary

This turns on QuickType suggestions for the name, email, and address fields. Also, using
a better keyboard for Payment Card fields.

For STPFormTextField, this was a lot harder than expected, due to *always* returning NO
from `textField:shouldChangeCharactersInRange:replacementString:`. There's a workaround
for the way UIKit behaves, which is only applicable for the Phone Number field right now.

Also using `UIKeyboardTypeASCIICapableNumberPad` in `STPPaymentCardTextField` if available

Per [WWDC 2016](http://asciiwwdc.com/2016/sessions/201), this was specifically added to
support things like credit card entry:

> We’ve also localized the keyboard number pads this year. [...]
> Now in some cases, you might want to specify ASCII capable number pad instead when you’re sure that the input that you have needs to be restricted to ASCII digits.
> Some examples of this are credit card numbers and IP addresses.

I think this is redundant for the Credit Card Number field (just setting the
`textContentType` is sufficient to use this keyboard), but it'll help w/the expiration
and CVC.

These text fields fall back to using .PhonePad, apparently to avoid localized & third
party keyboards (#358), and as far as I can tell `.ASCIICapableNumberPad` continues to
avoid them.


## Motivation

https://github.com/stripe/stripe-ios/issues/836

## Testing

Tested in the Standard Integration example app. Best tested on a device that knows an
address (simulator doesn't provide valid completions).

Both Shipping & Billing addresses are affected, and this also touches the Payment Card
text field.

Verified that enabling/using non-ASCII keyboards doesn't allow non-ASCII digits into
payment card fields.

Verified that 3rd party keyboards cannot be used for the credit card number entry.