### PR TITLE
Allow to hide CVC field

### DIFF
--- a/Stripe/PublicHeaders/STPPaymentCardTextField.h
+++ b/Stripe/PublicHeaders/STPPaymentCardTextField.h
@@ -206,6 +206,13 @@ The curent brand image displayed in the receiver.
 @property (nonatomic, readonly, nullable) NSString *postalCode;
 
 /**
+ Controls if a CVC entry field can be displayed to the user.
+
+ Default is YES (CVC entry will be displayed).
+ */
+@property (nonatomic, assign, readwrite) BOOL cvcEntryEnabled;
+
+/**
  Controls if a postal code entry field can be displayed to the user.
  
  Default is NO (no postal code entry will ever be displayed).

--- a/Stripe/STPPaymentCardTextFieldViewModel.h
+++ b/Stripe/STPPaymentCardTextFieldViewModel.h
@@ -27,6 +27,7 @@ typedef NS_ENUM(NSInteger, STPCardFieldType) {
 @property (nonatomic, readwrite, copy, nullable) NSString *rawExpiration;
 @property (nonatomic, readonly, nullable) NSString *expirationMonth;
 @property (nonatomic, readonly, nullable) NSString *expirationYear;
+@property (nonatomic, readwrite, assign) BOOL cvcRequired;
 @property (nonatomic, readwrite, copy, nullable) NSString *cvc;
 @property (nonatomic, readwrite, assign) BOOL postalCodeRequired;
 @property (nonatomic, readwrite, copy, nullable) NSString *postalCode;

--- a/Stripe/STPPaymentCardTextFieldViewModel.m
+++ b/Stripe/STPPaymentCardTextFieldViewModel.m
@@ -14,6 +14,13 @@
 
 @implementation STPPaymentCardTextFieldViewModel
 
+- (instancetype)init {
+    if (self = [super init]) {
+        self.cvcRequired = YES;
+    }
+    return self;
+}
+
 - (void)setCardNumber:(NSString *)cardNumber {
     NSString *sanitizedNumber = [STPCardValidator sanitizedNumericStringForString:cardNumber];
     STPCardBrand brand = [STPCardValidator brandForNumber:sanitizedNumber];
@@ -134,7 +141,7 @@
 - (BOOL)isValid {
     return ([self validationStateForField:STPCardFieldTypeNumber] == STPCardValidationStateValid
             && [self validationStateForField:STPCardFieldTypeExpiration] == STPCardValidationStateValid
-            && [self validationStateForField:STPCardFieldTypeCVC] == STPCardValidationStateValid
+            && (!self.cvcRequired || [self validationStateForField:STPCardFieldTypeCVC] == STPCardValidationStateValid)
             && (!self.postalCodeRequired
                 || [self validationStateForField:STPCardFieldTypePostalCode] == STPCardValidationStateValid));
 }


### PR DESCRIPTION
## Summary

This PR adds possibility to hide CVC field on `STPPaymentCardTextField`.

## Motivation

I want to present `STPPaymentCardTextField` in read-only mode with prefilled data (for screen where user can edit address or other card's details). I can't present CVC of existing card so I just want to present masked credit card number with expiry date.

## Testing

I tested this code by modifying `CardFieldViewController` in UI Examples.
