### PR TITLE
Reduce NSURLSession memory footprint

### DIFF
--- a/Stripe/STPAPIClient+Private.h
+++ b/Stripe/STPAPIClient+Private.h
@@ -24,7 +24,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 
 @property (nonatomic, strong, readwrite) NSURL *apiURL;
-@property (nonatomic, strong, readwrite) NSURLSession *urlSession;
+@property (nonatomic, strong, readonly) NSURLSession *urlSession;
+
+- (NSMutableURLRequest *)configuredRequestForURL:(NSURL *)url;
 
 @end
 

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -146,21 +146,6 @@ static NSString * const FileUploadURL = @"https://uploads.stripe.com/v1/files";
     return [additionalHeaders copy];
 }
 
-- (void)setUrlSession:(NSURLSession *)urlSession
-{
-    if (urlSession != _urlSession) {
-        [_urlSession invalidateAndCancel];
-        _urlSession = urlSession;
-    }
-}
-
-- (void)setApiKey:(NSString *)apiKey {
-    _apiKey = apiKey;
-
-    // Regenerate url session configuration
-//    self.urlSession = [NSURLSession sessionWithConfiguration:[self sessionConfiguration]];
-}
-
 - (void)setPublishableKey:(NSString *)publishableKey {
     self.configuration.publishableKey = [publishableKey copy];
     self.apiKey = [publishableKey copy];
@@ -168,13 +153,6 @@ static NSString * const FileUploadURL = @"https://uploads.stripe.com/v1/files";
 
 - (NSString *)publishableKey {
     return self.configuration.publishableKey;
-}
-
-- (void)setStripeAccount:(NSString *)stripeAccount {
-    _stripeAccount = stripeAccount;
-
-    // Regenerate url session configuration
-//    self.urlSession = [NSURLSession sessionWithConfiguration:[self sessionConfiguration]];
 }
 
 - (void)createTokenWithParameters:(NSDictionary *)parameters

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -124,7 +124,7 @@ static NSString * const FileUploadURL = @"https://uploads.stripe.com/v1/files";
         _stripeAccount = configuration.stripeAccount;
         _sourcePollers = [NSMutableDictionary dictionary];
         _sourcePollersQueue = dispatch_queue_create("com.stripe.sourcepollers", DISPATCH_QUEUE_SERIAL);
-        _urlSession = [NSURLSession sharedSession];
+        _urlSession = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
     }
     return self;
 }

--- a/Stripe/STPAPIRequest.m
+++ b/Stripe/STPAPIRequest.m
@@ -42,7 +42,7 @@ static NSString * const JSONKeyObject = @"object";
     NSURL *url = [apiClient.apiURL URLByAppendingPathComponent:endpoint];
 
     // Setup request
-    NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url];
+    NSMutableURLRequest *request = [apiClient configuredRequestForURL:url];
     request.HTTPMethod = HTTPMethodPOST;
     [request stp_setFormPayload:parameters];
 
@@ -66,7 +66,7 @@ static NSString * const JSONKeyObject = @"object";
     NSURL *url = [apiClient.apiURL URLByAppendingPathComponent:endpoint];
 
     // Setup request
-    NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url];
+    NSMutableURLRequest *request = [apiClient configuredRequestForURL:url];
     [request stp_addParametersToURL:parameters];
     request.HTTPMethod = HTTPMethodGET;
 
@@ -98,7 +98,7 @@ static NSString * const JSONKeyObject = @"object";
     NSURL *url = [apiClient.apiURL URLByAppendingPathComponent:endpoint];
 
     // Setup request
-    NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url];
+    NSMutableURLRequest *request = [apiClient configuredRequestForURL:url];
     [request stp_addParametersToURL:parameters];
     request.HTTPMethod = HTTPMethodDELETE;
 

--- a/Tests/Tests/STPAPIClientTest.m
+++ b/Tests/Tests/STPAPIClientTest.m
@@ -34,25 +34,25 @@
 
 - (void)testInitWithPublishableKey {
     STPAPIClient *sut = [[STPAPIClient alloc] initWithPublishableKey:@"pk_foo"];
-    NSString *authHeader = sut.urlSession.configuration.HTTPAdditionalHeaders[@"Authorization"];
+    NSString *authHeader = [sut configuredRequestForURL:[NSURL URLWithString:@"https://www.stripe.com"]].allHTTPHeaderFields[@"Authorization"];
     XCTAssertEqualObjects(authHeader, @"Bearer pk_foo");
 }
 
 - (void)testSetPublishableKey {
     STPAPIClient *sut = [[STPAPIClient alloc] initWithPublishableKey:@"pk_foo"];
-    NSString *authHeader = sut.urlSession.configuration.HTTPAdditionalHeaders[@"Authorization"];
+    NSString *authHeader = [sut configuredRequestForURL:[NSURL URLWithString:@"https://www.stripe.com"]].allHTTPHeaderFields[@"Authorization"];
     XCTAssertEqualObjects(authHeader, @"Bearer pk_foo");
     sut.publishableKey = @"pk_bar";
-    authHeader = sut.urlSession.configuration.HTTPAdditionalHeaders[@"Authorization"];
+    authHeader = [sut configuredRequestForURL:[NSURL URLWithString:@"https://www.stripe.com"]].allHTTPHeaderFields[@"Authorization"];
     XCTAssertEqualObjects(authHeader, @"Bearer pk_bar");
 }
 
 - (void)testSetStripeAccount {
     STPAPIClient *sut = [[STPAPIClient alloc] initWithPublishableKey:@"pk_foo"];
-    NSString *accountHeader = sut.urlSession.configuration.HTTPAdditionalHeaders[@"Stripe-Account"];
+    NSString *accountHeader = [sut configuredRequestForURL:[NSURL URLWithString:@"https://www.stripe.com"]].allHTTPHeaderFields[@"Stripe-Account"];
     XCTAssertNil(accountHeader);
     sut.stripeAccount = @"acct_123";
-    accountHeader = sut.urlSession.configuration.HTTPAdditionalHeaders[@"Stripe-Account"];
+    accountHeader = [sut configuredRequestForURL:[NSURL URLWithString:@"https://www.stripe.com"]].allHTTPHeaderFields[@"Stripe-Account"];
     XCTAssertEqualObjects(accountHeader, @"acct_123");
 }
 
@@ -63,7 +63,7 @@
     STPAPIClient *sut = [[STPAPIClient alloc] initWithConfiguration:config];
     XCTAssertEqualObjects(sut.publishableKey, config.publishableKey);
     XCTAssertEqualObjects(sut.stripeAccount, config.stripeAccount);
-    NSString *accountHeader = sut.urlSession.configuration.HTTPAdditionalHeaders[@"Stripe-Account"];
+    NSString *accountHeader = [sut configuredRequestForURL:[NSURL URLWithString:@"https://www.stripe.com"]].allHTTPHeaderFields[@"Stripe-Account"];
     XCTAssertEqualObjects(accountHeader, @"acct_123");
 }
 

--- a/Tests/Tests/STPAPIRequestTest.m
+++ b/Tests/Tests/STPAPIRequestTest.m
@@ -49,6 +49,14 @@
     STPAPIClient *apiClientMock = OCMClassMock([STPAPIClient class]);
     OCMStub([apiClientMock apiURL]).andReturn([NSURL URLWithString:@"https://api.stripe.com"]);
     OCMStub([apiClientMock urlSession]).andReturn(urlSessionMock);
+    OCMStub([apiClientMock configuredRequestForURL:[OCMArg isKindOfClass:[NSURL class]]]).andDo(^(NSInvocation *invocation)
+                                                                                                {
+                                                                                                    NSURL *urlArg;
+                                                                                                    [invocation getArgument:&urlArg atIndex:2];
+                                                                                                    NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:urlArg];
+                                                                                                    [invocation setReturnValue:&request];
+                                                                                                    [invocation retainArguments];
+                                                                                                });
 
     id apiRequestMock = OCMClassMock([STPAPIRequest class]);
     OCMStub([apiRequestMock parseResponse:[OCMArg any]
@@ -117,6 +125,14 @@
     STPAPIClient *apiClientMock = OCMClassMock([STPAPIClient class]);
     OCMStub([apiClientMock apiURL]).andReturn([NSURL URLWithString:@"https://api.stripe.com"]);
     OCMStub([apiClientMock urlSession]).andReturn(urlSessionMock);
+    OCMStub([apiClientMock configuredRequestForURL:[OCMArg isKindOfClass:[NSURL class]]]).andDo(^(NSInvocation *invocation)
+                                                                                                {
+                                                                                                    NSURL *urlArg;
+                                                                                                    [invocation getArgument:&urlArg atIndex:2];
+                                                                                                    NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:urlArg];
+                                                                                                    [invocation setReturnValue:&request];
+                                                                                                    [invocation retainArguments];
+                                                                                                });
 
     id apiRequestMock = OCMClassMock([STPAPIRequest class]);
     OCMStub([apiRequestMock parseResponse:[OCMArg any]
@@ -185,6 +201,14 @@
     STPAPIClient *apiClientMock = OCMClassMock([STPAPIClient class]);
     OCMStub([apiClientMock apiURL]).andReturn([NSURL URLWithString:@"https://api.stripe.com"]);
     OCMStub([apiClientMock urlSession]).andReturn(urlSessionMock);
+    OCMStub([apiClientMock configuredRequestForURL:[OCMArg isKindOfClass:[NSURL class]]]).andDo(^(NSInvocation *invocation)
+                                                                        {
+                                                                            NSURL *urlArg;
+                                                                            [invocation getArgument:&urlArg atIndex:2];
+                                                                            NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:urlArg];
+                                                                            [invocation setReturnValue:&request];
+                                                                            [invocation retainArguments];
+                                                                        });
 
     id apiRequestMock = OCMClassMock([STPAPIRequest class]);
     OCMStub([apiRequestMock parseResponse:[OCMArg any]


### PR DESCRIPTION
## Summary
Don't create a new NSURLSession instance for each ephemeral key request

## Motivation
https://jira.corp.stripe.com/browse/IOS-773

Creating NSURLSessions induces a memory overhead because iOS allocates and saves cache space (ref. https://developer.apple.com/library/archive/qa/qa1727/_index.html). We were also not properly invalidating old sessions as we replaced them, aggravating the problem.

The other option which appears to remove all memory leaks is to use the shared instance of NSURLSession, but we want to keep a private instance. Using an ephemeral configuration (see link below) can also remove any of the reported links, but does not suit our use case.

More references:

https://stackoverflow.com/questions/42780244/swift-3-urlsession-memory-leak
https://stackoverflow.com/questions/28223345/memory-leak-when-using-nsurlsession-downloadtaskwithurl/35757989#35757989
http://footle.org/2015/10/10/fixing-a-swift-memory-leak/


## Testing
I used the standard integration demo and was able to easily reproduce the reported leaks just by viewing an item. With the changes all leaks attributed to the Stripe library were gone.

