### PR TITLE
Improve Apple Pay Debugging

### DIFF
--- a/Example/Custom Integration (ObjC)/Info.plist
+++ b/Example/Custom Integration (ObjC)/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>

--- a/Stripe/STPAPIClient+ApplePay.m
+++ b/Stripe/STPAPIClient+ApplePay.m
@@ -71,11 +71,13 @@
 
 + (NSDictionary *)parametersForPayment:(PKPayment *)payment {
     NSCAssert(payment != nil, @"Cannot create a token with a nil payment.");
-    NSString *paymentString =
-    [[NSString alloc] initWithData:payment.token.paymentData encoding:NSUTF8StringEncoding];
+
+    NSString *paymentString = [[NSString alloc] initWithData:payment.token.paymentData encoding:NSUTF8StringEncoding];
     NSMutableDictionary *payload = [NSMutableDictionary new];
     payload[@"pk_token"] = paymentString;
     payload[@"card"] = [self addressParamsFromPKContact:payment.billingContact];
+
+    NSCAssert(!(paymentString.length == 0 && [[Stripe defaultPublishableKey] hasPrefix:@"pk_live"]), @"The pk_token is empty. Using Apple Pay with an iOS Simulator while not in Stripe Test Mode will always fail.");
 
     NSString *paymentInstrumentName = payment.token.paymentMethod.displayName;
     if (paymentInstrumentName) {


### PR DESCRIPTION
Following up from https://github.com/stripe/stripe-ios/issues/908, this adds an assertion error when attempting to test Apple Pay in an iOS Simulator while in Live Mode to help provide a better debugging message than "Invalid format".

- [x] Verify assertion does not hit when testmode + device
- [x] Verify assertion does not hit when livemode + device
- [x] Verify assertion does not hit when testmode + simulator
- [x] Verify assertion does hit when livemode + simulator

I don't think we need a changelog entry for this one.