### PR TITLE
Send payment_method_type analytic when you attempt to create a PM, co…

### DIFF
--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -743,11 +743,9 @@ toCustomerUsingKey:(STPEphemeralKey *)ephemeralKey
     NSCAssert([STPPaymentIntentParams isClientSecretValid:paymentIntentParams.clientSecret], @"`paymentIntentParams.clientSecret` format does not match expected client secret formatting.");
 
     NSString *identifier = paymentIntentParams.stripeId;
-    NSString *sourceType = paymentIntentParams.sourceParams.rawTypeString;
-    NSString *paymentMethodType = paymentIntentParams.paymentMethodParams.rawTypeString;
+    NSString *type = paymentIntentParams.paymentMethodParams.rawTypeString ?: paymentIntentParams.sourceParams.rawTypeString;
     [[STPAnalyticsClient sharedClient] logPaymentIntentConfirmationAttemptWithConfiguration:self.configuration
-                                                                                 sourceType:sourceType
-                                                                          paymentMethodType:paymentMethodType];
+                                                                          paymentMethodType:type];
 
     NSString *endpoint = [NSString stringWithFormat:@"%@/%@/confirm", APIEndpointPaymentIntents, identifier];
 

--- a/Stripe/STPAnalyticsClient.h
+++ b/Stripe/STPAnalyticsClient.h
@@ -36,7 +36,6 @@
 #pragma mark - Confirmation
 
 - (void)logPaymentIntentConfirmationAttemptWithConfiguration:(STPPaymentConfiguration *)configuration
-                                                  sourceType:(NSString *)sourceType
                                            paymentMethodType:(NSString *)paymentMethodType;
 
 - (void)logSetupIntentConfirmationAttemptWithConfiguration:(STPPaymentConfiguration *)configuration

--- a/Stripe/STPAnalyticsClient.h
+++ b/Stripe/STPAnalyticsClient.h
@@ -30,13 +30,14 @@
 - (void)logSourceCreationAttemptWithConfiguration:(STPPaymentConfiguration *)configuration
                                        sourceType:(NSString *)sourceType;
 
-- (void)logPaymentMethodCreationSucceededWithConfiguration:(STPPaymentConfiguration *)configuration
-                                           paymentMethodID:(NSString *)paymentMethodID;
+- (void)logPaymentMethodCreationAttemptWithConfiguration:(STPPaymentConfiguration *)configuration
+                                       paymentMethodType:(NSString *)paymentMethodType;
 
 #pragma mark - Confirmation
 
 - (void)logPaymentIntentConfirmationAttemptWithConfiguration:(STPPaymentConfiguration *)configuration
-                                                  sourceType:(NSString *)sourceType;
+                                                  sourceType:(NSString *)sourceType
+                                           paymentMethodType:(NSString *)paymentMethodType;
 
 - (void)logSetupIntentConfirmationAttemptWithConfiguration:(STPPaymentConfiguration *)configuration
                                          paymentMethodType:(NSString *)paymentMethodType;

--- a/Stripe/STPAnalyticsClient.m
+++ b/Stripe/STPAnalyticsClient.m
@@ -218,13 +218,13 @@
     [self logPayload:payload];
 }
 
-- (void)logPaymentMethodCreationSucceededWithConfiguration:(STPPaymentConfiguration *)configuration
-                                           paymentMethodID:(NSString *)paymentMethodID {
+- (void)logPaymentMethodCreationAttemptWithConfiguration:(STPPaymentConfiguration *)configuration
+                                       paymentMethodType:(NSString *)paymentMethodType {
     NSDictionary *configurationDictionary = [self.class serializeConfiguration:configuration];
     NSMutableDictionary *payload = [self.class commonPayload];
     [payload addEntriesFromDictionary:@{
                                         @"event": @"stripeios.payment_method_creation",
-                                        @"payment_method_id": paymentMethodID,
+                                        @"payment_method_type": paymentMethodType,
                                         @"additional_info": [self additionalInfo],
                                         }];
     [payload addEntriesFromDictionary:[self productUsageDictionary]];
@@ -233,12 +233,14 @@
 }
 
 - (void)logPaymentIntentConfirmationAttemptWithConfiguration:(STPPaymentConfiguration *)configuration
-                                                  sourceType:(NSString *)sourceType {
+                                                  sourceType:(NSString *)sourceType
+                                           paymentMethodType:(NSString *)paymentMethodType {
     NSDictionary *configurationDictionary = [self.class serializeConfiguration:configuration];
     NSMutableDictionary *payload = [self.class commonPayload];
     [payload addEntriesFromDictionary:@{
                                         @"event": @"stripeios.payment_intent_confirmation",
                                         @"source_type": sourceType ?: @"unknown",
+                                        @"payment_method_type": paymentMethodType ?: @"unknown",
                                         @"additional_info": [self additionalInfo],
                                         }];
     [payload addEntriesFromDictionary:[self productUsageDictionary]];

--- a/Stripe/STPAnalyticsClient.m
+++ b/Stripe/STPAnalyticsClient.m
@@ -224,7 +224,7 @@
     NSMutableDictionary *payload = [self.class commonPayload];
     [payload addEntriesFromDictionary:@{
                                         @"event": @"stripeios.payment_method_creation",
-                                        @"payment_method_type": paymentMethodType,
+                                        @"source_type": paymentMethodType,
                                         @"additional_info": [self additionalInfo],
                                         }];
     [payload addEntriesFromDictionary:[self productUsageDictionary]];
@@ -233,14 +233,12 @@
 }
 
 - (void)logPaymentIntentConfirmationAttemptWithConfiguration:(STPPaymentConfiguration *)configuration
-                                                  sourceType:(NSString *)sourceType
                                            paymentMethodType:(NSString *)paymentMethodType {
     NSDictionary *configurationDictionary = [self.class serializeConfiguration:configuration];
     NSMutableDictionary *payload = [self.class commonPayload];
     [payload addEntriesFromDictionary:@{
                                         @"event": @"stripeios.payment_intent_confirmation",
-                                        @"source_type": sourceType ?: @"unknown",
-                                        @"payment_method_type": paymentMethodType ?: @"unknown",
+                                        @"source_type": paymentMethodType,
                                         @"additional_info": [self additionalInfo],
                                         }];
     [payload addEntriesFromDictionary:[self productUsageDictionary]];
@@ -254,7 +252,7 @@
     NSMutableDictionary *payload = [self.class commonPayload];
     [payload addEntriesFromDictionary:@{
                                         @"event": @"stripeios.setup_intent_confirmation",
-                                        @"payment_method_type": paymentMethodType ?: @"unknown",
+                                        @"source_type": paymentMethodType ?: @"unknown",
                                         @"additional_info": [self additionalInfo],
                                         }];
     [payload addEntriesFromDictionary:[self productUsageDictionary]];

--- a/Stripe/STPAnalyticsClient.m
+++ b/Stripe/STPAnalyticsClient.m
@@ -224,7 +224,7 @@
     NSMutableDictionary *payload = [self.class commonPayload];
     [payload addEntriesFromDictionary:@{
                                         @"event": @"stripeios.payment_method_creation",
-                                        @"source_type": paymentMethodType,
+                                        @"source_type": paymentMethodType ?: @"unknown",
                                         @"additional_info": [self additionalInfo],
                                         }];
     [payload addEntriesFromDictionary:[self productUsageDictionary]];
@@ -238,7 +238,7 @@
     NSMutableDictionary *payload = [self.class commonPayload];
     [payload addEntriesFromDictionary:@{
                                         @"event": @"stripeios.payment_intent_confirmation",
-                                        @"source_type": paymentMethodType,
+                                        @"source_type": paymentMethodType ?: @"unknown",
                                         @"additional_info": [self additionalInfo],
                                         }];
     [payload addEntriesFromDictionary:[self productUsageDictionary]];


### PR DESCRIPTION
…nfirm a PI, confirm an SI

## Summary
Create a PM, confirm a PI, confirm an SI all send `payment_method_type` now.
Confirm PI no longer sends `bancontact` as `source_type` when there is no source.

## Motivation
https://jira.corp.stripe.com/browse/IOS-1610

## Testing
Ran basic integration example, created a PM and confirmed a PI.  Saw the expected analytics.