### PR TITLE
Przelewy24 PaymentMethod bindings

### DIFF
--- a/Example/Non-Card Payment Examples.xcodeproj/project.pbxproj
+++ b/Example/Non-Card Payment Examples.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		36B6CB5A234BE3FA00331C38 /* PaymentExampleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 36B6CB59234BE3FA00331C38 /* PaymentExampleViewController.m */; };
 		36B6CB5D234BEB8400331C38 /* SEPADebitExampleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 36B6CB5C234BEB8400331C38 /* SEPADebitExampleViewController.m */; };
 		36B6CB64234FD9AA00331C38 /* iDEALExampleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 36B6CB63234FD9AA00331C38 /* iDEALExampleViewController.m */; };
+		448895B424526C6B00F7D0C2 /* Przelewy24ExampleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 448895B324526C6B00F7D0C2 /* Przelewy24ExampleViewController.m */; };
 		8BBD79C6207FD2F900F85BED /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 8BBD79C8207FD2F900F85BED /* Localizable.strings */; };
 		B607FFBD2321DA99004203E0 /* MyAPIClient.m in Sources */ = {isa = PBXBuildFile; fileRef = B607FFBC2321DA99004203E0 /* MyAPIClient.m */; };
 		B65E8FCC22FA078A0057E64A /* WeChatPayExampleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B65E8FCB22FA078A0057E64A /* WeChatPayExampleViewController.m */; };
@@ -76,6 +77,8 @@
 		36B6CB5C234BEB8400331C38 /* SEPADebitExampleViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SEPADebitExampleViewController.m; sourceTree = "<group>"; };
 		36B6CB62234FD9AA00331C38 /* iDEALExampleViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = iDEALExampleViewController.h; sourceTree = "<group>"; };
 		36B6CB63234FD9AA00331C38 /* iDEALExampleViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = iDEALExampleViewController.m; sourceTree = "<group>"; };
+		448895B224526C6B00F7D0C2 /* Przelewy24ExampleViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Przelewy24ExampleViewController.h; sourceTree = "<group>"; };
+		448895B324526C6B00F7D0C2 /* Przelewy24ExampleViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Przelewy24ExampleViewController.m; sourceTree = "<group>"; };
 		8BBD79C7207FD2F900F85BED /* en */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		8BBD79C9207FD31A00F85BED /* zh-Hans */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		8BBD79CA207FD32100F85BED /* nl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -162,6 +165,8 @@
 				B6C1FC812330432E0097FC4C /* Non-Card Payment Examples-Bridging-Header.h */,
 				36B6CB58234BE3FA00331C38 /* PaymentExampleViewController.h */,
 				36B6CB59234BE3FA00331C38 /* PaymentExampleViewController.m */,
+				448895B224526C6B00F7D0C2 /* Przelewy24ExampleViewController.h */,
+				448895B324526C6B00F7D0C2 /* Przelewy24ExampleViewController.m */,
 				36B6CB5B234BEB8400331C38 /* SEPADebitExampleViewController.h */,
 				36B6CB5C234BEB8400331C38 /* SEPADebitExampleViewController.m */,
 				04533EB01A68802E00C7E52E /* ShippingManager.h */,
@@ -316,6 +321,7 @@
 				36B6CB5D234BEB8400331C38 /* SEPADebitExampleViewController.m in Sources */,
 				C12C50DD1E57B3C800EC6D58 /* BrowseExamplesViewController.m in Sources */,
 				364FC2D024201F62002879EB /* AUBECSDebitExampleViewController.m in Sources */,
+				448895B424526C6B00F7D0C2 /* Przelewy24ExampleViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/Non-Card Payment Examples/BrowseExamplesViewController.m
+++ b/Example/Non-Card Payment Examples/BrowseExamplesViewController.m
@@ -13,11 +13,12 @@
 
 #import "ApplePayExampleViewController.h"
 #import "AUBECSDebitExampleViewController.h"
-#import "iDEALExampleViewController.h"
-#import "SofortExampleViewController.h"
 #import "FPXExampleViewController.h"
 #import "GiropayExampleViewController.h"
+#import "iDEALExampleViewController.h"
+#import "Przelewy24ExampleViewController.h"
 #import "SEPADebitExampleViewController.h"
+#import "SofortExampleViewController.h"
 #import "WeChatPayExampleViewController.h"
 
 /**
@@ -40,7 +41,7 @@
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
-    return 11;
+    return 12;
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
@@ -78,6 +79,9 @@
             break;
         case 10:
             cell.textLabel.text = @"giropay";
+            break;
+        case 11:
+            cell.textLabel.text = @"Przelewy24";
             break;
     }
     return cell;
@@ -155,6 +159,12 @@
         }
         case 10: {
             GiropayExampleViewController *exampleVC = [GiropayExampleViewController new];
+            exampleVC.delegate = self;
+            viewController = exampleVC;
+            break;
+        }
+        case 11: {
+            Przelewy24ExampleViewController *exampleVC = [Przelewy24ExampleViewController new];
             exampleVC.delegate = self;
             viewController = exampleVC;
             break;

--- a/Example/Non-Card Payment Examples/Przelewy24ExampleViewController.h
+++ b/Example/Non-Card Payment Examples/Przelewy24ExampleViewController.h
@@ -1,0 +1,17 @@
+//
+//  Przelewy24ExampleViewController.h
+//  Non-Card Payment Examples
+//
+//  Created by Vineet Shah on 4/23/20.
+//  Copyright © 2020 Stripe. All rights reserved.
+//
+
+#import "PaymentExampleViewController.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface Przelewy24ExampleViewController : PaymentExampleViewController
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Example/Non-Card Payment Examples/Przelewy24ExampleViewController.m
+++ b/Example/Non-Card Payment Examples/Przelewy24ExampleViewController.m
@@ -61,7 +61,7 @@ NS_ASSUME_NONNULL_BEGIN
         STPPaymentMethodPrzelewy24Params *przelewy24 = [[STPPaymentMethodPrzelewy24Params alloc] init];
 
         // Przelewy24 does not require additional parameters so we only need to pass the init-ed
-        // STPPaymentMethoPrzelewy24Params instance to STPPaymentMethodParams
+        // STPPaymentMethodPrzelewy24Params instance to STPPaymentMethodParams
         paymentIntentParams.paymentMethodParams = [STPPaymentMethodParams paramsWithPrzelewy24:przelewy24
                                                                                 billingDetails:billingDetails
                                                                                       metadata:nil];

--- a/Example/Non-Card Payment Examples/Przelewy24ExampleViewController.m
+++ b/Example/Non-Card Payment Examples/Przelewy24ExampleViewController.m
@@ -1,0 +1,90 @@
+//
+//  Przelewy24ExampleViewController.m
+//  Non-Card Payment Examples
+//
+//  Created by Vineet Shah on 4/23/20.
+//  Copyright © 2020 Stripe. All rights reserved.
+//
+
+#import "Przelewy24ExampleViewController.h"
+
+#import "MyAPIClient.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface Przelewy24ExampleViewController ()
+
+@end
+
+@implementation Przelewy24ExampleViewController {
+    UITextField *_emailField;
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    self.title = @"Przelewy24";
+
+    _emailField = [[UITextField alloc] init];
+    _emailField.borderStyle = UITextBorderStyleRoundedRect;
+    _emailField.textContentType = UITextContentTypeEmailAddress;
+    _emailField.placeholder = @"Email";
+    _emailField.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.view addSubview:_emailField];
+
+    [self.payButton setTitle:@"Pay with Przelewy24" forState:UIControlStateNormal];
+    [self.payButton sizeToFit];
+
+    [NSLayoutConstraint activateConstraints:@[
+        [_emailField.centerXAnchor constraintEqualToAnchor:self.payButton.centerXAnchor],
+        [_emailField.bottomAnchor constraintEqualToAnchor:self.payButton.topAnchor constant:-12.f],
+        [_emailField.widthAnchor constraintEqualToConstant:240.f],
+    ]];
+}
+
+- (void)payButtonSelected {
+    [super payButtonSelected];
+    [self updateUIForPaymentInProgress:YES];
+
+    [[MyAPIClient sharedClient] createPaymentIntentWithCompletion:^(MyAPIClientResult status, NSString *clientSecret, NSError *error) {
+        if (status == MyAPIClientResultFailure || clientSecret == nil) {
+            [self.delegate exampleViewController:self didFinishWithError:error];
+            return;
+        }
+
+        STPPaymentIntentParams *paymentIntentParams = [[STPPaymentIntentParams alloc] initWithClientSecret:clientSecret];
+
+        STPPaymentMethodBillingDetails *billingDetails = [[STPPaymentMethodBillingDetails alloc] init];
+        billingDetails.email = self->_emailField.text;
+
+
+        STPPaymentMethodPrzelewy24Params *przelewy24 = [[STPPaymentMethodPrzelewy24Params alloc] init];
+
+        // Przelewy24 does not require additional parameters so we only need to pass the init-ed
+        // STPPaymentMethoPrzelewy24Params instance to STPPaymentMethodParams
+        paymentIntentParams.paymentMethodParams = [STPPaymentMethodParams paramsWithPrzelewy24:przelewy24
+                                                                                billingDetails:billingDetails
+                                                                                      metadata:nil];
+
+        paymentIntentParams.returnURL = @"payments-example://stripe-redirect";
+        [[STPPaymentHandler sharedHandler] confirmPayment:paymentIntentParams
+                                withAuthenticationContext:self.delegate
+                                               completion:^(STPPaymentHandlerActionStatus handlerStatus, STPPaymentIntent * handledIntent, NSError * _Nullable handlerError) {
+            switch (handlerStatus) {
+                case STPPaymentHandlerActionStatusFailed:
+                    [self.delegate exampleViewController:self didFinishWithError:handlerError];
+                    break;
+                case STPPaymentHandlerActionStatusCanceled:
+                    [self.delegate exampleViewController:self didFinishWithMessage:@"Canceled"];
+                    break;
+                case STPPaymentHandlerActionStatusSucceeded:
+                    [self.delegate exampleViewController:self didFinishWithMessage:@"Payment successfully created"];
+                    break;
+            }
+        }];
+    } additionalParameters:@"country=pl"];
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -744,6 +744,16 @@
 		36E5831422B45F000044F82C /* STP3DS2AuthenticateResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 36239BAC2295EA23004FB1A5 /* STP3DS2AuthenticateResponse.h */; };
 		36E8B98D2413159B007546C1 /* STPNumericStringValidator.h in Headers */ = {isa = PBXBuildFile; fileRef = 36E8B98B2413159B007546C1 /* STPNumericStringValidator.h */; };
 		36E8B98E2413159B007546C1 /* STPNumericStringValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = 36E8B98C2413159B007546C1 /* STPNumericStringValidator.m */; };
+		4488959D24523F9400F7D0C2 /* STPPaymentMethodPrzelewy24.m in Sources */ = {isa = PBXBuildFile; fileRef = 4488959B24523F9400F7D0C2 /* STPPaymentMethodPrzelewy24.m */; };
+		448895A12452406B00F7D0C2 /* STPPaymentMethodPrzelewy24.h in Headers */ = {isa = PBXBuildFile; fileRef = 448895A02452406B00F7D0C2 /* STPPaymentMethodPrzelewy24.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		448895A6245244FE00F7D0C2 /* STPPaymentMethodPrzelewy24Params.m in Sources */ = {isa = PBXBuildFile; fileRef = 448895A4245244FE00F7D0C2 /* STPPaymentMethodPrzelewy24Params.m */; };
+		448895A82452452600F7D0C2 /* STPPaymentMethodPrzelewy24Params.h in Headers */ = {isa = PBXBuildFile; fileRef = 448895A72452452600F7D0C2 /* STPPaymentMethodPrzelewy24Params.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		448895A92452454000F7D0C2 /* STPPaymentMethodPrzelewy24.h in Headers */ = {isa = PBXBuildFile; fileRef = 448895A02452406B00F7D0C2 /* STPPaymentMethodPrzelewy24.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		448895AA2452455C00F7D0C2 /* STPPaymentMethodPrzelewy24.m in Sources */ = {isa = PBXBuildFile; fileRef = 4488959B24523F9400F7D0C2 /* STPPaymentMethodPrzelewy24.m */; };
+		448895AB2452455F00F7D0C2 /* STPPaymentMethodPrzelewy24Params.h in Headers */ = {isa = PBXBuildFile; fileRef = 448895A72452452600F7D0C2 /* STPPaymentMethodPrzelewy24Params.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		448895AC2452456800F7D0C2 /* STPPaymentMethodPrzelewy24Params.m in Sources */ = {isa = PBXBuildFile; fileRef = 448895A4245244FE00F7D0C2 /* STPPaymentMethodPrzelewy24Params.m */; };
+		448895AF245255D800F7D0C2 /* STPPaymentMethodPrzelewy24ParamsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 448895AE245255D800F7D0C2 /* STPPaymentMethodPrzelewy24ParamsTests.m */; };
+		448895B1245262E500F7D0C2 /* STPPaymentMethodPrzelewy24Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 448895B0245262E500F7D0C2 /* STPPaymentMethodPrzelewy24Tests.m */; };
 		8B013C891F1E784A00DD831B /* STPPaymentConfigurationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B013C881F1E784A00DD831B /* STPPaymentConfigurationTest.m */; };
 		8B39128220E2F99600098401 /* EPSSource.json in Resources */ = {isa = PBXBuildFile; fileRef = 8B39128120E2F99600098401 /* EPSSource.json */; };
 		8B39128320E2F9A100098401 /* BancontactSource.json in Resources */ = {isa = PBXBuildFile; fileRef = 8B39127F20E2F6A500098401 /* BancontactSource.json */; };
@@ -1984,6 +1994,12 @@
 		36E8B98C2413159B007546C1 /* STPNumericStringValidator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPNumericStringValidator.m; sourceTree = "<group>"; };
 		36FA86272241710700D5B4D4 /* LocalizationTester-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "LocalizationTester-Debug.xcconfig"; sourceTree = "<group>"; };
 		36FA86292241718F00D5B4D4 /* LocalizationTester-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "LocalizationTester-Release.xcconfig"; sourceTree = "<group>"; };
+		4488959B24523F9400F7D0C2 /* STPPaymentMethodPrzelewy24.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodPrzelewy24.m; sourceTree = "<group>"; };
+		448895A02452406B00F7D0C2 /* STPPaymentMethodPrzelewy24.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = STPPaymentMethodPrzelewy24.h; path = PublicHeaders/STPPaymentMethodPrzelewy24.h; sourceTree = "<group>"; };
+		448895A4245244FE00F7D0C2 /* STPPaymentMethodPrzelewy24Params.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodPrzelewy24Params.m; sourceTree = "<group>"; };
+		448895A72452452600F7D0C2 /* STPPaymentMethodPrzelewy24Params.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = STPPaymentMethodPrzelewy24Params.h; path = PublicHeaders/STPPaymentMethodPrzelewy24Params.h; sourceTree = "<group>"; };
+		448895AE245255D800F7D0C2 /* STPPaymentMethodPrzelewy24ParamsTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodPrzelewy24ParamsTests.m; sourceTree = "<group>"; };
+		448895B0245262E500F7D0C2 /* STPPaymentMethodPrzelewy24Tests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodPrzelewy24Tests.m; sourceTree = "<group>"; };
 		4A0D74F918F6106100966D7B /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		7E0B1132203572FB00271AD3 /* fi */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = fi; path = Localizations/fi.lproj/Localizable.strings; sourceTree = "<group>"; };
 		8B013C881F1E784A00DD831B /* STPPaymentConfigurationTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPPaymentConfigurationTest.m; sourceTree = "<group>"; };
@@ -2723,14 +2739,15 @@
 		3626615F23C8F9CA00B13AE0 /* PaymentMethods */ = {
 			isa = PBXGroup;
 			children = (
-				36196240244FA5C80025D60B /* giropay */,
-				B656293023E10F6300458A8E /* Bacs Debit */,
 				3666589F240F177400D00354 /* AU BECS Debit */,
+				B656293023E10F6300458A8E /* Bacs Debit */,
 				3626616523C9048500B13AE0 /* Card */,
 				3626616623C9049000B13AE0 /* Card Present */,
 				3626616723C9049D00B13AE0 /* Card Wallet */,
 				3626616823C904AB00B13AE0 /* FPX */,
+				36196240244FA5C80025D60B /* giropay */,
 				3626616923C904B400B13AE0 /* iDEAL */,
+				4488959924523D6900F7D0C2 /* Przelewy24 */,
 				3626616A23C904C200B13AE0 /* SEPA Debit */,
 				B69FEC41222EE9E000273A16 /* STPPaymentMethod.h */,
 				B69FEC3C222EE8FE00273A16 /* STPPaymentMethod.m */,
@@ -3139,6 +3156,17 @@
 			name = "AU BECS Debit";
 			sourceTree = "<group>";
 		};
+		4488959924523D6900F7D0C2 /* Przelewy24 */ = {
+			isa = PBXGroup;
+			children = (
+				448895A02452406B00F7D0C2 /* STPPaymentMethodPrzelewy24.h */,
+				4488959B24523F9400F7D0C2 /* STPPaymentMethodPrzelewy24.m */,
+				448895A72452452600F7D0C2 /* STPPaymentMethodPrzelewy24Params.h */,
+				448895A4245244FE00F7D0C2 /* STPPaymentMethodPrzelewy24Params.m */,
+			);
+			name = Przelewy24;
+			sourceTree = "<group>";
+		};
 		8BD2133A1F0458B7007F6FD1 /* Source */ = {
 			isa = PBXGroup;
 			children = (
@@ -3299,6 +3327,8 @@
 				36196255244FBEB80025D60B /* STPPaymentMethodGiropayTests.m */,
 				B6EC63C922348D4600E4C0FB /* STPPaymentMethodiDEALTest.m */,
 				B63E42782231F8FE007B5B95 /* STPPaymentMethodParamsTest.m */,
+				448895AE245255D800F7D0C2 /* STPPaymentMethodPrzelewy24ParamsTests.m */,
+				448895B0245262E500F7D0C2 /* STPPaymentMethodPrzelewy24Tests.m */,
 				36B6CB56234BDC4400331C38 /* STPPaymentMethodSEPADebitTest.m */,
 				B66B39B3223044A2006D1CAD /* STPPaymentMethodTest.m */,
 				B66D5023222F5A27004A9210 /* STPPaymentMethodThreeDSecureUsageTest.m */,
@@ -3864,6 +3894,7 @@
 				F1D3A2541EB012350095BFA9 /* STPMultipartFormDataEncoder.h in Headers */,
 				C1C1012E1E57A26F00C7BFAE /* STPSource+Private.h in Headers */,
 				B67D7D4B2294A081000FBA12 /* STPPaymentMethodListDeserializer.h in Headers */,
+				448895AB2452455F00F7D0C2 /* STPPaymentMethodPrzelewy24Params.h in Headers */,
 				319A608922E9186B00AACF66 /* STDSConfigParameters.h in Headers */,
 				04A488431CA3580700506E53 /* UINavigationController+Stripe_Completion.h in Headers */,
 				B6B5FC42222F4C0200440249 /* STPPaymentMethodThreeDSecureUsage.h in Headers */,
@@ -4027,6 +4058,7 @@
 				319A609422E9186B00AACF66 /* STDSNotInitializedException.h in Headers */,
 				B3BDCAD720EEF5EC0034F7F5 /* STPPaymentIntentParams.h in Headers */,
 				F19491E81E60DD9C001E1FC2 /* STPSourceSEPADebitDetails.h in Headers */,
+				448895A92452454000F7D0C2 /* STPPaymentMethodPrzelewy24.h in Headers */,
 				8BD87B8E1EFB152B00269C2B /* STPSourceRedirect+Private.h in Headers */,
 				319A608F22E9186B00AACF66 /* STDSJSONDecodable.h in Headers */,
 				C184107C1EC2539F00178149 /* STPEphemeralKeyProvider.h in Headers */,
@@ -4251,6 +4283,7 @@
 				B656294023E2195600458A8E /* STPPaymentMethodBacsDebitParams.h in Headers */,
 				3626617C23C908BA00B13AE0 /* STPConfirmCardOptions.h in Headers */,
 				315CB8D722E7D96100E612A3 /* STDSJSONEncoder.h in Headers */,
+				448895A82452452600F7D0C2 /* STPPaymentMethodPrzelewy24Params.h in Headers */,
 				31F5A50B22F0EFB10033663B /* STPPaymentMethodFPX.h in Headers */,
 				3626617F23C908BA00B13AE0 /* STPConfirmPaymentMethodOptions.h in Headers */,
 				315CB8D822E7D96100E612A3 /* STDSChallengeParameters.h in Headers */,
@@ -4327,6 +4360,7 @@
 				F19491E71E60DD9C001E1FC2 /* STPSourceSEPADebitDetails.h in Headers */,
 				F15232201EA92FCF00D65C67 /* STPRedirectContext.h in Headers */,
 				B6B5FC41222F4C0200440249 /* STPPaymentMethodThreeDSecureUsage.h in Headers */,
+				448895A12452406B00F7D0C2 /* STPPaymentMethodPrzelewy24.h in Headers */,
 				C184107B1EC2539F00178149 /* STPEphemeralKeyProvider.h in Headers */,
 				3604007122C18C78004CF80B /* STPThreeDSNavigationBarCustomization.h in Headers */,
 				04A488421CA3580700506E53 /* UINavigationController+Stripe_Completion.h in Headers */,
@@ -5060,6 +5094,7 @@
 				073132982277A72D0019CE3F /* STPIssuingCardPin.m in Sources */,
 				C13538081D2C2186003F6157 /* STPAddCardViewControllerTest.m in Sources */,
 				B3302F462006FBA7005DDBE9 /* STPConnectAccountParamsTest.m in Sources */,
+				448895AF245255D800F7D0C2 /* STPPaymentMethodPrzelewy24ParamsTests.m in Sources */,
 				36AEBFC0241C3DD700CFCAE8 /* STPLabeledMultiFormTextFieldViewSnapshotTests.m in Sources */,
 				B613DD3C22C54AA800C7603F /* STPSetupIntentTest.m in Sources */,
 				04415C671A6605B5001225ED /* STPAPIClientTest.m in Sources */,
@@ -5075,6 +5110,7 @@
 				8B82C5CA1F2BC78F009639F7 /* STPApplePayPaymentOptionTest.m in Sources */,
 				B32B176320F6D722000D6EF8 /* STPGenericStripeObjectTest.m in Sources */,
 				B3BDCACF20EEF4640034F7F5 /* STPPaymentIntentFunctionalTest.m in Sources */,
+				448895B1245262E500F7D0C2 /* STPPaymentMethodPrzelewy24Tests.m in Sources */,
 				36AEBFBE241C3B7500CFCAE8 /* STPLabeledFormTextFieldViewSnapshotTests.m in Sources */,
 				0731329C2277AA200019CE3F /* STPPinManagementServiceFunctionalTest.m in Sources */,
 				B664D67422B96C9B00E6354B /* STPThreeDSTextFieldCustomizationTest.m in Sources */,
@@ -5181,6 +5217,7 @@
 				04A4C3901C4F25F900B3B290 /* UIViewController+Stripe_ParentViewController.m in Sources */,
 				04F94DA01D229F0B004FC826 /* STPPostalCodeValidator.m in Sources */,
 				C124A17F1CCAA0C2007D42EE /* NSMutableURLRequest+Stripe.m in Sources */,
+				448895AA2452455C00F7D0C2 /* STPPaymentMethodPrzelewy24.m in Sources */,
 				0413CB31233FECD5006429EA /* STPAPIClient+PushProvisioning.m in Sources */,
 				C15993411D8808A10047950D /* STPShippingMethodTableViewCell.m in Sources */,
 				B690DDEF222F01BF000B902D /* STPPaymentMethodBillingDetails.m in Sources */,
@@ -5256,6 +5293,7 @@
 				C18410791EC2529400178149 /* STPEphemeralKeyManager.m in Sources */,
 				0731329E2277ABF60019CE3F /* STPPinManagementService.m in Sources */,
 				04F94DB41D229F71004FC826 /* STPPaymentActivityIndicatorView.m in Sources */,
+				448895AC2452456800F7D0C2 /* STPPaymentMethodPrzelewy24Params.m in Sources */,
 				C1BD9B251E393FFE00CEE925 /* STPSourceReceiver.m in Sources */,
 				B6B5FC44222F4C0200440249 /* STPPaymentMethodThreeDSecureUsage.m in Sources */,
 				B6CF3136229D8C7000BA8AC2 /* STPCardBrand.m in Sources */,
@@ -5315,6 +5353,7 @@
 				B61D4B932457671F001AEBEF /* STPPaymentIntentShippingDetails.m in Sources */,
 				C1080F4A1CBECF7B007B2D89 /* STPAddress.m in Sources */,
 				04B31DE81D09D25F00EF1631 /* STPPaymentOptionsInternalViewController.m in Sources */,
+				448895A6245244FE00F7D0C2 /* STPPaymentMethodPrzelewy24Params.m in Sources */,
 				36B6CB872359063200331C38 /* STPMandateOnlineParams.m in Sources */,
 				F1D3A25C1EB014BD0095BFA9 /* UIImage+Stripe.m in Sources */,
 				0413CB30233FECD5006429EA /* STPAPIClient+PushProvisioning.m in Sources */,
@@ -5391,6 +5430,7 @@
 				0426B9731CEAE3EB006AC8DD /* UITableViewCell+Stripe_Borders.m in Sources */,
 				B664D67222B96A1300E6354B /* STPThreeDSTextFieldCustomization.m in Sources */,
 				C1BD9B241E393FFE00CEE925 /* STPSourceReceiver.m in Sources */,
+				4488959D24523F9400F7D0C2 /* STPPaymentMethodPrzelewy24.m in Sources */,
 				04E7D4C52340717400FC8C02 /* PKAddPaymentPassRequest+Stripe_Error.m in Sources */,
 				04B31DD61D08E6E200EF1631 /* STPCustomer.m in Sources */,
 				367B46D722A0969000730BE0 /* STPThreeDSCustomizationSettings.m in Sources */,

--- a/Stripe.xcodeproj/xcshareddata/xcschemes/StripeiOS.xcscheme
+++ b/Stripe.xcodeproj/xcshareddata/xcschemes/StripeiOS.xcscheme
@@ -27,18 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "NO">
-      <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "045E7C021A5F41DE004751EF"
-               BuildableName = "StripeiOS Tests.xctest"
-               BlueprintName = "StripeiOS Tests"
-               ReferencedContainer = "container:Stripe.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -55,8 +43,18 @@
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "045E7C021A5F41DE004751EF"
+               BuildableName = "StripeiOS Tests.xctest"
+               BlueprintName = "StripeiOS Tests"
+               ReferencedContainer = "container:Stripe.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -77,8 +75,6 @@
             ReferencedContainer = "container:Stripe.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Stripe/Payments/STPPaymentHandler.m
+++ b/Stripe/Payments/STPPaymentHandler.m
@@ -314,6 +314,7 @@ withAuthenticationContext:(id<STPAuthenticationContext>)authenticationContext
         case STPPaymentMethodTypeFPX:
         case STPPaymentMethodTypeCardPresent:
         case STPPaymentMethodTypeGiropay:
+        case STPPaymentMethodTypePrzelewy24:
             // fall through
         case STPPaymentMethodTypeUnknown:
             return NO;

--- a/Stripe/PublicHeaders/STPPaymentMethod.h
+++ b/Stripe/PublicHeaders/STPPaymentMethod.h
@@ -20,6 +20,7 @@ STPPaymentMethodCardPresent,
 STPPaymentMethodFPX,
 STPPaymentMethodGiropay,
 STPPaymentMethodiDEAL,
+STPPaymentMethodPrzelewy24,
 STPPaymentMethodSEPADebit;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -96,6 +97,11 @@ NS_ASSUME_NONNULL_BEGIN
  If this is a giropay PaymentMethod (i.e. `self.type == STPPaymentMethodTypeGiropay`), this contains additional details.
  */
 @property (nonatomic, nullable, readonly) STPPaymentMethodGiropay *giropay;
+
+/**
+ If this is a Przelewy24 PaymentMethod (i.e. `self.type == STPPaymentMethodTypePrzelewy24`), this contains additional details.
+*/
+@property (nonatomic, nullable, readonly) STPPaymentMethodPrzelewy24 *przelewy24;
 
 /**
  The ID of the Customer to which this PaymentMethod is saved. Nil when the PaymentMethod has not been saved to a Customer.

--- a/Stripe/PublicHeaders/STPPaymentMethodEnums.h
+++ b/Stripe/PublicHeaders/STPPaymentMethodEnums.h
@@ -49,6 +49,11 @@ typedef NS_ENUM(NSUInteger, STPPaymentMethodType) {
      A giropay payment method.
      */
     STPPaymentMethodTypeGiropay,
+
+    /**
+     A Przelewy24 Debit payment method.
+     */
+    STPPaymentMethodTypePrzelewy24,
     
     /**
      An unknown type.

--- a/Stripe/PublicHeaders/STPPaymentMethodParams.h
+++ b/Stripe/PublicHeaders/STPPaymentMethodParams.h
@@ -20,6 +20,7 @@ STPPaymentMethodCardParams,
 STPPaymentMethodFPXParams,
 STPPaymentMethodGiropayParams,
 STPPaymentMethodiDEALParams,
+STPPaymentMethodPrzelewy24Params,
 STPPaymentMethodSEPADebitParams;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -86,9 +87,14 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nullable) STPPaymentMethodAUBECSDebitParams *auBECSDebit;
 
 /**
-If this is a giropay PaymentMethod, this contains additional details.
+ If this is a giropay PaymentMethod, this contains additional details.
 */
 @property (nonatomic, nullable) STPPaymentMethodGiropayParams *giropay;
+
+/**
+ If this is a Przelewy24 PaymentMethod, this contains additional details.
+ */
+@property (nonatomic, nullable) STPPaymentMethodPrzelewy24Params *przelewy24;
 
 /**
  Set of key-value pairs that you can attach to the PaymentMethod. This can be useful for storing additional information about the PaymentMethod in a structured format.
@@ -171,6 +177,16 @@ If this is a giropay PaymentMethod, this contains additional details.
 + (nullable STPPaymentMethodParams *)paramsWithGiropay:(STPPaymentMethodGiropayParams *)giropay
                                         billingDetails:(STPPaymentMethodBillingDetails *)billingDetails
                                               metadata:(nullable NSDictionary<NSString *, NSString *> *)metadata;
+
+/**
+ Creates params for a Przelewy24 PaymentMethod;
+ @param przelewy24   An object containing additional Przelewy24 details.
+ @param billingDetails  An object containing the user's billing details. Note that `billingDetails.email` is required for Przelewy24 PaymentMethods.
+ @param metadata     Additional information to attach to the PaymentMethod.
+ */
++ (nullable STPPaymentMethodParams *)paramsWithPrzelewy24:(STPPaymentMethodPrzelewy24Params *)przelewy24
+                                           billingDetails:(STPPaymentMethodBillingDetails *)billingDetails
+                                                 metadata:(nullable NSDictionary<NSString *, NSString *> *)metadata;
 
 /**
  Creates params from a single-use PaymentMethod. This is useful for recreating a new payment method

--- a/Stripe/PublicHeaders/STPPaymentMethodPrzelewy24.h
+++ b/Stripe/PublicHeaders/STPPaymentMethodPrzelewy24.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 A Przelewy24 Payment Method.
 
-@see https://stripe.com/docs/sources/p24
+@see https://stripe.com/docs/payments/p24
 */
 @interface STPPaymentMethodPrzelewy24 : NSObject <STPAPIResponseDecodable>
 

--- a/Stripe/PublicHeaders/STPPaymentMethodPrzelewy24.h
+++ b/Stripe/PublicHeaders/STPPaymentMethodPrzelewy24.h
@@ -1,0 +1,36 @@
+//
+//  STPPaymentMethodPrzelewy24.h
+//  StripeiOS
+//
+//  Created by Vineet Shah on 4/23/20.
+//  Copyright © 2020 Stripe, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "STPAPIResponseDecodable.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+A Przelewy24 Payment Method.
+
+@see https://stripe.com/docs/sources/p24
+*/
+@interface STPPaymentMethodPrzelewy24 : NSObject <STPAPIResponseDecodable>
+
+/**
+You cannot directly instantiate an `STPPaymentMethodPrzelewy24`.
+You should only use one that is part of an existing `STPPaymentMethod` object.
+*/
+- (instancetype)init NS_UNAVAILABLE;
+
+/**
+You cannot directly instantiate an `STPPaymentMethodPrzelewy24`.
+You should only use one that is part of an existing `STPPaymentMethod` object.
+*/
++ (instancetype)new NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Stripe/PublicHeaders/STPPaymentMethodPrzelewy24Params.h
+++ b/Stripe/PublicHeaders/STPPaymentMethodPrzelewy24Params.h
@@ -1,0 +1,22 @@
+//
+//  STPPaymentMethodPrzelewy24Params.h
+//  StripeiOS
+//
+//  Created by Vineet Shah on 4/23/20.
+//  Copyright © 2020 Stripe, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "STPFormEncodable.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+An object representing parameters used to create a Przelewy24 Payment Method
+*/
+@interface STPPaymentMethodPrzelewy24Params : NSObject <STPFormEncodable>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Stripe/PublicHeaders/Stripe.h
+++ b/Stripe/PublicHeaders/Stripe.h
@@ -93,6 +93,8 @@
 #import "STPPaymentMethodGiropay.h"
 #import "STPPaymentMethodGiropayParams.h"
 #import "STPPaymentMethodParams.h"
+#import "STPPaymentMethodPrzelewy24.h"
+#import "STPPaymentMethodPrzelewy24Params.h"
 #import "STPPaymentMethodSEPADebit.h"
 #import "STPPaymentMethodSEPADebitParams.h"
 #import "STPPaymentMethodThreeDSecureUsage.h"

--- a/Stripe/Resources/Localizations/en.lproj/Localizable.strings
+++ b/Stripe/Resources/Localizations/en.lproj/Localizable.strings
@@ -151,6 +151,9 @@
 /* Caption for Province field on address form (only countries that use province, like Canada) */
 "Province" = "Province";
 
+/* Payment Method type brand name. */
+"Przelewy24" = "Przelewy24";
+
 /* Text for button to scan a credit card */
 "Scan Card" = "Scan Card";
 

--- a/Stripe/STPPaymentMethod.m
+++ b/Stripe/STPPaymentMethod.m
@@ -19,6 +19,7 @@
 #import "STPPaymentMethodFPX.h"
 #import "STPPaymentMethodGiropay.h"
 #import "STPPaymentMethodiDEAL.h"
+#import "STPPaymentMethodPrzelewy24.h"
 #import "STPPaymentMethodSEPADebit.h"
 
 @interface STPPaymentMethod ()
@@ -36,6 +37,7 @@
 @property (nonatomic, strong, nullable, readwrite) STPPaymentMethodSEPADebit *sepaDebit;
 @property (nonatomic, strong, nullable, readwrite) STPPaymentMethodAUBECSDebit *auBECSDebit;
 @property (nonatomic, strong, nullable, readwrite) STPPaymentMethodGiropay *giropay;
+@property (nonatomic, strong, nullable, readwrite) STPPaymentMethodPrzelewy24 *przelewy24;
 @property (nonatomic, copy, nullable, readwrite) NSString *customerId;
 @property (nonatomic, copy, nullable, readwrite) NSDictionary<NSString*, NSString *> *metadata;
 @property (nonatomic, copy, nonnull, readwrite) NSDictionary *allResponseFields;
@@ -64,6 +66,7 @@
                        [NSString stringWithFormat:@"ideal = %@", self.iDEAL],
                        [NSString stringWithFormat:@"fpx = %@", self.fpx],
                        [NSString stringWithFormat:@"giropay = %@", self.giropay],
+                       [NSString stringWithFormat:@"przelewy24 = %@", self.przelewy24],
                        [NSString stringWithFormat:@"sepaDebit = %@", self.sepaDebit],
                        [NSString stringWithFormat:@"liveMode = %@", self.liveMode ? @"YES" : @"NO"],
                        [NSString stringWithFormat:@"metadata = %@", self.metadata],
@@ -84,6 +87,7 @@
              @"bacs_debit": @(STPPaymentMethodTypeBacsDebit),
              @"au_becs_debit": @(STPPaymentMethodTypeAUBECSDebit),
              @"giropay": @(STPPaymentMethodTypeGiropay),
+             @"p24": @(STPPaymentMethodTypePrzelewy24),
              };
 }
 
@@ -139,6 +143,7 @@
     paymentMethod.bacsDebit = [STPPaymentMethodBacsDebit decodedObjectFromAPIResponse:[dict stp_dictionaryForKey:@"bacs_debit"]];
     paymentMethod.auBECSDebit = [STPPaymentMethodAUBECSDebit decodedObjectFromAPIResponse:[dict stp_dictionaryForKey:@"au_becs_debit"]];
     paymentMethod.giropay = [STPPaymentMethodGiropay decodedObjectFromAPIResponse:[dict stp_dictionaryForKey:@"giropay"]];
+    paymentMethod.przelewy24 = [STPPaymentMethodPrzelewy24 decodedObjectFromAPIResponse:[dict stp_dictionaryForKey:@"p24"]];
     paymentMethod.customerId = [dict stp_stringForKey:@"customer"];
     paymentMethod.metadata = [[dict stp_dictionaryForKey:@"metadata"] stp_dictionaryByRemovingNonStrings];
     return paymentMethod;
@@ -185,6 +190,8 @@
             return STPLocalizedString(@"AU BECS Debit", @"Payment Method type brand name.");
         case STPPaymentMethodTypeGiropay:
             return STPLocalizedString(@"giropay", @"Payment Method type brand name.");
+        case STPPaymentMethodTypePrzelewy24:
+            return STPLocalizedString(@"Przelewy24", @"Payment Method type brand name.");
         case STPPaymentMethodTypeBacsDebit:
         case STPPaymentMethodTypeCardPresent:
             // fall through
@@ -206,6 +213,7 @@
         case STPPaymentMethodTypeFPX:
         case STPPaymentMethodTypeCardPresent:
         case STPPaymentMethodTypeGiropay:
+        case STPPaymentMethodTypePrzelewy24:
             // fall through
         case STPPaymentMethodTypeUnknown:
             return NO;

--- a/Stripe/STPPaymentMethodParams.m
+++ b/Stripe/STPPaymentMethodParams.m
@@ -12,6 +12,7 @@
 #import "STPFormEncoder.h"
 #import "STPFPXBankBrand.h"
 #import "STPImageLibrary+Private.h"
+#import "STPPaymentMethodBacsDebit.h"
 #import "STPLocalizationUtils.h"
 #import "STPPaymentMethod+Private.h"
 #import "STPPaymentMethodBacsDebit.h"
@@ -21,6 +22,7 @@
 #import "STPPaymentMethodGiropayParams.h"
 #import "STPPaymentMethodiDEAL.h"
 #import "STPPaymentMethodiDEALParams.h"
+#import "STPPaymentMethodPrzelewy24Params.h"
 #import "STPPaymentMethodSEPADebitParams.h"
 
 @implementation STPPaymentMethodParams
@@ -96,6 +98,17 @@ billingDetails:(STPPaymentMethodBillingDetails *)billingDetails
     return params;
 }
 
++ (STPPaymentMethodParams *)paramsWithPrzelewy24:(STPPaymentMethodPrzelewy24Params *)przelewy24
+                                  billingDetails:(STPPaymentMethodBillingDetails *)billingDetails
+                                        metadata:(NSDictionary<NSString *,NSString *> *)metadata {
+    STPPaymentMethodParams *params = [self new];
+    params.type = STPPaymentMethodTypePrzelewy24;
+    params.przelewy24 = przelewy24;
+    params.billingDetails = billingDetails;
+    params.metadata = metadata;
+    return params;
+}
+
 + (nullable STPPaymentMethodParams *)paramsWithSingleUsePaymentMethod:(STPPaymentMethod *)paymentMethod {
     STPPaymentMethodParams *params = [self new];
     switch ([paymentMethod type]) {
@@ -124,6 +137,15 @@ billingDetails:(STPPaymentMethodBillingDetails *)billingDetails
             params.type = STPPaymentMethodTypeGiropay;
             STPPaymentMethodGiropayParams *giropay = [[STPPaymentMethodGiropayParams alloc] init];
             params.giropay = giropay;
+            params.billingDetails = paymentMethod.billingDetails;
+            params.metadata = paymentMethod.metadata;
+            break;
+        }
+        case STPPaymentMethodTypePrzelewy24:
+        {
+            params.type = STPPaymentMethodTypePrzelewy24;
+            STPPaymentMethodPrzelewy24Params *przelewy24 = [[STPPaymentMethodPrzelewy24Params alloc] init];
+            params.przelewy24 = przelewy24;
             params.billingDetails = paymentMethod.billingDetails;
             params.metadata = paymentMethod.metadata;
             break;
@@ -167,6 +189,7 @@ billingDetails:(STPPaymentMethodBillingDetails *)billingDetails
              NSStringFromSelector(@selector(bacsDebit)): @"bacs_debit",
              NSStringFromSelector(@selector(auBECSDebit)): @"au_becs_debit",
              NSStringFromSelector(@selector(giropay)): @"giropay",
+             NSStringFromSelector(@selector(przelewy24)): @"p24",
              NSStringFromSelector(@selector(metadata)): @"metadata",
              };
 }
@@ -218,6 +241,8 @@ billingDetails:(STPPaymentMethodBillingDetails *)billingDetails
             return @"AU BECS Debit";
         case STPPaymentMethodTypeGiropay:
             return @"giropay";
+        case STPPaymentMethodTypePrzelewy24:
+            return @"Przelewy24";
         case STPPaymentMethodTypeCardPresent:
         case STPPaymentMethodTypeUnknown:
             return STPLocalizedString(@"Unknown", @"Default missing source type label");
@@ -238,6 +263,7 @@ billingDetails:(STPPaymentMethodBillingDetails *)billingDetails
         case STPPaymentMethodTypeFPX:
         case STPPaymentMethodTypeCardPresent:
         case STPPaymentMethodTypeGiropay:
+        case STPPaymentMethodTypePrzelewy24:
             // fall through
         case STPPaymentMethodTypeUnknown:
             return NO;

--- a/Stripe/STPPaymentMethodPrzelewy24.m
+++ b/Stripe/STPPaymentMethodPrzelewy24.m
@@ -1,0 +1,50 @@
+//
+//  STPPaymentMethodPrzelewy24.m
+//  StripeiOS
+//
+//  Created by Vineet Shah on 4/23/20.
+//  Copyright © 2020 Stripe, Inc. All rights reserved.
+//
+
+#import "STPPaymentMethodPrzelewy24.h"
+
+#import "NSDictionary+Stripe.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation STPPaymentMethodPrzelewy24
+
+@synthesize allResponseFields = _allResponseFields;
+
+#pragma mark - Description
+
+- (NSString *)description {
+    NSArray *props = @[
+                       // Object
+                       [NSString stringWithFormat:@"%@: %p", NSStringFromClass([self class]), self],
+                       ];
+
+    return [NSString stringWithFormat:@"<%@>", [props componentsJoinedByString:@"; "]];
+}
+
+#pragma mark - STPAPIResponseDecodable
+
++ (nullable instancetype)decodedObjectFromAPIResponse:(nullable NSDictionary *)response {
+    NSDictionary *dict = [response stp_dictionaryByRemovingNulls];
+    if (!dict) {
+        return nil;
+    }
+    return [[self alloc] initWithDictionary:dict];
+}
+
+- (nullable instancetype)initWithDictionary:(NSDictionary *)dict {
+    self = [super init];
+    if (self) {
+        _allResponseFields = dict.copy;
+    }
+    return self;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Stripe/STPPaymentMethodPrzelewy24Params.m
+++ b/Stripe/STPPaymentMethodPrzelewy24Params.m
@@ -1,0 +1,28 @@
+//
+//  STPPaymentMethodPrzelewy24Params.m
+//  StripeiOS
+//
+//  Created by Vineet Shah on 4/23/20.
+//  Copyright © 2020 Stripe, Inc. All rights reserved.
+//
+
+#import "STPPaymentMethodPrzelewy24Params.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation STPPaymentMethodPrzelewy24Params
+
+@synthesize additionalAPIParameters = _additionalAPIParameters;
+
++ (nullable NSString *)rootObjectName {
+    return @"p24";
+}
+
++ (NSDictionary *)propertyNamesToFormFieldNamesMapping {
+    return @{
+             };
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Tests/Tests/STPPaymentIntentFunctionalTest.m
+++ b/Tests/Tests/STPPaymentIntentFunctionalTest.m
@@ -412,6 +412,58 @@
     [self waitForExpectationsWithTimeout:STPTestingNetworkRequestTimeout handler:nil];
 }
 
+#pragma mark - Przelewy24
+
+- (void)testConfirmPaymentIntentWithPrzelewy24 {
+    __block NSString *clientSecret = nil;
+    XCTestExpectation *createExpectation = [self expectationWithDescription:@"Create PaymentIntent."];
+    [[STPTestingAPIClient sharedClient] createPaymentIntentWithParams:@{
+        @"payment_method_types": @[@"p24"],
+        @"currency": @"eur",
+    }
+                                                           completion:^(NSString * _Nullable createdClientSecret, NSError * _Nullable creationError) {
+        XCTAssertNotNil(createdClientSecret);
+        XCTAssertNil(creationError);
+        [createExpectation fulfill];
+        clientSecret = [createdClientSecret copy];
+    }];
+    [self waitForExpectationsWithTimeout:STPTestingNetworkRequestTimeout handler:nil];
+    XCTAssertNotNil(clientSecret);
+
+    STPAPIClient *client = [[STPAPIClient alloc] initWithPublishableKey:STPTestingDefaultPublishableKey];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Payment Intent confirm"];
+
+    STPPaymentIntentParams *paymentIntentParams = [[STPPaymentIntentParams alloc] initWithClientSecret:clientSecret];
+    STPPaymentMethodPrzelewy24Params *przelewy24Params = [STPPaymentMethodPrzelewy24Params new];
+
+    STPPaymentMethodBillingDetails *billingDetails = [STPPaymentMethodBillingDetails new];
+    billingDetails.email = @"email@email.com";
+
+    paymentIntentParams.paymentMethodParams = [STPPaymentMethodParams paramsWithPrzelewy24:przelewy24Params
+                                                                            billingDetails:billingDetails
+                                                                                  metadata:@{@"test_key": @"test_value"}];
+    paymentIntentParams.returnURL = @"example-app-scheme://authorized";
+    [client confirmPaymentIntentWithParams:paymentIntentParams
+                                completion:^(STPPaymentIntent * _Nullable paymentIntent, NSError * _Nullable error) {
+                                    XCTAssertNil(error, @"With valid key + secret, should be able to confirm the intent");
+
+                                    XCTAssertNotNil(paymentIntent);
+                                    XCTAssertEqualObjects(paymentIntent.stripeId, paymentIntentParams.stripeId);
+                                    XCTAssertFalse(paymentIntent.livemode);
+                                    XCTAssertNotNil(paymentIntent.paymentMethodId);
+
+                                    // Przelewy24 requires a redirect
+                                    XCTAssertEqual(paymentIntent.status, STPPaymentIntentStatusRequiresAction);
+                                    XCTAssertNotNil(paymentIntent.nextAction.redirectToURL.returnURL);
+                                    XCTAssertEqualObjects(paymentIntent.nextAction.redirectToURL.returnURL,
+                                                          [NSURL URLWithString:@"example-app-scheme://authorized"]);
+
+                                    [expectation fulfill];
+                                }];
+
+    [self waitForExpectationsWithTimeout:STPTestingNetworkRequestTimeout handler:nil];
+}
+
 #pragma mark - Helpers
 
 - (STPSourceParams *)cardSourceParams {

--- a/Tests/Tests/STPPaymentMethodPrzelewy24ParamsTests.m
+++ b/Tests/Tests/STPPaymentMethodPrzelewy24ParamsTests.m
@@ -1,0 +1,59 @@
+//
+//  STPPaymentMethodPrzelewy24ParamsTests.m
+//  StripeiOS Tests
+//
+//  Created by Vineet Shah on 4/23/20.
+//  Copyright © 2020 Stripe, Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "STPAPIClient.h"
+#import "STPPaymentMethod.h"
+#import "STPPaymentMethodBillingDetails.h"
+#import "STPPaymentMethodParams.h"
+#import "STPPaymentMethodPrzelewy24Params.h"
+#import "STPTestingAPIClient.h"
+
+@interface STPPaymentMethodPrzelewy24ParamsTests : XCTestCase
+
+@end
+
+@implementation STPPaymentMethodPrzelewy24ParamsTests
+
+- (void)testCreatePrzelewy24PaymentMethod {
+    STPAPIClient *client = [[STPAPIClient alloc] initWithPublishableKey:STPTestingDefaultPublishableKey];
+    STPPaymentMethodPrzelewy24Params *przelewy24Params = [STPPaymentMethodPrzelewy24Params new];
+
+    STPPaymentMethodBillingDetails *billingDetails = [STPPaymentMethodBillingDetails new];
+    billingDetails.email = @"email@email.com";
+
+    STPPaymentMethodParams *params = [STPPaymentMethodParams paramsWithPrzelewy24:przelewy24Params
+                                                                   billingDetails:billingDetails
+                                                                         metadata:@{@"test_key": @"test_value"}];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Payment Method Przelewy24 create"];
+
+    [client createPaymentMethodWithParams:params
+                               completion:^(STPPaymentMethod * _Nullable paymentMethod, NSError * _Nullable error) {
+        [expectation fulfill];
+
+        XCTAssertNil(error, @"Unexpected error creating Przelewy24 PaymentMethod: %@", error);
+        XCTAssertNotNil(paymentMethod, @"Failed to create Przelewy24 PaymentMethod");
+        XCTAssertNotNil(paymentMethod.stripeId, @"Missing stripeId");
+        XCTAssertNotNil(paymentMethod.created, @"Missing created");
+        XCTAssertFalse(paymentMethod.liveMode, @"Incorrect livemode");
+        XCTAssertEqual(paymentMethod.type, STPPaymentMethodTypePrzelewy24, @"Incorrect PaymentMethod type");
+        XCTAssertEqualObjects(paymentMethod.metadata, @{@"test_key": @"test_value"}, @"Incorrect metadata");
+
+        // Billing Details
+        XCTAssertEqualObjects(paymentMethod.billingDetails.email, @"email@email.com", @"Incorrect email");
+
+        // Przelewy24 Details
+        XCTAssertNotNil(paymentMethod.przelewy24, @"Missing Przelewy24");
+    }];
+
+    [self waitForExpectationsWithTimeout:STPTestingNetworkRequestTimeout handler:nil];
+}
+
+@end

--- a/Tests/Tests/STPPaymentMethodPrzelewy24Tests.m
+++ b/Tests/Tests/STPPaymentMethodPrzelewy24Tests.m
@@ -27,7 +27,7 @@
         completion(self.przelewy24JSON);
     } else {
         STPAPIClient *client = [[STPAPIClient alloc] initWithPublishableKey:STPTestingDefaultPublishableKey];
-        [client retrievePaymentIntentWithClientSecret:@"pi_1GbFK2FY0qyl6XeWQ37XICJV_secret_6KKrMKcONxH3oM6XldyyIGj9s"
+        [client retrievePaymentIntentWithClientSecret:@"pi_1GciHFFY0qyl6XeWp9RdhmFF_secret_rFeERcidL1O5o1lwQUcIjLEZz"
                                                expand:@[@"payment_method"]
                                            completion:^(STPPaymentIntent * _Nullable paymentIntent, __unused NSError * _Nullable error) {
             self->_przelewy24JSON = paymentIntent.paymentMethod.przelewy24.allResponseFields;
@@ -37,10 +37,13 @@
 }
 
 - (void)testCorrectParsing {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Retrieve payment intent"];
     [self _retrievePrzelewy24JSON:^(NSDictionary *json) {
         STPPaymentMethodPrzelewy24 *przelewy24 = [STPPaymentMethodPrzelewy24 decodedObjectFromAPIResponse:json];
         XCTAssertNotNil(przelewy24, @"Failed to decode JSON");
+        [expectation fulfill];
     }];
+    [self waitForExpectationsWithTimeout:STPTestingNetworkRequestTimeout handler:nil];
 }
 
 @end

--- a/Tests/Tests/STPPaymentMethodPrzelewy24Tests.m
+++ b/Tests/Tests/STPPaymentMethodPrzelewy24Tests.m
@@ -1,0 +1,46 @@
+//
+//  STPPaymentMethodPrzelewy24Tests.m
+//  StripeiOS Tests
+//
+//  Created by Vineet Shah on 4/23/20.
+//  Copyright © 2020 Stripe, Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "STPAPIClient+Private.h"
+#import "STPPaymentIntent+Private.h"
+#import "STPPaymentMethod.h"
+#import "STPPaymentMethodPrzelewy24.h"
+#import "STPTestingAPIClient.h"
+
+@interface STPPaymentMethodPrzelewy24Tests : XCTestCase
+
+@property (nonatomic, readonly) NSDictionary *przelewy24JSON;
+
+@end
+
+@implementation STPPaymentMethodPrzelewy24Tests
+
+- (void)_retrievePrzelewy24JSON:(void (^)(NSDictionary *))completion {
+    if (self.przelewy24JSON) {
+        completion(self.przelewy24JSON);
+    } else {
+        STPAPIClient *client = [[STPAPIClient alloc] initWithPublishableKey:STPTestingDefaultPublishableKey];
+        [client retrievePaymentIntentWithClientSecret:@"pi_1GbFK2FY0qyl6XeWQ37XICJV_secret_6KKrMKcONxH3oM6XldyyIGj9s"
+                                               expand:@[@"payment_method"]
+                                           completion:^(STPPaymentIntent * _Nullable paymentIntent, __unused NSError * _Nullable error) {
+            self->_przelewy24JSON = paymentIntent.paymentMethod.przelewy24.allResponseFields;
+            completion(self.przelewy24JSON);
+        }];
+    }
+}
+
+- (void)testCorrectParsing {
+    [self _retrievePrzelewy24JSON:^(NSDictionary *json) {
+        STPPaymentMethodPrzelewy24 *przelewy24 = [STPPaymentMethodPrzelewy24 decodedObjectFromAPIResponse:json];
+        XCTAssertNotNil(przelewy24, @"Failed to decode JSON");
+    }];
+}
+
+@end

--- a/Tests/Tests/STPPaymentMethodTest.m
+++ b/Tests/Tests/STPPaymentMethodTest.m
@@ -86,6 +86,9 @@
             case STPPaymentMethodTypeGiropay:
                 XCTAssertEqualObjects(string, @"giropay");
                 break;
+            case STPPaymentMethodTypePrzelewy24:
+                XCTAssertEqualObjects(string, @"p24");
+                break;
             case STPPaymentMethodTypeUnknown:
                 XCTAssertNil(string);
                 break;


### PR DESCRIPTION
## Summary
Adds bindings for Przelewy24 on PaymentMethods

## Motivation
Migrating Sources->PaymentMethods

## Testing
Automated tests and added to non-card examples