### PR TITLE
Fix crash when adding/removing postal code cells

### DIFF
--- a/Stripe/STPAddCardViewController.m
+++ b/Stripe/STPAddCardViewController.m
@@ -64,7 +64,6 @@
 @property (nonatomic) STPAddressViewModel *addressViewModel;
 @property (nonatomic) UIToolbar *inputAccessoryToolbar;
 @property (nonatomic) BOOL lookupSucceeded;
-@property (nonatomic) NSUInteger numberOfRowsInAddressSection;
 @end
 
 static NSString *const STPPaymentCardCellReuseIdentifier = @"STPPaymentCardCellReuseIdentifier";
@@ -95,7 +94,6 @@ typedef NS_ENUM(NSUInteger, STPPaymentCardSection) {
     _apiClient = [[STPAPIClient alloc] initWithConfiguration:configuration];
     _addressViewModel = [[STPAddressViewModel alloc] initWithRequiredBillingFields:configuration.requiredBillingAddressFields availableCountries:configuration._availableCountries];
     _addressViewModel.delegate = self;
-    _numberOfRowsInAddressSection = _addressViewModel.addressCells.count;
     self.title = STPLocalizedString(@"Add a Card", @"Title for Add a Card view");
 }
 
@@ -418,7 +416,6 @@ typedef NS_ENUM(NSUInteger, STPPaymentCardSection) {
 }
 
 - (void)addressViewModelDidUpdate:(__unused STPAddressViewModel *)addressViewModel {
-    self.numberOfRowsInAddressSection = self.addressViewModel.addressCells.count;
     [self.tableView endUpdates];
 }
 
@@ -432,7 +429,7 @@ typedef NS_ENUM(NSUInteger, STPPaymentCardSection) {
     if (section == STPPaymentCardNumberSection) {
         return 1;
     } else if (section == STPPaymentCardBillingAddressSection) {
-        return self.numberOfRowsInAddressSection;
+        return self.addressViewModel.addressCells.count;
     }
     return 0;
 }

--- a/Stripe/STPAddCardViewController.m
+++ b/Stripe/STPAddCardViewController.m
@@ -125,7 +125,7 @@ typedef NS_ENUM(NSUInteger, STPPaymentCardSection) {
     [self updateInputAccessoryVisiblity];
     self.tableView.dataSource = self;
     self.tableView.delegate = self;
-
+    [self.tableView reloadData];
     if (self.prefilledInformation.billingAddress != nil) {
         self.addressViewModel.address = self.prefilledInformation.billingAddress;
     }

--- a/Stripe/STPAddressViewModel.h
+++ b/Stripe/STPAddressViewModel.h
@@ -17,6 +17,8 @@
 - (void)addressViewModelDidChange:(STPAddressViewModel *)addressViewModel;
 - (void)addressViewModel:(STPAddressViewModel *)addressViewModel addedCellAtIndex:(NSUInteger)index;
 - (void)addressViewModel:(STPAddressViewModel *)addressViewModel removedCellAtIndex:(NSUInteger)index;
+- (void)addressViewModelWillUpdate:(STPAddressViewModel *)addressViewModel;
+- (void)addressViewModelDidUpdate:(STPAddressViewModel *)addressViewModel;
 
 @end
 

--- a/Stripe/STPAddressViewModel.m
+++ b/Stripe/STPAddressViewModel.m
@@ -123,6 +123,7 @@
 }
 
 - (void)updatePostalCodeCellIfNecessary {
+    [self.delegate addressViewModelWillUpdate:self];
     BOOL shouldBeShowingPostalCode = [STPPostalCodeValidator postalCodeIsRequiredForCountryCode:self.addressFieldTableViewCountryCode];
     if (shouldBeShowingPostalCode && !self.showingPostalCodeCell) {
         if (self.isBillingAddress && self.requiredBillingAddressFields == STPBillingAddressFieldsZip) {
@@ -169,6 +170,7 @@
         }
     }
     self.showingPostalCodeCell = shouldBeShowingPostalCode;
+    [self.delegate addressViewModelDidUpdate:self];
 }
 
 - (BOOL)containsStateAndPostalFields {

--- a/Stripe/STPBankSelectionViewController.m
+++ b/Stripe/STPBankSelectionViewController.m
@@ -82,6 +82,7 @@ static NSString *const STPBankSelectionCellReuseIdentifier = @"STPBankSelectionC
 
     self.tableView.dataSource = self;
     self.tableView.delegate = self;
+    [self.tableView reloadData];
 }
 
 - (void)updateAppearance {

--- a/Stripe/STPPaymentOptionsInternalViewController.m
+++ b/Stripe/STPPaymentOptionsInternalViewController.m
@@ -80,6 +80,7 @@ static NSInteger const PaymentOptionSectionAPM = 2;
 
     self.tableView.dataSource = self;
     self.tableView.delegate = self;
+    [self.tableView reloadData];
 
     // Table header view
     UIImageView *cardImageView = [[UIImageView alloc] initWithImage:[STPImageLibrary largeCardFrontImage]];

--- a/Stripe/STPShippingAddressViewController.m
+++ b/Stripe/STPShippingAddressViewController.m
@@ -40,7 +40,6 @@
 @property (nonatomic) STPAddress *billingAddress;
 @property (nonatomic) BOOL hasUsedBillingAddress;
 @property (nonatomic) STPSectionHeaderView *addressHeaderView;
-@property (nonatomic) NSUInteger numberOfRows;
 @end
 
 @implementation STPShippingAddressViewController
@@ -97,7 +96,6 @@
             _addressViewModel.address = prefilledInformation.shippingAddress;
         }
         self.title = [self titleForShippingType:self.configuration.shippingType];
-        self.numberOfRows = _addressViewModel.addressCells.count;
     }
     return self;
 }
@@ -309,7 +307,6 @@
 }
 
 - (void)addressViewModelDidUpdate:(__unused STPAddressViewModel *)addressViewModel {
-    self.numberOfRows = self.addressViewModel.addressCells.count;
     [self.tableView endUpdates];
 }
 
@@ -320,7 +317,7 @@
 }
 
 - (NSInteger)tableView:(__unused UITableView *)tableView numberOfRowsInSection:(__unused NSInteger)section {
-    return self.numberOfRows;
+    return self.addressViewModel.addressCells.count;
 }
 
 - (UITableViewCell *)tableView:(__unused UITableView *)tableView

--- a/Stripe/STPShippingAddressViewController.m
+++ b/Stripe/STPShippingAddressViewController.m
@@ -132,6 +132,7 @@
 
     self.tableView.dataSource = self;
     self.tableView.delegate = self;
+    [self.tableView reloadData];
     [self.view addGestureRecognizer:[[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(endEditing)]];
 
     STPSectionHeaderView *headerView = [STPSectionHeaderView new];

--- a/Stripe/STPShippingAddressViewController.m
+++ b/Stripe/STPShippingAddressViewController.m
@@ -40,6 +40,7 @@
 @property (nonatomic) STPAddress *billingAddress;
 @property (nonatomic) BOOL hasUsedBillingAddress;
 @property (nonatomic) STPSectionHeaderView *addressHeaderView;
+@property (nonatomic) NSUInteger numberOfRows;
 @end
 
 @implementation STPShippingAddressViewController
@@ -96,6 +97,7 @@
             _addressViewModel.address = prefilledInformation.shippingAddress;
         }
         self.title = [self titleForShippingType:self.configuration.shippingType];
+        self.numberOfRows = _addressViewModel.addressCells.count;
     }
     return self;
 }
@@ -307,6 +309,7 @@
 }
 
 - (void)addressViewModelDidUpdate:(__unused STPAddressViewModel *)addressViewModel {
+    self.numberOfRows = self.addressViewModel.addressCells.count;
     [self.tableView endUpdates];
 }
 
@@ -317,7 +320,7 @@
 }
 
 - (NSInteger)tableView:(__unused UITableView *)tableView numberOfRowsInSection:(__unused NSInteger)section {
-    return self.addressViewModel.addressCells.count;
+    return self.numberOfRows;
 }
 
 - (UITableViewCell *)tableView:(__unused UITableView *)tableView

--- a/Stripe/STPShippingAddressViewController.m
+++ b/Stripe/STPShippingAddressViewController.m
@@ -302,6 +302,14 @@
     [self updateDoneButton];
 }
 
+- (void)addressViewModelWillUpdate:(__unused STPAddressViewModel *)addressViewModel {
+    [self.tableView beginUpdates];
+}
+
+- (void)addressViewModelDidUpdate:(__unused STPAddressViewModel *)addressViewModel {
+    [self.tableView endUpdates];
+}
+
 #pragma mark - UITableView
 
 - (NSInteger)numberOfSectionsInTableView:(__unused UITableView *)tableView {

--- a/Stripe/STPShippingMethodsViewController.m
+++ b/Stripe/STPShippingMethodsViewController.m
@@ -70,6 +70,7 @@ static NSString *const STPShippingMethodCellReuseIdentifier = @"STPShippingMetho
     self.tableView.tableHeaderView = imageView;
     self.tableView.dataSource = self;
     self.tableView.delegate = self;
+    [self.tableView reloadData];
 
     STPSectionHeaderView *headerView = [STPSectionHeaderView new];
     headerView.theme = self.theme;


### PR DESCRIPTION
## Summary
We're creating a UITableView and adding it to the view hierarchy before setting a `dataSource`, which causes it to set up an internal cache with its own default values (1 section, 0 rows). We then immediately swap out the `dataSource` for our real data, which doesn't match the data in UITableView's cache, so it throws various exceptions. We could wait to add our table view to the view hierarchy until after we've given it a `dataSource`, but a less invasive fix is to `reloadData` immediately after setting our new `dataSource`.

We also weren't calling `beginUpdates` and `endUpdates` when manipulating the UITableView. Fixing this should allow us to get rid of a few hacks we've added to work around that issue.

This changes the solution to #1004 and #1427. I tested both cases, and neither seem to have regressed.

This fixes #1449.

## Testing
Tested in CI and by manually flipping around the cells.