### PR TITLE
Fix incorrect dob parameter for account tokens

### DIFF
--- a/Stripe/PublicHeaders/STPConnectAccountIndividualParams.h
+++ b/Stripe/PublicHeaders/STPConnectAccountIndividualParams.h
@@ -160,4 +160,30 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+#pragma mark - Date of Birth
+
+/**
+ An individual's date of birth.
+ 
+ See https://stripe.com/docs/api/tokens/create_account#create_account_token-account-individual-dob
+ */
+@interface STPDateOfBirth : NSObject <STPFormEncodable>
+
+/**
+ The day of birth, between 1 and 31.
+ */
+@property (nonatomic) NSInteger day;
+
+/**
+ The month of birth, between 1 and 12.
+ */
+@property (nonatomic) NSInteger month;
+
+/**
+ The four-digit year of birth.
+ */
+@property (nonatomic) NSInteger year;
+
+@end
+
 NS_ASSUME_NONNULL_END

--- a/Stripe/STPConnectAccountIndividualParams.m
+++ b/Stripe/STPConnectAccountIndividualParams.m
@@ -43,12 +43,20 @@
 
 @synthesize additionalAPIParameters;
 
+- (STPDateOfBirth *)_dateOfBirth {
+    STPDateOfBirth *dob = [STPDateOfBirth new];
+    dob.day = self.dateOfBirth.day;
+    dob.month = self.dateOfBirth.month;
+    dob.year = self.dateOfBirth.year;
+    return dob;
+}
+
 + (nonnull NSDictionary *)propertyNamesToFormFieldNamesMapping {
     return @{
              NSStringFromSelector(@selector(address)): @"address",
              NSStringFromSelector(@selector(kanaAddress)): @"address_kana",
              NSStringFromSelector(@selector(kanjiAddress)): @"address_kanji",
-             NSStringFromSelector(@selector(dateOfBirth)): @"dob",
+             NSStringFromSelector(@selector(_dateOfBirth)): @"dob",
              NSStringFromSelector(@selector(email)): @"email",
              NSStringFromSelector(@selector(firstName)): @"first_name",
              NSStringFromSelector(@selector(kanaFirstName)): @"first_name_kana",
@@ -98,6 +106,25 @@
     return @{
              NSStringFromSelector(@selector(back)): @"back",
              NSStringFromSelector(@selector(front)): @"front",
+             };
+}
+
++ (nullable NSString *)rootObjectName {
+    return nil;
+}
+
+@end
+
+#pragma mark -
+
+@implementation STPDateOfBirth
+@synthesize additionalAPIParameters;
+
++ (nonnull NSDictionary *)propertyNamesToFormFieldNamesMapping {
+    return @{
+             NSStringFromSelector(@selector(day)): @"day",
+             NSStringFromSelector(@selector(month)): @"month",
+             NSStringFromSelector(@selector(year)): @"year",
              };
 }
 

--- a/Tests/Tests/STPConnectAccountFunctionalTest.m
+++ b/Tests/Tests/STPConnectAccountFunctionalTest.m
@@ -33,6 +33,11 @@
     self.client = [[STPAPIClient alloc] initWithPublishableKey:@"pk_test_vOo1umqsYxSrP5UXfOeL3ecm"];
     self.individual = [STPConnectAccountIndividualParams new];
     self.individual.firstName = @"Test";
+    NSDateComponents *dob = [NSDateComponents new];
+    dob.day = 31;
+    dob.month = 8;
+    dob.year = 2006;
+    self.individual.dateOfBirth = dob;
     self.company = [STPConnectAccountCompanyParams new];
     self.company.name = @"Test";
 }

--- a/Tests/recorded_network_traffic/STPConnectAccountFunctionalTest/testTokenCreationcompany/post_v1_tokens_0.tail
+++ b/Tests/recorded_network_traffic/STPConnectAccountFunctionalTest/testTokenCreationcompany/post_v1_tokens_0.tail
@@ -9,20 +9,20 @@ Server: nginx
 access-control-expose-headers: Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
 access-control-max-age: 300
 Cache-Control: no-cache, no-store
-Date: Fri, 02 Aug 2019 22:09:12 GMT
+Date: Mon, 09 Sep 2019 16:21:02 GMT
 stripe-version: 2019-05-16
 access-control-allow-credentials: true
 Content-Length: 178
-Strict-Transport-Security: max-age=31556926; includeSubDomains; preload
 Connection: keep-alive
-request-id: req_YzPZcexUT76Oh3
+Strict-Transport-Security: max-age=31556926; includeSubDomains; preload
+request-id: req_VVwj8Ua09CgDrf
 
 {
   "object" : "token",
-  "id" : "ct_1F38w0BbvEcIpqUbqNFhywyy",
+  "id" : "ct_1FGpbuBbvEcIpqUbym1HFoNY",
   "livemode" : false,
-  "client_ip" : "8.21.168.117",
-  "created" : 1564783752,
+  "client_ip" : "8.21.168.115",
+  "created" : 1568046062,
   "used" : false,
   "type" : "account"
 }

--- a/Tests/recorded_network_traffic/STPConnectAccountFunctionalTest/testTokenCreationcustomer/post_v1_tokens_0.tail
+++ b/Tests/recorded_network_traffic/STPConnectAccountFunctionalTest/testTokenCreationcustomer/post_v1_tokens_0.tail
@@ -9,20 +9,20 @@ Server: nginx
 access-control-expose-headers: Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
 access-control-max-age: 300
 Cache-Control: no-cache, no-store
-Date: Fri, 02 Aug 2019 22:09:12 GMT
+Date: Mon, 09 Sep 2019 16:21:02 GMT
 stripe-version: 2019-05-16
 access-control-allow-credentials: true
 Content-Length: 178
-Strict-Transport-Security: max-age=31556926; includeSubDomains; preload
 Connection: keep-alive
-request-id: req_8tr7nwFyYFlxKq
+Strict-Transport-Security: max-age=31556926; includeSubDomains; preload
+request-id: req_e7jL2oOx8HJpi8
 
 {
   "object" : "token",
-  "id" : "ct_1F38w0BbvEcIpqUbpGUZDsY9",
+  "id" : "ct_1FGpbuBbvEcIpqUb7PrMvpfL",
   "livemode" : false,
-  "client_ip" : "8.21.168.117",
-  "created" : 1564783752,
+  "client_ip" : "8.21.168.115",
+  "created" : 1568046062,
   "used" : false,
   "type" : "account"
 }


### PR DESCRIPTION
## Summary
Create `STPDateOfBirth <STPFormEncodable>`, send that instead of `NSDateComponents` when creating account token.

## Motivation
https://github.com/stripe/stripe-ios/issues/1358

## Testing
Added test - fails before change, passes after.