### PR TITLE
Trim whitespace from STPAddressFieldTableViewCell contents when reading the property.

### DIFF
--- a/Stripe/STPAddressFieldTableViewCell.m
+++ b/Stripe/STPAddressFieldTableViewCell.m
@@ -27,6 +27,8 @@
 
 @implementation STPAddressFieldTableViewCell
 
+@synthesize contents = _contents;
+
 - (instancetype)initWithType:(STPAddressFieldType)type
                     contents:(NSString *)contents
                   lastInList:(BOOL)lastInList
@@ -332,6 +334,13 @@
 
 - (NSString *)caption {
     return self.textField.placeholder;
+}
+
+- (NSString *)contents {
+    // iOS 11 QuickType completions from textContentType have a space at the end.
+    // This *keeps* that space in the `textField`, but removes leading/trailing spaces from
+    // the logical contents of this field, so they're ignored for validation and persisting
+    return [_contents stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
 }
 
 - (void)setContents:(NSString *)contents {


### PR DESCRIPTION
## Summary

When selecting email or zip code autocompletion suggestions, they fail validation. US zip
codes would fail immediately, while email addresses waited until the field lost focus.
This was an unpleasant UX experience.

This is both a very concise fix, but also one I like. It keeps the contents of the text
field unchanged, and does not interfere with editing in any way. Leading & trailing spaces
are simply ignored while validating, and they are likewise ignored when considering what
the logical contents of the cell/text field are.

This results in the trimmed string being persisted to the server, and the trimmed string
being passed around the payment context (like copying to the other address type)

## Motivation

Fixes a user-interaction issue (knowingly) introduced by #870.

## Testing

Manual testing in the Standard Integration, primarily around auto-filling from QuickType,
plus some others.