### PR TITLE
Run `STPImageLibraryTests` on iOS 9 using new `AssertEqualImages` macro from #976

### DIFF
--- a/Tests/Tests/STPImageLibraryTest.m
+++ b/Tests/Tests/STPImageLibraryTest.m
@@ -8,9 +8,12 @@
 
 #import <XCTest/XCTest.h>
 #import <OCMock/OCMock.h>
+
 #import "STPCardBrand.h"
 #import "STPImageLibrary.h"
 #import "STPImageLibrary+Private.h"
+
+#import "STPTestUtils.h"
 
 @interface STPImageLibraryTest : XCTestCase
 @property id mockLocale;
@@ -45,15 +48,15 @@
 }
 
 - (void)testCardIconMethods {
-    XCTAssertEqualObjects([STPImageLibrary applePayCardImage], [STPImageLibrary safeImageNamed:@"stp_card_applepay" templateIfAvailable:NO]);
-    XCTAssertEqualObjects([STPImageLibrary amexCardImage], [STPImageLibrary safeImageNamed:@"stp_card_amex" templateIfAvailable:NO]);
-    XCTAssertEqualObjects([STPImageLibrary dinersClubCardImage], [STPImageLibrary safeImageNamed:@"stp_card_diners" templateIfAvailable:NO]);
-    XCTAssertEqualObjects([STPImageLibrary discoverCardImage], [STPImageLibrary safeImageNamed:@"stp_card_discover" templateIfAvailable:NO]);
-    XCTAssertEqualObjects([STPImageLibrary jcbCardImage], [STPImageLibrary safeImageNamed:@"stp_card_jcb" templateIfAvailable:NO]);
-    XCTAssertEqualObjects([STPImageLibrary masterCardCardImage], [STPImageLibrary safeImageNamed:@"stp_card_mastercard" templateIfAvailable:NO]);
-    XCTAssertEqualObjects([STPImageLibrary unionPayCardImage], [STPImageLibrary safeImageNamed:@"stp_card_unionpay_en" templateIfAvailable:NO]);
-    XCTAssertEqualObjects([STPImageLibrary visaCardImage], [STPImageLibrary safeImageNamed:@"stp_card_visa" templateIfAvailable:NO]);
-    XCTAssertEqualObjects([STPImageLibrary unknownCardCardImage], [STPImageLibrary safeImageNamed:@"stp_card_unknown" templateIfAvailable:YES]);
+    AssertEqualImages([STPImageLibrary applePayCardImage], [STPImageLibrary safeImageNamed:@"stp_card_applepay" templateIfAvailable:NO]);
+    AssertEqualImages([STPImageLibrary amexCardImage], [STPImageLibrary safeImageNamed:@"stp_card_amex" templateIfAvailable:NO]);
+    AssertEqualImages([STPImageLibrary dinersClubCardImage], [STPImageLibrary safeImageNamed:@"stp_card_diners" templateIfAvailable:NO]);
+    AssertEqualImages([STPImageLibrary discoverCardImage], [STPImageLibrary safeImageNamed:@"stp_card_discover" templateIfAvailable:NO]);
+    AssertEqualImages([STPImageLibrary jcbCardImage], [STPImageLibrary safeImageNamed:@"stp_card_jcb" templateIfAvailable:NO]);
+    AssertEqualImages([STPImageLibrary masterCardCardImage], [STPImageLibrary safeImageNamed:@"stp_card_mastercard" templateIfAvailable:NO]);
+    AssertEqualImages([STPImageLibrary unionPayCardImage], [STPImageLibrary safeImageNamed:@"stp_card_unionpay_en" templateIfAvailable:NO]);
+    AssertEqualImages([STPImageLibrary visaCardImage], [STPImageLibrary safeImageNamed:@"stp_card_visa" templateIfAvailable:NO]);
+    AssertEqualImages([STPImageLibrary unknownCardCardImage], [STPImageLibrary safeImageNamed:@"stp_card_unknown" templateIfAvailable:YES]);
 }
 
 - (void)testBrandImageForCardBrand {
@@ -63,28 +66,28 @@
 
         switch (brand) {
             case STPCardBrandVisa:
-                XCTAssertEqualObjects(image, [STPImageLibrary safeImageNamed:@"stp_card_visa" templateIfAvailable:NO]);
+                AssertEqualImages(image, [STPImageLibrary safeImageNamed:@"stp_card_visa" templateIfAvailable:NO]);
                 break;
             case STPCardBrandAmex:
-                XCTAssertEqualObjects(image, [STPImageLibrary safeImageNamed:@"stp_card_amex" templateIfAvailable:NO]);
+                AssertEqualImages(image, [STPImageLibrary safeImageNamed:@"stp_card_amex" templateIfAvailable:NO]);
                 break;
             case STPCardBrandMasterCard:
-                XCTAssertEqualObjects(image, [STPImageLibrary safeImageNamed:@"stp_card_mastercard" templateIfAvailable:NO]);
+                AssertEqualImages(image, [STPImageLibrary safeImageNamed:@"stp_card_mastercard" templateIfAvailable:NO]);
                 break;
             case STPCardBrandDiscover:
-                XCTAssertEqualObjects(image, [STPImageLibrary safeImageNamed:@"stp_card_discover" templateIfAvailable:NO]);
+                AssertEqualImages(image, [STPImageLibrary safeImageNamed:@"stp_card_discover" templateIfAvailable:NO]);
                 break;
             case STPCardBrandJCB:
-                XCTAssertEqualObjects(image, [STPImageLibrary safeImageNamed:@"stp_card_jcb" templateIfAvailable:NO]);
+                AssertEqualImages(image, [STPImageLibrary safeImageNamed:@"stp_card_jcb" templateIfAvailable:NO]);
                 break;
             case STPCardBrandDinersClub:
-                XCTAssertEqualObjects(image, [STPImageLibrary safeImageNamed:@"stp_card_diners" templateIfAvailable:NO]);
+                AssertEqualImages(image, [STPImageLibrary safeImageNamed:@"stp_card_diners" templateIfAvailable:NO]);
                 break;
             case STPCardBrandUnionPay:
-                XCTAssertEqualObjects(image, [STPImageLibrary safeImageNamed:@"stp_card_unionpay_en" templateIfAvailable:NO]);
+                AssertEqualImages(image, [STPImageLibrary safeImageNamed:@"stp_card_unionpay_en" templateIfAvailable:NO]);
                 break;
             case STPCardBrandUnknown:
-                XCTAssertEqualObjects(image, [STPImageLibrary safeImageNamed:@"stp_card_unknown" templateIfAvailable:YES]);
+                AssertEqualImages(image, [STPImageLibrary safeImageNamed:@"stp_card_unknown" templateIfAvailable:YES]);
                 break;
         }
     }
@@ -98,7 +101,7 @@
     OCMStub([self.mockLocale localeIdentifier]).andReturn(@"ZH_HANT");
 
     UIImage *image = [STPImageLibrary brandImageForCardBrand:STPCardBrandUnionPay];
-    XCTAssertEqualObjects(image, [STPImageLibrary safeImageNamed:@"stp_card_unionpay_zh" templateIfAvailable:NO]);
+    AssertEqualImages(image, [STPImageLibrary safeImageNamed:@"stp_card_unionpay_zh" templateIfAvailable:NO]);
 }
 
 - (void)testTemplatedBrandImageForCardBrand {
@@ -108,28 +111,28 @@
 
         switch (brand) {
             case STPCardBrandVisa:
-                XCTAssertEqualObjects(image, [STPImageLibrary safeImageNamed:@"stp_card_visa_template" templateIfAvailable:YES]);
+                AssertEqualImages(image, [STPImageLibrary safeImageNamed:@"stp_card_visa_template" templateIfAvailable:YES]);
                 break;
             case STPCardBrandAmex:
-                XCTAssertEqualObjects(image, [STPImageLibrary safeImageNamed:@"stp_card_amex_template" templateIfAvailable:YES]);
+                AssertEqualImages(image, [STPImageLibrary safeImageNamed:@"stp_card_amex_template" templateIfAvailable:YES]);
                 break;
             case STPCardBrandMasterCard:
-                XCTAssertEqualObjects(image, [STPImageLibrary safeImageNamed:@"stp_card_mastercard_template" templateIfAvailable:YES]);
+                AssertEqualImages(image, [STPImageLibrary safeImageNamed:@"stp_card_mastercard_template" templateIfAvailable:YES]);
                 break;
             case STPCardBrandDiscover:
-                XCTAssertEqualObjects(image, [STPImageLibrary safeImageNamed:@"stp_card_discover_template" templateIfAvailable:YES]);
+                AssertEqualImages(image, [STPImageLibrary safeImageNamed:@"stp_card_discover_template" templateIfAvailable:YES]);
                 break;
             case STPCardBrandJCB:
-                XCTAssertEqualObjects(image, [STPImageLibrary safeImageNamed:@"stp_card_jcb_template" templateIfAvailable:YES]);
+                AssertEqualImages(image, [STPImageLibrary safeImageNamed:@"stp_card_jcb_template" templateIfAvailable:YES]);
                 break;
             case STPCardBrandDinersClub:
-                XCTAssertEqualObjects(image, [STPImageLibrary safeImageNamed:@"stp_card_diners_template" templateIfAvailable:YES]);
+                AssertEqualImages(image, [STPImageLibrary safeImageNamed:@"stp_card_diners_template" templateIfAvailable:YES]);
                 break;
             case STPCardBrandUnionPay:
-                XCTAssertEqualObjects(image, [STPImageLibrary safeImageNamed:@"stp_card_unionpay_template_en" templateIfAvailable:YES]);
+                AssertEqualImages(image, [STPImageLibrary safeImageNamed:@"stp_card_unionpay_template_en" templateIfAvailable:YES]);
                 break;
             case STPCardBrandUnknown:
-                XCTAssertEqualObjects(image, [STPImageLibrary safeImageNamed:@"stp_card_unknown" templateIfAvailable:YES]);
+                AssertEqualImages(image, [STPImageLibrary safeImageNamed:@"stp_card_unknown" templateIfAvailable:YES]);
                 break;
         }
     }
@@ -143,7 +146,7 @@
     OCMStub([self.mockLocale localeIdentifier]).andReturn(@"ZH_HANT");
 
     UIImage *image = [STPImageLibrary templatedBrandImageForCardBrand:STPCardBrandUnionPay];
-    XCTAssertEqualObjects(image, [STPImageLibrary safeImageNamed:@"stp_card_unionpay_template_zh" templateIfAvailable:YES]);
+    AssertEqualImages(image, [STPImageLibrary safeImageNamed:@"stp_card_unionpay_template_zh" templateIfAvailable:YES]);
 }
 
 - (void)testCVCImageForCardBrand {
@@ -153,11 +156,11 @@
 
         switch (brand) {
             case STPCardBrandAmex:
-                XCTAssertEqualObjects(image, [STPImageLibrary safeImageNamed:@"stp_card_cvc_amex" templateIfAvailable:NO]);
+                AssertEqualImages(image, [STPImageLibrary safeImageNamed:@"stp_card_cvc_amex" templateIfAvailable:NO]);
                 break;
 
             default:
-                XCTAssertEqualObjects(image, [STPImageLibrary safeImageNamed:@"stp_card_cvc" templateIfAvailable:NO]);
+                AssertEqualImages(image, [STPImageLibrary safeImageNamed:@"stp_card_cvc" templateIfAvailable:NO]);
                 break;
         }
     }
@@ -170,11 +173,11 @@
 
         switch (brand) {
             case STPCardBrandAmex:
-                XCTAssertEqualObjects(image, [STPImageLibrary safeImageNamed:@"stp_card_error_amex" templateIfAvailable:NO]);
+                AssertEqualImages(image, [STPImageLibrary safeImageNamed:@"stp_card_error_amex" templateIfAvailable:NO]);
                 break;
 
             default:
-                XCTAssertEqualObjects(image, [STPImageLibrary safeImageNamed:@"stp_card_error" templateIfAvailable:NO]);
+                AssertEqualImages(image, [STPImageLibrary safeImageNamed:@"stp_card_error" templateIfAvailable:NO]);
                 break;
         }
     }

--- a/ci_scripts/run_tests.sh
+++ b/ci_scripts/run_tests.sh
@@ -64,7 +64,6 @@ xcodebuild clean test \
   -skip-testing:"StripeiOS Tests/STPPaymentMethodsViewControllerLocalizationTests" \
   -skip-testing:"StripeiOS Tests/STPShippingAddressViewControllerLocalizationTests" \
   -skip-testing:"StripeiOS Tests/STPShippingMethodsViewControllerLocalizationTests" \
-  -skip-testing:"StripeiOS Tests/STPImageLibraryTest" \
   ONLY_ACTIVE_ARCH=NO \
   | xcpretty
 


### PR DESCRIPTION
## Summary
Same problem as d1e366948037a8f226b37ca4767f73f1170a0ed5, but they were disabled to avoid
build failures.

Now that we have a (hack/workaround) for image equality tests, use it.

## Motivation
Run more tests during CI on older devices.

## Testing
Ran the tests locally using the command from the build script.