### PR TITLE
PaymentHandler error improvements

### DIFF
--- a/Stripe/Payments/STPPaymentHandler.m
+++ b/Stripe/Payments/STPPaymentHandler.m
@@ -421,7 +421,12 @@ withAuthenticationContext:(nullable id<STPAuthenticationContext>)authenticationC
         return;
     }
     [self _markChallengeCompletedWithCompletion:^(__unused BOOL markedCompleted, __unused NSError * _Nullable error) {
-        completion(STPPaymentHandlerActionStatusFailed, self->_currentAction.paymentIntent, [protocolErrorEvent.errorMessage NSErrorValue]);
+        // Add localizedError to the 3DS2 SDK error
+        NSError *threeDSError = [protocolErrorEvent.errorMessage NSErrorValue];
+        NSMutableDictionary *userInfo = [threeDSError.userInfo mutableCopy];
+        userInfo[NSLocalizedDescriptionKey] = [NSError stp_unexpectedErrorMessage];
+        NSError *localizedError = [NSError errorWithDomain:threeDSError.domain code:threeDSError.code userInfo:userInfo];
+        completion(STPPaymentHandlerActionStatusFailed, self->_currentAction.paymentIntent, localizedError);
     }];
 }
 
@@ -432,7 +437,12 @@ withAuthenticationContext:(nullable id<STPAuthenticationContext>)authenticationC
         return;
     }
     [self _markChallengeCompletedWithCompletion:^(__unused BOOL markedCompleted, __unused NSError * _Nullable error) {
-        completion(STPPaymentHandlerActionStatusFailed, self->_currentAction.paymentIntent, [runtimeErrorEvent NSErrorValue]);
+        // Add localizedError to the 3DS2 SDK error
+        NSError *threeDSError = [runtimeErrorEvent NSErrorValue];
+        NSMutableDictionary *userInfo = [threeDSError.userInfo mutableCopy];
+        userInfo[NSLocalizedDescriptionKey] = [NSError stp_unexpectedErrorMessage];
+        NSError *localizedError = [NSError errorWithDomain:threeDSError.domain code:threeDSError.code userInfo:userInfo];
+        completion(STPPaymentHandlerActionStatusFailed, self->_currentAction.paymentIntent, localizedError);
     }];
 }
 

--- a/Stripe/Payments/STPPaymentHandler.m
+++ b/Stripe/Payments/STPPaymentHandler.m
@@ -184,7 +184,7 @@ withAuthenticationContext:(nullable id<STPAuthenticationContext>)authenticationC
         case STPPaymentIntentStatusUnknown:
             completion(STPPaymentHandlerActionStatusFailed, paymentIntent, [NSError errorWithDomain:STPPaymentHandlerErrorDomain
                                                                                                code:STPPaymentHandlerPaymentIntentStatusErrorCode
-                                                                                           userInfo:nil]);
+                                                                                           userInfo:@{@"STPPaymentIntent": paymentIntent.description}]);
             break;
 
         case STPPaymentIntentStatusRequiresPaymentMethod:
@@ -243,7 +243,7 @@ withAuthenticationContext:(nullable id<STPAuthenticationContext>)authenticationC
         case STPPaymentIntentActionTypeUnknown:
             completion(STPPaymentHandlerActionStatusFailed, paymentIntent, [NSError errorWithDomain:STPPaymentHandlerErrorDomain
                                                                                                code:STPPaymentHandlerUnsupportedAuthenticationErrorCode
-                                                                                           userInfo:nil]);
+                                                                                           userInfo:@{@"STPPaymentIntentAction": authenticationAction.description}]);
             break;
         case STPPaymentIntentActionTypeRedirectToURL: {
             NSURL *url = authenticationAction.redirectToURL.url;
@@ -275,7 +275,7 @@ withAuthenticationContext:(nullable id<STPAuthenticationContext>)authenticationC
                 case STPPaymentIntentActionUseStripeSDKTypeUnknown:
                     completion(STPPaymentHandlerActionStatusFailed, paymentIntent, [NSError errorWithDomain:STPPaymentHandlerErrorDomain
                                                                                                        code:STPPaymentHandlerUnsupportedAuthenticationErrorCode
-                                                                                                   userInfo:nil]);
+                                                                                                   userInfo:@{@"STPPaymentIntentActionUseStripeSDK": authenticationAction.useStripeSDK.description}]);
                     break;
                 case STPPaymentIntentActionUseStripeSDKType3DS2Fingerprint: {
                     STDSThreeDS2Service *threeDSService = _currentAction.threeDS2Service;

--- a/Stripe/Payments/STPPaymentHandler.m
+++ b/Stripe/Payments/STPPaymentHandler.m
@@ -221,7 +221,8 @@ withAuthenticationContext:(nullable id<STPAuthenticationContext>)authenticationC
 
     // Checking for authenticationPresentingViewController instead of just authenticationContext == nil
     // also allows us to catch contexts that are not behaving correctly (i.e. returning nil vc when they shouldn't)
-    if ([_currentAction.authenticationContext authenticationPresentingViewController] == nil) {
+    UIViewController *presentingViewController = [_currentAction.authenticationContext authenticationPresentingViewController];
+    if (presentingViewController == nil || presentingViewController.view.window == nil) {
         completion(STPPaymentHandlerActionStatusFailed, paymentIntent, [self _errorForCode:STPPaymentHandlerRequiresAuthenticationContextErrorCode userInfo:nil]);
         return;
     }

--- a/Stripe/Payments/STPPaymentHandler.m
+++ b/Stripe/Payments/STPPaymentHandler.m
@@ -383,7 +383,7 @@ withAuthenticationContext:(nullable id<STPAuthenticationContext>)authenticationC
         // going to ignore the rest of the status types because they provide more detail than we require
         [self _markChallengeCompletedWithCompletion:^(__unused BOOL markedCompleted, __unused NSError * _Nullable error) {
             completion(STPPaymentHandlerActionStatusFailed, self->_currentAction.paymentIntent, [NSError errorWithDomain:STPPaymentHandlerErrorDomain
-                                                                                                              code:STPPaymentHandlerThreeDomainSecureErrorCode
+                                                                                                              code:STPPaymentHandlerNotAuthenticatedErrorCode
                                                                                                           userInfo:@{@"transaction_status": transactionStatus}]);
         }];
     }

--- a/Stripe/Payments/STPPaymentHandler.m
+++ b/Stripe/Payments/STPPaymentHandler.m
@@ -193,9 +193,7 @@ withAuthenticationContext:(nullable id<STPAuthenticationContext>)authenticationC
                                                                                            userInfo:nil]);
             break;
         case STPPaymentIntentStatusRequiresConfirmation:
-            completion(STPPaymentHandlerActionStatusFailed, paymentIntent, [NSError errorWithDomain:STPPaymentHandlerErrorDomain
-                                                                                               code:STPPaymentHandlerPaymentIntentStatusErrorCode
-                                                                                           userInfo:nil]);
+            completion(STPPaymentHandlerActionStatusSucceeded, paymentIntent, nil);
             break;
         case STPPaymentIntentStatusRequiresAction:
             if (attemptAuthentication) {
@@ -215,9 +213,7 @@ withAuthenticationContext:(nullable id<STPAuthenticationContext>)authenticationC
             completion(STPPaymentHandlerActionStatusSucceeded, paymentIntent, nil);
             break;
         case STPPaymentIntentStatusRequiresCapture:
-            completion(STPPaymentHandlerActionStatusFailed, paymentIntent, [NSError errorWithDomain:STPPaymentHandlerErrorDomain
-                                                                                               code:STPPaymentHandlerPaymentIntentStatusErrorCode
-                                                                                           userInfo:nil]);
+            completion(STPPaymentHandlerActionStatusSucceeded, paymentIntent, nil);
             break;
         case STPPaymentIntentStatusCanceled:
             completion(STPPaymentHandlerActionStatusCanceled, paymentIntent, nil);

--- a/Stripe/PublicHeaders/STPPaymentHandler.h
+++ b/Stripe/PublicHeaders/STPPaymentHandler.h
@@ -76,11 +76,6 @@ typedef NS_ENUM(NSInteger, STPPaymentHandlerErrorCode) {
     STPPaymentHandlerThreeDomainSecureErrorCode,
 
     /**
-     There was an internal error processing the action.
-     */
-    STPPaymentHandlerInternalErrorCode,
-
-    /**
      `STPPaymentHandler` does not support concurrent actions.
      */
     STPPaymentHandlerNoConcurrentActionsErrorCode,

--- a/Stripe/PublicHeaders/STPPaymentHandler.h
+++ b/Stripe/PublicHeaders/STPPaymentHandler.h
@@ -71,9 +71,9 @@ typedef NS_ENUM(NSInteger, STPPaymentHandlerErrorCode) {
     STPPaymentHandlerStripe3DS2ErrorCode,
 
     /**
-     There was an error in the Three Domain Secure process.
+     The transaction did not authenticate (e.g. user entered the wrong code).
      */
-    STPPaymentHandlerThreeDomainSecureErrorCode,
+    STPPaymentHandlerNotAuthenticatedErrorCode,
 
     /**
      `STPPaymentHandler` does not support concurrent actions.

--- a/Stripe/PublicHeaders/STPPaymentHandler.h
+++ b/Stripe/PublicHeaders/STPPaymentHandler.h
@@ -22,6 +22,8 @@ NS_ASSUME_NONNULL_BEGIN
 typedef NS_ENUM(NSInteger, STPPaymentHandlerActionStatus) {
     /**
      The action succeeded.
+
+     The PaymentIntent status will always be either STPPaymentIntentStatusRequiresConfirmation, STPPaymentIntentStatusRequiresCapture, or STPPaymentIntentStatusRequiresConfirmation. In the latter two cases, capture or confirm the PaymentIntent to complete the payment.
      */
     STPPaymentHandlerActionStatusSucceeded,
 

--- a/Stripe/PublicHeaders/STPPaymentHandler.h
+++ b/Stripe/PublicHeaders/STPPaymentHandler.h
@@ -53,7 +53,7 @@ typedef NS_ENUM(NSInteger, STPPaymentHandlerErrorCode) {
     STPPaymentHandlerUnsupportedAuthenticationErrorCode,
 
     /**
-     The PaymentIntent could not be confirmed because it is missing an associated payment method.
+     Attach a payment method to the PaymentIntent before using `STPPaymentHandler`.
      */
     STPPaymentHandlerRequiresPaymentMethodErrorCode,
 

--- a/Stripe/STPPaymentIntentActionUseStripeSDK.m
+++ b/Stripe/STPPaymentIntentActionUseStripeSDK.m
@@ -16,6 +16,22 @@ NS_ASSUME_NONNULL_BEGIN
 
 @synthesize allResponseFields = _allResponseFields;
 
+- (NSString *)description {
+    NSMutableArray *props = [@[
+                               // Object
+                               [NSString stringWithFormat:@"%@: %p", NSStringFromClass([self class]), self],
+                               
+                               // PaymentIntentActionUseStripeSDK details (alphabetical)
+                               [NSString stringWithFormat:@"directoryServer = %@", self.directoryServer],
+                               [NSString stringWithFormat:@"serverTransactionID = %@", self.serverTransactionID],
+                               [NSString stringWithFormat:@"threeDS2SourceID = %@", self.threeDS2SourceID],
+                               [NSString stringWithFormat:@"type = %@", self.allResponseFields[@"type"]],
+                               
+                               ] mutableCopy];
+    
+    return [NSString stringWithFormat:@"<%@>", [props componentsJoinedByString:@"; "]];
+}
+
 + (nullable instancetype)decodedObjectFromAPIResponse:(nullable NSDictionary *)response {
     NSDictionary *dict = [response stp_dictionaryByRemovingNulls];
     if (!dict) {


### PR DESCRIPTION
## Summary
* Adds localizedDescription and STPErrorMessageKey to error's userInfo.  
* Considers .requiresConfirmation and .requiresCapture PI status as success (previously considered failed)
* Replace `STPPaymentHandlerInternalErrorCode` with generic parsing error & an assertion - this only happens when PaymentIntent is nil, which should never happen and would be a programming error on our part.  
* `STPPaymentHandlerRequiresPaymentMethodErrorCode` is only for programmer errors where the user forgot to attach a payment method.  If we encounter a requires_payment_method status after the flow, it means authentication failed.  
* Also checks authentication context presenting UIViewController is in the window

## Motivation
https://jira.corp.stripe.com/browse/IOS-1268
https://jira.corp.stripe.com/browse/MOBILE3DS2-405
https://jira.corp.stripe.com/browse/IOS-1273

## Testing
* Tested 3DS1 flow, success and failure, on the standard integration app.
* There's an existing issue with 3DS2 that prevents me from testing the flow.
