### PR TITLE
Fixes completion block type definition

### DIFF
--- a/Stripe/STPAPIClient+Private.h
+++ b/Stripe/STPAPIClient+Private.h
@@ -41,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSURLSessionDataTask *)retrieveSourceWithId:(NSString *)identifier
                                   clientSecret:(NSString *)secret
-                            responseCompletion:(STPAPIResponseBlock)completion;
+                            responseCompletion:(void (^)(STPSource * _Nullable, NSHTTPURLResponse * _Nullable, NSError * _Nullable))completion;
 
 @end
 

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -515,7 +515,9 @@ static NSString *_defaultPublishableKey;
     }];
 }
 
-- (NSURLSessionDataTask *)retrieveSourceWithId:(NSString *)identifier clientSecret:(NSString *)secret responseCompletion:(STPAPIResponseBlock)completion {
+- (NSURLSessionDataTask *)retrieveSourceWithId:(NSString *)identifier
+                                  clientSecret:(NSString *)secret
+                            responseCompletion:(void (^)(STPSource * _Nullable, NSHTTPURLResponse * _Nullable, NSError * _Nullable))completion {
     NSString *endpoint = [NSString stringWithFormat:@"%@/%@", APIEndpointSources, identifier];
     NSDictionary *parameters = @{@"client_secret": secret};
     return [STPAPIRequest<STPSource *> getWithAPIClient:self


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
We were using a typedef-ed block param that depended on a class generic outside of that class. Updating to 11.4 caught the error.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fixes build on Xcode 11.4

## Testing
<!-- How was the code tested? Be as specific as possible. -->
Made sure build and analyzer passed with change