### PR TITLE
Adds paymentMethodTypes to PaymentIntent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   * Renames all properties, methods, comments referencing 'PaymentMethod' to 'PaymentOption'
 * Adds `[STPAPI createPaymentMethodWithParams:completion:]`, which creates a PaymentMethod.
 * Adds paymentMethodParams, paymentMethodId to STPPaymentIntentParams.
+* Adds paymentMethodTypes to STPPaymentIntent.
 * Deprecates `saveSourceToCustomer` on `STPPaymentIntentParams`, replaced by `savePaymentMethod`
 * Deprecates `STPPaymentIntentsStatusRequiresSource`, replaced by `STPPaymentIntentsStatusRequiresPaymentMethod`
 * Deprecates `STPPaymentIntentsStatusRequiresSourceAction`, replaced by `STPPaymentIntentsStatusRequiresAction`

--- a/Stripe/PublicHeaders/STPPaymentIntent.h
+++ b/Stripe/PublicHeaders/STPPaymentIntent.h
@@ -10,6 +10,7 @@
 
 #import "STPAPIResponseDecodable.h"
 #import "STPPaymentIntentEnums.h"
+#import "STPPaymentMethodEnums.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -105,6 +106,11 @@ NS_ASSUME_NONNULL_BEGIN
  Status of the PaymentIntent
  */
 @property (nonatomic, readonly) STPPaymentIntentStatus status;
+
+/**
+ The list of payment method types (e.g. `@[@(STPPaymentMethodTypeCard)]`) that this PaymentIntent is allowed to use.
+ */
+@property (nonatomic, nullable, readonly) NSArray<NSNumber *> *paymentMethodTypes;
 
 #pragma mark - Deprecated
 

--- a/Stripe/STPPaymentIntent.m
+++ b/Stripe/STPPaymentIntent.m
@@ -10,8 +10,10 @@
 #import "STPPaymentIntent+Private.h"
 #import "STPPaymentIntentSourceAction.h"
 #import "STPPaymentIntentAction.h"
+#import "STPPaymentMethod+Private.h"
 
 #import "NSDictionary+Stripe.h"
+#import "NSArray+Stripe.h"
 
 @interface STPPaymentIntent ()
 @property (nonatomic, copy, readwrite) NSString *stripeId;
@@ -29,6 +31,7 @@
 @property (nonatomic, copy, nullable, readwrite) NSString *sourceId;
 @property (nonatomic, copy, nullable, readwrite) NSString *paymentMethodId;
 @property (nonatomic, assign, readwrite) STPPaymentIntentStatus status;
+@property (nonatomic, copy, nullable, readwrite) NSArray<NSNumber *> *paymentMethodTypes;
 
 @property (nonatomic, copy, nonnull, readwrite) NSDictionary *allResponseFields;
 @end
@@ -55,6 +58,7 @@
                        [NSString stringWithFormat:@"livemode = %@", self.livemode ? @"YES" : @"NO"],
                        [NSString stringWithFormat:@"nextAction = %@", self.nextAction],
                        [NSString stringWithFormat:@"paymentMethodId = %@", self.paymentMethodId],
+                       [NSString stringWithFormat:@"paymentMethodTypes = %@", [self.allResponseFields stp_arrayForKey:@"payment_method_types"]],
                        [NSString stringWithFormat:@"receiptEmail = %@", self.receiptEmail],
                        [NSString stringWithFormat:@"shipping = %@", self.allResponseFields[@"shipping"]],
                        [NSString stringWithFormat:@"sourceId = %@", self.sourceId],
@@ -185,6 +189,10 @@
     // FIXME: add support for `shipping`
     paymentIntent.sourceId = [dict stp_stringForKey:@"source"];
     paymentIntent.paymentMethodId = [dict stp_stringForKey:@"payment_method"];
+    NSArray<NSString *> *rawPaymentMethodTypes = [[dict stp_arrayForKey:@"payment_method_types"] stp_arrayByRemovingNulls];
+    if (rawPaymentMethodTypes) {
+        paymentIntent.paymentMethodTypes = [STPPaymentMethod typesFromStrings:rawPaymentMethodTypes];
+    }
     paymentIntent.status = [[self class] statusFromString:rawStatus];
 
     paymentIntent.allResponseFields = dict;

--- a/Stripe/STPPaymentMethod+Private.h
+++ b/Stripe/STPPaymentMethod+Private.h
@@ -13,6 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface STPPaymentMethod ()
 
 + (STPPaymentMethodType)typeFromString:(NSString *)string;
++ (NSArray<NSNumber *> *)typesFromStrings:(NSArray<NSString *> *)strings;
 + (nullable NSString *)stringFromType:(STPPaymentMethodType)type;
 
 @end

--- a/Stripe/STPPaymentMethod.m
+++ b/Stripe/STPPaymentMethod.m
@@ -80,6 +80,14 @@
     return STPPaymentMethodTypeUnknown;
 }
 
++ (NSArray<NSNumber *> *)typesFromStrings:(NSArray<NSString *> *)strings {
+    NSMutableArray *types = [NSMutableArray new];
+    for (NSString *string in strings) {
+        [types addObject:@([STPPaymentMethod typeFromString:string])];
+    }
+    return [types copy];
+}
+
 #pragma mark - STPAPIResponseDecodable
 
 + (nullable instancetype)decodedObjectFromAPIResponse:(nullable NSDictionary *)response {

--- a/Stripe/STPPaymentMethod.m
+++ b/Stripe/STPPaymentMethod.m
@@ -83,7 +83,7 @@
 + (NSArray<NSNumber *> *)typesFromStrings:(NSArray<NSString *> *)strings {
     NSMutableArray *types = [NSMutableArray new];
     for (NSString *string in strings) {
-        [types addObject:@([STPPaymentMethod typeFromString:string])];
+        [types addObject:@([self typeFromString:string])];
     }
     return [types copy];
 }

--- a/Tests/Tests/PaymentIntent.json
+++ b/Tests/Tests/PaymentIntent.json
@@ -43,5 +43,8 @@
     "tracking_number": "xyz123abc"
   },
   "source": "src_1Cl1AdIl4IdHmuTbseiDWq6m",
-  "status": "requires_source_action"
+  "status": "requires_source_action",
+  "payment_method_types" : [
+      "card"
+  ],
 }

--- a/Tests/Tests/STPPaymentIntentTest.m
+++ b/Tests/Tests/STPPaymentIntentTest.m
@@ -205,6 +205,8 @@
     XCTAssertEqualObjects(url, [NSURL URLWithString:@"https://hooks.stripe.com/redirect/authenticate/src_1Cl1AeIl4IdHmuTb1L7x083A?client_secret=src_client_secret_DBNwUe9qHteqJ8qQBwNWiigk"]);
     XCTAssertEqualObjects(paymentIntent.sourceId, @"src_1Cl1AdIl4IdHmuTbseiDWq6m");
     XCTAssertEqual(paymentIntent.status, STPPaymentIntentStatusRequiresAction);
+    
+    XCTAssertEqualObjects(paymentIntent.paymentMethodTypes, @[@(STPPaymentMethodTypeCard)]);
 
     XCTAssertNotEqual(paymentIntent.allResponseFields, response, @"should have own copy of fields");
     XCTAssertEqualObjects(paymentIntent.allResponseFields, response, @"fields values should match");

--- a/Tests/Tests/STPPaymentMethodTest.m
+++ b/Tests/Tests/STPPaymentMethodTest.m
@@ -30,6 +30,12 @@
     XCTAssertEqual([STPPaymentMethod typeFromString:@"unknown_string"], STPPaymentMethodTypeUnknown);
 }
 
+- (void)testTypesFromStrings {
+    NSArray *rawTypes = @[@"card", @"ideal", @"card_present"];
+    NSArray *expectedTypes = @[@(STPPaymentMethodTypeCard), @(STPPaymentMethodTypeiDEAL), @(STPPaymentMethodTypeCardPresent)];
+    XCTAssertEqualObjects([STPPaymentMethod typesFromStrings:rawTypes], expectedTypes);
+}
+
 - (void)testStringFromType {
     NSArray<NSNumber *> *values = @[
                                     @(STPPaymentMethodTypeCard),


### PR DESCRIPTION
## Summary
Adds paymentMethodTypes to PaymentIntent

## Motivation
4th item in https://paper.dropbox.com/doc/API-Changes-for-mid-Feb-version--AZU3sDrHWyKkPsD_rIXF_66uAg-PC7zkuMmx0i42AeypiP04

No need to add `paymentMethodTypes` as a parameter, since `confirm` doesn't support it.

## Testing
Updated `PaymentIntent.json` to include this field (and the 2015 API does indeed return this), and updated tests.