### PR TITLE
Move Travis to Xcode 11.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode11.3
+osx_image: xcode11.4
 branches:
   only:
     - master


### PR DESCRIPTION
## Summary
Moves Travis to Xcode 11.4.

## Testing
Yes.
