### PR TITLE
Sample App should allow us to test without entering a shipping address

### DIFF
--- a/Example/Standard Integration/CheckoutViewController.swift
+++ b/Example/Standard Integration/CheckoutViewController.swift
@@ -321,7 +321,7 @@ See https://stripe.com/docs/testing.
             self.shippingRow?.detail = "Select address"
         }
         self.totalRow.detail = self.numberFormatter.string(from: NSNumber(value: Float(self.paymentContext.paymentAmount)/100))!
-        buyButton.isEnabled = paymentContext.selectedPaymentOption != nil && paymentContext.selectedShippingMethod != nil
+        buyButton.isEnabled = paymentContext.selectedPaymentOption != nil && (paymentContext.selectedShippingMethod != nil || self.shippingRow == nil)
     }
 
     func paymentContext(_ paymentContext: STPPaymentContext, didFailToLoadWithError error: Error) {


### PR DESCRIPTION
## Summary
Setting `Settings -> Required Shipping Address Fields` to `None` in the Standard Integration app will now allow you to run a transaction without filling out a shipping address. (Setting requiredShippingAddressFields = .None in code also works.)

## Motivation
I spent too much of my time mailing emoji pants to Schenectady.

## Testing
Ran the app, turned off the setting, it worked.