### PR TITLE
Remove SCA + Apple Pay recommendation in docs, example code

### DIFF
--- a/Stripe/Payments/STPPaymentHandler.m
+++ b/Stripe/Payments/STPPaymentHandler.m
@@ -657,9 +657,9 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
     
     // Is it the Apple Pay VC?
     if ([presentingViewController isKindOfClass:[PKPaymentAuthorizationViewController class]]) {
-        // We can't present over Apple Pay, user must implement prepareAuthenticationContextForPresentation: to dismiss it.
+        // Trying to present over the Apple Pay sheet silently fails. Authentication should never happen if you're paying with Apple Pay.
         canPresent = NO;
-        errorMessage = @"authenticationPresentingViewController is a PKPaymentAuthorizationViewController, which cannot be presented over. Dismiss it in `prepareAuthenticationContextForPresentation:`. You should probably return the UIViewController that presented the PKPaymentAuthorizationViewController in `authenticationPresentingViewController` instead.";
+        errorMessage = @"authenticationPresentingViewController is a PKPaymentAuthorizationViewController, which cannot be presented over.";
     }
     
     // Is it already presenting something?

--- a/Stripe/PublicHeaders/STPAuthenticationContext.h
+++ b/Stripe/PublicHeaders/STPAuthenticationContext.h
@@ -32,11 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  This method is called before presenting a UIViewController for authentication.
 
- Implement this method if your customer is using Apple Pay.  For security, it's impossible to present UIViewControllers above the Apple Pay sheet.
- This method should dismiss the PKPaymentAuthorizationViewController and call `completion` in the dismissal's completion block.
- 
  @note `STPPaymentHandler` will not proceed until `completion` is called.
- @note `paymentAuthorizationViewControllerDidFinish` is not called after `PKPaymentAuthorizationViewController` is dismissed.
  */
 - (void)prepareAuthenticationContextForPresentation:(STPVoidBlock)completion;
 

--- a/Stripe/PublicHeaders/STPPaymentHandler.h
+++ b/Stripe/PublicHeaders/STPPaymentHandler.h
@@ -84,7 +84,6 @@ typedef NS_ERROR_ENUM(STPPaymentHandlerErrorDomain, STPPaymentHandlerErrorCode) 
 
     /**
      Payment requires a valid `STPAuthenticationContext`.  Make sure your presentingViewController isn't already presenting.
-     If you're using Apple Pay, you must implement `STPAuthenticationContext prepareAuthenticationContextForPresentation:`
      */
     STPPaymentHandlerRequiresAuthenticationContextErrorCode NS_SWIFT_NAME(requiresAuthenticationContext),
     
@@ -110,8 +109,6 @@ typedef void (^STPPaymentHandlerActionSetupIntentCompletionBlock)(STPPaymentHand
 /**
  `STPPaymentHandler` is a utility class that confirms PaymentIntents/SetupIntents and handles any authentication required, such as 3DS1/3DS2 for Strong Customer Authentication.
  It can present authentication UI on top of your app or redirect users out of your app (to e.g. their banking app).
-
- @note If you're using Apple Pay, you must implement `STPAuthenticationContext prepareAuthenticationContextForPresentation:`.  See that method's docstring for more details.
 
  @see https://stripe.com/docs/mobile/ios/authentication
  */


### PR DESCRIPTION
## Summary
Remove unnecessary Apple Pay + SCA code.

## Motivation
https://jira.corp.stripe.com/browse/IOS-1373

## Testing
Tested Apple Pay on device.  
Simulator is weird, delegate method doesn't get called.
