### PR TITLE
Make iDEAL `name` parameter optional, and accept empty string as nil.

### DIFF
--- a/Stripe/PublicHeaders/STPSourceParams.h
+++ b/Stripe/PublicHeaders/STPSourceParams.h
@@ -145,7 +145,7 @@ NS_ASSUME_NONNULL_BEGIN
  @see https://stripe.com/docs/sources/ideal#create-source
  
  @param amount               The amount to charge the customer in EUR.
- @param name                 The full name of the account holder.
+ @param name                 (Optional) The full name of the account holder.
  @param returnURL            The URL the customer should be redirected to after
  they have successfully verified the payment.
  @param statementDescriptor  (Optional) A custom statement descriptor for t
@@ -158,7 +158,7 @@ NS_ASSUME_NONNULL_BEGIN
  @return an STPSourceParams object populated with the provided values.
  */
 + (STPSourceParams *)idealParamsWithAmount:(NSUInteger)amount
-                                      name:(NSString *)name
+                                      name:(nullable NSString *)name
                                  returnURL:(NSString *)returnURL
                        statementDescriptor:(nullable NSString *)statementDescriptor
                                       bank:(nullable NSString *)bank;

--- a/Stripe/STPSourceParams.m
+++ b/Stripe/STPSourceParams.m
@@ -152,7 +152,7 @@
 }
 
 + (STPSourceParams *)idealParamsWithAmount:(NSUInteger)amount
-                                      name:(NSString *)name
+                                      name:(nullable NSString *)name
                                  returnURL:(NSString *)returnURL
                        statementDescriptor:(nullable NSString *)statementDescriptor
                                       bank:(nullable NSString *)bank {
@@ -160,12 +160,14 @@
     params.type = STPSourceTypeIDEAL;
     params.amount = @(amount);
     params.currency = @"eur"; // iDEAL must always use eur
-    params.owner = @{ @"name": name };
+    if (name.length > 0) {
+        params.owner = @{ @"name": name };
+    }
     params.redirect = @{ @"return_url": returnURL };
-    if (statementDescriptor != nil || bank != nil) {
+    if (statementDescriptor.length > 0 || bank.length > 0) {
         NSMutableDictionary *idealDict = [NSMutableDictionary dictionary];
-        idealDict[@"statement_descriptor"] = statementDescriptor;
-        idealDict[@"bank"] = bank;
+        idealDict[@"statement_descriptor"] = (statementDescriptor.length > 0) ? statementDescriptor : nil;
+        idealDict[@"bank"] = (bank.length > 0) ? bank : nil;
         params.additionalAPIParameters = @{ @"ideal": idealDict };
     }
     return params;

--- a/Tests/Tests/STPSourceFunctionalTest.m
+++ b/Tests/Tests/STPSourceFunctionalTest.m
@@ -135,7 +135,64 @@ static NSString *const apiKey = @"pk_test_vOo1umqsYxSrP5UXfOeL3ecm";
         XCTAssertEqualObjects(source.redirect.returnURL, [NSURL URLWithString:@"https://shop.example.com/crtABC"]);
         XCTAssertNotNil(source.redirect.url);
         XCTAssertEqualObjects(source.details[@"bank"], @"ing");
+        XCTAssertEqualObjects(source.details[@"statement_descriptor"], @"ORDER AT123");
         XCTAssertEqualObjects(source.metadata, params.metadata);
+
+        [expectation fulfill];
+    }];
+    [self waitForExpectationsWithTimeout:5.0f handler:nil];
+}
+
+- (void)testCreateSource_ideal_missingOptionalFields {
+    STPSourceParams *params = [STPSourceParams idealParamsWithAmount:1099
+                                                                name:nil
+                                                           returnURL:@"https://shop.example.com/crtABC"
+                                                 statementDescriptor:nil
+                                                                bank:nil];
+
+    STPAPIClient *client = [[STPAPIClient alloc] initWithPublishableKey:apiKey];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Source creation"];
+    [client createSourceWithParams:params completion:^(STPSource *source, NSError * error) {
+        XCTAssertNil(error);
+        XCTAssertNotNil(source);
+        XCTAssertEqual(source.type, STPSourceTypeIDEAL);
+        XCTAssertEqualObjects(source.amount, params.amount);
+        XCTAssertEqualObjects(source.currency, params.currency);
+        XCTAssertNil(source.owner.name);
+        XCTAssertEqual(source.redirect.status, STPSourceRedirectStatusPending);
+        XCTAssertEqualObjects(source.redirect.returnURL, [NSURL URLWithString:@"https://shop.example.com/crtABC"]);
+        XCTAssertNotNil(source.redirect.url);
+        XCTAssertNil(source.details[@"bank"]);
+        XCTAssertNil(source.details[@"statement_descriptor"]);
+        XCTAssertEqualObjects(source.metadata, @{});
+
+        [expectation fulfill];
+    }];
+    [self waitForExpectationsWithTimeout:5.0f handler:nil];
+}
+
+- (void)testCreateSource_ideal_emptyOptionalFields {
+    STPSourceParams *params = [STPSourceParams idealParamsWithAmount:1099
+                                                                name:@""
+                                                           returnURL:@"https://shop.example.com/crtABC"
+                                                 statementDescriptor:@""
+                                                                bank:@""];
+
+    STPAPIClient *client = [[STPAPIClient alloc] initWithPublishableKey:apiKey];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Source creation"];
+    [client createSourceWithParams:params completion:^(STPSource *source, NSError * error) {
+        XCTAssertNil(error);
+        XCTAssertNotNil(source);
+        XCTAssertEqual(source.type, STPSourceTypeIDEAL);
+        XCTAssertEqualObjects(source.amount, params.amount);
+        XCTAssertEqualObjects(source.currency, params.currency);
+        XCTAssertNil(source.owner.name);
+        XCTAssertEqual(source.redirect.status, STPSourceRedirectStatusPending);
+        XCTAssertEqualObjects(source.redirect.returnURL, [NSURL URLWithString:@"https://shop.example.com/crtABC"]);
+        XCTAssertNotNil(source.redirect.url);
+        XCTAssertNil(source.details[@"bank"]);
+        XCTAssertNil(source.details[@"statement_descriptor"]);
+        XCTAssertEqualObjects(source.metadata, @{});
 
         [expectation fulfill];
     }];


### PR DESCRIPTION
## Summary

I considered removing the `name:` parameter completely, but this maintains backwards
compatibility, by just marking it as nullable/optional.

Also handling the empty string the same as `nil` for these optional fields, so that there
isn't a surprise waiting. IMO, an optional field that contains the empty string shouldn't
cause the request to fail.

## Motivation

When iDEAL support was originally implemented in the iOS SDK, this was a required
parameter. It isn't any more.

IOS-739

## Testing

Added a couple of functional tests that exercise this case.