### PR TITLE
Update to latest Xcode version 10.2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode9.2
+osx_image: xcode10.2.1
 branches:
   only:
     - master

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,4 +1,4 @@
-github "facebook/ios-snapshot-test-case"
+github "uber/ios-snapshot-test-case"
 github "erikdoe/ocmock"
-github "AliSoftware/OHHTTPStubs"
+github "AliSoftware/OHHTTPStubs" >= 8.0.0
 github "capitalone/SWHttpTrafficRecorder"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "AliSoftware/OHHTTPStubs" "6.1.0"
+github "AliSoftware/OHHTTPStubs" "8.0.0"
 github "capitalone/SWHttpTrafficRecorder" "1.0.2"
 github "erikdoe/ocmock" "v3.4.3"
-github "facebook/ios-snapshot-test-case" "2.1.4"
+github "uber/ios-snapshot-test-case" "6.0.3"

--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -187,7 +187,7 @@
 		049E84D31A605E6A000B66CD /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FAFC12C516E5767F0066297F /* UIKit.framework */; };
 		049E84D41A605E7C000B66CD /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 11C74B9B164043050071C2CA /* Foundation.framework */; };
 		049E84D51A605E82000B66CD /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A0D74F918F6106100966D7B /* Security.framework */; };
-		049E84D61A605E8F000B66CD /* PassKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04D5BF9019BF958F009521A5 /* PassKit.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		049E84D61A605E8F000B66CD /* PassKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04D5BF9019BF958F009521A5 /* PassKit.framework */; settings = {ATTRIBUTES = (Required, ); }; };
 		049E84D71A605E99000B66CD /* AddressBook.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04B94BC71A47B78A00092C46 /* AddressBook.framework */; };
 		049E84D91A605EF0000B66CD /* Stripe.h in Headers */ = {isa = PBXBuildFile; fileRef = 04CDB4A91A5F30A700B854EE /* Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		049E84E61A605EF0000B66CD /* STPAPIClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 04CDB4C21A5F30A700B854EE /* STPAPIClient.h */; settings = {ATTRIBUTES = (Public, ); }; };

--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -482,7 +482,6 @@
 		B66D5021222F5611004A9210 /* STPPaymentMethodCardChecks.m in Sources */ = {isa = PBXBuildFile; fileRef = B66D5020222F5611004A9210 /* STPPaymentMethodCardChecks.m */; };
 		B66D5022222F5611004A9210 /* STPPaymentMethodCardChecks.m in Sources */ = {isa = PBXBuildFile; fileRef = B66D5020222F5611004A9210 /* STPPaymentMethodCardChecks.m */; };
 		B66D5024222F5A27004A9210 /* STPPaymentMethodThreeDSecureUsageTest.m in Sources */ = {isa = PBXBuildFile; fileRef = B66D5023222F5A27004A9210 /* STPPaymentMethodThreeDSecureUsageTest.m */; };
-		B66D5025222F62E3004A9210 /* STPCustomerTest.m in Copy Files */ = {isa = PBXBuildFile; fileRef = C1D23FAC1D37F81F002FD83C /* STPCustomerTest.m */; };
 		B66D5027222F8605004A9210 /* STPPaymentMethodCardChecksTest.m in Sources */ = {isa = PBXBuildFile; fileRef = B66D5026222F8605004A9210 /* STPPaymentMethodCardChecksTest.m */; };
 		B68F1C792234740B0030B438 /* STPPaymentMethodCardWalletTest.m in Sources */ = {isa = PBXBuildFile; fileRef = B68F1C782234740B0030B438 /* STPPaymentMethodCardWalletTest.m */; };
 		B690DDEC222F01BF000B902D /* STPPaymentMethodBillingDetails.h in Headers */ = {isa = PBXBuildFile; fileRef = B690DDEA222F01BF000B902D /* STPPaymentMethodBillingDetails.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -976,7 +975,6 @@
 			dstSubfolderSpec = 16;
 			files = (
 				04B33F361BC7488D00DD8120 /* Info.plist in Copy Files */,
-				B66D5025222F62E3004A9210 /* STPCustomerTest.m in Copy Files */,
 			);
 			name = "Copy Files";
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ci_scripts/export_builds.sh
+++ b/ci_scripts/export_builds.sh
@@ -82,6 +82,7 @@ info "Compiling static framework..."
 cd "${root_dir}" || die "Executing \`cd\` failed"
 
 xcodebuild clean build \
+  -UseModernBuildSystem=NO \
   -workspace "Stripe.xcworkspace" \
   -scheme "StripeiOSStaticFramework" \
   -configuration "Release" \


### PR DESCRIPTION
## Summary
* Require PassKit framework to remove Xcode and `export_builds.sh` warnings.  [This was set as optional](https://github.com/stripe/stripe-ios/commit/56338c28904b34c9be87281831bf3382a39bb44e) in v2.0.1).  I'm guessing we did that because the SDK at that time supported iOS 5.0 and PassKit was introduced in iOS 6.0.  
* Remove STPCustomerTest from StripeiOSStaticFramework Copy Files phase.  I accidentally added this in https://github.com/stripe/stripe-ios/commit/85aa37d2b431aa518c956f4077a297b5c9f1a1e5
* Bump travis xcode version from 9.2 to 10.2.1
* Don't use new Xcode 10 build system in `export_builds.sh`.
* Switch from facebook/ios-snapshot-test-case 2.1.4 to uber/ios-snapshot-test-case 6.0.3
* Update OHHTTPStubs from 2.1.4 to 6.0.3

## Motivation
Support the latest Xcode version!

## Testing
- `export_builds.sh` runs 
- Tests pass
- Set `recordingMode = YES` for a functional test to exercise OHHTTPStubs, ran the test, then set it back to `NO`.  Test passes.