### PR TITLE
add stripeAccount to STPPaymentConfiguration

### DIFF
--- a/Stripe/PublicHeaders/STPPaymentConfiguration.h
+++ b/Stripe/PublicHeaders/STPPaymentConfiguration.h
@@ -109,6 +109,15 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, assign, readwrite) BOOL canDeletePaymentMethods;
 
+/**
+ In order to perform API requests on behalf of a connected account, e.g. to
+ create a source on a connected account, set this property to the ID of the
+ account for which this request is being made.
+
+ @see https://stripe.com/docs/connect/authentication#authentication-via-the-stripe-account-header
+ */
+@property (nonatomic, copy, nullable) NSString *stripeAccount;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -120,10 +120,11 @@ static NSString * const FileUploadURL = @"https://uploads.stripe.com/v1/files";
     if (self) {
         _apiKey = publishableKey;
         _apiURL = [NSURL URLWithString:APIBaseURL];
-        _urlSession = [NSURLSession sessionWithConfiguration:[self sessionConfiguration]];
         _configuration = configuration;
+        _stripeAccount = configuration.stripeAccount;
         _sourcePollers = [NSMutableDictionary dictionary];
         _sourcePollersQueue = dispatch_queue_create("com.stripe.sourcepollers", DISPATCH_QUEUE_SERIAL);
+        _urlSession = [NSURLSession sessionWithConfiguration:[self sessionConfiguration]];
     }
     return self;
 }

--- a/Tests/Tests/STPAPIClientTest.m
+++ b/Tests/Tests/STPAPIClientTest.m
@@ -9,6 +9,7 @@
 @import XCTest;
 
 #import "STPAPIClient+Private.h"
+#import "STPFixtures.h"
 
 @interface STPAPIClient (Testing)
 
@@ -52,6 +53,17 @@
     XCTAssertNil(accountHeader);
     sut.stripeAccount = @"acct_123";
     accountHeader = sut.urlSession.configuration.HTTPAdditionalHeaders[@"Stripe-Account"];
+    XCTAssertEqualObjects(accountHeader, @"acct_123");
+}
+
+- (void)testInitWithConfiguration {
+    STPPaymentConfiguration *config = [STPFixtures paymentConfiguration];
+    config.stripeAccount = @"acct_123";
+
+    STPAPIClient *sut = [[STPAPIClient alloc] initWithConfiguration:config];
+    XCTAssertEqualObjects(sut.publishableKey, config.publishableKey);
+    XCTAssertEqualObjects(sut.stripeAccount, config.stripeAccount);
+    NSString *accountHeader = sut.urlSession.configuration.HTTPAdditionalHeaders[@"Stripe-Account"];
     XCTAssertEqualObjects(accountHeader, @"acct_123");
 }
 


### PR DESCRIPTION
r? @danj-stripe 

Currently, there's no way to use PaymentContext/AddCardVC on behalf of a connected account.

IOS-597