### PR TITLE
Fix a few VoiceOver issues

### DIFF
--- a/Stripe/STPAddressFieldTableViewCell.m
+++ b/Stripe/STPAddressFieldTableViewCell.m
@@ -329,6 +329,18 @@
     }
 }
 
+- (NSInteger)accessibilityElementCount {
+    return 1;
+}
+
+- (id)accessibilityElementAtIndex:(__unused NSInteger)index {
+    return self.textField;
+}
+
+- (NSInteger)indexOfAccessibilityElement:(__unused id)element {
+    return 0;
+}
+
 #pragma mark - UITextFieldDelegate
 
 - (void)textFieldTextDidChange:(STPValidatedTextField *)textField {

--- a/Stripe/STPFormTextField.m
+++ b/Stripe/STPFormTextField.m
@@ -218,9 +218,11 @@ typedef NSAttributedString* (^STPFormTextTransformationBlock)(NSAttributedString
 
 - (NSAttributedString *)accessibilityAttributedValue {
     NSMutableAttributedString *attributedString = [self.attributedText mutableCopy];
+    #ifdef __IPHONE_13_0
     if (@available(iOS 13.0, *)) {
         [attributedString addAttribute:UIAccessibilitySpeechAttributeSpellOut value:@(YES) range:NSMakeRange(0, [attributedString length])];
     }
+    #endif
     if (!self.validText) {
         NSString *invalidData = STPLocalizedString(@"Invalid data.", @"Spoken during VoiceOver when a form field has failed validation.");
         NSMutableAttributedString *failedString = [[NSMutableAttributedString alloc] initWithString:invalidData attributes:@{UIAccessibilitySpeechAttributePitch: @(0.6)}];

--- a/Stripe/STPFormTextField.m
+++ b/Stripe/STPFormTextField.m
@@ -9,6 +9,7 @@
 #import "STPFormTextField.h"
 
 #import "NSString+Stripe.h"
+#import "STPLocalizationUtils.h"
 #import "STPCardValidator.h"
 #import "STPCardValidator+Private.h"
 #import "STPDelegateProxy.h"
@@ -204,6 +205,29 @@ typedef NSAttributedString* (^STPFormTextTransformationBlock)(NSAttributedString
             [self.formDelegate formTextFieldTextDidChange:self];
         }
     }
+}
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpartial-availability"
+// accessibilityAttributedValue is only defined on iOS 11 and up, but we
+// implement it immediately below, so we should just ignore the warning.
+- (NSString *)accessibilityValue {
+    return [[self accessibilityAttributedValue] string];
+}
+#pragma clang diagnostic pop
+
+- (NSAttributedString *)accessibilityAttributedValue {
+    NSMutableAttributedString *attributedString = [self.attributedText mutableCopy];
+    if (@available(iOS 13.0, *)) {
+        [attributedString addAttribute:UIAccessibilitySpeechAttributeSpellOut value:@(YES) range:NSMakeRange(0, [attributedString length])];
+    }
+    if (!self.validText) {
+        NSString *invalidData = STPLocalizedString(@"Invalid data.", @"Spoken during VoiceOver when a form field has failed validation.");
+        NSMutableAttributedString *failedString = [[NSMutableAttributedString alloc] initWithString:invalidData attributes:@{UIAccessibilitySpeechAttributePitch: @(0.6)}];
+        [failedString appendAttributedString:attributedString];
+        attributedString = failedString;
+    }
+    return attributedString;
 }
 
 - (void)setAttributedPlaceholder:(NSAttributedString *)attributedPlaceholder {

--- a/Stripe/STPPaymentCardTextField+Private.h
+++ b/Stripe/STPPaymentCardTextField+Private.h
@@ -8,6 +8,9 @@
 
 #import <Stripe/Stripe.h>
 
+@class STPFormTextField;
+
 @interface STPPaymentCardTextField (Private)
+@property (nonatomic, strong) NSArray<STPFormTextField *> *allFields;
 - (void)commonInit;
 @end

--- a/Stripe/STPPaymentCardTextField.m
+++ b/Stripe/STPPaymentCardTextField.m
@@ -1244,6 +1244,7 @@ typedef void (^STPLayoutAnimationCompletionBlock)(BOOL completed);
 - (void)formTextFieldDidBackspaceOnEmpty:(__unused STPFormTextField *)formTextField {
     STPFormTextField *previous = [self previousField];
     [previous becomeFirstResponder];
+    UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, nil);
     if (previous.hasText) {
         [previous deleteBackward];
     }
@@ -1327,13 +1328,14 @@ typedef void (^STPLayoutAnimationCompletionBlock)(BOOL completed);
 
             // This is a no-op if this is the last field & they're all valid
             [[self nextFirstResponderField] becomeFirstResponder];
+            UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, nil);
+            
             break;
         }
     }
 
     [self onChange];
 }
-
 
 typedef NS_ENUM(NSInteger, STPFieldEditingTransitionCallSite) {
     STPFieldEditingTransitionCallSiteShouldBegin,
@@ -1489,6 +1491,7 @@ typedef NS_ENUM(NSInteger, STPFieldEditingTransitionCallSite) {
     } else {
         // otherwise, move to the next field
         [[self nextFirstResponderField] becomeFirstResponder];
+        UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, nil);
     }
 
     return NO;

--- a/Stripe/STPPaymentCardTextFieldCell.m
+++ b/Stripe/STPPaymentCardTextFieldCell.m
@@ -7,6 +7,7 @@
 //
 
 #import "STPPaymentCardTextFieldCell.h"
+#import "STPPaymentCardTextField+Private.h"
 
 #import "UIView+Stripe_SafeAreaBounds.h"
 
@@ -65,14 +66,20 @@
 }
 
 - (NSInteger)accessibilityElementCount {
-    return 1;
+    return [[self.paymentField allFields] count];
 }
 
 - (id)accessibilityElementAtIndex:(__unused NSInteger)index {
-    return self.paymentField;
+    return [self.paymentField allFields][index];
 }
 
 - (NSInteger)indexOfAccessibilityElement:(__unused id)element {
+    NSArray *fields = [self.paymentField allFields];
+    for (NSUInteger i = 0; i < [fields count]; i++) {
+        if (element == fields[i]) {
+            return i;
+        }
+    }
     return 0;
 }
 

--- a/Stripe/STPPaymentCardTextFieldCell.m
+++ b/Stripe/STPPaymentCardTextFieldCell.m
@@ -64,5 +64,17 @@
     return [self.paymentField becomeFirstResponder];
 }
 
+- (NSInteger)accessibilityElementCount {
+    return 1;
+}
+
+- (id)accessibilityElementAtIndex:(__unused NSInteger)index {
+    return self.paymentField;
+}
+
+- (NSInteger)indexOfAccessibilityElement:(__unused id)element {
+    return 0;
+}
+
 
 @end

--- a/Stripe/STPPaymentCardTextFieldCell.m
+++ b/Stripe/STPPaymentCardTextFieldCell.m
@@ -69,11 +69,11 @@
     return [[self.paymentField allFields] count];
 }
 
-- (id)accessibilityElementAtIndex:(__unused NSInteger)index {
+- (id)accessibilityElementAtIndex:(NSInteger)index {
     return [self.paymentField allFields][index];
 }
 
-- (NSInteger)indexOfAccessibilityElement:(__unused id)element {
+- (NSInteger)indexOfAccessibilityElement:(id)element {
     NSArray *fields = [self.paymentField allFields];
     for (NSUInteger i = 0; i < [fields count]; i++) {
         if (element == fields[i]) {


### PR DESCRIPTION
## Summary
* STPPaymentCardTextField should announce to the user when the insertion point moves between the different fields. This would ideally be handled by a targeted `UIAccessibilityLayoutChangedNotification` with the new targeted view, but that doesn't appear to work. `UIAccessibilityScreenChangedNotification` resolves this, alerting the user whenever the firstResponder changes. (But it's a big hammer. 😥)
* A VoiceOver user should be able to tell if a field contains invalid input. To implement this, we'll copy Safari's behavior for the [aria-invalid form attribute](https://www.w3.org/WAI/WCAG21/working-examples/aria-invalid-data-format/), which causes it to speak "Invalid Data" when the element is tapped after validation has failed.
* In iOS 13, VoiceOver can speak out a text field letter-by-letter when prompted, which is a behavior we'll want to adopt on all our card fields. (This seems preferable to having VoiceOver try to pronounce a British postal code, or read out a card number as "four hundred twenty four thousand etc".)
* In iOS 13, a VoiceOver user will face a crash deep in the Accessibility framework (related to mutating an array while iterating through it) when they open an STPAddCardViewController. This seems like an iOS bug, but we can work around it by explicitly defining the `accessibilityElementCount` for the STPPaymentCardTextFieldCell.
* VoiceOver users should be able to swipe between fields in an STPAddCardViewController. We'll fix this by implementing `accessibilityElementAtIndex` to access each field in the underlying `STPPaymentCardTextField` of `STPPaymentCardTextFieldCell`.
* Our shipping fields had a similar issue, with the STPAddressFieldTableViewCell being identified as a separate element from the underlying text field.

## Motivation
#1030

## Testing
Tested on my iOS 13 phone using VoiceOver.
