### PR TITLE
Remove preferredStatusBarStyle from STPThreeDSUICustomization

### DIFF
--- a/Stripe/Payments/STPThreeDSUICustomization.m
+++ b/Stripe/Payments/STPThreeDSUICustomization.m
@@ -120,12 +120,4 @@
    self.uiCustomization.blurStyle = blurStyle;
 }
 
-- (void)setPreferredStatusBarStyle:(UIStatusBarStyle)preferredStatusBarStyle {
-    self.uiCustomization.preferredStatusBarStyle = preferredStatusBarStyle;
-}
-
-- (UIStatusBarStyle)preferredStatusBarStyle {
-    return self.uiCustomization.preferredStatusBarStyle;
-}
-
 @end

--- a/Stripe/PublicHeaders/STPThreeDSNavigationBarCustomization.h
+++ b/Stripe/PublicHeaders/STPThreeDSNavigationBarCustomization.h
@@ -29,6 +29,10 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  The navigation bar style.
  Defaults to UIBarStyleDefault.
+ 
+ @note This property controls the `UIStatusBarStyle`. Set this to `UIBarStyleBlack`
+ to change the `statusBarStyle` to `UIStatusBarStyleLightContent` - even if you also set
+ `barTintColor` to change the actual color of the navigation bar.
  */
 @property (nonatomic) UIBarStyle barStyle;
 

--- a/Stripe/PublicHeaders/STPThreeDSUICustomization.h
+++ b/Stripe/PublicHeaders/STPThreeDSUICustomization.h
@@ -84,13 +84,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, strong) STPThreeDSSelectionCustomization *selectionCustomization;
 
-/**
- The preferred status bar style for all UIViewControllers displayed during 3D Secure authentication.
- 
- Defaults to `UIStatusBarStyleDefault`.
- */
-@property (nonatomic) UIStatusBarStyle preferredStatusBarStyle;
-
 #pragma mark - Progress View
 
 /**

--- a/Tests/Tests/STPThreeDSUICustomizationTest.m
+++ b/Tests/Tests/STPThreeDSUICustomizationTest.m
@@ -90,9 +90,6 @@
     
     XCTAssertEqual(UIBlurEffectStyleDark, customization.blurStyle);
     XCTAssertEqual(customization.blurStyle, customization.uiCustomization.blurStyle);
-    
-    XCTAssertEqual(UIStatusBarStyleLightContent, customization.preferredStatusBarStyle);
-    XCTAssertEqual(customization.preferredStatusBarStyle, customization.uiCustomization.preferredStatusBarStyle);
 }
 
 @end

--- a/Tests/Tests/STPThreeDSUICustomizationTest.m
+++ b/Tests/Tests/STPThreeDSUICustomizationTest.m
@@ -80,7 +80,6 @@
     customization.backgroundColor = UIColor.redColor;
     customization.activityIndicatorViewStyle = UIActivityIndicatorViewStyleWhiteLarge;
     customization.blurStyle = UIBlurEffectStyleDark;
-    customization.preferredStatusBarStyle = UIStatusBarStyleLightContent;
 
     XCTAssertEqual(UIColor.redColor, customization.backgroundColor);
     XCTAssertEqual(customization.backgroundColor, customization.uiCustomization.backgroundColor);


### PR DESCRIPTION
## Summary
It turns out this property doesn't work as expected.  When a `UIViewController` is in a `UINavigationController` (always for our 3DS2 SDK), the `UINavigationController.barStyle` decides what color the status bar is.  

Since it therefore does nothing, I've removed it and documented how to use `barStyle` to control the color instead.

[0] https://forums.developer.apple.com/thread/30435
>  preferredStatusBarStyle is called on the application's top-most fullscreen view controller (the root view controller if there are no modal presentations)...UINavigationController delegates to the top view controller only when its navigation bar is hidden, otherwise it determines the status bar style itself.

## Motivation
https://github.com/stripe/stripe-ios/issues/1301

## Testing
Tested dark mode configuration in Standard Integration example app, works as expected.  Not committing it b/c we are implementing a better version soon here https://github.com/stripe/stripe-ios/pull/1307