### PR TITLE
Let users set a default payment option for Standard Integration

### DIFF
--- a/Stripe/PublicHeaders/STPPaymentContext.h
+++ b/Stripe/PublicHeaders/STPPaymentContext.h
@@ -137,6 +137,13 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) BOOL loading;
 
 /**
+ The Stripe ID of a payment method to display as the default pre-selected option.
+ 
+ Customer doesn't have a default payment method property, but you can store one (in its metadata, for example) and set this property accordingly.
+ */
+@property (nonatomic, copy, nullable) NSString *defaultPaymentMethod;
+
+/**
  The user's currently selected payment option. May be nil.
  */
 @property (nonatomic, readonly, nullable) id<STPPaymentOption> selectedPaymentOption;

--- a/Stripe/PublicHeaders/STPPaymentOptionsViewController.h
+++ b/Stripe/PublicHeaders/STPPaymentOptionsViewController.h
@@ -102,6 +102,16 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) STPUserInformation *prefilledInformation;
 
 /**
+ The Stripe ID of a payment method to display as the default pre-selected option.
+ 
+ Customer doesn't have a default payment method property, but you can store one
+ (in its metadata, for example) and set this property accordingly.
+
+ @note Setting this after the view controller's view has loaded has no effect.
+ */
+@property (nonatomic, copy, nullable) NSString *defaultPaymentMethod;
+
+/**
  A view that will be placed as the footer of the view controller when it is
  showing a list of saved payment methods to select from.
 

--- a/Stripe/STPPaymentContext.m
+++ b/Stripe/STPPaymentContext.m
@@ -157,7 +157,7 @@ typedef NS_ENUM(NSUInteger, STPPaymentContextState) {
                         [self.loadingPromise fail:error];
                         return;
                     }
-                    STPPaymentOptionTuple *paymentTuple = [STPPaymentOptionTuple tupleFilteredForUIWithPaymentMethods:paymentMethods configuration:self.configuration];
+                    STPPaymentOptionTuple *paymentTuple = [STPPaymentOptionTuple tupleFilteredForUIWithPaymentMethods:paymentMethods selectedPaymentMethod:self.defaultPaymentMethod configuration:self.configuration];
                     [self.loadingPromise succeed:paymentTuple];
                 });
             }];
@@ -303,6 +303,7 @@ typedef NS_ENUM(NSUInteger, STPPaymentContextState) {
             STPPaymentOptionsViewController *paymentOptionsViewController = [[STPPaymentOptionsViewController alloc] initWithPaymentContext:self];
             self.paymentOptionsViewController = paymentOptionsViewController;
             paymentOptionsViewController.prefilledInformation = self.prefilledInformation;
+            paymentOptionsViewController.defaultPaymentMethod = self.defaultPaymentMethod;
             paymentOptionsViewController.paymentOptionsViewControllerFooterView = self.paymentOptionsViewControllerFooterView;
             paymentOptionsViewController.addCardViewControllerFooterView = self.addCardViewControllerFooterView;
             if (@available(iOS 11, *)) {
@@ -340,6 +341,7 @@ typedef NS_ENUM(NSUInteger, STPPaymentContextState) {
             STPPaymentOptionsViewController *paymentOptionsViewController = [[STPPaymentOptionsViewController alloc] initWithPaymentContext:self];
             self.paymentOptionsViewController = paymentOptionsViewController;
             paymentOptionsViewController.prefilledInformation = self.prefilledInformation;
+            paymentOptionsViewController.defaultPaymentMethod = self.defaultPaymentMethod;
             paymentOptionsViewController.paymentOptionsViewControllerFooterView = self.paymentOptionsViewControllerFooterView;
             paymentOptionsViewController.addCardViewControllerFooterView = self.addCardViewControllerFooterView;
             if (@available(iOS 11, *)) {

--- a/Stripe/STPPaymentOptionTuple.h
+++ b/Stripe/STPPaymentOptionTuple.h
@@ -30,6 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
  @return A new tuple ready to be used by the SDK's UI elements
  */
 + (instancetype)tupleFilteredForUIWithPaymentMethods:(NSArray<STPPaymentMethod *> *)paymentMethods
+                               selectedPaymentMethod:(nullable NSString *)selectedPaymentMethod
                                        configuration:(STPPaymentConfiguration *)configuration;
 
 @property (nonatomic, nullable, readonly) id<STPPaymentOption> selectedPaymentOption;

--- a/Stripe/STPPaymentOptionTuple.m
+++ b/Stripe/STPPaymentOptionTuple.m
@@ -50,16 +50,21 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 + (instancetype)tupleFilteredForUIWithPaymentMethods:(NSArray<STPPaymentMethod *> *)paymentMethods
+                               selectedPaymentMethod:(nullable NSString *)selectedPaymentMethodID
                                        configuration:(STPPaymentConfiguration *)configuration {
     NSMutableArray *paymentOptions = [NSMutableArray new];
+    STPPaymentMethod *selectedPaymentMethod = nil;
     for (STPPaymentMethod *paymentMethod in paymentMethods) {
         if (paymentMethod.type == STPPaymentMethodTypeCard) {
             [paymentOptions addObject:paymentMethod];
+            if ([paymentMethod.stripeId isEqualToString:selectedPaymentMethodID]) {
+                selectedPaymentMethod = paymentMethod;
+            }
         }
     }
 
     return [[self class] tupleWithPaymentOptions:paymentOptions
-                                    selectedPaymentOption:nil
+                                    selectedPaymentOption:selectedPaymentMethod
                                         addApplePayOption:configuration.applePayEnabled];
 }
 

--- a/Stripe/STPPaymentOptionsViewController.m
+++ b/Stripe/STPPaymentOptionsViewController.m
@@ -39,7 +39,6 @@
 @property (nonatomic) STPPromise<STPPaymentOptionTuple *> *loadingPromise;
 @property (nonatomic, weak) STPPaymentActivityIndicatorView *activityIndicator;
 @property (nonatomic, weak) UIViewController *internalViewController;
-@property (nonatomic) BOOL loading;
 
 @end
 
@@ -151,9 +150,7 @@
         }];
         [self.navigationItem setRightBarButtonItem:internal.stp_navigationItemProxy.rightBarButtonItem animated:YES];
         self.internalViewController = internal;
-        self.loading = NO;
     }];
-    self.loading = YES;
 }
 
 - (void)viewDidLayoutSubviews {

--- a/Stripe/STPPaymentOptionsViewController.m
+++ b/Stripe/STPPaymentOptionsViewController.m
@@ -82,7 +82,7 @@
             if (error) {
                 [promise fail:error];
             } else {
-                STPPaymentOptionTuple *paymentTuple = [STPPaymentOptionTuple tupleFilteredForUIWithPaymentMethods:paymentMethods configuration:configuration];
+                STPPaymentOptionTuple *paymentTuple = [STPPaymentOptionTuple tupleFilteredForUIWithPaymentMethods:paymentMethods selectedPaymentMethod:self.defaultPaymentMethod configuration:configuration];
                 [promise succeed:paymentTuple];
             }
         });
@@ -151,6 +151,7 @@
         }];
         [self.navigationItem setRightBarButtonItem:internal.stp_navigationItemProxy.rightBarButtonItem animated:YES];
         self.internalViewController = internal;
+        self.loading = NO;
     }];
     self.loading = YES;
 }


### PR DESCRIPTION
## Summary
Adds `defaultPaymentMethod` property to `STPPaymentContext` and `STPPaymentOptionsViewController`.  

## Motivation
https://github.com/stripe/stripe-ios/issues/1245

## Testing
Manually tested setting and not setting the property.
