### PR TITLE
Add client-side metadata `charge_request_id` to requests to `example-ios-backend`

### DIFF
--- a/Example/Custom Integration (ObjC)/BrowseExamplesViewController.m
+++ b/Example/Custom Integration (ObjC)/BrowseExamplesViewController.m
@@ -118,7 +118,12 @@
     NSURL *url = [NSURL URLWithString:urlString];
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url];
     request.HTTPMethod = @"POST";
-    NSString *postBody = [NSString stringWithFormat:@"source=%@&amount=%@", sourceID, @1099];
+    NSString *postBody = [NSString stringWithFormat:
+                          @"source=%@&amount=%@&metadata[charge_request_id]=%@",
+                          sourceID,
+                          @1099,
+                          // example-ios-backend allows passing metadata through to Stripe
+                          @"B3E611D1-5FA1-4410-9CEC-00958A5126CB"];
     NSData *data = [postBody dataUsingEncoding:NSUTF8StringEncoding];
 
     NSURLSessionUploadTask *uploadTask = [session uploadTaskWithRequest:request
@@ -169,7 +174,12 @@
     NSURL *url = [NSURL URLWithString:urlString];
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url];
     request.HTTPMethod = @"POST";
-    NSString *postBody = [NSString stringWithFormat:@"amount=%@", amount];
+    NSString *postBody = [NSString stringWithFormat:
+                          @"amount=%@&metadata[charge_request_id]=%@",
+                          amount,
+                          // example-ios-backend allows passing metadata through to Stripe
+                          @"B3E611D1-5FA1-4410-9CEC-00958A5126CB"
+                          ];
     NSData *data = [postBody dataUsingEncoding:NSUTF8StringEncoding];
 
     NSURLSessionUploadTask *uploadTask = [session uploadTaskWithRequest:request

--- a/Example/Custom Integration (ObjC)/Constants.m
+++ b/Example/Custom Integration (ObjC)/Constants.m
@@ -11,7 +11,7 @@
 // This can be found at https://dashboard.stripe.com/account/apikeys
 NSString *const StripePublishableKey = nil; // TODO: replace nil with your own value
 
-// To set this up, check out https://github.com/stripe/example-ios-backend/tree/v13.1.0
+// To set this up, check out https://github.com/stripe/example-ios-backend/tree/v13.2.0
 // This should be in the format https://my-shiny-backend.herokuapp.com
 NSString *const BackendBaseURL = nil; // TODO: replace nil with your own value
 

--- a/Example/Custom Integration (ObjC)/README.md
+++ b/Example/Custom Integration (ObjC)/README.md
@@ -10,7 +10,7 @@ For more details on using Sources, see https://stripe.com/docs/mobile/ios/source
 2. Execute `./setup.sh` from the root of the repository to build the necessary dependencies
 3. Open `./Stripe.xcworkspace` (not `./Stripe.xcodeproj`) with Xcode
 4. Fill in the `stripePublishableKey` constant in `./Example/Custom Integration (ObjC)/Constants.m` with your test "Publishable key" from Stripe. This key should start with `pk_test`.
-5. Head to [example-ios-backend](https://github.com/stripe/example-ios-backend/tree/v13.1.0) and click "Deploy to Heroku". Provide your Stripe test "Secret key" as the `STRIPE_TEST_SECRET_KEY` environment variable. This key should start with `sk_test`.
+5. Head to [example-ios-backend](https://github.com/stripe/example-ios-backend/tree/v13.2.0) and click "Deploy to Heroku". Provide your Stripe test "Secret key" as the `STRIPE_TEST_SECRET_KEY` environment variable. This key should start with `sk_test`.
 6. Fill in the `backendBaseURL` constant in `Constants.m` with the app URL Heroku provides (e.g. "https://my-example-app.herokuapp.com")
 
 After this is done, you can make test payments through the app and see them in your Stripe dashboard.

--- a/Example/Standard Integration (Swift)/CheckoutViewController.swift
+++ b/Example/Standard Integration (Swift)/CheckoutViewController.swift
@@ -16,7 +16,7 @@ class CheckoutViewController: UIViewController, STPPaymentContextDelegate {
     let stripePublishableKey = ""
 
     // 2) Next, optionally, to have this demo save your user's payment details, head to
-    // https://github.com/stripe/example-ios-backend/tree/v13.1.0, click "Deploy to Heroku", and follow
+    // https://github.com/stripe/example-ios-backend/tree/v13.2.0, click "Deploy to Heroku", and follow
     // the instructions (don't worry, it's free). Replace nil on the line below with your
     // Heroku URL (it looks like https://blazing-sunrise-1234.herokuapp.com ).
     let backendBaseURL: String? = nil

--- a/Example/Standard Integration (Swift)/MyAPIClient.swift
+++ b/Example/Standard Integration (Swift)/MyAPIClient.swift
@@ -30,8 +30,12 @@ class MyAPIClient: NSObject, STPEphemeralKeyProvider {
         let url = self.baseURL.appendingPathComponent("charge")
         var params: [String: Any] = [
             "source": result.source.stripeID,
-            "amount": amount
-        ]
+            "amount": amount,
+            "metadata": [
+                // example-ios-backend allows passing metadata through to Stripe
+                "charge_request_id": "B3E611D1-5FA1-4410-9CEC-00958A5126CB",
+            ],
+            ]
         params["shipping"] = STPAddress.shippingInfoForCharge(with: shippingAddress, shippingMethod: shippingMethod)
         Alamofire.request(url, method: .post, parameters: params)
             .validate(statusCode: 200..<300)

--- a/Example/Standard Integration (Swift)/README.md
+++ b/Example/Standard Integration (Swift)/README.md
@@ -8,7 +8,7 @@ For a detailed guide, see https://stripe.com/docs/mobile/ios/standard
 2. Execute `./setup.sh` from the root of the repository to build the necessary dependencies
 3. Open `./Stripe.xcworkspace` (not `./Stripe.xcodeproj`) with Xcode
 4. Fill in the `stripePublishableKey` constant in `./Example/Standard Integration (Swift)/CheckoutViewController.swift` with your test "Publishable key" from Stripe. This key should start with `pk_test`.
-5. Head to [example-ios-backend](https://github.com/stripe/example-ios-backend/tree/v13.1.0) and click "Deploy to Heroku". Provide your Stripe test "Secret key" as the `STRIPE_TEST_SECRET_KEY` environment variable. This key should start with `pk_test`.
+5. Head to [example-ios-backend](https://github.com/stripe/example-ios-backend/tree/v13.2.0) and click "Deploy to Heroku". Provide your Stripe test "Secret key" as the `STRIPE_TEST_SECRET_KEY` environment variable. This key should start with `pk_test`.
 6. Fill in the `backendBaseURL` constant in `./Example/Standard Integration (Swift)/CheckoutViewController.swift` with the app URL Heroku provides (e.g. "https://my-example-app.herokuapp.com")
 
 After this is done, you can make test payments through the app and see them in your Stripe dashboard.

--- a/Stripe/PublicHeaders/STPEphemeralKeyProvider.h
+++ b/Stripe/PublicHeaders/STPEphemeralKeyProvider.h
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
  On your backend, you should create a new ephemeral key for the Stripe customer
  associated with your user, and return the raw JSON response from the Stripe API.
  For an example Ruby implementation of this API, refer to our example backend:
- https://github.com/stripe/example-ios-backend/blob/v13.1.0/web.rb
+ https://github.com/stripe/example-ios-backend/blob/v13.2.0/web.rb
 
  Back in your iOS app, once you have a response from this API, call the provided
  completion block with the JSON response, or an error if one occurred.


### PR DESCRIPTION
## Summary

The sample apps are now sending a (meaningless) randomly generated UUID value through
stripe/example-ios-backend as metadata from the client.

`charge_request_id: B3E611D1-5FA1-4410-9CEC-00958A5126CB`

Also updating all of our links to the example-ios-backend to use the latest release
that includes support for this feature.

## Motivation
IOS-356

Along with the changes from stripe/example-ios-backend#35, this shows off some of what
`metadata` can be used for.

## Testing
Ran each of the sample apps, created Charges and a PaymentIntent, and then manually
verified the metadata was associated with the newly created Payments in the web dashboard.

We don't have automated testing of the sample apps, and this doesn't change the SDK.