### PR TITLE
Changes paymentContext:didCreatePaymentResult:completion: completion …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## ??
+* Changes paymentContext:didCreatePaymentResult:completion: completion block type to STPPaymentStatusBlock, to let you inform the context the user canceled.
+
 ## 16.0.3 2019-08-01
 * Changes to code obfuscation, resolving an issue with App Store review [#1269](https://github.com/stripe/stripe-ios/pull/1269)
 * Adds Apple Pay support to STPPaymentHandler [#1264](https://github.com/stripe/stripe-ios/pull/1264)

--- a/Example/Standard Integration/CheckoutViewController.swift
+++ b/Example/Standard Integration/CheckoutViewController.swift
@@ -233,54 +233,54 @@ See https://stripe.com/docs/testing.
 
     // MARK: STPPaymentContextDelegate
 
-    func paymentContext(_ paymentContext: STPPaymentContext, didCreatePaymentResult paymentResult: STPPaymentResult, completion: @escaping STPErrorBlock) {
+    func paymentContext(_ paymentContext: STPPaymentContext, didCreatePaymentResult paymentResult: STPPaymentResult, completion: @escaping STPPaymentStatusBlock) {
         MyAPIClient.sharedClient.createAndConfirmPaymentIntent(paymentResult,
                                                                amount: self.paymentContext.paymentAmount,
                                                                returnURL: "payments-example://stripe-redirect",
                                                                shippingAddress: self.paymentContext.shippingAddress,
                                                                shippingMethod: self.paymentContext.selectedShippingMethod) { (clientSecret, error) in
                                                                 guard let clientSecret = clientSecret else {
-                                                                    completion(error ?? NSError(domain: StripeDomain, code: 123, userInfo: [NSLocalizedDescriptionKey: "Unable to parse clientSecret from response"]))
+                                                                    completion(.error, error ?? NSError(domain: StripeDomain, code: 123, userInfo: [NSLocalizedDescriptionKey: "Unable to parse clientSecret from response"]))
                                                                     return
                                                                 }
                                                                 STPPaymentHandler.shared().handleNextAction(forPayment: clientSecret, with: paymentContext, returnURL: "payments-example://stripe-redirect") { (status, handledPaymentIntent, actionError) in
                                                                     switch (status) {
                                                                     case .succeeded:
                                                                         guard let handledPaymentIntent = handledPaymentIntent else {
-                                                                            completion(actionError ?? NSError(domain: StripeDomain, code: 123, userInfo: [NSLocalizedDescriptionKey: "Unknown failure"]))
+                                                                            completion(.error, actionError ?? NSError(domain: StripeDomain, code: 123, userInfo: [NSLocalizedDescriptionKey: "Unknown failure"]))
                                                                             return
                                                                         }
                                                                         if (handledPaymentIntent.status == .requiresConfirmation) {
                                                                             // Confirm again on the backend
                                                                             MyAPIClient.sharedClient.confirmPaymentIntent(handledPaymentIntent) { clientSecret, error in
                                                                                 guard let clientSecret = clientSecret else {
-                                                                                    completion(error ?? NSError(domain: StripeDomain, code: 123, userInfo: [NSLocalizedDescriptionKey: "Unable to parse clientSecret from response"]))
+                                                                                    completion(.error, error ?? NSError(domain: StripeDomain, code: 123, userInfo: [NSLocalizedDescriptionKey: "Unable to parse clientSecret from response"]))
                                                                                     return
                                                                                 }
                                                                                 
                                                                                 // Retrieve the Payment Intent and check the status for success
                                                                                 STPAPIClient.shared().retrievePaymentIntent(withClientSecret: clientSecret) { (paymentIntent, retrieveError) in
                                                                                     guard let paymentIntent = paymentIntent else {
-                                                                                        completion(retrieveError ?? NSError(domain: StripeDomain, code: 123, userInfo: [NSLocalizedDescriptionKey: "Unable to parse payment intent from response"]))
+                                                                                        completion(.error, retrieveError ?? NSError(domain: StripeDomain, code: 123, userInfo: [NSLocalizedDescriptionKey: "Unable to parse payment intent from response"]))
                                                                                         return
                                                                                     }
                                                                                     
                                                                                     if paymentIntent.status == .succeeded {
-                                                                                        completion(nil)
+                                                                                        completion(.success, nil)
                                                                                     }
                                                                                     else {
-                                                                                        completion(NSError(domain: StripeDomain, code: 123, userInfo: [NSLocalizedDescriptionKey: "Authentication failed."]))
+                                                                                        completion(.error, NSError(domain: StripeDomain, code: 123, userInfo: [NSLocalizedDescriptionKey: "Authentication failed."]))
                                                                                     }
                                                                                 }
                                                                             }
                                                                         } else {
                                                                             // Success
-                                                                            completion(nil)
+                                                                            completion(.success, nil)
                                                                         }
                                                                     case .failed:
-                                                                        completion(actionError)
+                                                                        completion(.error, actionError)
                                                                     case .canceled:
-                                                                        completion(NSError(domain: StripeDomain, code: 123, userInfo: [NSLocalizedDescriptionKey: "User canceled authentication."]))
+                                                                        completion(.userCancellation, nil)
                                                                     }
                                                                 }
         }

--- a/Stripe/PKPaymentAuthorizationViewController+Stripe_Blocks.h
+++ b/Stripe/PKPaymentAuthorizationViewController+Stripe_Blocks.h
@@ -14,7 +14,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef void(^STPApplePayPaymentMethodHandlerBlock)(STPPaymentMethod *paymentMethod, STPErrorBlock completion);
+typedef void(^STPApplePayPaymentMethodHandlerBlock)(STPPaymentMethod *paymentMethod, STPPaymentStatusBlock completion);
 typedef void (^STPPaymentCompletionBlock)(STPPaymentStatus status,  NSError * __nullable error);
 typedef void (^STPPaymentSummaryItemCompletionBlock)(NSArray<PKPaymentSummaryItem*> *summaryItems);
 typedef void (^STPShippingMethodSelectionBlock)(PKShippingMethod *selectedMethod, STPPaymentSummaryItemCompletionBlock completion);
@@ -29,7 +29,7 @@ typedef void (^STPPaymentAuthorizationBlock)(PKPayment *payment);
                       onShippingAddressSelection:(STPShippingAddressSelectionBlock)onShippingAddressSelection
                        onShippingMethodSelection:(STPShippingMethodSelectionBlock)onShippingMethodSelection
                           onPaymentAuthorization:(STPPaymentAuthorizationBlock)onPaymentAuthorization
-                                 onTokenCreation:(STPApplePayPaymentMethodHandlerBlock)onTokenCreation
+                         onPaymentMethodCreation:(STPApplePayPaymentMethodHandlerBlock)onPaymentMethodCreation
                                         onFinish:(STPPaymentCompletionBlock)onFinish;
 
 

--- a/Stripe/PKPaymentAuthorizationViewController+Stripe_Blocks.m
+++ b/Stripe/PKPaymentAuthorizationViewController+Stripe_Blocks.m
@@ -44,8 +44,8 @@ typedef void (^STPPaymentAuthorizationStatusCallback)(PKPaymentAuthorizationStat
             completion(PKPaymentAuthorizationStatusFailure);
             return;
         }
-        self.onPaymentMethodCreation(result, ^(NSError *error) {
-            if (error) {
+        self.onPaymentMethodCreation(result, ^(STPPaymentStatus status, NSError *error) {
+            if (status != STPPaymentStatusSuccess || error) {
                 self.lastError = error;
                 completion(PKPaymentAuthorizationStatusFailure);
                 if (controller.presentingViewController == nil) {
@@ -116,14 +116,14 @@ typedef void (^STPPaymentAuthorizationStatusCallback)(PKPaymentAuthorizationStat
                       onShippingAddressSelection:(STPShippingAddressSelectionBlock)onShippingAddressSelection
                        onShippingMethodSelection:(STPShippingMethodSelectionBlock)onShippingMethodSelection
                           onPaymentAuthorization:(STPPaymentAuthorizationBlock)onPaymentAuthorization
-                                 onTokenCreation:(STPApplePayPaymentMethodHandlerBlock)onTokenCreation
+                         onPaymentMethodCreation:(STPApplePayPaymentMethodHandlerBlock)onPaymentMethodCreation
                                         onFinish:(STPPaymentCompletionBlock)onFinish {
     STPBlockBasedApplePayDelegate *delegate = [STPBlockBasedApplePayDelegate new];
     delegate.apiClient = apiClient;
     delegate.onShippingAddressSelection = onShippingAddressSelection;
     delegate.onShippingMethodSelection = onShippingMethodSelection;
     delegate.onPaymentAuthorization = onPaymentAuthorization;
-    delegate.onPaymentMethodCreation = onTokenCreation;
+    delegate.onPaymentMethodCreation = onPaymentMethodCreation;
     delegate.onFinish = onFinish;
     PKPaymentAuthorizationViewController *viewController = [[self alloc] initWithPaymentRequest:paymentRequest];
     viewController.delegate = delegate;

--- a/Stripe/PublicHeaders/STPBlocks.h
+++ b/Stripe/PublicHeaders/STPBlocks.h
@@ -228,3 +228,10 @@ typedef void (^STPPinCompletionBlock)(STPIssuingCardPin * __nullable cardPin, ST
  @param error                   The error returned from the response, or nil if none occurs.
  */
 typedef void (^STP3DS2AuthenticateCompletionBlock)(STP3DS2AuthenticateResponse * _Nullable authenticateResponse, NSError * _Nullable error);
+
+/**
+ A block called with a payment status and an optionaala error.
+ 
+ @param error The error that occurred, if any.
+ */
+typedef void (^STPPaymentStatusBlock)(STPPaymentStatus status, NSError * __nullable error);

--- a/Stripe/PublicHeaders/STPPaymentContext.h
+++ b/Stripe/PublicHeaders/STPPaymentContext.h
@@ -372,14 +372,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Inside this method, you should make a call to your backend API to make a PaymentIntent with that Customer + payment method, and invoke the `completion` block when that is done.
-
+ 
  @param paymentContext The context that succeeded
  @param paymentResult  Information associated with the payment that you can pass to your server. You should go to your backend API with this payment result and use the PaymentIntent API to complete the payment. See https://stripe.com/docs/mobile/ios/standard#submit-payment-intents. Once that's done call the `completion` block with any error that occurred (or none, if the payment succeeded). @see STPPaymentResult.h
- @param completion     Call this block when you're done creating a payment intent (or subscription, etc) on your backend. If it succeeded, call `completion(nil)`. If it failed with an error, call `completion(error)`.
+ @param completion     Call this block when you're done creating a payment intent (or subscription, etc) on your backend. If it succeeded, call `completion(STPPaymentStatusSuccess, nil)`. If it failed with an error, call `completion(STPPaymentStatusError, error)`. If the user canceled, call `completion(STPPaymentStatusUserCancellation, nil)`.
  */
 - (void)paymentContext:(STPPaymentContext *)paymentContext
 didCreatePaymentResult:(STPPaymentResult *)paymentResult
-            completion:(STPErrorBlock)completion;
+            completion:(STPPaymentStatusBlock)completion;
 
 /**
  This is invoked by an `STPPaymentContext` when it is finished. This will be called after the payment is done and all necessary UI has been dismissed. You should inspect the returned `status` and behave appropriately. For example: if it's `STPPaymentStatusSuccess`, show the user a receipt. If it's `STPPaymentStatusError`, inform the user of the error. If it's `STPPaymentStatusUserCanceled`, do nothing.


### PR DESCRIPTION
…block type to STPPaymentStatusBlock, to let you inform the context the user canceled.

## Summary
The big downside is that this is a breaking change.  We could deprecate the current method, but we'd have to rename the new one (paymentContext:didCreatePaymentResult:completionBlock?).

## Motivation
https://github.com/stripe/stripe-ios/issues/1268

## Testing
Manually tested the following combos:
Standard Integration example app x 
Apple Pay (3063), 3063 card, 3220 card x
cancel, error, success
