### PR TITLE
Add advancedFraudSignalsEnabled property

### DIFF
--- a/Stripe/PublicHeaders/STPAPIClient.h
+++ b/Stripe/PublicHeaders/STPAPIClient.h
@@ -43,6 +43,24 @@ static NSString *const STPSDKVersion = @"19.1.0";
  */
 + (nullable NSString *)defaultPublishableKey;
 
+/**
+ A Boolean value that determines whether additional device data is sent to Stripe for fraud prevention.
+ 
+ Returns YES if the Stripe SDK is collecting additional device data for fraud prevention.
+ For more details on the information we collect, visit https://stripe.com/docs/disputes/prevention/advanced-fraud-detection
+ The default value is YES.
+ */
++ (BOOL)advancedFraudSignalsEnabled;
+
+/**
+ Set whether additional device data is sent to Stripe for fraud prevention.
+ 
+ @param   enabled If YES, additional device signals will be sent to Stripe.
+ For more details on the information we collect, visit https://stripe.com/docs/disputes/prevention/advanced-fraud-detection
+ Disabling this setting will reduce Stripe's ability to protect your business from fraudulent payments.
+ */
++ (void)setAdvancedFraudSignalsEnabled:(BOOL)enabled;
+
 @end
 
 /**

--- a/Stripe/STPAPIClient.m
+++ b/Stripe/STPAPIClient.m
@@ -72,6 +72,7 @@ static NSString * const APIEndpointFPXStatus = @"fpx/bank_statuses";
 
 static NSArray<PKPaymentNetwork> *_additionalEnabledApplePayNetworks;
 static NSString *_defaultPublishableKey;
+static BOOL _advancedFraudSignalsEnabled;
 
 + (void)setDefaultPublishableKey:(NSString *)publishableKey {
     _defaultPublishableKey = [publishableKey copy];
@@ -79,6 +80,19 @@ static NSString *_defaultPublishableKey;
 
 + (NSString *)defaultPublishableKey {
     return _defaultPublishableKey;
+}
+
++ (void)setAdvancedFraudSignalsEnabled:(BOOL)enabled {
+    [self advancedFraudSignalsEnabled];
+    _advancedFraudSignalsEnabled = enabled;
+}
+
++ (BOOL)advancedFraudSignalsEnabled {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        _advancedFraudSignalsEnabled = YES;
+    });
+    return _advancedFraudSignalsEnabled;
 }
 
 @end

--- a/Stripe/STPTelemetryClient.m
+++ b/Stripe/STPTelemetryClient.m
@@ -15,7 +15,6 @@
 #import "STPAPIClient+Private.h"
 
 @interface STPTelemetryClient ()
-@property (nonatomic) NSDate *appOpenTime;
 @property (nonatomic, readwrite) NSURLSession *urlSession;
 @end
 
@@ -25,7 +24,7 @@
 #if TARGET_OS_SIMULATOR
     return NO;
 #else
-    return NSClassFromString(@"XCTest") == nil;
+    return [Stripe advancedFraudSignalsEnabled] && NSClassFromString(@"XCTest") == nil;
 #endif
 }
 
@@ -47,37 +46,17 @@
     self = [super init];
     if (self) {
         _urlSession = [NSURLSession sessionWithConfiguration:config];
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationDidBecomeActive) name:UIApplicationDidBecomeActiveNotification object:nil];
-        [[UIDevice currentDevice] setBatteryMonitoringEnabled:YES];
     }
     return self;
 }
 
-- (void)dealloc {
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-}
-
 - (void)addTelemetryFieldsToParams:(NSMutableDictionary *)params {
     params[@"muid"] = [self muid];
-    params[@"time_on_page"] = [self timeOnPage];
-}
-
-- (void)applicationDidBecomeActive {
-    self.appOpenTime = [NSDate date];
 }
 
 - (NSString *)muid {
     NSString *muid = [[[UIDevice currentDevice] identifierForVendor] UUIDString];
     return muid ?: @"";
-}
-
-- (NSNumber *)timeOnPage {
-    if (!self.appOpenTime) {
-        return @(0);
-    }
-    NSTimeInterval seconds = [[NSDate date] timeIntervalSinceDate:self.appOpenTime];
-    NSInteger millis = (NSInteger)round(seconds*1000);
-    return @(MAX(millis, 0));
 }
 
 - (NSString *)language {

--- a/Tests/Tests/STPTelemetryClientTest.m
+++ b/Tests/Tests/STPTelemetryClientTest.m
@@ -8,6 +8,7 @@
 
 #import <XCTest/XCTest.h>
 #import "STPTelemetryClient.h"
+#import "STPAPIClient.h"
 
 @interface STPTelemetryClientTest : XCTestCase
 
@@ -17,17 +18,20 @@
 
 - (void)testAddTelemetryData {
     STPTelemetryClient *sut = [STPTelemetryClient sharedInstance];
-    [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationDidBecomeActiveNotification object:nil];
     NSMutableDictionary *params = [@{@"foo": @"bar"} mutableCopy];
     XCTestExpectation *exp = [self expectationWithDescription:@"delay"];
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1*NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         [sut addTelemetryFieldsToParams:params];
-        NSInteger time = [params[@"time_on_page"] integerValue];
-        XCTAssertTrue(time > 0);
         XCTAssertNotNil(params[@"muid"]);
         [exp fulfill];
     });
     [self waitForExpectationsWithTimeout:2 handler:nil];
+}
+
+- (void)testAdvancedFraudSignalsSwitch {
+    XCTAssertTrue([Stripe advancedFraudSignalsEnabled]);
+    [Stripe setAdvancedFraudSignalsEnabled:NO];
+    XCTAssertFalse([Stripe advancedFraudSignalsEnabled]);
 }
 
 @end


### PR DESCRIPTION
This allows you to control whether the Stripe SDK is collecting additional device data for fraud prevention.
For more details on the information we collect, visit https://stripe.com/docs/disputes/prevention/advanced-fraud-detection