### PR TITLE
PaymentOptionsViewController fails to update when a new card is added

### DIFF
--- a/Example/UI Examples/MockAPIClient.swift
+++ b/Example/UI Examples/MockAPIClient.swift
@@ -37,42 +37,6 @@ extension STPAddCardViewController {
 }
 
 class MockAPIClient: STPAPIClient {
-
-    override func createToken(withCard card: STPCardParams, completion: STPTokenCompletionBlock? = nil) {
-        guard let completion = completion else { return }
-
-        // Generate a mock card model using the given card params
-        var cardJSON: [String: Any] = [:]
-        cardJSON["id"] = "\(card.hashValue)"
-        cardJSON["exp_month"] = "\(card.expMonth)"
-        cardJSON["exp_year"] = "\(card.expYear)"
-        cardJSON["name"] = card.name
-        cardJSON["address_line1"] = card.address.line1
-        cardJSON["address_line2"] = card.address.line2
-        cardJSON["address_state"] = card.address.state
-        cardJSON["address_zip"] = card.address.postalCode
-        cardJSON["address_country"] = card.address.country
-        cardJSON["last4"] = card.last4()
-        if let number = card.number {
-            let brand = STPCardValidator.brand(forNumber: number)
-            cardJSON["brand"] = STPCard.string(from: brand)
-        }
-        cardJSON["fingerprint"] = "\(card.hashValue)"
-        cardJSON["country"] = "US"
-        let tokenJSON: [String: Any] = [
-            "id": "\(card.hashValue)",
-            "object": "token",
-            "livemode": false,
-            "created": NSDate().timeIntervalSince1970,
-            "used": false,
-            "card": cardJSON,
-        ]
-        let token = STPToken.decodedObject(fromAPIResponse: tokenJSON)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
-            completion(token, nil)
-        }
-    }
-    
     override func createPaymentMethod(with paymentMethodParams: STPPaymentMethodParams, completion: @escaping STPPaymentMethodCompletionBlock) {
         guard let card = paymentMethodParams.card, let billingDetails = paymentMethodParams.billingDetails else { return }
         

--- a/Example/UI Examples/MockAPIClient.swift
+++ b/Example/UI Examples/MockAPIClient.swift
@@ -72,4 +72,43 @@ class MockAPIClient: STPAPIClient {
             completion(token, nil)
         }
     }
+    
+    override func createPaymentMethod(with paymentMethodParams: STPPaymentMethodParams, completion: @escaping STPPaymentMethodCompletionBlock) {
+        guard let card = paymentMethodParams.card, let billingDetails = paymentMethodParams.billingDetails else { return }
+        
+        // Generate a mock card model using the given card params
+        var cardJSON: [String: Any] = [:]
+        var billingDetailsJSON: [String: Any] = [:]
+        cardJSON["id"] = "\(card.hashValue)"
+        cardJSON["exp_month"] = "\(card.expMonth ?? 0)"
+        cardJSON["exp_year"] = "\(card.expYear ?? 0)"
+        cardJSON["last4"] = card.number?.suffix(4)
+        billingDetailsJSON["name"] = billingDetails.name
+        billingDetailsJSON["line1"] = billingDetails.address?.line1
+        billingDetailsJSON["line2"] = billingDetails.address?.line2
+        billingDetailsJSON["state"] = billingDetails.address?.state
+        billingDetailsJSON["postal_code"] = billingDetails.address?.postalCode
+        billingDetailsJSON["country"] = billingDetails.address?.country
+        cardJSON["country"] = billingDetails.address?.country
+        if let number = card.number {
+            let brand = STPCardValidator.brand(forNumber: number)
+            cardJSON["brand"] = STPCard.string(from: brand)
+        }
+        cardJSON["fingerprint"] = "\(card.hashValue)"
+        cardJSON["country"] = "US"
+        let paymentMethodJSON: [String: Any] = [
+            "id": "\(card.hashValue)",
+            "object": "payment_method",
+            "type": "card",
+            "livemode": false,
+            "created": NSDate().timeIntervalSince1970,
+            "used": false,
+            "card": cardJSON,
+            "billing_details": billingDetailsJSON,
+        ]
+        let paymentMethod = STPPaymentMethod.decodedObject(fromAPIResponse: paymentMethodJSON)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+            completion(paymentMethod, nil)
+        }
+    }
 }

--- a/Stripe/STPPaymentOptionsViewController.m
+++ b/Stripe/STPPaymentOptionsViewController.m
@@ -191,6 +191,19 @@
         stpDispatchToMainThreadIfNecessary(^{
             completion(error);
             if (!error) {
+                STPPromise<STPPaymentOptionTuple *> *promise = [self retrievePaymentMethodsWithConfiguration:self.configuration apiAdapter:self.apiAdapter];
+                WEAK(self);
+                [promise onSuccess:^(STPPaymentOptionTuple *tuple) {
+                    STRONG(self);
+                    if (!self) {
+                        return;
+                    }
+                    STPPaymentOptionTuple *paymentTuple = [STPPaymentOptionTuple tupleWithPaymentOptions:tuple.paymentOptions selectedPaymentOption:paymentMethod];
+                    if ([self.internalViewController isKindOfClass:[STPPaymentOptionsInternalViewController class]]) {
+                        STPPaymentOptionsInternalViewController *paymentOptionsVC = (STPPaymentOptionsInternalViewController *)self.internalViewController;
+                        [paymentOptionsVC updateWithPaymentOptionTuple:paymentTuple];
+                    }
+                }];
                 [self finishWithPaymentOption:(id<STPPaymentOption>)paymentMethod];
             }
         });


### PR DESCRIPTION
## Summary
* Refresh PaymentOptionsViewController when a new card is added.
* Fix UI Examples to mock createPaymentMethod instead of createToken.

## Motivation
In v15, PaymentOptionsViewController would be updated when a new card was added. This regressed in v16 as part of the PaymentMethods refactor. I'm not sure how common this use case is, but it did break UI Examples.

## Testing
Tested in CI and on simulator.