### PR TITLE
Don't percent encode entire form bodies

### DIFF
--- a/Stripe/STPFormEncoder.m
+++ b/Stripe/STPFormEncoder.m
@@ -137,7 +137,7 @@ NSString * STPPercentEscapedStringFromString(NSString *string) {
 
 - (instancetype)initWithField:(id)field value:(id)value;
 
-- (NSString *)URLEncodedStringValue;
+- (NSString *)stringValue;
 @end
 
 @implementation STPQueryStringPair
@@ -154,20 +154,11 @@ NSString * STPPercentEscapedStringFromString(NSString *string) {
     return self;
 }
 
-- (NSString *)URLEncodedStringValue {
+- (NSString *)stringValue {
     if (!self.value || [self.value isEqual:[NSNull null]]) {
-        return STPPercentEscapedStringFromString([self.field description]);
+        return [self.field description] ? : @"";
     } else {
-        NSString *unescapedValue = [self.value description];
-
-        // coerce boxed BOOL values back into true/false
-        // https://stackoverflow.com/a/30223989/1196205
-        if ([self.value isKindOfClass:[NSNumber class]]
-            && (CFBooleanGetTypeID() == CFGetTypeID((__bridge CFTypeRef)(self.value)))) {
-            unescapedValue = [self.value boolValue] ? @"true" : @"false";
-        }
-
-        return [NSString stringWithFormat:@"%@=%@", STPPercentEscapedStringFromString([self.field description]), STPPercentEscapedStringFromString(unescapedValue)];
+        return [NSString stringWithFormat:@"%@=%@", [self.field description], [self.value description]];
     }
 }
 
@@ -175,20 +166,68 @@ NSString * STPPercentEscapedStringFromString(NSString *string) {
 
 #pragma mark -
 
-FOUNDATION_EXPORT NSArray * STPQueryStringPairsFromDictionary(NSDictionary *dictionary);
 FOUNDATION_EXPORT NSArray * STPQueryStringPairsFromKeyAndValue(NSString *key, id value);
+FOUNDATION_EXPORT id STPPercentEscapedObject(id object);
 
 NSString * STPQueryStringFromParameters(NSDictionary *parameters) {
-    NSMutableArray *mutablePairs = [NSMutableArray array];
-    for (STPQueryStringPair *pair in STPQueryStringPairsFromDictionary(parameters)) {
-        [mutablePairs addObject:[pair URLEncodedStringValue]];
+    
+    // Escape any reserved characters. due to the implementation of `STPQueryStringPairsFromKeyAndValue`, it's much easier to do this now, as when that function is called recursively on a dictionary, `key` will (correctly) contain characters like `[]`.
+    NSDictionary *escaped = STPPercentEscapedObject(parameters);
+    
+    NSString *descriptionSelector = NSStringFromSelector(@selector(description));
+    NSSortDescriptor *sortDescriptor = [NSSortDescriptor sortDescriptorWithKey:descriptionSelector ascending:YES selector:@selector(compare:)];
+    
+    // For each dictionary key-value pair, form-encode the pair (potentially recursively). Thus {foo: {bar: "baz"}} becomes the tuple, ("foo[bar]", "baz"). Each one of these tuples will become a key/value pair in the final query string (e.g. POST /v1/charges?foo[bar]=baz).
+    NSMutableArray *mutablePairs = [NSMutableArray array];    
+    for (id key in [escaped.allKeys sortedArrayUsingDescriptors:@[ sortDescriptor ]]) {
+        id value = escaped[key];
+        NSArray *pairs = STPQueryStringPairsFromKeyAndValue(key, value);
+        [mutablePairs addObjectsFromArray:pairs];
     }
     
-    return [mutablePairs componentsJoinedByString:@"&"];
+    NSMutableArray *mutablePathComponents = [NSMutableArray array];
+    for (STPQueryStringPair *pair in mutablePairs) {
+        [mutablePathComponents addObject:[pair stringValue]];
+    }
+    
+    return [mutablePathComponents componentsJoinedByString:@"&"];
 }
 
-NSArray * STPQueryStringPairsFromDictionary(NSDictionary *dictionary) {
-    return STPQueryStringPairsFromKeyAndValue(nil, dictionary);
+// This function recursively converts an object into a version that is safe to convert into
+// a form-encoded path string by escaping any reserved characters in it or its children.
+id STPPercentEscapedObject(id object) {
+    if (!object) {
+        return @{};
+    } else if (object == [NSNull null]) {
+        return @"";
+    } else if ([object isKindOfClass:[NSArray class]]) {
+        NSMutableArray *escapedArray = [NSMutableArray array];
+        for (id subObject in object) {
+            [escapedArray addObject:STPPercentEscapedObject(subObject)];
+        }
+        return escapedArray;
+    } else if ([object isKindOfClass:[NSSet class]]) {
+        NSMutableSet *escapedSet = [NSMutableSet set];
+        for (id subObject in object) {
+            [escapedSet addObject:STPPercentEscapedObject(subObject)];
+        }
+        return escapedSet;
+    } else if ([object isKindOfClass:[NSDictionary class]]) {
+        NSMutableDictionary *escapedDictionary = [NSMutableDictionary dictionary];
+        for (id key in object) {
+            id escapedKey = STPPercentEscapedStringFromString([key description]);
+            id subObject = object[key];
+            escapedDictionary[escapedKey] = STPPercentEscapedObject(subObject);
+        }
+        return escapedDictionary;
+    } else if ([object isKindOfClass:[NSNumber class]]
+               && (CFBooleanGetTypeID() == CFGetTypeID((__bridge CFTypeRef)(object)))) {
+        // Unbox NSNumbers containing booleans
+        // https://stackoverflow.com/a/30223989/1196205
+        return [object boolValue] ? @"true" : @"false";
+    } else {
+        return STPPercentEscapedStringFromString([object description]);
+    }
 }
 
 NSArray * STPQueryStringPairsFromKeyAndValue(NSString *key, id value) {
@@ -198,18 +237,18 @@ NSArray * STPQueryStringPairsFromKeyAndValue(NSString *key, id value) {
     
     if ([value isKindOfClass:[NSDictionary class]]) {
         NSDictionary *dictionary = value;
-        // Sort dictionary keys to ensure consistent ordering in query string, which is important when deserializing potentially ambiguous sequences, such as an array of dictionaries
+        // Sort dictionary keys to ensure consistent ordering in query string, which is important when serializing potentially ambiguous sequences, such as an array of dictionaries
         for (id nestedKey in [dictionary.allKeys sortedArrayUsingDescriptors:@[ sortDescriptor ]]) {
             id nestedValue = dictionary[nestedKey];
-            if (nestedValue) {
-                [mutableQueryStringComponents addObjectsFromArray:STPQueryStringPairsFromKeyAndValue((key ? [NSString stringWithFormat:@"%@[%@]", key, nestedKey] : nestedKey), nestedValue)];
-            }
+            // Call ourselves recursively, building up a larger param string
+            NSString *combinedKey = [NSString stringWithFormat:@"%@[%@]", key, nestedKey];
+            [mutableQueryStringComponents addObjectsFromArray:STPQueryStringPairsFromKeyAndValue(combinedKey, nestedValue)];
         }
     } else if ([value isKindOfClass:[NSArray class]]) {
         NSArray *array = value;
-        [array enumerateObjectsUsingBlock:^(id  _Nonnull nestedValue, NSUInteger idx, __unused BOOL * _Nonnull stop) {
-            [mutableQueryStringComponents addObjectsFromArray:STPQueryStringPairsFromKeyAndValue([NSString stringWithFormat:@"%@[%lu]", key, (unsigned long)idx], nestedValue)];
-        }];
+        for (id nestedValue in array) {
+            [mutableQueryStringComponents addObjectsFromArray:STPQueryStringPairsFromKeyAndValue([NSString stringWithFormat:@"%@[]", key], nestedValue)];
+        }
     } else if ([value isKindOfClass:[NSSet class]]) {
         NSSet *set = value;
         for (id obj in [set sortedArrayUsingDescriptors:@[ sortDescriptor ]]) {

--- a/Stripe/STPFormEncoder.m
+++ b/Stripe/STPFormEncoder.m
@@ -171,7 +171,7 @@ FOUNDATION_EXPORT id STPPercentEscapedObject(id object);
 
 NSString * STPQueryStringFromParameters(NSDictionary *parameters) {
     
-    if (!parameters || parameters == [NSNull null]) {
+    if (!parameters) {
         return @"";
     }
     

--- a/Tests/Tests/STPCardFunctionalTest.m
+++ b/Tests/Tests/STPCardFunctionalTest.m
@@ -45,6 +45,7 @@
                          XCTAssertEqual(2024U, token.card.expYear);
                          XCTAssertEqualObjects(@"4242", token.card.last4);
                          XCTAssertEqualObjects(@"usd", token.card.currency);
+                         XCTAssertEqualObjects(@"10002", token.card.address.postalCode);
                      }];
     [self waitForExpectationsWithTimeout:5.0f handler:nil];
 }

--- a/Tests/Tests/STPFormEncoderTest.m
+++ b/Tests/Tests/STPFormEncoderTest.m
@@ -94,7 +94,7 @@
     STPTestFormEncodableObject *testObject = [STPTestFormEncodableObject new];
     testObject.testProperty = @"success";
     testObject.testArrayProperty = @[@1, @2, @3];
-    XCTAssertEqualObjects([self encodeObject:testObject], @"test_object[test_array_property][]=1&test_object[test_array_property][]=2&test_object[test_array_property][]=3&test_object[test_property]=success");
+    XCTAssertEqualObjects([self encodeObject:testObject], @"test_object[test_array_property][0]=1&test_object[test_array_property][1]=2&test_object[test_array_property][2]=3&test_object[test_property]=success");
 }
 
 - (void)testFormEncoding_BoolAndNumbers {
@@ -105,11 +105,11 @@
                                      [[NSNumber alloc] initWithBool:YES],
                                      @YES];
     XCTAssertEqualObjects([self encodeObject:testObject],
-                          @"test_object[test_array_property][]=0"
-                          "&test_object[test_array_property][]=1"
-                          "&test_object[test_array_property][]=false"
-                          "&test_object[test_array_property][]=true"
-                          "&test_object[test_array_property][]=true");
+                          @"test_object[test_array_property][0]=0"
+                          "&test_object[test_array_property][1]=1"
+                          "&test_object[test_array_property][2]=false"
+                          "&test_object[test_array_property][3]=true"
+                          "&test_object[test_array_property][4]=true");
 }
 
 - (void)testFormEncoding_arrayOfEncodable {
@@ -123,8 +123,8 @@
     testObject.testArrayProperty = @[inner1, inner2];
 
     XCTAssertEqualObjects([self encodeObject:testObject],
-                          @"test_object[test_array_property][][test_property]=inner1"
-                          "&test_object[test_array_property][][test_array_property][]=inner2");
+                          @"test_object[test_array_property][0][test_property]=inner1"
+                          "&test_object[test_array_property][1][test_array_property][0]=inner2");
 }
 
 - (void)testFormEncoding_dictionaryValue_empty {
@@ -153,7 +153,7 @@
 
     XCTAssertEqualObjects([self encodeObject:testObject],
                           @"test_object[test_dictionary_property][one][test_property]=inner1"
-                          "&test_object[test_dictionary_property][two][test_array_property][]=inner2");
+                          "&test_object[test_dictionary_property][two][test_array_property][0]=inner2");
 }
 
 - (void)testFormEncoding_setOfEncodable {
@@ -165,7 +165,7 @@
     testObject.testArrayProperty = @[[NSSet setWithObject:inner]];
 
     XCTAssertEqualObjects([self encodeObject:testObject],
-                          @"test_object[test_array_property][][test_property]=inner");
+                          @"test_object[test_array_property][0][test_property]=inner");
 }
 
 - (void)testFormEncoding_nestedValue {
@@ -187,9 +187,10 @@
     NSDictionary *params = @{
                              @"foo]": @"bar",
                              @"baz": @"qux[",
+                             @"woo;": @";hoo",
                              };
     NSString *result = [STPFormEncoder queryStringFromParameters:params];
-    XCTAssertEqualObjects(result, @"baz=qux%5B&foo%5D=bar");
+    XCTAssertEqualObjects(result, @"baz=qux%5B&foo%5D=bar&woo%3B=%3Bhoo");
 }
 
 - (void)testQueryStringFromParameters {
@@ -218,7 +219,7 @@
                                      },
                              };
     NSString *result = [STPFormEncoder queryStringFromParameters:params];
-    XCTAssertEqualObjects(result, @"ios[certificates][]=cert1&ios[certificates][]=cert2&ios[nonce]=123mynonce&ios[nonce_signature]=sig");
+    XCTAssertEqualObjects(result, @"ios[certificates][0]=cert1&ios[certificates][1]=cert2&ios[nonce]=123mynonce&ios[nonce_signature]=sig");
 }
 
 @end


### PR DESCRIPTION
## Summary
On GET and POST request, we currently percent-escape the entire query - for example, trying to GET a URL like /v1/charges with a hash of parameters like `{foo: "bar]"}` will end up looking like `GET /v1/charges?foo=bar%5D` (which, to be clear, is what you want).

We are overzealously applying this logic, however, to array and dictionary-like structures. The same request above, with a param hash like `{foo: {bar: "baz"}}` will be serialized to `GET /v1/charges?foo%5Bbar%5D=baz`, when really what you want is `GET /v1/charges?foo[bar]=baz`. The thing you don't want is _user-provided_ characters like `]` not getting escaped. While our API is generally robust against encoding like this, certain components don't like it.

To do this, I've refactored our form encoder quite a bit. I've tried to make it a bit clearer how it works, and document some of my changes along the way. Basically, where the path used to be something like (NSDictionary of parameters) -> (form-encoded path) -> (percent-escaping) it is now (NSDictionary of parameters) -> (NSDictionary of percent-escaped parameters) -> (form-encoded path).

<!-- Simple summary of what was changed. -->

## Motivation
I'm working on an upcoming release that is finickier-than-usual about how requests are encoded.
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
Added some automated tests.
<!-- How was the code tested? Be as specific as possible. -->
