### PR TITLE
Adds support for use_stripe_sdk parameter

### DIFF
--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -383,6 +383,7 @@
 		3691EB722119111A008C49E1 /* STPCardValidator+Private.m in Sources */ = {isa = PBXBuildFile; fileRef = 3691EB702119111A008C49E1 /* STPCardValidator+Private.m */; };
 		3691EB74211A4F31008C49E1 /* STPShippingAddressViewControllerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 3691EB73211A4F31008C49E1 /* STPShippingAddressViewControllerTest.m */; };
 		36A734282121F8A700784615 /* STPCardValidator+Private.m in Sources */ = {isa = PBXBuildFile; fileRef = 3691EB702119111A008C49E1 /* STPCardValidator+Private.m */; };
+		36D4EA6122DD33DF00619BA8 /* STPSetupIntentConfirmParamsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 36D4EA6022DD33DF00619BA8 /* STPSetupIntentConfirmParamsTest.m */; };
 		36E582F722B4537B0044F82C /* Stripe3DS2.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 36E582F622B4537B0044F82C /* Stripe3DS2.framework */; };
 		36E582FA22B453C40044F82C /* Stripe3DS2.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 36E582F922B453C40044F82C /* Stripe3DS2.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		36E582FB22B4566A0044F82C /* STPPaymentHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 365BE89C2285F6080068D824 /* STPPaymentHandler.m */; };
@@ -1368,6 +1369,7 @@
 		36D153B921AE111500567EFE /* pt-BR */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "Localizations/pt-BR.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		36D153BA21AE111F00567EFE /* pt-PT */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "pt-PT"; path = "Localizations/pt-PT.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		36D153BB21AE11CF00567EFE /* sv */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = sv; path = Localizations/sv.lproj/Localizable.strings; sourceTree = "<group>"; };
+		36D4EA6022DD33DF00619BA8 /* STPSetupIntentConfirmParamsTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSetupIntentConfirmParamsTest.m; sourceTree = "<group>"; };
 		36E582F622B4537B0044F82C /* Stripe3DS2.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Stripe3DS2.framework; path = InternalFrameworks/Stripe3DS2.framework; sourceTree = "<group>"; };
 		36E582F922B453C40044F82C /* Stripe3DS2.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Stripe3DS2.framework; path = InternalFrameworks/Stripe3DS2.framework; sourceTree = "<group>"; };
 		36FA86272241710700D5B4D4 /* LocalizationTester-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "LocalizationTester-Debug.xcconfig"; sourceTree = "<group>"; };
@@ -2200,12 +2202,12 @@
 				C16F66AA1CA21BAC006A21B5 /* STPFormTextFieldTest.m */,
 				B32B176220F6D722000D6EF8 /* STPGenericStripeObjectTest.m */,
 				04827D171D257A6C002DB3E8 /* STPImageLibraryTest.m */,
+				B36C6D772193A16F00D17575 /* STPIntentActionTest.m */,
 				B3302F4B200700AB005DDBE9 /* STPLegalEntityParamsTest.m */,
 				045A62AA1B8E7259000165CE /* STPPaymentCardTextFieldTest.m */,
 				0438EF4B1B741B0100D506CC /* STPPaymentCardTextFieldViewModelTest.m */,
 				8B013C881F1E784A00DD831B /* STPPaymentConfigurationTest.m */,
 				F14C872E1D4FCDBA00C7CC6A /* STPPaymentContextApplePayTest.m */,
-				B36C6D772193A16F00D17575 /* STPIntentActionTest.m */,
 				B3BDCAD020EEF5B90034F7F5 /* STPPaymentIntentParamsTest.m */,
 				B3BDCACC20EEF4540034F7F5 /* STPPaymentIntentTest.m */,
 				B6D6C932223076600092AFC8 /* STPPaymentMethodAddressTest.m */,
@@ -2223,6 +2225,7 @@
 				C1EEDCC91CA2186300A54582 /* STPPhoneNumberValidatorTest.m */,
 				C1FEE5981CBFF24000A7632B /* STPPostalCodeValidatorTest.m */,
 				F152321A1EA92F9D00D65C67 /* STPRedirectContextTest.m */,
+				36D4EA6022DD33DF00619BA8 /* STPSetupIntentConfirmParamsTest.m */,
 				B613DD3B22C54AA800C7603F /* STPSetupIntentTest.m */,
 				3691EB73211A4F31008C49E1 /* STPShippingAddressViewControllerTest.m */,
 				8BD87B8A1EFB136F00269C2B /* STPSourceCardDetailsTest.m */,
@@ -3732,6 +3735,7 @@
 				C1EF044D1DD2397500FBF452 /* STPShippingAddressViewControllerLocalizationTests.m in Sources */,
 				C1080F4C1CBED48A007B2D89 /* STPAddressTests.m in Sources */,
 				C1C02CCE1ECCE92900DF5643 /* STPEphemeralKeyTest.m in Sources */,
+				36D4EA6122DD33DF00619BA8 /* STPSetupIntentConfirmParamsTest.m in Sources */,
 				B36C6D782193A16F00D17575 /* STPIntentActionTest.m in Sources */,
 				C14C4DB11EC3B34500C2FDF6 /* STPAPIRequestTest.m in Sources */,
 				F1D96F9B1DC7DCDE00477E64 /* STPLocalizationUtils+STPTestAdditions.m in Sources */,

--- a/Stripe/NSDictionary+Stripe.m
+++ b/Stripe/NSDictionary+Stripe.m
@@ -128,7 +128,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable NSURL *)stp_urlForKey:(NSString *)key {
     id value = self[key];
-    if (value && [value isKindOfClass:[NSString class]]) {
+    if (value && [value isKindOfClass:[NSString class]] && ((NSString *)value).length > 0) {
         return [NSURL URLWithString:value];
     }
     return nil;

--- a/Stripe/Payments/STPPaymentHandler.m
+++ b/Stripe/Payments/STPPaymentHandler.m
@@ -97,7 +97,7 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
     // We always set useStripeSDK = @YES in STPPaymentHandler
     if (!paymentParams.useStripeSDK.boolValue) {
         paymentParams = [paymentParams copy];
-        paymentParams.useStripeSDK = [NSNumber numberWithBool:YES];
+        paymentParams.useStripeSDK = @YES;
     }
     [self.apiClient confirmPaymentIntentWithParams:paymentParams
                                         completion:confirmCompletionBlock];
@@ -206,7 +206,7 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
     };
     if (!setupIntentConfirmParams.useStripeSDK.boolValue) {
         setupIntentConfirmParams = [setupIntentConfirmParams copy];
-        setupIntentConfirmParams.useStripeSDK = [NSNumber numberWithBool:YES];
+        setupIntentConfirmParams.useStripeSDK = @YES;
     }
     [self.apiClient confirmSetupIntentWithParams:setupIntentConfirmParams completion:confirmCompletionBlock];
 }

--- a/Stripe/Payments/STPPaymentHandler.m
+++ b/Stripe/Payments/STPPaymentHandler.m
@@ -94,6 +94,11 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
                                          }];
         }
     };
+    // We always set useStripeSDK = @YES in STPPaymentHandler
+    if (!paymentParams.useStripeSDK.boolValue) {
+        paymentParams = [paymentParams copy];
+        paymentParams.useStripeSDK = [NSNumber numberWithBool:YES];
+    }
     [self.apiClient confirmPaymentIntentWithParams:paymentParams
                                         completion:confirmCompletionBlock];
 }
@@ -199,6 +204,10 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
             }
         }
     };
+    if (!setupIntentConfirmParams.useStripeSDK.boolValue) {
+        setupIntentConfirmParams = [setupIntentConfirmParams copy];
+        setupIntentConfirmParams.useStripeSDK = [NSNumber numberWithBool:YES];
+    }
     [self.apiClient confirmSetupIntentWithParams:setupIntentConfirmParams completion:confirmCompletionBlock];
 }
 

--- a/Stripe/Payments/STPPaymentHandler.m
+++ b/Stripe/Payments/STPPaymentHandler.m
@@ -476,11 +476,18 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
     [[UIApplication sharedApplication] openURL:url
                                        options:@{UIApplicationOpenURLOptionUniversalLinksOnly: @(YES)}
                              completionHandler:^(BOOL success){
-                                 if(!success) {
+                                 if (!success) {
                                      // no app installed, launch safari view controller
                                      SFSafariViewController *safariViewController = [[SFSafariViewController alloc] initWithURL:url];
                                      safariViewController.delegate = self;
-                                     [[self->_currentAction.authenticationContext authenticationPresentingViewController] presentViewController:safariViewController animated:YES completion:nil];
+                                     UIViewController *presentingViewController = [self->_currentAction.authenticationContext authenticationPresentingViewController];
+
+                                     if (presentingViewController == nil || presentingViewController.view.window == nil) {
+                                         [self->_currentAction completeWithStatus:STPPaymentHandlerActionStatusFailed error:[self _errorForCode:STPPaymentHandlerRequiresAuthenticationContextErrorCode userInfo:nil]];
+                                         return;
+                                     }
+
+                                     [presentingViewController presentViewController:safariViewController animated:YES completion:nil];
                                  } else {
                                      [[NSNotificationCenter defaultCenter] addObserver:self
                                                                               selector:@selector(_handleWillForegroundNotification)

--- a/Stripe/Payments/STPPaymentHandler.m
+++ b/Stripe/Payments/STPPaymentHandler.m
@@ -94,12 +94,13 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
                                          }];
         }
     };
+    STPPaymentIntentParams *params = paymentParams;
     // We always set useStripeSDK = @YES in STPPaymentHandler
-    if (!paymentParams.useStripeSDK.boolValue) {
-        paymentParams = [paymentParams copy];
-        paymentParams.useStripeSDK = @YES;
+    if (!params.useStripeSDK.boolValue) {
+        params = [paymentParams copy];
+        params.useStripeSDK = @YES;
     }
-    [self.apiClient confirmPaymentIntentWithParams:paymentParams
+    [self.apiClient confirmPaymentIntentWithParams:params
                                         completion:confirmCompletionBlock];
 }
 
@@ -204,11 +205,12 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
             }
         }
     };
-    if (!setupIntentConfirmParams.useStripeSDK.boolValue) {
-        setupIntentConfirmParams = [setupIntentConfirmParams copy];
-        setupIntentConfirmParams.useStripeSDK = @YES;
+    STPSetupIntentConfirmParams *params = setupIntentConfirmParams;
+    if (!params.useStripeSDK.boolValue) {
+        params = [setupIntentConfirmParams copy];
+        params.useStripeSDK = @YES;
     }
-    [self.apiClient confirmSetupIntentWithParams:setupIntentConfirmParams completion:confirmCompletionBlock];
+    [self.apiClient confirmSetupIntentWithParams:params completion:confirmCompletionBlock];
 }
 
 

--- a/Stripe/PublicHeaders/STPPaymentHandler.h
+++ b/Stripe/PublicHeaders/STPPaymentHandler.h
@@ -130,7 +130,7 @@ NS_EXTENSION_UNAVAILABLE("STPPaymentHandler is not available in extensions")
  
  Call this method if you are using automatic confirmation.  @see https://stripe.com/docs/payments/payment-intents/ios
  
- @param paymentParams The params used to confirm the PaymentIntent.
+ @param paymentParams The params used to confirm the PaymentIntent. Note that use of STPPaymentHandler enforces that a useStripeSDK value of true is set during the confirm call, regardless of paymentParams.useStripeSDK value.
  @param authenticationContext The authentication context used to authenticate the payment.
  @param completion The completion block. If the status returned is `STPPaymentHandlerActionStatusSucceeded`, the PaymentIntent status will always be either STPPaymentIntentStatusSucceeded or STPPaymentIntentStatusRequiresCapture if you are using manual capture. In the latter case, capture the PaymentIntent to complete the payment.
  */
@@ -159,7 +159,7 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
  
  @see https://stripe.com/docs/payments/cards/saving-cards#saving-card-without-payment
  
- @param setupIntentConfirmParams The params used to confirm the SetupIntent.
+ @param setupIntentConfirmParams The params used to confirm the SetupIntent. Note that use of STPPaymentHandler enforces that a useStripeSDK value of true is set during the confirm call, regardless of setupIntentConfirmParams.useStripeSDK value.
  @param authenticationContext The authentication context used to authenticate the SetupIntent.
  @param completion The completion block. If the status returned is `STPPaymentHandlerActionStatusSucceeded`, the SetupIntent status will always be STPSetupIntentStatusSucceeded.
  */

--- a/Stripe/PublicHeaders/STPPaymentHandler.h
+++ b/Stripe/PublicHeaders/STPPaymentHandler.h
@@ -130,7 +130,7 @@ NS_EXTENSION_UNAVAILABLE("STPPaymentHandler is not available in extensions")
  
  Call this method if you are using automatic confirmation.  @see https://stripe.com/docs/payments/payment-intents/ios
  
- @param paymentParams The params used to confirm the PaymentIntent. Note that use of STPPaymentHandler enforces that a useStripeSDK value of true is set during the confirm call, regardless of paymentParams.useStripeSDK value.
+ @param paymentParams The params used to confirm the PaymentIntent. Note that this method overrides the value of `paymentParams.useStripeSDK` to `@YES`.
  @param authenticationContext The authentication context used to authenticate the payment.
  @param completion The completion block. If the status returned is `STPPaymentHandlerActionStatusSucceeded`, the PaymentIntent status will always be either STPPaymentIntentStatusSucceeded or STPPaymentIntentStatusRequiresCapture if you are using manual capture. In the latter case, capture the PaymentIntent to complete the payment.
  */
@@ -159,7 +159,7 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
  
  @see https://stripe.com/docs/payments/cards/saving-cards#saving-card-without-payment
  
- @param setupIntentConfirmParams The params used to confirm the SetupIntent. Note that use of STPPaymentHandler enforces that a useStripeSDK value of true is set during the confirm call, regardless of setupIntentConfirmParams.useStripeSDK value.
+ @param setupIntentConfirmParams The params used to confirm the SetupIntent. Note that this method overrides the value of `setupIntentConfirmParams.useStripeSDK` to `@YES`.
  @param authenticationContext The authentication context used to authenticate the SetupIntent.
  @param completion The completion block. If the status returned is `STPPaymentHandlerActionStatusSucceeded`, the SetupIntent status will always be STPSetupIntentStatusSucceeded.
  */

--- a/Stripe/PublicHeaders/STPPaymentIntentParams.h
+++ b/Stripe/PublicHeaders/STPPaymentIntentParams.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @see https://stripe.com/docs/api#confirm_payment_intent
  */
-@interface STPPaymentIntentParams : NSObject<STPFormEncodable>
+@interface STPPaymentIntentParams : NSObject <NSCopying, STPFormEncodable>
 
 /**
  Initialize this `STPPaymentIntentParams` with a `clientSecret`, which is the only required
@@ -105,6 +105,14 @@ NS_ASSUME_NONNULL_BEGIN
  @see STPPaymentIntentSetupFutureUsage for more details on what values you can provide.
  */
 @property (nonatomic, nullable) NSNumber *setupFutureUsage;
+
+/**
+ A boolean number to indicate whether you intend to use the Stripe SDK's functionality to handle any PaymentIntent next actions.
+ If set to false, STPPaymentIntent.nextAction will only ever contain a redirect url that can be opened in a webview or mobile browser.
+ When set to true, the nextAction may contain information that the Stripe SDK can use to perform native authentication within your
+ app.
+ */
+@property (nonatomic, nullable) NSNumber *useStripeSDK;
 
 /**
  The URL to redirect your customer back to after they authenticate or cancel

--- a/Stripe/PublicHeaders/STPSetupIntentConfirmParams.h
+++ b/Stripe/PublicHeaders/STPSetupIntentConfirmParams.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @see https://stripe.com/docs/api/setup_intents/confirm
  */
-@interface STPSetupIntentConfirmParams : NSObject <STPFormEncodable>
+@interface STPSetupIntentConfirmParams : NSObject <NSCopying, STPFormEncodable>
 
 /**
  Initialize this `STPSetupIntentParams` with a `clientSecret`.
@@ -60,6 +60,14 @@ NS_ASSUME_NONNULL_BEGIN
  This should probably be a URL that opens your iOS app.
  */
 @property (nonatomic, copy, nullable) NSString *returnURL;
+
+/**
+ A boolean number to indicate whether you intend to use the Stripe SDK's functionality to handle any SetupIntent next actions.
+ If set to false, STPSetupIntent.nextAction will only ever contain a redirect url that can be opened in a webview or mobile browser.
+ When set to true, the nextAction may contain information that the Stripe SDK can use to perform native authentication within your
+ app.
+ */
+@property (nonatomic, nullable) NSNumber *useStripeSDK;
 
 @end
 

--- a/Stripe/STPAnalyticsClient.m
+++ b/Stripe/STPAnalyticsClient.m
@@ -246,7 +246,7 @@
     NSDictionary *configurationDictionary = [self.class serializeConfiguration:configuration];
     NSMutableDictionary *payload = [self.class commonPayload];
     [payload addEntriesFromDictionary:@{
-                                        @"event": @"stripios.3ds2_authenticate",
+                                        @"event": @"stripeios.3ds2_authenticate",
                                         @"additional_info": [self additionalInfo],
                                         }];
     [payload addEntriesFromDictionary:[self productUsageDictionary]];
@@ -258,7 +258,7 @@
     NSDictionary *configurationDictionary = [self.class serializeConfiguration:configuration];
     NSMutableDictionary *payload = [self.class commonPayload];
     [payload addEntriesFromDictionary:@{
-                                        @"event": @"stripios.3ds2_challenge_flow_presented",
+                                        @"event": @"stripeios.3ds2_challenge_flow_presented",
                                         @"additional_info": [self additionalInfo],
                                         }];
     [payload addEntriesFromDictionary:[self productUsageDictionary]];
@@ -273,7 +273,7 @@
     NSMutableDictionary *payload = [self.class commonPayload];
     [payload addEntriesFromDictionary:@{
                                         @"intent_id": intentID,
-                                        @"event": @"stripios.3ds2_challenge_flow_errored",
+                                        @"event": @"stripeios.3ds2_challenge_flow_errored",
                                         @"additional_info": [self additionalInfo],
                                         @"error_dictionary": errorDictionary,
                                         }];

--- a/Stripe/STPPaymentIntentParams.m
+++ b/Stripe/STPPaymentIntentParams.m
@@ -45,6 +45,7 @@
                        [NSString stringWithFormat:@"returnURL = %@", self.returnURL],
                        [NSString stringWithFormat:@"savePaymentMethod = %@", (self.savePaymentMethod.boolValue) ? @"YES" : @"NO"],
                        [NSString stringWithFormat:@"setupFutureUsage = %@", self.setupFutureUsage],
+                       [NSString stringWithFormat:@"useStripeSDK = %@", (self.useStripeSDK.boolValue) ? @"YES" : @"NO"],
                        
                        // Source
                        [NSString stringWithFormat:@"sourceId = %@", self.sourceId],
@@ -95,6 +96,26 @@
     self.savePaymentMethod = saveSourceToCustomer;
 }
 
+#pragma mark - NSCopying
+
+- (instancetype)copyWithZone:(NSZone *)zone {
+    __typeof(self) copy = [[[self class] allocWithZone:zone] init];
+
+    copy.clientSecret = self.clientSecret;
+    copy.paymentMethodParams = self.paymentMethodParams;
+    copy.paymentMethodId = self.paymentMethodId;
+    copy.sourceParams = self.sourceParams;
+    copy.sourceId = self.sourceId;
+    copy.receiptEmail = self.receiptEmail;
+    copy.savePaymentMethod = self.savePaymentMethod;
+    copy.returnURL = self.returnURL;
+    copy.setupFutureUsage = self.setupFutureUsage;
+    copy.useStripeSDK = self.useStripeSDK;
+    copy.additionalAPIParameters = self.additionalAPIParameters;
+
+    return copy;
+}
+
 #pragma mark - STPFormEncodable
 
 + (nullable NSString *)rootObjectName {
@@ -112,6 +133,7 @@
              NSStringFromSelector(@selector(receiptEmail)): @"receipt_email",
              NSStringFromSelector(@selector(savePaymentMethod)): @"save_payment_method",
              NSStringFromSelector(@selector(returnURL)): @"return_url",
+             NSStringFromSelector(@selector(useStripeSDK)) : @"use_stripe_sdk",
              };
 }
 

--- a/Stripe/STPSetupIntentConfirmParams.m
+++ b/Stripe/STPSetupIntentConfirmParams.m
@@ -12,6 +12,11 @@
 
 @synthesize additionalAPIParameters = _additionalAPIParameters;
 
+- (instancetype)init {
+    // Not a valid clientSecret, but at least it'll be non-null
+    return [self initWithClientSecret:@""];
+}
+
 - (instancetype)initWithClientSecret:(NSString *)clientSecret {
     self = [super init];
     if (self) {
@@ -31,12 +36,28 @@
                        [NSString stringWithFormat:@"returnURL = %@", self.returnURL],
                        [NSString stringWithFormat:@"paymentMethodId = %@", self.paymentMethodID],
                        [NSString stringWithFormat:@"paymentMethodParams = %@", self.paymentMethodParams],
+                       [NSString stringWithFormat:@"useStripeSDK = %@", self.useStripeSDK],
                        
                        // Additional params set by app
                        [NSString stringWithFormat:@"additionalAPIParameters = %@", self.additionalAPIParameters],
                        ];
     
     return [NSString stringWithFormat:@"<%@>", [props componentsJoinedByString:@"; "]];
+}
+
+#pragma mark - NSCopying
+
+- (instancetype)copyWithZone:(NSZone *)zone {
+    __typeof(self) copy = [[[self class] allocWithZone:zone] init];
+
+    copy.clientSecret = self.clientSecret;
+    copy.paymentMethodParams = self.paymentMethodParams;
+    copy.paymentMethodID = self.paymentMethodID;
+    copy.returnURL = self.returnURL;
+    copy.useStripeSDK = self.useStripeSDK;
+    copy.additionalAPIParameters = self.additionalAPIParameters;
+
+    return copy;
 }
 
 #pragma mark - STPFormEncodable
@@ -51,6 +72,7 @@
              NSStringFromSelector(@selector(paymentMethodParams)): @"payment_method_data",
              NSStringFromSelector(@selector(paymentMethodID)): @"payment_method",
              NSStringFromSelector(@selector(returnURL)): @"return_url",
+             NSStringFromSelector(@selector(useStripeSDK)): @"use_stripe_sdk",
              };
 }
 

--- a/Tests/Tests/STPPaymentIntentParamsTest.m
+++ b/Tests/Tests/STPPaymentIntentParamsTest.m
@@ -8,6 +8,7 @@
 
 #import <XCTest/XCTest.h>
 #import "STPPaymentIntentParams.h"
+#import "STPPaymentmethodParams.h"
 
 @interface STPPaymentIntentParamsTest : XCTestCase
 
@@ -36,6 +37,7 @@
         XCTAssertNil(params.savePaymentMethod);
         XCTAssertNil(params.returnURL);
         XCTAssertNil(params.setupFutureUsage);
+        XCTAssertNil(params.useStripeSDK);
     }
 }
 
@@ -99,6 +101,31 @@
     }
 
     XCTAssertEqual([[mapping allValues] count], [[NSSet setWithArray:[mapping allValues]] count]);
+}
+
+- (void)testCopy {
+    STPPaymentIntentParams *params = [[STPPaymentIntentParams alloc] initWithClientSecret:@"test_client_secret"];
+    params.paymentMethodParams = [[STPPaymentMethodParams alloc] init];
+    params.paymentMethodId = @"test_payment_method_id";
+    params.savePaymentMethod = @YES;
+    params.returnURL = @"fake://testing_only";
+    params.setupFutureUsage = @(1);
+    params.useStripeSDK = @YES;
+    params.additionalAPIParameters = @{@"other_param" : @"other_value"};
+
+    STPPaymentIntentParams *paramsCopy = [params copy];
+    XCTAssertEqualObjects(params.clientSecret, paramsCopy.clientSecret);
+    XCTAssertEqualObjects(params.paymentMethodId, paramsCopy.paymentMethodId);
+
+    // assert equal, not equal objects, because this is a shallow copy
+    XCTAssertEqual(params.paymentMethodParams, paramsCopy.paymentMethodParams);
+
+    XCTAssertEqualObjects(params.savePaymentMethod, paramsCopy.savePaymentMethod);
+    XCTAssertEqualObjects(params.returnURL, paramsCopy.returnURL);
+    XCTAssertEqualObjects(params.useStripeSDK, paramsCopy.useStripeSDK);
+    XCTAssertEqualObjects(params.additionalAPIParameters, paramsCopy.additionalAPIParameters);
+
+
 }
 
 @end

--- a/Tests/Tests/STPSetupIntentConfirmParamsTest.m
+++ b/Tests/Tests/STPSetupIntentConfirmParamsTest.m
@@ -1,0 +1,87 @@
+//
+//  STPSetupIntentConfirmParamsTest.m
+//  StripeiOS Tests
+//
+//  Created by Cameron Sabol on 7/15/19.
+//  Copyright © 2019 Stripe, Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "STPSetupIntentConfirmParams.h"
+
+#import "STPPaymentMethodParams.h"
+
+@interface STPSetupIntentConfirmParamsTest : XCTestCase
+
+@end
+
+@implementation STPSetupIntentConfirmParamsTest
+
+- (void)testInit {
+    for (STPSetupIntentConfirmParams *params in @[[[STPSetupIntentConfirmParams alloc] initWithClientSecret:@"secret"],
+                                             [[STPSetupIntentConfirmParams alloc] init],
+                                             [STPSetupIntentConfirmParams new],
+                                             ]) {
+        XCTAssertNotNil(params);
+        XCTAssertNotNil(params.clientSecret);
+        XCTAssertNotNil(params.additionalAPIParameters);
+        XCTAssertEqual(params.additionalAPIParameters.count, 0UL);
+        XCTAssertNil(params.paymentMethodID);
+        XCTAssertNil(params.returnURL);
+        XCTAssertNil(params.useStripeSDK);
+    }
+}
+
+- (void)testDescription {
+    STPSetupIntentConfirmParams *params = [[STPSetupIntentConfirmParams alloc] init];
+    XCTAssertNotNil(params.description);
+}
+
+#pragma mark STPFormEncodable Tests
+
+- (void)testRootObjectName {
+    XCTAssertNil([STPSetupIntentConfirmParams rootObjectName]);
+}
+
+- (void)testPropertyNamesToFormFieldNamesMapping {
+    STPSetupIntentConfirmParams *params = [STPSetupIntentConfirmParams new];
+
+    NSDictionary *mapping = [STPSetupIntentConfirmParams propertyNamesToFormFieldNamesMapping];
+
+    for (NSString *propertyName in [mapping allKeys]) {
+        XCTAssertFalse([propertyName containsString:@":"]);
+        XCTAssert([params respondsToSelector:NSSelectorFromString(propertyName)]);
+    }
+
+    for (NSString *formFieldName in [mapping allValues]) {
+        XCTAssert([formFieldName isKindOfClass:[NSString class]]);
+        XCTAssert([formFieldName length] > 0);
+    }
+
+    XCTAssertEqual([[mapping allValues] count], [[NSSet setWithArray:[mapping allValues]] count]);
+}
+
+- (void)testCopy {
+    STPSetupIntentConfirmParams *params = [[STPSetupIntentConfirmParams alloc] initWithClientSecret:@"test_client_secret"];
+    params.paymentMethodParams = [[STPPaymentMethodParams alloc] init];
+    params.paymentMethodID = @"test_payment_method_id";
+    params.returnURL = @"fake://testing_only";
+    params.useStripeSDK = @YES;
+    params.additionalAPIParameters = @{@"other_param" : @"other_value"};
+
+    STPSetupIntentConfirmParams *paramsCopy = [params copy];
+    XCTAssertEqualObjects(params.clientSecret, paramsCopy.clientSecret);
+    XCTAssertEqualObjects(params.paymentMethodID, paramsCopy.paymentMethodID);
+
+    // assert equal, not equal objects, because this is a shallow copy
+    XCTAssertEqual(params.paymentMethodParams, paramsCopy.paymentMethodParams);
+
+    XCTAssertEqualObjects(params.returnURL, paramsCopy.returnURL);
+    XCTAssertEqualObjects(params.useStripeSDK, paramsCopy.useStripeSDK);
+    XCTAssertEqualObjects(params.additionalAPIParameters, paramsCopy.additionalAPIParameters);
+
+
+}
+
+@end


### PR DESCRIPTION
## Summary
Also fixes some analytics typos and adds unit testing for STPSetupIntentConfirmParams

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Required for manual confirmation flows with 3DS2 + return_url.

## Testing
<!-- How was the code tested? Be as specific as possible. -->
Unit tests. End-to-end tests waiting on server change
