### PR TITLE
Deprecate old methods in STPAddCardViewController

### DIFF
--- a/Stripe/PublicHeaders/STPAddCardViewController.h
+++ b/Stripe/PublicHeaders/STPAddCardViewController.h
@@ -110,6 +110,24 @@ NS_ASSUME_NONNULL_BEGIN
        didCreatePaymentMethod:(STPPaymentMethod *)paymentMethod
                    completion:(STPErrorBlock)completion;
 
+# pragma mark - Deprecated
+
+/**
+  This method is deprecated as of v16.0.0 (https://github.com/stripe/stripe-ios/blob/master/MIGRATING.md#migrating-from-versions--1600).
+  To use this class, migrate your integration from Charges to PaymentIntents. See https://stripe.com/docs/payments/payment-intents/migration/charges#read
+ */
+- (void)addCardViewController:(STPAddCardViewController *)addCardViewController
+               didCreateToken:(STPToken *)token
+                   completion:(STPErrorBlock)completion __attribute__((deprecated("Use addCardViewController:didCreatePaymentMethod:completion: instead and migrate your integration to PaymentIntents. See https://stripe.com/docs/payments/payment-intents/migration/charges#read", "addCardViewController:didCreatePaymentMethod:completion:")));
+
+/**
+ This method is deprecated as of v16.0.0 (https://github.com/stripe/stripe-ios/blob/master/MIGRATING.md#migrating-from-versions--1600).
+ To use this class, migrate your integration from Charges to PaymentIntents. See https://stripe.com/docs/payments/payment-intents/migration/charges#read
+*/
+- (void)addCardViewController:(STPAddCardViewController *)addCardViewController
+              didCreateSource:(STPSource *)source
+                   completion:(STPErrorBlock)completion __attribute__((deprecated("Use addCardViewController:didCreatePaymentMethod:completion: instead and migrate your integration to PaymentIntents. See https://stripe.com/docs/payments/payment-intents/migration/charges#read", "addCardViewController:didCreatePaymentMethod:completion:")));
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
## Summary
Not deprecating optional protocol methods is particularly bad because there is no indication an upgrading user's integration is now broken; the old methods are simply never called.

## Motivation
https://jira.corp.stripe.com/browse/IOS-1447

## Testing
They show up as deprecated when implemented in objc, but not in Basic Integration (swift).  Not sure why.  The methods show up as crossed out in the autocomplete.
