### PR TITLE
Allow unknown AuthenticateResponse state

### DIFF
--- a/Stripe/Payments/STPPaymentHandler.m
+++ b/Stripe/Payments/STPPaymentHandler.m
@@ -375,7 +375,13 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
                                           if (authenticateResponse == nil) {
                                               [self->_currentAction completeWithStatus:STPPaymentHandlerActionStatusFailed error:error];
                                           } else {
-                                              STDSChallengeParameters *challengeParameters = [[STDSChallengeParameters alloc] initWithAuthenticationResponse:authenticateResponse.authenticationResponse];
+                                              id<STDSAuthenticationResponse> aRes = authenticateResponse.authenticationResponse;
+                                              if (!aRes.challengeMandated) {
+                                                  // Challenge not required, finish the flow.
+                                                  [self _retrieveAndCheckIntentForCurrentAction];
+                                                  return;
+                                              }
+                                              STDSChallengeParameters *challengeParameters = [[STDSChallengeParameters alloc] initWithAuthenticationResponse:aRes];
                                               @try {
                                                   [transaction doChallengeWithViewController:[self->_currentAction.authenticationContext authenticationPresentingViewController]
                                                                          challengeParameters:challengeParameters

--- a/Stripe/Payments/STPPaymentHandler.m
+++ b/Stripe/Payments/STPPaymentHandler.m
@@ -378,6 +378,7 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
                                               id<STDSAuthenticationResponse> aRes = authenticateResponse.authenticationResponse;
                                               if (!aRes.challengeMandated) {
                                                   // Challenge not required, finish the flow.
+                                                  [transaction close];
                                                   [self _retrieveAndCheckIntentForCurrentAction];
                                                   return;
                                               }

--- a/Stripe/STP3DS2AuthenticateResponse.m
+++ b/Stripe/STP3DS2AuthenticateResponse.m
@@ -42,10 +42,6 @@ NS_ASSUME_NONNULL_BEGIN
         state = STP3DS2AuthenticateResponseStateChallengeRequired;
     }
 
-    if (state == STP3DS2AuthenticateResponseStateUnknown) {
-        return nil;
-    }
-
     STP3DS2AuthenticateResponse *authResponse = [self new];
     authResponse->_authenticationResponse = authenticationResponse;
     authResponse->_state = state;


### PR DESCRIPTION
## Summary
* Allow unknown AuthenticateResponse state (in this case, 'attempted')
* Only doChallenge if aRes.challengeMandated is YES
^ **I think** in the else case, we just retrieve the PI and finish the flow.  

## Motivation
Make 3DS2 work

## Testing
Amex test card now fails as expected, instead of `doChallenge` erroring since there is no `acsSignedContent`.
