### PR TITLE
Hide 'scan card' button while STPAddCardViewController is loading

### DIFF
--- a/Stripe/STPAddCardViewController.m
+++ b/Stripe/STPAddCardViewController.m
@@ -200,12 +200,6 @@ typedef NS_ENUM(NSUInteger, STPPaymentCardSection) {
     [self.cardIOProxy presentCardIOFromViewController:self];
 }
 
-- (void)cardIOProxy:(__unused STPCardIOProxy *)proxy didFinishWithCardParams:(STPPaymentMethodCardParams *)cardParams {
-    if (cardParams) {
-        self.paymentCell.paymentField.cardParams = cardParams;
-    }
-}
-
 - (void)endEditing {
     [self.view endEditing:NO];
 }
@@ -242,8 +236,10 @@ typedef NS_ENUM(NSUInteger, STPPaymentCardSection) {
         [self.tableView endEditing:YES];
         UIBarButtonItem *loadingItem = [[UIBarButtonItem alloc] initWithCustomView:self.activityIndicator];
         [self.stp_navigationItemProxy setRightBarButtonItem:loadingItem animated:YES];
+        self.cardHeaderView.buttonHidden = YES;
     } else {
         [self.stp_navigationItemProxy setRightBarButtonItem:self.doneItem animated:YES];
+        self.cardHeaderView.buttonHidden = NO;
     }
     NSArray *cells = self.addressViewModel.addressCells;
     for (UITableViewCell *cell in [cells arrayByAddingObject:self.paymentCell]) {
@@ -517,5 +513,14 @@ typedef NS_ENUM(NSUInteger, STPPaymentCardSection) {
     }];
     [self.tableView endUpdates];
 }
+
+#pragma mark - STPCardIOProxyDelegate
+
+- (void)cardIOProxy:(__unused STPCardIOProxy *)proxy didFinishWithCardParams:(STPPaymentMethodCardParams *)cardParams {
+    if (cardParams) {
+        self.paymentCell.paymentField.cardParams = cardParams;
+    }
+}
+
 
 @end


### PR DESCRIPTION
## Summary

## Motivation
https://github.com/stripe/stripe-ios/issues/1356

## Testing
Repro'd issue before, see expected behavior after.