### PR TITLE
Create UI integration tests

### DIFF
--- a/Example/Standard Integration.xcodeproj/project.pbxproj
+++ b/Example/Standard Integration.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		04BC29A01CD81D3900318357 /* BrowseProductsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04BC299F1CD81D3900318357 /* BrowseProductsViewController.swift */; };
 		04D0761D1A69E66F00094431 /* Stripe.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04D076191A69C14700094431 /* Stripe.framework */; };
 		04D0761E1A69E66F00094431 /* Stripe.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 04D076191A69C14700094431 /* Stripe.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		3143AB43230DF738003A54FC /* StandardIntegrationUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3143AB42230DF738003A54FC /* StandardIntegrationUITests.swift */; };
 		B67046BB229F0D7E006CB603 /* EmojiCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B67046BA229F0D7E006CB603 /* EmojiCell.swift */; };
 		B67046BD229F61CF006CB603 /* EmojiCheckoutCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B67046BC229F61CF006CB603 /* EmojiCheckoutCell.swift */; };
 		B690AC5122A1A52900D3F50A /* UIColor+Stripe.swift in Sources */ = {isa = PBXBuildFile; fileRef = B690AC5022A1A52900D3F50A /* UIColor+Stripe.swift */; };
@@ -24,6 +25,16 @@
 		C1B83CBD1CCE6C0700F0790B /* Buttons.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B83CBC1CCE6C0700F0790B /* Buttons.swift */; };
 		F1D12FE71F91721600CE68A7 /* PaymentContextFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D12FE61F91721600CE68A7 /* PaymentContextFooterView.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		3143AB45230DF738003A54FC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 04823F701A6849200098400B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 04823F771A6849200098400B;
+			remoteInfo = "Standard Integration";
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
 		04D0761F1A69E66F00094431 /* Embed Frameworks */ = {
@@ -47,6 +58,9 @@
 		04BC299F1CD81D3900318357 /* BrowseProductsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BrowseProductsViewController.swift; sourceTree = "<group>"; };
 		04D075D91A69B82B00094431 /* Standard Integration.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Standard Integration.entitlements"; sourceTree = "<group>"; };
 		04D076191A69C14700094431 /* Stripe.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Stripe.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3143AB40230DF738003A54FC /* StandardIntegrationUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StandardIntegrationUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		3143AB42230DF738003A54FC /* StandardIntegrationUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandardIntegrationUITests.swift; sourceTree = "<group>"; };
+		3143AB44230DF738003A54FC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3635C32E22A87D36004298B8 /* Stripe3DS2.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Stripe3DS2.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8BBD79D2207FD44300F85BED /* fi */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = fi; path = Localizations/fi.lproj/Localizable.strings; sourceTree = "<group>"; };
 		8BBD79D3207FD45A00F85BED /* nb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = nb; path = Localizations/nb.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -81,6 +95,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		3143AB3D230DF738003A54FC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -112,6 +133,7 @@
 				04823F791A6849200098400B /* Products */,
 				C18A6EE11F1EB78B005600CC /* README.md */,
 				042CA4131A685E8D00D778E7 /* Standard Integration */,
+				3143AB41230DF738003A54FC /* StandardIntegrationUITests */,
 				B690AC5022A1A52900D3F50A /* UIColor+Stripe.swift */,
 			);
 			sourceTree = "<group>";
@@ -120,6 +142,7 @@
 			isa = PBXGroup;
 			children = (
 				04823F781A6849200098400B /* Standard Integration.app */,
+				3143AB40230DF738003A54FC /* StandardIntegrationUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -132,6 +155,15 @@
 				04D076191A69C14700094431 /* Stripe.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		3143AB41230DF738003A54FC /* StandardIntegrationUITests */ = {
+			isa = PBXGroup;
+			children = (
+				3143AB42230DF738003A54FC /* StandardIntegrationUITests.swift */,
+				3143AB44230DF738003A54FC /* Info.plist */,
+			);
+			path = StandardIntegrationUITests;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -158,13 +190,31 @@
 			productReference = 04823F781A6849200098400B /* Standard Integration.app */;
 			productType = "com.apple.product-type.application";
 		};
+		3143AB3F230DF738003A54FC /* StandardIntegrationUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3143AB49230DF738003A54FC /* Build configuration list for PBXNativeTarget "StandardIntegrationUITests" */;
+			buildPhases = (
+				3143AB3C230DF738003A54FC /* Sources */,
+				3143AB3D230DF738003A54FC /* Frameworks */,
+				3143AB3E230DF738003A54FC /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				3143AB46230DF738003A54FC /* PBXTargetDependency */,
+			);
+			name = StandardIntegrationUITests;
+			productName = StandardIntegrationUITests;
+			productReference = 3143AB40230DF738003A54FC /* StandardIntegrationUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		04823F701A6849200098400B /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0800;
+				LastSwiftUpdateCheck = 1030;
 				LastUpgradeCheck = 0940;
 				ORGANIZATIONNAME = Stripe;
 				TargetAttributes = {
@@ -183,6 +233,11 @@
 								enabled = 0;
 							};
 						};
+					};
+					3143AB3F230DF738003A54FC = {
+						CreatedOnToolsVersion = 10.3;
+						ProvisioningStyle = Automatic;
+						TestTargetID = 04823F771A6849200098400B;
 					};
 				};
 			};
@@ -209,6 +264,7 @@
 			projectRoot = "";
 			targets = (
 				04823F771A6849200098400B /* Standard Integration */,
+				3143AB3F230DF738003A54FC /* StandardIntegrationUITests */,
 			);
 		};
 /* End PBXProject section */
@@ -220,6 +276,13 @@
 			files = (
 				042CA4201A685E8D00D778E7 /* Images.xcassets in Resources */,
 				C13886661F293F9F00380D46 /* Localizable.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3143AB3E230DF738003A54FC /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -290,7 +353,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		3143AB3C230DF738003A54FC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3143AB43230DF738003A54FC /* StandardIntegrationUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		3143AB46230DF738003A54FC /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 04823F771A6849200098400B /* Standard Integration */;
+			targetProxy = 3143AB45230DF738003A54FC /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		C13886641F293F9F00380D46 /* Localizable.strings */ = {
@@ -474,6 +553,61 @@
 			};
 			name = Release;
 		};
+		3143AB47230DF738003A54FC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = StandardIntegrationUITests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.stripe.StandardIntegrationUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OBJC_BRIDGING_HEADER = "";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = "Standard Integration";
+			};
+			name = Debug;
+		};
+		3143AB48230DF738003A54FC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = StandardIntegrationUITests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.stripe.StandardIntegrationUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = "Standard Integration";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -491,6 +625,15 @@
 			buildConfigurations = (
 				04823F981A6849200098400B /* Debug */,
 				04823F991A6849200098400B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3143AB49230DF738003A54FC /* Build configuration list for PBXNativeTarget "StandardIntegrationUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3143AB47230DF738003A54FC /* Debug */,
+				3143AB48230DF738003A54FC /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Example/Standard Integration.xcodeproj/xcshareddata/xcschemes/Standard Integration.xcscheme
+++ b/Example/Standard Integration.xcodeproj/xcshareddata/xcschemes/Standard Integration.xcscheme
@@ -38,6 +38,16 @@
                ReferencedContainer = "container:../Stripe.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3143AB3F230DF738003A54FC"
+               BuildableName = "StandardIntegrationUITests.xctest"
+               BlueprintName = "StandardIntegrationUITests"
+               ReferencedContainer = "container:Standard Integration.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/Example/Standard Integration/CheckoutViewController.swift
+++ b/Example/Standard Integration/CheckoutViewController.swift
@@ -13,17 +13,17 @@ class CheckoutViewController: UIViewController, STPPaymentContextDelegate {
 
     // 1) To get started with this demo, first head to https://dashboard.stripe.com/account/apikeys
     // and copy your "Test Publishable Key" (it looks like pk_test_abcdef) into the line below.
-    let stripePublishableKey = ""
+    var stripePublishableKey = ""
 
     // 2) Next, optionally, to have this demo save your user's payment details, head to
     // https://github.com/stripe/example-ios-backend/tree/v16.0.0, click "Deploy to Heroku", and follow
     // the instructions (don't worry, it's free). Replace nil on the line below with your
     // Heroku URL (it looks like https://blazing-sunrise-1234.herokuapp.com ).
-    let backendBaseURL: String? = nil
+    var backendBaseURL: String? = nil
 
     // 3) Optionally, to enable Apple Pay, follow the instructions at https://stripe.com/docs/mobile/apple-pay
     // to create an Apple Merchant ID. Replace nil on the line below with it (it looks like merchant.com.yourappname).
-    let appleMerchantID: String? = ""
+    var appleMerchantID: String? = ""
 
     // These values will be shown to the user when they purchase with Apple Pay.
     let companyName = "Emoji Apparel"
@@ -59,7 +59,12 @@ class CheckoutViewController: UIViewController, STPPaymentContextDelegate {
     }
     
     init(products: [Product], settings: Settings) {
-
+        if let stripePublishableKey = UserDefaults.standard.string(forKey: "StripePublishableKey") {
+            self.stripePublishableKey = stripePublishableKey
+        }
+        if let backendBaseURL = UserDefaults.standard.string(forKey: "StripeBackendBaseURL") {
+            self.backendBaseURL = backendBaseURL
+        }
         let stripePublishableKey = self.stripePublishableKey
         let backendBaseURL = self.backendBaseURL
 

--- a/Example/StandardIntegrationUITests/Info.plist
+++ b/Example/StandardIntegrationUITests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Example/StandardIntegrationUITests/StandardIntegrationUITests.swift
+++ b/Example/StandardIntegrationUITests/StandardIntegrationUITests.swift
@@ -1,0 +1,183 @@
+//
+//  StandardIntegrationUITests.swift
+//  StandardIntegrationUITests
+//
+//  Created by David Estes on 8/21/19.
+//  Copyright © 2019 Stripe. All rights reserved.
+//
+
+import XCTest
+
+class StandardIntegrationUITests: XCTestCase {
+
+    override func setUp() {
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // UI tests must launch the application that they test. Doing this in setup will make sure it happens for each test method.
+        let app = XCUIApplication()
+        let stripePublishableKey = "pk_test_6Q7qTzl8OkUj5K5ArgayVsFD00Sa5AHMj3"
+        let backendBaseURL = "https://stripe-mobile-test-backend.herokuapp.com/"
+        app.launchArguments.append(contentsOf: ["-StripePublishableKey", stripePublishableKey, "-StripeBackendBaseURL", backendBaseURL])
+        app.launch()
+    }
+
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+    
+    func disableAddressEntry(_ app: XCUIApplication) {
+        app.navigationBars["Emoji Apparel"].buttons["Settings"].tap()
+        app.tables.children(matching: .cell).element(boundBy: 8).staticTexts["None"].tap()
+        app.navigationBars["Settings"].buttons["Done"].tap()
+    }
+    
+    func selectItems(_ app: XCUIApplication) {
+        let cellsQuery = app.collectionViews.cells
+        cellsQuery.otherElements.containing(.staticText, identifier:"👠").element.tap()
+        app.collectionViews/*@START_MENU_TOKEN@*/.staticTexts["👞"]/*[[".cells.staticTexts[\"👞\"]",".staticTexts[\"👞\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
+        cellsQuery.otherElements.containing(.staticText, identifier:"👗").children(matching: .other).element(boundBy: 0).tap()
+    }
+    
+    func waitToAppear(_ target: Any?) {
+        let exists = NSPredicate(format: "exists == 1")
+        expectation(for: exists, evaluatedWith: target, handler: nil)
+        waitForExpectations(timeout: 60.0, handler: nil)
+    }
+    
+    func testSimpleTransaction() {
+        let app = XCUIApplication()
+        disableAddressEntry(app)
+        selectItems(app)
+        
+        app.buttons["Buy Now"].tap()
+        app.tables.otherElements.containing(.staticText, identifier:"Pay from").children(matching: .button).element.tap()
+        let visa = app.tables/*@START_MENU_TOKEN@*/.staticTexts["Visa Ending In 4242"]/*[[".cells.staticTexts[\"Visa Ending In 4242\"]",".staticTexts[\"Visa Ending In 4242\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/
+        waitToAppear(visa)
+        visa.tap()
+        app.buttons["Buy"].tap()
+        let success = app.alerts["Success"].buttons["OK"]
+        waitToAppear(success)
+        success.tap()
+    }
+    
+    func test3DS1() {
+        let app = XCUIApplication()
+        disableAddressEntry(app)
+        selectItems(app)
+
+        let buyNowButton = app.buttons["Buy Now"]
+        buyNowButton.tap()
+
+        app.tables.otherElements.containing(.staticText, identifier:"Pay from").children(matching: .button).element.tap()
+        let visa3063 = app.tables/*@START_MENU_TOKEN@*/.staticTexts["Visa Ending In 3063"]/*[[".cells.staticTexts[\"Visa Ending In 3063\"]",".staticTexts[\"Visa Ending In 3063\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/
+        waitToAppear(visa3063)
+        visa3063.tap()
+
+        let buyButton = app.buttons["Buy"]
+        buyButton.tap()
+        
+        let webViewsQuery = app.webViews
+        let completeAuth = webViewsQuery/*@START_MENU_TOKEN@*/.buttons["COMPLETE AUTHENTICATION"]/*[[".otherElements[\"Stripe payment test page\"]",".otherElements[\"main\"].buttons[\"COMPLETE AUTHENTICATION\"]",".buttons[\"COMPLETE AUTHENTICATION\"]"],[[[-1,2],[-1,1],[-1,0,1]],[[-1,2],[-1,1]]],[0]]@END_MENU_TOKEN@*/
+        waitToAppear(completeAuth)
+        completeAuth.tap()
+        var returnToMerchant = webViewsQuery/*@START_MENU_TOKEN@*/.staticTexts["Return to Merchant"]/*[[".links.matching(identifier: \"Return to Merchant\").staticTexts[\"Return to Merchant\"]",".staticTexts[\"Return to Merchant\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/
+        waitToAppear(returnToMerchant)
+        returnToMerchant.tap()
+        let successButton = app.alerts["Success"].buttons["OK"]
+        waitToAppear(successButton)
+        successButton.tap()
+        buyButton.tap()
+
+        let failAuth = webViewsQuery/*@START_MENU_TOKEN@*/.buttons["FAIL AUTHENTICATION"]/*[[".otherElements[\"Stripe payment test page\"]",".otherElements[\"main\"].buttons[\"FAIL AUTHENTICATION\"]",".buttons[\"FAIL AUTHENTICATION\"]"],[[[-1,2],[-1,1],[-1,0,1]],[[-1,2],[-1,1]]],[0]]@END_MENU_TOKEN@*/
+        waitToAppear(failAuth)
+        failAuth.tap()
+        returnToMerchant = webViewsQuery/*@START_MENU_TOKEN@*/.staticTexts["Return to Merchant"]/*[[".links.matching(identifier: \"Return to Merchant\").staticTexts[\"Return to Merchant\"]",".staticTexts[\"Return to Merchant\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/
+        waitToAppear(returnToMerchant)
+        app.buttons["Close"].tap()
+        let errorButton = app.alerts["Error"].buttons["OK"]
+        waitToAppear(errorButton)
+        errorButton.tap()
+    }
+    
+    func test3DS2() {
+        let app = XCUIApplication()
+        disableAddressEntry(app)
+        selectItems(app)
+
+        let buyNowButton = app.buttons["Buy Now"]
+        buyNowButton.tap()
+        app.tables.otherElements.containing(.staticText, identifier:"Pay from").children(matching: .button).element.tap()
+        let visa = app.tables/*@START_MENU_TOKEN@*/.staticTexts["Visa Ending In 3220"]/*[[".cells.staticTexts[\"Visa Ending In 3220\"]",".staticTexts[\"Visa Ending In 3220\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/
+        waitToAppear(visa)
+        visa.tap()
+        app.buttons["Buy"].tap()
+        
+        let elementsQuery = app.scrollViews.otherElements
+        let learnMore = elementsQuery/*@START_MENU_TOKEN@*/.staticTexts["Learn more about authentication"]/*[[".otherElements.matching(identifier: \"STDSExpandableInformationView\").staticTexts[\"Learn more about authentication\"]",".staticTexts[\"Learn more about authentication\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/
+        waitToAppear(learnMore)
+        learnMore.tap()
+        elementsQuery/*@START_MENU_TOKEN@*/.staticTexts["Need help?"]/*[[".otherElements.matching(identifier: \"STDSExpandableInformationView\").staticTexts[\"Need help?\"]",".staticTexts[\"Need help?\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
+        app.scrollViews.otherElements/*@START_MENU_TOKEN@*/.buttons["Continue"]/*[[".buttons[\"Complete Authentication\"]",".buttons[\"Continue\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
+        let success = app.alerts["Success"].buttons["OK"]
+        waitToAppear(success)
+        success.tap()
+    }
+    
+    func testPopApplePaySheet() {
+        let app = XCUIApplication()
+        disableAddressEntry(app)
+        selectItems(app)
+
+        let buyNowButton = app.buttons["Buy Now"]
+        buyNowButton.tap()
+        
+        let tablesQuery = app.tables
+        tablesQuery.otherElements.containing(.staticText, identifier:"Pay from").children(matching: .button).element.tap()
+        let applePay = tablesQuery/*@START_MENU_TOKEN@*/.staticTexts["Apple Pay"]/*[[".cells.staticTexts[\"Apple Pay\"]",".staticTexts[\"Apple Pay\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/
+        waitToAppear(applePay)
+        applePay.tap()
+        app.buttons["Buy"].tap()
+    }
+    
+    func testCCEntry() {
+        let app = XCUIApplication()
+        disableAddressEntry(app)
+        selectItems(app)
+        
+        let buyNowButton = app.buttons["Buy Now"]
+        buyNowButton.tap()
+        let tablesQuery = app.tables
+        tablesQuery.otherElements.containing(.staticText, identifier:"Pay from").children(matching: .button).element.tap()
+        
+        let addButton = app.tables/*@START_MENU_TOKEN@*/.staticTexts["Add New Card…"]/*[[".cells[\"PaymentOptionsTableViewAddNewCardButtonIdentifier\"].staticTexts[\"Add New Card…\"]",".staticTexts[\"Add New Card…\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/
+        waitToAppear(addButton)
+        addButton.tap()
+        
+        let cardNumberField = tablesQuery/*@START_MENU_TOKEN@*/.textFields["card number"]/*[[".cells.textFields[\"card number\"]",".textFields[\"card number\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/
+        let cvcField = tablesQuery/*@START_MENU_TOKEN@*/.textFields["CVC"]/*[[".cells.textFields[\"CVC\"]",".textFields[\"CVC\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/
+        let expirationDateField = tablesQuery/*@START_MENU_TOKEN@*/.textFields["expiration date"]/*[[".cells.textFields[\"expiration date\"]",".textFields[\"expiration date\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/
+        cardNumberField.tap()
+        cardNumberField.typeText("4000000000000069")
+        expirationDateField.tap()
+        expirationDateField.typeText("02/28")
+        cvcField.tap()
+        cvcField.typeText("223")
+
+        let addcardviewcontrollernavbardonebuttonidentifierButton = app.navigationBars["Add a Card"]/*@START_MENU_TOKEN@*/.buttons["AddCardViewControllerNavBarDoneButtonIdentifier"]/*[[".buttons[\"Done\"]",".buttons[\"AddCardViewControllerNavBarDoneButtonIdentifier\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/
+        addcardviewcontrollernavbardonebuttonidentifierButton.tap()
+        app.alerts["Your card has expired"].buttons["OK"].tap()
+        cardNumberField.tap()
+        let deleteString = String(repeating: XCUIKeyboardKey.delete.rawValue, count: 4)
+        cardNumberField.typeText(deleteString)
+        cardNumberField.typeText("0341")
+        addcardviewcontrollernavbardonebuttonidentifierButton.tap()
+        let buyButton = app.buttons["Buy"]
+        waitToAppear(buyButton)
+        buyButton.tap()
+        let errorButton = app.alerts["Error"].buttons["OK"]
+        waitToAppear(errorButton)
+        errorButton.tap()
+    }
+
+}


### PR DESCRIPTION
## Summary
We don't have any end-to-end UI tests, so I'm adding a basic one to exercise the usual Standard Integration app tests. I plan to run this on iOS 9-13 to make sure nothing is obviously broken.

## Motivation
We've added some slightly brittle things to support 3DS2 and iOS 13, I'd like to make sure they don't break.

## Testing
It is a test.