### PR TITLE
Add helpers for EPS and Multibanco source creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 * Fixes payment method label overlapping the checkmark, for Amex on small devices [#952](https://github.com/stripe/stripe-ios/pull/952)
+* Adds EPS and Multibanco support to `STPSourceParams` [#961](https://github.com/stripe/stripe-ios/pull/961)
 
 ## 13.0.2 2018-05-24
 * Makes iDEAL `name` parameter optional, also accepts empty string as `nil` [#940](https://github.com/stripe/stripe-ios/pull/940)

--- a/Stripe/PublicHeaders/STPSourceEnums.h
+++ b/Stripe/PublicHeaders/STPSourceEnums.h
@@ -147,6 +147,16 @@ typedef NS_ENUM(NSInteger, STPSourceType) {
     STPSourceTypeP24,
 
     /**
+     An EPS source. @see https://stripe.com/docs/sources/eps
+     */
+    STPSourceTypeEPS,
+
+    /**
+     A Multibanco source. @see https://stripe.com/docs/sources/multibanco
+     */
+    STPSourceTypeMultibanco,
+
+    /**
      An unknown type of source.
      */
     STPSourceTypeUnknown,

--- a/Stripe/PublicHeaders/STPSourceParams.h
+++ b/Stripe/PublicHeaders/STPSourceParams.h
@@ -300,6 +300,39 @@ NS_ASSUME_NONNULL_BEGIN
 + (STPSourceParams *)masterpassParamsWithCartId:(NSString *)cartId
                                   transactionId:(NSString *)transactionId;
 
+/**
+ Create params for an EPS source
+ @see https://stripe.com/docs/sources/eps
+
+ @param amount                  The amount to charge the customer.
+ @param name                    The full name of the account holder.
+ @param returnURL               The URL the customer should be redirected to
+ after the authorization process.
+ @param statementDescriptor     A custom statement descriptor for the
+ payment (optional).
+
+ @return An STPSourceParams object populated with the provided values.
+ */
++ (STPSourceParams *)epsParamsWithAmount:(NSUInteger)amount
+                                    name:(NSString *)name
+                               returnURL:(NSString *)returnURL
+                     statementDescriptor:(nullable NSString *)statementDescriptor;
+
+/**
+ Create params for a Multibanco source
+ @see https://stripe.com/docs/sources/multibanco
+
+ @param amount      The amount to charge the customer.
+ @param returnURL   The URL the customer should be redirected to after the
+ authorization process.
+ @param email       The full email address of the customer.
+
+ @return An STPSourceParams object populated with the provided values.
+ */
++ (STPSourceParams *)multibancoParamsWithAmount:(NSUInteger)amount
+                                      returnURL:(NSString *)returnURL
+                                          email:(NSString *)email;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Stripe/STPSource.m
+++ b/Stripe/STPSource.m
@@ -60,6 +60,8 @@
              @"three_d_secure": @(STPSourceTypeThreeDSecure),
              @"alipay": @(STPSourceTypeAlipay),
              @"p24": @(STPSourceTypeP24),
+             @"eps": @(STPSourceTypeEPS),
+             @"multibanco": @(STPSourceTypeMultibanco),
              };
 }
 

--- a/Stripe/STPSourceParams.m
+++ b/Stripe/STPSourceParams.m
@@ -314,6 +314,36 @@
     return params;
 }
 
++ (STPSourceParams *)epsParamsWithAmount:(NSUInteger)amount
+                                    name:(NSString *)name
+                               returnURL:(NSString *)returnURL
+                     statementDescriptor:(nullable NSString *)statementDescriptor {
+    STPSourceParams *params = [self new];
+    params.type = STPSourceTypeEPS;
+    params.amount = @(amount);
+    params.currency = @"eur"; // EPS must always use eur
+    params.owner = @{ @"name": name };
+    params.redirect = @{ @"return_url": returnURL };
+
+    if (statementDescriptor.length > 0) {
+        params.additionalAPIParameters = @{ @"statement_descriptor": statementDescriptor };
+    }
+
+    return params;
+}
+
++ (STPSourceParams *)multibancoParamsWithAmount:(NSUInteger)amount
+                                      returnURL:(NSString *)returnURL
+                                          email:(NSString *)email {
+    STPSourceParams *params = [self new];
+    params.type = STPSourceTypeMultibanco;
+    params.currency = @"eur"; // Multibanco must always use eur
+    params.amount = @(amount);
+    params.redirect = @{ @"return_url": returnURL };
+    params.owner = @{ @"email": email };
+    return params;
+}
+
 #pragma mark - Redirect Dictionary
 
 /**

--- a/Tests/Tests/STPSourceFunctionalTest.m
+++ b/Tests/Tests/STPSourceFunctionalTest.m
@@ -462,4 +462,58 @@ static NSString *const apiKey = @"pk_test_vOo1umqsYxSrP5UXfOeL3ecm";
     [self waitForExpectationsWithTimeout:5.0f handler:nil];
 }
 
+- (void)testCreateSource_eps {
+    STPSourceParams *params = [STPSourceParams epsParamsWithAmount:1099
+                                                              name:@"Jenny Rosen"
+                                                         returnURL:@"https://shop.example.com/crtABC"
+                                               statementDescriptor:@"ORDER AT123"];
+    params.metadata = @{@"foo": @"bar"};
+
+    STPAPIClient *client = [[STPAPIClient alloc] initWithPublishableKey:apiKey];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Source creation"];
+    [client createSourceWithParams:params completion:^(STPSource *source, NSError * error) {
+        XCTAssertNil(error);
+        XCTAssertNotNil(source);
+        XCTAssertEqual(source.type, STPSourceTypeEPS);
+        XCTAssertEqualObjects(source.amount, params.amount);
+        XCTAssertEqualObjects(source.currency, params.currency);
+        XCTAssertEqualObjects(source.owner.name, params.owner[@"name"]);
+        XCTAssertEqual(source.redirect.status, STPSourceRedirectStatusPending);
+        XCTAssertEqualObjects(source.redirect.returnURL, [NSURL URLWithString:@"https://shop.example.com/crtABC"]);
+        XCTAssertNotNil(source.redirect.url);
+        XCTAssertEqualObjects(source.metadata, params.metadata);
+        XCTAssertEqualObjects(source.allResponseFields[@"statement_descriptor"], @"ORDER AT123");
+
+        [expectation fulfill];
+    }];
+    [self waitForExpectationsWithTimeout:5.0f handler:nil];
+}
+
+- (void)testCreateSource_eps_no_statement_descriptor {
+    STPSourceParams *params = [STPSourceParams epsParamsWithAmount:1099
+                                                              name:@"Jenny Rosen"
+                                                         returnURL:@"https://shop.example.com/crtABC"
+                                               statementDescriptor:nil];
+    params.metadata = @{@"foo": @"bar"};
+
+    STPAPIClient *client = [[STPAPIClient alloc] initWithPublishableKey:apiKey];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Source creation"];
+    [client createSourceWithParams:params completion:^(STPSource *source, NSError * error) {
+        XCTAssertNil(error);
+        XCTAssertNotNil(source);
+        XCTAssertEqual(source.type, STPSourceTypeEPS);
+        XCTAssertEqualObjects(source.amount, params.amount);
+        XCTAssertEqualObjects(source.currency, params.currency);
+        XCTAssertEqualObjects(source.owner.name, params.owner[@"name"]);
+        XCTAssertEqual(source.redirect.status, STPSourceRedirectStatusPending);
+        XCTAssertEqualObjects(source.redirect.returnURL, [NSURL URLWithString:@"https://shop.example.com/crtABC"]);
+        XCTAssertNotNil(source.redirect.url);
+        XCTAssertEqualObjects(source.metadata, params.metadata);
+        XCTAssertNil(source.allResponseFields[@"statement_descriptor"]);
+
+        [expectation fulfill];
+    }];
+    [self waitForExpectationsWithTimeout:5.0f handler:nil];
+}
+
 @end

--- a/Tests/Tests/STPSourceFunctionalTest.m
+++ b/Tests/Tests/STPSourceFunctionalTest.m
@@ -516,4 +516,27 @@ static NSString *const apiKey = @"pk_test_vOo1umqsYxSrP5UXfOeL3ecm";
     [self waitForExpectationsWithTimeout:5.0f handler:nil];
 }
 
+- (void)testCreateSource_multibanco {
+    STPSourceParams *params = [STPSourceParams multibancoParamsWithAmount:1099
+                                                                returnURL:@"https://shop.example.com/crtABC"
+                                                                    email:@"user@example.com"];
+    params.metadata = @{@"foo": @"bar"};
+
+    STPAPIClient *client = [[STPAPIClient alloc] initWithPublishableKey:apiKey];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Source creation"];
+    [client createSourceWithParams:params completion:^(STPSource *source, NSError * error) {
+        XCTAssertNil(error);
+        XCTAssertNotNil(source);
+        XCTAssertEqual(source.type, STPSourceTypeMultibanco);
+        XCTAssertEqualObjects(source.amount, params.amount);
+        XCTAssertEqual(source.redirect.status, STPSourceRedirectStatusPending);
+        XCTAssertEqualObjects(source.redirect.returnURL, [NSURL URLWithString:@"https://shop.example.com/crtABC"]);
+        XCTAssertNotNil(source.redirect.url);
+        XCTAssertEqualObjects(source.metadata, params.metadata);
+
+        [expectation fulfill];
+    }];
+    [self waitForExpectationsWithTimeout:5.0f handler:nil];
+}
+
 @end

--- a/Tests/Tests/STPSourceParamsTest.m
+++ b/Tests/Tests/STPSourceParamsTest.m
@@ -68,6 +68,12 @@
     sourceParams.rawTypeString = @"p24";
     XCTAssertEqual(sourceParams.type, STPSourceTypeP24);
 
+    sourceParams.rawTypeString = @"eps";
+    XCTAssertEqual(sourceParams.type, STPSourceTypeEPS);
+
+    sourceParams.rawTypeString = @"multibanco";
+    XCTAssertEqual(sourceParams.type, STPSourceTypeMultibanco);
+
     sourceParams.rawTypeString = @"unknown";
     XCTAssertEqual(sourceParams.type, STPSourceTypeUnknown);
 
@@ -105,6 +111,12 @@
 
     sourceParams.type = STPSourceTypeP24;
     XCTAssertEqualObjects(sourceParams.rawTypeString, @"p24");
+
+    sourceParams.type = STPSourceTypeEPS;
+    XCTAssertEqualObjects(sourceParams.rawTypeString, @"eps");
+
+    sourceParams.type = STPSourceTypeMultibanco;
+    XCTAssertEqualObjects(sourceParams.rawTypeString, @"multibanco");
 
     sourceParams.type = STPSourceTypeUnknown;
     XCTAssertNil(sourceParams.rawTypeString);

--- a/Tests/Tests/STPSourceTest.m
+++ b/Tests/Tests/STPSourceTest.m
@@ -63,6 +63,12 @@
     XCTAssertEqual([STPSource typeFromString:@"p24"], STPSourceTypeP24);
     XCTAssertEqual([STPSource typeFromString:@"P24"], STPSourceTypeP24);
 
+    XCTAssertEqual([STPSource typeFromString:@"eps"], STPSourceTypeEPS);
+    XCTAssertEqual([STPSource typeFromString:@"EPS"], STPSourceTypeEPS);
+
+    XCTAssertEqual([STPSource typeFromString:@"multibanco"], STPSourceTypeMultibanco);
+    XCTAssertEqual([STPSource typeFromString:@"MULTIBANCO"], STPSourceTypeMultibanco);
+
     XCTAssertEqual([STPSource typeFromString:@"unknown"], STPSourceTypeUnknown);
     XCTAssertEqual([STPSource typeFromString:@"UNKNOWN"], STPSourceTypeUnknown);
 
@@ -81,6 +87,8 @@
                                     @(STPSourceTypeThreeDSecure),
                                     @(STPSourceTypeAlipay),
                                     @(STPSourceTypeP24),
+                                    @(STPSourceTypeEPS),
+                                    @(STPSourceTypeMultibanco),
                                     @(STPSourceTypeUnknown),
                                     ];
 
@@ -115,6 +123,12 @@
                 break;
             case STPSourceTypeP24:
                 XCTAssertEqualObjects(string, @"p24");
+                break;
+            case STPSourceTypeEPS:
+                XCTAssertEqualObjects(string, @"eps");
+                break;
+            case STPSourceTypeMultibanco:
+                XCTAssertEqualObjects(string, @"multibanco");
                 break;
             case STPSourceTypeUnknown:
                 XCTAssertNil(string);


### PR DESCRIPTION
https://stripe.com/docs/sources/eps

https://stripe.com/docs/sources/multibanco

I generally searched for "P24" and verified we updated anywhere that's referenced to include EPS and Multibanco