### PR TITLE
SetupIntents example, more changes

### DIFF
--- a/Example/Custom Integration.xcodeproj/project.pbxproj
+++ b/Example/Custom Integration.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		366F93B0225FF2A2005CFBF6 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 366F93AF225FF2A2005CFBF6 /* README.md */; };
 		8BBD79C6207FD2F900F85BED /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 8BBD79C8207FD2F900F85BED /* Localizable.strings */; };
 		B3BDCADD20EF03010034F7F5 /* CardAutomaticConfirmationViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B3BDCADB20EF03010034F7F5 /* CardAutomaticConfirmationViewController.m */; };
+		B66AC61E22CAAB8F0064C551 /* CardSetupIntentExampleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B66AC61D22CAAB8F0064C551 /* CardSetupIntentExampleViewController.m */; };
 		C12C50DD1E57B3C800EC6D58 /* BrowseExamplesViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C12C50DC1E57B3C800EC6D58 /* BrowseExamplesViewController.m */; };
 		C1CACE861E5DE6C3002D0821 /* CardManualConfirmationExampleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C1CACE851E5DE6C3002D0821 /* CardManualConfirmationExampleViewController.m */; };
 		C1CACE891E5DF7A9002D0821 /* ApplePayExampleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C1CACE881E5DF7A9002D0821 /* ApplePayExampleViewController.m */; };
@@ -66,6 +67,8 @@
 		8BBD79D1207FD35200F85BED /* es */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
 		B3BDCADB20EF03010034F7F5 /* CardAutomaticConfirmationViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CardAutomaticConfirmationViewController.m; sourceTree = "<group>"; };
 		B3BDCADC20EF03010034F7F5 /* CardAutomaticConfirmationViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CardAutomaticConfirmationViewController.h; sourceTree = "<group>"; };
+		B66AC61C22CAAB8F0064C551 /* CardSetupIntentExampleViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CardSetupIntentExampleViewController.h; sourceTree = "<group>"; };
+		B66AC61D22CAAB8F0064C551 /* CardSetupIntentExampleViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CardSetupIntentExampleViewController.m; sourceTree = "<group>"; };
 		C12C50DB1E57B3C800EC6D58 /* BrowseExamplesViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BrowseExamplesViewController.h; sourceTree = "<group>"; };
 		C12C50DC1E57B3C800EC6D58 /* BrowseExamplesViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BrowseExamplesViewController.m; sourceTree = "<group>"; };
 		C1CACE841E5DE6C3002D0821 /* CardManualConfirmationExampleViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CardManualConfirmationExampleViewController.h; sourceTree = "<group>"; };
@@ -121,6 +124,8 @@
 				B3BDCADB20EF03010034F7F5 /* CardAutomaticConfirmationViewController.m */,
 				C1CACE841E5DE6C3002D0821 /* CardManualConfirmationExampleViewController.h */,
 				C1CACE851E5DE6C3002D0821 /* CardManualConfirmationExampleViewController.m */,
+				B66AC61C22CAAB8F0064C551 /* CardSetupIntentExampleViewController.h */,
+				B66AC61D22CAAB8F0064C551 /* CardSetupIntentExampleViewController.m */,
 				04533F171A688A0A00C7E52E /* Constants.h */,
 				04533F181A688A0A00C7E52E /* Constants.m */,
 				04533E971A687F5D00C7E52E /* Images.xcassets */,
@@ -239,6 +244,7 @@
 				C1CACE861E5DE6C3002D0821 /* CardManualConfirmationExampleViewController.m in Sources */,
 				04533EB21A68802E00C7E52E /* ShippingManager.m in Sources */,
 				B3BDCADD20EF03010034F7F5 /* CardAutomaticConfirmationViewController.m in Sources */,
+				B66AC61E22CAAB8F0064C551 /* CardSetupIntentExampleViewController.m in Sources */,
 				04533E901A687F5D00C7E52E /* AppDelegate.m in Sources */,
 				C1CACE891E5DF7A9002D0821 /* ApplePayExampleViewController.m in Sources */,
 				04533E8D1A687F5D00C7E52E /* main.m in Sources */,

--- a/Example/Custom Integration/ApplePayExampleViewController.m
+++ b/Example/Custom Integration/ApplePayExampleViewController.m
@@ -155,7 +155,7 @@
     [self.delegate createAndConfirmPaymentIntentWithAmount:@(1000)
                                              paymentMethod:paymentMethod.stripeId
                                                  returnURL:@"payments-example://stripe-redirect"
-                                                completion:^(STPBackendResult status, STPPaymentIntent *paymentIntent, NSError *error) {
+                                                completion:^(STPBackendResult status, NSString *clientSecret, NSError *error) {
                                                     if (error) {
                                                         self.applePayError = error;
                                                         completion(PKPaymentAuthorizationStatusFailure);

--- a/Example/Custom Integration/BrowseExamplesViewController.h
+++ b/Example/Custom Integration/BrowseExamplesViewController.h
@@ -18,6 +18,7 @@ typedef void (^STPPaymentIntentCreationHandler)(STPBackendResult status, NSStrin
 typedef void (^STPPaymentIntentCreateAndConfirmHandler)(STPBackendResult status, STPPaymentIntent *paymentIntent, NSError *error);
 typedef void (^STPRedirectCompletionHandler)(STPPaymentIntent *retrievedIntent, NSError *error);
 typedef void (^STPConfirmPaymentIntentCompletionHandler)(STPBackendResult status, STPPaymentIntent *paymentIntent, NSError *error);
+typedef void (^STPConfirmSetupIntentCompletionHandler)(STPBackendResult status, NSString *clientSecret, NSError *error);
 
 
 @protocol ExampleViewControllerDelegate <STPAuthenticationContext>
@@ -31,6 +32,7 @@ typedef void (^STPConfirmPaymentIntentCompletionHandler)(STPBackendResult status
                                       returnURL:(NSString *)returnURL
                                      completion:(STPPaymentIntentCreateAndConfirmHandler)completion;
 - (void)confirmPaymentIntent:(STPPaymentIntent *)paymentIntent completion:(STPConfirmPaymentIntentCompletionHandler)completion;
+- (void)createSetupIntentWithCompletion:(STPConfirmSetupIntentCompletionHandler)completion;
 
 @end
 

--- a/Example/Custom Integration/BrowseExamplesViewController.h
+++ b/Example/Custom Integration/BrowseExamplesViewController.h
@@ -15,10 +15,10 @@ typedef NS_ENUM(NSInteger, STPBackendResult) {
 };
 
 typedef void (^STPPaymentIntentCreationHandler)(STPBackendResult status, NSString *clientSecret, NSError *error);
-typedef void (^STPPaymentIntentCreateAndConfirmHandler)(STPBackendResult status, STPPaymentIntent *paymentIntent, NSError *error);
+typedef void (^STPPaymentIntentCreateAndConfirmHandler)(STPBackendResult status, NSString *clientSecret, NSError *error);
 typedef void (^STPRedirectCompletionHandler)(STPPaymentIntent *retrievedIntent, NSError *error);
-typedef void (^STPConfirmPaymentIntentCompletionHandler)(STPBackendResult status, STPPaymentIntent *paymentIntent, NSError *error);
-typedef void (^STPConfirmSetupIntentCompletionHandler)(STPBackendResult status, NSString *clientSecret, NSError *error);
+typedef void (^STPConfirmPaymentIntentCompletionHandler)(STPBackendResult status, NSString *clientSecret, NSError *error);
+typedef void (^STPCreateSetupIntentCompletionHandler)(STPBackendResult status, NSString *clientSecret, NSError *error);
 
 
 @protocol ExampleViewControllerDelegate <STPAuthenticationContext>
@@ -32,7 +32,7 @@ typedef void (^STPConfirmSetupIntentCompletionHandler)(STPBackendResult status, 
                                       returnURL:(NSString *)returnURL
                                      completion:(STPPaymentIntentCreateAndConfirmHandler)completion;
 - (void)confirmPaymentIntent:(STPPaymentIntent *)paymentIntent completion:(STPConfirmPaymentIntentCompletionHandler)completion;
-- (void)createSetupIntentWithCompletion:(STPConfirmSetupIntentCompletionHandler)completion;
+- (void)createSetupIntentWithCompletion:(STPCreateSetupIntentCompletionHandler)completion;
 
 @end
 

--- a/Example/Custom Integration/BrowseExamplesViewController.m
+++ b/Example/Custom Integration/BrowseExamplesViewController.m
@@ -223,14 +223,7 @@
                                                               if (json && [json isKindOfClass:[NSDictionary class]]) {
                                                                   NSString *clientSecret = json[@"secret"];
                                                                   if (clientSecret != nil) {
-                                                                      [[STPAPIClient sharedClient] retrievePaymentIntentWithClientSecret:clientSecret
-                                                                                                                              completion:^(STPPaymentIntent * _Nullable paymentIntent, NSError * _Nullable retrieveError) {
-                                                                                                                                  if (paymentIntent != nil) {
-                                                                                                                                      [self _callOnMainThread:^{ completion(STPBackendResultSuccess, paymentIntent, nil); }];
-                                                                                                                                  } else {
-                                                                                                                                      [self _callOnMainThread:^{ completion(STPBackendResultFailure, nil, retrieveError); }];
-                                                                                                                                  }
-                                                                                                                              }];
+                                                                      [self _callOnMainThread:^{ completion(STPBackendResultSuccess, clientSecret, nil); }];
                                                                   } else {
                                                                       [self _callOnMainThread:^{ completion(STPBackendResultFailure, nil, [NSError errorWithDomain:StripeDomain
                                                                                                                                                               code:STPAPIError
@@ -283,14 +276,7 @@
                                                               if (json && [json isKindOfClass:[NSDictionary class]]) {
                                                                   NSString *clientSecret = json[@"secret"];
                                                                   if (clientSecret != nil) {
-                                                                      [[STPAPIClient sharedClient] retrievePaymentIntentWithClientSecret:clientSecret
-                                                                                                                              completion:^(STPPaymentIntent * _Nullable paymentIntent, NSError * _Nullable retrieveError) {
-                                                                                                                                  if (paymentIntent != nil) {
-                                                                                                                                      [self _callOnMainThread:^{ completion(STPBackendResultSuccess, paymentIntent, nil); }];
-                                                                                                                                  } else {
-                                                                                                                                      [self _callOnMainThread:^{ completion(STPBackendResultFailure, nil, retrieveError); }];
-                                                                                                                                  }
-                                                                                                                              }];
+                                                                      [self _callOnMainThread:^{ completion(STPBackendResultSuccess, clientSecret, nil); }];
                                                                   } else {
                                                                       [self _callOnMainThread:^{ completion(STPBackendResultFailure, nil, [NSError errorWithDomain:StripeDomain
                                                                                                                                                               code:STPAPIError
@@ -305,7 +291,7 @@
     [uploadTask resume];
 }
 
-- (void)createSetupIntentWithCompletion:(STPConfirmSetupIntentCompletionHandler)completion {
+- (void)createSetupIntentWithCompletion:(STPCreateSetupIntentCompletionHandler)completion {
     if (!BackendBaseURL) {
         NSError *error = [NSError errorWithDomain:StripeDomain
                                              code:STPInvalidRequestError

--- a/Example/Custom Integration/CardAutomaticConfirmationViewController.m
+++ b/Example/Custom Integration/CardAutomaticConfirmationViewController.m
@@ -131,42 +131,19 @@
         [[STPPaymentHandler sharedHandler] confirmPayment:paymentIntentParams
                                 withAuthenticationContext:self.delegate
                                                completion:^(STPPaymentHandlerActionStatus handlerStatus, STPPaymentIntent * _Nullable handledIntent, NSError * _Nullable handlerError) {
-                                                   if (handlerError != nil) {
-                                                       [self.delegate exampleViewController:self didFinishWithError:handlerError];
-                                                   } else {
-                                                       [self finishWithStatus:handledIntent.status];
+                                                   switch (handlerStatus) {
+                                                       case STPPaymentHandlerActionStatusFailed:
+                                                           [self.delegate exampleViewController:self didFinishWithError:handlerError];
+                                                           break;
+                                                       case STPPaymentHandlerActionStatusCanceled:
+                                                           [self.delegate exampleViewController:self didFinishWithMessage:@"Canceled"];
+                                                           break;
+                                                       case STPPaymentHandlerActionStatusSucceeded:
+                                                           [self.delegate exampleViewController:self didFinishWithMessage:@"Payment successfully created"];
+                                                           break;
                                                    }
                                                }];
     }];
-}
-
-- (void)finishWithStatus:(STPPaymentIntentStatus)status {
-    switch (status) {
-        // There may have been a problem with the payment method (STPPaymentMethodParams or STPSourceParams)
-        case STPPaymentIntentStatusRequiresPaymentMethod:
-        // did you call `confirmPaymentIntentWithParams:completion`?
-        case STPPaymentIntentStatusRequiresConfirmation:
-        // App should have handled the action, but didn't for some reason
-        case STPPaymentIntentStatusRequiresAction:
-        // The PaymentIntent was canceled (maybe by the backend?)
-        case STPPaymentIntentStatusCanceled:
-            [self.delegate exampleViewController:self didFinishWithMessage:@"Payment failed"];
-            break;
-
-        // Processing. You could detect this case and poll for the final status of the PaymentIntent
-        case STPPaymentIntentStatusProcessing:
-        // Unknown status
-        case STPPaymentIntentStatusUnknown:
-            [self.delegate exampleViewController:self didFinishWithMessage:@"Order received"];
-            break;
-
-        // if captureMethod is manual, backend needs to capture it to receive the funds
-        case STPPaymentIntentStatusRequiresCapture:
-        // succeeded
-        case STPPaymentIntentStatusSucceeded:
-            [self.delegate exampleViewController:self didFinishWithMessage:@"Payment successfully created"];
-            break;
-    }
 }
 
 @end

--- a/Example/Custom Integration/CardAutomaticConfirmationViewController.m
+++ b/Example/Custom Integration/CardAutomaticConfirmationViewController.m
@@ -130,7 +130,7 @@
         paymentIntentParams.returnURL = @"payments-example://stripe-redirect";
         [[STPPaymentHandler sharedHandler] confirmPayment:paymentIntentParams
                                 withAuthenticationContext:self.delegate
-                                               completion:^(STPPaymentHandlerActionStatus handlerStatus, STPPaymentIntent * _Nullable handledIntent, NSError * _Nullable handlerError) {
+                                               completion:^(STPPaymentHandlerActionStatus handlerStatus, STPPaymentIntent * handledIntent, NSError * _Nullable handlerError) {
                                                    switch (handlerStatus) {
                                                        case STPPaymentHandlerActionStatusFailed:
                                                            [self.delegate exampleViewController:self didFinishWithError:handlerError];

--- a/Example/Custom Integration/CardManualConfirmationExampleViewController.m
+++ b/Example/Custom Integration/CardManualConfirmationExampleViewController.m
@@ -108,23 +108,34 @@
                 [self.delegate exampleViewController:self didFinishWithMessage:@"Canceled authentication"];
                 break;
             case STPPaymentHandlerActionStatusSucceeded:
-                // Manually confirm the PaymentIntent on the backend agan to complete the payment.
-                [self.delegate confirmPaymentIntent:paymentIntent completion:^(STPBackendResult status, __unused STPPaymentIntent *pi, NSError *error) {
+                // Manually confirm the PaymentIntent on the backend again to complete the payment.
+                [self.delegate confirmPaymentIntent:paymentIntent completion:^(STPBackendResult status, NSString *clientSecret, NSError *error) {
                     if (status == STPBackendResultFailure || error) {
                         [self.delegate exampleViewController:self didFinishWithError:error];
-                    } else {
-                       [self.delegate exampleViewController:self didFinishWithMessage:@"Payment successfully created"];
+                        return;
                     }
+                    [[STPAPIClient sharedClient] retrievePaymentIntentWithClientSecret:clientSecret completion:^(STPPaymentIntent *finalPaymentIntent, NSError *finalError) {
+                        if (finalError) {
+                            [self.delegate exampleViewController:self didFinishWithError:error];
+                            return;
+                        }
+                        if (finalPaymentIntent.status == STPPaymentIntentStatusSucceeded) {
+                            [self.delegate exampleViewController:self didFinishWithMessage:@"Payment successfully created"];
+                        } else {
+                            [self.delegate exampleViewController:self didFinishWithMessage:@"Payment failed"];
+                        }
+                        
+                    }];
                 }];
                 break;
         }
     };
-    STPPaymentIntentCreateAndConfirmHandler createAndConfirmCompletion = ^(STPBackendResult status, STPPaymentIntent *paymentIntent, NSError *error) {
+    STPPaymentIntentCreateAndConfirmHandler createAndConfirmCompletion = ^(STPBackendResult status, NSString *clientSecret, NSError *error) {
         if (status == STPBackendResultFailure || error) {
             [self.delegate exampleViewController:self didFinishWithError:error];
             return;
         }
-        [[STPPaymentHandler sharedHandler] handleNextActionForPayment:paymentIntent
+        [[STPPaymentHandler sharedHandler] handleNextActionForPayment:clientSecret
                                             withAuthenticationContext:self.delegate
                                                            completion:paymentHandlerCompletion];
     };
@@ -132,64 +143,6 @@
                                              paymentMethod:paymentMethod.stripeId
                                                  returnURL:@"payments-example://stripe-redirect"
                                                 completion:createAndConfirmCompletion];
-}
-
-- (void)_handlePaymentIntentCompletionWithStatus:(STPBackendResult)status
-                                   paymentIntent:(nullable STPPaymentIntent *)paymentIntent
-                                           error:(nullable NSError *)error {
-    if (status == STPBackendResultFailure || error) {
-        [self.delegate exampleViewController:self didFinishWithError:error];
-        return;
-    }
-
-    switch (paymentIntent.status) {
-        case STPPaymentIntentStatusRequiresConfirmation: {
-            [self.delegate confirmPaymentIntent:paymentIntent completion:^(STPBackendResult confirmStatus, STPPaymentIntent *confirmedIntent, NSError *confirmError) {
-                [self _handlePaymentIntentCompletionWithStatus:confirmStatus
-                                                 paymentIntent:confirmedIntent
-                                                         error:confirmError];
-            }];
-        }
-            break;
-
-        case STPPaymentIntentStatusRequiresAction:
-            [self _handleNextActionForPaymentIntent:paymentIntent];
-            break;
-
-        case STPPaymentIntentStatusProcessing:
-            [self.delegate exampleViewController:self didFinishWithMessage:@"Payment is processing"];
-            break;
-        case STPPaymentIntentStatusSucceeded:
-            [self.delegate exampleViewController:self didFinishWithMessage:@"Payment successfully created"];
-            break;
-
-        case STPPaymentIntentStatusCanceled:
-            [self.delegate exampleViewController:self didFinishWithMessage:@"Payment canceled"];
-            break;
-
-        case STPPaymentIntentStatusUnknown:
-        case STPPaymentIntentStatusRequiresPaymentMethod:
-        case STPPaymentIntentStatusRequiresCapture:
-            [self.delegate exampleViewController:self didFinishWithMessage:@"Payment failed"];
-            break;
-
-    }
-}
-
-- (void)_handleNextActionForPaymentIntent:(STPPaymentIntent *)paymentIntent {
-    [[STPPaymentHandler sharedHandler] handleNextActionForPayment:paymentIntent
-                                        withAuthenticationContext:self.delegate
-                                                       completion:^(STPPaymentHandlerActionStatus handlerStatus, STPPaymentIntent * _Nullable handledIntent, NSError * _Nullable handlerError) {
-                                                           if (handlerError != nil || handlerStatus == STPPaymentHandlerActionStatusFailed) {
-                                                               [self.delegate exampleViewController:self didFinishWithError:handlerError];
-                                                           } else if (handlerStatus == STPPaymentHandlerActionStatusCanceled) {
-                                                               [self.delegate exampleViewController:self didFinishWithMessage:@"Canceled authentication"];
-                                                           } else {
-                                                               [self _handlePaymentIntentCompletionWithStatus:STPBackendResultSuccess
-                                                                                                paymentIntent:handledIntent
-                                                                                                        error:handlerError];
-                                                           }
-                                                       }];
 }
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView {

--- a/Example/Custom Integration/CardSetupIntentExampleViewController.h
+++ b/Example/Custom Integration/CardSetupIntentExampleViewController.h
@@ -1,0 +1,21 @@
+//
+//  CardSetupIntentExampleViewController.h
+//  Custom Integration
+//
+//  Created by Yuki Tokuhiro on 7/1/19.
+//  Copyright © 2019 Stripe. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@protocol ExampleViewControllerDelegate;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface CardSetupIntentExampleViewController : UIViewController
+
+@property (nonatomic, weak) id<ExampleViewControllerDelegate> delegate;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Example/Custom Integration/CardSetupIntentExampleViewController.m
+++ b/Example/Custom Integration/CardSetupIntentExampleViewController.m
@@ -1,29 +1,24 @@
 //
-//  CardAutomaticConfirmationViewController.m
+//  CardSetupIntentExampleViewController.m
 //  Custom Integration
 //
-//  Created by Daniel Jackson on 7/5/18.
-//  Copyright © 2018 Stripe. All rights reserved.
+//  Created by Yuki Tokuhiro on 7/1/19.
+//  Copyright © 2019 Stripe. All rights reserved.
 //
 
 @import Stripe;
 
-#import "CardAutomaticConfirmationViewController.h"
+#import "CardSetupIntentExampleViewController.h"
 #import "BrowseExamplesViewController.h"
 
 /**
- This example demonstrates using PaymentIntents to accept card payments verified using 3D Secure.
-
+ This example demonstrates using SetupIntents to accept card payments verified using 3D Secure.
+ 
  1. Collect user's card information via `STPPaymentCardTextField`
- 2. Create a `PaymentIntent` on our backend (this can happen concurrently with #1)
- 3. Confirm PaymentIntent using the `STPPaymentMethodParams` for the user's card information.
- 4. If the user needs to go through the 3D Secure authentication flow, use `STPRedirectContext` to do so.
- 5. When user returns to the app, or finishes the SafariVC redirect flow, `STPRedirectContext` notifies via callback
-
- See the documentation at https://stripe.com/docs/payments/payment-intents/ios for more information
- on using PaymentIntents for dynamic authentication.
+ 2. Create a `SetupIntent` on our backend (this can happen concurrently with #1)
+ 3. Confirm SetupIntent with `STPPaymentHandler`, using the `STPPaymentMethodParams` for the user's card information.
  */
-@interface CardAutomaticConfirmationViewController () <STPPaymentCardTextFieldDelegate>
+@interface CardSetupIntentExampleViewController () <STPPaymentCardTextFieldDelegate>
 
 @property (weak, nonatomic) STPPaymentCardTextField *paymentTextField;
 @property (weak, nonatomic) UILabel *waitingLabel;
@@ -31,14 +26,14 @@
 
 @end
 
-@implementation CardAutomaticConfirmationViewController
+@implementation CardSetupIntentExampleViewController
 
 - (void)viewDidLoad {
     [super viewDidLoad];
     self.view.backgroundColor = [UIColor whiteColor];
     self.title = @"Card";
     self.edgesForExtendedLayout = UIRectEdgeNone;
-
+    
     STPPaymentCardTextField *paymentTextField = [[STPPaymentCardTextField alloc] init];
     STPPaymentMethodCardParams *cardParams = [STPPaymentMethodCardParams new];
     // Only successful 3D Secure transactions on this test card will succeed.
@@ -48,7 +43,7 @@
     paymentTextField.cursorColor = [UIColor purpleColor];
     self.paymentTextField = paymentTextField;
     [self.view addSubview:paymentTextField];
-
+    
     UILabel *label = [UILabel new];
     label.text = @"Waiting for payment authorization";
     [label sizeToFit];
@@ -56,12 +51,12 @@
     label.alpha = 0;
     [self.view addSubview:label];
     self.waitingLabel = label;
-
+    
     NSString *title = @"Pay";
     UIBarButtonItem *payButton = [[UIBarButtonItem alloc] initWithTitle:title style:UIBarButtonItemStyleDone target:self action:@selector(pay)];
     payButton.enabled = paymentTextField.isValid;
     self.navigationItem.rightBarButtonItem = payButton;
-
+    
     UIActivityIndicatorView *activityIndicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleGray];
     activityIndicator.hidesWhenStopped = YES;
     self.activityIndicator = activityIndicator;
@@ -112,61 +107,33 @@
         return;
     }
     [self updateUIForPaymentInProgress:YES];
-
-    // In a more interesting app, you'll probably create your PaymentIntent as soon as you know the
-    // payment amount you wish to collect from your customer. For simplicity, this example does it once they've
-    // pushed the Pay button.
-    // https://stripe.com/docs/payments/dynamic-authentication#create-payment-intent
-    [self.delegate createBackendPaymentIntentWithAmount:@1099 completion:^(STPBackendResult status, NSString *clientSecret, NSError *error) {
+    [self.delegate createSetupIntentWithCompletion:^(STPBackendResult status, NSString *clientSecret, NSError *error) {
         if (status == STPBackendResultFailure || clientSecret == nil) {
             [self.delegate exampleViewController:self didFinishWithError:error];
             return;
         }
-
-        STPPaymentIntentParams *paymentIntentParams = [[STPPaymentIntentParams alloc] initWithClientSecret:clientSecret];
-        paymentIntentParams.paymentMethodParams = [STPPaymentMethodParams paramsWithCard:self.paymentTextField.cardParams
-                                                                          billingDetails:nil
-                                                                                metadata:nil];
-        paymentIntentParams.returnURL = @"payments-example://stripe-redirect";
-        [[STPPaymentHandler sharedHandler] confirmPayment:paymentIntentParams
+        STPSetupIntentConfirmParams *setupIntentConfirmParams = [[STPSetupIntentConfirmParams alloc] initWithClientSecret:clientSecret];
+        setupIntentConfirmParams.paymentMethodParams = [STPPaymentMethodParams paramsWithCard:self.paymentTextField.cardParams
+                                                                               billingDetails:nil
+                                                                                     metadata:nil];
+        setupIntentConfirmParams.returnURL = @"payments-example://stripe-redirect";
+        [[STPPaymentHandler sharedHandler] confirmSetupIntent:setupIntentConfirmParams
                                 withAuthenticationContext:self.delegate
-                                               completion:^(STPPaymentHandlerActionStatus handlerStatus, STPPaymentIntent * _Nullable handledIntent, NSError * _Nullable handlerError) {
-                                                   if (handlerError != nil) {
-                                                       [self.delegate exampleViewController:self didFinishWithError:handlerError];
-                                                   } else {
-                                                       [self finishWithStatus:handledIntent.status];
+                                               completion:^(STPPaymentHandlerActionStatus handlerStatus, STPSetupIntent * _Nullable handledIntent, NSError * _Nullable handlerError) {
+                                                   switch (handlerStatus) {
+                                                       case STPPaymentHandlerActionStatusSucceeded:
+                                                           [self.delegate exampleViewController:self didFinishWithMessage:@"Payment successfully created"];
+                                                           break;
+                                                       case STPPaymentHandlerActionStatusCanceled:
+                                                           [self.delegate exampleViewController:self didFinishWithMessage:@"Cancelled"];
+                                                           break;
+                                                       case STPPaymentHandlerActionStatusFailed:
+                                                           [self.delegate exampleViewController:self didFinishWithError:handlerError];
+                                                           break;
                                                    }
                                                }];
+
     }];
-}
-
-- (void)finishWithStatus:(STPPaymentIntentStatus)status {
-    switch (status) {
-        // There may have been a problem with the payment method (STPPaymentMethodParams or STPSourceParams)
-        case STPPaymentIntentStatusRequiresPaymentMethod:
-        // did you call `confirmPaymentIntentWithParams:completion`?
-        case STPPaymentIntentStatusRequiresConfirmation:
-        // App should have handled the action, but didn't for some reason
-        case STPPaymentIntentStatusRequiresAction:
-        // The PaymentIntent was canceled (maybe by the backend?)
-        case STPPaymentIntentStatusCanceled:
-            [self.delegate exampleViewController:self didFinishWithMessage:@"Payment failed"];
-            break;
-
-        // Processing. You could detect this case and poll for the final status of the PaymentIntent
-        case STPPaymentIntentStatusProcessing:
-        // Unknown status
-        case STPPaymentIntentStatusUnknown:
-            [self.delegate exampleViewController:self didFinishWithMessage:@"Order received"];
-            break;
-
-        // if captureMethod is manual, backend needs to capture it to receive the funds
-        case STPPaymentIntentStatusRequiresCapture:
-        // succeeded
-        case STPPaymentIntentStatusSucceeded:
-            [self.delegate exampleViewController:self didFinishWithMessage:@"Payment successfully created"];
-            break;
-    }
 }
 
 @end

--- a/Example/Custom Integration/CardSetupIntentExampleViewController.m
+++ b/Example/Custom Integration/CardSetupIntentExampleViewController.m
@@ -122,7 +122,7 @@
                                                completion:^(STPPaymentHandlerActionStatus handlerStatus, STPSetupIntent * _Nullable handledIntent, NSError * _Nullable handlerError) {
                                                    switch (handlerStatus) {
                                                        case STPPaymentHandlerActionStatusSucceeded:
-                                                           [self.delegate exampleViewController:self didFinishWithMessage:@"Payment successfully created"];
+                                                           [self.delegate exampleViewController:self didFinishWithMessage:@"SetupIntent successfully created"];
                                                            break;
                                                        case STPPaymentHandlerActionStatusCanceled:
                                                            [self.delegate exampleViewController:self didFinishWithMessage:@"Cancelled"];

--- a/Example/Standard Integration/CheckoutViewController.swift
+++ b/Example/Standard Integration/CheckoutViewController.swift
@@ -250,11 +250,17 @@ See https://stripe.com/docs/testing.
                                                                     completion(error ?? NSError(domain: StripeDomain, code: 123, userInfo: [NSLocalizedDescriptionKey: "Unable to parse clientSecret from response"]))
                                                                     return
                                                                 }
-                                                                // Retrieve the PaymentIntent
-                                                                STPPaymentHandler.shared().handleNextAction(forPayment: paymentIntent, with: self) { (status, handledPaymentIntent, actionError) in
+                                                                STPPaymentHandler.shared().handleNextAction(forPayment: clientSecret, with: self) { (status, handledPaymentIntent, actionError) in
                                                                     switch (status) {
                                                                     case .succeeded:
-                                                                        MyAPIClient.sharedClient.confirmPaymentIntent(handledPaymentIntent) { clientSecret, error in
+                                                                        // Confirm again on the backend
+                                                                        MyAPIClient.sharedClient.confirmPaymentIntent(handledPaymentIntent!) { clientSecret, error in
+                                                                            guard let clientSecret = clientSecret else {
+                                                                                completion(error ?? NSError(domain: StripeDomain, code: 123, userInfo: [NSLocalizedDescriptionKey: "Unable to parse clientSecret from response"]))
+                                                                                return
+                                                                            }
+
+                                                                            // Retrieve the Payment Intent and check the status for success
                                                                             STPAPIClient.shared().retrievePaymentIntent(withClientSecret: clientSecret) { (paymentIntent, retrieveError) in
                                                                                 guard let paymentIntent = paymentIntent else {
                                                                                     completion(retrieveError ?? NSError(domain: StripeDomain, code: 123, userInfo: [NSLocalizedDescriptionKey: "Unable to parse payment intent from response"]))

--- a/Example/Standard Integration/CheckoutViewController.swift
+++ b/Example/Standard Integration/CheckoutViewController.swift
@@ -253,9 +253,13 @@ See https://stripe.com/docs/testing.
                                                                 STPPaymentHandler.shared().handleNextAction(forPayment: clientSecret, with: self) { (status, handledPaymentIntent, actionError) in
                                                                     switch (status) {
                                                                     case .succeeded:
-                                                                        if (handledPaymentIntent!.status == .requiresConfirmation) {
+                                                                        guard let handledPaymentIntent = handledPaymentIntent else {
+                                                                            completion(actionError ?? NSError(domain: StripeDomain, code: 123, userInfo: [NSLocalizedDescriptionKey: "Unknown failure"]))
+                                                                            return
+                                                                        }
+                                                                        if (handledPaymentIntent.status == .requiresConfirmation) {
                                                                             // Confirm again on the backend
-                                                                            MyAPIClient.sharedClient.confirmPaymentIntent(handledPaymentIntent!) { clientSecret, error in
+                                                                            MyAPIClient.sharedClient.confirmPaymentIntent(handledPaymentIntent) { clientSecret, error in
                                                                                 guard let clientSecret = clientSecret else {
                                                                                     completion(error ?? NSError(domain: StripeDomain, code: 123, userInfo: [NSLocalizedDescriptionKey: "Unable to parse clientSecret from response"]))
                                                                                     return

--- a/Stripe/Payments/STPPaymentHandler.m
+++ b/Stripe/Payments/STPPaymentHandler.m
@@ -64,15 +64,16 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
     __weak __typeof(self) weakSelf = self;
     // wrappedCompletion ensures we perform some final logic before calling the completion block.
     STPPaymentHandlerActionPaymentIntentCompletionBlock wrappedCompletion = ^(STPPaymentHandlerActionStatus status, STPPaymentIntent *paymentIntent, NSError *error) {
+        __typeof(self) strongSelf = weakSelf;
         // Reset our internal state
-        weakSelf.inProgress = NO;
+        strongSelf.inProgress = NO;
         // Ensure the .succeeded case returns a PaymentIntent in the expected state.
         if (status == STPPaymentHandlerActionStatusSucceeded) {
             if (error == nil && paymentIntent != nil && (paymentIntent.status == STPPaymentIntentStatusSucceeded || paymentIntent.status == STPPaymentIntentStatusRequiresCapture)) {
                 completion(STPPaymentHandlerActionStatusSucceeded, paymentIntent, nil);
             } else {
                 NSAssert(NO, @"Calling completion with invalid state");
-                completion(STPPaymentHandlerActionStatusFailed, paymentIntent, error ?: [self _errorForCode:STPPaymentHandlerIntentStatusErrorCode userInfo:nil]);
+                completion(STPPaymentHandlerActionStatusFailed, paymentIntent, error ?: [strongSelf _errorForCode:STPPaymentHandlerIntentStatusErrorCode userInfo:nil]);
             }
             return;
         }
@@ -106,15 +107,16 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
     __weak __typeof(self) weakSelf = self;
     // wrappedCompletion ensures we perform some final logic before calling the completion block.
     STPPaymentHandlerActionPaymentIntentCompletionBlock wrappedCompletion = ^(STPPaymentHandlerActionStatus status, STPPaymentIntent *paymentIntent, NSError *error) {
+        __typeof(self) strongSelf = weakSelf;
         // Reset our internal state
-        weakSelf.inProgress = NO;
+        strongSelf.inProgress = NO;
         // Ensure the .succeeded case returns a PaymentIntent in the expected state.
         if (status == STPPaymentHandlerActionStatusSucceeded) {
             if (error == nil && paymentIntent != nil && (paymentIntent.status == STPPaymentIntentStatusSucceeded || paymentIntent.status == STPPaymentIntentStatusRequiresCapture || paymentIntent.status == STPPaymentIntentStatusRequiresConfirmation)) {
                 completion(STPPaymentHandlerActionStatusSucceeded, paymentIntent, nil);
             } else {
                 NSAssert(NO, @"Calling completion with invalid state");
-                completion(STPPaymentHandlerActionStatusFailed, paymentIntent, error ?: [self _errorForCode:STPPaymentHandlerIntentStatusErrorCode userInfo:nil]);
+                completion(STPPaymentHandlerActionStatusFailed, paymentIntent, error ?: [strongSelf _errorForCode:STPPaymentHandlerIntentStatusErrorCode userInfo:nil]);
             }
             return;
         }
@@ -128,7 +130,7 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
         } else {
             if (paymentIntent.status == STPPaymentIntentStatusRequiresConfirmation) {
                 // The caller forgot to confirm the paymentIntent on the backend before calling this method
-                wrappedCompletion(STPPaymentHandlerActionStatusFailed, paymentIntent, [self _errorForCode:STPPaymentHandlerIntentStatusErrorCode userInfo:@{STPErrorMessageKey: @"Confirm the PaymentIntent on the backend before calling handleNextActionForPayment:withAuthenticationContext:completion."}]);
+                wrappedCompletion(STPPaymentHandlerActionStatusFailed, paymentIntent, [strongSelf _errorForCode:STPPaymentHandlerIntentStatusErrorCode userInfo:@{STPErrorMessageKey: @"Confirm the PaymentIntent on the backend before calling handleNextActionForPayment:withAuthenticationContext:completion."}]);
             }
             [strongSelf _handleNextActionForPayment:paymentIntent
                           withAuthenticationContext:authenticationContext
@@ -153,6 +155,7 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
     __weak __typeof(self) weakSelf = self;
     // wrappedCompletion ensures we perform some final logic before calling the completion block.
     STPPaymentHandlerActionSetupIntentCompletionBlock wrappedCompletion = ^(STPPaymentHandlerActionStatus status, STPSetupIntent *setupIntent, NSError *error) {
+        __typeof(self) strongSelf = weakSelf;
         // Reset our internal state
         weakSelf.inProgress = NO;
         // Ensure the .succeeded case returns a PaymentIntent in the expected state.
@@ -161,7 +164,7 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
                 completion(STPPaymentHandlerActionStatusSucceeded, setupIntent, nil);
             } else {
                 NSAssert(NO, @"Calling completion with invalid state");
-                completion(STPPaymentHandlerActionStatusFailed, setupIntent, error ?: [self _errorForCode:STPPaymentHandlerIntentStatusErrorCode userInfo:nil]);
+                completion(STPPaymentHandlerActionStatusFailed, setupIntent, error ?: [strongSelf _errorForCode:STPPaymentHandlerIntentStatusErrorCode userInfo:nil]);
             }
             return;
         }

--- a/Stripe/Payments/STPPaymentHandler.m
+++ b/Stripe/Payments/STPPaymentHandler.m
@@ -110,6 +110,10 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
     BOOL requiresAction = [self _handlePaymentIntentStatusForAction:action];
     if (requiresAction) {
         [self _handleAuthenticationForCurrentAction];
+    } else {
+        [_currentAction completeWithStatus:STPPaymentHandlerActionStatusSucceeded error:nil];
+        _currentAction = nil;
+        self.inProgress = NO;
     }
 }
 
@@ -143,6 +147,10 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
             BOOL requiresAction = [self _handleSetupIntentStatusForAction:action];
             if (requiresAction) {
                 [self _handleAuthenticationForCurrentAction];
+            } else {
+                [self->_currentAction completeWithStatus:STPPaymentHandlerActionStatusSucceeded error:nil];
+                self->_currentAction = nil;
+                self.inProgress = NO;
             }
         }
     };

--- a/Stripe/PublicHeaders/STPPaymentContext.h
+++ b/Stripe/PublicHeaders/STPPaymentContext.h
@@ -361,11 +361,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)paymentContextDidChange:(STPPaymentContext *)paymentContext;
 
 /**
- Inside this method, you should make a call to your backend API to make a charge with that Customer + source, and invoke the `completion` block when that is done.
+ Inside this method, you should make a call to your backend API to make a PaymentIntent with that Customer + payment method, and invoke the `completion` block when that is done.
 
  @param paymentContext The context that succeeded
  @param paymentResult  Information associated with the payment that you can pass to your server. You should go to your backend API with this payment result and use the PaymentIntent API to complete the payment. See https://stripe.com/docs/mobile/ios/standard#submit-payment-intents. Once that's done call the `completion` block with any error that occurred (or none, if the payment succeeded). @see STPPaymentResult.h
- @param completion     Call this block when you're done creating a charge (or subscription, etc) on your backend. If it succeeded, call `completion(nil)`. If it failed with an error, call `completion(error)`.
+ @param completion     Call this block when you're done creating a payment intent (or subscription, etc) on your backend. If it succeeded, call `completion(nil)`. If it failed with an error, call `completion(error)`.
  */
 - (void)paymentContext:(STPPaymentContext *)paymentContext
 didCreatePaymentResult:(STPPaymentResult *)paymentResult

--- a/Stripe/PublicHeaders/STPPaymentHandler.h
+++ b/Stripe/PublicHeaders/STPPaymentHandler.h
@@ -132,7 +132,7 @@ NS_EXTENSION_UNAVAILABLE("STPPaymentHandler is not available in extensions")
  
  @param paymentParams The params used to confirm the PaymentIntent.
  @param authenticationContext The authentication context used to authenticate the payment.
- @param completion The completion block. If the status returned is `STPPaymentHandlerActionStatusSucceeded`, the PaymentIntent status will always be either STPPaymentIntentStatusSucceeded, STPPaymentIntentStatusRequiresCapture, or STPPaymentIntentStatusRequiresConfirmation. In the latter two cases, capture or confirm the PaymentIntent to complete the payment.
+ @param completion The completion block. If the status returned is `STPPaymentHandlerActionStatusSucceeded`, the PaymentIntent status will always be either STPPaymentIntentStatusSucceeded or STPPaymentIntentStatusRequiresCapture if you are using manual capture. In the latter case, capture the PaymentIntent to complete the payment.
  */
 - (void)confirmPayment:(STPPaymentIntentParams *)paymentParams
 withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
@@ -145,7 +145,7 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
  
  @param paymentIntentClientSecret The client secret of the PaymentIntent to handle next actions for.
  @param authenticationContext The authentication context used to authenticate the payment.
- @param completion The completion block. If the status returned is `STPPaymentHandlerActionStatusSucceeded`, the PaymentIntent status will always be either STPPaymentIntentStatusSucceeded, STPPaymentIntentStatusRequiresCapture, or STPPaymentIntentStatusRequiresConfirmation. In the latter two cases, capture or confirm the PaymentIntent on your backend to complete the payment.
+ @param completion The completion block. If the status returned is `STPPaymentHandlerActionStatusSucceeded`, the PaymentIntent status will always be either STPPaymentIntentStatusSucceeded, or STPPaymentIntentStatusRequiresConfirmation, or STPPaymentIntentStatusRequiresCapture if you are using manual capture. In the latter two cases, confirm or capture the PaymentIntent on your backend to complete the payment.
  */
 - (void)handleNextActionForPayment:(NSString *)paymentIntentClientSecret
          withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
@@ -159,7 +159,7 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
  
  @param setupIntentConfirmParams The params used to confirm the SetupIntent.
  @param authenticationContext The authentication context used to authenticate the SetupIntent.
- @param completion The completion block. If the status returned is `STPPaymentHandlerActionStatusSucceeded`, the SetupIntent status will always be either STPSetupIntentStatusSucceeded or STPSetupIntentStatusRequiresConfirmation. In the latter case, confirm the Setupintent to complete it.
+ @param completion The completion block. If the status returned is `STPPaymentHandlerActionStatusSucceeded`, the SetupIntent status will always be STPSetupIntentStatusSucceeded.
  */
 - (void)confirmSetupIntent:(STPSetupIntentConfirmParams *)setupIntentConfirmParams
  withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext

--- a/Stripe/PublicHeaders/STPPaymentHandler.h
+++ b/Stripe/PublicHeaders/STPPaymentHandler.h
@@ -143,17 +143,19 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
  
  Call this method if you are using manual confirmation.  @see https://stripe.com/docs/payments/payment-intents/ios
  
- @param paymentIntent The PaymentIntent to handle next actions for.
+ @param paymentIntentClientSecret The client secret of the PaymentIntent to handle next actions for.
  @param authenticationContext The authentication context used to authenticate the payment.
  @param completion The completion block. If the status returned is `STPPaymentHandlerActionStatusSucceeded`, the PaymentIntent status will always be either STPPaymentIntentStatusSucceeded, STPPaymentIntentStatusRequiresCapture, or STPPaymentIntentStatusRequiresConfirmation. In the latter two cases, capture or confirm the PaymentIntent on your backend to complete the payment.
  */
-- (void)handleNextActionForPayment:(STPPaymentIntent *)paymentIntent
+- (void)handleNextActionForPayment:(NSString *)paymentIntentClientSecret
          withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
                         completion:(STPPaymentHandlerActionPaymentIntentCompletionBlock)completion;
 
 /**
  Confirms the SetupIntent with the provided parameters and handles any `nextAction` required
  to authenticate the SetupIntent.
+ 
+ @see https://stripe.com/docs/payments/cards/saving-cards#saving-card-without-payment
  
  @param setupIntentConfirmParams The params used to confirm the SetupIntent.
  @param authenticationContext The authentication context used to authenticate the SetupIntent.


### PR DESCRIPTION
## Summary
* Refactor STPPaymentHandler handleNextActionForPayment to take a string and fetch the PaymentIntent, instead of taking a PaymentIntent directly.  Rework example code to match.
* Fix inProgress not being reset in the frictionless case
* Add SetupIntent example VC

I changed the example code to check `STPPaymentHandlerActionStatus` instead of `STPPaymentIntentStatus`.  This is easier for users (just 3 cases to check - `success`, `failure`, `canceled`).  

I added `wrappedCompletionBlock` in the 3 public APIs to guarantee a valid Intent in the `.success` case.  This could probably be better; we're mapping internal state to the final completion block's `STPPaymentHandlerActionStatus` in multiple places and the internal flow of logic is confusing to follow.  

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
Will need to manually test all manual/automatic/setupintents, for 3DS2 and 3DS1, for cancel/failed/success.
