### PR TITLE
Fix STPEncodable to work with collections of STPEncodable objects, add array index to encoded string

### DIFF
--- a/Stripe/STPFormEncoder.m
+++ b/Stripe/STPFormEncoder.m
@@ -53,6 +53,14 @@ FOUNDATION_EXPORT NSString * STPQueryStringFromParameters(NSDictionary *paramete
 + (id)formEncodableValueForObject:(NSObject *)object {
     if ([object conformsToProtocol:@protocol(STPFormEncodable)]) {
         return [self keyPairDictionaryForObject:(NSObject<STPFormEncodable>*)object];
+    } else if ([object isKindOfClass:[NSArray class]]) {
+        NSArray *array = (NSArray *)object;
+        NSMutableArray *result = [NSMutableArray arrayWithCapacity:array.count];
+
+        for (NSObject *element in array) {
+            [result addObject:[self formEncodableValueForObject:element]];
+        }
+        return result;
     } else {
         return object;
     }
@@ -174,9 +182,9 @@ NSArray * STPQueryStringPairsFromKeyAndValue(NSString *key, id value) {
         }
     } else if ([value isKindOfClass:[NSArray class]]) {
         NSArray *array = value;
-        for (id nestedValue in array) {
-            [mutableQueryStringComponents addObjectsFromArray:STPQueryStringPairsFromKeyAndValue([NSString stringWithFormat:@"%@[]", key], nestedValue)];
-        }
+        [array enumerateObjectsUsingBlock:^(id  _Nonnull nestedValue, NSUInteger idx, __unused BOOL * _Nonnull stop) {
+            [mutableQueryStringComponents addObjectsFromArray:STPQueryStringPairsFromKeyAndValue([NSString stringWithFormat:@"%@[%lu]", key, (unsigned long)idx], nestedValue)];
+        }];
     } else if ([value isKindOfClass:[NSSet class]]) {
         NSSet *set = value;
         for (id obj in [set sortedArrayUsingDescriptors:@[ sortDescriptor ]]) {

--- a/Stripe/STPFormEncoder.m
+++ b/Stripe/STPFormEncoder.m
@@ -53,11 +53,28 @@ FOUNDATION_EXPORT NSString * STPQueryStringFromParameters(NSDictionary *paramete
 + (id)formEncodableValueForObject:(NSObject *)object {
     if ([object conformsToProtocol:@protocol(STPFormEncodable)]) {
         return [self keyPairDictionaryForObject:(NSObject<STPFormEncodable>*)object];
+    } else if ([object isKindOfClass:[NSDictionary class]]) {
+        NSDictionary *dict = (NSDictionary *)object;
+        NSMutableDictionary *result = [NSMutableDictionary dictionaryWithCapacity:dict.count];
+
+        [dict enumerateKeysAndObjectsUsingBlock:^(id  _Nonnull key, id  _Nonnull value, __unused BOOL * _Nonnull stop) {
+            result[[self formEncodableValueForObject:key]] = [self formEncodableValueForObject:value];
+        }];
+
+        return result;
     } else if ([object isKindOfClass:[NSArray class]]) {
         NSArray *array = (NSArray *)object;
         NSMutableArray *result = [NSMutableArray arrayWithCapacity:array.count];
 
         for (NSObject *element in array) {
+            [result addObject:[self formEncodableValueForObject:element]];
+        }
+        return result;
+    } else if ([object isKindOfClass:[NSSet class]]) {
+        NSSet *set = (NSSet *)object;
+        NSMutableSet *result = [NSMutableSet setWithCapacity:set.count];
+
+        for (NSObject *element in set) {
             [result addObject:[self formEncodableValueForObject:element]];
         }
         return result;

--- a/Tests/Tests/STPFormEncoderTest.m
+++ b/Tests/Tests/STPFormEncoderTest.m
@@ -95,7 +95,22 @@
     STPTestFormEncodableObject *testObject = [STPTestFormEncodableObject new];
     testObject.testProperty = @"success";
     testObject.testArrayProperty = @[@1, @2, @3];
-    XCTAssertEqualObjects([self encodeObject:testObject], @"test_object[test_array_property][]=1&test_object[test_array_property][]=2&test_object[test_array_property][]=3&test_object[test_property]=success");
+    XCTAssertEqualObjects([self encodeObject:testObject], @"test_object[test_array_property][0]=1&test_object[test_array_property][1]=2&test_object[test_array_property][2]=3&test_object[test_property]=success");
+}
+
+- (void)testFormEncoding_arrayOfEncodable {
+    STPTestFormEncodableObject *testObject = [STPTestFormEncodableObject new];
+
+    STPTestFormEncodableObject *inner1 = [STPTestFormEncodableObject new];
+    inner1.testProperty = @"inner1";
+    STPTestFormEncodableObject *inner2 = [STPTestFormEncodableObject new];
+    inner2.testArrayProperty = @[@"inner2"];
+
+    testObject.testArrayProperty = @[inner1, inner2];
+
+    XCTAssertEqualObjects([self encodeObject:testObject],
+                          @"test_object[test_array_property][0][test_property]=inner1"
+                          "&test_object[test_array_property][1][test_array_property][0]=inner2");
 }
 
 - (void)testFormEncoding_dictionaryValue_empty {

--- a/Tests/Tests/STPFormEncoderTest.m
+++ b/Tests/Tests/STPFormEncoderTest.m
@@ -127,6 +127,33 @@
     XCTAssertEqualObjects([self encodeObject:testObject], @"test_object[test_dictionary_property][foo]=bar&test_object[test_property]=success");
 }
 
+- (void)testFormEncoding_dictionaryOfEncodable {
+    STPTestFormEncodableObject *testObject = [STPTestFormEncodableObject new];
+
+    STPTestFormEncodableObject *inner1 = [STPTestFormEncodableObject new];
+    inner1.testProperty = @"inner1";
+    STPTestFormEncodableObject *inner2 = [STPTestFormEncodableObject new];
+    inner2.testArrayProperty = @[@"inner2"];
+
+    testObject.testDictionaryProperty = @{@"one": inner1, @"two": inner2};
+
+    XCTAssertEqualObjects([self encodeObject:testObject],
+                          @"test_object[test_dictionary_property][one][test_property]=inner1"
+                          "&test_object[test_dictionary_property][two][test_array_property][0]=inner2");
+}
+
+- (void)testFormEncoding_setOfEncodable {
+    STPTestFormEncodableObject *testObject = [STPTestFormEncodableObject new];
+
+    STPTestFormEncodableObject *inner = [STPTestFormEncodableObject new];
+    inner.testProperty = @"inner";
+
+    testObject.testArrayProperty = @[[NSSet setWithObject:inner]];
+
+    XCTAssertEqualObjects([self encodeObject:testObject],
+                          @"test_object[test_array_property][0][test_property]=inner");
+}
+
 - (void)testFormEncoding_nestedValue {
     STPTestFormEncodableObject *testObject1 = [STPTestFormEncodableObject new];
     STPTestFormEncodableObject *testObject2 = [STPTestFormEncodableObject new];


### PR DESCRIPTION
## Summary

Fix STPEncodable to work with arrays, dictionaries and sets of STPEncodable objects, and add array index to the encoded string.

## Motivation

It currently only works if the collection contains primitive items, and it's ambiguous if the array contains nested objects:

It won't work with just `[]`, because this particular test case could either deserialize
as a single object with two properties filled out, or two objects with one property
each.

## Testing

Added unit tests to expose the bugs & verify it works as expected.

Quick pass through the standard integration to ensure taking a payment still works.

Manually used the Connect Account Token API to verify that the Stripe API accepts `[0]=` instead of `[]=` for setting array contents.