### PR TITLE
Add PaymentMethod to PaymentIntentParams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   * Renames `STPPaymentMethodsViewController` to `STPPaymentOptionsViewController`
   * Renames all properties, methods, comments referencing 'PaymentMethod' to 'PaymentOption'
 * Adds `[STPAPI createPaymentMethodWithParams:completion:]`, which creates a PaymentMethod.
-* Adds paymentMethod, paymentMethodId to STPPaymentIntentParams
+* Adds paymentMethodParams, paymentMethodId to STPPaymentIntentParams.
 * Deprecates `saveSourceToCustomer` on `STPPaymentIntentParams`, replaced by `savePaymentMethod`
 
 ## 14.0.0 2018-11-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   * Renames `STPPaymentMethodsViewController` to `STPPaymentOptionsViewController`
   * Renames all properties, methods, comments referencing 'PaymentMethod' to 'PaymentOption'
 * Adds `[STPAPI createPaymentMethodWithParams:completion:]`, which creates a PaymentMethod.
+* Adds paymentMethod, paymentMethodId to STPPaymentIntentParams
+* Deprecates `saveSourceToCustomer` on `STPPaymentIntentParams`, replaced by `savePaymentMethod`
 
 ## 14.0.0 2018-11-14
 * Changes `STPPaymentCardTextField`, which now copies the `cardParams` property. See [MIGRATING.md](/MIGRATING.md) for more details. [#1031](https://github.com/stripe/stripe-ios/pull/1031)

--- a/Stripe/PublicHeaders/STPPaymentIntent.h
+++ b/Stripe/PublicHeaders/STPPaymentIntent.h
@@ -97,6 +97,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nullable, readonly) NSString *sourceId;
 
 /**
+ The Stripe ID of the PaymentMethod used in this PaymentIntent.
+ */
+@property (nonatomic, nullable, readonly) NSString *paymentMethodId;
+
+/**
  Status of the PaymentIntent
  */
 @property (nonatomic, readonly) STPPaymentIntentStatus status;

--- a/Stripe/PublicHeaders/STPPaymentIntentParams.h
+++ b/Stripe/PublicHeaders/STPPaymentIntentParams.h
@@ -12,17 +12,17 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class STPSourceParams;
+@class STPSourceParams, STPPaymentMethodParams;
 
 /**
  An object representing parameters used to confirm a PaymentIntent object.
 
- A PaymentIntent must have a Source associated in order to successfully confirm it.
+ A PaymentIntent must have a PaymentMethod or Source associated in order to successfully confirm it.
 
- That Source can either be:
+ That PaymentMethod or Source can either be:
 
- - created during confirmation, by passing in a `STPSourceParams` object in the `sourceParams` field
- - a pre-existing Source can be associated by passing its id in the `sourceId` field
+ - created during confirmation, by passing in a `STPPaymentMethodParams` or `STPSourceParams` object in the `paymentMethodParams` or `sourceParams` field
+ - a pre-existing PaymentMethod or Source can be associated by passing its id in the `paymentMethodId` or `sourceId` field
  - or already set via your backend, either when creating or updating the PaymentIntent
 
  @see https://stripe.com/docs/api#confirm_payment_intent
@@ -48,6 +48,21 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, readwrite) NSString *clientSecret;
 
 /**
+ Provide a supported `STPPaymentMethodParams` object, and Stripe will create a
+ PaymentMethod during PaymentIntent confirmation.
+ 
+ @note alternative to `paymentMethodId`
+ */
+@property (nonatomic, strong, nullable, readwrite) STPPaymentMethodParams *paymentMethodParams;
+
+/**
+ Provide an already created PaymentMethod's id, and it will be used to confirm the PaymentIntent.
+ 
+ @note alternative to `paymentMethodParams`
+ */
+@property (nonatomic, copy, nullable, readwrite) NSString *paymentMethodId;
+
+/**
  Provide a supported `STPSourceParams` object into here, and Stripe will create a Source
  during PaymentIntent confirmation.
 
@@ -68,12 +83,12 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable, readwrite) NSString *receiptEmail;
 
 /**
- `@YES` to save this PaymentIntent’s Source to the associated Customer,
- if the Source is not already attached.
-
+ `@YES` to save this PaymentIntent’s PaymentMethod or Source to the associated Customer,
+ if the PaymentMethod/Source is not already attached.
+ 
  This should be a boolean NSNumber, so that it can be `nil`
  */
-@property (nonatomic, strong, nullable, readwrite) NSNumber *saveSourceToCustomer;
+@property (nonatomic, strong, nullable, readwrite) NSNumber *savePaymentMethod;
 
 /**
  The URL to redirect your customer back to after they authenticate or cancel
@@ -89,6 +104,17 @@ NS_ASSUME_NONNULL_BEGIN
  This property has been renamed to `returnURL` and deprecated.
  */
 @property (nonatomic, copy, nullable, readwrite) NSString *returnUrl __attribute__((deprecated("returnUrl has been renamed to returnURL", "returnURL")));
+
+
+/**
+ `@YES` to save this PaymentIntent’s Source to the associated Customer,
+ if the Source is not already attached.
+ 
+ This should be a boolean NSNumber, so that it can be `nil`
+ 
+ This property has been renamed to `savePaymentMethodToCustomer` and deprecated.
+ */
+@property (nonatomic, strong, nullable, readwrite) NSNumber *saveSourceToCustomer __attribute__((deprecated("saveSourceToCustomer has been renamed to savePaymentMethod", "saveSourceToCustomer")));
 
 @end
 

--- a/Stripe/PublicHeaders/STPPaymentIntentParams.h
+++ b/Stripe/PublicHeaders/STPPaymentIntentParams.h
@@ -45,7 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  The client secret of the PaymentIntent. Required
  */
-@property (nonatomic, copy, readwrite) NSString *clientSecret;
+@property (nonatomic, copy) NSString *clientSecret;
 
 /**
  Provide a supported `STPPaymentMethodParams` object, and Stripe will create a
@@ -53,14 +53,14 @@ NS_ASSUME_NONNULL_BEGIN
  
  @note alternative to `paymentMethodId`
  */
-@property (nonatomic, strong, nullable, readwrite) STPPaymentMethodParams *paymentMethodParams;
+@property (nonatomic, strong, nullable) STPPaymentMethodParams *paymentMethodParams;
 
 /**
  Provide an already created PaymentMethod's id, and it will be used to confirm the PaymentIntent.
  
  @note alternative to `paymentMethodParams`
  */
-@property (nonatomic, copy, nullable, readwrite) NSString *paymentMethodId;
+@property (nonatomic, copy, nullable) NSString *paymentMethodId;
 
 /**
  Provide a supported `STPSourceParams` object into here, and Stripe will create a Source
@@ -68,19 +68,19 @@ NS_ASSUME_NONNULL_BEGIN
 
  @note alternative to `sourceId`
  */
-@property (nonatomic, strong, nullable, readwrite) STPSourceParams *sourceParams;
+@property (nonatomic, strong, nullable) STPSourceParams *sourceParams;
 
 /**
  Provide an already created Source's id, and it will be used to confirm the PaymentIntent.
 
  @note alternative to `sourceParams`
  */
-@property (nonatomic, copy, nullable, readwrite) NSString *sourceId;
+@property (nonatomic, copy, nullable) NSString *sourceId;
 
 /**
  Email address that the receipt for the resulting payment will be sent to.
  */
-@property (nonatomic, copy, nullable, readwrite) NSString *receiptEmail;
+@property (nonatomic, copy, nullable) NSString *receiptEmail;
 
 /**
  `@YES` to save this PaymentIntent’s PaymentMethod or Source to the associated Customer,
@@ -88,14 +88,14 @@ NS_ASSUME_NONNULL_BEGIN
  
  This should be a boolean NSNumber, so that it can be `nil`
  */
-@property (nonatomic, strong, nullable, readwrite) NSNumber *savePaymentMethod;
+@property (nonatomic, strong, nullable) NSNumber *savePaymentMethod;
 
 /**
  The URL to redirect your customer back to after they authenticate or cancel
  their payment on the payment method’s app or site.
  This should probably be a URL that opens your iOS app.
  */
-@property (nonatomic, copy, nullable, readwrite) NSString *returnURL;
+@property (nonatomic, copy, nullable) NSString *returnURL;
 
 /**
  The URL to redirect your customer back to after they authenticate or cancel
@@ -103,7 +103,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  This property has been renamed to `returnURL` and deprecated.
  */
-@property (nonatomic, copy, nullable, readwrite) NSString *returnUrl __attribute__((deprecated("returnUrl has been renamed to returnURL", "returnURL")));
+@property (nonatomic, copy, nullable) NSString *returnUrl __attribute__((deprecated("returnUrl has been renamed to returnURL", "returnURL")));
 
 
 /**
@@ -112,9 +112,9 @@ NS_ASSUME_NONNULL_BEGIN
  
  This should be a boolean NSNumber, so that it can be `nil`
  
- This property has been renamed to `savePaymentMethodToCustomer` and deprecated.
+ This property has been renamed to `savePaymentMethod` and deprecated.
  */
-@property (nonatomic, strong, nullable, readwrite) NSNumber *saveSourceToCustomer __attribute__((deprecated("saveSourceToCustomer has been renamed to savePaymentMethod", "saveSourceToCustomer")));
+@property (nonatomic, strong, nullable) NSNumber *saveSourceToCustomer __attribute__((deprecated("saveSourceToCustomer has been renamed to savePaymentMethod", "saveSourceToCustomer")));
 
 @end
 

--- a/Stripe/STPPaymentIntent.m
+++ b/Stripe/STPPaymentIntent.m
@@ -26,6 +26,7 @@
 @property (nonatomic, strong, nullable, readwrite) STPPaymentIntentSourceAction* nextSourceAction;
 @property (nonatomic, copy, nullable, readwrite) NSString *receiptEmail;
 @property (nonatomic, copy, nullable, readwrite) NSString *sourceId;
+@property (nonatomic, copy, nullable, readwrite) NSString *paymentMethodId;
 @property (nonatomic, assign, readwrite) STPPaymentIntentStatus status;
 
 @property (nonatomic, copy, nonnull, readwrite) NSDictionary *allResponseFields;
@@ -52,6 +53,7 @@
                        [NSString stringWithFormat:@"description = %@", self.stripeDescription],
                        [NSString stringWithFormat:@"livemode = %@", self.livemode ? @"YES" : @"NO"],
                        [NSString stringWithFormat:@"nextSourceAction = %@", self.nextSourceAction],
+                       [NSString stringWithFormat:@"paymentMethodId = %@", self.paymentMethodId],
                        [NSString stringWithFormat:@"receiptEmail = %@", self.receiptEmail],
                        [NSString stringWithFormat:@"shipping = %@", self.allResponseFields[@"shipping"]],
                        [NSString stringWithFormat:@"sourceId = %@", self.sourceId],
@@ -174,6 +176,7 @@
     paymentIntent.receiptEmail = [dict stp_stringForKey:@"receipt_email"];
     // FIXME: add support for `shipping`
     paymentIntent.sourceId = [dict stp_stringForKey:@"source"];
+    paymentIntent.paymentMethodId = [dict stp_stringForKey:@"payment_method"];
     paymentIntent.status = [[self class] statusFromString:rawStatus];
 
     paymentIntent.allResponseFields = dict;

--- a/Stripe/STPPaymentIntentParams.m
+++ b/Stripe/STPPaymentIntentParams.m
@@ -43,9 +43,15 @@
                        [NSString stringWithFormat:@"clientSecret = %@", (self.clientSecret.length > 0) ? @"<redacted>" : @""],
                        [NSString stringWithFormat:@"receiptEmail = %@", self.receiptEmail],
                        [NSString stringWithFormat:@"returnURL = %@", self.returnURL],
-                       [NSString stringWithFormat:@"saveSourceToCustomer = %@", (self.saveSourceToCustomer.boolValue) ? @"YES" : @"NO"],
+                       [NSString stringWithFormat:@"savePaymentMethod = %@", (self.savePaymentMethod.boolValue) ? @"YES" : @"NO"],
+
+                       // Source
                        [NSString stringWithFormat:@"sourceId = %@", self.sourceId],
                        [NSString stringWithFormat:@"sourceParams = %@", self.sourceParams],
+                       
+                       // PaymentMethod
+                       [NSString stringWithFormat:@"paymentMethodId = %@", self.paymentMethodId],
+                       [NSString stringWithFormat:@"paymentMethodParams = %@", self.paymentMethodParams],
 
                        // Additional params set by app
                        [NSString stringWithFormat:@"additionalAPIParameters = %@", self.additionalAPIParameters],
@@ -64,6 +70,14 @@
     self.returnURL = returnUrl;
 }
 
+- (NSNumber *)saveSourceToCustomer {
+    return self.savePaymentMethod;
+}
+
+- (void)setSaveSourceToCustomer:(NSNumber *)saveSourceToCustomer {
+    self.savePaymentMethod = saveSourceToCustomer;
+}
+
 #pragma mark - STPFormEncodable
 
 + (nullable NSString *)rootObjectName {
@@ -73,10 +87,12 @@
 + (nonnull NSDictionary *)propertyNamesToFormFieldNamesMapping {
     return @{
              NSStringFromSelector(@selector(clientSecret)): @"client_secret",
+             NSStringFromSelector(@selector(paymentMethodParams)): @"payment_method_data",
+             NSStringFromSelector(@selector(paymentMethodId)): @"payment_method",
              NSStringFromSelector(@selector(sourceParams)): @"source_data",
              NSStringFromSelector(@selector(sourceId)): @"source",
              NSStringFromSelector(@selector(receiptEmail)): @"receipt_email",
-             NSStringFromSelector(@selector(saveSourceToCustomer)): @"save_source_to_customer",
+             NSStringFromSelector(@selector(savePaymentMethod)): @"save_payment_method",
              NSStringFromSelector(@selector(returnURL)): @"return_url",
              };
 }

--- a/Tests/Tests/STPPaymentIntentFunctionalTest.m
+++ b/Tests/Tests/STPPaymentIntentFunctionalTest.m
@@ -109,7 +109,7 @@
 
 #pragma mark - Disabled Tests
 /*
- These tests exists so that you can manually plug in an id + secret and verify that confirming a PaymentIntent
+ These tests exist so that you can manually plug in an id + secret and verify that confirming a PaymentIntent
  succeeds, as a one time thing.
 
  These are disabled because we don't have an automatic method for creating PaymentIntents, but you can create one using

--- a/Tests/Tests/STPPaymentIntentParamsTest.m
+++ b/Tests/Tests/STPPaymentIntentParamsTest.m
@@ -29,7 +29,11 @@
         XCTAssertNil(params.sourceParams);
         XCTAssertNil(params.sourceId);
         XCTAssertNil(params.receiptEmail);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
         XCTAssertNil(params.saveSourceToCustomer);
+#pragma clang diagnostic pop
+        XCTAssertNil(params.savePaymentMethod);
         XCTAssertNil(params.returnURL);
     }
 }
@@ -55,6 +59,19 @@
 
     params.returnUrl = @"set via old name";
     XCTAssertEqualObjects(params.returnURL, @"set via old name");
+}
+
+- (void)testSaveSourceToCustomerRenaming {
+    STPPaymentIntentParams *params = [[STPPaymentIntentParams alloc] init];
+    
+    XCTAssertNil(params.saveSourceToCustomer);
+    XCTAssertNil(params.savePaymentMethod);
+    
+    params.savePaymentMethod = @NO;
+    XCTAssertEqualObjects(params.saveSourceToCustomer, @NO);
+    
+    params.saveSourceToCustomer = @YES;
+    XCTAssertEqualObjects(params.savePaymentMethod, @YES);
 }
 
 #pragma clang diagnostic pop

--- a/Tests/Tests/STPPaymentMethodFunctionalTest.m
+++ b/Tests/Tests/STPPaymentMethodFunctionalTest.m
@@ -23,7 +23,7 @@
 }
 
 - (void)testCreatePaymentMethod {
-    STPAPIClient *client = [[STPAPIClient alloc] initWithPublishableKey:@"pk_test_vOo1umqsYxSrP5UXfOeL3ecm"];
+    STPAPIClient *client = [[STPAPIClient alloc] initWithPublishableKey:@"pk_test_dCyfhfyeO2CZkcvT5xyIDdJj"];
     STPPaymentMethodCardParams *card = [STPPaymentMethodCardParams new];
     card.number = @"4242424242424242";
     card.expMonth = 10;

--- a/Tests/recorded_network_traffic/STPPaymentIntentFunctionalTest/testConfirmCanceledPaymentIntentFails/post_v1_payment_intents_pi_1ChlnaIl4IdHmuTbVnM2HCCf_confirm_0.tail
+++ b/Tests/recorded_network_traffic/STPPaymentIntentFunctionalTest/testConfirmCanceledPaymentIntentFails/post_v1_payment_intents_pi_1ChlnaIl4IdHmuTbVnM2HCCf_confirm_0.tail
@@ -9,18 +9,18 @@ Server: nginx
 Access-Control-Expose-Headers: Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
 Access-Control-Max-Age: 300
 Cache-Control: no-cache, no-store
-Date: Sun, 25 Nov 2018 07:34:38 GMT
+Date: Fri, 08 Mar 2019 00:50:08 GMT
 Stripe-Version: 2015-10-12
 Access-Control-Allow-Credentials: true
-Content-Length: 1220
+Content-Length: 1322
 Connection: keep-alive
 Strict-Transport-Security: max-age=31556926; includeSubDomains; preload
-Request-Id: req_NgRyl8xusf23qu
+Request-Id: req_yrV1xBfpdj0kOF
 
 {
   "error" : {
     "code" : "payment_intent_unexpected_state",
-    "message" : "This PaymentIntent could not be updated because it has a status of canceled. Only a PaymentIntent with one of the following statuses may be updated: requires_source, requires_confirmation, requires_source_action, requires_capture.",
+    "message" : "This PaymentIntent's source could not be updated because it has a status of canceled. You may only update the source of a PaymentIntent with one of the following statuses: requires_payment_method, requires_confirmation.",
     "payment_intent" : {
       "next_source_action" : null,
       "source" : null,
@@ -34,7 +34,9 @@ Request-Id: req_NgRyl8xusf23qu
       "currency" : "usd",
       "last_payment_error" : null,
       "cancellation_reason" : null,
+      "next_action" : null,
       "return_url" : "payments-example:\/\/stripe-redirect",
+      "payment_method" : null,
       "client_secret" : "pi_1ChlnaIl4IdHmuTbVnM2HCCf_secret_0T6n3wuf21l04Jun2ZCOB8rOZ",
       "id" : "pi_1ChlnaIl4IdHmuTbVnM2HCCf",
       "allowed_source_types" : [
@@ -42,6 +44,9 @@ Request-Id: req_NgRyl8xusf23qu
       ],
       "confirmation_method" : "publishable",
       "receipt_email" : null,
+      "payment_method_types" : [
+        "card"
+      ],
       "created" : 1530137258,
       "description" : "Example PaymentIntent charge"
     },

--- a/Tests/recorded_network_traffic/STPPaymentIntentFunctionalTest/testRetrieveMismatchedPublishableKey/get_v1_payment_intents_pi_1ChlnaIl4IdHmuTbVnM2HCCf_0.tail
+++ b/Tests/recorded_network_traffic/STPPaymentIntentFunctionalTest/testRetrieveMismatchedPublishableKey/get_v1_payment_intents_pi_1ChlnaIl4IdHmuTbVnM2HCCf_0.tail
@@ -9,18 +9,18 @@ Server: nginx
 Access-Control-Expose-Headers: Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
 Access-Control-Max-Age: 300
 Cache-Control: no-cache, no-store
-Date: Sun, 25 Nov 2018 07:34:38 GMT
+Date: Fri, 08 Mar 2019 00:50:08 GMT
 Stripe-Version: 2015-10-12
 Access-Control-Allow-Credentials: true
-Content-Length: 252
+Content-Length: 253
 Connection: keep-alive
 Strict-Transport-Security: max-age=31556926; includeSubDomains; preload
-Request-Id: req_BRINqNhDFkv8zd
+Request-Id: req_6tHuAm68N5m92I
 
 {
   "error" : {
     "code" : "resource_missing",
-    "message" : "No such paymentintent: pi_1ChlnaIl4IdHmuTbVnM2HCCf",
+    "message" : "No such payment_intent: pi_1ChlnaIl4IdHmuTbVnM2HCCf",
     "param" : "intent",
     "type" : "invalid_request_error",
     "doc_url" : "https:\/\/stripe.com\/docs\/error-codes\/resource-missing"

--- a/Tests/recorded_network_traffic/STPPaymentIntentFunctionalTest/testRetrievePreviousCreatedPaymentIntent/get_v1_payment_intents_pi_1ChlnaIl4IdHmuTbVnM2HCCf_0.tail
+++ b/Tests/recorded_network_traffic/STPPaymentIntentFunctionalTest/testRetrievePreviousCreatedPaymentIntent/get_v1_payment_intents_pi_1ChlnaIl4IdHmuTbVnM2HCCf_0.tail
@@ -9,13 +9,13 @@ Server: nginx
 Access-Control-Expose-Headers: Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
 Access-Control-Max-Age: 300
 Cache-Control: no-cache, no-store
-Date: Sun, 25 Nov 2018 07:34:38 GMT
+Date: Fri, 08 Mar 2019 00:50:08 GMT
 Stripe-Version: 2015-10-12
 Access-Control-Allow-Credentials: true
-Content-Length: 666
+Content-Length: 759
 Connection: keep-alive
 Strict-Transport-Security: max-age=31556926; includeSubDomains; preload
-Request-Id: req_kG4PviQlbWMTXt
+Request-Id: req_runuXHL1NGNQxC
 
 {
   "next_source_action" : null,
@@ -30,7 +30,9 @@ Request-Id: req_kG4PviQlbWMTXt
   "currency" : "usd",
   "last_payment_error" : null,
   "cancellation_reason" : null,
+  "next_action" : null,
   "return_url" : "payments-example:\/\/stripe-redirect",
+  "payment_method" : null,
   "client_secret" : "pi_1ChlnaIl4IdHmuTbVnM2HCCf_secret_0T6n3wuf21l04Jun2ZCOB8rOZ",
   "id" : "pi_1ChlnaIl4IdHmuTbVnM2HCCf",
   "allowed_source_types" : [
@@ -38,6 +40,9 @@ Request-Id: req_kG4PviQlbWMTXt
   ],
   "confirmation_method" : "publishable",
   "receipt_email" : null,
+  "payment_method_types" : [
+    "card"
+  ],
   "created" : 1530137258,
   "description" : "Example PaymentIntent charge"
 }

--- a/Tests/recorded_network_traffic/STPPaymentIntentFunctionalTest/testRetrieveWithWrongSecret/get_v1_payment_intents_pi_1ChlnaIl4IdHmuTbVnM2HCCf_0.tail
+++ b/Tests/recorded_network_traffic/STPPaymentIntentFunctionalTest/testRetrieveWithWrongSecret/get_v1_payment_intents_pi_1ChlnaIl4IdHmuTbVnM2HCCf_0.tail
@@ -9,13 +9,13 @@ Server: nginx
 Access-Control-Expose-Headers: Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
 Access-Control-Max-Age: 300
 Cache-Control: no-cache, no-store
-Date: Sun, 25 Nov 2018 07:34:38 GMT
+Date: Fri, 08 Mar 2019 00:50:09 GMT
 Stripe-Version: 2015-10-12
 Access-Control-Allow-Credentials: true
 Content-Length: 335
 Connection: keep-alive
 Strict-Transport-Security: max-age=31556926; includeSubDomains; preload
-Request-Id: req_SOlyOG0QqITuit
+Request-Id: req_cf7BKurhrRk5nk
 
 {
   "error" : {


### PR DESCRIPTION
## Summary
* Adds paymentMethod, paymentMethodId to STPPaymentIntentParams
* Deprecates `saveSourceToCustomer` on `STPPaymentIntentParams`, replaced by `savePaymentMethod`

## Motivation
Adding support for PaymentMethod

## Testing
Added another semi-manual test `disabled_testConfirmPaymentIntentWithCardPaymentMethodSucceeds` to STPPaymentIntentFunctionalTest and confirmed it passes with a manually created PaymentIntent.  