### PR TITLE
Encode NSNumber-wrapped boolean values as `true`/`false`, not `1`/`0`

### DIFF
--- a/Stripe/STPFormEncoder.m
+++ b/Stripe/STPFormEncoder.m
@@ -159,7 +159,16 @@ NSString * STPPercentEscapedStringFromString(NSString *string) {
     if (!self.value || [self.value isEqual:[NSNull null]]) {
         return STPPercentEscapedStringFromString([self.field description]);
     } else {
-        return [NSString stringWithFormat:@"%@=%@", STPPercentEscapedStringFromString([self.field description]), STPPercentEscapedStringFromString([self.value description])];
+        NSString *unescapedValue = [self.value description];
+
+        // coerce boxed BOOL values back into true/false
+        // https://stackoverflow.com/a/30223989/1196205
+        if ([self.value isKindOfClass:[NSNumber class]]
+            && (CFBooleanGetTypeID() == CFGetTypeID((__bridge CFTypeRef)(self.value)))) {
+            unescapedValue = [self.value boolValue] ? @"true" : @"false";
+        }
+
+        return [NSString stringWithFormat:@"%@=%@", STPPercentEscapedStringFromString([self.field description]), STPPercentEscapedStringFromString(unescapedValue)];
     }
 }
 

--- a/Tests/Tests/STPFormEncoderTest.m
+++ b/Tests/Tests/STPFormEncoderTest.m
@@ -98,6 +98,21 @@
     XCTAssertEqualObjects([self encodeObject:testObject], @"test_object[test_array_property][0]=1&test_object[test_array_property][1]=2&test_object[test_array_property][2]=3&test_object[test_property]=success");
 }
 
+- (void)testFormEncoding_BoolAndNumbers {
+    STPTestFormEncodableObject *testObject = [STPTestFormEncodableObject new];
+    testObject.testArrayProperty = @[@0,
+                                     @1,
+                                     [NSNumber numberWithBool:NO],
+                                     [[NSNumber alloc] initWithBool:YES],
+                                     @YES];
+    XCTAssertEqualObjects([self encodeObject:testObject],
+                          @"test_object[test_array_property][0]=0"
+                          "&test_object[test_array_property][1]=1"
+                          "&test_object[test_array_property][2]=false"
+                          "&test_object[test_array_property][3]=true"
+                          "&test_object[test_array_property][4]=true");
+}
+
 - (void)testFormEncoding_arrayOfEncodable {
     STPTestFormEncodableObject *testObject = [STPTestFormEncodableObject new];
 


### PR DESCRIPTION
## Summary

Identify NSNumbers that were created via any of the `bool` constructors, and encode them
as `true`/`false`.

## Motivation

Trying to encode/serialize a BOOL/NSNumber field in Connect Account token creation failed
with invalid value because it was sending `1` instead of `true`.

## Testing

Adding a test to verify this works, and that this doesn't break other NSNumber instances
that store 0 or 1.

Verified that it works with the new Connect Account token API