### PR TITLE
Add an option to STPPaymentConfiguration to filter the country list

### DIFF
--- a/LocalizationTester/ViewController.m
+++ b/LocalizationTester/ViewController.m
@@ -24,6 +24,7 @@ typedef NS_ENUM(NSInteger, LocalizedScreen) {
     LocalizedScreenPaymentOptionsVCLoading,
     LocalizedScreenShippingAddressVC,
     LocalizedScreenShippingAddressVCBadAddress,
+    LocalizedScreenShippingAddressVCCountryOutsideAvailable,
     LocalizedScreenShippingAddressVCDelivery,
     LocalizedScreenShippingAddressVCContact,
 };
@@ -46,6 +47,8 @@ static NSString * TitleForLocalizedScreen(LocalizedScreen screen) {
             return @"Shipping Address VC";
         case LocalizedScreenShippingAddressVCBadAddress:
             return @"Shipping Address VC Bad Address";
+        case LocalizedScreenShippingAddressVCCountryOutsideAvailable:
+            return @"Shipping Address VC Country Outside Available";
         case LocalizedScreenShippingAddressVCDelivery:
             return @"Shipping Address VC for Delivery";
         case LocalizedScreenShippingAddressVCContact:
@@ -74,6 +77,7 @@ static NSString * TitleForLocalizedScreen(LocalizedScreen screen) {
                          @(LocalizedScreenPaymentOptionsVCLoading),
                          @(LocalizedScreenShippingAddressVC),
                          @(LocalizedScreenShippingAddressVCBadAddress),
+                         @(LocalizedScreenShippingAddressVCCountryOutsideAvailable),
                          @(LocalizedScreenShippingAddressVCDelivery),
                          @(LocalizedScreenShippingAddressVCContact),
                          ];
@@ -258,6 +262,28 @@ static NSString * TitleForLocalizedScreen(LocalizedScreen screen) {
                 billingAddress.country = @"US"; // We're just going to hard code that "US" country triggers failure below
                 prefilledInfo.billingAddress = billingAddress;
 
+                STPShippingAddressViewController *shippingAddressVC = [[STPShippingAddressViewController alloc] initWithConfiguration:configuration
+                                                                                                                                theme:[STPTheme defaultTheme]
+                                                                                                                             currency:@"usd"
+                                                                                                                      shippingAddress:nil
+                                                                                                               selectedShippingMethod:nil
+                                                                                                                 prefilledInformation:prefilledInfo];
+                shippingAddressVC.delegate = self;
+                vc = shippingAddressVC;
+            }
+                break;
+
+            case LocalizedScreenShippingAddressVCCountryOutsideAvailable:
+            {
+                STPPaymentConfiguration *configuration = [[STPPaymentConfiguration alloc] init];
+                configuration.requiredShippingAddressFields = [NSSet setWithObjects:STPContactFieldPostalAddress, STPContactFieldEmailAddress, STPContactFieldPhoneNumber, STPContactFieldName, nil];
+                configuration.availableCountries = [NSSet setWithArray:@[@"BT"]];
+                STPUserInformation *prefilledInfo = [[STPUserInformation alloc] init];
+                STPAddress *billingAddress = [[STPAddress alloc] init];
+                billingAddress.name = @"Test";
+                billingAddress.country = @"GB";
+                prefilledInfo.billingAddress = billingAddress;
+                
                 STPShippingAddressViewController *shippingAddressVC = [[STPShippingAddressViewController alloc] initWithConfiguration:configuration
                                                                                                                                 theme:[STPTheme defaultTheme]
                                                                                                                              currency:@"usd"

--- a/LocalizationTesterUITests/LocalizationTesterUITests.m
+++ b/LocalizationTesterUITests/LocalizationTesterUITests.m
@@ -111,6 +111,16 @@
     [[errorAlert.buttons elementBoundByIndex:0] tap]; // dismiss alert
     [app.navigationBars.buttons[@"CoreViewControllerCancelIdentifier"] tap];
 
+#pragma mark - Visit the Shipping Address VC Country Outside Available Countries
+    [tablesQuery.staticTexts[@"Shipping Address VC Country Outside Available"] tap];
+    [self _waitForElementToAppear:app.navigationBars.buttons[@"ShippingViewControllerNextButtonIdentifier"]];
+    
+    // Fill out the shipping Info
+    [tablesQuery.buttons[@"ShippingAddressViewControllerUseBillingButton"] tap];
+    [self _takeScreenShotNamed:@"Shipping Address VC Country Outside Available"];
+
+    [app.navigationBars.buttons[@"CoreViewControllerCancelIdentifier"] tap];
+
 #pragma mark - Visit the Shipping Info VC for Delivery
     [tablesQuery.staticTexts[@"Shipping Address VC for Delivery"] tap];
     [self _waitForElementToAppear:app.navigationBars.buttons[@"ShippingViewControllerNextButtonIdentifier"]];

--- a/Stripe/PublicHeaders/STPPaymentConfiguration.h
+++ b/Stripe/PublicHeaders/STPPaymentConfiguration.h
@@ -78,6 +78,15 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign, readwrite) STPShippingType shippingType;
 
 /**
+ The set of countries supported when entering an address. This property accepts
+ a set of ISO 2-character country codes.
+
+ The default value is nil, which will display all known countries. Setting this
+ property will limit the available countries to your selected set.
+ */
+@property (nonatomic, copy, nullable, readwrite) NSSet<NSString *> *availableCountries;
+
+/**
  The name of your company, for displaying to the user during payment flows. For 
  example, when using Apple Pay, the payment sheet's final line item will read
  "PAY {companyName}". 

--- a/Stripe/PublicHeaders/STPPaymentConfiguration.h
+++ b/Stripe/PublicHeaders/STPPaymentConfiguration.h
@@ -81,10 +81,10 @@ NS_ASSUME_NONNULL_BEGIN
  The set of countries supported when entering an address. This property accepts
  a set of ISO 2-character country codes.
 
- The default value is nil, which will display all known countries. Setting this
- property will limit the available countries to your selected set.
+ The default value is all known countries. Setting this property will limit
+ the available countries to your selected set.
  */
-@property (nonatomic, copy, nullable, readwrite) NSSet<NSString *> *availableCountries;
+@property (nonatomic, copy, null_resettable, readwrite) NSSet<NSString *> *availableCountries;
 
 /**
  The name of your company, for displaying to the user during payment flows. For 

--- a/Stripe/STPAddCardViewController.m
+++ b/Stripe/STPAddCardViewController.m
@@ -93,7 +93,7 @@ typedef NS_ENUM(NSUInteger, STPPaymentCardSection) {
     _shippingAddress = nil;
     _hasUsedShippingAddress = NO;
     _apiClient = [[STPAPIClient alloc] initWithConfiguration:configuration];
-    _addressViewModel = [[STPAddressViewModel alloc] initWithRequiredBillingFields:configuration.requiredBillingAddressFields];
+    _addressViewModel = [[STPAddressViewModel alloc] initWithRequiredBillingFields:configuration.requiredBillingAddressFields availableCountries:configuration.availableCountries];
     _addressViewModel.delegate = self;
 
     self.title = STPLocalizedString(@"Add a Card", @"Title for Add a Card view");

--- a/Stripe/STPAddCardViewController.m
+++ b/Stripe/STPAddCardViewController.m
@@ -93,7 +93,7 @@ typedef NS_ENUM(NSUInteger, STPPaymentCardSection) {
     _shippingAddress = nil;
     _hasUsedShippingAddress = NO;
     _apiClient = [[STPAPIClient alloc] initWithConfiguration:configuration];
-    _addressViewModel = [[STPAddressViewModel alloc] initWithRequiredBillingFields:configuration.requiredBillingAddressFields availableCountries:configuration.availableCountries];
+    _addressViewModel = [[STPAddressViewModel alloc] initWithRequiredBillingFields:configuration.requiredBillingAddressFields availableCountries:configuration._availableCountries];
     _addressViewModel.delegate = self;
 
     self.title = STPLocalizedString(@"Add a Card", @"Title for Add a Card view");

--- a/Stripe/STPAddressFieldTableViewCell.h
+++ b/Stripe/STPAddressFieldTableViewCell.h
@@ -34,6 +34,7 @@ typedef NS_ENUM(NSInteger, STPAddressFieldType) {
 - (void)addressFieldTableViewCellDidReturn:(STPAddressFieldTableViewCell *)cell;
 - (void)addressFieldTableViewCellDidEndEditing:(STPAddressFieldTableViewCell *)cell;
 @property (nonatomic, copy) NSString *addressFieldTableViewCountryCode;
+@property (nonatomic, copy) NSSet<NSString *> *availableCountries;
 
 @end
 

--- a/Stripe/STPAddressFieldTableViewCell.m
+++ b/Stripe/STPAddressFieldTableViewCell.m
@@ -69,9 +69,18 @@
         _inputAccessoryToolbar = toolbar;
         
         NSString *countryCode = [[NSLocale autoupdatingCurrentLocale] objectForKey:NSLocaleCountryCode];
-        NSMutableArray *otherCountryCodes = [[NSLocale ISOCountryCodes] mutableCopy];
+        NSMutableArray *otherCountryCodes = [[self.delegate.availableCountries allObjects] mutableCopy];
+        if (otherCountryCodes == nil) {            
+            otherCountryCodes = [[NSLocale ISOCountryCodes] mutableCopy];
+        }
+        if ([otherCountryCodes containsObject:countryCode]) {
+            // Remove the current country code to re-add it once we sort the list.
+            [otherCountryCodes removeObject:countryCode];
+        } else {
+            // If it isn't in the list (if we've been configured to not show that country), don't re-add it.
+            countryCode = nil;
+        }
         NSLocale *locale = [NSLocale currentLocale];
-        [otherCountryCodes removeObject:countryCode];
         [otherCountryCodes sortUsingComparator:^NSComparisonResult(NSString *code1, NSString *code2) {
             NSString *localeID1 = [NSLocale localeIdentifierFromComponents:@{NSLocaleCountryCode: code1}];
             NSString *localeID2 = [NSLocale localeIdentifierFromComponents:@{NSLocaleCountryCode: code2}];
@@ -179,6 +188,11 @@
             self.textField.keyboardType = UIKeyboardTypeDefault;
             // Don't set textContentType for Country, because we don't want iOS to skip the UIPickerView for input
             self.textField.inputView = self.countryPickerView;
+            
+            // If we're being set directly to a country we don't allow, add it to the allowed list
+            if (![self.countryCodes containsObject:self.contents] && [[NSLocale ISOCountryCodes] containsObject:self.contents]) {
+                self.countryCodes = [self.countryCodes arrayByAddingObject:self.contents];
+            }
             NSInteger index = [self.countryCodes indexOfObject:self.contents];
             if (index == NSNotFound) {
                 self.textField.text = @"";

--- a/Stripe/STPAddressViewModel.h
+++ b/Stripe/STPAddressViewModel.h
@@ -25,10 +25,13 @@
 @property (nonatomic, readonly) NSArray<STPAddressFieldTableViewCell *> *addressCells;
 @property (nonatomic, weak) id<STPAddressViewModelDelegate>delegate;
 @property (nonatomic) STPAddress *address;
+@property (nonatomic, copy, readwrite) NSSet<NSString *> *availableCountries;
 @property (nonatomic, readonly) BOOL isValid;
 
 - (instancetype)initWithRequiredBillingFields:(STPBillingAddressFields)requiredBillingAddressFields;
 - (instancetype)initWithRequiredShippingFields:(NSSet<STPContactField> *)requiredShippingAddressFields;
+- (instancetype)initWithRequiredBillingFields:(STPBillingAddressFields)requiredBillingAddressFields availableCountries:(NSSet<NSString *> *)availableCountries;
+- (instancetype)initWithRequiredShippingFields:(NSSet<STPContactField> *)requiredShippingAddressFields availableCountries:(NSSet<NSString *> *)availableCountries;
 - (STPAddressFieldTableViewCell *)cellAtIndex:(NSInteger)index;
 
 @end

--- a/Stripe/STPAddressViewModel.h
+++ b/Stripe/STPAddressViewModel.h
@@ -30,6 +30,8 @@
 
 - (instancetype)initWithRequiredBillingFields:(STPBillingAddressFields)requiredBillingAddressFields;
 - (instancetype)initWithRequiredShippingFields:(NSSet<STPContactField> *)requiredShippingAddressFields;
+
+/* The default value of availableCountries is nil, which will allow all known countries. */
 - (instancetype)initWithRequiredBillingFields:(STPBillingAddressFields)requiredBillingAddressFields availableCountries:(NSSet<NSString *> *)availableCountries;
 - (instancetype)initWithRequiredShippingFields:(NSSet<STPContactField> *)requiredShippingAddressFields availableCountries:(NSSet<NSString *> *)availableCountries;
 - (STPAddressFieldTableViewCell *)cellAtIndex:(NSInteger)index;

--- a/Stripe/STPAddressViewModel.m
+++ b/Stripe/STPAddressViewModel.m
@@ -32,7 +32,7 @@
     self = [super init];
     if (self) {
         _isBillingAddress = YES;
-        _availableCountries = availableCountries;
+        _availableCountries = [availableCountries copy];
         _requiredBillingAddressFields = requiredBillingAddressFields;
         switch (requiredBillingAddressFields) {
             case STPBillingAddressFieldsNone:
@@ -69,7 +69,7 @@
     self = [super init];
     if (self) {
         _isBillingAddress = NO;
-        _availableCountries = availableCountries;
+        _availableCountries = [availableCountries copy];
         _requiredShippingAddressFields = requiredShippingAddressFields;
         NSMutableArray *cells = [NSMutableArray new];
         if ([requiredShippingAddressFields containsObject:STPContactFieldName]) {

--- a/Stripe/STPAddressViewModel.m
+++ b/Stripe/STPAddressViewModel.m
@@ -26,11 +26,13 @@
 @implementation STPAddressViewModel
 
 @synthesize addressFieldTableViewCountryCode = _addressFieldTableViewCountryCode;
+@synthesize availableCountries = _availableCountries;
 
-- (instancetype)initWithRequiredBillingFields:(STPBillingAddressFields)requiredBillingAddressFields {
+- (instancetype)initWithRequiredBillingFields:(STPBillingAddressFields)requiredBillingAddressFields availableCountries:(NSSet<NSString *> *)availableCountries {
     self = [super init];
     if (self) {
         _isBillingAddress = YES;
+        _availableCountries = availableCountries;
         _requiredBillingAddressFields = requiredBillingAddressFields;
         switch (requiredBillingAddressFields) {
             case STPBillingAddressFieldsNone:
@@ -63,10 +65,11 @@
     return self;
 }
 
-- (instancetype)initWithRequiredShippingFields:(NSSet<STPContactField> *)requiredShippingAddressFields {
+- (instancetype)initWithRequiredShippingFields:(NSSet<STPContactField> *)requiredShippingAddressFields availableCountries:(NSSet<NSString *> *)availableCountries {
     self = [super init];
     if (self) {
         _isBillingAddress = NO;
+        _availableCountries = availableCountries;
         _requiredShippingAddressFields = requiredShippingAddressFields;
         NSMutableArray *cells = [NSMutableArray new];
         if ([requiredShippingAddressFields containsObject:STPContactFieldName]) {
@@ -101,6 +104,13 @@
         [self commonInit];
     }
     return self;
+}
+
+- (instancetype)initWithRequiredBillingFields:(STPBillingAddressFields)requiredBillingAddressFields {
+    return [self initWithRequiredBillingFields:requiredBillingAddressFields availableCountries:nil];
+}
+- (instancetype)initWithRequiredShippingFields:(NSSet<STPContactField> *)requiredShippingAddressFields {
+    return [self initWithRequiredShippingFields:requiredShippingAddressFields availableCountries:nil];
 }
 
 - (void)commonInit {

--- a/Stripe/STPPaymentConfiguration+Private.h
+++ b/Stripe/STPPaymentConfiguration+Private.h
@@ -11,6 +11,7 @@
 @interface STPPaymentConfiguration ()
 
 @property (nonatomic, assign, readonly) BOOL applePayEnabled;
+@property (nonatomic, assign, readonly) NSSet<NSString *> *_availableCountries;
 
 @end
 

--- a/Stripe/STPPaymentConfiguration.m
+++ b/Stripe/STPPaymentConfiguration.m
@@ -56,6 +56,18 @@
     [Stripe deviceSupportsApplePay];
 }
 
+- (NSSet<NSString *> *)availableCountries {
+    if (_availableCountries == nil) {
+        return [NSSet setWithArray:[NSLocale ISOCountryCodes]];
+    } else {
+        return _availableCountries;
+    }
+}
+
+- (NSSet<NSString *> *)_availableCountries {
+    return _availableCountries;
+}
+
 #pragma mark - Description
 
 - (NSString *)description {
@@ -144,7 +156,7 @@
     copy.companyName = self.companyName;
     copy.appleMerchantIdentifier = self.appleMerchantIdentifier;
     copy.canDeletePaymentOptions = self.canDeletePaymentOptions;
-    copy.availableCountries = self.availableCountries;
+    copy.availableCountries = _availableCountries;
     return copy;
 }
 

--- a/Stripe/STPPaymentConfiguration.m
+++ b/Stripe/STPPaymentConfiguration.m
@@ -120,6 +120,7 @@
                        [NSString stringWithFormat:@"requiredShippingAddressFields = %@", requiredShippingAddressFieldsDescription],
                        [NSString stringWithFormat:@"verifyPrefilledShippingAddress = %@", (self.verifyPrefilledShippingAddress) ? @"YES" : @"NO"],
                        [NSString stringWithFormat:@"shippingType = %@", shippingTypeDescription],
+                       [NSString stringWithFormat:@"availableCountries = %@", _availableCountries],
 
                        // Additional configuration
                        [NSString stringWithFormat:@"companyName = %@", self.companyName],
@@ -143,6 +144,7 @@
     copy.companyName = self.companyName;
     copy.appleMerchantIdentifier = self.appleMerchantIdentifier;
     copy.canDeletePaymentOptions = self.canDeletePaymentOptions;
+    copy.availableCountries = self.availableCountries;
     return copy;
 }
 

--- a/Stripe/STPShippingAddressViewController.m
+++ b/Stripe/STPShippingAddressViewController.m
@@ -87,7 +87,7 @@
         _selectedShippingMethod = selectedShippingMethod;
         _billingAddress = prefilledInformation.billingAddress;
         _hasUsedBillingAddress = NO;
-        _addressViewModel = [[STPAddressViewModel alloc] initWithRequiredShippingFields:configuration.requiredShippingAddressFields];
+        _addressViewModel = [[STPAddressViewModel alloc] initWithRequiredShippingFields:configuration.requiredShippingAddressFields availableCountries:configuration.availableCountries];
         _addressViewModel.delegate = self;
         if (shippingAddress != nil) {
             _addressViewModel.address = shippingAddress;

--- a/Stripe/STPShippingAddressViewController.m
+++ b/Stripe/STPShippingAddressViewController.m
@@ -16,6 +16,7 @@
 #import "STPImageLibrary+Private.h"
 #import "STPLocalizationUtils.h"
 #import "STPPaymentActivityIndicatorView.h"
+#import "STPPaymentConfiguration+Private.h"
 #import "STPPaymentContext+Private.h"
 #import "STPSectionHeaderView.h"
 #import "STPShippingMethodsViewController.h"
@@ -87,7 +88,7 @@
         _selectedShippingMethod = selectedShippingMethod;
         _billingAddress = prefilledInformation.billingAddress;
         _hasUsedBillingAddress = NO;
-        _addressViewModel = [[STPAddressViewModel alloc] initWithRequiredShippingFields:configuration.requiredShippingAddressFields availableCountries:configuration.availableCountries];
+        _addressViewModel = [[STPAddressViewModel alloc] initWithRequiredShippingFields:configuration.requiredShippingAddressFields availableCountries:configuration._availableCountries];
         _addressViewModel.delegate = self;
         if (shippingAddress != nil) {
             _addressViewModel.address = shippingAddress;

--- a/Tests/Tests/STPPaymentConfigurationTest.m
+++ b/Tests/Tests/STPPaymentConfigurationTest.m
@@ -107,6 +107,7 @@
     paymentConfigurationA.requiredBillingAddressFields = STPBillingAddressFieldsFull;
     paymentConfigurationA.requiredShippingAddressFields = allFields;
     paymentConfigurationA.verifyPrefilledShippingAddress = NO;
+    paymentConfigurationA.availableCountries = [NSSet setWithArray:@[@"US", @"CA", @"BT"]];
     paymentConfigurationA.shippingType = STPShippingTypeDelivery;
     paymentConfigurationA.companyName = @"companyName";
     paymentConfigurationA.appleMerchantIdentifier = @"appleMerchantIdentifier";
@@ -123,6 +124,8 @@
     XCTAssertEqual(paymentConfigurationB.shippingType, STPShippingTypeDelivery);
     XCTAssertEqualObjects(paymentConfigurationB.companyName, @"companyName");
     XCTAssertEqualObjects(paymentConfigurationB.appleMerchantIdentifier, @"appleMerchantIdentifier");
+    NSSet *availableCountries = [NSSet setWithArray:@[@"US", @"CA", @"BT"]];
+    XCTAssertEqualObjects(paymentConfigurationB.availableCountries, availableCountries);
     XCTAssertEqual(paymentConfigurationA.canDeletePaymentOptions, paymentConfigurationB.canDeletePaymentOptions);
 }
 

--- a/Tests/Tests/STPShippingAddressViewControllerTest.m
+++ b/Tests/Tests/STPShippingAddressViewControllerTest.m
@@ -46,6 +46,38 @@
     XCTAssertNoThrow([sut viewDidLoad]);
 }
 
+- (void)testPrefilledBillingAddress_addAddressWithLimitedCountries {
+    [NSLocale stp_setCurrentLocale:[NSLocale localeWithLocaleIdentifier:@"en_ZW"]];
+    // Zimbabwe does not require zip codes, while the default locale for tests (US) does
+    // Sanity checks
+    XCTAssertFalse([STPPostalCodeValidator postalCodeIsRequiredForCountryCode:@"ZW"]);
+    XCTAssertTrue([STPPostalCodeValidator postalCodeIsRequiredForCountryCode:@"US"]);
+    STPPaymentConfiguration *config = [STPFixtures paymentConfiguration];
+    config.requiredShippingAddressFields = [NSSet setWithObject:STPContactFieldPostalAddress];
+    config.availableCountries = [[NSSet alloc] initWithArray:@[@"CA", @"BT"]];
+
+    STPAddress *address = [STPAddress new];
+    address.name = @"John Smith Doe";
+    address.phone = @"8885551212";
+    address.email = @"foo@example.com";
+    address.line1 = @"55 John St";
+    address.city = @"New York";
+    address.state = @"NY";
+    address.postalCode = @"10002";
+    address.country = @"US";
+
+    STPShippingAddressViewController *sut = [[STPShippingAddressViewController alloc] initWithConfiguration:config
+                                                                                                      theme:[STPTheme defaultTheme]
+                                                                                                   currency:nil
+                                                                                            shippingAddress:address
+                                                                                     selectedShippingMethod:nil
+                                                                                       prefilledInformation:nil];
+
+    XCTAssertNoThrow([sut loadView]);
+    XCTAssertNoThrow([sut viewDidLoad]);
+    [NSLocale stp_resetCurrentLocale];
+}
+
 - (void)testPrefilledBillingAddress_addAddress {
     [NSLocale stp_setCurrentLocale:[NSLocale localeWithLocaleIdentifier:@"en_ZW"]];
     // Zimbabwe does not require zip codes, while the default locale for tests (US) does


### PR DESCRIPTION
## Summary
Add a new `availableCountries` property to STPPaymentConfiguration, allowing a developer to filter the list of countries.

This is nil, displaying all countries, by default. It can be set to a list of ISO country codes, which will filter our UI to only display those countries.
* If the user locale's country code is in that list, it will be selected by default. If not, the country field will be empty.
* If setAddress is called with a country code outside of this list, that country code will be added to the UI.

## Motivation
Fixes #1314 and many other out-of-band requests for this feature.

## Testing
Updated some related tests, though I'm going to write a specific UI test before shipping.