### PR TITLE
Add 3DS example VC that uses PaymentIntents to charge the user

### DIFF
--- a/Example/Custom Integration (ObjC).xcodeproj/project.pbxproj
+++ b/Example/Custom Integration (ObjC).xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		04533F191A688A0A00C7E52E /* Constants.m in Sources */ = {isa = PBXBuildFile; fileRef = 04533F181A688A0A00C7E52E /* Constants.m */; };
 		04D076171A69C11600094431 /* Stripe.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 04533F0C1A68812D00C7E52E /* Stripe.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		8BBD79C6207FD2F900F85BED /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 8BBD79C8207FD2F900F85BED /* Localizable.strings */; };
+		B3BDCADD20EF03010034F7F5 /* ThreeDSPaymentIntentExampleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B3BDCADB20EF03010034F7F5 /* ThreeDSPaymentIntentExampleViewController.m */; };
 		C12C50DD1E57B3C800EC6D58 /* BrowseExamplesViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C12C50DC1E57B3C800EC6D58 /* BrowseExamplesViewController.m */; };
 		C1CACE861E5DE6C3002D0821 /* CardExampleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C1CACE851E5DE6C3002D0821 /* CardExampleViewController.m */; };
 		C1CACE891E5DF7A9002D0821 /* ApplePayExampleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C1CACE881E5DF7A9002D0821 /* ApplePayExampleViewController.m */; };
@@ -62,6 +63,8 @@
 		8BBD79CF207FD34200F85BED /* ja */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
 		8BBD79D0207FD34A00F85BED /* nb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = nb; path = nb.lproj/Localizable.strings; sourceTree = "<group>"; };
 		8BBD79D1207FD35200F85BED /* es */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
+		B3BDCADB20EF03010034F7F5 /* ThreeDSPaymentIntentExampleViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ThreeDSPaymentIntentExampleViewController.m; sourceTree = "<group>"; };
+		B3BDCADC20EF03010034F7F5 /* ThreeDSPaymentIntentExampleViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThreeDSPaymentIntentExampleViewController.h; sourceTree = "<group>"; };
 		C12C50DB1E57B3C800EC6D58 /* BrowseExamplesViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BrowseExamplesViewController.h; sourceTree = "<group>"; };
 		C12C50DC1E57B3C800EC6D58 /* BrowseExamplesViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BrowseExamplesViewController.m; sourceTree = "<group>"; };
 		C18A6EE31F1EB7A6005600CC /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = "Custom Integration (ObjC)/README.md"; sourceTree = "<group>"; };
@@ -110,25 +113,27 @@
 		04533E891A687F5D00C7E52E /* Custom Integration (ObjC) */ = {
 			isa = PBXGroup;
 			children = (
-				04533EB01A68802E00C7E52E /* ShippingManager.h */,
-				04533EB11A68802E00C7E52E /* ShippingManager.m */,
-				04533F171A688A0A00C7E52E /* Constants.h */,
-				04533F181A688A0A00C7E52E /* Constants.m */,
 				04533E8E1A687F5D00C7E52E /* AppDelegate.h */,
 				04533E8F1A687F5D00C7E52E /* AppDelegate.m */,
+				C1CACE871E5DF7A9002D0821 /* ApplePayExampleViewController.h */,
+				C1CACE881E5DF7A9002D0821 /* ApplePayExampleViewController.m */,
 				C12C50DB1E57B3C800EC6D58 /* BrowseExamplesViewController.h */,
 				C12C50DC1E57B3C800EC6D58 /* BrowseExamplesViewController.m */,
 				C1CACE841E5DE6C3002D0821 /* CardExampleViewController.h */,
 				C1CACE851E5DE6C3002D0821 /* CardExampleViewController.m */,
-				C1CACE8D1E5E0F94002D0821 /* ThreeDSExampleViewController.h */,
-				C1CACE8E1E5E0F94002D0821 /* ThreeDSExampleViewController.m */,
-				C1CACE871E5DF7A9002D0821 /* ApplePayExampleViewController.h */,
-				C1CACE881E5DF7A9002D0821 /* ApplePayExampleViewController.m */,
+				04533F171A688A0A00C7E52E /* Constants.h */,
+				04533F181A688A0A00C7E52E /* Constants.m */,
+				04533E971A687F5D00C7E52E /* Images.xcassets */,
+				8BBD79C8207FD2F900F85BED /* Localizable.strings */,
+				04533EB01A68802E00C7E52E /* ShippingManager.h */,
+				04533EB11A68802E00C7E52E /* ShippingManager.m */,
 				C1CACE921E5E3DF6002D0821 /* SofortExampleViewController.h */,
 				C1CACE931E5E3DF6002D0821 /* SofortExampleViewController.m */,
-				04533E971A687F5D00C7E52E /* Images.xcassets */,
 				04533E8A1A687F5D00C7E52E /* Supporting Files */,
-				8BBD79C8207FD2F900F85BED /* Localizable.strings */,
+				C1CACE8D1E5E0F94002D0821 /* ThreeDSExampleViewController.h */,
+				C1CACE8E1E5E0F94002D0821 /* ThreeDSExampleViewController.m */,
+				B3BDCADC20EF03010034F7F5 /* ThreeDSPaymentIntentExampleViewController.h */,
+				B3BDCADB20EF03010034F7F5 /* ThreeDSPaymentIntentExampleViewController.m */,
 			);
 			path = "Custom Integration (ObjC)";
 			sourceTree = "<group>";
@@ -235,6 +240,7 @@
 				C1CACE941E5E3DF6002D0821 /* SofortExampleViewController.m in Sources */,
 				C1CACE861E5DE6C3002D0821 /* CardExampleViewController.m in Sources */,
 				04533EB21A68802E00C7E52E /* ShippingManager.m in Sources */,
+				B3BDCADD20EF03010034F7F5 /* ThreeDSPaymentIntentExampleViewController.m in Sources */,
 				04533E901A687F5D00C7E52E /* AppDelegate.m in Sources */,
 				C1CACE891E5DF7A9002D0821 /* ApplePayExampleViewController.m in Sources */,
 				04533E8D1A687F5D00C7E52E /* main.m in Sources */,

--- a/Example/Custom Integration (ObjC)/ApplePayExampleViewController.m
+++ b/Example/Custom Integration (ObjC)/ApplePayExampleViewController.m
@@ -121,8 +121,8 @@
     [[STPAPIClient sharedClient] createTokenWithPayment:payment
                                              completion:^(STPToken *token, NSError *error) {
                                                  [self.delegate createBackendChargeWithSource:token.tokenId
-                                                                                   completion:^(STPBackendChargeResult status, NSError *error) {
-                                                                                       if (status == STPBackendChargeResultSuccess) {
+                                                                                   completion:^(STPBackendResult status, NSError *error) {
+                                                                                       if (status == STPBackendResultSuccess) {
                                                                                            self.applePaySucceeded = YES;
                                                                                            completion(PKPaymentAuthorizationStatusSuccess);
                                                                                        } else {

--- a/Example/Custom Integration (ObjC)/BrowseExamplesViewController.h
+++ b/Example/Custom Integration (ObjC)/BrowseExamplesViewController.h
@@ -9,12 +9,12 @@
 #import <UIKit/UIKit.h>
 #import <Stripe/Stripe.h>
 
-typedef NS_ENUM(NSInteger, STPBackendChargeResult) {
-    STPBackendChargeResultSuccess,
-    STPBackendChargeResultFailure,
+typedef NS_ENUM(NSInteger, STPBackendResult) {
+    STPBackendResultSuccess,
+    STPBackendResultFailure,
 };
 
-typedef void (^STPSourceSubmissionHandler)(STPBackendChargeResult status, NSError *error);
+typedef void (^STPSourceSubmissionHandler)(STPBackendResult status, NSError *error);
 
 @protocol ExampleViewControllerDelegate <NSObject>
 

--- a/Example/Custom Integration (ObjC)/BrowseExamplesViewController.h
+++ b/Example/Custom Integration (ObjC)/BrowseExamplesViewController.h
@@ -15,12 +15,15 @@ typedef NS_ENUM(NSInteger, STPBackendResult) {
 };
 
 typedef void (^STPSourceSubmissionHandler)(STPBackendResult status, NSError *error);
+typedef void (^STPPaymentIntentCreationHandler)(STPBackendResult status, NSString *clientSecret, NSError *error);
+
 
 @protocol ExampleViewControllerDelegate <NSObject>
 
 - (void)exampleViewController:(UIViewController *)controller didFinishWithMessage:(NSString *)message;
 - (void)exampleViewController:(UIViewController *)controller didFinishWithError:(NSError *)error;
 - (void)createBackendChargeWithSource:(NSString *)sourceID completion:(STPSourceSubmissionHandler)completion;
+- (void)createBackendPaymentIntentWithAmount:(NSNumber *)amount returnUrl:(NSString *)returnUrl completion:(STPPaymentIntentCreationHandler)completion;
 
 @end
 

--- a/Example/Custom Integration (ObjC)/BrowseExamplesViewController.h
+++ b/Example/Custom Integration (ObjC)/BrowseExamplesViewController.h
@@ -23,7 +23,7 @@ typedef void (^STPPaymentIntentCreationHandler)(STPBackendResult status, NSStrin
 - (void)exampleViewController:(UIViewController *)controller didFinishWithMessage:(NSString *)message;
 - (void)exampleViewController:(UIViewController *)controller didFinishWithError:(NSError *)error;
 - (void)createBackendChargeWithSource:(NSString *)sourceID completion:(STPSourceSubmissionHandler)completion;
-- (void)createBackendPaymentIntentWithAmount:(NSNumber *)amount returnUrl:(NSString *)returnUrl completion:(STPPaymentIntentCreationHandler)completion;
+- (void)createBackendPaymentIntentWithAmount:(NSNumber *)amount completion:(STPPaymentIntentCreationHandler)completion;
 
 @end
 

--- a/Example/Custom Integration (ObjC)/BrowseExamplesViewController.m
+++ b/Example/Custom Integration (ObjC)/BrowseExamplesViewController.m
@@ -96,7 +96,7 @@
         NSError *error = [NSError errorWithDomain:StripeDomain
                                              code:STPInvalidRequestError
                                          userInfo:@{NSLocalizedDescriptionKey: @"You must set a backend base URL in Constants.m to create a charge."}];
-        completion(STPBackendChargeResultFailure, error);
+        completion(STPBackendResultFailure, error);
         return;
     }
 
@@ -121,7 +121,7 @@
                                                                                       userInfo:@{NSLocalizedDescriptionKey: @"There was an error connecting to your payment backend."}];
                                                           }
                                                           if (error) {
-                                                              completion(STPBackendChargeResultFailure, error);
+                                                              completion(STPBackendResultFailure, error);
                                                           } else {
                                                               completion(STPBackendChargeResultSuccess, nil);
                                                           }

--- a/Example/Custom Integration (ObjC)/BrowseExamplesViewController.m
+++ b/Example/Custom Integration (ObjC)/BrowseExamplesViewController.m
@@ -152,7 +152,7 @@
  @param amount Amount to charge the customer
  @param completion completion block called with status of backend call & the client secret if successful.
  */
-- (void)createBackendPaymentIntentWithAmount:(NSNumber *)amount returnUrl:(NSString *)returnUrl completion:(STPPaymentIntentCreationHandler)completion {
+- (void)createBackendPaymentIntentWithAmount:(NSNumber *)amount completion:(STPPaymentIntentCreationHandler)completion {
     if (!BackendBaseURL) {
         NSError *error = [NSError errorWithDomain:StripeDomain
                                              code:STPInvalidRequestError
@@ -169,8 +169,7 @@
     NSURL *url = [NSURL URLWithString:urlString];
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url];
     request.HTTPMethod = @"POST";
-    NSString *encodedReturnUrl = [returnUrl stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet alphanumericCharacterSet]];
-    NSString *postBody = [NSString stringWithFormat:@"amount=%@&return_url=%@", amount, encodedReturnUrl];
+    NSString *postBody = [NSString stringWithFormat:@"amount=%@", amount];
     NSData *data = [postBody dataUsingEncoding:NSUTF8StringEncoding];
 
     NSURLSessionUploadTask *uploadTask = [session uploadTaskWithRequest:request

--- a/Example/Custom Integration (ObjC)/BrowseExamplesViewController.m
+++ b/Example/Custom Integration (ObjC)/BrowseExamplesViewController.m
@@ -44,20 +44,20 @@
     UITableViewCell *cell = [UITableViewCell new];
     switch (indexPath.row) {
         case 0:
-        cell.textLabel.text = @"Card";
-        break;
+            cell.textLabel.text = @"Card";
+            break;
         case 1:
-        cell.textLabel.text = @"Card + 3DS";
-        break;
+            cell.textLabel.text = @"Card + 3DS";
+            break;
         case 2:
-        cell.textLabel.text = @"Apple Pay";
-        break;
+            cell.textLabel.text = @"Apple Pay";
+            break;
         case 3:
-        cell.textLabel.text = @"Sofort";
-        break;
+            cell.textLabel.text = @"Sofort";
+            break;
         case 4:
-        cell.textLabel.text = @"PaymentIntent: Card + 3DS";
-        break;
+            cell.textLabel.text = @"PaymentIntent: Card + 3DS";
+            break;
     }
     return cell;
 }
@@ -132,7 +132,8 @@
                                                           }
                                                           if (error) {
                                                               completion(STPBackendResultFailure, error);
-                                                          } else {
+                                                          }
+                                                          else {
                                                               completion(STPBackendResultSuccess, nil);
                                                           }
                                                       }];
@@ -142,9 +143,9 @@
 
 
 /**
- Ask the example backed to create a PaymentIntent with the specified amount.
+ Ask the example backend to create a PaymentIntent with the specified amount.
 
- The implementation of this function is not interesting nor relevant to using PaymentIntents. The
+ The implementation of this function is not interesting or relevant to using PaymentIntents. The
  method signature is the most interesting part: you need some way to ask *your* backend to create
  a PaymentIntent with the correct properties, and then it needs to pass the client secret back.
 

--- a/Example/Custom Integration (ObjC)/BrowseExamplesViewController.m
+++ b/Example/Custom Integration (ObjC)/BrowseExamplesViewController.m
@@ -56,7 +56,7 @@
         cell.textLabel.text = @"Sofort";
         break;
         case 4:
-        cell.textLabel.text = @"Card + 3DS + PaymentIntent";
+        cell.textLabel.text = @"PaymentIntent: Card + 3DS";
         break;
     }
     return cell;

--- a/Example/Custom Integration (ObjC)/CardExampleViewController.m
+++ b/Example/Custom Integration (ObjC)/CardExampleViewController.m
@@ -88,7 +88,7 @@
                                               if (error) {
                                                   [self.delegate exampleViewController:self didFinishWithError:error];
                                               }
-                                              [self.delegate createBackendChargeWithSource:token.tokenId completion:^(STPBackendChargeResult result, NSError *error) {
+                                              [self.delegate createBackendChargeWithSource:token.tokenId completion:^(STPBackendResult result, NSError *error) {
                                                   if (error) {
                                                       [self.delegate exampleViewController:self didFinishWithError:error];
                                                       return;

--- a/Example/Custom Integration (ObjC)/ThreeDSExampleViewController.m
+++ b/Example/Custom Integration (ObjC)/ThreeDSExampleViewController.m
@@ -165,7 +165,7 @@
                 }
             }];
         } else {
-            [self.delegate createBackendChargeWithSource:source.stripeID completion:^(STPBackendChargeResult status, NSError *error) {
+            [self.delegate createBackendChargeWithSource:source.stripeID completion:^(STPBackendResult status, NSError *error) {
                 if (error) {
                     [self.delegate exampleViewController:self didFinishWithError:error];
                     return;

--- a/Example/Custom Integration (ObjC)/ThreeDSPaymentIntentExampleViewController.h
+++ b/Example/Custom Integration (ObjC)/ThreeDSPaymentIntentExampleViewController.h
@@ -1,0 +1,14 @@
+//
+//  ThreeDSPaymentIntentExampleViewController.h
+//  Custom Integration (ObjC)
+//
+//  Created by Daniel Jackson on 7/5/18.
+//  Copyright © 2018 Stripe. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import "ThreeDSExampleViewController.h"
+
+@interface ThreeDSPaymentIntentExampleViewController : ThreeDSExampleViewController
+
+@end

--- a/Example/Custom Integration (ObjC)/ThreeDSPaymentIntentExampleViewController.m
+++ b/Example/Custom Integration (ObjC)/ThreeDSPaymentIntentExampleViewController.m
@@ -1,0 +1,133 @@
+//
+//  ThreeDSPaymentIntentExampleViewController.m
+//  Custom Integration (ObjC)
+//
+//  Created by Daniel Jackson on 7/5/18.
+//  Copyright © 2018 Stripe. All rights reserved.
+//
+
+@import Stripe;
+
+#import "ThreeDSPaymentIntentExampleViewController.h"
+#import "BrowseExamplesViewController.h"
+
+@interface ThreeDSExampleViewController (PrivateMethods)
+- (void)updateUIForPaymentInProgress:(BOOL)paymentInProgress;
+
+@property (weak, nonatomic) STPPaymentCardTextField *paymentTextField;
+@property (nonatomic) STPRedirectContext *redirectContext;
+@end
+
+/**
+ This example demonstrates using PaymentIntents to accept card payments verified using 3D Secure.
+ This builds on ThreeDSExampleViewController, which has the same UI but creates a Source instead of using
+ PaymentIntents.
+
+ 1. Collect user's card information via `STPPaymentCardTextField`
+ 2. Create a `PaymentIntent` on our backend (this can happen concurrently with #1)
+ 3. Confirm PaymentIntent using the `STPSourceParams` for the user's card information.
+ 4. If the user needs to go through the 3D Secure authentication flow, use `STPRedirectContext` to do so.
+ 5. When user returns to the app, or finishes the SafariVC redirect flow, `STPRedirectContext` notifies via callback
+
+ See the documentation at https://stripe.com/docs/payments/dynamic-authentication for more information
+ on using PaymentIntents for dynamic authentication.
+ */
+@interface ThreeDSPaymentIntentExampleViewController ()
+
+@end
+
+@implementation ThreeDSPaymentIntentExampleViewController
+
+- (void)pay {
+    if (![self.paymentTextField isValid]) {
+        return;
+    }
+    if (![Stripe defaultPublishableKey]) {
+        [self.delegate exampleViewController:self didFinishWithMessage:@"Please set a Stripe Publishable Key in Constants.m"];
+        return;
+    }
+    [self updateUIForPaymentInProgress:YES];
+
+    NSString *returnUrl = @"payments-example://stripe-redirect";
+    // In a more interesting app, you'll probably create your PaymentIntent as soon as you know the
+    // payment amount you wish to collect from your customer. For simplicity, this example does it once they've
+    // pushed the Pay button.
+    // https://stripe.com/docs/payments/dynamic-authentication#create-payment-intent
+    [self.delegate createBackendPaymentIntentWithAmount:@1099 returnUrl:returnUrl completion:^(STPBackendResult status, NSString *clientSecret, NSError *error) {
+        if (status == STPBackendResultFailure || clientSecret == nil) {
+            [self.delegate exampleViewController:self didFinishWithError:error];
+            return;
+        }
+
+        STPAPIClient *stripeClient = [STPAPIClient sharedClient];
+        STPPaymentIntentParams *paymentIntentParams = [[STPPaymentIntentParams alloc] initWithClientSecret:clientSecret];
+        paymentIntentParams.sourceParams = [STPSourceParams cardParamsWithCard:self.paymentTextField.cardParams];
+
+        [stripeClient confirmPaymentIntentWithParams:paymentIntentParams completion:^(STPPaymentIntent * _Nullable paymentIntent, NSError * _Nullable error) {
+            if (error) {
+                [self.delegate exampleViewController:self didFinishWithError:error];
+                return;
+            }
+
+            if (paymentIntent.status == STPPaymentIntentStatusRequiresSourceAction) {
+                self.redirectContext = [[STPRedirectContext alloc] initWithPaymentIntent:paymentIntent returnUrl:returnUrl completion:^(NSString * _Nonnull clientSecret, NSError * _Nullable error) {
+                    if (error) {
+                        [self.delegate exampleViewController:self didFinishWithError:error];
+                    }
+                    else {
+                        [stripeClient retrievePaymentIntentWithClientSecret:clientSecret completion:^(STPPaymentIntent * _Nullable paymentIntent, NSError * _Nullable error) {
+                            if (error) {
+                                [self.delegate exampleViewController:self didFinishWithError:error];
+                            } else {
+                                [self finishWithStatus:paymentIntent.status];
+                            }
+                        }];
+                    }
+                    self.redirectContext = nil; // break retain cycle
+                }];
+
+                if (self.redirectContext) {
+                    [self.redirectContext startRedirectFlowFromViewController:self];
+                }
+                else {
+                    // Could not create STPRedirectContext even though it RequiresSourceAction
+                    [self finishWithStatus:paymentIntent.status];
+                }
+            }
+            else {
+                [self finishWithStatus:paymentIntent.status];
+            }
+        }];
+    }];
+}
+
+- (void)finishWithStatus:(STPPaymentIntentStatus)status {
+    switch (status) {
+        // There may have been a problem with the STPSourceParams
+        case STPPaymentIntentStatusRequiresSource:
+        // did you call `confirmPaymentIntentWithParams:completion`?
+        case STPPaymentIntentStatusRequiresConfirmation:
+        // App should have handled the source action, but didn't for some reason
+        case STPPaymentIntentStatusRequiresSourceAction:
+        // The PaymentIntent was canceled (maybe by the backend?)
+        case STPPaymentIntentStatusCanceled:
+            [self.delegate exampleViewController:self didFinishWithMessage:@"Payment failed"];
+            break;
+
+        // Processing. You could detect this case and poll for the final status of the PaymentIntent
+        case STPPaymentIntentStatusProcessing:
+        // Unknown status
+        case STPPaymentIntentStatusUnknown:
+            [self.delegate exampleViewController:self didFinishWithMessage:@"Order received"];
+            break;
+
+        // if captureMethod is manual, backend needs to capture it to receive the funds
+        case STPPaymentIntentStatusRequiresCapture:
+        // succeeded
+        case STPPaymentIntentStatusSucceeded:
+            [self.delegate exampleViewController:self didFinishWithMessage:@"Payment successfully created"];
+            break;
+    }
+}
+
+@end

--- a/Example/Custom Integration (ObjC)/ThreeDSPaymentIntentExampleViewController.m
+++ b/Example/Custom Integration (ObjC)/ThreeDSPaymentIntentExampleViewController.m
@@ -54,12 +54,11 @@
     }
     [self updateUIForPaymentInProgress:YES];
 
-    NSString *returnUrl = @"payments-example://stripe-redirect";
     // In a more interesting app, you'll probably create your PaymentIntent as soon as you know the
     // payment amount you wish to collect from your customer. For simplicity, this example does it once they've
     // pushed the Pay button.
     // https://stripe.com/docs/payments/dynamic-authentication#create-payment-intent
-    [self.delegate createBackendPaymentIntentWithAmount:@1099 returnUrl:returnUrl completion:^(STPBackendResult status, NSString *clientSecret, NSError *error) {
+    [self.delegate createBackendPaymentIntentWithAmount:@1099 completion:^(STPBackendResult status, NSString *clientSecret, NSError *error) {
         if (status == STPBackendResultFailure || clientSecret == nil) {
             [self.delegate exampleViewController:self didFinishWithError:error];
             return;
@@ -68,6 +67,7 @@
         STPAPIClient *stripeClient = [STPAPIClient sharedClient];
         STPPaymentIntentParams *paymentIntentParams = [[STPPaymentIntentParams alloc] initWithClientSecret:clientSecret];
         paymentIntentParams.sourceParams = [STPSourceParams cardParamsWithCard:self.paymentTextField.cardParams];
+        paymentIntentParams.returnUrl = @"payments-example://stripe-redirect";
 
         [stripeClient confirmPaymentIntentWithParams:paymentIntentParams completion:^(STPPaymentIntent * _Nullable paymentIntent, NSError * _Nullable error) {
             if (error) {
@@ -76,7 +76,7 @@
             }
 
             if (paymentIntent.status == STPPaymentIntentStatusRequiresSourceAction) {
-                self.redirectContext = [[STPRedirectContext alloc] initWithPaymentIntent:paymentIntent returnUrl:returnUrl completion:^(NSString * _Nonnull clientSecret, NSError * _Nullable error) {
+                self.redirectContext = [[STPRedirectContext alloc] initWithPaymentIntent:paymentIntent completion:^(NSString * _Nonnull clientSecret, NSError * _Nullable error) {
                     if (error) {
                         [self.delegate exampleViewController:self didFinishWithError:error];
                     }

--- a/Example/Custom Integration (ObjC)/ThreeDSPaymentIntentExampleViewController.m
+++ b/Example/Custom Integration (ObjC)/ThreeDSPaymentIntentExampleViewController.m
@@ -38,6 +38,12 @@
 
 @implementation ThreeDSPaymentIntentExampleViewController
 
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    self.title = @"PaymentIntent: Card + 3DS";
+}
+
 - (void)pay {
     if (![self.paymentTextField isValid]) {
         return;

--- a/Stripe/PublicHeaders/STPPaymentIntent.h
+++ b/Stripe/PublicHeaders/STPPaymentIntent.h
@@ -84,6 +84,15 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nullable, readonly) NSString *receiptEmail;
 
 /**
+ The URL to redirect your customer back to after they authenticate or cancel their
+ payment on the payment method’s app or site.
+
+ This should be a URL that your app handles if the PaymentIntent is going to
+ be confirmed in your app, and it has a redirect authorization flow.
+ */
+@property (nonatomic, nullable, readonly) NSURL *returnUrl;
+
+/**
  The Stripe ID of the Source used in this PaymentIntent.
  */
 @property (nonatomic, nullable, readonly) NSString *sourceId;

--- a/Stripe/PublicHeaders/STPRedirectContext.h
+++ b/Stripe/PublicHeaders/STPRedirectContext.h
@@ -128,15 +128,7 @@ NS_EXTENSION_UNAVAILABLE("STPRedirectContext is not available in extensions")
  This should be used when the `status` is `STPPaymentIntentStatusRequiresSourceAction`.
  If the next action involves a redirect, this init method will return a non-nil object.
 
- @note You must ensure that the `returnURL` set up in the created PaymentIntent
- correctly goes to your app so that users can be returned once
- they complete the redirect in the web broswer. The *same* value should be passed
- into this method, otherwise `+ [Stripe handleStripeURLCallbackWithURL:]` won't
- recognize it.
-
  @param paymentIntent The STPPaymentIntent that needs a redirect.
- @param returnUrl The same `returnUrl` that the PaymentIntent has, either passed during creation
- by your backend, or in `STPPaymentIntentParams.returnUrl`
  @param completion A block to fire when the action is believed to have
  been completed.
 
@@ -147,7 +139,6 @@ NS_EXTENSION_UNAVAILABLE("STPRedirectContext is not available in extensions")
  successfully performed the redirect action.
  */
 - (nullable instancetype)initWithPaymentIntent:(STPPaymentIntent *)paymentIntent
-                                     returnUrl:(NSString *)returnUrl
                                     completion:(STPRedirectContextPaymentIntentCompletionBlock)completion;
 
 /**

--- a/Stripe/STPPaymentIntent.m
+++ b/Stripe/STPPaymentIntent.m
@@ -23,6 +23,7 @@
 @property (nonatomic, copy, nullable, readwrite) NSString *stripeDescription;
 @property (nonatomic, assign, readwrite) BOOL livemode;
 @property (nonatomic, copy, nullable, readwrite) NSString *receiptEmail;
+@property (nonatomic, copy, nullable, readwrite) NSURL *returnUrl;
 @property (nonatomic, copy, nullable, readwrite) NSString *sourceId;
 @property (nonatomic, assign, readwrite) STPPaymentIntentStatus status;
 
@@ -51,6 +52,7 @@
                        [NSString stringWithFormat:@"livemode = %@", self.livemode ? @"YES" : @"NO"],
                        [NSString stringWithFormat:@"nextSourceAction = %@", self.allResponseFields[@"next_source_action"]],
                        [NSString stringWithFormat:@"receiptEmail = %@", self.receiptEmail],
+                       [NSString stringWithFormat:@"returnUrl = %@", self.returnUrl],
                        [NSString stringWithFormat:@"shipping = %@", self.allResponseFields[@"shipping"]],
                        [NSString stringWithFormat:@"sourceId = %@", self.sourceId],
                        [NSString stringWithFormat:@"status = %@", [self.allResponseFields stp_stringForKey:@"status"]],
@@ -148,6 +150,7 @@
     // next_source_action is not being parsed. Today type=`authorize_with_url` is the only one
     // and STPRedirectContext reaches directly into it. Not yet sure how I want to model
     // this polymorphic object, so keeping it out of the public API.
+    paymentIntent.returnUrl = [dict stp_urlForKey:@"return_url"];
     paymentIntent.receiptEmail = [dict stp_stringForKey:@"receipt_email"];
     // FIXME: add support for `shipping`
     paymentIntent.sourceId = [dict stp_stringForKey:@"source"];

--- a/Stripe/STPRedirectContext.m
+++ b/Stripe/STPRedirectContext.m
@@ -55,9 +55,8 @@ typedef void (^STPBoolCompletionBlock)(BOOL success);
 }
 
 - (nullable instancetype)initWithPaymentIntent:(STPPaymentIntent *)paymentIntent
-                                     returnUrl:(NSString *)returnUrl
                                     completion:(STPRedirectContextPaymentIntentCompletionBlock)completion {
-    if (!(returnUrl != nil
+    if (!(paymentIntent.returnUrl != nil
           && paymentIntent.status == STPPaymentIntentStatusRequiresSourceAction
           && [paymentIntent.allResponseFields[@"next_source_action"] isKindOfClass: [NSDictionary class]])) {
         return nil;
@@ -73,7 +72,7 @@ typedef void (^STPBoolCompletionBlock)(BOOL success);
     NSString *redirectUrl = nextSourceAction[@"value"][@"url"];
     return [self initWithNativeRedirectUrl:nil
                                redirectUrl:[NSURL URLWithString:redirectUrl]
-                                 returnUrl:[NSURL URLWithString:returnUrl]
+                                 returnUrl:paymentIntent.returnUrl
                                 completion:^(NSError * _Nullable error) {
                                     completion(paymentIntent.clientSecret, error);
                                 }];

--- a/Tests/Tests/STPPaymentIntentFunctionalTest.m
+++ b/Tests/Tests/STPPaymentIntentFunctionalTest.m
@@ -32,6 +32,7 @@
                                            XCTAssertFalse(paymentIntent.livemode);
                                            XCTAssertNil(paymentIntent.sourceId);
                                            XCTAssertEqual(paymentIntent.status, STPPaymentIntentStatusCanceled);
+                                           XCTAssertEqualObjects(paymentIntent.returnUrl, [NSURL URLWithString:@"payments-example://stripe-redirect"]);
 
                                            [expectation fulfill];
                                        }];

--- a/Tests/Tests/STPPaymentIntentTest.m
+++ b/Tests/Tests/STPPaymentIntentTest.m
@@ -159,6 +159,8 @@
     XCTAssertEqualObjects(paymentIntent.stripeDescription, @"My Sample PaymentIntent");
     XCTAssertFalse(paymentIntent.livemode);
     XCTAssertEqualObjects(paymentIntent.receiptEmail, @"danj@example.com");
+    XCTAssertNotNil(paymentIntent.returnUrl);
+    XCTAssertEqualObjects(paymentIntent.returnUrl, [NSURL URLWithString:@"payments-example://stripe-redirect"]);
     XCTAssertEqualObjects(paymentIntent.sourceId, @"src_1Cl1AdIl4IdHmuTbseiDWq6m");
     XCTAssertEqual(paymentIntent.status, STPPaymentIntentStatusRequiresSourceAction);
 


### PR DESCRIPTION
## Summary
Add 3DS example VC that uses PaymentIntents to charge the user

This is built on top of the existing 3DS example VC (using the same UI),
but intercepts the `pay` button response to use a PaymentIntent instead.

This relies on #986 and #987.

## Motivation
IOS-792

## Testing
Ran the example VC and played around with it. This was used as the test app for the previous
PRs.