### PR TITLE
Store last selected payment method

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ We welcome contributions of any kind including new features, bug fixes, and docu
 1. Install Carthage (if you have homebrew installed, `brew install carthage`)
 2. From the root of the repo, install test dependencies by running `carthage bootstrap --platform ios --configuration Release --no-use-binaries`
 3. Open Stripe.xcworkspace
-4. Choose the "StripeiOS" scheme with the iPhone 6, iOS 11.2 simulator (required for snapshot tests to pass)
+4. Choose the "StripeiOS" scheme with the iPhone 7, iOS 12.2 simulator (required for snapshot tests to pass)
 5. Run Product -> Test
 
 ## Migrating from Older Versions

--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -1924,6 +1924,7 @@
 		B64763B222FE193800C01BC0 /* STPSetupIntentLastSetupError.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = STPSetupIntentLastSetupError.h; path = PublicHeaders/STPSetupIntentLastSetupError.h; sourceTree = "<group>"; };
 		B64763B322FE193800C01BC0 /* STPSetupIntentLastSetupError.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSetupIntentLastSetupError.m; sourceTree = "<group>"; };
 		B64763B822FE1AF700C01BC0 /* STPSetupIntentLastSetupErrorTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSetupIntentLastSetupErrorTest.m; sourceTree = "<group>"; };
+		B65D7C632384ACDD000C6D34 /* STPCustomerContext+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCustomerContext+Private.h"; sourceTree = "<group>"; };
 		B664D64722B800AF00E6354B /* STPThreeDSButtonCustomization.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPThreeDSButtonCustomization.m; sourceTree = "<group>"; };
 		B664D64A22B8034D00E6354B /* STPThreeDSCustomization+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPThreeDSCustomization+Private.h"; sourceTree = "<group>"; };
 		B664D64D22B8085900E6354B /* STPThreeDSUICustomization.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPThreeDSUICustomization.m; sourceTree = "<group>"; };
@@ -3152,6 +3153,7 @@
 		F1728CF41EAAA457002E0C29 /* PaymentContext */ = {
 			isa = PBXGroup;
 			children = (
+				B65D7C632384ACDD000C6D34 /* STPCustomerContext+Private.h */,
 				04E39F5A1CECFAFD00AF3B96 /* STPPaymentContext+Private.h */,
 			);
 			name = PaymentContext;

--- a/Stripe/PublicHeaders/STPPaymentContext.h
+++ b/Stripe/PublicHeaders/STPPaymentContext.h
@@ -138,10 +138,12 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) BOOL loading;
 
 /**
+ @note This is no longer recommended as of v18.3.0 - the SDK automatically saves the Stripe ID of the last selected
+ payment method using NSUserDefaults and displays it as the default pre-selected option.  You can override this behavior
+ by setting this property.
+ 
  The Stripe ID of a payment method to display as the default pre-selected option.
  
- Customer doesn't have a default payment method property, but you can store one (in its metadata, for example) and set this property accordingly.
-
  @note Set this property immediately after initializing STPPaymentContext, or call `retryLoading` afterwards.
  */
 @property (nonatomic, copy, nullable) NSString *defaultPaymentMethod;

--- a/Stripe/PublicHeaders/STPPaymentOptionsViewController.h
+++ b/Stripe/PublicHeaders/STPPaymentOptionsViewController.h
@@ -102,14 +102,13 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) STPUserInformation *prefilledInformation;
 
 /**
+ @note This is no longer recommended as of v18.3.0 - the SDK automatically saves the Stripe ID of the last selected
+ payment method using NSUserDefaults and displays it as the default pre-selected option.  You can override this behavior
+ by setting this property.
+ 
  The Stripe ID of a payment method to display as the default pre-selected option.
 
- Customer doesn't have a default payment method property, but you can store one
- (in its metadata, for example) and set this property accordingly.
-
  @note Setting this after the view controller's view has loaded has no effect.
- @note This class automatically saves the Stripe ID of the last selected payment method using NSUserDefaults
- and displays it as the default pre-selected option.  Settting this value overrides that behavior.
  */
 @property (nonatomic, copy, nullable) NSString *defaultPaymentMethod;
 

--- a/Stripe/PublicHeaders/STPPaymentOptionsViewController.h
+++ b/Stripe/PublicHeaders/STPPaymentOptionsViewController.h
@@ -103,11 +103,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  The Stripe ID of a payment method to display as the default pre-selected option.
- 
+
  Customer doesn't have a default payment method property, but you can store one
  (in its metadata, for example) and set this property accordingly.
 
  @note Setting this after the view controller's view has loaded has no effect.
+ @note This class automatically saves the Stripe ID of the last selected payment method using NSUserDefaults
+ and displays it as the default pre-selected option.  Settting this value overrides that behavior.
  */
 @property (nonatomic, copy, nullable) NSString *defaultPaymentMethod;
 
@@ -159,6 +161,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable instancetype)initWithCoder:(NSCoder *)aDecoder NS_UNAVAILABLE;
 
 @end
+
+#pragma mark - STPPaymentOptionsViewControllerDelegate
 
 /**
  An `STPPaymentOptionsViewControllerDelegate` responds when a user selects a 

--- a/Stripe/STPCustomerContext+Private.h
+++ b/Stripe/STPCustomerContext+Private.h
@@ -1,0 +1,20 @@
+//
+//  STPCustomerContext+Private.h
+//  Stripe
+//
+//  Created by Yuki Tokuhiro on 11/19/19.
+//  Copyright © 2019 Stripe, Inc. All rights reserved.
+//
+
+#import <Stripe/Stripe.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface STPCustomerContext ()
+
+- (void)saveLastSelectedPaymentMethodIDForCustomer:(nullable NSString *)paymentMethodID completion:(nullable STPErrorBlock)completion;
+
+- (void)retrieveLastSelectedPaymentMethodIDForCustomerWithCompletion:(void (^)(NSString * _Nullable, NSError * _Nullable))completion;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Stripe/STPPaymentContext.m
+++ b/Stripe/STPPaymentContext.m
@@ -11,7 +11,7 @@
 
 #import "PKPaymentAuthorizationViewController+Stripe_Blocks.h"
 #import "STPAddCardViewController+Private.h"
-#import "STPCustomerContext.h"
+#import "STPCustomerContext+Private.h"
 #import "STPDispatchFunctions.h"
 #import "STPPaymentConfiguration+Private.h"
 #import "STPPaymentContext+Private.h"
@@ -157,8 +157,18 @@ typedef NS_ENUM(NSUInteger, STPPaymentContextState) {
                         [strongSelf2.loadingPromise fail:error];
                         return;
                     }
-                    STPPaymentOptionTuple *paymentTuple = [STPPaymentOptionTuple tupleFilteredForUIWithPaymentMethods:paymentMethods selectedPaymentMethod:strongSelf2.defaultPaymentMethod configuration:strongSelf2.configuration];
-                    [strongSelf2.loadingPromise succeed:paymentTuple];
+
+                    if (self.defaultPaymentMethod == nil && [strongSelf2.apiAdapter isKindOfClass:[STPCustomerContext class]]) {
+                        // Retrieve the last selected payment method saved by STPCustomerContext
+                        [((STPCustomerContext *)strongSelf2.apiAdapter) retrieveLastSelectedPaymentMethodIDForCustomerWithCompletion:^(NSString * _Nullable paymentMethodID, NSError * _Nullable __unused _) {
+                            __strong typeof(self) strongSelf3 = weakSelf;
+                            STPPaymentOptionTuple *paymentTuple = [STPPaymentOptionTuple tupleFilteredForUIWithPaymentMethods:paymentMethods selectedPaymentMethod:paymentMethodID configuration:strongSelf3.configuration];
+                            [strongSelf3.loadingPromise succeed:paymentTuple];
+                        }];
+                    } else {
+                        STPPaymentOptionTuple *paymentTuple = [STPPaymentOptionTuple tupleFilteredForUIWithPaymentMethods:paymentMethods selectedPaymentMethod:self.defaultPaymentMethod configuration:strongSelf2.configuration];
+                        [strongSelf2.loadingPromise succeed:paymentTuple];
+                    }
                 });
             }];
         });

--- a/Stripe/STPPaymentOptionTableViewCell.m
+++ b/Stripe/STPPaymentOptionTableViewCell.m
@@ -78,6 +78,7 @@ static const CGFloat kCheckmarkWidth = 14.f;
             [self.titleLabel.centerYAnchor constraintEqualToAnchor:self.contentView.centerYAnchor],
 
         ]];
+        self.isAccessibilityElement = YES;
     }
     return self;
 }
@@ -120,6 +121,13 @@ static const CGFloat kCheckmarkWidth = 14.f;
     // Checkmark icon
     self.checkmarkIcon.tintColor = theme.accentColor;
     self.checkmarkIcon.hidden = !selected;
+    
+    // Accessibility
+    if (selected) {
+        self.accessibilityTraits |= UIAccessibilityTraitSelected;
+    } else {
+        self.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+    }
 
     [self setNeedsLayout];
 }

--- a/Stripe/STPPaymentOptionTuple.m
+++ b/Stripe/STPPaymentOptionTuple.m
@@ -71,9 +71,9 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     return [[self class] tupleWithPaymentOptions:paymentOptions
-                                    selectedPaymentOption:selectedPaymentMethod
-                                        addApplePayOption:configuration.applePayEnabled
-                                        additionalOptions:configuration.additionalPaymentOptions];
+                           selectedPaymentOption:selectedPaymentMethod
+                               addApplePayOption:configuration.applePayEnabled
+                               additionalOptions:configuration.additionalPaymentOptions];
 }
 
 @end

--- a/Stripe/STPPaymentOptionsViewController.m
+++ b/Stripe/STPPaymentOptionsViewController.m
@@ -13,6 +13,7 @@
 #import "STPCard.h"
 #import "STPColorUtils.h"
 #import "STPCoreViewController+Private.h"
+#import "STPCustomerContext+Private.h"
 #import "STPDispatchFunctions.h"
 #import "STPLocalizationUtils.h"
 #import "STPPaymentActivityIndicatorView.h"
@@ -80,7 +81,15 @@
             if (error) {
                 [promise fail:error];
             } else {
-                STPPaymentOptionTuple *paymentTuple = [STPPaymentOptionTuple tupleFilteredForUIWithPaymentMethods:paymentMethods selectedPaymentMethod:self.defaultPaymentMethod configuration:configuration];
+                NSString *defaultPaymentMethod = self.defaultPaymentMethod;
+                if (defaultPaymentMethod == nil && [apiAdapter isKindOfClass:[STPCustomerContext class]]) {
+                    // Retrieve the last selected payment method saved by STPCustomerContext
+                    [((STPCustomerContext *)apiAdapter) retrieveLastSelectedPaymentMethodIDForCustomerWithCompletion:^(NSString * _Nullable paymentMethodID, NSError * _Nullable __unused _) {
+                        STPPaymentOptionTuple *paymentTuple = [STPPaymentOptionTuple tupleFilteredForUIWithPaymentMethods:paymentMethods selectedPaymentMethod:paymentMethodID configuration:configuration];
+                        [promise succeed:paymentTuple];
+                    }];
+                }
+                STPPaymentOptionTuple *paymentTuple = [STPPaymentOptionTuple tupleFilteredForUIWithPaymentMethods:paymentMethods selectedPaymentMethod:defaultPaymentMethod configuration:configuration];
                 [promise succeed:paymentTuple];
             }
         });
@@ -166,6 +175,19 @@
 }
     
 - (void)finishWithPaymentOption:(id<STPPaymentOption>)paymentOption {
+    BOOL isReusablePaymentMethod = [paymentOption isKindOfClass:[STPPaymentMethod class]] && ((STPPaymentMethod *)paymentOption).type == STPPaymentMethodTypeCard;
+    
+    if ([self.apiAdapter isKindOfClass:[STPCustomerContext class]]) {
+        if (isReusablePaymentMethod) {
+            // Save the payment method
+            STPPaymentMethod *paymentMethod = (STPPaymentMethod *)paymentOption;
+            [((STPCustomerContext *)self.apiAdapter) saveLastSelectedPaymentMethodIDForCustomer:paymentMethod.stripeId completion:nil];
+        } else {
+            // The customer selected something else (like Apple Pay)
+            [((STPCustomerContext *)self.apiAdapter) saveLastSelectedPaymentMethodIDForCustomer:nil completion:nil];
+        }
+    }
+    
     if ([self.delegate respondsToSelector:@selector(paymentOptionsViewController:didSelectPaymentOption:)]) {
         [self.delegate paymentOptionsViewController:self didSelectPaymentOption:paymentOption];
     }

--- a/Stripe/STPPaymentOptionsViewController.m
+++ b/Stripe/STPPaymentOptionsViewController.m
@@ -175,7 +175,7 @@
 }
     
 - (void)finishWithPaymentOption:(id<STPPaymentOption>)paymentOption {
-    BOOL isReusablePaymentMethod = [paymentOption isKindOfClass:[STPPaymentMethod class]] && ((STPPaymentMethod *)paymentOption).type == STPPaymentMethodTypeCard;
+    BOOL isReusablePaymentMethod = [paymentOption isKindOfClass:[STPPaymentMethod class]] && ((STPPaymentMethod *)paymentOption).isReusable;
     
     if ([self.apiAdapter isKindOfClass:[STPCustomerContext class]]) {
         if (isReusablePaymentMethod) {

--- a/Tests/Tests/STPMocks.m
+++ b/Tests/Tests/STPMocks.m
@@ -11,6 +11,7 @@
 #import "STPFixtures.h"
 #import "STPPaymentConfiguration+Private.h"
 #import "STPPaymentContext+Private.h"
+#import "STPCustomerContext+Private.h"
 #import "UIViewController+Stripe_Promises.h"
 
 @interface STPPaymentConfiguration (STPMocks)
@@ -58,6 +59,11 @@
         completion(paymentMethods, nil);
     });
     OCMStub([mock attachPaymentMethodToCustomer:[OCMArg any] completion:[OCMArg invokeBlock]]);
+    OCMStub([mock retrieveLastSelectedPaymentMethodIDForCustomerWithCompletion:[OCMArg any]]).andDo(^(NSInvocation *invocation){
+        void (^completion)(NSString *, NSError *);
+        [invocation getArgument:&completion atIndex:2];
+        completion(nil, nil);
+    });
     return mock;
 }
 

--- a/ci_scripts/run_builds.sh
+++ b/ci_scripts/run_builds.sh
@@ -19,8 +19,8 @@ if ! command -v xcpretty > /dev/null; then
   gem install xcpretty --no-document || die "Executing \`gem install xcpretty\` failed"
 fi
 
-# Execute sample app builds (iPhone 6, iOS 11.x)
-info "Executing sample app builds (iPhone 6, iOS 11.x)..."
+# Execute sample app builds
+info "Executing sample app builds (iPhone 7, iOS 12.2)..."
 
 xcodebuild build \
   -workspace "Stripe.xcworkspace" \


### PR DESCRIPTION
## Summary
`STPPaymentContext` and `STPPaymentOptionsViewController` pre-select the last selected payment method via a `{customer_id: last_selected_payment_method_id}` store in NSUserDefaults.

* This aims to return the lost feature, not implement https://paper.dropbox.com/doc/Saving-last-selected-payment-method--Ao40PI6L1boSl8DXBN0S3zUxAg-YiSHZtquibTm2xrQ9me7O
## Motivation
https://jira.corp.stripe.com/browse/IOS-1365


## Testing
Added a UI test that covers reading, writing a PM id, writing nil, and multiple customers.