### PR TITLE
PaymentContext left in bad state after cancel

### DIFF
--- a/Stripe/STPPaymentOptionsViewController.m
+++ b/Stripe/STPPaymentOptionsViewController.m
@@ -201,6 +201,10 @@
     [self.delegate paymentOptionsViewControllerDidCancel:self];
 }
 
+- (void)handleCancelTapped:(__unused id)sender {
+    [self.delegate paymentOptionsViewControllerDidCancel:self];
+}
+
 - (void)addCardViewControllerDidCancel:(__unused STPAddCardViewController *)addCardViewController {
     // Add card is only our direct delegate if there are no other payment methods possible
     // and we skipped directly to this screen. In this case, a cancel from it is the same as a cancel to us.


### PR DESCRIPTION
## Summary
PaymentOptionsViewController doesn't send a cancellation message if it's in the middle of loading, which can get STPPaymentContext into a bad state. We'll fix this by overriding handleCancelTapped as we do in other controllers.

## Motivation
Once broken, STPPaymentContext will refuse to pushPaymentOptionsViewController or pushShippingViewController. You can repro this in the Standard Integration example app by tapping "Pay from", "Cancel", then tapping "Pay from" again: It won't push any view controllers for the lifetime of the STPPaymentContext.

## Testing
I repro'd and tapped the cells, it worked before and after load.