### PR TITLE
[Request for comments] let people prefill card information for STPAddCardViewController

### DIFF
--- a/Stripe/PublicHeaders/STPAddCardViewController.h
+++ b/Stripe/PublicHeaders/STPAddCardViewController.h
@@ -51,6 +51,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) STPUserInformation *prefilledInformation;
 
 /**
+ You can set this property to pre-fill any information you've already collected from your user. @see STPCardParams.h
+ */
+@property (nonatomic, strong, nullable) STPCardParams *prefilledCardInformation;
+
+/**
  If you're using the token generated from STPAddCardViewController to make a Managed Account, you should set this property to the currency that account will use. Otherwise, you should leave it empty. For more information, see https://stripe.com/docs/api#create_card_token-card-currency
  */
 @property (nonatomic, copy, nullable) NSString *managedAccountCurrency;

--- a/Stripe/STPAddCardViewController.m
+++ b/Stripe/STPAddCardViewController.m
@@ -115,9 +115,6 @@ typedef NS_ENUM(NSUInteger, STPPaymentCardSection) {
 
     STPPaymentCardTextFieldCell *paymentCell = [[STPPaymentCardTextFieldCell alloc] init];
     paymentCell.paymentField.delegate = self;
-    if (self.prefilledCardInformation != nil) {
-        paymentCell.paymentField.cardParams = self.prefilledCardInformation;
-    }
     self.paymentCell = paymentCell;
     
     self.activityIndicator = [[STPPaymentActivityIndicatorView alloc] initWithFrame:CGRectMake(0, 0, 20.0f, 20.0f)];
@@ -252,6 +249,9 @@ typedef NS_ENUM(NSUInteger, STPPaymentCardSection) {
     [self stp_beginObservingKeyboardAndInsettingScrollView:self.tableView
                                              onChangeBlock:nil];
     [[self firstEmptyField] becomeFirstResponder];
+    if (self.prefilledCardInformation != nil) {
+        self.paymentCell.paymentField.cardParams = self.prefilledCardInformation;
+    }
 }
 
 - (UIResponder *)firstEmptyField {

--- a/Stripe/STPAddCardViewController.m
+++ b/Stripe/STPAddCardViewController.m
@@ -115,6 +115,9 @@ typedef NS_ENUM(NSUInteger, STPPaymentCardSection) {
 
     STPPaymentCardTextFieldCell *paymentCell = [[STPPaymentCardTextFieldCell alloc] init];
     paymentCell.paymentField.delegate = self;
+    if (self.prefilledCardInformation != nil) {
+        paymentCell.paymentField.cardParams = self.prefilledCardInformation;
+    }
     self.paymentCell = paymentCell;
     
     self.activityIndicator = [[STPPaymentActivityIndicatorView alloc] initWithFrame:CGRectMake(0, 0, 20.0f, 20.0f)];


### PR DESCRIPTION
## Summary
This PR adds the ability to prefill card information in the STPAddCardViewController.

## Motivation
This functionality is useful for people who use external libraries to scan credit cards (e.g., https://cardscan.io/) before using Stripe to finish entering the rest of the information and tokenize the card.

## Testing
Tried it out on a local project

Not sure if you'd find this useful or not. If so, please send me a pointer to any guidelines you have for external people committing code to your repo and I'll be happy to follow the expected conventions.