### PR TITLE
Update to latest Xcode version 10.2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode10.2.1
+osx_image: xcode10.2
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ env:
   - TEST_TYPE=installation_carthage
   - TEST_TYPE=installation_cocoapods
   - TEST_TYPE=installation_cocoapods_frameworks
-  - TEST_TYPE=lint
   - TEST_TYPE=tests
   - TEST_TYPE=builds
   - TEST_TYPE=analyzer
@@ -17,6 +16,16 @@ env:
 
   global:
     secure: gZMOaHQIeG7nplBCuH7EKf9o6Ez2rtoSskrv3nOTziSxFfZq322MrxvkidDpEN7AKWYQm27FO+tCzgq0slXb578lQ9P5ySDwEdExKtk/jMtKsBsf3cr4dzSMiqV5D5TbsH2jE9HQlpYUoJeoMBicR2XsTmd7wiu2jAzNBFqGfiY=
+matrix:
+  include:
+  - env:
+    - TEST_TYPE=lint
+    - secure: "RPtZBXKq0EArFHt8eR0hyxb/13QaA08Lc37p0zw/UNjj3ie6d1Vmi+BVqMBB0j7T2T71gkBjjUTV/o7T1VxONpJkEnk1fO4/1OYDbVPTKbkNS0JdmFYzQPFtewFZUhsGLnz/HhfATe8H18PeN0eS9jZbASXIu+Ssah6APt+P78w="
+    osx_image: xcode9.2 # This is the last 10.12 image
+    addons:
+      homebrew:
+        casks:
+        - fauxpas
 
 before_install:
 - SIMULATOR_ID=$(xcrun instruments -s | grep -o "iPhone 6 (11.2) \[.*\]" | grep -o

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
 - SIMULATOR_ID=$(xcrun instruments -s | grep -o "iPhone 6 (11.2) \[.*\]" | grep -o
   "\[.*\]" | sed "s/^\[\(.*\)\]$/\1/")
 script:
-- open -a "simulator" --args -CurrentDeviceUDID $SIMULATOR_ID
+- open /Applications/Xcode.app/Contents/Developer/Applications/Simulator.app --args -CurrentDeviceUDID $SIMULATOR_ID
 - "./ci_scripts/check_version.rb"
 - "./ci_scripts/check_public_headers.rb"
 - "./ci_scripts/check_category_linking.rb"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode9.2
+osx_image: xcode10.2.1
 branches:
   only:
     - master

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,4 +1,4 @@
-github "facebook/ios-snapshot-test-case"
+github "uber/ios-snapshot-test-case"
 github "erikdoe/ocmock"
-github "AliSoftware/OHHTTPStubs"
+github "AliSoftware/OHHTTPStubs" >= 8.0.0
 github "capitalone/SWHttpTrafficRecorder"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "AliSoftware/OHHTTPStubs" "6.1.0"
+github "AliSoftware/OHHTTPStubs" "8.0.0"
 github "capitalone/SWHttpTrafficRecorder" "1.0.2"
 github "erikdoe/ocmock" "v3.4.3"
-github "facebook/ios-snapshot-test-case" "2.1.4"
+github "uber/ios-snapshot-test-case" "6.0.3"

--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -484,7 +484,6 @@
 		B66D5021222F5611004A9210 /* STPPaymentMethodCardChecks.m in Sources */ = {isa = PBXBuildFile; fileRef = B66D5020222F5611004A9210 /* STPPaymentMethodCardChecks.m */; };
 		B66D5022222F5611004A9210 /* STPPaymentMethodCardChecks.m in Sources */ = {isa = PBXBuildFile; fileRef = B66D5020222F5611004A9210 /* STPPaymentMethodCardChecks.m */; };
 		B66D5024222F5A27004A9210 /* STPPaymentMethodThreeDSecureUsageTest.m in Sources */ = {isa = PBXBuildFile; fileRef = B66D5023222F5A27004A9210 /* STPPaymentMethodThreeDSecureUsageTest.m */; };
-		B66D5025222F62E3004A9210 /* STPCustomerTest.m in Copy Files */ = {isa = PBXBuildFile; fileRef = C1D23FAC1D37F81F002FD83C /* STPCustomerTest.m */; };
 		B66D5027222F8605004A9210 /* STPPaymentMethodCardChecksTest.m in Sources */ = {isa = PBXBuildFile; fileRef = B66D5026222F8605004A9210 /* STPPaymentMethodCardChecksTest.m */; };
 		B67D7D4B2294A081000FBA12 /* STPPaymentMethodListDeserializer.h in Headers */ = {isa = PBXBuildFile; fileRef = B665CE45228DE4C4008B546F /* STPPaymentMethodListDeserializer.h */; };
 		B67D7D4D2294A0FD000FBA12 /* STPPaymentMethodListDeserializer.m in Sources */ = {isa = PBXBuildFile; fileRef = B665CE46228DE4C4008B546F /* STPPaymentMethodListDeserializer.m */; };
@@ -980,7 +979,6 @@
 			dstSubfolderSpec = 16;
 			files = (
 				04B33F361BC7488D00DD8120 /* Info.plist in Copy Files */,
-				B66D5025222F62E3004A9210 /* STPCustomerTest.m in Copy Files */,
 			);
 			name = "Copy Files";
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -187,7 +187,7 @@
 		049E84D31A605E6A000B66CD /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FAFC12C516E5767F0066297F /* UIKit.framework */; };
 		049E84D41A605E7C000B66CD /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 11C74B9B164043050071C2CA /* Foundation.framework */; };
 		049E84D51A605E82000B66CD /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A0D74F918F6106100966D7B /* Security.framework */; };
-		049E84D61A605E8F000B66CD /* PassKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04D5BF9019BF958F009521A5 /* PassKit.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		049E84D61A605E8F000B66CD /* PassKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04D5BF9019BF958F009521A5 /* PassKit.framework */; settings = {ATTRIBUTES = (Required, ); }; };
 		049E84D71A605E99000B66CD /* AddressBook.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04B94BC71A47B78A00092C46 /* AddressBook.framework */; };
 		049E84D91A605EF0000B66CD /* Stripe.h in Headers */ = {isa = PBXBuildFile; fileRef = 04CDB4A91A5F30A700B854EE /* Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		049E84E61A605EF0000B66CD /* STPAPIClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 04CDB4C21A5F30A700B854EE /* STPAPIClient.h */; settings = {ATTRIBUTES = (Public, ); }; };

--- a/Tests/Tests/STPColorUtilsTest.m
+++ b/Tests/Tests/STPColorUtilsTest.m
@@ -22,7 +22,7 @@
     // Using 0.3 as the cutoff from bright/non-bright because that's what
     // the current implementation does.
 
-    for (CGFloat white = 0.0; white < 0.3; white += 0.05) {
+    for (CGFloat white = 0.0; white < 0.3; white += (CGFloat)0.05) {
         components[0] = white;
         CGColorRef cgcolor = CGColorCreate(space, components);
         UIColor *color = [UIColor colorWithCGColor:cgcolor];
@@ -31,7 +31,7 @@
         CGColorRelease(cgcolor);
     }
 
-    for (CGFloat white = (CGFloat)0.3001; white < 2; white += 0.1) {
+    for (CGFloat white = (CGFloat)0.3001; white < 2; white += (CGFloat)0.1) {
         components[0] = white;
         CGColorRef cgcolor = CGColorCreate(space, components);
         UIColor *color = [UIColor colorWithCGColor:cgcolor];

--- a/Tests/installation_tests/carthage/CarthageTest.xcodeproj/project.pbxproj
+++ b/Tests/installation_tests/carthage/CarthageTest.xcodeproj/project.pbxproj
@@ -179,6 +179,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -360,7 +361,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.jflinter.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -376,7 +377,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.jflinter.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -392,7 +393,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.jflinter.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CarthageTest.app/CarthageTest";
 			};
 			name = Debug;
@@ -405,7 +406,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.jflinter.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CarthageTest.app/CarthageTest";
 			};
 			name = Release;

--- a/Tests/installation_tests/carthage/CarthageTest/AppDelegate.swift
+++ b/Tests/installation_tests/carthage/CarthageTest/AppDelegate.swift
@@ -14,7 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }

--- a/Tests/installation_tests/carthage/CarthageTest/ViewController.swift
+++ b/Tests/installation_tests/carthage/CarthageTest/ViewController.swift
@@ -14,7 +14,7 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         Stripe.setDefaultPublishableKey("test")
-        Stripe.paymentRequest(withMerchantIdentifier: "test")
+        Stripe.paymentRequest(withMerchantIdentifier: "test", country:"US", currency:"USD")
         // Do any additional setup after loading the view, typically from a nib.
     }
 

--- a/ci_scripts/check_fauxpas.sh
+++ b/ci_scripts/check_fauxpas.sh
@@ -19,27 +19,26 @@ if ! command -v fauxpas > /dev/null; then
     exit 1
   fi
 
-  echo "Installing fauxpas..."
-
-  brew update
-  if [[ "$?" != 0 ]]; then
-    echo "ERROR: Executing brew update exited with a non-zero status code"
-    exit 1
+  if [[ -z "${FAUX_PAS_LICENSE}" ]]; then
+    echo "ERROR: FAUX_PAS_LICENSE environment variable is missing. Add it to .travis.yaml, after encrypting it:"
+    echo
+    echo "travis encrypt FAUX_PAS_LICENSE=..."
+    echo "https://docs.travis-ci.com/user/environment-variables/#encrypting-environment-variables"
+    echo
+    echo "Any of our organizational seat licenses can be used: http://fauxpasapp.com/faq/#how-does-licensing-work-for-continuous-integration-ci-servers"
+    exit 10
+  else
+    echo "Found FAUX_PAS_LICENSE environment variable"
   fi
 
-  brew cask install fauxpas
-  if [[ "$?" != 0 ]]; then
-    echo "ERROR: Executing brew cask install fauxpas exited with a non-zero status code"
-    exit 1
-  fi
-
+  echo "Installing fauxpas CLI..."
   /Applications/FauxPas.app/Contents/Resources/install-cli-tools
   if [[ "$?" != 0 ]]; then
     echo "ERROR: Executing install-cli-tools exited with a non-zero status code"
     exit 1
   fi
 
-  fauxpas updatelicense "organization-seat" "Stripe, Inc" "${FAUX_PAS_LICENSE}"
+  fauxpas updatelicense "organization-seat" "Stripe" "${FAUX_PAS_LICENSE}"
   if [[ "$?" != 0 ]]; then
     echo "ERROR: Executing updatelicense exited with a non-zero status code"
     exit 1

--- a/ci_scripts/export_builds.sh
+++ b/ci_scripts/export_builds.sh
@@ -82,6 +82,7 @@ info "Compiling static framework..."
 cd "${root_dir}" || die "Executing \`cd\` failed"
 
 xcodebuild clean build \
+  -UseModernBuildSystem=NO \
   -workspace "Stripe.xcworkspace" \
   -scheme "StripeiOSStaticFramework" \
   -configuration "Release" \

--- a/ci_scripts/run_tests.sh
+++ b/ci_scripts/run_tests.sh
@@ -52,6 +52,10 @@ fi
 # - Set `ONLY_ACTIVE_ARCH=NO` to build both 32-bit and 64-bit products
 info "Executing tests on legacy devices (iPhone 6 @ iOS 10.x, iPhone 6 @ iOS 9.x, iPhone 4s @ iOS 9.x)..."
 
+# Workaround for iOS 9.3 erroring w/ “dyld: Library not loaded: /usr/lib/libauto.dylib” 
+# See https://developer.apple.com/documentation/xcode_release_notes/xcode_10_2_1_release_notes
+sudo mkdir '/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 9.3.simruntime/Contents/Resources/RuntimeRoot/usr/lib/swift'
+
 xcodebuild clean test \
   -workspace "Stripe.xcworkspace" \
   -scheme "StripeiOS" \


### PR DESCRIPTION
## Summary
* Require PassKit framework to remove Xcode and `export_builds.sh` warnings.  [This was set as optional](https://github.com/stripe/stripe-ios/commit/56338c28904b34c9be87281831bf3382a39bb44e) in v2.0.1).  I'm guessing we did that because the SDK at that time supported iOS 5.0 and PassKit was introduced in iOS 6.0.  
* Remove STPCustomerTest from StripeiOSStaticFramework Copy Files phase.  I accidentally added this in https://github.com/stripe/stripe-ios/commit/85aa37d2b431aa518c956f4077a297b5c9f1a1e5
* Bump travis xcode version from 9.2 to 10.2.1
* Don't use new Xcode 10 build system in `export_builds.sh`.
* Switch from facebook/ios-snapshot-test-case 2.1.4 to uber/ios-snapshot-test-case 6.0.3
* Update OHHTTPStubs from 2.1.4 to 6.0.3
* Workaround for iOS 9.3 erroring w/ “dyld: Library not loaded: /usr/lib/libauto.dylib”
* Update CarthageTest project to Swift 5
* Change travis.yml to open simulator from full path instead of -a "simulator"
* Fix STPColorUtilsTest not compiling on 32-bit
* Make fauxpas run on Xcode 9.3

## Motivation
Support the latest Xcode version!

## Testing
- `export_builds.sh` runs 
- Tests pass
- Set `recordingMode = YES` for a functional test to exercise OHHTTPStubs, ran the test, then set it back to `NO`.  Test passes.