### PR TITLE
Add document_back property to STPVerificationParams

### DIFF
--- a/Stripe/PublicHeaders/STPLegalEntityParams.h
+++ b/Stripe/PublicHeaders/STPLegalEntityParams.h
@@ -135,6 +135,10 @@ NS_ASSUME_NONNULL_BEGIN
  The file id for the uploaded verification document.
  */
 @property (nonatomic, copy, nullable) NSString *document;
+
+/**
+ The file id for the uploaded verification document (back side).
+ */
 @property (nonatomic, copy, nullable) NSString *documentBack;
 
 @end

--- a/Stripe/PublicHeaders/STPLegalEntityParams.h
+++ b/Stripe/PublicHeaders/STPLegalEntityParams.h
@@ -135,6 +135,7 @@ NS_ASSUME_NONNULL_BEGIN
  The file id for the uploaded verification document.
  */
 @property (nonatomic, copy, nullable) NSString *document;
+@property (nonatomic, copy, nullable) NSString *documentBack;
 
 @end
 

--- a/Stripe/STPLegalEntityParams.m
+++ b/Stripe/STPLegalEntityParams.m
@@ -18,6 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
     NSArray *props = @[
                        [NSString stringWithFormat:@"%@: %p", NSStringFromClass([self class]), self],
                        [NSString stringWithFormat:@"document = %@", self.document],
+                       [NSString stringWithFormat:@"documentBack = %@", self.documentBack],
                        ];
 
     return [NSString stringWithFormat:@"<%@>", [props componentsJoinedByString:@"; "]];
@@ -30,6 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (nonnull NSDictionary *)propertyNamesToFormFieldNamesMapping {
     return @{
              NSStringFromSelector(@selector(document)): @"document",
+             NSStringFromSelector(@selector(documentBack)): @"document_back",
              };
 }
 

--- a/Tests/Tests/STPFixtures.m
+++ b/Tests/Tests/STPFixtures.m
@@ -280,6 +280,7 @@ NSString *const STPTestJSONSourceSOFORT = @"SOFORTSource";
 
     legalEntity.verification = [STPVerificationParams new];
     legalEntity.verification.document = @"file_abc";
+    legalEntity.verification.documentBack = @"file_def";
 
     STPPersonParams *jenny = [self personParams], *jacob = [self personParams];
     jenny.firstName = @"Jenny";


### PR DESCRIPTION
## Summary
Add document_back property 

## Motivation
Can see this property in go project (https://github.com/stripe/stripe-go/blob/master/account.go#L211)
Hope iOS SDK can also have it