### PR TITLE
Add additionalSupportedApplePayNetworks. Replaces isJCBPaymentNetwork…

### DIFF
--- a/Stripe/PublicHeaders/STPAPIClient+ApplePay.h
+++ b/Stripe/PublicHeaders/STPAPIClient+ApplePay.h
@@ -11,7 +11,7 @@
 #import "STPAPIClient.h"
 
 /**
- STPAPIClient extensions to create Stripe tokens from Apple Pay PKPayment objects.
+ STPAPIClient extensions to create Stripe Tokens, Sources, or PaymentMethods from Apple Pay PKPayment objects.
  */
 @interface STPAPIClient (ApplePay)
 

--- a/Stripe/PublicHeaders/STPAPIClient.h
+++ b/Stripe/PublicHeaders/STPAPIClient.h
@@ -287,7 +287,15 @@ static NSString *const STPSDKVersion = @"16.0.6";
  
  The default value is NO.
  */
-@property (class, nonatomic, getter=isJCBPaymentNetworkSupported) BOOL JCBPaymentNetworkSupported;
+@property (class, nonatomic, getter=isJCBPaymentNetworkSupported) BOOL JCBPaymentNetworkSupported __attribute__((deprecated("Set additionalApplePayNetworks = @[PKPaymentNetworkJCB] instead")));
+
+/**
+ Set this to enable additional networks for Apple Pay if needed.
+ By default, the SDK supports Amex, MasterCard, Visa, and Discover.
+ 
+ For example, `Stripe.additionalSupportedApplePayNetworks = @[PKPaymentNetworkJCB];` enables JCB (note this requires onboarding from JCB and Stripe).
+ */
+@property (class, nonatomic, nonnull) NSArray<PKPaymentNetwork> *additionalSupportedApplePayNetworks;
 
 @end
 

--- a/Stripe/STPAPIClient+ApplePay.m
+++ b/Stripe/STPAPIClient+ApplePay.m
@@ -122,7 +122,6 @@
     return payload;
 }
 
-
 @end
 
 void linkSTPAPIClientApplePayCategory(void){}

--- a/Tests/Tests/STPApplePayTest.m
+++ b/Tests/Tests/STPApplePayTest.m
@@ -48,15 +48,15 @@
     XCTAssertFalse([Stripe canSubmitPaymentRequest:request]);
 }
 
-- (void)testJCBPaymentNetwork {
+- (void)testAdditionalPaymentNetwork {
     if (&PKPaymentNetworkJCB == NULL) {
         XCTAssertTrue([Stripe supportedPKPaymentNetworks].count > 0); // Sanity check this doesn't crash
         return;
     }
     XCTAssertFalse([[Stripe supportedPKPaymentNetworks] containsObject:PKPaymentNetworkJCB]);
-    [Stripe setJCBPaymentNetworkSupported:YES];
+    Stripe.additionalSupportedApplePayNetworks = @[PKPaymentNetworkJCB];
     XCTAssertTrue([[Stripe supportedPKPaymentNetworks] containsObject:PKPaymentNetworkJCB]);
-    [Stripe setJCBPaymentNetworkSupported:NO];
+    Stripe.additionalSupportedApplePayNetworks = @[];
 }
 
 @end


### PR DESCRIPTION
…Supported

## Summary
We added support to enable JCB for Apple Pay here: https://github.com/stripe/stripe-ios/pull/1158
This PR replaces that with a generalized way to enable any additional Apple Pay networks.

## Motivation
https://jira.corp.stripe.com/browse/MOBILE-120

## Testing
Unit test. 