### PR TITLE
Update examples to Swift 5 & iOS 13

### DIFF
--- a/Example/Standard Integration.xcodeproj/project.pbxproj
+++ b/Example/Standard Integration.xcodeproj/project.pbxproj
@@ -215,7 +215,7 @@
 				TargetAttributes = {
 					04823F771A6849200098400B = {
 						CreatedOnToolsVersion = 6.1.1;
-						LastSwiftMigration = 0920;
+						LastSwiftMigration = 1100;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
 							com.apple.ApplePay = {
@@ -501,7 +501,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -528,7 +528,7 @@
 				PRODUCT_NAME = "Standard Integration";
 				PROVISIONING_PROFILE = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/Example/Standard Integration/AppDelegate.swift
+++ b/Example/Standard Integration/AppDelegate.swift
@@ -13,7 +13,7 @@ import Stripe
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         let rootVC = BrowseProductsViewController()
         let navigationController = UINavigationController(rootViewController: rootVC)
         let window = UIWindow(frame: UIScreen.main.bounds)
@@ -24,7 +24,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     // This method is where you handle URL opens if you are using a native scheme URLs (eg "yourexampleapp://")
-    func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
+    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
         let stripeHandled = Stripe.handleURLCallback(with: url)
 
         if (stripeHandled) {
@@ -39,7 +39,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     // This method is where you handle URL opens if you are using univeral link URLs (eg "https://example.com/stripe_ios_callback")
-    func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([Any]?) -> Void) -> Bool {
+    func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
         if userActivity.activityType == NSUserActivityTypeBrowsingWeb {
             if let url = userActivity.webpageURL {
                 let stripeHandled = Stripe.handleURLCallback(with: url)

--- a/Example/Standard Integration/BrowseProductsViewController.swift
+++ b/Example/Standard Integration/BrowseProductsViewController.swift
@@ -117,16 +117,16 @@ class BrowseProductsViewController: UICollectionViewController {
         self.navigationController?.navigationBar.barTintColor = theme.secondaryBackgroundColor
         self.navigationController?.navigationBar.tintColor = theme.accentColor
         let titleAttributes = [
-            NSAttributedStringKey.foregroundColor: theme.primaryForegroundColor,
-            NSAttributedStringKey.font: theme.font,
-        ] as [NSAttributedStringKey : Any]
+            NSAttributedString.Key.foregroundColor: theme.primaryForegroundColor,
+            NSAttributedString.Key.font: theme.font,
+        ] as [NSAttributedString.Key : Any]
         let buttonAttributes = [
-            NSAttributedStringKey.foregroundColor: theme.accentColor,
-            NSAttributedStringKey.font: theme.font,
-        ] as [NSAttributedStringKey : Any]
+            NSAttributedString.Key.foregroundColor: theme.accentColor,
+            NSAttributedString.Key.font: theme.font,
+        ] as [NSAttributedString.Key : Any]
         self.navigationController?.navigationBar.titleTextAttributes = titleAttributes
-        self.navigationItem.leftBarButtonItem?.setTitleTextAttributes(buttonAttributes, for: UIControlState())
-        self.navigationItem.backBarButtonItem?.setTitleTextAttributes(buttonAttributes, for: UIControlState())
+        self.navigationItem.leftBarButtonItem?.setTitleTextAttributes(buttonAttributes, for: UIControl.State())
+        self.navigationItem.backBarButtonItem?.setTitleTextAttributes(buttonAttributes, for: UIControl.State())
     }
 
     @objc func showSettings() {

--- a/Example/Standard Integration/BrowseProductsViewController.swift
+++ b/Example/Standard Integration/BrowseProductsViewController.swift
@@ -117,12 +117,12 @@ class BrowseProductsViewController: UICollectionViewController {
         self.navigationController?.navigationBar.barTintColor = theme.secondaryBackgroundColor
         self.navigationController?.navigationBar.tintColor = theme.accentColor
         let titleAttributes = [
-            NSAttributedString.Key.foregroundColor: theme.primaryForegroundColor,
-            NSAttributedString.Key.font: theme.font,
+            NSAttributedString.Key.foregroundColor: theme.primaryForegroundColor!,
+            NSAttributedString.Key.font: theme.font!,
         ] as [NSAttributedString.Key : Any]
         let buttonAttributes = [
-            NSAttributedString.Key.foregroundColor: theme.accentColor,
-            NSAttributedString.Key.font: theme.font,
+            NSAttributedString.Key.foregroundColor: theme.accentColor!,
+            NSAttributedString.Key.font: theme.font!,
         ] as [NSAttributedString.Key : Any]
         self.navigationController?.navigationBar.titleTextAttributes = titleAttributes
         self.navigationItem.leftBarButtonItem?.setTitleTextAttributes(buttonAttributes, for: UIControl.State())
@@ -131,6 +131,7 @@ class BrowseProductsViewController: UICollectionViewController {
 
     @objc func showSettings() {
         let navController = UINavigationController(rootViewController: settingsVC)
+        navController.modalPresentationStyle = .fullScreen
         self.present(navController, animated: true, completion: nil)
     }
     

--- a/Example/Standard Integration/Buttons.swift
+++ b/Example/Standard Integration/Buttons.swift
@@ -37,7 +37,7 @@ class BuyButton: UIButton {
     override var isEnabled: Bool {
         didSet {
             let color = isEnabled ? enabledColor : disabledColor
-            setTitleColor(.white, for: UIControlState())
+            setTitleColor(.white, for: UIControl.State())
             backgroundColor = color
         }
     }
@@ -51,7 +51,7 @@ class BuyButton: UIButton {
         layer.shadowRadius = 7
         layer.shadowOffset = CGSize(width: 0, height: 7)
         
-        setTitle(title, for: UIControlState())
+        setTitle(title, for: UIControl.State())
         titleLabel!.font = type(of: self).defaultFont
         isEnabled = enabled
     }

--- a/Example/Standard Integration/CheckoutRowView.swift
+++ b/Example/Standard Integration/CheckoutRowView.swift
@@ -44,7 +44,7 @@ class CheckoutRowView: UIView {
 
     fileprivate let titleLabel = UILabel()
     fileprivate let detailLabel = UILabel()
-    fileprivate let activityIndicator = UIActivityIndicatorView(activityIndicatorStyle: .gray)
+    fileprivate let activityIndicator = UIActivityIndicatorView(style: .gray)
     fileprivate let backgroundView = HighlightingButton()
 
     convenience init(title: String, detail: String, tappable: Bool = true) {
@@ -66,12 +66,12 @@ class CheckoutRowView: UIView {
         self.backgroundColor = .white
 
         self.detailLabel.textColor = .gray
-        self.activityIndicator.activityIndicatorViewStyle = .gray
+        self.activityIndicator.style = .gray
         #if canImport(CryptoKit)
         if #available(iOS 13.0, *) {
             self.backgroundColor = .systemBackground
             self.detailLabel.textColor = .secondaryLabel
-            self.activityIndicator.activityIndicatorViewStyle = .medium
+            self.activityIndicator.style = .medium
         }
         #endif
 

--- a/Example/Standard Integration/CheckoutViewController.swift
+++ b/Example/Standard Integration/CheckoutViewController.swift
@@ -38,7 +38,7 @@ class CheckoutViewController: UIViewController, STPPaymentContextDelegate {
     let totalRow: CheckoutRowView
     let buyButton: BuyButton
     let rowHeight: CGFloat = 52
-    let activityIndicator = UIActivityIndicatorView(activityIndicatorStyle: .gray)
+    let activityIndicator = UIActivityIndicatorView(style: .gray)
     let numberFormatter: NumberFormatter
     var products: [Product]
     var paymentInProgress: Bool = false {
@@ -170,7 +170,7 @@ See https://stripe.com/docs/testing.
         var red: CGFloat = 0
         
         self.theme.primaryBackgroundColor.getRed(&red, green: nil, blue: nil, alpha: nil)
-        self.activityIndicator.activityIndicatorViewStyle = red < 0.5 ? .white : .gray
+        self.activityIndicator.style = red < 0.5 ? .white : .gray
         self.navigationItem.title = "Checkout"
 
         // Footer
@@ -193,7 +193,7 @@ See https://stripe.com/docs/testing.
         spacerView.heightAnchor.constraint(equalToConstant: BuyButton.defaultHeight + 8).isActive = true
         let footerContainerView = UIStackView(arrangedSubviews: [shippingRow, makeSeparatorView(), paymentRow, makeSeparatorView(), totalRow, spacerView].compactMap({ $0 }))
         footerContainerView.axis = .vertical
-        footerContainerView.frame = CGRect(x: 0, y: 0, width: 0, height: footerContainerView.systemLayoutSizeFitting(UILayoutFittingCompressedSize).height)
+        footerContainerView.frame = CGRect(x: 0, y: 0, width: 0, height: footerContainerView.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).height)
 
         self.activityIndicator.alpha = 0
         self.buyButton.addTarget(self, action: #selector(didTapBuy), for: .touchUpInside)

--- a/Example/Standard Integration/CheckoutViewController.swift
+++ b/Example/Standard Integration/CheckoutViewController.swift
@@ -298,6 +298,8 @@ See https://stripe.com/docs/testing.
                                                                         completion(.error, actionError)
                                                                     case .canceled:
                                                                         completion(.userCancellation, nil)
+                                                                    @unknown default:
+                                                                        completion(.error, nil)
                                                                     }
                                                                 }
         }
@@ -315,6 +317,8 @@ See https://stripe.com/docs/testing.
             title = "Success"
             message = "Your purchase was successful!"
         case .userCancellation:
+            return
+        @unknown default:
             return
         }
         let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)

--- a/Example/Standard Integration/CheckoutViewController.swift
+++ b/Example/Standard Integration/CheckoutViewController.swift
@@ -317,9 +317,9 @@ See https://stripe.com/docs/testing.
             title = "Success"
             message = "Your purchase was successful!"
         case .userCancellation:
-            return
+            return()
         @unknown default:
-            return
+            return()
         }
         let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
         let action = UIAlertAction(title: "OK", style: .default, handler: nil)

--- a/Example/Standard Integration/EmojiCheckoutCell.swift
+++ b/Example/Standard Integration/EmojiCheckoutCell.swift
@@ -13,7 +13,7 @@ class EmojiCheckoutCell: UITableViewCell {
     let detailLabel: UILabel
     let priceLabel: UILabel
     
-    override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         priceLabel = UILabel()
         priceLabel.font = UIFont.systemFont(ofSize: 18, weight: .regular)
         detailLabel = UILabel()

--- a/Example/Standard Integration/MyAPIClient.swift
+++ b/Example/Standard Integration/MyAPIClient.swift
@@ -48,7 +48,7 @@ class MyAPIClient: NSObject, STPCustomerEphemeralKeyProvider {
             guard let response = response as? HTTPURLResponse,
                 response.statusCode == 200,
                 let data = data,
-                let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String : Any],
+                let json = ((try? JSONSerialization.jsonObject(with: data, options: []) as? [String : Any]) as [String : Any]??),
                 let secret = json?["secret"] as? String else {
                 completion(nil, error)
                 return
@@ -71,7 +71,7 @@ class MyAPIClient: NSObject, STPCustomerEphemeralKeyProvider {
             guard let response = response as? HTTPURLResponse,
                 response.statusCode == 200,
                 let data = data,
-                let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String : Any],
+                let json = ((try? JSONSerialization.jsonObject(with: data, options: []) as? [String : Any]) as [String : Any]??),
                 let secret = json?["secret"] as? String else {
                 completion(nil, error)
                 return
@@ -91,7 +91,7 @@ class MyAPIClient: NSObject, STPCustomerEphemeralKeyProvider {
             guard let response = response as? HTTPURLResponse,
                 response.statusCode == 200,
                 let data = data,
-                let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String : Any] else {
+                let json = ((try? JSONSerialization.jsonObject(with: data, options: []) as? [String : Any]) as [String : Any]??) else {
                 completion(nil, error)
                 return
             }

--- a/Example/Standard Integration/PaymentContextFooterView.swift
+++ b/Example/Standard Integration/PaymentContextFooterView.swift
@@ -11,7 +11,7 @@ import Stripe
 
 class PaymentContextFooterView: UIView {
 
-    var insetMargins: UIEdgeInsets = UIEdgeInsetsMake(10, 10, 10, 10)
+    var insetMargins: UIEdgeInsets = UIEdgeInsets.init(top: 10, left: 10, bottom: 10, right: 10)
 
     var text: String = "" {
         didSet {
@@ -40,7 +40,7 @@ class PaymentContextFooterView: UIView {
     }
 
     override func layoutSubviews() {
-        textLabel.frame = UIEdgeInsetsInsetRect(self.bounds, insetMargins)
+        textLabel.frame = self.bounds.inset(by: insetMargins)
     }
 
     override func sizeThatFits(_ size: CGSize) -> CGSize {

--- a/Example/UI Examples.xcodeproj/project.pbxproj
+++ b/Example/UI Examples.xcodeproj/project.pbxproj
@@ -145,7 +145,7 @@
 				TargetAttributes = {
 					C1140CBC1F1EC0FC002084AB = {
 						CreatedOnToolsVersion = 9.0;
-						LastSwiftMigration = 0920;
+						LastSwiftMigration = 1100;
 					};
 				};
 			};
@@ -346,7 +346,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.stripe.uiexamples;
 				PRODUCT_NAME = "Stripe UI Examples";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -360,7 +360,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.stripe.uiexamples;
 				PRODUCT_NAME = "Stripe UI Examples";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/Example/UI Examples/AppDelegate.swift
+++ b/Example/UI Examples/AppDelegate.swift
@@ -14,7 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         let rootVC = BrowseViewController()
         let navController = UINavigationController(rootViewController: rootVC)
         let window = UIWindow(frame: UIScreen.main.bounds)

--- a/Example/UI Examples/MockCustomerContext.swift
+++ b/Example/UI Examples/MockCustomerContext.swift
@@ -111,7 +111,7 @@ class MockCustomerContext: STPCustomerContext {
     }
 
     override func detachPaymentMethod(fromCustomer paymentMethod: STPPaymentMethod, completion: STPErrorBlock? = nil) {
-        if let index = customer.paymentMethods.index(where: { $0.stripeId == paymentMethod.stripeId }) {
+        if let index = customer.paymentMethods.firstIndex(where: { $0.stripeId == paymentMethod.stripeId }) {
             customer.paymentMethods.remove(at: index)
         }
         if let completion = completion {


### PR DESCRIPTION
## Summary
Just running the Xcode migrator.

Set SettingsViewController to .fullScreen while we're at it, as otherwise it doesn't properly obscure the BrowseProductsViewController during a theme change.

## Motivation
These are used as a code-copying resource for folks adopting Stripe, so we should keep them up to date.

## Testing
Standard Integration and UI Examples still work.