### PR TITLE
Bacs Debit PI & SI examples

### DIFF
--- a/Example/Non-Card Payment Examples.xcodeproj/project.pbxproj
+++ b/Example/Non-Card Payment Examples.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		8BBD79C6207FD2F900F85BED /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 8BBD79C8207FD2F900F85BED /* Localizable.strings */; };
 		B607FFBD2321DA99004203E0 /* MyAPIClient.m in Sources */ = {isa = PBXBuildFile; fileRef = B607FFBC2321DA99004203E0 /* MyAPIClient.m */; };
 		B65E8FCC22FA078A0057E64A /* WeChatPayExampleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B65E8FCB22FA078A0057E64A /* WeChatPayExampleViewController.m */; };
+		B68882D323FC5BD30057C5AD /* BacsDebitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B68882D223FC5BD30057C5AD /* BacsDebitViewController.swift */; };
 		B6C1FC832330432E0097FC4C /* AlipayExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C1FC822330432E0097FC4C /* AlipayExampleViewController.swift */; };
 		C12C50DD1E57B3C800EC6D58 /* BrowseExamplesViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C12C50DC1E57B3C800EC6D58 /* BrowseExamplesViewController.m */; };
 		C1CACE891E5DF7A9002D0821 /* ApplePayExampleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C1CACE881E5DF7A9002D0821 /* ApplePayExampleViewController.m */; };
@@ -83,6 +84,7 @@
 		B607FFBC2321DA99004203E0 /* MyAPIClient.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MyAPIClient.m; sourceTree = "<group>"; };
 		B65E8FCA22FA078A0057E64A /* WeChatPayExampleViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WeChatPayExampleViewController.h; sourceTree = "<group>"; };
 		B65E8FCB22FA078A0057E64A /* WeChatPayExampleViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WeChatPayExampleViewController.m; sourceTree = "<group>"; };
+		B68882D223FC5BD30057C5AD /* BacsDebitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BacsDebitViewController.swift; sourceTree = "<group>"; };
 		B6C1FC812330432E0097FC4C /* Non-Card Payment Examples-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Non-Card Payment Examples-Bridging-Header.h"; sourceTree = "<group>"; };
 		B6C1FC822330432E0097FC4C /* AlipayExampleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlipayExampleViewController.swift; sourceTree = "<group>"; };
 		C12C50DB1E57B3C800EC6D58 /* BrowseExamplesViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BrowseExamplesViewController.h; sourceTree = "<group>"; };
@@ -129,24 +131,25 @@
 			isa = PBXGroup;
 			children = (
 				B6C1FC822330432E0097FC4C /* AlipayExampleViewController.swift */,
-				31C108D723677C0100FE91B7 /* KlarnaExampleViewController.swift */,
 				04533E8E1A687F5D00C7E52E /* AppDelegate.h */,
 				04533E8F1A687F5D00C7E52E /* AppDelegate.m */,
 				C1CACE871E5DF7A9002D0821 /* ApplePayExampleViewController.h */,
 				C1CACE881E5DF7A9002D0821 /* ApplePayExampleViewController.m */,
+				B68882D223FC5BD30057C5AD /* BacsDebitViewController.swift */,
 				C12C50DB1E57B3C800EC6D58 /* BrowseExamplesViewController.h */,
 				C12C50DC1E57B3C800EC6D58 /* BrowseExamplesViewController.m */,
 				04533F171A688A0A00C7E52E /* Constants.h */,
 				04533F181A688A0A00C7E52E /* Constants.m */,
-				B6C1FC812330432E0097FC4C /* Non-Card Payment Examples-Bridging-Header.h */,
 				31A8934B230F6ABD007ABE37 /* FPXExampleViewController.h */,
 				31A8934C230F6ABD007ABE37 /* FPXExampleViewController.m */,
 				36B6CB62234FD9AA00331C38 /* iDEALExampleViewController.h */,
 				36B6CB63234FD9AA00331C38 /* iDEALExampleViewController.m */,
 				04533E971A687F5D00C7E52E /* Images.xcassets */,
+				31C108D723677C0100FE91B7 /* KlarnaExampleViewController.swift */,
 				8BBD79C8207FD2F900F85BED /* Localizable.strings */,
 				B607FFBB2321DA99004203E0 /* MyAPIClient.h */,
 				B607FFBC2321DA99004203E0 /* MyAPIClient.m */,
+				B6C1FC812330432E0097FC4C /* Non-Card Payment Examples-Bridging-Header.h */,
 				36B6CB58234BE3FA00331C38 /* PaymentExampleViewController.h */,
 				36B6CB59234BE3FA00331C38 /* PaymentExampleViewController.m */,
 				36B6CB5B234BEB8400331C38 /* SEPADebitExampleViewController.h */,
@@ -293,6 +296,7 @@
 				04533E901A687F5D00C7E52E /* AppDelegate.m in Sources */,
 				B65E8FCC22FA078A0057E64A /* WeChatPayExampleViewController.m in Sources */,
 				36B6CB5A234BE3FA00331C38 /* PaymentExampleViewController.m in Sources */,
+				B68882D323FC5BD30057C5AD /* BacsDebitViewController.swift in Sources */,
 				C1CACE891E5DF7A9002D0821 /* ApplePayExampleViewController.m in Sources */,
 				B6C1FC832330432E0097FC4C /* AlipayExampleViewController.swift in Sources */,
 				B607FFBD2321DA99004203E0 /* MyAPIClient.m in Sources */,

--- a/Example/Non-Card Payment Examples/BacsDebitViewController.swift
+++ b/Example/Non-Card Payment Examples/BacsDebitViewController.swift
@@ -1,0 +1,158 @@
+//
+//  BacsDebitViewController.swift
+//  Non-Card Payment Examples
+//
+//  Created by Yuki Tokuhiro on 2/18/20.
+//  Copyright © 2020 Stripe. All rights reserved.
+//
+
+import UIKit
+import Stripe
+
+/**
+ An example of accepting Bacs Debit payments.
+ 
+ There are some limitations:
+ 1. Your Stripe account's country must be UK
+ 2. The currency value of the PaymentIntent or SetupIntent must be GBP
+ 3. The UI to collect payment details is subject to strict requirements and must be approved by Stripe - contact bacs-debit@stripe.com
+ */
+class BacsDebitExampleViewController: UIViewController {
+    @objc weak var delegate: ExampleViewControllerDelegate?
+    var inProgress: Bool = false {
+        didSet {
+            navigationController?.navigationBar.isUserInteractionEnabled = !inProgress
+            payButton.isEnabled = !inProgress
+            inProgress ? activityIndicatorView.startAnimating() : activityIndicatorView.stopAnimating()
+        }
+    }
+    
+    // UI
+    lazy var activityIndicatorView = {
+       return UIActivityIndicatorView(style: .gray)
+    }()
+    lazy var payButton: UIButton = {
+        let button = UIButton(type: .roundedRect)
+        button.setTitle("Pay with Bacs Debit", for: .normal)
+        button.addTarget(self, action: #selector(didTapPayButton), for: .touchUpInside)
+        return button
+    }()
+    lazy var setupButton: UIButton = {
+        let button = UIButton(type: .roundedRect)
+        button.setTitle("Set up Bacs Debit for future payment", for: .normal)
+        button.addTarget(self, action: #selector(didTapSetupButton), for: .touchUpInside)
+        return button
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .white
+        title = "Bacs Debit"
+        [payButton, setupButton, activityIndicatorView].forEach { subview in
+            view.addSubview(subview)
+            subview.translatesAutoresizingMaskIntoConstraints = false
+        }
+
+        let constraints = [
+            payButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            payButton.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            
+            setupButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            setupButton.topAnchor.constraint(equalTo: payButton.bottomAnchor),
+            
+            activityIndicatorView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            activityIndicatorView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+        ]
+        NSLayoutConstraint.activate(constraints)
+    }
+    
+    @objc func didTapPayButton(sender: UIButton) {
+        inProgress = true
+        
+        /**
+         You must provide UI to collect the following hard-coded customer information. Bacs in the UK has strict requirements around customer-facing mandate collection forms. Stripe needs to approve any forms for collecting mandates. Contact bacs-debits@stripe.com with any questions.
+         */
+        let bacsDebitParams = STPPaymentMethodBacsDebitParams()
+        bacsDebitParams.accountNumber = "00012345"
+        bacsDebitParams.sortCode = "108800"
+        
+        let address = STPPaymentMethodAddress()
+        address.line1 = "29 Arlington Avenue"
+        address.city = "London"
+        address.postalCode = "N1 7BE"
+        address.country = "GB"
+        
+        let billingDetails = STPPaymentMethodBillingDetails()
+        billingDetails.name = "Chiaki"
+        billingDetails.email = "email@email.com"
+        billingDetails.address = address
+        
+        let paymentMethodParams = STPPaymentMethodParams(bacsDebit: bacsDebitParams, billingDetails: billingDetails, metadata: nil)
+        
+        MyAPIClient.shared().createPaymentIntent(completion: { (result, clientSecret, error) in
+            guard let clientSecret = clientSecret else {
+                self.delegate?.exampleViewController(self, didFinishWithError: error)
+                return
+            }
+            
+            let paymentIntentParams = STPPaymentIntentParams(clientSecret: clientSecret)
+            paymentIntentParams.paymentMethodParams = paymentMethodParams
+
+            STPPaymentHandler.shared().confirmPayment(withParams: paymentIntentParams, authenticationContext: self) { (status, intent, error) in
+                guard error == nil else {
+                    self.delegate?.exampleViewController(self, didFinishWithError: error)
+                    return
+                }
+                self.delegate?.exampleViewController(self, didFinishWithMessage: "Your order was received and is awaiting payment confirmation.")
+            }
+        }, additionalParameters: nil)
+    }
+    
+    @objc func didTapSetupButton() {
+        inProgress = true
+        
+        /**
+         You must provide UI to collect the following hard-coded customer information. Bacs in the UK has strict requirements around customer-facing mandate collection forms. Stripe needs to approve any forms for collecting mandates. Contact bacs-debits@stripe.com with any questions.
+         */
+        let bacsDebitParams = STPPaymentMethodBacsDebitParams()
+        bacsDebitParams.accountNumber = "00012345"
+        bacsDebitParams.sortCode = "108800"
+        
+        let address = STPPaymentMethodAddress()
+        address.line1 = "29 Arlington Avenue"
+        address.city = "London"
+        address.postalCode = "N1 7BE"
+        address.country = "GB"
+        
+        let billingDetails = STPPaymentMethodBillingDetails()
+        billingDetails.name = "Chiaki"
+        billingDetails.email = "email@email.com"
+        billingDetails.address = address
+        
+        let paymentMethodParams = STPPaymentMethodParams(bacsDebit: bacsDebitParams, billingDetails: billingDetails, metadata: nil)
+        
+        MyAPIClient.shared().createSetupIntent() { (result, clientSecret, error) in
+            guard let clientSecret = clientSecret else {
+                self.delegate?.exampleViewController(self, didFinishWithError: error)
+                return
+            }
+            
+            let setupIntentParams = STPSetupIntentConfirmParams(clientSecret: clientSecret)
+            setupIntentParams.paymentMethodParams = paymentMethodParams
+            STPPaymentHandler.shared().confirmSetupIntent(withParams: setupIntentParams, authenticationContext: self) { (status, setupIntent, error) in
+                guard error == nil else {
+                    self.delegate?.exampleViewController(self, didFinishWithError: error)
+                    return
+                }
+                self.delegate?.exampleViewController(self, didFinishWithMessage: "Your order was received and is awaiting payment confirmation.")
+            }
+        }
+    }
+}
+
+// MARK: -
+extension BacsDebitExampleViewController: STPAuthenticationContext {
+    func authenticationPresentingViewController() -> UIViewController {
+        self
+    }
+}

--- a/Example/Non-Card Payment Examples/Non-Card Payment Examples-Bridging-Header.h
+++ b/Example/Non-Card Payment Examples/Non-Card Payment Examples-Bridging-Header.h
@@ -3,3 +3,4 @@
 //
 
 #import "BrowseExamplesViewController.h"
+#import "MyAPIClient.h"

--- a/Stripe/STPPaymentIntentParams.m
+++ b/Stripe/STPPaymentIntentParams.m
@@ -107,9 +107,11 @@
 }
 
 - (STPMandateDataParams *)mandateData {
+    BOOL paymentMethodRequiresMandate = self.paymentMethodParams.type == STPPaymentMethodTypeSEPADebit || self.paymentMethodParams.type == STPPaymentMethodTypeBacsDebit;
+    
     if (_mandateData != nil) {
         return _mandateData;
-    } else if (self.paymentMethodParams.type == STPPaymentMethodTypeSEPADebit && self.mandate == nil) {
+    } else if (self.mandate == nil && paymentMethodRequiresMandate) {
         // Create default infer from client mandate_data
         STPMandateDataParams *mandateData = [[STPMandateDataParams alloc] init];
         STPMandateCustomerAcceptanceParams *customerAcceptance = [[STPMandateCustomerAcceptanceParams alloc] init];

--- a/Stripe/STPSetupIntentConfirmParams.m
+++ b/Stripe/STPSetupIntentConfirmParams.m
@@ -60,9 +60,11 @@
 }
 
 - (STPMandateDataParams *)mandateData {
+    BOOL paymentMethodRequiresMandate = self.paymentMethodParams.type == STPPaymentMethodTypeSEPADebit || self.paymentMethodParams.type == STPPaymentMethodTypeBacsDebit;
+    
     if (_mandateData != nil) {
         return _mandateData;
-    } else if (self.paymentMethodParams.type == STPPaymentMethodTypeSEPADebit && self.mandate == nil) {
+    } else if (self.mandate == nil && paymentMethodRequiresMandate) {
         // Create default infer from client mandate_data
         STPMandateDataParams *mandateData = [[STPMandateDataParams alloc] init];
         STPMandateCustomerAcceptanceParams *customerAcceptance = [[STPMandateCustomerAcceptanceParams alloc] init];


### PR DESCRIPTION
## Summary
Bacs Debit PI & SI examples
Also automatically generating `mandateData` for Bacs debit in addition to sepa debit.

## Motivation
https://jira.corp.stripe.com/browse/IOS-1451

## Testing
Tested PI and SI flows w/ testmode account numbers.  The success and failure case look the same on the client (intent state == processing).
