### PR TITLE
Adds API bindings for AU BECS Debit PaymentMethod

### DIFF
--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -607,6 +607,8 @@
 		3604007B22C18DAE004CF80B /* STPThreeDSTextFieldCustomization.h in Headers */ = {isa = PBXBuildFile; fileRef = 3604006D22C18C78004CF80B /* STPThreeDSTextFieldCustomization.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3604007C22C18DB3004CF80B /* STPThreeDSUICustomization.h in Headers */ = {isa = PBXBuildFile; fileRef = 3604006A22C18C77004CF80B /* STPThreeDSUICustomization.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3604007D22C18DBA004CF80B /* STPThreeDSButtonCustomization.h in Headers */ = {isa = PBXBuildFile; fileRef = 3604006B22C18C78004CF80B /* STPThreeDSButtonCustomization.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		360EC5C124241F5900372F1C /* STPPaymentMethodAUBECSDebit.h in Headers */ = {isa = PBXBuildFile; fileRef = 366658AE240F20AC00D00354 /* STPPaymentMethodAUBECSDebit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		360EC5C224241F6600372F1C /* STPPaymentMethodAUBECSDebitParams.h in Headers */ = {isa = PBXBuildFile; fileRef = 366658AF240F20AD00D00354 /* STPPaymentMethodAUBECSDebitParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3617A51420FE5BBB001A9E6A /* NSLocale+STPSwizzling.h in Headers */ = {isa = PBXBuildFile; fileRef = 3617A51220FE5BBB001A9E6A /* NSLocale+STPSwizzling.h */; };
 		3617A51520FE5BBB001A9E6A /* NSLocale+STPSwizzling.m in Sources */ = {isa = PBXBuildFile; fileRef = 3617A51320FE5BBB001A9E6A /* NSLocale+STPSwizzling.m */; };
 		3620B63021C41E08009FC6FB /* MockCustomerContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 3620B62F21C41E08009FC6FB /* MockCustomerContext.m */; };
@@ -3690,6 +3692,7 @@
 				B32B176620F80442000D6EF8 /* STPRedirectContext+Private.h in Headers */,
 				319A608722E9186B00AACF66 /* STDSChallengeStatusReceiver.h in Headers */,
 				F1D3A2561EB012350095BFA9 /* STPMultipartFormDataPart.h in Headers */,
+				360EC5C224241F6600372F1C /* STPPaymentMethodAUBECSDebitParams.h in Headers */,
 				B604CF2222C56E9B00A23CC4 /* STPIntentActionRedirectToURL.h in Headers */,
 				B6DB0CA7223817A300AEF640 /* STPPaymentMethodEnums.h in Headers */,
 				04F94DCD1D22A22F004FC826 /* UIViewController+Stripe_KeyboardAvoiding.h in Headers */,
@@ -3763,6 +3766,7 @@
 				3604007A22C18DA9004CF80B /* STPThreeDSSelectionCustomization.h in Headers */,
 				0413CB29233FECD5006429EA /* STPPushProvisioningDetailsParams.h in Headers */,
 				3604007D22C18DBA004CF80B /* STPThreeDSButtonCustomization.h in Headers */,
+				360EC5C124241F5900372F1C /* STPPaymentMethodAUBECSDebit.h in Headers */,
 				3604007622C18D93004CF80B /* STPThreeDSCustomization+Private.h in Headers */,
 				F152322B1EA9306100D65C67 /* NSURLComponents+Stripe.h in Headers */,
 				C1A06F111E1D8A7F004DCA06 /* STPCard+Private.h in Headers */,

--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -644,6 +644,12 @@
 		365FC5AB21C18F550092ADB0 /* Stripe.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 04CDB4421A5F2E1800B854EE /* Stripe.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		3666589C23FF494400D00354 /* STPTestingAPIClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 3666589A23FF494400D00354 /* STPTestingAPIClient.h */; };
 		3666589D23FF494400D00354 /* STPTestingAPIClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 3666589B23FF494400D00354 /* STPTestingAPIClient.m */; };
+		366658A3240F17A300D00354 /* STPPaymentMethodAUBECSDebit.m in Sources */ = {isa = PBXBuildFile; fileRef = 366658A1240F17A300D00354 /* STPPaymentMethodAUBECSDebit.m */; };
+		366658A9240F1D7D00D00354 /* STPPaymentMethodAUBECSDebitParams.m in Sources */ = {isa = PBXBuildFile; fileRef = 366658A7240F1D7C00D00354 /* STPPaymentMethodAUBECSDebitParams.m */; };
+		366658B0240F20AD00D00354 /* STPPaymentMethodAUBECSDebit.h in Headers */ = {isa = PBXBuildFile; fileRef = 366658AE240F20AC00D00354 /* STPPaymentMethodAUBECSDebit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		366658B1240F20AD00D00354 /* STPPaymentMethodAUBECSDebitParams.h in Headers */ = {isa = PBXBuildFile; fileRef = 366658AF240F20AD00D00354 /* STPPaymentMethodAUBECSDebitParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		366658B324105EF200D00354 /* STPPaymentMethodAUBECSDebitTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 366658B224105EF200D00354 /* STPPaymentMethodAUBECSDebitTests.m */; };
+		366658B52410756100D00354 /* STPPaymentMethodAUBECSDebitParamsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 366658B42410756100D00354 /* STPPaymentMethodAUBECSDebitParamsTests.m */; };
 		367B46D722A0969000730BE0 /* STPThreeDSCustomizationSettings.m in Sources */ = {isa = PBXBuildFile; fileRef = 367B46D522A0969000730BE0 /* STPThreeDSCustomizationSettings.m */; };
 		3680BFCC23A9926500DB54AA /* STPPaymentIntentParams+Utilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 3680BFCB23A9926500DB54AA /* STPPaymentIntentParams+Utilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3680BFCD23A9926500DB54AA /* STPPaymentIntentParams+Utilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 3680BFCB23A9926500DB54AA /* STPPaymentIntentParams+Utilities.h */; };
@@ -1824,6 +1830,12 @@
 		365BE8A1228CAB6A0068D824 /* STPIntentActionUseStripeSDK.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPIntentActionUseStripeSDK.m; sourceTree = "<group>"; };
 		3666589A23FF494400D00354 /* STPTestingAPIClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPTestingAPIClient.h; sourceTree = "<group>"; };
 		3666589B23FF494400D00354 /* STPTestingAPIClient.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPTestingAPIClient.m; sourceTree = "<group>"; };
+		366658A1240F17A300D00354 /* STPPaymentMethodAUBECSDebit.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodAUBECSDebit.m; sourceTree = "<group>"; };
+		366658A7240F1D7C00D00354 /* STPPaymentMethodAUBECSDebitParams.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodAUBECSDebitParams.m; sourceTree = "<group>"; };
+		366658AE240F20AC00D00354 /* STPPaymentMethodAUBECSDebit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = STPPaymentMethodAUBECSDebit.h; path = PublicHeaders/STPPaymentMethodAUBECSDebit.h; sourceTree = "<group>"; };
+		366658AF240F20AD00D00354 /* STPPaymentMethodAUBECSDebitParams.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = STPPaymentMethodAUBECSDebitParams.h; path = PublicHeaders/STPPaymentMethodAUBECSDebitParams.h; sourceTree = "<group>"; };
+		366658B224105EF200D00354 /* STPPaymentMethodAUBECSDebitTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodAUBECSDebitTests.m; sourceTree = "<group>"; };
+		366658B42410756100D00354 /* STPPaymentMethodAUBECSDebitParamsTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodAUBECSDebitParamsTests.m; sourceTree = "<group>"; };
 		3674EAD4232AEE24008ADA25 /* en-GB */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-GB"; path = "en-GB.lproj/LaunchScreen.strings"; sourceTree = "<group>"; };
 		3674EAD5232AEE25008ADA25 /* en-GB */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "en-GB"; path = "Localizations/en-GB.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		3674EAD6232AEE37008ADA25 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
@@ -2739,6 +2751,7 @@
 			isa = PBXGroup;
 			children = (
 				B656293023E10F6300458A8E /* Bacs Debit */,
+				3666589F240F177400D00354 /* AU BECS Debit */,
 				3626616523C9048500B13AE0 /* Card */,
 				3626616623C9049000B13AE0 /* Card Present */,
 				3626616723C9049D00B13AE0 /* Card Wallet */,
@@ -2984,6 +2997,17 @@
 			name = Backend;
 			sourceTree = "<group>";
 		};
+		3666589F240F177400D00354 /* AU BECS Debit */ = {
+			isa = PBXGroup;
+			children = (
+				366658AE240F20AC00D00354 /* STPPaymentMethodAUBECSDebit.h */,
+				366658A1240F17A300D00354 /* STPPaymentMethodAUBECSDebit.m */,
+				366658AF240F20AD00D00354 /* STPPaymentMethodAUBECSDebitParams.h */,
+				366658A7240F1D7C00D00354 /* STPPaymentMethodAUBECSDebitParams.m */,
+			);
+			name = "AU BECS Debit";
+			sourceTree = "<group>";
+		};
 		8BD2133A1F0458B7007F6FD1 /* Source */ = {
 			isa = PBXGroup;
 			children = (
@@ -3121,6 +3145,8 @@
 				B3BDCACC20EEF4540034F7F5 /* STPPaymentIntentTest.m */,
 				B6D6C932223076600092AFC8 /* STPPaymentMethodAddressTest.m */,
 				B656292423E10AB100458A8E /* STPPaymentMethodBacsDebitTest.m */,
+				366658B42410756100D00354 /* STPPaymentMethodAUBECSDebitParamsTests.m */,
+				366658B224105EF200D00354 /* STPPaymentMethodAUBECSDebitTests.m */,
 				B6D6C934223078840092AFC8 /* STPPaymentMethodBillingDetailsTest.m */,
 				B66D5026222F8605004A9210 /* STPPaymentMethodCardChecksTest.m */,
 				B628476122307A4100957149 /* STPPaymentMethodCardTest.m */,
@@ -3918,6 +3944,7 @@
 				36239BAE2295EA23004FB1A5 /* STP3DS2AuthenticateResponse.h in Headers */,
 				C158AB3F1E1EE98900348D01 /* STPSectionHeaderView.h in Headers */,
 				04EBC7571B7533C300A0E6AE /* STPCardValidator.h in Headers */,
+				366658B0240F20AD00D00354 /* STPPaymentMethodAUBECSDebit.h in Headers */,
 				046FE9A11CE55D1D00DA6A7B /* STPPaymentActivityIndicatorView.h in Headers */,
 				C11810861CC6AF4C0022FB55 /* STPPaymentOption.h in Headers */,
 				0413CB28233FECD5006429EA /* STPPushProvisioningDetailsParams.h in Headers */,
@@ -3998,6 +4025,7 @@
 				0731328F2277A3F60019CE3F /* STPPinManagementService.h in Headers */,
 				3604007222C18C78004CF80B /* STPThreeDSUICustomization.h in Headers */,
 				B32B175E20F6D2C4000D6EF8 /* STPGenericStripeObject.h in Headers */,
+				366658B1240F20AD00D00354 /* STPPaymentMethodAUBECSDebitParams.h in Headers */,
 				049A3F991CC76A2400F57DE7 /* NSBundle+Stripe_AppName.h in Headers */,
 				3621DDCB22A5E4FD00281BC4 /* STPPaymentHandler.h in Headers */,
 				04E32A9D1B7A9490009C9E35 /* STPPaymentCardTextField.h in Headers */,
@@ -4803,6 +4831,7 @@
 				F14C872F1D4FCDBA00C7CC6A /* STPPaymentContextApplePayTest.m in Sources */,
 				3626615B23C8F8CD00B13AE0 /* STPConfirmCardOptions.m in Sources */,
 				C1BD9B1F1E390A2700CEE925 /* STPSourceParamsTest.m in Sources */,
+				366658B324105EF200D00354 /* STPPaymentMethodAUBECSDebitTests.m in Sources */,
 				B664D65922B81C1700E6354B /* STPThreeDSFooterCustomizationTest.m in Sources */,
 				B66D5027222F8605004A9210 /* STPPaymentMethodCardChecksTest.m in Sources */,
 				B664D66222B83BAF00E6354B /* STPThreeDSLabelCustomizationTest.m in Sources */,
@@ -4843,6 +4872,7 @@
 				8B013C891F1E784A00DD831B /* STPPaymentConfigurationTest.m in Sources */,
 				C1EEDCC81CA2172700A54582 /* NSString+StripeTest.m in Sources */,
 				3626615223C8F89F00B13AE0 /* STPConfirmPaymentMethodOptions.m in Sources */,
+				366658B52410756100D00354 /* STPPaymentMethodAUBECSDebitParamsTests.m in Sources */,
 				8BD87B901EFB17AA00269C2B /* STPSourceRedirectTest.m in Sources */,
 				04415C6A1A6605B5001225ED /* STPApplePayFunctionalTest.m in Sources */,
 				8BE5AE8B1EF8905B0081A33C /* STPCardParamsTest.m in Sources */,
@@ -5117,6 +5147,7 @@
 				3626615A23C8F8CD00B13AE0 /* STPConfirmCardOptions.m in Sources */,
 				B640DB1422C58E82003C8810 /* STPSetupIntentConfirmParams.m in Sources */,
 				B664D64F22B8085900E6354B /* STPThreeDSUICustomization.m in Sources */,
+				366658A3240F17A300D00354 /* STPPaymentMethodAUBECSDebit.m in Sources */,
 				04BC29A51CD8697900318357 /* STPTheme.m in Sources */,
 				C15993391D8808680047950D /* STPShippingMethodTableViewCell.m in Sources */,
 				C1BD9B2A1E39406C00CEE925 /* STPSourceOwner.m in Sources */,
@@ -5159,6 +5190,7 @@
 				F148ABC81D5D334B0014FD92 /* STPLocalizationUtils.m in Sources */,
 				04A4C38B1C4F25F900B3B290 /* NSArray+Stripe.m in Sources */,
 				3691EB722119111A008C49E1 /* STPCardValidator+Private.m in Sources */,
+				366658A9240F1D7D00D00354 /* STPPaymentMethodAUBECSDebitParams.m in Sources */,
 				0413CB22233FECD5006429EA /* STPPushProvisioningContext.m in Sources */,
 				F19491E41E60DD72001E1FC2 /* STPSourceSEPADebitDetails.m in Sources */,
 				04A4C38F1C4F25F900B3B290 /* UIViewController+Stripe_ParentViewController.m in Sources */,

--- a/Stripe/Payments/STPPaymentHandler.m
+++ b/Stripe/Payments/STPPaymentHandler.m
@@ -306,11 +306,14 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
     switch (type) {
         case STPPaymentMethodTypeSEPADebit:
         case STPPaymentMethodTypeBacsDebit: // Bacs Debit takes 2-3 business days
+            // fall through
+        case STPPaymentMethodTypeAUBECSDebit:
             return YES;
         case STPPaymentMethodTypeCard:
         case STPPaymentMethodTypeiDEAL:
         case STPPaymentMethodTypeFPX:
         case STPPaymentMethodTypeCardPresent:
+            // fall through
         case STPPaymentMethodTypeUnknown:
             return NO;
     }

--- a/Stripe/PublicHeaders/STPPaymentMethod.h
+++ b/Stripe/PublicHeaders/STPPaymentMethod.h
@@ -12,7 +12,8 @@
 #import "STPPaymentMethodEnums.h"
 #import "STPPaymentOption.h"
 
-@class STPPaymentMethodBillingDetails,
+@class STPPaymentMethodAUBECSDebit,
+STPPaymentMethodBillingDetails,
 STPPaymentMethodCard,
 STPPaymentMethodCardPresent,
 STPPaymentMethodFPX,
@@ -84,6 +85,11 @@ NS_ASSUME_NONNULL_BEGIN
  If this is a Bacs Debit PaymentMethod (ie `self.type == STPPaymentMethodTypeBacsDebit`), this contains additional details.
  */
 @property (nonatomic, nullable, readonly) STPPaymentMethodBacsDebit *bacsDebit;
+
+/**
+ If this is an AU BECS Debit PaymentMethod (i.e. `self.type == STPPaymentMethodTypeAUBECSDebit`), this contains additional details.
+*/
+@property (nonatomic, nullable, readonly) STPPaymentMethodAUBECSDebit *auBECSDebit;
 
 /**
  The ID of the Customer to which this PaymentMethod is saved. Nil when the PaymentMethod has not been saved to a Customer.

--- a/Stripe/PublicHeaders/STPPaymentMethodAUBECSDebit.h
+++ b/Stripe/PublicHeaders/STPPaymentMethodAUBECSDebit.h
@@ -1,0 +1,45 @@
+//
+//  STPPaymentMethodAUBECSDebit.h
+//  StripeiOS
+//
+//  Created by Cameron Sabol on 3/3/20.
+//  Copyright © 2020 Stripe, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "STPAPIResponseDecodable.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+An AU BECS Debit Payment Method.
+
+@see https://stripe.com/docs/api/payment_methods/object#payment_method_object-au_becs_debit
+*/
+@interface STPPaymentMethodAUBECSDebit : NSObject <STPAPIResponseDecodable>
+
+/**
+You cannot directly instantiate an `STPPaymentMethodAUBECSDebit`.
+You should only use one that is part of an existing `STPPaymentMethod` object.
+*/
+- (instancetype)init NS_UNAVAILABLE;
+
+/**
+ Six-digit number identifying bank and branch associated with this bank account.
+ */
+@property (nonatomic, readonly, copy) NSString *bsbNumber;
+
+/**
+ Uniquely identifies this particular bank account. You can use this attribute to check whether two bank accounts are the same.
+ */
+@property (nonatomic, readonly, copy) NSString *fingerprint;
+
+/**
+ Last four digits of the bank account number.
+ */
+@property (nonatomic, readonly, copy) NSString *last4;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Stripe/PublicHeaders/STPPaymentMethodAUBECSDebitParams.h
+++ b/Stripe/PublicHeaders/STPPaymentMethodAUBECSDebitParams.h
@@ -1,0 +1,32 @@
+//
+//  STPPaymentMethodAUBECSDebitParams.h
+//  StripeiOS
+//
+//  Created by Cameron Sabol on 3/3/20.
+//  Copyright © 2020 Stripe, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "STPFormEncodable.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ An object representing parameters used to create an AU BECS Debit Payment Method
+ */
+@interface STPPaymentMethodAUBECSDebitParams : NSObject <STPFormEncodable>
+
+/**
+ The account number to debit.
+ */
+@property (nonatomic, copy) NSString *accountNumber;
+
+/**
+ Six-digit number identifying bank and branch associated with this bank account.
+ */
+@property (nonatomic, copy) NSString *bsbNumber;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Stripe/PublicHeaders/STPPaymentMethodEnums.h
+++ b/Stripe/PublicHeaders/STPPaymentMethodEnums.h
@@ -34,6 +34,11 @@ typedef NS_ENUM(NSUInteger, STPPaymentMethodType) {
      A SEPA Debit payment method.
      */
     STPPaymentMethodTypeSEPADebit,
+
+    /**
+     An AU BECS Debit payment method.
+     */
+    STPPaymentMethodTypeAUBECSDebit,
     
     /**
      A Bacs Debit payment method.

--- a/Stripe/PublicHeaders/STPPaymentMethodParams.h
+++ b/Stripe/PublicHeaders/STPPaymentMethodParams.h
@@ -14,6 +14,7 @@
 
 @class STPPaymentMethod,
 STPPaymentMethodBacsDebitParams,
+STPPaymentMethodAUBECSDebitParams,
 STPPaymentMethodBillingDetails,
 STPPaymentMethodCardParams,
 STPPaymentMethodFPXParams,
@@ -79,6 +80,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nullable) STPPaymentMethodBacsDebitParams *bacsDebit;
 
 /**
+ If this is an AU BECS Debit PaymentMethod, this contains details about the bank to debit.
+ */
+@property (nonatomic, nullable) STPPaymentMethodAUBECSDebitParams *auBECSDebit;
+
+/**
  Set of key-value pairs that you can attach to the PaymentMethod. This can be useful for storing additional information about the PaymentMethod in a structured format.
  */
 @property (nonatomic, copy, nullable) NSDictionary<NSString *, NSString *> *metadata;
@@ -138,6 +144,16 @@ NS_ASSUME_NONNULL_BEGIN
                                           billingDetails:(STPPaymentMethodBillingDetails *)billingDetails
                                                 metadata:(nullable NSDictionary<NSString *, NSString *> *)metadata;
 
+/**
+ Creates params for an AU BECS Debit PaymentMethod;
+
+ @param auBECSDebit   An object containing the AU BECS bank debit details.
+ @param billingDetails  An object containing the user's billing details. Note that `billingDetails.name` and `billingDetails.email` are required for AU BECS Debit PaymentMethods.
+ @param metadata     Additional information to attach to the PaymentMethod.
+ */
++ (nullable STPPaymentMethodParams *)paramsWithAUBECSDebit:(STPPaymentMethodAUBECSDebitParams *)auBECSDebit
+                                            billingDetails:(STPPaymentMethodBillingDetails *)billingDetails
+                                                  metadata:(nullable NSDictionary<NSString *, NSString *> *)metadata;
 
 /**
  Creates params from a single-use PaymentMethod. This is useful for recreating a new payment method

--- a/Stripe/PublicHeaders/Stripe.h
+++ b/Stripe/PublicHeaders/Stripe.h
@@ -68,6 +68,8 @@
 #import "STPPaymentMethodAddress.h"
 #import "STPPaymentMethodBacsDebit.h"
 #import "STPPaymentMethodBacsDebitParams.h"
+#import "STPPaymentMethodAUBECSDebit.h"
+#import "STPPaymentMethodAUBECSDebitParams.h"
 #import "STPPaymentMethodBillingDetails.h"
 #import "STPPaymentMethodCard.h"
 #import "STPPaymentMethodCardPresent.h"

--- a/Stripe/STPPaymentMethod.m
+++ b/Stripe/STPPaymentMethod.m
@@ -11,6 +11,7 @@
 #import "NSDictionary+Stripe.h"
 #import "STPImageLibrary.h"
 #import "STPLocalizationUtils.h"
+#import "STPPaymentMethodAUBECSDebit.h"
 #import "STPPaymentMethodBacsDebit.h"
 #import "STPPaymentMethodBillingDetails.h"
 #import "STPPaymentMethodCard.h"
@@ -32,6 +33,7 @@
 @property (nonatomic, strong, nullable, readwrite) STPPaymentMethodBacsDebit *bacsDebit;
 @property (nonatomic, strong, nullable, readwrite) STPPaymentMethodCardPresent *cardPresent;
 @property (nonatomic, strong, nullable, readwrite) STPPaymentMethodSEPADebit *sepaDebit;
+@property (nonatomic, strong, nullable, readwrite) STPPaymentMethodAUBECSDebit *auBECSDebit;
 @property (nonatomic, copy, nullable, readwrite) NSString *customerId;
 @property (nonatomic, copy, nullable, readwrite) NSDictionary<NSString*, NSString *> *metadata;
 @property (nonatomic, copy, nonnull, readwrite) NSDictionary *allResponseFields;
@@ -50,6 +52,7 @@
                        [NSString stringWithFormat:@"stripeId = %@", self.stripeId],
                        
                        // STPPaymentMethod details (alphabetical)
+                       [NSString stringWithFormat:@"auBECSDebit = %@", self.auBECSDebit],
                        [NSString stringWithFormat:@"bacsDebit = %@", self.bacsDebit],
                        [NSString stringWithFormat:@"billingDetails = %@", self.billingDetails],
                        [NSString stringWithFormat:@"card = %@", self.card],
@@ -76,6 +79,7 @@
              @"card_present": @(STPPaymentMethodTypeCardPresent),
              @"sepa_debit": @(STPPaymentMethodTypeSEPADebit),
              @"bacs_debit": @(STPPaymentMethodTypeBacsDebit),
+             @"au_becs_debit": @(STPPaymentMethodTypeAUBECSDebit),
              };
 }
 
@@ -129,6 +133,7 @@
     paymentMethod.cardPresent = [STPPaymentMethodCardPresent decodedObjectFromAPIResponse:[dict stp_dictionaryForKey:@"card_present"]];
     paymentMethod.sepaDebit = [STPPaymentMethodSEPADebit decodedObjectFromAPIResponse:[dict stp_dictionaryForKey:@"sepa_debit"]];
     paymentMethod.bacsDebit = [STPPaymentMethodBacsDebit decodedObjectFromAPIResponse:[dict stp_dictionaryForKey:@"bacs_debit"]];
+    paymentMethod.auBECSDebit = [STPPaymentMethodAUBECSDebit decodedObjectFromAPIResponse:[dict stp_dictionaryForKey:@"au_becs_debit"]];
     paymentMethod.customerId = [dict stp_stringForKey:@"customer"];
     paymentMethod.metadata = [[dict stp_dictionaryForKey:@"metadata"] stp_dictionaryByRemovingNonStrings];
     return paymentMethod;
@@ -171,15 +176,32 @@
             }
         case STPPaymentMethodTypeSEPADebit:
             return STPLocalizedString(@"SEPA Debit", @"Payment method brand name");
+        case STPPaymentMethodTypeAUBECSDebit:
+            return STPLocalizedString(@"AU BECS Debit", @"Payment Method type brand name.");
         case STPPaymentMethodTypeBacsDebit:
         case STPPaymentMethodTypeCardPresent:
+            // fall through
         case STPPaymentMethodTypeUnknown:
             return STPLocalizedString(@"Unknown", @"Default missing source type label");
     }
 }
 
 - (BOOL)isReusable {
-    return (self.type == STPPaymentMethodTypeCard);
+
+    switch (self.type) {
+        case STPPaymentMethodTypeCard:
+            return YES;
+
+        case STPPaymentMethodTypeAUBECSDebit:
+        case STPPaymentMethodTypeBacsDebit:
+        case STPPaymentMethodTypeSEPADebit:
+        case STPPaymentMethodTypeiDEAL:
+        case STPPaymentMethodTypeFPX:
+        case STPPaymentMethodTypeCardPresent:
+            // fall through
+        case STPPaymentMethodTypeUnknown:
+            return NO;
+    }
 }
 
 @end

--- a/Stripe/STPPaymentMethodAUBECSDebit.m
+++ b/Stripe/STPPaymentMethodAUBECSDebit.m
@@ -1,0 +1,65 @@
+//
+//  STPPaymentMethodAUBECSDebit.m
+//  StripeiOS
+//
+//  Created by Cameron Sabol on 3/3/20.
+//  Copyright © 2020 Stripe, Inc. All rights reserved.
+//
+
+#import "STPPaymentMethodAUBECSDebit.h"
+
+#import "NSDictionary+Stripe.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation STPPaymentMethodAUBECSDebit
+
+@synthesize allResponseFields = _allResponseFields;
+
+#pragma mark - Description
+
+- (NSString *)description {
+    NSArray *props = @[
+                       // Object
+                       [NSString stringWithFormat:@"%@: %p", NSStringFromClass([self class]), self],
+
+                       // AU BECS Debit details
+                       [NSString stringWithFormat:@"bsbNumber = %@", self.bsbNumber],
+                       [NSString stringWithFormat:@"fingerprint = %@", self.fingerprint],
+                       [NSString stringWithFormat:@"last4 = %@", self.last4],
+                       ];
+
+    return [NSString stringWithFormat:@"<%@>", [props componentsJoinedByString:@"; "]];
+}
+
+#pragma mark - STPAPIResponseDecodable
+
++ (nullable instancetype)decodedObjectFromAPIResponse:(nullable NSDictionary *)response {
+    NSDictionary *dict = [response stp_dictionaryByRemovingNulls];
+    if (!dict) {
+        return nil;
+    }
+    return [[self alloc] initWithDictionary:dict];
+}
+
+- (nullable instancetype)initWithDictionary:(NSDictionary *)dict {
+    self = [super init];
+    if (self) {
+        _bsbNumber = [[dict stp_stringForKey:@"bsb_number"] copy];
+        _fingerprint = [[dict stp_stringForKey:@"fingerprint"] copy];
+        _last4 = [[dict stp_stringForKey:@"last4"] copy];
+
+        if (_bsbNumber == nil ||
+            _fingerprint == nil ||
+            _last4 == nil) {
+            return nil;
+        }
+
+        _allResponseFields = dict.copy;
+    }
+    return self;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Stripe/STPPaymentMethodAUBECSDebitParams.m
+++ b/Stripe/STPPaymentMethodAUBECSDebitParams.m
@@ -1,0 +1,32 @@
+//
+//  STPPaymentMethodAUBECSDebitParams.m
+//  StripeiOS
+//
+//  Created by Cameron Sabol on 3/3/20.
+//  Copyright © 2020 Stripe, Inc. All rights reserved.
+//
+
+#import "STPPaymentMethodAUBECSDebitParams.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation STPPaymentMethodAUBECSDebitParams
+
+@synthesize additionalAPIParameters = _additionalAPIParameters;
+
+#pragma mark - STPFormEncodable
+
++ (nullable NSString *)rootObjectName {
+    return @"au_becs_debit";
+}
+
++ (NSDictionary *)propertyNamesToFormFieldNamesMapping {
+    return @{
+             NSStringFromSelector(@selector(accountNumber)): @"account_number",
+             NSStringFromSelector(@selector(bsbNumber)): @"bsb_number",
+             };
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Stripe/STPPaymentMethodParams.m
+++ b/Stripe/STPPaymentMethodParams.m
@@ -70,7 +70,18 @@ billingDetails:(STPPaymentMethodBillingDetails *)billingDetails
     params.bacsDebit = bacsDebit;
     params.billingDetails = billingDetails;
     params.metadata = metadata;
-        return params;
+    return params;
+}
+
++ (nullable STPPaymentMethodParams *)paramsWithAUBECSDebit:(STPPaymentMethodAUBECSDebitParams *)auBECSDebit
+                                            billingDetails:(STPPaymentMethodBillingDetails *)billingDetails
+                                                  metadata:(nullable NSDictionary<NSString *, NSString *> *)metadata {
+    STPPaymentMethodParams *params = [self new];
+    params.type = STPPaymentMethodTypeAUBECSDebit;
+    params.auBECSDebit = auBECSDebit;
+    params.billingDetails = billingDetails;
+    params.metadata = metadata;
+    return params;
 }
 
 + (nullable STPPaymentMethodParams *)paramsWithSingleUsePaymentMethod:(STPPaymentMethod *)paymentMethod {
@@ -100,6 +111,8 @@ billingDetails:(STPPaymentMethodBillingDetails *)billingDetails
         case STPPaymentMethodTypeBacsDebit:
         case STPPaymentMethodTypeCard:
         case STPPaymentMethodTypeCardPresent:
+        case STPPaymentMethodTypeAUBECSDebit:
+            // fall through
         case STPPaymentMethodTypeUnknown:
             return nil;
     }
@@ -131,6 +144,7 @@ billingDetails:(STPPaymentMethodBillingDetails *)billingDetails
              NSStringFromSelector(@selector(fpx)): @"fpx",
              NSStringFromSelector(@selector(sepaDebit)): @"sepa_debit",
              NSStringFromSelector(@selector(bacsDebit)): @"bacs_debit",
+             NSStringFromSelector(@selector(auBECSDebit)): @"au_becs_debit",
              NSStringFromSelector(@selector(metadata)): @"metadata",
              };
 }
@@ -178,14 +192,31 @@ billingDetails:(STPPaymentMethodBillingDetails *)billingDetails
             return @"SEPA Debit";
         case STPPaymentMethodTypeBacsDebit:
             return @"Bacs Debit";
+        case STPPaymentMethodTypeAUBECSDebit:
+            return @"AU BECS Debit";
         case STPPaymentMethodTypeCardPresent:
         case STPPaymentMethodTypeUnknown:
             return STPLocalizedString(@"Unknown", @"Default missing source type label");
+
     }
 }
 
 - (BOOL)isReusable {
-    return (self.type == STPPaymentMethodTypeCard);
+
+    switch (self.type) {
+        case STPPaymentMethodTypeCard:
+            return YES;
+
+        case STPPaymentMethodTypeAUBECSDebit:
+        case STPPaymentMethodTypeBacsDebit:
+        case STPPaymentMethodTypeSEPADebit:
+        case STPPaymentMethodTypeiDEAL:
+        case STPPaymentMethodTypeFPX:
+        case STPPaymentMethodTypeCardPresent:
+            // fall through
+        case STPPaymentMethodTypeUnknown:
+            return NO;
+    }
 }
 
 @end

--- a/Tests/Tests/STPPaymentMethodAUBECSDebitParamsTests.m
+++ b/Tests/Tests/STPPaymentMethodAUBECSDebitParamsTests.m
@@ -1,0 +1,67 @@
+//
+//  STPPaymentMethodAUBECSDebitParamsTests.m
+//  StripeiOS Tests
+//
+//  Created by Cameron Sabol on 3/4/20.
+//  Copyright © 2020 Stripe, Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "STPAPIClient.h"
+#import "STPPaymentMethod.h"
+#import "STPPaymentMethodAUBECSDebit.h"
+#import "STPPaymentMethodAUBECSDebitParams.h"
+#import "STPPaymentMethodBillingDetails.h"
+#import "STPPaymentMethodParams.h"
+#import "STPTestingAPIClient.h"
+
+@interface STPPaymentMethodAUBECSDebitParamsTests : XCTestCase
+
+@end
+
+@implementation STPPaymentMethodAUBECSDebitParamsTests
+
+// test disabled currently because our test account doesn't support AU BECS at the moment
+- (void)_disabled_testCreateAUBECSPaymentMethod {
+    STPAPIClient *client = [[STPAPIClient alloc] initWithPublishableKey:@""];
+    STPPaymentMethodAUBECSDebitParams *becsParams = [STPPaymentMethodAUBECSDebitParams new];
+    becsParams.bsbNumber = @"000000"; // Stripe test bank
+    becsParams.accountNumber = @"000123456"; // test account
+
+    STPPaymentMethodBillingDetails *billingDetails = [STPPaymentMethodBillingDetails new];
+    billingDetails.name = @"Jenny Rosen";
+    billingDetails.email = @"jrosen@example.com";
+
+    STPPaymentMethodParams *params = [STPPaymentMethodParams paramsWithAUBECSDebit:becsParams
+                                                                    billingDetails:billingDetails
+                                                                          metadata:@{@"test_key": @"test_value"}];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Payment Method AU BECS Debit create"];
+
+    [client createPaymentMethodWithParams:params
+                               completion:^(STPPaymentMethod * _Nullable paymentMethod, NSError * _Nullable error) {
+        [expectation fulfill];
+
+        XCTAssertNil(error, @"Unexpected error creating AU BECS Debit PaymentMethod: %@", error);
+        XCTAssertNotNil(paymentMethod, @"Failed to create AU BECS Debit PaymentMethod");
+        XCTAssertNotNil(paymentMethod.stripeId, @"Missing stripeId");
+        XCTAssertNotNil(paymentMethod.created, @"Missing created");
+        XCTAssertFalse(paymentMethod.liveMode, @"Incorrect livemode");
+        XCTAssertEqual(paymentMethod.type, STPPaymentMethodTypeAUBECSDebit, @"Incorrect PaymentMethod type");
+        XCTAssertEqualObjects(paymentMethod.metadata, @{@"test_key": @"test_value"}, @"Incorrect metadata");
+
+        // Billing Details
+        XCTAssertEqualObjects(paymentMethod.billingDetails.email, @"jrosen@example.com", @"Incorrect email");
+        XCTAssertEqualObjects(paymentMethod.billingDetails.name, @"Jenny Rosen", @"Incorrect name");
+
+        // AU BECS Debit
+        XCTAssertEqualObjects(paymentMethod.auBECSDebit.bsbNumber, @"000000", @"Incorrect BSB Number");
+        XCTAssertEqualObjects(paymentMethod.auBECSDebit.last4, @"3456", @"Incorrect last4");
+        XCTAssertNotNil(paymentMethod.auBECSDebit.fingerprint, @"Missing fingerprint");
+    }];
+
+    [self waitForExpectationsWithTimeout:STPTestingNetworkRequestTimeout handler:nil];
+}
+
+@end

--- a/Tests/Tests/STPPaymentMethodAUBECSDebitTests.m
+++ b/Tests/Tests/STPPaymentMethodAUBECSDebitTests.m
@@ -1,0 +1,70 @@
+//
+//  STPPaymentMethodAUBECSDebitTests.m
+//  StripeiOS Tests
+//
+//  Created by Cameron Sabol on 3/4/20.
+//  Copyright © 2020 Stripe, Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "STPAPIClient+Private.h"
+#import "STPPaymentIntent+Private.h"
+#import "STPPaymentMethod.h"
+#import "STPPaymentMethodAUBECSDebit.h"
+#import "STPTestingAPIClient.h"
+
+static NSString * kAUBECSDebitPaymentIntentClientSecret = @"";
+
+
+@interface STPPaymentMethodAUBECSDebitTests : XCTestCase
+
+@property (nonatomic, readonly) NSDictionary *auBECSDebitJSON;
+
+@end
+
+@implementation STPPaymentMethodAUBECSDebitTests
+
+- (void)_retrieveAUBECSDebitJSON:(void (^)(NSDictionary *))completion {
+    if (self.auBECSDebitJSON) {
+        completion(self.auBECSDebitJSON);
+    } else {
+        STPAPIClient *client = [[STPAPIClient alloc] initWithPublishableKey:@""];
+        [client retrievePaymentIntentWithClientSecret:kAUBECSDebitPaymentIntentClientSecret
+                                               expand:@[@"payment_method"] completion:^(STPPaymentIntent * _Nullable paymentIntent, __unused NSError * _Nullable error) {
+            self->_auBECSDebitJSON = paymentIntent.paymentMethod.auBECSDebit.allResponseFields;
+            completion(self.auBECSDebitJSON);
+        }];
+    }
+}
+
+// test disabled currently because our test account doesn't support AU BECS at the moment
+- (void)_disabled_testCorrectParsing {
+    [self _retrieveAUBECSDebitJSON:^(NSDictionary *json) {
+         STPPaymentMethodAUBECSDebit *auBECSDebit = [STPPaymentMethodAUBECSDebit decodedObjectFromAPIResponse:json];
+           XCTAssertNotNil(auBECSDebit, @"Failed to decode JSON");
+    }];
+}
+
+// test disabled currently because our test account doesn't support AU BECS at the moment
+- (void)_disabled_testFailWithoutRequired {
+    [self _retrieveAUBECSDebitJSON:^(NSDictionary *json) {
+        NSMutableDictionary *auBECSDebitJSON = [json mutableCopy];
+        [auBECSDebitJSON setValue:nil forKey:@"bsb_number"];
+        XCTAssertNil([STPPaymentMethodAUBECSDebit decodedObjectFromAPIResponse:auBECSDebitJSON], @"Should not intialize with missing `bsb_number`");
+    }];
+
+    [self _retrieveAUBECSDebitJSON:^(NSDictionary *json) {
+        NSMutableDictionary *auBECSDebitJSON = [json mutableCopy];
+        [auBECSDebitJSON setValue:nil forKey:@"last4"];
+        XCTAssertNil([STPPaymentMethodAUBECSDebit decodedObjectFromAPIResponse:auBECSDebitJSON], @"Should not intialize with missing `last4`");
+    }];
+
+    [self _retrieveAUBECSDebitJSON:^(NSDictionary *json) {
+        NSMutableDictionary *auBECSDebitJSON = [json mutableCopy];
+        [auBECSDebitJSON setValue:nil forKey:@"fingerprint"];
+        XCTAssertNil([STPPaymentMethodAUBECSDebit decodedObjectFromAPIResponse:auBECSDebitJSON], @"Should not intialize with missing `fingerprint`");
+    }];
+}
+
+@end

--- a/Tests/Tests/STPPaymentMethodFunctionalTest.m
+++ b/Tests/Tests/STPPaymentMethodFunctionalTest.m
@@ -21,7 +21,7 @@
     [super setUp];
 }
 
-- (void)testCreatePaymentMethod {
+- (void)testCreateCardPaymentMethod {
     STPAPIClient *client = [[STPAPIClient alloc] initWithPublishableKey:STPTestingPublishableKey];
     STPPaymentMethodCardParams *card = [STPPaymentMethodCardParams new];
     card.number = @"4242424242424242";
@@ -47,7 +47,7 @@
     STPPaymentMethodParams *params = [STPPaymentMethodParams paramsWithCard:card
                                                                  billingDetails:billingDetails
                                                                        metadata:@{@"test_key": @"test_value"}];
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Payment Method create"];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Payment Method Card create"];
     [client createPaymentMethodWithParams:params
                                completion:^(STPPaymentMethod *paymentMethod, NSError *error) {
                                    XCTAssertNil(error);

--- a/Tests/Tests/STPPaymentMethodTest.m
+++ b/Tests/Tests/STPPaymentMethodTest.m
@@ -21,6 +21,9 @@
 #pragma mark - STPPaymentMethodType Tests
 
 - (void)testTypeFromString {
+    XCTAssertEqual([STPPaymentMethod typeFromString:@"au_becs_debit"], STPPaymentMethodTypeAUBECSDebit);
+    XCTAssertEqual([STPPaymentMethod typeFromString:@"AU_BECS_DEBIT"], STPPaymentMethodTypeAUBECSDebit);
+    XCTAssertEqual([STPPaymentMethod typeFromString:@"BACS_DEBIT"], STPPaymentMethodTypeBacsDebit);
     XCTAssertEqual([STPPaymentMethod typeFromString:@"bacs_debit"], STPPaymentMethodTypeBacsDebit);
     XCTAssertEqual([STPPaymentMethod typeFromString:@"BACS_DEBIT"], STPPaymentMethodTypeBacsDebit);
     XCTAssertEqual([STPPaymentMethod typeFromString:@"card"], STPPaymentMethodTypeCard);
@@ -37,8 +40,8 @@
 }
 
 - (void)testTypesFromStrings {
-    NSArray *rawTypes = @[@"card", @"ideal", @"card_present", @"fpx", @"sepa_debit", @"bacs_debit"];
-    NSArray *expectedTypes = @[@(STPPaymentMethodTypeCard), @(STPPaymentMethodTypeiDEAL), @(STPPaymentMethodTypeCardPresent), @(STPPaymentMethodTypeFPX), @(STPPaymentMethodTypeSEPADebit), @(STPPaymentMethodTypeBacsDebit)];
+    NSArray *rawTypes = @[@"card", @"ideal", @"card_present", @"fpx", @"sepa_debit", @"bacs_debit", @"au_becs_debit"];
+    NSArray *expectedTypes = @[@(STPPaymentMethodTypeCard), @(STPPaymentMethodTypeiDEAL), @(STPPaymentMethodTypeCardPresent), @(STPPaymentMethodTypeFPX), @(STPPaymentMethodTypeSEPADebit), @(STPPaymentMethodTypeBacsDebit), @(STPPaymentMethodTypeAUBECSDebit)];
     XCTAssertEqualObjects([STPPaymentMethod typesFromStrings:rawTypes], expectedTypes);
 }
 
@@ -78,6 +81,7 @@
                 break;
             case STPPaymentMethodTypeAUBECSDebit:
                 XCTAssertEqualObjects(string, @"au_becs_debit");
+                break;
             case STPPaymentMethodTypeUnknown:
                 XCTAssertNil(string);
                 break;

--- a/Tests/Tests/STPPaymentMethodTest.m
+++ b/Tests/Tests/STPPaymentMethodTest.m
@@ -50,6 +50,7 @@
                                     @(STPPaymentMethodTypeFPX),
                                     @(STPPaymentMethodTypeSEPADebit),
                                     @(STPPaymentMethodTypeBacsDebit),
+                                    @(STPPaymentMethodTypeAUBECSDebit),
                                     @(STPPaymentMethodTypeUnknown),
                                     ];
     for (NSNumber *typeNumber in values) {
@@ -75,6 +76,8 @@
             case STPPaymentMethodTypeBacsDebit:
                 XCTAssertEqualObjects(string, @"bacs_debit");
                 break;
+            case STPPaymentMethodTypeAUBECSDebit:
+                XCTAssertEqualObjects(string, @"au_becs_debit");
             case STPPaymentMethodTypeUnknown:
                 XCTAssertNil(string);
                 break;


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Adds API support for new PaymentMethod type AU BECS Debit.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
It's a new payment method!

## Testing
<!-- How was the code tested? Be as specific as possible. -->
Added functional tests for creating and reading an AU BECS Debit PaymentMethod. (Currently disabled in CI until we can gate our test account in.)
