### PR TITLE
Correctly enable Done button after copying billing address into shipping (& vice-versa)

### DIFF
--- a/Stripe/STPAddressFieldTableViewCell.m
+++ b/Stripe/STPAddressFieldTableViewCell.m
@@ -320,6 +320,7 @@
     } else {
         self.textField.validText = [self validContents];
     }
+    [self.delegate addressFieldTableViewCellDidUpdateText:self];
 }
 
 - (BOOL)validContents {


### PR DESCRIPTION
## Summary

Trigger `addressFieldTableViewCellDidUpdateText:` after `setContents:` in STPAddressFieldTableViewCell

I missed a bug around the "Use Shipping" and "Use Billing" buttons: the Done button wasn't
properly updated if the copied information was all that was needed to be complete.

This was introduced by #867. Prior to #867, *all* changes when through the delegate
method `formTextFieldTextDidChange:`

These buttons programmatically set the contents, and we still need the delegate method
to be called in that case.

## Motivation

Steps to reproduce:

1. In Standard Integration, change Billing address to require Full
2. Fill out Shipping Address
3. In Payment, fully fill out card details
4. Press "Use Shipping"
5. Notice that all fields have valid contents

Expected: Done button in top right is enabled
Actual: It's disabled, because it didn't notice the screen was complete.

## Testing

Manual testing in the Standard Integration app.