### PR TITLE
Send maxTimeout as a 2 digit string

### DIFF
--- a/Stripe/Payments/STPThreeDSCustomizationSettings.m
+++ b/Stripe/Payments/STPThreeDSCustomizationSettings.m
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
     self = [super init];
     if (self) {
         _uiCustomization = [STPThreeDSUICustomization defaultSettings];
-        _authenticationTimeout = 5*60;
+        _authenticationTimeout = 5;
     }
     return self;
 }

--- a/Stripe/Payments/STPThreeDSCustomizationSettings.m
+++ b/Stripe/Payments/STPThreeDSCustomizationSettings.m
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
     self = [super init];
     if (self) {
         _uiCustomization = [STPThreeDSUICustomization defaultSettings];
-        _authenticationTimeout = 5;
+        _authenticationTimeout = 5*60;
     }
     return self;
 }

--- a/Stripe/PublicHeaders/STPThreeDSCustomizationSettings.h
+++ b/Stripe/PublicHeaders/STPThreeDSCustomizationSettings.h
@@ -38,11 +38,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  `authenticationTimeout` is the total time allowed for a user to complete a 3DS2 authentication
- interaction. This value *must* be at least 5 minutes.
+ interaction, in minutes.  This value *must* be at least 5 minutes.
  
  Defaults to 5 minutes.
  */
-@property (nonatomic) NSTimeInterval authenticationTimeout;
+@property (nonatomic) NSInteger authenticationTimeout;
 
 @end
 

--- a/Stripe/PublicHeaders/STPThreeDSCustomizationSettings.h
+++ b/Stripe/PublicHeaders/STPThreeDSCustomizationSettings.h
@@ -38,11 +38,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  `authenticationTimeout` is the total time allowed for a user to complete a 3DS2 authentication
- interaction, in minutes.  This value *must* be at least 5 minutes.
+ interaction. This value *must* be at least 5 minutes.
+ 
+ @note The value is rounded down to the nearest minute.
  
  Defaults to 5 minutes.
  */
-@property (nonatomic) NSInteger authenticationTimeout;
+@property (nonatomic) NSTimeInterval authenticationTimeout;
 
 @end
 

--- a/Stripe/PublicHeaders/STPThreeDSCustomizationSettings.h
+++ b/Stripe/PublicHeaders/STPThreeDSCustomizationSettings.h
@@ -38,13 +38,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  `authenticationTimeout` is the total time allowed for a user to complete a 3DS2 authentication
- interaction. This value *must* be at least 5 minutes.
- 
- @note The value is rounded down to the nearest minute.
+ interaction, in minutes.  This value *must* be at least 5 minutes.
  
  Defaults to 5 minutes.
  */
-@property (nonatomic) NSTimeInterval authenticationTimeout;
+@property (nonatomic) NSInteger authenticationTimeout;
 
 @end
 

--- a/Stripe/STPAPIClient+Private.h
+++ b/Stripe/STPAPIClient+Private.h
@@ -117,7 +117,7 @@ fromCustomerUsingKey:(STPEphemeralKey *)ephemeralKey
  */
 - (void)authenticate3DS2:(STDSAuthenticationRequestParameters *)authRequestParams
         sourceIdentifier:(NSString *)sourceID
-              maxTimeout:(NSInteger)maxTimeout
+              maxTimeout:(NSTimeInterval)maxTimeout
               completion:(STP3DS2AuthenticateCompletionBlock)completion;
 
 /**

--- a/Stripe/STPAPIClient+Private.h
+++ b/Stripe/STPAPIClient+Private.h
@@ -117,7 +117,7 @@ fromCustomerUsingKey:(STPEphemeralKey *)ephemeralKey
  */
 - (void)authenticate3DS2:(STDSAuthenticationRequestParameters *)authRequestParams
         sourceIdentifier:(NSString *)sourceID
-              maxTimeout:(NSTimeInterval)maxTimeout
+              maxTimeout:(NSInteger)maxTimeout
               completion:(STP3DS2AuthenticateCompletionBlock)completion;
 
 /**

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -656,7 +656,7 @@ toCustomerUsingKey:(STPEphemeralKey *)ephemeralKey
 
 - (void)authenticate3DS2:(STDSAuthenticationRequestParameters *)authRequestParams
         sourceIdentifier:(NSString *)sourceID
-              maxTimeout:(NSTimeInterval)maxTimeout
+              maxTimeout:(NSInteger)maxTimeout
               completion:(STP3DS2AuthenticateCompletionBlock)completion {
     NSString *endpoint = [NSString stringWithFormat:@"%@/authenticate", APIEndpoint3DS2];
 
@@ -664,7 +664,7 @@ toCustomerUsingKey:(STPEphemeralKey *)ephemeralKey
     appParams[@"deviceRenderOptions"] = @{@"sdkInterface": @"03",
                                           @"sdkUiType": @[@"01", @"02", @"03", @"04", @"05"],
                                           };
-    appParams[@"sdkMaxTimeout"] = @(maxTimeout / 60);
+    appParams[@"sdkMaxTimeout"] = [NSString stringWithFormat:@"%02ld", (long)maxTimeout];
     NSData *appData = [NSJSONSerialization dataWithJSONObject:appParams options:NSJSONWritingPrettyPrinted error:NULL];
      [STPAPIRequest<STP3DS2AuthenticateResponse *> postWithAPIClient:self
                                                             endpoint:endpoint

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -656,7 +656,7 @@ toCustomerUsingKey:(STPEphemeralKey *)ephemeralKey
 
 - (void)authenticate3DS2:(STDSAuthenticationRequestParameters *)authRequestParams
         sourceIdentifier:(NSString *)sourceID
-              maxTimeout:(NSInteger)maxTimeout
+              maxTimeout:(NSTimeInterval)maxTimeout
               completion:(STP3DS2AuthenticateCompletionBlock)completion {
     NSString *endpoint = [NSString stringWithFormat:@"%@/authenticate", APIEndpoint3DS2];
 
@@ -664,7 +664,7 @@ toCustomerUsingKey:(STPEphemeralKey *)ephemeralKey
     appParams[@"deviceRenderOptions"] = @{@"sdkInterface": @"03",
                                           @"sdkUiType": @[@"01", @"02", @"03", @"04", @"05"],
                                           };
-    appParams[@"sdkMaxTimeout"] = [NSString stringWithFormat:@"%02ld", (long)maxTimeout];
+    appParams[@"sdkMaxTimeout"] = [NSString stringWithFormat:@"%02ld", (long)(maxTimeout / 60)];
     NSData *appData = [NSJSONSerialization dataWithJSONObject:appParams options:NSJSONWritingPrettyPrinted error:NULL];
      [STPAPIRequest<STP3DS2AuthenticateResponse *> postWithAPIClient:self
                                                             endpoint:endpoint

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -656,7 +656,7 @@ toCustomerUsingKey:(STPEphemeralKey *)ephemeralKey
 
 - (void)authenticate3DS2:(STDSAuthenticationRequestParameters *)authRequestParams
         sourceIdentifier:(NSString *)sourceID
-              maxTimeout:(NSTimeInterval)maxTimeout
+              maxTimeout:(NSInteger)maxTimeout
               completion:(STP3DS2AuthenticateCompletionBlock)completion {
     NSString *endpoint = [NSString stringWithFormat:@"%@/authenticate", APIEndpoint3DS2];
 
@@ -664,7 +664,7 @@ toCustomerUsingKey:(STPEphemeralKey *)ephemeralKey
     appParams[@"deviceRenderOptions"] = @{@"sdkInterface": @"03",
                                           @"sdkUiType": @[@"01", @"02", @"03", @"04", @"05"],
                                           };
-    appParams[@"sdkMaxTimeout"] = [NSString stringWithFormat:@"%02ld", (long)(maxTimeout / 60)];
+    appParams[@"sdkMaxTimeout"] = [NSString stringWithFormat:@"%02ld", (long)maxTimeout];
     NSData *appData = [NSJSONSerialization dataWithJSONObject:appParams options:NSJSONWritingPrettyPrinted error:NULL];
      [STPAPIRequest<STP3DS2AuthenticateResponse *> postWithAPIClient:self
                                                             endpoint:endpoint


### PR DESCRIPTION
Also changed maxTimeout type from NSTimeInterval to NSInteger, since the precision is minutes not seconds.

## Motivation
https://jira.corp.stripe.com/browse/MOBILE3DS2-439

## Testing
Ran 3ds2 w/ card (automatic confirmation) example
