### PR TITLE
Use UOB0228 as the B2B bank for UOB

### DIFF
--- a/Stripe/STPFPXBankBrand.m
+++ b/Stripe/STPFPXBankBrand.m
@@ -242,7 +242,7 @@ NSString * STPBankCodeFromFPXBankBrand(STPFPXBankBrand brand, BOOL isBusiness) {
                 return @"SCB0216";
         case STPFPXBankBrandUOB:
             if (isBusiness)
-                return nil;
+                return @"UOB0228";
             else
                 return @"UOB0226";
         case STPFPXBankBrandUnknown:


### PR DESCRIPTION
## Summary
This is a follow up to https://github.com/stripe/stripe-ios/pull/1496 - we now want to set the B2B bank for UOB to UOB0228.

## Testing
Existing tests
