### PR TITLE
Fixes STPPaymentCardTextField layout issues on small screens

### DIFF
--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -324,11 +324,12 @@
 		04F94DD31D22A23F004FC826 /* NSBundle+Stripe_AppName.h in Headers */ = {isa = PBXBuildFile; fileRef = 049A3F971CC76A2400F57DE7 /* NSBundle+Stripe_AppName.h */; };
 		04F94DD41D22A242004FC826 /* NSBundle+Stripe_AppName.m in Sources */ = {isa = PBXBuildFile; fileRef = 049A3F981CC76A2400F57DE7 /* NSBundle+Stripe_AppName.m */; };
 		04FCFA191BD59A8C00297732 /* STPCategoryLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 04FCFA171BD59A8C00297732 /* STPCategoryLoader.h */; };
-		3691EB712119111A008C49E1 /* STPCardValidator+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 3691EB6F2119111A008C49E1 /* STPCardValidator+Private.h */; };
-		3691EB722119111A008C49E1 /* STPCardValidator+Private.m in Sources */ = {isa = PBXBuildFile; fileRef = 3691EB702119111A008C49E1 /* STPCardValidator+Private.m */; };
 		3617A51420FE5BBB001A9E6A /* NSLocale+STPSwizzling.h in Headers */ = {isa = PBXBuildFile; fileRef = 3617A51220FE5BBB001A9E6A /* NSLocale+STPSwizzling.h */; };
 		3617A51520FE5BBB001A9E6A /* NSLocale+STPSwizzling.m in Sources */ = {isa = PBXBuildFile; fileRef = 3617A51320FE5BBB001A9E6A /* NSLocale+STPSwizzling.m */; };
+		3691EB712119111A008C49E1 /* STPCardValidator+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 3691EB6F2119111A008C49E1 /* STPCardValidator+Private.h */; };
+		3691EB722119111A008C49E1 /* STPCardValidator+Private.m in Sources */ = {isa = PBXBuildFile; fileRef = 3691EB702119111A008C49E1 /* STPCardValidator+Private.m */; };
 		3691EB74211A4F31008C49E1 /* STPShippingAddressViewControllerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 3691EB73211A4F31008C49E1 /* STPShippingAddressViewControllerTest.m */; };
+		36A734282121F8A700784615 /* STPCardValidator+Private.m in Sources */ = {isa = PBXBuildFile; fileRef = 3691EB702119111A008C49E1 /* STPCardValidator+Private.m */; };
 		8B013C891F1E784A00DD831B /* STPPaymentConfigurationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B013C881F1E784A00DD831B /* STPPaymentConfigurationTest.m */; };
 		8B39128220E2F99600098401 /* EPSSource.json in Resources */ = {isa = PBXBuildFile; fileRef = 8B39128120E2F99600098401 /* EPSSource.json */; };
 		8B39128320E2F9A100098401 /* BancontactSource.json in Resources */ = {isa = PBXBuildFile; fileRef = 8B39127F20E2F6A500098401 /* BancontactSource.json */; };
@@ -1047,10 +1048,10 @@
 		04F94D6F1D21CB20004FC826 /* StripeiOSResources.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = StripeiOSResources.xcconfig; sourceTree = "<group>"; };
 		04FCFA171BD59A8C00297732 /* STPCategoryLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPCategoryLoader.h; sourceTree = "<group>"; };
 		11C74B9B164043050071C2CA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
-		3691EB6F2119111A008C49E1 /* STPCardValidator+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCardValidator+Private.h"; sourceTree = "<group>"; };
-		3691EB702119111A008C49E1 /* STPCardValidator+Private.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "STPCardValidator+Private.m"; sourceTree = "<group>"; };
 		3617A51220FE5BBB001A9E6A /* NSLocale+STPSwizzling.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSLocale+STPSwizzling.h"; sourceTree = "<group>"; };
 		3617A51320FE5BBB001A9E6A /* NSLocale+STPSwizzling.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSLocale+STPSwizzling.m"; sourceTree = "<group>"; };
+		3691EB6F2119111A008C49E1 /* STPCardValidator+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCardValidator+Private.h"; sourceTree = "<group>"; };
+		3691EB702119111A008C49E1 /* STPCardValidator+Private.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "STPCardValidator+Private.m"; sourceTree = "<group>"; };
 		3691EB73211A4F31008C49E1 /* STPShippingAddressViewControllerTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPShippingAddressViewControllerTest.m; sourceTree = "<group>"; };
 		4A0D74F918F6106100966D7B /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		7E0B1132203572FB00271AD3 /* fi */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = fi; path = Localizations/fi.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -2947,6 +2948,7 @@
 				04F94DA91D229F32004FC826 /* STPPaymentMethodTuple.m in Sources */,
 				C15608E01FE08F2E0032AE66 /* UIView+Stripe_SafeAreaBounds.m in Sources */,
 				F1A2F92F1EEB6A70006B0456 /* NSCharacterSet+Stripe.m in Sources */,
+				36A734282121F8A700784615 /* STPCardValidator+Private.m in Sources */,
 				F19491E51E60DD72001E1FC2 /* STPSourceSEPADebitDetails.m in Sources */,
 				C1785F5F1EC60B5E00E9CFAC /* STPCardIOProxy.m in Sources */,
 				0438EF311B7416BB00D506CC /* STPFormTextField.m in Sources */,

--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -324,6 +324,8 @@
 		04F94DD31D22A23F004FC826 /* NSBundle+Stripe_AppName.h in Headers */ = {isa = PBXBuildFile; fileRef = 049A3F971CC76A2400F57DE7 /* NSBundle+Stripe_AppName.h */; };
 		04F94DD41D22A242004FC826 /* NSBundle+Stripe_AppName.m in Sources */ = {isa = PBXBuildFile; fileRef = 049A3F981CC76A2400F57DE7 /* NSBundle+Stripe_AppName.m */; };
 		04FCFA191BD59A8C00297732 /* STPCategoryLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 04FCFA171BD59A8C00297732 /* STPCategoryLoader.h */; };
+		3691EB712119111A008C49E1 /* STPCardValidator+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 3691EB6F2119111A008C49E1 /* STPCardValidator+Private.h */; };
+		3691EB722119111A008C49E1 /* STPCardValidator+Private.m in Sources */ = {isa = PBXBuildFile; fileRef = 3691EB702119111A008C49E1 /* STPCardValidator+Private.m */; };
 		8B013C891F1E784A00DD831B /* STPPaymentConfigurationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B013C881F1E784A00DD831B /* STPPaymentConfigurationTest.m */; };
 		8B39128220E2F99600098401 /* EPSSource.json in Resources */ = {isa = PBXBuildFile; fileRef = 8B39128120E2F99600098401 /* EPSSource.json */; };
 		8B39128320E2F9A100098401 /* BancontactSource.json in Resources */ = {isa = PBXBuildFile; fileRef = 8B39127F20E2F6A500098401 /* BancontactSource.json */; };
@@ -1042,6 +1044,8 @@
 		04F94D6F1D21CB20004FC826 /* StripeiOSResources.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = StripeiOSResources.xcconfig; sourceTree = "<group>"; };
 		04FCFA171BD59A8C00297732 /* STPCategoryLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPCategoryLoader.h; sourceTree = "<group>"; };
 		11C74B9B164043050071C2CA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		3691EB6F2119111A008C49E1 /* STPCardValidator+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCardValidator+Private.h"; sourceTree = "<group>"; };
+		3691EB702119111A008C49E1 /* STPCardValidator+Private.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "STPCardValidator+Private.m"; sourceTree = "<group>"; };
 		4A0D74F918F6106100966D7B /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		7E0B1132203572FB00271AD3 /* fi */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = fi; path = Localizations/fi.lproj/Localizable.strings; sourceTree = "<group>"; };
 		8B013C881F1E784A00DD831B /* STPPaymentConfigurationTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPPaymentConfigurationTest.m; sourceTree = "<group>"; };
@@ -1875,6 +1879,8 @@
 				F12829D91D7747E4008B10D6 /* STPBundleLocator.m */,
 				C1785F5A1EC60B5E00E9CFAC /* STPCardIOProxy.h */,
 				C1785F5B1EC60B5E00E9CFAC /* STPCardIOProxy.m */,
+				3691EB6F2119111A008C49E1 /* STPCardValidator+Private.h */,
+				3691EB702119111A008C49E1 /* STPCardValidator+Private.m */,
 				04FCFA171BD59A8C00297732 /* STPCategoryLoader.h */,
 				04633B0A1CD44F6C009D4FB5 /* STPCategoryLoader.m */,
 				0426B96C1CEADC98006AC8DD /* STPColorUtils.h */,
@@ -2347,6 +2353,7 @@
 				049952D21BCF13DD0088C703 /* STPAPIClient+Private.h in Headers */,
 				8B429AD81EF9D4B400F95F34 /* STPBankAccountParams+Private.h in Headers */,
 				049A3F911CC740FF00F57DE7 /* NSDecimalNumber+Stripe_Currency.h in Headers */,
+				3691EB712119111A008C49E1 /* STPCardValidator+Private.h in Headers */,
 				04633B071CD44F47009D4FB5 /* STPAPIClient+ApplePay.h in Headers */,
 				04BC29BD1CDD535700318357 /* STPSwitchTableViewCell.h in Headers */,
 				04CDB5121A5F30A700B854EE /* STPToken.h in Headers */,
@@ -3098,6 +3105,7 @@
 				C158AB401E1EE98900348D01 /* STPSectionHeaderView.m in Sources */,
 				F148ABC81D5D334B0014FD92 /* STPLocalizationUtils.m in Sources */,
 				04A4C38B1C4F25F900B3B290 /* NSArray+Stripe.m in Sources */,
+				3691EB722119111A008C49E1 /* STPCardValidator+Private.m in Sources */,
 				F19491E41E60DD72001E1FC2 /* STPSourceSEPADebitDetails.m in Sources */,
 				04A4C38F1C4F25F900B3B290 /* UIViewController+Stripe_ParentViewController.m in Sources */,
 				049A3FAF1CC9AA9900F57DE7 /* STPAddressViewModel.m in Sources */,

--- a/Stripe/NSString+Stripe.h
+++ b/Stripe/NSString+Stripe.h
@@ -13,6 +13,7 @@
 - (NSString *)stp_safeSubstringToIndex:(NSUInteger)index;
 - (NSString *)stp_safeSubstringFromIndex:(NSUInteger)index;
 - (NSString *)stp_reversedString;
+- (NSString *)stp_stringByRemovingSuffix:(NSString *)suffix;
 
 @end
 

--- a/Stripe/NSString+Stripe.m
+++ b/Stripe/NSString+Stripe.m
@@ -28,6 +28,14 @@
     return [mutableReversedString copy];
 }
 
+- (NSString *)stp_stringByRemovingSuffix:(NSString *)suffix {
+    if (suffix != nil && [self hasSuffix:suffix]) {
+        return [self stp_safeSubstringToIndex:self.length-suffix.length];
+    } else {
+        return [self copy];
+    }
+}
+
 @end
 
 void linkNSStringCategory(void){}

--- a/Stripe/STPCardValidator+Private.h
+++ b/Stripe/STPCardValidator+Private.h
@@ -17,3 +17,5 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+
+void linkSTPCardValidatorPrivateCategory(void);

--- a/Stripe/STPCardValidator+Private.h
+++ b/Stripe/STPCardValidator+Private.h
@@ -1,0 +1,19 @@
+//
+//  STPCardValidator+Private.h
+//  StripeiOS
+//
+//  Created by Cameron Sabol on 8/6/18.
+//  Copyright © 2018 Stripe, Inc. All rights reserved.
+//
+
+#import "STPCardValidator.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface STPCardValidator (Private)
+
++ (NSArray<NSNumber *> *)cardNumberFormatForBrand:(STPCardBrand)brand;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Stripe/STPCardValidator+Private.m
+++ b/Stripe/STPCardValidator+Private.m
@@ -1,0 +1,29 @@
+//
+//  STPCardValidator+Private.m
+//  StripeiOS
+//
+//  Created by Cameron Sabol on 8/6/18.
+//  Copyright © 2018 Stripe, Inc. All rights reserved.
+//
+
+#import "STPCardValidator+Private.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation STPCardValidator (Private)
+
++ (NSArray<NSNumber *> *)cardNumberFormatForBrand:(STPCardBrand)brand
+{
+    switch (brand) {
+        case STPCardBrandAmex:
+            return @[@4, @6, @5];
+        case STPCardBrandDinersClub:
+            return @[@4, @6, @4];
+        default:
+            return @[@4, @4, @4, @4];
+    }
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Stripe/STPCardValidator+Private.m
+++ b/Stripe/STPCardValidator+Private.m
@@ -27,3 +27,5 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+
+void linkSTPCardValidatorPrivateCategory(void){}

--- a/Stripe/STPCardValidator.m
+++ b/Stripe/STPCardValidator.m
@@ -7,6 +7,7 @@
 //
 
 #import "STPCardValidator.h"
+#import "STPCardValidator+Private.h"
 
 #import "STPBINRange.h"
 #import "NSCharacterSet+Stripe.h"
@@ -241,14 +242,7 @@ static NSString * _Nonnull stringByRemovingCharactersFromSet(NSString * _Nonnull
 }
 
 + (NSInteger)fragmentLengthForCardBrand:(STPCardBrand)brand {
-    switch (brand) {
-        case STPCardBrandAmex:
-            return 5;
-        case STPCardBrandDinersClub:
-            return 2;
-        default:
-            return 4;
-    }
+    return [[[self cardNumberFormatForBrand:brand] lastObject] unsignedIntegerValue];
 }
 
 + (BOOL)stringIsValidLuhn:(NSString *)number {

--- a/Stripe/STPCategoryLoader.m
+++ b/Stripe/STPCategoryLoader.m
@@ -23,6 +23,7 @@
 #import "PKPaymentAuthorizationViewController+Stripe_Blocks.h"
 #import "STPAPIClient+ApplePay.h"
 #import "STPAspects.h"
+#import "STPCardValidator+Private.h"
 #import "STPCustomer+SourceTuple.h"
 #import "StripeError.h"
 #import "UIBarButtonItem+Stripe.h"
@@ -54,6 +55,7 @@
     linkPKPaymentAuthorizationViewControllerBlocksCategory();
     linkPKPaymentCategory();
     linkSTPAPIClientApplePayCategory();
+    linkSTPCardValidatorPrivateCategory();
     linkSTPCustomerSourceTupleCategory();
     linkUIBarButtonItemCategory();
     linkUIImageCategory();

--- a/Stripe/STPFormTextField.m
+++ b/Stripe/STPFormTextField.m
@@ -10,6 +10,7 @@
 
 #import "NSString+Stripe.h"
 #import "STPCardValidator.h"
+#import "STPCardValidator+Private.h"
 #import "STPDelegateProxy.h"
 #import "STPPhoneNumberValidator.h"
 #import "STPWeakStrongMacros.h"
@@ -132,20 +133,20 @@ typedef NSAttributedString* (^STPFormTextTransformationBlock)(NSAttributedString
                     return [inputString copy];
                 }
                 NSMutableAttributedString *attributedString = [inputString mutableCopy];
-                NSArray *cardSpacing;
                 STPCardBrand currentBrand = [STPCardValidator brandForNumber:attributedString.string];
-                if (currentBrand == STPCardBrandAmex) {
-                    cardSpacing = @[@3, @9];
-                } else {
-                    cardSpacing = @[@3, @7, @11];
-                }
-                for (NSUInteger i = 0; i < attributedString.length; i++) {
-                    if ([cardSpacing containsObject:@(i)]) {
-                        [attributedString addAttribute:NSKernAttributeName value:@(5)
-                                                 range:NSMakeRange(i, 1)];
-                    } else {
-                        [attributedString addAttribute:NSKernAttributeName value:@(0)
-                                                 range:NSMakeRange(i, 1)];
+                NSArray<NSNumber *> *cardNumberFormat = [STPCardValidator cardNumberFormatForBrand:currentBrand];
+
+                NSUInteger index = 0;
+                for (NSNumber *segmentLength in cardNumberFormat) {
+                    NSUInteger segmentIndex = 0;
+                    for (; index < attributedString.length && segmentIndex < [segmentLength unsignedIntegerValue]; index++, segmentIndex++) {
+                        if (segmentIndex + 1 == [segmentLength unsignedIntegerValue]) {
+                            [attributedString addAttribute:NSKernAttributeName value:@(5)
+                                                     range:NSMakeRange(index, 1)];
+                        } else {
+                            [attributedString addAttribute:NSKernAttributeName value:@(0)
+                                                     range:NSMakeRange(index, 1)];
+                        }
                     }
                 }
                 return [attributedString copy];

--- a/Stripe/STPFormTextField.m
+++ b/Stripe/STPFormTextField.m
@@ -140,7 +140,7 @@ typedef NSAttributedString* (^STPFormTextTransformationBlock)(NSAttributedString
                 for (NSNumber *segmentLength in cardNumberFormat) {
                     NSUInteger segmentIndex = 0;
                     for (; index < attributedString.length && segmentIndex < [segmentLength unsignedIntegerValue]; index++, segmentIndex++) {
-                        if (segmentIndex + 1 == [segmentLength unsignedIntegerValue]) {
+                        if (index + 1 != attributedString.length && segmentIndex + 1 == [segmentLength unsignedIntegerValue]) {
                             [attributedString addAttribute:NSKernAttributeName value:@(5)
                                                      range:NSMakeRange(index, 1)];
                         } else {

--- a/Stripe/STPPaymentCardTextField.m
+++ b/Stripe/STPPaymentCardTextField.m
@@ -733,11 +733,7 @@ CGFloat const STPPaymentCardTextFieldMinimumPadding = 10;
     NSUInteger fragmentLength = [STPCardValidator fragmentLengthForCardBrand:currentBrand];
     NSUInteger maxLength = MAX([[sortedCardNumberFormat lastObject] unsignedIntegerValue], fragmentLength);
 
-    NSMutableString *maxCompressedString = [[NSMutableString alloc] initWithCapacity:maxLength];
-    for (NSUInteger i = 0; i < maxLength; ++i) {
-        [maxCompressedString appendString:@"8"];
-    }
-
+    NSString *maxCompressedString = [@"" stringByPaddingToLength:maxLength withString:@"8" startingAtIndex:0];
     return [self widthForText:maxCompressedString];
 }
 

--- a/Stripe/STPPaymentCardTextField.m
+++ b/Stripe/STPPaymentCardTextField.m
@@ -726,18 +726,13 @@ CGFloat const STPPaymentCardTextFieldMinimumPadding = 10;
     }
 
     STPCardBrand currentBrand = [STPCardValidator brandForNumber:cardNumber];
-    NSArray<NSNumber *> *cardNumberFormat = [STPCardValidator cardNumberFormatForBrand:currentBrand];
+    NSArray<NSNumber *> *sortedCardNumberFormat = [[STPCardValidator cardNumberFormatForBrand:currentBrand] sortedArrayUsingSelector:@selector(unsignedIntegerValue)];
     NSUInteger fragmentLength = [STPCardValidator fragmentLengthForCardBrand:currentBrand];
+    NSUInteger maxLength = MAX([[sortedCardNumberFormat lastObject] unsignedIntegerValue], fragmentLength);
 
-    NSMutableString *maxCompressedString = [[NSMutableString alloc] init];
-    while (fragmentLength > maxCompressedString.length) {
+    NSMutableString *maxCompressedString = [[NSMutableString alloc] initWithCapacity:maxLength];
+    for (NSUInteger i = 0; i < maxLength; ++i) {
         [maxCompressedString appendString:@"8"];
-    }
-    for (NSNumber *segment in cardNumberFormat) {
-        NSUInteger segmentLength = [segment unsignedIntegerValue];
-        while (segmentLength > maxCompressedString.length) {
-            [maxCompressedString appendString:@"8"];
-        }
     }
 
     return [self widthForText:maxCompressedString];

--- a/Stripe/STPPaymentCardTextFieldViewModel.h
+++ b/Stripe/STPPaymentCardTextFieldViewModel.h
@@ -23,6 +23,7 @@ typedef NS_ENUM(NSInteger, STPCardFieldType) {
 @interface STPPaymentCardTextFieldViewModel : NSObject
 
 @property (nonatomic, readwrite, copy, nullable) NSString *cardNumber;
+@property (nonatomic, readonly, nullable) NSString *compressedCardNumber;
 @property (nonatomic, readwrite, copy, nullable) NSString *rawExpiration;
 @property (nonatomic, readonly, nullable) NSString *expirationMonth;
 @property (nonatomic, readonly, nullable) NSString *expirationYear;

--- a/Stripe/STPPaymentCardTextFieldViewModel.m
+++ b/Stripe/STPPaymentCardTextFieldViewModel.m
@@ -9,6 +9,7 @@
 #import "STPPaymentCardTextFieldViewModel.h"
 
 #import "NSString+Stripe.h"
+#import "STPCardValidator+Private.h"
 #import "STPPostalCodeValidator.h"
 
 @implementation STPPaymentCardTextFieldViewModel
@@ -18,6 +19,38 @@
     STPCardBrand brand = [STPCardValidator brandForNumber:sanitizedNumber];
     NSInteger maxLength = [STPCardValidator maxLengthForCardBrand:brand];
     _cardNumber = [sanitizedNumber stp_safeSubstringToIndex:maxLength];
+}
+
+- (NSString *)compressedCardNumber {
+    NSString *cardNumber = self.cardNumber;
+    if (cardNumber.length == 0) {
+        cardNumber = self.defaultPlaceholder;
+    }
+
+    STPCardBrand currentBrand = [STPCardValidator brandForNumber:cardNumber];
+    if ([self validationStateForField:STPCardFieldTypeNumber] == STPCardValidationStateValid) {
+        // Use fragment length
+        NSUInteger length = [STPCardValidator fragmentLengthForCardBrand:currentBrand];
+        NSUInteger index = cardNumber.length - length;
+
+        if (index < cardNumber.length) {
+            return [cardNumber stp_safeSubstringFromIndex:index];
+        }
+    } else {
+        // use the card number format
+        NSArray<NSNumber *> *cardNumberFormat = [STPCardValidator cardNumberFormatForBrand:currentBrand];
+
+        NSUInteger index = 0;
+        for (NSNumber *segment in cardNumberFormat) {
+            NSUInteger segmentLength = [segment unsignedIntegerValue];
+            if (index + segmentLength >= cardNumber.length) {
+                return [cardNumber stp_safeSubstringFromIndex:index];
+            }
+            index += segmentLength;
+        }
+    }
+
+    return nil;
 }
 
 // This might contain slashes.

--- a/Tests/Tests/NSString+StripeTest.m
+++ b/Tests/Tests/NSString+StripeTest.m
@@ -44,6 +44,18 @@
     XCTAssertEqualObjects([@"foobar" stp_stringByRemovingSuffix:@"foobar"], @"");
     XCTAssertEqualObjects([@"foobar" stp_stringByRemovingSuffix:@""], @"foobar");
     XCTAssertEqualObjects([@"foobar" stp_stringByRemovingSuffix:@"oba"], @"foobar");
+
+    XCTAssertEqualObjects([@"foobar☺¿" stp_stringByRemovingSuffix:@"bar☺¿"], @"foo");
+    XCTAssertEqualObjects([@"foobar☺¿" stp_stringByRemovingSuffix:@"bar¿"], @"foobar☺¿");
+
+    XCTAssertEqualObjects([@"foobar\u202C" stp_stringByRemovingSuffix:@"bar"], @"foobar\u202C");
+    XCTAssertEqualObjects([@"foobar\u202C" stp_stringByRemovingSuffix:@"bar\u202C"], @"foo");
+
+    // e + \u0041 => é
+    XCTAssertEqualObjects([@"foobare\u0301" stp_stringByRemovingSuffix:@"bare"], @"foobare\u0301");
+    XCTAssertEqualObjects([@"foobare\u0301" stp_stringByRemovingSuffix:@"bare\u0301"], @"foo");
+    XCTAssertEqualObjects([@"foobare" stp_stringByRemovingSuffix:@"bare\u0301"], @"foobare");
+
 }
 
 @end

--- a/Tests/Tests/NSString+StripeTest.m
+++ b/Tests/Tests/NSString+StripeTest.m
@@ -37,4 +37,13 @@
     XCTAssertEqualObjects([@"" stp_reversedString], @"");
 }
 
+- (void)testStringByRemovingSuffix {
+    XCTAssertEqualObjects([@"foobar" stp_stringByRemovingSuffix:@"bar"], @"foo");
+    XCTAssertEqualObjects([@"foobar" stp_stringByRemovingSuffix:@"baz"], @"foobar");
+    XCTAssertEqualObjects([@"foobar" stp_stringByRemovingSuffix:nil], @"foobar");
+    XCTAssertEqualObjects([@"foobar" stp_stringByRemovingSuffix:@"foobar"], @"");
+    XCTAssertEqualObjects([@"foobar" stp_stringByRemovingSuffix:@""], @"foobar");
+    XCTAssertEqualObjects([@"foobar" stp_stringByRemovingSuffix:@"oba"], @"foobar");
+}
+
 @end

--- a/Tests/Tests/STPCardValidatorTest.m
+++ b/Tests/Tests/STPCardValidatorTest.m
@@ -152,7 +152,7 @@
                        @[@(STPCardBrandMasterCard), @4],
                        @[@(STPCardBrandAmex), @5],
                        @[@(STPCardBrandDiscover), @4],
-                       @[@(STPCardBrandDinersClub), @2],
+                       @[@(STPCardBrandDinersClub), @4],
                        @[@(STPCardBrandJCB), @4],
                        @[@(STPCardBrandUnionPay), @4],
                        @[@(STPCardBrandUnknown), @4],

--- a/Tests/Tests/STPPaymentCardTextFieldViewModelTest.m
+++ b/Tests/Tests/STPPaymentCardTextFieldViewModelTest.m
@@ -103,7 +103,7 @@
     XCTAssertEqualObjects(self.viewModel.compressedCardNumber, @"12");
 
     self.viewModel.cardNumber = @"30569309025904";
-    XCTAssertEqualObjects(self.viewModel.compressedCardNumber, @"04"); // Use fragment length for valid card
+    XCTAssertEqualObjects(self.viewModel.compressedCardNumber, @"5904");
     self.viewModel.cardNumber = @"3056930902590";
     XCTAssertEqualObjects(self.viewModel.compressedCardNumber, @"590");
     self.viewModel.cardNumber = @"30569309025";

--- a/Tests/Tests/STPPaymentCardTextFieldViewModelTest.m
+++ b/Tests/Tests/STPPaymentCardTextFieldViewModelTest.m
@@ -84,4 +84,32 @@
     XCTAssertFalse([self.viewModel isValid]);
 }
 
+- (void)testCompressedCardNumber {
+    self.viewModel.cardNumber = nil;
+    XCTAssertEqualObjects(self.viewModel.compressedCardNumber, @"4242"); // Should use default placeholder
+
+    self.viewModel.cardNumber = @"424212345678";
+    XCTAssertEqualObjects(self.viewModel.compressedCardNumber, @"5678");
+    self.viewModel.cardNumber = @"42421234567";
+    XCTAssertEqualObjects(self.viewModel.compressedCardNumber, @"567");
+    self.viewModel.cardNumber = @"4242123456";
+    XCTAssertEqualObjects(self.viewModel.compressedCardNumber, @"56");
+    self.viewModel.cardNumber = @"424212345";
+    XCTAssertEqualObjects(self.viewModel.compressedCardNumber, @"5");
+    self.viewModel.cardNumber = @"42421234";
+    XCTAssertEqualObjects(self.viewModel.compressedCardNumber, @"1234");
+
+    self.viewModel.cardNumber = @"12";
+    XCTAssertEqualObjects(self.viewModel.compressedCardNumber, @"12");
+
+    self.viewModel.cardNumber = @"30569309025904";
+    XCTAssertEqualObjects(self.viewModel.compressedCardNumber, @"04"); // Use fragment length for valid card
+    self.viewModel.cardNumber = @"3056930902590";
+    XCTAssertEqualObjects(self.viewModel.compressedCardNumber, @"590");
+    self.viewModel.cardNumber = @"30569309025";
+    XCTAssertEqualObjects(self.viewModel.compressedCardNumber, @"5");
+    self.viewModel.cardNumber = @"3056930902";
+    XCTAssertEqualObjects(self.viewModel.compressedCardNumber, @"930902");
+}
+
 @end


### PR DESCRIPTION

## Summary
Adds correct formatting for Diner's Club card numbers
When compressed, STPPaymentCardTextField will now use the card number format (not just the fragment length) to decide which numbers to show, matching web behavior
Incomplete card numbers will be marked as invalid, matching web behavior
Correctly sizes card number text field when compressed so that it doesn't push other text fields off screen on small devices

## Motivation
https://jira.corp.stripe.com/browse/IOS-600
https://github.com/stripe/stripe-ios/issues/1007

## Testing
Manually tested on iPhone SE 11.4 simulator in portrait and landscape
