### PR TITLE
Show backend errors in custom example

### DIFF
--- a/Example/Custom Integration/BrowseExamplesViewController.m
+++ b/Example/Custom Integration/BrowseExamplesViewController.m
@@ -161,9 +161,10 @@
                                                       completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
                                                           NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
                                                           if (!error && httpResponse.statusCode != 200) {
+                                                              NSString *errorMessage = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] ?: @"There was an error connecting to your payment backend.";
                                                               error = [NSError errorWithDomain:StripeDomain
                                                                                           code:STPInvalidRequestError
-                                                                                      userInfo:@{NSLocalizedDescriptionKey: @"There was an error connecting to your payment backend."}];
+                                                                                      userInfo:@{NSLocalizedDescriptionKey: errorMessage}];
                                                           }
                                                           if (error || data == nil) {
                                                               [self _callOnMainThread:^{ completion(STPBackendResultFailure, nil, error); }];
@@ -218,9 +219,10 @@
                                                       completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
                                                           NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
                                                           if (!error && httpResponse.statusCode != 200) {
+                                                              NSString *errorMessage = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] ?: @"There was an error connecting to your payment backend.";
                                                               error = [NSError errorWithDomain:StripeDomain
                                                                                           code:STPInvalidRequestError
-                                                                                      userInfo:@{NSLocalizedDescriptionKey: @"There was an error connecting to your payment backend."}];
+                                                                                      userInfo:@{NSLocalizedDescriptionKey: errorMessage}];
                                                           }
                                                           if (error) {
                                                               [self _callOnMainThread:^{ completion(STPBackendResultFailure, nil, error); }];
@@ -271,9 +273,10 @@
                                                       completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
                                                           NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
                                                           if (!error && httpResponse.statusCode != 200) {
+                                                              NSString *errorMessage = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] ?: @"There was an error connecting to your payment backend.";
                                                               error = [NSError errorWithDomain:StripeDomain
                                                                                           code:STPInvalidRequestError
-                                                                                      userInfo:@{NSLocalizedDescriptionKey: @"There was an error connecting to your payment backend."}];
+                                                                                      userInfo:@{NSLocalizedDescriptionKey: errorMessage}];
                                                           }
                                                           if (error || data == nil) {
                                                               [self _callOnMainThread:^{ completion(STPBackendResultFailure, nil, error); }];
@@ -337,9 +340,10 @@
                                                       completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
                                                           NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
                                                           if (!error && httpResponse.statusCode != 200) {
+                                                              NSString *errorMessage = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] ?: @"There was an error connecting to your payment backend.";
                                                               error = [NSError errorWithDomain:StripeDomain
                                                                                           code:STPInvalidRequestError
-                                                                                      userInfo:@{NSLocalizedDescriptionKey: @"There was an error connecting to your payment backend."}];
+                                                                                      userInfo:@{NSLocalizedDescriptionKey: errorMessage}];
                                                           }
                                                           if (error || data == nil) {
                                                               [self _callOnMainThread:^{ completion(STPBackendResultFailure, nil, error); }];

--- a/Stripe/Payments/STPPaymentHandler.m
+++ b/Stripe/Payments/STPPaymentHandler.m
@@ -340,7 +340,7 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
            [action completeWithStatus:STPPaymentHandlerActionStatusFailed error:[self _errorForCode:STPPaymentHandlerIntentStatusErrorCode userInfo:@{@"STPSetupIntent": setupIntent.description}]];
         case STPSetupIntentStatusRequiresPaymentMethod:
             // If the user forgot to attach a PaymentMethod, they get an error before this point.
-            // If authentication fails, the SetupIntent transitions to this state.
+            // If authentication fails, or the card is declined, the SetupIntent transitions to this state.
             [action completeWithStatus:STPPaymentHandlerActionStatusFailed error:[self _errorForCode:STPPaymentHandlerNotAuthenticatedErrorCode userInfo:nil]];
             break;
         case STPSetupIntentStatusRequiresConfirmation:
@@ -377,7 +377,7 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
 
         case STPPaymentIntentStatusRequiresPaymentMethod:
             // If the user forgot to attach a PaymentMethod, they get an error before this point.
-            // If authentication fails, the PaymentIntent transitions to this state.
+            // If authentication fails, or the card is declined, the PaymentIntent transitions to this state.
             [action completeWithStatus:STPPaymentHandlerActionStatusFailed error:[self _errorForCode:STPPaymentHandlerNotAuthenticatedErrorCode userInfo:nil]];
             break;
         case STPPaymentIntentStatusRequiresConfirmation:


### PR DESCRIPTION
## Summary
* Show backend errors in custom example
* Card declining after authentication succeeds also results in intent status `.requiresPaymentMethod`, but the default error we supply is `STPPaymentHandlerNotAuthenticatedErrorCode` which isn't totally accurate.  I don't see how we can distinguish that case without looking at the PaymentIntent's `last_payment_error`.  I've just commented in the `.m` for now.  

## Motivation

## Testing
Manually tested test cards