### PR TITLE
Fix Large Title support in iOS 13

### DIFF
--- a/Stripe/UIBarButtonItem+Stripe.m
+++ b/Stripe/UIBarButtonItem+Stripe.m
@@ -34,6 +34,11 @@
                                    NSForegroundColorAttributeName: theme.secondaryForegroundColor,
                                    }
                         forState:UIControlStateDisabled];
+    [self setTitleTextAttributes:@{
+                                   NSFontAttributeName: self.style == UIBarButtonItemStylePlain ? theme.font : theme.emphasisFont,
+                                   NSForegroundColorAttributeName: theme.accentColor,
+                                   }
+                        forState:UIControlStateHighlighted];
 }
 
 @end

--- a/Stripe/UINavigationBar+Stripe_Theme.m
+++ b/Stripe/UINavigationBar+Stripe_Theme.m
@@ -38,6 +38,38 @@ static NSInteger const STPNavigationBarHairlineViewTag = 787473;
                                  NSFontAttributeName: theme.emphasisFont,
                                  NSForegroundColorAttributeName: theme.primaryForegroundColor,
                                  };
+
+    if (@available(iOS 13.0, *)) {
+        self.standardAppearance.backgroundColor = theme.secondaryBackgroundColor;
+        self.standardAppearance.titleTextAttributes = self.titleTextAttributes;
+        self.standardAppearance.largeTitleTextAttributes = self.largeTitleTextAttributes;
+        self.standardAppearance.buttonAppearance.normal.titleTextAttributes = @{
+            NSFontAttributeName: theme.font,
+            NSForegroundColorAttributeName: theme.accentColor,
+        };
+        self.standardAppearance.buttonAppearance.highlighted.titleTextAttributes = @{
+            NSFontAttributeName: theme.font,
+            NSForegroundColorAttributeName: theme.accentColor,
+        };
+        self.standardAppearance.buttonAppearance.disabled.titleTextAttributes = @{
+            NSFontAttributeName: theme.font,
+            NSForegroundColorAttributeName: theme.secondaryForegroundColor,
+        };
+        self.standardAppearance.doneButtonAppearance.normal.titleTextAttributes = @{
+            NSFontAttributeName: theme.emphasisFont,
+            NSForegroundColorAttributeName: theme.accentColor,
+        };
+        self.standardAppearance.doneButtonAppearance.highlighted.titleTextAttributes = @{
+            NSFontAttributeName: theme.emphasisFont,
+            NSForegroundColorAttributeName: theme.accentColor,
+        };
+        self.standardAppearance.doneButtonAppearance.disabled.titleTextAttributes = @{
+            NSFontAttributeName: theme.emphasisFont,
+            NSForegroundColorAttributeName: theme.secondaryForegroundColor,
+        };
+        self.scrollEdgeAppearance = self.standardAppearance;
+        self.compactAppearance = self.standardAppearance;
+    }
 }
 
 

--- a/Stripe/UINavigationBar+Stripe_Theme.m
+++ b/Stripe/UINavigationBar+Stripe_Theme.m
@@ -39,6 +39,7 @@ static NSInteger const STPNavigationBarHairlineViewTag = 787473;
                                  NSForegroundColorAttributeName: theme.primaryForegroundColor,
                                  };
 
+#ifdef __IPHONE_13_0
     if (@available(iOS 13.0, *)) {
         self.standardAppearance.backgroundColor = theme.secondaryBackgroundColor;
         self.standardAppearance.titleTextAttributes = self.titleTextAttributes;
@@ -70,6 +71,7 @@ static NSInteger const STPNavigationBarHairlineViewTag = 787473;
         self.scrollEdgeAppearance = self.standardAppearance;
         self.compactAppearance = self.standardAppearance;
     }
+#endif
 }
 
 


### PR DESCRIPTION
## Summary
iOS 13 UIViewControllers in Large Title mode now have transparent backgrounds, as seen in #1350. We don't want this behavior at the moment, so we'll fill the background with the colors from the STPTheme.

Also fix cancel/edit bar buttons, as the STPTheme font wasn't propagating to all of them.

## Testing
Tested in Standard Integration and UI Examples by forcing Large Title mode.
