### PR TITLE
Return an NSError for any HTTP errors in STPTestingAPIClient

### DIFF
--- a/Tests/Tests/STPPaymentIntentFunctionalTest.m
+++ b/Tests/Tests/STPPaymentIntentFunctionalTest.m
@@ -29,6 +29,16 @@
     [self waitForExpectationsWithTimeout:STPTestingNetworkRequestTimeout handler:nil];
 }
 
+- (void)testCreatePaymentIntentWithInvalidCurrency {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"PaymentIntent create."];
+    [[STPTestingAPIClient sharedClient] createPaymentIntentWithParams:@{@"payment_method_types": @[@"bancontact"]} completion:^(NSString * _Nullable clientSecret, NSError * _Nullable error) {
+        XCTAssertNil(clientSecret);
+        XCTAssertNotNil(error);
+        XCTAssertTrue([error.userInfo[STPErrorMessageKey] hasPrefix:@"Error creating PaymentIntent: The currency provided (usd) is invalid. Payments with bancontact support the following currencies: eur."]);
+        [expectation fulfill];
+    }];
+    [self waitForExpectationsWithTimeout:STPTestingNetworkRequestTimeout handler:nil];
+}
 
 - (void)testRetrievePreviousCreatedPaymentIntent {
     STPAPIClient *client = [[STPAPIClient alloc] initWithPublishableKey:STPTestingDefaultPublishableKey];

--- a/Tests/Tests/STPTestingAPIClient.m
+++ b/Tests/Tests/STPTestingAPIClient.m
@@ -8,6 +8,8 @@
 
 #import "STPTestingAPIClient.h"
 
+#import "NSError+Stripe.h"
+
 static NSString * const STPTestingBackendURL = @"https://floating-citadel-20318.herokuapp.com/";
 // staging backend
 // static NSString * const STPTestingBackendURL = @"https://ancient-headland-10388.herokuapp.com/";
@@ -49,10 +51,15 @@ NS_ASSUME_NONNULL_BEGIN
                                                                fromData:postData
                                                       completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
                                                           NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
-
-                                                          if (error || data == nil || httpResponse.statusCode != 200) {
+                                                          if (error) {
+                                                              completion(nil, error);
+                                                          } else if (data == nil || httpResponse.statusCode != 200) {
                                                               dispatch_async(dispatch_get_main_queue(), ^{
-                                                                  completion(nil, error);
+                                                                  NSDictionary *userInfo = @{
+                                                                                             STPErrorMessageKey: [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding],
+                                                                                             };
+                                                                  NSError *apiError = [NSError errorWithDomain:StripeDomain code:STPAPIError userInfo:userInfo];
+                                                                  completion(nil, apiError);
                                                               });
                                                           } else {
                                                               NSError *jsonError = nil;


### PR DESCRIPTION
## Summary
Previously we were not returning an `NSError` for any HTTP errors in `STPTestingAPIClient`. Now these errors (e.g. `4xx` responses from Stripe) will be return as `NSError` objects in the completion block.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
IOS-1669
Improve error handling/propagation of Stripe errors for the purpose of unit tests.

## Testing
<!-- How was the code tested? Be as specific as possible. -->
Added a unit test