### PR TITLE
Change to Alamofire version

### DIFF
--- a/Example/Cartfile
+++ b/Example/Cartfile
@@ -1,1 +1,1 @@
-github "Alamofire/Alamofire" "4.4.0"
+github "Alamofire/Alamofire" "4.8.2"


### PR DESCRIPTION
Support latest version of Swift

## Summary
References #1164

## Motivation
Unable to build with `setup.sh` due to a `SWIFT_VERSION` error on Alamofire 4.4.

## Testing
`setup.sh` runs successfully with this change.