### PR TITLE
Add Visa Checkout to STPSourceParams, allowing Sources to be created using the `callId`

### DIFF
--- a/Stripe/PublicHeaders/STPSourceParams.h
+++ b/Stripe/PublicHeaders/STPSourceParams.h
@@ -286,6 +286,18 @@ NS_ASSUME_NONNULL_BEGIN
                                     name:(nullable NSString *)name
                                returnURL:(NSString *)returnURL;
 
+
+/**
+ Creates params for a card source created from Visa Checkout.
+
+ @note Creating an STPSource with these params will give you a
+ source with type == STPSourceTypeCard
+
+ @param callId The callId property from a `VisaCheckoutResult` object.
+ @return An STPSourceParams object populated with the provided values.
+ */
++ (STPSourceParams *)visaCheckoutParamsWithCallId:(NSString *)callId;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Stripe/STPSourceParams.m
+++ b/Stripe/STPSourceParams.m
@@ -301,6 +301,13 @@
     return params;
 }
 
++ (STPSourceParams *)visaCheckoutParamsWithCallId:(NSString *)callId {
+    STPSourceParams *params = [self new];
+    params.type = STPSourceTypeCard;
+    params.additionalAPIParameters = @{ @"card": @{ @"visa_checkout": @{ @"callid": callId } } };
+    return params;
+}
+
 #pragma mark - Redirect Dictionary
 
 /**


### PR DESCRIPTION
## Summary

Adds a new `STPSourceParams` constructor, which creates necessary params to create a
card source using a Visa Checkout callid

## Motivation

Allowing integration with Visa Checkout SDK. Client apps must handle all of the integration
with the Visa Checkout SDK. However, once they've done that, a successful 
`VisaCheckoutResult` returned by that framework will be populated with the `callId`
necessary to integrate with Stripe.

see also stripe/stripe-android#512

## Testing

Wrote a one-off functional test with hard-coded `callId` and publishable key for QA server.
That test is not part of this PR, because as Visa Checkout becomes more available, I'd
like to create something more robust.