### PR TITLE
Change `STPPaymentCardTextField` to copy the `cardParams` object when it's set or read.

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,5 +1,26 @@
 ## Migration Guides
 
+### Migrating from versions < 14.0.0
+* `STPPaymentCardTextField` now copies the `STPCardParams` object when setting/getting the `cardParams` property, instead of sharing the object with the caller.
+  * Changes to the `STPCardParams` object after setting `cardParams` no longer mutate the object held by the `STPPaymentCardTextField`
+  * Changes to the object returned by `STPPaymentCardTextField.cardParams` no longer mutate the object held by the `STPPaymentCardTextField`
+  * This is a breaking change for code like: `paymentCardTextField.cardParams.name = @"Jane Doe";`
+* `STPCardParams` now copies the `STPAddress` object when setting the `address` property. However, unlike `STPPaymentCardTextField.cardParams`, `STPCardParams.address` still returns a reference to the `STPAddress` object held by the `STPCardParams` instance.
+
+```objective-c
+STPCardParams *cardParams = ...;
+
+STPAddress *myAddress = [[STPAddress alloc] init];
+cardParams.address = address;
+
+// Breaking change:
+// Changes to `myAddress` after setting `cardParams.address` don't change `cardParams`
+myAddress.line1 = @"123 Main St"; // no longer supported
+
+// This still works for `STPCardParams` objects:
+cardParams.address.line1 = @"456 Maple Ave";
+```
+
 ### Migrating from versions < 13.1.0
  * The SDK now supports PaymentIntents with `STPPaymentIntent`, which use `STPRedirectContext` in the same way that `STPSource` does
    * `STPRedirectContextCompletionBlock` has been renamed to `STPRedirectContextSourceCompletionBlock`. It has the same signature, and Xcode should offer a deprecation warning & fix-it to help you migrate.

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -118,22 +118,24 @@ Versions of Stripe-iOS prior to 1.2 included a class called `STPView`, which pro
 2. Replace any references to `STPView` with a `PTKView` instead. Similarly, any classes that implement `STPViewDelegate` should now instead implement the equivalent `PTKViewDelegate` methods. Note that unlike `STPView`, `PTKView` does not take a Stripe API key in its constructor.
 3. To submit the credit card details from your `PTKView` instance, where you would previously call `createToken` on your `STPView`, replace that with the following code (assuming `self.paymentView` is your `PTKView` instance):
 
-        if (![self.paymentView isValid]) {
-            return;
-        }
-        STPCard *card = [[STPCard alloc] init];
-        card.number = self.paymentView.card.number;
-        card.expMonth = self.paymentView.card.expMonth;
-        card.expYear = self.paymentView.card.expYear;
-        card.cvc = self.paymentView.card.cvc;
-        STPAPIClient *client = [[STPAPIClient alloc] initWithPublishableKey:publishableKey];
-        [client createTokenWithCard:card completion:^(STPToken *token, NSError *error) {
-            if (error) {
-                // handle the error as you did previously
-            } else {
-                // submit the token to your payment backend as you did previously
-            }
-        }];
+```objective-c
+if (![self.paymentView isValid]) {
+    return;
+}
+STPCard *card = [[STPCard alloc] init];
+card.number = self.paymentView.card.number;
+card.expMonth = self.paymentView.card.expMonth;
+card.expYear = self.paymentView.card.expYear;
+card.cvc = self.paymentView.card.cvc;
+STPAPIClient *client = [[STPAPIClient alloc] initWithPublishableKey:publishableKey];
+[client createTokenWithCard:card completion:^(STPToken *token, NSError *error) {
+    if (error) {
+        // handle the error as you did previously
+    } else {
+        // submit the token to your payment backend as you did previously
+    }
+}];
+```
 
 ## Misc. notes
 
@@ -149,10 +151,12 @@ The simplest thing you can do is to populate an `STPCard` object and, before sen
 
 To validate `STPCard` properties individually, you should use the following:
 
+```objective-c
  - (BOOL)validateNumber:error:
  - (BOOL)validateCvc:error:
  - (BOOL)validateExpMonth:error:
  - (BOOL)validateExpYear:error:
+```
 
 These methods follow the validation method convention used by [key-value validation](http://developer.apple.com/library/mac/#documentation/cocoa/conceptual/KeyValueCoding/Articles/Validation.html).  So, you can use these methods by invoking them directly, or by calling `[card validateValue:forKey:error]` for a property on the `STPCard` object.
 

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -5,21 +5,6 @@
   * Changes to the `STPCardParams` object after setting `cardParams` no longer mutate the object held by the `STPPaymentCardTextField`
   * Changes to the object returned by `STPPaymentCardTextField.cardParams` no longer mutate the object held by the `STPPaymentCardTextField`
   * This is a breaking change for code like: `paymentCardTextField.cardParams.name = @"Jane Doe";`
-* `STPCardParams` now copies the `STPAddress` object when setting the `address` property. However, unlike `STPPaymentCardTextField.cardParams`, `STPCardParams.address` still returns a reference to the `STPAddress` object held by the `STPCardParams` instance.
-
-```objective-c
-STPCardParams *cardParams = ...;
-
-STPAddress *myAddress = [[STPAddress alloc] init];
-cardParams.address = address;
-
-// Breaking change:
-// Changes to `myAddress` after setting `cardParams.address` don't change `cardParams`
-myAddress.line1 = @"123 Main St"; // no longer supported
-
-// This still works for `STPCardParams` objects:
-cardParams.address.line1 = @"456 Maple Ave";
-```
 
 ### Migrating from versions < 13.1.0
  * The SDK now supports PaymentIntents with `STPPaymentIntent`, which use `STPRedirectContext` in the same way that `STPSource` does

--- a/Stripe/PublicHeaders/STPAddress.h
+++ b/Stripe/PublicHeaders/STPAddress.h
@@ -71,7 +71,7 @@ extern STPContactField const STPContactFieldName;
 /**
  STPAddress Contains an address as represented by the Stripe API.
  */
-@interface STPAddress : NSObject<STPAPIResponseDecodable, STPFormEncodable>
+@interface STPAddress : NSObject<STPAPIResponseDecodable, STPFormEncodable, NSCopying>
 
 /**
  The user's full name (e.g. "Jane Doe")

--- a/Stripe/PublicHeaders/STPCardParams.h
+++ b/Stripe/PublicHeaders/STPCardParams.h
@@ -62,7 +62,7 @@
  be the value of `address.name`. However, changing `address.name` directly will
  *not* change `name`.
  */
-@property (nonatomic, strong, nonnull) STPAddress *address;
+@property (nonatomic, copy, nonnull) STPAddress *address;
 
 /**
  Three-letter ISO currency code representing the currency paid out to the bank 

--- a/Stripe/PublicHeaders/STPCardParams.h
+++ b/Stripe/PublicHeaders/STPCardParams.h
@@ -20,7 +20,7 @@
 
  @see https://stripe.com/docs/api#cards
  */
-@interface STPCardParams : NSObject<STPFormEncodable>
+@interface STPCardParams : NSObject<STPFormEncodable, NSCopying>
 
 /**
  The card's number.

--- a/Stripe/PublicHeaders/STPCardParams.h
+++ b/Stripe/PublicHeaders/STPCardParams.h
@@ -62,7 +62,7 @@
  be the value of `address.name`. However, changing `address.name` directly will
  *not* change `name`.
  */
-@property (nonatomic, copy, nonnull) STPAddress *address;
+@property (nonatomic, strong, nonnull) STPAddress *address;
 
 /**
  Three-letter ISO currency code representing the currency paid out to the bank 

--- a/Stripe/PublicHeaders/STPCardParams.h
+++ b/Stripe/PublicHeaders/STPCardParams.h
@@ -58,8 +58,9 @@
 /**
  The cardholder's address.
  
- @note Changing this property will also changing the name of the 
- param's `name` property
+ @note Setting `address` to a new value will also change the `name` property to
+ be the value of `address.name`. However, changing `address.name` directly will
+ *not* change `name`.
  */
 @property (nonatomic, strong, nonnull) STPAddress *address;
 

--- a/Stripe/PublicHeaders/STPPaymentCardTextField.h
+++ b/Stripe/PublicHeaders/STPPaymentCardTextField.h
@@ -236,7 +236,7 @@ The curent brand image displayed in the receiver.
  to scan your user's credit card with a camera, you can assemble that data into an STPCardParams
  object and set this property to that object to prefill the fields you've collected.
  */
-@property (nonatomic, strong, readwrite, nonnull) STPCardParams *cardParams;
+@property (nonatomic, copy, readwrite, nonnull) STPCardParams *cardParams;
 
 /**
  Causes the text field to begin editing. Presents the keyboard.

--- a/Stripe/PublicHeaders/STPPaymentCardTextField.h
+++ b/Stripe/PublicHeaders/STPPaymentCardTextField.h
@@ -235,6 +235,10 @@ The curent brand image displayed in the receiver.
  or programmatically setting the field's contents. For example, if you're using another library
  to scan your user's credit card with a camera, you can assemble that data into an STPCardParams
  object and set this property to that object to prefill the fields you've collected.
+
+ Accessing this property returns a *copied* `cardParams`. The only way to change properties in this
+ object is to make changes to a STPCardParams you own (retrieved from this text field if desired),
+ and then set this property to the new value.
  */
 @property (nonatomic, copy, readwrite, nonnull) STPCardParams *cardParams;
 

--- a/Stripe/STPAddress.m
+++ b/Stripe/STPAddress.m
@@ -332,6 +332,32 @@ STPContactField const STPContactFieldName = @"STPContactFieldName";
              };
 }
 
+#pragma mark NSCopying
+
+- (id)copyWithZone:(__unused NSZone *)zone {
+    STPAddress *copyAddress = [self.class new];
+
+    // Name might be stored as full name in _name, or split between given/family name
+    // access ivars directly and explicitly copy the instances.
+    copyAddress->_name = [self->_name copy];
+    copyAddress->_givenName = [self->_givenName copy];
+    copyAddress->_familyName = [self->_familyName copy];
+
+    copyAddress.line1 = self.line1;
+    copyAddress.line2 = self.line2;
+    copyAddress.city = self.city;
+    copyAddress.state = self.state;
+    copyAddress.postalCode = self.postalCode;
+    copyAddress.country = self.country;
+
+    copyAddress.phone = self.phone;
+    copyAddress.email = self.email;
+
+    copyAddress.allResponseFields = self.allResponseFields;
+
+    return copyAddress;
+}
+
 @end
 
 #pragma mark -

--- a/Stripe/STPCardParams.m
+++ b/Stripe/STPCardParams.m
@@ -33,6 +33,11 @@
     }
 }
 
+- (void)setName:(NSString *)name {
+    _name = name.copy;
+    self.address.name = name;
+}
+
 - (void)setAddress:(STPAddress *)address {
     _address = address;
     self.name = address.name;
@@ -85,11 +90,6 @@
              };
 }
 
-- (void)setName:(NSString *)name {
-    _name = name.copy;
-    self.address.name = name;
-}
-
 #pragma mark - Deprecated methods
 
 - (void)setAddressLine1:(NSString *)addressLine1 {
@@ -138,6 +138,26 @@
 
 - (NSString *)addressCountry {
     return self.address.country;
+}
+
+#pragma mark - NSCopying
+
+- (id)copyWithZone:(__unused NSZone *)zone {
+    STPCardParams *copyCardParams = [self.class new];
+
+    copyCardParams.number = self.number;
+    copyCardParams.expMonth = self.expMonth;
+    copyCardParams.expYear = self.expYear;
+    copyCardParams.cvc = self.cvc;
+
+    // Use ivar to avoid setName:/setAddress: behavior that'd possibly overwrite name/address.name
+    copyCardParams->_name = self.name;
+    copyCardParams->_address = [self.address copy];
+
+    copyCardParams.currency = self.currency;
+    copyCardParams.additionalAPIParameters = self.additionalAPIParameters;
+
+    return copyCardParams;
 }
 
 @end

--- a/Stripe/STPCardParams.m
+++ b/Stripe/STPCardParams.m
@@ -39,8 +39,8 @@
 }
 
 - (void)setAddress:(STPAddress *)address {
-    _address = [address copy];
-    _name = self.address.name;
+    _address = address;
+    _name = [address.name copy];
 }
 
 #pragma mark - Description

--- a/Stripe/STPCardParams.m
+++ b/Stripe/STPCardParams.m
@@ -34,13 +34,13 @@
 }
 
 - (void)setName:(NSString *)name {
-    _name = name.copy;
-    self.address.name = name;
+    _name = [name copy];
+    self.address.name = self.name;
 }
 
 - (void)setAddress:(STPAddress *)address {
-    _address = address;
-    self.name = address.name;
+    _address = [address copy];
+    _name = self.address.name;
 }
 
 #pragma mark - Description

--- a/Stripe/STPPaymentCardTextField.m
+++ b/Stripe/STPPaymentCardTextField.m
@@ -618,7 +618,7 @@ CGFloat const STPPaymentCardTextFieldMinimumPadding = 10;
         // if we are not showing the postal code entry field.
         self.internalCardParams.address.postalCode = self.postalCode;
     }
-    return self.internalCardParams;
+    return [self.internalCardParams copy];
 }
 
 - (void)setCardParams:(STPCardParams *)cardParams {

--- a/Stripe/STPPaymentCardTextField.m
+++ b/Stripe/STPPaymentCardTextField.m
@@ -638,7 +638,7 @@ CGFloat const STPPaymentCardTextFieldMinimumPadding = 10;
      */
     STPFormTextField *originalSubResponder = self.currentFirstResponderField;
 
-    self.internalCardParams = cardParams;
+    self.internalCardParams = [cardParams copy];
     [self setText:cardParams.number inField:STPCardFieldTypeNumber];
     BOOL expirationPresent = cardParams.expMonth && cardParams.expYear;
     if (expirationPresent) {

--- a/Stripe/STPPaymentCardTextField.m
+++ b/Stripe/STPPaymentCardTextField.m
@@ -621,7 +621,7 @@ CGFloat const STPPaymentCardTextFieldMinimumPadding = 10;
     return [self.internalCardParams copy];
 }
 
-- (void)setCardParams:(STPCardParams *)cardParams {
+- (void)setCardParams:(STPCardParams *)callersCardParams {
     /*
      Due to the way this class is written, programmatically setting field text
      behaves identically to user entering text (and will have the same forwarding 
@@ -638,21 +638,28 @@ CGFloat const STPPaymentCardTextFieldMinimumPadding = 10;
      */
     STPFormTextField *originalSubResponder = self.currentFirstResponderField;
 
-    self.internalCardParams = [cardParams copy];
-    [self setText:cardParams.number inField:STPCardFieldTypeNumber];
-    BOOL expirationPresent = cardParams.expMonth && cardParams.expYear;
+    /*
+     #1031 small footgun hiding here. Use copies to protect from mutations of
+     `internalCardParams` in the `cardParams` property accessor and any mutations
+     the app code might make to their `callersCardParams` object.
+     */
+    STPCardParams *desiredCardParams = [callersCardParams copy];
+    self.internalCardParams = [desiredCardParams copy];
+
+    [self setText:desiredCardParams.number inField:STPCardFieldTypeNumber];
+    BOOL expirationPresent = desiredCardParams.expMonth && desiredCardParams.expYear;
     if (expirationPresent) {
         NSString *text = [NSString stringWithFormat:@"%02lu%02lu",
-                          (unsigned long)cardParams.expMonth,
-                          (unsigned long)cardParams.expYear%100];
+                          (unsigned long)desiredCardParams.expMonth,
+                          (unsigned long)desiredCardParams.expYear%100];
         [self setText:text inField:STPCardFieldTypeExpiration];
     }
     else {
         [self setText:@"" inField:STPCardFieldTypeExpiration];
     }
-    [self setText:cardParams.cvc inField:STPCardFieldTypeCVC];
+    [self setText:desiredCardParams.cvc inField:STPCardFieldTypeCVC];
 
-    [self setText:cardParams.address.postalCode inField:STPCardFieldTypePostalCode];
+    [self setText:desiredCardParams.address.postalCode inField:STPCardFieldTypePostalCode];
 
     if ([self isFirstResponder]) {
         STPCardFieldType fieldType = originalSubResponder.tag;

--- a/Tests/Tests/STPAddressTests.m
+++ b/Tests/Tests/STPAddressTests.m
@@ -11,6 +11,7 @@
 #import <Contacts/Contacts.h>
 #import "STPAddress.h"
 #import "STPFixtures.h"
+#import "STPTestUtils.h"
 
 @interface STPAddressTests : XCTestCase
 
@@ -488,6 +489,37 @@
     }
 
     XCTAssertEqual([[mapping allValues] count], [[NSSet setWithArray:[mapping allValues]] count]);
+}
+
+#pragma mark NSCopying Tests
+
+- (void)testCopyWithZone {
+    STPAddress *address = [STPFixtures address];
+    STPAddress *copiedAddress = [address copy];
+
+    XCTAssertNotEqual(address, copiedAddress, @"should be different objects");
+
+    // The property names we expect to *not* be equal objects
+    NSArray *notEqualProperties = @[
+                                    // these include the object's address, so they won't be the same across copies
+                                    @"debugDescription",
+                                    @"description",
+                                    @"hash",
+                                    ];
+    // use runtime inspection to find the list of properties. If a new property is
+    // added to the fixture, but not the `copyWithZone:` implementation, this should catch it
+    for (NSString *property in [STPTestUtils propertyNamesOf:address]) {
+        if ([notEqualProperties containsObject:property]) {
+            XCTAssertNotEqualObjects([address valueForKey:property],
+                                     [copiedAddress valueForKey:property],
+                                     @"%@", property);
+        }
+        else {
+            XCTAssertEqualObjects([address valueForKey:property],
+                                  [copiedAddress valueForKey:property],
+                                  @"%@", property);
+        }
+    }
 }
 
 @end

--- a/Tests/Tests/STPCardParamsTest.m
+++ b/Tests/Tests/STPCardParamsTest.m
@@ -152,4 +152,16 @@
     }
 }
 
+- (void)testAddressIsNotCopied {
+    STPCardParams *cardParams = [STPFixtures cardParams];
+    cardParams.address = [STPFixtures address];
+    STPCardParams *secondCardParams = [STPCardParams new];
+
+    secondCardParams.address = cardParams.address;
+    cardParams.address.line1 = @"123 Main";
+
+    XCTAssertEqualObjects(cardParams.address.line1, @"123 Main");
+    XCTAssertEqualObjects(secondCardParams.address.line1, @"123 Main");
+}
+
 @end

--- a/Tests/Tests/STPCardParamsTest.m
+++ b/Tests/Tests/STPCardParamsTest.m
@@ -172,7 +172,7 @@
     }
 }
 
-- (void)testAddressIsCopied {
+- (void)testAddressIsNotCopied {
     STPCardParams *cardParams = [STPFixtures cardParams];
     cardParams.address = [STPFixtures address];
     STPCardParams *secondCardParams = [STPCardParams new];
@@ -181,7 +181,7 @@
     cardParams.address.line1 = @"123 Main";
 
     XCTAssertEqualObjects(cardParams.address.line1, @"123 Main");
-    XCTAssertEqualObjects(secondCardParams.address.line1, @"27 Smith St");
+    XCTAssertEqualObjects(secondCardParams.address.line1, @"123 Main");
 }
 
 @end

--- a/Tests/Tests/STPCardParamsTest.m
+++ b/Tests/Tests/STPCardParamsTest.m
@@ -172,7 +172,7 @@
     }
 }
 
-- (void)testAddressIsNotCopied {
+- (void)testAddressIsCopied {
     STPCardParams *cardParams = [STPFixtures cardParams];
     cardParams.address = [STPFixtures address];
     STPCardParams *secondCardParams = [STPCardParams new];
@@ -181,7 +181,7 @@
     cardParams.address.line1 = @"123 Main";
 
     XCTAssertEqualObjects(cardParams.address.line1, @"123 Main");
-    XCTAssertEqualObjects(secondCardParams.address.line1, @"123 Main");
+    XCTAssertEqualObjects(secondCardParams.address.line1, @"27 Smith St");
 }
 
 @end

--- a/Tests/Tests/STPCardParamsTest.m
+++ b/Tests/Tests/STPCardParamsTest.m
@@ -38,6 +38,26 @@
     XCTAssertNil(cardParams.last4);
 }
 
+- (void)testNameSharedWithAddress {
+    STPCardParams *cardParams = [STPCardParams new];
+
+    cardParams.name = @"James";
+    XCTAssertEqualObjects(cardParams.name, @"James");
+    XCTAssertEqualObjects(cardParams.address.name, @"James");
+
+    STPAddress *address = [STPAddress new];
+    address.name = @"Jim";
+
+    cardParams.address = address;
+    XCTAssertEqualObjects(cardParams.name, @"Jim");
+    XCTAssertEqualObjects(cardParams.address.name, @"Jim");
+
+    // Doesn't update `name`, since mutation invisible to the STPCardParams
+    cardParams.address.name = @"Smith";
+    XCTAssertEqualObjects(cardParams.name, @"Jim");
+    XCTAssertEqualObjects(cardParams.address.name, @"Smith");
+}
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated"
 

--- a/Tests/Tests/STPCardParamsTest.m
+++ b/Tests/Tests/STPCardParamsTest.m
@@ -10,6 +10,9 @@
 
 #import "STPCardParams.h"
 
+#import "STPFixtures.h"
+#import "STPTestUtils.h"
+
 @interface STPCardParamsTest : XCTestCase
 
 @end
@@ -112,6 +115,41 @@
     }
 
     XCTAssertEqual([[mapping allValues] count], [[NSSet setWithArray:[mapping allValues]] count]);
+}
+
+#pragma mark - NSCopying Tests
+
+- (void)testCopyWithZone {
+    STPCardParams *cardParams = [STPFixtures cardParams];
+    cardParams.address = [STPFixtures address];
+    STPCardParams *copiedCardParams = [cardParams copy];
+
+    XCTAssertNotEqual(cardParams, copiedCardParams, @"should be different objects");
+
+    // The property names we expect to *not* be equal objects
+    NSArray *notEqualProperties = @[
+                                    // these include the object's address, so they won't be the same across copies
+                                    @"debugDescription",
+                                    @"description",
+                                    @"hash",
+                                    // STPAddress does not override isEqual:, so this is pointer comparison
+                                    @"address",
+                                    ];
+
+    // use runtime inspection to find the list of properties. If a new property is
+    // added to the fixture, but not the `copyWithZone:` implementation, this should catch it
+    for (NSString *property in [STPTestUtils propertyNamesOf:cardParams]) {
+        if ([notEqualProperties containsObject:property]) {
+            XCTAssertNotEqualObjects([cardParams valueForKey:property],
+                                     [copiedCardParams valueForKey:property],
+                                     @"%@", property);
+        }
+        else {
+            XCTAssertEqualObjects([cardParams valueForKey:property],
+                                  [copiedCardParams valueForKey:property],
+                                  @"%@", property);
+        }
+    }
 }
 
 @end

--- a/Tests/Tests/STPCertTest.m
+++ b/Tests/Tests/STPCertTest.m
@@ -38,7 +38,7 @@ NSString *const STPExamplePublishableKey = @"bad_key";
 }
 
 - (void)testExpired {
-    [self createTokenWithBaseURL:[NSURL URLWithString:@"https://testssl-expire.disig.sk/index.en.html"]
+    [self createTokenWithBaseURL:[NSURL URLWithString:@"https://testssl-expire-r2i2.disig.sk/index.en.html"]
                       completion:^(STPToken *token, NSError *error) {
                           XCTAssertNil(token, @"Token should be nil.");
                           XCTAssertEqualObjects(error.domain, @"NSURLErrorDomain", @"Error should be NSURLErrorDomain");

--- a/Tests/Tests/STPPaymentCardTextFieldTest.m
+++ b/Tests/Tests/STPPaymentCardTextFieldTest.m
@@ -11,6 +11,7 @@
 @import OCMock;
 
 #import "Stripe.h"
+#import "STPFixtures.h"
 #import "STPFormTextField.h"
 #import "STPPaymentCardTextFieldViewModel.h"
 
@@ -26,6 +27,20 @@
 + (UIImage *)cvcImageForCardBrand:(STPCardBrand)cardBrand;
 + (UIImage *)brandImageForCardBrand:(STPCardBrand)cardBrand;
 @end
+
+/**
+ Class that implements STPPaymentCardTextFieldDelegate and uses a block for each delegate method.
+ */
+@interface PaymentCardTextFieldBlockDelegate: NSObject <STPPaymentCardTextFieldDelegate>
+@property (nonatomic, strong, nullable) void (^didChange)(STPPaymentCardTextField *);
+// add more properties for other delegate methods as this test needs them
+@end
+@implementation PaymentCardTextFieldBlockDelegate
+- (void)paymentCardTextFieldDidChange:(STPPaymentCardTextField *)textField {
+    self.didChange(textField);
+}
+@end
+
 
 @interface STPPaymentCardTextFieldTest : XCTestCase
 @end
@@ -348,6 +363,51 @@
     XCTAssertEqualObjects(params.cvc, @"123");
     XCTAssertEqual((int)params.expMonth, 10);
     XCTAssertEqual((int)params.expYear, 99);
+}
+
+- (void)testAccessingCardParamsDuringSettingCardParams {
+    PaymentCardTextFieldBlockDelegate *delegate = [PaymentCardTextFieldBlockDelegate new];
+    delegate.didChange = ^(STPPaymentCardTextField *textField) {
+        // delegate reads the `cardParams` for any reason it wants
+        [textField cardParams];
+    };
+    STPPaymentCardTextField *sut = [STPPaymentCardTextField new];
+    sut.delegate = delegate;
+
+    STPCardParams *params = [STPCardParams new];
+    params.number = @"4242424242424242";
+    params.cvc = @"123";
+    params.name = @"John";
+
+    sut.cardParams = params;
+    STPCardParams *actual = sut.cardParams;
+
+    XCTAssertEqualObjects(@"4242424242424242", actual.number);
+    XCTAssertEqualObjects(@"123", actual.cvc); // fails due to #1027
+    XCTAssertEqualObjects(@"John", actual.name);
+}
+
+- (void)testCardParamsDoesNotCopyObject {
+    // danj: I don't actually know if this behavior is desirable. It is the *current* behavior,
+    // and changing it might break a user's integration
+
+    STPPaymentCardTextField *sut = [STPPaymentCardTextField new];
+    STPCardParams *params = [STPCardParams new];
+
+    params.number = @"4242424242424242"; // legit
+    sut.cardParams = params;
+    params.name = @"John"; // wouldn't necessarily expect this to work
+    sut.cardParams.currency = @"GBP"; // reasonable?
+
+    STPCardParams *actual = sut.cardParams;
+    actual.address.line1 = @"123 Main St"; // address is also shared
+    params.address.line2 = @"Apt 3"; // shared with the original object too
+
+    XCTAssertEqualObjects(@"4242424242424242", sut.cardParams.number, @"set via setCardParams:");
+    XCTAssertEqualObjects(@"John", sut.cardParams.name, @"caller changed their copy after setCardParams:");
+    XCTAssertEqualObjects(@"GBP", sut.cardParams.currency, @"return value from cardParams edited inline");
+    XCTAssertEqualObjects(@"123 Main St", sut.cardParams.address.line1, @"address is also not copied");
+    XCTAssertEqualObjects(@"Apt 3", sut.cardParams.address.line2, @"address is also not copied");
 }
 
 @end

--- a/Tests/Tests/STPPaymentCardTextFieldTest.m
+++ b/Tests/Tests/STPPaymentCardTextFieldTest.m
@@ -393,16 +393,19 @@
 
     params.number = @"4242424242424242"; // legit
     sut.cardParams = params;
-    params.name = @"John"; // doesn't work
-    sut.cardParams.currency = @"GBP"; // reasonable, and it works
 
-    STPCardParams *actual = sut.cardParams;
-    actual.address.line1 = @"123 Main St"; // can fetch `sut.cardParams` and modify it
-    params.address.line2 = @"Apt 3"; // but `sut` has a copy, so edits to original params don't show up
+    // fetching `sut.cardParams` returns a copy, so edits happen to caller's copy
+    sut.cardParams.currency = @"GBP";
+    sut.cardParams.address.line1 = @"123 Main St";
+
+    // `sut` copied `params` (& `params.address`) when set, so edits to original don't show up
+    params.name = @"John";
+    params.address.line2 = @"Apt 3";
 
     XCTAssertEqualObjects(@"4242424242424242", sut.cardParams.number, @"set via setCardParams:");
-    XCTAssertEqualObjects(@"GBP", sut.cardParams.currency, @"return value from cardParams edited inline");
-    XCTAssertEqualObjects(@"123 Main St", sut.cardParams.address.line1, @"returned cardParams.address edited");
+
+    XCTAssertNotEqualObjects(@"GBP", sut.cardParams.currency, @"return value from cardParams cannot be edited inline");
+    XCTAssertNotEqualObjects(@"123 Main St", sut.cardParams.address.line1, @"returned cardParams.address cannot be edited inline");
 
     XCTAssertNotEqualObjects(@"John", sut.cardParams.name, @"caller changed their copy after setCardParams:");
     XCTAssertNotEqualObjects(@"Apt 3", sut.cardParams.address.line2, @"caller changed their copy after setCardParams:");

--- a/Tests/Tests/STPPaymentCardTextFieldTest.m
+++ b/Tests/Tests/STPPaymentCardTextFieldTest.m
@@ -383,31 +383,29 @@
     STPCardParams *actual = sut.cardParams;
 
     XCTAssertEqualObjects(@"4242424242424242", actual.number);
-    XCTAssertEqualObjects(@"123", actual.cvc); // fails due to #1027
+    XCTAssertEqualObjects(@"123", actual.cvc);
     XCTAssertEqualObjects(@"John", actual.name);
 }
 
-- (void)testCardParamsDoesNotCopyObject {
-    // danj: I don't actually know if this behavior is desirable. It is the *current* behavior,
-    // and changing it might break a user's integration
-
+- (void)testSetCardParamsCopiesObject {
     STPPaymentCardTextField *sut = [STPPaymentCardTextField new];
     STPCardParams *params = [STPCardParams new];
 
     params.number = @"4242424242424242"; // legit
     sut.cardParams = params;
-    params.name = @"John"; // wouldn't necessarily expect this to work
-    sut.cardParams.currency = @"GBP"; // reasonable?
+    params.name = @"John"; // doesn't work
+    sut.cardParams.currency = @"GBP"; // reasonable, and it works
 
     STPCardParams *actual = sut.cardParams;
-    actual.address.line1 = @"123 Main St"; // address is also shared
-    params.address.line2 = @"Apt 3"; // shared with the original object too
+    actual.address.line1 = @"123 Main St"; // can fetch `sut.cardParams` and modify it
+    params.address.line2 = @"Apt 3"; // but `sut` has a copy, so edits to original params don't show up
 
     XCTAssertEqualObjects(@"4242424242424242", sut.cardParams.number, @"set via setCardParams:");
-    XCTAssertEqualObjects(@"John", sut.cardParams.name, @"caller changed their copy after setCardParams:");
     XCTAssertEqualObjects(@"GBP", sut.cardParams.currency, @"return value from cardParams edited inline");
-    XCTAssertEqualObjects(@"123 Main St", sut.cardParams.address.line1, @"address is also not copied");
-    XCTAssertEqualObjects(@"Apt 3", sut.cardParams.address.line2, @"address is also not copied");
+    XCTAssertEqualObjects(@"123 Main St", sut.cardParams.address.line1, @"returned cardParams.address edited");
+
+    XCTAssertNotEqualObjects(@"John", sut.cardParams.name, @"caller changed their copy after setCardParams:");
+    XCTAssertNotEqualObjects(@"Apt 3", sut.cardParams.address.line2, @"caller changed their copy after setCardParams:");
 }
 
 @end

--- a/Tests/Tests/STPTestUtils.h
+++ b/Tests/Tests/STPTestUtils.h
@@ -12,6 +12,14 @@
 
 + (NSDictionary *)jsonNamed:(NSString *)name;
 
+/**
+ Using runtime inspection, what are all the property names for this object?
+
+ @param object the object to introspect
+ @return list of property names, usable with `valueForKey:`
+ */
++ (NSArray<NSString *> *)propertyNamesOf:(NSObject *)object;
+
 @end
 
 

--- a/Tests/Tests/STPTestUtils.m
+++ b/Tests/Tests/STPTestUtils.m
@@ -8,6 +8,8 @@
 
 #import "STPTestUtils.h"
 
+@import ObjectiveC.runtime;
+
 @implementation STPTestUtils
 
 + (NSDictionary *)jsonNamed:(NSString *)name {
@@ -16,6 +18,20 @@
         return [NSJSONSerialization JSONObjectWithData:data options:(NSJSONReadingOptions)kNilOptions error:nil];
     }
     return nil;
+}
+
++ (NSArray<NSString *> *)propertyNamesOf:(NSObject *)object {
+    uint propertyCount;
+    objc_property_t *propertyList = class_copyPropertyList([object class], &propertyCount);
+    NSMutableArray *propertyNames = [NSMutableArray arrayWithCapacity:propertyCount];
+
+    for (uint i = 0; i < propertyCount; i++) {
+        objc_property_t property = propertyList[i];
+        NSString *propertyName = [NSString stringWithUTF8String:property_getName(property)];
+        [propertyNames addObject:propertyName];
+    }
+    free(propertyList);
+    return propertyNames;
 }
 
 #pragma mark -


### PR DESCRIPTION
## Summary
Exposing the internal `STPCardParams` object led to weird interactions, like #1027. It
also doesn't match our desired information hiding. Setting some fields on the `cardParams`
would persist (name, address, etc), while setting others had no effect (card number, etc).

By copying in both setter & getter, the internal state of this view is protected, and
must be changed by setting a new object on the property.

We expect well-behaved code to be backwards compatible, but this is a breaking change
that'll require a major version bump because it changes the interface & behavior.

## Motivation
#1027 and IOS-958

## Testing
Tests were written that illustrate the problem & current behavior, and then updated as the
behavior changed.

Sample projects were inspected and tested to make sure they weren't using the payment text
field in an unsupported way.