### PR TITLE
Fix issue with XCode 11.4 for v17.0.2 (iOS 9)

### DIFF
--- a/Stripe/PublicHeaders/STPAPIClient.h
+++ b/Stripe/PublicHeaders/STPAPIClient.h
@@ -325,7 +325,7 @@ static NSString *const STPSDKVersion = @"17.0.2";
  @param secret      The client secret of the source. Cannot be nil.
  @param completion  The callback to run with the returned Source object, or an error.
  */
-- (void)retrieveSourceWithId:(NSString *)identifier clientSecret:(NSString *)secret completion:(STPSourceCompletionBlock)completion;
+- (void)retrieveSourceWithId:(NSString *)identifier clientSecret:(NSString *)secret completion:(void (^)(STPSource * _Nullable, NSHTTPURLResponse * _Nullable, NSError * _Nullable))completion;
 
 /**
  Starts polling the Source object with the given ID. For payment methods that require

--- a/Stripe/STPAPIClient+Private.h
+++ b/Stripe/STPAPIClient+Private.h
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSURLSessionDataTask *)retrieveSourceWithId:(NSString *)identifier
                                   clientSecret:(NSString *)secret
-                            responseCompletion:(STPAPIResponseBlock)completion;
+                            responseCompletion:(void (^)(STPSource * _Nullable, NSHTTPURLResponse * _Nullable, NSError * _Nullable))completion;
 
 @end
 

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -498,7 +498,7 @@ static NSArray<PKPaymentNetwork> *_additionalEnabledApplePayNetworks;
                                                endpoint:endpoint
                                              parameters:parameters
                                            deserializer:[STPSource new]
-                                             completion:completion];
+                                             completion:(void (^)(STPSource * _Nullable, NSHTTPURLResponse * _Nullable, NSError * _Nullable))completion];
 }
 
 - (void)startPollingSourceWithId:(NSString *)identifier clientSecret:(NSString *)secret timeout:(NSTimeInterval)timeout completion:(STPSourceCompletionBlock)completion {


### PR DESCRIPTION
## Summary
Just the same as #1526 forked from version 17.0.2.

## Motivation
Fixes build on Xcode 11.4 for version 17.0.2 (iOS 9).

## Testing
Made sure build and analyzer passed with change.
