### PR TITLE
Add missing nullability annotations to STPRedirectContextCompletionBlock

### DIFF
--- a/Stripe/PublicHeaders/STPRedirectContext.h
+++ b/Stripe/PublicHeaders/STPRedirectContext.h
@@ -47,7 +47,7 @@ typedef NS_ENUM(NSUInteger, STPRedirectContextState) {
  is if SFSafariViewController fails its initial load (like the user has no 
  internet connection, or servers are down).
  */
-typedef void (^STPRedirectContextCompletionBlock)(NSString *sourceID, NSString *clientSecret, NSError *error);
+typedef void (^STPRedirectContextCompletionBlock)(NSString *sourceID, NSString * __nullable clientSecret, NSError * __nullable error);
 
 /**
  This is a helper class for handling redirect sources.


### PR DESCRIPTION
## Summary

Marking `clientSecret` and `error` parameters as `__nullable`. Fixes #901

## Motivation

The header is marked with `NS_ASSUME_NONNULL_BEGIN`, so this fixes Swift compatibility when
checking whether the error is null.

## Testing

Unit tests for STPRedirectContext passing.

Wrote throwaway code in our swift integration example to verify the parameters are
imported as optional.