### PR TITLE
Use STPAPIClient.shared by default

### DIFF
--- a/Example/UI Examples/BrowseViewController.swift
+++ b/Example/UI Examples/BrowseViewController.swift
@@ -52,7 +52,6 @@ class BrowseViewController: UITableViewController, STPAddCardViewControllerDeleg
         tableView.tableFooterView = UIView()
         tableView.rowHeight = 60
         navigationController?.navigationBar.isTranslucent = false
-        STPAddCardViewController.startMockingAPIClient()
     }
 
     // MARK: UITableViewDelegate
@@ -90,6 +89,7 @@ class BrowseViewController: UITableViewController, STPAddCardViewControllerDeleg
             let config = STPPaymentConfiguration()
             config.requiredBillingAddressFields = .full
             let viewController = STPAddCardViewController(configuration: config, theme: theme)
+            viewController.apiClient = MockAPIClient()
             viewController.delegate = self
             let navigationController = UINavigationController(rootViewController: viewController)
             navigationController.navigationBar.stp_theme = theme
@@ -103,6 +103,7 @@ class BrowseViewController: UITableViewController, STPAddCardViewControllerDeleg
                                                                  theme: theme,
                                                                  customerContext: self.customerContext,
                                                                  delegate: self)
+            viewController.apiClient = MockAPIClient()
             let navigationController = UINavigationController(rootViewController: viewController)
             navigationController.navigationBar.stp_theme = theme
             present(navigationController, animated: true, completion: nil)
@@ -115,6 +116,7 @@ class BrowseViewController: UITableViewController, STPAddCardViewControllerDeleg
                                                                  theme: theme,
                                                                  customerContext: self.customerContext,
                                                                  delegate: self)
+            viewController.apiClient = MockAPIClient()
             let navigationController = UINavigationController(rootViewController: viewController)
             navigationController.navigationBar.stp_theme = theme
             present(navigationController, animated: true, completion: nil)

--- a/Example/UI Examples/MockAPIClient.swift
+++ b/Example/UI Examples/MockAPIClient.swift
@@ -9,33 +9,6 @@
 import Foundation
 import Stripe
 
-private let swizzle: (AnyClass, Selector, Selector) -> () = { forClass, originalSelector, swizzledSelector in
-    let originalMethod = class_getInstanceMethod(forClass, originalSelector)
-    let swizzledMethod = class_getInstanceMethod(forClass, swizzledSelector)
-    method_exchangeImplementations(originalMethod!, swizzledMethod!)
-}
-
-
-extension STPAddCardViewController {
-
-    // We can't swizzle in initialize because it's been deprecated in Swift 3.1.
-    // Instead, we have to call this method before STPAddCardViewController appears.
-    static func startMockingAPIClient() {
-        let originalSelector = #selector(apiClient)
-        let swizzledSelector = #selector(swizzled_apiClient)
-        swizzle(self, originalSelector, swizzledSelector)
-    }
-
-    // Expose the private `apiClient` property as a method
-    @objc func apiClient() -> STPAPIClient? {
-        return nil
-    }
-
-    @objc func swizzled_apiClient() -> STPAPIClient? {
-        return MockAPIClient()
-    }
-}
-
 class MockAPIClient: STPAPIClient {
     override func createPaymentMethod(with paymentMethodParams: STPPaymentMethodParams, completion: @escaping STPPaymentMethodCompletionBlock) {
         guard let card = paymentMethodParams.card, let billingDetails = paymentMethodParams.billingDetails else { return }

--- a/Stripe/PublicHeaders/STPAddCardViewController.h
+++ b/Stripe/PublicHeaders/STPAddCardViewController.h
@@ -18,7 +18,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class STPAddCardViewController;
+@class STPAddCardViewController, STPAPIClient;
 @protocol STPAddCardViewControllerDelegate;
 
 /** This view controller contains a credit card entry form that the user can fill out. On submission, it will use the Stripe API to convert the user's card details to a Stripe token. It renders a right bar button item that submits the form, so it must be shown inside a `UINavigationController`.
@@ -57,6 +57,13 @@ NS_ASSUME_NONNULL_BEGIN
  to be sized and positioned properly.
  */
 @property (nonatomic, strong, nullable) UIView *customFooterView;
+
+/**
+ The API Client to use to make requests.
+ 
+ Defaults to [STPAPIClient sharedClient]
+ */
+@property (nonatomic, strong) STPAPIClient *apiClient;
 
 /**
  Use init: or initWithConfiguration:theme:

--- a/Stripe/PublicHeaders/STPBankSelectionViewController.h
+++ b/Stripe/PublicHeaders/STPBankSelectionViewController.h
@@ -15,7 +15,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol STPBankSelectionViewControllerDelegate;
-@class STPPaymentMethodParams;
+@class STPPaymentMethodParams, STPAPIClient;
 
 /**
  The payment methods supported by STPBankSelectionViewController.
@@ -59,6 +59,13 @@ typedef NS_ENUM(NSInteger, STPBankSelectionMethod) {
 The view controller's delegate. This must be set before showing the view controller in order for it to work properly. @see STPBankSelectionViewControllerDelegate
 */
 @property (nonatomic, weak) id<STPBankSelectionViewControllerDelegate> delegate;
+
+/**
+ The API Client to use to make requests.
+ 
+ Defaults to [STPAPIClient sharedClient]
+ */
+@property (nonatomic, strong) STPAPIClient *apiClient;
 
 @end
 

--- a/Stripe/PublicHeaders/STPCustomerContext.h
+++ b/Stripe/PublicHeaders/STPCustomerContext.h
@@ -13,7 +13,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol STPCustomerEphemeralKeyProvider;
-@class STPEphemeralKey, STPEphemeralKeyManager;
+@class STPEphemeralKey, STPEphemeralKeyManager, STPAPIClient;
 
 /**
  An `STPCustomerContext` retrieves and updates a Stripe customer and their attached
@@ -37,6 +37,21 @@ NS_ASSUME_NONNULL_BEGIN
  @return the newly-instantiated customer context.
  */
 - (instancetype)initWithKeyProvider:(id<STPCustomerEphemeralKeyProvider>)keyProvider;
+
+/**
+Initializes a new `STPCustomerContext` with the specified key provider.
+Upon initialization, a CustomerContext will fetch a new ephemeral key from
+your backend and use it to prefetch the customer object specified in the key.
+Subsequent customer and payment method retrievals (e.g. by `STPPaymentContext`)
+will return the prefetched customer / attached payment methods immediately if
+its age does not exceed 60 seconds.
+
+@param keyProvider   The key provider the customer context will use.
+@param apiClient       The API Client to use to make requests.
+@return the newly-instantiated customer context.
+*/
+- (instancetype)initWithKeyProvider:(id<STPCustomerEphemeralKeyProvider>)keyProvider apiClient:(STPAPIClient *)apiClient;
+
 
 /**
  `STPCustomerContext` will cache its customer object and associated payment methods

--- a/Stripe/PublicHeaders/STPPaymentContext.h
+++ b/Stripe/PublicHeaders/STPPaymentContext.h
@@ -279,7 +279,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, strong) UIView *addCardViewControllerFooterView;
 
-
+/**
+ The API Client to use to make requests.
+ 
+ Defaults to [STPAPIClient sharedClient]
+ */
+@property (nonatomic, strong) STPAPIClient *apiClient;
 
 /**
  If `paymentContext:didFailToLoadWithError:` is called on your delegate, you

--- a/Stripe/PublicHeaders/STPPaymentOptionsViewController.h
+++ b/Stripe/PublicHeaders/STPPaymentOptionsViewController.h
@@ -17,7 +17,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol STPPaymentOption, STPPaymentOptionsViewControllerDelegate;
-@class STPPaymentContext, STPPaymentOptionsViewController, STPCustomerContext;
+@class STPPaymentContext, STPPaymentOptionsViewController, STPCustomerContext, STPAPIClient;
 
 /**
  This view controller presents a list of payment method options to the user, 
@@ -131,6 +131,13 @@ NS_ASSUME_NONNULL_BEGIN
  to be sized and positioned properly.
  */
 @property (nonatomic, strong) UIView *addCardViewControllerFooterView;
+
+/**
+ The API Client to use to make requests.
+ 
+ Defaults to [STPAPIClient sharedClient]
+ */
+@property (nonatomic, strong) STPAPIClient *apiClient;
 
 /**
  If you're pushing `STPPaymentOptionsViewController` onto an existing 

--- a/Stripe/PublicHeaders/STPPinManagementService.h
+++ b/Stripe/PublicHeaders/STPPinManagementService.h
@@ -16,6 +16,13 @@
 @interface STPPinManagementService : NSObject
 
 /**
+ The API Client to use to make requests.
+ 
+ Defaults to [STPAPIClient sharedClient]
+ */
+@property (nonatomic, strong) STPAPIClient *apiClient;
+
+/**
  Create a STPPinManagementService, you must provide an implementation of STPIssuingCardEphemeralKeyProvider
  */
 - (instancetype)initWithKeyProvider:(id<STPIssuingCardEphemeralKeyProvider>)keyProvider;

--- a/Stripe/PublicHeaders/STPPushProvisioningContext.h
+++ b/Stripe/PublicHeaders/STPPushProvisioningContext.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                                  brand:(STPCardBrand)brand;
 
 /**
-  In order to retreive the encrypted payload that PKAddPaymentPassViewController expects, the Stripe SDK must talk to the Stripe API. As this requires privileged access, you must write a "key provider" that generates an Ephemeral Key on your backend and provides it to the SDK when requested. For more information, see https://stripe.com/docs/mobile/ios/standard#prepare-your-api
+  In order to retreive the encrypted payload that PKAddPaymentPassViewController expects, the Stripe SDK must talk to the Stripe API. As this requires privileged access, you must write a "key provider" that generates an Ephemeral Key on your backend and provides it to the SDK when requested. For more information, see https://stripe.com/docs/mobile/ios/basic#ephemeral-key
  */
 - (instancetype)initWithKeyProvider:(id<STPIssuingCardEphemeralKeyProvider>)keyProvider;
 

--- a/Stripe/PublicHeaders/STPPushProvisioningContext.h
+++ b/Stripe/PublicHeaders/STPPushProvisioningContext.h
@@ -11,12 +11,21 @@
 #import "STPEphemeralKeyProvider.h"
 #import "STPCard.h"
 
+@class STPAPIClient;
+
 NS_ASSUME_NONNULL_BEGIN
 
 /**
  This class makes it easier to implement "Push Provisioning", the process by which an end-user can add a card to their Apple Pay wallet without having to type their number. This process is mediated by an Apple class called `PKAddPaymentPassViewController`; this class will help you implement that class' delegate methods. Note that this flow requires a special entitlement from Apple; for more information please see https://stripe.com/docs/issuing/cards/digital-wallets .
  */
 @interface STPPushProvisioningContext : NSObject
+
+/**
+ The API Client to use to make requests.
+ 
+ Defaults to [STPAPIClient sharedClient]
+ */
+@property (nonatomic, strong) STPAPIClient *apiClient;
 
 /**
  This is a helper method to generate a PKAddPaymentPassRequestConfiguration that will work with

--- a/Stripe/STPAPIClient+Private.h
+++ b/Stripe/STPAPIClient+Private.h
@@ -50,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  A helper method that returns the Authorization header to use for API requests. If ephemeralKey is nil, uses self.publishableKey instead.
  */
-- (NSDictionary<NSString *, NSString *> *)authorizationHeaderUsingEphemeralKey:(STPEphemeralKey *)ephemeralKey;
+- (NSDictionary<NSString *, NSString *> *)authorizationHeaderUsingEphemeralKey:(nullable STPEphemeralKey *)ephemeralKey;
 
 @end
 

--- a/Stripe/STPAPIClient+Private.h
+++ b/Stripe/STPAPIClient+Private.h
@@ -29,8 +29,10 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readwrite) NSURL *apiURL;
 @property (nonatomic, strong, readonly) NSURLSession *urlSession;
 
-- (NSMutableURLRequest *)configuredRequestForURL:(NSURL *)url;
-
+/**
+ @note `additionalHeaders` overwrites any headers provided by the api client.
+ */
+- (NSMutableURLRequest *)configuredRequestForURL:(NSURL *)url additionalHeaders:(NSDictionary<NSString *, NSString *> *)headers;
 + (NSURLSessionConfiguration *)sharedUrlSessionConfiguration;
 
 @end

--- a/Stripe/STPAPIClient+Private.h
+++ b/Stripe/STPAPIClient+Private.h
@@ -61,7 +61,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @see https://stripe.com/docs/api#retrieve_customer
  */
-+ (void)retrieveCustomerUsingKey:(STPEphemeralKey *)ephemeralKey
+- (void)retrieveCustomerUsingKey:(STPEphemeralKey *)ephemeralKey
                       completion:(STPCustomerCompletionBlock)completion;
 
 /**
@@ -69,7 +69,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @see https://stripe.com/docs/api#create_card
  */
-+ (void)addSource:(NSString *)sourceID
+- (void)addSource:(NSString *)sourceID
 toCustomerUsingKey:(STPEphemeralKey *)ephemeralKey
        completion:(STPSourceProtocolCompletionBlock)completion;
 
@@ -78,7 +78,7 @@ toCustomerUsingKey:(STPEphemeralKey *)ephemeralKey
 
  @see https://stripe.com/docs/api#update_customer
  */
-+ (void)updateCustomerWithParameters:(NSDictionary *)parameters
+- (void)updateCustomerWithParameters:(NSDictionary *)parameters
                             usingKey:(STPEphemeralKey *)ephemeralKey
                           completion:(STPCustomerCompletionBlock)completion;
 
@@ -87,7 +87,7 @@ toCustomerUsingKey:(STPEphemeralKey *)ephemeralKey
 
  @see https://stripe.com/docs/api#delete_card
  */
-+ (void)deleteSource:(NSString *)sourceID
+- (void)deleteSource:(NSString *)sourceID
 fromCustomerUsingKey:(STPEphemeralKey *)ephemeralKey
           completion:(STPErrorBlock)completion;
 
@@ -96,7 +96,7 @@ fromCustomerUsingKey:(STPEphemeralKey *)ephemeralKey
  
  @see https://stripe.com/docs/api/payment_methods/attach
  */
-+ (void)attachPaymentMethod:(NSString *)paymentMethodID
+- (void)attachPaymentMethod:(NSString *)paymentMethodID
          toCustomerUsingKey:(STPEphemeralKey *)ephemeralKey
                  completion:(STPErrorBlock)completion;
 
@@ -105,7 +105,7 @@ fromCustomerUsingKey:(STPEphemeralKey *)ephemeralKey
  
  @see https://stripe.com/docs/api/payment_methods/detach
  */
-+ (void)detachPaymentMethod:(NSString *)paymentMethodID
+- (void)detachPaymentMethod:(NSString *)paymentMethodID
        fromCustomerUsingKey:(STPEphemeralKey *)ephemeralKey
                  completion:(STPErrorBlock)completion;
 
@@ -114,7 +114,7 @@ fromCustomerUsingKey:(STPEphemeralKey *)ephemeralKey
  
  @note This only fetches card type Payment Methods
  */
-+ (void)listPaymentMethodsForCustomerUsingKey:(STPEphemeralKey *)ephemeralKey
+- (void)listPaymentMethodsForCustomerUsingKey:(STPEphemeralKey *)ephemeralKey
                                    completion:(STPPaymentMethodsCompletionBlock)completion;
 @end
 

--- a/Stripe/STPAPIClient+Private.h
+++ b/Stripe/STPAPIClient+Private.h
@@ -46,7 +46,12 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @interface STPAPIClient (EphemeralKeys)
-+ (instancetype)apiClientWithEphemeralKey:(STPEphemeralKey *)key;
+
+/**
+ A helper method that returns the Authorization header to use for API requests. If ephemeralKey is nil, uses self.publishableKey instead.
+ */
+- (NSDictionary<NSString *, NSString *> *)authorizationHeaderUsingEphemeralKey:(STPEphemeralKey *)ephemeralKey;
+
 @end
 
 @interface STPAPIClient (Customers)

--- a/Stripe/STPAPIClient+Private.h
+++ b/Stripe/STPAPIClient+Private.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  @note `additionalHeaders` overwrites any headers provided by the api client.
  */
-- (NSMutableURLRequest *)configuredRequestForURL:(NSURL *)url additionalHeaders:(NSDictionary<NSString *, NSString *> *)headers;
+- (NSMutableURLRequest *)configuredRequestForURL:(NSURL *)url additionalHeaders:(nullable NSDictionary<NSString *, NSString *> *)headers;
 + (NSURLSessionConfiguration *)sharedUrlSessionConfiguration;
 
 @end

--- a/Stripe/STPAPIClient+PushProvisioning.h
+++ b/Stripe/STPAPIClient+PushProvisioning.h
@@ -17,7 +17,8 @@ typedef void (^STPPushProvisioningDetailsCompletionBlock)(STPPushProvisioningDet
 @interface STPAPIClient (PushProvisioning)
     
 - (void)retrievePushProvisioningDetailsWithParams:(STPPushProvisioningDetailsParams *)params
-                                    completion:(STPPushProvisioningDetailsCompletionBlock)completion;
+                                     ephemeralKey:(STPEphemeralKey *)ephemeralKey
+                                       completion:(STPPushProvisioningDetailsCompletionBlock)completion;
 
 @end
 

--- a/Stripe/STPAPIClient+PushProvisioning.m
+++ b/Stripe/STPAPIClient+PushProvisioning.m
@@ -7,12 +7,13 @@
 //
 
 #import "STPAPIClient+PushProvisioning.h"
-#import "STPAPIRequest.h"
+#import "STPAPIRequest+Private.h"
 
 @implementation STPAPIClient (PushProvisioning)
 
 - (void)retrievePushProvisioningDetailsWithParams:(STPPushProvisioningDetailsParams *)params
-                                    completion:(STPPushProvisioningDetailsCompletionBlock)completion {
+                                     ephemeralKey:(STPEphemeralKey *)ephemeralKey
+                                       completion:(STPPushProvisioningDetailsCompletionBlock)completion {
     
     NSString *endpoint = [NSString stringWithFormat:@"issuing/cards/%@/push_provisioning_details", params.cardId];
     NSDictionary *parameters = @{
@@ -24,12 +25,13 @@
                                  };
     
     [STPAPIRequest<STPPushProvisioningDetails *> getWithAPIClient:self
-                                                      endpoint:endpoint
-                                                    parameters:parameters
-                                                  deserializer:[STPPushProvisioningDetails new]
-                                                    completion:^(STPPushProvisioningDetails *details, __unused     NSHTTPURLResponse *response, NSError *error) {
-                                                        completion(details, error);
-                                                    }];
+                                                         endpoint:endpoint
+                                                additionalHeaders:[self authorizationHeaderUsingEphemeralKey:ephemeralKey]
+                                                       parameters:parameters
+                                                     deserializer:[STPPushProvisioningDetails new]
+                                                       completion:^(STPPushProvisioningDetails *details, __unused     NSHTTPURLResponse *response, NSError *error) {
+        completion(details, error);
+    }];
 }
     
 @end

--- a/Stripe/STPAPIClient+PushProvisioning.m
+++ b/Stripe/STPAPIClient+PushProvisioning.m
@@ -7,7 +7,7 @@
 //
 
 #import "STPAPIClient+PushProvisioning.h"
-#import "STPAPIRequest+Private.h"
+#import "STPAPIClient+Private.h"
 
 @implementation STPAPIClient (PushProvisioning)
 

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -548,12 +548,11 @@ static NSArray<PKPaymentNetwork> *_additionalEnabledApplePayNetworks;
 
 @implementation STPAPIClient (Customers)
 
-+ (void)retrieveCustomerUsingKey:(STPEphemeralKey *)ephemeralKey completion:(STPCustomerCompletionBlock)completion {
-    STPAPIClient *client = [STPAPIClient sharedClient];
+- (void)retrieveCustomerUsingKey:(STPEphemeralKey *)ephemeralKey completion:(STPCustomerCompletionBlock)completion {
     NSString *endpoint = [NSString stringWithFormat:@"%@/%@", APIEndpointCustomers, ephemeralKey.customerID];
-    [STPAPIRequest<STPCustomer *> getWithAPIClient:client
+    [STPAPIRequest<STPCustomer *> getWithAPIClient:self
                                           endpoint:endpoint
-                                 additionalHeaders:[client authorizationHeaderUsingEphemeralKey:ephemeralKey]
+                                 additionalHeaders:[self authorizationHeaderUsingEphemeralKey:ephemeralKey]
                                         parameters:nil
                                       deserializer:[STPCustomer new]
                                         completion:^(STPCustomer *object, __unused NSHTTPURLResponse *response, NSError *error) {
@@ -561,14 +560,13 @@ static NSArray<PKPaymentNetwork> *_additionalEnabledApplePayNetworks;
                                         }];
 }
 
-+ (void)updateCustomerWithParameters:(NSDictionary *)parameters
+- (void)updateCustomerWithParameters:(NSDictionary *)parameters
                             usingKey:(STPEphemeralKey *)ephemeralKey
                           completion:(STPCustomerCompletionBlock)completion {
-    STPAPIClient *client = [STPAPIClient sharedClient];
     NSString *endpoint = [NSString stringWithFormat:@"%@/%@", APIEndpointCustomers, ephemeralKey.customerID];
-    [STPAPIRequest<STPCustomer *> postWithAPIClient:client
+    [STPAPIRequest<STPCustomer *> postWithAPIClient:self
                                            endpoint:endpoint
-                                  additionalHeaders:[client authorizationHeaderUsingEphemeralKey:ephemeralKey]
+                                  additionalHeaders:[self authorizationHeaderUsingEphemeralKey:ephemeralKey]
                                          parameters:parameters
                                        deserializer:[STPCustomer new]
                                          completion:^(STPCustomer *object, __unused NSHTTPURLResponse *response, NSError *error) {
@@ -576,14 +574,13 @@ static NSArray<PKPaymentNetwork> *_additionalEnabledApplePayNetworks;
                                          }];
 }
 
-+ (void)addSource:(NSString *)sourceID
+- (void)addSource:(NSString *)sourceID
 toCustomerUsingKey:(STPEphemeralKey *)ephemeralKey
        completion:(STPSourceProtocolCompletionBlock)completion { FAUXPAS_IGNORED(UnusedMethod)
-    STPAPIClient *client = [STPAPIClient sharedClient];
     NSString *endpoint = [NSString stringWithFormat:@"%@/%@/%@", APIEndpointCustomers, ephemeralKey.customerID, APIEndpointSources];
-    [STPAPIRequest<STPSourceProtocol> postWithAPIClient:client
+    [STPAPIRequest<STPSourceProtocol> postWithAPIClient:self
                                                endpoint:endpoint
-                                      additionalHeaders:[client authorizationHeaderUsingEphemeralKey:ephemeralKey]
+                                      additionalHeaders:[self authorizationHeaderUsingEphemeralKey:ephemeralKey]
                                              parameters:@{@"source": sourceID}
                                           deserializers:@[[STPCard new], [STPSource new]]
                                              completion:^(id object, __unused NSHTTPURLResponse *response, NSError *error) {
@@ -591,12 +588,11 @@ toCustomerUsingKey:(STPEphemeralKey *)ephemeralKey
                                              }];
 }
 
-+ (void)deleteSource:(NSString *)sourceID fromCustomerUsingKey:(STPEphemeralKey *)ephemeralKey completion:(STPErrorBlock)completion { FAUXPAS_IGNORED_ON_LINE(UnusedMethod)
-    STPAPIClient *client = [STPAPIClient sharedClient];
+- (void)deleteSource:(NSString *)sourceID fromCustomerUsingKey:(STPEphemeralKey *)ephemeralKey completion:(STPErrorBlock)completion { FAUXPAS_IGNORED_ON_LINE(UnusedMethod)
     NSString *endpoint = [NSString stringWithFormat:@"%@/%@/%@/%@", APIEndpointCustomers, ephemeralKey.customerID, APIEndpointSources, sourceID];
-    [STPAPIRequest<STPSourceProtocol> deleteWithAPIClient:client
+    [STPAPIRequest<STPSourceProtocol> deleteWithAPIClient:self
                                                  endpoint:endpoint
-                                        additionalHeaders:[client authorizationHeaderUsingEphemeralKey:ephemeralKey]
+                                        additionalHeaders:[self authorizationHeaderUsingEphemeralKey:ephemeralKey]
                                                parameters:nil
                                             deserializers:@[[STPGenericStripeObject new]]
                                                completion:^(__unused STPGenericStripeObject *object, __unused NSHTTPURLResponse *response, NSError *error) {
@@ -604,12 +600,11 @@ toCustomerUsingKey:(STPEphemeralKey *)ephemeralKey
                                                }];
 }
 
-+ (void)attachPaymentMethod:(NSString *)paymentMethodID toCustomerUsingKey:(STPEphemeralKey *)ephemeralKey completion:(STPErrorBlock)completion {
-    STPAPIClient *client = [STPAPIClient sharedClient];
+- (void)attachPaymentMethod:(NSString *)paymentMethodID toCustomerUsingKey:(STPEphemeralKey *)ephemeralKey completion:(STPErrorBlock)completion {
     NSString *endpoint = [NSString stringWithFormat:@"%@/%@/attach", APIEndpointPaymentMethods, paymentMethodID];
-    [STPAPIRequest<STPPaymentMethod *> postWithAPIClient:client
+    [STPAPIRequest<STPPaymentMethod *> postWithAPIClient:self
                                                 endpoint:endpoint
-                                       additionalHeaders:[client authorizationHeaderUsingEphemeralKey:ephemeralKey]
+                                       additionalHeaders:[self authorizationHeaderUsingEphemeralKey:ephemeralKey]
                                               parameters:@{@"customer": ephemeralKey.customerID}
                                             deserializer:[STPPaymentMethod new]
                                               completion:^(__unused STPPaymentMethod *paymentMethod, __unused NSHTTPURLResponse *response, NSError *error) {
@@ -617,12 +612,11 @@ toCustomerUsingKey:(STPEphemeralKey *)ephemeralKey
                                               }];
 }
 
-+ (void)detachPaymentMethod:(NSString *)paymentMethodID fromCustomerUsingKey:(STPEphemeralKey *)ephemeralKey completion:(STPErrorBlock)completion {
-    STPAPIClient *client = [STPAPIClient sharedClient];
+- (void)detachPaymentMethod:(NSString *)paymentMethodID fromCustomerUsingKey:(STPEphemeralKey *)ephemeralKey completion:(STPErrorBlock)completion {
     NSString *endpoint = [NSString stringWithFormat:@"%@/%@/detach", APIEndpointPaymentMethods, paymentMethodID];
-    [STPAPIRequest<STPPaymentMethod *> postWithAPIClient:client
+    [STPAPIRequest<STPPaymentMethod *> postWithAPIClient:self
                                                 endpoint:endpoint
-                                       additionalHeaders:[client authorizationHeaderUsingEphemeralKey:ephemeralKey]
+                                       additionalHeaders:[self authorizationHeaderUsingEphemeralKey:ephemeralKey]
                                               parameters:nil
                                             deserializer:[STPPaymentMethod new]
                                               completion:^(__unused STPPaymentMethod *paymentMethod, __unused NSHTTPURLResponse *response, NSError *error) {
@@ -630,15 +624,14 @@ toCustomerUsingKey:(STPEphemeralKey *)ephemeralKey
                                               }];
 }
 
-+ (void)listPaymentMethodsForCustomerUsingKey:(STPEphemeralKey *)ephemeralKey completion:(STPPaymentMethodsCompletionBlock)completion {
-    STPAPIClient *client = [STPAPIClient sharedClient];
+- (void)listPaymentMethodsForCustomerUsingKey:(STPEphemeralKey *)ephemeralKey completion:(STPPaymentMethodsCompletionBlock)completion {
     NSDictionary *params = @{
                              @"customer": ephemeralKey.customerID,
                              @"type": [STPPaymentMethod stringFromType:STPPaymentMethodTypeCard],
                              };
-    [STPAPIRequest<STPPaymentMethodListDeserializer *> getWithAPIClient:client
+    [STPAPIRequest<STPPaymentMethodListDeserializer *> getWithAPIClient:self
                                                                endpoint:APIEndpointPaymentMethods
-                                                      additionalHeaders:[client authorizationHeaderUsingEphemeralKey:ephemeralKey]
+                                                      additionalHeaders:[self authorizationHeaderUsingEphemeralKey:ephemeralKey]
                                                              parameters:params
                                                            deserializer:[STPPaymentMethodListDeserializer new]
                                                              completion:^(STPPaymentMethodListDeserializer *deserializer, __unused NSHTTPURLResponse *response, NSError *error) {

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -354,7 +354,7 @@ static NSArray<PKPaymentNetwork> *_additionalEnabledApplePayNetworks;
     NSString *boundary = [STPMultipartFormDataEncoder generateBoundary];
     NSData *data = [STPMultipartFormDataEncoder multipartFormDataForParts:@[purposePart, imagePart] boundary:boundary];
 
-    NSMutableURLRequest *request = [self configuredRequestForURL:[NSURL URLWithString:FileUploadURL] additionalHeaders:@{}];
+    NSMutableURLRequest *request = [self configuredRequestForURL:[NSURL URLWithString:FileUploadURL] additionalHeaders:nil];
     [request setHTTPMethod:@"POST"];
     [request stp_setMultipartFormData:data boundary:boundary];
 

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -256,7 +256,6 @@ static NSArray<PKPaymentNetwork> *_additionalEnabledApplePayNetworks;
     return [[NSString alloc] initWithData:[NSJSONSerialization dataWithJSONObject:[details copy] options:(NSJSONWritingOptions)kNilOptions error:NULL] encoding:NSUTF8StringEncoding];
 }
 
-/// A helper method that returns the Authorization header to use for API requests. If ephemeralKey is nil, uses self.publishableKey instead.
 - (NSDictionary<NSString *, NSString *> *)authorizationHeaderUsingEphemeralKey:(STPEphemeralKey *)ephemeralKey {
     NSString *authorizationBearer = self.apiKey ?: @"";
     if (ephemeralKey != nil) {

--- a/Stripe/STPAPIRequest.h
+++ b/Stripe/STPAPIRequest.h
@@ -11,73 +11,77 @@
 
 @class STPAPIClient;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface STPAPIRequest<__covariant ResponseType:id<STPAPIResponseDecodable>> : NSObject
 
-typedef void(^STPAPIResponseBlock)(ResponseType object, NSHTTPURLResponse *response, NSError *error);
+typedef void(^STPAPIResponseBlock)(ResponseType _Nullable object, NSHTTPURLResponse * _Nullable response, NSError * _Nullable error);
 
 + (NSURLSessionDataTask *)postWithAPIClient:(STPAPIClient *)apiClient
                                    endpoint:(NSString *)endpoint
-                                 parameters:(NSDictionary *)parameters
+                                 parameters:(nullable NSDictionary *)parameters
                                deserializer:(ResponseType)deserializer
                                  completion:(STPAPIResponseBlock)completion;
 
 + (NSURLSessionDataTask *)postWithAPIClient:(STPAPIClient *)apiClient
                                    endpoint:(NSString *)endpoint
-                          additionalHeaders:(NSDictionary<NSString *, NSString *> *)additionalHeaders
-                                 parameters:(NSDictionary *)parameters
+                          additionalHeaders:(nullable NSDictionary<NSString *, NSString *> *)additionalHeaders
+                                 parameters:(nullable NSDictionary *)parameters
                                deserializer:(ResponseType)deserializer
                                  completion:(STPAPIResponseBlock)completion;
 
 + (NSURLSessionDataTask *)postWithAPIClient:(STPAPIClient *)apiClient
                                     endpoint:(NSString *)endpoint
-                                  parameters:(NSDictionary *)parameters
+                                  parameters:(nullable NSDictionary *)parameters
                                deserializers:(NSArray<ResponseType> *)deserializers
                                   completion:(STPAPIResponseBlock)completion;
 
 + (NSURLSessionDataTask *)postWithAPIClient:(STPAPIClient *)apiClient
                                    endpoint:(NSString *)endpoint
-                          additionalHeaders:(NSDictionary<NSString *, NSString *> *)additionalHeaders
-                                 parameters:(NSDictionary *)parameters
+                          additionalHeaders:(nullable NSDictionary<NSString *, NSString *> *)additionalHeaders
+                                 parameters:(nullable NSDictionary *)parameters
                               deserializers:(NSArray<ResponseType> *)deserializers
                                  completion:(STPAPIResponseBlock)completion;
 
 + (NSURLSessionDataTask *)getWithAPIClient:(STPAPIClient *)apiClient
                                   endpoint:(NSString *)endpoint
-                                parameters:(NSDictionary *)parameters
+                                parameters:(nullable NSDictionary *)parameters
                               deserializer:(ResponseType)deserializer
                                 completion:(STPAPIResponseBlock)completion;
 
 + (NSURLSessionDataTask *)getWithAPIClient:(STPAPIClient *)apiClient
                                   endpoint:(NSString *)endpoint
-                         additionalHeaders:(NSDictionary<NSString *, NSString *> *)additionalHeaders
-                                parameters:(NSDictionary *)parameters
+                         additionalHeaders:(nullable NSDictionary<NSString *, NSString *> *)additionalHeaders
+                                parameters:(nullable NSDictionary *)parameters
                               deserializer:(ResponseType)deserializer
                                 completion:(STPAPIResponseBlock)completion;
 
 + (NSURLSessionDataTask *)deleteWithAPIClient:(STPAPIClient *)apiClient
                                      endpoint:(NSString *)endpoint
-                                   parameters:(NSDictionary *)parameters
+                                   parameters:(nullable NSDictionary *)parameters
                                  deserializer:(ResponseType)deserializer
                                    completion:(STPAPIResponseBlock)completion;
 
 + (NSURLSessionDataTask *)deleteWithAPIClient:(STPAPIClient *)apiClient
                                      endpoint:(NSString *)endpoint
-                            additionalHeaders:(NSDictionary<NSString *, NSString *> *)additionalHeaders
-                                   parameters:(NSDictionary *)parameters
+                            additionalHeaders:(nullable NSDictionary<NSString *, NSString *> *)additionalHeaders
+                                   parameters:(nullable NSDictionary *)parameters
                                  deserializer:(ResponseType)deserializer
                                    completion:(STPAPIResponseBlock)completion;
 
 + (NSURLSessionDataTask *)deleteWithAPIClient:(STPAPIClient *)apiClient
                                      endpoint:(NSString *)endpoint
-                                   parameters:(NSDictionary *)parameters
+                                   parameters:(nullable NSDictionary *)parameters
                                 deserializers:(NSArray<ResponseType> *)deserializer
                                    completion:(STPAPIResponseBlock)completion;
 
 + (NSURLSessionDataTask *)deleteWithAPIClient:(STPAPIClient *)apiClient
                                      endpoint:(NSString *)endpoint
-                            additionalHeaders:(NSDictionary<NSString *, NSString *> *)additionalHeaders
-                                   parameters:(NSDictionary *)parameters
+                            additionalHeaders:(nullable NSDictionary<NSString *, NSString *> *)additionalHeaders
+                                   parameters:(nullable NSDictionary *)parameters
                                 deserializers:(NSArray<ResponseType> *)deserializer
                                    completion:(STPAPIResponseBlock)completion;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Stripe/STPAPIRequest.h
+++ b/Stripe/STPAPIRequest.h
@@ -22,13 +22,34 @@ typedef void(^STPAPIResponseBlock)(ResponseType object, NSHTTPURLResponse *respo
                                  completion:(STPAPIResponseBlock)completion;
 
 + (NSURLSessionDataTask *)postWithAPIClient:(STPAPIClient *)apiClient
+                                   endpoint:(NSString *)endpoint
+                          additionalHeaders:(NSDictionary<NSString *, NSString *> *)additionalHeaders
+                                 parameters:(NSDictionary *)parameters
+                               deserializer:(ResponseType)deserializer
+                                 completion:(STPAPIResponseBlock)completion;
+
++ (NSURLSessionDataTask *)postWithAPIClient:(STPAPIClient *)apiClient
                                     endpoint:(NSString *)endpoint
                                   parameters:(NSDictionary *)parameters
                                deserializers:(NSArray<ResponseType> *)deserializers
                                   completion:(STPAPIResponseBlock)completion;
 
++ (NSURLSessionDataTask *)postWithAPIClient:(STPAPIClient *)apiClient
+                                   endpoint:(NSString *)endpoint
+                          additionalHeaders:(NSDictionary<NSString *, NSString *> *)additionalHeaders
+                                 parameters:(NSDictionary *)parameters
+                              deserializers:(NSArray<ResponseType> *)deserializers
+                                 completion:(STPAPIResponseBlock)completion;
+
 + (NSURLSessionDataTask *)getWithAPIClient:(STPAPIClient *)apiClient
                                   endpoint:(NSString *)endpoint
+                                parameters:(NSDictionary *)parameters
+                              deserializer:(ResponseType)deserializer
+                                completion:(STPAPIResponseBlock)completion;
+
++ (NSURLSessionDataTask *)getWithAPIClient:(STPAPIClient *)apiClient
+                                  endpoint:(NSString *)endpoint
+                         additionalHeaders:(NSDictionary<NSString *, NSString *> *)additionalHeaders
                                 parameters:(NSDictionary *)parameters
                               deserializer:(ResponseType)deserializer
                                 completion:(STPAPIResponseBlock)completion;
@@ -41,6 +62,20 @@ typedef void(^STPAPIResponseBlock)(ResponseType object, NSHTTPURLResponse *respo
 
 + (NSURLSessionDataTask *)deleteWithAPIClient:(STPAPIClient *)apiClient
                                      endpoint:(NSString *)endpoint
+                            additionalHeaders:(NSDictionary<NSString *, NSString *> *)additionalHeaders
+                                   parameters:(NSDictionary *)parameters
+                                 deserializer:(ResponseType)deserializer
+                                   completion:(STPAPIResponseBlock)completion;
+
++ (NSURLSessionDataTask *)deleteWithAPIClient:(STPAPIClient *)apiClient
+                                     endpoint:(NSString *)endpoint
+                                   parameters:(NSDictionary *)parameters
+                                deserializers:(NSArray<ResponseType> *)deserializer
+                                   completion:(STPAPIResponseBlock)completion;
+
++ (NSURLSessionDataTask *)deleteWithAPIClient:(STPAPIClient *)apiClient
+                                     endpoint:(NSString *)endpoint
+                            additionalHeaders:(NSDictionary<NSString *, NSString *> *)additionalHeaders
                                    parameters:(NSDictionary *)parameters
                                 deserializers:(NSArray<ResponseType> *)deserializer
                                    completion:(STPAPIResponseBlock)completion;

--- a/Stripe/STPAPIRequest.m
+++ b/Stripe/STPAPIRequest.m
@@ -35,6 +35,24 @@ static NSString * const JSONKeyObject = @"object";
 
 + (NSURLSessionDataTask *)postWithAPIClient:(STPAPIClient *)apiClient
                                    endpoint:(NSString *)endpoint
+                          additionalHeaders:(NSDictionary *)additionalHeaders
+                                 parameters:(NSDictionary *)parameters
+                               deserializer:(id<STPAPIResponseDecodable>)deserializer
+                                 completion:(STPAPIResponseBlock)completion {
+    return [self postWithAPIClient:apiClient endpoint:endpoint additionalHeaders:additionalHeaders parameters:parameters deserializers:@[deserializer] completion:completion];
+}
+
++ (NSURLSessionDataTask *)postWithAPIClient:(STPAPIClient *)apiClient
+                                   endpoint:(NSString *)endpoint
+                                 parameters:(NSDictionary *)parameters
+                              deserializers:(NSArray<id<STPAPIResponseDecodable>>*)deserializers
+                                 completion:(STPAPIResponseBlock)completion {
+    return  [self postWithAPIClient:apiClient endpoint:endpoint additionalHeaders:@{} parameters:parameters deserializers:deserializers completion:completion];
+}
+
++ (NSURLSessionDataTask *)postWithAPIClient:(STPAPIClient *)apiClient
+                                   endpoint:(NSString *)endpoint
+                          additionalHeaders:(NSDictionary *)additionalHeaders
                                  parameters:(NSDictionary *)parameters
                               deserializers:(NSArray<id<STPAPIResponseDecodable>>*)deserializers
                                  completion:(STPAPIResponseBlock)completion {
@@ -42,7 +60,7 @@ static NSString * const JSONKeyObject = @"object";
     NSURL *url = [apiClient.apiURL URLByAppendingPathComponent:endpoint];
 
     // Setup request
-    NSMutableURLRequest *request = [apiClient configuredRequestForURL:url];
+    NSMutableURLRequest *request = [apiClient configuredRequestForURL:url additionalHeaders:additionalHeaders];
     request.HTTPMethod = HTTPMethodPOST;
     [request stp_setFormPayload:parameters];
 
@@ -62,11 +80,20 @@ static NSString * const JSONKeyObject = @"object";
                                 parameters:(NSDictionary *)parameters
                               deserializer:(id<STPAPIResponseDecodable>)deserializer
                                 completion:(STPAPIResponseBlock)completion {
+    return [self getWithAPIClient:apiClient endpoint:endpoint additionalHeaders:@{} parameters:parameters deserializer:deserializer completion:completion];
+}
+
++ (NSURLSessionDataTask *)getWithAPIClient:(STPAPIClient *)apiClient
+                                  endpoint:(NSString *)endpoint
+                         additionalHeaders:(NSDictionary *)additionalHeaders
+                                parameters:(NSDictionary *)parameters
+                              deserializer:(id<STPAPIResponseDecodable>)deserializer
+                                completion:(STPAPIResponseBlock)completion {
     // Build url
     NSURL *url = [apiClient.apiURL URLByAppendingPathComponent:endpoint];
 
     // Setup request
-    NSMutableURLRequest *request = [apiClient configuredRequestForURL:url];
+    NSMutableURLRequest *request = [apiClient configuredRequestForURL:url additionalHeaders:additionalHeaders];
     [request stp_addParametersToURL:parameters];
     request.HTTPMethod = HTTPMethodGET;
 
@@ -91,6 +118,24 @@ static NSString * const JSONKeyObject = @"object";
 
 + (NSURLSessionDataTask *)deleteWithAPIClient:(STPAPIClient *)apiClient
                                      endpoint:(NSString *)endpoint
+                            additionalHeaders:(NSDictionary *)additionalHeaders
+                                   parameters:(NSDictionary *)parameters
+                                 deserializer:(id<STPAPIResponseDecodable>)deserializer
+                                   completion:(STPAPIResponseBlock)completion {
+    return [self deleteWithAPIClient:apiClient endpoint:endpoint additionalHeaders:additionalHeaders parameters:parameters deserializers:@[deserializer] completion:completion];
+}
+
++ (NSURLSessionDataTask *)deleteWithAPIClient:(STPAPIClient *)apiClient
+                                     endpoint:(NSString *)endpoint
+                                   parameters:(NSDictionary *)parameters
+                                deserializers:(NSArray<id<STPAPIResponseDecodable>> *)deserializers
+                                   completion:(STPAPIResponseBlock)completion {
+    return [self deleteWithAPIClient:apiClient endpoint:endpoint additionalHeaders:@{} parameters:parameters deserializers:deserializers completion:completion];
+}
+
++ (NSURLSessionDataTask *)deleteWithAPIClient:(STPAPIClient *)apiClient
+                                     endpoint:(NSString *)endpoint
+                            additionalHeaders:(NSDictionary *)additionalHeaders
                                    parameters:(NSDictionary *)parameters
                                 deserializers:(NSArray<id<STPAPIResponseDecodable>> *)deserializers
                                    completion:(STPAPIResponseBlock)completion {
@@ -98,7 +143,7 @@ static NSString * const JSONKeyObject = @"object";
     NSURL *url = [apiClient.apiURL URLByAppendingPathComponent:endpoint];
 
     // Setup request
-    NSMutableURLRequest *request = [apiClient configuredRequestForURL:url];
+    NSMutableURLRequest *request = [apiClient configuredRequestForURL:url additionalHeaders:additionalHeaders];
     [request stp_addParametersToURL:parameters];
     request.HTTPMethod = HTTPMethodDELETE;
 

--- a/Stripe/STPAddCardViewController.m
+++ b/Stripe/STPAddCardViewController.m
@@ -91,7 +91,7 @@ typedef NS_ENUM(NSUInteger, STPPaymentCardSection) {
     _configuration = configuration;
     _shippingAddress = nil;
     _hasUsedShippingAddress = NO;
-    _apiClient = [[STPAPIClient alloc] initWithConfiguration:configuration];
+    _apiClient = [STPAPIClient sharedClient];
     _addressViewModel = [[STPAddressViewModel alloc] initWithRequiredBillingFields:configuration.requiredBillingAddressFields availableCountries:configuration._availableCountries];
     _addressViewModel.delegate = self;
     self.title = STPLocalizedString(@"Add a Card", @"Title for Add a Card view");

--- a/Stripe/STPAddCardViewController.m
+++ b/Stripe/STPAddCardViewController.m
@@ -51,7 +51,6 @@
 @property (nonatomic) STPPaymentConfiguration *configuration;
 @property (nonatomic) STPAddress *shippingAddress;
 @property (nonatomic) BOOL hasUsedShippingAddress;
-@property (nonatomic) STPAPIClient *apiClient;
 @property (nonatomic, weak) UIImageView *cardImageView;
 @property (nonatomic) UIBarButtonItem *doneItem;
 @property (nonatomic) STPSectionHeaderView *cardHeaderView;

--- a/Stripe/STPAnalyticsClient.m
+++ b/Stripe/STPAnalyticsClient.m
@@ -84,7 +84,7 @@
                                                    [client setApiUsage:[client.apiUsage setByAddingObject:NSStringFromClass([STPAddCardViewController class])]];
                                                } error:nil];
         
-        [STPPaymentOptionsViewController stp_aspect_hookSelector:@selector(initWithConfiguration:apiAdapter:loadingPromise:theme:shippingAddress:delegate:)
+        [STPPaymentOptionsViewController stp_aspect_hookSelector:@selector(initWithConfiguration:apiAdapter:apiClient:loadingPromise:theme:shippingAddress:delegate:)
                                                      withOptions:STPAspectPositionAfter
                                                       usingBlock:^{
                                                           STPAnalyticsClient *client = [self sharedClient];

--- a/Stripe/STPBankSelectionViewController.m
+++ b/Stripe/STPBankSelectionViewController.m
@@ -28,7 +28,6 @@
 static NSString *const STPBankSelectionCellReuseIdentifier = @"STPBankSelectionCellReuseIdentifier";
 
 @interface STPBankSelectionViewController () <UITableViewDataSource, UITableViewDelegate>
-@property (nonatomic) STPAPIClient *apiClient;
 @property (nonatomic) STPBankSelectionMethod bankMethod;
 @property (nonatomic) STPFPXBankBrand selectedBank;
 @property (nonatomic) STPPaymentConfiguration *configuration;

--- a/Stripe/STPBankSelectionViewController.m
+++ b/Stripe/STPBankSelectionViewController.m
@@ -53,7 +53,7 @@ static NSString *const STPBankSelectionCellReuseIdentifier = @"STPBankSelectionC
         _bankMethod = bankMethod;
         _configuration = configuration;
         _selectedBank = STPFPXBankBrandUnknown;
-        _apiClient = [[STPAPIClient alloc] initWithConfiguration:configuration];
+        _apiClient = [STPAPIClient sharedClient];
         if (bankMethod == STPBankSelectionMethodFPX) {
             [self _refreshFPXStatus];
             [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_refreshFPXStatus) name:UIApplicationDidBecomeActiveNotification object:nil];

--- a/Stripe/STPCustomerContext.m
+++ b/Stripe/STPCustomerContext.m
@@ -25,7 +25,6 @@ static NSTimeInterval const CachedCustomerMaxAge = 60;
 
 @interface STPCustomerContext ()
 
-@property (nonatomic) STPAPIClient *apiClient;
 @property (nonatomic) STPCustomer *customer;
 @property (nonatomic) NSDate *customerRetrievedDate;
 @property (nonatomic, copy) NSArray<STPPaymentMethod *> *paymentMethods;

--- a/Stripe/STPCustomerContext.m
+++ b/Stripe/STPCustomerContext.m
@@ -30,6 +30,7 @@ static NSTimeInterval const CachedCustomerMaxAge = 60;
 @property (nonatomic, copy) NSArray<STPPaymentMethod *> *paymentMethods;
 @property (nonatomic) NSDate *paymentMethodsRetrievedDate;
 @property (nonatomic) STPEphemeralKeyManager *keyManager;
+@property (nonatomic) STPAPIClient *apiClient;
 
 @end
 
@@ -37,17 +38,22 @@ static NSTimeInterval const CachedCustomerMaxAge = 60;
 @synthesize paymentMethods=_paymentMethods;
 
 - (instancetype)initWithKeyProvider:(nonnull id<STPCustomerEphemeralKeyProvider>)keyProvider {
+    return [self initWithKeyProvider:keyProvider apiClient:[STPAPIClient sharedClient]];
+}
+
+- (instancetype)initWithKeyProvider:(id<STPCustomerEphemeralKeyProvider>)keyProvider apiClient:(STPAPIClient *)apiClient {
     STPEphemeralKeyManager *keyManager = [[STPEphemeralKeyManager alloc] initWithKeyProvider:keyProvider
 
                                                                                   apiVersion:[STPAPIClient apiVersion] performsEagerFetching:YES];
-    return [self initWithKeyManager:keyManager];
+    return [self initWithKeyManager:keyManager apiClient:apiClient];
 }
 
-- (instancetype)initWithKeyManager:(nonnull STPEphemeralKeyManager *)keyManager {
+- (instancetype)initWithKeyManager:(nonnull STPEphemeralKeyManager *)keyManager apiClient:(STPAPIClient *)apiClient {
     self = [self init];
     if (self) {
         _keyManager = keyManager;
         _includeApplePayPaymentMethods = NO;
+        _apiClient = apiClient;
         [self retrieveCustomer:nil];
         [self listPaymentMethodsForCustomerWithCompletion:nil];
     }
@@ -133,7 +139,7 @@ static NSTimeInterval const CachedCustomerMaxAge = 60;
             }
             return;
         }
-        [STPAPIClient retrieveCustomerUsingKey:ephemeralKey completion:^(STPCustomer *customer, NSError *error) {
+        [self.apiClient retrieveCustomerUsingKey:ephemeralKey completion:^(STPCustomer *customer, NSError *error) {
             if (customer) {
                 [customer updateSourcesFilteringApplePay:!self.includeApplePayPaymentMethods];
                 self.customer = customer;
@@ -160,7 +166,7 @@ static NSTimeInterval const CachedCustomerMaxAge = 60;
         NSMutableDictionary *params = [NSMutableDictionary new];
         params[@"shipping"] = [STPAddress shippingInfoForChargeWithAddress:shipping
                                                             shippingMethod:nil];
-        [STPAPIClient updateCustomerWithParameters:[params copy]
+        [self.apiClient updateCustomerWithParameters:[params copy]
                                           usingKey:ephemeralKey
                                         completion:^(STPCustomer *customer, NSError *error) {
                                             if (customer) {
@@ -187,7 +193,7 @@ static NSTimeInterval const CachedCustomerMaxAge = 60;
             return;
         }
         
-        [STPAPIClient attachPaymentMethod:paymentMethod.stripeId
+        [self.apiClient attachPaymentMethod:paymentMethod.stripeId
                        toCustomerUsingKey:ephemeralKey
                                completion:^(NSError *error) {
                                    [self clearCachedPaymentMethods];
@@ -211,7 +217,7 @@ static NSTimeInterval const CachedCustomerMaxAge = 60;
             return;
         }
         
-        [STPAPIClient detachPaymentMethod:paymentMethod.stripeId
+        [self.apiClient detachPaymentMethod:paymentMethod.stripeId
                      fromCustomerUsingKey:ephemeralKey
                                completion:^(NSError *error) {
                                    [self clearCachedPaymentMethods];
@@ -245,7 +251,7 @@ static NSTimeInterval const CachedCustomerMaxAge = 60;
             return;
         }
         
-        [STPAPIClient listPaymentMethodsForCustomerUsingKey:ephemeralKey completion:^(NSArray<STPPaymentMethod *> *paymentMethods, NSError *error) {
+        [self.apiClient listPaymentMethodsForCustomerUsingKey:ephemeralKey completion:^(NSArray<STPPaymentMethod *> *paymentMethods, NSError *error) {
             if (paymentMethods) {
                 self.paymentMethods = paymentMethods;
             }

--- a/Stripe/STPPaymentContext.m
+++ b/Stripe/STPPaymentContext.m
@@ -96,7 +96,7 @@ typedef NS_ENUM(NSUInteger, STPPaymentContextState) {
         _theme = theme;
         _willAppearPromise = [STPVoidPromise new];
         _didAppearPromise = [STPVoidPromise new];
-        _apiClient = [[STPAPIClient alloc] initWithPublishableKey:configuration.publishableKey];
+        _apiClient = [STPAPIClient sharedClient];
         _paymentCurrency = @"USD";
         _paymentCountry = @"US";
         _paymentAmountModel = [[STPPaymentContextAmountModel alloc] initWithAmount:0];

--- a/Stripe/STPPaymentContext.m
+++ b/Stripe/STPPaymentContext.m
@@ -41,7 +41,6 @@ typedef NS_ENUM(NSUInteger, STPPaymentContextState) {
     @property (nonatomic) STPPaymentConfiguration *configuration;
     @property (nonatomic) STPTheme *theme;
     @property (nonatomic) id<STPBackendAPIAdapter> apiAdapter;
-    @property (nonatomic) STPAPIClient *apiClient;
     @property (nonatomic) STPPromise<STPPaymentOptionTuple *> *loadingPromise;
 
     // these wrap hostViewController's promises because the hostVC is nil at init-time

--- a/Stripe/STPPaymentOptionsInternalViewController.h
+++ b/Stripe/STPPaymentOptionsInternalViewController.h
@@ -9,7 +9,7 @@
 #import "STPCoreTableViewController.h"
 #import "STPBlocks.h"
 
-@class STPAddress, STPCustomerContext, STPPaymentConfiguration, STPPaymentOptionTuple, STPPaymentMethod, STPUserInformation;
+@class STPAddress, STPCustomerContext, STPPaymentConfiguration, STPPaymentOptionTuple, STPPaymentMethod, STPUserInformation, STPAPIClient;
 
 @protocol STPPaymentOption;
 
@@ -28,6 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithConfiguration:(STPPaymentConfiguration *)configuration
                       customerContext:(nullable STPCustomerContext *)customerContext
+                            apiClient:(STPAPIClient *)apiClient
                                 theme:(STPTheme *)theme
                  prefilledInformation:(nullable STPUserInformation *)prefilledInformation
                       shippingAddress:(nullable STPAddress *)shippingAddress

--- a/Stripe/STPPaymentOptionsInternalViewController.m
+++ b/Stripe/STPPaymentOptionsInternalViewController.m
@@ -40,6 +40,7 @@ static NSInteger const PaymentOptionSectionAPM = 2;
 @property (nonatomic, strong, nullable, readwrite) STPUserInformation *prefilledInformation;
 @property (nonatomic, strong, nullable, readwrite) STPAddress *shippingAddress;
 @property (nonatomic, strong, readwrite) NSArray<id<STPPaymentOption>> *paymentOptions;
+@property (nonatomic, strong, readwrite) STPAPIClient *apiClient;
 @property (nonatomic, strong, nullable, readwrite) id<STPPaymentOption> selectedPaymentOption;
 @property (nonatomic, weak, nullable, readwrite) id<STPPaymentOptionsInternalViewControllerDelegate> delegate;
 
@@ -51,6 +52,7 @@ static NSInteger const PaymentOptionSectionAPM = 2;
 
 - (instancetype)initWithConfiguration:(STPPaymentConfiguration *)configuration
                       customerContext:(nullable STPCustomerContext *)customerContext
+                            apiClient:(STPAPIClient *)apiClient
                                 theme:(STPTheme *)theme
                  prefilledInformation:(nullable STPUserInformation *)prefilledInformation
                       shippingAddress:(nullable STPAddress *)shippingAddress
@@ -61,6 +63,7 @@ static NSInteger const PaymentOptionSectionAPM = 2;
         _configuration = configuration;
         // This parameter may be a custom API adapter, and not a CustomerContext.
         _apiAdapter = customerContext;
+        _apiClient = apiClient;
         _prefilledInformation = prefilledInformation;
         _shippingAddress = shippingAddress;
         _paymentOptions = tuple.paymentOptions;
@@ -373,6 +376,7 @@ static NSInteger const PaymentOptionSectionAPM = 2;
         [self.delegate internalViewControllerDidSelectPaymentOption:paymentOption];
     } else if (indexPath.section == PaymentOptionSectionAddCard) {
         STPAddCardViewController *paymentCardViewController = [[STPAddCardViewController alloc] initWithConfiguration:self.configuration theme:self.theme];
+        paymentCardViewController.apiClient = self.apiClient;
         paymentCardViewController.delegate = self;
         paymentCardViewController.prefilledInformation = self.prefilledInformation;
         paymentCardViewController.shippingAddress = self.shippingAddress;
@@ -385,6 +389,7 @@ static NSInteger const PaymentOptionSectionAPM = 2;
             STPPaymentMethodParams *paymentMethodParams = (STPPaymentMethodParams *)paymentOption;
             if (paymentMethodParams.type == STPPaymentMethodTypeFPX) {
                 STPBankSelectionViewController *bankSelectionViewController = [[STPBankSelectionViewController alloc] initWithBankMethod:STPBankSelectionMethodFPX configuration:self.configuration theme:self.theme];
+                bankSelectionViewController.apiClient = self.apiClient;
                 bankSelectionViewController.delegate = self;
                 
                 [self.navigationController pushViewController:bankSelectionViewController animated:YES];

--- a/Stripe/STPPaymentOptionsViewController+Private.h
+++ b/Stripe/STPPaymentOptionsViewController+Private.h
@@ -18,6 +18,7 @@
 
 - (instancetype)initWithConfiguration:(STPPaymentConfiguration *)configuration
                            apiAdapter:(id<STPBackendAPIAdapter>)apiAdapter
+                            apiClient:(STPAPIClient *)apiClient
                        loadingPromise:(STPPromise<STPPaymentOptionTuple *> *)loadingPromise
                                 theme:(STPTheme *)theme
                       shippingAddress:(STPAddress *)shippingAddress

--- a/Stripe/STPPaymentOptionsViewController.m
+++ b/Stripe/STPPaymentOptionsViewController.m
@@ -45,6 +45,7 @@
 - (instancetype)initWithPaymentContext:(STPPaymentContext *)paymentContext {
     return [self initWithConfiguration:paymentContext.configuration
                             apiAdapter:paymentContext.apiAdapter
+                             apiClient:paymentContext.apiClient
                         loadingPromise:paymentContext.currentValuePromise
                                  theme:paymentContext.theme
                        shippingAddress:paymentContext.shippingAddress
@@ -65,6 +66,7 @@
     STPPromise<STPPaymentOptionTuple *> *promise = [self retrievePaymentMethodsWithConfiguration:configuration apiAdapter:apiAdapter];
     return [self initWithConfiguration:configuration
                             apiAdapter:apiAdapter
+                             apiClient:[STPAPIClient sharedClient]
                         loadingPromise:promise
                                  theme:theme
                        shippingAddress:nil
@@ -115,6 +117,7 @@
             
             STPPaymentOptionsInternalViewController *payMethodsInternal = [[STPPaymentOptionsInternalViewController alloc] initWithConfiguration:strongSelf.configuration
                                                                                                                                  customerContext:customerContext
+                                                                                                                                       apiClient:strongSelf.apiClient
                                                                                                                                            theme:strongSelf.theme
                                                                                                                             prefilledInformation:strongSelf.prefilledInformation
                                                                                                                                  shippingAddress:strongSelf.shippingAddress
@@ -128,7 +131,8 @@
             }
             internal = payMethodsInternal;
         } else {
-            STPAddCardViewController *addCardViewController = [[STPAddCardViewController alloc] initWithConfiguration:strongSelf.configuration theme:self.theme];
+            STPAddCardViewController *addCardViewController = [[STPAddCardViewController alloc] initWithConfiguration:strongSelf.configuration theme:strongSelf.theme];
+            addCardViewController.apiClient = strongSelf.apiClient;
             addCardViewController.delegate = strongSelf;
             addCardViewController.prefilledInformation = strongSelf.prefilledInformation;
             addCardViewController.shippingAddress = strongSelf.shippingAddress;
@@ -275,6 +279,7 @@
     
 - (instancetype)initWithConfiguration:(STPPaymentConfiguration *)configuration
                            apiAdapter:(id<STPBackendAPIAdapter>)apiAdapter
+                            apiClient:(STPAPIClient *)apiClient
                        loadingPromise:(STPPromise<STPPaymentOptionTuple *> *)loadingPromise
                                 theme:(STPTheme *)theme
                       shippingAddress:(STPAddress *)shippingAddress
@@ -282,6 +287,7 @@
     self = [super initWithTheme:theme];
     if (self) {
         _configuration = configuration;
+        _apiClient = apiClient;
         _shippingAddress = shippingAddress;
         _apiAdapter = apiAdapter;
         _loadingPromise = loadingPromise;

--- a/Stripe/STPPaymentOptionsViewController.m
+++ b/Stripe/STPPaymentOptionsViewController.m
@@ -8,7 +8,6 @@
 
 #import "STPPaymentOptionsViewController.h"
 
-#import "STPAPIClient.h"
 #import "STPAddCardViewController+Private.h"
 #import "STPCard.h"
 #import "STPColorUtils.h"
@@ -35,7 +34,6 @@
     @property (nonatomic) STPPaymentConfiguration *configuration;
     @property (nonatomic) STPAddress *shippingAddress;
     @property (nonatomic) id<STPBackendAPIAdapter> apiAdapter;
-    @property (nonatomic) STPAPIClient *apiClient;
     @property (nonatomic) STPPromise<STPPaymentOptionTuple *> *loadingPromise;
     @property (nonatomic, weak) STPPaymentActivityIndicatorView *activityIndicator;
     @property (nonatomic, weak) UIViewController *internalViewController;
@@ -285,7 +283,6 @@
     if (self) {
         _configuration = configuration;
         _shippingAddress = shippingAddress;
-        _apiClient = [[STPAPIClient alloc] initWithPublishableKey:configuration.publishableKey];
         _apiAdapter = apiAdapter;
         _loadingPromise = loadingPromise;
         _delegate = delegate;

--- a/Stripe/STPPinManagementService.m
+++ b/Stripe/STPPinManagementService.m
@@ -42,9 +42,10 @@
             completion(nil, STPPinEphemeralKeyError, keyError);
             return;
         }
-        STPAPIClient *client = [STPAPIClient apiClientWithEphemeralKey:ephemeralKey];
+        STPAPIClient *client = [STPAPIClient sharedClient];
         [STPAPIRequest<STPIssuingCardPin *> getWithAPIClient:client
                                                     endpoint:endpoint
+                                           additionalHeaders:[client authorizationHeaderUsingEphemeralKey:ephemeralKey]
                                                   parameters:parameters
                                                 deserializer:[STPIssuingCardPin new]
                                                   completion:^(
@@ -92,9 +93,10 @@
             completion(nil, STPPinEphemeralKeyError, keyError);
             return;
         }
-        STPAPIClient *client = [STPAPIClient apiClientWithEphemeralKey:ephemeralKey];
+        STPAPIClient *client = [STPAPIClient sharedClient];
         [STPAPIRequest<STPIssuingCardPin *> postWithAPIClient:client
                                                     endpoint:endpoint
+                                            additionalHeaders:[client authorizationHeaderUsingEphemeralKey:ephemeralKey]
                                                   parameters:parameters
                                                 deserializer:[STPIssuingCardPin new]
                                                   completion:^(

--- a/Stripe/STPPinManagementService.m
+++ b/Stripe/STPPinManagementService.m
@@ -21,6 +21,7 @@
 - (instancetype)initWithKeyProvider:(id<STPIssuingCardEphemeralKeyProvider>)keyProvider {
     self = [super init];
     if (self) {
+        _apiClient = [STPAPIClient sharedClient];
         _keyManager = [[STPEphemeralKeyManager alloc] initWithKeyProvider:keyProvider apiVersion:[STPAPIClient apiVersion] performsEagerFetching:NO];
     }
     return self;
@@ -42,10 +43,10 @@
             completion(nil, STPPinEphemeralKeyError, keyError);
             return;
         }
-        STPAPIClient *client = [STPAPIClient sharedClient];
-        [STPAPIRequest<STPIssuingCardPin *> getWithAPIClient:client
+
+        [STPAPIRequest<STPIssuingCardPin *> getWithAPIClient:self.apiClient
                                                     endpoint:endpoint
-                                           additionalHeaders:[client authorizationHeaderUsingEphemeralKey:ephemeralKey]
+                                           additionalHeaders:[self.apiClient authorizationHeaderUsingEphemeralKey:ephemeralKey]
                                                   parameters:parameters
                                                 deserializer:[STPIssuingCardPin new]
                                                   completion:^(
@@ -93,10 +94,9 @@
             completion(nil, STPPinEphemeralKeyError, keyError);
             return;
         }
-        STPAPIClient *client = [STPAPIClient sharedClient];
-        [STPAPIRequest<STPIssuingCardPin *> postWithAPIClient:client
-                                                    endpoint:endpoint
-                                            additionalHeaders:[client authorizationHeaderUsingEphemeralKey:ephemeralKey]
+        [STPAPIRequest<STPIssuingCardPin *> postWithAPIClient:self.apiClient
+                                                     endpoint:endpoint
+                                            additionalHeaders:[self.apiClient authorizationHeaderUsingEphemeralKey:ephemeralKey]
                                                   parameters:parameters
                                                 deserializer:[STPIssuingCardPin new]
                                                   completion:^(

--- a/Stripe/STPPushProvisioningContext.m
+++ b/Stripe/STPPushProvisioningContext.m
@@ -58,8 +58,8 @@
             return;
         }
         STPPushProvisioningDetailsParams *params = [STPPushProvisioningDetailsParams paramsWithCardId:ephemeralKey.issuingCardID certificates:certificates nonce:nonce nonceSignature:nonceSignature];
-        STPAPIClient *client = [STPAPIClient apiClientWithEphemeralKey:ephemeralKey];
-        [client retrievePushProvisioningDetailsWithParams:params completion:^(STPPushProvisioningDetails * _Nullable details, NSError * _Nullable error) {
+        STPAPIClient *client = [STPAPIClient sharedClient];
+        [client retrievePushProvisioningDetailsWithParams:params ephemeralKey:ephemeralKey completion:^(STPPushProvisioningDetails * _Nullable details, NSError * _Nullable error) {
             if (error != nil) {
                 PKAddPaymentPassRequest *request = [PKAddPaymentPassRequest new];
                 request.stp_error = error;

--- a/Stripe/STPPushProvisioningContext.m
+++ b/Stripe/STPPushProvisioningContext.m
@@ -23,6 +23,7 @@
 - (instancetype)initWithKeyProvider:(id<STPIssuingCardEphemeralKeyProvider>)keyProvider {
     self = [super init];
     if (self) {
+        _apiClient = [STPAPIClient sharedClient];
         _keyManager = [[STPEphemeralKeyManager alloc] initWithKeyProvider:keyProvider apiVersion:[STPAPIClient apiVersion] performsEagerFetching:NO];
     }
     return self;
@@ -58,8 +59,7 @@
             return;
         }
         STPPushProvisioningDetailsParams *params = [STPPushProvisioningDetailsParams paramsWithCardId:ephemeralKey.issuingCardID certificates:certificates nonce:nonce nonceSignature:nonceSignature];
-        STPAPIClient *client = [STPAPIClient sharedClient];
-        [client retrievePushProvisioningDetailsWithParams:params ephemeralKey:ephemeralKey completion:^(STPPushProvisioningDetails * _Nullable details, NSError * _Nullable error) {
+        [self.apiClient retrievePushProvisioningDetailsWithParams:params ephemeralKey:ephemeralKey completion:^(STPPushProvisioningDetails * _Nullable details, NSError * _Nullable error) {
             if (error != nil) {
                 PKAddPaymentPassRequest *request = [PKAddPaymentPassRequest new];
                 request.stp_error = error;

--- a/Tests/Tests/STPAPIClientTest.m
+++ b/Tests/Tests/STPAPIClientTest.m
@@ -10,10 +10,13 @@
 
 #import "STPAPIClient+Private.h"
 #import "STPFixtures.h"
+#import "STPEphemeralKey.h"
 
 @interface STPAPIClient (Testing)
 
 @property (nonatomic, readwrite) NSURLSession *urlSession;
+
+- (NSDictionary<NSString *, NSString *> *)authorizationHeaderUsingEphemeralKey:(STPEphemeralKey *)ephemeralKey;
 
 @end
 
@@ -34,25 +37,33 @@
 
 - (void)testInitWithPublishableKey {
     STPAPIClient *sut = [[STPAPIClient alloc] initWithPublishableKey:@"pk_foo"];
-    NSString *authHeader = [sut configuredRequestForURL:[NSURL URLWithString:@"https://www.stripe.com"]].allHTTPHeaderFields[@"Authorization"];
+    NSString *authHeader = [sut configuredRequestForURL:[NSURL URLWithString:@"https://www.stripe.com"] additionalHeaders:nil].allHTTPHeaderFields[@"Authorization"];
     XCTAssertEqualObjects(authHeader, @"Bearer pk_foo");
 }
 
 - (void)testSetPublishableKey {
     STPAPIClient *sut = [[STPAPIClient alloc] initWithPublishableKey:@"pk_foo"];
-    NSString *authHeader = [sut configuredRequestForURL:[NSURL URLWithString:@"https://www.stripe.com"]].allHTTPHeaderFields[@"Authorization"];
+    NSString *authHeader = [sut configuredRequestForURL:[NSURL URLWithString:@"https://www.stripe.com"] additionalHeaders:nil].allHTTPHeaderFields[@"Authorization"];
     XCTAssertEqualObjects(authHeader, @"Bearer pk_foo");
     sut.publishableKey = @"pk_bar";
-    authHeader = [sut configuredRequestForURL:[NSURL URLWithString:@"https://www.stripe.com"]].allHTTPHeaderFields[@"Authorization"];
+    authHeader = [sut configuredRequestForURL:[NSURL URLWithString:@"https://www.stripe.com"] additionalHeaders:nil].allHTTPHeaderFields[@"Authorization"];
     XCTAssertEqualObjects(authHeader, @"Bearer pk_bar");
+}
+
+- (void)testEphemeralKeyOverwritesHeader {
+    STPAPIClient *sut = [[STPAPIClient alloc] initWithPublishableKey:@"pk_foo"];
+    STPEphemeralKey *ephemeralKey = [STPFixtures ephemeralKey];
+    NSDictionary *additionalHeaders = [sut authorizationHeaderUsingEphemeralKey:ephemeralKey];
+    NSString *authHeader = [sut configuredRequestForURL:[NSURL URLWithString:@"https://www.stripe.com"] additionalHeaders:additionalHeaders].allHTTPHeaderFields[@"Authorization"];
+    XCTAssertEqualObjects(authHeader, [@"Bearer " stringByAppendingString:ephemeralKey.secret]);
 }
 
 - (void)testSetStripeAccount {
     STPAPIClient *sut = [[STPAPIClient alloc] initWithPublishableKey:@"pk_foo"];
-    NSString *accountHeader = [sut configuredRequestForURL:[NSURL URLWithString:@"https://www.stripe.com"]].allHTTPHeaderFields[@"Stripe-Account"];
+    NSString *accountHeader = [sut configuredRequestForURL:[NSURL URLWithString:@"https://www.stripe.com"] additionalHeaders:nil].allHTTPHeaderFields[@"Stripe-Account"];
     XCTAssertNil(accountHeader);
     sut.stripeAccount = @"acct_123";
-    accountHeader = [sut configuredRequestForURL:[NSURL URLWithString:@"https://www.stripe.com"]].allHTTPHeaderFields[@"Stripe-Account"];
+    accountHeader = [sut configuredRequestForURL:[NSURL URLWithString:@"https://www.stripe.com"] additionalHeaders:nil].allHTTPHeaderFields[@"Stripe-Account"];
     XCTAssertEqualObjects(accountHeader, @"acct_123");
 }
 
@@ -63,14 +74,14 @@
     STPAPIClient *sut = [[STPAPIClient alloc] initWithConfiguration:config];
     XCTAssertEqualObjects(sut.publishableKey, config.publishableKey);
     XCTAssertEqualObjects(sut.stripeAccount, config.stripeAccount);
-    NSString *accountHeader = [sut configuredRequestForURL:[NSURL URLWithString:@"https://www.stripe.com"]].allHTTPHeaderFields[@"Stripe-Account"];
+    NSString *accountHeader = [sut configuredRequestForURL:[NSURL URLWithString:@"https://www.stripe.com"] additionalHeaders:nil].allHTTPHeaderFields[@"Stripe-Account"];
     XCTAssertEqualObjects(accountHeader, @"acct_123");
 }
 
 - (void)testSetAppInfo {
     STPAPIClient *sut = [[STPAPIClient alloc] initWithPublishableKey:@"pk_foo"];
     sut.appInfo = [[STPAppInfo alloc] initWithName:@"MyAwesomeLibrary" partnerId:@"pp_partner_1234" version:@"1.2.34" url:@"https://myawesomelibrary.info"];
-    NSString *userAgentHeader = [sut configuredRequestForURL:[NSURL URLWithString:@"https://www.stripe.com"]].allHTTPHeaderFields[@"X-Stripe-User-Agent"];
+    NSString *userAgentHeader = [sut configuredRequestForURL:[NSURL URLWithString:@"https://www.stripe.com"] additionalHeaders:nil].allHTTPHeaderFields[@"X-Stripe-User-Agent"];
     NSDictionary *userAgentHeaderDict = [NSJSONSerialization JSONObjectWithData:[userAgentHeader dataUsingEncoding:NSUTF8StringEncoding] options:0 error:nil];
     XCTAssertEqualObjects(userAgentHeaderDict[@"name"], @"MyAwesomeLibrary");
     XCTAssertEqualObjects(userAgentHeaderDict[@"partner_id"], @"pp_partner_1234");

--- a/Tests/Tests/STPAPIRequestTest.m
+++ b/Tests/Tests/STPAPIRequestTest.m
@@ -49,7 +49,7 @@
     STPAPIClient *apiClientMock = OCMClassMock([STPAPIClient class]);
     OCMStub([apiClientMock apiURL]).andReturn([NSURL URLWithString:@"https://api.stripe.com"]);
     OCMStub([apiClientMock urlSession]).andReturn(urlSessionMock);
-    OCMStub([apiClientMock configuredRequestForURL:[OCMArg isKindOfClass:[NSURL class]]]).andDo(^(NSInvocation *invocation)
+    OCMStub([apiClientMock configuredRequestForURL:[OCMArg isKindOfClass:[NSURL class]] additionalHeaders:[OCMArg any]]).andDo(^(NSInvocation *invocation)
                                                                                                 {
                                                                                                     NSURL *urlArg;
                                                                                                     [invocation getArgument:&urlArg atIndex:2];
@@ -125,7 +125,7 @@
     STPAPIClient *apiClientMock = OCMClassMock([STPAPIClient class]);
     OCMStub([apiClientMock apiURL]).andReturn([NSURL URLWithString:@"https://api.stripe.com"]);
     OCMStub([apiClientMock urlSession]).andReturn(urlSessionMock);
-    OCMStub([apiClientMock configuredRequestForURL:[OCMArg isKindOfClass:[NSURL class]]]).andDo(^(NSInvocation *invocation)
+    OCMStub([apiClientMock configuredRequestForURL:[OCMArg isKindOfClass:[NSURL class]] additionalHeaders:[OCMArg any]]).andDo(^(NSInvocation *invocation)
                                                                                                 {
                                                                                                     NSURL *urlArg;
                                                                                                     [invocation getArgument:&urlArg atIndex:2];
@@ -201,7 +201,7 @@
     STPAPIClient *apiClientMock = OCMClassMock([STPAPIClient class]);
     OCMStub([apiClientMock apiURL]).andReturn([NSURL URLWithString:@"https://api.stripe.com"]);
     OCMStub([apiClientMock urlSession]).andReturn(urlSessionMock);
-    OCMStub([apiClientMock configuredRequestForURL:[OCMArg isKindOfClass:[NSURL class]]]).andDo(^(NSInvocation *invocation)
+    OCMStub([apiClientMock configuredRequestForURL:[OCMArg isKindOfClass:[NSURL class]] additionalHeaders:[OCMArg any]]).andDo(^(NSInvocation *invocation)
                                                                         {
                                                                             NSURL *urlArg;
                                                                             [invocation getArgument:&urlArg atIndex:2];

--- a/Tests/Tests/STPPushProvisioningDetailsFunctionalTest.m
+++ b/Tests/Tests/STPPushProvisioningDetailsFunctionalTest.m
@@ -10,6 +10,7 @@
 #import <Stripe/Stripe.h>
 #import "STPAPIClient+PushProvisioning.h"
 #import "STPNetworkStubbingTestCase.h"
+#import "STPFixtures.h"
 
 @interface STPPushProvisioningDetailsFunctionalTest : STPNetworkStubbingTestCase
 @end
@@ -34,7 +35,9 @@
                        ];
     XCTestExpectation *expectation = [self expectationWithDescription:@"Push provisioning details"];
     STPPushProvisioningDetailsParams *params = [STPPushProvisioningDetailsParams paramsWithCardId:@"ic_1C0Xig4JYtv6MPZK91WoXa9u" certificates:certs nonce:[[NSData alloc] initWithBase64EncodedString:nonce options:0] nonceSignature:[[NSData alloc] initWithBase64EncodedString:nonceSignature options:0]];
-    [client retrievePushProvisioningDetailsWithParams:params completion:^(STPPushProvisioningDetails * _Nullable details, NSError * _Nullable error) {
+    // To re-record this test, get an ephemeral key for the above Issuing card and pass that instead of [STPFixtures ephemeralKey]
+    STPEphemeralKey *ephemeralKey = [STPFixtures ephemeralKey];
+    [client retrievePushProvisioningDetailsWithParams:params ephemeralKey:ephemeralKey completion:^(STPPushProvisioningDetails * _Nullable details, NSError * _Nullable error) {
         [expectation fulfill];
         XCTAssertNil(error);
         XCTAssert([details.cardId isEqualToString:cardId]);


### PR DESCRIPTION
## Summary
Make `STPPaymentContext`, `STPCustomerContext`, `STPPinManagementService`, `STPPushProvisioningContext`, `STPAddCardViewController`:
1. Use an explicit APIClient property to make API requests
2. Expose that property publicly
3. Default that property value to `STPAPIClient.shared`

Previously, they used various APIClient instances, leading to inconsistent and unclear configurations of APIClient properties like `stripeAccount`.

## Motivation
https://paper.dropbox.com/doc/psyduck-why-iOS-SDK-API-Configuration-LTvIMxj6CBy1Mw4ntaU0l#:uid=436909486618175148450143&h2=Proposal

https://jira.corp.stripe.com/browse/IOS-1437

## Testing
Manually test basic integration app and make sure customer things work.
