### PR TITLE
New type of ephemeral keys

### DIFF
--- a/Stripe/PublicHeaders/STPCustomerContext.h
+++ b/Stripe/PublicHeaders/STPCustomerContext.h
@@ -12,7 +12,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@protocol STPEphemeralKeyProvider;
+@protocol STPCustomerEphemeralKeyProvider;
 @class STPEphemeralKey, STPEphemeralKeyManager;
 
 /**
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param keyProvider   The key provider the customer context will use.
  @return the newly-instantiated customer context.
  */
-- (instancetype)initWithKeyProvider:(id<STPEphemeralKeyProvider>)keyProvider;
+- (instancetype)initWithKeyProvider:(id<STPCustomerEphemeralKeyProvider>)keyProvider;
 
 /**
  `STPCustomerContext` will cache its customer object for up to 60 seconds.

--- a/Stripe/PublicHeaders/STPEphemeralKeyProvider.h
+++ b/Stripe/PublicHeaders/STPEphemeralKeyProvider.h
@@ -14,6 +14,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class STPEphemeralKey;
 
+/**
+ You should make your application's API client conform to this interface.
+ It provides a way for Stripe utility classes to request a new ephemeral key from
+ your backend, which it will use to retrieve and update Stripe API objects.
+ */
 @protocol STPCustomerEphemeralKeyProvider <NSObject>
 /**
  Creates a new ephemeral key for retrieving and updating a Stripe customer.
@@ -36,6 +41,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)createCustomerKeyWithAPIVersion:(NSString *)apiVersion completion:(STPJSONResponseCompletionBlock)completion;
 @end
 
+/**
+ You should make your application's API client conform to this interface.
+ It provides a way for Stripe utility classes to request a new ephemeral key from
+ your backend, which it will use to retrieve and update Stripe API objects.
+ */
 @protocol STPIssuingCardEphemeralKeyProvider <NSObject>
 /**
  Creates a new ephemeral key for retrieving and updating a Stripe Issuing Card.

--- a/Stripe/PublicHeaders/STPEphemeralKeyProvider.h
+++ b/Stripe/PublicHeaders/STPEphemeralKeyProvider.h
@@ -14,23 +14,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class STPEphemeralKey;
 
-/**
- You should make your application's API client conform to this interface.
- It provides a way for `STPCustomerContext` to request a new ephemeral key from
- your backend, which it will use to retrieve and update a Stripe customer.
- */
-@protocol STPEphemeralKeyProvider <NSObject>
-
+@protocol STPCustomerEphemeralKeyProvider <NSObject>
 /**
  Creates a new ephemeral key for retrieving and updating a Stripe customer.
  On your backend, you should create a new ephemeral key for the Stripe customer
  associated with your user, and return the raw JSON response from the Stripe API.
  For an example Ruby implementation of this API, refer to our example backend:
  https://github.com/stripe/example-ios-backend/blob/v14.0.0/web.rb
-
+ 
  Back in your iOS app, once you have a response from this API, call the provided
  completion block with the JSON response, or an error if one occurred.
-
+ 
  @param apiVersion  The Stripe API version to use when creating a key.
  You should pass this parameter to your backend, and use it to set the API version
  in your key creation request. Passing this version parameter ensures that the
@@ -40,7 +34,39 @@ NS_ASSUME_NONNULL_BEGIN
  or `completion(nil, error)` if an error is returned.
  */
 - (void)createCustomerKeyWithAPIVersion:(NSString *)apiVersion completion:(STPJSONResponseCompletionBlock)completion;
+@end
 
+@protocol STPIssuingCardEphemeralKeyProvider <NSObject>
+/**
+ Creates a new ephemeral key for retrieving and updating a Stripe Issuing Card.
+ On your backend, you should create a new ephemeral key for your logged-in user's
+ primary Issuing Card, and return the raw JSON response from the Stripe API.
+ For an example Ruby implementation of this API, refer to our example backend:
+ https://github.com/stripe/example-ios-backend/blob/v14.0.0/web.rb
+ 
+ Back in your iOS app, once you have a response from this API, call the provided
+ completion block with the JSON response, or an error if one occurred.
+ 
+ @param apiVersion  The Stripe API version to use when creating a key.
+ You should pass this parameter to your backend, and use it to set the API version
+ in your key creation request. Passing this version parameter ensures that the
+ Stripe SDK can always parse the ephemeral key response from your server.
+ @param completion  Call this callback when you're done fetching a new ephemeral
+ key from your backend. For example, `completion(json, nil)` (if your call succeeds)
+ or `completion(nil, error)` if an error is returned.
+ */
+- (void)createIssuingCardKeyWithAPIVersion:(NSString *)apiVersion completion:(STPJSONResponseCompletionBlock)completion;
+@end
+
+/**
+ You should make your application's API client conform to this interface.
+ It provides a way for Stripe utility classes to request a new ephemeral key from
+ your backend, which it will use to retrieve and update Stripe API objects.
+ @deprecated use `STPCustomerEphemeralKeyProvider` or `STPIssuingCardEphemeralKeyProvider`
+depending on the type of key that will be fetched.
+ */
+__attribute__ ((deprecated("STPEphemeralKeyProvider has been renamed to STPCustomerEphemeralKeyProvider", "STPCustomerEphemeralKeyProvider")))
+@protocol STPEphemeralKeyProvider <STPCustomerEphemeralKeyProvider>
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Stripe/STPAPIClient+Private.h
+++ b/Stripe/STPAPIClient+Private.h
@@ -40,6 +40,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+@interface STPAPIClient (EphemeralKeys)
++ (instancetype)apiClientWithEphemeralKey:(STPEphemeralKey *)key;
+@end
+
 @interface STPAPIClient (Customers)
 
 /**

--- a/Stripe/STPCustomerContext.m
+++ b/Stripe/STPCustomerContext.m
@@ -28,9 +28,10 @@ static NSTimeInterval const CachedCustomerMaxAge = 60;
 
 @implementation STPCustomerContext
 
-- (instancetype)initWithKeyProvider:(nonnull id<STPEphemeralKeyProvider>)keyProvider {
+- (instancetype)initWithKeyProvider:(nonnull id<STPCustomerEphemeralKeyProvider>)keyProvider {
     STPEphemeralKeyManager *keyManager = [[STPEphemeralKeyManager alloc] initWithKeyProvider:keyProvider
-                                                                                  apiVersion:[STPAPIClient apiVersion]];
+
+                                                                                  apiVersion:[STPAPIClient apiVersion] performsEagerFetching:YES];
     return [self initWithKeyManager:keyManager];
 }
 
@@ -75,7 +76,7 @@ static NSTimeInterval const CachedCustomerMaxAge = 60;
         }
         return;
     }
-    [self.keyManager getCustomerKey:^(STPEphemeralKey *ephemeralKey, NSError *retrieveKeyError) {
+    [self.keyManager getOrCreateKey:^(STPEphemeralKey *ephemeralKey, NSError *retrieveKeyError) {
         if (retrieveKeyError) {
             if (completion) {
                 stpDispatchToMainThreadIfNecessary(^{
@@ -99,7 +100,7 @@ static NSTimeInterval const CachedCustomerMaxAge = 60;
 }
 
 - (void)attachSourceToCustomer:(id<STPSourceProtocol>)source completion:(STPErrorBlock)completion {
-    [self.keyManager getCustomerKey:^(STPEphemeralKey *ephemeralKey, NSError *retrieveKeyError) {
+    [self.keyManager getOrCreateKey:^(STPEphemeralKey *ephemeralKey, NSError *retrieveKeyError) {
         if (retrieveKeyError) {
             if (completion) {
                 stpDispatchToMainThreadIfNecessary(^{
@@ -123,7 +124,7 @@ static NSTimeInterval const CachedCustomerMaxAge = 60;
 }
 
 - (void)selectDefaultCustomerSource:(id<STPSourceProtocol>)source completion:(STPErrorBlock)completion {
-    [self.keyManager getCustomerKey:^(STPEphemeralKey *ephemeralKey, NSError *retrieveKeyError) {
+    [self.keyManager getOrCreateKey:^(STPEphemeralKey *ephemeralKey, NSError *retrieveKeyError) {
         if (retrieveKeyError) {
             if (completion) {
                 stpDispatchToMainThreadIfNecessary(^{
@@ -149,7 +150,7 @@ static NSTimeInterval const CachedCustomerMaxAge = 60;
 }
 
 - (void)updateCustomerWithShippingAddress:(STPAddress *)shipping completion:(STPErrorBlock)completion {
-    [self.keyManager getCustomerKey:^(STPEphemeralKey *ephemeralKey, NSError *retrieveKeyError) {
+    [self.keyManager getOrCreateKey:^(STPEphemeralKey *ephemeralKey, NSError *retrieveKeyError) {
         if (retrieveKeyError) {
             if (completion) {
                 stpDispatchToMainThreadIfNecessary(^{
@@ -178,7 +179,7 @@ static NSTimeInterval const CachedCustomerMaxAge = 60;
 }
 
 - (void)detachSourceFromCustomer:(id<STPSourceProtocol>)source completion:(STPErrorBlock)completion {
-    [self.keyManager getCustomerKey:^(STPEphemeralKey *ephemeralKey, NSError *retrieveKeyError) {
+    [self.keyManager getOrCreateKey:^(STPEphemeralKey *ephemeralKey, NSError *retrieveKeyError) {
         if (retrieveKeyError) {
             if (completion) {
                 stpDispatchToMainThreadIfNecessary(^{

--- a/Stripe/STPEphemeralKey.h
+++ b/Stripe/STPEphemeralKey.h
@@ -19,7 +19,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) BOOL livemode;
 @property (nonatomic, readonly) NSString *secret;
 @property (nonatomic, readonly) NSDate *expires;
-@property (nonatomic, readonly) NSString *customerID;
+@property (nonatomic, readonly, nullable) NSString *customerID;
+@property (nonatomic, readonly, nullable) NSString *issuingCardID;
 
 /**
  You cannot directly instantiate an `STPEphemeralKey`. You should instead use

--- a/Stripe/STPEphemeralKey.m
+++ b/Stripe/STPEphemeralKey.m
@@ -17,7 +17,8 @@
 @property (nonatomic, readwrite) BOOL livemode;
 @property (nonatomic, readwrite) NSString *secret;
 @property (nonatomic, readwrite) NSDate *expires;
-@property (nonatomic, readwrite) NSString *customerID;
+@property (nonatomic, readwrite, nullable) NSString *customerID;
+@property (nonatomic, readwrite, nullable) NSString *issuingCardID;
 @property (nonatomic, readwrite, nonnull, copy) NSDictionary *allResponseFields;
 
 @end
@@ -40,19 +41,24 @@
     }
 
     NSString *customerID;
+    NSString *issuingCardID;
     for (id obj in associatedObjects) {
         if ([obj isKindOfClass:[NSDictionary class]]) {
             NSString *type = [obj stp_stringForKey:@"type"];
             if ([type isEqualToString:@"customer"]) {
                 customerID = [obj stp_stringForKey:@"id"];
             }
+            if ([type isEqualToString:@"issuing.card"]) {
+                issuingCardID = [obj stp_stringForKey:@"id"];
+            }
         }
     }
-    if (!customerID) {
+    if (!customerID && !issuingCardID) {
         return nil;
     }
     STPEphemeralKey *key = [self new];
     key.customerID = customerID;
+    key.issuingCardID = issuingCardID;
     key.stripeID = stripeId;
     key.livemode = [dict stp_boolForKey:@"livemode" or:YES];
     key.created = created;
@@ -73,14 +79,11 @@
     if (!object || ![object isKindOfClass:self.class]) {
         return NO;
     }
-    return [self isEqualToResourceKey:object];
+    return [self isEqualToEphemeralKey:object];
 }
 
-- (BOOL)isEqualToResourceKey:(STPEphemeralKey *)other {
-    return [self.stripeID isEqualToString:other.stripeID] 
-        && [self.secret isEqualToString:other.secret]
-        && [self.expires isEqual:other.expires]
-        && [self.customerID isEqual:other.customerID];
+- (BOOL)isEqualToEphemeralKey:(STPEphemeralKey *)other {
+    return [self.stripeID isEqualToString:other.stripeID];
 }
 
 @end

--- a/Stripe/STPEphemeralKeyManager.h
+++ b/Stripe/STPEphemeralKeyManager.h
@@ -17,29 +17,37 @@ typedef void (^STPEphemeralKeyCompletionBlock)(STPEphemeralKey * __nullable ephe
 
 /**
  If the current ephemeral key expires in less than this time interval, a call
- to `getCustomerKey` will request a new key from the manager's key provider.
+ to `getOrCreateKey` will request a new key from the manager's key provider.
  The maximum allowed value is one hour – higher values will be clamped.
  */
 @property (nonatomic, assign) NSTimeInterval expirationInterval;
 
 /**
- Initializes a new `STPEphemeralKeyManager` with the specified key provider.
-
- @param keyProvider    The key provider the manager will use.
- @param apiVersion     The Stripe API version the manager will use.
- @return the newly-initiated `STPEphemeralKeyManager`.
+ If this value is YES, the manager will eagerly refresh its key on app foregrounding.
  */
-- (instancetype)initWithKeyProvider:(id<STPEphemeralKeyProvider>)keyProvider apiVersion:(NSString *)apiVersion;
+@property (nonatomic, readonly, assign) BOOL performsEagerFetching;
 
 /**
- If the retriever's stored customer ephemeral key has not expired, it will be
+ Initializes a new `STPEphemeralKeyManager` with the specified key provider.
+
+ @param keyProvider               The key provider the manager will use.
+ @param apiVersion                The Stripe API version the manager will use.
+ @param performsEagerFetching     If the manager should eagerly refresh its key on app foregrounding.
+ @return the newly-initiated `STPEphemeralKeyManager`.
+ */
+- (instancetype)initWithKeyProvider:(id)keyProvider
+                         apiVersion:(NSString *)apiVersion
+              performsEagerFetching:(BOOL)performsEagerFetching;
+
+/**
+ If the retriever's stored ephemeral key has not expired, it will be
  returned immediately to the given callback. If the stored key is expiring, a
  new key will be requested from the key provider, and returned to the callback. 
  If the retriever is unable to provide an unexpired key, an error will be returned.
 
  @param completion The callback to be run with the returned key, or an error.
  */
-- (void)getCustomerKey:(STPEphemeralKeyCompletionBlock)completion;
+- (void)getOrCreateKey:(STPEphemeralKeyCompletionBlock)completion;
 
 @end
 

--- a/Stripe/STPEphemeralKeyManager.m
+++ b/Stripe/STPEphemeralKeyManager.m
@@ -74,7 +74,7 @@ static NSTimeInterval const MinEagerRefreshInterval = 60*60;
     }
 }
 
-- (void)createKey {
+- (void)_createKey {
     STPJSONResponseCompletionBlock jsonCompletion = ^(NSDictionary *jsonResponse, NSError *error) {
         STPEphemeralKey *key = [STPEphemeralKey decodedObjectFromAPIResponse:jsonResponse];
         if (key) {
@@ -125,7 +125,7 @@ static NSTimeInterval const MinEagerRefreshInterval = 60*60;
             }] onFailure:^(NSError *error) {
                 completion(nil, error);
             }];
-            [self createKey];
+            [self _createKey];
         }
     }
 }

--- a/Stripe/STPEphemeralKeyManager.m
+++ b/Stripe/STPEphemeralKeyManager.m
@@ -83,11 +83,17 @@ static NSTimeInterval const MinEagerRefreshInterval = 60*60;
             // the API request failed
             if (error) {
                 [self.createKeyPromise fail:error];
-            }
-            // the ephemeral key could not be decoded
-            else {
+            } else {
+                // the ephemeral key could not be decoded
                 [self.createKeyPromise fail:[NSError stp_ephemeralKeyDecodingError]];
-                NSAssert(NO, @"Could not parse the ephemeral key response. Make sure your backend is sending the unmodified JSON of the ephemeral key to your app. For more info, see https://stripe.com/docs/mobile/ios/standard#prepare-your-api");
+                NSString protocol = "unknown";
+                if ([self.keyProvider conformsToProtocol:@protocol(STPCustomerEphemeralKeyProvider)]) {
+                    protocol = @"STPCustomerEphemeralKeyProvider";
+                }
+                else if ([self.keyProvider conformsToProtocol:@protocol(STPIssuingCardEphemeralKeyProvider)]) {
+                    protocol = @"STPIssuingCardEphemeralKeyProvider";
+                }
+                NSAssert(NO, [NSString stringWithFormat:@"Could not parse the ephemeral key response following protocol %@. Make sure your backend is sending the unmodified JSON of the ephemeral key to your app. For more info, see https://stripe.com/docs/mobile/ios/standard#prepare-your-api", protocol]);
             }
         }
         self.createKeyPromise = nil;

--- a/Stripe/STPEphemeralKeyManager.m
+++ b/Stripe/STPEphemeralKeyManager.m
@@ -65,7 +65,7 @@ static NSTimeInterval const MinEagerRefreshInterval = 60*60;
 - (void)handleWillForegroundNotification {
     // To make sure we don't end up hitting the ephemeral keys endpoint on every
     // foreground (e.g. if there's an issue decoding the ephemeral key), throttle
-    // eager refreshses to once per hour.
+    // eager refreshes to once per hour.
     if (!self.currentKeyIsUnexpired && self.shouldPerformEagerRefresh) {
         self.lastEagerKeyRefresh = [NSDate date];
         [self getOrCreateKey:^(__unused STPEphemeralKey * _Nullable ephemeralKey, __unused NSError * _Nullable error) {
@@ -89,8 +89,7 @@ static NSTimeInterval const MinEagerRefreshInterval = 60*60;
                 NSString protocol = "unknown";
                 if ([self.keyProvider conformsToProtocol:@protocol(STPCustomerEphemeralKeyProvider)]) {
                     protocol = @"STPCustomerEphemeralKeyProvider";
-                }
-                else if ([self.keyProvider conformsToProtocol:@protocol(STPIssuingCardEphemeralKeyProvider)]) {
+                } else if ([self.keyProvider conformsToProtocol:@protocol(STPIssuingCardEphemeralKeyProvider)]) {
                     protocol = @"STPIssuingCardEphemeralKeyProvider";
                 }
                 NSAssert(NO, [NSString stringWithFormat:@"Could not parse the ephemeral key response following protocol %@. Make sure your backend is sending the unmodified JSON of the ephemeral key to your app. For more info, see https://stripe.com/docs/mobile/ios/standard#prepare-your-api", protocol]);
@@ -102,8 +101,7 @@ static NSTimeInterval const MinEagerRefreshInterval = 60*60;
     if ([self.keyProvider conformsToProtocol:@protocol(STPCustomerEphemeralKeyProvider)]) {
         id<STPCustomerEphemeralKeyProvider> provider = self.keyProvider;
         [provider createCustomerKeyWithAPIVersion:self.apiVersion completion:jsonCompletion];
-    }
-    else if ([self.keyProvider conformsToProtocol:@protocol(STPIssuingCardEphemeralKeyProvider)]) {
+    } else if ([self.keyProvider conformsToProtocol:@protocol(STPIssuingCardEphemeralKeyProvider)]) {
         id<STPIssuingCardEphemeralKeyProvider> provider = self.keyProvider;
         [provider createIssuingCardKeyWithAPIVersion:self.apiVersion completion:jsonCompletion];
     }

--- a/Stripe/STPEphemeralKeyManager.m
+++ b/Stripe/STPEphemeralKeyManager.m
@@ -69,7 +69,7 @@ static NSTimeInterval const MinEagerRefreshInterval = 60*60;
     if (!self.currentKeyIsUnexpired && self.shouldPerformEagerRefresh) {
         self.lastEagerKeyRefresh = [NSDate date];
         [self getOrCreateKey:^(__unused STPEphemeralKey * _Nullable ephemeralKey, __unused NSError * _Nullable error) {
-            
+            // getOrCreateKey sets the self.ephemeralKey. Nothing left to do for us here
         }];
     }
 }

--- a/Stripe/STPEphemeralKeyManager.m
+++ b/Stripe/STPEphemeralKeyManager.m
@@ -9,7 +9,6 @@
 #import "STPEphemeralKeyManager.h"
 
 #import "NSError+Stripe.h"
-#import "STPCustomerContext.h"
 #import "STPEphemeralKey.h"
 #import "STPPromise.h"
 
@@ -17,21 +16,26 @@ static NSTimeInterval const DefaultExpirationInterval = 60;
 static NSTimeInterval const MinEagerRefreshInterval = 60*60;
 
 @interface STPEphemeralKeyManager ()
-@property (nonatomic) STPEphemeralKey *customerKey;
+@property (nonatomic) STPEphemeralKey *ephemeralKey;
 @property (nonatomic) NSString *apiVersion;
-@property (nonatomic, weak) id<STPEphemeralKeyProvider> keyProvider;
+@property (nonatomic) id keyProvider;
+@property (nonatomic, readwrite, assign) BOOL performsEagerFetching;
 @property (nonatomic) NSDate *lastEagerKeyRefresh;
 @property (nonatomic) STPPromise<STPEphemeralKey *>*createKeyPromise;
 @end
 
 @implementation STPEphemeralKeyManager
 
-- (instancetype)initWithKeyProvider:(id<STPEphemeralKeyProvider>)keyProvider apiVersion:(NSString *)apiVersion {
+- (instancetype)initWithKeyProvider:(id)keyProvider
+                         apiVersion:(NSString *)apiVersion
+              performsEagerFetching:(BOOL)performsEagerFetching {
     self = [super init];
     if (self) {
+        NSAssert([keyProvider conformsToProtocol:@protocol(STPCustomerEphemeralKeyProvider)] || [keyProvider conformsToProtocol:@protocol(STPIssuingCardEphemeralKeyProvider)], @"Your STPEphemeralKeyProvider must either implement `STPCustomerEphemeralKeyProvider` or `STPIssuingCardEphemeralKeyProvider`.");
         _expirationInterval = DefaultExpirationInterval;
         _keyProvider = keyProvider;
         _apiVersion = apiVersion;
+        _performsEagerFetching = performsEagerFetching;
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(handleWillForegroundNotification)
                                                      name:UIApplicationWillEnterForegroundNotification
@@ -51,11 +55,11 @@ static NSTimeInterval const MinEagerRefreshInterval = 60*60;
 }
 
 - (BOOL)currentKeyIsUnexpired {
-    return self.customerKey && self.customerKey.expires.timeIntervalSinceNow > self.expirationInterval;
+    return self.ephemeralKey && self.ephemeralKey.expires.timeIntervalSinceNow > self.expirationInterval;
 }
 
 - (BOOL)shouldPerformEagerRefresh {
-    return !self.lastEagerKeyRefresh || self.lastEagerKeyRefresh.timeIntervalSinceNow > MinEagerRefreshInterval;
+    return self.performsEagerFetching && (!self.lastEagerKeyRefresh || self.lastEagerKeyRefresh.timeIntervalSinceNow > MinEagerRefreshInterval);
 }
 
 - (void)handleWillForegroundNotification {
@@ -64,18 +68,44 @@ static NSTimeInterval const MinEagerRefreshInterval = 60*60;
     // eager refreshses to once per hour.
     if (!self.currentKeyIsUnexpired && self.shouldPerformEagerRefresh) {
         self.lastEagerKeyRefresh = [NSDate date];
-        [self.keyProvider createCustomerKeyWithAPIVersion:self.apiVersion completion:^(NSDictionary *jsonResponse, __unused NSError *error) {
-            STPEphemeralKey *key = [STPEphemeralKey decodedObjectFromAPIResponse:jsonResponse];
-            if (key) {
-                self.customerKey = key;
-            }
+        [self getOrCreateKey:^(__unused STPEphemeralKey * _Nullable ephemeralKey, __unused NSError * _Nullable error) {
+            
         }];
     }
 }
 
-- (void)getCustomerKey:(STPEphemeralKeyCompletionBlock)completion {
+- (void)createKey {
+    STPJSONResponseCompletionBlock jsonCompletion = ^(NSDictionary *jsonResponse, NSError *error) {
+        STPEphemeralKey *key = [STPEphemeralKey decodedObjectFromAPIResponse:jsonResponse];
+        if (key) {
+            [self.createKeyPromise succeed:key];
+        } else {
+            // the API request failed
+            if (error) {
+                [self.createKeyPromise fail:error];
+            }
+            // the ephemeral key could not be decoded
+            else {
+                [self.createKeyPromise fail:[NSError stp_ephemeralKeyDecodingError]];
+                NSAssert(NO, @"Could not parse the ephemeral key response. Make sure your backend is sending the unmodified JSON of the ephemeral key to your app. For more info, see https://stripe.com/docs/mobile/ios/standard#prepare-your-api");
+            }
+        }
+        self.createKeyPromise = nil;
+    };
+    
+    if ([self.keyProvider conformsToProtocol:@protocol(STPCustomerEphemeralKeyProvider)]) {
+        id<STPCustomerEphemeralKeyProvider> provider = self.keyProvider;
+        [provider createCustomerKeyWithAPIVersion:self.apiVersion completion:jsonCompletion];
+    }
+    else if ([self.keyProvider conformsToProtocol:@protocol(STPIssuingCardEphemeralKeyProvider)]) {
+        id<STPIssuingCardEphemeralKeyProvider> provider = self.keyProvider;
+        [provider createIssuingCardKeyWithAPIVersion:self.apiVersion completion:jsonCompletion];
+    }
+}
+
+- (void)getOrCreateKey:(STPEphemeralKeyCompletionBlock)completion {
     if (self.currentKeyIsUnexpired) {
-        completion(self.customerKey, nil);
+        completion(self.ephemeralKey, nil);
     } else {
         if (self.createKeyPromise) {
             // coalesce repeated calls into one request
@@ -86,28 +116,12 @@ static NSTimeInterval const MinEagerRefreshInterval = 60*60;
             }];
         } else {
             self.createKeyPromise = [[[STPPromise<STPEphemeralKey *> new] onSuccess:^(STPEphemeralKey *key) {
-                self.customerKey = key;
+                self.ephemeralKey = key;
                 completion(key, nil);
             }] onFailure:^(NSError *error) {
                 completion(nil, error);
             }];
-            [self.keyProvider createCustomerKeyWithAPIVersion:self.apiVersion completion:^(NSDictionary *jsonResponse, NSError *error) {
-                STPEphemeralKey *key = [STPEphemeralKey decodedObjectFromAPIResponse:jsonResponse];
-                if (key) {
-                    [self.createKeyPromise succeed:key];
-                } else {
-                    // the API request failed
-                    if (error) {
-                        [self.createKeyPromise fail:error];
-                    }
-                    // the ephemeral key could not be decoded
-                    else {
-                        [self.createKeyPromise fail:[NSError stp_ephemeralKeyDecodingError]];
-                        NSAssert(NO, @"Could not parse the ephemeral key response. Make sure your backend is sending the unmodified JSON of the ephemeral key to your app. For more info, see https://stripe.com/docs/mobile/ios/standard#prepare-your-api");
-                    }
-                }
-                self.createKeyPromise = nil;
-            }];
+            [self createKey];
         }
     }
 }

--- a/Stripe/STPEphemeralKeyManager.m
+++ b/Stripe/STPEphemeralKeyManager.m
@@ -86,14 +86,12 @@ static NSTimeInterval const MinEagerRefreshInterval = 60*60;
             } else {
                 // the ephemeral key could not be decoded
                 [self.createKeyPromise fail:[NSError stp_ephemeralKeyDecodingError]];
-                NSString *protocol = @"unknown";
                 if ([self.keyProvider conformsToProtocol:@protocol(STPCustomerEphemeralKeyProvider)]) {
-                    protocol = @"STPCustomerEphemeralKeyProvider";
+                    NSAssert(NO, @"Could not parse the ephemeral key response following protocol STPCustomerEphemeralKeyProvider. Make sure your backend is sending the unmodified JSON of the ephemeral key to your app. For more info, see https://stripe.com/docs/mobile/ios/standard#prepare-your-api");
                 } else if ([self.keyProvider conformsToProtocol:@protocol(STPIssuingCardEphemeralKeyProvider)]) {
-                    protocol = @"STPIssuingCardEphemeralKeyProvider";
+                    NSAssert(NO, @"Could not parse the ephemeral key response following protocol STPCustomerEphemeralKeyProvider. Make sure your backend is sending the unmodified JSON of the ephemeral key to your app. For more info, see https://stripe.com/docs/mobile/ios/standard#prepare-your-api");
                 }
-                NSString *errorString = [NSString stringWithFormat:@"Could not parse the ephemeral key response following protocol %@. Make sure your backend is sending the unmodified JSON of the ephemeral key to your app. For more info, see https://stripe.com/docs/mobile/ios/standard#prepare-your-api", protocol];
-                NSAssert(NO, errorString);
+                NSAssert(NO, @"Could not parse the ephemeral key response. Make sure your backend is sending the unmodified JSON of the ephemeral key to your app. For more info, see https://stripe.com/docs/mobile/ios/standard#prepare-your-api");
             }
         }
         self.createKeyPromise = nil;

--- a/Stripe/STPEphemeralKeyManager.m
+++ b/Stripe/STPEphemeralKeyManager.m
@@ -86,13 +86,14 @@ static NSTimeInterval const MinEagerRefreshInterval = 60*60;
             } else {
                 // the ephemeral key could not be decoded
                 [self.createKeyPromise fail:[NSError stp_ephemeralKeyDecodingError]];
-                NSString protocol = "unknown";
+                NSString *protocol = @"unknown";
                 if ([self.keyProvider conformsToProtocol:@protocol(STPCustomerEphemeralKeyProvider)]) {
                     protocol = @"STPCustomerEphemeralKeyProvider";
                 } else if ([self.keyProvider conformsToProtocol:@protocol(STPIssuingCardEphemeralKeyProvider)]) {
                     protocol = @"STPIssuingCardEphemeralKeyProvider";
                 }
-                NSAssert(NO, [NSString stringWithFormat:@"Could not parse the ephemeral key response following protocol %@. Make sure your backend is sending the unmodified JSON of the ephemeral key to your app. For more info, see https://stripe.com/docs/mobile/ios/standard#prepare-your-api", protocol]);
+                NSString *errorString = [NSString stringWithFormat:@"Could not parse the ephemeral key response following protocol %@. Make sure your backend is sending the unmodified JSON of the ephemeral key to your app. For more info, see https://stripe.com/docs/mobile/ios/standard#prepare-your-api", protocol];
+                NSAssert(NO, errorString);
             }
         }
         self.createKeyPromise = nil;

--- a/Tests/Tests/STPCustomerContextTest.m
+++ b/Tests/Tests/STPCustomerContextTest.m
@@ -31,7 +31,7 @@
 
 - (id)mockKeyManagerWithKey:(STPEphemeralKey *)ephemeralKey {
     id mockKeyManager = OCMClassMock([STPEphemeralKeyManager class]);
-    OCMStub([mockKeyManager getCustomerKey:[OCMArg any]])
+    OCMStub([mockKeyManager getOrCreateKey:[OCMArg any]])
     .andDo(^(NSInvocation *invocation) {
         STPEphemeralKeyCompletionBlock completion;
         [invocation getArgument:&completion atIndex:2];
@@ -42,7 +42,7 @@
 
 - (id)mockKeyManagerWithError:(NSError *)error {
     id mockKeyManager = OCMClassMock([STPEphemeralKeyManager class]);
-    OCMStub([mockKeyManager getCustomerKey:[OCMArg any]])
+    OCMStub([mockKeyManager getOrCreateKey:[OCMArg any]])
     .andDo(^(NSInvocation *invocation) {
         STPEphemeralKeyCompletionBlock completion;
         [invocation getArgument:&completion atIndex:2];
@@ -78,7 +78,7 @@
     });
 }
 
-- (void)testGetCustomerKeyErrorForwardedToRetrieveCustomer {
+- (void)testgetOrCreateKeyErrorForwardedToRetrieveCustomer {
     NSError *expectedError = [NSError errorWithDomain:@"foo" code:123 userInfo:nil];
     id mockAPIClient = OCMClassMock([STPAPIClient class]);
     OCMReject([mockAPIClient retrieveCustomerUsingKey:[OCMArg any] completion:[OCMArg any]]);

--- a/Tests/Tests/STPEphemeralKeyManagerTest.m
+++ b/Tests/Tests/STPEphemeralKeyManagerTest.m
@@ -15,7 +15,7 @@
 #import "STPFixtures.h"
 
 @interface STPEphemeralKeyManager (Testing)
-@property (nonatomic) STPEphemeralKey *customerKey;
+@property (nonatomic) STPEphemeralKey *ephemeralKey;
 @property (nonatomic) NSDate *lastEagerKeyRefresh;
 @end
 
@@ -68,7 +68,7 @@
     OCMReject([mockKeyProvider createCustomerKeyWithAPIVersion:[OCMArg any] completion:[OCMArg any]]);
     STPEphemeralKeyManager *sut = [[STPEphemeralKeyManager alloc] initWithKeyProvider:mockKeyProvider apiVersion:self.apiVersion performsEagerFetching:YES];
     STPEphemeralKey *expectedKey = [STPFixtures ephemeralKey];
-    sut.customerKey = expectedKey;
+    sut.ephemeralKey = expectedKey;
     XCTestExpectation *exp = [self expectationWithDescription:@"getOrCreateKey"];
     [sut getOrCreateKey:^(STPEphemeralKey *resourceKey, NSError *error) {
         XCTAssertEqualObjects(resourceKey, expectedKey);
@@ -83,7 +83,7 @@
     NSDictionary *keyResponse = [expectedKey allResponseFields];
     id mockKeyProvider = [self mockKeyProviderWithKeyResponse:keyResponse];
     STPEphemeralKeyManager *sut = [[STPEphemeralKeyManager alloc] initWithKeyProvider:mockKeyProvider apiVersion:self.apiVersion performsEagerFetching:YES];
-    sut.customerKey = [STPFixtures expiringEphemeralKey];
+    sut.ephemeralKey = [STPFixtures expiringEphemeralKey];
     XCTestExpectation *exp = [self expectationWithDescription:@"retrieve"];
     [sut getOrCreateKey:^(STPEphemeralKey *resourceKey, NSError *error) {
         XCTAssertEqualObjects(resourceKey, expectedKey);
@@ -163,7 +163,7 @@
     id mockKeyProvider = OCMProtocolMock(@protocol(STPEphemeralKeyProvider));
     OCMReject([mockKeyProvider createCustomerKeyWithAPIVersion:[OCMArg any] completion:[OCMArg any]]);
     STPEphemeralKeyManager *sut = [[STPEphemeralKeyManager alloc] initWithKeyProvider:mockKeyProvider apiVersion:self.apiVersion performsEagerFetching:YES];
-    sut.customerKey = [STPFixtures ephemeralKey];
+    sut.ephemeralKey = [STPFixtures ephemeralKey];
     [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationWillEnterForegroundNotification object:nil];
 }
 
@@ -171,7 +171,7 @@
     id mockKeyProvider = OCMProtocolMock(@protocol(STPEphemeralKeyProvider));
     OCMReject([mockKeyProvider createCustomerKeyWithAPIVersion:[OCMArg any] completion:[OCMArg any]]);
     STPEphemeralKeyManager *sut = [[STPEphemeralKeyManager alloc] initWithKeyProvider:mockKeyProvider apiVersion:self.apiVersion performsEagerFetching:YES];
-    sut.customerKey = [STPFixtures expiringEphemeralKey];
+    sut.ephemeralKey = [STPFixtures expiringEphemeralKey];
     sut.lastEagerKeyRefresh = [NSDate dateWithTimeIntervalSinceNow:-60];
     [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationWillEnterForegroundNotification object:nil];
 }

--- a/Tests/Tests/STPEphemeralKeyManagerTest.m
+++ b/Tests/Tests/STPEphemeralKeyManagerTest.m
@@ -37,7 +37,7 @@
     OCMStub([mockKeyProvider createCustomerKeyWithAPIVersion:[OCMArg isEqual:self.apiVersion]
                                                   completion:[OCMArg any]])
     .andDo(^(NSInvocation *invocation) {
-        [invocation retainArguments];
+        [invocation retainArguments]; // avoids https://github.com/erikdoe/ocmock/issues/147
         STPJSONResponseCompletionBlock completion;
         [invocation getArgument:&completion atIndex:3];
         completion(keyResponse, nil);
@@ -99,7 +99,7 @@
     OCMStub([mockKeyProvider createCustomerKeyWithAPIVersion:[OCMArg isEqual:self.apiVersion]
                                                   completion:[OCMArg any]])
     .andDo(^(NSInvocation *invocation) {
-        [invocation retainArguments];
+        [invocation retainArguments]; // avoids https://github.com/erikdoe/ocmock/issues/147
         STPJSONResponseCompletionBlock completion;
         [invocation getArgument:&completion atIndex:3];
         [createExp fulfill];
@@ -131,7 +131,7 @@
     OCMStub([mockKeyProvider createCustomerKeyWithAPIVersion:[OCMArg isEqual:self.apiVersion]
                                                   completion:[OCMArg any]])
     .andDo(^(NSInvocation *invocation) {
-        [invocation retainArguments];
+        [invocation retainArguments]; // avoids https://github.com/erikdoe/ocmock/issues/147
         STPJSONResponseCompletionBlock completion;
         [invocation getArgument:&completion atIndex:3];
         XCTAssertThrows(completion(invalidKeyResponse, nil));

--- a/Tests/Tests/STPEphemeralKeyManagerTest.m
+++ b/Tests/Tests/STPEphemeralKeyManagerTest.m
@@ -102,6 +102,7 @@
     OCMStub([mockKeyProvider createCustomerKeyWithAPIVersion:[OCMArg isEqual:self.apiVersion]
                                                   completion:[OCMArg any]])
     .andDo(^(NSInvocation *invocation) {
+        [invocation retainArguments];
         STPJSONResponseCompletionBlock completion;
         [invocation getArgument:&completion atIndex:3];
         [createExp fulfill];
@@ -133,6 +134,7 @@
     OCMStub([mockKeyProvider createCustomerKeyWithAPIVersion:[OCMArg isEqual:self.apiVersion]
                                                   completion:[OCMArg any]])
     .andDo(^(NSInvocation *invocation) {
+        [invocation retainArguments];
         STPJSONResponseCompletionBlock completion;
         [invocation getArgument:&completion atIndex:3];
         XCTAssertThrows(completion(invalidKeyResponse, nil));

--- a/Tests/Tests/STPEphemeralKeyManagerTest.m
+++ b/Tests/Tests/STPEphemeralKeyManagerTest.m
@@ -31,9 +31,6 @@
     self.apiVersion = @"2015-03-03";
 }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated"
-
 - (id)mockKeyProviderWithKeyResponse:(NSDictionary *)keyResponse {
     XCTestExpectation *exp = [self expectationWithDescription:@"createCustomerKey"];
     id mockKeyProvider = OCMProtocolMock(@protocol(STPEphemeralKeyProvider));
@@ -177,7 +174,5 @@
     sut.lastEagerKeyRefresh = [NSDate dateWithTimeIntervalSinceNow:-60];
     [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationWillEnterForegroundNotification object:nil];
 }
-
-#pragma clang diagnostic pop
 
 @end

--- a/Tests/Tests/STPEphemeralKeyManagerTest.m
+++ b/Tests/Tests/STPEphemeralKeyManagerTest.m
@@ -7,7 +7,6 @@
 //
 
 #import <XCTest/XCTest.h>
-#import <OCMock/OCMock.h>
 #import <Stripe/Stripe.h>
 #import "NSError+Stripe.h"
 #import "STPEphemeralKey.h"
@@ -41,6 +40,7 @@
     OCMStub([mockKeyProvider createCustomerKeyWithAPIVersion:[OCMArg isEqual:self.apiVersion]
                                                   completion:[OCMArg any]])
     .andDo(^(NSInvocation *invocation) {
+        [invocation retainArguments];
         STPJSONResponseCompletionBlock completion;
         [invocation getArgument:&completion atIndex:3];
         completion(keyResponse, nil);


### PR DESCRIPTION
## Summary
Allowing for ephemeral keys that are not customer

## Motivation
Stripe Issuing will need those

## Testing
Existing ephemeral keys test apply