### PR TITLE
Support pasting in four-digit expiration years

### DIFF
--- a/Stripe/STPFormTextField.m
+++ b/Stripe/STPFormTextField.m
@@ -14,6 +14,7 @@
 #import "STPCardValidator+Private.h"
 #import "STPDelegateProxy.h"
 #import "STPPhoneNumberValidator.h"
+#import "STPStringUtils.h"
 
 @interface STPTextFieldDelegateProxy : STPDelegateProxy<UITextFieldDelegate>
 @property (nonatomic, assign) STPFormTextFieldAutoFormattingBehavior autoformattingBehavior;
@@ -260,6 +261,8 @@ typedef NSAttributedString* (^STPFormTextTransformationBlock)(NSAttributedString
 - (void)paste:(id)sender {
     if (self.preservesContentsOnPaste) {
         [super paste:sender];
+    } else if (self.autoFormattingBehavior == STPFormTextFieldAutoFormattingBehaviorExpiration) {
+        self.text = [STPStringUtils expirationDateStringFromString:[UIPasteboard generalPasteboard].string];
     } else {
         self.text = [UIPasteboard generalPasteboard].string;
     }

--- a/Stripe/STPStringUtils.h
+++ b/Stripe/STPStringUtils.h
@@ -52,4 +52,12 @@ typedef void(^STPTaggedSubstringsCompletionBlock)(NSString *string, NSDictionary
 + (void)parseRangesFromString:(NSString *)string
                      withTags:(NSSet<NSString *> *)tags
                    completion:(STPTaggedSubstringsCompletionBlock)completion;
+
+
+/**
+ * tktktk
+ */
+
++ (NSString *)expirationDateStringFromString:(NSString *)string;
+
 @end

--- a/Stripe/STPStringUtils.h
+++ b/Stripe/STPStringUtils.h
@@ -55,7 +55,8 @@ typedef void(^STPTaggedSubstringsCompletionBlock)(NSString *string, NSDictionary
 
 
 /**
- * tktktk
+ * Reformats an expiration date with a four-digit year to one with a two digit year.
+ * Ex: `01/2021` to `01/21`.
  */
 
 + (NSString *)expirationDateStringFromString:(NSString *)string;

--- a/Stripe/STPStringUtils.m
+++ b/Stripe/STPStringUtils.m
@@ -110,5 +110,27 @@
     completion(finalString, finalTagRange);
 }
 
++ (NSString *)expirationDateStringFromString:(NSString *)string {
+    static dispatch_once_t onceToken;
+    static NSRegularExpression *regex = nil;
+    dispatch_once(&onceToken, ^{
+        // Regex stolen from Stripe.js/expiry.js
+        regex = [[NSRegularExpression alloc] initWithPattern:@"^(\\d{2}\\D{1,3})(\\d{1,4})?"
+                                                     options:0
+                                                       error:NULL];
+    });
+    NSTextCheckingResult *result = [[regex matchesInString:string options:0 range:NSMakeRange(0, string.length)] firstObject];
+    if (result && [result numberOfRanges] > 1 && [result rangeAtIndex:2].length == 4) {
+        // If a 4-digit year was pasted, shorten it to the last 2 digits
+        NSRange range = [result rangeAtIndex:2];
+        range.length = 2;
+        range.location = range.location + 2;
+        NSString *month = [string substringWithRange:[result rangeAtIndex:1]];
+        NSString *year = [string substringWithRange:range];
+        return [NSString stringWithFormat:@"%@%@", month, year];
+    }
+    
+    return string;
+}
 
 @end

--- a/Stripe/STPStringUtils.m
+++ b/Stripe/STPStringUtils.m
@@ -111,10 +111,10 @@
 }
 
 + (NSString *)expirationDateStringFromString:(NSString *)string {
+    // This code was adapted from Stripe.js
     static dispatch_once_t onceToken;
     static NSRegularExpression *regex = nil;
     dispatch_once(&onceToken, ^{
-        // Regex stolen from Stripe.js/expiry.js
         regex = [[NSRegularExpression alloc] initWithPattern:@"^(\\d{2}\\D{1,3})(\\d{1,4})?"
                                                      options:0
                                                        error:NULL];

--- a/Tests/Tests/STPStringUtilsTest.m
+++ b/Tests/Tests/STPStringUtilsTest.m
@@ -77,5 +77,20 @@
                                }];
 }
 
+- (void)testExpirationDateStrings {
+    XCTAssertEqualObjects([STPStringUtils expirationDateStringFromString:@"12/1995"], @"12/95");
+    XCTAssertEqualObjects([STPStringUtils expirationDateStringFromString:@"12 / 1995"], @"12 / 95");
+    XCTAssertEqualObjects([STPStringUtils expirationDateStringFromString:@"12 /1995"], @"12 /95");
+    XCTAssertEqualObjects([STPStringUtils expirationDateStringFromString:@"1295"], @"1295");
+    XCTAssertEqualObjects([STPStringUtils expirationDateStringFromString:@"08/2001"], @"08/01");
+    XCTAssertEqualObjects([STPStringUtils expirationDateStringFromString:@" 08/a 2001"], @" 08/a 2001");
+    XCTAssertEqualObjects([STPStringUtils expirationDateStringFromString:@"20/2022"], @"20/22");
+    XCTAssertEqualObjects([STPStringUtils expirationDateStringFromString:@"20/202222"], @"20/22");
+    XCTAssertEqualObjects([STPStringUtils expirationDateStringFromString:@""], @"");
+    XCTAssertEqualObjects([STPStringUtils expirationDateStringFromString:@" "], @" ");
+    XCTAssertEqualObjects([STPStringUtils expirationDateStringFromString:@"12/"], @"12/");
+}
+
+
 
 @end

--- a/Tests/Tests/STPStringUtilsTest.m
+++ b/Tests/Tests/STPStringUtilsTest.m
@@ -82,6 +82,7 @@
     XCTAssertEqualObjects([STPStringUtils expirationDateStringFromString:@"12 / 1995"], @"12 / 95");
     XCTAssertEqualObjects([STPStringUtils expirationDateStringFromString:@"12 /1995"], @"12 /95");
     XCTAssertEqualObjects([STPStringUtils expirationDateStringFromString:@"1295"], @"1295");
+    XCTAssertEqualObjects([STPStringUtils expirationDateStringFromString:@"12/95"], @"12/95");
     XCTAssertEqualObjects([STPStringUtils expirationDateStringFromString:@"08/2001"], @"08/01");
     XCTAssertEqualObjects([STPStringUtils expirationDateStringFromString:@" 08/a 2001"], @" 08/a 2001");
     XCTAssertEqualObjects([STPStringUtils expirationDateStringFromString:@"20/2022"], @"20/22");


### PR DESCRIPTION
## Summary
Pasting in expiration dates in the format of "12/2024" (from 1Password, for example) enters "12/20" in the expiration date field instead of the expected "12/24." Stripe Elements handles this correctly, so we'll do something similar here.

## Testing
Wrote a unit test for the formatter and tested by pasting from 1Password on my phone.