### PR TITLE
Set `internalCardParams` after setting fields to avoid params overriding

### DIFF
--- a/Stripe/STPPaymentCardTextField.m
+++ b/Stripe/STPPaymentCardTextField.m
@@ -638,7 +638,6 @@ CGFloat const STPPaymentCardTextFieldMinimumPadding = 10;
      */
     STPFormTextField *originalSubResponder = self.currentFirstResponderField;
 
-    self.internalCardParams = cardParams;
     [self setText:cardParams.number inField:STPCardFieldTypeNumber];
     BOOL expirationPresent = cardParams.expMonth && cardParams.expYear;
     if (expirationPresent) {
@@ -653,6 +652,8 @@ CGFloat const STPPaymentCardTextFieldMinimumPadding = 10;
     [self setText:cardParams.cvc inField:STPCardFieldTypeCVC];
 
     [self setText:cardParams.address.postalCode inField:STPCardFieldTypePostalCode];
+
+    self.internalCardParams = cardParams;
 
     if ([self isFirstResponder]) {
         STPCardFieldType fieldType = originalSubResponder.tag;


### PR DESCRIPTION
## Summary
In `STPPaymentCardTextField`, set `internalCardParams` *after* setting text fields in `setCardParams:(STPCardParams *)cardParams`

## Motivation
With the current implementation, setting `cardParams` triggers `paymentCardTextFieldDidChange`. 
If you just access `textField.cardParams` in this delegate, it will modify params and thus only fill the first field `STPCardFieldTypeNumber`, not the other ones. 

## Testing
Setting `paymentCardTextField.cardParams = cardParams` with custom params. 
Accessing `textField.cardParams` in `paymentCardTextFieldDidChange` by printing them for instance.
Accessing will modify the data, and not fill all the Fields. 