### PR TITLE
STPRedirectContext: nil out `safariVC` after dismissing

### DIFF
--- a/Stripe/STPRedirectContext.m
+++ b/Stripe/STPRedirectContext.m
@@ -323,6 +323,7 @@ typedef void (^STPBoolCompletionBlock)(BOOL success);
     if (self.safariVC) {
         [self.safariVC.presentingViewController dismissViewControllerAnimated:YES
                                                                    completion:nil];
+        self.safariVC = nil;
     }
 }
 


### PR DESCRIPTION
This addresses #1215