### PR TITLE
`pkPaymentErrorForStripeError` no longer returns PKPaymentUnknownErrors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## ???
+* `pkPaymentErrorForStripeError` no longer returns PKPaymentUnknownErrors. Instead, it returns the original NSError back, resulting in dismissal of the Apple Pay sheet. This means ApplePayContext dismisses the Apple Pay sheet for all errors that aren't specifically PKPaymentError types.
+
 ## 19.3.0 2020-05-28
 * Adds giropay PaymentMethod bindings [#1569](https://github.com/stripe/stripe-ios/pull/1569)
 * Adds Przelewy24 (P24) PaymentMethod bindings [#1556](https://github.com/stripe/stripe-ios/pull/1556)

--- a/Stripe/PublicHeaders/STPAPIClient+ApplePay.h
+++ b/Stripe/PublicHeaders/STPAPIClient+ApplePay.h
@@ -45,15 +45,16 @@ NS_ASSUME_NONNULL_BEGIN
                             completion:(STPPaymentMethodCompletionBlock)completion;
 
 /**
- Converts Stripe errors into the appropriate Apple Pay error, for use in `PKPaymentAuthorizationResult`. The error is displayed in the Apple Pay sheet, and the user can try again.
+ Converts Stripe errors into the appropriate Apple Pay error, for use in `PKPaymentAuthorizationResult`.
  
- We can convert billing address related errors into a PKPaymentError that helpfully points to the billing address field in the Apple Pay sheet.
- All other errors map to PKPaymentUnknownError, resulting in a generic error message in the Apple Pay sheet.
+ If the error can be fixed by the customer within the Apple Pay sheet, we return an NSError that can be displayed in the Apple Pay sheet.
+ Otherwise, the original error is returned, resulting in the Apple Pay sheet being dismissed. You should display the error message to the customer afterwards.
  
- Apple Pay should prevent most card errors (e.g. invalid CVC) when you add a card to the wallet.
+ Currently, we convert billing address related errors into a PKPaymentError that helpfully points to the billing address field in the Apple Pay sheet.
+  
+ Note that Apple Pay should prevent most card errors (e.g. invalid CVC, expired cards) when you add a card to the wallet.
  
  @param stripeError   An error from the Stripe SDK.
- @see ApplePayExampleViewController for an example of how to use this method in your Apple Pay integration.
  */
 + (nullable NSError *)pkPaymentErrorForStripeError:(nullable NSError *)stripeError API_AVAILABLE(ios(11.0), watchos(4.0));
 

--- a/Stripe/STPAPIClient+ApplePay.m
+++ b/Stripe/STPAPIClient+ApplePay.m
@@ -155,15 +155,15 @@
     if (stripeError == nil) {
         return nil;
     }
-    NSMutableDictionary *userInfo = [stripeError.userInfo mutableCopy];
-    PKPaymentErrorCode errorCode = PKPaymentUnknownError;
-    if (stripeError.domain == StripeDomain) {
-        if ([stripeError.userInfo[STPCardErrorCodeKey] isEqualToString:STPIncorrectZip]) {
-            errorCode = PKPaymentBillingContactInvalidError;
-            userInfo[PKPaymentErrorPostalAddressUserInfoKey] = CNPostalAddressPostalCodeKey;
-        }
+
+    if (stripeError.domain == StripeDomain && [stripeError.userInfo[STPCardErrorCodeKey] isEqualToString:STPIncorrectZip]) {
+        NSMutableDictionary *userInfo = [stripeError.userInfo mutableCopy];
+        PKPaymentErrorCode errorCode = PKPaymentUnknownError;
+        errorCode = PKPaymentBillingContactInvalidError;
+        userInfo[PKPaymentErrorPostalAddressUserInfoKey] = CNPostalAddressPostalCodeKey;
+        return [NSError errorWithDomain:StripeDomain code:errorCode userInfo:userInfo];
     }
-    return [NSError errorWithDomain:PKPaymentErrorDomain code:errorCode userInfo:userInfo];
+    return stripeError;
 }
 
 @end


### PR DESCRIPTION
## Summary
`pkPaymentErrorForStripeError` no longer returns PKPaymentUnknownErrors. Instead, it returns the original NSError back, resulting in dismissal of the Apple Pay sheet. 

The Apple Pay sheet doesn't provide useful error messages for PKPaymentUnknownErrors - it's better UX to dismiss the sheet and show the error message to the user yourself.

## Motivation
https://jira.corp.stripe.com/browse/MOBILE-255

## Testing
Forced an error in example VC, saw expected behavior.