### PR TITLE
Fixed payment account API

### DIFF
--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -331,6 +331,14 @@
 		04F94DD31D22A23F004FC826 /* NSBundle+Stripe_AppName.h in Headers */ = {isa = PBXBuildFile; fileRef = 049A3F971CC76A2400F57DE7 /* NSBundle+Stripe_AppName.h */; };
 		04F94DD41D22A242004FC826 /* NSBundle+Stripe_AppName.m in Sources */ = {isa = PBXBuildFile; fileRef = 049A3F981CC76A2400F57DE7 /* NSBundle+Stripe_AppName.m */; };
 		04FCFA191BD59A8C00297732 /* STPCategoryLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 04FCFA171BD59A8C00297732 /* STPCategoryLoader.h */; };
+		1D9A8B82227474CC000421EC /* STPConnectIndividualAccountParams.h in Headers */ = {isa = PBXBuildFile; fileRef = 1D9A8B81227474CB000421EC /* STPConnectIndividualAccountParams.h */; };
+		1D9A8B83227474CC000421EC /* STPConnectIndividualAccountParams.h in Headers */ = {isa = PBXBuildFile; fileRef = 1D9A8B81227474CB000421EC /* STPConnectIndividualAccountParams.h */; };
+		1D9A8B852274798D000421EC /* STPIndividualParams.h in Headers */ = {isa = PBXBuildFile; fileRef = 1D9A8B842274798D000421EC /* STPIndividualParams.h */; };
+		1D9A8B862274798D000421EC /* STPIndividualParams.h in Headers */ = {isa = PBXBuildFile; fileRef = 1D9A8B842274798D000421EC /* STPIndividualParams.h */; };
+		1D9A8B8822747E30000421EC /* STPIndividualParams.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D9A8B8722747E2F000421EC /* STPIndividualParams.m */; };
+		1D9A8B8922747E30000421EC /* STPIndividualParams.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D9A8B8722747E2F000421EC /* STPIndividualParams.m */; };
+		1D9A8B8B22748274000421EC /* STPConnectIndividualAccountParams.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D9A8B8A22748274000421EC /* STPConnectIndividualAccountParams.m */; };
+		1D9A8B8C22748274000421EC /* STPConnectIndividualAccountParams.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D9A8B8A22748274000421EC /* STPConnectIndividualAccountParams.m */; };
 		3617A51420FE5BBB001A9E6A /* NSLocale+STPSwizzling.h in Headers */ = {isa = PBXBuildFile; fileRef = 3617A51220FE5BBB001A9E6A /* NSLocale+STPSwizzling.h */; };
 		3617A51520FE5BBB001A9E6A /* NSLocale+STPSwizzling.m in Sources */ = {isa = PBXBuildFile; fileRef = 3617A51320FE5BBB001A9E6A /* NSLocale+STPSwizzling.m */; };
 		3620B63021C41E08009FC6FB /* MockCustomerContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 3620B62F21C41E08009FC6FB /* MockCustomerContext.m */; };
@@ -1194,6 +1202,10 @@
 		04F94D6F1D21CB20004FC826 /* StripeiOSResources.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = StripeiOSResources.xcconfig; sourceTree = "<group>"; };
 		04FCFA171BD59A8C00297732 /* STPCategoryLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STPCategoryLoader.h; sourceTree = "<group>"; };
 		11C74B9B164043050071C2CA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		1D9A8B81227474CB000421EC /* STPConnectIndividualAccountParams.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = STPConnectIndividualAccountParams.h; path = PublicHeaders/STPConnectIndividualAccountParams.h; sourceTree = "<group>"; };
+		1D9A8B842274798D000421EC /* STPIndividualParams.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = STPIndividualParams.h; path = PublicHeaders/STPIndividualParams.h; sourceTree = "<group>"; };
+		1D9A8B8722747E2F000421EC /* STPIndividualParams.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPIndividualParams.m; sourceTree = "<group>"; };
+		1D9A8B8A22748274000421EC /* STPConnectIndividualAccountParams.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPConnectIndividualAccountParams.m; sourceTree = "<group>"; };
 		3617A51220FE5BBB001A9E6A /* NSLocale+STPSwizzling.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSLocale+STPSwizzling.h"; sourceTree = "<group>"; };
 		3617A51320FE5BBB001A9E6A /* NSLocale+STPSwizzling.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSLocale+STPSwizzling.m"; sourceTree = "<group>"; };
 		3620B62E21C41E08009FC6FB /* MockCustomerContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MockCustomerContext.h; sourceTree = "<group>"; };
@@ -2346,6 +2358,8 @@
 				04CDE5BB1BC1F21500548833 /* STPCardParams.h */,
 				04CDE5B41BC1F1F100548833 /* STPCardParams.m */,
 				04EBC7511B7533C300A0E6AE /* STPCardValidationState.h */,
+				1D9A8B81227474CB000421EC /* STPConnectIndividualAccountParams.h */,
+				1D9A8B8A22748274000421EC /* STPConnectIndividualAccountParams.m */,
 				B3A241371FFEB57400A2F00D /* STPConnectAccountParams.h */,
 				B3A241381FFEB57400A2F00D /* STPConnectAccountParams.m */,
 				04B31DD21D08E6E200EF1631 /* STPCustomer.h */,
@@ -2353,6 +2367,8 @@
 				F1D3A2501EB0120F0095BFA9 /* STPFile.h */,
 				F1D3A2461EB012010095BFA9 /* STPFile.m */,
 				04F213301BCEAB61001D6F22 /* STPFormEncodable.h */,
+				1D9A8B842274798D000421EC /* STPIndividualParams.h */,
+				1D9A8B8722747E2F000421EC /* STPIndividualParams.m */,
 				B3A99BC11FEAF2CA003F6ED3 /* STPLegalEntityParams.h */,
 				B3A99BC21FEAF2CA003F6ED3 /* STPLegalEntityParams.m */,
 				B3BDCAC620EEF22D0034F7F5 /* STPPaymentIntent.h */,
@@ -2604,6 +2620,7 @@
 				B36C6D742193676600D17575 /* STPPaymentIntentSourceActionAuthorizeWithURL.h in Headers */,
 				8B429AD91EF9D4B500F95F34 /* STPBankAccountParams+Private.h in Headers */,
 				F1BEB2FE1F3508BB0043F48C /* NSError+Stripe.h in Headers */,
+				1D9A8B83227474CC000421EC /* STPConnectIndividualAccountParams.h in Headers */,
 				04E32AA01B7A9490009C9E35 /* STPPaymentCardTextField.h in Headers */,
 				04F94DA81D229F2F004FC826 /* STPPaymentOptionTuple.h in Headers */,
 				0438EF491B74183100D506CC /* STPCardBrand.h in Headers */,
@@ -2657,6 +2674,7 @@
 				04633AFD1CD129AF009D4FB5 /* STPPhoneNumberValidator.h in Headers */,
 				04633AFE1CD129B4009D4FB5 /* STPDelegateProxy.h in Headers */,
 				F1FA6F961E25960500EB444D /* STPCoreScrollViewController+Private.h in Headers */,
+				1D9A8B862274798D000421EC /* STPIndividualParams.h in Headers */,
 				04FCFA191BD59A8C00297732 /* STPCategoryLoader.h in Headers */,
 				C1D7B5211E36C32F002181F5 /* STPSource.h in Headers */,
 				049A3FB41CC9FF0500F57DE7 /* UIToolbar+Stripe_InputAccessory.h in Headers */,
@@ -2719,6 +2737,7 @@
 				C1D7B5201E36C32F002181F5 /* STPSource.h in Headers */,
 				B621F053223454E9002141B7 /* STPPaymentMethodCardWallet.h in Headers */,
 				049A3F7A1CC18D5300F57DE7 /* UIView+Stripe_FirstResponder.h in Headers */,
+				1D9A8B852274798D000421EC /* STPIndividualParams.h in Headers */,
 				04CDB50E1A5F30A700B854EE /* STPCard.h in Headers */,
 				C1BD9B391E39416700CEE925 /* STPSourceOwner.h in Headers */,
 				C1080F491CBECF7B007B2D89 /* STPAddress.h in Headers */,
@@ -2756,6 +2775,7 @@
 				C1785F5C1EC60B5E00E9CFAC /* STPCardIOProxy.h in Headers */,
 				049952CF1BCF13510088C703 /* STPAPIRequest.h in Headers */,
 				C15993381D8808680047950D /* STPShippingMethodTableViewCell.h in Headers */,
+				1D9A8B82227474CC000421EC /* STPConnectIndividualAccountParams.h in Headers */,
 				049A3FB21CC9FEFC00F57DE7 /* UIToolbar+Stripe_InputAccessory.h in Headers */,
 				F1FA6F981E25970F00EB444D /* STPCoreTableViewController+Private.h in Headers */,
 				F1DEB8901E2052150066B8E8 /* STPCoreScrollViewController.h in Headers */,
@@ -3020,6 +3040,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				"zh-Hans",
 				de,
@@ -3521,6 +3542,7 @@
 				049E84D01A605DE0000B66CD /* STPCard.m in Sources */,
 				04F94DA21D229F14004FC826 /* STPAddressFieldTableViewCell.m in Sources */,
 				049A3FB71CCA6B8900F57DE7 /* STPAddress.m in Sources */,
+				1D9A8B8922747E30000421EC /* STPIndividualParams.m in Sources */,
 				04F94DD41D22A242004FC826 /* NSBundle+Stripe_AppName.m in Sources */,
 				F152321E1EA92FC100D65C67 /* STPRedirectContext.m in Sources */,
 				C126553A1CAA2392006F7265 /* STPAddCardViewController.m in Sources */,
@@ -3555,6 +3577,7 @@
 				0426B9791CEBD001006AC8DD /* UINavigationBar+Stripe_Theme.m in Sources */,
 				C192268A1EBA228900BED563 /* STPTelemetryClient.m in Sources */,
 				045D71231CEFA57000F6CD65 /* UIViewController+Stripe_Promises.m in Sources */,
+				1D9A8B8C22748274000421EC /* STPConnectIndividualAccountParams.m in Sources */,
 				04BC29A11CD8412000318357 /* STPPaymentContext.m in Sources */,
 				04CDE5C71BC20AF800548833 /* STPBankAccountParams.m in Sources */,
 				C1363BBA1D7633D800EB82B4 /* STPPaymentOptionTableViewCell.m in Sources */,
@@ -3573,6 +3596,7 @@
 				C17A030E1CBEE7A2006C819F /* STPAddressFieldTableViewCell.m in Sources */,
 				049A3F921CC740FF00F57DE7 /* NSDecimalNumber+Stripe_Currency.m in Sources */,
 				B66D5021222F5611004A9210 /* STPPaymentMethodCardChecks.m in Sources */,
+				1D9A8B8822747E30000421EC /* STPIndividualParams.m in Sources */,
 				C1080F4A1CBECF7B007B2D89 /* STPAddress.m in Sources */,
 				04B31DE81D09D25F00EF1631 /* STPPaymentOptionsInternalViewController.m in Sources */,
 				F1D3A25C1EB014BD0095BFA9 /* UIImage+Stripe.m in Sources */,
@@ -3627,6 +3651,7 @@
 				0438EF351B7416BB00D506CC /* STPPaymentCardTextField.m in Sources */,
 				B3A2413B1FFEB57400A2F00D /* STPConnectAccountParams.m in Sources */,
 				B690DDFA222F0564000B902D /* STPPaymentMethodCard.m in Sources */,
+				1D9A8B8B22748274000421EC /* STPConnectIndividualAccountParams.m in Sources */,
 				F1D3A24F1EB012010095BFA9 /* STPMultipartFormDataPart.m in Sources */,
 				04827D121D2575C6002DB3E8 /* STPImageLibrary.m in Sources */,
 				04CDB5041A5F30A700B854EE /* STPFormEncoder.m in Sources */,

--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -3017,7 +3017,7 @@
 					};
 					04CDB4411A5F2E1800B854EE = {
 						CreatedOnToolsVersion = 6.1.1;
-						DevelopmentTeam = Y28TH9SHX7;
+						DevelopmentTeam = U9E7JWZWR9;
 					};
 					3650AA3D21C07E3C002B0893 = {
 						CreatedOnToolsVersion = 9.4.1;
@@ -3868,7 +3868,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 04F39F101AEF2AFE005B926E /* StripeiOS-Debug.xcconfig */;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = U9E7JWZWR9;
 			};
 			name = Debug;
 		};
@@ -3876,7 +3876,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 04F39F111AEF2AFE005B926E /* StripeiOS-Release.xcconfig */;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = U9E7JWZWR9;
 			};
 			name = Release;
 		};

--- a/Stripe/PublicHeaders/STPAPIClient.h
+++ b/Stripe/PublicHeaders/STPAPIClient.h
@@ -20,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 static NSString *const STPSDKVersion = @"15.0.1";
 
-@class STPBankAccount, STPBankAccountParams, STPCard, STPCardParams, STPConnectAccountParams;
+@class STPBankAccount, STPBankAccountParams, STPCard, STPCardParams, STPConnectAccountParams, STPConnectIndividualAccountParams;
 @class STPPaymentConfiguration, STPPaymentIntentParams, STPSourceParams, STPToken, STPPaymentMethodParams;
 
 /**
@@ -145,6 +145,16 @@ static NSString *const STPSDKVersion = @"15.0.1";
  @param completion The callback to run with the returned Stripe token (and any errors that may have occurred).
  */
 - (void)createTokenWithConnectAccount:(STPConnectAccountParams *)account completion:(__nullable STPTokenCompletionBlock)completion;
+    
+/**
+ Converts an `STPConnectIndividualAccountParams` object into a Stripe token using the Stripe API.
+ 
+ This allows the connected account to accept the Terms of Service, and/or send Legal Entity information.
+ 
+ @param account The Connect Individual Account parameters. Cannot be nil.
+ @param completion The callback to run with the returned Stripe token (and any errors that may have occurred).
+ */
+- (void)createTokenWithConnectIndividualAccount:(STPConnectIndividualAccountParams *)account completion:(__nullable STPTokenCompletionBlock)completion;
 
 @end
 

--- a/Stripe/PublicHeaders/STPConnectIndividualAccountParams.h
+++ b/Stripe/PublicHeaders/STPConnectIndividualAccountParams.h
@@ -1,0 +1,81 @@
+//
+//  STPConnectIndividualAccountParams.h
+//  Stripe
+//
+//  Created by Peter Suwara on 27/4/19.
+//  Copyright © 2019 Stripe, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "STPFormEncodable.h"
+
+@class STPIndividualParams;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Parameters for creating a Connect Account token.
+ */
+@interface STPConnectIndividualAccountParams : NSObject<STPFormEncodable>
+
+/**
+ Optional boolean indicating that the Terms Of Service were shown to the user &
+ the user accepted them.
+ */
+@property (nonatomic, nullable, readonly) NSNumber *tosShownAndAccepted;
+
+/**
+ Required string that defines the business type. In this case it needs to be "individual"
+ */
+@property (nonatomic, nullable, readonly) NSString *businessType;
+
+/**
+ Required property that defines the individual for an account.
+
+ At least one field in the legalEntity must have a value, otherwise the create token
+ call will fail.
+ */
+@property (nonatomic, readonly) STPIndividualParams *individual;
+
+/**
+ `STPConnectIndividualAccountParams` cannot be directly instantiated, use `initWithTosShownAndAccepted:businesstype:legalEntity:`
+ or `initWithLegalEntity:`
+ */
+- (instancetype)init __attribute__((unavailable("Cannot be directly instantiated")));
+
+/**
+ Initialize `STPConnectIndividualAccountParams` with tosShownAndAccepted = YES
+
+ This method cannot be called with `wasAccepted == NO`, guarded by a `NSParameterAssert()`.
+
+ Use this init method if you want to set the `tosShownAndAccepted` parameter. If you
+ don't, use the `initWithLegalEntity:` version instead.
+
+ @param wasAccepted Must be YES, but only if the user was shown & accepted the ToS
+ @param individual The data associated with the individual
+ @param businessType Indicates whether this will be an individual or company
+ */
+- (instancetype)initWithTosShownAndAccepted:(BOOL)wasAccepted
+                               businessType:(NSString *)businessType
+                                 individual:(STPIndividualParams*)individual;
+
+/**
+ Initialize `STPConnectIndividualAccountParams` with the `STPLegalEntityParams` provided.
+
+ This init method cannot change the `tosShownAndAccepted` parameter. Use
+ `initWithTosShownAndAccepted:legalEntity:` instead if you need to do that.
+
+ These two init methods exist to avoid the (slightly awkward) NSNumber box that would
+ be needed around `tosShownAndAccepted` if it was optional/nullable, and to enforce
+ that it is either nil or YES. This also forces the business type to "individual"
+
+ @param individual The data associated with the individual
+ */
+- (instancetype)initWithIndividual:(STPIndividualParams *)individual;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+

--- a/Stripe/PublicHeaders/STPIndividualParams.h
+++ b/Stripe/PublicHeaders/STPIndividualParams.h
@@ -77,14 +77,14 @@ NS_ASSUME_NONNULL_BEGIN
 @interface STPIndividualVerificationParams: NSObject<STPFormEncodable>
 
 /**
- The file id for the uploaded verification document.
+ The file id for the uploaded verificatoin document (front side).
  */
-@property (nonatomic, copy, nullable) NSString *document;
+@property (nonatomic, copy, nullable) NSString *front;
 
 /**
  The file id for the uploaded verification document (back side).
  */
-@property (nonatomic, copy, nullable) NSString *documentBack;
+@property (nonatomic, copy, nullable) NSString *back;
 
 @end
 

--- a/Stripe/PublicHeaders/STPIndividualParams.h
+++ b/Stripe/PublicHeaders/STPIndividualParams.h
@@ -1,0 +1,91 @@
+//
+//  STPIndividualParams.h
+//  Stripe
+//
+//  Created by Daniel Jackson on 12/20/17.
+//  Copyright © 2017 Stripe, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "STPFormEncodable.h"
+
+@class STPAddress, STPVerificationParams;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Stripe API parameters to define a Person. Things like their name, address, etc.
+
+ All of the fields are optional.
+ */
+@interface STPIndividualParams: NSObject<STPFormEncodable>
+
+/**
+ The address parameter. For `STPPersonParams`, this is the address of the person.
+ For the `STPLegalEntityParams` subclass, see also `personalAddress`.
+ */
+@property (nonatomic, strong, nullable) STPAddress *address;
+
+/**
+ The date of birth (dob) of this person.
+
+ Must include `day`, `month`, and `year`, and only those fields are used.
+ */
+@property (nonatomic, copy, nullable) NSDateComponents *dateOfBirth;
+
+/**
+ The first name of this person.
+ */
+@property (nonatomic, copy, nullable) NSString *firstName;
+
+/**
+ The last name of this person.
+ */
+@property (nonatomic, copy, nullable) NSString *lastName;
+
+/**
+ The first name of this person.
+ */
+@property (nonatomic, copy, nullable) NSString *gender;
+
+/**
+ The first name of this person.
+ */
+@property (nonatomic, copy, nullable) NSString *ssnLast4;
+
+/**
+ The first name of this person.
+ */
+@property (nonatomic, copy, nullable) NSString *phone;
+
+/**
+ The first name of this person.
+ */
+@property (nonatomic, copy, nullable) NSString *idNumber;
+
+/**
+ Verification document for this person.
+ */
+@property (nonatomic, strong, nullable) STPVerificationParams *verification;
+
+@end
+
+
+/**
+ Parameters for supported types of verification.
+ */
+@interface STPVerificationParams: NSObject<STPFormEncodable>
+
+/**
+ The file id for the uploaded verification document.
+ */
+@property (nonatomic, copy, nullable) NSString *document;
+
+/**
+ The file id for the uploaded verification document (back side).
+ */
+@property (nonatomic, copy, nullable) NSString *documentBack;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Stripe/PublicHeaders/STPIndividualParams.h
+++ b/Stripe/PublicHeaders/STPIndividualParams.h
@@ -79,7 +79,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  The file id for the uploaded verificatoin document (front side).
  */
-@property (nonatomic, strong, nullable) STPIndividualDocumentParams *front;
+@property (nonatomic, strong, nullable) STPIndividualDocumentParams *document;
 
 @end
 

--- a/Stripe/PublicHeaders/STPIndividualParams.h
+++ b/Stripe/PublicHeaders/STPIndividualParams.h
@@ -2,14 +2,14 @@
 //  STPIndividualParams.h
 //  Stripe
 //
-//  Created by Daniel Jackson on 12/20/17.
+//  Created by Peter Suwara on 4/28/19.
 //  Copyright © 2017 Stripe, Inc. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
 #import "STPFormEncodable.h"
 
-@class STPAddress, STPVerificationParams;
+@class STPAddress, STPIndividualVerificationParams;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -66,7 +66,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Verification document for this person.
  */
-@property (nonatomic, strong, nullable) STPVerificationParams *verification;
+@property (nonatomic, strong, nullable) STPIndividualVerificationParams *verification;
 
 @end
 
@@ -74,7 +74,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Parameters for supported types of verification.
  */
-@interface STPVerificationParams: NSObject<STPFormEncodable>
+@interface STPIndividualVerificationParams: NSObject<STPFormEncodable>
 
 /**
  The file id for the uploaded verification document.

--- a/Stripe/PublicHeaders/STPIndividualParams.h
+++ b/Stripe/PublicHeaders/STPIndividualParams.h
@@ -9,7 +9,7 @@
 #import <Foundation/Foundation.h>
 #import "STPFormEncodable.h"
 
-@class STPAddress, STPIndividualVerificationParams;
+@class STPAddress, STPIndividualVerificationParams, STPIndividualDocumentParams;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -79,10 +79,22 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  The file id for the uploaded verificatoin document (front side).
  */
+@property (nonatomic, strong, nullable) STPIndividualDocumentParams *front;
+
+@end
+
+/**
+ Parameter that contains the front and back of a document.
+ */
+@interface STPIndividualDocumentParams: NSObject<STPFormEncodable>
+
+/**
+ The file id for the uploaded document (front side).
+ */
 @property (nonatomic, copy, nullable) NSString *front;
 
 /**
- The file id for the uploaded verification document (back side).
+ The file id for the uploaded document (back side).
  */
 @property (nonatomic, copy, nullable) NSString *back;
 

--- a/Stripe/PublicHeaders/Stripe.h
+++ b/Stripe/PublicHeaders/Stripe.h
@@ -22,6 +22,7 @@
 #import "STPCardParams.h"
 #import "STPCardValidationState.h"
 #import "STPCardValidator.h"
+#import "STPConnectIndividualAccountParams.h"
 #import "STPConnectAccountParams.h"
 #import "STPCoreScrollViewController.h"
 #import "STPCoreTableViewController.h"

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -308,6 +308,13 @@ static BOOL _jcbPaymentNetworkSupported = NO;
     [[STPTelemetryClient sharedInstance] sendTelemetryData];
 }
 
+    
+- (void)createTokenWithConnectIndividualAccount:(STPConnectIndividualAccountParams *)account completion:(__nullable STPTokenCompletionBlock)completion {
+    NSMutableDictionary *params = [[STPFormEncoder dictionaryForObject:account] mutableCopy];
+    [[STPTelemetryClient sharedInstance] addTelemetryFieldsToParams:params];
+    [self createTokenWithParameters:params completion:completion];
+    [[STPTelemetryClient sharedInstance] sendTelemetryData];
+}
 @end
 
 #pragma mark - Upload

--- a/Stripe/STPConnectIndividualAccountParams.m
+++ b/Stripe/STPConnectIndividualAccountParams.m
@@ -1,0 +1,74 @@
+//
+//  STPConnectIndividualAccountParams.m
+//  Stripe
+//
+//  Created by Peter Suwara on 27/4/19.
+//  Copyright © 2018 Stripe, Inc. All rights reserved.
+//
+
+#import "STPConnectIndividualAccountParams.h"
+
+#import "STPIndividualParams.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation STPConnectIndividualAccountParams
+
+@synthesize additionalAPIParameters;
+
+- (instancetype)initWithTosShownAndAccepted:(BOOL)wasAccepted
+                               businessType:(NSString *)businessType
+                                 individual:(STPIndividualParams *)individual {
+    // It is an error to call this method with wasAccepted == NO
+    NSParameterAssert(wasAccepted == YES);
+    self = [super init];
+    if (self) {
+        _tosShownAndAccepted = @(wasAccepted);
+        _businessType = businessType;
+        _individual = individual;
+    }
+    return self;
+}
+
+- (instancetype)initWithIndividual:(STPIndividualParams *)individual {
+    self = [super init];
+    if (self) {
+        _tosShownAndAccepted = nil;
+        _businessType = @"individual";
+        _individual = individual;
+    }
+    return self;
+}
+
+#pragma mark - description
+
+- (NSString *)description {
+    NSArray *props = @[
+                       [NSString stringWithFormat:@"%@: %p", NSStringFromClass([self class]), self],
+                       // We use NSParameterAssert to block this being NO:
+                       [NSString stringWithFormat:@"tosShownAndAccepted = %@",
+                        self.tosShownAndAccepted != nil ? @"YES" : @"<nil>"],
+                       [NSString stringWithFormat:@"individual = %@", self.individual.description],
+                       ];
+
+    return [NSString stringWithFormat:@"<%@>", [props componentsJoinedByString:@"; "]];
+}
+
+#pragma mark - STPFormEncodable
+
++ (nullable NSString *)rootObjectName {
+    return @"account";
+}
+
++ (nonnull NSDictionary *)propertyNamesToFormFieldNamesMapping {
+    return @{
+             NSStringFromSelector(@selector(tosShownAndAccepted)): @"tos_shown_and_accepted",
+             NSStringFromSelector(@selector(individual)): @"individual",
+             NSStringFromSelector(@selector(businessType)): @"business_type",
+             };
+}
+
+@end
+
+NS_ASSUME_NONNULL_END
+

--- a/Stripe/STPIndividualParams.m
+++ b/Stripe/STPIndividualParams.m
@@ -11,7 +11,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@implementation STPVerificationParams
+@implementation STPIndividualVerificationParams
 @synthesize additionalAPIParameters;
 
 - (NSString *)description {

--- a/Stripe/STPIndividualParams.m
+++ b/Stripe/STPIndividualParams.m
@@ -11,7 +11,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@implementation STPIndividualVerificationParams
+@implementation STPIndividualDocumentParams
 @synthesize additionalAPIParameters;
 
 - (NSString *)description {
@@ -20,18 +20,43 @@ NS_ASSUME_NONNULL_BEGIN
                        [NSString stringWithFormat:@"front = %@", self.front],
                        [NSString stringWithFormat:@"back = %@", self.back],
                        ];
-
+    
     return [NSString stringWithFormat:@"<%@>", [props componentsJoinedByString:@"; "]];
 }
 
 + (nullable NSString *)rootObjectName {
-    return @"verification";
+    return @"document";
 }
 
 + (nonnull NSDictionary *)propertyNamesToFormFieldNamesMapping {
     return @{
              NSStringFromSelector(@selector(front)): @"front",
              NSStringFromSelector(@selector(back)): @"back",
+             };
+}
+
+@end
+
+@implementation STPIndividualVerificationParams
+@synthesize additionalAPIParameters;
+
+- (NSString *)description {
+    NSArray *props = @[
+                       [NSString stringWithFormat:@"%@: %p", NSStringFromClass([self class]), self],
+                       [NSString stringWithFormat:@"document = %@", self.front],
+                       [NSString stringWithFormat:@"back = %@", self.back],
+                       ];
+
+    return [NSString stringWithFormat:@"<%@>", [props componentsJoinedByString:@"; "]];
+}
+
++ (nullable NSString *)rootObjectName {
+    return @"document";
+}
+
++ (nonnull NSDictionary *)propertyNamesToFormFieldNamesMapping {
+    return @{
+             NSStringFromSelector(@selector(document)): @"document",
              };
 }
 

--- a/Stripe/STPIndividualParams.m
+++ b/Stripe/STPIndividualParams.m
@@ -1,0 +1,118 @@
+//
+//  STPIndividualParams.m
+//  Stripe
+//
+//  Created by Peter Suwra on 04/27/17.
+//  Copyright © 2019 Stripe, Inc. All rights reserved.
+//
+
+#import "STPIndividualParams.h"
+#import "FauxPasAnnotations.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation STPVerificationParams
+@synthesize additionalAPIParameters;
+
+- (NSString *)description {
+    NSArray *props = @[
+                       [NSString stringWithFormat:@"%@: %p", NSStringFromClass([self class]), self],
+                       [NSString stringWithFormat:@"document = %@", self.document],
+                       [NSString stringWithFormat:@"documentBack = %@", self.documentBack],
+                       ];
+
+    return [NSString stringWithFormat:@"<%@>", [props componentsJoinedByString:@"; "]];
+}
+
++ (nullable NSString *)rootObjectName {
+    return @"verification";
+}
+
++ (nonnull NSDictionary *)propertyNamesToFormFieldNamesMapping {
+    return @{
+             NSStringFromSelector(@selector(document)): @"document",
+             NSStringFromSelector(@selector(documentBack)): @"document_back",
+             };
+}
+
+@end
+
+@implementation STPIndividualParams
+@synthesize additionalAPIParameters;
+
+- (NSString *)description {
+    NSArray *props = @[
+                       [NSString stringWithFormat:@"%@: %p", NSStringFromClass([self class]), self],
+                       [NSString stringWithFormat:@"address = <%@>", self.address],
+                       [NSString stringWithFormat:@"dateOfBirth = <%@>", self.dateOfBirth],
+                       [NSString stringWithFormat:@"firstName = %@", self.firstName],
+                       [NSString stringWithFormat:@"lastName = %@", self.lastName],
+                       [NSString stringWithFormat:@"gender = %@", self.gender],
+                       [NSString stringWithFormat:@"ssnLast4 = %@", self.ssnLast4],
+                       [NSString stringWithFormat:@"phone = %@", self.phone],
+                       [NSString stringWithFormat:@"idNumber = %@", self.idNumber],
+                       [NSString stringWithFormat:@"verification = %@", self.verification],
+                       ];
+
+    return [NSString stringWithFormat:@"<%@>", [props componentsJoinedByString:@"; "]];
+}
+
++ (nullable NSString *)rootObjectName {
+    return @"individual";
+}
+
++ (nonnull NSDictionary *)propertyNamesToFormFieldNamesMapping {
+    return @{
+             NSStringFromSelector(@selector(address)): @"address",
+             NSStringFromSelector(@selector(dateOfBirth)): @"dob",
+             NSStringFromSelector(@selector(firstName)): @"first_name",
+             NSStringFromSelector(@selector(lastName)): @"last_name",
+             NSStringFromSelector(@selector(gender)): @"gender",
+             NSStringFromSelector(@selector(ssnLast4)): @"ssn_last_4",
+             NSStringFromSelector(@selector(phone)): @"phone",
+             NSStringFromSelector(@selector(idNumber)): @"idNumber",
+             NSStringFromSelector(@selector(verification)): @"verification",
+             };
+}
+
+@end
+
+/*
+ Add STPFormEncodable conformance for `STPIndividualParams.dateOfBirth`.
+
+ Faux Pas (correctly) points out this is dangerous. Probably a better thing to do
+ is either prefix all of these methods in the protocol, or add custom support for
+ `NSDateComponents` in `+[STPFormEncoder formEncodableValueForObject:]`.
+
+ For now, I think this is safe enough.
+ */
+@interface NSDateComponents (STPFormEncodable) <STPFormEncodable> @end
+@implementation NSDateComponents (STPFormEncodable)
+
+- (NSDictionary *)additionalAPIParameters {
+    FAUXPAS_IGNORED_IN_METHOD(UnprefixedCategoryMethod)
+    return @{};
+}
+
+- (void)setAdditionalAPIParameters:(__unused NSDictionary *)additionalAPIParameters {
+    FAUXPAS_IGNORED_IN_METHOD(UnprefixedCategoryMethod)
+    [self doesNotRecognizeSelector:_cmd];
+}
+
++ (nullable NSString *)rootObjectName {
+    FAUXPAS_IGNORED_IN_METHOD(UnprefixedCategoryMethod)
+    return nil;
+}
+
++ (nonnull NSDictionary *)propertyNamesToFormFieldNamesMapping {
+    FAUXPAS_IGNORED_IN_METHOD(UnprefixedCategoryMethod)
+    return @{
+             NSStringFromSelector(@selector(day)): @"day",
+             NSStringFromSelector(@selector(month)): @"month",
+             NSStringFromSelector(@selector(year)): @"year",
+             };
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Stripe/STPIndividualParams.m
+++ b/Stripe/STPIndividualParams.m
@@ -43,8 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSString *)description {
     NSArray *props = @[
                        [NSString stringWithFormat:@"%@: %p", NSStringFromClass([self class]), self],
-                       [NSString stringWithFormat:@"document = %@", self.front],
-                       [NSString stringWithFormat:@"back = %@", self.back],
+                       [NSString stringWithFormat:@"document = %@", self.document],
                        ];
 
     return [NSString stringWithFormat:@"<%@>", [props componentsJoinedByString:@"; "]];

--- a/Stripe/STPIndividualParams.m
+++ b/Stripe/STPIndividualParams.m
@@ -70,7 +70,7 @@ NS_ASSUME_NONNULL_BEGIN
              NSStringFromSelector(@selector(gender)): @"gender",
              NSStringFromSelector(@selector(ssnLast4)): @"ssn_last_4",
              NSStringFromSelector(@selector(phone)): @"phone",
-             NSStringFromSelector(@selector(idNumber)): @"idNumber",
+             NSStringFromSelector(@selector(idNumber)): @"id_number",
              NSStringFromSelector(@selector(verification)): @"verification",
              };
 }

--- a/Stripe/STPIndividualParams.m
+++ b/Stripe/STPIndividualParams.m
@@ -17,8 +17,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSString *)description {
     NSArray *props = @[
                        [NSString stringWithFormat:@"%@: %p", NSStringFromClass([self class]), self],
-                       [NSString stringWithFormat:@"document = %@", self.document],
-                       [NSString stringWithFormat:@"documentBack = %@", self.documentBack],
+                       [NSString stringWithFormat:@"front = %@", self.front],
+                       [NSString stringWithFormat:@"back = %@", self.back],
                        ];
 
     return [NSString stringWithFormat:@"<%@>", [props componentsJoinedByString:@"; "]];
@@ -30,8 +30,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (nonnull NSDictionary *)propertyNamesToFormFieldNamesMapping {
     return @{
-             NSStringFromSelector(@selector(document)): @"document",
-             NSStringFromSelector(@selector(documentBack)): @"document_back",
+             NSStringFromSelector(@selector(front)): @"front",
+             NSStringFromSelector(@selector(back)): @"back",
              };
 }
 


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Connect Account data has changed in the Web API and the iOS SDK no longer correctly supports these functions for creating connect account. I have added calls to support the new connect accounts while still having the old Beta Connect calls available for backward compatiility.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
The Connect API has been updated.

## Testing
<!-- How was the code tested? Be as specific as possible. -->
It was test against a REST webapi that forward to the Stripe ConnectAccount API. Connect accounts were created.