### PR TITLE
Add `dispatch_async` to `[STPRedirectContext handleWillForegroundNotification]`

### DIFF
--- a/Tests/Tests/STPRedirectContextTest.m
+++ b/Tests/Tests/STPRedirectContextTest.m
@@ -401,21 +401,25 @@
  block and dismiss method should be called.
  */
 - (void)testSafariAppRedirectFlow_foregroundNotification {
+    id sut;
+
     STPSource *source = [STPFixtures iDEALSource];
     XCTestExpectation *exp = [self expectationWithDescription:@"completion"];
     STPRedirectContext *context = [[STPRedirectContext alloc] initWithSource:source completion:^(NSString *sourceID, NSString *clientSecret, NSError *error) {
         XCTAssertEqualObjects(sourceID, source.stripeID);
         XCTAssertEqualObjects(clientSecret, source.clientSecret);
         XCTAssertNil(error);
+
+        OCMVerify([sut unsubscribeFromNotifications]);
+        OCMVerify([sut dismissPresentedViewController]);
+
         [exp fulfill];
     }];
-    id sut = OCMPartialMock(context);
+    sut = OCMPartialMock(context);
 
     [sut startSafariAppRedirectFlow];
     [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationWillEnterForegroundNotification object:nil];
 
-    OCMVerify([sut unsubscribeFromNotifications]);
-    OCMVerify([sut dismissPresentedViewController]);
     [self waitForExpectationsWithTimeout:2 handler:nil];
 }
 


### PR DESCRIPTION
Add `dispatch_async` to `[STPRedirectContext handleWillForegroundNotification]` to allow `[STPRedirectContext handleURLCallback]` to be prioritized

We considered some other approaches and landed on this one:

Option 1:

Delete `STPURLCallback` completely

The downside to this approach is the host app will still get `[AppDelegate application:openURL:options:]` calls. If `STPURLCallback` was gone, the host app won't know whether or not that `[AppDelegate application:openURL:options:]` call should be ignored by their own app's routing logic.

Option 2:
Don't unschedule `STPURLCallback` and let the `STPRedirectContext` stay in the `STPRedirectContextStateCompleted` state

The downside to this approach is the `STPRedirectContext` ends up holding a non-negligible amount of memory in order to just store the `STPRedirectContextStateCompleted` state.

Option 3:

Similarly to the last one, we can avoid unscheduling the `STPURLCallback` for a second or so.

This is very similar to the approach we landed on but would require more significant code changes. Also the reasoning behind how much delay to have is unclear.
