### PR TITLE
Change Styleguide around acronym capitalization, and fix recent PaymentIntent code

### DIFF
--- a/Example/Custom Integration (ObjC)/ThreeDSPaymentIntentExampleViewController.m
+++ b/Example/Custom Integration (ObjC)/ThreeDSPaymentIntentExampleViewController.m
@@ -67,7 +67,7 @@
         STPAPIClient *stripeClient = [STPAPIClient sharedClient];
         STPPaymentIntentParams *paymentIntentParams = [[STPPaymentIntentParams alloc] initWithClientSecret:clientSecret];
         paymentIntentParams.sourceParams = [STPSourceParams cardParamsWithCard:self.paymentTextField.cardParams];
-        paymentIntentParams.returnUrl = @"payments-example://stripe-redirect";
+        paymentIntentParams.returnURL = @"payments-example://stripe-redirect";
 
         [stripeClient confirmPaymentIntentWithParams:paymentIntentParams completion:^(STPPaymentIntent * _Nullable paymentIntent, NSError * _Nullable error) {
             if (error) {

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -5,6 +5,7 @@
   * Changes to the `STPCardParams` object after setting `cardParams` no longer mutate the object held by the `STPPaymentCardTextField`
   * Changes to the object returned by `STPPaymentCardTextField.cardParams` no longer mutate the object held by the `STPPaymentCardTextField`
   * This is a breaking change for code like: `paymentCardTextField.cardParams.name = @"Jane Doe";`
+* `STPPaymentIntentParams.returnUrl` has been renamed to `STPPaymentIntentParams.returnURL`. Xcode should offer a deprecation warning & fix-it to help you migrate.
 
 ### Migrating from versions < 13.1.0
  * The SDK now supports PaymentIntents with `STPPaymentIntent`, which use `STPRedirectContext` in the same way that `STPSource` does

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -18,7 +18,7 @@
 
 - Avoid single letter variables. Try using `idx` / `jdx` instead of `i` / `j` in for loops.
 
-- Prefer `urlString` over `URLString` (acronym prefix), `baseUrlString` over `baseURLString` (acronym infix), and `stripeId` over `stripeID` (acronym suffix)
+- Acronyms should be all lowercase as a method prefix (ex:`url` or `urlString`). Otherwise, they should be all caps when occurring elsewhere in the method name, or as a class name (ex: `handleStripeURLCallbackWithURL`, `stripeID` or `STPAPIClient`)
 
 ### Control Flow
 

--- a/Stripe/PublicHeaders/STPPaymentIntentParams.h
+++ b/Stripe/PublicHeaders/STPPaymentIntentParams.h
@@ -80,7 +80,15 @@ NS_ASSUME_NONNULL_BEGIN
  their payment on the payment method’s app or site.
  This should probably be a URL that opens your iOS app.
  */
-@property (nonatomic, copy, nullable, readwrite) NSString *returnUrl;
+@property (nonatomic, copy, nullable, readwrite) NSString *returnURL;
+
+/**
+ The URL to redirect your customer back to after they authenticate or cancel
+ their payment on the payment method’s app or site.
+
+ This property has been renamed to `returnURL` and deprecated.
+ */
+@property (nonatomic, copy, nullable, readwrite) NSString *returnUrl __attribute__((deprecated("returnUrl has been renamed to returnURL", "returnURL")));
 
 @end
 

--- a/Stripe/STPPaymentIntentParams.m
+++ b/Stripe/STPPaymentIntentParams.m
@@ -42,7 +42,7 @@
                        // PaymentIntentParams details (alphabetical)
                        [NSString stringWithFormat:@"clientSecret = %@", (self.clientSecret.length > 0) ? @"<redacted>" : @""],
                        [NSString stringWithFormat:@"receiptEmail = %@", self.receiptEmail],
-                       [NSString stringWithFormat:@"returnUrl = %@", self.returnUrl],
+                       [NSString stringWithFormat:@"returnURL = %@", self.returnURL],
                        [NSString stringWithFormat:@"saveSourceToCustomer = %@", (self.saveSourceToCustomer.boolValue) ? @"YES" : @"NO"],
                        [NSString stringWithFormat:@"sourceId = %@", self.sourceId],
                        [NSString stringWithFormat:@"sourceParams = %@", self.sourceParams],
@@ -67,7 +67,7 @@
              NSStringFromSelector(@selector(sourceId)): @"source",
              NSStringFromSelector(@selector(receiptEmail)): @"receipt_email",
              NSStringFromSelector(@selector(saveSourceToCustomer)): @"save_source_to_customer",
-             NSStringFromSelector(@selector(returnUrl)): @"return_url",
+             NSStringFromSelector(@selector(returnURL)): @"return_url",
              };
 }
 

--- a/Stripe/STPPaymentIntentParams.m
+++ b/Stripe/STPPaymentIntentParams.m
@@ -54,6 +54,16 @@
     return [NSString stringWithFormat:@"<%@>", [props componentsJoinedByString:@"; "]];
 }
 
+#pragma mark - Deprecated Properties
+
+- (NSString *)returnUrl {
+    return self.returnURL;
+}
+
+- (void)setReturnUrl:(NSString *)returnUrl {
+    self.returnURL = returnUrl;
+}
+
 #pragma mark - STPFormEncodable
 
 + (nullable NSString *)rootObjectName {

--- a/Stripe/STPRedirectContext+Private.h
+++ b/Stripe/STPRedirectContext+Private.h
@@ -12,12 +12,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface STPRedirectContext()
 
-/// Optional URL for a native app. This is passed directly to `UIApplication openURL:`, and if it fails this class falls back to `redirectUrl`
-@property (nonatomic, nullable, copy) NSURL *nativeRedirectUrl;
-/// The URL to redirect to, assuming `nativeRedirectUrl` is nil or fails to open. Cannot be nil if `nativeRedirectUrl` is.
-@property (nonatomic, nullable, copy) NSURL *redirectUrl;
-/// The expected `returnUrl`, passed to STPURLCallbackHandler
-@property (nonatomic, copy) NSURL *returnUrl;
+/// Optional URL for a native app. This is passed directly to `UIApplication openURL:`, and if it fails this class falls back to `redirectURL`
+@property (nonatomic, nullable, copy) NSURL *nativeRedirectURL;
+/// The URL to redirect to, assuming `nativeRedirectURL` is nil or fails to open. Cannot be nil if `nativeRedirectURL` is.
+@property (nonatomic, nullable, copy) NSURL *redirectURL;
+/// The expected `returnURL`, passed to STPURLCallbackHandler
+@property (nonatomic, copy) NSURL *returnURL;
 /// Completion block to execute when finished redirecting, with optional error parameter.
 @property (nonatomic, copy) STPErrorBlock completion;
 

--- a/Tests/Tests/STPFixtures.h
+++ b/Tests/Tests/STPFixtures.h
@@ -127,7 +127,7 @@ extern NSString *const STPTestJSONSourceSOFORT;
 /**
  A Source object with type Alipay and a native redirect url
  */
-+ (STPSource *)alipaySourceWithNativeUrl;
++ (STPSource *)alipaySourceWithNativeURL;
 
 /**
  A PaymentIntent object

--- a/Tests/Tests/STPFixtures.m
+++ b/Tests/Tests/STPFixtures.m
@@ -189,7 +189,7 @@ NSString *const STPTestJSONSourceSOFORT = @"SOFORTSource";
     return [STPSource decodedObjectFromAPIResponse:[STPTestUtils jsonNamed:STPTestJSONSourceAlipay]];
 }
 
-+ (STPSource *)alipaySourceWithNativeUrl {
++ (STPSource *)alipaySourceWithNativeURL {
     NSMutableDictionary *dictionary = [STPTestUtils jsonNamed:STPTestJSONSourceAlipay].mutableCopy;
     NSMutableDictionary *detailsDictionary = ((NSDictionary *)dictionary[@"alipay"]).mutableCopy;
     detailsDictionary[@"native_url"] = @"alipay://test";

--- a/Tests/Tests/STPPaymentIntentParamsTest.m
+++ b/Tests/Tests/STPPaymentIntentParamsTest.m
@@ -30,7 +30,7 @@
         XCTAssertNil(params.sourceId);
         XCTAssertNil(params.receiptEmail);
         XCTAssertNil(params.saveSourceToCustomer);
-        XCTAssertNil(params.returnUrl);
+        XCTAssertNil(params.returnURL);
     }
 }
 

--- a/Tests/Tests/STPPaymentIntentParamsTest.m
+++ b/Tests/Tests/STPPaymentIntentParamsTest.m
@@ -39,6 +39,26 @@
     XCTAssertNotNil(params.description);
 }
 
+#pragma mark Deprecated Property
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
+
+- (void)testReturnURLRenaming {
+    STPPaymentIntentParams *params = [[STPPaymentIntentParams alloc] init];
+
+    XCTAssertNil(params.returnURL);
+    XCTAssertNil(params.returnUrl);
+
+    params.returnURL = @"set via new name";
+    XCTAssertEqualObjects(params.returnUrl, @"set via new name");
+
+    params.returnUrl = @"set via old name";
+    XCTAssertEqualObjects(params.returnURL, @"set via old name");
+}
+
+#pragma clang diagnostic pop
+
 #pragma mark STPFormEncodable Tests
 
 - (void)testRootObjectName {

--- a/Tests/Tests/STPRedirectContextTest.m
+++ b/Tests/Tests/STPRedirectContextTest.m
@@ -102,7 +102,7 @@
 }
 
 - (void)testInitWithSourceWithNativeURL {
-    STPSource *source = [STPFixtures alipaySourceWithNativeUrl];
+    STPSource *source = [STPFixtures alipaySourceWithNativeURL];
     __block BOOL completionCalled = NO;
     NSURL *nativeURL = [NSURL URLWithString:source.details[@"native_url"]];
     NSError *fakeError = [NSError new];
@@ -568,7 +568,7 @@
  url, an app to app redirect should attempt to be initiated.
  */
 - (void)testNativeRedirectSupportingSourceFlow_validNativeURL {
-    STPSource *source = [STPFixtures alipaySourceWithNativeUrl];
+    STPSource *source = [STPFixtures alipaySourceWithNativeURL];
     NSURL *sourceURL = [NSURL URLWithString:source.details[@"native_url"]];
 
     STPRedirectContext *context = [[STPRedirectContext alloc] initWithSource:source

--- a/Tests/Tests/STPRedirectContextTest.m
+++ b/Tests/Tests/STPRedirectContextTest.m
@@ -92,9 +92,9 @@
     }];
 
     // Make sure the initWithSource: method pulled out the right values from the Source
-    XCTAssertNil(sut.nativeRedirectUrl);
-    XCTAssertEqualObjects(sut.redirectUrl, source.redirect.url);
-    XCTAssertEqualObjects(sut.returnUrl, source.redirect.returnURL);
+    XCTAssertNil(sut.nativeRedirectURL);
+    XCTAssertEqualObjects(sut.redirectURL, source.redirect.url);
+    XCTAssertEqualObjects(sut.returnURL, source.redirect.returnURL);
 
     // and make sure the completion calls the completion block above
     sut.completion(fakeError);
@@ -115,9 +115,9 @@
     }];
 
     // Make sure the initWithSource: method pulled out the right values from the Source
-    XCTAssertEqualObjects(sut.nativeRedirectUrl, nativeURL);
-    XCTAssertEqualObjects(sut.redirectUrl, source.redirect.url);
-    XCTAssertEqualObjects(sut.returnUrl, source.redirect.returnURL);
+    XCTAssertEqualObjects(sut.nativeRedirectURL, nativeURL);
+    XCTAssertEqualObjects(sut.redirectURL, source.redirect.url);
+    XCTAssertEqualObjects(sut.returnURL, source.redirect.returnURL);
 
     // and make sure the completion calls the completion block above
     sut.completion(fakeError);
@@ -136,10 +136,10 @@
     }];
 
     // Make sure the initWithPaymentIntent: method pulled out the right values from the PaymentIntent
-    XCTAssertNil(sut.nativeRedirectUrl);
-    XCTAssertEqualObjects(sut.redirectUrl.absoluteString,
+    XCTAssertNil(sut.nativeRedirectURL);
+    XCTAssertEqualObjects(sut.redirectURL.absoluteString,
                           @"https://hooks.stripe.com/redirect/authenticate/src_1Cl1AeIl4IdHmuTb1L7x083A?client_secret=src_client_secret_DBNwUe9qHteqJ8qQBwNWiigk");
-    XCTAssertEqualObjects(sut.returnUrl, paymentIntent.returnUrl);
+    XCTAssertEqualObjects(sut.returnURL, paymentIntent.returnUrl);
 
     // and make sure the completion calls the completion block above
     sut.completion(fakeError);
@@ -245,7 +245,7 @@
         XCTAssertNil(error);
         [exp fulfill];
     }];
-    XCTAssertEqualObjects(source.redirect.returnURL, context.returnUrl);
+    XCTAssertEqualObjects(source.redirect.returnURL, context.returnURL);
     id sut = OCMPartialMock(context);
 
     [sut startSafariViewControllerRedirectFlowFromViewController:mockVC];
@@ -291,7 +291,7 @@
     BOOL(^checker)(id) = ^BOOL(id vc) {
         if ([vc isKindOfClass:[SFSafariViewController class]]) {
             NSURL *url = [NSURL URLWithString:@"my-app://some_path"];
-            XCTAssertNotEqualObjects(url, context.returnUrl);
+            XCTAssertNotEqualObjects(url, context.returnURL);
             [[STPURLCallbackHandler shared] handleURLCallback:url];
             return YES;
         }
@@ -576,8 +576,8 @@
         XCTFail(@"completion called");
     }];
 
-    XCTAssertNotNil(context.nativeRedirectUrl);
-    XCTAssertEqualObjects(context.nativeRedirectUrl, sourceURL);
+    XCTAssertNotNil(context.nativeRedirectURL);
+    XCTAssertEqualObjects(context.nativeRedirectURL, sourceURL);
 
     id sut = OCMPartialMock(context);
 
@@ -620,7 +620,7 @@
                                                                   completion:^(__unused NSString *sourceID, __unused NSString *clientSecret, __unused NSError *error) {
                                                                       XCTFail(@"completion called");
                                                                   }];
-    XCTAssertNil(context.nativeRedirectUrl);
+    XCTAssertNil(context.nativeRedirectURL);
 
     id sut = OCMPartialMock(context);
 


### PR DESCRIPTION
## Summary
Fixes the styleguide to match the codebase, and updates recent code that was written
to follow the (incorrect) styleguide re: URL vs Url.

Only one public-facing property needed changing. Deprecated it, along with a fixit to
make the upgrade path easier for users. Everything else was private or test-only.

## Motivation
I'd been following the STYLEGUIDE.md while working on the last PaymentIntent-related PRs.
While working on another PaymentIntent-related PR, I noticed the inconsistency, and
took the time to fix all of the `Url` cases.

## Testing
I specifically checked URL vs `Url`, and it was overwhelmingly `URL`.
`stripeID` beats `stripeId` by about 2 to 1, but I'm not going to change them.
You can see fully capitalized acronyms in class names too.

The automated tests verify no functionality change, and the fixit on the only
public-facing property worked to update the sample code.