### PR TITLE
Improve Xcode9.3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode9.2
+osx_image: xcode9.3
 branches:
   only:
     - master

--- a/Example/Cartfile
+++ b/Example/Cartfile
@@ -1,1 +1,1 @@
-github "Alamofire/Alamofire" "4.4.0"
+github "Alamofire/Alamofire" "4.7.1"

--- a/Stripe.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Stripe.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
- Upgrade Alamofire from `4.4.0` to `4.7.1` for compatibility with Xcode 9.3
- Add auto-generated Xcode 9.3 "IDEWorkspaceChecks.plist" file
- Build using Xcode 9.3 on travis

We probably need to do a new version release that is compiled using Swift 4.1 instead of the current Swift 4.0.3