### PR TITLE
Deprecate non-APIClient sources of publishableKey, stripeAccount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 19.0.0 ??
+* Deprecates the `STPAPIClient` `initWithConfiguration:` method. Set the `configuration` property on the `STPAPIClient` instance instead. [#1474](https://github.com/stripe/stripe-ios/pull/1474)
+* Deprecates `publishableKey` and `stripeAccount` properties of `STPPaymentConfiguration`. See [MIGRATING.md](https://github.com/stripe/stripe-ios/blob/master/MIGRATING.md) for more details. [#1474](https://github.com/stripe/stripe-ios/pull/1474)
+* Adds explicit STPAPIClient properties on all SDK components that make API requests. These default to `[STPAPIClient sharedClient]`. This is a breaking change for some users of `stripeAccount`. See [MIGRATING.md](https://github.com/stripe/stripe-ios/blob/master/MIGRATING.md) for more details. [#1469](https://github.com/stripe/stripe-ios/pull/1469)
+
 ## 18.4.0 2020-01-15
 * Adds support for Klarna Pay on Sources API [#1444](https://github.com/stripe/stripe-ios/pull/1444)
 * Compresses images using `pngcrush` to reduce SDK size [#1471](https://github.com/stripe/stripe-ios/pull/1471)

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -15,7 +15,7 @@ You are affected by this change if:
 2. You use one of the above affected classes
 3. You are setting different `stripeAccount` values on `STPPaymentConfiguration` and `STPAPIClient`, i.e. `STPPaymentConfiguration.shared.stripeAccount != STPAPIClient.shared.stripeAccount`
 
-If these are all true, you must update your integration!  The SDK used to send the `STPPaymentConfiguration.shared.stripeAccount`, and will now send `STPAPIClient.shared.stripeAccount`.  
+If all three of the above conditions are true, you must update your integration!  The SDK used to send the `STPPaymentConfiguration.shared.stripeAccount`, and will now send `STPAPIClient.shared.stripeAccount`.  
 
 For example, if you are a Connect user who stores Payment Methods on your platform, but clones PaymentMethods to a connected count and create direct charges on that connected account ie if:
 

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -17,7 +17,7 @@ You are affected by this change if:
 
 If all three of the above conditions are true, you must update your integration! The SDK used to send `STPPaymentConfiguration.shared.stripeAccount`, and will now send `STPAPIClient.shared.stripeAccount`.  
 
-For example, if you are a Connect user who stores Payment Methods on your platform, but clones PaymentMethods to a connected account and create direct charges on that connected account ie if:
+For example, if you are a Connect user who stores Payment Methods on your platform, but clones PaymentMethods to a connected account and creates direct charges on that connected account i.e. if:
 
 1. You never set `STPPaymentConfiguration.shared.stripeAccount`
 2. You set `STPAPIClient.shared.stripeAccount`

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -11,7 +11,7 @@ This changes the behavior of the following classes, which previously used API cl
 
 You are affected by this change if:
 
-1. You set `stripeAccount`
+1. You use `stripeAccount` to work with your Connected accounts
 2. You use one of the above affected classes
 3. `STPPaymentConfiguration.shared.stripeAccount != STPAPIClient.shared.stripeAccount`
 

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,5 +1,48 @@
 ## Migration Guides
 
+### Migrating from versions < 19.0.0
+
+* Deprecates `publishableKey` and `stripeAccount` properties of `STPPaymentConfiguration`. 
+  * If you used `STPPaymentConfiguration.sharedConfiguration` to set `publishableKey` and/or `stripeAccount`, use `STPAPIClient.sharedClient` instead. 
+  * If you passed a STPPaymentConfiguration instance to an SDK component, you should instead create an STPAPIClient, set publishableKey on it, and set the SDK component's APIClient property.
+* The SDK now uses `STPAPIClient.sharedClient` to make API requests by default.
+
+This changes the behavior of the following classes, which previously used API client instances configured from `STPPaymentConfiguration.shared`: `STPCustomerContext`, `STPPaymentOptionsViewController`, `STPAddCardViewController`, `STPPaymentContext`, `STPPinManagementService`, `STPPushProvisioningContext`. 
+
+You are affected by this change if:
+
+1. You set `stripeAccount`
+2. You use one of these classes
+3. `STPPaymentConfiguration.shared.stripeAccount != STPAPIClient.shared.stripeAccount`
+
+If these are all true, you must update your integration!  The SDK used to send the `STPPaymentConfiguration.shared.stripeAccount`, and will now send `STPAPIClient.shared.stripeAccount`.  
+
+For example, if you are a Connect user who stores Payment Methods on your platform, but clones PaymentMethods to a connected count and create direct charges on that connected account ie if:
+
+1. You never set `STPPaymentConfiguration.shared.stripeAccount`
+2. You set `STPAPIClient.shared.stripeAccount`
+
+We recommend you do the following:
+
+```
+    // By default, you don't want the SDK to pass stripeAccount
+    STPAPIClient.shared().publishableKey = "pk_platform"
+    STPAPIClient.shared().stripeAccount = nil
+
+    // You do want the SDK to pass stripeAccount when it makes payments directly on your connected account, so 
+    // you create a separate APIClient instance...
+    let connectedAccountAPIClient = STPAPIClient(publishableKey: "pk_platform")
+
+    // ...set stripeAccount on it...
+    connectedAccountAPIClient.stripeAccount = "your connected account's id"
+    
+    // ...and either set the relevant SDK components' apiClient property to your custom APIClient instance:
+    STPPaymentHandler.shared().apiClient = connectedAccountAPIClient // e.g. if you are using PaymentIntents
+
+    // ...or use it directly to make API requests with `stripeAccount` set:
+    connectedAccountAPIClient.createToken(withCard:...) // e.g. if you are using Tokens + Charges
+```
+
 ### Migrating from versions < 18.0.0
 * Some error messages from the Payment Intents API are now localized to the user's display language. If your application's logic depends on specific `message` strings from the Stripe API, please use the error [`code`](https://stripe.com/docs/error-codes) instead.
 * `STPPaymentResult` may contain a `paymentMethodParams` instead of a `paymentMethod` when using single-use payment methods such as FPX. Because of this, `STPPaymentResult.paymentMethod` is now nullable. Instead of setting the `paymentMethodId` manually on your `paymentIntentParams`, you may now call `paymentIntentParams.configure(with result: STPPaymentResult)`:

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -13,11 +13,11 @@ You are affected by this change if:
 
 1. You use `stripeAccount` to work with your Connected accounts
 2. You use one of the above affected classes
-3. You are setting different `stripeAccount` values on `STPPaymentConfiguration` and `STPAPIClient`, i.e. `STPPaymentConfiguration.shared.stripeAccount != STPAPIClient.shared.stripeAccount`
+3. You set different `stripeAccount` values on `STPPaymentConfiguration` and `STPAPIClient`, i.e. `STPPaymentConfiguration.shared.stripeAccount != STPAPIClient.shared.stripeAccount`
 
-If all three of the above conditions are true, you must update your integration!  The SDK used to send the `STPPaymentConfiguration.shared.stripeAccount`, and will now send `STPAPIClient.shared.stripeAccount`.  
+If all three of the above conditions are true, you must update your integration! The SDK used to send `STPPaymentConfiguration.shared.stripeAccount`, and will now send `STPAPIClient.shared.stripeAccount`.  
 
-For example, if you are a Connect user who stores Payment Methods on your platform, but clones PaymentMethods to a connected count and create direct charges on that connected account ie if:
+For example, if you are a Connect user who stores Payment Methods on your platform, but clones PaymentMethods to a connected account and create direct charges on that connected account ie if:
 
 1. You never set `STPPaymentConfiguration.shared.stripeAccount`
 2. You set `STPAPIClient.shared.stripeAccount`

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -12,7 +12,7 @@ This changes the behavior of the following classes, which previously used API cl
 You are affected by this change if:
 
 1. You set `stripeAccount`
-2. You use one of these classes
+2. You use one of the above affected classes
 3. `STPPaymentConfiguration.shared.stripeAccount != STPAPIClient.shared.stripeAccount`
 
 If these are all true, you must update your integration!  The SDK used to send the `STPPaymentConfiguration.shared.stripeAccount`, and will now send `STPAPIClient.shared.stripeAccount`.  

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -13,7 +13,7 @@ You are affected by this change if:
 
 1. You use `stripeAccount` to work with your Connected accounts
 2. You use one of the above affected classes
-3. `STPPaymentConfiguration.shared.stripeAccount != STPAPIClient.shared.stripeAccount`
+3. You are setting different `stripeAccount` values on `STPPaymentConfiguration` and `STPAPIClient`, i.e. `STPPaymentConfiguration.shared.stripeAccount != STPAPIClient.shared.stripeAccount`
 
 If these are all true, you must update your integration!  The SDK used to send the `STPPaymentConfiguration.shared.stripeAccount`, and will now send `STPAPIClient.shared.stripeAccount`.  
 

--- a/Stripe/PublicHeaders/STPAPIClient.h
+++ b/Stripe/PublicHeaders/STPAPIClient.h
@@ -67,14 +67,6 @@ static NSString *const STPSDKVersion = @"18.4.0";
 - (instancetype)initWithPublishableKey:(NSString *)publishableKey;
 
 /**
- Initializes an API client with the given configuration.
-
- @param configuration The configuration to use.
- @return An instance of STPAPIClient.
- */
-- (instancetype)initWithConfiguration:(STPPaymentConfiguration *)configuration;
-
-/**
  The client's publishable key.
  
  The default value is [Stripe defaultPublishableKey].
@@ -483,6 +475,20 @@ Converts the last 4 SSN digits into a Stripe token using the Stripe API.
  @return YES if the URL is expected and will be handled by Stripe. NO otherwise.
  */
 + (BOOL)handleStripeURLCallbackWithURL:(NSURL *)url;
+
+@end
+
+#pragma mark - Deprecated
+
+@interface STPAPIClient (Deprecated)
+
+/**
+ Initializes an API client with the given configuration.
+
+ @param configuration The configuration to use.
+ @return An instance of STPAPIClient.
+ */
+- (instancetype)initWithConfiguration:(STPPaymentConfiguration *)configuration DEPRECATED_MSG_ATTRIBUTE("This initializer previously configured publishableKey and stripeAccount via the STPPaymentConfiguration instance. This behavior is deprecated; set the STPAPIClient configuration, publishableKey, and stripeAccount properties directly on the STPAPIClient instead.");
 
 @end
 

--- a/Stripe/PublicHeaders/STPAPIClient.h
+++ b/Stripe/PublicHeaders/STPAPIClient.h
@@ -30,18 +30,17 @@ static NSString *const STPSDKVersion = @"18.4.0";
 @interface Stripe : NSObject FAUXPAS_IGNORED_ON_LINE(UnprefixedClass);
 
 /**
- Set your Stripe API key with this method. New instances of STPAPIClient will be initialized with this value. You should call this method as early as
- possible in your application's lifecycle, preferably in your AppDelegate.
-
- @param   publishableKey Your publishable key, obtained from https://stripe.com/account/apikeys
+ Sets your default Stripe API key with this method. You should call this method as early as  possible in your application's lifecycle, preferably in your AppDelegate.
+ 
+ @param   publishableKey Your publishable key, obtained from https://dashboard.stripe.com/apikeys
  @warning Make sure not to ship your test API keys to the App Store! This will log a warning if you use your test key in a release build.
  */
-+ (void)setDefaultPublishableKey:(NSString *)publishableKey;
++ (void)setDefaultPublishableKey:(NSString *)publishableKey DEPRECATED_MSG_ATTRIBUTE("Set STPAPIClient.shared.publishableKey instead");
 
 /**
  The current default publishable key.
  */
-+ (nullable NSString *)defaultPublishableKey;
++ (nullable NSString *)defaultPublishableKey DEPRECATED_MSG_ATTRIBUTE("Use STPAPIClient.shared.publishableKey instead");
 
 @end
 

--- a/Stripe/PublicHeaders/STPAPIClient.h
+++ b/Stripe/PublicHeaders/STPAPIClient.h
@@ -30,7 +30,7 @@ static NSString *const STPSDKVersion = @"18.4.0";
 @interface Stripe : NSObject FAUXPAS_IGNORED_ON_LINE(UnprefixedClass);
 
 /**
- Set your Stripe API key with this method. This is the default value for all instances of STPAPIClient. You should call this method as early as
+ Set your Stripe API key with this method. New instances of STPAPIClient will be initialized with this value. You should call this method as early as
  possible in your application's lifecycle, preferably in your AppDelegate.
  
  @param   publishableKey Your publishable key, obtained from https://dashboard.stripe.com/apikeys

--- a/Stripe/PublicHeaders/STPAPIClient.h
+++ b/Stripe/PublicHeaders/STPAPIClient.h
@@ -30,10 +30,9 @@ static NSString *const STPSDKVersion = @"18.4.0";
 @interface Stripe : NSObject FAUXPAS_IGNORED_ON_LINE(UnprefixedClass);
 
 /**
- Set your Stripe API key with this method. This sets the publishable key of [APIClient sharedClient], the default client used to make API requests.
- You should call this method as early as possible in your application's lifecycle, preferably in your AppDelegate.
+ Set your Stripe API key with this method. This is the default value for all instances of STPAPIClient. You should call this method as early as
+ possible in your application's lifecycle, preferably in your AppDelegate.
  
- @note    New instances of STPAPIClient will be initialized with this value.
  @param   publishableKey Your publishable key, obtained from https://dashboard.stripe.com/apikeys
  @warning Make sure not to ship your test API keys to the App Store! This will log a warning if you use your test key in a release build.
  */
@@ -65,15 +64,14 @@ static NSString *const STPSDKVersion = @"18.4.0";
  @param publishableKey The publishable key to use.
  @return An instance of STPAPIClient.
  */
-- (instancetype)initWithPublishableKey:(NSString *)publishableKey NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithPublishableKey:(NSString *)publishableKey;
 
 /**
  The client's publishable key.
  
- If not specified during initialization, defaults to [Stripe defaultPublishableKey].
- @note Set the [STPAPIClient sharedClient] singleton's property via [Stripe setDefaultPublishableKey:]
+ The default value is [Stripe defaultPublishableKey].
  */
-@property (nonatomic, copy, nullable, readonly) NSString *publishableKey;
+@property (nonatomic, copy, nullable) NSString *publishableKey;
 
 /**
  The client's configuration.

--- a/Stripe/PublicHeaders/STPAPIClient.h
+++ b/Stripe/PublicHeaders/STPAPIClient.h
@@ -30,9 +30,10 @@ static NSString *const STPSDKVersion = @"18.4.0";
 @interface Stripe : NSObject FAUXPAS_IGNORED_ON_LINE(UnprefixedClass);
 
 /**
- Set your Stripe API key with this method. This is the default value for all instances of STPAPIClient. You should call this method as early as
- possible in your application's lifecycle, preferably in your AppDelegate.
+ Set your Stripe API key with this method. This sets the publishable key of [APIClient sharedClient], the default client used to make API requests.
+ You should call this method as early as possible in your application's lifecycle, preferably in your AppDelegate.
  
+ @note    New instances of STPAPIClient will be initialized with this value.
  @param   publishableKey Your publishable key, obtained from https://dashboard.stripe.com/apikeys
  @warning Make sure not to ship your test API keys to the App Store! This will log a warning if you use your test key in a release build.
  */
@@ -64,14 +65,15 @@ static NSString *const STPSDKVersion = @"18.4.0";
  @param publishableKey The publishable key to use.
  @return An instance of STPAPIClient.
  */
-- (instancetype)initWithPublishableKey:(NSString *)publishableKey;
+- (instancetype)initWithPublishableKey:(NSString *)publishableKey NS_DESIGNATED_INITIALIZER;
 
 /**
  The client's publishable key.
  
- The default value is [Stripe defaultPublishableKey].
+ If not specified during initialization, defaults to [Stripe defaultPublishableKey].
+ @note Set the [STPAPIClient sharedClient] singleton's property via [Stripe setDefaultPublishableKey:]
  */
-@property (nonatomic, copy, nullable) NSString *publishableKey;
+@property (nonatomic, copy, nullable, readonly) NSString *publishableKey;
 
 /**
  The client's configuration.

--- a/Stripe/PublicHeaders/STPAPIClient.h
+++ b/Stripe/PublicHeaders/STPAPIClient.h
@@ -30,10 +30,8 @@ static NSString *const STPSDKVersion = @"18.4.0";
 @interface Stripe : NSObject FAUXPAS_IGNORED_ON_LINE(UnprefixedClass);
 
 /**
- Set your Stripe API key with this method. You should call this method as early as
+ Set your Stripe API key with this method. This is the default value for all instances of STPAPIClient. You should call this method as early as
  possible in your application's lifecycle, preferably in your AppDelegate.
- 
- This is the same as setting STPAPIClient.shared.publishableKey.
  
  @param   publishableKey Your publishable key, obtained from https://dashboard.stripe.com/apikeys
  @warning Make sure not to ship your test API keys to the App Store! This will log a warning if you use your test key in a release build.
@@ -78,6 +76,8 @@ static NSString *const STPSDKVersion = @"18.4.0";
 
 /**
  The client's publishable key.
+ 
+ The default value is [Stripe defaultPublishableKey].
  */
 @property (nonatomic, copy, nullable) NSString *publishableKey;
 

--- a/Stripe/PublicHeaders/STPAPIClient.h
+++ b/Stripe/PublicHeaders/STPAPIClient.h
@@ -480,6 +480,9 @@ Converts the last 4 SSN digits into a Stripe token using the Stripe API.
 
 #pragma mark - Deprecated
 
+/**
+ Deprecated STPAPIClient methods
+ */
 @interface STPAPIClient (Deprecated)
 
 /**

--- a/Stripe/PublicHeaders/STPAPIClient.h
+++ b/Stripe/PublicHeaders/STPAPIClient.h
@@ -51,18 +51,11 @@ static NSString *const STPSDKVersion = @"18.4.0";
 
 /**
  A shared singleton API client. Its API key will be initially equal to [Stripe defaultPublishableKey].
+ 
+ By default, the SDK uses this instance to make API requests
+ eg in STPPaymentHandler, STPPaymentContext, STPCustomerContext, etc.
  */
 + (instancetype)sharedClient;
-
-
-/**
- Initializes an API client with the given configuration. Its API key will be
- set to the configuration's publishable key.
-
- @param configuration The configuration to use.
- @return An instance of STPAPIClient.
- */
-- (instancetype)initWithConfiguration:(STPPaymentConfiguration *)configuration NS_DESIGNATED_INITIALIZER;
 
 /**
  Initializes an API client with the given publishable key.
@@ -73,12 +66,22 @@ static NSString *const STPSDKVersion = @"18.4.0";
 - (instancetype)initWithPublishableKey:(NSString *)publishableKey;
 
 /**
+ Initializes an API client with the given configuration.
+
+ @param configuration The configuration to use.
+ @return An instance of STPAPIClient.
+ */
+- (instancetype)initWithConfiguration:(STPPaymentConfiguration *)configuration;
+
+/**
  The client's publishable key.
  */
 @property (nonatomic, copy, nullable) NSString *publishableKey;
 
 /**
  The client's configuration.
+ 
+ Defaults to [STPPaymentConfiguration sharedConfiguration].
  */
 @property (nonatomic, copy) STPPaymentConfiguration *configuration;
 

--- a/Stripe/PublicHeaders/STPAPIClient.h
+++ b/Stripe/PublicHeaders/STPAPIClient.h
@@ -30,17 +30,20 @@ static NSString *const STPSDKVersion = @"18.4.0";
 @interface Stripe : NSObject FAUXPAS_IGNORED_ON_LINE(UnprefixedClass);
 
 /**
- Sets your default Stripe API key with this method. You should call this method as early as  possible in your application's lifecycle, preferably in your AppDelegate.
+ Set your Stripe API key with this method. You should call this method as early as
+ possible in your application's lifecycle, preferably in your AppDelegate.
+ 
+ This is the same as setting STPAPIClient.shared.publishableKey.
  
  @param   publishableKey Your publishable key, obtained from https://dashboard.stripe.com/apikeys
  @warning Make sure not to ship your test API keys to the App Store! This will log a warning if you use your test key in a release build.
  */
-+ (void)setDefaultPublishableKey:(NSString *)publishableKey DEPRECATED_MSG_ATTRIBUTE("Set STPAPIClient.shared.publishableKey instead");
++ (void)setDefaultPublishableKey:(NSString *)publishableKey;
 
 /**
  The current default publishable key.
  */
-+ (nullable NSString *)defaultPublishableKey DEPRECATED_MSG_ATTRIBUTE("Use STPAPIClient.shared.publishableKey instead");
++ (nullable NSString *)defaultPublishableKey;
 
 @end
 
@@ -50,7 +53,7 @@ static NSString *const STPSDKVersion = @"18.4.0";
 @interface STPAPIClient : NSObject
 
 /**
- A shared singleton API client. Its API key will be initially equal to [Stripe defaultPublishableKey].
+ A shared singleton API client.
  
  By default, the SDK uses this instance to make API requests
  eg in STPPaymentHandler, STPPaymentContext, STPCustomerContext, etc.

--- a/Stripe/PublicHeaders/STPPaymentConfiguration.h
+++ b/Stripe/PublicHeaders/STPPaymentConfiguration.h
@@ -115,16 +115,16 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Deprecated
 
 /**
- Instead of this property, use STPAPIClient.shared.publishableKey.  The SDK uses STPAPIClient.shared to make API requests by default.
+ Instead of this property, use [STPAPIClient sharedClient].publishableKey.  The SDK uses [STPAPIClient sharedClient] to make API requests by default.
  
  Your Stripe publishable key
  
  @see https://dashboard.stripe.com/account/apikeys
  */
-@property (nonatomic, copy, readwrite) NSString *publishableKey DEPRECATED_MSG_ATTRIBUTE("Use STPAPIClient.shared.publishableKey instead");
+@property (nonatomic, copy, readwrite) NSString *publishableKey DEPRECATED_MSG_ATTRIBUTE("Use [STPAPIClient sharedClient].publishableKey instead");
 
 /**
- Instead of this property, use STPAPIClient.shared.stripeAccount.  The SDK uses STPAPIClient.shared to make API requests by default.
+ Instead of this property, use [STPAPIClient sharedClient].stripeAccount.  The SDK uses [STPAPIClient sharedClient] to make API requests by default.
 
  In order to perform API requests on behalf of a connected account, e.g. to
  create charges for a connected account, set this property to the ID of the
@@ -132,7 +132,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @see https://stripe.com/docs/payments/payment-intents/use-cases#connected-accounts
  */
-@property (nonatomic, copy, nullable) NSString *stripeAccount DEPRECATED_MSG_ATTRIBUTE("Use STPAPIClient.shared.stripeAccount instead");;
+@property (nonatomic, copy, nullable) NSString *stripeAccount DEPRECATED_MSG_ATTRIBUTE("Use [STPAPIClient sharedClient].stripeAccount instead");;
 
 @end
 

--- a/Stripe/PublicHeaders/STPPaymentConfiguration.h
+++ b/Stripe/PublicHeaders/STPPaymentConfiguration.h
@@ -115,16 +115,16 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Deprecated
 
 /**
- Instead of this property, use [STPAPIClient sharedClient].publishableKey.  The SDK uses [STPAPIClient sharedClient] to make API requests by default.
+ If you used [STPPaymentConfiguration sharedConfiguration].publishableKey, use [STPAPIClient sharedClient].publishableKey instead.  The SDK uses [STPAPIClient sharedClient] to make API requests by default.
  
  Your Stripe publishable key
  
  @see https://dashboard.stripe.com/account/apikeys
  */
-@property (nonatomic, copy, readwrite) NSString *publishableKey DEPRECATED_MSG_ATTRIBUTE("Use [STPAPIClient sharedClient].publishableKey instead");
+@property (nonatomic, copy, readwrite) NSString *publishableKey DEPRECATED_MSG_ATTRIBUTE("If you used [STPPaymentConfiguration sharedConfiguration].publishableKey, use [STPAPIClient sharedClient].publishableKey instead. If you passed a STPPaymentConfiguration instance to an SDK component, create an STPAPIClient, set publishableKey on it, and set the SDK component's APIClient property.");
 
 /**
- Instead of this property, use [STPAPIClient sharedClient].stripeAccount.  The SDK uses [STPAPIClient sharedClient] to make API requests by default.
+ If you used [STPPaymentConfiguration sharedConfiguration].stripeAccount, use [STPAPIClient sharedClient].stripeAccount instead.  The SDK uses [STPAPIClient sharedClient] to make API requests by default.
 
  In order to perform API requests on behalf of a connected account, e.g. to
  create charges for a connected account, set this property to the ID of the
@@ -132,7 +132,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @see https://stripe.com/docs/payments/payment-intents/use-cases#connected-accounts
  */
-@property (nonatomic, copy, nullable) NSString *stripeAccount DEPRECATED_MSG_ATTRIBUTE("Use [STPAPIClient sharedClient].stripeAccount instead");;
+@property (nonatomic, copy, nullable) NSString *stripeAccount DEPRECATED_MSG_ATTRIBUTE("If you used [STPPaymentConfiguration sharedConfiguration].stripeAccount, use [STPAPIClient sharedClient].stripeAccount instead. If you passed a STPPaymentConfiguration instance to an SDK component, create an STPAPIClient, set stripeAccount on it, and set the SDK component's APIClient property.");;
 
 @end
 

--- a/Stripe/PublicHeaders/STPPaymentConfiguration.h
+++ b/Stripe/PublicHeaders/STPPaymentConfiguration.h
@@ -31,13 +31,6 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)sharedConfiguration;
 
 /**
- Your Stripe publishable key
- 
- @see https://dashboard.stripe.com/account/apikeys
- */
-@property (nonatomic, copy, readwrite) NSString *publishableKey;
-
-/**
  An enum value representing which payment options you will accept from your user
  in addition to credit cards.
  
@@ -119,14 +112,27 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, assign, readwrite) BOOL canDeletePaymentOptions;
 
+#pragma mark - Deprecated
+
 /**
+ Instead of this property, use STPAPIClient.shared.publishableKey.  The SDK uses STPAPIClient.shared to make API requests by default.
+ 
+ Your Stripe publishable key
+ 
+ @see https://dashboard.stripe.com/account/apikeys
+ */
+@property (nonatomic, copy, readwrite) NSString *publishableKey DEPRECATED_MSG_ATTRIBUTE("Use STPAPIClient.shared.publishableKey instead");
+
+/**
+ Instead of this property, use STPAPIClient.shared.stripeAccount.  The SDK uses STPAPIClient.shared to make API requests by default.
+
  In order to perform API requests on behalf of a connected account, e.g. to
  create charges for a connected account, set this property to the ID of the
  account for which this request is being made.
 
  @see https://stripe.com/docs/payments/payment-intents/use-cases#connected-accounts
  */
-@property (nonatomic, copy, nullable) NSString *stripeAccount;
+@property (nonatomic, copy, nullable) NSString *stripeAccount DEPRECATED_MSG_ATTRIBUTE("Use STPAPIClient.shared.stripeAccount instead");;
 
 @end
 

--- a/Stripe/STPAPIClient+ApplePay.m
+++ b/Stripe/STPAPIClient+ApplePay.m
@@ -126,7 +126,7 @@
     payload[@"pk_token"] = paymentString;
     payload[@"card"] = [self addressParamsFromPKContact:payment.billingContact];
 
-    NSCAssert(!(paymentString.length == 0 && [[Stripe defaultPublishableKey] hasPrefix:@"pk_live"]), @"The pk_token is empty. Using Apple Pay with an iOS Simulator while not in Stripe Test Mode will always fail.");
+    NSCAssert(!(paymentString.length == 0 && [[STPAPIClient sharedClient].publishableKey hasPrefix:@"pk_live"]), @"The pk_token is empty. Using Apple Pay with an iOS Simulator while not in Stripe Test Mode will always fail.");
 
     NSString *paymentInstrumentName = payment.token.paymentMethod.displayName;
     if (paymentInstrumentName) {

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -96,8 +96,6 @@ static NSString *_defaultPublishableKey;
 
 @implementation STPAPIClient
 
-@synthesize publishableKey = _publishableKey;
-
 + (NSString *)apiVersion {
     return APIVersion;
 }
@@ -125,6 +123,7 @@ static NSString *_defaultPublishableKey;
         _sourcePollers = [NSMutableDictionary dictionary];
         _sourcePollersQueue = dispatch_queue_create("com.stripe.sourcepollers", DISPATCH_QUEUE_SERIAL);
         _urlSession = [NSURLSession sessionWithConfiguration:[self.class sharedUrlSessionConfiguration]];
+        _publishableKey = [Stripe defaultPublishableKey];
     }
     return self;
 }
@@ -178,13 +177,6 @@ static NSString *_defaultPublishableKey;
 - (void)setPublishableKey:(NSString *)publishableKey {
     [self.class validateKey:publishableKey];
     _publishableKey = [publishableKey copy];
-}
-
-- (NSString *)publishableKey {
-    if (_publishableKey == nil) {
-        return _defaultPublishableKey;
-    }
-    return _publishableKey;
 }
 
 - (void)createTokenWithParameters:(NSDictionary *)parameters

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -118,6 +118,10 @@ static NSString *_defaultPublishableKey;
 }
 
 - (instancetype)init {
+    return [self initWithPublishableKey:[Stripe defaultPublishableKey]];
+}
+
+- (instancetype)initWithPublishableKey:(NSString *)publishableKey {
     self = [super init];
     if (self) {
         _apiURL = [NSURL URLWithString:APIBaseURL];
@@ -125,22 +129,16 @@ static NSString *_defaultPublishableKey;
         _sourcePollers = [NSMutableDictionary dictionary];
         _sourcePollersQueue = dispatch_queue_create("com.stripe.sourcepollers", DISPATCH_QUEUE_SERIAL);
         _urlSession = [NSURLSession sessionWithConfiguration:[self.class sharedUrlSessionConfiguration]];
+        _publishableKey = [publishableKey copy];
     }
     return self;
-}
-
-- (instancetype)initWithPublishableKey:(NSString *)publishableKey {
-    STPAPIClient *apiClient = [self init];
-    apiClient.publishableKey = publishableKey;
-    return apiClient;
 }
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (instancetype)initWithConfiguration:(STPPaymentConfiguration *)configuration {
     // For legacy reasons, we'll support this initializer and use the deprecated configuration.{publishableKey, stripeAccount} properties
-    STPAPIClient *apiClient = [self init];
-    apiClient.publishableKey = configuration.publishableKey;
+    STPAPIClient *apiClient = [self initWithPublishableKey:configuration.publishableKey];
     apiClient.stripeAccount = configuration.stripeAccount;
     return apiClient;
 }
@@ -175,14 +173,9 @@ static NSString *_defaultPublishableKey;
     return [defaultHeaders copy];
 }
 
-- (void)setPublishableKey:(NSString *)publishableKey {
-    [self.class validateKey:publishableKey];
-    _publishableKey = [publishableKey copy];
-}
-
 - (NSString *)publishableKey {
-    if (_publishableKey == nil) {
-        return _defaultPublishableKey;
+    if (self == [STPAPIClient sharedClient]) {
+        return [Stripe defaultPublishableKey];
     }
     return _publishableKey;
 }

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -73,12 +73,11 @@ static NSString * const APIEndpointFPXStatus = @"fpx/bank_statuses";
 static NSArray<PKPaymentNetwork> *_additionalEnabledApplePayNetworks;
 
 + (void)setDefaultPublishableKey:(NSString *)publishableKey {
-    [STPAPIClient validateKey:publishableKey];
-    [STPPaymentConfiguration sharedConfiguration].publishableKey = publishableKey;
+    [STPAPIClient sharedClient].publishableKey = publishableKey;
 }
 
 + (NSString *)defaultPublishableKey {
-    return [STPPaymentConfiguration sharedConfiguration].publishableKey;
+    return [STPAPIClient sharedClient].publishableKey;
 }
 
 @end

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -88,7 +88,6 @@ static NSArray<PKPaymentNetwork> *_additionalEnabledApplePayNetworks;
 
 @property (nonatomic, strong, readwrite) NSMutableDictionary<NSString *,NSObject *> *sourcePollers;
 @property (nonatomic, strong, readwrite) dispatch_queue_t sourcePollersQueue;
-@property (nonatomic, strong, readwrite) NSString *apiKey;
 
 // See STPAPIClient+Private.h
 
@@ -132,7 +131,7 @@ static NSArray<PKPaymentNetwork> *_additionalEnabledApplePayNetworks;
     }
     self = [super init];
     if (self) {
-        _apiKey = publishableKey;
+        _publishableKey = publishableKey;
         _apiURL = [NSURL URLWithString:APIBaseURL];
         _configuration = configuration;
         _stripeAccount = configuration.stripeAccount;
@@ -174,12 +173,7 @@ static NSArray<PKPaymentNetwork> *_additionalEnabledApplePayNetworks;
 
 - (void)setPublishableKey:(NSString *)publishableKey {
     [self.class validateKey:publishableKey];
-    self.configuration.publishableKey = [publishableKey copy];
-    self.apiKey = [publishableKey copy];
-}
-
-- (NSString *)publishableKey {
-    return self.configuration.publishableKey;
+    _publishableKey = [publishableKey copy];
 }
 
 - (void)createTokenWithParameters:(NSDictionary *)parameters
@@ -258,7 +252,7 @@ static NSArray<PKPaymentNetwork> *_additionalEnabledApplePayNetworks;
 }
 
 - (NSDictionary<NSString *, NSString *> *)authorizationHeaderUsingEphemeralKey:(STPEphemeralKey *)ephemeralKey {
-    NSString *authorizationBearer = self.apiKey ?: @"";
+    NSString *authorizationBearer = self.publishableKey ?: @"";
     if (ephemeralKey != nil) {
         authorizationBearer = ephemeralKey.secret;
     }

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -125,7 +125,6 @@ static NSString *_defaultPublishableKey;
         _sourcePollers = [NSMutableDictionary dictionary];
         _sourcePollersQueue = dispatch_queue_create("com.stripe.sourcepollers", DISPATCH_QUEUE_SERIAL);
         _urlSession = [NSURLSession sessionWithConfiguration:[self.class sharedUrlSessionConfiguration]];
-        _publishableKey = [Stripe defaultPublishableKey];
     }
     return self;
 }

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -118,10 +118,6 @@ static NSString *_defaultPublishableKey;
 }
 
 - (instancetype)init {
-    return [self initWithPublishableKey:[Stripe defaultPublishableKey]];
-}
-
-- (instancetype)initWithPublishableKey:(NSString *)publishableKey {
     self = [super init];
     if (self) {
         _apiURL = [NSURL URLWithString:APIBaseURL];
@@ -129,16 +125,22 @@ static NSString *_defaultPublishableKey;
         _sourcePollers = [NSMutableDictionary dictionary];
         _sourcePollersQueue = dispatch_queue_create("com.stripe.sourcepollers", DISPATCH_QUEUE_SERIAL);
         _urlSession = [NSURLSession sessionWithConfiguration:[self.class sharedUrlSessionConfiguration]];
-        _publishableKey = [publishableKey copy];
     }
     return self;
+}
+
+- (instancetype)initWithPublishableKey:(NSString *)publishableKey {
+    STPAPIClient *apiClient = [self init];
+    apiClient.publishableKey = publishableKey;
+    return apiClient;
 }
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (instancetype)initWithConfiguration:(STPPaymentConfiguration *)configuration {
     // For legacy reasons, we'll support this initializer and use the deprecated configuration.{publishableKey, stripeAccount} properties
-    STPAPIClient *apiClient = [self initWithPublishableKey:configuration.publishableKey];
+    STPAPIClient *apiClient = [self init];
+    apiClient.publishableKey = configuration.publishableKey;
     apiClient.stripeAccount = configuration.stripeAccount;
     return apiClient;
 }
@@ -173,9 +175,14 @@ static NSString *_defaultPublishableKey;
     return [defaultHeaders copy];
 }
 
+- (void)setPublishableKey:(NSString *)publishableKey {
+    [self.class validateKey:publishableKey];
+    _publishableKey = [publishableKey copy];
+}
+
 - (NSString *)publishableKey {
-    if (self == [STPAPIClient sharedClient]) {
-        return [Stripe defaultPublishableKey];
+    if (_publishableKey == nil) {
+        return _defaultPublishableKey;
     }
     return _publishableKey;
 }

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -136,16 +136,16 @@ static NSString *_defaultPublishableKey;
     return apiClient;
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (instancetype)initWithConfiguration:(STPPaymentConfiguration *)configuration {
     // For legacy reasons, we'll support this initializer and use the deprecated configuration.{publishableKey, stripeAccount} properties
     STPAPIClient *apiClient = [self init];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated"
     apiClient.publishableKey = configuration.publishableKey;
     apiClient.stripeAccount = configuration.stripeAccount;
-#pragma clang diagnostic pop
     return apiClient;
 }
+#pragma clang diagnostic pop
 
 + (NSURLSessionConfiguration *)sharedUrlSessionConfiguration {
     static NSURLSessionConfiguration  *STPSharedURLSessionConfiguration;

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -115,31 +115,32 @@ static NSArray<PKPaymentNetwork> *_additionalEnabledApplePayNetworks;
 }
 
 - (instancetype)init {
-    return [self initWithConfiguration:[STPPaymentConfiguration sharedConfiguration]];
-}
-
-- (instancetype)initWithPublishableKey:(NSString *)publishableKey {
-    STPPaymentConfiguration *config = [[STPPaymentConfiguration alloc] init];
-    config.publishableKey = [publishableKey copy];
-    return [self initWithConfiguration:config];
-}
-
-- (instancetype)initWithConfiguration:(STPPaymentConfiguration *)configuration {
-    NSString *publishableKey = [configuration.publishableKey copy];
-    if (publishableKey) {
-        [self.class validateKey:publishableKey];
-    }
     self = [super init];
     if (self) {
-        _publishableKey = publishableKey;
         _apiURL = [NSURL URLWithString:APIBaseURL];
-        _configuration = configuration;
-        _stripeAccount = configuration.stripeAccount;
+        _configuration = [STPPaymentConfiguration sharedConfiguration];
         _sourcePollers = [NSMutableDictionary dictionary];
         _sourcePollersQueue = dispatch_queue_create("com.stripe.sourcepollers", DISPATCH_QUEUE_SERIAL);
         _urlSession = [NSURLSession sessionWithConfiguration:[self.class sharedUrlSessionConfiguration]];
     }
     return self;
+}
+
+- (instancetype)initWithPublishableKey:(NSString *)publishableKey {
+    STPAPIClient *apiClient = [self init];
+    apiClient.publishableKey = publishableKey;
+    return apiClient;
+}
+
+- (instancetype)initWithConfiguration:(STPPaymentConfiguration *)configuration {
+    // For legacy reasons, we'll support this initializer and use the deprecated configuration.{publishableKey, stripeAccount} properties
+    STPAPIClient *apiClient = [self init];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
+    apiClient.publishableKey = configuration.publishableKey;
+    apiClient.stripeAccount = configuration.stripeAccount;
+#pragma clang diagnostic pop
+    return apiClient;
 }
 
 + (NSURLSessionConfiguration *)sharedUrlSessionConfiguration {

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -71,13 +71,14 @@ static NSString * const APIEndpointFPXStatus = @"fpx/bank_statuses";
 @implementation Stripe
 
 static NSArray<PKPaymentNetwork> *_additionalEnabledApplePayNetworks;
+static NSString *_defaultPublishableKey;
 
 + (void)setDefaultPublishableKey:(NSString *)publishableKey {
-    [STPAPIClient sharedClient].publishableKey = publishableKey;
+    _defaultPublishableKey = [publishableKey copy];
 }
 
 + (NSString *)defaultPublishableKey {
-    return [STPAPIClient sharedClient].publishableKey;
+    return _defaultPublishableKey;
 }
 
 @end
@@ -94,6 +95,8 @@ static NSArray<PKPaymentNetwork> *_additionalEnabledApplePayNetworks;
 @end
 
 @implementation STPAPIClient
+
+@synthesize publishableKey = _publishableKey;
 
 + (NSString *)apiVersion {
     return APIVersion;
@@ -122,6 +125,7 @@ static NSArray<PKPaymentNetwork> *_additionalEnabledApplePayNetworks;
         _sourcePollers = [NSMutableDictionary dictionary];
         _sourcePollersQueue = dispatch_queue_create("com.stripe.sourcepollers", DISPATCH_QUEUE_SERIAL);
         _urlSession = [NSURLSession sessionWithConfiguration:[self.class sharedUrlSessionConfiguration]];
+        _publishableKey = [Stripe defaultPublishableKey];
     }
     return self;
 }
@@ -175,6 +179,13 @@ static NSArray<PKPaymentNetwork> *_additionalEnabledApplePayNetworks;
 - (void)setPublishableKey:(NSString *)publishableKey {
     [self.class validateKey:publishableKey];
     _publishableKey = [publishableKey copy];
+}
+
+- (NSString *)publishableKey {
+    if (_publishableKey == nil) {
+        return _defaultPublishableKey;
+    }
+    return _publishableKey;
 }
 
 - (void)createTokenWithParameters:(NSDictionary *)parameters

--- a/Stripe/STPAnalyticsClient.m
+++ b/Stripe/STPAnalyticsClient.m
@@ -410,7 +410,7 @@
 
 + (NSDictionary *)serializeConfiguration:(STPPaymentConfiguration *)configuration {
     NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
-    dictionary[@"publishable_key"] = configuration.publishableKey ?: @"unknown";
+    dictionary[@"publishable_key"] = [STPAPIClient sharedClient].publishableKey ?: @"unknown";
     
     if (configuration.additionalPaymentOptions == STPPaymentOptionTypeDefault) {
         dictionary[@"additional_payment_methods"] = @"default";

--- a/Stripe/STPPaymentConfiguration.m
+++ b/Stripe/STPPaymentConfiguration.m
@@ -126,7 +126,6 @@
                        [NSString stringWithFormat:@"%@: %p", NSStringFromClass([self class]), self],
 
                        // Basic configuration
-                       [NSString stringWithFormat:@"publishableKey = %@", (self.publishableKey) ? @"<redacted>" : nil],
                        [NSString stringWithFormat:@"additionalPaymentOptions = %@", additionalPaymentOptionsDescription],
 
                        // Billing and shipping
@@ -149,7 +148,6 @@
 
 - (id)copyWithZone:(__unused NSZone *)zone {
     STPPaymentConfiguration *copy = [self.class new];
-    copy.publishableKey = self.publishableKey;
     copy.additionalPaymentOptions = self.additionalPaymentOptions;
     copy.requiredBillingAddressFields = self.requiredBillingAddressFields;
     copy.requiredShippingAddressFields = self.requiredShippingAddressFields;
@@ -160,6 +158,24 @@
     copy.canDeletePaymentOptions = self.canDeletePaymentOptions;
     copy.availableCountries = _availableCountries;
     return copy;
+}
+
+#pragma mark - Deprecated
+
+- (void)setPublishableKey:(NSString *)publishableKey {
+    [STPAPIClient sharedClient].publishableKey = publishableKey;
+}
+
+- (NSString *)publishableKey {
+    return [STPAPIClient sharedClient].publishableKey;
+}
+
+- (void)setStripeAccount:(NSString *)stripeAccount {
+    [STPAPIClient sharedClient].stripeAccount = stripeAccount;
+}
+
+- (NSString *)stripeAccount {
+    return [STPAPIClient sharedClient].stripeAccount;
 }
 
 @end

--- a/Stripe/STPPaymentConfiguration.m
+++ b/Stripe/STPPaymentConfiguration.m
@@ -175,7 +175,7 @@
 
 - (void)setPublishableKey:(NSString *)publishableKey {
     if (self == [STPPaymentConfiguration sharedConfiguration]) {
-        [STPAPIClient sharedClient].publishableKey = publishableKey;
+        [Stripe setDefaultPublishableKey:publishableKey];
     } else {
         _publishableKey = [publishableKey copy];
     }

--- a/Stripe/STPPaymentConfiguration.m
+++ b/Stripe/STPPaymentConfiguration.m
@@ -22,6 +22,9 @@
 
 @implementation STPPaymentConfiguration
 
+@synthesize publishableKey = _publishableKey;
+@synthesize stripeAccount = _stripeAccount;
+
 + (void)initialize {
     [STPAnalyticsClient initializeIfNeeded];
     [STPTelemetryClient sharedInstance];
@@ -163,19 +166,33 @@
 #pragma mark - Deprecated
 
 - (void)setPublishableKey:(NSString *)publishableKey {
-    [STPAPIClient sharedClient].publishableKey = publishableKey;
+    if (self == [STPPaymentConfiguration sharedConfiguration]) {
+        [STPAPIClient sharedClient].publishableKey = publishableKey;
+    } else {
+        _publishableKey = [publishableKey copy];
+    }
 }
 
 - (NSString *)publishableKey {
-    return [STPAPIClient sharedClient].publishableKey;
+    if (self == [STPPaymentConfiguration sharedConfiguration]) {
+        return [STPAPIClient sharedClient].publishableKey;
+    }
+    return _publishableKey;
 }
 
 - (void)setStripeAccount:(NSString *)stripeAccount {
-    [STPAPIClient sharedClient].stripeAccount = stripeAccount;
+    if (self == [STPPaymentConfiguration sharedConfiguration]) {
+        [STPAPIClient sharedClient].stripeAccount = stripeAccount;
+    } else {
+        _stripeAccount = [stripeAccount copy];
+    }
 }
 
 - (NSString *)stripeAccount {
-    return [STPAPIClient sharedClient].stripeAccount;
+    if (self == [STPPaymentConfiguration sharedConfiguration]) {
+        return [STPAPIClient sharedClient].stripeAccount;
+    }
+    return _stripeAccount;
 }
 
 @end

--- a/Stripe/STPPaymentConfiguration.m
+++ b/Stripe/STPPaymentConfiguration.m
@@ -160,10 +160,18 @@
     copy.appleMerchantIdentifier = self.appleMerchantIdentifier;
     copy.canDeletePaymentOptions = self.canDeletePaymentOptions;
     copy.availableCountries = _availableCountries;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
+    copy.publishableKey = self.publishableKey;
+    copy.stripeAccount = self.stripeAccount;
+#pragma clang diagnostic pop
+    
     return copy;
 }
 
 #pragma mark - Deprecated
+
+// For legacy reasons, we'll try to keep the same behavior as before if setting these properties on the singleton.
 
 - (void)setPublishableKey:(NSString *)publishableKey {
     if (self == [STPPaymentConfiguration sharedConfiguration]) {

--- a/Stripe/STPPaymentConfiguration.m
+++ b/Stripe/STPPaymentConfiguration.m
@@ -175,7 +175,7 @@
 
 - (void)setPublishableKey:(NSString *)publishableKey {
     if (self == [STPPaymentConfiguration sharedConfiguration]) {
-        [Stripe setDefaultPublishableKey:publishableKey];
+        [STPAPIClient sharedClient].publishableKey = publishableKey;
     } else {
         _publishableKey = [publishableKey copy];
     }

--- a/Tests/Tests/STPAPIClientTest.m
+++ b/Tests/Tests/STPAPIClientTest.m
@@ -63,11 +63,16 @@
 
 - (void)testInitWithConfiguration {
     STPPaymentConfiguration *config = [STPFixtures paymentConfiguration];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
+    config.publishableKey = @"pk_123";
     config.stripeAccount = @"acct_123";
 
     STPAPIClient *sut = [[STPAPIClient alloc] initWithConfiguration:config];
     XCTAssertEqualObjects(sut.publishableKey, config.publishableKey);
     XCTAssertEqualObjects(sut.stripeAccount, config.stripeAccount);
+#pragma clang diagnostic pop
+
     NSString *accountHeader = [sut configuredRequestForURL:[NSURL URLWithString:@"https://www.stripe.com"] additionalHeaders:nil].allHTTPHeaderFields[@"Stripe-Account"];
     XCTAssertEqualObjects(accountHeader, @"acct_123");
 }

--- a/Tests/Tests/STPAPIClientTest.m
+++ b/Tests/Tests/STPAPIClientTest.m
@@ -37,11 +37,17 @@
     XCTAssertEqualObjects(sharedClient.publishableKey, @"test");
     XCTAssertEqualObjects(clientInitializedBefore.publishableKey, @"test");
     XCTAssertEqualObjects(clientInitializedAfter.publishableKey, @"test");
+    
+    // Setting defaultPublishableKey to a new value updates everything
+    [Stripe setDefaultPublishableKey:@"test-updated"];
+    XCTAssertEqualObjects(sharedClient.publishableKey, @"test-updated");
+    XCTAssertEqualObjects(clientInitializedBefore.publishableKey, @"test-updated");
+    XCTAssertEqualObjects(clientInitializedAfter.publishableKey, @"test-updated");
 
     // Setting the STPAPIClient instance overrides default
     sharedClient.publishableKey = @"test2";
     XCTAssertEqualObjects(sharedClient.publishableKey, @"test2");
-    XCTAssertEqualObjects(Stripe.defaultPublishableKey, @"test");
+    XCTAssertEqualObjects(Stripe.defaultPublishableKey, @"test-updated");
 }
 
 - (void)testInitWithPublishableKey {

--- a/Tests/Tests/STPAPIClientTest.m
+++ b/Tests/Tests/STPAPIClientTest.m
@@ -29,12 +29,6 @@
     XCTAssertEqualObjects([STPAPIClient sharedClient], [STPAPIClient sharedClient]);
 }
 
-- (void)testSetDefaultPublishableKey {
-    [Stripe setDefaultPublishableKey:@"test"];
-    STPAPIClient *client = [STPAPIClient sharedClient];
-    XCTAssertEqualObjects(client.publishableKey, @"test");
-}
-
 - (void)testInitWithPublishableKey {
     STPAPIClient *sut = [[STPAPIClient alloc] initWithPublishableKey:@"pk_foo"];
     NSString *authHeader = [sut configuredRequestForURL:[NSURL URLWithString:@"https://www.stripe.com"] additionalHeaders:nil].allHTTPHeaderFields[@"Authorization"];

--- a/Tests/Tests/STPAPIClientTest.m
+++ b/Tests/Tests/STPAPIClientTest.m
@@ -29,6 +29,12 @@
     XCTAssertEqualObjects([STPAPIClient sharedClient], [STPAPIClient sharedClient]);
 }
 
+- (void)testSetDefaultPublishableKey {
+    [Stripe setDefaultPublishableKey:@"test"];
+    STPAPIClient *client = [STPAPIClient sharedClient];
+    XCTAssertEqualObjects(client.publishableKey, @"test");
+}
+
 - (void)testInitWithPublishableKey {
     STPAPIClient *sut = [[STPAPIClient alloc] initWithPublishableKey:@"pk_foo"];
     NSString *authHeader = [sut configuredRequestForURL:[NSURL URLWithString:@"https://www.stripe.com"] additionalHeaders:nil].allHTTPHeaderFields[@"Authorization"];

--- a/Tests/Tests/STPAPIClientTest.m
+++ b/Tests/Tests/STPAPIClientTest.m
@@ -29,40 +29,28 @@
     XCTAssertEqualObjects([STPAPIClient sharedClient], [STPAPIClient sharedClient]);
 }
 
-- (void)testSetDefaultPublishableKey {
+- (void)testSetDefaultPublishableKeySetsOnlyNewInstances {
+    // Setting defaultPublishableKey only affects *new* instances of APIClient
+    [Stripe setDefaultPublishableKey:@"publishableKey1"];
     STPAPIClient *clientInitializedBefore = [STPAPIClient new];
-    [Stripe setDefaultPublishableKey:@"test"];
+    [Stripe setDefaultPublishableKey:@"publishableKey2"];
     STPAPIClient *clientInitializedAfter = [STPAPIClient new];
-    STPAPIClient *sharedClient = [STPAPIClient sharedClient];
-    XCTAssertEqualObjects(sharedClient.publishableKey, @"test");
-    XCTAssertEqualObjects(clientInitializedBefore.publishableKey, @"test");
-    XCTAssertEqualObjects(clientInitializedAfter.publishableKey, @"test");
     
-    // Setting defaultPublishableKey to a new value updates everything
-    [Stripe setDefaultPublishableKey:@"test-updated"];
-    XCTAssertEqualObjects(sharedClient.publishableKey, @"test-updated");
-    XCTAssertEqualObjects(clientInitializedBefore.publishableKey, @"test-updated");
-    XCTAssertEqualObjects(clientInitializedAfter.publishableKey, @"test-updated");
+    XCTAssertEqualObjects(clientInitializedBefore.publishableKey, @"publishableKey1");
+    XCTAssertEqualObjects(clientInitializedAfter.publishableKey, @"publishableKey2");
+}
 
-    // Setting the STPAPIClient instance overrides default
-    sharedClient.publishableKey = @"test2";
-    XCTAssertEqualObjects(sharedClient.publishableKey, @"test2");
-    XCTAssertEqualObjects(Stripe.defaultPublishableKey, @"test-updated");
+- (void)testSetDefaultPublishableKeySetsSharedAPIClient {
+    // Setting defaultPublishableKey sets APIClient sharedClient
+    STPAPIClient *sharedClient = [STPAPIClient sharedClient];
+    [Stripe setDefaultPublishableKey:@"testSetDefaultPublishableKeySetsSharedAPIClient"];
+    XCTAssertEqualObjects(sharedClient.publishableKey, @"testSetDefaultPublishableKeySetsSharedAPIClient");
 }
 
 - (void)testInitWithPublishableKey {
     STPAPIClient *sut = [[STPAPIClient alloc] initWithPublishableKey:@"pk_foo"];
     NSString *authHeader = [sut configuredRequestForURL:[NSURL URLWithString:@"https://www.stripe.com"] additionalHeaders:nil].allHTTPHeaderFields[@"Authorization"];
     XCTAssertEqualObjects(authHeader, @"Bearer pk_foo");
-}
-
-- (void)testSetPublishableKey {
-    STPAPIClient *sut = [[STPAPIClient alloc] initWithPublishableKey:@"pk_foo"];
-    NSString *authHeader = [sut configuredRequestForURL:[NSURL URLWithString:@"https://www.stripe.com"] additionalHeaders:nil].allHTTPHeaderFields[@"Authorization"];
-    XCTAssertEqualObjects(authHeader, @"Bearer pk_foo");
-    sut.publishableKey = @"pk_bar";
-    authHeader = [sut configuredRequestForURL:[NSURL URLWithString:@"https://www.stripe.com"] additionalHeaders:nil].allHTTPHeaderFields[@"Authorization"];
-    XCTAssertEqualObjects(authHeader, @"Bearer pk_bar");
 }
 
 - (void)testEphemeralKeyOverwritesHeader {

--- a/Tests/Tests/STPAPIClientTest.m
+++ b/Tests/Tests/STPAPIClientTest.m
@@ -30,9 +30,18 @@
 }
 
 - (void)testSetDefaultPublishableKey {
+    STPAPIClient *clientInitializedBefore = [STPAPIClient new];
     [Stripe setDefaultPublishableKey:@"test"];
-    STPAPIClient *client = [STPAPIClient sharedClient];
-    XCTAssertEqualObjects(client.publishableKey, @"test");
+    STPAPIClient *clientInitializedAfter = [STPAPIClient new];
+    STPAPIClient *sharedClient = [STPAPIClient sharedClient];
+    XCTAssertEqualObjects(sharedClient.publishableKey, @"test");
+    XCTAssertEqualObjects(clientInitializedBefore.publishableKey, @"test");
+    XCTAssertEqualObjects(clientInitializedAfter.publishableKey, @"test");
+
+    // Setting the STPAPIClient instance overrides default
+    sharedClient.publishableKey = @"test2";
+    XCTAssertEqualObjects(sharedClient.publishableKey, @"test2");
+    XCTAssertEqualObjects(Stripe.defaultPublishableKey, @"test");
 }
 
 - (void)testInitWithPublishableKey {

--- a/Tests/Tests/STPAPIClientTest.m
+++ b/Tests/Tests/STPAPIClientTest.m
@@ -30,20 +30,12 @@
 }
 
 - (void)testSetDefaultPublishableKey {
-    STPAPIClient *clientInitializedBefore = [STPAPIClient new];
     [Stripe setDefaultPublishableKey:@"test"];
     STPAPIClient *clientInitializedAfter = [STPAPIClient new];
     STPAPIClient *sharedClient = [STPAPIClient sharedClient];
     XCTAssertEqualObjects(sharedClient.publishableKey, @"test");
-    XCTAssertEqualObjects(clientInitializedBefore.publishableKey, @"test");
     XCTAssertEqualObjects(clientInitializedAfter.publishableKey, @"test");
     
-    // Setting defaultPublishableKey to a new value updates everything
-    [Stripe setDefaultPublishableKey:@"test-updated"];
-    XCTAssertEqualObjects(sharedClient.publishableKey, @"test-updated");
-    XCTAssertEqualObjects(clientInitializedBefore.publishableKey, @"test-updated");
-    XCTAssertEqualObjects(clientInitializedAfter.publishableKey, @"test-updated");
-
     // Setting the STPAPIClient instance overrides default
     sharedClient.publishableKey = @"test2";
     XCTAssertEqualObjects(sharedClient.publishableKey, @"test2");

--- a/Tests/Tests/STPAPIClientTest.m
+++ b/Tests/Tests/STPAPIClientTest.m
@@ -36,10 +36,12 @@
     XCTAssertEqualObjects(sharedClient.publishableKey, @"test");
     XCTAssertEqualObjects(clientInitializedAfter.publishableKey, @"test");
     
-    // Setting the STPAPIClient instance overrides default
+    // Setting the STPAPIClient instance overrides Stripe.defaultPublishableKey...
     sharedClient.publishableKey = @"test2";
     XCTAssertEqualObjects(sharedClient.publishableKey, @"test2");
-    XCTAssertEqualObjects(Stripe.defaultPublishableKey, @"test-updated");
+    
+    // ...while Stripe.defaultPublishableKey remains the same
+    XCTAssertEqualObjects(Stripe.defaultPublishableKey, @"test");
 }
 
 - (void)testInitWithPublishableKey {

--- a/Tests/Tests/STPFixtures.m
+++ b/Tests/Tests/STPFixtures.m
@@ -226,7 +226,6 @@ NSString *const STPTestJSONSourceWeChatPay = @"WeChatPaySource";
 
 + (STPPaymentConfiguration *)paymentConfiguration {
     STPPaymentConfiguration *config = [STPPaymentConfiguration new];
-    config.publishableKey = @"pk_fake_publishable_key";
     return config;
 }
 

--- a/Tests/Tests/STPPaymentConfigurationTest.m
+++ b/Tests/Tests/STPPaymentConfigurationTest.m
@@ -31,7 +31,6 @@
 
     STPPaymentConfiguration *paymentConfiguration = [[STPPaymentConfiguration alloc] init];
 
-    XCTAssertNil(paymentConfiguration.publishableKey);
     XCTAssertEqual(paymentConfiguration.additionalPaymentOptions, STPPaymentOptionTypeDefault);
     XCTAssertEqual(paymentConfiguration.requiredBillingAddressFields, STPBillingAddressFieldsNone);
     XCTAssertNil(paymentConfiguration.requiredShippingAddressFields);
@@ -102,7 +101,11 @@
                                                               STPContactFieldName]];
 
     STPPaymentConfiguration *paymentConfigurationA = [[STPPaymentConfiguration alloc] init];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
     paymentConfigurationA.publishableKey = @"publishableKey";
+    paymentConfigurationA.stripeAccount = @"stripeAccount";
+#pragma clang diagnostic pop
     paymentConfigurationA.additionalPaymentOptions = STPPaymentOptionTypeApplePay;
     paymentConfigurationA.requiredBillingAddressFields = STPBillingAddressFieldsFull;
     paymentConfigurationA.requiredShippingAddressFields = allFields;
@@ -115,8 +118,12 @@
 
     STPPaymentConfiguration *paymentConfigurationB = [paymentConfigurationA copy];
     XCTAssertNotEqual(paymentConfigurationA, paymentConfigurationB);
-
+    
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
     XCTAssertEqualObjects(paymentConfigurationB.publishableKey, @"publishableKey");
+    XCTAssertEqualObjects(paymentConfigurationB.stripeAccount, @"stripeAccount");
+#pragma clang diagnostic pop
     XCTAssertEqual(paymentConfigurationB.additionalPaymentOptions, STPPaymentOptionTypeApplePay);
     XCTAssertEqual(paymentConfigurationB.requiredBillingAddressFields, STPBillingAddressFieldsFull);
     XCTAssertEqualObjects(paymentConfigurationB.requiredShippingAddressFields, allFields);

--- a/Tests/Tests/UINavigationBar+StripeTest.m
+++ b/Tests/Tests/UINavigationBar+StripeTest.m
@@ -21,7 +21,6 @@
 - (STPPaymentOptionsViewController *)buildPaymentOptionsViewController {
     id customerContext = [STPMocks staticCustomerContext];
     STPPaymentConfiguration *config = [STPFixtures paymentConfiguration];
-    config.publishableKey = @"pk_test";
     STPTheme *theme = [STPTheme defaultTheme];
     id delegate = OCMProtocolMock(@protocol(STPPaymentOptionsViewControllerDelegate));
     STPPaymentOptionsViewController *paymentOptionsVC = [[STPPaymentOptionsViewController alloc] initWithConfiguration:config


### PR DESCRIPTION
## Summary
Part 2 of https://github.com/stripe/stripe-ios/pull/1469

1. Preserve `Stripe.setDefaultPublishableKey` behavior

This is the default value (in the programmatic sense) of publishable key for any new APIClient instance.  

2. Deprecate `STPPaymentConfiguration.{publishableKey, stripeAccount}`

For legacy reasons, make this a proxy for `STPAPIClient.shared.{publishableKey, stripeAccount}` if using the singleton.

3. Remove `apiKey` private property APIClient
4. Simplify the APIClient initializers by removing the dependency on PaymentConfiguration.  PaymentConfiguration is just another property in APIClient, instead of the sorta-source-of-truth of publishableKey.  It defaults to [PaymentConfiguration sharedConfiguration].

## Motivation

https://paper.dropbox.com/doc/psyduck-why-iOS-SDK-API-Configuration-LTvIMxj6CBy1Mw4ntaU0l#:uid=989210153385098517970797&h2=Risks

If users ignore the deprecation warnings, the updated behavior of these deprecated properties should result in no change for most (~everyone except for Connect users cloning PMs and direct charging their connected accounts).

## Testing
Existing tests still pass.