### PR TITLE
Add API to create PaymentMethod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * Renames `STPPaymentMethodTuple` to `STPPaymentOptionTuple`
   * Renames `STPPaymentMethodsViewController` to `STPPaymentOptionsViewController`
   * Renames all properties, methods, comments referencing 'PaymentMethod' to 'PaymentOption'
+* Adds `[STPAPI createPaymentMethodWithParams:completion:]`, which creates a PaymentMethod.
 
 ## 14.0.0 2018-11-14
 * Changes `STPPaymentCardTextField`, which now copies the `cardParams` property. See [MIGRATING.md](/MIGRATING.md) for more details. [#1031](https://github.com/stripe/stripe-ios/pull/1031)

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -232,6 +232,8 @@ NS_ASSUME_NON_NULL_END
 @property (<nonatomic / atomic>, <assign>, <readonly / readwrite>) <type> <name>;
 ```
 
+- Omit default properties (`assign`, `readwrite`), except for `strong`
+
 - Use `copy` for classes with mutable counterparts such as `NSString`, `NSArray`, `NSDictionary`
 
 - Leverage auto property synthesis whenever possible

--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -450,6 +450,7 @@
 		B628476222307A4100957149 /* STPPaymentMethodCardTest.m in Sources */ = {isa = PBXBuildFile; fileRef = B628476122307A4100957149 /* STPPaymentMethodCardTest.m */; };
 		B63E42762231D78D007B5B95 /* STPPaymentMethodCardParams.m in Sources */ = {isa = PBXBuildFile; fileRef = B6027BC12230ABAE0025DB29 /* STPPaymentMethodCardParams.m */; };
 		B63E42772231D78D007B5B95 /* STPPaymentMethodCardParams.m in Sources */ = {isa = PBXBuildFile; fileRef = B6027BC12230ABAE0025DB29 /* STPPaymentMethodCardParams.m */; };
+		B63E42792231F8FE007B5B95 /* STPPaymentMethodParamsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = B63E42782231F8FE007B5B95 /* STPPaymentMethodParamsTest.m */; };
 		B66B39B4223044A2006D1CAD /* STPPaymentMethodTest.m in Sources */ = {isa = PBXBuildFile; fileRef = B66B39B3223044A2006D1CAD /* STPPaymentMethodTest.m */; };
 		B66B39B6223045EF006D1CAD /* PaymentMethod.json in Resources */ = {isa = PBXBuildFile; fileRef = B66B39B5223045EF006D1CAD /* PaymentMethod.json */; };
 		B66D5021222F5611004A9210 /* STPPaymentMethodCardChecks.m in Sources */ = {isa = PBXBuildFile; fileRef = B66D5020222F5611004A9210 /* STPPaymentMethodCardChecks.m */; };
@@ -1208,6 +1209,7 @@
 		B6027BC02230ABAE0025DB29 /* STPPaymentMethodCardParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = STPPaymentMethodCardParams.h; path = PublicHeaders/STPPaymentMethodCardParams.h; sourceTree = "<group>"; };
 		B6027BC12230ABAE0025DB29 /* STPPaymentMethodCardParams.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodCardParams.m; sourceTree = "<group>"; };
 		B628476122307A4100957149 /* STPPaymentMethodCardTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodCardTest.m; sourceTree = "<group>"; };
+		B63E42782231F8FE007B5B95 /* STPPaymentMethodParamsTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodParamsTest.m; sourceTree = "<group>"; };
 		B66B39B3223044A2006D1CAD /* STPPaymentMethodTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodTest.m; sourceTree = "<group>"; };
 		B66B39B5223045EF006D1CAD /* PaymentMethod.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = PaymentMethod.json; sourceTree = "<group>"; };
 		B66D5020222F5611004A9210 /* STPPaymentMethodCardChecks.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodCardChecks.m; sourceTree = "<group>"; };
@@ -1826,6 +1828,7 @@
 				B6D6C934223078840092AFC8 /* STPPaymentMethodBillingDetailsTest.m */,
 				B66D5026222F8605004A9210 /* STPPaymentMethodCardChecksTest.m */,
 				B628476122307A4100957149 /* STPPaymentMethodCardTest.m */,
+				B63E42782231F8FE007B5B95 /* STPPaymentMethodParamsTest.m */,
 				B66B39B3223044A2006D1CAD /* STPPaymentMethodTest.m */,
 				B66D5023222F5A27004A9210 /* STPPaymentMethodThreeDSecureUsageTest.m */,
 				F1DE87FF1F8D410D00602F4C /* STPPaymentOptionsViewControllerTest.m */,
@@ -3085,6 +3088,7 @@
 				B600F3C3223088F900264403 /* STPPaymentMethodFunctionalTest.m in Sources */,
 				8BD87B951EFB1CB100269C2B /* STPSourceVerificationTest.m in Sources */,
 				C124A1811CCAA1BF007D42EE /* NSMutableURLRequest+StripeTest.m in Sources */,
+				B63E42792231F8FE007B5B95 /* STPPaymentMethodParamsTest.m in Sources */,
 				B3BDCACD20EEF4540034F7F5 /* STPPaymentIntentTest.m in Sources */,
 				B66B39B4223044A2006D1CAD /* STPPaymentMethodTest.m in Sources */,
 				C1EEDCC61CA2126000A54582 /* STPDelegateProxyTest.m in Sources */,

--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -444,7 +444,12 @@
 		B3BDCAD720EEF5EC0034F7F5 /* STPPaymentIntentParams.h in Headers */ = {isa = PBXBuildFile; fileRef = B3BDCAD520EEF5EC0034F7F5 /* STPPaymentIntentParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B3BDCADF20F0142C0034F7F5 /* PaymentIntent.json in Resources */ = {isa = PBXBuildFile; fileRef = B3BDCADE20F0142C0034F7F5 /* PaymentIntent.json */; };
 		B3C9CF2D2004595A005502ED /* STPConnectAccountFunctionalTest.m in Sources */ = {isa = PBXBuildFile; fileRef = B3C9CF2C2004595A005502ED /* STPConnectAccountFunctionalTest.m */; };
+		B600F3C3223088F900264403 /* STPPaymentMethodFunctionalTest.m in Sources */ = {isa = PBXBuildFile; fileRef = B600F3C2223088F900264403 /* STPPaymentMethodFunctionalTest.m */; };
+		B6027BC22230ABAE0025DB29 /* STPPaymentMethodCardParams.h in Headers */ = {isa = PBXBuildFile; fileRef = B6027BC02230ABAE0025DB29 /* STPPaymentMethodCardParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B6027BC32230ABAE0025DB29 /* STPPaymentMethodCardParams.h in Headers */ = {isa = PBXBuildFile; fileRef = B6027BC02230ABAE0025DB29 /* STPPaymentMethodCardParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B628476222307A4100957149 /* STPPaymentMethodCardTest.m in Sources */ = {isa = PBXBuildFile; fileRef = B628476122307A4100957149 /* STPPaymentMethodCardTest.m */; };
+		B63E42762231D78D007B5B95 /* STPPaymentMethodCardParams.m in Sources */ = {isa = PBXBuildFile; fileRef = B6027BC12230ABAE0025DB29 /* STPPaymentMethodCardParams.m */; };
+		B63E42772231D78D007B5B95 /* STPPaymentMethodCardParams.m in Sources */ = {isa = PBXBuildFile; fileRef = B6027BC12230ABAE0025DB29 /* STPPaymentMethodCardParams.m */; };
 		B66B39B4223044A2006D1CAD /* STPPaymentMethodTest.m in Sources */ = {isa = PBXBuildFile; fileRef = B66B39B3223044A2006D1CAD /* STPPaymentMethodTest.m */; };
 		B66B39B6223045EF006D1CAD /* PaymentMethod.json in Resources */ = {isa = PBXBuildFile; fileRef = B66B39B5223045EF006D1CAD /* PaymentMethod.json */; };
 		B66D5021222F5611004A9210 /* STPPaymentMethodCardChecks.m in Sources */ = {isa = PBXBuildFile; fileRef = B66D5020222F5611004A9210 /* STPPaymentMethodCardChecks.m */; };
@@ -476,6 +481,10 @@
 		B6B5FC44222F4C0200440249 /* STPPaymentMethodThreeDSecureUsage.m in Sources */ = {isa = PBXBuildFile; fileRef = B6B5FC40222F4C0200440249 /* STPPaymentMethodThreeDSecureUsage.m */; };
 		B6D6C933223076600092AFC8 /* STPPaymentMethodBillingDetailsAddressTest.m in Sources */ = {isa = PBXBuildFile; fileRef = B6D6C932223076600092AFC8 /* STPPaymentMethodBillingDetailsAddressTest.m */; };
 		B6D6C935223078840092AFC8 /* STPPaymentMethodBillingDetailsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = B6D6C934223078840092AFC8 /* STPPaymentMethodBillingDetailsTest.m */; };
+		B6DE52DB2230981200B70A66 /* STPPaymentMethodParams.h in Headers */ = {isa = PBXBuildFile; fileRef = B6DE52D92230981200B70A66 /* STPPaymentMethodParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B6DE52DC2230981200B70A66 /* STPPaymentMethodParams.h in Headers */ = {isa = PBXBuildFile; fileRef = B6DE52D92230981200B70A66 /* STPPaymentMethodParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B6DE52DD2230981200B70A66 /* STPPaymentMethodParams.m in Sources */ = {isa = PBXBuildFile; fileRef = B6DE52DA2230981200B70A66 /* STPPaymentMethodParams.m */; };
+		B6DE52DE2230981200B70A66 /* STPPaymentMethodParams.m in Sources */ = {isa = PBXBuildFile; fileRef = B6DE52DA2230981200B70A66 /* STPPaymentMethodParams.m */; };
 		B6E2F308222F442E0001FED4 /* STPPaymentMethodCardChecks.h in Headers */ = {isa = PBXBuildFile; fileRef = B6E2F306222F442E0001FED4 /* STPPaymentMethodCardChecks.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B6E2F309222F442E0001FED4 /* STPPaymentMethodCardChecks.h in Headers */ = {isa = PBXBuildFile; fileRef = B6E2F306222F442E0001FED4 /* STPPaymentMethodCardChecks.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C1054F911FE197AE0033C87E /* STPPaymentContextSnapshotTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C1054F901FE197AE0033C87E /* STPPaymentContextSnapshotTests.m */; };
@@ -1195,6 +1204,9 @@
 		B3BDCAD520EEF5EC0034F7F5 /* STPPaymentIntentParams.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = STPPaymentIntentParams.h; path = PublicHeaders/STPPaymentIntentParams.h; sourceTree = "<group>"; };
 		B3BDCADE20F0142C0034F7F5 /* PaymentIntent.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = PaymentIntent.json; sourceTree = "<group>"; };
 		B3C9CF2C2004595A005502ED /* STPConnectAccountFunctionalTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPConnectAccountFunctionalTest.m; sourceTree = "<group>"; };
+		B600F3C2223088F900264403 /* STPPaymentMethodFunctionalTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodFunctionalTest.m; sourceTree = "<group>"; };
+		B6027BC02230ABAE0025DB29 /* STPPaymentMethodCardParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = STPPaymentMethodCardParams.h; path = PublicHeaders/STPPaymentMethodCardParams.h; sourceTree = "<group>"; };
+		B6027BC12230ABAE0025DB29 /* STPPaymentMethodCardParams.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodCardParams.m; sourceTree = "<group>"; };
 		B628476122307A4100957149 /* STPPaymentMethodCardTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodCardTest.m; sourceTree = "<group>"; };
 		B66B39B3223044A2006D1CAD /* STPPaymentMethodTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodTest.m; sourceTree = "<group>"; };
 		B66B39B5223045EF006D1CAD /* PaymentMethod.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = PaymentMethod.json; sourceTree = "<group>"; };
@@ -1214,6 +1226,8 @@
 		B6B5FC40222F4C0200440249 /* STPPaymentMethodThreeDSecureUsage.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodThreeDSecureUsage.m; sourceTree = "<group>"; };
 		B6D6C932223076600092AFC8 /* STPPaymentMethodBillingDetailsAddressTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodBillingDetailsAddressTest.m; sourceTree = "<group>"; };
 		B6D6C934223078840092AFC8 /* STPPaymentMethodBillingDetailsTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodBillingDetailsTest.m; sourceTree = "<group>"; };
+		B6DE52D92230981200B70A66 /* STPPaymentMethodParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = STPPaymentMethodParams.h; path = PublicHeaders/STPPaymentMethodParams.h; sourceTree = "<group>"; };
+		B6DE52DA2230981200B70A66 /* STPPaymentMethodParams.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodParams.m; sourceTree = "<group>"; };
 		B6E2F306222F442E0001FED4 /* STPPaymentMethodCardChecks.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = STPPaymentMethodCardChecks.h; path = PublicHeaders/STPPaymentMethodCardChecks.h; sourceTree = "<group>"; };
 		C1054F901FE197AE0033C87E /* STPPaymentContextSnapshotTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentContextSnapshotTests.m; sourceTree = "<group>"; };
 		C1080F471CBECF7B007B2D89 /* STPAddress.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = STPAddress.h; path = PublicHeaders/STPAddress.h; sourceTree = "<group>"; };
@@ -1755,6 +1769,7 @@
 				B3C9CF2C2004595A005502ED /* STPConnectAccountFunctionalTest.m */,
 				C1CFCB6F1ED5E11500BE45DF /* STPFileFunctionalTest.m */,
 				B3BDCACE20EEF4640034F7F5 /* STPPaymentIntentFunctionalTest.m */,
+				B600F3C2223088F900264403 /* STPPaymentMethodFunctionalTest.m */,
 				C1CFCB711ED5E11500BE45DF /* STPPIIFunctionalTest.m */,
 				C1D7B5241E36C70D002181F5 /* STPSourceFunctionalTest.m */,
 			);
@@ -2173,6 +2188,10 @@
 				B690DDF7222F0564000B902D /* STPPaymentMethodCard.m */,
 				B6E2F306222F442E0001FED4 /* STPPaymentMethodCardChecks.h */,
 				B66D5020222F5611004A9210 /* STPPaymentMethodCardChecks.m */,
+				B6027BC12230ABAE0025DB29 /* STPPaymentMethodCardParams.m */,
+				B6027BC02230ABAE0025DB29 /* STPPaymentMethodCardParams.h */,
+				B6DE52D92230981200B70A66 /* STPPaymentMethodParams.h */,
+				B6DE52DA2230981200B70A66 /* STPPaymentMethodParams.m */,
 				B6B5FC3F222F4C0200440249 /* STPPaymentMethodThreeDSecureUsage.h */,
 				B6B5FC40222F4C0200440249 /* STPPaymentMethodThreeDSecureUsage.m */,
 				C1D7B51E1E36C32F002181F5 /* STPSource.h */,
@@ -2309,6 +2328,7 @@
 			files = (
 				04EBC7561B7533C300A0E6AE /* STPCardValidationState.h in Headers */,
 				04F94DA11D229F12004FC826 /* STPAddressFieldTableViewCell.h in Headers */,
+				B6027BC32230ABAE0025DB29 /* STPPaymentMethodCardParams.h in Headers */,
 				04EBC75A1B7533C300A0E6AE /* STPCardValidator.h in Headers */,
 				C159933D1D8808970047950D /* STPShippingMethodsViewController.h in Headers */,
 				F15232251EA9303800D65C67 /* STPURLCallbackHandler.h in Headers */,
@@ -2354,6 +2374,7 @@
 				049E84E91A605EF0000B66CD /* STPBankAccount.h in Headers */,
 				C15993401D88089E0047950D /* STPShippingMethodTableViewCell.h in Headers */,
 				04B31DD51D08E6E200EF1631 /* STPCustomer.h in Headers */,
+				B6DE52DC2230981200B70A66 /* STPPaymentMethodParams.h in Headers */,
 				04633AFB1CD1299B009D4FB5 /* NSString+Stripe.h in Headers */,
 				04B31E001D131D9000EF1631 /* STPPaymentCardTextFieldCell.h in Headers */,
 				04BFFFDA1D240B13005F2340 /* STPAddCardViewController+Private.h in Headers */,
@@ -2568,6 +2589,7 @@
 				B3BDCAD620EEF5EC0034F7F5 /* STPPaymentIntentParams.h in Headers */,
 				04F213351BCECB1C001D6F22 /* STPAPIResponseDecodable.h in Headers */,
 				04695AD31C77F9DB00E08063 /* NSString+Stripe.h in Headers */,
+				B6027BC22230ABAE0025DB29 /* STPPaymentMethodCardParams.h in Headers */,
 				C1BD9B341E3940C400CEE925 /* STPSourceVerification.h in Headers */,
 				C1BD9B2E1E3940A200CEE925 /* STPSourceRedirect.h in Headers */,
 				04BC29A41CD8697900318357 /* STPTheme.h in Headers */,
@@ -2578,6 +2600,7 @@
 				04CDB4D31A5F30A700B854EE /* Stripe.h in Headers */,
 				F1A0197C1EA5733200354301 /* STPSourceParams+Private.h in Headers */,
 				B6E2F308222F442E0001FED4 /* STPPaymentMethodCardChecks.h in Headers */,
+				B6DE52DB2230981200B70A66 /* STPPaymentMethodParams.h in Headers */,
 				F19491E71E60DD9C001E1FC2 /* STPSourceSEPADebitDetails.h in Headers */,
 				F15232201EA92FCF00D65C67 /* STPRedirectContext.h in Headers */,
 				B6B5FC41222F4C0200440249 /* STPPaymentMethodThreeDSecureUsage.h in Headers */,
@@ -3059,6 +3082,7 @@
 				B66D5027222F8605004A9210 /* STPPaymentMethodCardChecksTest.m in Sources */,
 				C1D7B5251E36C70D002181F5 /* STPSourceFunctionalTest.m in Sources */,
 				0438EF4D1B741B0100D506CC /* STPPaymentCardTextFieldViewModelTest.m in Sources */,
+				B600F3C3223088F900264403 /* STPPaymentMethodFunctionalTest.m in Sources */,
 				8BD87B951EFB1CB100269C2B /* STPSourceVerificationTest.m in Sources */,
 				C124A1811CCAA1BF007D42EE /* NSMutableURLRequest+StripeTest.m in Sources */,
 				B3BDCACD20EEF4540034F7F5 /* STPPaymentIntentTest.m in Sources */,
@@ -3158,6 +3182,7 @@
 				B690DDFB222F0564000B902D /* STPPaymentMethodCard.m in Sources */,
 				F19491DC1E5F606F001E1FC2 /* STPSourceCardDetails.m in Sources */,
 				04F94DAA1D229F36004FC826 /* STPTheme.m in Sources */,
+				B6DE52DE2230981200B70A66 /* STPPaymentMethodParams.m in Sources */,
 				0439B98A1C454F97005A1ED5 /* STPPaymentOptionsViewController.m in Sources */,
 				C113D21C1EBB9A36006FACC2 /* STPEphemeralKey.m in Sources */,
 				04F94DAE1D229F54004FC826 /* STPColorUtils.m in Sources */,
@@ -3178,6 +3203,7 @@
 				B36C6D762193676600D17575 /* STPPaymentIntentSourceActionAuthorizeWithURL.m in Sources */,
 				B3A99BC61FEAF2CA003F6ED3 /* STPLegalEntityParams.m in Sources */,
 				C180211D1E3A58710089D712 /* STPSourcePoller.m in Sources */,
+				B63E42772231D78D007B5B95 /* STPPaymentMethodCardParams.m in Sources */,
 				04F94DB91D229F86004FC826 /* STPApplePayPaymentOption.m in Sources */,
 				B3A2413C1FFEB57400A2F00D /* STPConnectAccountParams.m in Sources */,
 				C1BD9B2B1E39406C00CEE925 /* STPSourceOwner.m in Sources */,
@@ -3284,6 +3310,7 @@
 				C15993391D8808680047950D /* STPShippingMethodTableViewCell.m in Sources */,
 				C1BD9B2A1E39406C00CEE925 /* STPSourceOwner.m in Sources */,
 				F1DEB89B1E2074480066B8E8 /* STPCoreViewController.m in Sources */,
+				B6DE52DD2230981200B70A66 /* STPPaymentMethodParams.m in Sources */,
 				C1D7B5221E36C32F002181F5 /* STPSource.m in Sources */,
 				B3BDCAC220EEF2150034F7F5 /* STPPaymentIntent.m in Sources */,
 				049A3F8A1CC73C7100F57DE7 /* STPPaymentContext.m in Sources */,
@@ -3311,6 +3338,7 @@
 				3691EB722119111A008C49E1 /* STPCardValidator+Private.m in Sources */,
 				F19491E41E60DD72001E1FC2 /* STPSourceSEPADebitDetails.m in Sources */,
 				04A4C38F1C4F25F900B3B290 /* UIViewController+Stripe_ParentViewController.m in Sources */,
+				B63E42762231D78D007B5B95 /* STPPaymentMethodCardParams.m in Sources */,
 				049A3FAF1CC9AA9900F57DE7 /* STPAddressViewModel.m in Sources */,
 				04695ADC1C77F9EF00E08063 /* STPPhoneNumberValidator.m in Sources */,
 				C1785F5E1EC60B5E00E9CFAC /* STPCardIOProxy.m in Sources */,

--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -482,6 +482,10 @@
 		B6B5FC44222F4C0200440249 /* STPPaymentMethodThreeDSecureUsage.m in Sources */ = {isa = PBXBuildFile; fileRef = B6B5FC40222F4C0200440249 /* STPPaymentMethodThreeDSecureUsage.m */; };
 		B6D6C933223076600092AFC8 /* STPPaymentMethodBillingDetailsAddressTest.m in Sources */ = {isa = PBXBuildFile; fileRef = B6D6C932223076600092AFC8 /* STPPaymentMethodBillingDetailsAddressTest.m */; };
 		B6D6C935223078840092AFC8 /* STPPaymentMethodBillingDetailsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = B6D6C934223078840092AFC8 /* STPPaymentMethodBillingDetailsTest.m */; };
+		B6DB0CA6223817A300AEF640 /* STPPaymentMethodEnums.h in Headers */ = {isa = PBXBuildFile; fileRef = B6DB0CA5223817A300AEF640 /* STPPaymentMethodEnums.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B6DB0CA7223817A300AEF640 /* STPPaymentMethodEnums.h in Headers */ = {isa = PBXBuildFile; fileRef = B6DB0CA5223817A300AEF640 /* STPPaymentMethodEnums.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B6DB0CA922381B4900AEF640 /* STPPaymentMethod+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = B6DB0CA822381B4900AEF640 /* STPPaymentMethod+Private.h */; };
+		B6DB0CAA22381B4900AEF640 /* STPPaymentMethod+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = B6DB0CA822381B4900AEF640 /* STPPaymentMethod+Private.h */; };
 		B6DE52DB2230981200B70A66 /* STPPaymentMethodParams.h in Headers */ = {isa = PBXBuildFile; fileRef = B6DE52D92230981200B70A66 /* STPPaymentMethodParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B6DE52DC2230981200B70A66 /* STPPaymentMethodParams.h in Headers */ = {isa = PBXBuildFile; fileRef = B6DE52D92230981200B70A66 /* STPPaymentMethodParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B6DE52DD2230981200B70A66 /* STPPaymentMethodParams.m in Sources */ = {isa = PBXBuildFile; fileRef = B6DE52DA2230981200B70A66 /* STPPaymentMethodParams.m */; };
@@ -1228,6 +1232,8 @@
 		B6B5FC40222F4C0200440249 /* STPPaymentMethodThreeDSecureUsage.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodThreeDSecureUsage.m; sourceTree = "<group>"; };
 		B6D6C932223076600092AFC8 /* STPPaymentMethodBillingDetailsAddressTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodBillingDetailsAddressTest.m; sourceTree = "<group>"; };
 		B6D6C934223078840092AFC8 /* STPPaymentMethodBillingDetailsTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodBillingDetailsTest.m; sourceTree = "<group>"; };
+		B6DB0CA5223817A300AEF640 /* STPPaymentMethodEnums.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = STPPaymentMethodEnums.h; path = PublicHeaders/STPPaymentMethodEnums.h; sourceTree = "<group>"; };
+		B6DB0CA822381B4900AEF640 /* STPPaymentMethod+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPPaymentMethod+Private.h"; sourceTree = "<group>"; };
 		B6DE52D92230981200B70A66 /* STPPaymentMethodParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = STPPaymentMethodParams.h; path = PublicHeaders/STPPaymentMethodParams.h; sourceTree = "<group>"; };
 		B6DE52DA2230981200B70A66 /* STPPaymentMethodParams.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodParams.m; sourceTree = "<group>"; };
 		B6E2F306222F442E0001FED4 /* STPPaymentMethodCardChecks.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = STPPaymentMethodCardChecks.h; path = PublicHeaders/STPPaymentMethodCardChecks.h; sourceTree = "<group>"; };
@@ -2089,6 +2095,7 @@
 				F1D3A2491EB012010095BFA9 /* STPMultipartFormDataPart.h */,
 				F1D3A24A1EB012010095BFA9 /* STPMultipartFormDataPart.m */,
 				B3BDCAC120EEF2150034F7F5 /* STPPaymentIntent+Private.h */,
+				B6DB0CA822381B4900AEF640 /* STPPaymentMethod+Private.h */,
 				B69CFB4922370547001E9885 /* STPPaymentMethodCardChecks+Private.h */,
 				B32B176420F80442000D6EF8 /* STPRedirectContext+Private.h */,
 				C1C1012C1E57A26F00C7BFAE /* STPSource+Private.h */,
@@ -2193,6 +2200,7 @@
 				B66D5020222F5611004A9210 /* STPPaymentMethodCardChecks.m */,
 				B6027BC12230ABAE0025DB29 /* STPPaymentMethodCardParams.m */,
 				B6027BC02230ABAE0025DB29 /* STPPaymentMethodCardParams.h */,
+				B6DB0CA5223817A300AEF640 /* STPPaymentMethodEnums.h */,
 				B6DE52D92230981200B70A66 /* STPPaymentMethodParams.h */,
 				B6DE52DA2230981200B70A66 /* STPPaymentMethodParams.m */,
 				B6B5FC3F222F4C0200440249 /* STPPaymentMethodThreeDSecureUsage.h */,
@@ -2338,6 +2346,7 @@
 				B3A2413A1FFEB57400A2F00D /* STPConnectAccountParams.h in Headers */,
 				B32B176620F80442000D6EF8 /* STPRedirectContext+Private.h in Headers */,
 				F1D3A2561EB012350095BFA9 /* STPMultipartFormDataPart.h in Headers */,
+				B6DB0CA7223817A300AEF640 /* STPPaymentMethodEnums.h in Headers */,
 				04F94DCD1D22A22F004FC826 /* UIViewController+Stripe_KeyboardAvoiding.h in Headers */,
 				C1BD9B3A1E39416700CEE925 /* STPSourceOwner.h in Headers */,
 				F1D3A2541EB012350095BFA9 /* STPMultipartFormDataEncoder.h in Headers */,
@@ -2446,6 +2455,7 @@
 				04B31DDB1D09A4DC00EF1631 /* STPPaymentConfiguration+Private.h in Headers */,
 				045D710F1CEEE30500F6CD65 /* STPAspects.h in Headers */,
 				04F94DAF1D229F59004FC826 /* STPPaymentOptionsViewController+Private.h in Headers */,
+				B6DB0CAA22381B4900AEF640 /* STPPaymentMethod+Private.h in Headers */,
 				B3BDCAC520EEF2150034F7F5 /* STPPaymentIntent+Private.h in Headers */,
 				04633AFD1CD129AF009D4FB5 /* STPPhoneNumberValidator.h in Headers */,
 				04633AFE1CD129B4009D4FB5 /* STPDelegateProxy.h in Headers */,
@@ -2529,6 +2539,7 @@
 				F1FA6F951E25960500EB444D /* STPCoreScrollViewController+Private.h in Headers */,
 				C17A030D1CBEE7A2006C819F /* STPAddressFieldTableViewCell.h in Headers */,
 				C1C1012D1E57A26F00C7BFAE /* STPSource+Private.h in Headers */,
+				B6DB0CA922381B4900AEF640 /* STPPaymentMethod+Private.h in Headers */,
 				04A4C3891C4F25F900B3B290 /* NSArray+Stripe.h in Headers */,
 				04827D151D257764002DB3E8 /* STPImageLibrary+Private.h in Headers */,
 				049952D21BCF13DD0088C703 /* STPAPIClient+Private.h in Headers */,
@@ -2586,6 +2597,7 @@
 				0426B96E1CEADC98006AC8DD /* STPColorUtils.h in Headers */,
 				04B31DDA1D09A4DC00EF1631 /* STPPaymentConfiguration+Private.h in Headers */,
 				F1D96F961DC7D82400477E64 /* STPLocalizationUtils.h in Headers */,
+				B6DB0CA6223817A300AEF640 /* STPPaymentMethodEnums.h in Headers */,
 				0438EF381B7416BB00D506CC /* STPPaymentCardTextFieldViewModel.h in Headers */,
 				04CDE5BC1BC1F21500548833 /* STPCardParams.h in Headers */,
 				C19D098F1EAEAE4000A4AB3E /* STPTelemetryClient.h in Headers */,

--- a/Stripe/PublicHeaders/STPAPIClient.h
+++ b/Stripe/PublicHeaders/STPAPIClient.h
@@ -371,9 +371,9 @@ static NSString *const STPSDKVersion = @"15.0.0";
 /**
  Creates a PaymentMethod object with the provided params object.
  
- @see https://site-admin.stripe.com/docs/api/payment_methods/create
+ @see https://stripe.com/docs/api/payment_methods/create
  
- @param paymentMethodParams  The `STPPaymentMethodParams` to pass to `/payment_methods`.  Cannot be nil.
+ @param paymentMethodParams  The `STPPaymentMethodParams` to pass to `/v1/payment_methods`.  Cannot be nil.
  @param completion           The callback to run with the returned PaymentMethod object, or an error.
  */
 - (void)createPaymentMethodWithParams:(STPPaymentMethodParams *)paymentMethodParams

--- a/Stripe/PublicHeaders/STPAPIClient.h
+++ b/Stripe/PublicHeaders/STPAPIClient.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 static NSString *const STPSDKVersion = @"15.0.0";
 
 @class STPBankAccount, STPBankAccountParams, STPCard, STPCardParams, STPConnectAccountParams;
-@class STPPaymentConfiguration, STPPaymentIntentParams, STPSourceParams, STPToken;
+@class STPPaymentConfiguration, STPPaymentIntentParams, STPSourceParams, STPToken, STPPaymentMethodParams;
 
 /**
  A top-level class that imports the rest of the Stripe SDK.
@@ -357,6 +357,27 @@ static NSString *const STPSDKVersion = @"15.0.0";
  */
 - (void)confirmPaymentIntentWithParams:(STPPaymentIntentParams *)paymentIntentParams
                             completion:(STPPaymentIntentCompletionBlock)completion;
+
+@end
+
+
+#pragma mark Payment Methods
+
+/**
+ STPAPIClient extensions for working with PaymentMethod objects.
+ */
+@interface STPAPIClient (PaymentMethods)
+
+/**
+ Creates a PaymentMethod object with the provided params object.
+ 
+ @see https://site-admin.stripe.com/docs/api/payment_methods/create
+ 
+ @param paymentMethodParams  The `STPPaymentMethodParams` to pass to `/payment_methods`.  Cannot be nil.
+ @param completion           The callback to run with the returned PaymentMethod object, or an error.
+ */
+- (void)createPaymentMethodWithParams:(STPPaymentMethodParams *)paymentMethodParams
+                           completion:(STPPaymentMethodCompletionBlock)completion;
 
 @end
 

--- a/Stripe/PublicHeaders/STPBlocks.h
+++ b/Stripe/PublicHeaders/STPBlocks.h
@@ -15,6 +15,7 @@
 @class STPCustomer;
 @protocol STPSourceProtocol;
 @class STPPaymentIntent;
+@class STPPaymentMethod;
 
 /**
  These values control the labels used in the shipping info collection form.
@@ -114,6 +115,14 @@ typedef void (^STPSourceProtocolCompletionBlock)(id<STPSourceProtocol> __nullabl
  @param error The error returned from the response, or nil if none occurs. @see StripeError.h for possible values.
  */
 typedef void (^STPPaymentIntentCompletionBlock)(STPPaymentIntent * __nullable paymentIntent, NSError * __nullable error);
+
+/**
+ A callback to be run with a PaymentMethod response from the Stripe API.
+ 
+ @param paymentMethod The Stripe PaymentMethod from the response. Will be nil if an error occurs. @see STPPaymentMethod
+ @param error The error returned from the response, or nil if none occurs. @see StripeError.h for possible values.
+ */
+typedef void (^STPPaymentMethodCompletionBlock)(STPPaymentMethod * __nullable paymentMethod, NSError * __nullable error);
 
 /**
  A callback to be run with a validation result and shipping methods for a 

--- a/Stripe/PublicHeaders/STPPaymentMethod.h
+++ b/Stripe/PublicHeaders/STPPaymentMethod.h
@@ -9,6 +9,7 @@
 #import <Foundation/Foundation.h>
 
 #import "STPAPIResponseDecodable.h"
+#import "STPPaymentMethodEnums.h"
 
 @class STPPaymentMethodBillingDetails, STPPaymentMethodCard;
 
@@ -37,9 +38,10 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) BOOL liveMode;
 
 /**
- The type of the PaymentMethod, currently only @"card" is supported. The corresponding property (`card`) contains additional information specific to the PaymentMethod type.
+ The type of the PaymentMethod.  The corresponding, similarly named property contains additional information specific to the PaymentMethod type.
+ e.g. if the type is `STPPaymentMethodTypeCard`, the `card` property is also populated.
  */
-@property (nonatomic, nullable, readonly) NSString *type;
+@property (nonatomic, readonly) STPPaymentMethodType type;
 
 /**
  Billing information associated with the PaymentMethod that may be used or required by particular types of payment methods.
@@ -47,7 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nullable, readonly) STPPaymentMethodBillingDetails *billingDetails;
 
 /**
- If this is a card PaymentMethod (ie `self.type == @"card"`), this contains details about the card.
+ If this is a card PaymentMethod (ie `self.type == STPPaymentMethodTypeCard`), this contains additional details.
  */
 @property (nonatomic, nullable, readonly) STPPaymentMethodCard *card;
 

--- a/Stripe/PublicHeaders/STPPaymentMethodBillingDetails.h
+++ b/Stripe/PublicHeaders/STPPaymentMethodBillingDetails.h
@@ -9,6 +9,7 @@
 #import <Foundation/Foundation.h>
 
 #import "STPAPIResponseDecodable.h"
+#import "STPFormEncodable.h"
 
 @class STPPaymentMethodBillingDetailsAddress;
 
@@ -19,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @see https://stripe.com/docs/api/payment_methods/object#payment_method_object-billing_details
  */
-@interface STPPaymentMethodBillingDetails : NSObject <STPAPIResponseDecodable>
+@interface STPPaymentMethodBillingDetails : NSObject <STPAPIResponseDecodable, STPFormEncodable>
 
 /**
  Billing address.

--- a/Stripe/PublicHeaders/STPPaymentMethodBillingDetails.h
+++ b/Stripe/PublicHeaders/STPPaymentMethodBillingDetails.h
@@ -25,22 +25,22 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Billing address.
  */
-@property (nonatomic, nullable) STPPaymentMethodBillingDetailsAddress *address;
+@property (nonatomic, strong, nullable, readwrite) STPPaymentMethodBillingDetailsAddress *address;
 
 /**
  Email address.
  */
-@property (nonatomic, copy, nullable) NSString *email;
+@property (nonatomic, copy, nullable, readwrite) NSString *email;
 
 /**
  Full name.
  */
-@property (nonatomic, copy, nullable) NSString *name;
+@property (nonatomic, copy, nullable, readwrite) NSString *name;
 
 /**
  Billing phone number (including extension).
  */
-@property (nonatomic, copy, nullable) NSString *phone;
+@property (nonatomic, copy, nullable, readwrite) NSString *phone;
 
 @end
 

--- a/Stripe/PublicHeaders/STPPaymentMethodBillingDetails.h
+++ b/Stripe/PublicHeaders/STPPaymentMethodBillingDetails.h
@@ -25,22 +25,22 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Billing address.
  */
-@property (nonatomic, strong, nullable, readwrite) STPPaymentMethodBillingDetailsAddress *address;
+@property (nonatomic, strong, nullable) STPPaymentMethodBillingDetailsAddress *address;
 
 /**
  Email address.
  */
-@property (nonatomic, copy, nullable, readwrite) NSString *email;
+@property (nonatomic, copy, nullable) NSString *email;
 
 /**
  Full name.
  */
-@property (nonatomic, copy, nullable, readwrite) NSString *name;
+@property (nonatomic, copy, nullable) NSString *name;
 
 /**
  Billing phone number (including extension).
  */
-@property (nonatomic, copy, nullable, readwrite) NSString *phone;
+@property (nonatomic, copy, nullable) NSString *phone;
 
 @end
 

--- a/Stripe/PublicHeaders/STPPaymentMethodBillingDetailsAddress.h
+++ b/Stripe/PublicHeaders/STPPaymentMethodBillingDetailsAddress.h
@@ -9,13 +9,14 @@
 #import <Foundation/Foundation.h>
 
 #import "STPAPIResponseDecodable.h"
+#import "STPFormEncodable.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 /**
  The billing address, a property on `STPPaymentMethodBillingDetails`
  */
-@interface STPPaymentMethodBillingDetailsAddress : NSObject <STPAPIResponseDecodable>
+@interface STPPaymentMethodBillingDetailsAddress : NSObject <STPAPIResponseDecodable, STPFormEncodable>
 
 /**
  City/District/Suburb/Town/Village.

--- a/Stripe/PublicHeaders/STPPaymentMethodCardParams.h
+++ b/Stripe/PublicHeaders/STPPaymentMethodCardParams.h
@@ -22,12 +22,12 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Two-digit number representing the card's expiration month.
  */
-@property (nonatomic, nullable) NSString *expMonth;
+@property (nonatomic) NSUInteger expMonth;
 
 /**
  Two- or four-digit number representing the card's expiration year.
  */
-@property (nonatomic, nullable) NSString *expYear;
+@property (nonatomic) NSUInteger expYear;
 
 /**
  For backwards compatibility, you can alternatively set this as a Stripe token (e.g., for apple pay)

--- a/Stripe/PublicHeaders/STPPaymentMethodCardParams.h
+++ b/Stripe/PublicHeaders/STPPaymentMethodCardParams.h
@@ -12,6 +12,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ The user's card details.
+ */
 @interface STPPaymentMethodCardParams : NSObject <STPFormEncodable>
 
 /**

--- a/Stripe/PublicHeaders/STPPaymentMethodCardParams.h
+++ b/Stripe/PublicHeaders/STPPaymentMethodCardParams.h
@@ -20,27 +20,27 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  The card number, as a string without any separators. Ex. @"4242424242424242"
  */
-@property (nonatomic, copy, nullable, readwrite) NSString *number;
+@property (nonatomic, copy, nullable) NSString *number;
 
 /**
  Two-digit number representing the card's expiration month.
  */
-@property (nonatomic, readwrite) NSUInteger expMonth;
+@property (nonatomic) NSUInteger expMonth;
 
 /**
  Two- or four-digit number representing the card's expiration year.
  */
-@property (nonatomic, readwrite) NSUInteger expYear;
+@property (nonatomic) NSUInteger expYear;
 
 /**
  For backwards compatibility, you can alternatively set this as a Stripe token (e.g., for apple pay)
  */
-@property (nonatomic, copy, nullable, readwrite) NSString *token;
+@property (nonatomic, copy, nullable) NSString *token;
 
 /**
  Card security code. It is highly recommended to always include this value.
  */
-@property (nonatomic, copy, nullable, readwrite) NSString *cvc;
+@property (nonatomic, copy, nullable) NSString *cvc;
 
 @end
 

--- a/Stripe/PublicHeaders/STPPaymentMethodCardParams.h
+++ b/Stripe/PublicHeaders/STPPaymentMethodCardParams.h
@@ -1,0 +1,44 @@
+//
+//  STPPaymentMethodCardParams.h
+//  Stripe
+//
+//  Created by Yuki Tokuhiro on 3/6/19.
+//  Copyright © 2019 Stripe, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "STPFormEncodable.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface STPPaymentMethodCardParams : NSObject <STPFormEncodable>
+
+/**
+ The card number, as a string without any separators. Ex. @"4242424242424242"
+ */
+@property (nonatomic, nullable) NSString *number;
+
+/**
+ Two-digit number representing the card's expiration month.
+ */
+@property (nonatomic, nullable) NSString *expMonth;
+
+/**
+ Two- or four-digit number representing the card's expiration year.
+ */
+@property (nonatomic, nullable) NSString *expYear;
+
+/**
+ For backwards compatibility, you can alternatively set this as a Stripe token (e.g., for apple pay)
+ */
+@property (nonatomic, nullable) NSString *token;
+
+/**
+ Card security code. It is highly recommended to always include this value.
+ */
+@property (nonatomic, nullable) NSString *cvc;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Stripe/PublicHeaders/STPPaymentMethodCardParams.h
+++ b/Stripe/PublicHeaders/STPPaymentMethodCardParams.h
@@ -17,27 +17,27 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  The card number, as a string without any separators. Ex. @"4242424242424242"
  */
-@property (nonatomic, nullable) NSString *number;
+@property (nonatomic, copy, nullable, readwrite) NSString *number;
 
 /**
  Two-digit number representing the card's expiration month.
  */
-@property (nonatomic) NSUInteger expMonth;
+@property (nonatomic, readwrite) NSUInteger expMonth;
 
 /**
  Two- or four-digit number representing the card's expiration year.
  */
-@property (nonatomic) NSUInteger expYear;
+@property (nonatomic, readwrite) NSUInteger expYear;
 
 /**
  For backwards compatibility, you can alternatively set this as a Stripe token (e.g., for apple pay)
  */
-@property (nonatomic, nullable) NSString *token;
+@property (nonatomic, copy, nullable, readwrite) NSString *token;
 
 /**
  Card security code. It is highly recommended to always include this value.
  */
-@property (nonatomic, nullable) NSString *cvc;
+@property (nonatomic, copy, nullable, readwrite) NSString *cvc;
 
 @end
 

--- a/Stripe/PublicHeaders/STPPaymentMethodEnums.h
+++ b/Stripe/PublicHeaders/STPPaymentMethodEnums.h
@@ -1,0 +1,22 @@
+//
+//  Header.h
+//  Stripe
+//
+//  Created by Yuki Tokuhiro on 3/12/19.
+//  Copyright © 2019 Stripe, Inc. All rights reserved.
+//
+
+/**
+ The type of the PaymentMethod.
+ */
+typedef NS_ENUM(NSUInteger, STPPaymentMethodType) {
+    /**
+     A card payment method.
+     */
+    STPPaymentMethodTypeCard,
+    
+    /**
+     An unknown type.
+     */
+    STPPaymentMethodTypeUnknown,
+};

--- a/Stripe/PublicHeaders/STPPaymentMethodEnums.h
+++ b/Stripe/PublicHeaders/STPPaymentMethodEnums.h
@@ -1,5 +1,5 @@
 //
-//  Header.h
+//  STPPaymentMethodEnums.h
 //  Stripe
 //
 //  Created by Yuki Tokuhiro on 3/12/19.

--- a/Stripe/PublicHeaders/STPPaymentMethodParams.h
+++ b/Stripe/PublicHeaders/STPPaymentMethodParams.h
@@ -15,6 +15,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ An object representing parameters used to create a PaymentMethod object.
+ @see https://stripe.com/docs/api/payment_methods/create
+ */
 @interface STPPaymentMethodParams : NSObject <STPFormEncodable>
 
 /**

--- a/Stripe/PublicHeaders/STPPaymentMethodParams.h
+++ b/Stripe/PublicHeaders/STPPaymentMethodParams.h
@@ -1,0 +1,59 @@
+//
+//  STPPaymentMethodParams.h
+//  Stripe
+//
+//  Created by Yuki Tokuhiro on 3/6/19.
+//  Copyright © 2019 Stripe, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "STPFormEncodable.h"
+
+@class STPPaymentMethodBillingDetails, STPPaymentMethodCardParams;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Types of a PaymentMethod
+ */
+typedef NS_ENUM(NSUInteger, STPPaymentMethodParamsType) {
+    STPPaymentMethodParamsTypeCard,
+};
+
+@interface STPPaymentMethodParams : NSObject <STPFormEncodable>
+
+/**
+ The type of payment method.  The associated property will contain additional information (e.g. `type == STPPaymentMethodParamsTypeCard` means `card` should also be populated).
+ */
+@property (nonatomic, assign) STPPaymentMethodParamsType type;
+
+/**
+ Billing information associated with the PaymentMethod that may be used or required by particular types of payment methods.
+ */
+@property (nonatomic, nullable) STPPaymentMethodBillingDetails *billingDetails;
+
+/**
+ If this is a card PaymentMethod, this contains the user’s card details.
+ */
+@property (nonatomic, nullable) STPPaymentMethodCardParams *card;
+
+/**
+ Set of key-value pairs that you can attach to the PaymentMethod. This can be useful for storing additional information about the PaymentMethod in a structured format.
+ */
+@property (nonatomic, nullable) NSDictionary<NSString *, NSString *> *metadata;
+
+/**
+ Creates params for a card PaymentMethod.
+ 
+ @param card                An object containing the user's card details.
+ @param billingDetails      An object containing the user's billing details.
+ @param metadata            Additional information to attach to the PaymentMethod.
+ */
++ (STPPaymentMethodParams *)cardParamsWithCard:(STPPaymentMethodCardParams *)card
+                                billingDetails:(nullable STPPaymentMethodBillingDetails *)billingDetails
+                                      metadata:(nullable NSDictionary<NSString *, NSString *> *)metadata;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Stripe/PublicHeaders/STPPaymentMethodParams.h
+++ b/Stripe/PublicHeaders/STPPaymentMethodParams.h
@@ -50,7 +50,7 @@ typedef NS_ENUM(NSUInteger, STPPaymentMethodParamsType) {
  @param billingDetails      An object containing the user's billing details.
  @param metadata            Additional information to attach to the PaymentMethod.
  */
-+ (STPPaymentMethodParams *)cardParamsWithCard:(STPPaymentMethodCardParams *)card
++ (STPPaymentMethodParams *)paramsWithCard:(STPPaymentMethodCardParams *)card
                                 billingDetails:(nullable STPPaymentMethodBillingDetails *)billingDetails
                                       metadata:(nullable NSDictionary<NSString *, NSString *> *)metadata;
 

--- a/Stripe/PublicHeaders/STPPaymentMethodParams.h
+++ b/Stripe/PublicHeaders/STPPaymentMethodParams.h
@@ -9,24 +9,30 @@
 #import <Foundation/Foundation.h>
 
 #import "STPFormEncodable.h"
+#import "STPPaymentMethodEnums.h"
 
 @class STPPaymentMethodBillingDetails, STPPaymentMethodCardParams;
 
 NS_ASSUME_NONNULL_BEGIN
 
-/**
- Types of a PaymentMethod
- */
-typedef NS_ENUM(NSUInteger, STPPaymentMethodParamsType) {
-    STPPaymentMethodParamsTypeCard,
-};
-
 @interface STPPaymentMethodParams : NSObject <STPFormEncodable>
 
 /**
- The type of payment method.  The associated property will contain additional information (e.g. `type == STPPaymentMethodParamsTypeCard` means `card` should also be populated).
+ The type of payment method.  The associated property will contain additional information (e.g. `type == STPPaymentMethodTypeCard` means `card` should also be populated).
  */
-@property (nonatomic, assign, readwrite) STPPaymentMethodParamsType type;
+@property (nonatomic, assign, readwrite) STPPaymentMethodType type;
+
+/**
+ The raw underlying type string sent to the server.
+ 
+ Generally you should use `type` instead unless you have a reason not to.
+ You can use this if you want to create a param of a type not yet supported
+ by the current version of the SDK's `STPPaymentMethodType` enum.
+ 
+ Setting this to a value not known by the SDK causes `type` to
+ return `STPPaymentMethodTypeUnknown`
+ */
+@property (nonatomic, copy) NSString *rawTypeString;
 
 /**
  Billing information associated with the PaymentMethod that may be used or required by particular types of payment methods.

--- a/Stripe/PublicHeaders/STPPaymentMethodParams.h
+++ b/Stripe/PublicHeaders/STPPaymentMethodParams.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  The type of payment method.  The associated property will contain additional information (e.g. `type == STPPaymentMethodTypeCard` means `card` should also be populated).
  */
-@property (nonatomic, assign, readwrite) STPPaymentMethodType type;
+@property (nonatomic) STPPaymentMethodType type;
 
 /**
  The raw underlying type string sent to the server.
@@ -41,17 +41,17 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Billing information associated with the PaymentMethod that may be used or required by particular types of payment methods.
  */
-@property (nonatomic, strong, nullable, readwrite) STPPaymentMethodBillingDetails *billingDetails;
+@property (nonatomic, strong, nullable) STPPaymentMethodBillingDetails *billingDetails;
 
 /**
  If this is a card PaymentMethod, this contains the user’s card details.
  */
-@property (nonatomic, strong, nullable, readwrite) STPPaymentMethodCardParams *card;
+@property (nonatomic, strong, nullable) STPPaymentMethodCardParams *card;
 
 /**
  Set of key-value pairs that you can attach to the PaymentMethod. This can be useful for storing additional information about the PaymentMethod in a structured format.
  */
-@property (nonatomic, copy, nullable, readwrite) NSDictionary<NSString *, NSString *> *metadata;
+@property (nonatomic, copy, nullable) NSDictionary<NSString *, NSString *> *metadata;
 
 /**
  Creates params for a card PaymentMethod.

--- a/Stripe/PublicHeaders/STPPaymentMethodParams.h
+++ b/Stripe/PublicHeaders/STPPaymentMethodParams.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  The type of payment method.  The associated property will contain additional information (e.g. `type == STPPaymentMethodTypeCard` means `card` should also be populated).
  */
-@property (nonatomic) STPPaymentMethodType type;
+@property (nonatomic, readonly) STPPaymentMethodType type;
 
 /**
  The raw underlying type string sent to the server.

--- a/Stripe/PublicHeaders/STPPaymentMethodParams.h
+++ b/Stripe/PublicHeaders/STPPaymentMethodParams.h
@@ -26,22 +26,22 @@ typedef NS_ENUM(NSUInteger, STPPaymentMethodParamsType) {
 /**
  The type of payment method.  The associated property will contain additional information (e.g. `type == STPPaymentMethodParamsTypeCard` means `card` should also be populated).
  */
-@property (nonatomic, assign) STPPaymentMethodParamsType type;
+@property (nonatomic, assign, readwrite) STPPaymentMethodParamsType type;
 
 /**
  Billing information associated with the PaymentMethod that may be used or required by particular types of payment methods.
  */
-@property (nonatomic, nullable) STPPaymentMethodBillingDetails *billingDetails;
+@property (nonatomic, strong, nullable, readwrite) STPPaymentMethodBillingDetails *billingDetails;
 
 /**
  If this is a card PaymentMethod, this contains the user’s card details.
  */
-@property (nonatomic, nullable) STPPaymentMethodCardParams *card;
+@property (nonatomic, strong, nullable, readwrite) STPPaymentMethodCardParams *card;
 
 /**
  Set of key-value pairs that you can attach to the PaymentMethod. This can be useful for storing additional information about the PaymentMethod in a structured format.
  */
-@property (nonatomic, nullable) NSDictionary<NSString *, NSString *> *metadata;
+@property (nonatomic, copy, nullable, readwrite) NSDictionary<NSString *, NSString *> *metadata;
 
 /**
  Creates params for a card PaymentMethod.

--- a/Stripe/PublicHeaders/STPSourceParams.h
+++ b/Stripe/PublicHeaders/STPSourceParams.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
  Setting this to a value not known by the SDK causes `type` to 
  return `STPSourceTypeUnknown`
  */
-@property (nonatomic, copy) NSString *rawTypeString;
+@property (nonatomic, copy, nullable) NSString *rawTypeString;
 
 /**
  A positive integer in the smallest currency unit representing the

--- a/Stripe/PublicHeaders/Stripe.h
+++ b/Stripe/PublicHeaders/Stripe.h
@@ -48,6 +48,7 @@
 #import "STPPaymentMethodCard.h"
 #import "STPPaymentMethodCardChecks.h"
 #import "STPPaymentMethodCardParams.h"
+#import "STPPaymentMethodEnums.h"
 #import "STPPaymentMethodParams.h"
 #import "STPPaymentMethodThreeDSecureUsage.h"
 #import "STPPaymentOption.h"

--- a/Stripe/PublicHeaders/Stripe.h
+++ b/Stripe/PublicHeaders/Stripe.h
@@ -47,6 +47,8 @@
 #import "STPPaymentMethodBillingDetailsAddress.h"
 #import "STPPaymentMethodCard.h"
 #import "STPPaymentMethodCardChecks.h"
+#import "STPPaymentMethodCardParams.h"
+#import "STPPaymentMethodParams.h"
 #import "STPPaymentMethodThreeDSecureUsage.h"
 #import "STPPaymentOption.h"
 #import "STPPaymentOptionsViewController.h"

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -27,6 +27,7 @@
 #import "STPMultipartFormDataEncoder.h"
 #import "STPMultipartFormDataPart.h"
 #import "STPPaymentConfiguration.h"
+#import "STPPaymentMethodParams.h"
 #import "STPPaymentIntent+Private.h"
 #import "STPPaymentIntentParams.h"
 #import "STPSource+Private.h"
@@ -53,6 +54,7 @@ static NSString * const APIEndpointSources = @"sources";
 static NSString * const APIEndpointCustomers = @"customers";
 static NSString * const FileUploadURL = @"https://uploads.stripe.com/v1/files";
 static NSString * const APIEndpointPaymentIntents = @"payment_intents";
+static NSString * const APIEndpointPaymentMethods = @"payment_methods";
 
 #pragma mark - Stripe
 
@@ -618,6 +620,28 @@ toCustomerUsingKey:(STPEphemeralKey *)ephemeralKey
                                               completion:^(STPPaymentIntent *paymentIntent, __unused NSHTTPURLResponse *response, NSError *error) {
                                                   completion(paymentIntent, error);
                                               }];
+}
+
+@end
+
+#pragma mark - Payment Methods
+
+@implementation STPAPIClient (PaymentMethods)
+
+- (void)createPaymentMethodWithParams:(STPPaymentMethodParams *)paymentMethodParams
+                                 completion:(STPPaymentMethodCompletionBlock)completion {
+    NSCAssert(paymentMethodParams != nil, @"'paymentMethodParams' is required to create a PaymentMethod");
+    
+    NSMutableDictionary *params = [[STPFormEncoder dictionaryForObject:paymentMethodParams] mutableCopy];
+
+    [STPAPIRequest<STPPaymentMethod *> postWithAPIClient:self
+                                               endpoint:APIEndpointPaymentMethods
+                                             parameters:params
+                                           deserializer:[STPPaymentMethod new]
+                                             completion:^(STPPaymentMethod *paymentMethod, __unused NSHTTPURLResponse *response, NSError *error) {
+                                                 completion(paymentMethod, error);
+                                             }];
+
 }
 
 @end

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -632,11 +632,9 @@ toCustomerUsingKey:(STPEphemeralKey *)ephemeralKey
                                  completion:(STPPaymentMethodCompletionBlock)completion {
     NSCAssert(paymentMethodParams != nil, @"'paymentMethodParams' is required to create a PaymentMethod");
     
-    NSMutableDictionary *params = [[STPFormEncoder dictionaryForObject:paymentMethodParams] mutableCopy];
-
     [STPAPIRequest<STPPaymentMethod *> postWithAPIClient:self
                                                endpoint:APIEndpointPaymentMethods
-                                             parameters:params
+                                             parameters:[STPFormEncoder dictionaryForObject:paymentMethodParams]
                                            deserializer:[STPPaymentMethod new]
                                              completion:^(STPPaymentMethod *paymentMethod, __unused NSHTTPURLResponse *response, NSError *error) {
                                                  completion(paymentMethod, error);

--- a/Stripe/STPPaymentMethod+Private.h
+++ b/Stripe/STPPaymentMethod+Private.h
@@ -1,0 +1,20 @@
+//
+//  STPPaymentMethod+Private.h
+//  Stripe
+//
+//  Created by Yuki Tokuhiro on 3/12/19.
+//  Copyright © 2019 Stripe, Inc. All rights reserved.
+//
+
+#import "STPPaymentMethod.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface STPPaymentMethod ()
+
++ (STPPaymentMethodType)typeFromString:(NSString *)string;
++ (nullable NSString *)stringFromType:(STPPaymentMethodType)type;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Stripe/STPPaymentMethod+Private.h
+++ b/Stripe/STPPaymentMethod+Private.h
@@ -10,7 +10,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface STPPaymentMethod (Private)
+@interface STPPaymentMethod ()
 
 + (STPPaymentMethodType)typeFromString:(NSString *)string;
 + (nullable NSString *)stringFromType:(STPPaymentMethodType)type;

--- a/Stripe/STPPaymentMethod+Private.h
+++ b/Stripe/STPPaymentMethod+Private.h
@@ -10,7 +10,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface STPPaymentMethod ()
+@interface STPPaymentMethod (Private)
 
 + (STPPaymentMethodType)typeFromString:(NSString *)string;
 + (nullable NSString *)stringFromType:(STPPaymentMethodType)type;

--- a/Stripe/STPPaymentMethodBillingDetails.m
+++ b/Stripe/STPPaymentMethodBillingDetails.m
@@ -33,6 +33,22 @@
     return [NSString stringWithFormat:@"<%@>", [props componentsJoinedByString:@"; "]];
 }
 
+#pragma mark - STPFormEncodable
+@synthesize additionalAPIParameters;
+
++ (nonnull NSDictionary *)propertyNamesToFormFieldNamesMapping {
+    return @{
+             NSStringFromSelector(@selector(address)): @"address",
+             NSStringFromSelector(@selector(email)): @"email",
+             NSStringFromSelector(@selector(name)): @"name",
+             NSStringFromSelector(@selector(phone)): @"phone",
+             };
+}
+
++ (nullable NSString *)rootObjectName {
+    return nil;
+}
+
 #pragma mark - STPAPIResponseDecodable
 
 + (nullable instancetype)decodedObjectFromAPIResponse:(nullable NSDictionary *)response {

--- a/Stripe/STPPaymentMethodBillingDetailsAddress.m
+++ b/Stripe/STPPaymentMethodBillingDetailsAddress.m
@@ -35,6 +35,24 @@
     return [NSString stringWithFormat:@"<%@>", [props componentsJoinedByString:@"; "]];
 }
 
+#pragma mark - STPFormEncodable
+
+@synthesize additionalAPIParameters;
+
++ (nonnull NSDictionary *)propertyNamesToFormFieldNamesMapping {
+    return @{
+             NSStringFromSelector(@selector(line1)): @"line1",
+             NSStringFromSelector(@selector(line2)): @"line2",
+             NSStringFromSelector(@selector(city)): @"city",
+             NSStringFromSelector(@selector(country)): @"country",
+             NSStringFromSelector(@selector(state)): @"state",
+             NSStringFromSelector(@selector(postalCode)): @"postal_code",
+             };
+}
+
++ (nullable NSString *)rootObjectName {
+    return nil;
+}
 
 #pragma mark - STPAPIResponseDecodable
 

--- a/Stripe/STPPaymentMethodCardParams.m
+++ b/Stripe/STPPaymentMethodCardParams.m
@@ -1,0 +1,31 @@
+//
+//  STPPaymentMethodCardParams.m
+//  Stripe
+//
+//  Created by Yuki Tokuhiro on 3/6/19.
+//  Copyright © 2019 Stripe, Inc. All rights reserved.
+//
+
+#import "STPPaymentMethodCardParams.h"
+
+@implementation STPPaymentMethodCardParams
+
+@synthesize additionalAPIParameters = _additionalAPIParameters;
+
+#pragma mark - STPFormEncodable
+
++ (NSString *)rootObjectName {
+    return @"card";
+}
+
++ (NSDictionary *)propertyNamesToFormFieldNamesMapping {
+    return @{
+             NSStringFromSelector(@selector(number)): @"number",
+             NSStringFromSelector(@selector(expMonth)): @"exp_month",
+             NSStringFromSelector(@selector(expYear)): @"exp_year",
+             NSStringFromSelector(@selector(cvc)): @"cvc",
+             NSStringFromSelector(@selector(token)): @"token",
+             };
+}
+
+@end

--- a/Stripe/STPPaymentMethodParams.m
+++ b/Stripe/STPPaymentMethodParams.m
@@ -1,0 +1,47 @@
+//
+//  STPPaymentMethodParams.m
+//  Stripe
+//
+//  Created by Yuki Tokuhiro on 3/6/19.
+//  Copyright © 2019 Stripe, Inc. All rights reserved.
+//
+
+#import "STPPaymentMethodParams.h"
+#import "STPPaymentMethod.h"
+
+@implementation STPPaymentMethodParams
+
+@synthesize additionalAPIParameters = _additionalAPIParameters;
+
++ (STPPaymentMethodParams *)cardParamsWithCard:(STPPaymentMethodCardParams *)card billingDetails:(STPPaymentMethodBillingDetails *)billingDetails metadata:(NSDictionary<NSString *,NSString *> *)metadata {
+    STPPaymentMethodParams *params = [STPPaymentMethodParams new];
+    params.type = STPPaymentMethodParamsTypeCard;
+    params.card = card;
+    params.billingDetails = billingDetails;
+    params.metadata = metadata;
+    return params;
+}
+
+- (NSString *)apiStringType {
+    switch (self.type) {
+        case STPPaymentMethodParamsTypeCard:
+            return @"card";
+    }
+}
+
+#pragma mark - STPFormEncodable
+
++ (nullable NSString *)rootObjectName {
+    return nil;
+}
+
++ (nonnull NSDictionary *)propertyNamesToFormFieldNamesMapping {
+    return @{
+             NSStringFromSelector(@selector(apiStringType)): @"type",
+             NSStringFromSelector(@selector(billingDetails)): @"billing_details",
+             NSStringFromSelector(@selector(card)): @"card",
+             NSStringFromSelector(@selector(metadata)): @"metadata",
+             };
+}
+
+@end

--- a/Stripe/STPPaymentMethodParams.m
+++ b/Stripe/STPPaymentMethodParams.m
@@ -7,7 +7,7 @@
 //
 
 #import "STPPaymentMethodParams.h"
-#import "STPPaymentMethod.h"
+#import "STPPaymentMethod+Private.h"
 
 @implementation STPPaymentMethodParams
 
@@ -15,17 +15,30 @@
 
 + (STPPaymentMethodParams *)paramsWithCard:(STPPaymentMethodCardParams *)card billingDetails:(STPPaymentMethodBillingDetails *)billingDetails metadata:(NSDictionary<NSString *,NSString *> *)metadata {
     STPPaymentMethodParams *params = [STPPaymentMethodParams new];
-    params.type = STPPaymentMethodParamsTypeCard;
+    params.type = STPPaymentMethodTypeCard;
     params.card = card;
     params.billingDetails = billingDetails;
     params.metadata = metadata;
     return params;
 }
 
+- (STPPaymentMethodType)type {
+    return [STPPaymentMethod typeFromString:self.rawTypeString];
+}
+
+- (void)setType:(STPPaymentMethodType)type {
+    // If setting unknown and we're already unknown, don't want to override raw value
+    if (type != self.type) {
+        self.rawTypeString = [STPPaymentMethod stringFromType:type];
+    }
+}
+
 - (NSString *)apiStringType {
     switch (self.type) {
-        case STPPaymentMethodParamsTypeCard:
+        case STPPaymentMethodTypeCard:
             return @"card";
+        case STPPaymentMethodTypeUnknown:
+            return @"";
     }
 }
 

--- a/Stripe/STPPaymentMethodParams.m
+++ b/Stripe/STPPaymentMethodParams.m
@@ -14,7 +14,7 @@
 @synthesize additionalAPIParameters = _additionalAPIParameters;
 
 + (STPPaymentMethodParams *)paramsWithCard:(STPPaymentMethodCardParams *)card billingDetails:(STPPaymentMethodBillingDetails *)billingDetails metadata:(NSDictionary<NSString *,NSString *> *)metadata {
-    STPPaymentMethodParams *params = [STPPaymentMethodParams new];
+    STPPaymentMethodParams *params = [self new];
     params.type = STPPaymentMethodTypeCard;
     params.card = card;
     params.billingDetails = billingDetails;

--- a/Stripe/STPPaymentMethodParams.m
+++ b/Stripe/STPPaymentMethodParams.m
@@ -33,15 +33,6 @@
     }
 }
 
-- (NSString *)apiStringType {
-    switch (self.type) {
-        case STPPaymentMethodTypeCard:
-            return @"card";
-        case STPPaymentMethodTypeUnknown:
-            return @"";
-    }
-}
-
 #pragma mark - STPFormEncodable
 
 + (nullable NSString *)rootObjectName {
@@ -50,7 +41,7 @@
 
 + (nonnull NSDictionary *)propertyNamesToFormFieldNamesMapping {
     return @{
-             NSStringFromSelector(@selector(apiStringType)): @"type",
+             NSStringFromSelector(@selector(rawTypeString)): @"type",
              NSStringFromSelector(@selector(billingDetails)): @"billing_details",
              NSStringFromSelector(@selector(card)): @"card",
              NSStringFromSelector(@selector(metadata)): @"metadata",

--- a/Stripe/STPPaymentMethodParams.m
+++ b/Stripe/STPPaymentMethodParams.m
@@ -13,7 +13,7 @@
 
 @synthesize additionalAPIParameters = _additionalAPIParameters;
 
-+ (STPPaymentMethodParams *)cardParamsWithCard:(STPPaymentMethodCardParams *)card billingDetails:(STPPaymentMethodBillingDetails *)billingDetails metadata:(NSDictionary<NSString *,NSString *> *)metadata {
++ (STPPaymentMethodParams *)paramsWithCard:(STPPaymentMethodCardParams *)card billingDetails:(STPPaymentMethodBillingDetails *)billingDetails metadata:(NSDictionary<NSString *,NSString *> *)metadata {
     STPPaymentMethodParams *params = [STPPaymentMethodParams new];
     params.type = STPPaymentMethodParamsTypeCard;
     params.card = card;

--- a/Stripe/STPPaymentMethodParams.m
+++ b/Stripe/STPPaymentMethodParams.m
@@ -27,7 +27,6 @@
 }
 
 - (void)setType:(STPPaymentMethodType)type {
-    // If setting unknown and we're already unknown, don't want to override raw value
     if (type != self.type) {
         self.rawTypeString = [STPPaymentMethod stringFromType:type];
     }

--- a/Stripe/STPSourceParams.m
+++ b/Stripe/STPSourceParams.m
@@ -40,7 +40,7 @@
 }
 
 - (void)setType:(STPSourceType)type {
-    // If setting unknown and we're already unknown, don't want to override raw value
+    NSCAssert(type != STPSourceTypeUnknown, @"Set the rawTypeString directly instead, and `type` will have the appropriate value");
     if (type != self.type) {
         self.rawTypeString = [STPSource stringFromType:type];
     }

--- a/Stripe/STPSourceParams.m
+++ b/Stripe/STPSourceParams.m
@@ -40,7 +40,7 @@
 }
 
 - (void)setType:(STPSourceType)type {
-    NSCAssert(type != STPSourceTypeUnknown, @"Set the rawTypeString directly instead, and `type` will have the appropriate value");
+    // If setting unknown and we're already unknown, don't want to override raw value
     if (type != self.type) {
         self.rawTypeString = [STPSource stringFromType:type];
     }

--- a/Tests/Tests/STPPaymentMethodFunctionalTest.m
+++ b/Tests/Tests/STPPaymentMethodFunctionalTest.m
@@ -48,7 +48,7 @@
     STPPaymentMethodParams *params = [STPPaymentMethodParams paramsWithCard:card
                                                                  billingDetails:billingDetails
                                                                        metadata:@{@"test_key": @"test_value"}];
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Payment Method retrieve"];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Payment Method create"];
     [client createPaymentMethodWithParams:params
                                completion:^(STPPaymentMethod *paymentMethod, NSError *error) {
                                    XCTAssertNil(error);

--- a/Tests/Tests/STPPaymentMethodFunctionalTest.m
+++ b/Tests/Tests/STPPaymentMethodFunctionalTest.m
@@ -26,8 +26,8 @@
     STPAPIClient *client = [[STPAPIClient alloc] initWithPublishableKey:@"pk_test_vOo1umqsYxSrP5UXfOeL3ecm"];
     STPPaymentMethodCardParams *card = [STPPaymentMethodCardParams new];
     card.number = @"4242424242424242";
-    card.expMonth = @"10";
-    card.expYear = @"2022";
+    card.expMonth = 10;
+    card.expYear = 2022;
     card.cvc = @"100";
     
     STPPaymentMethodBillingDetailsAddress *billingAddress = [STPPaymentMethodBillingDetailsAddress new];
@@ -45,7 +45,7 @@
     billingDetails.phone = @"555-555-5555";
     
     
-    STPPaymentMethodParams *params = [STPPaymentMethodParams cardParamsWithCard:card
+    STPPaymentMethodParams *params = [STPPaymentMethodParams paramsWithCard:card
                                                                  billingDetails:billingDetails
                                                                        metadata:@{@"test_key": @"test_value"}];
     XCTestExpectation *expectation = [self expectationWithDescription:@"Payment Method retrieve"];
@@ -53,7 +53,7 @@
                                completion:^(STPPaymentMethod *paymentMethod, NSError *error) {
                                    XCTAssertNil(error);
                                    XCTAssertNotNil(paymentMethod);
-                                   XCTAssertEqualObjects(paymentMethod.identifier, @"pm_1EBSEWBbvEcIpqUbBHBUkXgQ");
+                                   XCTAssertEqualObjects(paymentMethod.stripeId, @"pm_1EBSEWBbvEcIpqUbBHBUkXgQ");
                                    XCTAssertEqualObjects(paymentMethod.created, [NSDate dateWithTimeIntervalSince1970:1551988224]);
                                    XCTAssertFalse(paymentMethod.liveMode);
                                    XCTAssertEqualObjects(paymentMethod.type, @"card");
@@ -73,10 +73,10 @@
                                    XCTAssertEqualObjects(paymentMethod.billingDetails.address.postalCode, @"94103");
                                    
                                    // Card
-                                   XCTAssertEqualObjects(paymentMethod.card.brand, @"visa");
-                                   XCTAssertEqualObjects(paymentMethod.card.checks.cvcCheck, @"unchecked");
-                                   XCTAssertEqualObjects(paymentMethod.card.checks.addressLine1Check, @"unchecked");
-                                   XCTAssertEqualObjects(paymentMethod.card.checks.addressPostalCodeCheck, @"unchecked");
+                                   XCTAssertEqual(paymentMethod.card.brand, STPCardBrandVisa);
+                                   XCTAssertEqual(paymentMethod.card.checks.cvcCheck, STPPaymentMethodCardCheckResultUnchecked);
+                                   XCTAssertEqual(paymentMethod.card.checks.addressLine1Check, STPPaymentMethodCardCheckResultUnchecked);
+                                   XCTAssertEqual(paymentMethod.card.checks.addressPostalCodeCheck, STPPaymentMethodCardCheckResultUnchecked);
                                    XCTAssertEqualObjects(paymentMethod.card.country, @"US");
                                    XCTAssertEqual(paymentMethod.card.expMonth, 10);
                                    XCTAssertEqual(paymentMethod.card.expYear, 2022);

--- a/Tests/Tests/STPPaymentMethodFunctionalTest.m
+++ b/Tests/Tests/STPPaymentMethodFunctionalTest.m
@@ -56,7 +56,7 @@
                                    XCTAssertEqualObjects(paymentMethod.stripeId, @"pm_1EBSEWBbvEcIpqUbBHBUkXgQ");
                                    XCTAssertEqualObjects(paymentMethod.created, [NSDate dateWithTimeIntervalSince1970:1551988224]);
                                    XCTAssertFalse(paymentMethod.liveMode);
-                                   XCTAssertEqualObjects(paymentMethod.type, @"card");
+                                   XCTAssertEqual(paymentMethod.type, STPPaymentMethodTypeCard);
                                    XCTAssertEqualObjects(paymentMethod.metadata, @{@"test_key": @"test_value"});
                                    
                                    // Billing Details

--- a/Tests/Tests/STPPaymentMethodFunctionalTest.m
+++ b/Tests/Tests/STPPaymentMethodFunctionalTest.m
@@ -1,0 +1,92 @@
+//
+//  STPPaymentMethodFunctionalTest.m
+//  StripeiOS Tests
+//
+//  Created by Yuki Tokuhiro on 3/6/19.
+//  Copyright © 2019 Stripe, Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "STPNetworkStubbingTestCase.h"
+
+@import Stripe;
+
+@interface STPPaymentMethodFunctionalTest : STPNetworkStubbingTestCase
+
+@end
+
+@implementation STPPaymentMethodFunctionalTest
+
+- (void)setUp {
+//    self.recordingMode = YES;
+    [super setUp];
+}
+
+- (void)testCreatePaymentMethod {
+    STPAPIClient *client = [[STPAPIClient alloc] initWithPublishableKey:@"pk_test_vOo1umqsYxSrP5UXfOeL3ecm"];
+    STPPaymentMethodCardParams *card = [STPPaymentMethodCardParams new];
+    card.number = @"4242424242424242";
+    card.expMonth = @"10";
+    card.expYear = @"2022";
+    card.cvc = @"100";
+    
+    STPPaymentMethodBillingDetailsAddress *billingAddress = [STPPaymentMethodBillingDetailsAddress new];
+    billingAddress.city = @"San Francisco";
+    billingAddress.country = @"United States";
+    billingAddress.line1 = @"150 Townsend St";
+    billingAddress.line2 = @"4th Floor";
+    billingAddress.postalCode = @"94103";
+    billingAddress.state = @"CA";
+    
+    STPPaymentMethodBillingDetails *billingDetails = [STPPaymentMethodBillingDetails new];
+    billingDetails.address = billingAddress;
+    billingDetails.email = @"email@email.com";
+    billingDetails.name = @"Isaac Asimov";
+    billingDetails.phone = @"555-555-5555";
+    
+    
+    STPPaymentMethodParams *params = [STPPaymentMethodParams cardParamsWithCard:card
+                                                                 billingDetails:billingDetails
+                                                                       metadata:@{@"test_key": @"test_value"}];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Payment Method retrieve"];
+    [client createPaymentMethodWithParams:params
+                               completion:^(STPPaymentMethod *paymentMethod, NSError *error) {
+                                   XCTAssertNil(error);
+                                   XCTAssertNotNil(paymentMethod);
+                                   XCTAssertEqualObjects(paymentMethod.identifier, @"pm_1EBSEWBbvEcIpqUbBHBUkXgQ");
+                                   XCTAssertEqualObjects(paymentMethod.created, [NSDate dateWithTimeIntervalSince1970:1551988224]);
+                                   XCTAssertFalse(paymentMethod.liveMode);
+                                   XCTAssertEqualObjects(paymentMethod.type, @"card");
+                                   XCTAssertEqualObjects(paymentMethod.metadata, @{@"test_key": @"test_value"});
+                                   
+                                   // Billing Details
+                                   XCTAssertEqualObjects(paymentMethod.billingDetails.email, @"email@email.com");
+                                   XCTAssertEqualObjects(paymentMethod.billingDetails.name, @"Isaac Asimov");
+                                   XCTAssertEqualObjects(paymentMethod.billingDetails.phone, @"555-555-5555");
+                                   
+                                   // Billing Details Address
+                                   XCTAssertEqualObjects(paymentMethod.billingDetails.address.line1, @"150 Townsend St");
+                                   XCTAssertEqualObjects(paymentMethod.billingDetails.address.line2, @"4th Floor");
+                                   XCTAssertEqualObjects(paymentMethod.billingDetails.address.city, @"San Francisco");
+                                   XCTAssertEqualObjects(paymentMethod.billingDetails.address.country, @"United States");
+                                   XCTAssertEqualObjects(paymentMethod.billingDetails.address.state, @"CA");
+                                   XCTAssertEqualObjects(paymentMethod.billingDetails.address.postalCode, @"94103");
+                                   
+                                   // Card
+                                   XCTAssertEqualObjects(paymentMethod.card.brand, @"visa");
+                                   XCTAssertEqualObjects(paymentMethod.card.checks.cvcCheck, @"unchecked");
+                                   XCTAssertEqualObjects(paymentMethod.card.checks.addressLine1Check, @"unchecked");
+                                   XCTAssertEqualObjects(paymentMethod.card.checks.addressPostalCodeCheck, @"unchecked");
+                                   XCTAssertEqualObjects(paymentMethod.card.country, @"US");
+                                   XCTAssertEqual(paymentMethod.card.expMonth, 10);
+                                   XCTAssertEqual(paymentMethod.card.expYear, 2022);
+                                   XCTAssertEqualObjects(paymentMethod.card.funding, @"credit");
+                                   XCTAssertEqualObjects(paymentMethod.card.last4, @"4242");
+                                   XCTAssertTrue(paymentMethod.card.threeDSecureUsage.supported);
+                                   [expectation fulfill];
+                               }];
+
+    [self waitForExpectationsWithTimeout:5 handler:nil];
+}
+
+@end

--- a/Tests/Tests/STPPaymentMethodParamsTest.m
+++ b/Tests/Tests/STPPaymentMethodParamsTest.m
@@ -1,0 +1,43 @@
+//
+//  STPPaymentMethodParamsTest.m
+//  StripeiOS Tests
+//
+//  Created by Yuki Tokuhiro on 3/7/19.
+//  Copyright © 2019 Stripe, Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "STPPaymentMethodParams.h"
+
+@interface STPPaymentMethodParamsTest : XCTestCase
+
+@end
+
+@implementation STPPaymentMethodParamsTest
+
+#pragma mark STPFormEncodable Tests
+
+- (void)testRootObjectName {
+    XCTAssertNil([STPPaymentMethodParams rootObjectName]);
+}
+
+- (void)testPropertyNamesToFormFieldNamesMapping {
+    STPPaymentMethodParams *params = [STPPaymentMethodParams new];
+    
+    NSDictionary *mapping = [STPPaymentMethodParams propertyNamesToFormFieldNamesMapping];
+    
+    for (NSString *propertyName in [mapping allKeys]) {
+        XCTAssertFalse([propertyName containsString:@":"]);
+        XCTAssert([params respondsToSelector:NSSelectorFromString(propertyName)]);
+    }
+    
+    for (NSString *formFieldName in [mapping allValues]) {
+        XCTAssert([formFieldName isKindOfClass:[NSString class]]);
+        XCTAssert([formFieldName length] > 0);
+    }
+    
+    XCTAssertEqual([[mapping allValues] count], [[NSSet setWithArray:[mapping allValues]] count]);
+}
+
+@end

--- a/Tests/Tests/STPPaymentMethodTest.m
+++ b/Tests/Tests/STPPaymentMethodTest.m
@@ -8,7 +8,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import "STPPaymentMethod.h"
+#import "STPPaymentMethod+Private.h"
 #import "STPTestUtils.h"
 #import "STPFixtures.h"
 
@@ -17,6 +17,35 @@
 @end
 
 @implementation STPPaymentMethodTest
+
+#pragma mark - STPPaymentMethodType Tests
+
+- (void)testTypeFromString {
+    XCTAssertEqual([STPPaymentMethod typeFromString:@"card"], STPPaymentMethodTypeCard);
+    XCTAssertEqual([STPPaymentMethod typeFromString:@"CARD"], STPPaymentMethodTypeCard);
+    XCTAssertEqual([STPPaymentMethod typeFromString:@"unknown_string"], STPPaymentMethodTypeUnknown);
+}
+
+- (void)testStringFromType {
+    NSArray<NSNumber *> *values = @[
+                                    @(STPPaymentMethodTypeCard),
+                                    @(STPPaymentMethodTypeUnknown),
+                                    ];
+    for (NSNumber *typeNumber in values) {
+        STPPaymentMethodType type = (STPPaymentMethodType)[typeNumber integerValue];
+        NSString *string = [STPPaymentMethod stringFromType:type];
+        
+        switch (type) {
+            case STPPaymentMethodTypeCard:
+                XCTAssertEqualObjects(string, @"card");
+                break;
+            case STPPaymentMethodTypeUnknown:
+                XCTAssertNil(string);
+                break;
+        }
+    }
+}
+
 
 #pragma mark - STPAPIResponseDecodable Tests
 
@@ -44,7 +73,7 @@
     XCTAssertEqualObjects(paymentMethod.stripeId, @"pm_123456789");
     XCTAssertEqualObjects(paymentMethod.created, [NSDate dateWithTimeIntervalSince1970:123456789]);
     XCTAssertEqual(paymentMethod.liveMode, NO);
-    XCTAssertEqualObjects(paymentMethod.type, @"card");
+    XCTAssertEqual(paymentMethod.type, STPPaymentMethodTypeCard);
     XCTAssertNotNil(paymentMethod.billingDetails);
     XCTAssertNotNil(paymentMethod.card);
     XCTAssertNil(paymentMethod.customerId);

--- a/Tests/recorded_network_traffic/STPPaymentMethodFunctionalTest/testCreatePaymentMethod/post_v1_payment_methods_0.tail
+++ b/Tests/recorded_network_traffic/STPPaymentMethodFunctionalTest/testCreatePaymentMethod/post_v1_payment_methods_0.tail
@@ -1,0 +1,60 @@
+POST
+/v1/payment_methods$
+200
+application/json
+Content-Type: application/json
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Methods: GET, POST, HEAD, OPTIONS, DELETE
+Server: nginx
+Access-Control-Expose-Headers: Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+Access-Control-Max-Age: 300
+Cache-Control: no-cache, no-store
+Date: Thu, 07 Mar 2019 19:50:24 GMT
+Stripe-Version: 2015-10-12
+Access-Control-Allow-Credentials: true
+Content-Length: 895
+Connection: keep-alive
+Strict-Transport-Security: max-age=31556926; includeSubDomains; preload
+Request-Id: req_uf29STbAxtVqtU
+
+{
+  "object" : "payment_method",
+  "id" : "pm_1EBSEWBbvEcIpqUbBHBUkXgQ",
+  "billing_details" : {
+    "email" : "email@email.com",
+    "phone" : "555-555-5555",
+    "name" : "Isaac Asimov",
+    "address" : {
+      "state" : "CA",
+      "country" : "United States",
+      "line2" : "4th Floor",
+      "city" : "San Francisco",
+      "line1" : "150 Townsend St",
+      "postal_code" : "94103"
+    }
+  },
+  "card" : {
+    "checks" : {
+      "address_postal_code_check" : "unchecked",
+      "cvc_check" : "unchecked",
+      "address_line1_check" : "unchecked"
+    },
+    "exp_month" : 10,
+    "country" : "US",
+    "funding" : "credit",
+    "wallet" : null,
+    "brand" : "visa",
+    "last4" : "4242",
+    "three_d_secure_usage" : {
+      "supported" : true
+    },
+    "exp_year" : 2022
+  },
+  "livemode" : false,
+  "created" : 1551988224,
+  "type" : "card",
+  "customer" : null,
+  "metadata" : {
+    "test_key" : "test_value"
+  }
+}


### PR DESCRIPTION
## Summary
Add `createPaymentMethod...` method to `STPAPIClient`

## Motivation
We're adding support for PaymentMethods!

## Testing
Added a unit test for STPPaymentMethodParams
Added a functional test that exercises `createPaymentMethod`