### PR TITLE
Rework, add ApplePayContext to analytics

### DIFF
--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -101,7 +101,6 @@ static NSString *_defaultPublishableKey;
 }
 
 + (void)initialize {
-    [STPAnalyticsClient initializeIfNeeded];
     [STPTelemetryClient sharedInstance];
 #ifdef STP_STATIC_LIBRARY_BUILD
     [STPCategoryLoader loadCategories];

--- a/Stripe/STPAddCardViewController.m
+++ b/Stripe/STPAddCardViewController.m
@@ -74,9 +74,8 @@ typedef NS_ENUM(NSUInteger, STPPaymentCardSection) {
 
 @implementation STPAddCardViewController
 
-+ (instancetype)alloc {
-    [[STPAnalyticsClient sharedClient] addClassToAPIUsageIfNecessary:[self class]];
-    return [super alloc];
++ (void)initialize{
+    [[STPAnalyticsClient sharedClient] addClassToProductUsageIfNecessary:[self class]];
 }
 
 - (instancetype)init {

--- a/Stripe/STPAddCardViewController.m
+++ b/Stripe/STPAddCardViewController.m
@@ -74,6 +74,11 @@ typedef NS_ENUM(NSUInteger, STPPaymentCardSection) {
 
 @implementation STPAddCardViewController
 
++ (instancetype)alloc {
+    [[STPAnalyticsClient sharedClient] addClassToAPIUsageIfNecessary:[self class]];
+    return [super alloc];
+}
+
 - (instancetype)init {
     return [self initWithConfiguration:[STPPaymentConfiguration sharedConfiguration] theme:[STPTheme defaultTheme]];
 }

--- a/Stripe/STPAnalyticsClient.h
+++ b/Stripe/STPAnalyticsClient.h
@@ -17,7 +17,7 @@
 
 + (NSString *)tokenTypeFromParameters:(NSDictionary *)parameters;
 
-- (void)addClassToAPIUsageIfNecessary:(Class)klass;
+- (void)addClassToProductUsageIfNecessary:(Class)klass;
 
 - (void)addAdditionalInfo:(NSString *)info;
 

--- a/Stripe/STPAnalyticsClient.h
+++ b/Stripe/STPAnalyticsClient.h
@@ -15,9 +15,9 @@
 
 + (instancetype)sharedClient;
 
-+ (void)initializeIfNeeded;
-
 + (NSString *)tokenTypeFromParameters:(NSDictionary *)parameters;
+
+- (void)addClassToAPIUsageIfNecessary:(Class)klass;
 
 - (void)addAdditionalInfo:(NSString *)info;
 

--- a/Stripe/STPAnalyticsClient.m
+++ b/Stripe/STPAnalyticsClient.m
@@ -83,7 +83,9 @@
 }
 
 - (void)addClassToProductUsageIfNecessary:(Class)klass {
-    [self.productUsage addObject:NSStringFromClass(klass)];
+    @synchronized (self) {
+        [self.productUsage addObject:NSStringFromClass(klass)];
+    }
 }
 
 - (void)addAdditionalInfo:(NSString *)info {
@@ -103,6 +105,10 @@
 - (NSDictionary *)productUsageDictionary {
     NSSortDescriptor *sortDescriptor = [NSSortDescriptor sortDescriptorWithKey:NSStringFromSelector(@selector(description)) ascending:YES];
     NSMutableDictionary *usage = [NSMutableDictionary new];
+    NSArray *productUsage;
+    @synchronized (self) {
+        productUsage = [self.productUsage sortedArrayUsingDescriptors:@[sortDescriptor]] ?: @[];
+    }
 
     NSString *uiUsageLevel = nil;
     if ([self.productUsage containsObject:NSStringFromClass([STPPaymentContext class])]) {
@@ -116,7 +122,7 @@
         uiUsageLevel = @"none";
     }
     usage[@"ui_usage_level"] = uiUsageLevel;
-    usage[@"product_usage"] = [self.productUsage sortedArrayUsingDescriptors:@[sortDescriptor]] ?: @[];
+    usage[@"product_usage"] = productUsage;
 
     return [usage copy];
 }

--- a/Stripe/STPAnalyticsClient.m
+++ b/Stripe/STPAnalyticsClient.m
@@ -30,7 +30,7 @@
 
 @interface STPAnalyticsClient()
 
-@property (nonatomic) NSMutableSet *apiUsage;
+@property (nonatomic) NSMutableSet *productUsage;
 @property (nonatomic) NSSet *additionalInfoSet;
 @property (nonatomic, readwrite) NSURLSession *urlSession;
 
@@ -82,7 +82,7 @@
     return self;
 }
 
-- (void)addClassToAPIUsageIfNecessary:(Class)klass {
+- (void)addClassToProductUsageIfNecessary:(Class)klass {
     [self.productUsage addObject:NSStringFromClass(klass)];
 }
 
@@ -100,14 +100,9 @@
     return additionalInfo ?: @[];
 }
 
-- (NSArray *)productUsage {
-    NSSortDescriptor *sortDescriptor = [NSSortDescriptor sortDescriptorWithKey:NSStringFromSelector(@selector(description)) ascending:YES];
-    NSArray *productUsage = [self.productUsage sortedArrayUsingDescriptors:@[sortDescriptor]];
-    return productUsage ?: @[];
-}
-
 - (NSDictionary *)productUsageDictionary {
-    NSMutableDictionary *productUsage = [NSMutableDictionary new];
+    NSSortDescriptor *sortDescriptor = [NSSortDescriptor sortDescriptorWithKey:NSStringFromSelector(@selector(description)) ascending:YES];
+    NSMutableDictionary *usage = [NSMutableDictionary new];
 
     NSString *uiUsageLevel = nil;
     if ([self.productUsage containsObject:NSStringFromClass([STPPaymentContext class])]) {
@@ -120,10 +115,10 @@
     } else {
         uiUsageLevel = @"none";
     }
-    productUsage[@"ui_usage_level"] = uiUsageLevel;
-    productUsage[@"product_usage"] = [self productUsage];
+    usage[@"ui_usage_level"] = uiUsageLevel;
+    usage[@"product_usage"] = [self.productUsage sortedArrayUsingDescriptors:@[sortDescriptor]] ?: @[];
 
-    return productUsage.copy;
+    return [usage copy];
 }
 
 - (void)logTokenCreationAttemptWithConfiguration:(STPPaymentConfiguration *)configuration

--- a/Stripe/STPApplePayContext.m
+++ b/Stripe/STPApplePayContext.m
@@ -45,9 +45,8 @@ typedef NS_ENUM(NSUInteger, STPPaymentState) {
 
 @implementation STPApplePayContext
 
-+ (instancetype)alloc {
-    [[STPAnalyticsClient sharedClient] addClassToAPIUsageIfNecessary:[self class]];
-    return [super alloc];
++ (void)initialize {
+    [[STPAnalyticsClient sharedClient] addClassToProductUsageIfNecessary:[self class]];
 }
 
 - (nullable instancetype)initWithPaymentRequest:(PKPaymentRequest *)paymentRequest delegate:(id<STPApplePayContextDelegate>)delegate {

--- a/Stripe/STPApplePayContext.m
+++ b/Stripe/STPApplePayContext.m
@@ -10,6 +10,7 @@
 
 #import <objc/runtime.h>
 
+#import "STPAnalyticsClient.h"
 #import "STPAPIClient+ApplePay.h"
 #import "STPPaymentMethod.h"
 #import "STPPaymentIntentParams.h"
@@ -43,6 +44,11 @@ typedef NS_ENUM(NSUInteger, STPPaymentState) {
 @end
 
 @implementation STPApplePayContext
+
++ (instancetype)alloc {
+    [[STPAnalyticsClient sharedClient] addClassToAPIUsageIfNecessary:[self class]];
+    return [super alloc];
+}
 
 - (nullable instancetype)initWithPaymentRequest:(PKPaymentRequest *)paymentRequest delegate:(id<STPApplePayContextDelegate>)delegate {
     if (![Stripe canSubmitPaymentRequest:paymentRequest]) {

--- a/Stripe/STPBankSelectionViewController.m
+++ b/Stripe/STPBankSelectionViewController.m
@@ -9,6 +9,7 @@
 #import "STPBankSelectionViewController.h"
 
 #import "NSArray+Stripe.h"
+#import "STPAnalyticsClient.h"
 #import "STPAPIClient+Private.h"
 #import "STPFPXBankStatusResponse.h"
 #import "STPColorUtils.h"
@@ -38,6 +39,11 @@ static NSString *const STPBankSelectionCellReuseIdentifier = @"STPBankSelectionC
 @end
 
 @implementation STPBankSelectionViewController
+
++ (instancetype)alloc {
+    [[STPAnalyticsClient sharedClient] addClassToAPIUsageIfNecessary:[self class]];
+    return [super alloc];
+}
 
 - (instancetype)initWithBankMethod:(STPBankSelectionMethod)bankMethod {
     return [self initWithBankMethod:bankMethod configuration:[STPPaymentConfiguration sharedConfiguration] theme:[STPTheme defaultTheme]];

--- a/Stripe/STPBankSelectionViewController.m
+++ b/Stripe/STPBankSelectionViewController.m
@@ -40,9 +40,8 @@ static NSString *const STPBankSelectionCellReuseIdentifier = @"STPBankSelectionC
 
 @implementation STPBankSelectionViewController
 
-+ (instancetype)alloc {
-    [[STPAnalyticsClient sharedClient] addClassToAPIUsageIfNecessary:[self class]];
-    return [super alloc];
++ (void)initialize{
+    [[STPAnalyticsClient sharedClient] addClassToProductUsageIfNecessary:[self class]];
 }
 
 - (instancetype)initWithBankMethod:(STPBankSelectionMethod)bankMethod {

--- a/Stripe/STPCustomerContext.m
+++ b/Stripe/STPCustomerContext.m
@@ -9,6 +9,7 @@
 #import "STPCustomerContext.h"
 #import "STPCustomerContext+Private.h"
 
+#import "STPAnalyticsClient.h"
 #import "STPAPIClient+Private.h"
 #import "STPCustomer+Private.h"
 #import "STPEphemeralKey.h"
@@ -36,6 +37,11 @@ static NSTimeInterval const CachedCustomerMaxAge = 60;
 
 @implementation STPCustomerContext
 @synthesize paymentMethods=_paymentMethods;
+
++ (instancetype)alloc {
+    [[STPAnalyticsClient sharedClient] addClassToAPIUsageIfNecessary:[self class]];
+    return [super alloc];
+}
 
 - (instancetype)initWithKeyProvider:(nonnull id<STPCustomerEphemeralKeyProvider>)keyProvider {
     return [self initWithKeyProvider:keyProvider apiClient:[STPAPIClient sharedClient]];

--- a/Stripe/STPCustomerContext.m
+++ b/Stripe/STPCustomerContext.m
@@ -38,9 +38,8 @@ static NSTimeInterval const CachedCustomerMaxAge = 60;
 @implementation STPCustomerContext
 @synthesize paymentMethods=_paymentMethods;
 
-+ (instancetype)alloc {
-    [[STPAnalyticsClient sharedClient] addClassToAPIUsageIfNecessary:[self class]];
-    return [super alloc];
++ (void)initialize{
+    [[STPAnalyticsClient sharedClient] addClassToProductUsageIfNecessary:[self class]];
 }
 
 - (instancetype)initWithKeyProvider:(nonnull id<STPCustomerEphemeralKeyProvider>)keyProvider {

--- a/Stripe/STPPaymentCardTextField.m
+++ b/Stripe/STPPaymentCardTextField.m
@@ -105,9 +105,8 @@ CGFloat const STPPaymentCardTextFieldMinimumPadding = 10;
 
 #pragma mark initializers
 
-+ (instancetype)alloc {
-    [[STPAnalyticsClient sharedClient] addClassToAPIUsageIfNecessary:[self class]];
-    return [super alloc];
++ (void)initialize {
+    [[STPAnalyticsClient sharedClient] addClassToProductUsageIfNecessary:[self class]];
 }
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {

--- a/Stripe/STPPaymentCardTextField.m
+++ b/Stripe/STPPaymentCardTextField.m
@@ -19,6 +19,7 @@
 #import "STPPostalCodeValidator.h"
 #import "Stripe.h"
 #import "STPLocalizationUtils.h"
+#import "STPAnalyticsClient.h"
 
 @interface STPPaymentCardTextField()<STPFormTextFieldDelegate>
 
@@ -103,6 +104,11 @@ CGFloat const STPPaymentCardTextFieldDefaultInsets = 13;
 CGFloat const STPPaymentCardTextFieldMinimumPadding = 10;
 
 #pragma mark initializers
+
++ (instancetype)alloc {
+    [[STPAnalyticsClient sharedClient] addClassToAPIUsageIfNecessary:[self class]];
+    return [super alloc];
+}
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
     self = [super initWithCoder:aDecoder];

--- a/Stripe/STPPaymentConfiguration.m
+++ b/Stripe/STPPaymentConfiguration.m
@@ -26,7 +26,6 @@
 @synthesize stripeAccount = _stripeAccount;
 
 + (void)initialize {
-    [STPAnalyticsClient initializeIfNeeded];
     [STPTelemetryClient sharedInstance];
 }
 

--- a/Stripe/STPPaymentContext.m
+++ b/Stripe/STPPaymentContext.m
@@ -68,9 +68,8 @@ typedef NS_ENUM(NSUInteger, STPPaymentContextState) {
 
 @implementation STPPaymentContext
 
-+ (instancetype)alloc {
-    [[STPAnalyticsClient sharedClient] addClassToAPIUsageIfNecessary:[self class]];
-    return [super alloc];
++ (void)initialize{
+    [[STPAnalyticsClient sharedClient] addClassToProductUsageIfNecessary:[self class]];
 }
 
 - (instancetype)initWithCustomerContext:(STPCustomerContext *)customerContext {

--- a/Stripe/STPPaymentContext.m
+++ b/Stripe/STPPaymentContext.m
@@ -10,6 +10,7 @@
 #import <objc/runtime.h>
 
 #import "PKPaymentAuthorizationViewController+Stripe_Blocks.h"
+#import "STPAnalyticsClient.h"
 #import "STPAddCardViewController+Private.h"
 #import "STPCustomerContext+Private.h"
 #import "STPDispatchFunctions.h"
@@ -66,6 +67,11 @@ typedef NS_ENUM(NSUInteger, STPPaymentContextState) {
     @end
 
 @implementation STPPaymentContext
+
++ (instancetype)alloc {
+    [[STPAnalyticsClient sharedClient] addClassToAPIUsageIfNecessary:[self class]];
+    return [super alloc];
+}
 
 - (instancetype)initWithCustomerContext:(STPCustomerContext *)customerContext {
     return [self initWithAPIAdapter:customerContext];

--- a/Stripe/STPPaymentOptionsViewController.m
+++ b/Stripe/STPPaymentOptionsViewController.m
@@ -8,6 +8,7 @@
 
 #import "STPPaymentOptionsViewController.h"
 
+#import "STPAnalyticsClient.h"
 #import "STPAddCardViewController+Private.h"
 #import "STPCard.h"
 #import "STPColorUtils.h"
@@ -41,6 +42,11 @@
     @end
 
 @implementation STPPaymentOptionsViewController
+
++ (instancetype)alloc {
+    [[STPAnalyticsClient sharedClient] addClassToAPIUsageIfNecessary:[self class]];
+    return [super alloc];
+}
     
 - (instancetype)initWithPaymentContext:(STPPaymentContext *)paymentContext {
     return [self initWithConfiguration:paymentContext.configuration

--- a/Stripe/STPPaymentOptionsViewController.m
+++ b/Stripe/STPPaymentOptionsViewController.m
@@ -43,9 +43,8 @@
 
 @implementation STPPaymentOptionsViewController
 
-+ (instancetype)alloc {
-    [[STPAnalyticsClient sharedClient] addClassToAPIUsageIfNecessary:[self class]];
-    return [super alloc];
++ (void)initialize{
+    [[STPAnalyticsClient sharedClient] addClassToProductUsageIfNecessary:[self class]];
 }
     
 - (instancetype)initWithPaymentContext:(STPPaymentContext *)paymentContext {

--- a/Stripe/STPShippingAddressViewController.m
+++ b/Stripe/STPShippingAddressViewController.m
@@ -45,9 +45,8 @@
 
 @implementation STPShippingAddressViewController
 
-+ (instancetype)alloc {
-    [[STPAnalyticsClient sharedClient] addClassToAPIUsageIfNecessary:[self class]];
-    return [super alloc];
++ (void)initialize{
+    [[STPAnalyticsClient sharedClient] addClassToProductUsageIfNecessary:[self class]];
 }
 
 - (instancetype)init {

--- a/Stripe/STPShippingAddressViewController.m
+++ b/Stripe/STPShippingAddressViewController.m
@@ -9,6 +9,7 @@
 #import "STPShippingAddressViewController.h"
 
 #import "NSArray+Stripe.h"
+#import "STPAnalyticsClient.h"
 #import "STPAddress.h"
 #import "STPAddressViewModel.h"
 #import "STPColorUtils.h"
@@ -43,6 +44,11 @@
 @end
 
 @implementation STPShippingAddressViewController
+
++ (instancetype)alloc {
+    [[STPAnalyticsClient sharedClient] addClassToAPIUsageIfNecessary:[self class]];
+    return [super alloc];
+}
 
 - (instancetype)init {
     return [self initWithConfiguration:[STPPaymentConfiguration sharedConfiguration] theme:[STPTheme defaultTheme] currency:nil shippingAddress:nil selectedShippingMethod:nil prefilledInformation:nil];

--- a/Tests/Tests/STPAnalyticsClientTest.m
+++ b/Tests/Tests/STPAnalyticsClientTest.m
@@ -18,6 +18,7 @@
 
 @interface STPAnalyticsClient (Testing)
 + (BOOL)shouldCollectAnalytics;
+@property (nonatomic) NSSet *productUsage;
 @end
 
 @interface STPAnalyticsClientTest : XCTestCase
@@ -46,6 +47,45 @@
     PKPayment *applePay = [STPFixtures applePayPayment];
     NSDictionary *applePayDict = [self addTelemetry:[STPAPIClient parametersForPayment:applePay]];
     XCTAssertEqualObjects([STPAnalyticsClient tokenTypeFromParameters:applePayDict], @"apple_pay");
+}
+
+#pragma mark - Tests various classes report usage
+
+- (void)testCardTextFieldAddsUsage {
+    STPPaymentCardTextField *_ = [[STPPaymentCardTextField alloc] init];
+    XCTAssertTrue([[STPAnalyticsClient sharedClient].productUsage containsObject:NSStringFromClass([_ class])]);
+}
+
+- (void)testPaymentContextAddsUsage{
+    STPPaymentContext *_ = [[STPPaymentContext alloc] initWithCustomerContext:[STPCustomerContext new]];
+    XCTAssertTrue([[STPAnalyticsClient sharedClient].productUsage containsObject:NSStringFromClass([_ class])]);
+}
+
+- (void)testApplePayContextAddsUsage{
+    id delegate;
+    STPApplePayContext *_ = [[STPApplePayContext alloc] initWithPaymentRequest:[STPFixtures applePayRequest] delegate:delegate];
+    XCTAssertTrue([[STPAnalyticsClient sharedClient].productUsage containsObject:NSStringFromClass([_ class])]);
+}
+
+- (void)testCustomerContextAddsUsage {
+    STPCustomerContext *_ = [[STPCustomerContext alloc] init];
+    XCTAssertTrue([[STPAnalyticsClient sharedClient].productUsage containsObject:NSStringFromClass([_ class])]);
+}
+
+
+- (void)testAddCardVCAddsUsage {
+    STPAddCardViewController *_ = [[STPAddCardViewController alloc] init];
+    XCTAssertTrue([[STPAnalyticsClient sharedClient].productUsage containsObject:NSStringFromClass([_ class])]);
+}
+
+- (void)testBankSelectionVCAddsUsage {
+    STPBankSelectionViewController *_ = [[STPBankSelectionViewController alloc] init];
+    XCTAssertTrue([[STPAnalyticsClient sharedClient].productUsage containsObject:NSStringFromClass([_ class])]);
+}
+
+- (void)testShippingVCAddsUsage {
+    STPShippingAddressViewController *_ = [[STPShippingAddressViewController alloc] init];
+    XCTAssertTrue([[STPAnalyticsClient sharedClient].productUsage containsObject:NSStringFromClass([_ class])]);
 }
 
 #pragma mark - Helpers

--- a/Tests/Tests/STPAnalyticsClientTest.m
+++ b/Tests/Tests/STPAnalyticsClientTest.m
@@ -84,7 +84,9 @@
 }
 
 - (void)testShippingVCAddsUsage {
-    STPShippingAddressViewController *_ = [[STPShippingAddressViewController alloc] init];
+    STPPaymentConfiguration *config = [STPFixtures paymentConfiguration];
+    config.requiredShippingAddressFields = [NSSet setWithObject:STPContactFieldPostalAddress];
+    STPShippingAddressViewController *_ = [[STPShippingAddressViewController alloc] initWithConfiguration:config theme:[STPTheme defaultTheme] currency:nil shippingAddress:nil selectedShippingMethod:nil prefilledInformation:nil];
     XCTAssertTrue([[STPAnalyticsClient sharedClient].productUsage containsObject:NSStringFromClass([_ class])]);
 }
 


### PR DESCRIPTION
## Summary
* Rework how STPAnalyticsClient calculates productUsage FKA apiUsage.  
* Also track ApplePayContext usage in analytics

## Motivation
Swizzling the init has a problem where `STPAnalyticsClient initializeIfNeeded` isn't always called before the init.  If we always have to call this method before init in every class we want to track, we might as well not swizzle.

I put the `addClassToAPIUsageIfNecessary` calls in `alloc` because it's easier than identifying the designated initializer and stable (what if we change the designated init in the future?).

## Testing
See tests
