### PR TITLE
Remove `response` parameter from `STPCustomer` method to update Sources with/without Apple Pay

### DIFF
--- a/Stripe/STPCustomer+Private.h
+++ b/Stripe/STPCustomer+Private.h
@@ -13,14 +13,13 @@ NS_ASSUME_NONNULL_BEGIN
 @interface STPCustomer ()
 
 /**
- Replaces the customer's sources and defaultSource with the contents of a
- Customer API response.
+ Replaces the customer's `sources` and `defaultSource` based on whether or not
+ they should include Apple Pay sources. More details on documentation for
+ `STPCustomerContext includeApplePaySources`
 
- @param response            The Customer API response
  @param filterApplePay      If YES, Apple Pay sources will be ignored
  */
-- (void)updateSourcesWithResponse:(NSDictionary *)response
-                filteringApplePay:(BOOL)filterApplePay;
+- (void)updateSourcesFilteringApplePay:(BOOL)filterApplePay;
 
 @end
 

--- a/Stripe/STPCustomer.m
+++ b/Stripe/STPCustomer.m
@@ -82,13 +82,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     customer.sources = @[];
     customer.defaultSource = nil;
-    [customer updateSourcesWithResponse:dict filteringApplePay:YES];
     customer.allResponseFields = dict;
+    [customer updateSourcesFilteringApplePay:YES];
     return customer;
 }
 
-- (void)updateSourcesWithResponse:(NSDictionary *)response
-                filteringApplePay:(BOOL)filterApplePay {
+- (void)updateSourcesFilteringApplePay:(BOOL)filterApplePay {
+    NSDictionary *response = self.allResponseFields;
     NSArray *data;
     NSDictionary *sourcesDict = [response stp_dictionaryForKey:@"sources"];
     if (sourcesDict) {

--- a/Stripe/STPCustomerContext.m
+++ b/Stripe/STPCustomerContext.m
@@ -87,7 +87,7 @@ static NSTimeInterval const CachedCustomerMaxAge = 60;
         }
         [STPAPIClient retrieveCustomerUsingKey:ephemeralKey completion:^(STPCustomer *customer, NSError *error) {
             if (customer) {
-                [customer updateSourcesWithResponse:self.customer.allResponseFields
+                [customer updateSourcesWithResponse:customer.allResponseFields
                                   filteringApplePay:!self.includeApplePaySources];
                 self.customer = customer;
             }
@@ -138,7 +138,7 @@ static NSTimeInterval const CachedCustomerMaxAge = 60;
                                           usingKey:ephemeralKey
                                         completion:^(STPCustomer *customer, NSError *error) {
                                             if (customer) {
-                                                [customer updateSourcesWithResponse:self.customer.allResponseFields
+                                                [customer updateSourcesWithResponse:customer.allResponseFields
                                                                   filteringApplePay:!self.includeApplePaySources];
                                                 self.customer = customer;
                                             }
@@ -168,7 +168,7 @@ static NSTimeInterval const CachedCustomerMaxAge = 60;
                                           usingKey:ephemeralKey
                                         completion:^(STPCustomer *customer, NSError *error) {
                                             if (customer) {
-                                                [customer updateSourcesWithResponse:self.customer.allResponseFields
+                                                [customer updateSourcesWithResponse:customer.allResponseFields
                                                                   filteringApplePay:!self.includeApplePaySources];
                                                 self.customer = customer;
                                             }

--- a/Stripe/STPCustomerContext.m
+++ b/Stripe/STPCustomerContext.m
@@ -55,8 +55,7 @@ static NSTimeInterval const CachedCustomerMaxAge = 60;
 
 - (void)setIncludeApplePaySources:(BOOL)includeApplePaySources {
     _includeApplePaySources = includeApplePaySources;
-    [self.customer updateSourcesWithResponse:self.customer.allResponseFields
-                           filteringApplePay:!includeApplePaySources];
+    [self.customer updateSourcesFilteringApplePay:!includeApplePaySources];
 }
 
 - (BOOL)shouldUseCachedCustomer {
@@ -87,8 +86,7 @@ static NSTimeInterval const CachedCustomerMaxAge = 60;
         }
         [STPAPIClient retrieveCustomerUsingKey:ephemeralKey completion:^(STPCustomer *customer, NSError *error) {
             if (customer) {
-                [customer updateSourcesWithResponse:customer.allResponseFields
-                                  filteringApplePay:!self.includeApplePaySources];
+                [customer updateSourcesFilteringApplePay:!self.includeApplePaySources];
                 self.customer = customer;
             }
             if (completion) {
@@ -138,8 +136,7 @@ static NSTimeInterval const CachedCustomerMaxAge = 60;
                                           usingKey:ephemeralKey
                                         completion:^(STPCustomer *customer, NSError *error) {
                                             if (customer) {
-                                                [customer updateSourcesWithResponse:customer.allResponseFields
-                                                                  filteringApplePay:!self.includeApplePaySources];
+                                                [customer updateSourcesFilteringApplePay:!self.includeApplePaySources];
                                                 self.customer = customer;
                                             }
                                             if (completion) {
@@ -168,8 +165,7 @@ static NSTimeInterval const CachedCustomerMaxAge = 60;
                                           usingKey:ephemeralKey
                                         completion:^(STPCustomer *customer, NSError *error) {
                                             if (customer) {
-                                                [customer updateSourcesWithResponse:customer.allResponseFields
-                                                                  filteringApplePay:!self.includeApplePaySources];
+                                                [customer updateSourcesFilteringApplePay:!self.includeApplePaySources];
                                                 self.customer = customer;
                                             }
                                             if (completion) {


### PR DESCRIPTION
## Summary
Looks like a copy/paste error from f3b2d7250a50c1705c1776cb312f7a30676a86d2 in #864.

`STPCustomerContext` holds onto a `STPCustomer`. There are three places
where it retrieves a new `STPCustomer` - and when it does it needs to
update the `sources` of that customer based on the
`STPCustomerContext.includeApplePaySources` boolean.

The bug is that we were using the *old* `STPCustomer.allResponseFields`
(via `self.customer`) instead of the `allResponseFields` property on the newly
retrieved `STPCustomer` object.

So, instead of allowing the caller to pass in the `NSDictionary` representing the response, just use the one that's already on our `STPCustomer` object that's being updated via `self.allResponseFields` *inside* the method.

## Motivation
IOS-870

## Testing
Extended the existing unit test to catch this failure, and then fixed it.