### PR TITLE
Fix createsCardSources <> didCreatePaymentResult , Apple Pay

### DIFF
--- a/Example/Standard Integration (Swift)/CheckoutViewController.swift
+++ b/Example/Standard Integration (Swift)/CheckoutViewController.swift
@@ -82,6 +82,9 @@ class CheckoutViewController: UIViewController, STPPaymentContextDelegate {
         config.shippingType = settings.shippingType
         config.additionalPaymentMethods = settings.additionalPaymentMethods
 
+        // Create card sources instead of card tokens
+        config.createCardSources = true;
+
         let customerContext = STPCustomerContext(keyProvider: MyAPIClient.sharedClient)
         let paymentContext = STPPaymentContext(customerContext: customerContext,
                                                configuration: config,

--- a/Stripe/PKPaymentAuthorizationViewController+Stripe_Blocks.h
+++ b/Stripe/PKPaymentAuthorizationViewController+Stripe_Blocks.h
@@ -14,7 +14,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef void(^STPApplePayTokenHandlerBlock)(STPToken *token, STPErrorBlock completion);
+typedef void(^STPApplePaySourceHandlerBlock)(id<STPSourceProtocol> source, STPErrorBlock completion);
 typedef void (^STPPaymentCompletionBlock)(STPPaymentStatus status,  NSError * __nullable error);
 typedef void (^STPPaymentSummaryItemCompletionBlock)(NSArray<PKPaymentSummaryItem*> *summaryItems);
 typedef void (^STPShippingMethodSelectionBlock)(PKShippingMethod *selectedMethod, STPPaymentSummaryItemCompletionBlock completion);
@@ -26,10 +26,11 @@ typedef void (^STPPaymentAuthorizationBlock)(PKPayment *payment);
 
 + (instancetype)stp_controllerWithPaymentRequest:(PKPaymentRequest *)paymentRequest
                                        apiClient:(STPAPIClient *)apiClient
+                                    createSource:(BOOL)createSource
                       onShippingAddressSelection:(STPShippingAddressSelectionBlock)onShippingAddressSelection
                        onShippingMethodSelection:(STPShippingMethodSelectionBlock)onShippingMethodSelection
                           onPaymentAuthorization:(STPPaymentAuthorizationBlock)onPaymentAuthorization
-                                 onTokenCreation:(STPApplePayTokenHandlerBlock)onTokenCreation
+                                 onTokenCreation:(STPApplePaySourceHandlerBlock)onTokenCreation
                                         onFinish:(STPPaymentCompletionBlock)onFinish;
 
 

--- a/Stripe/PKPaymentAuthorizationViewController+Stripe_Blocks.m
+++ b/Stripe/PKPaymentAuthorizationViewController+Stripe_Blocks.m
@@ -10,7 +10,9 @@
 
 #import "PKPaymentAuthorizationViewController+Stripe_Blocks.h"
 #import "STPAPIClient+ApplePay.h"
-
+#import "STPCard.h"
+#import "STPSource.h"
+#import "STPToken.h"
 
 static char kSTPBlockBasedApplePayDelegateAssociatedObjectKey;
 
@@ -22,10 +24,11 @@ typedef void (^STPApplePayShippingAddressCompletionBlock)(PKPaymentAuthorization
 @property (nonatomic, copy) STPShippingAddressSelectionBlock onShippingAddressSelection;
 @property (nonatomic, copy) STPShippingMethodSelectionBlock onShippingMethodSelection;
 @property (nonatomic, copy) STPPaymentAuthorizationBlock onPaymentAuthorization;
-@property (nonatomic, copy) STPApplePayTokenHandlerBlock onTokenCreation;
+@property (nonatomic, copy) STPApplePaySourceHandlerBlock onSourceCreation;
 @property (nonatomic, copy) STPPaymentCompletionBlock onFinish;
 @property (nonatomic) NSError *lastError;
 @property (nonatomic) BOOL didSucceed;
+@property (nonatomic) BOOL createSource;
 @end
 
 typedef void (^STPPaymentAuthorizationStatusCallback)(PKPaymentAuthorizationStatus status);
@@ -35,22 +38,37 @@ typedef void (^STPPaymentAuthorizationStatusCallback)(PKPaymentAuthorizationStat
 - (void)paymentAuthorizationViewController:(__unused PKPaymentAuthorizationViewController *)controller
                        didAuthorizePayment:(PKPayment *)payment completion:(STPPaymentAuthorizationStatusCallback)completion {
     self.onPaymentAuthorization(payment);
-    [self.apiClient createTokenWithPayment:payment completion:^(STPToken * _Nullable token, NSError * _Nullable error) {
+
+    void(^tokenOrSourceCompletion)(id<STPSourceProtocol>, NSError *) = ^(id<STPSourceProtocol> result, NSError *error) {
         if (error) {
             self.lastError = error;
             completion(PKPaymentAuthorizationStatusFailure);
             return;
         }
-        self.onTokenCreation(token, ^(NSError *tokenCreationError){
-            if (tokenCreationError) {
-                self.lastError = tokenCreationError;
+        id<STPSourceProtocol> source;
+        // return the child card, not the STPToken
+        if ([result isKindOfClass:[STPToken class]]) {
+            source = ((STPToken *)result).card;
+        }
+        else if ([result isKindOfClass:[STPSource class]]) {
+            source = (STPSource *)result;
+        }
+        self.onSourceCreation(result, ^(NSError *sourceCreation){
+            if (sourceCreation) {
+                self.lastError = sourceCreation;
                 completion(PKPaymentAuthorizationStatusFailure);
                 return;
             }
             self.didSucceed = YES;
             completion(PKPaymentAuthorizationStatusSuccess);
         });
-    }];
+    };
+    if (self.createSource) {
+        [self.apiClient createSourceWithPayment:payment completion:(STPSourceCompletionBlock)tokenOrSourceCompletion];
+    }
+    else {
+        [self.apiClient createTokenWithPayment:payment completion:(STPTokenCompletionBlock)tokenOrSourceCompletion];
+    }
 }
 
 - (void)paymentAuthorizationViewController:(__unused PKPaymentAuthorizationViewController *)controller
@@ -97,17 +115,19 @@ typedef void (^STPPaymentAuthorizationStatusCallback)(PKPaymentAuthorizationStat
 
 + (instancetype)stp_controllerWithPaymentRequest:(PKPaymentRequest *)paymentRequest
                                        apiClient:(STPAPIClient *)apiClient
+                                    createSource:(BOOL)createSource
                       onShippingAddressSelection:(STPShippingAddressSelectionBlock)onShippingAddressSelection
                        onShippingMethodSelection:(STPShippingMethodSelectionBlock)onShippingMethodSelection
                           onPaymentAuthorization:(STPPaymentAuthorizationBlock)onPaymentAuthorization
-                                 onTokenCreation:(STPApplePayTokenHandlerBlock)onTokenCreation
+                                 onTokenCreation:(STPApplePaySourceHandlerBlock)onTokenCreation
                                         onFinish:(STPPaymentCompletionBlock)onFinish {
     STPBlockBasedApplePayDelegate *delegate = [STPBlockBasedApplePayDelegate new];
     delegate.apiClient = apiClient;
+    delegate.createSource = createSource;
     delegate.onShippingAddressSelection = onShippingAddressSelection;
     delegate.onShippingMethodSelection = onShippingMethodSelection;
     delegate.onPaymentAuthorization = onPaymentAuthorization;
-    delegate.onTokenCreation = onTokenCreation;
+    delegate.onSourceCreation = onTokenCreation;
     delegate.onFinish = onFinish;
     PKPaymentAuthorizationViewController *viewController = [[self alloc] initWithPaymentRequest:paymentRequest];
     viewController.delegate = delegate;

--- a/Stripe/PKPaymentAuthorizationViewController+Stripe_Blocks.m
+++ b/Stripe/PKPaymentAuthorizationViewController+Stripe_Blocks.m
@@ -53,7 +53,7 @@ typedef void (^STPPaymentAuthorizationStatusCallback)(PKPaymentAuthorizationStat
         else if ([result isKindOfClass:[STPSource class]]) {
             source = (STPSource *)result;
         }
-        self.onSourceCreation(result, ^(NSError *sourceCreation){
+        self.onSourceCreation(source, ^(NSError *sourceCreation){
             if (sourceCreation) {
                 self.lastError = sourceCreation;
                 completion(PKPaymentAuthorizationStatusFailure);

--- a/Stripe/STPPaymentContext.m
+++ b/Stripe/STPPaymentContext.m
@@ -582,9 +582,10 @@ typedef NS_ENUM(NSUInteger, STPPaymentContextState) {
         else if ([self requestPaymentShouldPresentShippingViewController]) {
             [self presentShippingViewControllerWithNewState:STPPaymentContextStateRequestingPayment];
         }
-        else if ([self.selectedPaymentMethod isKindOfClass:[STPCard class]]) {
+        else if ([self.selectedPaymentMethod isKindOfClass:[STPCard class]] ||
+                 [self.selectedPaymentMethod isKindOfClass:[STPSource class]]) {
             self.state = STPPaymentContextStateRequestingPayment;
-            STPPaymentResult *result = [[STPPaymentResult alloc] initWithSource:(STPCard *)self.selectedPaymentMethod];
+            STPPaymentResult *result = [[STPPaymentResult alloc] initWithSource:(id<STPSourceProtocol>)self.selectedPaymentMethod];
             [self.delegate paymentContext:self didCreatePaymentResult:result completion:^(NSError * _Nullable error) {
                 stpDispatchToMainThreadIfNecessary(^{
                     if (error) {

--- a/Stripe/STPPaymentContext.m
+++ b/Stripe/STPPaymentContext.m
@@ -648,10 +648,11 @@ typedef NS_ENUM(NSUInteger, STPPaymentContextState) {
             paymentAuthVC = [PKPaymentAuthorizationViewController
                              stp_controllerWithPaymentRequest:paymentRequest
                              apiClient:self.apiClient
+                             createSource:self.configuration.createCardSources
                              onShippingAddressSelection:shippingAddressHandler
                              onShippingMethodSelection:shippingMethodHandler
                              onPaymentAuthorization:paymentHandler
-                             onTokenCreation:applePayTokenHandler
+                             onTokenCreation:applePaySourceHandler
                              onFinish:^(STPPaymentStatus status, NSError * _Nullable error) {
                                  [self.hostViewController dismissViewControllerAnimated:[self transitionAnimationsEnabled]
                                                                              completion:^{

--- a/Stripe/STPPaymentContext.m
+++ b/Stripe/STPPaymentContext.m
@@ -625,19 +625,19 @@ typedef NS_ENUM(NSUInteger, STPPaymentContextState) {
                     [customerContext updateCustomerWithShippingAddress:self.shippingAddress completion:nil];
                 }
             };
-            STPApplePayTokenHandlerBlock applePayTokenHandler = ^(STPToken *token, STPErrorBlock tokenCompletion) {
-                [self.apiAdapter attachSourceToCustomer:token completion:^(NSError *tokenError) {
+            STPApplePaySourceHandlerBlock applePaySourceHandler = ^(id<STPSourceProtocol> source, STPErrorBlock completion) {
+                [self.apiAdapter attachSourceToCustomer:source completion:^(NSError *attachSourceError) {
                     stpDispatchToMainThreadIfNecessary(^{
-                        if (tokenError) {
-                            tokenCompletion(tokenError);
+                        if (attachSourceError) {
+                            completion(attachSourceError);
                         } else {
-                            STPPaymentResult *result = [[STPPaymentResult alloc] initWithSource:token.card];
+                            STPPaymentResult *result = [[STPPaymentResult alloc] initWithSource:source];
                             [self.delegate paymentContext:self didCreatePaymentResult:result completion:^(NSError * error) {
                                 // for Apple Pay, the didFinishWithStatus callback is fired later when Apple Pay VC finishes
                                 if (error) {
-                                    tokenCompletion(error);
+                                    completion(error);
                                 } else {
-                                    tokenCompletion(nil);
+                                    completion(nil);
                                 }
                             }];
                         }


### PR DESCRIPTION
r? @danj-stripe 

This fixes two issues:
- didCreatePaymentResult wasn't called when createsCardSources = true
- selecting apple pay created a card token when createsCardSources = true

I tested Apple Pay and didCreatePaymentResult in the example app with sources. I've also updated the example app to always create card sources.