### PR TITLE
Enable UINavigationBar translucency by default

### DIFF
--- a/Stripe/PublicHeaders/STPTheme.h
+++ b/Stripe/PublicHeaders/STPTheme.h
@@ -84,7 +84,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  A Boolean value indicating whether the navigation bar for any view controllers
- presented modally by the SDK should be translucent. The default value is NO.
+ presented modally by the SDK should be translucent. The default value is YES
+ on iOS 13 or later, NO on iOS 12 or earlier.
  */
 @property (nonatomic) BOOL translucentNavigationBar;
 

--- a/Stripe/PublicHeaders/STPTheme.h
+++ b/Stripe/PublicHeaders/STPTheme.h
@@ -84,8 +84,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  A Boolean value indicating whether the navigation bar for any view controllers
- presented modally by the SDK should be translucent. The default value is YES
- on iOS 13 or later, NO on iOS 12 or earlier.
+ presented modally by the SDK should be translucent. The default value is YES.
  */
 @property (nonatomic) BOOL translucentNavigationBar;
 

--- a/Stripe/STPTheme.m
+++ b/Stripe/STPTheme.m
@@ -71,13 +71,7 @@ static UIFont  *STPThemeDefaultMediumFont;
         _errorColor = STPThemeDefaultErrorColor;
         _font = STPThemeDefaultFont;
         _emphasisFont = STPThemeDefaultMediumFont;
-        _translucentNavigationBar = NO;
-        if (@available(iOS 13.0, *)) {
-            // Various UIKit transitions break in iOS 13 when using prefersLargeTitles
-            // and a non-translucent navigation bar with nothing behind it.
-            // We're working around this by making translucency the default for iOS 13 or later.
-            _translucentNavigationBar = YES;
-        }
+        _translucentNavigationBar = YES;
     }
     return self;
 }

--- a/Stripe/STPTheme.m
+++ b/Stripe/STPTheme.m
@@ -72,6 +72,12 @@ static UIFont  *STPThemeDefaultMediumFont;
         _font = STPThemeDefaultFont;
         _emphasisFont = STPThemeDefaultMediumFont;
         _translucentNavigationBar = NO;
+        if (@available(iOS 13.0, *)) {
+            // Various UIKit transitions break in iOS 13 when using prefersLargeTitles
+            // and a non-translucent navigation bar with nothing behind it.
+            // We're working around this by making translucency the default for iOS 13 or later.
+            _translucentNavigationBar = YES;
+        }
     }
     return self;
 }
@@ -204,6 +210,7 @@ static UIFont  *STPThemeDefaultMediumFont;
     copyTheme.errorColor = self.errorColor;
     copyTheme.font = self.font;
     copyTheme.emphasisFont = self.emphasisFont;
+    copyTheme.translucentNavigationBar = self.translucentNavigationBar;
     return copyTheme;
 }
 


### PR DESCRIPTION
## Summary
Enable translucency by default to fix a few `prefersLargeTitles`-related bugs.

## Motivation
It doesn't feel like UIViewController's Large Title support was designed with `translucency = NO` in mind. It expects the UIViewController's view to draw underneath the area of the UINavigationBar, which doesn't happen when translucency is disabled. I considered enabling `extendedLayoutIncludesOpaqueBars` instead, which would only enable the overdrawing behavior, but no longer opting out of translucency seems like it would bring us closer to the UIKit happy path.

## Testing
Tested in simulator on iOS 12.2 and iOS 13 in Standard Integration and UI Examples with `prefersLargeTitles = YES`.