### PR TITLE
Workaround for SafariVC reporting failure while redirecting to iDEAL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 13.0.1 2018-05-17
+* Fixes bug in `STPRedirectContext` that'd close the `SFSafariViewController` during the initial redirects, but only in livemode. [#937](https://github.com/stripe/stripe-ios/pull/937)
+
 ## 13.0.0 2018-04-26
 * Removes Bitcoin source support. See MIGRATING.md. [#931](https://github.com/stripe/stripe-ios/pull/931)
 * Adds Masterpass support to `STPSourceParams` [#928](https://github.com/stripe/stripe-ios/pull/928)

--- a/Example/Custom Integration (ObjC)/SofortExampleViewController.m
+++ b/Example/Custom Integration (ObjC)/SofortExampleViewController.m
@@ -100,31 +100,35 @@
             // your app delegate to forward URLs to the Stripe SDK.
             // See `[Stripe handleStripeURLCallback:]`
             self.redirectContext = [[STPRedirectContext alloc] initWithSource:source completion:^(NSString *sourceID, NSString *clientSecret, NSError *error) {
-                [[STPAPIClient sharedClient] startPollingSourceWithId:sourceID
-                                                         clientSecret:clientSecret
-                                                              timeout:10
-                                                           completion:^(STPSource *source, NSError *error) {
-                                                               [self updateUIForPaymentInProgress:NO];
-                                                               if (error) {
-                                                                   [self.delegate exampleViewController:self didFinishWithError:error];
-                                                               } else {
-                                                                   switch (source.status) {
-                                                                       case STPSourceStatusChargeable:
-                                                                       case STPSourceStatusConsumed:
-                                                                           [self.delegate exampleViewController:self didFinishWithMessage:@"Payment successfully created"];
-                                                                           break;
-                                                                       case STPSourceStatusCanceled:
-                                                                           [self.delegate exampleViewController:self didFinishWithMessage:@"Payment failed"];
-                                                                           break;
-                                                                       case STPSourceStatusPending:
-                                                                       case STPSourceStatusFailed:
-                                                                       case STPSourceStatusUnknown:
-                                                                           [self.delegate exampleViewController:self didFinishWithMessage:@"Order received"];
-                                                                           break;
+                if (error) {
+                    [self.delegate exampleViewController:self didFinishWithError:error];
+                } else {
+                    [[STPAPIClient sharedClient] startPollingSourceWithId:sourceID
+                                                             clientSecret:clientSecret
+                                                                  timeout:10
+                                                               completion:^(STPSource *source, NSError *error) {
+                                                                   [self updateUIForPaymentInProgress:NO];
+                                                                   if (error) {
+                                                                       [self.delegate exampleViewController:self didFinishWithError:error];
+                                                                   } else {
+                                                                       switch (source.status) {
+                                                                           case STPSourceStatusChargeable:
+                                                                           case STPSourceStatusConsumed:
+                                                                               [self.delegate exampleViewController:self didFinishWithMessage:@"Payment successfully created"];
+                                                                               break;
+                                                                           case STPSourceStatusCanceled:
+                                                                               [self.delegate exampleViewController:self didFinishWithMessage:@"Payment failed"];
+                                                                               break;
+                                                                           case STPSourceStatusPending:
+                                                                           case STPSourceStatusFailed:
+                                                                           case STPSourceStatusUnknown:
+                                                                               [self.delegate exampleViewController:self didFinishWithMessage:@"Order received"];
+                                                                               break;
+                                                                       }
                                                                    }
-                                                               }
-                                                               self.redirectContext = nil;
-                                                           }];
+                                                                   self.redirectContext = nil;
+                                                               }];
+                }
             }];
             [self.redirectContext startRedirectFlowFromViewController:self];
         }

--- a/Example/Custom Integration (ObjC)/ThreeDSExampleViewController.m
+++ b/Example/Custom Integration (ObjC)/ThreeDSExampleViewController.m
@@ -129,31 +129,35 @@
                     // your app delegate to forwards URLs to the Stripe SDK.
                     // See `[Stripe handleStripeURLCallback:]`
                     self.redirectContext = [[STPRedirectContext alloc] initWithSource:source completion:^(NSString *sourceID, NSString *clientSecret, NSError *error) {
-                        [[STPAPIClient sharedClient] startPollingSourceWithId:sourceID
-                                                                 clientSecret:clientSecret
-                                                                      timeout:10
-                                                                   completion:^(STPSource *source, NSError *error) {
-                                                                       [self updateUIForPaymentInProgress:NO];
-                                                                       if (error) {
-                                                                           [self.delegate exampleViewController:self didFinishWithError:error];
-                                                                       } else {
-                                                                           switch (source.status) {
-                                                                               case STPSourceStatusChargeable:
-                                                                               case STPSourceStatusConsumed:
-                                                                                   [self.delegate exampleViewController:self didFinishWithMessage:@"Payment successfully created"];
-                                                                                   break;
-                                                                               case STPSourceStatusCanceled:
-                                                                                   [self.delegate exampleViewController:self didFinishWithMessage:@"Payment failed"];
-                                                                                   break;
-                                                                               case STPSourceStatusPending:
-                                                                               case STPSourceStatusFailed:
-                                                                               case STPSourceStatusUnknown:
-                                                                                   [self.delegate exampleViewController:self didFinishWithMessage:@"Order received"];
-                                                                                   break;
+                        if (error) {
+                            [self.delegate exampleViewController:self didFinishWithError:error];
+                        } else {
+                            [[STPAPIClient sharedClient] startPollingSourceWithId:sourceID
+                                                                     clientSecret:clientSecret
+                                                                          timeout:10
+                                                                       completion:^(STPSource *source, NSError *error) {
+                                                                           [self updateUIForPaymentInProgress:NO];
+                                                                           if (error) {
+                                                                               [self.delegate exampleViewController:self didFinishWithError:error];
+                                                                           } else {
+                                                                               switch (source.status) {
+                                                                                   case STPSourceStatusChargeable:
+                                                                                   case STPSourceStatusConsumed:
+                                                                                       [self.delegate exampleViewController:self didFinishWithMessage:@"Payment successfully created"];
+                                                                                       break;
+                                                                                   case STPSourceStatusCanceled:
+                                                                                       [self.delegate exampleViewController:self didFinishWithMessage:@"Payment failed"];
+                                                                                       break;
+                                                                                   case STPSourceStatusPending:
+                                                                                   case STPSourceStatusFailed:
+                                                                                   case STPSourceStatusUnknown:
+                                                                                       [self.delegate exampleViewController:self didFinishWithMessage:@"Order received"];
+                                                                                       break;
+                                                                               }
                                                                            }
-                                                                       }
-                                                                       self.redirectContext = nil;
-                                                                   }];
+                                                                           self.redirectContext = nil;
+                                                                       }];
+                        }
                     }];
                     [self.redirectContext startRedirectFlowFromViewController:self];
                 }

--- a/Stripe/STPRedirectContext.m
+++ b/Stripe/STPRedirectContext.m
@@ -25,6 +25,8 @@ typedef void (^STPBoolCompletionBlock)(BOOL success);
 @property (nonatomic, strong) STPSource *source;
 @property (nonatomic, strong, nullable) SFSafariViewController *safariVC;
 @property (nonatomic, assign, readwrite) STPRedirectContextState state;
+/// If we're on iOS 11+ and in the SafariVC flow, this tracks the latest URL loaded/redirected to during the initial load
+@property (nonatomic, strong, readwrite, nullable) NSURL *latestSafariVCUrl;
 
 @property (nonatomic, assign) BOOL subscribedToURLNotifications;
 @property (nonatomic, assign) BOOL subscribedToForegroundNotifications;
@@ -121,7 +123,8 @@ typedef void (^STPBoolCompletionBlock)(BOOL success);
     if (self.state == STPRedirectContextStateNotStarted) {
         _state = STPRedirectContextStateInProgress;
         [self subscribeToUrlNotifications];
-        self.safariVC = [[SFSafariViewController alloc] initWithURL:self.source.redirect.url];
+        self.latestSafariVCUrl = self.source.redirect.url;
+        self.safariVC = [[SFSafariViewController alloc] initWithURL:self.latestSafariVCUrl];
         self.safariVC.delegate = self;
         [presentingViewController presentViewController:self.safariVC
                                                animated:YES
@@ -154,12 +157,35 @@ typedef void (^STPBoolCompletionBlock)(BOOL success);
 }
 
 - (void)safariViewController:(__unused SFSafariViewController *)controller didCompleteInitialLoad:(BOOL)didLoadSuccessfully {
+    /*
+     SafariVC is, imo, over-eager to report errors. The way that (for example) girogate.de redirects
+     can cause SafariVC to report that the initial load failed, even though it completes successfully.
+
+     So, only report failures to complete the initial load if the host was a Stripe domain.
+     Stripe uses 302 redirects, and this should catch local connection problems as well as
+     server-side failures from Stripe.
+
+     We can only track the latest URL loaded on iOS 11, because `safariViewController:initialLoadDidRedirectToURL:`
+     didn't exist prior to that.
+     */
     if (didLoadSuccessfully == NO) {
-        stpDispatchToMainThreadIfNecessary(^{
-            [self handleRedirectCompletionWithError:[NSError stp_genericConnectionError]
-                        shouldDismissViewController:YES];
-        });
+        if (@available(iOS 11, *)) {
+            stpDispatchToMainThreadIfNecessary(^{
+                if ([self.latestSafariVCUrl.host containsString:@"stripe.com"]) {
+                    [self handleRedirectCompletionWithError:[NSError stp_genericConnectionError]
+                                shouldDismissViewController:YES];
+                }
+            });
+        }
     }
+}
+
+- (void)safariViewController:(__unused SFSafariViewController *)controller initialLoadDidRedirectToURL:(NSURL *)URL {
+    stpDispatchToMainThreadIfNecessary(^{
+        // This is only kept up to date during the "initial load", but we only need the value in
+        // `safariViewController:didCompleteInitialLoad:`, so that's fine.
+        self.latestSafariVCUrl = URL;
+    });
 }
 
 #pragma mark - Private methods -


### PR DESCRIPTION
## Summary

Ignores reported errors from SafariVC unless we know the error was for a
`stripe.com` domain.

Adds missing error handling to the example app for errors from `STPRedirectContext`

## Motivation

Reported in #917 and to Stripe support, more details internally in IOS-729.

SafariVC is basically a black box: give it a URL and ask it to load. It'll
report via the delegate method when the initial load finishes, and whether
it was successful or not.

Prior to this commit, iDEAL (and others?) would fail and close SafariVC.
However, it hadn't actually failed, and just leaving the SafariVC open
would allow the user to finish the redirect workflow.

It's strange to me that SafariVC behaves this way. It's also a little
strange how the redirects are being handled by girogate.de. This works
around the interaction between the two, while still attempting to report
legitimate errors, so the host application can tell the user and allow them
to retry.


## Testing

This is very much dependent on the specific behavior of the 3rd party and SafariVC, and
only shows up with livemode transactions.

I was able to isolate this behavior in a test application that just used SafariVC, hitting
a sinatra web-app that mimicked the redirect behavior I observed from girogate. That allowed
me to eliminate any Stripe SDK-specific code, and experiment to verify hypotheses.

Then, applied this fix, and made sure that the "SafariVC opens and then closes before the 
page loads" bug wasn't happening any more.

Automated tests are passing.