### PR TITLE
Fix analytics: this wasn't sending the `token_type` for anything other than Apple Pay

### DIFF
--- a/Stripe/STPAnalyticsClient.m
+++ b/Stripe/STPAnalyticsClient.m
@@ -116,14 +116,16 @@
 }
 
 + (NSString *)tokenTypeFromParameters:(NSDictionary *)parameters {
-    if ([parameters.allKeys count] == 1) {
-        NSArray *validTypes = @[@"account", @"bank_account", @"card", @"pii"];
-        NSString *type = [parameters.allKeys firstObject];
-        if ([validTypes containsObject:type]) {
+    NSArray *parameterKeys = parameters.allKeys;
+    // these are currently mutually exclusive, so we can just run through and find the first match
+    NSArray *tokenTypes = @[@"account", @"bank_account", @"card", @"pii"];
+    for (NSString *type in tokenTypes) {
+        if ([parameterKeys containsObject:type]) {
             return type;
         }
     }
-    if ([parameters.allKeys containsObject:@"pk_token"]) {
+    // We want to use a different value for pk_token, that's why it's not above
+    if ([parameterKeys containsObject:@"pk_token"]) {
         return @"apple_pay";
     }
     return nil;


### PR DESCRIPTION
## Summary

Updated so we're correctly sending the `token_type` for all token creations.

The analytics client assumed there'd only ever be one top-level key in the params
dictionary. That isn't true, we also (now) have `muid` #572 and `time_on_page` #653.

## Motivation

IOS-643

## Testing

Updated the existing unit test to show the bug.