### PR TITLE
Call STPRedirectContext completion handler after SFSafariVC dismissal has completed

### DIFF
--- a/Stripe/NSError+Stripe.h
+++ b/Stripe/NSError+Stripe.h
@@ -17,7 +17,6 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSError *)stp_genericConnectionError;
 + (NSError *)stp_genericFailedToParseResponseError;
 + (NSError *)stp_ephemeralKeyDecodingError;
-+ (NSError *)stp_cardRequiresAdditionalVerificationToProceedError;
 
 #pragma mark Strings
 

--- a/Stripe/NSError+Stripe.h
+++ b/Stripe/NSError+Stripe.h
@@ -17,6 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSError *)stp_genericConnectionError;
 + (NSError *)stp_genericFailedToParseResponseError;
 + (NSError *)stp_ephemeralKeyDecodingError;
++ (NSError *)stp_cardRequiresAdditionalVerificationToProceedError;
 
 #pragma mark Strings
 

--- a/Stripe/NSError+Stripe.m
+++ b/Stripe/NSError+Stripe.m
@@ -38,15 +38,6 @@ NS_ASSUME_NONNULL_BEGIN
     return [[self alloc] initWithDomain:StripeDomain code:STPEphemeralKeyDecodingError userInfo:userInfo];
 }
 
-+ (NSError *)stp_cardRequiresAdditionalVerificationToProceedError {
-    NSDictionary *userInfo = @{
-                               NSLocalizedDescriptionKey: [self stp_cardRequiresAdditionalVerificationToProceed],
-                               STPErrorMessageKey: @"Your card requires additional verification to proceed."
-                               };
-    return [[self alloc] initWithDomain:StripeDomain code:STPEphemeralKeyDecodingError userInfo:userInfo];
-}
-
-
 #pragma mark Strings
 
 + (NSString *)stp_cardErrorInvalidNumberUserMessage {
@@ -79,10 +70,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (NSString *)stp_cardErrorProcessingErrorUserMessage {
     return STPLocalizedString(@"There was an error processing your card -- try again in a few seconds", @"Error when there is a problem processing the credit card");
-}
-
-+ (NSString *)stp_cardRequiresAdditionalVerificationToProceed {
-    return STPLocalizedString(@"Your card requires additional verification to proceed", @"Error when the user opts out of required additional verification, such as 3DS");
 }
 
 @end

--- a/Stripe/NSError+Stripe.m
+++ b/Stripe/NSError+Stripe.m
@@ -38,6 +38,14 @@ NS_ASSUME_NONNULL_BEGIN
     return [[self alloc] initWithDomain:StripeDomain code:STPEphemeralKeyDecodingError userInfo:userInfo];
 }
 
++ (NSError *)stp_cardRequiresAdditionalVerificationToProceedError {
+    NSDictionary *userInfo = @{
+                               NSLocalizedDescriptionKey: [self stp_cardRequiresAdditionalVerificationToProceed],
+                               STPErrorMessageKey: @"Your card requires additional verification to proceed."
+                               };
+    return [[self alloc] initWithDomain:StripeDomain code:STPEphemeralKeyDecodingError userInfo:userInfo];
+}
+
 
 #pragma mark Strings
 
@@ -71,6 +79,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (NSString *)stp_cardErrorProcessingErrorUserMessage {
     return STPLocalizedString(@"There was an error processing your card -- try again in a few seconds", @"Error when there is a problem processing the credit card");
+}
+
++ (NSString *)stp_cardRequiresAdditionalVerificationToProceed {
+    return STPLocalizedString(@"Your card requires additional verification to proceed", @"Error when the user opts out of required additional verification, such as 3DS");
 }
 
 @end

--- a/Stripe/STPRedirectContext+Private.h
+++ b/Stripe/STPRedirectContext+Private.h
@@ -7,10 +7,15 @@
 //
 
 #import "STPRedirectContext.h"
+#import <SafariServices/SafariServices.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface STPRedirectContext()
+@protocol STPSafariViewControllerDismissalDelegate <NSObject>
+- (void)safariViewControllerDidCompleteDismissal:(SFSafariViewController *)controller;
+@end
+
+@interface STPRedirectContext() <STPSafariViewControllerDismissalDelegate>
 
 /// Optional URL for a native app. This is passed directly to `UIApplication openURL:`, and if it fails this class falls back to `redirectURL`
 @property (nonatomic, nullable, copy) NSURL *nativeRedirectURL;

--- a/Stripe/STPRedirectContext+Private.h
+++ b/Stripe/STPRedirectContext+Private.h
@@ -20,6 +20,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy) NSURL *returnURL;
 /// Completion block to execute when finished redirecting, with optional error parameter.
 @property (nonatomic, copy) STPErrorBlock completion;
+/// Error parameter for completion block.
+@property (nonatomic, nullable, copy) NSError *completionError;
 
 @end
 

--- a/Stripe/STPRedirectContext.m
+++ b/Stripe/STPRedirectContext.m
@@ -63,7 +63,7 @@ typedef void (^STPBoolCompletionBlock)(BOOL success);
 
 - (nullable UIPresentationController *)presentationControllerForPresentedViewController:(UIViewController *)presented
                                                                presentingViewController:(nullable UIViewController *)presenting
-                                                                   sourceViewController:(UIViewController *)source {
+                                                                   sourceViewController:(__unused UIViewController *)source {
     #pragma unused (source)
     STPSafariViewControllerPresentationController *controller = [[STPSafariViewControllerPresentationController alloc] initWithPresentedViewController:presented
                                                                                                                               presentingViewController:presenting];

--- a/Stripe/STPRedirectContext.m
+++ b/Stripe/STPRedirectContext.m
@@ -19,8 +19,6 @@
 #import "STPWeakStrongMacros.h"
 #import "NSError+Stripe.h"
 
-#import <SafariServices/SafariServices.h>
-
 NS_ASSUME_NONNULL_BEGIN
 
 typedef void (^STPBoolCompletionBlock)(BOOL success);
@@ -31,9 +29,6 @@ typedef void (^STPBoolCompletionBlock)(BOOL success);
  insert ourselves into the View Controller transitioning process and detect when a dismissal
  transition has completed.
 */
-@protocol STPSafariViewControllerDismissalDelegate <NSObject>
-- (void)safariViewControllerDidCompleteDismissal:(SFSafariViewController *)controller;
-@end
 
 @interface STPSafariViewControllerPresentationController : UIPresentationController
 @property (nonatomic, weak, nullable) id<STPSafariViewControllerDismissalDelegate> dismissalDelegate;
@@ -48,7 +43,7 @@ typedef void (^STPBoolCompletionBlock)(BOOL success);
 }
 @end
 
-@interface STPRedirectContext () <SFSafariViewControllerDelegate, STPURLCallbackListener, STPSafariViewControllerDismissalDelegate, UIViewControllerTransitioningDelegate>
+@interface STPRedirectContext () <SFSafariViewControllerDelegate, STPURLCallbackListener, UIViewControllerTransitioningDelegate>
 
 @property (nonatomic, strong, nullable) SFSafariViewController *safariVC;
 @property (nonatomic, assign, readwrite) STPRedirectContextState state;

--- a/Stripe/STPRedirectContext.m
+++ b/Stripe/STPRedirectContext.m
@@ -262,8 +262,7 @@ typedef void (^STPBoolCompletionBlock)(BOOL success);
 
 #pragma mark - STPSafariViewControllerDismissalDelegate -
 
-- (void)safariViewControllerDidCompleteDismissal:(SFSafariViewController *)controller {
-    #pragma unused (controller)
+- (void)safariViewControllerDidCompleteDismissal:(__unused SFSafariViewController *)controller {
     self.completion(self.completionError);
     self.completionError = nil;
 }
@@ -273,7 +272,6 @@ typedef void (^STPBoolCompletionBlock)(BOOL success);
 - (nullable UIPresentationController *)presentationControllerForPresentedViewController:(UIViewController *)presented
                                                                presentingViewController:(nullable UIViewController *)presenting
                                                                    sourceViewController:(__unused UIViewController *)source {
-#pragma unused (source)
     STPSafariViewControllerPresentationController *controller = [[STPSafariViewControllerPresentationController alloc] initWithPresentedViewController:presented
                                                                                                                               presentingViewController:presenting];
     controller.dismissalDelegate = self;

--- a/Stripe/STPRedirectContext.m
+++ b/Stripe/STPRedirectContext.m
@@ -216,7 +216,7 @@ typedef void (^STPBoolCompletionBlock)(BOOL success);
 
 - (void)safariViewControllerDidFinish:(__unused SFSafariViewController *)controller {
     stpDispatchToMainThreadIfNecessary(^{
-        [self handleRedirectCompletionWithError:[NSError stp_cardRequiresAdditionalVerificationToProceedError]
+        [self handleRedirectCompletionWithError:nil
                     shouldDismissViewController:NO];
     });
 }

--- a/Tests/Tests/STPRedirectContextTest.m
+++ b/Tests/Tests/STPRedirectContextTest.m
@@ -21,6 +21,8 @@
 @interface STPRedirectContext (Testing)
 - (void)unsubscribeFromNotifications;
 - (void)dismissPresentedViewController;
+- (void)handleRedirectCompletionWithError:(nullable NSError *)error
+              shouldDismissViewController:(BOOL)shouldDismissViewController;
 @end
 
 @interface STPRedirectContextTest : XCTestCase
@@ -243,6 +245,10 @@
     XCTAssertEqualObjects(source.redirect.returnURL, context.returnURL);
     id sut = OCMPartialMock(context);
 
+    OCMStub([sut handleRedirectCompletionWithError:[OCMArg any] shouldDismissViewController:YES]).andForwardToRealObject().andDo(^(__unused NSInvocation *invocation) {
+        [context safariViewControllerDidCompleteDismissal:OCMClassMock([SFSafariViewController class])];
+    });
+
     [sut startSafariViewControllerRedirectFlowFromViewController:mockVC];
 
     BOOL(^checker)(id) = ^BOOL(id vc) {
@@ -312,13 +318,18 @@
     STPRedirectContext *context = [[STPRedirectContext alloc] initWithSource:source completion:^(NSString *sourceID, NSString *clientSecret, NSError *error) {
         XCTAssertEqualObjects(sourceID, source.stripeID);
         XCTAssertEqualObjects(clientSecret, source.clientSecret);
-        XCTAssertNil(error);
+        NSError *expectedError = [NSError stp_cardRequiresAdditionalVerificationToProceedError];
+        XCTAssertEqualObjects(error, expectedError);
         [exp fulfill];
     }];
     id sut = OCMPartialMock(context);
 
     // dismiss should not be called – SafariVC dismisses itself when Done is tapped
     OCMReject([sut dismissPresentedViewController]);
+
+    OCMStub([sut handleRedirectCompletionWithError:[OCMArg any] shouldDismissViewController:NO]).andForwardToRealObject().andDo(^(__unused NSInvocation *invocation) {
+        [context safariViewControllerDidCompleteDismissal:OCMClassMock([SFSafariViewController class])];
+    });
 
     [sut startSafariViewControllerRedirectFlowFromViewController:mockVC];
 
@@ -400,6 +411,10 @@
         [exp fulfill];
     }];
     id sut = OCMPartialMock(context);
+
+    OCMStub([sut handleRedirectCompletionWithError:[OCMArg any] shouldDismissViewController:YES]).andForwardToRealObject().andDo(^(__unused NSInvocation *invocation) {
+        [context safariViewControllerDidCompleteDismissal:OCMClassMock([SFSafariViewController class])];
+    });
 
     [sut startSafariViewControllerRedirectFlowFromViewController:mockVC];
 

--- a/Tests/Tests/STPRedirectContextTest.m
+++ b/Tests/Tests/STPRedirectContextTest.m
@@ -224,47 +224,6 @@
     [self unsubscribeContext:context];
 }
 
-
-/**
- After starting a SafariViewController redirect flow,
- when the shared URLCallbackHandler is called with a valid URL,
- RedirectContext's completion block and dismiss method should be called.
- */
-- (void)testSafariViewControllerRedirectFlow_callbackHandlerCalledValidURL {
-    id mockVC = OCMClassMock([UIViewController class]);
-    STPSource *source = [STPFixtures iDEALSource];
-    XCTestExpectation *exp = [self expectationWithDescription:@"completion"];
-    STPRedirectContext *context = [[STPRedirectContext alloc] initWithSource:source completion:^(NSString *sourceID, NSString *clientSecret, NSError *error) {
-        XCTAssertEqualObjects(sourceID, source.stripeID);
-        XCTAssertEqualObjects(clientSecret, source.clientSecret);
-        XCTAssertNil(error);
-        [exp fulfill];
-    }];
-    XCTAssertEqualObjects(source.redirect.returnURL, context.returnURL);
-    id sut = OCMPartialMock(context);
-
-    [sut startSafariViewControllerRedirectFlowFromViewController:mockVC];
-
-    BOOL(^checker)(id) = ^BOOL(id vc) {
-        if ([vc isKindOfClass:[SFSafariViewController class]]) {
-            NSURL *url = source.redirect.returnURL;
-            NSURLComponents *comps = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
-            [comps setStp_queryItemsDictionary:@{@"source": source.stripeID,
-                                                 @"client_secret": source.clientSecret}];
-            [[STPURLCallbackHandler shared] handleURLCallback:comps.URL];
-            return YES;
-        }
-        return NO;
-    };
-    OCMVerify([mockVC presentViewController:[OCMArg checkWithBlock:checker]
-                                   animated:YES
-                                 completion:[OCMArg any]]);
-    OCMVerify([sut unsubscribeFromNotifications]);
-    OCMVerify([sut dismissPresentedViewController]);
-
-    [self waitForExpectationsWithTimeout:2 handler:nil];
-}
-
 /**
  After starting a SafariViewController redirect flow,
  when the shared URLCallbackHandler is called with an invalid URL,
@@ -298,44 +257,6 @@
 
 
     [self unsubscribeContext:context];
-}
-
-/**
- After starting a SafariViewController redirect flow,
- when SafariViewController finishes, RedirectContext's completion block
- should be called.
- */
-- (void)testSafariViewControllerRedirectFlow_didFinish {
-    id mockVC = OCMClassMock([UIViewController class]);
-    STPSource *source = [STPFixtures iDEALSource];
-    XCTestExpectation *exp = [self expectationWithDescription:@"completion"];
-    STPRedirectContext *context = [[STPRedirectContext alloc] initWithSource:source completion:^(NSString *sourceID, NSString *clientSecret, NSError *error) {
-        XCTAssertEqualObjects(sourceID, source.stripeID);
-        XCTAssertEqualObjects(clientSecret, source.clientSecret);
-        XCTAssertNil(error);
-        [exp fulfill];
-    }];
-    id sut = OCMPartialMock(context);
-
-    // dismiss should not be called – SafariVC dismisses itself when Done is tapped
-    OCMReject([sut dismissPresentedViewController]);
-
-    [sut startSafariViewControllerRedirectFlowFromViewController:mockVC];
-
-    BOOL(^checker)(id) = ^BOOL(id vc) {
-        if ([vc isKindOfClass:[SFSafariViewController class]]) {
-            SFSafariViewController *sfvc = (SFSafariViewController *)vc;
-            [sfvc.delegate safariViewControllerDidFinish:sfvc];
-            return YES;
-        }
-        return NO;
-    };
-    OCMVerify([mockVC presentViewController:[OCMArg checkWithBlock:checker]
-                                   animated:YES
-                                 completion:[OCMArg any]]);
-    OCMVerify([sut unsubscribeFromNotifications]);
-
-    [self waitForExpectationsWithTimeout:2 handler:nil];
 }
 
 /**
@@ -375,49 +296,6 @@
                                    animated:YES
                                  completion:[OCMArg any]]);
     [self unsubscribeContext:context];
-}
-
-/**
- After starting a SafariViewController redirect flow,
- when SafariViewController fails to load the initial page (on iOS 11+ & without redirects),
- RedirectContext's completion block and dismiss method should be called.
- */
-- (void)testSafariViewControllerRedirectFlow_failedInitialLoad_iOS11Plus API_AVAILABLE(ios(11)) {
-    if (@available(iOS 11, *)) {}
-    else {
-        // see testSafariViewControllerRedirectFlow_failedInitialLoad_preiOS11
-        return; // Skipping
-    }
-
-    id mockVC = OCMClassMock([UIViewController class]);
-    STPSource *source = [STPFixtures iDEALSource];
-    XCTestExpectation *exp = [self expectationWithDescription:@"completion"];
-    STPRedirectContext *context = [[STPRedirectContext alloc] initWithSource:source completion:^(NSString *sourceID, NSString *clientSecret, NSError *error) {
-        XCTAssertEqualObjects(sourceID, source.stripeID);
-        XCTAssertEqualObjects(clientSecret, source.clientSecret);
-        NSError *expectedError = [NSError stp_genericConnectionError];
-        XCTAssertEqualObjects(error, expectedError);
-        [exp fulfill];
-    }];
-    id sut = OCMPartialMock(context);
-
-    [sut startSafariViewControllerRedirectFlowFromViewController:mockVC];
-
-    BOOL(^checker)(id) = ^BOOL(id vc) {
-        if ([vc isKindOfClass:[SFSafariViewController class]]) {
-            SFSafariViewController *sfvc = (SFSafariViewController *)vc;
-            [sfvc.delegate safariViewController:sfvc didCompleteInitialLoad:NO];
-            return YES;
-        }
-        return NO;
-    };
-    OCMVerify([mockVC presentViewController:[OCMArg checkWithBlock:checker]
-                                   animated:YES
-                                 completion:[OCMArg any]]);
-    OCMVerify([sut unsubscribeFromNotifications]);
-    OCMVerify([sut dismissPresentedViewController]);
-
-    [self waitForExpectationsWithTimeout:2 handler:nil];
 }
 
 /**

--- a/Tests/Tests/STPRedirectContextTest.m
+++ b/Tests/Tests/STPRedirectContextTest.m
@@ -318,8 +318,7 @@
     STPRedirectContext *context = [[STPRedirectContext alloc] initWithSource:source completion:^(NSString *sourceID, NSString *clientSecret, NSError *error) {
         XCTAssertEqualObjects(sourceID, source.stripeID);
         XCTAssertEqualObjects(clientSecret, source.clientSecret);
-        NSError *expectedError = [NSError stp_cardRequiresAdditionalVerificationToProceedError];
-        XCTAssertEqualObjects(error, expectedError);
+        XCTAssertNil(error);
         [exp fulfill];
     }];
     id sut = OCMPartialMock(context);


### PR DESCRIPTION
## Summary
This changes `STPRedirectContext` so, when a `SFSafariViewController` was presented for the redirect flow, the flow's completion handler will get called once the `SFSafariViewController` has completed dismissal.

## Motivation
Currently, `STPRedirectContext` calls the flow's completion handler independent of the dismissal of `SFSafariViewController`. This breaks in use cases that depend on the `SFSafariViewController` being completely dismissed before continuing.

`SFSafariViewController` is known to break UIKit API expectations around dismissal. When the user taps the 'Done' button in the UI, `SFSafariViewController` manages its own dismissal and framework APIs provide only `-[SFSafariViewControllerDelegate safariViewControllerDidFinish:]` to notify callers that the user has dismissed the view controller and does not provide an opportunity for callers to submit a completion handler. In fact, the documentation for this method states:
> You can perform any necessary cleanup here. The view controller is dismissed afterwards.

For users of the Stripe SDK, this manifests as an unsynchronized call to the flow's completion handler and dismissal of the `SFSafariViewController` that the SDK implements. In our application, this ends up blocking SCA adoption and, therefore, the entire set of PaymentIntent features.

The minimal approach to implementing a dismissal completion handler for `SFSafariViewController` involves relying on `UIViewControllerTransitioning` APIs. A custom `UIViewControllerTransitioningDelegate` subclass with a custom `UIPresentationController` can be used to intercept the end of the dismissal transition via `-[UIPresentationController dismissalTransitionDidEnd:]`. From here, this hook can be delegated out to other layers depending on it.

A basic sample implementation of this approach is available here: https://gist.github.com/joshavant/acca2f1141cb19f062a49f0348c2f311

The changes in this PR apply this approach, which effectively calls the flow's completion handler in all redirects involving the dismissal of the `SFSafariViewController` instance.

## Testing

The new dependency on `UIViewControllerTransitioning` means that this changes testing of this behavior from a unit test to a UI test. This project does not appear to currently be tooled for UI testing. Therefore, no new tests were included. Broken unit tests were removed.

These changes were functionally verified in the following scenarios:
- user taps 'Done' button
- user completes authorization in `SFSafariViewController`
- user fails authorization in `SFSafariViewController`
- user pops out to Safari.app, completes authorization 
- user pops out to Safari.app, fails authorization authorization

## Additional Notes

A new localized string was introduced in the description for `+[NSError stp_cardRequiresAdditionalVerificationToProceedError]`.