### PR TITLE
Change mention of MIGRATING.md in README.md to be a link

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,4 +65,4 @@ We welcome contributions of any kind including new features, bug fixes, and docu
 
 ## Migrating from Older Versions
 
-See `MIGRATING.md`
+See [MIGRATING.md](https://github.com/stripe/stripe-ios/blob/master/MIGRATING.md)


### PR DESCRIPTION
## Summary
Adding a link

## Motivation
Was reading the README and was surprised it wasn't.

## Testing
Viewing the README on github.