### PR TITLE
Remove development team from project file

### DIFF
--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -3295,7 +3295,6 @@
 					};
 					04CDB4411A5F2E1800B854EE = {
 						CreatedOnToolsVersion = 6.1.1;
-						DevelopmentTeam = Y28TH9SHX7;
 					};
 					3650AA3D21C07E3C002B0893 = {
 						CreatedOnToolsVersion = 9.4.1;
@@ -4185,6 +4184,7 @@
 			baseConfigurationReference = 04F39F101AEF2AFE005B926E /* StripeiOS-Debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = "";
 			};
 			name = Debug;
 		};
@@ -4193,6 +4193,7 @@
 			baseConfigurationReference = 04F39F111AEF2AFE005B926E /* StripeiOS-Release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = "";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
## Summary
It appears that the team information is still in the Xcode project causing the framework to not build when testing on device. This is similar to #1172 and #1157.

## Motivation
With a team selected, Xcode tries to code sign the framework. While the framework builds fine when embedded in a project, it won't build when targeting a device for testing.

## Testing
Tested locally.