### PR TITLE
Make STPRedirectContext error look more like the other SDK errors

### DIFF
--- a/Stripe/PublicHeaders/STPRedirectContext.h
+++ b/Stripe/PublicHeaders/STPRedirectContext.h
@@ -19,12 +19,12 @@ FOUNDATION_EXPORT NSString *const STPRedirectContextErrorDomain;
 /**
  Error codes specific to `STPRedirectContext`
  */
-typedef NS_ERROR_ENUM(STPRedirectContextErrorDomain, STPRedirectContextError) {
+typedef NS_ERROR_ENUM(STPRedirectContextErrorDomain, STPRedirectContextErrorCode) {
     /**
      `STPRedirectContext` failed to redirect to the app to complete the payment.
      This could be because the app is not installed on the user's device.
      */
-    STPRedirectContextErrorAppRedirect,
+    STPRedirectContextAppRedirectError,
 };
 
 /**

--- a/Stripe/STPRedirectContext.m
+++ b/Stripe/STPRedirectContext.m
@@ -156,7 +156,7 @@ typedef void (^STPBoolCompletionBlock)(BOOL success);
             if (self.source.type == STPSourceTypeWeChatPay) {
                 // ...and this Source doesn't support web-based redirect — finish with an error.
                 NSError *error = [[NSError alloc] initWithDomain:STPRedirectContextErrorDomain
-                                                            code:STPRedirectContextErrorAppRedirect
+                                                            code:STPRedirectContextAppRedirectError
                                                         userInfo:@{
                                                                    NSLocalizedDescriptionKey: [NSError stp_unexpectedErrorMessage],
                                                                    STPErrorMessageKey: @"Redirecting to WeChat failed. Only offer WeChat Pay if the WeChat app is installed.",

--- a/Tests/Tests/STPRedirectContextTest.m
+++ b/Tests/Tests/STPRedirectContextTest.m
@@ -721,7 +721,7 @@
                                                                   completion:^(__unused NSString *sourceID, __unused NSString *clientSecret, __unused NSError *error) {
                                                                       XCTAssertNotNil(error);
                                                                       XCTAssertEqual(error.domain, STPRedirectContextErrorDomain);
-                                                                      XCTAssertEqual(error.code, STPRedirectContextErrorAppRedirect);
+                                                                      XCTAssertEqual(error.code, STPRedirectContextAppRedirectError);
                                                                       [expectation fulfill];
                                                                   }];
     


### PR DESCRIPTION
## Summary
Follow-up to https://github.com/stripe/stripe-ios/pull/1335

* `STPRedirectContextError` -> `STPRedirectContextErrorCode` 
  * (swift error type is unchanged)
* `STPRedirectContextErrorAppRedirect` -> `STPRedirectContextAppRedirectError`
  * (`.appRedirect `-> `.appRedirectError`)

## Motivation
 I modeled this after `PKError.h`.
The other Stripe NSErrors:
```
STPPaymentHandlerErrorCode/STPPaymentHandlerIntentStatusErrorCode
STPErrorCode/STPConnectionError
```

## Testing
Wrote the following swift code
```
func f(_ error: Error) {
   if let error = error as? STPRedirectContextError, error.code == .appRedirectError {
}
```
