### PR TITLE
Hotfix for redirect context dismissing the presenting view controller.

### DIFF
--- a/Stripe/STPRedirectContext.m
+++ b/Stripe/STPRedirectContext.m
@@ -321,8 +321,8 @@ typedef void (^STPBoolCompletionBlock)(BOOL success);
 
 - (void)dismissPresentedViewController {
     if (self.safariVC) {
-        [self.safariVC.presentingViewController dismissViewControllerAnimated:YES
-                                                                   completion:nil];
+        [self.safariVC dismissViewControllerAnimated:YES
+                                          completion:nil];
     }
 }
 


### PR DESCRIPTION
Once redirect was complete, if SFSafariViewController was presented
from a modal view controller, it would dismiss the entire modal stack.

The fix is to only dismiss the presented view controller off the stack.

Fixes https://github.com/stripe/stripe-ios/issues/1199

## Summary
<!-- Simple summary of what was changed. -->
Only dismiss the presented view controller and not the presenting view controller.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
STPRedirectContext shouldn't dismiss the presenting view controller, it should only dismiss the presented view controller, i.e. SFSafariViewController

## Testing
<!-- How was the code tested? Be as specific as possible. -->
This has been tested locally on a client application. 