### PR TITLE
Add Masterpass to STPSourceParams, allowing Sources to be created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Adding Masterpass support to `STPSourceParams` [#928](https://github.com/stripe/stripe-ios/pull/928)
 * Silence STPAddress deprecation warnings we ignore to stay compatible with older iOS versions
 * Fix "Card IO" link in full SDK reference https://github.com/stripe/stripe-ios/pull/913
 

--- a/Stripe/PublicHeaders/STPSourceParams.h
+++ b/Stripe/PublicHeaders/STPSourceParams.h
@@ -298,6 +298,20 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (STPSourceParams *)visaCheckoutParamsWithCallId:(NSString *)callId;
 
+
+/**
+ Creates params for a card source created from Masterpass.
+
+ @note Creating an STPSource with these params will give you a
+ source with type == STPSourceTypeCard
+
+ @param cartId The cartId from a `MCCCheckoutResponse` object.
+ @param transactionId The transactionid from a `MCCCheckoutResponse` object.
+ @return An STPSourceParams object populated with the provided values.
+ */
++ (STPSourceParams *)masterpassParamsWithCartId:(NSString *)cartId
+                                  transactionId:(NSString *)transactionId;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Stripe/PublicHeaders/STPSourceParams.h
+++ b/Stripe/PublicHeaders/STPSourceParams.h
@@ -289,6 +289,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Creates params for a card source created from Visa Checkout.
+ @see https://stripe.com/docs/visa-checkout
 
  @note Creating an STPSource with these params will give you a
  source with type == STPSourceTypeCard
@@ -301,6 +302,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Creates params for a card source created from Masterpass.
+ @see https://stripe.com/docs/masterpass
 
  @note Creating an STPSource with these params will give you a
  source with type == STPSourceTypeCard

--- a/Stripe/STPSourceParams.m
+++ b/Stripe/STPSourceParams.m
@@ -308,6 +308,21 @@
     return params;
 }
 
++ (STPSourceParams *)masterpassParamsWithCartId:(NSString *)cartId
+                                  transactionId:(NSString *)transactionId {
+    STPSourceParams *params = [self new];
+    params.type = STPSourceTypeCard;
+    params.additionalAPIParameters = @{ @"card": @{
+                                                @"masterpass": @{
+                                                        @"cart_id": cartId,
+                                                        @"transaction_id": transactionId,
+                                                        }
+                                                }
+
+                                        };
+    return params;
+}
+
 #pragma mark - Redirect Dictionary
 
 /**

--- a/Tests/Tests/STPSourceFunctionalTest.m
+++ b/Tests/Tests/STPSourceFunctionalTest.m
@@ -299,6 +299,32 @@ static NSString *const apiKey = @"pk_test_vOo1umqsYxSrP5UXfOeL3ecm";
     [self waitForExpectationsWithTimeout:5.0f handler:nil];
 }
 
+- (void)skip_testCreateSourceVisaCheckout {
+    // The SDK does not have a means of generating Visa Checkout params for testing. Supply your own
+    // callId, and the correct publishable key, and you can run this test case
+    // manually after removing the `skip_` prefix. It'll log the source's stripeID, and that
+    // can be verified in dashboard.
+    STPSourceParams *params = [STPSourceParams visaCheckoutParamsWithCallId:@""];
+    STPAPIClient *client = [[STPAPIClient alloc] initWithPublishableKey:@"pk_"];
+    client.apiURL = [NSURL URLWithString:@"https://api.stripe.com/v1"];
+
+    XCTestExpectation *sourceExp = [self expectationWithDescription:@"VCO source created"];
+    [client createSourceWithParams:params completion:^(STPSource * _Nullable source, NSError * _Nullable error) {
+        [sourceExp fulfill];
+
+        XCTAssertNil(error);
+        XCTAssertNotNil(source);
+        XCTAssertEqual(source.type, STPSourceTypeCard);
+        XCTAssertEqual(source.flow, STPSourceFlowNone);
+        XCTAssertEqual(source.status, STPSourceStatusChargeable);
+        XCTAssertEqual(source.usage, STPSourceUsageReusable);
+        XCTAssertTrue([source.stripeID hasPrefix:@"src_"]);
+        NSLog(@"Created a VCO source %@", source.stripeID);
+    }];
+
+    [self waitForExpectationsWithTimeout:10.0 handler:nil];
+}
+
 - (void)skip_testCreateSourceMasterpass {
     // The SDK does not have a means of generating Masterpass params for testing. Supply your own
     // cartId & transactionId, and the correct publishable key, and you can run this test case

--- a/Tests/Tests/STPSourceFunctionalTest.m
+++ b/Tests/Tests/STPSourceFunctionalTest.m
@@ -16,6 +16,10 @@ static NSString *const apiKey = @"pk_test_vOo1umqsYxSrP5UXfOeL3ecm";
 
 @end
 
+@interface STPAPIClient (WritableURL)
+@property (nonatomic, readwrite) NSURL *apiURL;
+@end
+
 @implementation STPSourceFunctionalTest
 
 - (void)testCreateSource_bancontact {
@@ -293,6 +297,32 @@ static NSString *const apiKey = @"pk_test_vOo1umqsYxSrP5UXfOeL3ecm";
     }];
 
     [self waitForExpectationsWithTimeout:5.0f handler:nil];
+}
+
+- (void)skip_testCreateSourceMasterpass {
+    // The SDK does not have a means of generating Masterpass params for testing. Supply your own
+    // cartId & transactionId, and the correct publishable key, and you can run this test case
+    // manually after removing the `skip_` prefix. It'll log the source's stripeID, and that
+    // can be verified in dashboard.
+    STPSourceParams *params = [STPSourceParams masterpassParamsWithCartId:@"" transactionId:@""];
+    STPAPIClient *client = [[STPAPIClient alloc] initWithPublishableKey:@"pk_"];
+    client.apiURL = [NSURL URLWithString:@"https://api.stripe.com/v1"];
+
+    XCTestExpectation *sourceExp = [self expectationWithDescription:@"Masterpass source created"];
+    [client createSourceWithParams:params completion:^(STPSource * _Nullable source, NSError * _Nullable error) {
+        [sourceExp fulfill];
+
+        XCTAssertNil(error);
+        XCTAssertNotNil(source);
+        XCTAssertEqual(source.type, STPSourceTypeCard);
+        XCTAssertEqual(source.flow, STPSourceFlowNone);
+        XCTAssertEqual(source.status, STPSourceStatusChargeable);
+        XCTAssertEqual(source.usage, STPSourceUsageSingleUse);
+        XCTAssertTrue([source.stripeID hasPrefix:@"src_"]);
+        NSLog(@"Created a Masterpass source %@", source.stripeID);
+    }];
+
+    [self waitForExpectationsWithTimeout:10.0 handler:nil];
 }
 
 - (void)testCreateSource_alipay {

--- a/Tests/Tests/STPSourceParamsTest.m
+++ b/Tests/Tests/STPSourceParamsTest.m
@@ -203,6 +203,19 @@
     XCTAssertEqualObjects(sourceAddress[@"country"], card.address.country);
 }
 
+- (void)testParamsWithMasterPass {
+    STPSourceParams *params = [STPSourceParams masterpassParamsWithCartId:@"12345678"
+                                                            transactionId:@"87654321"];
+
+    XCTAssertEqual(params.type, STPSourceTypeCard);
+    NSDictionary *sourceCard = params.additionalAPIParameters[@"card"];
+    XCTAssertNotNil(sourceCard);
+    NSDictionary *sourceMasterpass = sourceCard[@"masterpass"];
+    XCTAssertNotNil(sourceMasterpass);
+    XCTAssertEqualObjects(sourceMasterpass[@"cart_id"], @"12345678");
+    XCTAssertEqualObjects(sourceMasterpass[@"transaction_id"], @"87654321");
+}
+
 
 #pragma mark - Redirect Dictionary Tests
 

--- a/Tests/Tests/STPSourceParamsTest.m
+++ b/Tests/Tests/STPSourceParamsTest.m
@@ -203,6 +203,17 @@
     XCTAssertEqualObjects(sourceAddress[@"country"], card.address.country);
 }
 
+- (void)testParamsWithVisaCheckout {
+    STPSourceParams *params = [STPSourceParams visaCheckoutParamsWithCallId:@"12345678"];
+
+    XCTAssertEqual(params.type, STPSourceTypeCard);
+    NSDictionary *sourceCard = params.additionalAPIParameters[@"card"];
+    XCTAssertNotNil(sourceCard);
+    NSDictionary *sourceVisaCheckout = sourceCard[@"visa_checkout"];
+    XCTAssertNotNil(sourceVisaCheckout);
+    XCTAssertEqualObjects(sourceVisaCheckout[@"callid"], @"12345678");
+}
+
 - (void)testParamsWithMasterPass {
     STPSourceParams *params = [STPSourceParams masterpassParamsWithCartId:@"12345678"
                                                             transactionId:@"87654321"];


### PR DESCRIPTION
## Summary

Adds a new `STPSourceParams` constructor, which creates necessary params to create a
card source using the Masterpass `cartId` and `transactionId`

## Motivation

Allowing integration with Masterpass SDK. Client apps must handle all of the integration
with the Masterpass SDK. However, once they've done that, a successful
`MCCCheckoutResponse` returned by that framework will be populated with the `cartId` and
`transactionId` necessary to integrate with Stripe.

see also stripe/stripe-android#549

## Testing

Basic unit test + manually running a functional test. Larry and I worked together to
generate cartId + transactionId, and ran them through the functional test.
Successfully created `src_1CI1AkDAu10Yox5RoAvqOE9U`

I've also *slightly* improved the VCO (#889) tests to reach parity