### PR TITLE
Mark invalid view controller initializers as unavailable

### DIFF
--- a/Stripe/PublicHeaders/STPAddCardViewController.h
+++ b/Stripe/PublicHeaders/STPAddCardViewController.h
@@ -64,6 +64,22 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, strong, nullable) UIView *customFooterView;
 
+/**
+ Use init: or initWithConfiguration:theme:
+ */
+- (instancetype)initWithTheme:(STPTheme *)theme NS_UNAVAILABLE;
+
+/**
+ Use init: or initWithConfiguration:theme:
+ */
+- (instancetype)initWithNibName:(nullable NSString *)nibNameOrNil
+                         bundle:(nullable NSBundle *)nibBundleOrNil NS_UNAVAILABLE;
+
+/**
+ Use init: or initWithConfiguration:theme:
+ */
+- (nullable instancetype)initWithCoder:(NSCoder *)aDecoder NS_UNAVAILABLE;
+
 @end
 
 /**

--- a/Stripe/PublicHeaders/STPPaymentMethodsViewController.h
+++ b/Stripe/PublicHeaders/STPPaymentMethodsViewController.h
@@ -132,6 +132,22 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)dismissWithCompletion:(nullable STPVoidBlock)completion;
 
+/**
+ Use one of the initializers declared in this interface.
+ */
+- (instancetype)initWithTheme:(STPTheme *)theme NS_UNAVAILABLE;
+
+/**
+ Use one of the initializers declared in this interface.
+ */
+- (instancetype)initWithNibName:(nullable NSString *)nibNameOrNil
+                         bundle:(nullable NSBundle *)nibBundleOrNil NS_UNAVAILABLE;
+
+/**
+ Use one of the initializers declared in this interface.
+ */
+- (nullable instancetype)initWithCoder:(NSCoder *)aDecoder NS_UNAVAILABLE;
+
 @end
 
 /**

--- a/Stripe/PublicHeaders/STPShippingAddressViewController.h
+++ b/Stripe/PublicHeaders/STPShippingAddressViewController.h
@@ -61,6 +61,22 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)dismissWithCompletion:(nullable STPVoidBlock)completion;
 
+/**
+ Use one of the initializers declared in this interface.
+ */
+- (instancetype)initWithTheme:(STPTheme *)theme NS_UNAVAILABLE;
+
+/**
+ Use one of the initializers declared in this interface.
+ */
+- (instancetype)initWithNibName:(nullable NSString *)nibNameOrNil
+                         bundle:(nullable NSBundle *)nibBundleOrNil NS_UNAVAILABLE;
+
+/**
+ Use one of the initializers declared in this interface.
+ */
+- (nullable instancetype)initWithCoder:(NSCoder *)aDecoder NS_UNAVAILABLE;
+
 @end
 
 /**


### PR DESCRIPTION
r? @danj-stripe 
Fixes #903 

`STPCoreViewController` defines `initWithTheme`, which should be unavailable in all public subclasses (as should the `UIViewController`-defined initializers)

Autocomplete will now only show valid init options.

![image](https://user-images.githubusercontent.com/23086960/37106885-e18bb454-2200-11e8-8e2a-4bf5a5cde5de.png)
