### PR TITLE
Remove unused STPPRedirect* code, 

### DIFF
--- a/Example/Custom Integration/BrowseExamplesViewController.h
+++ b/Example/Custom Integration/BrowseExamplesViewController.h
@@ -16,7 +16,6 @@ typedef NS_ENUM(NSInteger, STPBackendResult) {
 
 typedef void (^STPPaymentIntentCreationHandler)(STPBackendResult status, NSString *clientSecret, NSError *error);
 typedef void (^STPPaymentIntentCreateAndConfirmHandler)(STPBackendResult status, NSString *clientSecret, NSError *error);
-typedef void (^STPRedirectCompletionHandler)(STPPaymentIntent *retrievedIntent, NSError *error);
 typedef void (^STPConfirmPaymentIntentCompletionHandler)(STPBackendResult status, NSString *clientSecret, NSError *error);
 typedef void (^STPCreateSetupIntentCompletionHandler)(STPBackendResult status, NSString *clientSecret, NSError *error);
 

--- a/Example/Custom Integration/BrowseExamplesViewController.m
+++ b/Example/Custom Integration/BrowseExamplesViewController.m
@@ -23,9 +23,7 @@
 @interface BrowseExamplesViewController () <ExampleViewControllerDelegate>
 @end
 
-@implementation BrowseExamplesViewController {
-    STPRedirectContext *_redirectContext;
-}
+@implementation BrowseExamplesViewController
 
 - (void)viewDidLoad {
     [super viewDidLoad];

--- a/Example/Custom Integration/CardAutomaticConfirmationViewController.m
+++ b/Example/Custom Integration/CardAutomaticConfirmationViewController.m
@@ -17,8 +17,8 @@
  1. Collect user's card information via `STPPaymentCardTextField`
  2. Create a `PaymentIntent` on our backend (this can happen concurrently with #1)
  3. Confirm PaymentIntent using the `STPPaymentMethodParams` for the user's card information.
- 4. If the user needs to go through the 3D Secure authentication flow, use `STPRedirectContext` to do so.
- 5. When user returns to the app, or finishes the SafariVC redirect flow, `STPRedirectContext` notifies via callback
+ 4. If the user needs to go through the 3D Secure authentication flow, use `STPPaymentHandler` to do so.
+ 5. When user finishes native authentication, returns to the app, or finishes the SafariVC redirect flow, `STPPaymentHandler` notifies via callback
 
  See the documentation at https://stripe.com/docs/payments/payment-intents/ios for more information
  on using PaymentIntents for dynamic authentication.

--- a/Example/Standard Integration/CheckoutViewController.swift
+++ b/Example/Standard Integration/CheckoutViewController.swift
@@ -58,8 +58,6 @@ class CheckoutViewController: UIViewController, STPPaymentContextDelegate, STPAu
         }
     }
     
-    private var redirectContext: STPRedirectContext?
-
     init(products: [Product], settings: Settings) {
 
         let stripePublishableKey = self.stripePublishableKey

--- a/Stripe/Payments/STPPaymentHandler.m
+++ b/Stripe/Payments/STPPaymentHandler.m
@@ -340,11 +340,9 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
             NSURL *url = authenticationAction.redirectToURL.url;
             NSURL *returnURL = authenticationAction.redirectToURL.returnURL;
             [self _handleRedirectToURL:url withReturnURL:returnURL];
-        }
             break;
-
+        }
         case STPIntentActionTypeUseStripeSDK:
-
             switch (authenticationAction.useStripeSDK.type) {
                 case STPIntentActionUseStripeSDKTypeUnknown:
                     [_currentAction completeWithStatus:STPPaymentHandlerActionStatusFailed error:[self _errorForCode:STPPaymentHandlerUnsupportedAuthenticationErrorCode userInfo:@{@"STPIntentActionUseStripeSDK": authenticationAction.useStripeSDK.description}]];

--- a/Stripe/PublicHeaders/STPAPIClient.h
+++ b/Stripe/PublicHeaders/STPAPIClient.h
@@ -369,7 +369,9 @@ static NSString *const STPSDKVersion = @"15.0.1";
  At a minimum, the params object must include the `clientSecret`.
 
  @see https://stripe.com/docs/api#confirm_payment_intent
-
+ 
+ @note Use the `confirmPayment:withAuthenticationContext:completion:` method on `STPPaymentHandler` instead
+ of calling this method directly. It handles any authentication necessary for you. @see https://stripe.com/docs/mobile/ios/authentication
  @param paymentIntentParams  The `STPPaymentIntentParams` to pass to `/confirm`
  @param completion           The callback to run with the returned PaymentIntent object, or an error.
  */
@@ -400,7 +402,9 @@ static NSString *const STPSDKVersion = @"15.0.1";
  At a minimum, the params object must include the `clientSecret`.
  
  @see https://stripe.com/docs/api/setup_intents/confirm
- 
+
+ @note Use the `confirmSetupIntent:withAuthenticationContext:completion:` method on `STPPaymentHandler` instead
+ of calling this method directly. It handles any authentication necessary for you. @see https://stripe.com/docs/mobile/ios/authentication
  @param setupIntentParams    The `STPSetupIntentParams` to pass to `/confirm`
  @param completion           The callback to run with the returned PaymentIntent object, or an error.
  */

--- a/Stripe/PublicHeaders/STPIntentAction.h
+++ b/Stripe/PublicHeaders/STPIntentAction.h
@@ -31,13 +31,12 @@ typedef NS_ENUM(NSUInteger, STPIntentActionType)  {
     
     /**
      The payment intent needs to be authorized by the user. We provide
-     `STPRedirectContext` to handle the url redirections necessary.
+     `STPPaymentHandler` to handle the url redirections necessary.
      */
     STPIntentActionTypeRedirectToURL,
     
     /**
-     The payment intent requires additional action that is handled by the
-     Stripe SDK.
+     The payment intent requires additional action handled by `STPPaymentHandler`.
      */
     STPIntentActionTypeUseStripeSDK,
     


### PR DESCRIPTION
## Summary
* Remove unused STPPRedirect* code / reworks comments
* Redirects users to `STPPaymentHandler` in the `confirm*Intent` method docstrings