### PR TITLE
Update Apple Pay to iOS 11 APIs

### DIFF
--- a/Example/Custom Integration.xcodeproj/project.pbxproj
+++ b/Example/Custom Integration.xcodeproj/project.pbxproj
@@ -443,7 +443,7 @@
 					"$(PROJECT_DIR)/**",
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/Custom Integration/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.stripe.CustomSDKExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -468,7 +468,7 @@
 					"$(PROJECT_DIR)/**",
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/Custom Integration/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.stripe.CustomSDKExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Example/Custom Integration/ApplePayExampleViewController.m
+++ b/Example/Custom Integration/ApplePayExampleViewController.m
@@ -121,8 +121,7 @@
 - (void)paymentAuthorizationViewController:(PKPaymentAuthorizationViewController *)controller didAuthorizePayment:(PKPayment *)payment handler:(void (^)(PKPaymentAuthorizationResult * _Nonnull))completion  API_AVAILABLE(ios(11.0)) {
     [[STPAPIClient sharedClient] createPaymentMethodWithPayment:payment completion:^(STPPaymentMethod *paymentMethod, NSError *error) {
         if (error) {
-            self.applePayError = error;
-            NSError *pkError = [NSError errorWithDomain:PKPaymentErrorDomain code:PKPaymentUnknownError userInfo:error.userInfo];
+            NSError *pkError = [STPAPIClient pkPaymentErrorForStripeError:error];
             PKPaymentAuthorizationResult *result = [[PKPaymentAuthorizationResult alloc] initWithStatus:PKPaymentAuthorizationStatusFailure errors:@[pkError]];
             completion(result);
         } else {
@@ -142,7 +141,7 @@
             NSArray<NSError *> *errors;
             if (self.applePayError) {
                 // Note: The docs say localizedDescription can be shown in the Apple Pay sheet, but I haven't observed this.
-                errors = @[[NSError errorWithDomain:PKPaymentErrorDomain code:PKPaymentUnknownError userInfo:self.applePayError.userInfo]];
+                errors = @[[STPAPIClient pkPaymentErrorForStripeError:self.applePayError]];
             }
             // Note: if status is .failure and an error is provided, the user is prompted to try again.  Otherwise, the sheet is dismissed.
             PKPaymentAuthorizationResult *result = [[PKPaymentAuthorizationResult alloc] initWithStatus:status errors:errors];

--- a/Stripe/PublicHeaders/STPAPIClient+ApplePay.h
+++ b/Stripe/PublicHeaders/STPAPIClient+ApplePay.h
@@ -10,6 +10,8 @@
 
 #import "STPAPIClient.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  STPAPIClient extensions to create Stripe Tokens, Sources, or PaymentMethods from Apple Pay PKPayment objects.
  */
@@ -21,8 +23,8 @@
  @param payment     The user's encrypted payment information as returned from a PKPaymentAuthorizationViewController. Cannot be nil.
  @param completion  The callback to run with the returned Stripe token (and any errors that may have occurred).
  */
-- (void)createTokenWithPayment:(nonnull PKPayment *)payment
-                    completion:(nonnull STPTokenCompletionBlock)completion;
+- (void)createTokenWithPayment:(PKPayment *)payment
+                    completion:(STPTokenCompletionBlock)completion;
 
 /**
  Converts a PKPayment object into a Stripe source using the Stripe API.
@@ -30,8 +32,8 @@
  @param payment     The user's encrypted payment information as returned from a PKPaymentAuthorizationViewController. Cannot be nil.
  @param completion  The callback to run with the returned Stripe source (and any errors that may have occurred).
  */
-- (void)createSourceWithPayment:(nonnull PKPayment *)payment
-                     completion:(nonnull STPSourceCompletionBlock)completion;
+- (void)createSourceWithPayment:(PKPayment *)payment
+                     completion:(STPSourceCompletionBlock)completion;
 
 /**
  Converts a PKPayment object into a Stripe Payment Method using the Stripe API.
@@ -39,10 +41,25 @@
  @param payment     The user's encrypted payment information as returned from a PKPaymentAuthorizationViewController. Cannot be nil.
  @param completion  The callback to run with the returned Stripe source (and any errors that may have occurred).
  */
-- (void)createPaymentMethodWithPayment:(nonnull PKPayment *)payment
-                     completion:(nonnull STPPaymentMethodCompletionBlock)completion;
+- (void)createPaymentMethodWithPayment:(PKPayment *)payment
+                            completion:(STPPaymentMethodCompletionBlock)completion;
+
+/**
+ Converts Stripe errors into the appropriate Apple Pay error, for use in `PKPaymentAuthorizationResult`. The error is displayed in the Apple Pay sheet, and the user can try again.
+ 
+ We can convert billing address related errors into a PKPaymentError that helpfully points to the billing address field in the Apple Pay sheet.
+ All other errors map to PKPaymentUnknownError, resulting in a generic error message in the Apple Pay sheet.
+ 
+ Apple Pay should prevent most card errors (e.g. invalid CVC) when you add a card to the wallet.
+ 
+ @param stripeError   An error from the Stripe SDK.
+ @see ApplePayExampleViewController for an example of how to use this method in your Apple Pay integration.
+ */
++ (NSError *)pkPaymentErrorForStripeError:(NSError *)stripeError API_AVAILABLE(ios(11.0), watchos(4.0));
 
 @end
+
+NS_ASSUME_NONNULL_END
 
 /**
  This function should not be called directly.

--- a/Stripe/PublicHeaders/STPAPIClient+ApplePay.h
+++ b/Stripe/PublicHeaders/STPAPIClient+ApplePay.h
@@ -55,7 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param stripeError   An error from the Stripe SDK.
  @see ApplePayExampleViewController for an example of how to use this method in your Apple Pay integration.
  */
-+ (NSError *)pkPaymentErrorForStripeError:(NSError *)stripeError API_AVAILABLE(ios(11.0), watchos(4.0));
++ (nullable NSError *)pkPaymentErrorForStripeError:(nullable NSError *)stripeError API_AVAILABLE(ios(11.0), watchos(4.0));
 
 @end
 

--- a/Stripe/PublicHeaders/STPApplePayPaymentOption.h
+++ b/Stripe/PublicHeaders/STPApplePayPaymentOption.h
@@ -14,7 +14,7 @@
  be checked on an `STPPaymentContext`, e.g:
  
  ```
- if ([paymentContext.selectedPaymentOption isKindOfClass:[STPApplePay class]]) {
+ if ([paymentContext.selectedPaymentOption isKindOfClass:[STPApplePayPaymentOption class]]) {
     // Don't ask the user for their card number; they want to pay with apple pay.
  }
  ```

--- a/Stripe/PublicHeaders/STPPaymentMethodParams.h
+++ b/Stripe/PublicHeaders/STPPaymentMethodParams.h
@@ -17,6 +17,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  An object representing parameters used to create a PaymentMethod object.
+ 
+ @note To create a PaymentMethod from an Apple Pay PKPaymentToken, see `STPAPIClient createPaymentMethodWithPayment:completion:`
+ 
  @see https://stripe.com/docs/api/payment_methods/create
  */
 @interface STPPaymentMethodParams : NSObject <STPFormEncodable>

--- a/Stripe/PublicHeaders/StripeError.h
+++ b/Stripe/PublicHeaders/StripeError.h
@@ -154,6 +154,11 @@ FOUNDATION_EXPORT STPCardErrorCode __nonnull const STPIncorrectCVC;
 FOUNDATION_EXPORT STPCardErrorCode __nonnull const STPProcessingError;
 
 /**
+ The postal code is incorrect.
+ */
+FOUNDATION_EXPORT STPCardErrorCode __nonnull const STPIncorrectZip;
+
+/**
  NSError extensions for creating error objects from Stripe API responses.
  */
 @interface NSError(Stripe)

--- a/Stripe/STPAPIClient+ApplePay.m
+++ b/Stripe/STPAPIClient+ApplePay.m
@@ -154,10 +154,13 @@
 #pragma mark - Errors
 
 + (NSError *)pkPaymentErrorForStripeError:(NSError *)stripeError {
+    if (stripeError == nil) {
+        return nil;
+    }
     NSMutableDictionary *userInfo = [stripeError.userInfo mutableCopy];
     PKPaymentErrorCode errorCode = PKPaymentUnknownError;
     if (stripeError.domain == StripeDomain) {
-        if (stripeError.userInfo[STPCardErrorCodeKey] == STPIncorrectZip) {
+        if ([stripeError.userInfo[STPCardErrorCodeKey] isEqualToString:STPIncorrectZip]) {
             errorCode = PKPaymentBillingContactInvalidError;
             userInfo[PKPaymentErrorPostalAddressUserInfoKey] = CNPostalAddressPostalCodeKey;
         }

--- a/Stripe/STPAPIClient+ApplePay.m
+++ b/Stripe/STPAPIClient+ApplePay.m
@@ -151,6 +151,20 @@
     return payload;
 }
 
+#pragma mark - Errors
+
++ (NSError *)pkPaymentErrorForStripeError:(NSError *)stripeError {
+    NSMutableDictionary *userInfo = [stripeError.userInfo mutableCopy];
+    PKPaymentErrorCode errorCode = PKPaymentUnknownError;
+    if (stripeError.domain == StripeDomain) {
+        if (stripeError.userInfo[STPCardErrorCodeKey] == STPIncorrectZip) {
+            errorCode = PKPaymentBillingContactInvalidError;
+            userInfo[PKPaymentErrorPostalAddressUserInfoKey] = CNPostalAddressPostalCodeKey;
+        }
+    }
+    return [NSError errorWithDomain:PKPaymentErrorDomain code:errorCode userInfo:userInfo];
+}
+
 @end
 
 void linkSTPAPIClientApplePayCategory(void){}

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -812,7 +812,7 @@ toCustomerUsingKey:(STPEphemeralKey *)ephemeralKey
 - (void)createPaymentMethodWithParams:(STPPaymentMethodParams *)paymentMethodParams
                                  completion:(STPPaymentMethodCompletionBlock)completion {
     NSCAssert(paymentMethodParams != nil, @"'paymentMethodParams' is required to create a PaymentMethod");
-    
+    NSCAssert(paymentMethodParams.rawTypeString != nil, @"Set the `type` or `rawTypeString` property on paymentMethodParams.");
     [STPAPIRequest<STPPaymentMethod *> postWithAPIClient:self
                                                endpoint:APIEndpointPaymentMethods
                                              parameters:[STPFormEncoder dictionaryForObject:paymentMethodParams]

--- a/Stripe/STPPaymentMethodCardParams.m
+++ b/Stripe/STPPaymentMethodCardParams.m
@@ -27,6 +27,34 @@
     return self;
 }
 
+#pragma mark - Description
+
+- (NSString *)description {
+    NSArray *props = @[
+                       // Object
+                       [NSString stringWithFormat:@"%@: %p", NSStringFromClass([self class]), self],
+                       
+                       // Basic card details
+                       [NSString stringWithFormat:@"last4 = %@", self.last4],
+                       [NSString stringWithFormat:@"expMonth = %@", self.expMonth],
+                       [NSString stringWithFormat:@"expYear = %@", self.expYear],
+                       [NSString stringWithFormat:@"cvc = %@", (self.cvc) ? @"<redacted>" : nil],
+                       
+                       // Token
+                       [NSString stringWithFormat:@"token = %@", self.token],
+                       ];
+    
+    return [NSString stringWithFormat:@"<%@>", [props componentsJoinedByString:@"; "]];
+}
+
+- (NSString *)last4 {
+    if (self.number && self.number.length >= 4) {
+        return [self.number substringFromIndex:(self.number.length - 4)];
+    } else {
+        return nil;
+    }
+}
+
 #pragma mark - STPFormEncodable
 
 

--- a/Stripe/StripeError.m
+++ b/Stripe/StripeError.m
@@ -27,6 +27,7 @@ NSString *const STPExpiredCard = @"com.stripe.lib:ExpiredCard";
 NSString *const STPCardDeclined = @"com.stripe.lib:CardDeclined";
 NSString *const STPProcessingError = @"com.stripe.lib:ProcessingError";
 NSString *const STPIncorrectCVC = @"com.stripe.lib:IncorrectCVC";
+NSString *const STPIncorrectZip = @"com.stripe.lib:IncorrectZip";
 
 @implementation NSError (Stripe)
 
@@ -75,6 +76,7 @@ NSString *const STPIncorrectCVC = @"com.stripe.lib:IncorrectCVC";
                                   @"incorrect_cvc": @{@"code": STPIncorrectCVC, @"message": [self stp_cardInvalidCVCUserMessage]},
                                   @"card_declined": @{@"code": STPCardDeclined, @"message": [self stp_cardErrorDeclinedUserMessage]},
                                   @"processing_error": @{@"code": STPProcessingError, @"message": [self stp_cardErrorProcessingErrorUserMessage]},
+                                  @"incorrect_zip": @{@"code": STPIncorrectZip},
                                   };
         NSDictionary *codeMapEntry = codeMap[stripeErrorCode];
         NSDictionary *cardErrorCode = codeMapEntry[@"code"];


### PR DESCRIPTION
## Summary
* Update ApplePayExampleViewController to use iOS 11+ APIs.  I also bumped the Custom Integration project to target iOS 11.  Which target to choose is open but for the purpose of this PR, iOS 11 or 12 doesn't make a difference.
* Update ApplePayExampleViewController automatic confirmation, this is the new recommended default.
* The new `didAuthorizePayment` API completion block has an errors param.  If you populate it, the apple sheet shows an error and doesn't dismiss, letting the user try again.  I added `pkPaymentErrorForStripeError` for this.  

TODO in another PR: Update STPPaymentContext's Apple Pay integration to the new APIs

## Motivation
Example code is probably more useful targeting iOS 11+.

## Testing
Tested ApplePayExampleViewController on my device w/ invalid zip test card:
![image](https://user-images.githubusercontent.com/47796191/64050000-9f68f980-cb2b-11e9-883e-41c8d371e5dd.png)

"stolen" test card:
![image](https://user-images.githubusercontent.com/47796191/64050025-af80d900-cb2b-11e9-802a-18bcb404e0cf.png)
 
