### PR TITLE
Adds support for 3ds_redirect action

### DIFF
--- a/Example/Custom Integration/CardManualConfirmationExampleViewController.m
+++ b/Example/Custom Integration/CardManualConfirmationExampleViewController.m
@@ -137,6 +137,7 @@
         }
         [[STPPaymentHandler sharedHandler] handleNextActionForPayment:clientSecret
                                             withAuthenticationContext:self.delegate
+                                                            returnURL:@"payments-example://stripe-redirect"
                                                            completion:paymentHandlerCompletion];
     };
     [self.delegate createAndConfirmPaymentIntentWithAmount:@(100)

--- a/Example/Standard Integration/CheckoutViewController.swift
+++ b/Example/Standard Integration/CheckoutViewController.swift
@@ -250,7 +250,7 @@ See https://stripe.com/docs/testing.
                                                                     completion(error ?? NSError(domain: StripeDomain, code: 123, userInfo: [NSLocalizedDescriptionKey: "Unable to parse clientSecret from response"]))
                                                                     return
                                                                 }
-                                                                STPPaymentHandler.shared().handleNextAction(forPayment: clientSecret, with: self) { (status, handledPaymentIntent, actionError) in
+                                                                STPPaymentHandler.shared().handleNextAction(forPayment: clientSecret, with: self, returnURL: "payments-example://stripe-redirect") { (status, handledPaymentIntent, actionError) in
                                                                     switch (status) {
                                                                     case .succeeded:
                                                                         guard let handledPaymentIntent = handledPaymentIntent else {

--- a/Stripe/Payments/STPPaymentHandler.m
+++ b/Stripe/Payments/STPPaymentHandler.m
@@ -16,6 +16,7 @@
 #import "STPAPIClient+Private.h"
 #import "STPAuthenticationContext.h"
 #import "STPPaymentIntent.h"
+#import "STPPaymentIntentParams.h"
 #import "STPPaymentHandlerActionParams.h"
 #import "STPIntentAction+Private.h"
 #import "STPIntentActionRedirectToURL.h"
@@ -86,6 +87,7 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
         } else {
             [strongSelf _handleNextActionForPayment:paymentIntent
                           withAuthenticationContext:authenticationContext
+                                          returnURL:paymentParams.returnURL
                                          completion:^(STPPaymentHandlerActionStatus status, STPPaymentIntent *completedPaymentIntent, NSError *completedError) {
                                              wrappedCompletion(status, completedPaymentIntent, completedError);
                                          }];
@@ -97,7 +99,8 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
 
 - (void)handleNextActionForPayment:(NSString *)paymentIntentClientSecret
          withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
-                        completion:(STPPaymentHandlerActionPaymentIntentCompletionBlock)completion {
+                         returnURL:(nullable NSString *)returnURL
+                        completion:(STPPaymentHandlerActionPaymentIntentCompletionBlock)completion{
     if (self.isInProgress) {
         NSAssert(NO, @"Should not handle multiple payments at once.");
         completion(STPPaymentHandlerActionStatusFailed, nil, [self _errorForCode:STPPaymentHandlerNoConcurrentActionsErrorCode userInfo:nil]);
@@ -134,6 +137,7 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
             }
             [strongSelf _handleNextActionForPayment:paymentIntent
                           withAuthenticationContext:authenticationContext
+                                          returnURL:returnURL
                                          completion:^(STPPaymentHandlerActionStatus status, STPPaymentIntent *completedPaymentIntent, NSError *completedError) {
                                              wrappedCompletion(status, completedPaymentIntent, completedError);
                                          }];
@@ -179,6 +183,7 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
                                                                                                              authenticationContext:authenticationContext
                                                                                                       threeDSCustomizationSettings:self.threeDSCustomizationSettings
                                                                                                                        setupIntent:setupIntent
+                                                                                                                         returnURL:setupIntentConfirmParams.returnURL
                                                                                                                         completion:^(STPPaymentHandlerActionStatus status, STPSetupIntent * _Nullable resultSetupIntent, NSError * _Nullable resultError) {
                                                                                                                             __typeof(self) strongSelf = weakSelf;
                                                                                                                             if (strongSelf != nil) {
@@ -201,6 +206,7 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
 
 - (void)_handleNextActionForPayment:(STPPaymentIntent *)paymentIntent
           withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
+                          returnURL:(nullable NSString *)returnURLString
                          completion:(STPPaymentHandlerActionPaymentIntentCompletionBlock)completion {
     if (paymentIntent.status == STPPaymentIntentStatusRequiresPaymentMethod) {
         // The caller forgot to attach a paymentMethod.
@@ -213,6 +219,7 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
                                                                                                          authenticationContext:authenticationContext
                                                                                                   threeDSCustomizationSettings:self.threeDSCustomizationSettings
                                                                                                                  paymentIntent:paymentIntent
+                                                                                                                     returnURL:returnURLString
                                                                                                                     completion:^(STPPaymentHandlerActionStatus status, STPPaymentIntent * _Nullable resultPaymentIntent, NSError * _Nullable error) {
                                                                                                                         __typeof(self) strongSelf = weakSelf;
                                                                                                                         if (strongSelf != nil) {
@@ -352,37 +359,42 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
                         [_currentAction completeWithStatus:STPPaymentHandlerActionStatusFailed error:[self _errorForCode:STPPaymentHandlerStripe3DS2ErrorCode userInfo:@{@"exception": exception.description}]];
                     }
 
-                    [_apiClient authenticate3DS2:authRequestParams
-                                sourceIdentifier:authenticationAction.useStripeSDK.threeDS2SourceID
-                                      maxTimeout:_currentAction.threeDSCustomizationSettings.authenticationTimeout
-                                      completion:^(STP3DS2AuthenticateResponse * _Nullable authenticateResponse, NSError * _Nullable error) {
-                                          if (authenticateResponse == nil) {
-                                              [self->_currentAction completeWithStatus:STPPaymentHandlerActionStatusFailed error:error];
-                                          } else {
-                                              id<STDSAuthenticationResponse> aRes = authenticateResponse.authenticationResponse;
-                                              if (!aRes.challengeMandated) {
-                                                  // Challenge not required, finish the flow.
-                                                  [transaction close];
-                                                  [self _retrieveAndCheckIntentForCurrentAction];
-                                                  return;
-                                              }
-                                              STDSChallengeParameters *challengeParameters = [[STDSChallengeParameters alloc] initWithAuthenticationResponse:aRes];
-                                              @try {
-                                                  [transaction doChallengeWithViewController:[self->_currentAction.authenticationContext authenticationPresentingViewController]
-                                                                         challengeParameters:challengeParameters
-                                                                     challengeStatusReceiver:self
-                                                                                     timeout:self->_currentAction.threeDSCustomizationSettings.authenticationTimeout*60];
-                                              } @catch (NSException *exception) {
-                                                  [self->_currentAction completeWithStatus:STPPaymentHandlerActionStatusFailed error:[self _errorForCode:STPPaymentHandlerStripe3DS2ErrorCode  userInfo:@{@"exception": exception}]];
-                                              }
+                    [_currentAction.apiClient authenticate3DS2:authRequestParams
+                                              sourceIdentifier:authenticationAction.useStripeSDK.threeDS2SourceID
+                                                    maxTimeout:_currentAction.threeDSCustomizationSettings.authenticationTimeout
+                                                    completion:^(STP3DS2AuthenticateResponse * _Nullable authenticateResponse, NSError * _Nullable error) {
+                                                        if (authenticateResponse == nil) {
+                                                            [self->_currentAction completeWithStatus:STPPaymentHandlerActionStatusFailed error:error];
+                                                        } else {
+                                                            id<STDSAuthenticationResponse> aRes = authenticateResponse.authenticationResponse;
+                                                            if (!aRes.challengeMandated) {
+                                                                // Challenge not required, finish the flow.
+                                                                [transaction close];
+                                                                [self _retrieveAndCheckIntentForCurrentAction];
+                                                                return;
+                                                            }
+                                                            STDSChallengeParameters *challengeParameters = [[STDSChallengeParameters alloc] initWithAuthenticationResponse:aRes];
+                                                            @try {
+                                                                [transaction doChallengeWithViewController:[self->_currentAction.authenticationContext authenticationPresentingViewController]
+                                                                                       challengeParameters:challengeParameters
+                                                                                   challengeStatusReceiver:self
+                                                                                                   timeout:self->_currentAction.threeDSCustomizationSettings.authenticationTimeout*60];
+                                                            } @catch (NSException *exception) {
+                                                                [self->_currentAction completeWithStatus:STPPaymentHandlerActionStatusFailed error:[self _errorForCode:STPPaymentHandlerStripe3DS2ErrorCode  userInfo:@{@"exception": exception}]];
+                                                            }
 
-                                          }
-                                      }];
+                                                        }
+                                                    }];
                 }
                     break;
                 case STPIntentActionUseStripeSDKType3DS2Redirect: {
                     NSURL *url = authenticationAction.useStripeSDK.redirectURL;
-                    [self _handleRedirectToURL:url withReturnURL:nil]; // TODO : can we get this?
+                    NSURL *returnURL = nil;
+                    NSString *returnURLString = _currentAction.returnURLString;
+                    if (returnURLString != nil) {
+                        returnURL = [NSURL URLWithString:returnURLString];
+                    }
+                    [self _handleRedirectToURL:url withReturnURL:returnURL];
                 }
                     break;
             }

--- a/Stripe/PublicHeaders/STPPaymentHandler.h
+++ b/Stripe/PublicHeaders/STPPaymentHandler.h
@@ -145,7 +145,7 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
  
  @param paymentIntentClientSecret The client secret of the PaymentIntent to handle next actions for.
  @param authenticationContext The authentication context used to authenticate the payment.
- @param returnURL The URL to redirect your customer back to after they authenticate or cancel. This should match the returnURL you specified during paymentIntent creation
+ @param returnURL An optional URL to redirect your customer back to after they authenticate or cancel in a webview. This should match the returnURL you specified during PaymentIntent confirmation.
  @param completion The completion block. If the status returned is `STPPaymentHandlerActionStatusSucceeded`, the PaymentIntent status will always be either STPPaymentIntentStatusSucceeded, or STPPaymentIntentStatusRequiresConfirmation, or STPPaymentIntentStatusRequiresCapture if you are using manual capture. In the latter two cases, confirm or capture the PaymentIntent on your backend to complete the payment.
  */
 - (void)handleNextActionForPayment:(NSString *)paymentIntentClientSecret

--- a/Stripe/PublicHeaders/STPPaymentHandler.h
+++ b/Stripe/PublicHeaders/STPPaymentHandler.h
@@ -145,10 +145,12 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
  
  @param paymentIntentClientSecret The client secret of the PaymentIntent to handle next actions for.
  @param authenticationContext The authentication context used to authenticate the payment.
+ @param returnURL The URL to redirect your customer back to after they authenticate or cancel. This should match the returnURL you specified during paymentIntent creation
  @param completion The completion block. If the status returned is `STPPaymentHandlerActionStatusSucceeded`, the PaymentIntent status will always be either STPPaymentIntentStatusSucceeded, or STPPaymentIntentStatusRequiresConfirmation, or STPPaymentIntentStatusRequiresCapture if you are using manual capture. In the latter two cases, confirm or capture the PaymentIntent on your backend to complete the payment.
  */
 - (void)handleNextActionForPayment:(NSString *)paymentIntentClientSecret
          withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
+                         returnURL:(nullable NSString *)returnURL
                         completion:(STPPaymentHandlerActionPaymentIntentCompletionBlock)completion;
 
 /**

--- a/Stripe/STPIntentActionUseStripeSDK.h
+++ b/Stripe/STPIntentActionUseStripeSDK.h
@@ -15,6 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 typedef NS_ENUM(NSInteger, STPIntentActionUseStripeSDKType) {
     STPIntentActionUseStripeSDKTypeUnknown = 0,
     STPIntentActionUseStripeSDKType3DS2Fingerprint,
+    STPIntentActionUseStripeSDKType3DS2Redirect,
 };
 
 @interface STPIntentActionUseStripeSDK : NSObject <STPAPIResponseDecodable>
@@ -36,6 +37,9 @@ typedef NS_ENUM(NSInteger, STPIntentActionUseStripeSDKType) {
 
 @property (nonatomic, nullable, copy, readonly) NSString *serverTransactionID;
 @property (nonatomic, nullable, copy, readonly) NSString *threeDS2SourceID;
+
+#pragma mark - 3DS2 Redirect
+@property (nonatomic, nullable, readonly) NSURL *redirectURL;
 
 @end
 

--- a/Stripe/STPIntentActionUseStripeSDK.m
+++ b/Stripe/STPIntentActionUseStripeSDK.m
@@ -29,6 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
                                [NSString stringWithFormat:@"directoryServerCertificate = %@", self.directoryServerCertificate.length > 0 ? @"<redacted>" : nil],
                                [NSString stringWithFormat:@"threeDS2SourceID = %@", self.threeDS2SourceID],
                                [NSString stringWithFormat:@"type = %@", self.allResponseFields[@"type"]],
+                               [NSString stringWithFormat:@"redirectURL = %@", self.redirectURL],
                                
                                ] mutableCopy];
     

--- a/Stripe/STPPaymentHandlerActionParams.h
+++ b/Stripe/STPPaymentHandlerActionParams.h
@@ -21,6 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nullable, readonly, strong) id<STPAuthenticationContext> authenticationContext;
 @property (nonatomic, readonly, strong) STPAPIClient *apiClient;
 @property (nonatomic, readonly, strong) STPThreeDSCustomizationSettings *threeDSCustomizationSettings;
+@property (nonatomic, nullable, readonly) NSString *returnURLString;
 /// Returns the payment or setup intent's next action
 - (nullable STPIntentAction *)nextAction;
 - (void)completeWithStatus:(STPPaymentHandlerActionStatus)status error:(nullable NSError *)error;
@@ -33,6 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
             authenticationContext:(nullable id<STPAuthenticationContext>)authenticationContext
      threeDSCustomizationSettings:(STPThreeDSCustomizationSettings *)threeDSCustomizationSettings
                     paymentIntent:(STPPaymentIntent *)paymentIntent
+                        returnURL:(nullable NSString *)returnURLString
                        completion:(STPPaymentHandlerActionPaymentIntentCompletionBlock)completion;
 
 @property (nonatomic, nullable, readonly) STDSThreeDS2Service *threeDS2Service;
@@ -50,6 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
             authenticationContext:(nullable id<STPAuthenticationContext>)authenticationContext
      threeDSCustomizationSettings:(STPThreeDSCustomizationSettings *)threeDSCustomizationSettings
                       setupIntent:(STPSetupIntent *)setupIntent
+                        returnURL:(nullable NSString *)returnURLString
                        completion:(STPPaymentHandlerActionSetupIntentCompletionBlock)completion;
 
 @property (nonatomic, readonly, copy) STPPaymentHandlerActionSetupIntentCompletionBlock setupIntentCompletion;

--- a/Stripe/STPPaymentHandlerActionParams.m
+++ b/Stripe/STPPaymentHandlerActionParams.m
@@ -21,17 +21,20 @@
 }
 
 @synthesize threeDS2Service = _threeDS2Service;
+@synthesize returnURLString = _returnURLString;
 
 - (instancetype)initWithAPIClient:(STPAPIClient *)apiClient
             authenticationContext:(nullable id<STPAuthenticationContext>)authenticationContext
      threeDSCustomizationSettings:(STPThreeDSCustomizationSettings *)threeDSCustomizationSettings
                     paymentIntent:(STPPaymentIntent *)paymentIntent
+                        returnURL:(nullable NSString *)returnURLString
                        completion:(STPPaymentHandlerActionPaymentIntentCompletionBlock)completion {
     self = [super init];
     if (self) {
         _apiClient = apiClient;
         _authenticationContext = authenticationContext;
         _threeDSCustomizationSettings = threeDSCustomizationSettings;
+        _returnURLString = [returnURLString copy];
         _paymentIntent = paymentIntent;
         _paymentIntentCompletion = [completion copy];
     }
@@ -85,16 +88,20 @@
 
 @implementation STPPaymentHandlerSetupIntentActionParams
 
+@synthesize returnURLString = _returnURLString;
+
 - (instancetype)initWithAPIClient:(STPAPIClient *)apiClient
             authenticationContext:(nullable id<STPAuthenticationContext>)authenticationContext
      threeDSCustomizationSettings:(STPThreeDSCustomizationSettings *)threeDSCustomizationSettings
                       setupIntent:(STPSetupIntent *)setupIntent
+                        returnURL:(nullable NSString *)returnURLString
                        completion:(STPPaymentHandlerActionSetupIntentCompletionBlock)completion {
     self = [super init];
     if (self) {
         _apiClient = apiClient;
         _authenticationContext = authenticationContext;
         _threeDSCustomizationSettings = threeDSCustomizationSettings;
+        _returnURLString = [returnURLString copy];
         _setupIntent = setupIntent;
         _setupIntentCompletion = [completion copy];
     }


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Uses the same code as the top level redirect action for the 3DS specific one.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Required for hosted 3DS2 fallback.

## Testing
<!-- How was the code tested? Be as specific as possible. -->
Tested by opting out of 3DS2 feature and not including a return URL in custom integration.
