### PR TITLE
Update example code for #994: `returnUrl` from `STPPaymentIntent`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   - TEST_TYPE=installation_cocoapods_frameworks
   - TEST_TYPE=lint
   - TEST_TYPE=tests
+  - TEST_TYPE=builds
   - TEST_TYPE=analyzer
   - TEST_TYPE=documentation
 
@@ -28,6 +29,7 @@ script:
 - "./ci_scripts/check_resource_bundle.rb"
 - '[ "$TEST_TYPE" != lint ] || ./ci_scripts/check_fauxpas.sh'
 - '[ "$TEST_TYPE" != tests ] || travis_retry ./ci_scripts/run_tests.sh'
+- '[ "$TEST_TYPE" != builds ] || travis_retry ./ci_scripts/run_builds.sh'
 - '[ "$TEST_TYPE" != analyzer ] || ./ci_scripts/run_analyzer.sh'
 - '[ "$TEST_TYPE" != installation_cocoapods_objc ] || ./Tests/installation_tests/cocoapods/without_frameworks_objc/test.sh'
 - '[ "$TEST_TYPE" != installation_cocoapods_frameworks_objc ] || ./Tests/installation_tests/cocoapods/with_frameworks_objc/test.sh'

--- a/Example/Custom Integration (ObjC)/BrowseExamplesViewController.h
+++ b/Example/Custom Integration (ObjC)/BrowseExamplesViewController.h
@@ -23,7 +23,7 @@ typedef void (^STPPaymentIntentCreationHandler)(STPBackendResult status, NSStrin
 - (void)exampleViewController:(UIViewController *)controller didFinishWithMessage:(NSString *)message;
 - (void)exampleViewController:(UIViewController *)controller didFinishWithError:(NSError *)error;
 - (void)createBackendChargeWithSource:(NSString *)sourceID completion:(STPSourceSubmissionHandler)completion;
-- (void)createBackendPaymentIntentWithAmount:(NSNumber *)amount returnUrl:(NSString *)returnUrl completion:(STPPaymentIntentCreationHandler)completion;
+- (void)createBackendPaymentIntentWithAmount:(NSNumber *)amount completion:(STPPaymentIntentCreationHandler)completion;
 
 @end
 

--- a/Example/Custom Integration (ObjC)/BrowseExamplesViewController.m
+++ b/Example/Custom Integration (ObjC)/BrowseExamplesViewController.m
@@ -152,7 +152,7 @@
  @param amount Amount to charge the customer
  @param completion completion block called with status of backend call & the client secret if successful.
  */
-- (void)createBackendPaymentIntentWithAmount:(NSNumber *)amount returnUrl:(NSString *)returnUrl completion:(STPPaymentIntentCreationHandler)completion {
+- (void)createBackendPaymentIntentWithAmount:(NSNumber *)amount completion:(STPPaymentIntentCreationHandler)completion {
     if (!BackendBaseURL) {
         NSError *error = [NSError errorWithDomain:StripeDomain
                                              code:STPInvalidRequestError
@@ -169,8 +169,7 @@
     NSURL *url = [NSURL URLWithString:urlString];
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url];
     request.HTTPMethod = @"POST";
-    NSString *encodedReturnUrl = [returnUrl stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet alphanumericCharacterSet]];
-    NSString *postBody = [NSString stringWithFormat:@"amount=%@&return_url=%@", amount, encodedReturnUrl];
+    NSString *postBody = [NSString stringWithFormat:@"amount=%@", amount];
     NSData *data = [postBody dataUsingEncoding:NSUTF8StringEncoding];
 
     NSURLSessionUploadTask *uploadTask = [session uploadTaskWithRequest:request

--- a/Example/Custom Integration (ObjC)/ThreeDSPaymentIntentExampleViewController.m
+++ b/Example/Custom Integration (ObjC)/ThreeDSPaymentIntentExampleViewController.m
@@ -54,12 +54,11 @@
     }
     [self updateUIForPaymentInProgress:YES];
 
-    NSString *returnUrl = @"payments-example://stripe-redirect";
     // In a more interesting app, you'll probably create your PaymentIntent as soon as you know the
     // payment amount you wish to collect from your customer. For simplicity, this example does it once they've
     // pushed the Pay button.
     // https://stripe.com/docs/payments/dynamic-authentication#create-payment-intent
-    [self.delegate createBackendPaymentIntentWithAmount:@1099 returnUrl:returnUrl completion:^(STPBackendResult status, NSString *clientSecret, NSError *error) {
+    [self.delegate createBackendPaymentIntentWithAmount:@1099 completion:^(STPBackendResult status, NSString *clientSecret, NSError *error) {
         if (status == STPBackendResultFailure || clientSecret == nil) {
             [self.delegate exampleViewController:self didFinishWithError:error];
             return;
@@ -68,6 +67,7 @@
         STPAPIClient *stripeClient = [STPAPIClient sharedClient];
         STPPaymentIntentParams *paymentIntentParams = [[STPPaymentIntentParams alloc] initWithClientSecret:clientSecret];
         paymentIntentParams.sourceParams = [STPSourceParams cardParamsWithCard:self.paymentTextField.cardParams];
+        paymentIntentParams.returnUrl = @"payments-example://stripe-redirect";
 
         [stripeClient confirmPaymentIntentWithParams:paymentIntentParams completion:^(STPPaymentIntent * _Nullable paymentIntent, NSError * _Nullable error) {
             if (error) {
@@ -76,7 +76,7 @@
             }
 
             if (paymentIntent.status == STPPaymentIntentStatusRequiresSourceAction) {
-                self.redirectContext = [[STPRedirectContext alloc] initWithPaymentIntent:paymentIntent returnUrl:returnUrl completion:^(NSString * _Nonnull clientSecret, NSError * _Nullable error) {
+                self.redirectContext = [[STPRedirectContext alloc] initWithPaymentIntent:paymentIntent completion:^(NSString * _Nonnull clientSecret, NSError * _Nullable error) {
                     if (error) {
                         [self.delegate exampleViewController:self didFinishWithError:error];
                     }

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,5 +1,9 @@
 ## Migration Guides
 
+### Migrating from versions < 13.1.0
+ * The SDK now supports PaymentIntents with `STPPaymentIntent`, which use `STPRedirectContext` in the same way that `STPSource` does
+   * `STPRedirectContextCompletionBlock` has been renamed to `STPRedirectContextSourceCompletionBlock`. It has the same signature, and Xcode should offer a deprecation warning & fix-it to help you migrate.
+
 ### Migrating from versions < 13.0.0
 * Remove Bitcoin source support because Stripe no longer processes Bitcoin payments: https://stripe.com/blog/ending-bitcoin-support
   * Sources can no longer have a "STPSourceTypeBitcoin" source type. These sources will now be interpreted as "STPSourceTypeUnknown".

--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -373,6 +373,13 @@
 		8BD87B951EFB1CB100269C2B /* STPSourceVerificationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BD87B941EFB1CB100269C2B /* STPSourceVerificationTest.m */; };
 		8BE5AE8B1EF8905B0081A33C /* STPCardParamsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BE5AE8A1EF8905B0081A33C /* STPCardParamsTest.m */; };
 		B318518320BE011700EE8C0F /* STPColorUtilsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = B318518220BE011700EE8C0F /* STPColorUtilsTest.m */; };
+		B32B175E20F6D2C4000D6EF8 /* STPGenericStripeObject.h in Headers */ = {isa = PBXBuildFile; fileRef = B32B175C20F6D2C4000D6EF8 /* STPGenericStripeObject.h */; };
+		B32B175F20F6D2C4000D6EF8 /* STPGenericStripeObject.h in Headers */ = {isa = PBXBuildFile; fileRef = B32B175C20F6D2C4000D6EF8 /* STPGenericStripeObject.h */; };
+		B32B176020F6D2C4000D6EF8 /* STPGenericStripeObject.m in Sources */ = {isa = PBXBuildFile; fileRef = B32B175D20F6D2C4000D6EF8 /* STPGenericStripeObject.m */; };
+		B32B176120F6D2C4000D6EF8 /* STPGenericStripeObject.m in Sources */ = {isa = PBXBuildFile; fileRef = B32B175D20F6D2C4000D6EF8 /* STPGenericStripeObject.m */; };
+		B32B176320F6D722000D6EF8 /* STPGenericStripeObjectTest.m in Sources */ = {isa = PBXBuildFile; fileRef = B32B176220F6D722000D6EF8 /* STPGenericStripeObjectTest.m */; };
+		B32B176520F80442000D6EF8 /* STPRedirectContext+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = B32B176420F80442000D6EF8 /* STPRedirectContext+Private.h */; };
+		B32B176620F80442000D6EF8 /* STPRedirectContext+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = B32B176420F80442000D6EF8 /* STPRedirectContext+Private.h */; };
 		B3302F462006FBA7005DDBE9 /* STPConnectAccountParamsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = B3302F452006FBA7005DDBE9 /* STPConnectAccountParamsTest.m */; };
 		B3302F4C200700AB005DDBE9 /* STPLegalEntityParamsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = B3302F4B200700AB005DDBE9 /* STPLegalEntityParamsTest.m */; };
 		B347DD481FE35423006B3BAC /* STPValidatedTextField.h in Headers */ = {isa = PBXBuildFile; fileRef = B347DD461FE35423006B3BAC /* STPValidatedTextField.h */; };
@@ -1063,6 +1070,10 @@
 		8BD87B941EFB1CB100269C2B /* STPSourceVerificationTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPSourceVerificationTest.m; sourceTree = "<group>"; };
 		8BE5AE8A1EF8905B0081A33C /* STPCardParamsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPCardParamsTest.m; sourceTree = "<group>"; };
 		B318518220BE011700EE8C0F /* STPColorUtilsTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPColorUtilsTest.m; sourceTree = "<group>"; };
+		B32B175C20F6D2C4000D6EF8 /* STPGenericStripeObject.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPGenericStripeObject.h; sourceTree = "<group>"; };
+		B32B175D20F6D2C4000D6EF8 /* STPGenericStripeObject.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPGenericStripeObject.m; sourceTree = "<group>"; };
+		B32B176220F6D722000D6EF8 /* STPGenericStripeObjectTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPGenericStripeObjectTest.m; sourceTree = "<group>"; };
+		B32B176420F80442000D6EF8 /* STPRedirectContext+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPRedirectContext+Private.h"; sourceTree = "<group>"; };
 		B3302F452006FBA7005DDBE9 /* STPConnectAccountParamsTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPConnectAccountParamsTest.m; sourceTree = "<group>"; };
 		B3302F4B200700AB005DDBE9 /* STPLegalEntityParamsTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPLegalEntityParamsTest.m; sourceTree = "<group>"; };
 		B347DD461FE35423006B3BAC /* STPValidatedTextField.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPValidatedTextField.h; sourceTree = "<group>"; };
@@ -1645,6 +1656,7 @@
 				C1CFCB701ED5E11500BE45DF /* STPFileTest.m */,
 				04CDB51F1A5F3A9300B854EE /* STPFormEncoderTest.m */,
 				C16F66AA1CA21BAC006A21B5 /* STPFormTextFieldTest.m */,
+				B32B176220F6D722000D6EF8 /* STPGenericStripeObjectTest.m */,
 				04827D171D257A6C002DB3E8 /* STPImageLibraryTest.m */,
 				B3302F4B200700AB005DDBE9 /* STPLegalEntityParamsTest.m */,
 				045A62AA1B8E7259000165CE /* STPPaymentCardTextFieldTest.m */,
@@ -1815,9 +1827,9 @@
 				04CDB4C31A5F30A700B854EE /* STPAPIClient.m */,
 				04633B061CD44F47009D4FB5 /* STPAPIClient+ApplePay.h */,
 				04633B041CD44F1C009D4FB5 /* STPAPIClient+ApplePay.m */,
+				C184107A1EC2539F00178149 /* STPEphemeralKeyProvider.h */,
 				F152321F1EA92FCF00D65C67 /* STPRedirectContext.h */,
 				F152321C1EA92FC100D65C67 /* STPRedirectContext.m */,
-				C184107A1EC2539F00178149 /* STPEphemeralKeyProvider.h */,
 			);
 			name = "API Bindings";
 			sourceTree = "<group>";
@@ -1900,11 +1912,15 @@
 				8B429ADD1EF9EFF600F95F34 /* STPFile+Private.h */,
 				04CDB4C41A5F30A700B854EE /* STPFormEncoder.h */,
 				04CDB4C51A5F30A700B854EE /* STPFormEncoder.m */,
+				B32B175C20F6D2C4000D6EF8 /* STPGenericStripeObject.h */,
+				B32B175D20F6D2C4000D6EF8 /* STPGenericStripeObject.m */,
 				C1CFCB661ED4E38900BE45DF /* STPInternalAPIResponseDecodable.h */,
 				F1D3A2471EB012010095BFA9 /* STPMultipartFormDataEncoder.h */,
 				F1D3A2481EB012010095BFA9 /* STPMultipartFormDataEncoder.m */,
 				F1D3A2491EB012010095BFA9 /* STPMultipartFormDataPart.h */,
 				F1D3A24A1EB012010095BFA9 /* STPMultipartFormDataPart.m */,
+				B3BDCAC120EEF2150034F7F5 /* STPPaymentIntent+Private.h */,
+				B32B176420F80442000D6EF8 /* STPRedirectContext+Private.h */,
 				C1C1012C1E57A26F00C7BFAE /* STPSource+Private.h */,
 				8BD87B871EFB131400269C2B /* STPSourceCardDetails+Private.h */,
 				F1A0197A1EA5733200354301 /* STPSourceParams+Private.h */,
@@ -1988,7 +2004,6 @@
 				B3A99BC21FEAF2CA003F6ED3 /* STPLegalEntityParams.m */,
 				B3BDCAC620EEF22D0034F7F5 /* STPPaymentIntent.h */,
 				B3BDCAC020EEF2150034F7F5 /* STPPaymentIntent.m */,
-				B3BDCAC120EEF2150034F7F5 /* STPPaymentIntent+Private.h */,
 				B3BDCAC720EEF22D0034F7F5 /* STPPaymentIntentEnums.h */,
 				B3BDCAD520EEF5EC0034F7F5 /* STPPaymentIntentParams.h */,
 				B3BDCAD220EEF5E00034F7F5 /* STPPaymentIntentParams.m */,
@@ -2128,6 +2143,7 @@
 				C159933D1D8808970047950D /* STPShippingMethodsViewController.h in Headers */,
 				F15232251EA9303800D65C67 /* STPURLCallbackHandler.h in Headers */,
 				B3A2413A1FFEB57400A2F00D /* STPConnectAccountParams.h in Headers */,
+				B32B176620F80442000D6EF8 /* STPRedirectContext+Private.h in Headers */,
 				F1D3A2561EB012350095BFA9 /* STPMultipartFormDataPart.h in Headers */,
 				04F94DCD1D22A22F004FC826 /* UIViewController+Stripe_KeyboardAvoiding.h in Headers */,
 				C1BD9B3A1E39416700CEE925 /* STPSourceOwner.h in Headers */,
@@ -2187,6 +2203,7 @@
 				0438EF491B74183100D506CC /* STPCardBrand.h in Headers */,
 				F12C8DC21D63DE9F00ADA0D7 /* STPPaymentContextAmountModel.h in Headers */,
 				F1D96F971DC7D82400477E64 /* STPLocalizationUtils.h in Headers */,
+				B32B175F20F6D2C4000D6EF8 /* STPGenericStripeObject.h in Headers */,
 				049A3FA91CC96B3B00F57DE7 /* STPBackendAPIAdapter.h in Headers */,
 				049952D61BCF14930088C703 /* STPAPIRequest.h in Headers */,
 				04827D111D2575C6002DB3E8 /* STPImageLibrary.h in Headers */,
@@ -2271,6 +2288,7 @@
 				C11810A71CC6EE840022FB55 /* STPBackendAPIAdapter.h in Headers */,
 				F12C8DC01D63DE9F00ADA0D7 /* STPPaymentContextAmountModel.h in Headers */,
 				B3A241391FFEB57400A2F00D /* STPConnectAccountParams.h in Headers */,
+				B32B176520F80442000D6EF8 /* STPRedirectContext+Private.h in Headers */,
 				F19491DE1E5F6B8C001E1FC2 /* STPSourceCardDetails.h in Headers */,
 				0439B9871C454F97005A1ED5 /* STPPaymentMethodsViewController.h in Headers */,
 				04B31DF91D11AC6400EF1631 /* STPUserInformation.h in Headers */,
@@ -2330,6 +2348,7 @@
 				F12829DA1D7747E4008B10D6 /* STPBundleLocator.h in Headers */,
 				C11810951CC6C4700022FB55 /* PKPaymentAuthorizationViewController+Stripe_Blocks.h in Headers */,
 				04CDB5161A5F30A700B854EE /* StripeError.h in Headers */,
+				B32B175E20F6D2C4000D6EF8 /* STPGenericStripeObject.h in Headers */,
 				049A3F991CC76A2400F57DE7 /* NSBundle+Stripe_AppName.h in Headers */,
 				04E32A9D1B7A9490009C9E35 /* STPPaymentCardTextField.h in Headers */,
 				C1BD9B221E393FFE00CEE925 /* STPSourceReceiver.h in Headers */,
@@ -2843,6 +2862,7 @@
 				C11810991CC6D46D0022FB55 /* NSDecimalNumber+StripeTest.m in Sources */,
 				8B5B4B441EFDD925005CF475 /* STPSourceOwnerTest.m in Sources */,
 				8B82C5CA1F2BC78F009639F7 /* STPApplePayPaymentMethodTest.m in Sources */,
+				B32B176320F6D722000D6EF8 /* STPGenericStripeObjectTest.m in Sources */,
 				B3BDCACF20EEF4640034F7F5 /* STPPaymentIntentFunctionalTest.m in Sources */,
 				8B013C891F1E784A00DD831B /* STPPaymentConfigurationTest.m in Sources */,
 				C1EEDCC81CA2172700A54582 /* NSString+StripeTest.m in Sources */,
@@ -2935,6 +2955,7 @@
 				B3A2413C1FFEB57400A2F00D /* STPConnectAccountParams.m in Sources */,
 				C1BD9B2B1E39406C00CEE925 /* STPSourceOwner.m in Sources */,
 				C1BD9B311E3940A200CEE925 /* STPSourceRedirect.m in Sources */,
+				B32B176120F6D2C4000D6EF8 /* STPGenericStripeObject.m in Sources */,
 				04B31DE91D09D25F00EF1631 /* STPPaymentMethodsInternalViewController.m in Sources */,
 				F12C8DC51D63DE9F00ADA0D7 /* STPPaymentContextAmountModel.m in Sources */,
 				04633B011CD129CB009D4FB5 /* STPPhoneNumberValidator.m in Sources */,
@@ -3001,6 +3022,7 @@
 				0438EF2F1B7416BB00D506CC /* STPFormTextField.m in Sources */,
 				045D71101CEEE30500F6CD65 /* STPAspects.m in Sources */,
 				F152321D1EA92FC100D65C67 /* STPRedirectContext.m in Sources */,
+				B32B176020F6D2C4000D6EF8 /* STPGenericStripeObject.m in Sources */,
 				04B31E011D131D9000EF1631 /* STPPaymentCardTextFieldCell.m in Sources */,
 				04633B0D1CD44F6C009D4FB5 /* PKPayment+Stripe.m in Sources */,
 				F1852F951D80B6EC00367C86 /* STPStringUtils.m in Sources */,

--- a/Stripe/PublicHeaders/STPPaymentIntent.h
+++ b/Stripe/PublicHeaders/STPPaymentIntent.h
@@ -84,6 +84,15 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nullable, readonly) NSString *receiptEmail;
 
 /**
+ The URL to redirect your customer back to after they authenticate or cancel their
+ payment on the payment method’s app or site.
+
+ This should be a URL that your app handles if the PaymentIntent is going to
+ be confirmed in your app, and it has a redirect authorization flow.
+ */
+@property (nonatomic, nullable, readonly) NSURL *returnUrl;
+
+/**
  The Stripe ID of the Source used in this PaymentIntent.
  */
 @property (nonatomic, nullable, readonly) NSString *sourceId;

--- a/Stripe/PublicHeaders/STPRedirectContext.h
+++ b/Stripe/PublicHeaders/STPRedirectContext.h
@@ -128,15 +128,7 @@ NS_EXTENSION_UNAVAILABLE("STPRedirectContext is not available in extensions")
  This should be used when the `status` is `STPPaymentIntentStatusRequiresSourceAction`.
  If the next action involves a redirect, this init method will return a non-nil object.
 
- @note You must ensure that the `returnURL` set up in the created PaymentIntent
- correctly goes to your app so that users can be returned once
- they complete the redirect in the web broswer. The *same* value should be passed
- into this method, otherwise `+ [Stripe handleStripeURLCallbackWithURL:]` won't
- recognize it.
-
  @param paymentIntent The STPPaymentIntent that needs a redirect.
- @param returnUrl The same `returnUrl` that the PaymentIntent has, either passed during creation
- by your backend, or in `STPPaymentIntentParams.returnUrl`
  @param completion A block to fire when the action is believed to have
  been completed.
 
@@ -147,7 +139,6 @@ NS_EXTENSION_UNAVAILABLE("STPRedirectContext is not available in extensions")
  successfully performed the redirect action.
  */
 - (nullable instancetype)initWithPaymentIntent:(STPPaymentIntent *)paymentIntent
-                                     returnUrl:(NSString *)returnUrl
                                     completion:(STPRedirectContextPaymentIntentCompletionBlock)completion;
 
 /**

--- a/Stripe/STPAPIClient+Private.h
+++ b/Stripe/STPAPIClient+Private.h
@@ -73,7 +73,7 @@ toCustomerUsingKey:(STPEphemeralKey *)ephemeralKey
  */
 + (void)deleteSource:(NSString *)sourceID
 fromCustomerUsingKey:(STPEphemeralKey *)ephemeralKey
-          completion:(STPSourceProtocolCompletionBlock)completion;
+          completion:(STPErrorBlock)completion;
 
 @end
 

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -15,16 +15,17 @@
 
 #import "NSBundle+Stripe_AppName.h"
 #import "NSError+Stripe.h"
-#import "STPAPIRequest.h"
+#import "NSMutableURLRequest+Stripe.h"
 #import "STPAnalyticsClient.h"
+#import "STPAPIRequest.h"
 #import "STPBankAccount.h"
 #import "STPCard.h"
 #import "STPDispatchFunctions.h"
 #import "STPEphemeralKey.h"
 #import "STPFormEncoder.h"
+#import "STPGenericStripeObject.h"
 #import "STPMultipartFormDataEncoder.h"
 #import "STPMultipartFormDataPart.h"
-#import "NSMutableURLRequest+Stripe.h"
 #import "STPPaymentConfiguration.h"
 #import "STPPaymentIntent+Private.h"
 #import "STPPaymentIntentParams.h"
@@ -542,15 +543,15 @@ toCustomerUsingKey:(STPEphemeralKey *)ephemeralKey
                                              }];
 }
 
-+ (void)deleteSource:(NSString *)sourceID fromCustomerUsingKey:(STPEphemeralKey *)ephemeralKey completion:(STPSourceProtocolCompletionBlock)completion {
++ (void)deleteSource:(NSString *)sourceID fromCustomerUsingKey:(STPEphemeralKey *)ephemeralKey completion:(STPErrorBlock)completion {
     STPAPIClient *client = [self apiClientWithEphemeralKey:ephemeralKey];
     NSString *endpoint = [NSString stringWithFormat:@"%@/%@/%@/%@", APIEndpointCustomers, ephemeralKey.customerID, APIEndpointSources, sourceID];
     [STPAPIRequest<STPSourceProtocol> deleteWithAPIClient:client
                                                  endpoint:endpoint
                                                parameters:nil
-                                            deserializers:@[[STPCard new], [STPSource new]]
-                                               completion:^(id object, __unused NSHTTPURLResponse *response, NSError *error) {
-                                                   completion(object, error);
+                                            deserializers:@[[STPGenericStripeObject new]]
+                                               completion:^(__unused STPGenericStripeObject *object, __unused NSHTTPURLResponse *response, NSError *error) {
+                                                   completion(error);
                                                }];
 }
 

--- a/Stripe/STPCustomerContext.m
+++ b/Stripe/STPCustomerContext.m
@@ -194,7 +194,7 @@ static NSTimeInterval const CachedCustomerMaxAge = 60;
 
         [STPAPIClient deleteSource:source.stripeID
               fromCustomerUsingKey:ephemeralKey
-                        completion:^(__unused id<STPSourceProtocol> obj, NSError *error) {
+                        completion:^(NSError *error) {
                             [self clearCachedCustomer];
 
                             if (completion) {

--- a/Stripe/STPGenericStripeObject.h
+++ b/Stripe/STPGenericStripeObject.h
@@ -1,0 +1,37 @@
+//
+//  STPGenericStripeObject.h
+//  Stripe
+//
+//  Created by Daniel Jackson on 7/11/18.
+//  Copyright © 2018 Stripe, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "STPAPIResponseDecodable.h"
+#import "STPSourceProtocol.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Generic decodable Stripe object. It only has an `id`
+
+ `STPAPIRequest` expects to be able to parse an object out of the result, otherwise
+ it considers the request to have failed.
+ This primarily exists to handle the response to calls like these:
+ - https://stripe.com/docs/api#delete_card + https://stripe.com/docs/api#detach_source
+ - https://stripe.com/docs/api#customer_delete_bank_account
+
+ This will probably never be useful to expose publicly, the caller probably already has the
+ id.
+ */
+@interface STPGenericStripeObject : NSObject <STPAPIResponseDecodable>
+
+/**
+ The stripe id of this object.
+ */
+@property (nonatomic, readonly) NSString *stripeId;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Stripe/STPGenericStripeObject.m
+++ b/Stripe/STPGenericStripeObject.m
@@ -1,0 +1,36 @@
+//
+//  STPGenericStripeObject.m
+//  Stripe
+//
+//  Created by Daniel Jackson on 7/11/18.
+//  Copyright © 2018 Stripe, Inc. All rights reserved.
+//
+
+#import "STPGenericStripeObject.h"
+
+#import "NSDictionary+Stripe.h"
+
+@interface STPGenericStripeObject ()
+@property (nonatomic, copy, readwrite) NSString *stripeId;
+@property (nonatomic, copy, readwrite) NSDictionary *allResponseFields;
+@end
+
+@implementation STPGenericStripeObject
+
++ (nullable instancetype)decodedObjectFromAPIResponse:(nullable NSDictionary *)response {
+    NSDictionary *dict = [response stp_dictionaryByRemovingNulls];
+    NSString *stripeId = [dict stp_stringForKey:@"id"];
+
+    // required fields
+    if (!stripeId) {
+        return nil;
+    }
+    STPGenericStripeObject *source = [self new];
+
+    source.stripeId = response[@"id"];
+    source.allResponseFields = dict;
+
+    return source;
+}
+
+@end

--- a/Stripe/STPPaymentIntent.m
+++ b/Stripe/STPPaymentIntent.m
@@ -23,6 +23,7 @@
 @property (nonatomic, copy, nullable, readwrite) NSString *stripeDescription;
 @property (nonatomic, assign, readwrite) BOOL livemode;
 @property (nonatomic, copy, nullable, readwrite) NSString *receiptEmail;
+@property (nonatomic, copy, nullable, readwrite) NSURL *returnUrl;
 @property (nonatomic, copy, nullable, readwrite) NSString *sourceId;
 @property (nonatomic, assign, readwrite) STPPaymentIntentStatus status;
 
@@ -51,6 +52,7 @@
                        [NSString stringWithFormat:@"livemode = %@", self.livemode ? @"YES" : @"NO"],
                        [NSString stringWithFormat:@"nextSourceAction = %@", self.allResponseFields[@"next_source_action"]],
                        [NSString stringWithFormat:@"receiptEmail = %@", self.receiptEmail],
+                       [NSString stringWithFormat:@"returnUrl = %@", self.returnUrl],
                        [NSString stringWithFormat:@"shipping = %@", self.allResponseFields[@"shipping"]],
                        [NSString stringWithFormat:@"sourceId = %@", self.sourceId],
                        [NSString stringWithFormat:@"status = %@", [self.allResponseFields stp_stringForKey:@"status"]],
@@ -148,6 +150,7 @@
     // next_source_action is not being parsed. Today type=`authorize_with_url` is the only one
     // and STPRedirectContext reaches directly into it. Not yet sure how I want to model
     // this polymorphic object, so keeping it out of the public API.
+    paymentIntent.returnUrl = [dict stp_urlForKey:@"return_url"];
     paymentIntent.receiptEmail = [dict stp_stringForKey:@"receipt_email"];
     // FIXME: add support for `shipping`
     paymentIntent.sourceId = [dict stp_stringForKey:@"source"];

--- a/Stripe/STPRedirectContext+Private.h
+++ b/Stripe/STPRedirectContext+Private.h
@@ -1,0 +1,26 @@
+//
+//  STPRedirectContext+Private.h
+//  Stripe
+//
+//  Created by Daniel Jackson on 7/12/18.
+//  Copyright © 2018 Stripe, Inc. All rights reserved.
+//
+
+#import "STPRedirectContext.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface STPRedirectContext()
+
+/// Optional URL for a native app. This is passed directly to `UIApplication openURL:`, and if it fails this class falls back to `redirectUrl`
+@property (nonatomic, nullable, copy) NSURL *nativeRedirectUrl;
+/// The URL to redirect to, assuming `nativeRedirectUrl` is nil or fails to open. Cannot be nil if `nativeRedirectUrl` is.
+@property (nonatomic, nullable, copy) NSURL *redirectUrl;
+/// The expected `returnUrl`, passed to STPURLCallbackHandler
+@property (nonatomic, copy) NSURL *returnUrl;
+/// Completion block to execute when finished redirecting, with optional error parameter.
+@property (nonatomic, copy) STPErrorBlock completion;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Tests/Tests/STPColorUtilsTest.m
+++ b/Tests/Tests/STPColorUtilsTest.m
@@ -104,32 +104,35 @@
     };
 
     CFStringRef colorSpaceNames[] = {
-      kCGColorSpaceSRGB,
-      kCGColorSpaceDCIP3,
-      kCGColorSpaceROMMRGB,
-      kCGColorSpaceITUR_709,
-      kCGColorSpaceDisplayP3,
-      kCGColorSpaceITUR_2020,
-      kCGColorSpaceGenericRGB,
-      kCGColorSpaceGenericXYZ,
-      kCGColorSpaceLinearGray,
-      kCGColorSpaceLinearSRGB,
-      kCGColorSpaceGenericCMYK,
-      kCGColorSpaceGenericGray,
-      kCGColorSpaceACESCGLinear,
-      kCGColorSpaceAdobeRGB1998,
-      kCGColorSpaceExtendedGray,
-      kCGColorSpaceExtendedSRGB,
-      kCGColorSpaceGenericRGBLinear,
-      kCGColorSpaceExtendedLinearGray,
-      kCGColorSpaceExtendedLinearSRGB,
-      kCGColorSpaceGenericGrayGamma2_2,
+        kCGColorSpaceSRGB,
+        kCGColorSpaceDCIP3,
+        kCGColorSpaceROMMRGB,
+        kCGColorSpaceITUR_709,
+        kCGColorSpaceDisplayP3,
+        kCGColorSpaceITUR_2020,
+        kCGColorSpaceGenericRGB,
+        kCGColorSpaceGenericXYZ,
+        kCGColorSpaceLinearSRGB,
+        kCGColorSpaceGenericCMYK,
+        kCGColorSpaceGenericGray,
+        kCGColorSpaceACESCGLinear,
+        kCGColorSpaceAdobeRGB1998,
+        kCGColorSpaceExtendedGray,
+        kCGColorSpaceExtendedSRGB,
+        kCGColorSpaceGenericRGBLinear,
+        kCGColorSpaceExtendedLinearSRGB,
+        kCGColorSpaceGenericGrayGamma2_2,
     };
 
     int colorSpaceCount = sizeof(colorSpaceNames) / sizeof(colorSpaceNames[0]);
     for (int i = 0; i < colorSpaceCount; ++i) {
         // CMYK is the only one where all 1's results in a dark color
         testColorSpace(colorSpaceNames[i], colorSpaceNames[i] != kCGColorSpaceGenericCMYK);
+    }
+
+    if (@available(iOS 10.0, *)) {
+        testColorSpace(kCGColorSpaceLinearGray, YES);
+        testColorSpace(kCGColorSpaceExtendedLinearGray, YES);
     }
 
     if (@available(iOS 11.0, *)) {

--- a/Tests/Tests/STPCustomerContextTest.m
+++ b/Tests/Tests/STPCustomerContextTest.m
@@ -285,9 +285,9 @@
                    fromCustomerUsingKey:[OCMArg isEqual:customerKey]
                              completion:[OCMArg any]])
     .andDo(^(NSInvocation *invocation) {
-        STPCustomerCompletionBlock completion;
+        STPErrorBlock completion;
         [invocation getArgument:&completion atIndex:4];
-        completion([STPFixtures customerWithSingleCardTokenSource], nil);
+        completion(nil);
         [exp fulfill];
     });
     id mockKeyManager = [self mockKeyManagerWithKey:customerKey];

--- a/Tests/Tests/STPFixtures.h
+++ b/Tests/Tests/STPFixtures.h
@@ -15,6 +15,8 @@ extern NSString *const STPTestJSONCustomer;
 
 extern NSString *const STPTestJSONCard;
 
+extern NSString *const STPTestJSONPaymentIntent;
+
 extern NSString *const STPTestJSONSourceAlipay;
 extern NSString *const STPTestJSONSourceCard;
 extern NSString *const STPTestJSONSource3DS;
@@ -120,6 +122,11 @@ extern NSString *const STPTestJSONSourceSEPADebit;
  A Source object with type Alipay and a native redirect url
  */
 + (STPSource *)alipaySourceWithNativeUrl;
+
+/**
+ A PaymentIntent object
+ */
++ (STPPaymentIntent *)paymentIntent;
 
 /**
  A PaymentConfiguration object with a fake publishable key. Use this to avoid

--- a/Tests/Tests/STPFixtures.m
+++ b/Tests/Tests/STPFixtures.m
@@ -14,6 +14,8 @@ NSString *const STPTestJSONCustomer = @"Customer";
 
 NSString *const STPTestJSONCard = @"Card";
 
+NSString *const STPTestJSONPaymentIntent = @"PaymentIntent";
+
 NSString *const STPTestJSONSourceAlipay = @"AlipaySource";
 NSString *const STPTestJSONSourceCard = @"CardSource";
 NSString *const STPTestJSONSource3DS = @"3DSSource";
@@ -186,6 +188,10 @@ NSString *const STPTestJSONSourceSEPADebit = @"SEPADebitSource";
     detailsDictionary[@"native_url"] = @"alipay://test";
     dictionary[@"alipay"] = detailsDictionary;
     return [STPSource decodedObjectFromAPIResponse:dictionary];
+}
+
++ (STPPaymentIntent *)paymentIntent {
+    return [STPPaymentIntent decodedObjectFromAPIResponse:[STPTestUtils jsonNamed:@"PaymentIntent"]];
 }
 
 + (STPPaymentConfiguration *)paymentConfiguration {

--- a/Tests/Tests/STPGenericStripeObjectTest.m
+++ b/Tests/Tests/STPGenericStripeObjectTest.m
@@ -1,0 +1,27 @@
+//
+//  STPGenericStripeObjectTest.m
+//  StripeiOS Tests
+//
+//  Created by Daniel Jackson on 7/11/18.
+//  Copyright © 2018 Stripe, Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "STPGenericStripeObject.h"
+
+@interface STPGenericStripeObjectTest : XCTestCase
+
+@end
+
+@implementation STPGenericStripeObjectTest
+
+- (void)testDecodedObject {
+    XCTAssertNil([STPGenericStripeObject decodedObjectFromAPIResponse:@{}]);
+
+    STPGenericStripeObject *obj = [STPGenericStripeObject decodedObjectFromAPIResponse:@{@"id": @"card_XYZ"}];
+    XCTAssertNotNil(obj);
+    XCTAssertEqualObjects(obj.stripeId, @"card_XYZ");
+}
+
+@end

--- a/Tests/Tests/STPPaymentIntentFunctionalTest.m
+++ b/Tests/Tests/STPPaymentIntentFunctionalTest.m
@@ -32,6 +32,7 @@
                                            XCTAssertFalse(paymentIntent.livemode);
                                            XCTAssertNil(paymentIntent.sourceId);
                                            XCTAssertEqual(paymentIntent.status, STPPaymentIntentStatusCanceled);
+                                           XCTAssertEqualObjects(paymentIntent.returnUrl, [NSURL URLWithString:@"payments-example://stripe-redirect"]);
 
                                            [expectation fulfill];
                                        }];

--- a/Tests/Tests/STPPaymentIntentTest.m
+++ b/Tests/Tests/STPPaymentIntentTest.m
@@ -11,6 +11,7 @@
 #import "STPPaymentIntent.h"
 #import "STPPaymentIntent+Private.h"
 
+#import "STPFixtures.h"
 #import "STPTestUtils.h"
 
 @interface STPPaymentIntentTest : XCTestCase
@@ -109,7 +110,7 @@
 #pragma mark - Description Tests
 
 - (void)testDescription {
-    STPPaymentIntent *paymentIntent = [STPPaymentIntent decodedObjectFromAPIResponse:[STPTestUtils jsonNamed:@"PaymentIntent"]];
+    STPPaymentIntent *paymentIntent = [STPFixtures paymentIntent];
 
     XCTAssertNotNil(paymentIntent);
     NSString *desc = paymentIntent.description;
@@ -120,7 +121,7 @@
 #pragma mark - STPAPIResponseDecodable Tests
 
 - (void)testDecodedObjectFromAPIResponseRequiredFields {
-    NSDictionary *fullJson = [STPTestUtils jsonNamed:@"PaymentIntent"];
+    NSDictionary *fullJson = [STPTestUtils jsonNamed:STPTestJSONPaymentIntent];
 
     XCTAssertNotNil([STPPaymentIntent decodedObjectFromAPIResponse:fullJson], @"can decode with full json");
 
@@ -158,6 +159,8 @@
     XCTAssertEqualObjects(paymentIntent.stripeDescription, @"My Sample PaymentIntent");
     XCTAssertFalse(paymentIntent.livemode);
     XCTAssertEqualObjects(paymentIntent.receiptEmail, @"danj@example.com");
+    XCTAssertNotNil(paymentIntent.returnUrl);
+    XCTAssertEqualObjects(paymentIntent.returnUrl, [NSURL URLWithString:@"payments-example://stripe-redirect"]);
     XCTAssertEqualObjects(paymentIntent.sourceId, @"src_1Cl1AdIl4IdHmuTbseiDWq6m");
     XCTAssertEqual(paymentIntent.status, STPPaymentIntentStatusRequiresSourceAction);
 

--- a/Tests/Tests/STPRedirectContextTest.m
+++ b/Tests/Tests/STPRedirectContextTest.m
@@ -8,10 +8,12 @@
 
 #import <SafariServices/SafariServices.h>
 #import <XCTest/XCTest.h>
+
 #import "NSError+Stripe.h"
 #import "NSURLComponents+Stripe.h"
 #import "STPFixtures.h"
 #import "STPRedirectContext.h"
+#import "STPRedirectContext+Private.h"
 #import "STPTestUtils.h"
 #import "STPURLCallbackHandler.h"
 #import "STPWeakStrongMacros.h"
@@ -77,6 +79,123 @@
     XCTAssertNil(sut);
 }
 
+- (void)testInitWithSource {
+    STPSource *source = [STPFixtures iDEALSource];
+    XCTestExpectation *expect = [self expectationWithDescription:@"completion"];
+    NSError *fakeError = [NSError new];
+
+    STPRedirectContext *sut = [[STPRedirectContext alloc] initWithSource:source completion:^(NSString * _Nonnull sourceID, NSString * _Nullable clientSecret, NSError * _Nullable error) {
+        XCTAssertEqualObjects(source.stripeID, sourceID);
+        XCTAssertEqualObjects(source.clientSecret, clientSecret);
+        XCTAssertEqual(error, fakeError, @"Should be the same NSError object passed to completion() below");
+        [expect fulfill];
+    }];
+
+    // Make sure the initWithSource: method pulled out the right values from the Source
+    XCTAssertNil(sut.nativeRedirectUrl);
+    XCTAssertEqualObjects(sut.redirectUrl, source.redirect.url);
+    XCTAssertEqualObjects(sut.returnUrl, source.redirect.returnURL);
+
+    // and make sure the completion calls the completion block above
+    sut.completion(fakeError);
+    [self waitForExpectationsWithTimeout:0 handler:nil];
+}
+
+- (void)testInitWithSourceWithNativeURL {
+    STPSource *source = [STPFixtures alipaySourceWithNativeUrl];
+    XCTestExpectation *expect = [self expectationWithDescription:@"completion"];
+    NSURL *nativeURL = [NSURL URLWithString:source.details[@"native_url"]];
+    NSError *fakeError = [NSError new];
+
+    STPRedirectContext *sut = [[STPRedirectContext alloc] initWithSource:source completion:^(NSString * _Nonnull sourceID, NSString * _Nullable clientSecret, NSError * _Nullable error) {
+        XCTAssertEqualObjects(source.stripeID, sourceID);
+        XCTAssertEqualObjects(source.clientSecret, clientSecret);
+        XCTAssertEqual(error, fakeError, @"Should be the same NSError object passed to completion() below");
+        [expect fulfill];
+    }];
+
+    // Make sure the initWithSource: method pulled out the right values from the Source
+    XCTAssertEqualObjects(sut.nativeRedirectUrl, nativeURL);
+    XCTAssertEqualObjects(sut.redirectUrl, source.redirect.url);
+    XCTAssertEqualObjects(sut.returnUrl, source.redirect.returnURL);
+
+    // and make sure the completion calls the completion block above
+    sut.completion(fakeError);
+    [self waitForExpectationsWithTimeout:0 handler:nil];
+}
+
+- (void)testInitWithPaymentIntent {
+    STPPaymentIntent *paymentIntent = [STPFixtures paymentIntent];
+    XCTestExpectation *expect = [self expectationWithDescription:@"completion"];
+    NSError *fakeError = [NSError new];
+
+    STPRedirectContext *sut = [[STPRedirectContext alloc] initWithPaymentIntent:paymentIntent completion:^(NSString * _Nonnull clientSecret, NSError * _Nullable error) {
+        XCTAssertEqualObjects(paymentIntent.clientSecret, clientSecret);
+        XCTAssertEqual(error, fakeError, @"Should be the same NSError object passed to completion() below");
+        [expect fulfill];
+    }];
+
+    // Make sure the initWithPaymentIntent: method pulled out the right values from the PaymentIntent
+    XCTAssertNil(sut.nativeRedirectUrl);
+    XCTAssertEqualObjects(sut.redirectUrl.absoluteString,
+                          @"https://hooks.stripe.com/redirect/authenticate/src_1Cl1AeIl4IdHmuTb1L7x083A?client_secret=src_client_secret_DBNwUe9qHteqJ8qQBwNWiigk");
+    XCTAssertEqualObjects(sut.returnUrl, paymentIntent.returnUrl);
+
+    // and make sure the completion calls the completion block above
+    sut.completion(fakeError);
+    [self waitForExpectationsWithTimeout:0 handler:nil];
+}
+
+- (void)testInitWithPaymentIntentFailures {
+    NSMutableDictionary *json = [[STPTestUtils jsonNamed:STPTestJSONPaymentIntent] mutableCopy];
+    json[@"next_source_action"] = [json[@"next_source_action"] mutableCopy];
+    json[@"next_source_action"][@"value"] = [json[@"next_source_action"][@"value"] mutableCopy];
+
+    void (^unusedCompletion)(NSString *, NSError *) = ^(__unused NSString * _Nonnull clientSecret, __unused NSError * _Nullable error) {
+        XCTFail(@"should not be constructed, definitely not completed");
+    };
+
+    STPRedirectContext *(^create)(void) = ^{
+        STPPaymentIntent *paymentIntent = [STPPaymentIntent decodedObjectFromAPIResponse:json];
+        return [[STPRedirectContext alloc] initWithPaymentIntent:paymentIntent
+                                                      completion:unusedCompletion];
+    };
+
+    XCTAssertNotNil(create(), @"before mutation of json, creation should succeed");
+
+    // `next_source_action` is not (currently) represented in the public API, and so there aren't
+    // any tests on it's decoding *other* than these right here. This is a white-box test for each condition
+    // that might result in a nil `STPRedirectContext`, because `STPRedirectContext` is the only place that
+    // understands `next_source_action` right now.
+
+    json[@"next_source_action"][@"value"][@"url"] = @"not a valid URL";
+    XCTAssertNil(create(), @"not created with an invalid URL in next_source_action.value.url");
+
+    json[@"next_source_action"][@"value"][@"url"] = @[@"an array", @"not a string"];
+    XCTAssertNil(create(), @"not created with a non-string next_source_action.value.url");
+
+    json[@"next_source_action"][@"value"] = @"not a dictionary";
+    XCTAssertNil(create(), @"not created with a non-dictionary next_source_action.value");
+
+    json[@"next_source_action"][@"value"] = @{ @"url": @"http://example.com/" };
+    json[@"next_source_action"][@"type"] = @"not_authorize_with_url";
+    XCTAssertNil(create(), @"not created with wrong next_source_action.type");
+
+    json[@"next_source_action"][@"type"] = @"authorize_with_url";
+    NSString *correctStatus = json[@"status"];
+    json[@"status"] = @"processing";
+    XCTAssertNil(create(), @"not created with wrong status");
+
+    json[@"status"] = correctStatus;
+    NSDictionary *nextSourceAction = json[@"next_source_action"];
+    json[@"next_source_action"] = @"not a dictionary";
+    XCTAssertNil(create(), @"not created with a non-dictionary next_source_action");
+
+    json[@"next_source_action"] = nextSourceAction;
+    json[@"return_url"] = @"not a url";
+    XCTAssertNil(create(), @"not created with invalid returnUrl");
+}
+
 /**
  After starting a SafariViewController redirect flow,
  when a WillEnterForeground notification is posted, RedirectContext's completion
@@ -126,6 +245,7 @@
         XCTAssertNil(error);
         [exp fulfill];
     }];
+    XCTAssertEqualObjects(source.redirect.returnURL, context.returnUrl);
     id sut = OCMPartialMock(context);
 
     [sut startSafariViewControllerRedirectFlowFromViewController:mockVC];
@@ -171,6 +291,7 @@
     BOOL(^checker)(id) = ^BOOL(id vc) {
         if ([vc isKindOfClass:[SFSafariViewController class]]) {
             NSURL *url = [NSURL URLWithString:@"my-app://some_path"];
+            XCTAssertNotEqualObjects(url, context.returnUrl);
             [[STPURLCallbackHandler shared] handleURLCallback:url];
             return YES;
         }
@@ -454,13 +575,22 @@
                                                                   completion:^(__unused NSString *sourceID, __unused NSString *clientSecret, __unused NSError *error) {
         XCTFail(@"completion called");
     }];
+
+    XCTAssertNotNil(context.nativeRedirectUrl);
+    XCTAssertEqualObjects(context.nativeRedirectUrl, sourceURL);
+
     id sut = OCMPartialMock(context);
 
     id applicationMock = OCMClassMock([UIApplication class]);
     OCMStub([applicationMock sharedApplication]).andReturn(applicationMock);
-    OCMStub([applicationMock openURL:[OCMArg any]
-                             options:[OCMArg any]
-                   completionHandler:([OCMArg invokeBlockWithArgs:@YES, nil])]);
+    if (@available(iOS 10, *)) {
+        OCMStub([applicationMock openURL:[OCMArg any]
+                                 options:[OCMArg any]
+                       completionHandler:([OCMArg invokeBlockWithArgs:@YES, nil])]);
+    }
+    else {
+        OCMStub([applicationMock openURL:[OCMArg any]]).andReturn(YES);
+    }
 
     OCMReject([sut startSafariViewControllerRedirectFlowFromViewController:[OCMArg any]]);
     OCMReject([sut startSafariAppRedirectFlow]);
@@ -468,9 +598,14 @@
     id mockVC = OCMClassMock([UIViewController class]);
     [sut startRedirectFlowFromViewController:mockVC];
 
-    OCMVerify([applicationMock openURL:[OCMArg isEqual:sourceURL]
-                               options:[OCMArg isEqual:@{}]
-                     completionHandler:[OCMArg isNotNil]]);
+    if (@available(iOS 10, *)) {
+        OCMVerify([applicationMock openURL:[OCMArg isEqual:sourceURL]
+                                   options:[OCMArg isEqual:@{}]
+                         completionHandler:[OCMArg isNotNil]]);
+    }
+    else {
+        OCMVerify([applicationMock openURL:[OCMArg isEqual:sourceURL]]);
+    }
 
     [sut unsubscribeFromNotifications];
 }
@@ -481,19 +616,26 @@
  */
 - (void)testNativeRedirectSupportingSourceFlow_invalidNativeURL {
     STPSource *source = [STPFixtures alipaySource];
-
     STPRedirectContext *context = [[STPRedirectContext alloc] initWithSource:source
                                                                   completion:^(__unused NSString *sourceID, __unused NSString *clientSecret, __unused NSError *error) {
                                                                       XCTFail(@"completion called");
                                                                   }];
+    XCTAssertNil(context.nativeRedirectUrl);
+
     id sut = OCMPartialMock(context);
 
     id applicationMock = OCMClassMock([UIApplication class]);
     OCMStub([applicationMock sharedApplication]).andReturn(applicationMock);
 
-    OCMReject([applicationMock openURL:[OCMArg any]
-                               options:[OCMArg any]
-                     completionHandler:[OCMArg any]]);
+    if (@available(iOS 10, *)) {
+        OCMReject([applicationMock openURL:[OCMArg any]
+                                   options:[OCMArg any]
+                         completionHandler:[OCMArg any]]);
+    }
+    else {
+        OCMReject([applicationMock openURL:[OCMArg any]]);
+    }
+
 
     id mockVC = OCMClassMock([UIViewController class]);
     [sut startRedirectFlowFromViewController:mockVC];

--- a/ci_scripts/run_builds.sh
+++ b/ci_scripts/run_builds.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+function info {
+  echo "[$(basename "${0}")] [INFO] ${1}"
+}
+
+function die {
+  echo "[$(basename "${0}")] [ERROR] ${1}"
+  exit 1
+}
+
+# Verify xcpretty is installed
+if ! command -v xcpretty > /dev/null; then
+  if [[ "${CI}" != "true" ]]; then
+    die "Please install xcpretty: https://github.com/supermarin/xcpretty#installation"
+  fi
+
+  info "Installing xcpretty..."
+  gem install xcpretty --no-ri --no-rdoc || die "Executing \`gem install xcpretty\` failed"
+fi
+
+# Install sample app dependencies
+info "Installing sample app dependencies..."
+
+cd "Example" || die "Executing \`cd\` failed"
+carthage bootstrap --platform iOS
+carthage_exit_code="$?"
+cd .. || die "Executing \`cd\` failed"
+
+if [[ "${carthage_exit_code}" != 0 ]]; then
+  die "Executing carthage failed with status code: ${carthage_exit_code}"
+fi
+
+# Execute sample app builds (iPhone 6, iOS 11.x)
+info "Executing sample app builds (iPhone 6, iOS 11.x)..."
+
+xcodebuild build \
+  -workspace "Stripe.xcworkspace" \
+  -scheme "Standard Integration (Swift)" \
+  -sdk "iphonesimulator" \
+  -destination "platform=iOS Simulator,name=iPhone 6,OS=11.2" \
+  | xcpretty
+
+exit_code="${PIPESTATUS[0]}"
+
+if [[ "${exit_code}" != 0 ]]; then
+  die "xcodebuild exited with non-zero status code: ${exit_code}"
+fi
+
+xcodebuild build \
+  -workspace "Stripe.xcworkspace" \
+  -scheme "Custom Integration (ObjC)" \
+  -sdk "iphonesimulator" \
+  -destination "platform=iOS Simulator,name=iPhone 6,OS=11.2" \
+  | xcpretty
+
+exit_code="${PIPESTATUS[0]}"
+
+if [[ "${exit_code}" != 0 ]]; then
+  die "xcodebuild exited with non-zero status code: ${exit_code}"
+fi
+
+info "All good!"

--- a/ci_scripts/run_tests.sh
+++ b/ci_scripts/run_tests.sh
@@ -1,10 +1,77 @@
-set -euf -o pipefail
+#!/bin/bash
 
-carthage bootstrap --platform ios --configuration Release --no-use-binaries
-cd Example; carthage bootstrap --platform ios; cd ..
+function info {
+  echo "[$(basename "${0}")] [INFO] ${1}"
+}
 
-gem install xcpretty --no-ri --no-rdoc
-xcodebuild clean build build-for-testing -workspace Stripe.xcworkspace -scheme "StripeiOS" -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=11.2' | xcpretty -c
-xcodebuild test-without-building -workspace Stripe.xcworkspace -scheme "StripeiOS" -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=11.2' | xcpretty -c
-xcodebuild build -workspace Stripe.xcworkspace -scheme "Standard Integration (Swift)" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=11.2'  | xcpretty -c
-xcodebuild build -workspace Stripe.xcworkspace -scheme "Custom Integration (ObjC)" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=11.2' | xcpretty -c
+function die {
+  echo "[$(basename "${0}")] [ERROR] ${1}"
+  exit 1
+}
+
+# Verify xcpretty is installed
+if ! command -v xcpretty > /dev/null; then
+  if [[ "${CI}" != "true" ]]; then
+    die "Please install xcpretty: https://github.com/supermarin/xcpretty#installation"
+  fi
+
+  info "Installing xcpretty..."
+  gem install xcpretty --no-ri --no-rdoc || die "Executing \`gem install xcpretty\` failed"
+fi
+
+# Install test dependencies
+info "Installing test dependencies..."
+
+carthage bootstrap --platform iOS --configuration Release --no-use-binaries
+carthage_exit_code="$?"
+
+if [[ "${carthage_exit_code}" != 0 ]]; then
+  die "Executing carthage failed with status code: ${carthage_exit_code}"
+fi
+
+# Execute tests (iPhone 6 @ iOS 11.2)
+info "Executing tests (iPhone 6 @ iOS 11.2)..."
+
+xcodebuild clean test \
+  -workspace "Stripe.xcworkspace" \
+  -scheme "StripeiOS" \
+  -configuration "Debug" \
+  -sdk "iphonesimulator" \
+  -destination "platform=iOS Simulator,name=iPhone 6,OS=11.2" \
+  | xcpretty
+
+exit_code="${PIPESTATUS[0]}"
+
+if [[ "${exit_code}" != 0 ]]; then
+  die "xcodebuild exited with non-zero status code: ${exit_code}"
+fi
+
+# Execute tests on legacy devices (iPhone 6 @ iOS 10.x, iPhone 6 @ iOS 9.x, iPhone 4s @ iOS 9.x)
+# - Skips snapshot tests because they're recorded for the iPhone 6 on the newest iOS version only
+# - Not sure why tests STPImageLibraryTest fail on older iOS versions
+# - Set `ONLY_ACTIVE_ARCH=NO` to build both 32-bit and 64-bit products
+info "Executing tests on legacy devices (iPhone 6 @ iOS 10.x, iPhone 6 @ iOS 9.x, iPhone 4s @ iOS 9.x)..."
+
+xcodebuild clean test \
+  -workspace "Stripe.xcworkspace" \
+  -scheme "StripeiOS" \
+  -configuration "Debug" \
+  -sdk "iphonesimulator" \
+  -destination "platform=iOS Simulator,name=iPhone 6,OS=10.3.1" \
+  -destination "platform=iOS Simulator,name=iPhone 6,OS=9.3" \
+  -destination "platform=iOS Simulator,name=iPhone 4s,OS=9.3" \
+  -skip-testing:"StripeiOS Tests/STPAddCardViewControllerLocalizationTests" \
+  -skip-testing:"StripeiOS Tests/STPPaymentMethodsViewControllerLocalizationTests" \
+  -skip-testing:"StripeiOS Tests/STPShippingAddressViewControllerLocalizationTests" \
+  -skip-testing:"StripeiOS Tests/STPShippingMethodsViewControllerLocalizationTests" \
+  -skip-testing:"StripeiOS Tests/STPImageLibraryTest" \
+  ONLY_ACTIVE_ARCH=NO \
+  | xcpretty
+
+exit_code="${PIPESTATUS[0]}"
+
+if [[ "${exit_code}" != 0 ]]; then
+  die "xcodebuild exited with non-zero status code: ${exit_code}"
+fi
+
+info "All good!"


### PR DESCRIPTION
## Summary
Updates the example code from #988 with the proposed change from #994.

This *also* attaches the `returnUrl` to the PaymentIntent via `/confirm` instead of sending it to the backend during PaymentIntent creation.

## Motivation
Simplifies the example code.

## Testing
Made sure it worked in the Custom Integration example app.