### PR TITLE
Fix text color for large titles

### DIFF
--- a/Example/UI Examples/BrowseViewController.swift
+++ b/Example/UI Examples/BrowseViewController.swift
@@ -12,7 +12,7 @@ import Stripe
 class BrowseViewController: UITableViewController, STPAddCardViewControllerDelegate, STPPaymentOptionsViewControllerDelegate, STPShippingAddressViewControllerDelegate {
 
     enum Demo: Int {
-        static let count = 5
+        static let count = 6
         case STPPaymentCardTextField
         case STPAddCardViewController
         case STPPaymentOptionsViewController

--- a/Stripe/UINavigationBar+Stripe_Theme.m
+++ b/Stripe/UINavigationBar+Stripe_Theme.m
@@ -38,6 +38,11 @@ static NSInteger const STPNavigationBarHairlineViewTag = 787473;
                                  NSFontAttributeName: theme.emphasisFont,
                                  NSForegroundColorAttributeName: theme.primaryForegroundColor,
                                  };
+    if (@available(iOS 11.0, *)) {
+        self.largeTitleTextAttributes = @{
+            NSForegroundColorAttributeName: theme.primaryForegroundColor,
+        };
+    }
 
 #ifdef __IPHONE_13_0
     if (@available(iOS 13.0, *)) {


### PR DESCRIPTION
## Summary
Propagate color info from STPTheme to largeTitleTextAttributes. Also fix a bug with accessing the theme menu in the UI Examples app.

## Motivation
Large titles were occasionally unreadable against certain backgrounds.

## Testing
Tested by enabling large titles in UI Examples.
