### PR TITLE
Fix PaymentOptionsVC race condition where payment method loading race…

### DIFF
--- a/Stripe/STPPaymentOptionsViewController.m
+++ b/Stripe/STPPaymentOptionsViewController.m
@@ -77,7 +77,8 @@
                                                                      apiAdapter:(id<STPBackendAPIAdapter>)apiAdapter {
     STPPromise<STPPaymentOptionTuple *> *promise = [STPPromise new];
     [apiAdapter listPaymentMethodsForCustomerWithCompletion:^(NSArray<STPPaymentMethod *> * _Nullable paymentMethods, NSError * _Nullable error) {
-        stpDispatchToMainThreadIfNecessary(^{
+        // We don't use stpDispatchToMainThreadIfNecessary here because we want this completion block to always be called asynchronously, so that users can set self.defaultPaymentMethod in time.
+        dispatch_async(dispatch_get_main_queue(), ^{
             if (error) {
                 [promise fail:error];
             } else {

--- a/Tests/Tests/STPPaymentOptionsViewControllerLocalizationTests.m
+++ b/Tests/Tests/STPPaymentOptionsViewControllerLocalizationTests.m
@@ -13,6 +13,13 @@
 #import "STPFixtures.h"
 #import "STPMocks.h"
 #import "STPLocalizationUtils+STPTestAdditions.h"
+#import "STPPromise.h"
+#import "STPPaymentOptionTuple.h"
+
+@interface STPPaymentOptionsViewController (Testing)
+@property (nonatomic) STPPromise<STPPaymentOptionTuple *> *loadingPromise;
+@end
+
 
 @interface STPPaymentOptionsViewControllerLocalizationTests : FBSnapshotTestCase
 @end
@@ -39,7 +46,11 @@
                                                                                                                  theme:theme
                                                                                                        customerContext:customerContext
                                                                                                               delegate:delegate];
-
+    XCTestExpectation *didLoadExpectation = [self expectationWithDescription:@"VC did load"];
+    [paymentOptionsVC.loadingPromise onSuccess:^(STPPaymentOptionTuple * _Nonnull __unused value) {
+        [didLoadExpectation fulfill];
+    }];
+    [self waitForExpectations:@[didLoadExpectation] timeout:2];
 
     UIView *viewToTest = [self stp_preparedAndSizedViewForSnapshotTestFromViewController:paymentOptionsVC];
 


### PR DESCRIPTION
…s against setting defaultPaymentMethod.  

We end up checking `defaultPaymentMethod` before initialization returns, leaving no room for the user to set the property.

This happens b/c
- We make a network request for payment methods in init
- That request can call the completion block synchronously if cached
- We don't clear the cache in PaymentOptionsVC (unlike PaymentContext)

I find all of this surprising but to avoid breaking other things, I'm leaving all of these things as-is and making the smallest fix.

## Motivation
https://github.com/stripe/stripe-ios/issues/1475

## Testing
Tested on UI Examples app, which always synchronously returns. Repro'd pre-fix, cant repro post-fix.