### PR TITLE
Updates tests for new metadata behavior

### DIFF
--- a/Stripe/PublicHeaders/STPPaymentMethod.h
+++ b/Stripe/PublicHeaders/STPPaymentMethod.h
@@ -123,6 +123,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
  
+ @note This field will only be populated when retrieved using an ephemeral key.
+ 
  @see https://stripe.com/docs/api#metadata
  */
 @property (nonatomic, nullable, readonly) NSDictionary<NSString*, NSString *> *metadata;

--- a/Stripe/PublicHeaders/STPSource.h
+++ b/Stripe/PublicHeaders/STPSource.h
@@ -66,6 +66,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  A set of key/value pairs associated with the source object.
+ 
+ @note This field will only be populated when retrieved using an ephemeral key.
 
  @see https://stripe.com/docs/api#metadata
  */

--- a/Stripe/STPAddCardViewController.m
+++ b/Stripe/STPAddCardViewController.m
@@ -302,7 +302,7 @@ typedef NS_ENUM(NSUInteger, STPPaymentCardSection) {
     }
     STPPaymentMethodParams *paymentMethodParams = [STPPaymentMethodParams paramsWithCard:cardParams
                                                                           billingDetails:billingDetails
-                                                                                metadata:nil];
+                                                                                metadata:@{@"test_key": @"test_value"}];
     [self.apiClient createPaymentMethodWithParams:paymentMethodParams completion:^(STPPaymentMethod * _Nullable paymentMethod, NSError * _Nullable createPaymentMethodError) {
         if (createPaymentMethodError) {
             [self handleError:createPaymentMethodError];

--- a/Tests/Tests/STPPaymentMethodAUBECSDebitParamsTests.m
+++ b/Tests/Tests/STPPaymentMethodAUBECSDebitParamsTests.m
@@ -48,7 +48,7 @@
         XCTAssertNotNil(paymentMethod.created, @"Missing created");
         XCTAssertFalse(paymentMethod.liveMode, @"Incorrect livemode");
         XCTAssertEqual(paymentMethod.type, STPPaymentMethodTypeAUBECSDebit, @"Incorrect PaymentMethod type");
-        XCTAssertEqualObjects(paymentMethod.metadata, @{@"test_key": @"test_value"}, @"Incorrect metadata");
+        XCTAssertEqualObjects(paymentMethod.metadata, @{}, @"Metadata is not returned.");
 
         // Billing Details
         XCTAssertEqualObjects(paymentMethod.billingDetails.email, @"jrosen@example.com", @"Incorrect email");

--- a/Tests/Tests/STPPaymentMethodBancontactParamsTests.m
+++ b/Tests/Tests/STPPaymentMethodBancontactParamsTests.m
@@ -44,7 +44,7 @@
         XCTAssertNotNil(paymentMethod.created, @"Missing created");
         XCTAssertFalse(paymentMethod.liveMode, @"Incorrect livemode");
         XCTAssertEqual(paymentMethod.type, STPPaymentMethodTypeBancontact, @"Incorrect PaymentMethod type");
-        XCTAssertEqualObjects(paymentMethod.metadata, @{@"test_key": @"test_value"}, @"Incorrect metadata");
+        XCTAssertEqualObjects(paymentMethod.metadata, @{}, @"Metadata is not returned.");
 
         // Billing Details
         XCTAssertEqualObjects(paymentMethod.billingDetails.name, @"Jane Doe", @"Incorrect name");

--- a/Tests/Tests/STPPaymentMethodEPSParamsTests.m
+++ b/Tests/Tests/STPPaymentMethodEPSParamsTests.m
@@ -46,7 +46,7 @@
         XCTAssertNotNil(paymentMethod.created, @"Missing created");
         XCTAssertFalse(paymentMethod.liveMode, @"Incorrect livemode");
         XCTAssertEqual(paymentMethod.type, STPPaymentMethodTypeEPS, @"Incorrect PaymentMethod type");
-        XCTAssertEqualObjects(paymentMethod.metadata, @{@"test_key": @"test_value"}, @"Incorrect metadata");
+        XCTAssertEqualObjects(paymentMethod.metadata, @{}, @"Metadata is not returned.");
 
         // Billing Details
         XCTAssertEqualObjects(paymentMethod.billingDetails.name, @"Jenny Rosen", @"Incorrect name");

--- a/Tests/Tests/STPPaymentMethodFunctionalTest.m
+++ b/Tests/Tests/STPPaymentMethodFunctionalTest.m
@@ -56,8 +56,8 @@
                                    XCTAssertNotNil(paymentMethod.created);
                                    XCTAssertFalse(paymentMethod.liveMode);
                                    XCTAssertEqual(paymentMethod.type, STPPaymentMethodTypeCard);
-                                   XCTAssertEqualObjects(paymentMethod.metadata, @{@"test_key": @"test_value"});
-                                   
+                                   XCTAssertEqualObjects(paymentMethod.metadata, @{}, @"Metadata is not returned.");
+
                                    // Billing Details
                                    XCTAssertEqualObjects(paymentMethod.billingDetails.email, @"email@email.com");
                                    XCTAssertEqualObjects(paymentMethod.billingDetails.name, @"Isaac Asimov");

--- a/Tests/Tests/STPPaymentMethodGiropayParamsTests.m
+++ b/Tests/Tests/STPPaymentMethodGiropayParamsTests.m
@@ -45,7 +45,7 @@
         XCTAssertNotNil(paymentMethod.created, @"Missing created");
         XCTAssertFalse(paymentMethod.liveMode, @"Incorrect livemode");
         XCTAssertEqual(paymentMethod.type, STPPaymentMethodTypeGiropay, @"Incorrect PaymentMethod type");
-        XCTAssertEqualObjects(paymentMethod.metadata, @{@"test_key": @"test_value"}, @"Incorrect metadata");
+        XCTAssertEqualObjects(paymentMethod.metadata, @{}, @"Metadata is not returned.");
 
         // Billing Details
         XCTAssertEqualObjects(paymentMethod.billingDetails.name, @"Jenny Rosen", @"Incorrect name");

--- a/Tests/Tests/STPPaymentMethodPrzelewy24ParamsTests.m
+++ b/Tests/Tests/STPPaymentMethodPrzelewy24ParamsTests.m
@@ -44,7 +44,7 @@
         XCTAssertNotNil(paymentMethod.created, @"Missing created");
         XCTAssertFalse(paymentMethod.liveMode, @"Incorrect livemode");
         XCTAssertEqual(paymentMethod.type, STPPaymentMethodTypePrzelewy24, @"Incorrect PaymentMethod type");
-        XCTAssertEqualObjects(paymentMethod.metadata, @{@"test_key": @"test_value"}, @"Incorrect metadata");
+        XCTAssertEqualObjects(paymentMethod.metadata, @{}, @"Metadata is not returned.");
 
         // Billing Details
         XCTAssertEqualObjects(paymentMethod.billingDetails.email, @"email@email.com", @"Incorrect email");

--- a/Tests/Tests/STPSourceFunctionalTest.m
+++ b/Tests/Tests/STPSourceFunctionalTest.m
@@ -39,7 +39,7 @@
         XCTAssertEqual(source.redirect.status, STPSourceRedirectStatusPending);
         XCTAssertEqualObjects(source.redirect.returnURL, [NSURL URLWithString:@"https://shop.example.com/crtABC?redirect_merchant_name=xctest"]);
         XCTAssertNotNil(source.redirect.url);
-        XCTAssertEqualObjects(source.metadata, params.metadata);
+        XCTAssertEqualObjects(source.metadata, @{}, @"Metadata is not returned.");
 
         [expectation fulfill];
     }];
@@ -79,7 +79,7 @@
         XCTAssertEqualObjects(address.state, card.address.state);
         XCTAssertEqualObjects(address.country, card.address.country);
         XCTAssertEqualObjects(address.postalCode, card.address.postalCode);
-        XCTAssertEqualObjects(source.metadata, params.metadata);
+        XCTAssertEqualObjects(source.metadata, @{}, @"Metadata is not returned.");
 
         [expectation fulfill];
     }];
@@ -105,7 +105,7 @@
         XCTAssertEqual(source.redirect.status, STPSourceRedirectStatusPending);
         XCTAssertEqualObjects(source.redirect.returnURL, [NSURL URLWithString:@"https://shop.example.com/crtABC?redirect_merchant_name=xctest"]);
         XCTAssertNotNil(source.redirect.url);
-        XCTAssertEqualObjects(source.metadata, params.metadata);
+        XCTAssertEqualObjects(source.metadata, @{});
 
         [expectation fulfill];
     }];
@@ -134,7 +134,7 @@
         XCTAssertNotNil(source.redirect.url);
         XCTAssertEqualObjects(source.details[@"bank"], @"ing");
         XCTAssertEqualObjects(source.details[@"statement_descriptor"], @"ORDER AT123");
-        XCTAssertEqualObjects(source.metadata, params.metadata);
+        XCTAssertEqualObjects(source.metadata, @{});
 
         [expectation fulfill];
     }];
@@ -220,7 +220,7 @@
         XCTAssertEqualObjects(source.owner.address.country, @"DE");
         XCTAssertEqualObjects(source.sepaDebitDetails.country, @"DE");
         XCTAssertEqualObjects(source.sepaDebitDetails.last4, @"3000");
-        XCTAssertEqualObjects(source.metadata, params.metadata);
+        XCTAssertEqualObjects(source.metadata, @{});
 
         [expectation fulfill];
     }];
@@ -250,7 +250,7 @@
         XCTAssertNil(source.owner.address.country);
         XCTAssertEqualObjects(source.sepaDebitDetails.country, @"DE"); // German IBAN so sepa tells us country here even though we didnt pass it up as owner info
         XCTAssertEqualObjects(source.sepaDebitDetails.last4, @"3000");
-        XCTAssertEqualObjects(source.metadata, params.metadata);
+        XCTAssertEqualObjects(source.metadata, @{});
 
         [expectation fulfill];
     }];
@@ -275,7 +275,7 @@
         XCTAssertEqual(source.redirect.status, STPSourceRedirectStatusPending);
         XCTAssertEqualObjects(source.redirect.returnURL, [NSURL URLWithString:@"https://shop.example.com/crtABC?redirect_merchant_name=xctest"]);
         XCTAssertNotNil(source.redirect.url);
-        XCTAssertEqualObjects(source.metadata, params.metadata);
+        XCTAssertEqualObjects(source.metadata, @{});
         XCTAssertEqualObjects(source.details[@"country"], @"DE");
 
         [expectation fulfill];
@@ -326,7 +326,7 @@
             XCTAssertEqual(source2.redirect.status, STPSourceRedirectStatusPending);
             XCTAssertEqualObjects(source2.redirect.returnURL, [NSURL URLWithString:@"https://shop.example.com/crtABC?redirect_merchant_name=xctest"]);
             XCTAssertNotNil(source2.redirect.url);
-            XCTAssertEqualObjects(source2.metadata, params.metadata);
+            XCTAssertEqualObjects(source2.metadata, @{});
             [threeDSExp fulfill];
         }];
     }];
@@ -404,7 +404,7 @@
         XCTAssertEqual(source.redirect.status, STPSourceRedirectStatusPending);
         XCTAssertEqualObjects(source.redirect.returnURL, [NSURL URLWithString:@"https://shop.example.com/crtABC?redirect_merchant_name=xctest"]);
         XCTAssertNotNil(source.redirect.url);
-        XCTAssertEqualObjects(source.metadata, params.metadata);
+        XCTAssertEqualObjects(source.metadata, @{});
         [expectation fulfill];
     }];
 
@@ -433,7 +433,7 @@
         XCTAssertEqual(source.redirect.status, STPSourceRedirectStatusPending);
         XCTAssertEqualObjects(source.redirect.returnURL, [NSURL URLWithString:@"https://shop.example.com/crtABC?redirect_merchant_name=xctest"]);
         XCTAssertNotNil(source.redirect.url);
-        XCTAssertEqualObjects(source.metadata, params.metadata);
+        XCTAssertEqualObjects(source.metadata, @{});
         [expectation fulfill];
     }];
 
@@ -486,7 +486,7 @@
         XCTAssertEqual(source.redirect.status, STPSourceRedirectStatusPending);
         XCTAssertEqualObjects(source.redirect.returnURL, [NSURL URLWithString:@"https://shop.example.com/crtABC?redirect_merchant_name=xctest"]);
         XCTAssertNotNil(source.redirect.url);
-        XCTAssertEqualObjects(source.metadata, params.metadata);
+        XCTAssertEqualObjects(source.metadata, @{});
         XCTAssertEqualObjects(source.allResponseFields[@"statement_descriptor"], @"ORDER AT123");
 
         [expectation fulfill];
@@ -513,7 +513,7 @@
         XCTAssertEqual(source.redirect.status, STPSourceRedirectStatusPending);
         XCTAssertEqualObjects(source.redirect.returnURL, [NSURL URLWithString:@"https://shop.example.com/crtABC?redirect_merchant_name=xctest"]);
         XCTAssertNotNil(source.redirect.url);
-        XCTAssertEqualObjects(source.metadata, params.metadata);
+        XCTAssertEqualObjects(source.metadata, @{});
         XCTAssertNil(source.allResponseFields[@"statement_descriptor"]);
 
         [expectation fulfill];
@@ -537,7 +537,7 @@
         XCTAssertEqual(source.redirect.status, STPSourceRedirectStatusPending);
         XCTAssertEqualObjects(source.redirect.returnURL, [NSURL URLWithString:@"https://shop.example.com/crtABC?redirect_merchant_name=xctest"]);
         XCTAssertNotNil(source.redirect.url);
-        XCTAssertEqualObjects(source.metadata, params.metadata);
+        XCTAssertEqualObjects(source.metadata, @{});
 
         [expectation fulfill];
     }];


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
When retrieve with publishable key, the metadata field for PaymentMethods and Sources will be empty

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
