### PR TITLE
Add brew update to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ matrix:
       homebrew:
         casks:
         - fauxpas
+        update: true
 
 before_install:
 - SIMULATOR_ID=$(xcrun instruments -s | grep -o "iPhone 6 (11.2) \[.*\]" | grep -o


### PR DESCRIPTION
## Summary
Runs `brew update` in travis-ci for the fauxpas job.

## Motivation
travis-ci started failing with "Error: Your Homebrew is outdated. Please run `brew update`.
Error: Kernel.exit"

## Testing
CI build should pass now
