### PR TITLE
Update `STPPaymentIntentFunctionalTest.testConfirmCanceledPaymentIntentFails`

### DIFF
--- a/Tests/Tests/STPPaymentIntentFunctionalTest.m
+++ b/Tests/Tests/STPPaymentIntentFunctionalTest.m
@@ -93,8 +93,8 @@
                                     XCTAssertNotNil(error);
                                     XCTAssertEqualObjects(error.domain, StripeDomain);
                                     XCTAssertEqual(error.code, STPInvalidRequestError);
-                                    XCTAssertEqualObjects(error.userInfo[STPErrorMessageKey],
-                                                          @"This PaymentIntent could not be updated because it has a status of canceled. Only a PaymentIntent with one of the following statuses may be updated: requires_source, requires_confirmation, requires_source_action.");
+                                    XCTAssertTrue([error.userInfo[STPErrorMessageKey] hasPrefix:@"This PaymentIntent could not be updated because it has a status of canceled."],
+                                                  @"Expected error message to complain about status being canceled. Actual msg: `%@`", error.userInfo[STPErrorMessageKey]);
 
                                     [expectation fulfill];
                                 }];


### PR DESCRIPTION
## Summary
Making it slightly less brittle to server-side changes. Previous test was failing
due to the addition of `requires_capture` in the list of acceptable statuses.

This is still asserting on a server-side string that might change, but I want some way
to make sure the error is the one I expect.

## Motivation
Test is broken on master.

## Testing
Ran the tests locally, CI will run them too