### PR TITLE
Migrates CI to use Xcode 11.6 and removes Xcode 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode11.4
+osx_image: xcode11.6
 branches:
   only:
     - master
@@ -23,7 +23,7 @@ matrix:
   - env:
     - TEST_TYPE=lint
     - secure: "RPtZBXKq0EArFHt8eR0hyxb/13QaA08Lc37p0zw/UNjj3ie6d1Vmi+BVqMBB0j7T2T71gkBjjUTV/o7T1VxONpJkEnk1fO4/1OYDbVPTKbkNS0JdmFYzQPFtewFZUhsGLnz/HhfATe8H18PeN0eS9jZbASXIu+Ssah6APt+P78w="
-    osx_image: xcode11.2
+    osx_image: xcode11.6
     addons:
       homebrew:
         casks:
@@ -33,10 +33,10 @@ matrix:
   include:
   - name: legacy-tests-10
     env: TEST_TYPE=legacy-tests-10
-    osx_image: xcode10.2
+    osx_image: xcode11.6
   - name: legacy-tests-11
     env: TEST_TYPE=legacy-tests-11
-    osx_image: xcode10.2        
+    osx_image: xcode11.6        
 
 before_install:
 - SIMULATOR_ID=$(xcrun instruments -s | grep -o "iPhone 6 (11.4) \[.*\]" | grep -o


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
All CI tests will now be run on Xcode 11.6, the latest stable version and the minimum major version allowed for app store submission

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Xcode 10 can no longer be used for building apps or updates that are submitted to the App Store, and fixing warnings in Xcode 11 and 12 require rebuilding our libraries (3ds2) using Xcode 11, which breaks when integrated with Xcode 10.

## Testing
<!-- How was the code tested? Be as specific as possible. -->
