### PR TITLE
ApplePay support in STPPaymentHandler, STPPaymentContext

### DIFF
--- a/Example/Custom Integration/ApplePayExampleViewController.m
+++ b/Example/Custom Integration/ApplePayExampleViewController.m
@@ -19,11 +19,12 @@
  that address. After the user submits their information, we create a token using the authorized PKPayment,
  and then send it to our backend to create the charge request.
  */
-@interface ApplePayExampleViewController () <PKPaymentAuthorizationViewControllerDelegate>
+@interface ApplePayExampleViewController () <PKPaymentAuthorizationViewControllerDelegate, STPAuthenticationContext>
 @property (nonatomic) ShippingManager *shippingManager;
 @property (nonatomic, weak) UIButton *payButton;
 @property (nonatomic) BOOL applePaySucceeded;
 @property (nonatomic) NSError *applePayError;
+@property (nonatomic) PKPaymentAuthorizationViewController *applePayVC;
 @end
 
 @implementation ApplePayExampleViewController
@@ -79,10 +80,11 @@
 
     PKPaymentRequest *paymentRequest = [self buildPaymentRequest];
     if ([Stripe canSubmitPaymentRequest:paymentRequest]) {
-        PKPaymentAuthorizationViewController *auth = [[PKPaymentAuthorizationViewController alloc] initWithPaymentRequest:paymentRequest];
-        auth.delegate = self;
-        if (auth) {
-            [self presentViewController:auth animated:YES completion:nil];
+        self.applePayVC = [[PKPaymentAuthorizationViewController alloc] initWithPaymentRequest:paymentRequest];
+        self.applePayVC.delegate = self;
+        
+        if (self.applePayVC) {
+            [self presentViewController:self.applePayVC animated:YES completion:nil];
         } else {
             NSLog(@"Apple Pay returned a nil PKPaymentAuthorizationViewController - make sure you've configured Apple Pay correctly, as outlined at https://stripe.com/docs/mobile/apple-pay");
         }
@@ -118,66 +120,115 @@
 - (void)paymentAuthorizationViewController:(PKPaymentAuthorizationViewController *)controller
                        didAuthorizePayment:(PKPayment *)payment
                                 completion:(void (^)(PKPaymentAuthorizationStatus))completion {
-    [[STPAPIClient sharedClient] createTokenWithPayment:payment
-                                             completion:^(STPToken *token, NSError *error) {
-                                                 if (error) {
-                                                     self.applePayError = error;
-                                                     completion(PKPaymentAuthorizationStatusFailure);
-                                                 } else {
-                                                     // We could also send the token.stripeID to our backend to create
-                                                     // a payment method and subsequent payment intent
-                                                     [self _createPaymentMethodForApplePayToken:token completion:completion];
-                                                 }
-                                             }];
-}
-
-- (void)_createPaymentMethodForApplePayToken:(STPToken *)token completion:(void (^)(PKPaymentAuthorizationStatus))completion {
-    STPPaymentMethodCardParams *applePayParams = [[STPPaymentMethodCardParams alloc] init];
-    applePayParams.token = token.stripeID;
-    STPPaymentMethodParams *paymentMethodParams = [STPPaymentMethodParams paramsWithCard:applePayParams
-                                                                          billingDetails:nil
-                                                                                metadata:nil];
-
-    [[STPAPIClient sharedClient] createPaymentMethodWithParams:paymentMethodParams
-                                                    completion:^(STPPaymentMethod * _Nullable paymentMethod, NSError * _Nullable error) {
-                                                        if (error) {
-                                                            self.applePayError = error;
-                                                            completion(PKPaymentAuthorizationStatusFailure);
-                                                        } else {
-                                                            [self _createAndConfirmPaymentIntentWithPaymentMethod:paymentMethod
-                                                                                                       completion:completion];
-                                                        }
-                                                    }];
+    [[STPAPIClient sharedClient] createPaymentMethodWithPayment:payment completion:^(STPPaymentMethod *paymentMethod, NSError *error) {
+        if (error) {
+            self.applePayError = error;
+            completion(PKPaymentAuthorizationStatusFailure);
+        } else {
+            // We could also send the token.stripeID to our backend to create
+            // a payment method and subsequent payment intent
+            [self _createAndConfirmPaymentIntentWithPaymentMethod:paymentMethod
+                                                       completion:completion];
+        }
+    }];
 }
 
 - (void)_createAndConfirmPaymentIntentWithPaymentMethod:(STPPaymentMethod *)paymentMethod completion:(void (^)(PKPaymentAuthorizationStatus))completion {
+    void (^reconfirmPaymentIntent)(STPPaymentIntent *) = ^(STPPaymentIntent *paymentIntent) {
+        [self.delegate confirmPaymentIntent:paymentIntent completion:^(STPBackendResult status, NSString *clientSecret, NSError *error) {
+            if (status == STPBackendResultFailure || error) {
+                self.applePayError = error;
+                self.applePayVC ? completion(PKPaymentAuthorizationStatusFailure) : [self _finish];
+                return;
+            }
+            [[STPAPIClient sharedClient] retrievePaymentIntentWithClientSecret:clientSecret completion:^(STPPaymentIntent *finalPaymentIntent, NSError *finalError) {
+                if (finalError) {
+                    self.applePayError = finalError;
+                    self.applePayVC ? completion(PKPaymentAuthorizationStatusFailure) : [self _finish];
+                    return;
+                }
+                if (finalPaymentIntent.status == STPPaymentIntentStatusSucceeded || finalPaymentIntent.status == STPPaymentIntentStatusRequiresCapture) {
+                    self.applePaySucceeded = YES;
+                    self.applePayVC ? completion(PKPaymentAuthorizationStatusSuccess) : [self _finish];
+                } else {
+                    self.applePayVC ? completion(PKPaymentAuthorizationStatusFailure) : [self _finish];
+                }
+            }];
+        }];
+    };
+    STPPaymentHandlerActionPaymentIntentCompletionBlock paymentHandlerCompletion = ^(STPPaymentHandlerActionStatus handlerStatus, STPPaymentIntent * _Nullable paymentIntent, NSError * _Nullable handlerError) {
+        switch (handlerStatus) {
+            case STPPaymentHandlerActionStatusFailed:
+                self.applePayError = handlerError;
+                self.applePayVC ? completion(PKPaymentAuthorizationStatusFailure) : [self _finish];
+                break;
+            case STPPaymentHandlerActionStatusCanceled:
+                self.applePayError = [NSError errorWithDomain:StripeDomain code:123 userInfo:@{NSLocalizedDescriptionKey: @"User cancelled"}];
+                self.applePayVC ? completion(PKPaymentAuthorizationStatusFailure) : [self _finish];
+                break;
+            case STPPaymentHandlerActionStatusSucceeded:
+                if (paymentIntent.status == STPPaymentIntentStatusRequiresConfirmation) {
+                    // Manually confirm the PaymentIntent on the backend again to complete the payment.
+                    reconfirmPaymentIntent(paymentIntent);
+                    break;
+                } else {
+                    self.applePayVC ? completion(PKPaymentAuthorizationStatusSuccess) : [self _finish];
+                }
+        }
+    };
+    STPPaymentIntentCreateAndConfirmHandler createAndConfirmCompletion = ^(STPBackendResult status, NSString *clientSecret, NSError *error) {
+        if (status == STPBackendResultFailure || error) {
+            self.applePayError = error;
+            completion(PKPaymentAuthorizationStatusFailure);
+            return;
+        }
+        [[STPPaymentHandler sharedHandler] handleNextActionForPayment:clientSecret
+                                            withAuthenticationContext:self
+                                                            returnURL:@"payments-example://stripe-redirect"
+                                                           completion:paymentHandlerCompletion];
+    };
 
     [self.delegate createAndConfirmPaymentIntentWithAmount:@(1000)
                                              paymentMethod:paymentMethod.stripeId
                                                  returnURL:@"payments-example://stripe-redirect"
-                                                completion:^(STPBackendResult status, NSString *clientSecret, NSError *error) {
-                                                    if (error) {
-                                                        self.applePayError = error;
-                                                        completion(PKPaymentAuthorizationStatusFailure);
-                                                    } else {
-                                                        self.applePaySucceeded = YES;
-                                                        completion(PKPaymentAuthorizationStatusSuccess);
-                                                    }
-                                                }];
+                                                completion:createAndConfirmCompletion];
 }
 
 - (void)paymentAuthorizationViewControllerDidFinish:(PKPaymentAuthorizationViewController *)controller {
     dispatch_async(dispatch_get_main_queue(), ^{
+        // This only gets called if you call the PKPaymentAuthorizationStatus completion block before dismissing PKPaymentAuthorizationViewController
         [self dismissViewControllerAnimated:YES completion:^{
-            if (self.applePaySucceeded) {
-                [self.delegate exampleViewController:self didFinishWithMessage:@"Payment successfully created"];
-            } else if (self.applePayError) {
-                [self.delegate exampleViewController:self didFinishWithError:self.applePayError];
-            }
-            self.applePaySucceeded = NO;
-            self.applePayError = nil;
+            [self _finish];
         }];
     });
+}
+
+- (void)_finish {
+    if (self.applePaySucceeded) {
+        [self.delegate exampleViewController:self didFinishWithMessage:@"Payment successfully created"];
+    } else if (self.applePayError) {
+        [self.delegate exampleViewController:self didFinishWithError:self.applePayError];
+    }
+    self.applePaySucceeded = NO;
+    self.applePayError = nil;
+    self.applePayVC = nil;
+}
+
+#pragma mark - STPAuthenticationContext
+
+- (UIViewController *)authenticationPresentingViewController {
+    return self;
+}
+
+- (void)authenticationWillPresent:(STPVoidBlock)continueBlock {
+    if (self.applePayVC.presentingViewController != nil) {
+        [self dismissViewControllerAnimated:YES completion:^{
+            self.applePayVC = nil;
+            continueBlock();
+        }];
+    } else {
+        continueBlock();
+    }
 }
 
 @end

--- a/Example/Standard Integration/CheckoutViewController.swift
+++ b/Example/Standard Integration/CheckoutViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 import Stripe
 
-class CheckoutViewController: UIViewController, STPPaymentContextDelegate, STPAuthenticationContext {
+class CheckoutViewController: UIViewController, STPPaymentContextDelegate {
 
     // 1) To get started with this demo, first head to https://dashboard.stripe.com/account/apikeys
     // and copy your "Test Publishable Key" (it looks like pk_test_abcdef) into the line below.
@@ -231,11 +231,6 @@ See https://stripe.com/docs/testing.
         self.paymentContext.requestPayment()
     }
 
-    // MARK: STPAuthenticationContext
-    func authenticationPresentingViewController() -> UIViewController {
-        return self
-    }
-
     // MARK: STPPaymentContextDelegate
 
     func paymentContext(_ paymentContext: STPPaymentContext, didCreatePaymentResult paymentResult: STPPaymentResult, completion: @escaping STPErrorBlock) {
@@ -248,7 +243,7 @@ See https://stripe.com/docs/testing.
                                                                     completion(error ?? NSError(domain: StripeDomain, code: 123, userInfo: [NSLocalizedDescriptionKey: "Unable to parse clientSecret from response"]))
                                                                     return
                                                                 }
-                                                                STPPaymentHandler.shared().handleNextAction(forPayment: clientSecret, with: self, returnURL: "payments-example://stripe-redirect") { (status, handledPaymentIntent, actionError) in
+                                                                STPPaymentHandler.shared().handleNextAction(forPayment: clientSecret, with: paymentContext, returnURL: "payments-example://stripe-redirect") { (status, handledPaymentIntent, actionError) in
                                                                     switch (status) {
                                                                     case .succeeded:
                                                                         guard let handledPaymentIntent = handledPaymentIntent else {

--- a/Stripe/PKPaymentAuthorizationViewController+Stripe_Blocks.m
+++ b/Stripe/PKPaymentAuthorizationViewController+Stripe_Blocks.m
@@ -34,7 +34,7 @@ typedef void (^STPPaymentAuthorizationStatusCallback)(PKPaymentAuthorizationStat
 
 @implementation STPBlockBasedApplePayDelegate
 
-- (void)paymentAuthorizationViewController:(__unused PKPaymentAuthorizationViewController *)controller
+- (void)paymentAuthorizationViewController:(PKPaymentAuthorizationViewController *)controller
                        didAuthorizePayment:(PKPayment *)payment completion:(STPPaymentAuthorizationStatusCallback)completion {
     self.onPaymentAuthorization(payment);
 

--- a/Stripe/PKPaymentAuthorizationViewController+Stripe_Blocks.m
+++ b/Stripe/PKPaymentAuthorizationViewController+Stripe_Blocks.m
@@ -48,10 +48,18 @@ typedef void (^STPPaymentAuthorizationStatusCallback)(PKPaymentAuthorizationStat
             if (error) {
                 self.lastError = error;
                 completion(PKPaymentAuthorizationStatusFailure);
+                if (controller.presentingViewController == nil) {
+                    // If we call completion() after dismissing, didFinishWithStatus is NOT called.
+                    [self _finish];
+                }
                 return;
             }
             self.didSucceed = YES;
             completion(PKPaymentAuthorizationStatusSuccess);
+            if (controller.presentingViewController == nil) {
+                // If we call completion() after dismissing, didFinishWithStatus is NOT called.
+                [self _finish];
+            }
         });
     };
     [self.apiClient createPaymentMethodWithPayment:payment completion:paymentMethodCreateCompletion];
@@ -80,6 +88,10 @@ typedef void (^STPPaymentAuthorizationStatusCallback)(PKPaymentAuthorizationStat
 }
 
 - (void)paymentAuthorizationViewControllerDidFinish:(__unused PKPaymentAuthorizationViewController *)controller {
+    [self _finish];
+}
+
+- (void)_finish {
     if (self.didSucceed) {
         self.onFinish(STPPaymentStatusSuccess, nil);
     }

--- a/Stripe/Payments/STPPaymentHandler.m
+++ b/Stripe/Payments/STPPaymentHandler.m
@@ -488,8 +488,8 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
                                                                     [self->_currentAction completeWithStatus:STPPaymentHandlerActionStatusFailed error:[self _errorForCode:STPPaymentHandlerStripe3DS2ErrorCode  userInfo:@{@"exception": exception}]];
                                                                 }
                                                             };
-                                                            if ([self->_currentAction.authenticationContext respondsToSelector:@selector(authenticationWillPresent:)]) {
-                                                                [self->_currentAction.authenticationContext authenticationWillPresent:doChallenge];
+                                                            if ([self->_currentAction.authenticationContext respondsToSelector:@selector(prepareAuthenticationContextForPresentation:)]) {
+                                                                [self->_currentAction.authenticationContext prepareAuthenticationContextForPresentation:doChallenge];
                                                             } else {
                                                                 doChallenge();
                                                             }
@@ -576,8 +576,8 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
             safariViewController.delegate = self;
             [presentingViewController presentViewController:safariViewController animated:YES completion:nil];
         };
-        if ([self->_currentAction.authenticationContext respondsToSelector:@selector(authenticationWillPresent:)]) {
-            [self->_currentAction.authenticationContext authenticationWillPresent:doChallenge];
+        if ([self->_currentAction.authenticationContext respondsToSelector:@selector(prepareAuthenticationContextForPresentation:)]) {
+            [self->_currentAction.authenticationContext prepareAuthenticationContextForPresentation:doChallenge];
         } else {
             doChallenge();
         }
@@ -611,16 +611,16 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
     
     // Is it the Apple Pay VC?
     if ([presentingViewController isKindOfClass:[PKPaymentAuthorizationViewController class]]) {
-        // We can't present over Apple Pay, user must implement authenticationWillPresent to dismiss it.
-        return [authenticationContext respondsToSelector:@selector(authenticationWillPresent:)];
+        // We can't present over Apple Pay, user must implement prepareAuthenticationContextForPresentation: to dismiss it.
+        return [authenticationContext respondsToSelector:@selector(prepareAuthenticationContextForPresentation:)];
     }
     
     // Is it already presenting something?
     if (presentingViewController.presentedViewController == nil) {
         return YES;
     } else {
-        // Hopefully the user implemented authenticationWillPresent: to dismiss it.
-        return [authenticationContext respondsToSelector:@selector(authenticationWillPresent:)];
+        // Hopefully the user implemented prepareAuthenticationContextForPresentation: to dismiss it.
+        return [authenticationContext respondsToSelector:@selector(prepareAuthenticationContextForPresentation:)];
     }
 }
 

--- a/Stripe/PublicHeaders/STPAuthenticationContext.h
+++ b/Stripe/PublicHeaders/STPAuthenticationContext.h
@@ -30,9 +30,10 @@ NS_ASSUME_NONNULL_BEGIN
  This method is called before presenting a UIViewController for authentication.
 
  Implement this method if your customer is using Apple Pay.  For security, it's impossible to present UIViewControllers above the Apple Pay sheet.
- This method should dismiss the PKPaymentAuthorizationViewController and call `continueBlock` in the dismissal's completion block.
+ This method should dismiss the PKPaymentAuthorizationViewController and call `completion` in the dismissal's completion block.
  
- Note that `paymentAuthorizationViewControllerDidFinish` is not called after `PKPaymentAuthorizationViewController` is dismissed.
+ @note `STPPaymentHandler` will not proceed until `completion` is called.
+ @note `paymentAuthorizationViewControllerDidFinish` is not called after `PKPaymentAuthorizationViewController` is dismissed.
  */
 - (void)prepareAuthenticationContextForPresentation:(STPVoidBlock)completion;
 

--- a/Stripe/PublicHeaders/STPAuthenticationContext.h
+++ b/Stripe/PublicHeaders/STPAuthenticationContext.h
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  Note that `paymentAuthorizationViewControllerDidFinish` is not called after `PKPaymentAuthorizationViewController` is dismissed.
  */
-- (void)authenticationWillPresent:(STPVoidBlock)continueBlock;
+- (void)prepareAuthenticationContextForPresentation:(STPVoidBlock)completion;
 
 @end
 

--- a/Stripe/PublicHeaders/STPAuthenticationContext.h
+++ b/Stripe/PublicHeaders/STPAuthenticationContext.h
@@ -25,6 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (UIViewController *)authenticationPresentingViewController;
 
+@optional
 /**
  This method is called before presenting a UIViewController for authentication.
 
@@ -33,7 +34,6 @@ NS_ASSUME_NONNULL_BEGIN
  
  Note that `paymentAuthorizationViewControllerDidFinish` is not called after `PKPaymentAuthorizationViewController` is dismissed.
  */
-@optional
 - (void)authenticationWillPresent:(STPVoidBlock)continueBlock;
 
 @end

--- a/Stripe/PublicHeaders/STPAuthenticationContext.h
+++ b/Stripe/PublicHeaders/STPAuthenticationContext.h
@@ -8,6 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
+#import "STPBlocks.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -23,6 +24,17 @@ NS_ASSUME_NONNULL_BEGIN
  authentication, like in the Challenge Flow for 3DS2 transactions.
  */
 - (UIViewController *)authenticationPresentingViewController;
+
+/**
+ This method is called before presenting a UIViewController for authentication.
+
+ Implement this method if your customer is using Apple Pay.  For security, it's impossible to present UIViewControllers above the Apple Pay sheet.
+ This method should dismiss the PKPaymentAuthorizationViewController and call `continueBlock` in the dismissal's completion block.
+ 
+ Note that `paymentAuthorizationViewControllerDidFinish` is not called after `PKPaymentAuthorizationViewController` is dismissed.
+ */
+@optional
+- (void)authenticationWillPresent:(STPVoidBlock)continueBlock;
 
 @end
 

--- a/Stripe/PublicHeaders/STPPaymentContext.h
+++ b/Stripe/PublicHeaders/STPPaymentContext.h
@@ -11,6 +11,7 @@
 #import <PassKit/PassKit.h>
 
 #import "STPAddress.h"
+#import "STPAuthenticationContext.h"
 #import "STPBlocks.h"
 #import "STPPaymentConfiguration.h"
 #import "STPPaymentOption.h"
@@ -29,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  `STPPaymentContext` saves information about a user's payment methods to a Stripe customer object, and requires an `STPCustomerContext` to manage retrieving and modifying the customer.
  */
-@interface STPPaymentContext : NSObject
+@interface STPPaymentContext : NSObject <STPAuthenticationContext>
 
 /**
  This is a convenience initializer; it is equivalent to calling 

--- a/Stripe/PublicHeaders/STPPaymentContext.h
+++ b/Stripe/PublicHeaders/STPPaymentContext.h
@@ -140,6 +140,8 @@ NS_ASSUME_NONNULL_BEGIN
  The Stripe ID of a payment method to display as the default pre-selected option.
  
  Customer doesn't have a default payment method property, but you can store one (in its metadata, for example) and set this property accordingly.
+
+ @note Set this property immediately after initializing STPPaymentContext, or call `retryLoading` afterwards.
  */
 @property (nonatomic, copy, nullable) NSString *defaultPaymentMethod;
 

--- a/Stripe/PublicHeaders/STPPaymentHandler.h
+++ b/Stripe/PublicHeaders/STPPaymentHandler.h
@@ -84,7 +84,7 @@ typedef NS_ENUM(NSInteger, STPPaymentHandlerErrorCode) {
 
     /**
      Payment requires a valid `STPAuthenticationContext`.  Make sure your presentingViewController isn't already presenting.
-     If you're using Apple Pay, you must implement `STPAuthenticationContext authenticationWillPresent`
+     If you're using Apple Pay, you must implement `STPAuthenticationContext prepareAuthenticationContextForPresentation:`
      */
     STPPaymentHandlerRequiresAuthenticationContextErrorCode,
 };
@@ -104,7 +104,7 @@ typedef void (^STPPaymentHandlerActionSetupIntentCompletionBlock)(STPPaymentHand
  `STPPaymentHandler` is a utility class that can confirm PaymentIntents and handle
  any additional required actions for 3DS(2) authentication. It can present authentication UI on top of your app or redirect users out of your app (to e.g. their banking app).
 
- @note If you're using Apple Pay, you must implement `STPAuthenticationContext authenticationWillPresent`.  See that method's docstring for more details.
+ @note If you're using Apple Pay, you must implement `STPAuthenticationContext prepareAuthenticationContextForPresentation:`.  See that method's docstring for more details.
 
  @see https://stripe.com/docs/mobile/ios/authentication
  */

--- a/Stripe/PublicHeaders/STPPaymentHandler.h
+++ b/Stripe/PublicHeaders/STPPaymentHandler.h
@@ -83,7 +83,8 @@ typedef NS_ENUM(NSInteger, STPPaymentHandlerErrorCode) {
     STPPaymentHandlerNoConcurrentActionsErrorCode,
 
     /**
-     Payment requires an `STPAuthenticationContext`.
+     Payment requires a valid `STPAuthenticationContext`.  Make sure your presentingViewController isn't already presenting.
+     If you're using Apple Pay, you must implement `STPAuthenticationContext authenticationWillPresent`
      */
     STPPaymentHandlerRequiresAuthenticationContextErrorCode,
 };
@@ -102,6 +103,10 @@ typedef void (^STPPaymentHandlerActionSetupIntentCompletionBlock)(STPPaymentHand
 /**
  `STPPaymentHandler` is a utility class that can confirm PaymentIntents and handle
  any additional required actions for 3DS(2) authentication. It can present authentication UI on top of your app or redirect users out of your app (to e.g. their banking app).
+
+ @note If you're using Apple Pay, you must implement `STPAuthenticationContext authenticationWillPresent`.  See that method's docstring for more details.
+
+ @see https://stripe.com/docs/mobile/ios/authentication
  */
 NS_EXTENSION_UNAVAILABLE("STPPaymentHandler is not available in extensions")
 @interface STPPaymentHandler : NSObject

--- a/Stripe/PublicHeaders/STPPaymentMethodCardParams.h
+++ b/Stripe/PublicHeaders/STPPaymentMethodCardParams.h
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSString *number;
 
 /**
- Two-digit number representing the card's expiration month.
+ Number representing the card's expiration month. Ex. @1
  */
 @property (nonatomic, nullable) NSNumber *expMonth;
 

--- a/Stripe/STPPaymentContext.m
+++ b/Stripe/STPPaymentContext.m
@@ -607,6 +607,7 @@ typedef NS_ENUM(NSUInteger, STPPaymentContextState) {
             }];
         }
         else if ([self.selectedPaymentOption isKindOfClass:[STPApplePayPaymentOption class]]) {
+            NSCAssert(self.hostViewController != nil, @"hostViewController must not be nil on STPPaymentContext. Next time, set the hostViewController property first!");
             self.state = STPPaymentContextStateRequestingPayment;
             PKPaymentRequest *paymentRequest = [self buildPaymentRequest];
             STPShippingAddressSelectionBlock shippingAddressHandler = ^(STPAddress *shippingAddress, STPShippingAddressValidationBlock completion) {

--- a/Stripe/STPPaymentContext.m
+++ b/Stripe/STPPaymentContext.m
@@ -752,14 +752,14 @@ static char kSTPPaymentCoordinatorAssociatedObjectKey;
     return self.hostViewController;
 }
 
-- (void)authenticationWillPresent:(STPVoidBlock)continueBlock {
+- (void)prepareAuthenticationContextForPresentation:(STPVoidBlock)completion {
     if (self.applePayVC && self.applePayVC.presentingViewController != nil) {
         [self.hostViewController dismissViewControllerAnimated:[self transitionAnimationsEnabled]
                                                     completion:^{
-                                                        continueBlock();
+                                                        completion();
                                                     }];
     } else {
-        continueBlock();
+        completion();
     }
 }
 


### PR DESCRIPTION
## Summary
STPPaymentHandler can't present on top of the Apple Pay sheet.  This PR adds a `authenticationWillPresent:` delegate method to `STPAuthenticationContext` to let the user dismiss the Apple Pay sheet.  

I also reworked users of `STPPaymentHandler` to handle this:
* `STPPaymentContext` now conforms to `STPAuthenticationContext`, and users should pass it to `STPPaymentHandler`
* Standard Integration updated to do ^
* ApplePayExampleViewController now uses `STPPaymentHandler`

## Motivation
Make Apple Pay work with STPPaymentHandler

## Testing
Manually tested the following combinations:

STPPaymentContext, Custom Integration
x
Apple Pay, manual card entry
x 
Test cards 3220, 3063, 4242 (3DS2, 3DS1, regular)
