### PR TITLE
% Addressed Xcode 11.4 compile issue

### DIFF
--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -522,7 +522,9 @@ static NSString *_defaultPublishableKey;
                                                endpoint:endpoint
                                              parameters:parameters
                                            deserializer:[STPSource new]
-                                             completion:completion];
+                                             completion:^(STPSource *source, NSHTTPURLResponse *response, NSError *error) {
+                                                 completion(source, response, error);
+                                             }];
 }
 
 - (void)startPollingSourceWithId:(NSString *)identifier clientSecret:(NSString *)secret timeout:(NSTimeInterval)timeout completion:(STPSourceCompletionBlock)completion {


### PR DESCRIPTION
## Summary
Changed how completion handler is called in order to allow Xcode 11.4 to compile the framework.

## Motivation
When compiling with Xcode 11.4, the compiler throws an error when trying to cast the completion handle to an STPAPIResponseBlock. This change explicitly calls the completion handler with the STPSource parameter.

## Testing
This was visually inspected to verify that the completion handler was called with the correct parameters.