### PR TITLE
Add support for STPPaymentIntent to STPRedirectContext

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,5 +1,9 @@
 ## Migration Guides
 
+### Migrating from versions < XX.X.X
+ * The SDK now supports PaymentIntents with `STPPaymentIntent`, which use `STPRedirectContext` in the same way that `STPSource` does
+   * `STPRedirectContextCompletionBlock` has been renamed to `STPRedirectContextSourceCompletionBlock`. It has the same signature, and Xcode should offer a deprecation warning & fix-it to help you migrate.
+
 ### Migrating from versions < 13.0.0
 * Remove Bitcoin source support because Stripe no longer processes Bitcoin payments: https://stripe.com/blog/ending-bitcoin-support
   * Sources can no longer have a "STPSourceTypeBitcoin" source type. These sources will now be interpreted as "STPSourceTypeUnknown".

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,6 +1,6 @@
 ## Migration Guides
 
-### Migrating from versions < XX.X.X
+### Migrating from versions < 13.1.0
  * The SDK now supports PaymentIntents with `STPPaymentIntent`, which use `STPRedirectContext` in the same way that `STPSource` does
    * `STPRedirectContextCompletionBlock` has been renamed to `STPRedirectContextSourceCompletionBlock`. It has the same signature, and Xcode should offer a deprecation warning & fix-it to help you migrate.
 

--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -373,6 +373,8 @@
 		8BD87B951EFB1CB100269C2B /* STPSourceVerificationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BD87B941EFB1CB100269C2B /* STPSourceVerificationTest.m */; };
 		8BE5AE8B1EF8905B0081A33C /* STPCardParamsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BE5AE8A1EF8905B0081A33C /* STPCardParamsTest.m */; };
 		B318518320BE011700EE8C0F /* STPColorUtilsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = B318518220BE011700EE8C0F /* STPColorUtilsTest.m */; };
+		B32B176520F80442000D6EF8 /* STPRedirectContext+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = B32B176420F80442000D6EF8 /* STPRedirectContext+Private.h */; };
+		B32B176620F80442000D6EF8 /* STPRedirectContext+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = B32B176420F80442000D6EF8 /* STPRedirectContext+Private.h */; };
 		B3302F462006FBA7005DDBE9 /* STPConnectAccountParamsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = B3302F452006FBA7005DDBE9 /* STPConnectAccountParamsTest.m */; };
 		B3302F4C200700AB005DDBE9 /* STPLegalEntityParamsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = B3302F4B200700AB005DDBE9 /* STPLegalEntityParamsTest.m */; };
 		B347DD481FE35423006B3BAC /* STPValidatedTextField.h in Headers */ = {isa = PBXBuildFile; fileRef = B347DD461FE35423006B3BAC /* STPValidatedTextField.h */; };
@@ -1058,6 +1060,7 @@
 		8BD87B941EFB1CB100269C2B /* STPSourceVerificationTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPSourceVerificationTest.m; sourceTree = "<group>"; };
 		8BE5AE8A1EF8905B0081A33C /* STPCardParamsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPCardParamsTest.m; sourceTree = "<group>"; };
 		B318518220BE011700EE8C0F /* STPColorUtilsTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPColorUtilsTest.m; sourceTree = "<group>"; };
+		B32B176420F80442000D6EF8 /* STPRedirectContext+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPRedirectContext+Private.h"; sourceTree = "<group>"; };
 		B3302F452006FBA7005DDBE9 /* STPConnectAccountParamsTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPConnectAccountParamsTest.m; sourceTree = "<group>"; };
 		B3302F4B200700AB005DDBE9 /* STPLegalEntityParamsTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPLegalEntityParamsTest.m; sourceTree = "<group>"; };
 		B347DD461FE35423006B3BAC /* STPValidatedTextField.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPValidatedTextField.h; sourceTree = "<group>"; };
@@ -1806,9 +1809,9 @@
 				04CDB4C31A5F30A700B854EE /* STPAPIClient.m */,
 				04633B061CD44F47009D4FB5 /* STPAPIClient+ApplePay.h */,
 				04633B041CD44F1C009D4FB5 /* STPAPIClient+ApplePay.m */,
+				C184107A1EC2539F00178149 /* STPEphemeralKeyProvider.h */,
 				F152321F1EA92FCF00D65C67 /* STPRedirectContext.h */,
 				F152321C1EA92FC100D65C67 /* STPRedirectContext.m */,
-				C184107A1EC2539F00178149 /* STPEphemeralKeyProvider.h */,
 			);
 			name = "API Bindings";
 			sourceTree = "<group>";
@@ -1896,6 +1899,8 @@
 				F1D3A2481EB012010095BFA9 /* STPMultipartFormDataEncoder.m */,
 				F1D3A2491EB012010095BFA9 /* STPMultipartFormDataPart.h */,
 				F1D3A24A1EB012010095BFA9 /* STPMultipartFormDataPart.m */,
+				B3BDCAC120EEF2150034F7F5 /* STPPaymentIntent+Private.h */,
+				B32B176420F80442000D6EF8 /* STPRedirectContext+Private.h */,
 				C1C1012C1E57A26F00C7BFAE /* STPSource+Private.h */,
 				8BD87B871EFB131400269C2B /* STPSourceCardDetails+Private.h */,
 				F1A0197A1EA5733200354301 /* STPSourceParams+Private.h */,
@@ -1979,7 +1984,6 @@
 				B3A99BC21FEAF2CA003F6ED3 /* STPLegalEntityParams.m */,
 				B3BDCAC620EEF22D0034F7F5 /* STPPaymentIntent.h */,
 				B3BDCAC020EEF2150034F7F5 /* STPPaymentIntent.m */,
-				B3BDCAC120EEF2150034F7F5 /* STPPaymentIntent+Private.h */,
 				B3BDCAC720EEF22D0034F7F5 /* STPPaymentIntentEnums.h */,
 				C1D7B51E1E36C32F002181F5 /* STPSource.h */,
 				C1D7B51F1E36C32F002181F5 /* STPSource.m */,
@@ -2117,6 +2121,7 @@
 				C159933D1D8808970047950D /* STPShippingMethodsViewController.h in Headers */,
 				F15232251EA9303800D65C67 /* STPURLCallbackHandler.h in Headers */,
 				B3A2413A1FFEB57400A2F00D /* STPConnectAccountParams.h in Headers */,
+				B32B176620F80442000D6EF8 /* STPRedirectContext+Private.h in Headers */,
 				F1D3A2561EB012350095BFA9 /* STPMultipartFormDataPart.h in Headers */,
 				04F94DCD1D22A22F004FC826 /* UIViewController+Stripe_KeyboardAvoiding.h in Headers */,
 				C1BD9B3A1E39416700CEE925 /* STPSourceOwner.h in Headers */,
@@ -2259,6 +2264,7 @@
 				C11810A71CC6EE840022FB55 /* STPBackendAPIAdapter.h in Headers */,
 				F12C8DC01D63DE9F00ADA0D7 /* STPPaymentContextAmountModel.h in Headers */,
 				B3A241391FFEB57400A2F00D /* STPConnectAccountParams.h in Headers */,
+				B32B176520F80442000D6EF8 /* STPRedirectContext+Private.h in Headers */,
 				F19491DE1E5F6B8C001E1FC2 /* STPSourceCardDetails.h in Headers */,
 				0439B9871C454F97005A1ED5 /* STPPaymentMethodsViewController.h in Headers */,
 				04B31DF91D11AC6400EF1631 /* STPUserInformation.h in Headers */,

--- a/Stripe/PublicHeaders/STPRedirectContext.h
+++ b/Stripe/PublicHeaders/STPRedirectContext.h
@@ -47,12 +47,29 @@ typedef NS_ENUM(NSUInteger, STPRedirectContextState) {
  is if SFSafariViewController fails its initial load (like the user has no 
  internet connection, or servers are down).
  */
-typedef void (^STPRedirectContextCompletionBlock)(NSString *sourceID, NSString * __nullable clientSecret, NSError * __nullable error);
+typedef void (^STPRedirectContextSourceCompletionBlock)(NSString *sourceID, NSString * __nullable clientSecret, NSError * __nullable error);
+
+__attribute__((deprecated("STPRedirectContextCompletionBlock has been renamed to STPRedirectContextSourceCompletionBlock", "STPRedirectContextSourceCompletionBlock")))
+typedef STPRedirectContextSourceCompletionBlock STPRedirectContextCompletionBlock;
+
 
 /**
- This is a helper class for handling redirect sources.
+ A callback run when the context believes the redirect action has been completed.
 
- Init and retain an instance with the redirect flow source you want to handle,
+ @param clientSecret The client secret of the PaymentIntent
+ @param error An error if one occured. Note that a lack of an error does not
+ mean that the action was completed successfully, the presence of one confirms
+ that it was not. Currently the only possible error the context can know about
+ is if SFSafariViewController fails its initial load (like the user has no
+ internet connection, or servers are down).
+ */
+typedef void(^STPRedirectContextPaymentIntentCompletionBlock)(NSString *clientSecret, NSError * __nullable error);
+
+/**
+ This is a helper class for handling redirects associated with STPSource and
+ STPPaymentIntents.
+
+ Init and retain an instance with the Source or PaymentIntent you want to handle,
  then choose a redirect method. The context will fire the completion handler
  when the redirect completes.
 
@@ -65,13 +82,13 @@ typedef void (^STPRedirectContextCompletionBlock)(NSString *sourceID, NSString *
  have not actually completed the necessary actions to authorize the charge.
 
  You should not use either this class, nor `STPAPIClient`, as a way
- to determine when you should charge the source or to determine if the redirect
- was successful. Use Stripe webhooks on your backend server to listen for source
+ to determine when you should charge the Source or to determine if the redirect
+ was successful. Use Stripe webhooks on your backend server to listen for Source
  state changes and to make the charge.
  
  See https://stripe.com/docs/sources/best-practices
  */
-NS_EXTENSION_UNAVAILABLE("Redirect based sources are not available in extensions")
+NS_EXTENSION_UNAVAILABLE("STPRedirectContext is not available in extensions")
 @interface STPRedirectContext : NSObject
 
 /**
@@ -80,7 +97,7 @@ NS_EXTENSION_UNAVAILABLE("Redirect based sources are not available in extensions
 @property (nonatomic, readonly) STPRedirectContextState state;
 
 /**
- Initializer for context.
+ Initializer for context from an `STPSource`.
 
  @note You must ensure that the returnURL set up in the created source
  correctly goes to your app so that users can be returned once
@@ -98,7 +115,35 @@ NS_EXTENSION_UNAVAILABLE("Redirect based sources are not available in extensions
  change webhooks on your backend to determine the result of a redirect.
  */
 - (nullable instancetype)initWithSource:(STPSource *)source
-                             completion:(STPRedirectContextCompletionBlock)completion;
+                             completion:(STPRedirectContextSourceCompletionBlock)completion;
+
+/**
+ Initializer for context from an `STPPaymentIntent`.
+
+ This should be used when the `status` is `STPPaymentIntentStatusRequiresSourceAction`.
+ If the next action involves a redirect, this init method will return a non-nil object.
+
+ @note You must ensure that the `returnURL` set up in the created PaymentIntent
+ correctly goes to your app so that users can be returned once
+ they complete the redirect in the web broswer. The *same* value should be passed
+ into this method, otherwise `+ [Stripe handleStripeURLCallbackWithURL:]` won't
+ recognize it.
+
+ @param paymentIntent The STPPaymentIntent that needs a redirect.
+ @param returnUrl The same `returnUrl` that the PaymentIntent has, either passed during creation
+ by your backend, or in `STPPaymentIntentParams.returnUrl`
+ @param completion A block to fire when the action is believed to have
+ been completed.
+
+ @return Nil if the provided PaymentIntent does not need a redirect. Otherwise
+ a new context object.
+
+ @note Firing of the completion block does not necessarily mean the user
+ successfully performed the redirect action.
+ */
+- (nullable instancetype)initWithPaymentIntent:(STPPaymentIntent *)paymentIntent
+                                     returnUrl:(NSString *)returnUrl
+                                    completion:(STPRedirectContextPaymentIntentCompletionBlock)completion;
 
 /**
  Use `initWithSource:completion:`
@@ -109,7 +154,7 @@ NS_EXTENSION_UNAVAILABLE("Redirect based sources are not available in extensions
  Starts a redirect flow.
 
  You must ensure that your app delegate listens for  the `returnURL` that you
- set on your source object, and forwards it to the Stripe SDK so that the
+ set on the Stripe object, and forwards it to the Stripe SDK so that the
  context can be notified when the redirect is completed and dismiss the
  view controller. See `[Stripe handleStripeURLCallbackWithURL:]`
 
@@ -122,7 +167,7 @@ NS_EXTENSION_UNAVAILABLE("Redirect based sources are not available in extensions
  over the redirect method, you can use `startSafariViewControllerRedirectFlowFromViewController` 
  or `startSafariAppRedirectFlow`
  
- If the source supports a native app, and that app is is installed on the user's
+ If the redirect supports a native app, and that app is is installed on the user's
  device, this call will do a direct app-to-app redirect instead of showing
  a web url. 
 
@@ -139,7 +184,7 @@ NS_EXTENSION_UNAVAILABLE("Redirect based sources are not available in extensions
  from the passed in view controller.
 
  You must ensure that your app delegate listens for  the `returnURL` that you
- set on your source object, and forwards it to the Stripe SDK so that the
+ set on the Stripe object, and forwards it to the Stripe SDK so that the
  context can be notified when the redirect is completed and dismiss the
  view controller. See `[Stripe handleStripeURLCallbackWithURL:]`
 

--- a/Stripe/PublicHeaders/STPRedirectContext.h
+++ b/Stripe/PublicHeaders/STPRedirectContext.h
@@ -49,6 +49,11 @@ typedef NS_ENUM(NSUInteger, STPRedirectContextState) {
  */
 typedef void (^STPRedirectContextSourceCompletionBlock)(NSString *sourceID, NSString * __nullable clientSecret, NSError * __nullable error);
 
+/**
+ A callback run when the context believes the redirect action has been completed.
+
+ This type has been renamed to `STPRedirectContextSourceCompletionBlock` and deprecated.
+ */
 __attribute__((deprecated("STPRedirectContextCompletionBlock has been renamed to STPRedirectContextSourceCompletionBlock", "STPRedirectContextSourceCompletionBlock")))
 typedef STPRedirectContextSourceCompletionBlock STPRedirectContextCompletionBlock;
 

--- a/Stripe/PublicHeaders/STPRedirectContext.h
+++ b/Stripe/PublicHeaders/STPRedirectContext.h
@@ -37,7 +37,7 @@ typedef NS_ENUM(NSUInteger, STPRedirectContextState) {
 };
 
 /**
- A callback run when the context believes the redirect action has been completed.
+ A callback that is executed when the context believes the redirect action has been completed.
 
  @param sourceID The stripe id of the source.
  @param clientSecret The client secret of the source.
@@ -50,7 +50,7 @@ typedef NS_ENUM(NSUInteger, STPRedirectContextState) {
 typedef void (^STPRedirectContextSourceCompletionBlock)(NSString *sourceID, NSString * __nullable clientSecret, NSError * __nullable error);
 
 /**
- A callback run when the context believes the redirect action has been completed.
+ A callback that is executed when the context believes the redirect action has been completed.
 
  This type has been renamed to `STPRedirectContextSourceCompletionBlock` and deprecated.
  */
@@ -59,7 +59,7 @@ typedef STPRedirectContextSourceCompletionBlock STPRedirectContextCompletionBloc
 
 
 /**
- A callback run when the context believes the redirect action has been completed.
+ A callback that is executed when the context believes the redirect action has been completed.
 
  @param clientSecret The client secret of the PaymentIntent
  @param error An error if one occured. Note that a lack of an error does not
@@ -112,10 +112,10 @@ NS_EXTENSION_UNAVAILABLE("STPRedirectContext is not available in extensions")
  @param completion A block to fire when the action is believed to have 
  been completed.
 
- @return Nil if the specified source is not a redirect-flow source. Otherwise 
+ @return nil if the specified source is not a redirect-flow source. Otherwise
  a new context object.
 
- @note Firing of the completion block does not necessarily mean the user 
+ @note Execution of the completion block does not necessarily mean the user
  successfully performed the redirect action. You should listen for source status
  change webhooks on your backend to determine the result of a redirect.
  */
@@ -140,10 +140,10 @@ NS_EXTENSION_UNAVAILABLE("STPRedirectContext is not available in extensions")
  @param completion A block to fire when the action is believed to have
  been completed.
 
- @return Nil if the provided PaymentIntent does not need a redirect. Otherwise
+ @return nil if the provided PaymentIntent does not need a redirect. Otherwise
  a new context object.
 
- @note Firing of the completion block does not necessarily mean the user
+ @note Execution of the completion block does not necessarily mean the user
  successfully performed the redirect action.
  */
 - (nullable instancetype)initWithPaymentIntent:(STPPaymentIntent *)paymentIntent

--- a/Stripe/PublicHeaders/STPRedirectContext.h
+++ b/Stripe/PublicHeaders/STPRedirectContext.h
@@ -44,7 +44,7 @@ typedef NS_ENUM(NSUInteger, STPRedirectContextState) {
  @param error An error if one occured. Note that a lack of an error does not 
  mean that the action was completed successfully, the presence of one confirms 
  that it was not. Currently the only possible error the context can know about 
- is if SFSafariViewController fails its initial load (like the user has no 
+ is if SFSafariViewController fails its initial load (e.g. the user has no
  internet connection, or servers are down).
  */
 typedef void (^STPRedirectContextSourceCompletionBlock)(NSString *sourceID, NSString * __nullable clientSecret, NSError * __nullable error);
@@ -60,7 +60,7 @@ typedef STPRedirectContextSourceCompletionBlock STPRedirectContextCompletionBloc
  @param error An error if one occured. Note that a lack of an error does not
  mean that the action was completed successfully, the presence of one confirms
  that it was not. Currently the only possible error the context can know about
- is if SFSafariViewController fails its initial load (like the user has no
+ is if SFSafariViewController fails its initial load (e.g. the user has no
  internet connection, or servers are down).
  */
 typedef void(^STPRedirectContextPaymentIntentCompletionBlock)(NSString *clientSecret, NSError * __nullable error);

--- a/Stripe/STPRedirectContext+Private.h
+++ b/Stripe/STPRedirectContext+Private.h
@@ -1,0 +1,26 @@
+//
+//  STPRedirectContext+Private.h
+//  Stripe
+//
+//  Created by Daniel Jackson on 7/12/18.
+//  Copyright © 2018 Stripe, Inc. All rights reserved.
+//
+
+#import "STPRedirectContext.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface STPRedirectContext()
+
+/// Optional URL for a native app. This is passed directly to `UIApplication openURL:`, and if it fails this class falls back to `redirectUrl`
+@property (nonatomic, nullable, copy) NSURL *nativeRedirectUrl;
+/// The URL to redirect to, assuming `nativeRedirectUrl` is nil or fails to open. Cannot be nil if `nativeRedirectUrl` is.
+@property (nonatomic, nullable, copy) NSURL *redirectUrl;
+/// The expected `returnUrl`, passed to STPURLCallbackHandler
+@property (nonatomic, copy) NSURL *returnUrl;
+/// Completion block to execute when finished redirecting, with optional error parameter.
+@property (nonatomic, copy) STPErrorBlock completion;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Stripe/STPRedirectContext.m
+++ b/Stripe/STPRedirectContext.m
@@ -7,6 +7,7 @@
 //
 
 #import "STPRedirectContext.h"
+#import "STPRedirectContext+Private.h"
 
 #import "STPBlocks.h"
 #import "STPDispatchFunctions.h"
@@ -23,14 +24,6 @@ NS_ASSUME_NONNULL_BEGIN
 typedef void (^STPBoolCompletionBlock)(BOOL success);
 
 @interface STPRedirectContext () <SFSafariViewControllerDelegate, STPURLCallbackListener>
-/// Optional URL for a native app. This is passed directly to `UIApplication openURL:`, and if it fails this class falls back to `redirectUrl`
-@property (nonatomic, nullable, copy) NSURL *nativeRedirectUrl;
-/// The URL to redirect to, assuming `nativeRedirectUrl` is nil or fails to open. Cannot be nil if `nativeRedirectUrl` is.
-@property (nonatomic, nullable, copy) NSURL *redirectUrl;
-/// The expected `returnUrl`, passed to STPURLCallbackHandler
-@property (nonatomic, copy) NSURL *returnUrl;
-/// Completion block to execute when finished redirecting, with optional error parameter.
-@property (nonatomic, copy) STPErrorBlock completion;
 
 @property (nonatomic, strong, nullable) SFSafariViewController *safariVC;
 @property (nonatomic, assign, readwrite) STPRedirectContextState state;

--- a/Tests/Tests/STPFixtures.h
+++ b/Tests/Tests/STPFixtures.h
@@ -15,6 +15,8 @@ extern NSString *const STPTestJSONCustomer;
 
 extern NSString *const STPTestJSONCard;
 
+extern NSString *const STPTestJSONPaymentIntent;
+
 extern NSString *const STPTestJSONSourceAlipay;
 extern NSString *const STPTestJSONSourceCard;
 extern NSString *const STPTestJSONSource3DS;
@@ -120,6 +122,11 @@ extern NSString *const STPTestJSONSourceSEPADebit;
  A Source object with type Alipay and a native redirect url
  */
 + (STPSource *)alipaySourceWithNativeUrl;
+
+/**
+ A PaymentIntent object
+ */
++ (STPPaymentIntent *)paymentIntent;
 
 /**
  A PaymentConfiguration object with a fake publishable key. Use this to avoid

--- a/Tests/Tests/STPFixtures.m
+++ b/Tests/Tests/STPFixtures.m
@@ -14,6 +14,8 @@ NSString *const STPTestJSONCustomer = @"Customer";
 
 NSString *const STPTestJSONCard = @"Card";
 
+NSString *const STPTestJSONPaymentIntent = @"PaymentIntent";
+
 NSString *const STPTestJSONSourceAlipay = @"AlipaySource";
 NSString *const STPTestJSONSourceCard = @"CardSource";
 NSString *const STPTestJSONSource3DS = @"3DSSource";
@@ -186,6 +188,10 @@ NSString *const STPTestJSONSourceSEPADebit = @"SEPADebitSource";
     detailsDictionary[@"native_url"] = @"alipay://test";
     dictionary[@"alipay"] = detailsDictionary;
     return [STPSource decodedObjectFromAPIResponse:dictionary];
+}
+
++ (STPPaymentIntent *)paymentIntent {
+    return [STPPaymentIntent decodedObjectFromAPIResponse:[STPTestUtils jsonNamed:@"PaymentIntent"]];
 }
 
 + (STPPaymentConfiguration *)paymentConfiguration {

--- a/Tests/Tests/STPPaymentIntentTest.m
+++ b/Tests/Tests/STPPaymentIntentTest.m
@@ -11,6 +11,7 @@
 #import "STPPaymentIntent.h"
 #import "STPPaymentIntent+Private.h"
 
+#import "STPFixtures.h"
 #import "STPTestUtils.h"
 
 @interface STPPaymentIntentTest : XCTestCase
@@ -109,7 +110,7 @@
 #pragma mark - Description Tests
 
 - (void)testDescription {
-    STPPaymentIntent *paymentIntent = [STPPaymentIntent decodedObjectFromAPIResponse:[STPTestUtils jsonNamed:@"PaymentIntent"]];
+    STPPaymentIntent *paymentIntent = [STPFixtures paymentIntent];
 
     XCTAssertNotNil(paymentIntent);
     NSString *desc = paymentIntent.description;
@@ -120,7 +121,7 @@
 #pragma mark - STPAPIResponseDecodable Tests
 
 - (void)testDecodedObjectFromAPIResponseRequiredFields {
-    NSDictionary *fullJson = [STPTestUtils jsonNamed:@"PaymentIntent"];
+    NSDictionary *fullJson = [STPTestUtils jsonNamed:STPTestJSONPaymentIntent];
 
     XCTAssertNotNil([STPPaymentIntent decodedObjectFromAPIResponse:fullJson], @"can decode with full json");
 

--- a/Tests/Tests/STPRedirectContextTest.m
+++ b/Tests/Tests/STPRedirectContextTest.m
@@ -81,14 +81,14 @@
 
 - (void)testInitWithSource {
     STPSource *source = [STPFixtures iDEALSource];
-    XCTestExpectation *expect = [self expectationWithDescription:@"completion"];
+    __block BOOL completionCalled = NO;
     NSError *fakeError = [NSError new];
 
     STPRedirectContext *sut = [[STPRedirectContext alloc] initWithSource:source completion:^(NSString * _Nonnull sourceID, NSString * _Nullable clientSecret, NSError * _Nullable error) {
         XCTAssertEqualObjects(source.stripeID, sourceID);
         XCTAssertEqualObjects(source.clientSecret, clientSecret);
         XCTAssertEqual(error, fakeError, @"Should be the same NSError object passed to completion() below");
-        [expect fulfill];
+        completionCalled = YES;
     }];
 
     // Make sure the initWithSource: method pulled out the right values from the Source
@@ -98,12 +98,12 @@
 
     // and make sure the completion calls the completion block above
     sut.completion(fakeError);
-    [self waitForExpectationsWithTimeout:0 handler:nil];
+    XCTAssertTrue(completionCalled);
 }
 
 - (void)testInitWithSourceWithNativeURL {
     STPSource *source = [STPFixtures alipaySourceWithNativeUrl];
-    XCTestExpectation *expect = [self expectationWithDescription:@"completion"];
+    __block BOOL completionCalled = NO;
     NSURL *nativeURL = [NSURL URLWithString:source.details[@"native_url"]];
     NSError *fakeError = [NSError new];
 
@@ -111,7 +111,7 @@
         XCTAssertEqualObjects(source.stripeID, sourceID);
         XCTAssertEqualObjects(source.clientSecret, clientSecret);
         XCTAssertEqual(error, fakeError, @"Should be the same NSError object passed to completion() below");
-        [expect fulfill];
+        completionCalled = YES;
     }];
 
     // Make sure the initWithSource: method pulled out the right values from the Source
@@ -121,19 +121,19 @@
 
     // and make sure the completion calls the completion block above
     sut.completion(fakeError);
-    [self waitForExpectationsWithTimeout:0 handler:nil];
+    XCTAssertTrue(completionCalled);
 }
 
 - (void)testInitWithPaymentIntent {
     STPPaymentIntent *paymentIntent = [STPFixtures paymentIntent];
-    XCTestExpectation *expect = [self expectationWithDescription:@"completion"];
+    __block BOOL completionCalled = NO;
     NSError *fakeError = [NSError new];
     NSString *returnUrlString = @"payments-example://stripe-redirect";
 
     STPRedirectContext *sut = [[STPRedirectContext alloc] initWithPaymentIntent:paymentIntent returnUrl:returnUrlString completion:^(NSString * _Nonnull clientSecret, NSError * _Nullable error) {
         XCTAssertEqualObjects(paymentIntent.clientSecret, clientSecret);
         XCTAssertEqual(error, fakeError, @"Should be the same NSError object passed to completion() below");
-        [expect fulfill];
+        completionCalled = YES;
     }];
 
     // Make sure the initWithPaymentIntent: method pulled out the right values from the PaymentIntent
@@ -144,7 +144,7 @@
 
     // and make sure the completion calls the completion block above
     sut.completion(fakeError);
-    [self waitForExpectationsWithTimeout:0 handler:nil];
+    XCTAssertTrue(completionCalled);
 }
 
 - (void)testInitWithPaymentIntentFailures {


### PR DESCRIPTION
## Summary
Adding init method on STPRedirectContext that takes an STPPaymentIntent.

This relies on #985 (adds STPPaymentIntent) and #980 (refactored STPRedirectContext to
make this possible), and so it has merge commits from each of those branches.

## Motivation
IOS-792

## Testing
STPRedirectContext has extensive tests, which (still) need to be updated for this new feature