### PR TITLE
Fixes incorrect timeout value sent to 3DS2 SDK.

### DIFF
--- a/Stripe/Payments/STPPaymentHandler.m
+++ b/Stripe/Payments/STPPaymentHandler.m
@@ -379,7 +379,7 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
                                                   [transaction doChallengeWithViewController:[self->_currentAction.authenticationContext authenticationPresentingViewController]
                                                                          challengeParameters:challengeParameters
                                                                      challengeStatusReceiver:self
-                                                                                     timeout:self->_currentAction.threeDSCustomizationSettings.authenticationTimeout];
+                                                                                     timeout:self->_currentAction.threeDSCustomizationSettings.authenticationTimeout*60];
                                               } @catch (NSException *exception) {
                                                   [self->_currentAction completeWithStatus:STPPaymentHandlerActionStatusFailed error:[self _errorForCode:STPPaymentHandlerStripe3DS2ErrorCode  userInfo:@{@"exception": exception}]];
                                               }


### PR DESCRIPTION
## Summary
3DS2 SDK expects NSTimeInterval, so convert from minutes to seconds in interface.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
3ds2 wasn't working!

## Testing
<!-- How was the code tested? Be as specific as possible. -->
Tested with Custom Integration -- 3DS2 fails before, passes after.