### PR TITLE
Mark Payment Option Cells as buttons for accessibility

### DIFF
--- a/Stripe/STPPaymentOptionTableViewCell.m
+++ b/Stripe/STPPaymentOptionTableViewCell.m
@@ -78,6 +78,7 @@ static const CGFloat kCheckmarkWidth = 14.f;
             [self.titleLabel.centerYAnchor constraintEqualToAnchor:self.contentView.centerYAnchor],
 
         ]];
+        self.accessibilityTraits |= UIAccessibilityTraitButton;
         self.isAccessibilityElement = YES;
     }
     return self;


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Adds UIAccessibilityTraitButton accessibility trait.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Voiceover doesn't consider the payment option cells as buttons

## Testing
<!-- How was the code tested? Be as specific as possible. -->
Tested with voiceover on.
