### PR TITLE
Calls source_cancel endpoint for web-based 3DS challenge flow cancelations

### DIFF
--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -1780,6 +1780,7 @@
 		3674EAD9232AEE4B008ADA25 /* ru */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = ru; path = Localizations/ru.lproj/Localizable.strings; sourceTree = "<group>"; };
 		3674EADA232AEE5B008ADA25 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		3674EADB232AEE5B008ADA25 /* tr */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = tr; path = Localizations/tr.lproj/Localizable.strings; sourceTree = "<group>"; };
+		3676777B237CC8A800B8FA4F /* STPIntentActionRedirectToURL+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPIntentActionRedirectToURL+Private.h"; sourceTree = "<group>"; };
 		367B46D522A0969000730BE0 /* STPThreeDSCustomizationSettings.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPThreeDSCustomizationSettings.m; sourceTree = "<group>"; };
 		3691EB6F2119111A008C49E1 /* STPCardValidator+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCardValidator+Private.h"; sourceTree = "<group>"; };
 		3691EB702119111A008C49E1 /* STPCardValidator+Private.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "STPCardValidator+Private.m"; sourceTree = "<group>"; };
@@ -3193,6 +3194,7 @@
 				31F5B33422FCAC4000A71C64 /* STPFPXBankBrand.m */,
 				B613DD3F22C55F9500C7603F /* STPIntentAction.h */,
 				B613DD4022C55F9500C7603F /* STPIntentAction.m */,
+				3676777B237CC8A800B8FA4F /* STPIntentActionRedirectToURL+Private.h */,
 				B604CF1F22C56E9B00A23CC4 /* STPIntentActionRedirectToURL.h */,
 				B604CF2022C56E9B00A23CC4 /* STPIntentActionRedirectToURL.m */,
 				073132932277A72D0019CE3F /* STPIssuingCardPin.h */,

--- a/Stripe/Payments/STPPaymentHandler.m
+++ b/Stripe/Payments/STPPaymentHandler.m
@@ -823,6 +823,8 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
                                                                                uiType:transaction.presentedChallengeUIType];
 }
 
+// This is only called after web-redirects because native 3DS2 cancels go directly
+// to the ACS
 - (void)_markChallengeCanceledWithCompletion:(STPBooleanSuccessBlock)completion {
     NSString *threeDSSourceID = nil;
     switch (_currentAction.nextAction.type) {

--- a/Stripe/STPAPIClient+Private.h
+++ b/Stripe/STPAPIClient+Private.h
@@ -159,6 +159,24 @@ fromCustomerUsingKey:(STPEphemeralKey *)ephemeralKey
                                 expand:(nullable NSArray<NSString *> *)expand
                             completion:(STPPaymentIntentCompletionBlock)completion;
 
+/**
+ Endpoint to call to indicate that the web-based challenge flow for 3DS authentication was canceled.
+ */
+- (void)cancel3DSAuthenticationForPaymentIntent:(NSString *)paymentIntentID
+                                     withSource:(NSString *)sourceID
+                                     completion:(STPPaymentIntentCompletionBlock)completion;
+
+@end
+
+@interface STPAPIClient (SetupIntentPrivate)
+
+/**
+ Endpoint to call to indicate that the web-based challenge flow for 3DS authentication was canceled.
+ */
+- (void)cancel3DSAuthenticationForSetupIntent:(NSString *)setupIntentID
+                                   withSource:(NSString *)sourceID
+                                   completion:(STPSetupIntentCompletionBlock)completion;
+
 @end
 
 @interface Stripe (Private)

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -52,7 +52,7 @@
 #import "STPCategoryLoader.h"
 #endif
 
-static NSString * const APIVersion = @"2019-11-05";
+static NSString * const APIVersion = @"2019-05-16";
 static NSString * const APIBaseURL = @"https://api.stripe.com/v1";
 static NSString * const APIEndpointToken = @"tokens";
 static NSString * const APIEndpointSources = @"sources";

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -52,7 +52,7 @@
 #import "STPCategoryLoader.h"
 #endif
 
-static NSString * const APIVersion = @"2019-05-16";
+static NSString * const APIVersion = @"2019-11-05";
 static NSString * const APIBaseURL = @"https://api.stripe.com/v1";
 static NSString * const APIEndpointToken = @"tokens";
 static NSString * const APIEndpointSources = @"sources";
@@ -755,6 +755,18 @@ toCustomerUsingKey:(STPEphemeralKey *)ephemeralKey
                                               }];
 }
 
+- (void)cancel3DSAuthenticationForPaymentIntent:(NSString *)paymentIntentID
+                                     withSource:(NSString *)sourceID
+                                     completion:(STPPaymentIntentCompletionBlock)completion {
+    [STPAPIRequest<STPPaymentIntent *> postWithAPIClient:self
+                                                endpoint:[NSString stringWithFormat:@"%@/%@/source_cancel", APIEndpointPaymentIntents, paymentIntentID]
+                                              parameters:@{ @"source": sourceID }
+                                            deserializer:[STPPaymentIntent new]
+                                              completion:^(STPPaymentIntent *paymentIntent, __unused NSHTTPURLResponse *response, NSError *responseError) {
+        completion(paymentIntent, responseError);
+    }];
+}
+
 @end
 
 #pragma mark - Setup Intents
@@ -796,6 +808,18 @@ toCustomerUsingKey:(STPEphemeralKey *)ephemeralKey
                                               completion:^(STPSetupIntent *setupIntent, __unused NSHTTPURLResponse *response, NSError *error) {
                                                   completion(setupIntent, error);
                                               }];
+}
+
+- (void)cancel3DSAuthenticationForSetupIntent:(NSString *)setupIntentID
+                                   withSource:(NSString *)sourceID
+                                   completion:(STPSetupIntentCompletionBlock)completion {
+    [STPAPIRequest<STPSetupIntent *> postWithAPIClient:self
+                                              endpoint:[NSString stringWithFormat:@"%@/%@/source_cancel", APIEndpointSetupIntents, setupIntentID]
+                                            parameters:@{ @"source": sourceID }
+                                          deserializer:[STPSetupIntent new]
+                                            completion:^(STPSetupIntent *setupIntent, __unused NSHTTPURLResponse *response, NSError *responseError) {
+        completion(setupIntent, responseError);
+    }];
 }
 
 @end

--- a/Stripe/STPIntentActionRedirectToURL+Private.h
+++ b/Stripe/STPIntentActionRedirectToURL+Private.h
@@ -1,0 +1,19 @@
+//
+//  STPIntentActionRedirectToURL+Private.h
+//  Stripe
+//
+//  Created by Cameron Sabol on 11/13/19.
+//  Copyright © 2019 Stripe, Inc. All rights reserved.
+//
+
+#import "STPIntentActionRedirectToURL.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface STPIntentActionRedirectToURL (Private)
+
+@property (nonatomic, readonly, nullable) NSString *threeDSSourceID;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Stripe/STPIntentActionRedirectToURL.m
+++ b/Stripe/STPIntentActionRedirectToURL.m
@@ -53,8 +53,8 @@
     redirect.url = url;
     redirect.returnURL = [dict stp_urlForKey:@"return_url"];
     redirect.allResponseFields = dict;
-    redirect->_threeDSSourceID = [[[NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO] stp_queryItemsDictionary][@"client_secret"] copy];
-    
+    redirect.threeDSSourceID =  [url.lastPathComponent hasPrefix:@"src_"] ? url.lastPathComponent : nil;
+
     return redirect;
 }
 

--- a/Stripe/STPIntentActionRedirectToURL.m
+++ b/Stripe/STPIntentActionRedirectToURL.m
@@ -5,14 +5,16 @@
 //  Created by Yuki Tokuhiro on 6/27/19.
 //  Copyright © 2019 Stripe, Inc. All rights reserved.
 //
-#import "STPIntentActionRedirectToURL.h"
+#import "STPIntentActionRedirectToURL+Private.h"
 
 #import "NSDictionary+Stripe.h"
+#import "NSURLComponents+Stripe.h"
 
 @interface STPIntentActionRedirectToURL()
 
 @property (nonatomic, nonnull) NSURL *url;
 @property (nonatomic, nullable) NSURL *returnURL;
+@property (nonatomic, nullable) NSString *threeDSSourceID;
 @property (nonatomic, nonnull, copy) NSDictionary *allResponseFields;
 
 @end
@@ -51,6 +53,7 @@
     redirect.url = url;
     redirect.returnURL = [dict stp_urlForKey:@"return_url"];
     redirect.allResponseFields = dict;
+    redirect->_threeDSSourceID = [[[NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO] stp_queryItemsDictionary][@"client_secret"] copy];
     
     return redirect;
 }

--- a/Stripe/STPIntentActionRedirectToURL.m
+++ b/Stripe/STPIntentActionRedirectToURL.m
@@ -14,7 +14,7 @@
 
 @property (nonatomic, nonnull) NSURL *url;
 @property (nonatomic, nullable) NSURL *returnURL;
-@property (nonatomic, nullable) NSString *threeDSSourceID;
+@property (nonatomic, nullable, copy) NSString *threeDSSourceID;
 @property (nonatomic, nonnull, copy) NSDictionary *allResponseFields;
 
 @end

--- a/Stripe/STPIntentActionUseStripeSDK.h
+++ b/Stripe/STPIntentActionUseStripeSDK.h
@@ -37,7 +37,7 @@ typedef NS_ENUM(NSInteger, STPIntentActionUseStripeSDKType) {
 @property (nonatomic, nullable, copy, readonly) NSString *directoryServerKeyID;
 
 @property (nonatomic, nullable, copy, readonly) NSString *serverTransactionID;
-@property (nonatomic, nullable, copy, readonly) NSString *threeDS2SourceID;
+@property (nonatomic, nullable, copy, readonly) NSString *threeDSSourceID;
 
 #pragma mark - 3DS2 Redirect
 @property (nonatomic, nullable, readonly) NSURL *redirectURL;

--- a/Stripe/STPIntentActionUseStripeSDK.m
+++ b/Stripe/STPIntentActionUseStripeSDK.m
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
                                [NSString stringWithFormat:@"serverTransactionID = %@", self.serverTransactionID],
                                [NSString stringWithFormat:@"directoryServerCertificate = %@", self.directoryServerCertificate.length > 0 ? @"<redacted>" : nil],
                                [NSString stringWithFormat:@"rootCertificateStrings = %@", self.rootCertificateStrings.count > 0 ? @"<redacted>" : nil],
-                               [NSString stringWithFormat:@"threeDS2SourceID = %@", self.threeDS2SourceID],
+                               [NSString stringWithFormat:@"threeDSSourceID = %@", self.threeDSSourceID],
                                [NSString stringWithFormat:@"type = %@", self.allResponseFields[@"type"]],
                                [NSString stringWithFormat:@"redirectURL = %@", self.redirectURL],
                                
@@ -64,6 +64,7 @@ NS_ASSUME_NONNULL_BEGIN
     NSString *directoryServerKeyID = [encryptionInfo stp_stringForKey:@"key_id"];
 
     NSURL *redirectURL = [dict stp_urlForKey:@"stripe_js"];
+    NSString *threeDSSourceID = nil;
 
     // required checks
     switch (type) {
@@ -75,11 +76,15 @@ NS_ASSUME_NONNULL_BEGIN
             } else if (certificate.length == 0 || directoryServerID.length == 0) {
                 return nil;
             }
+            threeDSSourceID = [[dict stp_stringForKey:@"three_d_secure_2_source"] copy];
             break;
 
         case STPIntentActionUseStripeSDKType3DS2Redirect:
             if (redirectURL == nil) {
                 return nil;
+            }
+            if ([redirectURL.lastPathComponent hasPrefix:@"src_"]) {
+                threeDSSourceID = [redirectURL.lastPathComponent copy];
             }
             break;
 
@@ -97,7 +102,7 @@ NS_ASSUME_NONNULL_BEGIN
     action->_directoryServerID = [directoryServerID copy];
     action->_directoryServerKeyID = [directoryServerKeyID copy];
     action->_serverTransactionID = [[dict stp_stringForKey:@"server_transaction_id"] copy];
-    action->_threeDS2SourceID = [[dict stp_stringForKey:@"three_d_secure_2_source"] copy];
+    action->_threeDSSourceID = [threeDSSourceID copy];
     action->_redirectURL = redirectURL;
     action->_allResponseFields = dict;
     return action;


### PR DESCRIPTION

## Summary
<!-- Simple summary of what was changed. -->
When we determine that a webview closed before the action was completed, we cancel the 3DS source identified in the URL using the new `source_cancel` endpoints.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Sources were being left in an unresolved state.

## Testing
<!-- How was the code tested? Be as specific as possible. -->
Tested PaymentIntent path with "Basic Integration" sample. Tested SetupIntent with https://github.com/stripe-samples/mobile-saving-card-without-payment
