### PR TITLE
Adds support for cvc recollection token creation

### DIFF
--- a/Stripe/PublicHeaders/STPAPIClient.h
+++ b/Stripe/PublicHeaders/STPAPIClient.h
@@ -192,6 +192,14 @@ static NSString *const STPSDKVersion = @"14.0.0";
  */
 - (void)createTokenWithCard:(STPCardParams *)card completion:(nullable STPTokenCompletionBlock)completion;
 
+/**
+ Converts a CVC string into a Stripe token using the Stripe API.
+
+ @param cvc         The CVC/CVV number used to create the token. Cannot be nil.
+ @param completion  The callback to run with the returned Stripe token (and any errors that may have occurred).
+ */
+- (void)createTokenForCVCUpdate:(NSString *)cvc completion:(nullable STPTokenCompletionBlock)completion;
+
 @end
 
 /**

--- a/Stripe/PublicHeaders/STPToken.h
+++ b/Stripe/PublicHeaders/STPToken.h
@@ -17,10 +17,29 @@
  Possible Token types
  */
 typedef NS_ENUM(NSInteger, STPTokenType) {
+    /**
+     Account token type
+     */
     STPTokenTypeAccount = 0,
+
+    /**
+     Bank account token type
+     */
     STPTokenTypeBankAccount,
+
+    /**
+     Card token type
+     */
     STPTokenTypeCard,
+
+    /**
+     PII token type
+     */
     STPTokenTypePII,
+
+    /**
+     CVC update token type
+     */
     STPTokenTypeCVCUpdate,
 };
 

--- a/Stripe/PublicHeaders/STPToken.h
+++ b/Stripe/PublicHeaders/STPToken.h
@@ -14,6 +14,17 @@
 @class STPBankAccount;
 
 /**
+ Possible Token types
+ */
+typedef NS_ENUM(NSInteger, STPTokenType) {
+    STPTokenTypeAccount = 0,
+    STPTokenTypeBankAccount,
+    STPTokenTypeCard,
+    STPTokenTypePII,
+    STPTokenTypeCVCUpdate,
+};
+
+/**
  A token returned from submitting payment details to the Stripe API. You should not have to instantiate one of these directly.
  */
 @interface STPToken : NSObject<STPAPIResponseDecodable, STPSourceProtocol>
@@ -33,6 +44,11 @@
  Whether or not this token was created in livemode. Will be YES if you used your Live Publishable Key, and NO if you used your Test Publishable Key.
  */
 @property (nonatomic, readonly) BOOL livemode;
+
+/**
+ The type of this token.
+ */
+@property (nonatomic, readonly) STPTokenType type;
 
 /**
  The credit card details that were used to create the token. Will only be set if the token was created via a credit card or Apple Pay, otherwise it will be

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -387,6 +387,13 @@ static NSString * const APIEndpointPaymentIntents = @"payment_intents";
     [[STPTelemetryClient sharedInstance] sendTelemetryData];
 }
 
+- (void)createTokenForCVCUpdate:(NSString *)cvc completion:(nullable STPTokenCompletionBlock)completion {
+    NSMutableDictionary *params = [NSMutableDictionary dictionaryWithObject:@{@"cvc": cvc} forKey:@"cvc_update"];
+    [[STPTelemetryClient sharedInstance] addTelemetryFieldsToParams:params];
+    [self createTokenWithParameters:params completion:completion];
+    [[STPTelemetryClient sharedInstance] sendTelemetryData];
+}
+
 @end
 
 #pragma mark - Apple Pay

--- a/Stripe/STPAnalyticsClient.m
+++ b/Stripe/STPAnalyticsClient.m
@@ -119,7 +119,7 @@
 + (NSString *)tokenTypeFromParameters:(NSDictionary *)parameters {
     NSArray *parameterKeys = parameters.allKeys;
     // these are currently mutually exclusive, so we can just run through and find the first match
-    NSArray *tokenTypes = @[@"account", @"bank_account", @"card", @"pii"];
+    NSArray *tokenTypes = @[@"account", @"bank_account", @"card", @"pii", @"cvc_update"];
     for (NSString *type in tokenTypes) {
         if ([parameterKeys containsObject:type]) {
             return type;

--- a/Stripe/STPToken.m
+++ b/Stripe/STPToken.m
@@ -15,6 +15,7 @@
 @interface STPToken()
 @property (nonatomic, nonnull) NSString *tokenId;
 @property (nonatomic) BOOL livemode;
+@property (nonatomic) STPTokenType type;
 @property (nonatomic, nullable) STPCard *card;
 @property (nonatomic, nullable) STPBankAccount *bankAccount;
 @property (nonatomic, nullable) NSDate *created;
@@ -62,8 +63,13 @@
         return NO;
     }
 
-    return self.livemode == object.livemode && [self.tokenId isEqualToString:object.tokenId] && [self.created isEqualToDate:object.created] &&
-           [self.card isEqual:object.card] && [self.tokenId isEqualToString:object.tokenId] && [self.created isEqualToDate:object.created];
+    return self.livemode == object.livemode &&
+    self.type == object.type &&
+    [self.tokenId isEqualToString:object.tokenId] &&
+    [self.created isEqualToDate:object.created] &&
+    [self.card isEqual:object.card] &&
+    [self.tokenId isEqualToString:object.tokenId] &&
+    [self.created isEqualToDate:object.created];
 }
 
 #pragma mark - STPSourceProtocol
@@ -83,7 +89,8 @@
     // required fields
     NSString *stripeId = [dict stp_stringForKey:@"id"];
     NSDate *created = [dict stp_dateForKey:@"created"];
-    if (!stripeId || !created || !dict[@"livemode"]) {
+    NSString *rawType = [dict stp_stringForKey:@"type"];
+    if (!stripeId || !created || !dict[@"livemode"] || ![STPToken _isValidRawTokenType:rawType]) {
         return nil;
     }
     
@@ -91,6 +98,7 @@
     token.tokenId = stripeId;
     token.livemode = [dict stp_boolForKey:@"livemode" or:YES];
     token.created = created;
+    token.type = [STPToken _tokenTypeForString:rawType];
     
     NSDictionary *rawCard = [dict stp_dictionaryForKey:@"card"];
     token.card = [STPCard decodedObjectFromAPIResponse:rawCard];
@@ -100,6 +108,37 @@
 
     token.allResponseFields = dict;
     return token;
+}
+
+#pragma mark - STPTokenType
+
++ (BOOL)_isValidRawTokenType:(NSString *)rawType {
+    if ([rawType isEqualToString:@"account"] ||
+        [rawType isEqualToString:@"bank_account"] ||
+        [rawType isEqualToString:@"card"] ||
+        [rawType isEqualToString:@"pii"] ||
+        [rawType isEqualToString:@"cvc_update"]
+        ) {
+        return YES;
+    }
+    return NO;
+}
+
++ (STPTokenType)_tokenTypeForString:(NSString *)rawType {
+    if ([rawType isEqualToString:@"account"]) {
+        return STPTokenTypeAccount;
+    } else if ([rawType isEqualToString:@"bank_account"]) {
+        return STPTokenTypeBankAccount;
+    } else if ([rawType isEqualToString:@"card"]) {
+        return STPTokenTypeCard;
+    } else if ([rawType isEqualToString:@"pii"]) {
+        return STPTokenTypePII;
+    } else if ([rawType isEqualToString:@"cvc_update"]) {
+        return STPTokenTypeCVCUpdate;
+    }
+
+    // default return STPTokenTypeAccount (this matches other default enum behavior)
+    return STPTokenTypeAccount;
 }
 
 @end

--- a/Stripe/STPToken.m
+++ b/Stripe/STPToken.m
@@ -68,7 +68,6 @@
     [self.tokenId isEqualToString:object.tokenId] &&
     [self.created isEqualToDate:object.created] &&
     [self.card isEqual:object.card] &&
-    [self.tokenId isEqualToString:object.tokenId] &&
     [self.created isEqualToDate:object.created];
 }
 
@@ -90,7 +89,7 @@
     NSString *stripeId = [dict stp_stringForKey:@"id"];
     NSDate *created = [dict stp_dateForKey:@"created"];
     NSString *rawType = [dict stp_stringForKey:@"type"];
-    if (!stripeId || !created || !dict[@"livemode"] || ![STPToken _isValidRawTokenType:rawType]) {
+    if (!stripeId || !created || !dict[@"livemode"] || ![[self class] _isValidRawTokenType:rawType]) {
         return nil;
     }
     
@@ -98,7 +97,7 @@
     token.tokenId = stripeId;
     token.livemode = [dict stp_boolForKey:@"livemode" or:YES];
     token.created = created;
-    token.type = [STPToken _tokenTypeForString:rawType];
+    token.type = [[self class] _tokenTypeForString:rawType];
     
     NSDictionary *rawCard = [dict stp_dictionaryForKey:@"card"];
     token.card = [STPCard decodedObjectFromAPIResponse:rawCard];

--- a/Tests/Tests/STPBankAccountFunctionalTest.m
+++ b/Tests/Tests/STPBankAccountFunctionalTest.m
@@ -42,6 +42,7 @@
                                 XCTAssertNotNil(token, @"token should not be nil");
 
                                 XCTAssertNotNil(token.tokenId);
+                                XCTAssertEqual(token.type, STPTokenTypeBankAccount);
                                 XCTAssertNotNil(token.bankAccount.stripeID);
                                 XCTAssertEqualObjects(@"STRIPE TEST BANK", token.bankAccount.bankName);
                                 XCTAssertEqualObjects(@"6789", token.bankAccount.last4);

--- a/Tests/Tests/STPCardFunctionalTest.m
+++ b/Tests/Tests/STPCardFunctionalTest.m
@@ -47,6 +47,7 @@
                          XCTAssertNotNil(token, @"token should not be nil");
 
                          XCTAssertNotNil(token.tokenId);
+                         XCTAssertEqual(token.type, STPTokenTypeCard);
                          XCTAssertEqual(6U, token.card.expMonth);
                          XCTAssertEqual(2024U, token.card.expYear);
                          XCTAssertEqualObjects(@"4242", token.card.last4);
@@ -122,6 +123,41 @@
                          XCTAssertNotNil(error, @"error should not be nil");
                          XCTAssert([error.localizedDescription rangeOfString:@"asdf"].location != NSNotFound, @"error should contain last 4 of key");
                      }];
+    [self waitForExpectationsWithTimeout:5.0f handler:nil];
+}
+
+- (void)testCreateCVCUpdateToken {
+    // You have to be gated in to CVC Update tokens, so we use this differing key
+    STPAPIClient *client = [[STPAPIClient alloc] initWithPublishableKey:@"pk_test_6pRNASCoBOKtIshFeQd4XMUh"];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"CVC Update Token Creation"];
+
+    [client createTokenForCVCUpdate:@"1234"
+                         completion:^(STPToken *token, NSError *error) {
+                             [expectation fulfill];
+
+                             XCTAssertNil(error, @"error should be nil %@", error.localizedDescription);
+                             XCTAssertNotNil(token, @"token should not be nil");
+
+                             XCTAssertNotNil(token.tokenId);
+                             XCTAssertEqual(token.type, STPTokenTypeCVCUpdate, @"token should be type CVC Update");
+                         }];
+    [self waitForExpectationsWithTimeout:5.0f handler:nil];
+}
+
+- (void)testInvalidCVC {
+    // You have to be gated in to CVC Update tokens, so we use this differing key
+    STPAPIClient *client = [[STPAPIClient alloc] initWithPublishableKey:@"pk_test_6pRNASCoBOKtIshFeQd4XMUh"];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Invalid CVC"];
+
+    [client createTokenForCVCUpdate:@"1"
+                         completion:^(STPToken *token, NSError *error) {
+                             [expectation fulfill];
+
+                             XCTAssertNil(token, @"token should be nil");
+                             XCTAssertNotNil(error, @"error should not be nil");
+                         }];
     [self waitForExpectationsWithTimeout:5.0f handler:nil];
 }
 

--- a/Tests/Tests/STPConnectAccountFunctionalTest.m
+++ b/Tests/Tests/STPConnectAccountFunctionalTest.m
@@ -65,6 +65,7 @@
             XCTAssertNil(error);
             XCTAssertNotNil(token);
             XCTAssertNotNil(token.tokenId);
+            XCTAssertEqual(token.type, STPTokenTypeAccount);
         }
         else {
             XCTAssertNil(token);

--- a/Tests/Tests/STPFixtures.m
+++ b/Tests/Tests/STPFixtures.m
@@ -85,6 +85,7 @@ NSString *const STPTestJSONSourceSOFORT = @"SOFORTSource";
                                 @"object": @"token",
                                 @"livemode": @NO,
                                 @"created": @1353025450.0,
+                                @"type": @"card",
                                 @"used": @NO,
                                 @"card": cardDict
                                 };

--- a/Tests/Tests/STPPIIFunctionalTest.m
+++ b/Tests/Tests/STPPIIFunctionalTest.m
@@ -31,6 +31,7 @@
         XCTAssertNil(error, @"error should be nil %@", error.localizedDescription);
         XCTAssertNotNil(token, @"token should not be nil");
         XCTAssertNotNil(token.tokenId);
+        XCTAssertEqual(token.type, STPTokenTypePII);
     }];
     
     [self waitForExpectationsWithTimeout:5.0f handler:nil];

--- a/Tests/Tests/STPTokenTest.m
+++ b/Tests/Tests/STPTokenTest.m
@@ -33,7 +33,7 @@
                                @"country": @"JP",
                                };
     
-    NSDictionary *tokenDict = @{ @"id": @"id_for_token", @"object": @"token", @"livemode": @NO, @"created": @1353025450.0, @"used": @NO, @"card": cardDict };
+    NSDictionary *tokenDict = @{ @"id": @"id_for_token", @"object": @"token", @"livemode": @NO, @"created": @1353025450.0, @"used": @NO, @"card": cardDict, @"type": @"card" };
     return tokenDict;
 }
 
@@ -41,6 +41,7 @@
     STPToken *token = [STPToken decodedObjectFromAPIResponse:[self buildTestTokenResponse]];
     XCTAssertEqualObjects([token tokenId], @"id_for_token", @"Generated token has the correct id");
     XCTAssertEqual([token livemode], NO, @"Generated token has the correct livemode");
+    XCTAssertEqual([token type], STPTokenTypeCard, @"Generated token has incorrect type");
 
     XCTAssertEqualWithAccuracy([[token created] timeIntervalSince1970], 1353025450.0, 1.0, @"Generated token has the correct created time");
 }

--- a/Tests/recorded_network_traffic/STPCardFunctionalTest/testCreateCVCUpdateToken/post_v1_tokens_0.tail
+++ b/Tests/recorded_network_traffic/STPCardFunctionalTest/testCreateCVCUpdateToken/post_v1_tokens_0.tail
@@ -1,0 +1,28 @@
+POST
+/v1/tokens$
+200
+application/json
+Content-Type: application/json
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Methods: GET, POST, HEAD, OPTIONS, DELETE
+Server: nginx
+Access-Control-Expose-Headers: Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+Access-Control-Max-Age: 300
+Cache-Control: no-cache, no-store
+Date: Wed, 06 Feb 2019 22:24:42 GMT
+Stripe-Version: 2015-10-12
+Access-Control-Allow-Credentials: true
+Content-Length: 186
+Connection: keep-alive
+Strict-Transport-Security: max-age=31556926; includeSubDomains; preload
+Request-Id: req_EyyY4uKgwwuSZv
+
+{
+  "object" : "token",
+  "id" : "cvctok_1E0yow2eZvKYlo2C8IbhGTgj",
+  "livemode" : false,
+  "client_ip" : "45.48.237.136",
+  "created" : 1549491882,
+  "used" : false,
+  "type" : "cvc_update"
+}

--- a/Tests/recorded_network_traffic/STPCardFunctionalTest/testInvalidCVC/post_v1_tokens_0.tail
+++ b/Tests/recorded_network_traffic/STPCardFunctionalTest/testInvalidCVC/post_v1_tokens_0.tail
@@ -1,0 +1,28 @@
+POST
+/v1/tokens$
+402
+application/json
+Content-Type: application/json
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Methods: GET, POST, HEAD, OPTIONS, DELETE
+Server: nginx
+Access-Control-Expose-Headers: Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+Access-Control-Max-Age: 300
+Cache-Control: no-cache, no-store
+Date: Wed, 06 Feb 2019 22:30:14 GMT
+Stripe-Version: 2015-10-12
+Access-Control-Allow-Credentials: true
+Content-Length: 215
+Connection: keep-alive
+Strict-Transport-Security: max-age=31556926; includeSubDomains; preload
+Request-Id: req_1UECHuVFzRGixf
+
+{
+  "error" : {
+    "code" : "invalid_cvc",
+    "message" : "Your card's security code is invalid.",
+    "param" : "cvc",
+    "type" : "card_error",
+    "doc_url" : "https:\/\/stripe.com\/docs\/error-codes\/invalid-cvc"
+  }
+}


### PR DESCRIPTION
## Summary
Adds `type` to `STPToken`. N.B. `type` for apple pay tokens is `STPTokenTypeCard`
Adds new method to create a cvc collection token
Note that in order to successfully create these tokens your account must be whitelisted by Stripe

## Motivation
https://jira.corp.stripe.com/browse/IOS-1160

## Testing
Added automated tests. Updated existing tests to check for token type
