### PR TITLE
Fix compile error in test target when running on 32 bit device

### DIFF
--- a/Tests/Tests/STPColorUtilsTest.m
+++ b/Tests/Tests/STPColorUtilsTest.m
@@ -31,7 +31,7 @@
         CGColorRelease(cgcolor);
     }
 
-    for (CGFloat white = 0.3001; white < 2; white += 0.1) {
+    for (CGFloat white = (CGFloat)0.3001; white < 2; white += 0.1) {
         components[0] = white;
         CGColorRef cgcolor = CGColorCreate(space, components);
         UIColor *color = [UIColor colorWithCGColor:cgcolor];


### PR DESCRIPTION
## Summary
Added a cast to `CGFloat`

## Motivation
Warning about implicit conversion that our compiler settings elevate to an error.

## Testing
Compiled/ran test suite on both iPhone 5 & iPhone 6