### PR TITLE
SetupIntent Models

### DIFF
--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -512,6 +512,13 @@
 		B613DD4222C55F9500C7603F /* STPIntentAction.h in Headers */ = {isa = PBXBuildFile; fileRef = B613DD3F22C55F9500C7603F /* STPIntentAction.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B613DD4322C55F9500C7603F /* STPIntentAction.m in Sources */ = {isa = PBXBuildFile; fileRef = B613DD4022C55F9500C7603F /* STPIntentAction.m */; };
 		B613DD4422C55F9500C7603F /* STPIntentAction.m in Sources */ = {isa = PBXBuildFile; fileRef = B613DD4022C55F9500C7603F /* STPIntentAction.m */; };
+		B613DD3222C536C900C7603F /* STPSetupIntent.h in Headers */ = {isa = PBXBuildFile; fileRef = B613DD3022C536C900C7603F /* STPSetupIntent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B613DD3322C536C900C7603F /* STPSetupIntent.m in Sources */ = {isa = PBXBuildFile; fileRef = B613DD3122C536C900C7603F /* STPSetupIntent.m */; };
+		B613DD3422C5370400C7603F /* STPSetupIntent.h in Headers */ = {isa = PBXBuildFile; fileRef = B613DD3022C536C900C7603F /* STPSetupIntent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B613DD3722C5452600C7603F /* STPSetupIntentEnums.h in Headers */ = {isa = PBXBuildFile; fileRef = B613DD3522C5452500C7603F /* STPSetupIntentEnums.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B613DD3822C5452600C7603F /* STPSetupIntentEnums.h in Headers */ = {isa = PBXBuildFile; fileRef = B613DD3522C5452500C7603F /* STPSetupIntentEnums.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B613DD3C22C54AA800C7603F /* STPSetupIntentTest.m in Sources */ = {isa = PBXBuildFile; fileRef = B613DD3B22C54AA800C7603F /* STPSetupIntentTest.m */; };
+		B613DD3E22C54BA800C7603F /* SetupIntent.json in Resources */ = {isa = PBXBuildFile; fileRef = B613DD3D22C54BA700C7603F /* SetupIntent.json */; };
 		B61C996522BBFA12004980FD /* STPAppInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = B61C996322BBFA12004980FD /* STPAppInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B61C996622BBFA12004980FD /* STPAppInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = B61C996422BBFA12004980FD /* STPAppInfo.m */; };
 		B621F053223454E9002141B7 /* STPPaymentMethodCardWallet.h in Headers */ = {isa = PBXBuildFile; fileRef = B621F051223454E9002141B7 /* STPPaymentMethodCardWallet.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1430,6 +1437,11 @@
 		B604CF2022C56E9B00A23CC4 /* STPIntentActionRedirectToURL.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPIntentActionRedirectToURL.m; sourceTree = "<group>"; };
 		B613DD3F22C55F9500C7603F /* STPIntentAction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = STPIntentAction.h; path = PublicHeaders/STPIntentAction.h; sourceTree = "<group>"; };
 		B613DD4022C55F9500C7603F /* STPIntentAction.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPIntentAction.m; sourceTree = "<group>"; };
+		B613DD3022C536C900C7603F /* STPSetupIntent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = STPSetupIntent.h; path = PublicHeaders/STPSetupIntent.h; sourceTree = "<group>"; };
+		B613DD3122C536C900C7603F /* STPSetupIntent.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSetupIntent.m; sourceTree = "<group>"; };
+		B613DD3522C5452500C7603F /* STPSetupIntentEnums.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = STPSetupIntentEnums.h; path = PublicHeaders/STPSetupIntentEnums.h; sourceTree = "<group>"; };
+		B613DD3B22C54AA800C7603F /* STPSetupIntentTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSetupIntentTest.m; sourceTree = "<group>"; };
+		B613DD3D22C54BA700C7603F /* SetupIntent.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = SetupIntent.json; sourceTree = "<group>"; };
 		B61C996322BBFA12004980FD /* STPAppInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = STPAppInfo.h; path = PublicHeaders/STPAppInfo.h; sourceTree = "<group>"; };
 		B61C996422BBFA12004980FD /* STPAppInfo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPAppInfo.m; sourceTree = "<group>"; };
 		B621F051223454E9002141B7 /* STPPaymentMethodCardWallet.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = STPPaymentMethodCardWallet.h; path = PublicHeaders/STPPaymentMethodCardWallet.h; sourceTree = "<group>"; };
@@ -2184,6 +2196,7 @@
 				C1EEDCC91CA2186300A54582 /* STPPhoneNumberValidatorTest.m */,
 				C1FEE5981CBFF24000A7632B /* STPPostalCodeValidatorTest.m */,
 				F152321A1EA92F9D00D65C67 /* STPRedirectContextTest.m */,
+				B613DD3B22C54AA800C7603F /* STPSetupIntentTest.m */,
 				3691EB73211A4F31008C49E1 /* STPShippingAddressViewControllerTest.m */,
 				8BD87B8A1EFB136F00269C2B /* STPSourceCardDetailsTest.m */,
 				8B5B4B431EFDD925005CF475 /* STPSourceOwnerTest.m */,
@@ -2230,6 +2243,7 @@
 				8BD213381F0457A1007F6FD1 /* FileUpload.json */,
 				B3BDCADE20F0142C0034F7F5 /* PaymentIntent.json */,
 				B66B39B5223045EF006D1CAD /* PaymentMethod.json */,
+				B613DD3D22C54BA700C7603F /* SetupIntent.json */,
 				8BD2133A1F0458B7007F6FD1 /* Source */,
 			);
 			name = JSON;
@@ -2590,6 +2604,9 @@
 				B6DE52DA2230981200B70A66 /* STPPaymentMethodParams.m */,
 				B6B5FC3F222F4C0200440249 /* STPPaymentMethodThreeDSecureUsage.h */,
 				B6B5FC40222F4C0200440249 /* STPPaymentMethodThreeDSecureUsage.m */,
+				B613DD3022C536C900C7603F /* STPSetupIntent.h */,
+				B613DD3122C536C900C7603F /* STPSetupIntent.m */,
+				B613DD3522C5452500C7603F /* STPSetupIntentEnums.h */,
 				C1D7B51E1E36C32F002181F5 /* STPSource.h */,
 				C1D7B51F1E36C32F002181F5 /* STPSource.m */,
 				F19491DD1E5F6B8C001E1FC2 /* STPSourceCardDetails.h */,
@@ -2724,6 +2741,7 @@
 			files = (
 				04EBC7561B7533C300A0E6AE /* STPCardValidationState.h in Headers */,
 				04F94DA11D229F12004FC826 /* STPAddressFieldTableViewCell.h in Headers */,
+				B613DD3822C5452600C7603F /* STPSetupIntentEnums.h in Headers */,
 				B6027BC32230ABAE0025DB29 /* STPPaymentMethodCardParams.h in Headers */,
 				B69CFB462236F8E3001E9885 /* STPPaymentMethodCardPresent.h in Headers */,
 				04EBC75A1B7533C300A0E6AE /* STPCardValidator.h in Headers */,
@@ -2751,6 +2769,7 @@
 				C1363BB81D7633D800EB82B4 /* STPPaymentOptionTableViewCell.h in Headers */,
 				B69CFB4B22370547001E9885 /* STPPaymentMethodCardChecks+Private.h in Headers */,
 				C1271A3F1E3FA4EB00F25DFE /* STPSectionHeaderView.h in Headers */,
+				B613DD3422C5370400C7603F /* STPSetupIntent.h in Headers */,
 				049E84D91A605EF0000B66CD /* Stripe.h in Headers */,
 				0439B9881C454F97005A1ED5 /* STPPaymentOptionsViewController.h in Headers */,
 				3604007B22C18DAE004CF80B /* STPThreeDSTextFieldCustomization.h in Headers */,
@@ -2930,6 +2949,7 @@
 				3635C33322B03E00004298B8 /* STPEmptyStripeResponse.h in Headers */,
 				B690DDEC222F01BF000B902D /* STPPaymentMethodBillingDetails.h in Headers */,
 				04695AD91C77F9EF00E08063 /* STPDelegateProxy.h in Headers */,
+				B613DD3222C536C900C7603F /* STPSetupIntent.h in Headers */,
 				0433EB491BD06313003912B4 /* NSDictionary+Stripe.h in Headers */,
 				C124A1701CCA968B007D42EE /* STPAnalyticsClient.h in Headers */,
 				C15993281D8808490047950D /* STPShippingAddressViewController.h in Headers */,
@@ -3042,6 +3062,7 @@
 				04B31DF21D09F0A800EF1631 /* UIViewController+Stripe_NavigationItemProxy.h in Headers */,
 				B3BDCAC420EEF2150034F7F5 /* STPPaymentIntent+Private.h in Headers */,
 				8BD87B881EFB131700269C2B /* STPSourceCardDetails+Private.h in Headers */,
+				B613DD3722C5452600C7603F /* STPSetupIntentEnums.h in Headers */,
 				B69CFB452236F8E3001E9885 /* STPPaymentMethodCardPresent.h in Headers */,
 				8BD87B8D1EFB152B00269C2B /* STPSourceRedirect+Private.h in Headers */,
 				04CDB4D31A5F30A700B854EE /* Stripe.h in Headers */,
@@ -3300,6 +3321,7 @@
 				F1343BEA1D652CAD00F102D8 /* Customer.json in Resources */,
 				8BD2133E1F045D31007F6FD1 /* SEPADebitSource.json in Resources */,
 				B3BDCADF20F0142C0034F7F5 /* PaymentIntent.json in Resources */,
+				B613DD3E22C54BA800C7603F /* SetupIntent.json in Resources */,
 				B632989F2295BDD90007D287 /* ApplePayPaymentMethod.json in Resources */,
 				8BD213371F044B57007F6FD1 /* BankAccount.json in Resources */,
 				C1C02CCC1ECCD0ED00DF5643 /* EphemeralKey.json in Resources */,
@@ -3632,6 +3654,7 @@
 				073132982277A72D0019CE3F /* STPIssuingCardPin.m in Sources */,
 				C13538081D2C2186003F6157 /* STPAddCardViewControllerTest.m in Sources */,
 				B3302F462006FBA7005DDBE9 /* STPConnectAccountParamsTest.m in Sources */,
+				B613DD3C22C54AA800C7603F /* STPSetupIntentTest.m in Sources */,
 				04415C671A6605B5001225ED /* STPAPIClientTest.m in Sources */,
 				045D71311CF514BB00F6CD65 /* STPBinRangeTest.m in Sources */,
 				C15B02731EA176090026E606 /* StripeErrorTest.m in Sources */,
@@ -3833,6 +3856,7 @@
 				C1080F4A1CBECF7B007B2D89 /* STPAddress.m in Sources */,
 				04B31DE81D09D25F00EF1631 /* STPPaymentOptionsInternalViewController.m in Sources */,
 				F1D3A25C1EB014BD0095BFA9 /* UIImage+Stripe.m in Sources */,
+				B613DD3322C536C900C7603F /* STPSetupIntent.m in Sources */,
 				F1DEB8921E2052150066B8E8 /* STPCoreScrollViewController.m in Sources */,
 				C15608DF1FE08F2E0032AE66 /* UIView+Stripe_SafeAreaBounds.m in Sources */,
 				0438EF2F1B7416BB00D506CC /* STPFormTextField.m in Sources */,

--- a/Stripe/PublicHeaders/STPPaymentIntent.h
+++ b/Stripe/PublicHeaders/STPPaymentIntent.h
@@ -112,6 +112,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, nullable, readonly) NSArray<NSNumber *> *paymentMethodTypes;
 
+/**
+ When provided, this property indicates how you intend to use the payment method that your customer provides after the current payment completes. If applicable, additional authentication may be performed to comply with regional legislation or network rules required to enable the usage of the same payment method for additional payments.
+ Use on_session if you intend to only reuse the payment method when the customer is in your checkout flow. Use off_session if your customer may or may not be in your checkout flow.
+ */
+@property (nonatomic, readonly) STPPaymentIntentSetupFutureUsage setupFutureUsage;
+
 #pragma mark - Deprecated
 
 /**

--- a/Stripe/PublicHeaders/STPPaymentIntentEnums.h
+++ b/Stripe/PublicHeaders/STPPaymentIntentEnums.h
@@ -6,6 +6,8 @@
 //  Copyright © 2018 Stripe, Inc. All rights reserved.
 //
 
+#import "STPIntentAction.h"
+
 /**
  Status types for an STPPaymentIntent
  */
@@ -106,10 +108,13 @@ typedef NS_ENUM(NSInteger, STPPaymentIntentConfirmationMethod) {
     STPPaymentIntentConfirmationMethodSecret,
 };
 
+#pragma mark - Deprecated
+
 /**
  Types of Actions from a `STPPaymentIntent`, when the payment intent
  status is `STPPaymentIntentStatusRequiresAction`.
  */
+__attribute__((deprecated("Use STPIntentActionType instead", "STPIntentActionType")))
 typedef NS_ENUM(NSUInteger, STPPaymentIntentActionType)  {
     /**
      This is an unknown action, that's been added since the SDK
@@ -117,23 +122,14 @@ typedef NS_ENUM(NSUInteger, STPPaymentIntentActionType)  {
      Update your SDK, or use the `nextAction.allResponseFields`
      for custom handling.
      */
-    STPPaymentIntentActionTypeUnknown,
+    STPPaymentIntentActionTypeUnknown __attribute__((deprecated("Use STPIntentActionTypeUnknown instead", "STPIntentActionTypeUnknown"))) = STPIntentActionTypeUnknown,
     
     /**
      The payment intent needs to be authorized by the user. We provide
      `STPRedirectContext` to handle the url redirections necessary.
      */
-    STPPaymentIntentActionTypeRedirectToURL,
-
-    /**
-     The payment intent requires additional action that is handled by the the
-     Stripe SDK
-     */
-    STPPaymentIntentActionTypeUseStripeSDK,
-
+    STPPaymentIntentActionTypeRedirectToURL __attribute__((deprecated("Use STPIntentActionTypeRedirectToURL instead", "STPIntentActionTypeRedirectToURL"))) = STPIntentActionTypeRedirectToURL,
 };
-
-#pragma mark - Deprecated
 
 /**
  Types of Source Actions from a `STPPaymentIntent`, when the payment intent
@@ -141,7 +137,7 @@ typedef NS_ENUM(NSUInteger, STPPaymentIntentActionType)  {
  
  @deprecated Use`STPPaymentIntentActionType` instead.
  */
-__attribute__((deprecated("Use STPPaymentIntentActionType instead", "STPPaymentIntentActionType")))
+__attribute__((deprecated("Use STPIntentActionType instead", "STPIntentActionType")))
 typedef NS_ENUM(NSUInteger, STPPaymentIntentSourceActionType)  {
     /**
      This is an unknown source action, that's been added since the SDK
@@ -149,13 +145,13 @@ typedef NS_ENUM(NSUInteger, STPPaymentIntentSourceActionType)  {
      Update your SDK, or use the `nextSourceAction.allResponseFields`
      for custom handling.
      */
-    STPPaymentIntentSourceActionTypeUnknown __attribute__((deprecated("Use STPPaymentIntentActionTypeUnknown instead", "STPPaymentIntentActionTypeUnknown"))) = STPPaymentIntentActionTypeUnknown,
+    STPPaymentIntentSourceActionTypeUnknown __attribute__((deprecated("Use STPIntentActionTypeUnknown instead", "STPIntentActionTypeUnknown"))) = STPIntentActionTypeUnknown,
 
     /**
      The payment intent needs to be authorized by the user. We provide
      `STPRedirectContext` to handle the url redirections necessary.
      */
-    STPPaymentIntentSourceActionTypeAuthorizeWithURL __attribute__((deprecated("Use STPPaymentIntentActionTypeRedirectToURL instead", "STPPaymentIntentActionTypeRedirectToURL"))) = STPPaymentIntentActionTypeRedirectToURL,
+    STPPaymentIntentSourceActionTypeAuthorizeWithURL __attribute__((deprecated("Use STPIntentActionTypeRedirectToURL instead", "STPIntentActionTypeRedirectToURL"))) = STPIntentActionTypeRedirectToURL,
 };
 
 

--- a/Stripe/PublicHeaders/STPPaymentIntentEnums.h
+++ b/Stripe/PublicHeaders/STPPaymentIntentEnums.h
@@ -108,6 +108,36 @@ typedef NS_ENUM(NSInteger, STPPaymentIntentConfirmationMethod) {
     STPPaymentIntentConfirmationMethodSecret,
 };
 
+/**
+ Indicates how you intend to use the payment method that your customer provides after the current payment completes.
+ 
+ If applicable, additional authentication may be performed to comply with regional legislation or network rules required to enable the usage of the same payment method for additional payments.
+ 
+ @see https://stripe.com/docs/api/payment_intents/object#payment_intent_object-setup_future_usage
+ */
+typedef NS_ENUM(NSInteger, STPPaymentIntentSetupFutureUsage) {
+    
+    /**
+     Unknown value.  Update your SDK, or use `allResponseFields` for custom handling.
+     */
+    STPPaymentIntentSetupFutureUsageUnknown,
+    
+    /**
+     No value was provided.
+     */
+    STPPaymentIntentSetupFutureUsageNone,
+    
+    /**
+     Indicates you intend to only reuse the payment method when the customer is in your checkout flow.
+     */
+    STPPaymentIntentSetupFutureUsageOnSession,
+    
+    /**
+     Indicates you intend to reuse the payment method when the customer may or may not be in your checkout flow.
+     */
+    STPPaymentIntentSetupFutureUsageOffSession,
+};
+
 #pragma mark - Deprecated
 
 /**

--- a/Stripe/PublicHeaders/STPSetupIntent.h
+++ b/Stripe/PublicHeaders/STPSetupIntent.h
@@ -79,6 +79,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, readonly) STPSetupIntentStatus status;
 
+/**
+ Indicates how the payment method is intended to be used in the future.
+ */
+@property (nonatomic, readonly) STPSetupIntentUsage usage;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Stripe/PublicHeaders/STPSetupIntent.h
+++ b/Stripe/PublicHeaders/STPSetupIntent.h
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  The Stripe ID of the SetupIntent.
  */
-@property (nonatomic, readonly) NSString *stripeId;
+@property (nonatomic, readonly) NSString *stripeID;
 
 /**
  The client secret of this SetupIntent. Used for client-side retrieval using a publishable key.
@@ -40,7 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  ID of the Customer this SetupIntent belongs to, if one exists.
  */
-@property (nonatomic, nullable, readonly) NSString *customerId;
+@property (nonatomic, nullable, readonly) NSString *customerID;
 
 /**
  An arbitrary string attached to the object. Often useful for displaying to users.
@@ -67,7 +67,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  ID of the payment method used with this SetupIntent.
  */
-@property (nonatomic, nullable, readonly) NSString *paymentMethodId;
+@property (nonatomic, nullable, readonly) NSString *paymentMethodID;
 
 /**
  The list of payment method types (e.g. `@[@(STPPaymentMethodTypeCard)]`) that this SetupIntent is allowed to set up.

--- a/Stripe/PublicHeaders/STPSetupIntent.h
+++ b/Stripe/PublicHeaders/STPSetupIntent.h
@@ -1,0 +1,84 @@
+//
+//  STPSetupIntent.h
+//  StripeiOS
+//
+//  Created by Yuki Tokuhiro on 6/27/19.
+//  Copyright © 2019 Stripe, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "STPAPIResponseDecodable.h"
+#import "STPSetupIntentEnums.h"
+
+@class STPIntentAction;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ A SetupIntent guides you through the process of setting up a customer's payment credentials for future payments.
+
+ @see https://stripe.com/docs/api/setup_intents
+ */
+@interface STPSetupIntent : NSObject<STPAPIResponseDecodable>
+
+/**
+ The Stripe ID of the SetupIntent.
+ */
+@property (nonatomic, readonly) NSString *stripeId;
+
+/**
+ The client secret of this SetupIntent. Used for client-side retrieval using a publishable key.
+ */
+@property (nonatomic, readonly) NSString *clientSecret;
+
+/**
+ Time at which the object was created.
+ */
+@property (nonatomic, readonly) NSDate *created;
+
+/**
+ ID of the Customer this SetupIntent belongs to, if one exists.
+ */
+@property (nonatomic, nullable, readonly) NSString *customerId;
+
+/**
+ An arbitrary string attached to the object. Often useful for displaying to users.
+ */
+@property (nonatomic, nullable, readonly) NSString *stripeDescription;
+
+/**
+ Has the value `YES` if the object exists in live mode or the value `NO` if the object exists in test mode.
+ */
+@property (nonatomic, readonly) BOOL livemode;
+
+/**
+ Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+ 
+ @see https://stripe.com/docs/api#metadata
+ */
+@property (nonatomic, nullable, readonly) NSDictionary<NSString*, NSString *> *metadata;
+
+/**
+ If present, this property tells you what actions you need to take in order for your customer to set up this payment method.
+ */
+@property (nonatomic, nullable, readonly) STPIntentAction *nextAction;
+
+/**
+ ID of the payment method used with this SetupIntent.
+ */
+@property (nonatomic, nullable, readonly) NSString *paymentMethodId;
+
+/**
+ The list of payment method types (e.g. `@[@(STPPaymentMethodTypeCard)]`) that this SetupIntent is allowed to set up.
+ */
+@property (nonatomic, readonly) NSArray<NSNumber *> *paymentMethodTypes;
+
+/**
+ Status of this SetupIntent.
+ */
+@property (nonatomic, readonly) STPSetupIntentStatus status;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Stripe/PublicHeaders/STPSetupIntentEnums.h
+++ b/Stripe/PublicHeaders/STPSetupIntentEnums.h
@@ -47,3 +47,31 @@ typedef NS_ENUM(NSInteger, STPSetupIntentStatus) {
      */
     STPSetupIntentStatusCanceled,
 };
+
+/**
+ Indicates how the payment method is intended to be used in the future.
+ 
+ @see https://stripe.com/docs/api/setup_intents/create#create_setup_intent-usage
+ */
+typedef NS_ENUM(NSInteger, STPSetupIntentUsage) {
+    
+    /**
+     Unknown value.  Update your SDK, or use `allResponseFields` for custom handling.
+     */
+    STPSetupIntentUsageUnknown,
+    
+    /**
+     No value was provided.
+     */
+    STPSetupIntentUsageNone,
+    
+    /**
+     Indicates you intend to only reuse the payment method when the customer is in your checkout flow.
+     */
+    STPSetupIntentUsageOnSession,
+    
+    /**
+     Indicates you intend to reuse the payment method when the customer may or may not be in your checkout flow.
+     */
+    STPSetupIntentUsageOffSession,
+};

--- a/Stripe/PublicHeaders/STPSetupIntentEnums.h
+++ b/Stripe/PublicHeaders/STPSetupIntentEnums.h
@@ -1,0 +1,49 @@
+//
+//  STPSetupIntentEnums.h
+//  Stripe
+//
+//  Created by Yuki Tokuhiro on 6/27/19.
+//  Copyright © 2019 Stripe, Inc. All rights reserved.
+//
+
+/**
+ Status types for an STPSetupIntent
+ */
+typedef NS_ENUM(NSInteger, STPSetupIntentStatus) {
+    
+    /**
+     Unknown status
+     */
+    STPSetupIntentStatusUnknown,
+
+    /**
+     This SetupIntent requires a PaymentMethod
+     */
+    STPSetupIntentStatusRequiresPaymentMethod,
+    
+    /**
+     This SetupIntent needs to be confirmed
+     */
+    STPSetupIntentStatusRequiresConfirmation,
+    
+    /**
+     The selected PaymentMethod requires additional authentication steps.
+     Additional actions found via the `nextAction` property of `STPSetupIntent`
+     */
+    STPSetupIntentStatusRequiresAction,
+    
+    /**
+     Stripe is processing this SetupIntent
+     */
+    STPSetupIntentStatusProcessing,
+    
+    /**
+     The SetupIntent has succeeded
+     */
+    STPSetupIntentStatusSucceeded,
+    
+    /**
+     This SetupIntent was canceled and cannot be changed.
+     */
+    STPSetupIntentStatusCanceled,
+};

--- a/Stripe/PublicHeaders/Stripe.h
+++ b/Stripe/PublicHeaders/Stripe.h
@@ -71,6 +71,7 @@
 #import "STPPaymentResult.h"
 #import "STPRedirectContext.h"
 #import "STPSetupIntent.h"
+#import "STPSetupIntentEnums.h"
 #import "STPShippingAddressViewController.h"
 #import "STPSource.h"
 #import "STPSourceCardDetails.h"

--- a/Stripe/PublicHeaders/Stripe.h
+++ b/Stripe/PublicHeaders/Stripe.h
@@ -70,6 +70,7 @@
 #import "STPPaymentOptionsViewController.h"
 #import "STPPaymentResult.h"
 #import "STPRedirectContext.h"
+#import "STPSetupIntent.h"
 #import "STPShippingAddressViewController.h"
 #import "STPSource.h"
 #import "STPSourceCardDetails.h"

--- a/Stripe/STPPaymentIntent+Private.h
+++ b/Stripe/STPPaymentIntent+Private.h
@@ -40,9 +40,17 @@ NS_ASSUME_NONNULL_BEGIN
  Parse the string and return the correct `STPPaymentIntentConfirmationMethod`,
  or `STPPaymentIntentConfirmationMethodUnknown` if it's unrecognized by this version of the SDK.
 
- @param string the NSString with the capture method
+ @param string the NSString with the confirmation method
  */
 + (STPPaymentIntentConfirmationMethod)confirmationMethodFromString:(NSString *)string;
+
+/**
+ Parse the string and return the correct `STPPaymentIntentSetupFutureUsage`,
+ or `STPPaymentIntentSetupFutureUsageUnknown` if it's unrecognized by this version of the SDK.
+ 
+ @param string the NSString with the setup future usage value
+ */
++ (STPPaymentIntentSetupFutureUsage)setupFutureUsageFromString:(NSString *)string;
 
 @end
 

--- a/Stripe/STPPaymentIntent.m
+++ b/Stripe/STPPaymentIntent.m
@@ -32,6 +32,7 @@
 @property (nonatomic, copy, nullable, readwrite) NSString *paymentMethodId;
 @property (nonatomic, assign, readwrite) STPPaymentIntentStatus status;
 @property (nonatomic, copy, nullable, readwrite) NSArray<NSNumber *> *paymentMethodTypes;
+@property (nonatomic) STPPaymentIntentSetupFutureUsage setupFutureUsage;
 
 @property (nonatomic, copy, nonnull, readwrite) NSDictionary *allResponseFields;
 @end
@@ -60,6 +61,7 @@
                        [NSString stringWithFormat:@"paymentMethodId = %@", self.paymentMethodId],
                        [NSString stringWithFormat:@"paymentMethodTypes = %@", [self.allResponseFields stp_arrayForKey:@"payment_method_types"]],
                        [NSString stringWithFormat:@"receiptEmail = %@", self.receiptEmail],
+                       [NSString stringWithFormat:@"setupFutureUsage = %@", self.allResponseFields[@"setup_future_usage"]],
                        [NSString stringWithFormat:@"shipping = %@", self.allResponseFields[@"shipping"]],
                        [NSString stringWithFormat:@"sourceId = %@", self.sourceId],
                        [NSString stringWithFormat:@"status = %@", [self.allResponseFields stp_stringForKey:@"status"]],
@@ -123,6 +125,18 @@
     return statusNumber.integerValue;
 }
 
++ (STPPaymentIntentSetupFutureUsage)setupFutureUsageFromString:(NSString *)string {
+    NSDictionary<NSString *, NSNumber *> *map = @{
+                                                  @"on_session": @(STPPaymentIntentSetupFutureUsageOnSession),
+                                                  @"off_session": @(STPPaymentIntentSetupFutureUsageOffSession),
+                                                  };
+    
+    NSString *key = string.lowercaseString;
+    NSNumber *statusNumber = map[key] ?: @(STPPaymentIntentSetupFutureUsageUnknown);
+    return statusNumber.integerValue;
+
+}
+
 #pragma mark - Deprecated
 
 - (STPPaymentIntentAction *)nextSourceAction {
@@ -172,6 +186,8 @@
         paymentIntent.paymentMethodTypes = [STPPaymentMethod typesFromStrings:rawPaymentMethodTypes];
     }
     paymentIntent.status = [[self class] statusFromString:rawStatus];
+    NSString *rawSetupFutureUsage = [dict stp_stringForKey:@"setup_future_usage"];
+    paymentIntent.setupFutureUsage = rawSetupFutureUsage ? [[self class] setupFutureUsageFromString:rawSetupFutureUsage] : STPPaymentIntentSetupFutureUsageNone;
 
     paymentIntent.allResponseFields = dict;
 

--- a/Stripe/STPRedirectContext.m
+++ b/Stripe/STPRedirectContext.m
@@ -62,7 +62,7 @@ typedef void (^STPBoolCompletionBlock)(BOOL success);
     NSURL *returnURL = paymentIntent.nextAction.redirectToURL.returnURL;
 
     if (paymentIntent.status != STPPaymentIntentStatusRequiresAction
-        || paymentIntent.nextAction.type != STPPaymentIntentActionTypeRedirectToURL
+        || paymentIntent.nextAction.type != STPIntentActionTypeRedirectToURL
         || !redirectURL
         || !returnURL) {
         return nil;

--- a/Stripe/STPSetupIntent.m
+++ b/Stripe/STPSetupIntent.m
@@ -26,6 +26,7 @@
 @property (nonatomic, nullable) NSString *paymentMethodId;
 @property (nonatomic) NSArray<NSNumber *> *paymentMethodTypes;
 @property (nonatomic) STPSetupIntentStatus status;
+@property (nonatomic) STPSetupIntentUsage usage;
 
 @property (nonatomic, copy, nonnull, readwrite) NSDictionary *allResponseFields;
 @end
@@ -51,6 +52,7 @@
                        [NSString stringWithFormat:@"paymentMethodId = %@", self.paymentMethodId],
                        [NSString stringWithFormat:@"paymentMethodTypes = %@", [self.allResponseFields stp_arrayForKey:@"payment_method_types"]],
                        [NSString stringWithFormat:@"status = %@", [self.allResponseFields stp_stringForKey:@"status"]],
+                       [NSString stringWithFormat:@"usage = %@", [self.allResponseFields stp_stringForKey:@"usage"]],
                        ];
     
     return [NSString stringWithFormat:@"<%@>", [props componentsJoinedByString:@"; "]];
@@ -70,6 +72,17 @@
     
     NSString *key = string.lowercaseString;
     NSNumber *statusNumber = map[key] ?: @(STPSetupIntentStatusUnknown);
+    return statusNumber.integerValue;
+}
+
++ (STPSetupIntentUsage)usageFromString:(NSString *)string {
+    NSDictionary<NSString *, NSNumber *> *map = @{
+                                                  @"off_session": @(STPSetupIntentUsageOffSession),
+                                                  @"on_session": @(STPSetupIntentUsageOnSession),
+                                                  };
+    
+    NSString *key = string.lowercaseString;
+    NSNumber *statusNumber = map[key] ?: @(STPSetupIntentUsageUnknown);
     return statusNumber.integerValue;
 }
 
@@ -106,6 +119,8 @@
         setupIntent.paymentMethodTypes = [STPPaymentMethod typesFromStrings:rawPaymentMethodTypes];
     }
     setupIntent.status = [[self class] statusFromString:rawStatus];
+    NSString *rawUsage = [dict stp_stringForKey:@"usage"];
+    setupIntent.usage = rawUsage ? [[self class] usageFromString:rawUsage] : STPSetupIntentUsageNone;
     
     setupIntent.allResponseFields = dict;
     

--- a/Stripe/STPSetupIntent.m
+++ b/Stripe/STPSetupIntent.m
@@ -1,0 +1,115 @@
+//
+//  STPSetupIntent.m
+//  StripeiOS
+//
+//  Created by Yuki Tokuhiro on 6/27/19.
+//  Copyright © 2019 Stripe, Inc. All rights reserved.
+//
+
+#import "STPSetupIntent.h"
+
+#import "STPIntentAction.h"
+#import "STPPaymentMethod+Private.h"
+
+#import "NSArray+Stripe.h"
+#import "NSDictionary+Stripe.h"
+
+@interface STPSetupIntent()
+@property (nonatomic) NSString *stripeId;
+@property (nonatomic) NSString *clientSecret;
+@property (nonatomic) NSDate *created;
+@property (nonatomic, nullable) NSString *customerId;
+@property (nonatomic, nullable) NSString *stripeDescription;
+@property (nonatomic) BOOL livemode;
+@property (nonatomic, nullable) NSDictionary<NSString*, NSString *> *metadata;
+@property (nonatomic, nullable) STPIntentAction *nextAction;
+@property (nonatomic, nullable) NSString *paymentMethodId;
+@property (nonatomic) NSArray<NSNumber *> *paymentMethodTypes;
+@property (nonatomic) STPSetupIntentStatus status;
+
+@property (nonatomic, copy, nonnull, readwrite) NSDictionary *allResponseFields;
+@end
+
+@implementation STPSetupIntent
+
+- (NSString *)description {
+    NSArray *props = @[
+                       // Object
+                       [NSString stringWithFormat:@"%@: %p", NSStringFromClass([self class]), self],
+                       
+                       // Identifier
+                       [NSString stringWithFormat:@"stripeId = %@", self.stripeId],
+                       
+                       // SetupIntent details (alphabetical)
+                       [NSString stringWithFormat:@"clientSecret = %@", (self.clientSecret) ? @"<redacted>" : nil],
+                       [NSString stringWithFormat:@"created = %@", self.created],
+                       [NSString stringWithFormat:@"customerId = %@", self.customerId],
+                       [NSString stringWithFormat:@"description = %@", self.stripeDescription],
+                       [NSString stringWithFormat:@"livemode = %@", self.livemode ? @"YES" : @"NO"],
+                       [NSString stringWithFormat:@"metadata = %@", self.metadata],
+                       [NSString stringWithFormat:@"nextAction = %@", self.nextAction],
+                       [NSString stringWithFormat:@"paymentMethodId = %@", self.paymentMethodId],
+                       [NSString stringWithFormat:@"paymentMethodTypes = %@", [self.allResponseFields stp_arrayForKey:@"payment_method_types"]],
+                       [NSString stringWithFormat:@"status = %@", [self.allResponseFields stp_stringForKey:@"status"]],
+                       ];
+    
+    return [NSString stringWithFormat:@"<%@>", [props componentsJoinedByString:@"; "]];
+}
+
+#pragma mark - STPSetupIntentEnum support
+
++ (STPSetupIntentStatus)statusFromString:(NSString *)string {
+    NSDictionary<NSString *, NSNumber *> *map = @{
+                                                  @"requires_payment_method": @(STPSetupIntentStatusRequiresPaymentMethod),
+                                                  @"requires_confirmation": @(STPSetupIntentStatusRequiresConfirmation),
+                                                  @"requires_action": @(STPSetupIntentStatusRequiresAction),
+                                                  @"processing": @(STPSetupIntentStatusProcessing),
+                                                  @"succeeded": @(STPSetupIntentStatusSucceeded),
+                                                  @"canceled": @(STPSetupIntentStatusCanceled),
+                                                  };
+    
+    NSString *key = string.lowercaseString;
+    NSNumber *statusNumber = map[key] ?: @(STPSetupIntentStatusUnknown);
+    return statusNumber.integerValue;
+}
+
+#pragma mark - STPAPIResponseDecodable
+
++ (nullable instancetype)decodedObjectFromAPIResponse:(nullable NSDictionary *)response {
+    NSDictionary *dict = [response stp_dictionaryByRemovingNulls];
+    if (!dict) {
+        return nil;
+    }
+    
+    // required fields
+    NSString *stripeId = [dict stp_stringForKey:@"id"];
+    NSString *clientSecret = [dict stp_stringForKey:@"client_secret"];
+    NSString *rawStatus = [dict stp_stringForKey:@"status"];
+    if (!stripeId || !clientSecret || !rawStatus || !dict[@"livemode"]) {
+        return nil;
+    }
+    
+    STPSetupIntent *setupIntent = [self new];
+    
+    setupIntent.stripeId = stripeId;
+    setupIntent.clientSecret = clientSecret;
+    setupIntent.created = [dict stp_dateForKey:@"created"];
+    setupIntent.customerId = [dict stp_stringForKey:@"customer"];
+    setupIntent.stripeDescription = [dict stp_stringForKey:@"description"];
+    setupIntent.livemode = [dict stp_boolForKey:@"livemode" or:YES];
+    setupIntent.metadata = [[dict stp_dictionaryForKey:@"metadata"] stp_dictionaryByRemovingNonStrings];
+    NSDictionary *nextActionDict = [dict stp_dictionaryForKey:@"next_action"];
+    setupIntent.nextAction = [STPIntentAction decodedObjectFromAPIResponse:nextActionDict];
+    setupIntent.paymentMethodId = [dict stp_stringForKey:@"payment_method"];
+    NSArray<NSString *> *rawPaymentMethodTypes = [[dict stp_arrayForKey:@"payment_method_types"] stp_arrayByRemovingNulls];
+    if (rawPaymentMethodTypes) {
+        setupIntent.paymentMethodTypes = [STPPaymentMethod typesFromStrings:rawPaymentMethodTypes];
+    }
+    setupIntent.status = [[self class] statusFromString:rawStatus];
+    
+    setupIntent.allResponseFields = dict;
+    
+    return setupIntent;
+}
+
+@end

--- a/Stripe/STPSetupIntent.m
+++ b/Stripe/STPSetupIntent.m
@@ -15,16 +15,16 @@
 #import "NSDictionary+Stripe.h"
 
 @interface STPSetupIntent()
-@property (nonatomic) NSString *stripeId;
-@property (nonatomic) NSString *clientSecret;
+@property (nonatomic, copy) NSString *stripeID;
+@property (nonatomic, copy) NSString *clientSecret;
 @property (nonatomic) NSDate *created;
-@property (nonatomic, nullable) NSString *customerId;
-@property (nonatomic, nullable) NSString *stripeDescription;
+@property (nonatomic, copy, nullable) NSString *customerID;
+@property (nonatomic, copy, nullable) NSString *stripeDescription;
 @property (nonatomic) BOOL livemode;
-@property (nonatomic, nullable) NSDictionary<NSString*, NSString *> *metadata;
+@property (nonatomic, copy, nullable) NSDictionary<NSString*, NSString *> *metadata;
 @property (nonatomic, nullable) STPIntentAction *nextAction;
-@property (nonatomic, nullable) NSString *paymentMethodId;
-@property (nonatomic) NSArray<NSNumber *> *paymentMethodTypes;
+@property (nonatomic, copy, nullable) NSString *paymentMethodID;
+@property (nonatomic, copy) NSArray<NSNumber *> *paymentMethodTypes;
 @property (nonatomic) STPSetupIntentStatus status;
 @property (nonatomic) STPSetupIntentUsage usage;
 
@@ -39,17 +39,17 @@
                        [NSString stringWithFormat:@"%@: %p", NSStringFromClass([self class]), self],
                        
                        // Identifier
-                       [NSString stringWithFormat:@"stripeId = %@", self.stripeId],
+                       [NSString stringWithFormat:@"stripeId = %@", self.stripeID],
                        
                        // SetupIntent details (alphabetical)
                        [NSString stringWithFormat:@"clientSecret = %@", (self.clientSecret) ? @"<redacted>" : nil],
                        [NSString stringWithFormat:@"created = %@", self.created],
-                       [NSString stringWithFormat:@"customerId = %@", self.customerId],
+                       [NSString stringWithFormat:@"customerId = %@", self.customerID],
                        [NSString stringWithFormat:@"description = %@", self.stripeDescription],
                        [NSString stringWithFormat:@"livemode = %@", self.livemode ? @"YES" : @"NO"],
                        [NSString stringWithFormat:@"metadata = %@", self.metadata],
                        [NSString stringWithFormat:@"nextAction = %@", self.nextAction],
-                       [NSString stringWithFormat:@"paymentMethodId = %@", self.paymentMethodId],
+                       [NSString stringWithFormat:@"paymentMethodId = %@", self.paymentMethodID],
                        [NSString stringWithFormat:@"paymentMethodTypes = %@", [self.allResponseFields stp_arrayForKey:@"payment_method_types"]],
                        [NSString stringWithFormat:@"status = %@", [self.allResponseFields stp_stringForKey:@"status"]],
                        [NSString stringWithFormat:@"usage = %@", [self.allResponseFields stp_stringForKey:@"usage"]],
@@ -104,16 +104,16 @@
     
     STPSetupIntent *setupIntent = [self new];
     
-    setupIntent.stripeId = stripeId;
+    setupIntent.stripeID = stripeId;
     setupIntent.clientSecret = clientSecret;
     setupIntent.created = [dict stp_dateForKey:@"created"];
-    setupIntent.customerId = [dict stp_stringForKey:@"customer"];
+    setupIntent.customerID = [dict stp_stringForKey:@"customer"];
     setupIntent.stripeDescription = [dict stp_stringForKey:@"description"];
     setupIntent.livemode = [dict stp_boolForKey:@"livemode" or:YES];
     setupIntent.metadata = [[dict stp_dictionaryForKey:@"metadata"] stp_dictionaryByRemovingNonStrings];
     NSDictionary *nextActionDict = [dict stp_dictionaryForKey:@"next_action"];
     setupIntent.nextAction = [STPIntentAction decodedObjectFromAPIResponse:nextActionDict];
-    setupIntent.paymentMethodId = [dict stp_stringForKey:@"payment_method"];
+    setupIntent.paymentMethodID = [dict stp_stringForKey:@"payment_method"];
     NSArray<NSString *> *rawPaymentMethodTypes = [[dict stp_arrayForKey:@"payment_method_types"] stp_arrayByRemovingNulls];
     if (rawPaymentMethodTypes) {
         setupIntent.paymentMethodTypes = [STPPaymentMethod typesFromStrings:rawPaymentMethodTypes];

--- a/Tests/Tests/STPFixtures.h
+++ b/Tests/Tests/STPFixtures.h
@@ -16,6 +16,7 @@ extern NSString *const STPTestJSONCustomer;
 extern NSString *const STPTestJSONCard;
 
 extern NSString *const STPTestJSONPaymentIntent;
+extern NSString *const STPTestJSONSetupIntent;
 extern NSString *const STPTestJSONPaymentMethod;
 extern NSString *const STPTestJSONApplePayPaymentMethod;
 
@@ -135,6 +136,11 @@ extern NSString *const STPTestJSONSourceSOFORT;
  A PaymentIntent object
  */
 + (STPPaymentIntent *)paymentIntent;
+
+/**
+ A SetupIntent object
+ */
++ (STPSetupIntent *)setupIntent;
 
 /**
  A PaymentConfiguration object with a fake publishable key. Use this to avoid

--- a/Tests/Tests/STPFixtures.m
+++ b/Tests/Tests/STPFixtures.m
@@ -15,6 +15,7 @@ NSString *const STPTestJSONCustomer = @"Customer";
 NSString *const STPTestJSONCard = @"Card";
 
 NSString *const STPTestJSONPaymentIntent = @"PaymentIntent";
+NSString *const STPTestJSONSetupIntent = @"SetupIntent";
 NSString *const STPTestJSONPaymentMethod = @"PaymentMethod";
 NSString *const STPTestJSONApplePayPaymentMethod = @"ApplePayPaymentMethod";
 
@@ -211,6 +212,10 @@ NSString *const STPTestJSONSourceSOFORT = @"SOFORTSource";
 
 + (STPPaymentIntent *)paymentIntent {
     return [STPPaymentIntent decodedObjectFromAPIResponse:[STPTestUtils jsonNamed:@"PaymentIntent"]];
+}
+
++ (STPSetupIntent *)setupIntent {
+    return [STPSetupIntent decodedObjectFromAPIResponse:[STPTestUtils jsonNamed:@"SetupIntent"]];
 }
 
 + (STPPaymentConfiguration *)paymentConfiguration {

--- a/Tests/Tests/STPPaymentIntentFunctionalTest.m
+++ b/Tests/Tests/STPPaymentIntentFunctionalTest.m
@@ -38,6 +38,7 @@
                                            XCTAssertNil(paymentIntent.sourceId);
                                            XCTAssertNil(paymentIntent.paymentMethodId);
                                            XCTAssertEqual(paymentIntent.status, STPPaymentIntentStatusCanceled);
+                                           XCTAssertEqual(paymentIntent.setupFutureUsage, STPPaymentIntentSetupFutureUsageNone);
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated"
                                            XCTAssertNil(paymentIntent.nextSourceAction);

--- a/Tests/Tests/STPPaymentIntentTest.m
+++ b/Tests/Tests/STPPaymentIntentTest.m
@@ -181,7 +181,7 @@
 
     // nextAction
     XCTAssertNotNil(paymentIntent.nextAction);
-    XCTAssertEqual(paymentIntent.nextAction.type, STPPaymentIntentActionTypeRedirectToURL);
+    XCTAssertEqual(paymentIntent.nextAction.type, STPIntentActionTypeRedirectToURL);
     XCTAssertNotNil(paymentIntent.nextAction.redirectToURL);
     XCTAssertNotNil(paymentIntent.nextAction.redirectToURL.url);
     NSURL *returnURL = paymentIntent.nextAction.redirectToURL.returnURL;

--- a/Tests/Tests/STPPaymentIntentTest.m
+++ b/Tests/Tests/STPPaymentIntentTest.m
@@ -119,6 +119,23 @@
                    STPPaymentIntentConfirmationMethodUnknown);
 }
 
+- (void)testSetupFutureUsageFromString {
+    XCTAssertEqual([STPPaymentIntent setupFutureUsageFromString:@"on_session"],
+                   STPPaymentIntentSetupFutureUsageOnSession);
+    XCTAssertEqual([STPPaymentIntent setupFutureUsageFromString:@"ON_SESSION"],
+                   STPPaymentIntentSetupFutureUsageOnSession);
+
+    XCTAssertEqual([STPPaymentIntent setupFutureUsageFromString:@"off_session"],
+                   STPPaymentIntentSetupFutureUsageOffSession);
+    XCTAssertEqual([STPPaymentIntent setupFutureUsageFromString:@"OFF_SESSION"],
+                   STPPaymentIntentSetupFutureUsageOffSession);
+    
+    XCTAssertEqual([STPPaymentIntent setupFutureUsageFromString:@"garbage"],
+                   STPPaymentIntentSetupFutureUsageUnknown);
+    XCTAssertEqual([STPPaymentIntent setupFutureUsageFromString:@"GARBAGE"],
+                   STPPaymentIntentSetupFutureUsageUnknown);
+}
+
 #pragma mark - Description Tests
 
 - (void)testDescription {
@@ -193,6 +210,7 @@
     XCTAssertEqualObjects(url, [NSURL URLWithString:@"https://hooks.stripe.com/redirect/authenticate/src_1Cl1AeIl4IdHmuTb1L7x083A?client_secret=src_client_secret_DBNwUe9qHteqJ8qQBwNWiigk"]);
     XCTAssertEqualObjects(paymentIntent.sourceId, @"src_1Cl1AdIl4IdHmuTbseiDWq6m");
     XCTAssertEqual(paymentIntent.status, STPPaymentIntentStatusRequiresAction);
+    XCTAssertEqual(paymentIntent.setupFutureUsage, STPPaymentIntentSetupFutureUsageNone);
     
     XCTAssertEqualObjects(paymentIntent.paymentMethodTypes, @[@(STPPaymentMethodTypeCard)]);
 

--- a/Tests/Tests/STPSetupIntentTest.m
+++ b/Tests/Tests/STPSetupIntentTest.m
@@ -57,12 +57,12 @@
     NSDictionary *response = [STPTestUtils jsonNamed:@"SetupIntent"];
     STPSetupIntent *setupIntent = [STPSetupIntent decodedObjectFromAPIResponse:response];
     
-    XCTAssertEqualObjects(setupIntent.stripeId, @"seti_123456789");
+    XCTAssertEqualObjects(setupIntent.stripeID, @"seti_123456789");
     XCTAssertEqualObjects(setupIntent.clientSecret, @"seti_123456789_secret_123456789");
     XCTAssertEqualObjects(setupIntent.created, [NSDate dateWithTimeIntervalSince1970:123456789]);
-    XCTAssertEqualObjects(setupIntent.customerId, @"cus_123456");
+    XCTAssertEqualObjects(setupIntent.customerID, @"cus_123456");
     XCTAssertEqualObjects(setupIntent.metadata, @{@"user_id": @"guest_1234567"});
-    XCTAssertEqualObjects(setupIntent.paymentMethodId, @"pm_123456");
+    XCTAssertEqualObjects(setupIntent.paymentMethodID, @"pm_123456");
     XCTAssertEqualObjects(setupIntent.stripeDescription, @"My Sample SetupIntent");
     XCTAssertFalse(setupIntent.livemode);
     // nextAction
@@ -77,7 +77,7 @@
     XCTAssertNotNil(url);
     
     XCTAssertEqualObjects(url, [NSURL URLWithString:@"https://hooks.stripe.com/redirect/authenticate/src_1Cl1AeIl4IdHmuTb1L7x083A?client_secret=src_client_secret_DBNwUe9qHteqJ8qQBwNWiigk"]);
-    XCTAssertEqualObjects(setupIntent.paymentMethodId, @"pm_123456");
+    XCTAssertEqualObjects(setupIntent.paymentMethodID, @"pm_123456");
     XCTAssertEqual(setupIntent.status, STPSetupIntentStatusRequiresAction);
     XCTAssertEqual(setupIntent.usage, STPSetupIntentUsageOffSession);
     

--- a/Tests/Tests/STPSetupIntentTest.m
+++ b/Tests/Tests/STPSetupIntentTest.m
@@ -79,6 +79,7 @@
     XCTAssertEqualObjects(url, [NSURL URLWithString:@"https://hooks.stripe.com/redirect/authenticate/src_1Cl1AeIl4IdHmuTb1L7x083A?client_secret=src_client_secret_DBNwUe9qHteqJ8qQBwNWiigk"]);
     XCTAssertEqualObjects(setupIntent.paymentMethodId, @"pm_123456");
     XCTAssertEqual(setupIntent.status, STPSetupIntentStatusRequiresAction);
+    XCTAssertEqual(setupIntent.usage, STPSetupIntentUsageOffSession);
     
     XCTAssertEqualObjects(setupIntent.paymentMethodTypes, @[@(STPPaymentMethodTypeCard)]);
     

--- a/Tests/Tests/STPSetupIntentTest.m
+++ b/Tests/Tests/STPSetupIntentTest.m
@@ -1,0 +1,89 @@
+//
+//  STPSetupIntentTest.m
+//  StripeiOS Tests
+//
+//  Created by Yuki Tokuhiro on 6/27/19.
+//  Copyright © 2019 Stripe, Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "STPSetupIntent.h"
+#import "STPFixtures.h"
+#import "STPTestUtils.h"
+
+@interface STPSetupIntentTest : XCTestCase
+
+@end
+
+@implementation STPSetupIntentTest
+
+#pragma mark - Description Tests
+
+- (void)testDescription {
+    STPSetupIntent *setupIntent = [STPFixtures setupIntent];
+    
+    XCTAssertNotNil(setupIntent);
+    NSString *desc = setupIntent.description;
+    XCTAssertTrue([desc containsString:NSStringFromClass([setupIntent class])]);
+    XCTAssertGreaterThan(desc.length, 500UL, @"Custom description should be long");
+}
+
+#pragma mark - STPAPIResponseDecodable Tests
+
+- (void)testDecodedObjectFromAPIResponseRequiredFields {
+    NSDictionary *fullJson = [STPTestUtils jsonNamed:STPTestJSONSetupIntent];
+    
+    XCTAssertNotNil([STPSetupIntent decodedObjectFromAPIResponse:fullJson], @"can decode with full json");
+    
+    NSArray<NSString *> *requiredFields = @[
+                                            @"id",
+                                            @"client_secret",
+                                            @"livemode",
+                                            @"status",
+                                            ];
+    
+    for (NSString *field in requiredFields) {
+        NSMutableDictionary *partialJson = [fullJson mutableCopy];
+        
+        XCTAssertNotNil(partialJson[field], @"json should contain %@", field);
+        [partialJson removeObjectForKey:field];
+        
+        XCTAssertNil([STPSetupIntent decodedObjectFromAPIResponse:partialJson], @"should not decode without %@", field);
+    }
+}
+
+- (void)testDecodedObjectFromAPIResponseMapping {
+    NSDictionary *response = [STPTestUtils jsonNamed:@"SetupIntent"];
+    STPSetupIntent *setupIntent = [STPSetupIntent decodedObjectFromAPIResponse:response];
+    
+    XCTAssertEqualObjects(setupIntent.stripeId, @"seti_123456789");
+    XCTAssertEqualObjects(setupIntent.clientSecret, @"seti_123456789_secret_123456789");
+    XCTAssertEqualObjects(setupIntent.created, [NSDate dateWithTimeIntervalSince1970:123456789]);
+    XCTAssertEqualObjects(setupIntent.customerId, @"cus_123456");
+    XCTAssertEqualObjects(setupIntent.metadata, @{@"user_id": @"guest_1234567"});
+    XCTAssertEqualObjects(setupIntent.paymentMethodId, @"pm_123456");
+    XCTAssertEqualObjects(setupIntent.stripeDescription, @"My Sample SetupIntent");
+    XCTAssertFalse(setupIntent.livemode);
+    // nextAction
+    XCTAssertNotNil(setupIntent.nextAction);
+    XCTAssertEqual(setupIntent.nextAction.type, STPIntentActionTypeRedirectToURL);
+    XCTAssertNotNil(setupIntent.nextAction.redirectToURL);
+    XCTAssertNotNil(setupIntent.nextAction.redirectToURL.url);
+    NSURL *returnURL = setupIntent.nextAction.redirectToURL.returnURL;
+    XCTAssertNotNil(returnURL);
+    XCTAssertEqualObjects(returnURL, [NSURL URLWithString:@"payments-example://stripe-redirect"]);
+    NSURL *url = setupIntent.nextAction.redirectToURL.url;
+    XCTAssertNotNil(url);
+    
+    XCTAssertEqualObjects(url, [NSURL URLWithString:@"https://hooks.stripe.com/redirect/authenticate/src_1Cl1AeIl4IdHmuTb1L7x083A?client_secret=src_client_secret_DBNwUe9qHteqJ8qQBwNWiigk"]);
+    XCTAssertEqualObjects(setupIntent.paymentMethodId, @"pm_123456");
+    XCTAssertEqual(setupIntent.status, STPSetupIntentStatusRequiresAction);
+    
+    XCTAssertEqualObjects(setupIntent.paymentMethodTypes, @[@(STPPaymentMethodTypeCard)]);
+    
+    XCTAssertNotEqual(setupIntent.allResponseFields, response, @"should have own copy of fields");
+}
+
+
+@end

--- a/Tests/Tests/SetupIntent.json
+++ b/Tests/Tests/SetupIntent.json
@@ -23,5 +23,6 @@
   "payment_method_types": [
     "card"
   ],
-  "status": "requires_action"
+  "status": "requires_action",
+  "usage": "off_session"
 }

--- a/Tests/Tests/SetupIntent.json
+++ b/Tests/Tests/SetupIntent.json
@@ -1,0 +1,27 @@
+{
+  "id": "seti_123456789",
+  "object": "setup_intent",
+  "application": "ca_123456789",
+  "client_secret": "seti_123456789_secret_123456789",
+  "created": 123456789,
+  "customer": "cus_123456",
+  "description": "My Sample SetupIntent",
+  "last_setup_error": null,
+  "livemode": false,
+  "metadata": {
+    "user_id": "guest_1234567"
+  },
+  "next_action": {
+      "type": "redirect_to_url",
+      "redirect_to_url": {
+          "return_url": "payments-example://stripe-redirect",
+          "url": "https://hooks.stripe.com/redirect/authenticate/src_1Cl1AeIl4IdHmuTb1L7x083A?client_secret=src_client_secret_DBNwUe9qHteqJ8qQBwNWiigk"
+      }
+  },
+  "on_behalf_of": null,
+  "payment_method": "pm_123456",
+  "payment_method_types": [
+    "card"
+  ],
+  "status": "requires_action"
+}


### PR DESCRIPTION
## Summary
* Adds SetupIntent model
* Deprecate STPPaymentIntentActionType enums in favor of STPIntentActionType
* Add usage field to PaymentIntent, SetupIntent

## Motivation
SetupIntent support

## Testing
`STPSetupIntentTest` unit test