### PR TITLE
Add support for iOS 13 Dark Mode to Custom Integration

### DIFF
--- a/Example/Custom Integration/ApplePayExampleViewController.m
+++ b/Example/Custom Integration/ApplePayExampleViewController.m
@@ -32,6 +32,11 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     self.view.backgroundColor = [UIColor whiteColor];
+    #ifdef __IPHONE_13_0
+    if (@available(iOS 13.0, *)) {
+        self.view.backgroundColor = [UIColor systemBackgroundColor];
+    }
+    #endif
     self.title = @"Apple Pay";
     self.edgesForExtendedLayout = UIRectEdgeNone;
 

--- a/Example/Custom Integration/CardAutomaticConfirmationViewController.m
+++ b/Example/Custom Integration/CardAutomaticConfirmationViewController.m
@@ -36,6 +36,11 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     self.view.backgroundColor = [UIColor whiteColor];
+    #ifdef __IPHONE_13_0
+    if (@available(iOS 13.0, *)) {
+        self.view.backgroundColor = [UIColor systemBackgroundColor];
+    }
+    #endif
     self.title = @"Card";
     self.edgesForExtendedLayout = UIRectEdgeNone;
 
@@ -46,6 +51,11 @@
     paymentTextField.cardParams = cardParams;
     paymentTextField.delegate = self;
     paymentTextField.cursorColor = [UIColor purpleColor];
+    #ifdef __IPHONE_13_0
+    if (@available(iOS 13.0, *)) {
+        paymentTextField.cursorColor = [UIColor systemPurpleColor];
+    }
+    #endif
     self.paymentTextField = paymentTextField;
     [self.view addSubview:paymentTextField];
 
@@ -53,6 +63,12 @@
     label.text = @"Waiting for payment authorization";
     [label sizeToFit];
     label.textColor = [UIColor grayColor];
+    #ifdef __IPHONE_13_0
+    if (@available(iOS 13.0, *)) {
+        label.textColor = [UIColor secondaryLabelColor];
+    }
+    #endif
+
     label.alpha = 0;
     [self.view addSubview:label];
     self.waitingLabel = label;

--- a/Example/Custom Integration/CardManualConfirmationExampleViewController.m
+++ b/Example/Custom Integration/CardManualConfirmationExampleViewController.m
@@ -28,6 +28,12 @@
     scrollView.delegate = self;
     scrollView.alwaysBounceVertical = YES;
     scrollView.backgroundColor = [UIColor whiteColor];
+    #ifdef __IPHONE_13_0
+    if (@available(iOS 13.0, *)) {
+        scrollView.backgroundColor = [UIColor systemBackgroundColor];
+    }
+    #endif
+
     self.view = scrollView;
     self.scrollView = scrollView;
 }
@@ -45,6 +51,11 @@
     STPPaymentCardTextField *paymentTextField = [[STPPaymentCardTextField alloc] init];
     paymentTextField.delegate = self;
     paymentTextField.cursorColor = [UIColor purpleColor];
+    #ifdef __IPHONE_13_0
+    if (@available(iOS 13.0, *)) {
+        paymentTextField.cursorColor = [UIColor systemPurpleColor];
+    }
+    #endif
     paymentTextField.postalCodeEntryEnabled = YES;
     self.paymentTextField = paymentTextField;
     [self.view addSubview:paymentTextField];

--- a/Example/Custom Integration/CardSetupIntentBackendExampleViewController.m
+++ b/Example/Custom Integration/CardSetupIntentBackendExampleViewController.m
@@ -30,6 +30,12 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     self.view.backgroundColor = [UIColor whiteColor];
+    #ifdef __IPHONE_13_0
+    if (@available(iOS 13.0, *)) {
+        self.view.backgroundColor = [UIColor systemBackgroundColor];
+    }
+    #endif
+
     self.title = @"Card SetupIntent (Backend)";
     self.edgesForExtendedLayout = UIRectEdgeNone;
 
@@ -40,6 +46,11 @@
     paymentTextField.cardParams = cardParams;
     paymentTextField.delegate = self;
     paymentTextField.cursorColor = [UIColor purpleColor];
+    #ifdef __IPHONE_13_0
+    if (@available(iOS 13.0, *)) {
+        paymentTextField.cursorColor = [UIColor systemPurpleColor];
+    }
+    #endif
     self.paymentTextField = paymentTextField;
     [self.view addSubview:paymentTextField];
 
@@ -47,6 +58,11 @@
     label.text = @"Waiting for payment authorization";
     [label sizeToFit];
     label.textColor = [UIColor grayColor];
+    #ifdef __IPHONE_13_0
+    if (@available(iOS 13.0, *)) {
+        label.textColor = [UIColor secondaryLabelColor];
+    }
+    #endif
     label.alpha = 0;
     [self.view addSubview:label];
     self.waitingLabel = label;

--- a/Example/Custom Integration/CardSetupIntentExampleViewController.m
+++ b/Example/Custom Integration/CardSetupIntentExampleViewController.m
@@ -31,6 +31,11 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     self.view.backgroundColor = [UIColor whiteColor];
+    #ifdef __IPHONE_13_0
+    if (@available(iOS 13.0, *)) {
+        self.view.backgroundColor = [UIColor systemBackgroundColor];
+    }
+    #endif
     self.title = @"Card";
     self.edgesForExtendedLayout = UIRectEdgeNone;
     
@@ -41,6 +46,11 @@
     paymentTextField.cardParams = cardParams;
     paymentTextField.delegate = self;
     paymentTextField.cursorColor = [UIColor purpleColor];
+    #ifdef __IPHONE_13_0
+    if (@available(iOS 13.0, *)) {
+        paymentTextField.cursorColor = [UIColor systemPurpleColor];
+    }
+    #endif
     self.paymentTextField = paymentTextField;
     [self.view addSubview:paymentTextField];
     
@@ -48,6 +58,11 @@
     label.text = @"Waiting for payment authorization";
     [label sizeToFit];
     label.textColor = [UIColor grayColor];
+    #ifdef __IPHONE_13_0
+    if (@available(iOS 13.0, *)) {
+        label.textColor = [UIColor secondaryLabelColor];
+    }
+    #endif
     label.alpha = 0;
     [self.view addSubview:label];
     self.waitingLabel = label;

--- a/Example/Custom Integration/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/Example/Custom Integration/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -39,6 +39,11 @@
       "idiom" : "iphone",
       "size" : "60x60",
       "scale" : "3x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
     }
   ],
   "info" : {

--- a/Example/Custom Integration/SofortExampleViewController.m
+++ b/Example/Custom Integration/SofortExampleViewController.m
@@ -35,6 +35,11 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     self.view.backgroundColor = [UIColor whiteColor];
+    #ifdef __IPHONE_13_0
+    if (@available(iOS 13.0, *)) {
+        self.view.backgroundColor = [UIColor systemBackgroundColor];
+    }
+    #endif
     self.title = @"Sofort";
     self.edgesForExtendedLayout = UIRectEdgeNone;
 
@@ -49,6 +54,11 @@
     label.text = @"Waiting for payment authorization";
     [label sizeToFit];
     label.textColor = [UIColor grayColor];
+    #ifdef __IPHONE_13_0
+    if (@available(iOS 13.0, *)) {
+        label.textColor = [UIColor secondaryLabelColor];
+    }
+    #endif
     label.alpha = 0;
     [self.view addSubview:label];
     self.waitingLabel = label;

--- a/Stripe/PublicHeaders/STPPaymentCardTextField.h
+++ b/Stripe/PublicHeaders/STPPaymentCardTextField.h
@@ -36,7 +36,7 @@ IB_DESIGNABLE
 @property (nonatomic, copy, null_resettable) UIFont *font UI_APPEARANCE_SELECTOR;
 
 /**
- The text color to be used when entering valid text. Default is [UIColor blackColor]. 
+ The text color to be used when entering valid text. Default is [UIColor labelColor].
  
  Set this property to nil to reset to the default.
  */
@@ -55,7 +55,7 @@ IB_DESIGNABLE
 
  This will also set the color of the card placeholder icon.
 
- Default is [UIColor lightGrayColor]. Set this property to nil to reset to the default.
+ Default is [UIColor systemGray2Color]. Set this property to nil to reset to the default.
  */
 @property (nonatomic, copy, null_resettable) UIColor *placeholderColor UI_APPEARANCE_SELECTOR;
 
@@ -98,7 +98,7 @@ IB_DESIGNABLE
  
  Can be nil (in which case no border will be drawn).
 
- Default is [UIColor lightGrayColor].
+ Default is [UIColor systemGray2Color].
  */
 @property (nonatomic, copy, nullable) UIColor *borderColor UI_APPEARANCE_SELECTOR;
 

--- a/Stripe/STPPaymentCardTextField.m
+++ b/Stripe/STPPaymentCardTextField.m
@@ -225,6 +225,12 @@ CGFloat const STPPaymentCardTextFieldMinimumPadding = 10;
 }
 
 + (UIColor *)placeholderGrayColor {
+    #ifdef __IPHONE_13_0
+        if (@available(iOS 13.0, *)) {
+            return [UIColor systemGray2Color];
+        }
+    #endif
+    
     return [UIColor lightGrayColor];
 }
 
@@ -234,7 +240,14 @@ CGFloat const STPPaymentCardTextFieldMinimumPadding = 10;
 }
 
 - (UIColor *)backgroundColor {
-    return [super backgroundColor] ?: [UIColor whiteColor];
+    UIColor *defaultColor = [UIColor whiteColor];
+    #ifdef __IPHONE_13_0
+        if (@available(iOS 13.0, *)) {
+            defaultColor = [UIColor systemBackgroundColor];
+        }
+    #endif
+    
+    return [super backgroundColor] ?: defaultColor;
 }
 
 - (void)setFont:(UIFont *)font {
@@ -284,7 +297,14 @@ CGFloat const STPPaymentCardTextFieldMinimumPadding = 10;
 }
 
 - (UIColor *)textColor {
-    return _textColor ?: [UIColor blackColor];
+    UIColor *defaultColor = [UIColor blackColor];
+    #ifdef __IPHONE_13_0
+        if (@available(iOS 13.0, *)) {
+            defaultColor = [UIColor labelColor];
+        }
+    #endif
+
+    return _textColor ?: defaultColor;
 }
 
 - (void)setTextErrorColor:(UIColor *)textErrorColor {
@@ -296,7 +316,14 @@ CGFloat const STPPaymentCardTextFieldMinimumPadding = 10;
 }
 
 - (UIColor *)textErrorColor {
-    return _textErrorColor ?: [UIColor redColor];
+    UIColor *defaultColor = [UIColor redColor];
+    #ifdef __IPHONE_13_0
+        if (@available(iOS 13.0, *)) {
+            defaultColor = [UIColor systemRedColor];
+        }
+    #endif
+    
+    return _textErrorColor ?: defaultColor;
 }
 
 - (void)setPlaceholderColor:(UIColor *)placeholderColor {
@@ -1088,6 +1115,11 @@ typedef NS_ENUM(NSInteger, STPCardTextFieldState) {
                                                                         (width - hiddenWidth),
                                                                         fieldsHeight)];
             maskView.backgroundColor = [UIColor blackColor];
+            #ifdef __IPHONE_13_0
+                if (@available(iOS 13.0, *)) {
+                    maskView.backgroundColor = [UIColor systemBackgroundColor];
+                }
+            #endif
             maskView.opaque = YES;
             maskView.userInteractionEnabled = NO;
             [UIView performWithoutAnimation:^{


### PR DESCRIPTION
## Summary
The Custom Integration app (and STPPaymentCardTextField) should also support Dark Mode.

## Testing
On iOS 13 and in CI.