### PR TITLE
Relax need for dob with full name connect account params

### DIFF
--- a/Stripe/STPConnectAccountIndividualParams.m
+++ b/Stripe/STPConnectAccountIndividualParams.m
@@ -44,6 +44,10 @@
 @synthesize additionalAPIParameters;
 
 - (STPDateOfBirth *)_dateOfBirth {
+    if (!self.dateOfBirth) {
+        return nil;
+    }
+
     STPDateOfBirth *dob = [STPDateOfBirth new];
     dob.day = self.dateOfBirth.day;
     dob.month = self.dateOfBirth.month;


### PR DESCRIPTION
## Summary
The required information to enable transfers and payouts for custom connect accounts has been updated. For the first threshold, only the first name and last name are required. Previously date of birth was also required for this first threshold.

https://stripe.com/docs/connect/required-verification-information#individual-transfers-us

The Stripe API and the Stripe Android SDK allow for the relaxed requirements when tokenizing individual account params. iOS has a subtle error which prevents this from working. A STPDateOfBirth object is always constructed when submitting STPConnectAccountIndividualParams. This results in a dob of 00/00/0000 being sent to the Stripe API, which results in a rejected tokenization request.

## Motivation
We are updating our KYC flow to only collect the minimum required information for each threshold. The current iOS SDK does not support the updated flow.

## Testing
This was tested by providing only first and last name fields to STPConnectAccountIndividualParams and attempting to tokenize. With this change the operation succeeds, without it the operation fails.
