### PR TITLE
Add HUF to the list of zero-decimal currencies

### DIFF
--- a/Stripe/NSDecimalNumber+Stripe_Currency.m
+++ b/Stripe/NSDecimalNumber+Stripe_Currency.m
@@ -11,7 +11,7 @@
 @implementation NSDecimalNumber (Stripe_Currency)
 
 + (NSArray *)stp_currenciesWithNoDecimal {
-    return @[@"bif", @"clp",@"djf",@"gnf",
+    return @[@"bif", @"clp",@"djf",@"gnf",@"huf",
              @"jpy",@"kmf",@"krw",@"mga",@"pyg",@"rwf",@"vnd",
              @"vuv",@"xaf",@"xof", @"xpf"];
 }


### PR DESCRIPTION
## Summary
Add HUF to the list of zero-decimal currencies.

## Motivation
MOBILE-247

## Testing
CI