### PR TITLE
Fixes linter issues

### DIFF
--- a/LocalizationTesterUITests/Info.plist
+++ b/LocalizationTesterUITests/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
-	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<string>en_US</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -11,7 +11,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>$(PRODUCT_NAME)</string>
+	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>

--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -1198,7 +1198,9 @@
 		3617A51320FE5BBB001A9E6A /* NSLocale+STPSwizzling.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSLocale+STPSwizzling.m"; sourceTree = "<group>"; };
 		3620B62E21C41E08009FC6FB /* MockCustomerContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MockCustomerContext.h; sourceTree = "<group>"; };
 		3620B62F21C41E08009FC6FB /* MockCustomerContext.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MockCustomerContext.m; sourceTree = "<group>"; };
-		3650AA3E21C07E3C002B0893 /* Stripe.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Stripe.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		3634DB292241845F00E4AA7E /* LocalizationTester-Shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "LocalizationTester-Shared.xcconfig"; sourceTree = "<group>"; };
+		3634DB2A2241879400E4AA7E /* LocalizationTesterUITests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = LocalizationTesterUITests.xcconfig; sourceTree = "<group>"; };
+		3650AA3E21C07E3C002B0893 /* LocalizationTester.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LocalizationTester.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		3650AA4021C07E3C002B0893 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		3650AA4121C07E3C002B0893 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
 		3650AA4321C07E3C002B0893 /* ViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
@@ -1814,6 +1816,8 @@
 			children = (
 				36FA86272241710700D5B4D4 /* LocalizationTester-Debug.xcconfig */,
 				36FA86292241718F00D5B4D4 /* LocalizationTester-Release.xcconfig */,
+				3634DB292241845F00E4AA7E /* LocalizationTester-Shared.xcconfig */,
+				3634DB2A2241879400E4AA7E /* LocalizationTesterUITests.xcconfig */,
 				04F39F0A1AEF2AFE005B926E /* Project-Debug.xcconfig */,
 				04F39F0B1AEF2AFE005B926E /* Project-Release.xcconfig */,
 				04F39F0C1AEF2AFE005B926E /* Project-Shared.xcconfig */,
@@ -1850,7 +1854,7 @@
 				045E7C031A5F41DE004751EF /* StripeiOS Tests.xctest */,
 				049E84AB1A605D93000B66CD /* libStripe.a */,
 				C1B630B31D1D817900A05285 /* Stripe.bundle */,
-				3650AA3E21C07E3C002B0893 /* Stripe.app */,
+				3650AA3E21C07E3C002B0893 /* LocalizationTester.app */,
 				3650AA5521C07E3D002B0893 /* LocalizationTesterUITests.xctest */,
 			);
 			name = Products;
@@ -2932,7 +2936,7 @@
 			);
 			name = LocalizationTester;
 			productName = LocalizationTester;
-			productReference = 3650AA3E21C07E3C002B0893 /* Stripe.app */;
+			productReference = 3650AA3E21C07E3C002B0893 /* LocalizationTester.app */;
 			productType = "com.apple.product-type.application";
 		};
 		3650AA5421C07E3D002B0893 /* LocalizationTesterUITests */ = {
@@ -3885,127 +3889,15 @@
 		};
 		3650AA5E21C07E3D002B0893 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 36FA86272241710700D5B4D4 /* LocalizationTester-Debug.xcconfig */;
+			baseConfigurationReference = 3634DB2A2241879400E4AA7E /* LocalizationTesterUITests.xcconfig */;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_ENABLE_OBJC_WEAK = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CODE_SIGN_STYLE = Automatic;
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = Y28TH9SHX7;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu11;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				INFOPLIST_FILE = LocalizationTesterUITests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = stripe.LocalizationTesterUITests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_TARGET_NAME = LocalizationTester;
 			};
 			name = Debug;
 		};
 		3650AA5F21C07E3D002B0893 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 36FA86292241718F00D5B4D4 /* LocalizationTester-Release.xcconfig */;
+			baseConfigurationReference = 3634DB2A2241879400E4AA7E /* LocalizationTesterUITests.xcconfig */;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_ENABLE_OBJC_WEAK = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CODE_SIGN_STYLE = Automatic;
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = Y28TH9SHX7;
-				ENABLE_NS_ASSERTIONS = NO;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu11;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				INFOPLIST_FILE = LocalizationTesterUITests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_BUNDLE_IDENTIFIER = stripe.LocalizationTesterUITests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_TARGET_NAME = LocalizationTester;
-				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
 		};

--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -1198,7 +1198,7 @@
 		3617A51320FE5BBB001A9E6A /* NSLocale+STPSwizzling.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSLocale+STPSwizzling.m"; sourceTree = "<group>"; };
 		3620B62E21C41E08009FC6FB /* MockCustomerContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MockCustomerContext.h; sourceTree = "<group>"; };
 		3620B62F21C41E08009FC6FB /* MockCustomerContext.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MockCustomerContext.m; sourceTree = "<group>"; };
-		3650AA3E21C07E3C002B0893 /* LocalizationTester.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LocalizationTester.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		3650AA3E21C07E3C002B0893 /* Stripe.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Stripe.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		3650AA4021C07E3C002B0893 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		3650AA4121C07E3C002B0893 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
 		3650AA4321C07E3C002B0893 /* ViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
@@ -1237,6 +1237,8 @@
 		36D153B921AE111500567EFE /* pt-BR */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "Localizations/pt-BR.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		36D153BA21AE111F00567EFE /* pt-PT */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "pt-PT"; path = "Localizations/pt-PT.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		36D153BB21AE11CF00567EFE /* sv */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = sv; path = Localizations/sv.lproj/Localizable.strings; sourceTree = "<group>"; };
+		36FA86272241710700D5B4D4 /* LocalizationTester-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "LocalizationTester-Debug.xcconfig"; sourceTree = "<group>"; };
+		36FA86292241718F00D5B4D4 /* LocalizationTester-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "LocalizationTester-Release.xcconfig"; sourceTree = "<group>"; };
 		4A0D74F918F6106100966D7B /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		7E0B1132203572FB00271AD3 /* fi */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = fi; path = Localizations/fi.lproj/Localizable.strings; sourceTree = "<group>"; };
 		8B013C881F1E784A00DD831B /* STPPaymentConfigurationTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPPaymentConfigurationTest.m; sourceTree = "<group>"; };
@@ -1810,6 +1812,8 @@
 		04F39F091AEF2AFE005B926E /* BuildConfigurations */ = {
 			isa = PBXGroup;
 			children = (
+				36FA86272241710700D5B4D4 /* LocalizationTester-Debug.xcconfig */,
+				36FA86292241718F00D5B4D4 /* LocalizationTester-Release.xcconfig */,
 				04F39F0A1AEF2AFE005B926E /* Project-Debug.xcconfig */,
 				04F39F0B1AEF2AFE005B926E /* Project-Release.xcconfig */,
 				04F39F0C1AEF2AFE005B926E /* Project-Shared.xcconfig */,
@@ -1846,7 +1850,7 @@
 				045E7C031A5F41DE004751EF /* StripeiOS Tests.xctest */,
 				049E84AB1A605D93000B66CD /* libStripe.a */,
 				C1B630B31D1D817900A05285 /* Stripe.bundle */,
-				3650AA3E21C07E3C002B0893 /* LocalizationTester.app */,
+				3650AA3E21C07E3C002B0893 /* Stripe.app */,
 				3650AA5521C07E3D002B0893 /* LocalizationTesterUITests.xctest */,
 			);
 			name = Products;
@@ -2928,7 +2932,7 @@
 			);
 			name = LocalizationTester;
 			productName = LocalizationTester;
-			productReference = 3650AA3E21C07E3C002B0893 /* LocalizationTester.app */;
+			productReference = 3650AA3E21C07E3C002B0893 /* Stripe.app */;
 			productType = "com.apple.product-type.application";
 		};
 		3650AA5421C07E3D002B0893 /* LocalizationTesterUITests */ = {
@@ -3836,7 +3840,6 @@
 			baseConfigurationReference = 04F39F101AEF2AFE005B926E /* StripeiOS-Debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_TEAM = Y28TH9SHX7;
 			};
 			name = Debug;
 		};
@@ -3845,7 +3848,6 @@
 			baseConfigurationReference = 04F39F111AEF2AFE005B926E /* StripeiOS-Release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_TEAM = Y28TH9SHX7;
 			};
 			name = Release;
 		};
@@ -3867,137 +3869,23 @@
 		};
 		3650AA5C21C07E3D002B0893 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 04F39F101AEF2AFE005B926E /* StripeiOS-Debug.xcconfig */;
+			baseConfigurationReference = 36FA86272241710700D5B4D4 /* LocalizationTester-Debug.xcconfig */;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_ENABLE_OBJC_WEAK = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CODE_SIGN_STYLE = Automatic;
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = Y28TH9SHX7;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu11;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				INFOPLIST_FILE = LocalizationTester/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = stripe.LocalizationTester;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
 		3650AA5D21C07E3D002B0893 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 04F39F111AEF2AFE005B926E /* StripeiOS-Release.xcconfig */;
+			baseConfigurationReference = 36FA86292241718F00D5B4D4 /* LocalizationTester-Release.xcconfig */;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_ENABLE_OBJC_WEAK = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CODE_SIGN_STYLE = Automatic;
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = Y28TH9SHX7;
-				ENABLE_NS_ASSERTIONS = NO;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu11;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					NDEBUG,
-					"$(STP_EXTRA_PREPROCESSOR_MACROS)",
-				);
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				INFOPLIST_FILE = LocalizationTester/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_BUNDLE_IDENTIFIER = stripe.LocalizationTester;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
 		};
 		3650AA5E21C07E3D002B0893 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 04F39F101AEF2AFE005B926E /* StripeiOS-Debug.xcconfig */;
+			baseConfigurationReference = 36FA86272241710700D5B4D4 /* LocalizationTester-Debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -4062,7 +3950,7 @@
 		};
 		3650AA5F21C07E3D002B0893 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 04F39F111AEF2AFE005B926E /* StripeiOS-Release.xcconfig */;
+			baseConfigurationReference = 36FA86292241718F00D5B4D4 /* LocalizationTester-Release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;

--- a/Stripe/BuildConfigurations/LocalizationTester-Debug.xcconfig
+++ b/Stripe/BuildConfigurations/LocalizationTester-Debug.xcconfig
@@ -1,0 +1,18 @@
+//
+//  LocalizationTester-Debug.xcconfig
+//  LocalizationTester
+//
+//  Created by Cameron Sabol on 3/19/19.
+//  Copyright © 2019 Stripe, Inc. All rights reserved.
+//
+
+#include "StripeiOS-Shared.xcconfig"
+
+GCC_PREPROCESSOR_DEFINITIONS = DEBUG=1 $(inherited)
+
+INFOPLIST_FILE = LocalizationTester/Info.plist
+
+PRODUCT_BUNDLE_IDENTIFIER = com.stripe.LocalizationTester
+
+EXECUTABLE_NAME = LocalizationTester
+

--- a/Stripe/BuildConfigurations/LocalizationTester-Debug.xcconfig
+++ b/Stripe/BuildConfigurations/LocalizationTester-Debug.xcconfig
@@ -6,13 +6,6 @@
 //  Copyright © 2019 Stripe, Inc. All rights reserved.
 //
 
-#include "StripeiOS-Shared.xcconfig"
+#include "LocalizationTester-Shared.xcconfig"
 
-GCC_PREPROCESSOR_DEFINITIONS = DEBUG=1 $(inherited)
-
-INFOPLIST_FILE = LocalizationTester/Info.plist
-
-PRODUCT_BUNDLE_IDENTIFIER = com.stripe.LocalizationTester
-
-EXECUTABLE_NAME = LocalizationTester
 

--- a/Stripe/BuildConfigurations/LocalizationTester-Release.xcconfig
+++ b/Stripe/BuildConfigurations/LocalizationTester-Release.xcconfig
@@ -6,13 +6,4 @@
 //  Copyright © 2019 Stripe, Inc. All rights reserved.
 //
 
-#include "StripeiOS Tests-Shared.xcconfig"
-
-GCC_PREPROCESSOR_DEFINITIONS = DEBUG=1 $(inherited)
-
-INFOPLIST_FILE = LocalizationTester/Info.plist
-
-PRODUCT_BUNDLE_IDENTIFIER = com.stripe.LocalizationTester
-
-EXECUTABLE_NAME = LocalizationTester
-
+#include "LocalizationTester-Shared.xcconfig"

--- a/Stripe/BuildConfigurations/LocalizationTester-Release.xcconfig
+++ b/Stripe/BuildConfigurations/LocalizationTester-Release.xcconfig
@@ -1,0 +1,18 @@
+//
+//  LocalizationTester-Release.xcconfig
+//  Stripe
+//
+//  Created by Cameron Sabol on 3/19/19.
+//  Copyright © 2019 Stripe, Inc. All rights reserved.
+//
+
+#include "StripeiOS Tests-Shared.xcconfig"
+
+GCC_PREPROCESSOR_DEFINITIONS = DEBUG=1 $(inherited)
+
+INFOPLIST_FILE = LocalizationTester/Info.plist
+
+PRODUCT_BUNDLE_IDENTIFIER = com.stripe.LocalizationTester
+
+EXECUTABLE_NAME = LocalizationTester
+

--- a/Stripe/BuildConfigurations/LocalizationTester-Shared.xcconfig
+++ b/Stripe/BuildConfigurations/LocalizationTester-Shared.xcconfig
@@ -1,0 +1,167 @@
+//
+//  LocalizationTester-Shared.xcconfig
+//  Stripe
+//
+//  Created by Cameron Sabol on 3/19/19.
+//  Copyright © 2019 Stripe, Inc. All rights reserved.
+//
+
+APPLICATION_EXTENSION_API_ONLY = YES
+
+CLANG_CXX_LANGUAGE_STANDARD = gnu++0x
+
+
+CLANG_CXX_LIBRARY = libc++
+
+
+CLANG_ENABLE_MODULES = YES
+
+
+CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR
+
+
+CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR
+
+CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES
+CLANG_WARN_INFINITE_RECURSION = YES
+CLANG_WARN_SUSPICIOUS_MOVE = YES
+CLANG_WARN_ASSIGN_ENUM = YES
+CLANG_WARN_DOCUMENTATION_COMMENTS = YES
+CLANG_WARN_UNGUARDED_AVAILABILITY = YES
+
+// Code Signing Identity
+//
+// The name ("common name") of a valid code-signing certificate in a keychain within your
+// keychain path.   A missing or invalid certificate will cause a build error.
+
+CODE_SIGN_IDENTITY[sdk=iphoneos*] =
+
+
+// Current Project Version
+//
+// This setting defines the the current version of the project. The value must be a
+// integer or floating point number like 57 or 365.8.
+
+CURRENT_PROJECT_VERSION = 1
+
+
+// Defines Module
+//
+// If enabled, the product will be treated as defining its own module. This enables
+// automatic production of LLVM module map files when appropriate, and allows the product
+// to be imported as a module.
+
+DEFINES_MODULE = YES
+
+
+// Compatibility Version
+//
+// Determines the compatibility version of the resulting library, bundle, or framework
+// binary.
+
+DYLIB_COMPATIBILITY_VERSION = 1
+
+
+// Current Library Version
+//
+// This setting defines the the current version of any framework built by the project.
+// Like "Current Project Version", the value must be an integer or floating point number
+// like 57 or 365.8. By default it is set to $(CURRENT_PROJECT_VERSION).
+
+DYLIB_CURRENT_VERSION = 1
+
+
+// Dynamic Library Install Name Base
+//
+// Sets the base value for the internal "install path" (LC_ID_DYLIB) in a dynamic
+// library. This will be combined with the EXECUTABLE_PATH to form the full install path.
+// Setting LD_DYLIB_INSTALL_NAME directly will override this setting. This setting
+// defaults to the target's INSTALL_PATH. It is ignored when building any product other
+// than a dynamic library. [-install_name]
+
+DYLIB_INSTALL_NAME_BASE = @rpath
+
+
+GCC_TREAT_WARNINGS_AS_ERRORS = YES
+
+
+GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR
+
+
+GCC_WARN_SHADOW = YES
+
+
+GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE
+
+GCC_TREAT_IMPLICIT_FUNCTION_DECLARATIONS_AS_ERRORS = YES
+GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = YES
+GCC_WARN_FOUR_CHARACTER_CONSTANTS = YES
+GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED = YES
+GCC_WARN_UNKNOWN_PRAGMAS = YES
+GCC_WARN_UNUSED_LABEL = YES
+GCC_WARN_UNUSED_PARAMETER = YES
+
+INFOPLIST_FILE = LocalizationTester/Info.plist
+
+PRODUCT_BUNDLE_IDENTIFIER = com.stripe.LocalizationTester
+
+EXECUTABLE_NAME = LocalizationTester
+
+
+// Installation Directory
+//
+// The directory to install the build products in. This path is prepended by the
+// 'Installation Build Products Location' (i.e., $(DSTROOT)).
+
+//INSTALL_PATH = $(LOCAL_LIBRARY_DIR)/Frameworks
+
+
+// Runpath Search Paths
+//
+// This is a list of paths to be added to the runpath search path list for the image
+// being created.  At runtime, dyld uses the runpath when searching for dylibs whose load
+// path begins with '@rpath/'. [-rpath]
+
+LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/Frameworks @loader_path/Frameworks
+
+// Product Name
+//
+// This is the basename of the product generated.
+
+PRODUCT_NAME = LocalizationTester
+
+// Skip Install
+//
+// Activating this setting when deployment locations are used causes the product to be
+// built into an alternative location instead of the install location.
+
+
+// Targeted Device Family
+//
+// The build system uses the selected device to set the correct value for the
+// UIDeviceFamily key it adds to the target's Info.plist file.
+//
+// iPhone - Application is built for iPhone and iPod touch.
+// iPad - Application is built for iPad.
+// iPhone/iPad - Application is built Universal for iPhone, iPod touch, and iPad.
+
+TARGETED_DEVICE_FAMILY = 1,2
+
+
+// Versioning Name Prefix
+//
+// Used as a prefix for the name of the version info symbol in the generated versioning
+// source file.  If you prefix your exported symbols you will probably want to set this
+// to the same prefix.
+
+VERSION_INFO_PREFIX =
+
+
+// Versioning System
+//
+// Selects the process used for version-stamping generated files.
+//
+// None - Use no versioning system. []
+// Apple Generic - Use the current project version setting. [apple-generic]
+
+VERSIONING_SYSTEM = apple-generic

--- a/Stripe/BuildConfigurations/LocalizationTesterUITests.xcconfig
+++ b/Stripe/BuildConfigurations/LocalizationTesterUITests.xcconfig
@@ -1,0 +1,109 @@
+//
+//  LocalizationTesterUITests.xcconfig
+//  Stripe
+//
+//  Created by Cameron Sabol on 3/19/19.
+//  Copyright © 2019 Stripe, Inc. All rights reserved.
+//
+
+CLANG_CXX_LANGUAGE_STANDARD = gnu++0x
+
+
+CLANG_CXX_LIBRARY = libc++
+
+
+CLANG_ENABLE_MODULES = YES
+
+
+CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR
+
+
+CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR
+
+
+// Code Signing Identity
+//
+// The name ("common name") of a valid code-signing certificate in a keychain within your
+// keychain path.   A missing or invalid certificate will cause a build error.
+
+CODE_SIGN_IDENTITY = iPhone Developer
+
+
+// Framework Search Paths
+//
+// This is a list of paths to folders containing frameworks to be searched by the
+// compiler for both included or imported header files when compiling C, Objective-C,
+// C++, or Objective-C++, and by the linker for frameworks used by the product. Paths are
+// delimited by whitespace, so any paths with spaces in them need to be properly quoted.
+// [-F]
+
+FRAMEWORK_SEARCH_PATHS = $(inherited) $(PROJECT_DIR)/Carthage/Build/iOS
+
+GCC_TREAT_WARNINGS_AS_ERRORS = YES
+
+
+GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR
+
+
+GCC_WARN_SHADOW = YES
+
+
+GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE
+
+CLANG_WARN_ASSIGN_ENUM = YES
+//CLANG_WARN_DOCUMENTATION_COMMENTS = YES not enabled because of errors in FBSnapshotTestCase headers
+CLANG_WARN_INFINITE_RECURSION = YES
+CLANG_WARN_SUSPICIOUS_MOVE = YES
+GCC_TREAT_IMPLICIT_FUNCTION_DECLARATIONS_AS_ERRORS = YES
+GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = YES
+GCC_WARN_FOUR_CHARACTER_CONSTANTS = YES
+GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED = YES
+GCC_WARN_UNKNOWN_PRAGMAS = YES
+GCC_WARN_UNUSED_LABEL = YES
+GCC_WARN_UNUSED_PARAMETER = YES
+
+
+// Header Search Paths
+//
+// This is a list of paths to folders to be searched by the compiler for included or
+// imported header files when compiling C, Objective-C, C++, or Objective-C++. Paths are
+// delimited by whitespace, so any paths with spaces in them need to be properly quoted.
+// [-I]
+
+HEADER_SEARCH_PATHS = $(inherited)
+
+
+// Info.plist File
+//
+// This is the project-relative path to the plist file that contains the Info.plist
+// information used by bundles.
+
+INFOPLIST_FILE = LocalizationTesterUITests/Info.plist;
+
+
+// Runpath Search Paths
+//
+// This is a list of paths to be added to the runpath search path list for the image
+// being created.  At runtime, dyld uses the runpath when searching for dylibs whose load
+// path begins with '@rpath/'. [-rpath]
+
+LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/Frameworks @loader_path/Frameworks
+
+
+OTHER_CFLAGS =
+
+
+// Product Name
+//
+// This is the basename of the product generated.
+TARGET_NAME = LocalizationTesterUITests
+PRODUCT_NAME = $(TARGET_NAME)
+
+
+ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES
+
+GCC_PREPROCESSOR_DEFINITIONS = DEBUG=1 $(inherited)
+DEBUG_INFORMATION_FORMAT = dwarf
+
+TEST_TARGET_NAME = LocalizationTester
+

--- a/Stripe/STPAddressFieldTableViewCell.m
+++ b/Stripe/STPAddressFieldTableViewCell.m
@@ -239,8 +239,6 @@
             return @"ShippingAddressFieldTypePhoneIdentifier";
         case STPAddressFieldTypeEmail:
             return @"ShippingAddressFieldTypeEmailIdentifier";
-        default:
-            return @"";
     }
 }
 


### PR DESCRIPTION


## Summary
Adds xcconfig files for LocalizationTester and removes build settings that were set by default in the project file.

## Motivation
linter was failing on master

## Testing
Made sure I could still manually build and run LocalizationTester and that the screenshot script still worked
