### PR TITLE
% Fixed Xcode 11.4 compiler error that won’t cast a ResponseType to an STPSource

### DIFF
--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -522,7 +522,9 @@ static NSString *_defaultPublishableKey;
                                                endpoint:endpoint
                                              parameters:parameters
                                            deserializer:[STPSource new]
-                                             completion:completion];
+                                             completion:^(STPSource *source, NSHTTPURLResponse *response, NSError *error) {
+                                                 completion(source, response, error);
+                                             }];
 }
 
 - (void)startPollingSourceWithId:(NSString *)identifier clientSecret:(NSString *)secret timeout:(NSTimeInterval)timeout completion:(STPSourceCompletionBlock)completion {


### PR DESCRIPTION
…n STPSource

## Summary
Xcode 11.4 is giving a compiler warning when casting the completion with an STPSource type to the generic STPAPIResponseBlock. This change fixes the compile error.

## Motivation
With Xcode 11.4m the current release can't be compiled.

## Testing
The code change was visually inspected to verify that the completion handler is called with the correct parameters.
