### PR TITLE
Generalize STPRedirectContext's implementation to not rely on the STPSource

### DIFF
--- a/Stripe/STPRedirectContext.m
+++ b/Stripe/STPRedirectContext.m
@@ -51,7 +51,7 @@ typedef void (^STPBoolCompletionBlock)(BOOL success);
         return nil;
     }
 
-    self = [self initWithNativeRedirectUrl:[STPRedirectContext nativeRedirectURLForSource:source]
+    self = [self initWithNativeRedirectUrl:[[self class] nativeRedirectURLForSource:source]
                                redirectUrl:source.redirect.url
                                  returnUrl:source.redirect.returnURL
                                 completion:^(NSError * _Nullable error) {


### PR DESCRIPTION
## Summary
Making `STPRedirectContext` less coupled to `STPSource`. Instead of storing & using the
Source and Source-specific completion block, the redirect context now stores just the 
URLs needed and a general closure to call when redirecting is finished.

This does *not* update any of the class documentation, nor does it change the external
API at all.

## Motivation
Clears the path for `STPRedirectContext` to be used with PaymentIntents, which similarly
want to redirect to a URL and wait for the user to return to the app.

## Testing
There's a pretty complete set of tests in `STPRedirectContextTest`, and they still pass.
Also, ran through the redirect flow in the Custom Integration sample app.