### PR TITLE
Allows deleting selected payment option

### DIFF
--- a/Stripe/STPPaymentOptionsInternalViewController.m
+++ b/Stripe/STPPaymentOptionsInternalViewController.m
@@ -307,7 +307,7 @@ static NSInteger const PaymentOptionSectionAddCard = 1;
             // in this function is not allowed)
             dispatch_async(dispatch_get_main_queue(), ^{
                 [self _endTableViewEditing];
-            })
+            });
             // manually set the value passed to reloadRightBarButtonItemWithTableViewIsEditing
             // below
             tableViewIsEditing = NO;

--- a/Stripe/STPPaymentOptionsInternalViewController.m
+++ b/Stripe/STPPaymentOptionsInternalViewController.m
@@ -160,11 +160,6 @@ static NSInteger const PaymentOptionSectionAddCard = 1;
         return NO;
     }
 
-    if (paymentOption == self.selectedPaymentOption) {
-        // Cannot detach selected payment method
-        return NO;
-    }
-
     if (![paymentOption conformsToProtocol:@protocol(STPSourceProtocol)]) {
         // Cannot detach non-source payment method
         return NO;
@@ -210,8 +205,12 @@ static NSInteger const PaymentOptionSectionAddCard = 1;
 }
 
 - (void)handleDoneButtonTapped:(__unused id)sender {
-    [self.tableView setEditing:NO animated:YES];
+    [self _endTableViewEditing];
     [self reloadRightBarButtonItemWithTableViewIsEditing:self.tableView.isEditing animated:YES];
+}
+
+- (void)_endTableViewEditing {
+    [self.tableView setEditing:NO animated:YES];
 }
 
 #pragma mark - UITableViewDataSource
@@ -301,8 +300,18 @@ static NSInteger const PaymentOptionSectionAddCard = 1;
         // Perform deletion animation for single row
         [tableView deleteRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
 
+        BOOL tableViewIsEditing = tableView.isEditing;
+        if (![self isAnyPaymentOptionDetachable]) {
+            // we deleted the last available payment option, stop editing
+            [self _endTableViewEditing];
+            // tableView.isEditing doesn't update immediately when called from this method
+            // so manually set the value passed to reloadRightBarButtonItemWithTableViewIsEditing
+            // below
+            tableViewIsEditing = NO;
+        }
+
         // Reload right bar button item text
-        [self reloadRightBarButtonItemWithTableViewIsEditing:tableView.isEditing animated:YES];
+        [self reloadRightBarButtonItemWithTableViewIsEditing:tableViewIsEditing animated:YES];
 
         // Notify delegate
         [self.delegate internalViewControllerDidDeletePaymentOption:paymentOptionToDelete];

--- a/Stripe/STPPaymentOptionsInternalViewController.m
+++ b/Stripe/STPPaymentOptionsInternalViewController.m
@@ -303,9 +303,12 @@ static NSInteger const PaymentOptionSectionAddCard = 1;
         BOOL tableViewIsEditing = tableView.isEditing;
         if (![self isAnyPaymentOptionDetachable]) {
             // we deleted the last available payment option, stop editing
-            [self _endTableViewEditing];
-            // tableView.isEditing doesn't update immediately when called from this method
-            // so manually set the value passed to reloadRightBarButtonItemWithTableViewIsEditing
+            // (but delay to next runloop because calling tableView setEditing:animated:
+            // in this function is not allowed)
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [self _endTableViewEditing];
+            })
+            // manually set the value passed to reloadRightBarButtonItemWithTableViewIsEditing
             // below
             tableViewIsEditing = NO;
         }


### PR DESCRIPTION


## Summary
Allows deleting selected payment option
Will automatically end editing if the last deletable payment option is removed.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
#1032

## Testing
<!-- How was the code tested? Be as specific as possible. -->
Tested deleting selected and last payment option in standard integration test app