### PR TITLE
Add StripeTests to the schemes for the example apps.

### DIFF
--- a/Example/Custom Integration (ObjC).xcodeproj/xcshareddata/xcschemes/Custom Integration (ObjC).xcscheme
+++ b/Example/Custom Integration (ObjC).xcodeproj/xcshareddata/xcschemes/Custom Integration (ObjC).xcscheme
@@ -28,6 +28,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "045E7C021A5F41DE004751EF"
+               BuildableName = "StripeiOS Tests.xctest"
+               BlueprintName = "StripeiOS Tests"
+               ReferencedContainer = "container:../Stripe.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/Example/Standard Integration (Swift).xcodeproj/xcshareddata/xcschemes/Standard Integration (Swift).xcscheme
+++ b/Example/Standard Integration (Swift).xcodeproj/xcshareddata/xcschemes/Standard Integration (Swift).xcscheme
@@ -28,6 +28,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "045E7C021A5F41DE004751EF"
+               BuildableName = "StripeiOS Tests.xctest"
+               BlueprintName = "StripeiOS Tests"
+               ReferencedContainer = "container:../Stripe.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference


### PR DESCRIPTION
## Summary
Add StripeTests to the schemes for the example apps.

## Motivation
This makes SDK development easier. Now I don't need to switch schemes to switch between
running the tests and running the sample apps.

## Testing
Tested using Xcode UI, that both Run + Test actions work for these two schemes.

Checked out a clean workspace, and verified that the Custom sample app runs out of the box. The Standard integration still requires running `./setup`. To successfully build & run the tests, the user (still) needs to run `carthage bootstrap --platform ios --configuration Release --no-use-binaries` first (as documented in our README)

<img width="896" alt="screen shot 2018-06-29 at 11 40 25 am" src="https://user-images.githubusercontent.com/30532866/42109074-4a04907a-7b91-11e8-9592-ffc4f30f6a11.png">
<img width="896" alt="screen shot 2018-06-29 at 11 40 36 am" src="https://user-images.githubusercontent.com/30532866/42109082-4d133546-7b91-11e8-9dda-a8a3da66349c.png">
