### PR TITLE
Fix example app setting deprecated paymentconfiguration.publishablekey

### DIFF
--- a/Example/Basic Integration/CheckoutViewController.swift
+++ b/Example/Basic Integration/CheckoutViewController.swift
@@ -76,8 +76,8 @@ class CheckoutViewController: UIViewController {
         MyAPIClient.sharedClient.baseURLString = self.backendBaseURL
 
         // This code is included here for the sake of readability, but in your application you should set up your configuration and theme earlier, preferably in your App Delegate.
+        Stripe.setDefaultPublishableKey(self.stripePublishableKey)
         let config = STPPaymentConfiguration.shared()
-        config.publishableKey = self.stripePublishableKey
         config.appleMerchantIdentifier = self.appleMerchantID
         config.companyName = self.companyName
         config.requiredBillingAddressFields = settings.requiredBillingAddressFields


### PR DESCRIPTION
## Motivation
Noticed a deprecation warning in the example app

## Testing
Warning is gone
