### PR TITLE
Add STPAPIClient method to convert ssn_last_4 to a Token

### DIFF
--- a/Stripe/PublicHeaders/STPAPIClient.h
+++ b/Stripe/PublicHeaders/STPAPIClient.h
@@ -134,6 +134,14 @@ static NSString *const STPSDKVersion = @"18.1.0";
  */
 - (void)createTokenWithPersonalIDNumber:(NSString *)pii completion:(__nullable STPTokenCompletionBlock)completion;
 
+/**
+Converts the last 4 SSN digits into a Stripe token using the Stripe API.
+
+@param ssnLast4 The last 4 digits of the user's SSN. Cannot be nil.
+@param completion  The callback to run with the returned Stripe token (and any errors that may have occurred).
+*/
+- (void)createTokenWithSSNLast4:(NSString *)ssnLast4 completion:(STPTokenCompletionBlock)completion;
+
 @end
 
 #pragma mark Connect Accounts

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -277,9 +277,15 @@ static NSArray<PKPaymentNetwork> *_additionalEnabledApplePayNetworks;
     NSMutableDictionary *params = [@{@"pii": @{ @"personal_id_number": pii }} mutableCopy];
     [[STPTelemetryClient sharedInstance] addTelemetryFieldsToParams:params];
     [self createTokenWithParameters:params completion:completion];
+    [[STPTelemetryClient sharedInstance] sendTelemetryData];}
+
+- (void)createTokenWithSSNLast4:(NSString *)ssnLast4 completion:(STPTokenCompletionBlock)completion {
+    NSMutableDictionary *params = [@{@"pii": @{ @"ssn_last_4": ssnLast4 }} mutableCopy];
+    [[STPTelemetryClient sharedInstance] addTelemetryFieldsToParams:params];
+    [self createTokenWithParameters:params completion:completion];
     [[STPTelemetryClient sharedInstance] sendTelemetryData];
 }
-
+    
 @end
 
 #pragma mark - Connect Accounts

--- a/Tests/Tests/STPPIIFunctionalTest.m
+++ b/Tests/Tests/STPPIIFunctionalTest.m
@@ -38,4 +38,20 @@
     [self waitForExpectationsWithTimeout:5.0f handler:nil];
 }
 
+- (void)testSSNLast4Token {
+    STPAPIClient *client = [[STPAPIClient alloc] initWithPublishableKey:@"pk_test_vOo1umqsYxSrP5UXfOeL3ecm"];
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"PII creation"];
+    
+    [client createTokenWithSSNLast4:@"1234" completion:^(STPToken * _Nullable token, NSError * _Nullable error) {
+        [expectation fulfill];
+        XCTAssertNil(error, @"error should be nil %@", error.localizedDescription);
+        XCTAssertNotNil(token, @"token should not be nil");
+        XCTAssertNotNil(token.tokenId);
+        XCTAssertEqual(token.type, STPTokenTypePII);
+    }];
+    
+    [self waitForExpectationsWithTimeout:5.0f handler:nil];
+}
+
 @end

--- a/Tests/recorded_network_traffic/STPPIIFunctionalTest/testSSNLast4Token/post_v1_tokens_0.tail
+++ b/Tests/recorded_network_traffic/STPPIIFunctionalTest/testSSNLast4Token/post_v1_tokens_0.tail
@@ -15,11 +15,11 @@ access-control-allow-credentials: true
 Content-Length: 175
 Connection: keep-alive
 Strict-Transport-Security: max-age=31556926; includeSubDomains; preload
-request-id: req_G0mrDBE9JwOmuv
+request-id: req_TqZBbf0VIoU6HU
 
 {
   "object" : "token",
-  "id" : "pii_1FZR1mBbvEcIpqUbR2ADMXtG",
+  "id" : "pii_1FZR1mBbvEcIpqUbmYvOI5c1",
   "livemode" : false,
   "client_ip" : "8.21.168.115",
   "created" : 1572479798,


### PR DESCRIPTION
## Summary
Add STPAPIClient method to convert ssn_last_4 to a Token. This parameter is undocumented, but supported by stripe-js (also due to the issue in the ticket).

## Motivation
https://jira.corp.stripe.com/browse/IOS-1445

## Testing
See the test. It created https://admin.corp.stripe.com/object/pii_1FZR1mBbvEcIpqUbmYvOI5c1
Also checked if it's possible to create a Token with both ssn_last_4 and personal_id_number - it's not.
