### PR TITLE
Share STPCardBrand methods between STPCard and STPPaymentMethodCard

### DIFF
--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -475,6 +475,7 @@
 		B621F062223465EE002141B7 /* STPPaymentMethodCardWalletVisaCheckout.m in Sources */ = {isa = PBXBuildFile; fileRef = B621F05E223465EE002141B7 /* STPPaymentMethodCardWalletVisaCheckout.m */; };
 		B628476222307A4100957149 /* STPPaymentMethodCardTest.m in Sources */ = {isa = PBXBuildFile; fileRef = B628476122307A4100957149 /* STPPaymentMethodCardTest.m */; };
 		B632989F2295BDD90007D287 /* ApplePayPaymentMethod.json in Resources */ = {isa = PBXBuildFile; fileRef = B632989E2295BDD80007D287 /* ApplePayPaymentMethod.json */; };
+		B634497822A5BC91003881DC /* STPCardBrandTest.m in Sources */ = {isa = PBXBuildFile; fileRef = B634497722A5BC91003881DC /* STPCardBrandTest.m */; };
 		B63E42762231D78D007B5B95 /* STPPaymentMethodCardParams.m in Sources */ = {isa = PBXBuildFile; fileRef = B6027BC12230ABAE0025DB29 /* STPPaymentMethodCardParams.m */; };
 		B63E42772231D78D007B5B95 /* STPPaymentMethodCardParams.m in Sources */ = {isa = PBXBuildFile; fileRef = B6027BC12230ABAE0025DB29 /* STPPaymentMethodCardParams.m */; };
 		B63E42792231F8FE007B5B95 /* STPPaymentMethodParamsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = B63E42782231F8FE007B5B95 /* STPPaymentMethodParamsTest.m */; };
@@ -1338,6 +1339,7 @@
 		B621F05E223465EE002141B7 /* STPPaymentMethodCardWalletVisaCheckout.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodCardWalletVisaCheckout.m; sourceTree = "<group>"; };
 		B628476122307A4100957149 /* STPPaymentMethodCardTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodCardTest.m; sourceTree = "<group>"; };
 		B632989E2295BDD80007D287 /* ApplePayPaymentMethod.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = ApplePayPaymentMethod.json; sourceTree = "<group>"; };
+		B634497722A5BC91003881DC /* STPCardBrandTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCardBrandTest.m; sourceTree = "<group>"; };
 		B63E42782231F8FE007B5B95 /* STPPaymentMethodParamsTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodParamsTest.m; sourceTree = "<group>"; };
 		B665CE45228DE4C4008B546F /* STPPaymentMethodListDeserializer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentMethodListDeserializer.h; sourceTree = "<group>"; };
 		B665CE46228DE4C4008B546F /* STPPaymentMethodListDeserializer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodListDeserializer.m; sourceTree = "<group>"; };
@@ -1994,6 +1996,7 @@
 				8B8DDBB21EF887A4004B141F /* STPBankAccountParamsTest.m */,
 				04CDB5231A5F3A9300B854EE /* STPBankAccountTest.m */,
 				045D71301CF514BB00F6CD65 /* STPBinRangeTest.m */,
+				B634497722A5BC91003881DC /* STPCardBrandTest.m */,
 				8BE5AE8A1EF8905B0081A33C /* STPCardParamsTest.m */,
 				04CDB5251A5F3A9300B854EE /* STPCardTest.m */,
 				0438EF4A1B741B0100D506CC /* STPCardValidatorTest.m */,
@@ -3383,6 +3386,7 @@
 				C1CFCB6E1ED5E0F800BE45DF /* STPMocks.m in Sources */,
 				B628476222307A4100957149 /* STPPaymentMethodCardTest.m in Sources */,
 				B318518320BE011700EE8C0F /* STPColorUtilsTest.m in Sources */,
+				B634497822A5BC91003881DC /* STPCardBrandTest.m in Sources */,
 				B6EC63CA22348D4600E4C0FB /* STPPaymentMethodiDEALTest.m in Sources */,
 				04827D181D257A6C002DB3E8 /* STPImageLibraryTest.m in Sources */,
 				0438EF4C1B741B0100D506CC /* STPCardValidatorTest.m in Sources */,

--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -529,6 +529,8 @@
 		B6B5FC43222F4C0200440249 /* STPPaymentMethodThreeDSecureUsage.m in Sources */ = {isa = PBXBuildFile; fileRef = B6B5FC40222F4C0200440249 /* STPPaymentMethodThreeDSecureUsage.m */; };
 		B6B5FC44222F4C0200440249 /* STPPaymentMethodThreeDSecureUsage.m in Sources */ = {isa = PBXBuildFile; fileRef = B6B5FC40222F4C0200440249 /* STPPaymentMethodThreeDSecureUsage.m */; };
 		B6C42817229897EF0044E419 /* NSURLComponents_StripeTest.m in Sources */ = {isa = PBXBuildFile; fileRef = B6C42816229897EF0044E419 /* NSURLComponents_StripeTest.m */; };
+		B6CF3135229D8C3600BA8AC2 /* STPCardBrand.m in Sources */ = {isa = PBXBuildFile; fileRef = B6CF3134229D8C3500BA8AC2 /* STPCardBrand.m */; };
+		B6CF3136229D8C7000BA8AC2 /* STPCardBrand.m in Sources */ = {isa = PBXBuildFile; fileRef = B6CF3134229D8C3500BA8AC2 /* STPCardBrand.m */; };
 		B6D6C933223076600092AFC8 /* STPPaymentMethodAddressTest.m in Sources */ = {isa = PBXBuildFile; fileRef = B6D6C932223076600092AFC8 /* STPPaymentMethodAddressTest.m */; };
 		B6D6C935223078840092AFC8 /* STPPaymentMethodBillingDetailsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = B6D6C934223078840092AFC8 /* STPPaymentMethodBillingDetailsTest.m */; };
 		B6DB0CA6223817A300AEF640 /* STPPaymentMethodEnums.h in Headers */ = {isa = PBXBuildFile; fileRef = B6DB0CA5223817A300AEF640 /* STPPaymentMethodEnums.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1366,6 +1368,7 @@
 		B6B5FC3F222F4C0200440249 /* STPPaymentMethodThreeDSecureUsage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = STPPaymentMethodThreeDSecureUsage.h; path = PublicHeaders/STPPaymentMethodThreeDSecureUsage.h; sourceTree = "<group>"; };
 		B6B5FC40222F4C0200440249 /* STPPaymentMethodThreeDSecureUsage.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodThreeDSecureUsage.m; sourceTree = "<group>"; };
 		B6C42816229897EF0044E419 /* NSURLComponents_StripeTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSURLComponents_StripeTest.m; sourceTree = "<group>"; };
+		B6CF3134229D8C3500BA8AC2 /* STPCardBrand.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCardBrand.m; sourceTree = "<group>"; };
 		B6D6C932223076600092AFC8 /* STPPaymentMethodAddressTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodAddressTest.m; sourceTree = "<group>"; };
 		B6D6C934223078840092AFC8 /* STPPaymentMethodBillingDetailsTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodBillingDetailsTest.m; sourceTree = "<group>"; };
 		B6DB0CA5223817A300AEF640 /* STPPaymentMethodEnums.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = STPPaymentMethodEnums.h; path = PublicHeaders/STPPaymentMethodEnums.h; sourceTree = "<group>"; };
@@ -2363,6 +2366,7 @@
 				04CDB4CA1A5F30A700B854EE /* STPCard.h */,
 				04CDB4CB1A5F30A700B854EE /* STPCard.m */,
 				0438EF461B74183100D506CC /* STPCardBrand.h */,
+				B6CF3134229D8C3500BA8AC2 /* STPCardBrand.m */,
 				04CDE5BB1BC1F21500548833 /* STPCardParams.h */,
 				04CDE5B41BC1F1F100548833 /* STPCardParams.m */,
 				04EBC7511B7533C300A0E6AE /* STPCardValidationState.h */,
@@ -2373,6 +2377,8 @@
 				F1D3A2501EB0120F0095BFA9 /* STPFile.h */,
 				F1D3A2461EB012010095BFA9 /* STPFile.m */,
 				04F213301BCEAB61001D6F22 /* STPFormEncodable.h */,
+				073132932277A72D0019CE3F /* STPIssuingCardPin.h */,
+				073132942277A72D0019CE3F /* STPIssuingCardPin.m */,
 				B3A99BC11FEAF2CA003F6ED3 /* STPLegalEntityParams.h */,
 				B3A99BC21FEAF2CA003F6ED3 /* STPLegalEntityParams.m */,
 				B3BDCAC620EEF22D0034F7F5 /* STPPaymentIntent.h */,
@@ -2388,31 +2394,31 @@
 				B36C6D712193676600D17575 /* STPPaymentIntentSourceActionAuthorizeWithURL.h */,
 				B69FEC41222EE9E000273A16 /* STPPaymentMethod.h */,
 				B69FEC3C222EE8FE00273A16 /* STPPaymentMethod.m */,
-				B690DDEA222F01BF000B902D /* STPPaymentMethodBillingDetails.h */,
-				B690DDEB222F01BF000B902D /* STPPaymentMethodBillingDetails.m */,
 				B690DDF0222F0211000B902D /* STPPaymentMethodAddress.h */,
 				B690DDF1222F0211000B902D /* STPPaymentMethodAddress.m */,
+				B690DDEA222F01BF000B902D /* STPPaymentMethodBillingDetails.h */,
+				B690DDEB222F01BF000B902D /* STPPaymentMethodBillingDetails.m */,
 				B690DDF6222F0564000B902D /* STPPaymentMethodCard.h */,
 				B690DDF7222F0564000B902D /* STPPaymentMethodCard.m */,
 				B6E2F306222F442E0001FED4 /* STPPaymentMethodCardChecks.h */,
 				B66D5020222F5611004A9210 /* STPPaymentMethodCardChecks.m */,
-				B6027BC12230ABAE0025DB29 /* STPPaymentMethodCardParams.m */,
 				B6027BC02230ABAE0025DB29 /* STPPaymentMethodCardParams.h */,
-				B6DB0CA5223817A300AEF640 /* STPPaymentMethodEnums.h */,
+				B6027BC12230ABAE0025DB29 /* STPPaymentMethodCardParams.m */,
 				B69CFB432236F8E3001E9885 /* STPPaymentMethodCardPresent.h */,
 				B69CFB442236F8E3001E9885 /* STPPaymentMethodCardPresent.m */,
-				B6DE52D92230981200B70A66 /* STPPaymentMethodParams.h */,
-				B6DE52DA2230981200B70A66 /* STPPaymentMethodParams.m */,
 				B621F051223454E9002141B7 /* STPPaymentMethodCardWallet.h */,
 				B621F052223454E9002141B7 /* STPPaymentMethodCardWallet.m */,
 				B621F05722346243002141B7 /* STPPaymentMethodCardWalletMasterpass.h */,
 				B621F05822346243002141B7 /* STPPaymentMethodCardWalletMasterpass.m */,
 				B621F05D223465EE002141B7 /* STPPaymentMethodCardWalletVisaCheckout.h */,
 				B621F05E223465EE002141B7 /* STPPaymentMethodCardWalletVisaCheckout.m */,
+				B6DB0CA5223817A300AEF640 /* STPPaymentMethodEnums.h */,
 				B6B41F77223484280020BA7F /* STPPaymentMethodiDEAL.h */,
 				B6B41F78223484280020BA7F /* STPPaymentMethodiDEAL.m */,
 				B6B41F7D22348A1E0020BA7F /* STPPaymentMethodiDEALParams.h */,
 				B6B41F7E22348A1E0020BA7F /* STPPaymentMethodiDEALParams.m */,
+				B6DE52D92230981200B70A66 /* STPPaymentMethodParams.h */,
+				B6DE52DA2230981200B70A66 /* STPPaymentMethodParams.m */,
 				B6B5FC3F222F4C0200440249 /* STPPaymentMethodThreeDSecureUsage.h */,
 				B6B5FC40222F4C0200440249 /* STPPaymentMethodThreeDSecureUsage.m */,
 				C1D7B51E1E36C32F002181F5 /* STPSource.h */,
@@ -2435,8 +2441,6 @@
 				C1BD9B331E3940C400CEE925 /* STPSourceVerification.m */,
 				04CDB4CC1A5F30A700B854EE /* STPToken.h */,
 				04CDB4CD1A5F30A700B854EE /* STPToken.m */,
-				073132932277A72D0019CE3F /* STPIssuingCardPin.h */,
-				073132942277A72D0019CE3F /* STPIssuingCardPin.m */,
 			);
 			name = Models;
 			sourceTree = "<group>";
@@ -3562,6 +3566,7 @@
 				04F94DB41D229F71004FC826 /* STPPaymentActivityIndicatorView.m in Sources */,
 				C1BD9B251E393FFE00CEE925 /* STPSourceReceiver.m in Sources */,
 				B6B5FC44222F4C0200440249 /* STPPaymentMethodThreeDSecureUsage.m in Sources */,
+				B6CF3136229D8C7000BA8AC2 /* STPCardBrand.m in Sources */,
 				04827D131D2575C6002DB3E8 /* STPImageLibrary.m in Sources */,
 				B3BDCAC320EEF2150034F7F5 /* STPPaymentIntent.m in Sources */,
 				045D712F1CF4ED7600F6CD65 /* STPBINRange.m in Sources */,
@@ -3691,6 +3696,7 @@
 				0438EF3B1B7416BB00D506CC /* STPPaymentCardTextFieldViewModel.m in Sources */,
 				C1BD9B301E3940A200CEE925 /* STPSourceRedirect.m in Sources */,
 				04CDE5B81BC1F1F100548833 /* STPCardParams.m in Sources */,
+				B6CF3135229D8C3600BA8AC2 /* STPCardBrand.m in Sources */,
 				F152322C1EA9306100D65C67 /* NSURLComponents+Stripe.m in Sources */,
 				0451CC461C49AE1C003B2CA6 /* STPPaymentResult.m in Sources */,
 				04E39F551CECF7A100AF3B96 /* STPPaymentOptionTuple.m in Sources */,

--- a/Stripe/PublicHeaders/STPCardBrand.h
+++ b/Stripe/PublicHeaders/STPCardBrand.h
@@ -63,21 +63,3 @@ typedef NS_ENUM(NSInteger, STPCardBrand) {
  @return A string representing the brand, suitable for displaying to a user.
  */
 NSString * STPStringFromCardBrand(STPCardBrand brand);
-
-/**
- This parses a string representing a card's brand into the appropriate
- STPCardBrand enum value,
- i.e. `[STPCard brandFromString:@"American Express"] == STPCardBrandAmex`.
- 
- The string values themselves are specific to Stripe as listed in the Stripe API
- documentation.
- 
- @see https://stripe.com/docs/api#card_object-brand
- 
- @param string a string representing the card's brand as returned from
- the Stripe API
- 
- @return an enum value mapped to that string. If the string is unrecognized,
- returns STPCardBrandUnknown.
- */
-STPCardBrand STPCardBrandFromString(NSString *string);

--- a/Stripe/PublicHeaders/STPCardBrand.h
+++ b/Stripe/PublicHeaders/STPCardBrand.h
@@ -53,3 +53,31 @@ typedef NS_ENUM(NSInteger, STPCardBrand) {
      */
     STPCardBrandUnknown,
 };
+
+/**
+ Returns a string representation for the provided card brand;
+ i.e. `[NSString stringFromBrand:STPCardBrandVisa] ==  @"Visa"`.
+ 
+ @param brand the brand you want to convert to a string
+ 
+ @return A string representing the brand, suitable for displaying to a user.
+ */
+NSString * STPStringFromCardBrand(STPCardBrand brand);
+
+/**
+ This parses a string representing a card's brand into the appropriate
+ STPCardBrand enum value,
+ i.e. `[STPCard brandFromString:@"American Express"] == STPCardBrandAmex`.
+ 
+ The string values themselves are specific to Stripe as listed in the Stripe API
+ documentation.
+ 
+ @see https://stripe.com/docs/api#card_object-brand
+ 
+ @param string a string representing the card's brand as returned from
+ the Stripe API
+ 
+ @return an enum value mapped to that string. If the string is unrecognized,
+ returns STPCardBrandUnknown.
+ */
+STPCardBrand STPCardBrandFromString(NSString *string);

--- a/Stripe/PublicHeaders/STPPaymentMethodCard.h
+++ b/Stripe/PublicHeaders/STPPaymentMethodCard.h
@@ -77,6 +77,16 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, nullable, readonly) STPPaymentMethodCardWallet *wallet;
 
+/**
+ Returns a string representation for the provided card brand;
+ i.e. `[NSString stringFromBrand:STPCardBrandVisa] ==  @"Visa"`.
+ 
+ @param brand the brand you want to convert to a string
+ 
+ @return A string representing the brand, suitable for displaying to a user.
+ */
++ (NSString *)stringFromBrand:(STPCardBrand)brand;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Stripe/PublicHeaders/STPPaymentMethodCard.h
+++ b/Stripe/PublicHeaders/STPPaymentMethodCard.h
@@ -77,16 +77,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, nullable, readonly) STPPaymentMethodCardWallet *wallet;
 
-/**
- Returns a string representation for the provided card brand;
- i.e. `[NSString stringFromBrand:STPCardBrandVisa] ==  @"Visa"`.
- 
- @param brand the brand you want to convert to a string
- 
- @return A string representing the brand, suitable for displaying to a user.
- */
-+ (NSString *)stringFromBrand:(STPCardBrand)brand;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Stripe/STPCard.m
+++ b/Stripe/STPCard.m
@@ -41,46 +41,11 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - STPCardBrand
 
 + (STPCardBrand)brandFromString:(NSString *)string {
-    // Documentation: https://stripe.com/docs/api#card_object-brand
-    NSString *brand = [string lowercaseString];
-    if ([brand isEqualToString:@"visa"]) {
-        return STPCardBrandVisa;
-    } else if ([brand isEqualToString:@"american express"]) {
-        return STPCardBrandAmex;
-    } else if ([brand isEqualToString:@"mastercard"]) {
-        return STPCardBrandMasterCard;
-    } else if ([brand isEqualToString:@"discover"]) {
-        return STPCardBrandDiscover;
-    } else if ([brand isEqualToString:@"jcb"]) {
-        return STPCardBrandJCB;
-    } else if ([brand isEqualToString:@"diners club"]) {
-        return STPCardBrandDinersClub;
-    } else if ([brand isEqualToString:@"unionpay"]) {
-        return STPCardBrandUnionPay;
-    } else {
-        return STPCardBrandUnknown;
-    }
+    return STPCardBrandFromString(string);
 }
 
 + (NSString *)stringFromBrand:(STPCardBrand)brand {
-    switch (brand) {
-        case STPCardBrandAmex:
-            return @"American Express";
-        case STPCardBrandDinersClub:
-            return @"Diners Club";
-        case STPCardBrandDiscover:
-            return @"Discover";
-        case STPCardBrandJCB:
-            return @"JCB";
-        case STPCardBrandMasterCard:
-            return @"MasterCard";
-        case STPCardBrandUnionPay:
-            return @"UnionPay";
-        case STPCardBrandVisa:
-            return @"Visa";
-        case STPCardBrandUnknown:
-            return @"Unknown";
-    }
+    return STPStringFromCardBrand(brand);
 }
 
 #pragma mark - STPCardFundingType

--- a/Stripe/STPCard.m
+++ b/Stripe/STPCard.m
@@ -41,7 +41,25 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - STPCardBrand
 
 + (STPCardBrand)brandFromString:(NSString *)string {
-    return STPCardBrandFromString(string);
+    // Documentation: https://stripe.com/docs/api#card_object-brand
+    NSString *brand = [string lowercaseString];
+    if ([brand isEqualToString:@"visa"]) {
+        return STPCardBrandVisa;
+    } else if ([brand isEqualToString:@"american express"]) {
+        return STPCardBrandAmex;
+    } else if ([brand isEqualToString:@"mastercard"]) {
+        return STPCardBrandMasterCard;
+    } else if ([brand isEqualToString:@"discover"]) {
+        return STPCardBrandDiscover;
+    } else if ([brand isEqualToString:@"jcb"]) {
+        return STPCardBrandJCB;
+    } else if ([brand isEqualToString:@"diners club"]) {
+        return STPCardBrandDinersClub;
+    } else if ([brand isEqualToString:@"unionpay"]) {
+        return STPCardBrandUnionPay;
+    } else {
+        return STPCardBrandUnknown;
+    }
 }
 
 + (NSString *)stringFromBrand:(STPCardBrand)brand {

--- a/Stripe/STPCardBrand.m
+++ b/Stripe/STPCardBrand.m
@@ -1,0 +1,52 @@
+//
+//  STPCardBrand.m
+//  Stripe
+//
+//  Created by Yuki Tokuhiro on 5/28/19.
+//  Copyright © 2019 Stripe, Inc. All rights reserved.
+//
+
+#import "STPCardBrand.h"
+
+NSString * STPStringFromCardBrand(STPCardBrand brand) {
+    switch (brand) {
+        case STPCardBrandAmex:
+            return @"American Express";
+        case STPCardBrandDinersClub:
+            return @"Diners Club";
+        case STPCardBrandDiscover:
+            return @"Discover";
+        case STPCardBrandJCB:
+            return @"JCB";
+        case STPCardBrandMasterCard:
+            return @"MasterCard";
+        case STPCardBrandUnionPay:
+            return @"UnionPay";
+        case STPCardBrandVisa:
+            return @"Visa";
+        case STPCardBrandUnknown:
+            return @"Unknown";
+    }
+}
+
+STPCardBrand STPCardBrandFromString(NSString *string) {
+    // Documentation: https://stripe.com/docs/api#card_object-brand
+    NSString *brand = [string lowercaseString];
+    if ([brand isEqualToString:@"visa"]) {
+        return STPCardBrandVisa;
+    } else if ([brand isEqualToString:@"american express"]) {
+        return STPCardBrandAmex;
+    } else if ([brand isEqualToString:@"mastercard"]) {
+        return STPCardBrandMasterCard;
+    } else if ([brand isEqualToString:@"discover"]) {
+        return STPCardBrandDiscover;
+    } else if ([brand isEqualToString:@"jcb"]) {
+        return STPCardBrandJCB;
+    } else if ([brand isEqualToString:@"diners club"]) {
+        return STPCardBrandDinersClub;
+    } else if ([brand isEqualToString:@"unionpay"]) {
+        return STPCardBrandUnionPay;
+    } else {
+        return STPCardBrandUnknown;
+    }
+}

--- a/Stripe/STPCardBrand.m
+++ b/Stripe/STPCardBrand.m
@@ -28,25 +28,3 @@ NSString * STPStringFromCardBrand(STPCardBrand brand) {
             return @"Unknown";
     }
 }
-
-STPCardBrand STPCardBrandFromString(NSString *string) {
-    // Documentation: https://stripe.com/docs/api#card_object-brand
-    NSString *brand = [string lowercaseString];
-    if ([brand isEqualToString:@"visa"]) {
-        return STPCardBrandVisa;
-    } else if ([brand isEqualToString:@"american express"]) {
-        return STPCardBrandAmex;
-    } else if ([brand isEqualToString:@"mastercard"]) {
-        return STPCardBrandMasterCard;
-    } else if ([brand isEqualToString:@"discover"]) {
-        return STPCardBrandDiscover;
-    } else if ([brand isEqualToString:@"jcb"]) {
-        return STPCardBrandJCB;
-    } else if ([brand isEqualToString:@"diners club"]) {
-        return STPCardBrandDinersClub;
-    } else if ([brand isEqualToString:@"unionpay"]) {
-        return STPCardBrandUnionPay;
-    } else {
-        return STPCardBrandUnknown;
-    }
-}

--- a/Stripe/STPPaymentMethod.m
+++ b/Stripe/STPPaymentMethod.m
@@ -141,10 +141,10 @@
     switch (self.type) {
         case STPPaymentMethodTypeCard:
             if (self.card != nil) {
-                NSString *brand = [STPPaymentMethodCard stringFromBrand:self.card.brand];
+                NSString *brand = STPStringFromCardBrand(self.card.brand);
                 return [NSString stringWithFormat:@"%@ %@", brand, self.card.last4];
             } else {
-                return [STPPaymentMethodCard stringFromBrand:STPCardBrandUnknown];
+                return STPStringFromCardBrand(STPCardBrandUnknown);
             }
         case STPPaymentMethodTypeiDEAL:
             return @"iDEAL";

--- a/Stripe/STPPaymentMethodCard.m
+++ b/Stripe/STPPaymentMethodCard.m
@@ -73,6 +73,12 @@
     return card;
 }
 
+#pragma mark - STPCardBrand
+
++ (NSString *)stringFromBrand:(STPCardBrand)brand {
+    return STPStringFromCardBrand(brand);
+}
+
 + (STPCardBrand)brandFromString:(NSString *)string {
     // Documentation: https://stripe.com/docs/api/payment_methods/object#payment_method_object-card-brand
     NSString *brand = [string lowercaseString];

--- a/Stripe/STPPaymentMethodCard.m
+++ b/Stripe/STPPaymentMethodCard.m
@@ -12,7 +12,6 @@
 #import "STPPaymentMethodCardWallet.h"
 #import "STPPaymentMethodCardChecks.h"
 #import "STPPaymentMethodThreeDSecureUsage.h"
-#import "STPCard.h"
 
 @interface STPPaymentMethodCard ()
 

--- a/Stripe/STPPaymentMethodCard.m
+++ b/Stripe/STPPaymentMethodCard.m
@@ -37,7 +37,7 @@
                        // Object
                        [NSString stringWithFormat:@"%@: %p", NSStringFromClass([self class]), self],
                        
-                       [NSString stringWithFormat:@"brand = %@", [STPCard stringFromBrand:self.brand]],
+                       [NSString stringWithFormat:@"brand = %@", STPStringFromCardBrand(self.brand)],
                        [NSString stringWithFormat:@"checks = %@", self.checks],
                        [NSString stringWithFormat:@"country = %@", self.country],
                        [NSString stringWithFormat:@"expMonth = %lu", (unsigned long)self.expMonth],
@@ -61,7 +61,7 @@
     }
     STPPaymentMethodCard *card = [self new];
     card.allResponseFields = dict;
-    card.brand = [STPCard brandFromString:[dict stp_stringForKey:@"brand"]];
+    card.brand = [self brandFromString:[dict stp_stringForKey:@"brand"]];
     card.checks = [STPPaymentMethodCardChecks decodedObjectFromAPIResponse:[dict stp_dictionaryForKey:@"checks"]];
     card.country = [dict stp_stringForKey:@"country"];
     card.expMonth = [dict stp_intForKey:@"exp_month" or:0];
@@ -72,6 +72,28 @@
     card.threeDSecureUsage = [STPPaymentMethodThreeDSecureUsage decodedObjectFromAPIResponse:[dict stp_dictionaryForKey:@"three_d_secure_usage"]];
     card.wallet = [STPPaymentMethodCardWallet decodedObjectFromAPIResponse:[dict stp_dictionaryForKey:@"wallet"]];
     return card;
+}
+
++ (STPCardBrand)brandFromString:(NSString *)string {
+    // Documentation: https://stripe.com/docs/api/payment_methods/object#payment_method_object-card-brand
+    NSString *brand = [string lowercaseString];
+    if ([brand isEqualToString:@"visa"]) {
+        return STPCardBrandVisa;
+    } else if ([brand isEqualToString:@"amex"]) {
+        return STPCardBrandAmex;
+    } else if ([brand isEqualToString:@"mastercard"]) {
+        return STPCardBrandMasterCard;
+    } else if ([brand isEqualToString:@"discover"]) {
+        return STPCardBrandDiscover;
+    } else if ([brand isEqualToString:@"jcb"]) {
+        return STPCardBrandJCB;
+    } else if ([brand isEqualToString:@"diners"]) {
+        return STPCardBrandDinersClub;
+    } else if ([brand isEqualToString:@"unionpay"]) {
+        return STPCardBrandUnionPay;
+    } else {
+        return STPCardBrandUnknown;
+    }
 }
 
 @end

--- a/Stripe/STPPaymentMethodCard.m
+++ b/Stripe/STPPaymentMethodCard.m
@@ -74,27 +74,4 @@
     return card;
 }
 
-#pragma mark - STPCardBrand
-
-+ (NSString *)stringFromBrand:(STPCardBrand)brand {
-    switch (brand) {
-        case STPCardBrandAmex:
-            return @"American Express";
-        case STPCardBrandDinersClub:
-            return @"Diners Club";
-        case STPCardBrandDiscover:
-            return @"Discover";
-        case STPCardBrandJCB:
-            return @"JCB";
-        case STPCardBrandMasterCard:
-            return @"MasterCard";
-        case STPCardBrandUnionPay:
-            return @"UnionPay";
-        case STPCardBrandVisa:
-            return @"Visa";
-        case STPCardBrandUnknown:
-            return @"Unknown";
-    }
-}
-
 @end

--- a/Tests/Tests/STPCardBrandTest.m
+++ b/Tests/Tests/STPCardBrandTest.m
@@ -1,0 +1,64 @@
+//
+//  STPCardBrandTest.m
+//  StripeiOS Tests
+//
+//  Created by Yuki Tokuhiro on 6/3/19.
+//  Copyright © 2019 Stripe, Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "STPCardBrand.h"
+
+@interface STPCardBrandTest : XCTestCase
+
+@end
+
+@implementation STPCardBrandTest
+
+- (void)testStringFromBrand {
+    NSArray<NSNumber *> *brands = @[
+                                    @(STPCardBrandAmex),
+                                    @(STPCardBrandDinersClub),
+                                    @(STPCardBrandDiscover),
+                                    @(STPCardBrandJCB),
+                                    @(STPCardBrandMasterCard),
+                                    @(STPCardBrandUnionPay),
+                                    @(STPCardBrandVisa),
+                                    @(STPCardBrandUnknown),
+                                    ];
+
+    for (NSNumber *brandNumber in brands) {
+        STPCardBrand brand = [brandNumber integerValue];
+        NSString *string = STPStringFromCardBrand(brand);
+        
+        switch (brand) {
+            case STPCardBrandAmex:
+                XCTAssertEqualObjects(string, @"American Express");
+                break;
+            case STPCardBrandDinersClub:
+                XCTAssertEqualObjects(string, @"Diners Club");
+                break;
+            case STPCardBrandDiscover:
+                XCTAssertEqualObjects(string, @"Discover");
+                break;
+            case STPCardBrandJCB:
+                XCTAssertEqualObjects(string, @"JCB");
+                break;
+            case STPCardBrandMasterCard:
+                XCTAssertEqualObjects(string, @"MasterCard");
+                break;
+            case STPCardBrandUnionPay:
+                XCTAssertEqualObjects(string, @"UnionPay");
+                break;
+            case STPCardBrandVisa:
+                XCTAssertEqualObjects(string, @"Visa");
+                break;
+            case STPCardBrandUnknown:
+                XCTAssertEqualObjects(string, @"Unknown");
+                break;
+        }
+    };
+}
+
+@end

--- a/Tests/Tests/STPCardTest.m
+++ b/Tests/Tests/STPCardTest.m
@@ -63,39 +63,6 @@
     XCTAssertEqual([STPCard brandFromString:@"GARBAGE"], STPCardBrandUnknown);
 }
 
-- (void)testStringFromBrand {
-    [self forEachBrand:^(STPCardBrand brand) {
-        NSString *string = [STPCard stringFromBrand:brand];
-
-        switch (brand) {
-            case STPCardBrandAmex:
-                XCTAssertEqualObjects(string, @"American Express");
-                break;
-            case STPCardBrandDinersClub:
-                XCTAssertEqualObjects(string, @"Diners Club");
-                break;
-            case STPCardBrandDiscover:
-                XCTAssertEqualObjects(string, @"Discover");
-                break;
-            case STPCardBrandJCB:
-                XCTAssertEqualObjects(string, @"JCB");
-                break;
-            case STPCardBrandMasterCard:
-                XCTAssertEqualObjects(string, @"MasterCard");
-                break;
-            case STPCardBrandUnionPay:
-                XCTAssertEqualObjects(string, @"UnionPay");
-                break;
-            case STPCardBrandVisa:
-                XCTAssertEqualObjects(string, @"Visa");
-                break;
-            case STPCardBrandUnknown:
-                XCTAssertEqualObjects(string, @"Unknown");
-                break;
-        }
-    }];
-}
-
 #pragma mark - STPCardFundingType Tests
 
 #pragma clang diagnostic push

--- a/Tests/Tests/STPPaymentMethodCardTest.m
+++ b/Tests/Tests/STPPaymentMethodCardTest.m
@@ -12,6 +12,10 @@
 #import "STPFixtures.h"
 #import "STPTestUtils.h"
 
+@interface STPPaymentMethodCard (Testing)
++ (STPCardBrand)brandFromString:(NSString *)string;
+@end
+
 @interface STPPaymentMethodCardTest : XCTestCase
 
 @end
@@ -45,6 +49,35 @@
     XCTAssertNotNil(card.threeDSecureUsage);
     XCTAssertEqual(card.threeDSecureUsage.supported, YES);
     XCTAssertNotNil(card.wallet);
+}
+
+- (void)testBrandFromString {
+    XCTAssertEqual([STPPaymentMethodCard brandFromString:@"visa"], STPCardBrandVisa);
+    XCTAssertEqual([STPPaymentMethodCard brandFromString:@"VISA"], STPCardBrandVisa);
+    
+    XCTAssertEqual([STPPaymentMethodCard brandFromString:@"amex"], STPCardBrandAmex);
+    XCTAssertEqual([STPPaymentMethodCard brandFromString:@"AMEX"], STPCardBrandAmex);
+    
+    XCTAssertEqual([STPPaymentMethodCard brandFromString:@"mastercard"], STPCardBrandMasterCard);
+    XCTAssertEqual([STPPaymentMethodCard brandFromString:@"MASTERCARD"], STPCardBrandMasterCard);
+    
+    XCTAssertEqual([STPPaymentMethodCard brandFromString:@"discover"], STPCardBrandDiscover);
+    XCTAssertEqual([STPPaymentMethodCard brandFromString:@"DISCOVER"], STPCardBrandDiscover);
+    
+    XCTAssertEqual([STPPaymentMethodCard brandFromString:@"jcb"], STPCardBrandJCB);
+    XCTAssertEqual([STPPaymentMethodCard brandFromString:@"JCB"], STPCardBrandJCB);
+    
+    XCTAssertEqual([STPPaymentMethodCard brandFromString:@"diners"], STPCardBrandDinersClub);
+    XCTAssertEqual([STPPaymentMethodCard brandFromString:@"DINERS"], STPCardBrandDinersClub);
+    
+    XCTAssertEqual([STPPaymentMethodCard brandFromString:@"unionpay"], STPCardBrandUnionPay);
+    XCTAssertEqual([STPPaymentMethodCard brandFromString:@"UNIONPAY"], STPCardBrandUnionPay);
+    
+    XCTAssertEqual([STPPaymentMethodCard brandFromString:@"unknown"], STPCardBrandUnknown);
+    XCTAssertEqual([STPPaymentMethodCard brandFromString:@"UNKNOWN"], STPCardBrandUnknown);
+    
+    XCTAssertEqual([STPPaymentMethodCard brandFromString:@"garbage"], STPCardBrandUnknown);
+    XCTAssertEqual([STPPaymentMethodCard brandFromString:@"GARBAGE"], STPCardBrandUnknown);
 }
 
 @end


### PR DESCRIPTION
## Summary
* Move `stringFromBrand` to `STPCardBrand` function, to share between `STPCard` & `STPPaymentMethodCard`
* Fix https://github.com/stripe/stripe-ios/issues/1191 by not reusing `STPCard`'s implementation in `STPPaymentMethodCard`

## Motivation
https://jira.corp.stripe.com/browse/IOS-1226
https://github.com/stripe/stripe-ios/issues/1191

## Testing
* Moves `stringFromBrand` test to `STPCardBrandTest`
* Adds `brandFromString` test to `STPPaymentMethodCardTest`
