### PR TITLE
Fix issue with apple pay token creation in PaymentContext

### DIFF
--- a/Stripe/PKPaymentAuthorizationViewController+Stripe_Blocks.m
+++ b/Stripe/PKPaymentAuthorizationViewController+Stripe_Blocks.m
@@ -45,15 +45,7 @@ typedef void (^STPPaymentAuthorizationStatusCallback)(PKPaymentAuthorizationStat
             completion(PKPaymentAuthorizationStatusFailure);
             return;
         }
-        id<STPSourceProtocol> source;
-        // return the child card, not the STPToken
-        if ([result isKindOfClass:[STPToken class]]) {
-            source = ((STPToken *)result).card;
-        }
-        else if ([result isKindOfClass:[STPSource class]]) {
-            source = (STPSource *)result;
-        }
-        self.onSourceCreation(source, ^(NSError *sourceCreation){
+        self.onSourceCreation(result, ^(NSError *sourceCreation){
             if (sourceCreation) {
                 self.lastError = sourceCreation;
                 completion(PKPaymentAuthorizationStatusFailure);

--- a/Stripe/STPPaymentContext.m
+++ b/Stripe/STPPaymentContext.m
@@ -633,8 +633,8 @@ typedef NS_ENUM(NSUInteger, STPPaymentContextState) {
                             completion(attachSourceError);
                         } else {
                             /**
-                             When createCardSources is false, the SDK must:
-                             1. Send the token to customers/[id]/sources. This
+                             When createCardSources is false, the SDK:
+                             1. Sends the token to customers/[id]/sources. This
                              adds token.card to the customer's sources list.
                              2. Return token.card to didCreatePaymentResult.
                              A charge request with the customer ID and token ID

--- a/Stripe/STPPaymentContext.m
+++ b/Stripe/STPPaymentContext.m
@@ -636,8 +636,11 @@ typedef NS_ENUM(NSUInteger, STPPaymentContextState) {
                              When createCardSources is false, the SDK:
                              1. Sends the token to customers/[id]/sources. This
                              adds token.card to the customer's sources list.
-                             2. Returns token.card to didCreatePaymentResult.
-                             A charge request with the customer ID and token ID
+                             Surprisingly, attaching token.card to the customer
+                             will fail.
+                             2. Returns token.card to didCreatePaymentResult,
+                             where the user tells their backend to create a charge.
+                             A charge request with the token ID and customer ID
                              will fail because the token is not linked to the
                              customer (the card is).
                              */

--- a/Stripe/STPPaymentContext.m
+++ b/Stripe/STPPaymentContext.m
@@ -636,7 +636,7 @@ typedef NS_ENUM(NSUInteger, STPPaymentContextState) {
                              When createCardSources is false, the SDK:
                              1. Sends the token to customers/[id]/sources. This
                              adds token.card to the customer's sources list.
-                             2. Return token.card to didCreatePaymentResult.
+                             2. Returns token.card to didCreatePaymentResult.
                              A charge request with the customer ID and token ID
                              will fail because the token is not linked to the
                              customer (the card is).

--- a/Stripe/STPPaymentContext.m
+++ b/Stripe/STPPaymentContext.m
@@ -632,6 +632,7 @@ typedef NS_ENUM(NSUInteger, STPPaymentContextState) {
                         if (attachSourceError) {
                             completion(attachSourceError);
                         } else {
+                            id<STPSourceProtocol> paymentResultSource = source;
                             /**
                              When createCardSources is false, the SDK:
                              1. Sends the token to customers/[id]/sources. This
@@ -644,12 +645,8 @@ typedef NS_ENUM(NSUInteger, STPPaymentContextState) {
                              will fail because the token is not linked to the
                              customer (the card is).
                              */
-                            id<STPSourceProtocol> paymentResultSource;
                             if ([source isKindOfClass:[STPToken class]]) {
                                 paymentResultSource = ((STPToken *)source).card;
-                            }
-                            else if ([source isKindOfClass:[STPSource class]]) {
-                                paymentResultSource = (STPSource *)source;
                             }
                             STPPaymentResult *result = [[STPPaymentResult alloc] initWithSource:paymentResultSource];
                             [self.delegate paymentContext:self didCreatePaymentResult:result completion:^(NSError * error) {

--- a/Stripe/STPPaymentMethodsViewController.m
+++ b/Stripe/STPPaymentMethodsViewController.m
@@ -223,7 +223,7 @@
                  When createCardSources is false, the SDK:
                  1. Sends the token to customers/[id]/sources. This
                  adds token.card to the customer's sources list.
-                 2. Return token.card to didCreatePaymentResult.
+                 2. Returns token.card to didCreatePaymentResult.
                  A charge request with the customer ID and token ID
                  will fail because the token is not linked to the
                  customer (the card is).

--- a/Stripe/STPPaymentMethodsViewController.m
+++ b/Stripe/STPPaymentMethodsViewController.m
@@ -219,10 +219,17 @@
         stpDispatchToMainThreadIfNecessary(^{
             completion(error);
             if (!error) {
-                // created a card token
+                /**
+                 When createCardSources is false, the SDK:
+                 1. Sends the token to customers/[id]/sources. This
+                 adds token.card to the customer's sources list.
+                 2. Return token.card to didCreatePaymentResult.
+                 A charge request with the customer ID and token ID
+                 will fail because the token is not linked to the
+                 customer (the card is).
+                 */
                 if ([source isKindOfClass:[STPToken class]]) {
-                    STPToken *token = (STPToken *)source;
-                    [self finishWithPaymentMethod:token.card];
+                    [self finishWithPaymentMethod:((STPToken *)source).card];
                 }
                 // created a card source
                 else if ([source isKindOfClass:[STPSource class]] &&

--- a/Stripe/STPPaymentMethodsViewController.m
+++ b/Stripe/STPPaymentMethodsViewController.m
@@ -222,9 +222,11 @@
                 /**
                  When createCardSources is false, the SDK:
                  1. Sends the token to customers/[id]/sources. This
-                 adds token.card to the customer's sources list.
-                 2. Returns token.card to didCreatePaymentResult.
-                 A charge request with the customer ID and token ID
+                 adds token.card to the customer's sources list. Surprisingly,
+                 attaching token.card to the customer will fail.
+                 2. Returns token.card to didCreatePaymentResult,
+                 where the user tells their backend to create a charge.
+                 A charge request with the token ID and customer ID
                  will fail because the token is not linked to the
                  customer (the card is).
                  */


### PR DESCRIPTION
r? @danj-stripe 

#893 introduced a regression where we unwrapped `token.card` one level upstream (before attaching to the customer, instead of before `didCreatePaymentResult`). I should have QA'd this more thoroughly (I think I manually tested the apple pay sources flow, but not the apple pay token flow).

Since this is pretty unintuitive, I've added comments explaining why we need to unwrap `token.card`. We unfortunately aren't really set up to unit test this code path right now.

Fixes #898 

