### PR TITLE
Fix `STPPaymentCardTextField` touch handling bugs for small devices on iOS 11

### DIFF
--- a/Stripe/STPPaymentCardTextField.m
+++ b/Stripe/STPPaymentCardTextField.m
@@ -1070,6 +1070,7 @@ typedef NS_ENUM(NSInteger, STPCardTextFieldState) {
                                                                     fieldsHeight)];
         maskView.backgroundColor = [UIColor blackColor];
         maskView.opaque = YES;
+        maskView.userInteractionEnabled = NO;
         [UIView performWithoutAnimation:^{
             self.numberField.maskView = maskView;
         }];

--- a/Stripe/STPPaymentCardTextField.m
+++ b/Stripe/STPPaymentCardTextField.m
@@ -195,6 +195,11 @@ CGFloat const STPPaymentCardTextFieldMinimumPadding = 10;
     }
 
     [self addSubview:brandImageView];
+    // On small screens, the number field fits ~4 numbers, and the brandImage is just as large.
+    // Previously, taps on the brand image would *dismiss* the keyboard. Make it move to the numberField instead
+    brandImageView.userInteractionEnabled = YES;
+    [brandImageView addGestureRecognizer:[[UITapGestureRecognizer alloc] initWithTarget:numberField
+                                                                                 action:@selector(becomeFirstResponder)]];
 
     self.focusedTextFieldForLayout = @(STPCardFieldTypeNumber);
     [self updateCVCPlaceholder];


### PR DESCRIPTION
## Summary

The `maskView` over `STPPaymentCardTextField` numbers no longer blocks touches on iOS 11.
Also, making the `brandImage` tappable to move focus/first responder to the numbers text
field.

## Motivation

Found while testing #870, #855, etc. Filed as IOS-601

## Testing

Manual testing in Standard Integration sample app, on small & large phones.