### PR TITLE
Marks header labels with accessibility trait

### DIFF
--- a/Stripe/STPSectionHeaderView.m
+++ b/Stripe/STPSectionHeaderView.m
@@ -23,6 +23,7 @@
         UILabel *label = [UILabel new];
         label.numberOfLines = 0;
         label.lineBreakMode = NSLineBreakByWordWrapping;
+        label.accessibilityTraits |= UIAccessibilityTraitHeader;
         [self addSubview:label];
         _label = label;
         UIButton *button = [UIButton buttonWithType:UIButtonTypeSystem];


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Adds UIAccessibilityTraitHeader trait to the label in STPSectionHeaderView so it is identified correctly by assistive technologies.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Accessibility fix.

## Testing
<!-- How was the code tested? Be as specific as possible. -->

