### PR TITLE
Fixes missing custom placeholder text

### DIFF
--- a/Stripe/STPPaymentCardTextField.m
+++ b/Stripe/STPPaymentCardTextField.m
@@ -1063,7 +1063,7 @@ typedef NS_ENUM(NSInteger, STPCardTextFieldState) {
         // Need to lower xOffset so pan is partially off-screen
 
         BOOL hasEnteredCardNumber = self.cardNumber.length > 0;
-        NSString *compressedCardNumber = self.viewModel.compressedCardNumber;
+        NSString *compressedCardNumber = [self.viewModel compressedCardNumberWithPlaceholder:self.numberPlaceholder];
         NSString *cardNumberToHide = [(hasEnteredCardNumber ? self.cardNumber : self.numberPlaceholder) stp_stringByRemovingSuffix:compressedCardNumber];
 
         if (cardNumberToHide.length > 0 && [STPCardValidator stringIsNumeric:cardNumberToHide]) {

--- a/Stripe/STPPaymentCardTextFieldViewModel.h
+++ b/Stripe/STPPaymentCardTextFieldViewModel.h
@@ -13,6 +13,8 @@
 #import "STPCardValidator.h"
 #import "STPPostalCodeValidator.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 typedef NS_ENUM(NSInteger, STPCardFieldType) {
     STPCardFieldTypeNumber,
     STPCardFieldTypeExpiration,
@@ -22,21 +24,23 @@ typedef NS_ENUM(NSInteger, STPCardFieldType) {
 
 @interface STPPaymentCardTextFieldViewModel : NSObject
 
-@property (nonatomic, readwrite, copy, nullable) NSString *cardNumber;
-@property (nonatomic, readonly, nullable) NSString *compressedCardNumber;
-@property (nonatomic, readwrite, copy, nullable) NSString *rawExpiration;
+@property (nonatomic, copy, nullable) NSString *cardNumber;
+@property (nonatomic, copy, nullable) NSString *rawExpiration;
 @property (nonatomic, readonly, nullable) NSString *expirationMonth;
 @property (nonatomic, readonly, nullable) NSString *expirationYear;
-@property (nonatomic, readwrite, copy, nullable) NSString *cvc;
-@property (nonatomic, readwrite, assign) BOOL postalCodeRequested;
+@property (nonatomic, copy, nullable) NSString *cvc;
+@property (nonatomic) BOOL postalCodeRequested;
 @property (nonatomic, readonly) BOOL postalCodeRequired;
-@property (nonatomic, readwrite, copy, nullable) NSString *postalCode;
-@property (nonatomic, readwrite, copy, nullable) NSString *postalCodeCountryCode;
+@property (nonatomic, copy, nullable) NSString *postalCode;
+@property (nonatomic, copy, nullable) NSString *postalCodeCountryCode;
 @property (nonatomic, readonly) STPCardBrand brand;
 @property (nonatomic, readonly) BOOL isValid;
 
-- (nonnull NSString *)defaultPlaceholder;
+- (NSString *)defaultPlaceholder;
+- (nullable NSString *)compressedCardNumberWithPlaceholder:(nullable NSString *)placeholder;
 
 - (STPCardValidationState)validationStateForField:(STPCardFieldType)fieldType;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Stripe/STPPaymentCardTextFieldViewModel.m
+++ b/Stripe/STPPaymentCardTextFieldViewModel.m
@@ -21,10 +21,10 @@
     _cardNumber = [sanitizedNumber stp_safeSubstringToIndex:maxLength];
 }
 
-- (NSString *)compressedCardNumber {
+- (nullable NSString *)compressedCardNumberWithPlaceholder:(nullable NSString *)placeholder {
     NSString *cardNumber = self.cardNumber;
     if (cardNumber.length == 0) {
-        cardNumber = self.defaultPlaceholder;
+        cardNumber = placeholder ?: self.defaultPlaceholder;
     }
 
     STPCardBrand currentBrand = [STPCardValidator brandForNumber:cardNumber];

--- a/Tests/Tests/STPPaymentCardTextFieldViewModelTest.m
+++ b/Tests/Tests/STPPaymentCardTextFieldViewModelTest.m
@@ -86,30 +86,31 @@
 
 - (void)testCompressedCardNumber {
     self.viewModel.cardNumber = nil;
-    XCTAssertEqualObjects(self.viewModel.compressedCardNumber, @"4242"); // Should use default placeholder
+    XCTAssertEqualObjects([self.viewModel compressedCardNumberWithPlaceholder:nil], @"4242"); // Should use default placeholder
+    XCTAssertEqualObjects([self.viewModel compressedCardNumberWithPlaceholder:@"1234567812345678"], @"5678");
 
     self.viewModel.cardNumber = @"424212345678";
-    XCTAssertEqualObjects(self.viewModel.compressedCardNumber, @"5678");
+    XCTAssertEqualObjects([self.viewModel compressedCardNumberWithPlaceholder:nil], @"5678");
     self.viewModel.cardNumber = @"42421234567";
-    XCTAssertEqualObjects(self.viewModel.compressedCardNumber, @"567");
+    XCTAssertEqualObjects([self.viewModel compressedCardNumberWithPlaceholder:nil], @"567");
     self.viewModel.cardNumber = @"4242123456";
-    XCTAssertEqualObjects(self.viewModel.compressedCardNumber, @"56");
+    XCTAssertEqualObjects([self.viewModel compressedCardNumberWithPlaceholder:nil], @"56");
     self.viewModel.cardNumber = @"424212345";
-    XCTAssertEqualObjects(self.viewModel.compressedCardNumber, @"5");
+    XCTAssertEqualObjects([self.viewModel compressedCardNumberWithPlaceholder:nil], @"5");
     self.viewModel.cardNumber = @"42421234";
-    XCTAssertEqualObjects(self.viewModel.compressedCardNumber, @"1234");
+    XCTAssertEqualObjects([self.viewModel compressedCardNumberWithPlaceholder:nil], @"1234");
 
     self.viewModel.cardNumber = @"12";
-    XCTAssertEqualObjects(self.viewModel.compressedCardNumber, @"12");
+    XCTAssertEqualObjects([self.viewModel compressedCardNumberWithPlaceholder:nil], @"12");
 
     self.viewModel.cardNumber = @"36227206271667";
-    XCTAssertEqualObjects(self.viewModel.compressedCardNumber, @"1667");
+    XCTAssertEqualObjects([self.viewModel compressedCardNumberWithPlaceholder:nil], @"1667");
     self.viewModel.cardNumber = @"3622720627166";
-    XCTAssertEqualObjects(self.viewModel.compressedCardNumber, @"166");
+    XCTAssertEqualObjects([self.viewModel compressedCardNumberWithPlaceholder:nil], @"166");
     self.viewModel.cardNumber = @"36227206271";
-    XCTAssertEqualObjects(self.viewModel.compressedCardNumber, @"1");
+    XCTAssertEqualObjects([self.viewModel compressedCardNumberWithPlaceholder:nil], @"1");
     self.viewModel.cardNumber = @"3622720627";
-    XCTAssertEqualObjects(self.viewModel.compressedCardNumber, @"720627");
+    XCTAssertEqualObjects([self.viewModel compressedCardNumberWithPlaceholder:nil], @"720627");
 }
 
 @end


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Changed compressedCardNumber to take a placeholder argument so that it doesn't always fall back to the default placeholder. The fallback to the default placeholder was causing custom placeholders to disappear when compressed.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://github.com/stripe/stripe-ios/issues/1575

## Testing
<!-- How was the code tested? Be as specific as possible. -->
Tested with submitted issue configuration. Added automated test
