### PR TITLE
Removed development teams

### DIFF
--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -2997,17 +2997,12 @@
 					};
 					04CDB4411A5F2E1800B854EE = {
 						CreatedOnToolsVersion = 6.1.1;
-						DevelopmentTeam = Y28TH9SHX7;
 					};
 					3650AA3D21C07E3C002B0893 = {
 						CreatedOnToolsVersion = 9.4.1;
-						DevelopmentTeam = Y28TH9SHX7;
-						ProvisioningStyle = Automatic;
 					};
 					3650AA5421C07E3D002B0893 = {
 						CreatedOnToolsVersion = 9.4.1;
-						DevelopmentTeam = Y28TH9SHX7;
-						ProvisioningStyle = Automatic;
 						TestTargetID = 3650AA3D21C07E3C002B0893;
 					};
 					C1B630B21D1D817900A05285 = {


### PR DESCRIPTION
## Summary
Removed developer account information from the `Stripe.xcodeproj/project.pbxproj` projevct

## Motivation
When including `Stripe.xcodeproj` as a build dependency, the application fails to compile with the following error:
![Screen Shot 2019-04-29 at 8 25 22 AM](https://user-images.githubusercontent.com/35780254/56895961-7db21580-6a58-11e9-8c53-aa42fb9e8362.png)

## Testing
Made these changes locally; did a full clean (deleting derived data folder); and then rebuilt our app. Was able to install on a phone without issue.
