### PR TITLE
Add configurable support for JCB (Apple Pay)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 15.?.? 2019-?-?
+* Adds configurable support for JCB (Apple Pay). [#1158](https://github.com/stripe/stripe-ios/pull/1158)
+
 ## 15.0.0 2019-3-19
 * Renames all former references to 'PaymentMethod' to 'PaymentOption'. See [MIGRATING.md](/MIGRATING.md) for more details. [#1139](https://github.com/stripe/stripe-ios/pull/1139) 
   * Renames `STPPaymentMethod` to `STPPaymentOption`

--- a/Stripe/PublicHeaders/STPAPIClient.h
+++ b/Stripe/PublicHeaders/STPAPIClient.h
@@ -227,8 +227,8 @@ static NSString *const STPSDKVersion = @"15.0.0";
  The Stripe supported Apple Pay card networks are:
  American Express, Visa, Mastercard, Discover.
  
- Japanese users can enable JCB, Diners Club and Discover via
- `setJCBPaymentNetworkSupported:`, after they have been approved by JCB.
+ Japanese users can enable JCB by setting `JCBPaymentNetworkSupported` to YES,
+ after they have been approved by JCB.
 
  @return YES if the device is currently able to make Apple Pay payments via one
  of the supported networks. NO if the user does not have a saved card of a
@@ -275,7 +275,7 @@ static NSString *const STPSDKVersion = @"15.0.0";
                                                   currency:(NSString *)currencyCode;
 
 /**
- Japanese users can enable JCB, Diners Club and Discover by calling this method with `YES`, after they have been approved by JCB.
+ Japanese users can enable JCB for Apple Pay by setting this to `YES`, after they have been approved by JCB.
  
  The default value is NO.
  */

--- a/Stripe/PublicHeaders/STPAPIClient.h
+++ b/Stripe/PublicHeaders/STPAPIClient.h
@@ -226,6 +226,9 @@ static NSString *const STPSDKVersion = @"15.0.0";
 
  The Stripe supported Apple Pay card networks are:
  American Express, Visa, Mastercard, Discover.
+ 
+ Japanese users can enable JCB, Diners Club and Discover via
+ `setJCBPaymentNetworkSupported:`, after they have been approved by JCB.
 
  @return YES if the device is currently able to make Apple Pay payments via one
  of the supported networks. NO if the user does not have a saved card of a
@@ -270,6 +273,13 @@ static NSString *const STPSDKVersion = @"15.0.0";
 + (PKPaymentRequest *)paymentRequestWithMerchantIdentifier:(NSString *)merchantIdentifier
                                                    country:(NSString *)countryCode
                                                   currency:(NSString *)currencyCode;
+
+/**
+ Japanese users can enable JCB, Diners Club and Discover by calling this method with `YES`, after they have been approved by JCB.
+ 
+ The default value is NO.
+ */
++ (void)setJCBPaymentNetworkSupported:(BOOL)isSupported;
 
 @end
 

--- a/Stripe/PublicHeaders/STPAPIClient.h
+++ b/Stripe/PublicHeaders/STPAPIClient.h
@@ -279,7 +279,7 @@ static NSString *const STPSDKVersion = @"15.0.0";
  
  The default value is NO.
  */
-+ (void)setJCBPaymentNetworkSupported:(BOOL)isSupported;
+@property (class, nonatomic, getter=isJCBPaymentNetworkSupported) BOOL JCBPaymentNetworkSupported;
 
 @end
 

--- a/Stripe/STPAPIClient+Private.h
+++ b/Stripe/STPAPIClient+Private.h
@@ -83,4 +83,9 @@ fromCustomerUsingKey:(STPEphemeralKey *)ephemeralKey
 
 @end
 
+@interface Stripe (Private)
+
++ (NSArray<NSString *> *)supportedPKPaymentNetworks;
+
+@end
 NS_ASSUME_NONNULL_END

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -60,6 +60,8 @@ static NSString * const APIEndpointPaymentMethods = @"payment_methods";
 
 @implementation Stripe
 
+static BOOL _JCBPaymentNetworkSupported = NO;
+
 + (void)setDefaultPublishableKey:(NSString *)publishableKey {
     [STPPaymentConfiguration sharedConfiguration].publishableKey = publishableKey;
 }
@@ -420,6 +422,9 @@ static NSString * const APIEndpointPaymentMethods = @"payment_methods";
     if ((&PKPaymentNetworkDiscover) != NULL) {
         supportedNetworks = [supportedNetworks arrayByAddingObject:PKPaymentNetworkDiscover];
     }
+    if ([self isJCBPaymentNetworkSupported]) {
+        supportedNetworks = [supportedNetworks arrayByAddingObject:PKPaymentNetworkJCB];
+    }
     return supportedNetworks;
 }
 
@@ -441,6 +446,14 @@ static NSString * const APIEndpointPaymentMethods = @"payment_methods";
     [paymentRequest setCountryCode:countryCode.uppercaseString];
     [paymentRequest setCurrencyCode:currencyCode.uppercaseString];
     return paymentRequest;
+}
+
++ (void)setJCBPaymentNetworkSupported:(BOOL)JCBPaymentNetworkSupported {
+    _JCBPaymentNetworkSupported = JCBPaymentNetworkSupported;
+}
+
++ (BOOL)isJCBPaymentNetworkSupported {
+    return _JCBPaymentNetworkSupported;
 }
 
 @end

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -60,7 +60,7 @@ static NSString * const APIEndpointPaymentMethods = @"payment_methods";
 
 @implementation Stripe
 
-static BOOL _JCBPaymentNetworkSupported = NO;
+static BOOL _jcbPaymentNetworkSupported = NO;
 
 + (void)setDefaultPublishableKey:(NSString *)publishableKey {
     [STPPaymentConfiguration sharedConfiguration].publishableKey = publishableKey;
@@ -449,11 +449,11 @@ static BOOL _JCBPaymentNetworkSupported = NO;
 }
 
 + (void)setJCBPaymentNetworkSupported:(BOOL)JCBPaymentNetworkSupported {
-    _JCBPaymentNetworkSupported = JCBPaymentNetworkSupported;
+    _jcbPaymentNetworkSupported = JCBPaymentNetworkSupported;
 }
 
 + (BOOL)isJCBPaymentNetworkSupported {
-    return _JCBPaymentNetworkSupported;
+    return _jcbPaymentNetworkSupported;
 }
 
 @end

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -422,7 +422,7 @@ static BOOL _jcbPaymentNetworkSupported = NO;
     if ((&PKPaymentNetworkDiscover) != NULL) {
         supportedNetworks = [supportedNetworks arrayByAddingObject:PKPaymentNetworkDiscover];
     }
-    if (self.isJCBPaymentNetworkSupported) {
+    if ((&PKPaymentNetworkJCB) && self.isJCBPaymentNetworkSupported) {
         supportedNetworks = [supportedNetworks arrayByAddingObject:PKPaymentNetworkJCB];
     }
     return supportedNetworks;

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -422,7 +422,7 @@ static BOOL _JCBPaymentNetworkSupported = NO;
     if ((&PKPaymentNetworkDiscover) != NULL) {
         supportedNetworks = [supportedNetworks arrayByAddingObject:PKPaymentNetworkDiscover];
     }
-    if ([self isJCBPaymentNetworkSupported]) {
+    if (self.isJCBPaymentNetworkSupported) {
         supportedNetworks = [supportedNetworks arrayByAddingObject:PKPaymentNetworkJCB];
     }
     return supportedNetworks;

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -422,7 +422,7 @@ static BOOL _jcbPaymentNetworkSupported = NO;
     if ((&PKPaymentNetworkDiscover) != NULL) {
         supportedNetworks = [supportedNetworks arrayByAddingObject:PKPaymentNetworkDiscover];
     }
-    if ((&PKPaymentNetworkJCB) && self.isJCBPaymentNetworkSupported) {
+    if ((&PKPaymentNetworkJCB) != NULL && self.isJCBPaymentNetworkSupported) {
         supportedNetworks = [supportedNetworks arrayByAddingObject:PKPaymentNetworkJCB];
     }
     return supportedNetworks;

--- a/Tests/Tests/STPApplePayTest.m
+++ b/Tests/Tests/STPApplePayTest.m
@@ -7,7 +7,7 @@
 //
 
 #import <XCTest/XCTest.h>
-#import "STPAPIClient.h"
+#import "STPAPIClient+Private.h"
 
 @interface STPApplePayTest : XCTestCase
 
@@ -46,6 +46,13 @@
     request.paymentSummaryItems = @[[PKPaymentSummaryItem summaryItemWithLabel:@"bar" amount:[NSDecimalNumber decimalNumberWithString:@"1.00"]]];
 
     XCTAssertFalse([Stripe canSubmitPaymentRequest:request]);
+}
+
+- (void)testJCBPaymentNetwork {
+    XCTAssertFalse([[Stripe supportedPKPaymentNetworks] containsObject:PKPaymentNetworkJCB]);
+    [Stripe setJCBPaymentNetworkSupported:YES];
+    XCTAssertTrue([[Stripe supportedPKPaymentNetworks] containsObject:PKPaymentNetworkJCB]);
+    [Stripe setJCBPaymentNetworkSupported:NO];
 }
 
 @end

--- a/Tests/Tests/STPApplePayTest.m
+++ b/Tests/Tests/STPApplePayTest.m
@@ -50,6 +50,7 @@
 
 - (void)testJCBPaymentNetwork {
     if (&PKPaymentNetworkJCB == NULL) {
+        XCTAssertTrue([Stripe supportedPKPaymentNetworks].count > 0); // Sanity check this doesn't crash
         return;
     }
     XCTAssertFalse([[Stripe supportedPKPaymentNetworks] containsObject:PKPaymentNetworkJCB]);

--- a/Tests/Tests/STPApplePayTest.m
+++ b/Tests/Tests/STPApplePayTest.m
@@ -49,6 +49,9 @@
 }
 
 - (void)testJCBPaymentNetwork {
+    if (&PKPaymentNetworkJCB == NULL) {
+        return;
+    }
     XCTAssertFalse([[Stripe supportedPKPaymentNetworks] containsObject:PKPaymentNetworkJCB]);
     [Stripe setJCBPaymentNetworkSupported:YES];
     XCTAssertTrue([[Stripe supportedPKPaymentNetworks] containsObject:PKPaymentNetworkJCB]);


### PR DESCRIPTION
## Summary
Add configurable support for JCB Apple Pay Payment Network

## Motivation
https://jira.corp.stripe.com/browse/IOS-1212

## Testing
Added a unit test (STPApplePayTest.testJCBPaymentNetwork)