### PR TITLE
Workaround iOS 13 TableViewRowData issue

### DIFF
--- a/Stripe/STPAddCardViewController.m
+++ b/Stripe/STPAddCardViewController.m
@@ -397,7 +397,7 @@ typedef NS_ENUM(NSUInteger, STPPaymentCardSection) {
 #pragma mark - STPAddressViewModelDelegate
 
 - (void)addressViewModel:(__unused STPAddressViewModel *)addressViewModel addedCellAtIndex:(NSUInteger)index {
-    NSInteger rowsInSection = [self.tableView numberOfRowsInSection:STPPaymentCardBillingAddressSection];
+    NSInteger rowsInSection = [self tableView:self.tableView numberOfRowsInSection:STPPaymentCardBillingAddressSection];
     if (rowsInSection != NSNotFound && rowsInSection < [self tableView:self.tableView numberOfRowsInSection:STPPaymentCardBillingAddressSection]) {
         NSIndexPath *indexPath = [NSIndexPath indexPathForRow:index inSection:STPPaymentCardBillingAddressSection];
         [self.tableView insertRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
@@ -406,7 +406,7 @@ typedef NS_ENUM(NSUInteger, STPPaymentCardSection) {
 }
 
 - (void)addressViewModel:(__unused STPAddressViewModel *)addressViewModel removedCellAtIndex:(NSUInteger)index {
-    NSInteger rowsInSection = [self.tableView numberOfRowsInSection:STPPaymentCardBillingAddressSection];
+    NSInteger rowsInSection = [self tableView:self.tableView numberOfRowsInSection:STPPaymentCardBillingAddressSection];
     if (rowsInSection != NSNotFound && index < (NSUInteger)rowsInSection) {
         NSIndexPath *indexPath = [NSIndexPath indexPathForRow:index inSection:STPPaymentCardBillingAddressSection];
         [self.tableView deleteRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];


### PR DESCRIPTION
## Summary
When we request numberOfRowsInSection from a UITableView while the UITableView's ViewController is being initialized, the internal UITableViewRowData is sometimes not in a good state and doesn't yet know how many sections we have. Work around this by requesting numberOfRowsInSection: from our controller instead of the tableView.

## Motivation
Fixes #1426.

## Testing
I can't reproduce the issue locally, but @odedharth says this fixed it.