### PR TITLE
ApplePayContext handles shipping

### DIFF
--- a/Example/Non-Card Payment Examples/ApplePayExampleViewController.m
+++ b/Example/Non-Card Payment Examples/ApplePayExampleViewController.m
@@ -90,7 +90,7 @@
 
 #pragma mark - STPApplePayContextDelegate
 
-- (void)applePayContext:(STPApplePayContext *)context didCreatePaymentMethod:(__unused STPPaymentMethod *)paymentMethod completion:(STPIntentClientSecretCompletionBlock)completion {
+- (void)applePayContext:(STPApplePayContext *)context didCreatePaymentMethod:(__unused STPPaymentMethod *)paymentMethod paymentInformation:(__unused PKPayment *)paymentInformation completion:(STPIntentClientSecretCompletionBlock)completion {
     // Create the Stripe PaymentIntent representing the payment on our backend
     [[MyAPIClient sharedClient] createPaymentIntentWithCompletion:^(MyAPIClientResult status, NSString *clientSecret, NSError *error) {
         // Call the completion block with the PaymentIntent's client secret

--- a/Stripe/PublicHeaders/STPApplePayContext.h
+++ b/Stripe/PublicHeaders/STPApplePayContext.h
@@ -24,12 +24,17 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Called after the customer has authorized Apple Pay.  Implement this method to call the completion block with the client secret of a PaymentIntent representing the payment.
  
- @param paymentMethod       The PaymentMethod that represents the customer's Apple Pay payment method.
+ @param paymentMethod                 The PaymentMethod that represents the customer's Apple Pay payment method.
  If you create the PaymentIntent with confirmation_method=manual, pass `paymentMethod.stripeId` as the payment_method and confirm=true. Otherwise, you can ignore this parameter.
- @param completion                  Call this with the PaymentIntent's client secret, or the error that occurred creating the PaymentIntent.
+ 
+ @param paymentInformation      The underlying PKPayment created by Apple Pay.
+ If you create the PaymentIntent with confirmation_method=manual, you can collect shipping information using its `shippingContact` and `shippingMethod` properties. Otherwise, you can ignore this parameter.
+ 
+ @param completion                        Call this with the PaymentIntent's client secret, or the error that occurred creating the PaymentIntent.
  */
 - (void)applePayContext:(STPApplePayContext *)context
  didCreatePaymentMethod:(STPPaymentMethod *)paymentMethod
+     paymentInformation:(PKPayment *)paymentInformation
              completion:(STPIntentClientSecretCompletionBlock)completion;
 
 /**
@@ -61,6 +66,8 @@ didSelectShippingMethod:(PKShippingMethod *)shippingMethod
 /**
  Called when the user has selected a new shipping address.  You should inspect the
  address and must invoke the completion block with an updated array of PKPaymentSummaryItem objects.
+ 
+ @note This does not contain full contact information - you can only receive that after the user authorizes payment, in the paymentInformation passed to `applePayContext:didCreatePaymentMethod:paymentInformation:completion:`
  */
 - (void)applePayContext:(STPApplePayContext *)context
 didSelectShippingContact:(PKContact *)contact
@@ -111,6 +118,11 @@ didSelectShippingMethod:(PKShippingMethod *)shippingMethod
  Use initWithPaymentRequest:delegate: instead.
  */
 - (instancetype)init NS_UNAVAILABLE;
+
+/**
+ Use initWithPaymentRequest:delegate: instead.
+ */
++ (instancetype)new NS_UNAVAILABLE;
 
 /**
  Presents the Apple Pay sheet, starting the payment process.

--- a/Stripe/PublicHeaders/STPApplePayContext.h
+++ b/Stripe/PublicHeaders/STPApplePayContext.h
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
  If you create the PaymentIntent with confirmation_method=manual, pass `paymentMethod.stripeId` as the payment_method and confirm=true. Otherwise, you can ignore this parameter.
  
  @param paymentInformation      The underlying PKPayment created by Apple Pay.
- If you create the PaymentIntent with confirmation_method=manual, you can collect shipping information using its `shippingContact` and `shippingMethod` properties. Otherwise, you can ignore this parameter.
+ If you create the PaymentIntent with confirmation_method=manual, you can collect shipping information using its `shippingContact` and `shippingMethod` properties.
  
  @param completion                        Call this with the PaymentIntent's client secret, or the error that occurred creating the PaymentIntent.
  */
@@ -67,7 +67,8 @@ didSelectShippingMethod:(PKShippingMethod *)shippingMethod
  Called when the user has selected a new shipping address.  You should inspect the
  address and must invoke the completion block with an updated array of PKPaymentSummaryItem objects.
  
- @note This does not contain full contact information - you can only receive that after the user authorizes payment, in the paymentInformation passed to `applePayContext:didCreatePaymentMethod:paymentInformation:completion:`
+ @note To maintain privacy, the shipping information is anonymized. For example, in the United States it only includes the city, state, and zip code. This provides enough information to calculate shipping costs, without revealing sensitive information until the user actually approves the purchase.
+ Receive full shipping information in the paymentInformation passed to `applePayContext:didCreatePaymentMethod:paymentInformation:completion:`
  */
 - (void)applePayContext:(STPApplePayContext *)context
 didSelectShippingContact:(PKContact *)contact

--- a/Stripe/PublicHeaders/STPBlocks.h
+++ b/Stripe/PublicHeaders/STPBlocks.h
@@ -249,7 +249,7 @@ typedef void (^STPPaymentStatusBlock)(STPPaymentStatus status, NSError * __nulla
  A block to be run with the client secret of a PaymentIntent or SetupIntent.
  
  @param clientSecret    The client secret of the PaymentIntent or SetupIntent. See https://stripe.com/docs/api/payment_intents/object#payment_intent_object-client_secret
- @param error                    The error creating the Intent, or nil if none occurred.
+ @param error                    The error that occurred when creating the Intent, or nil if none occurred.
  */
 typedef void (^STPIntentClientSecretCompletionBlock)(NSString * __nullable clientSecret, NSError * __nullable error);
 

--- a/Tests/Tests/STPApplePayContextTest.m
+++ b/Tests/Tests/STPApplePayContextTest.m
@@ -9,12 +9,14 @@
 #import <XCTest/XCTest.h>
 
 #import "STPApplePayContext.h"
+#import "STPFixtures.h"
 #import "Stripe.h"
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-parameter"
 
 @interface STPApplePayContext (Private) <PKPaymentAuthorizationViewControllerDelegate>
+- (STPPaymentIntentShippingDetailsParams *)_shippingDetailsFromPKPayment:(PKPayment *)payment;
 @end
 
 @interface STPApplePayTestDelegateiOS11 : NSObject <STPApplePayContextDelegate>
@@ -33,7 +35,10 @@
 }
 
 - (void)applePayContext:(__unused STPApplePayContext *)context didCompleteWithStatus:(__unused STPPaymentStatus)status error:(__unused NSError *)error {}
-- (void)applePayContext:(__unused STPApplePayContext *)context didCreatePaymentMethod:(__unused NSString *)paymentMethodID completion:(__unused STPIntentClientSecretCompletionBlock)completion {}
+
+- (void)applePayContext:(nonnull STPApplePayContext *)context didCreatePaymentMethod:(nonnull STPPaymentMethod *)paymentMethod paymentInformation:(nonnull PKPayment *)paymentInformation completion:(nonnull STPIntentClientSecretCompletionBlock)completion {
+    
+}
 
 @end
 
@@ -53,7 +58,10 @@
 }
 
 - (void)applePayContext:(__unused STPApplePayContext *)context didCompleteWithStatus:(__unused STPPaymentStatus)status error:(__unused NSError *)error {}
-- (void)applePayContext:(__unused STPApplePayContext *)context didCreatePaymentMethod:(__unused NSString *)paymentMethodID completion:(__unused STPIntentClientSecretCompletionBlock)completion {}
+
+- (void)applePayContext:(nonnull STPApplePayContext *)context didCreatePaymentMethod:(nonnull STPPaymentMethod *)paymentMethod paymentInformation:(nonnull PKPayment *)paymentInformation completion:(nonnull STPIntentClientSecretCompletionBlock)completion {
+}
+
 
 @end
 
@@ -129,6 +137,39 @@
     [self waitForExpectationsWithTimeout:2 handler:nil];
 }
 
+- (void)testConvertsShippingDetails {
+    STPApplePayTestDelegateiOS10 *delegate = [STPApplePayTestDelegateiOS10 new];
+    PKPaymentRequest *request = [Stripe paymentRequestWithMerchantIdentifier:@"foo" country:@"US" currency:@"USD"];
+    request.paymentSummaryItems = @[[PKPaymentSummaryItem summaryItemWithLabel:@"bar" amount:[NSDecimalNumber decimalNumberWithString:@"1.00"]]];
+    STPApplePayContext *context = [[STPApplePayContext alloc] initWithPaymentRequest:request delegate:delegate];
+    
+    PKPayment *payment = [STPFixtures simulatorApplePayPayment];
+    PKContact *shipping = [PKContact new];
+    shipping.name = [[NSPersonNameComponentsFormatter new] personNameComponentsFromString:@"Jane Doe"];
+    shipping.phoneNumber = [[CNPhoneNumber alloc] initWithStringValue:@"555-555-5555"];
+    CNMutablePostalAddress *address = [CNMutablePostalAddress new];
+    address.street = @"510 Townsend St";
+    address.city = @"San Francisco";
+    address.state = @"CA";
+    address.ISOCountryCode = @"US";
+    address.postalCode = @"94105";
+    shipping.postalAddress = address;
+    [payment performSelector:@selector(setShippingContact:) withObject:shipping];
+    
+    STPPaymentIntentShippingDetailsParams *shippingParams = [context _shippingDetailsFromPKPayment:payment];
+    XCTAssertNotNil(shippingParams);
+    XCTAssertEqualObjects(shippingParams.name, @"Jane Doe");
+    XCTAssertNil(shippingParams.carrier);
+    XCTAssertEqualObjects(shippingParams.phone, @"555-555-5555");
+    XCTAssertNil(shippingParams.trackingNumber);
+
+    XCTAssertEqualObjects(shippingParams.address.line1, @"510 Townsend St");
+    XCTAssertNil(shippingParams.address.line2);
+    XCTAssertEqualObjects(shippingParams.address.city, @"San Francisco");
+    XCTAssertEqualObjects(shippingParams.address.state, @"CA");
+    XCTAssertEqualObjects(shippingParams.address.country, @"US");
+    XCTAssertEqualObjects(shippingParams.address.postalCode, @"94105");
+}
 
 #pragma clang diagnostic pop
 

--- a/Tests/Tests/STPFixtures.m
+++ b/Tests/Tests/STPFixtures.m
@@ -264,6 +264,14 @@ NSString *const STPTestJSONSourceWeChatPay = @"WeChatPaySource";
     [paymentToken performSelector:@selector(setPaymentMethod:) withObject:paymentMethod];
 
     [payment performSelector:@selector(setToken:) withObject:paymentToken];
+    
+    // Add shipping
+    PKContact *shipping = [PKContact new];
+    shipping.name = [[NSPersonNameComponentsFormatter new] personNameComponentsFromString:@"Jane Doe"];
+    CNMutablePostalAddress *address = [CNMutablePostalAddress new];
+    address.street = @"510 Townsend St";
+    shipping.postalAddress = address;
+    [payment performSelector:@selector(setShippingContact:) withObject:shipping];
 #pragma clang diagnostic pop
     return payment;
 }


### PR DESCRIPTION
## Summary
`STPApplePayContext` automatically attaches shipping details to PaymentIntent upon confirmation, and also passes the raw `PKPayment` back to the user if they want to collect shipping details themselves.

## Motivation
https://jira.corp.stripe.com/browse/IOS-1668

## Testing
- STPApplePayContextFunctionalTest - tests shipping details are attached to the PI for automatic confirmation, and that `PKPayment` is passed.
- STPApplePayContextTest - tests converting from a PKPayment to STPPaymentIntentShippingDetailsParams.