### PR TITLE
STPPaymentCardTextField should work with non-numeric placeholders

### DIFF
--- a/Stripe/STPPaymentCardTextField.m
+++ b/Stripe/STPPaymentCardTextField.m
@@ -1078,7 +1078,7 @@ typedef NS_ENUM(NSInteger, STPCardTextFieldState) {
             maskView.backgroundColor = [UIColor blackColor];
             #ifdef __IPHONE_13_0
                 if (@available(iOS 13.0, *)) {
-                    maskView.backgroundColor = [UIColor systemBackgroundColor];
+                    maskView.backgroundColor = [UIColor labelColor];
                 }
             #endif
             maskView.opaque = YES;

--- a/Stripe/STPPaymentCardTextField.m
+++ b/Stripe/STPPaymentCardTextField.m
@@ -1064,9 +1064,9 @@ typedef NS_ENUM(NSInteger, STPCardTextFieldState) {
 
         BOOL hasEnteredCardNumber = self.cardNumber.length > 0;
         NSString *compressedCardNumber = self.viewModel.compressedCardNumber;
-        NSString *cardNumberToHide = [(hasEnteredCardNumber ? self.cardNumber : self.viewModel.defaultPlaceholder) stp_stringByRemovingSuffix:compressedCardNumber];
+        NSString *cardNumberToHide = [(hasEnteredCardNumber ? self.cardNumber : self.numberPlaceholder) stp_stringByRemovingSuffix:compressedCardNumber];
 
-        if (cardNumberToHide.length > 0) {
+        if (cardNumberToHide.length > 0 && [STPCardValidator stringIsNumeric:cardNumberToHide]) {
             width = hasEnteredCardNumber ? [self widthForCardNumber:self.cardNumber] : [self numberFieldFullWidth];
 
             CGFloat hiddenWidth = [self widthForCardNumber:cardNumberToHide];


### PR DESCRIPTION
## Summary
We were incorrectly treating non-numeric strings as if they were card numbers and masking them when compressing the card field.

## Motivation
I think this is related to #1379.

## Testing
UI Examples in iOS Simulator.