### PR TITLE
Fix MIGRATING instructions for v12.0, bad merge

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -7,9 +7,9 @@
     * Example: `(PKAddressField)(PKAddressFieldName|PKAddressFieldPostalAddress)` becomes `[NSSet setwithArray:@[STPContactFieldName, STPContactFieldPostalAddress]]`)
   * Anywhere you were using `PKAddressFieldNone` you can now simply pass in `nil`
   * If you were using `PKAddressFieldAll`, you must switch to manually listing all the fields that you want.
+  * The new constants also correspond to and work similarly to Apple's new `PKContactField` values.
 * `AddressBook` framework support has been removed. If you were using AddressBook related functionality, you must switch over to using the `Contacts` framework.
 * `STPRedirectContext` will no longer retain itself for the duration of the redirect. If you were relying on this functionality, you must change your code to explicitly maintain a reference to it.
-  * The new constants also correspond to and work similarly to Apple's new `PKContactField` values.
 
 ### Migrating from versions < 11.4.0
 * The `STPBackendAPIAdapter` protocol and all associated methods are no longer deprecated. We still recommend using `STPCustomerContext` to update a Stripe customer object on your behalf, rather than using your own implementation of `STPBackendAPIAdapter`.


### PR DESCRIPTION
## Summary

This sub-bullet was supposed to be part of the `STPPaymentConfiguration.requiredShippingAddress`
section, but got separated.

## Motivation

Looks like a bad merge conflict resolution in #848:
https://github.com/stripe/stripe-ios/pull/848/files#diff-b5d6af46ef11467d703d942392759fa8

## Testing

Previewed markdown file locally.