### PR TITLE
Add support for SetupIntents to STPPaymentHandler

### DIFF
--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -563,6 +563,10 @@
 		B664D67422B96C9B00E6354B /* STPThreeDSTextFieldCustomizationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = B664D67322B96C9B00E6354B /* STPThreeDSTextFieldCustomizationTest.m */; };
 		B665CE47228DE4C4008B546F /* STPPaymentMethodListDeserializer.h in Headers */ = {isa = PBXBuildFile; fileRef = B665CE45228DE4C4008B546F /* STPPaymentMethodListDeserializer.h */; };
 		B665CE48228DE4C4008B546F /* STPPaymentMethodListDeserializer.m in Sources */ = {isa = PBXBuildFile; fileRef = B665CE46228DE4C4008B546F /* STPPaymentMethodListDeserializer.m */; };
+		B66AC61422C6E6590064C551 /* STPPaymentHandlerActionParams.h in Headers */ = {isa = PBXBuildFile; fileRef = B66AC61222C6E6590064C551 /* STPPaymentHandlerActionParams.h */; };
+		B66AC61522C6E6590064C551 /* STPPaymentHandlerActionParams.h in Headers */ = {isa = PBXBuildFile; fileRef = B66AC61222C6E6590064C551 /* STPPaymentHandlerActionParams.h */; };
+		B66AC61622C6E6590064C551 /* STPPaymentHandlerActionParams.m in Sources */ = {isa = PBXBuildFile; fileRef = B66AC61322C6E6590064C551 /* STPPaymentHandlerActionParams.m */; };
+		B66AC61722C6E6590064C551 /* STPPaymentHandlerActionParams.m in Sources */ = {isa = PBXBuildFile; fileRef = B66AC61322C6E6590064C551 /* STPPaymentHandlerActionParams.m */; };
 		B66B39B4223044A2006D1CAD /* STPPaymentMethodTest.m in Sources */ = {isa = PBXBuildFile; fileRef = B66B39B3223044A2006D1CAD /* STPPaymentMethodTest.m */; };
 		B66B39B6223045EF006D1CAD /* PaymentMethod.json in Resources */ = {isa = PBXBuildFile; fileRef = B66B39B5223045EF006D1CAD /* PaymentMethod.json */; };
 		B66D5021222F5611004A9210 /* STPPaymentMethodCardChecks.m in Sources */ = {isa = PBXBuildFile; fileRef = B66D5020222F5611004A9210 /* STPPaymentMethodCardChecks.m */; };
@@ -1482,6 +1486,8 @@
 		B664D67322B96C9B00E6354B /* STPThreeDSTextFieldCustomizationTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPThreeDSTextFieldCustomizationTest.m; sourceTree = "<group>"; };
 		B665CE45228DE4C4008B546F /* STPPaymentMethodListDeserializer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentMethodListDeserializer.h; sourceTree = "<group>"; };
 		B665CE46228DE4C4008B546F /* STPPaymentMethodListDeserializer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodListDeserializer.m; sourceTree = "<group>"; };
+		B66AC61222C6E6590064C551 /* STPPaymentHandlerActionParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentHandlerActionParams.h; sourceTree = "<group>"; };
+		B66AC61322C6E6590064C551 /* STPPaymentHandlerActionParams.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentHandlerActionParams.m; sourceTree = "<group>"; };
 		B66B39B3223044A2006D1CAD /* STPPaymentMethodTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodTest.m; sourceTree = "<group>"; };
 		B66B39B5223045EF006D1CAD /* PaymentMethod.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = PaymentMethod.json; sourceTree = "<group>"; };
 		B66D5020222F5611004A9210 /* STPPaymentMethodCardChecks.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodCardChecks.m; sourceTree = "<group>"; };
@@ -2116,6 +2122,15 @@
 			name = Source;
 			sourceTree = "<group>";
 		};
+		B66AC61822C6E6770064C551 /* Payments */ = {
+			isa = PBXGroup;
+			children = (
+				B66AC61222C6E6590064C551 /* STPPaymentHandlerActionParams.h */,
+				B66AC61322C6E6590064C551 /* STPPaymentHandlerActionParams.m */,
+			);
+			name = Payments;
+			sourceTree = "<group>";
+		};
 		C18867D61E8B069E00A77634 /* Snapshot */ = {
 			isa = PBXGroup;
 			children = (
@@ -2292,6 +2307,7 @@
 				F1728CEA1EAAA262002E0C29 /* Categories */,
 				F1728CEF1EAAA306002E0C29 /* Helpers */,
 				F1728CF41EAAA457002E0C29 /* PaymentContext */,
+				B66AC61822C6E6770064C551 /* Payments */,
 				F1728CF21EAAA316002E0C29 /* UI */,
 			);
 			name = Project;
@@ -2804,6 +2820,7 @@
 				F1A0197D1EA5733200354301 /* STPSourceParams+Private.h in Headers */,
 				04633B161CD45222009D4FB5 /* STPAPIClient+ApplePay.h in Headers */,
 				0438EF2E1B7416BB00D506CC /* STPFormTextField.h in Headers */,
+				B66AC61522C6E6590064C551 /* STPPaymentHandlerActionParams.h in Headers */,
 				04A4C38A1C4F25F900B3B290 /* NSArray+Stripe.h in Headers */,
 				04F94D9D1D229EFF004FC826 /* STPEmailAddressValidator.h in Headers */,
 				0731329D2277ABF40019CE3F /* STPPinManagementService.h in Headers */,
@@ -3000,6 +3017,7 @@
 				B6DB0CA922381B4900AEF640 /* STPPaymentMethod+Private.h in Headers */,
 				04A4C3891C4F25F900B3B290 /* NSArray+Stripe.h in Headers */,
 				04827D151D257764002DB3E8 /* STPImageLibrary+Private.h in Headers */,
+				B66AC61422C6E6590064C551 /* STPPaymentHandlerActionParams.h in Headers */,
 				049952D21BCF13DD0088C703 /* STPAPIClient+Private.h in Headers */,
 				8B429AD81EF9D4B400F95F34 /* STPBankAccountParams+Private.h in Headers */,
 				049A3F911CC740FF00F57DE7 /* NSDecimalNumber+Stripe_Currency.h in Headers */,
@@ -3729,6 +3747,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0438EF451B74170D00D506CC /* STPCardValidator.m in Sources */,
+				B66AC61722C6E6590064C551 /* STPPaymentHandlerActionParams.m in Sources */,
 				04F94DBB1D229F8D004FC826 /* PKPaymentAuthorizationViewController+Stripe_Blocks.m in Sources */,
 				B6B41F7C223484280020BA7F /* STPPaymentMethodiDEAL.m in Sources */,
 				C1271A3E1E3FA4E800F25DFE /* STPSectionHeaderView.m in Sources */,
@@ -3911,6 +3930,7 @@
 				C1363BB91D7633D800EB82B4 /* STPPaymentOptionTableViewCell.m in Sources */,
 				C15993331D8808680047950D /* STPShippingAddressViewController.m in Sources */,
 				04633B051CD44F1C009D4FB5 /* STPAPIClient+ApplePay.m in Sources */,
+				B66AC61622C6E6590064C551 /* STPPaymentHandlerActionParams.m in Sources */,
 				B6B41F8122348A1E0020BA7F /* STPPaymentMethodiDEALParams.m in Sources */,
 				F1C7B8D31DBECF2400D9F6F0 /* STPDispatchFunctions.m in Sources */,
 				C19D09901EAEAE4000A4AB3E /* STPTelemetryClient.m in Sources */,

--- a/Stripe/STPPaymentHandlerActionParams.h
+++ b/Stripe/STPPaymentHandlerActionParams.h
@@ -15,7 +15,19 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface STPPaymentHandlerActionParams: NSObject
+@protocol STPPaymentHandlerActionParams
+
+@property (nonatomic, nullable, readonly) STDSThreeDS2Service *threeDS2Service;
+@property (nonatomic, nullable, readonly, strong) id<STPAuthenticationContext> authenticationContext;
+@property (nonatomic, readonly, strong) STPAPIClient *apiClient;
+@property (nonatomic, readonly, strong) STPThreeDSCustomizationSettings *threeDSCustomizationSettings;
+/// Returns the payment or setup intent's next action
+- (nullable STPIntentAction *)nextAction;
+- (void)completeWithStatus:(STPPaymentHandlerActionStatus)status error:(nullable NSError *)error;
+
+@end
+
+@interface STPPaymentHandlerPaymentIntentActionParams: NSObject <STPPaymentHandlerActionParams>
 
 - (instancetype)initWithAPIClient:(STPAPIClient *)apiClient
             authenticationContext:(nullable id<STPAuthenticationContext>)authenticationContext
@@ -23,27 +35,25 @@ NS_ASSUME_NONNULL_BEGIN
                     paymentIntent:(STPPaymentIntent *)paymentIntent
                        completion:(STPPaymentHandlerActionPaymentIntentCompletionBlock)completion;
 
-- (instancetype)initWithAPIClient:(STPAPIClient *)apiClient
-            authenticationContext:(nullable id<STPAuthenticationContext>)authenticationContext
-     threeDSCustomizationSettings:(STPThreeDSCustomizationSettings *)threeDSCustomizationSettings
-                    setupIntent:(STPSetupIntent *)setupIntent
-                       completion:(STPPaymentHandlerActionSetupIntentCompletionBlock)completion;
-
 @property (nonatomic, nullable, readonly) STDSThreeDS2Service *threeDS2Service;
-
 @property (nonatomic, nullable, readonly, strong) id<STPAuthenticationContext> authenticationContext;
 @property (nonatomic, readonly, strong) STPAPIClient *apiClient;
 @property (nonatomic, readonly, strong) STPThreeDSCustomizationSettings *threeDSCustomizationSettings;
 @property (nonatomic, readonly, copy) STPPaymentHandlerActionPaymentIntentCompletionBlock paymentIntentCompletion;
+@property (nonatomic, strong) STPPaymentIntent *paymentIntent;
+
+@end
+
+@interface STPPaymentHandlerSetupIntentActionParams: NSObject <STPPaymentHandlerActionParams>
+
+- (instancetype)initWithAPIClient:(STPAPIClient *)apiClient
+            authenticationContext:(nullable id<STPAuthenticationContext>)authenticationContext
+     threeDSCustomizationSettings:(STPThreeDSCustomizationSettings *)threeDSCustomizationSettings
+                      setupIntent:(STPSetupIntent *)setupIntent
+                       completion:(STPPaymentHandlerActionSetupIntentCompletionBlock)completion;
+
 @property (nonatomic, readonly, copy) STPPaymentHandlerActionSetupIntentCompletionBlock setupIntentCompletion;
-
-// ActionParams can contain either a paymentIntent or a setupIntent
-@property (nonatomic, nullable) STPPaymentIntent *paymentIntent;
-@property (nonatomic, nullable) STPSetupIntent *setupIntent;
-
-/// Returns the payment or setup intent's next action
-- (STPIntentAction *)nextAction;
-- (void)completeWithStatus:(STPPaymentHandlerActionStatus)status error:(nullable NSError *)error;
+@property (nonatomic, strong) STPSetupIntent *setupIntent;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Stripe/STPPaymentHandlerActionParams.h
+++ b/Stripe/STPPaymentHandlerActionParams.h
@@ -1,0 +1,49 @@
+//
+//  STPPaymentHandlerActionParams.h
+//  Stripe
+//
+//  Created by Yuki Tokuhiro on 6/28/19.
+//  Copyright © 2019 Stripe, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "STPPaymentHandler.h"
+#import "STPAuthenticationContext.h"
+
+@class STPAPIClient, STPThreeDSCustomizationSettings, STDSThreeDS2Service, STPSetupIntent, STPIntentAction;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface STPPaymentHandlerActionParams: NSObject
+
+- (instancetype)initWithAPIClient:(STPAPIClient *)apiClient
+            authenticationContext:(nullable id<STPAuthenticationContext>)authenticationContext
+     threeDSCustomizationSettings:(STPThreeDSCustomizationSettings *)threeDSCustomizationSettings
+                    paymentIntent:(STPPaymentIntent *)paymentIntent
+                       completion:(STPPaymentHandlerActionPaymentIntentCompletionBlock)completion;
+
+- (instancetype)initWithAPIClient:(STPAPIClient *)apiClient
+            authenticationContext:(nullable id<STPAuthenticationContext>)authenticationContext
+     threeDSCustomizationSettings:(STPThreeDSCustomizationSettings *)threeDSCustomizationSettings
+                    setupIntent:(STPSetupIntent *)setupIntent
+                       completion:(STPPaymentHandlerActionSetupIntentCompletionBlock)completion;
+
+@property (nonatomic, nullable, readonly) STDSThreeDS2Service *threeDS2Service;
+
+@property (nonatomic, nullable, readonly, strong) id<STPAuthenticationContext> authenticationContext;
+@property (nonatomic, readonly, strong) STPAPIClient *apiClient;
+@property (nonatomic, readonly, strong) STPThreeDSCustomizationSettings *threeDSCustomizationSettings;
+@property (nonatomic, readonly, copy) STPPaymentHandlerActionPaymentIntentCompletionBlock paymentIntentCompletion;
+@property (nonatomic, readonly, copy) STPPaymentHandlerActionSetupIntentCompletionBlock setupIntentCompletion;
+
+// ActionParams can contain either a paymentIntent or a setupIntent
+@property (nonatomic, nullable) STPPaymentIntent *paymentIntent;
+@property (nonatomic, nullable) STPSetupIntent *setupIntent;
+
+/// Returns the payment or setup intent's next action
+- (STPIntentAction *)nextAction;
+- (void)completeWithStatus:(STPPaymentHandlerActionStatus)status error:(nullable NSError *)error;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Stripe/STPPaymentHandlerActionParams.m
+++ b/Stripe/STPPaymentHandlerActionParams.m
@@ -1,0 +1,91 @@
+//
+//  STPPaymentHandlerActionParams.m
+//  Stripe
+//
+//  Created by Yuki Tokuhiro on 6/28/19.
+//  Copyright © 2019 Stripe, Inc. All rights reserved.
+//
+
+#import "STPPaymentHandlerActionParams.h"
+
+#import "STPAPIClient.h"
+#import <Stripe3DS2/Stripe3DS2.h>
+#import "STPThreeDSCustomizationSettings.h"
+#import "STPThreeDSCustomization+Private.h"
+
+@implementation STPPaymentHandlerActionParams
+{
+    BOOL _serviceInitialized;
+}
+
+@synthesize threeDS2Service = _threeDS2Service;
+
+- (instancetype)initWithAPIClient:(STPAPIClient *)apiClient
+            authenticationContext:(nullable id<STPAuthenticationContext>)authenticationContext
+     threeDSCustomizationSettings:(STPThreeDSCustomizationSettings *)threeDSCustomizationSettings
+                    paymentIntent:(STPPaymentIntent *)paymentIntent
+                       completion:(STPPaymentHandlerActionPaymentIntentCompletionBlock)completion {
+    self = [super init];
+    if (self) {
+        _apiClient = apiClient;
+        _authenticationContext = authenticationContext;
+        _threeDSCustomizationSettings = threeDSCustomizationSettings;
+        _paymentIntent = paymentIntent;
+        _paymentIntentCompletion = [completion copy];
+    }
+    
+    return self;
+}
+
+- (instancetype)initWithAPIClient:(STPAPIClient *)apiClient
+            authenticationContext:(nullable id<STPAuthenticationContext>)authenticationContext
+     threeDSCustomizationSettings:(STPThreeDSCustomizationSettings *)threeDSCustomizationSettings
+                    setupIntent:(STPSetupIntent *)setupIntent
+                       completion:(STPPaymentHandlerActionSetupIntentCompletionBlock)completion {
+    self = [super init];
+    if (self) {
+        _apiClient = apiClient;
+        _authenticationContext = authenticationContext;
+        _threeDSCustomizationSettings = threeDSCustomizationSettings;
+        _setupIntent = setupIntent;
+        _setupIntentCompletion = [completion copy];
+    }
+    
+    return self;
+}
+
+- (nullable STDSThreeDS2Service *)threeDS2Service {
+    if (!_serviceInitialized) {
+        _serviceInitialized = YES;
+        _threeDS2Service = [[STDSThreeDS2Service alloc] init];
+        @try {
+            STDSConfigParameters *configParams = [[STDSConfigParameters alloc] initWithStandardParameters];
+            [configParams addParameterNamed:@"kInternalStripeTestingConfigParam" withValue:@"Y"];
+            [_threeDS2Service initializeWithConfig:configParams
+                                            locale:[NSLocale autoupdatingCurrentLocale]
+                                        uiSettings:_threeDSCustomizationSettings.uiCustomization.uiCustomization];
+        } @catch (NSException *e) {
+            _threeDS2Service = nil;
+        }
+    }
+    
+    return _threeDS2Service;
+}
+
+- (STPIntentAction *)nextAction {
+    self.paymentIntent
+}
+
+- (void)completeWithStatus:(STPPaymentHandlerActionStatus)status error:(NSError *)error {
+    if (self.paymentIntent) {
+        NSAssert(self.paymentIntentCompletion != nil, @"Shouldn't have a nil completion block at this point.");
+        self.paymentIntentCompletion(status, self.paymentIntent, error);
+    } else if (self.setupIntent) {
+        NSAssert(self.setupIntentCompletion != nil, @"Shouldn't have a nil completion block at this point.");
+        self.setupIntentCompletion(status, self.setupIntent, error);
+    } else {
+        NSAssert(NO, @"Missing setupIntent or paymentIntent!");
+    }
+}
+
+@end


### PR DESCRIPTION
## Summary
* Moves `STPPaymentHandlerActionParams` to its own file
* Adds `confirmSetupIntent...` public API
* Renames some "PaymentIntent" things to "Intent"
* Internally, ActionParams can have either a SetupIntent or a PaymentIntent and the associated completion block.  

## Motivation
Support for SetupIntent

## Testing
Tested the 3DS1, 3DS2 flows for
- the Manual PI, Automatic PI, SetupIntent flows in Custom Integration app
- the Standard Integration app

Did this on a branch based off of this one that adds SetupIntent flow to Custom Integration app and makes other changes (to PR after this one).