### PR TITLE
Add `STPBillingAddressFieldsName` option for `STPBillingAddressFields`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 * Fixes payment method label overlapping the checkmark, for Amex on small devices [#952](https://github.com/stripe/stripe-ios/pull/952)
 * Adds EPS and Multibanco support to `STPSourceParams` [#961](https://github.com/stripe/stripe-ios/pull/961)
+* Adds `STPBillingAddressFieldsName` option to `STPBillingAddressFields` [#964](https://github.com/stripe/stripe-ios/pull/964)
 
 ## 13.0.2 2018-05-24
 * Makes iDEAL `name` parameter optional, also accepts empty string as `nil` [#940](https://github.com/stripe/stripe-ios/pull/940)

--- a/Example/Standard Integration (Swift)/SettingsViewController.swift
+++ b/Example/Standard Integration (Swift)/SettingsViewController.swift
@@ -111,12 +111,14 @@ class SettingsViewController: UITableViewController {
     fileprivate enum RequiredBillingAddressFields: String {
         case None = "None"
         case Zip = "Zip"
+        case Name = "Name"
         case Full = "Full"
 
         init(row: Int) {
             switch row {
             case 0: self = .None
             case 1: self = .Zip
+            case 2: self = .Name
             default: self = .Full
             }
         }
@@ -125,6 +127,7 @@ class SettingsViewController: UITableViewController {
             switch self {
             case .None: return .none
             case .Zip: return .zip
+            case .Name: return .name
             case .Full: return .full
             }
         }
@@ -196,7 +199,7 @@ class SettingsViewController: UITableViewController {
         switch Section(section: section) {
         case .Theme: return 3
         case .ApplePay: return 2
-        case .RequiredBillingAddressFields: return 3
+        case .RequiredBillingAddressFields: return 4
         case .RequiredShippingAddressFields: return 4
         case .ShippingType: return 2
         case .Session: return 1

--- a/Stripe/PublicHeaders/STPAddress.h
+++ b/Stripe/PublicHeaders/STPAddress.h
@@ -35,6 +35,11 @@ typedef NS_ENUM(NSUInteger, STPBillingAddressFields) {
      Request the user's full billing address
      */
     STPBillingAddressFieldsFull,
+
+    /**
+     Just request the user's billing name
+     */
+    STPBillingAddressFieldsName,
 };
 
 

--- a/Stripe/STPAddress.m
+++ b/Stripe/STPAddress.m
@@ -169,6 +169,8 @@ STPContactField const STPContactFieldName = @"STPContactFieldName";
                                                              countryCode:self.country] == STPCardValidationStateValid);
         case STPBillingAddressFieldsFull:
             return [self hasValidPostalAddress];
+        case STPBillingAddressFieldsName:
+            return self.name.length > 0;
     }
     return containsFields;
 }
@@ -181,6 +183,8 @@ STPContactField const STPContactFieldName = @"STPContactFieldName";
             return self.postalCode.length > 0;
         case STPBillingAddressFieldsFull:
             return [self hasPartialPostalAddress];
+        case STPBillingAddressFieldsName:
+            return self.name.length > 0;
     }
 
     return NO;
@@ -242,6 +246,8 @@ STPContactField const STPContactFieldName = @"STPContactFieldName";
         case STPBillingAddressFieldsZip:
         case STPBillingAddressFieldsFull:
             return PKAddressFieldPostalAddress;
+        case STPBillingAddressFieldsName:
+            return PKAddressFieldName;
     }
 }
 

--- a/Stripe/STPAddressViewModel.m
+++ b/Stripe/STPAddressViewModel.m
@@ -52,6 +52,11 @@
                                   [[STPAddressFieldTableViewCell alloc] initWithType:STPAddressFieldTypeCountry contents:_addressFieldTableViewCountryCode lastInList:YES delegate:self],
                                   ];
                 break;
+            case STPBillingAddressFieldsName:
+                _addressCells = @[
+                                  [[STPAddressFieldTableViewCell alloc] initWithType:STPAddressFieldTypeName contents:@"" lastInList:YES delegate:self]
+                                  ];
+                break;
         }
         [self commonInit];
     }

--- a/Stripe/STPAnalyticsClient.m
+++ b/Stripe/STPAnalyticsClient.m
@@ -251,6 +251,8 @@
             dictionary[@"required_billing_address_fields"] = @"zip";
         case STPBillingAddressFieldsFull:
             dictionary[@"required_billing_address_fields"] = @"full";
+        case STPBillingAddressFieldsName:
+            dictionary[@"required_billing_address_fields"] = @"name";
     }
     NSMutableArray<NSString *> *shippingFields = [NSMutableArray new];
     if ([configuration.requiredShippingAddressFields containsObject:STPContactFieldName]) {

--- a/Stripe/STPPaymentConfiguration.m
+++ b/Stripe/STPPaymentConfiguration.m
@@ -90,6 +90,9 @@
         case STPBillingAddressFieldsFull:
             requiredBillingAddressFieldsDescription = @"STPBillingAddressFieldsFull";
             break;
+        case STPBillingAddressFieldsName:
+            requiredBillingAddressFieldsDescription = @"STPBillingAddressFieldsName";
+            break;
     }
 
     NSString *requiredShippingAddressFieldsDescription = [self.requiredShippingAddressFields.allObjects componentsJoinedByString:@"|"];

--- a/Tests/Tests/STPAddressTests.m
+++ b/Tests/Tests/STPAddressTests.m
@@ -19,7 +19,6 @@
 @implementation STPAddressTests
 
 - (void)testInitWithPKContact_complete {
-
     PKContact *contact = [PKContact new];
     {
         NSPersonNameComponents *name = [NSPersonNameComponents new];
@@ -196,7 +195,6 @@
     XCTAssertTrue([address containsRequiredFields:STPBillingAddressFieldsNone]);
 }
 
-
 - (void)testContainsRequiredFieldsZip {
     STPAddress *address = [STPAddress new];
 
@@ -215,6 +213,7 @@
     address.country = nil; // nil treated as alphanumeric
     XCTAssertTrue([address containsRequiredFields:STPBillingAddressFieldsZip]);
 }
+
 - (void)testContainsRequiredFieldsFull {
     STPAddress *address = [STPAddress new];
     
@@ -268,6 +267,14 @@
     XCTAssertTrue([address containsRequiredFields:STPBillingAddressFieldsFull]);
 }
 
+- (void)testContainsRequiredFieldsName {
+    STPAddress *address = [STPAddress new];
+
+    XCTAssertFalse([address containsRequiredFields:STPBillingAddressFieldsName]);
+    address.name = @"Jane Doe";
+    XCTAssertTrue([address containsRequiredFields:STPBillingAddressFieldsName]);
+}
+
 - (void)testContainsContentForBillingAddressFields {
     STPAddress *address = [STPAddress new];
 
@@ -275,6 +282,7 @@
     XCTAssertFalse([address containsContentForBillingAddressFields:STPBillingAddressFieldsNone]);
     XCTAssertFalse([address containsContentForBillingAddressFields:STPBillingAddressFieldsZip]);
     XCTAssertFalse([address containsContentForBillingAddressFields:STPBillingAddressFieldsFull]);
+    XCTAssertFalse([address containsContentForBillingAddressFields:STPBillingAddressFieldsName]);
 
     // 1+ characters in postalCode will return true for .Zip && .Full
     address.postalCode = @"0";
@@ -288,6 +296,14 @@
     XCTAssertFalse([address containsContentForBillingAddressFields:STPBillingAddressFieldsFull]);
     address.postalCode = nil;
 
+    // 1+ characters in name will return true for .Name
+    address.name = @"Jane Doe";
+    XCTAssertTrue([address containsContentForBillingAddressFields:STPBillingAddressFieldsName]);
+    // empty string returns false
+    address.name = @"";
+    XCTAssertFalse([address containsContentForBillingAddressFields:STPBillingAddressFieldsName]);
+    address.name = nil;
+
     // Test every other property that contributes to the full address, ensuring it returns True for .Full only
     // This is *not* refactoring-safe, but I think it's better than a bunch of duplicated code
     for (NSString *propertyName in @[@"line1", @"line2", @"city", @"state", @"country"]) {
@@ -296,6 +312,7 @@
             XCTAssertFalse([address containsContentForBillingAddressFields:STPBillingAddressFieldsNone]);
             XCTAssertFalse([address containsContentForBillingAddressFields:STPBillingAddressFieldsZip]);
             XCTAssertTrue([address containsContentForBillingAddressFields:STPBillingAddressFieldsFull]);
+            XCTAssertFalse([address containsContentForBillingAddressFields:STPBillingAddressFieldsName]);
             [address setValue:nil forKey:propertyName];
         }
 
@@ -304,6 +321,7 @@
         XCTAssertFalse([address containsContentForBillingAddressFields:STPBillingAddressFieldsNone]);
         XCTAssertFalse([address containsContentForBillingAddressFields:STPBillingAddressFieldsZip]);
         XCTAssertFalse([address containsContentForBillingAddressFields:STPBillingAddressFieldsFull]);
+        XCTAssertFalse([address containsContentForBillingAddressFields:STPBillingAddressFieldsName]);
         [address setValue:nil forKey:propertyName];
     }
 
@@ -311,6 +329,7 @@
     XCTAssertFalse([address containsContentForBillingAddressFields:STPBillingAddressFieldsNone]);
     XCTAssertFalse([address containsContentForBillingAddressFields:STPBillingAddressFieldsZip]);
     XCTAssertFalse([address containsContentForBillingAddressFields:STPBillingAddressFieldsFull]);
+    XCTAssertFalse([address containsContentForBillingAddressFields:STPBillingAddressFieldsName]);
 }
 
 - (void)testContainsRequiredShippingAddressFields {

--- a/Tests/Tests/STPAddressViewModelTest.m
+++ b/Tests/Tests/STPAddressViewModelTest.m
@@ -39,6 +39,10 @@
     for (NSUInteger i=0; i<[sut.addressCells count]; i++) {
         XCTAssertEqual(sut.addressCells[i].type, [types[i] integerValue]);
     }
+
+    sut = [[STPAddressViewModel alloc] initWithRequiredBillingFields:STPBillingAddressFieldsName];
+    XCTAssertTrue([sut.addressCells count] == 1);
+    XCTAssertEqual(sut.addressCells[0].type, STPAddressFieldTypeName);
 }
 
 - (void)testInitWithRequiredShippingFields {
@@ -160,6 +164,22 @@
     sut.addressCells[4].contents = @"New York";
     sut.addressCells[5].contents = @"NY";
     sut.addressCells[6].contents = @"US";
+    XCTAssertTrue(sut.isValid);
+}
+
+- (void)testIsValid_Name {
+    STPAddressViewModel *sut = [[STPAddressViewModel alloc] initWithRequiredBillingFields:STPBillingAddressFieldsName];
+
+    STPAddress *address = [STPAddress new];
+
+    address.name = @"";
+    sut.address = address;
+    XCTAssertEqual(sut.addressCells.count, 1ul);
+    XCTAssertFalse(sut.isValid);
+
+    address.name = @"Jane Doe";
+    sut.address = address;
+    XCTAssertEqual(sut.addressCells.count, 1ul);
     XCTAssertTrue(sut.isValid);
 }
 


### PR DESCRIPTION
## Summary

Add `STPBillingAddressFieldsName` option for `STPBillingAddressFields` so users can require just the name part of the billing address. The full set of options are:

```
typedef NS_ENUM(NSUInteger, STPBillingAddressFields) {
    /**
     No billing address information
     */
    STPBillingAddressFieldsNone,
    /**
     Just request the user's billing ZIP code
     */
    STPBillingAddressFieldsZip,
    /**
     Request the user's full billing address
     */
    STPBillingAddressFieldsFull,

    /**
     Just request the user's billing name
     */
    STPBillingAddressFieldsName,
};
```

## Motivation

MOBILE-25

## Testing

![simulator screen shot - iphone 6s - 2018-06-11 at 14 02 42](https://user-images.githubusercontent.com/28276156/41257054-56e82a28-6d80-11e8-90b8-21cdca12868c.png)

