### PR TITLE
Improve accessibility of checkout in Basic Integration example

### DIFF
--- a/Example/Basic Integration/CheckoutRowView.swift
+++ b/Example/Basic Integration/CheckoutRowView.swift
@@ -30,12 +30,14 @@ class CheckoutRowView: UIView {
     var title: String = "" {
         didSet {
             self.titleLabel.text = title
+            updateAccessibilityElements()
         }
     }
 
     var detail: String = "" {
         didSet {
             self.detailLabel.text = detail
+            updateAccessibilityElements()
         }
     }
 
@@ -52,16 +54,19 @@ class CheckoutRowView: UIView {
         self.detail = detail
 
         self.backgroundView.addTarget(self, action: #selector(didTap), for: .touchUpInside)
+        self.backgroundView.isAccessibilityElement = false
         self.addSubview(self.backgroundView)
         self.titleLabel.text = title
         self.titleLabel.backgroundColor = UIColor.clear
         self.titleLabel.textAlignment = .left;
         self.titleLabel.font = .systemFont(ofSize: 16, weight: .medium)
+        self.titleLabel.isAccessibilityElement = false
         self.addSubview(self.titleLabel)
         self.detailLabel.text = detail
         self.detailLabel.backgroundColor = UIColor.clear
         self.detailLabel.textAlignment = .right;
         self.detailLabel.font = .systemFont(ofSize: 16, weight: .regular)
+        self.detailLabel.isAccessibilityElement = false
         self.backgroundColor = .white
 
         self.detailLabel.textColor = .gray
@@ -89,6 +94,10 @@ class CheckoutRowView: UIView {
             }
             #endif
         }
+
+        isAccessibilityElement = true
+        accessibilityTraits = tappable ? [.button] : [.staticText]
+        updateAccessibilityElements()
     }
 
     func installConstraints() {
@@ -117,6 +126,13 @@ class CheckoutRowView: UIView {
 
     @objc func didTap() {
         self.onTap()
+    }
+
+    // MARK: Private
+
+    private func updateAccessibilityElements() {
+        accessibilityLabel = title
+        accessibilityValue = detail
     }
 
 }

--- a/Example/Basic Integration/CheckoutRowView.swift
+++ b/Example/Basic Integration/CheckoutRowView.swift
@@ -131,6 +131,7 @@ class CheckoutRowView: UIView {
     // MARK: Private
 
     private func updateAccessibilityElements() {
+        accessibilityIdentifier = title
         accessibilityLabel = title
         accessibilityValue = detail
     }

--- a/Example/BasicIntegrationUITests/BasicIntegrationUITests.swift
+++ b/Example/BasicIntegrationUITests/BasicIntegrationUITests.swift
@@ -53,7 +53,7 @@ class BasicIntegrationUITests: XCTestCase {
         selectItems(app)
         
         app.buttons["Buy Now"].tap()
-        app.tables.otherElements.containing(.staticText, identifier:"Pay from").children(matching: .button).element.tap()
+        app.buttons.matching(identifier: "Pay from").element.tap()
         let visa = app.tables.staticTexts["Visa Ending In 4242"]
         waitToAppear(visa)
         visa.tap()
@@ -71,7 +71,7 @@ class BasicIntegrationUITests: XCTestCase {
         let buyNowButton = app.buttons["Buy Now"]
         buyNowButton.tap()
 
-        app.tables.otherElements.containing(.staticText, identifier:"Pay from").children(matching: .button).element.tap()
+        app.buttons.matching(identifier: "Pay from").element.tap()
         let visa3063 = app.tables.staticTexts["Visa Ending In 3063"]
         waitToAppear(visa3063)
         visa3063.tap()
@@ -103,7 +103,7 @@ class BasicIntegrationUITests: XCTestCase {
 
         let buyNowButton = app.buttons["Buy Now"]
         buyNowButton.tap()
-        app.tables.otherElements.containing(.staticText, identifier:"Pay from").children(matching: .button).element.tap()
+        app.buttons.matching(identifier: "Pay from").element.tap()
         let visa = app.tables.staticTexts["Visa Ending In 3220"]
         waitToAppear(visa)
         visa.tap()
@@ -128,9 +128,8 @@ class BasicIntegrationUITests: XCTestCase {
 
         let buyNowButton = app.buttons["Buy Now"]
         buyNowButton.tap()
-        
+        app.buttons.matching(identifier: "Pay from").element.tap()
         let tablesQuery = app.tables
-        tablesQuery.otherElements.containing(.staticText, identifier:"Pay from").children(matching: .button).element.tap()
         let applePay = tablesQuery.staticTexts["Apple Pay"]
         waitToAppear(applePay)
         applePay.tap()
@@ -144,13 +143,12 @@ class BasicIntegrationUITests: XCTestCase {
         
         let buyNowButton = app.buttons["Buy Now"]
         buyNowButton.tap()
+        app.buttons.matching(identifier: "Pay from").element.tap()
         let tablesQuery = app.tables
-        tablesQuery.otherElements.containing(.staticText, identifier:"Pay from").children(matching: .button).element.tap()
-        
         let addButton = app.tables.staticTexts["Add New Card…"]
         waitToAppear(addButton)
         addButton.tap()
-        
+
         let cardNumberField = tablesQuery.textFields["card number"]
         let cvcField = tablesQuery.textFields["CVC"]
         let expirationDateField = tablesQuery.textFields["expiration date"]
@@ -185,9 +183,10 @@ class BasicIntegrationUITests: XCTestCase {
         selectItems(app)
         let buyNowButton = app.buttons["Buy Now"]
         buyNowButton.tap()
-        let tablesQuery = app.tables
-        let payFromButton = tablesQuery.otherElements.containing(.staticText, identifier:"Pay from").children(matching: .button).element
+        let payFromButton = app.buttons.matching(identifier: "Pay from").element
         payFromButton.tap()
+
+        let tablesQuery = app.tables
 
         // ...preselects Apple Pay by default
         let applePay = tablesQuery.cells["Apple Pay"]
@@ -284,7 +283,7 @@ class FrenchAndBelizeBasicIntegrationUITests: XCTestCase {
         selectItems(app)
         
         app.buttons["Buy Now"].tap()
-        app.tables.otherElements.containing(.staticText, identifier:"Pay from").children(matching: .button).element.tap()
+        app.buttons.matching(identifier: "Pay from").element.tap()
         let visa = app.tables.staticTexts["Visa se terminant par 4242"]
         waitToAppear(visa)
         visa.tap()
@@ -302,7 +301,7 @@ class FrenchAndBelizeBasicIntegrationUITests: XCTestCase {
         let buyNowButton = app.buttons["Buy Now"]
         buyNowButton.tap()
 
-        app.tables.otherElements.containing(.staticText, identifier:"Pay from").children(matching: .button).element.tap()
+        app.buttons.matching(identifier: "Pay from").element.tap()
         let visa3063 = app.tables.staticTexts["Visa se terminant par 3063"]
         waitToAppear(visa3063)
         visa3063.tap()
@@ -334,7 +333,7 @@ class FrenchAndBelizeBasicIntegrationUITests: XCTestCase {
 
         let buyNowButton = app.buttons["Buy Now"]
         buyNowButton.tap()
-        app.tables.otherElements.containing(.staticText, identifier:"Pay from").children(matching: .button).element.tap()
+        app.buttons.matching(identifier: "Pay from").element.tap()
         let visa = app.tables.staticTexts["Visa se terminant par 3220"]
         waitToAppear(visa)
         visa.tap()
@@ -359,8 +358,8 @@ class FrenchAndBelizeBasicIntegrationUITests: XCTestCase {
         let buyNowButton = app.buttons["Buy Now"]
         buyNowButton.tap()
         
+        app.buttons.matching(identifier: "Pay from").element.tap()
         let tablesQuery = app.tables
-        tablesQuery.otherElements.containing(.staticText, identifier:"Pay from").children(matching: .button).element.tap()
         let applePay = tablesQuery.staticTexts["Apple Pay"]
         waitToAppear(applePay)
         applePay.tap()
@@ -374,13 +373,13 @@ class FrenchAndBelizeBasicIntegrationUITests: XCTestCase {
         
         let buyNowButton = app.buttons["Buy Now"]
         buyNowButton.tap()
-        let tablesQuery = app.tables
-        tablesQuery.otherElements.containing(.staticText, identifier:"Pay from").children(matching: .button).element.tap()
-        
+        app.buttons.matching(identifier: "Pay from").element.tap()
+
         let addButton = app.tables.staticTexts["Ajouter une nouvelle carte..."]
         waitToAppear(addButton)
         addButton.tap()
-        
+
+        let tablesQuery = app.tables
         let cardNumberField = tablesQuery.textFields["numéro de carte"]
         let cvcField = tablesQuery.textFields["Code CVC"]
         let expirationDateField = tablesQuery.textFields["date d\'expiration"]
@@ -413,9 +412,10 @@ class FrenchAndBelizeBasicIntegrationUITests: XCTestCase {
         selectItems(app)
         let buyNowButton = app.buttons["Buy Now"]
         buyNowButton.tap()
-        let tablesQuery = app.tables
-        let payFromButton = tablesQuery.otherElements.containing(.staticText, identifier:"Pay from").children(matching: .button).element
+        let payFromButton = app.buttons.matching(identifier: "Pay from").element
         payFromButton.tap()
+
+        let tablesQuery = app.tables
 
         // ...preselects Apple Pay by default
         let applePay = tablesQuery.cells["Apple Pay"]


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
`CheckoutRowView` is now a top-level accessibility element instead of exposing its subviews as individual accessibility elements.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
IOS-1542
IOS-1547

## Testing
<!-- How was the code tested? Be as specific as possible. -->
Accessibility Inspector on macOS running Basic Integration example app in iOS Simulator