### PR TITLE
Don't allow STPPaymentHandler to be initialized directly

### DIFF
--- a/Stripe/PublicHeaders/STPPaymentHandler.h
+++ b/Stripe/PublicHeaders/STPPaymentHandler.h
@@ -124,6 +124,11 @@ NS_EXTENSION_UNAVAILABLE("STPPaymentHandler is not available in extensions")
 + (instancetype)sharedHandler;
 
 /**
+ `STPPaymentHandler` should not be directly initialized.
+ */
+- (instancetype)init NS_UNAVAILABLE;
+
+/**
  By default `sharedHandler` initializes with [STPAPIClient sharedClient].
  */
 @property (nonatomic) STPAPIClient *apiClient;


### PR DESCRIPTION
## Summary
STPPaymentHandler should always be accessed through the `sharedHandler`.

## Motivation
Seen in #1310. They received an error of `Timeout value of 13 is less than 5`. Our error string in the 3DS2 library was `@"Timeout value of %ld is less than 5"`. A few problems with that:
* It should say `%ld seconds is less than 5 minutes`
* `%ld` would print the NSTimeInterval as a long, which is bogus. It should be `%lf` for a double.
* 13 as a long is `0D000000`, so the actual value as a double was ~0.

STPPaymentHandler sends `timeout:self->_currentAction.threeDSCustomizationSettings.authenticationTimeout*60` as an NSTimeInterval to the 3DS2 SDK. If STPPaymentHandler.threeDSCustomizationSettings is not initialized properly (which is the case when calling `[[STPPaymentHandler alloc] init]`), this would resolve to `nil*60`, which converts to the vaguely 0-shaped double we saw.

## Testing
Tested in CI.