### PR TITLE
Fix typo'd Xcode version in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If you're reading this on GitHub.com, please make sure you are looking at the [t
 
 ## Requirements
 
-The Stripe iOS SDK is compatible with apps supporting iOS 9 and above and requires Xcode 9 to build from source.
+The Stripe iOS SDK is compatible with apps supporting iOS 9 and above and requires Xcode 10.1 to build from source.
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary
Our minimum supported Xcode version is 10.1; our Readme was out of date.

## Motivation
Noticed and confirmed typo during Slack discussion.

**NB:** Should it say "requires at least Xcode 10.1 to build from source"?
