### PR TITLE
Adds analytics for 3DS2

### DIFF
--- a/Stripe/Payments/STPPaymentHandler.m
+++ b/Stripe/Payments/STPPaymentHandler.m
@@ -13,6 +13,7 @@
 
 #import "NSError+Stripe.h"
 #import "STP3DS2AuthenticateResponse.h"
+#import "STPAnalyticsClient.h"
 #import "STPAPIClient+Private.h"
 #import "STPAuthenticationContext.h"
 #import "STPPaymentIntent.h"
@@ -379,6 +380,9 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
                                                                                        challengeParameters:challengeParameters
                                                                                    challengeStatusReceiver:self
                                                                                                    timeout:self->_currentAction.threeDSCustomizationSettings.authenticationTimeout*60];
+
+                                                                [[STPAnalyticsClient sharedClient] log3DS2ChallengeFlowPresentedWithConfiguration:self->_currentAction.apiClient.configuration];
+
                                                             } @catch (NSException *exception) {
                                                                 [self->_currentAction completeWithStatus:STPPaymentHandlerActionStatusFailed error:[self _errorForCode:STPPaymentHandlerStripe3DS2ErrorCode  userInfo:@{@"exception": exception}]];
                                                             }
@@ -523,6 +527,12 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
         userInfo[NSLocalizedDescriptionKey] = [NSError stp_unexpectedErrorMessage];
         NSError *localizedError = [NSError errorWithDomain:threeDSError.domain code:threeDSError.code userInfo:userInfo];
         [self->_currentAction completeWithStatus:STPPaymentHandlerActionStatusFailed error:localizedError];
+        [[STPAnalyticsClient sharedClient] log3DS2ChallengeFlowErroredWithConfiguration:self->_currentAction.apiClient.configuration
+                                                                        errorDictionary:@{
+                                                                                          @"domain": threeDSError.domain,
+                                                                                          @"code": @(threeDSError.code),
+                                                                                          @"user_info": userInfo,
+                                                                                          }];
     }];
 }
 
@@ -534,6 +544,12 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
         userInfo[NSLocalizedDescriptionKey] = [NSError stp_unexpectedErrorMessage];
         NSError *localizedError = [NSError errorWithDomain:threeDSError.domain code:threeDSError.code userInfo:userInfo];
         [self->_currentAction completeWithStatus:STPPaymentHandlerActionStatusFailed error:localizedError];
+        [[STPAnalyticsClient sharedClient] log3DS2ChallengeFlowErroredWithConfiguration:self->_currentAction.apiClient.configuration
+                                                                        errorDictionary:@{
+                                                                                          @"domain": threeDSError.domain,
+                                                                                          @"code": @(threeDSError.code),
+                                                                                          @"user_info": userInfo,
+                                                                                          }];
     }];
 }
 

--- a/Stripe/Payments/STPPaymentHandler.m
+++ b/Stripe/Payments/STPPaymentHandler.m
@@ -528,6 +528,7 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
         NSError *localizedError = [NSError errorWithDomain:threeDSError.domain code:threeDSError.code userInfo:userInfo];
         [self->_currentAction completeWithStatus:STPPaymentHandlerActionStatusFailed error:localizedError];
         [[STPAnalyticsClient sharedClient] log3DS2ChallengeFlowErroredWithConfiguration:self->_currentAction.apiClient.configuration
+                                                                               intentID:self->_currentAction.intentStripeID
                                                                         errorDictionary:@{
                                                                                           @"domain": threeDSError.domain,
                                                                                           @"code": @(threeDSError.code),
@@ -545,6 +546,7 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
         NSError *localizedError = [NSError errorWithDomain:threeDSError.domain code:threeDSError.code userInfo:userInfo];
         [self->_currentAction completeWithStatus:STPPaymentHandlerActionStatusFailed error:localizedError];
         [[STPAnalyticsClient sharedClient] log3DS2ChallengeFlowErroredWithConfiguration:self->_currentAction.apiClient.configuration
+                                                                               intentID:self->_currentAction.intentStripeID
                                                                         errorDictionary:@{
                                                                                           @"domain": threeDSError.domain,
                                                                                           @"code": @(threeDSError.code),

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -660,6 +660,8 @@ toCustomerUsingKey:(STPEphemeralKey *)ephemeralKey
               completion:(STP3DS2AuthenticateCompletionBlock)completion {
     NSString *endpoint = [NSString stringWithFormat:@"%@/authenticate", APIEndpoint3DS2];
 
+    [[STPAnalyticsClient sharedClient] log3DS2AuthenticateAttemptWithConfiguration:self.configuration];
+
     NSMutableDictionary *appParams = [[STDSJSONEncoder dictionaryForObject:authRequestParams] mutableCopy];
     appParams[@"deviceRenderOptions"] = @{@"sdkInterface": @"03",
                                           @"sdkUiType": @[@"01", @"02", @"03", @"04", @"05"],
@@ -763,6 +765,11 @@ toCustomerUsingKey:(STPEphemeralKey *)ephemeralKey
 - (void)confirmSetupIntentWithParams:(STPSetupIntentConfirmParams *)setupIntentParams
                             completion:(STPSetupIntentCompletionBlock)completion {
     NSCAssert(setupIntentParams.clientSecret != nil, @"'clientSecret' is required to confirm a SetupIntent");
+
+    NSString *paymentMethodType = [STPPaymentMethod stringFromType:setupIntentParams.paymentMethodParams.type];
+    [[STPAnalyticsClient sharedClient] logSetupIntentConfirmationAttemptWithConfiguration:self.configuration
+                                                                        paymentMethodType:paymentMethodType];
+
     NSString *identifier = [STPSetupIntent idFromClientSecret:setupIntentParams.clientSecret];
     NSString *endpoint = [NSString stringWithFormat:@"%@/%@/confirm", APIEndpointSetupIntents, identifier];
     NSDictionary *params = [STPFormEncoder dictionaryForObject:setupIntentParams];

--- a/Stripe/STPAnalyticsClient.h
+++ b/Stripe/STPAnalyticsClient.h
@@ -40,6 +40,7 @@
 - (void)log3DS2ChallengeFlowPresentedWithConfiguration:(STPPaymentConfiguration *)configuration;
 
 - (void)log3DS2ChallengeFlowErroredWithConfiguration:(STPPaymentConfiguration *)configuration
-                                     errorDictionary:(NSDictionary *)errorDictionary;
+                                            intentID:(NSString *)intentID
+                                     errorDictionary:(NSDictionary *)errorDictionary ;
 
 @end

--- a/Stripe/STPAnalyticsClient.h
+++ b/Stripe/STPAnalyticsClient.h
@@ -32,4 +32,14 @@
 - (void)logPaymentIntentConfirmationAttemptWithConfiguration:(STPPaymentConfiguration *)configuration
                                                   sourceType:(NSString *)sourceType;
 
+- (void)logSetupIntentConfirmationAttemptWithConfiguration:(STPPaymentConfiguration *)configuration
+                                         paymentMethodType:(NSString *)paymentMethodType;
+
+- (void)log3DS2AuthenticateAttemptWithConfiguration:(STPPaymentConfiguration *)configuration;
+
+- (void)log3DS2ChallengeFlowPresentedWithConfiguration:(STPPaymentConfiguration *)configuration;
+
+- (void)log3DS2ChallengeFlowErroredWithConfiguration:(STPPaymentConfiguration *)configuration
+                                     errorDictionary:(NSDictionary *)errorDictionary;
+
 @end

--- a/Stripe/STPAnalyticsClient.m
+++ b/Stripe/STPAnalyticsClient.m
@@ -228,6 +228,58 @@
     [self logPayload:payload];
 }
 
+- (void)logSetupIntentConfirmationAttemptWithConfiguration:(STPPaymentConfiguration *)configuration
+                                         paymentMethodType:(NSString *)paymentMethodType {
+    NSDictionary *configurationDictionary = [self.class serializeConfiguration:configuration];
+    NSMutableDictionary *payload = [self.class commonPayload];
+    [payload addEntriesFromDictionary:@{
+                                        @"event": @"stripeios.setup_intent_confirmation",
+                                        @"payment_method_type": paymentMethodType ?: @"unknown",
+                                        @"additional_info": [self additionalInfo],
+                                        }];
+    [payload addEntriesFromDictionary:[self productUsageDictionary]];
+    [payload addEntriesFromDictionary:configurationDictionary];
+    [self logPayload:payload];
+}
+
+- (void)log3DS2AuthenticateAttemptWithConfiguration:(STPPaymentConfiguration *)configuration {
+    NSDictionary *configurationDictionary = [self.class serializeConfiguration:configuration];
+    NSMutableDictionary *payload = [self.class commonPayload];
+    [payload addEntriesFromDictionary:@{
+                                        @"event": @"stripios.3ds2_authenticate",
+                                        @"additional_info": [self additionalInfo],
+                                        }];
+    [payload addEntriesFromDictionary:[self productUsageDictionary]];
+    [payload addEntriesFromDictionary:configurationDictionary];
+    [self logPayload:payload];
+}
+
+- (void)log3DS2ChallengeFlowPresentedWithConfiguration:(STPPaymentConfiguration *)configuration {
+    NSDictionary *configurationDictionary = [self.class serializeConfiguration:configuration];
+    NSMutableDictionary *payload = [self.class commonPayload];
+    [payload addEntriesFromDictionary:@{
+                                        @"event": @"stripios.3ds2_challenge_flow_presented",
+                                        @"additional_info": [self additionalInfo],
+                                        }];
+    [payload addEntriesFromDictionary:[self productUsageDictionary]];
+    [payload addEntriesFromDictionary:configurationDictionary];
+    [self logPayload:payload];
+}
+
+- (void)log3DS2ChallengeFlowErroredWithConfiguration:(STPPaymentConfiguration *)configuration
+                                     errorDictionary:(NSDictionary *)errorDictionary {
+    NSDictionary *configurationDictionary = [self.class serializeConfiguration:configuration];
+    NSMutableDictionary *payload = [self.class commonPayload];
+    [payload addEntriesFromDictionary:@{
+                                        @"event": @"stripios.3ds2_challenge_flow_errored",
+                                        @"additional_info": [self additionalInfo],
+                                        @"error_dictionary": errorDictionary,
+                                        }];
+    [payload addEntriesFromDictionary:[self productUsageDictionary]];
+    [payload addEntriesFromDictionary:configurationDictionary];
+    [self logPayload:payload];
+}
+
 + (NSMutableDictionary *)commonPayload {
     NSMutableDictionary *payload = [NSMutableDictionary dictionary];
     payload[@"bindings_version"] = STPSDKVersion;

--- a/Stripe/STPAnalyticsClient.m
+++ b/Stripe/STPAnalyticsClient.m
@@ -267,10 +267,12 @@
 }
 
 - (void)log3DS2ChallengeFlowErroredWithConfiguration:(STPPaymentConfiguration *)configuration
+                                            intentID:(NSString *)intentID
                                      errorDictionary:(NSDictionary *)errorDictionary {
     NSDictionary *configurationDictionary = [self.class serializeConfiguration:configuration];
     NSMutableDictionary *payload = [self.class commonPayload];
     [payload addEntriesFromDictionary:@{
+                                        @"intent_id": intentID,
                                         @"event": @"stripios.3ds2_challenge_flow_errored",
                                         @"additional_info": [self additionalInfo],
                                         @"error_dictionary": errorDictionary,

--- a/Stripe/STPPaymentHandlerActionParams.h
+++ b/Stripe/STPPaymentHandlerActionParams.h
@@ -22,6 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, strong) STPAPIClient *apiClient;
 @property (nonatomic, readonly, strong) STPThreeDSCustomizationSettings *threeDSCustomizationSettings;
 @property (nonatomic, nullable, readonly) NSString *returnURLString;
+@property (nonatomic, readonly) NSString *intentStripeID;
 /// Returns the payment or setup intent's next action
 - (nullable STPIntentAction *)nextAction;
 - (void)completeWithStatus:(STPPaymentHandlerActionStatus)status error:(nullable NSError *)error;

--- a/Stripe/STPPaymentHandlerActionParams.m
+++ b/Stripe/STPPaymentHandlerActionParams.m
@@ -66,6 +66,10 @@
     return self.paymentIntent.nextAction;
 }
 
+- (NSString *)intentStripeID {
+    return self.paymentIntent.stripeId;
+}
+
 - (void)completeWithStatus:(STPPaymentHandlerActionStatus)status error:(NSError *)error {
     if (self.paymentIntent) {
         NSAssert(self.paymentIntentCompletion != nil, @"Shouldn't have a nil completion block at this point.");
@@ -131,6 +135,10 @@
 
 - (STPIntentAction *)nextAction {
     return self.setupIntent.nextAction;
+}
+
+- (NSString *)intentStripeID {
+    return self.setupIntent.stripeID;
 }
 
 - (void)completeWithStatus:(STPPaymentHandlerActionStatus)status error:(NSError *)error {


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Adds analytics for 3DS2  authenticate, challenge flow presentation, and challenge flow error
Adds analytics for SetupIntent confirm

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
MOBILE3DS2-424
Sets up tracking for issues with our 3DS2 integration.

## Testing
<!-- How was the code tested? Be as specific as possible. -->
Tested by triggering 3DS2 flows and a protocol error in Custom Integration and checking splunk for logs. Same with SetupIntent creation
