### PR TITLE
Move Travis to Xcode 11.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode11.1
+osx_image: xcode11.2
 branches:
   only:
     - master
@@ -23,7 +23,7 @@ matrix:
   - env:
     - TEST_TYPE=lint
     - secure: "RPtZBXKq0EArFHt8eR0hyxb/13QaA08Lc37p0zw/UNjj3ie6d1Vmi+BVqMBB0j7T2T71gkBjjUTV/o7T1VxONpJkEnk1fO4/1OYDbVPTKbkNS0JdmFYzQPFtewFZUhsGLnz/HhfATe8H18PeN0eS9jZbASXIu+Ssah6APt+P78w="
-    osx_image: xcode11.1
+    osx_image: xcode11.2
     addons:
       homebrew:
         casks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode11
+osx_image: xcode11.1
 branches:
   only:
     - master
@@ -23,7 +23,7 @@ matrix:
   - env:
     - TEST_TYPE=lint
     - secure: "RPtZBXKq0EArFHt8eR0hyxb/13QaA08Lc37p0zw/UNjj3ie6d1Vmi+BVqMBB0j7T2T71gkBjjUTV/o7T1VxONpJkEnk1fO4/1OYDbVPTKbkNS0JdmFYzQPFtewFZUhsGLnz/HhfATe8H18PeN0eS9jZbASXIu+Ssah6APt+P78w="
-    osx_image: xcode11
+    osx_image: xcode11.1
     addons:
       homebrew:
         casks:


### PR DESCRIPTION
## Summary
The Travis Xcode 11 image has been updated to remove the iOS 10 simulators. Move to their 11.2 image to see if it resolves this.
