### PR TITLE
Deprecates metadata field on retrieved API objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## ???
 * `pkPaymentErrorForStripeError` no longer returns PKPaymentUnknownErrors. Instead, it returns the original NSError back, resulting in dismissal of the Apple Pay sheet. This means ApplePayContext dismisses the Apple Pay sheet for all errors that aren't specifically PKPaymentError types.
+* `metadata` fields are no longer populated on retrieved Stripe API objects and must be fetched on your server using your secret key. If this is causing issues with your deployed app versions please reach out to [Stripe Support](https://support.stripe.com/?contact=true). These fields have been marked as deprecated and will be removed in a future SDK version.
 
 ## 19.3.0 2020-05-28
 * Adds giropay PaymentMethod bindings [#1569](https://github.com/stripe/stripe-ios/pull/1569)

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,5 +1,8 @@
 ## Migration Guides
 
+### Migrating from versions < ???
+* `metadata` fields are no longer populated on retrieved Stripe API objects and must be fetched on your server using your secret key. If this is causing issues with your deployed app versions please reach out to [Stripe Support](https://support.stripe.com/?contact=true). These fields have been marked as deprecated and will be removed in a future SDK version.
+
 ### Migrating from versions < 19.3.0
 * `STPAUBECSFormView` now inherits from `UIView` instead of `UIControl`
 

--- a/Stripe/PublicHeaders/STPBankAccount.h
+++ b/Stripe/PublicHeaders/STPBankAccount.h
@@ -101,18 +101,20 @@ typedef NS_ENUM(NSInteger, STPBankAccountStatus) {
 @property (nonatomic, nullable, readonly) NSString *fingerprint;
 
 /**
- A set of key/value pairs associated with the bank account object.
-
- @see https://stripe.com/docs/api#metadata
- */
-@property (nonatomic, copy, nullable, readonly) NSDictionary<NSString *, NSString *> *metadata;
-
-/**
  The validation status of the bank account. @see STPBankAccountStatus
  */
 @property (nonatomic, readonly) STPBankAccountStatus status;
 
 #pragma mark - Deprecated methods
+
+/**
+ A set of key/value pairs associated with the bank account object.
+ 
+ @deprecated Metadata is no longer returned to clients using publishable keys. Retrieve them on your server using you secret key instead.
+ 
+ @see https://stripe.com/docs/api#metadata
+ */
+@property (nonatomic, nullable, readonly) NSDictionary<NSString*, NSString *> *metadata DEPRECATED_MSG_ATTRIBUTE("Metadata is no longer returned to clients using publishable keys. Retrieve them on your server using you secret key instead.");
 
 /**
  The Stripe ID for the bank account.

--- a/Stripe/PublicHeaders/STPBankAccount.h
+++ b/Stripe/PublicHeaders/STPBankAccount.h
@@ -110,11 +110,11 @@ typedef NS_ENUM(NSInteger, STPBankAccountStatus) {
 /**
  A set of key/value pairs associated with the bank account object.
  
- @deprecated Metadata is no longer returned to clients using publishable keys. Retrieve them on your server using you secret key instead.
+ @deprecated Metadata is no longer returned to clients using publishable keys. Retrieve them on your server using yoursecret key instead.
  
  @see https://stripe.com/docs/api#metadata
  */
-@property (nonatomic, nullable, readonly) NSDictionary<NSString*, NSString *> *metadata DEPRECATED_MSG_ATTRIBUTE("Metadata is no longer returned to clients using publishable keys. Retrieve them on your server using you secret key instead.");
+@property (nonatomic, nullable, readonly) NSDictionary<NSString*, NSString *> *metadata DEPRECATED_MSG_ATTRIBUTE("Metadata is no longer returned to clients using publishable keys. Retrieve them on your server using yoursecret key instead.");
 
 /**
  The Stripe ID for the bank account.

--- a/Stripe/PublicHeaders/STPCard.h
+++ b/Stripe/PublicHeaders/STPCard.h
@@ -115,13 +115,6 @@ typedef NS_ENUM(NSInteger, STPCardFundingType) {
 @property (nonatomic, nullable, readonly) NSString *currency;
 
 /**
- A set of key/value pairs associated with the card object.
-
- @see https://stripe.com/docs/api#metadata
- */
-@property (nonatomic, copy, nullable, readonly) NSDictionary<NSString *, NSString *> *metadata;
-
-/**
  Returns a string representation for the provided card brand; 
  i.e. `[NSString stringFromBrand:STPCardBrandVisa] ==  @"Visa"`.
 
@@ -150,6 +143,15 @@ typedef NS_ENUM(NSInteger, STPCardFundingType) {
 + (STPCardBrand)brandFromString:(NSString *)string;
 
 #pragma mark - Deprecated methods
+
+/**
+ A set of key/value pairs associated with the card object.
+ 
+ @deprecated Metadata is no longer returned to clients using publishable keys. Retrieve them on your server using you secret key instead.
+ 
+ @see https://stripe.com/docs/api#metadata
+ */
+@property (nonatomic, nullable, readonly) NSDictionary<NSString*, NSString *> *metadata DEPRECATED_MSG_ATTRIBUTE("Metadata is no longer returned to clients using publishable keys. Retrieve them on your server using you secret key instead.");
 
 /**
  The Stripe ID for the card.

--- a/Stripe/PublicHeaders/STPCard.h
+++ b/Stripe/PublicHeaders/STPCard.h
@@ -147,11 +147,11 @@ typedef NS_ENUM(NSInteger, STPCardFundingType) {
 /**
  A set of key/value pairs associated with the card object.
  
- @deprecated Metadata is no longer returned to clients using publishable keys. Retrieve them on your server using you secret key instead.
+ @deprecated Metadata is no longer returned to clients using publishable keys. Retrieve them on your server using yoursecret key instead.
  
  @see https://stripe.com/docs/api#metadata
  */
-@property (nonatomic, nullable, readonly) NSDictionary<NSString*, NSString *> *metadata DEPRECATED_MSG_ATTRIBUTE("Metadata is no longer returned to clients using publishable keys. Retrieve them on your server using you secret key instead.");
+@property (nonatomic, nullable, readonly) NSDictionary<NSString*, NSString *> *metadata DEPRECATED_MSG_ATTRIBUTE("Metadata is no longer returned to clients using publishable keys. Retrieve them on your server using yoursecret key instead.");
 
 /**
  The Stripe ID for the card.

--- a/Stripe/PublicHeaders/STPPaymentMethod.h
+++ b/Stripe/PublicHeaders/STPPaymentMethod.h
@@ -126,14 +126,16 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, nullable, readonly) NSString *customerId;
 
+#pragma mark - Deprecated
+
 /**
  Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
  
- @note This field will only be populated when retrieved using an ephemeral key.
+ @deprecated Metadata is no longer returned to clients using publishable keys. Retrieve them on your server using you secret key instead.
  
  @see https://stripe.com/docs/api#metadata
  */
-@property (nonatomic, nullable, readonly) NSDictionary<NSString*, NSString *> *metadata;
+@property (nonatomic, nullable, readonly) NSDictionary<NSString*, NSString *> *metadata DEPRECATED_MSG_ATTRIBUTE("Metadata is no longer returned to clients using publishable keys. Retrieve them on your server using you secret key instead.");
 
 @end
 

--- a/Stripe/PublicHeaders/STPPaymentMethod.h
+++ b/Stripe/PublicHeaders/STPPaymentMethod.h
@@ -131,11 +131,11 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
  
- @deprecated Metadata is no longer returned to clients using publishable keys. Retrieve them on your server using you secret key instead.
+ @deprecated Metadata is no longer returned to clients using publishable keys. Retrieve them on your server using yoursecret key instead.
  
  @see https://stripe.com/docs/api#metadata
  */
-@property (nonatomic, nullable, readonly) NSDictionary<NSString*, NSString *> *metadata DEPRECATED_MSG_ATTRIBUTE("Metadata is no longer returned to clients using publishable keys. Retrieve them on your server using you secret key instead.");
+@property (nonatomic, nullable, readonly) NSDictionary<NSString*, NSString *> *metadata DEPRECATED_MSG_ATTRIBUTE("Metadata is no longer returned to clients using publishable keys. Retrieve them on your server using yoursecret key instead.");
 
 @end
 

--- a/Stripe/PublicHeaders/STPPaymentMethodCardChecks.h
+++ b/Stripe/PublicHeaders/STPPaymentMethodCardChecks.h
@@ -58,25 +58,25 @@ typedef NS_ENUM(NSUInteger, STPPaymentMethodCardCheckResult) {
 /**
  If a address line1 was provided, results of the check.
 
- @deprecated Card check values are no longer returned to clients using publishable keys. Retrieve them on your server using you secret key instead.
+ @deprecated Card check values are no longer returned to clients using publishable keys. Retrieve them on your server using yoursecret key instead.
  */
-@property (nonatomic, readonly) STPPaymentMethodCardCheckResult addressLine1Check DEPRECATED_MSG_ATTRIBUTE("Card check values are no longer returned to clients using publishable keys. Retrieve them on your server using you secret key instead.");
+@property (nonatomic, readonly) STPPaymentMethodCardCheckResult addressLine1Check DEPRECATED_MSG_ATTRIBUTE("Card check values are no longer returned to clients using publishable keys. Retrieve them on your server using yoursecret key instead.");
 
 /**
  If a address postal code was provided, results of the check.
 
 
- @deprecated Card check values are no longer returned to clients using publishable keys. Retrieve them on your server using you secret key instead.
+ @deprecated Card check values are no longer returned to clients using publishable keys. Retrieve them on your server using yoursecret key instead.
  */
-@property (nonatomic, readonly) STPPaymentMethodCardCheckResult addressPostalCodeCheck DEPRECATED_MSG_ATTRIBUTE("Card check values are no longer returned to clients using publishable keys. Retrieve them on your server using you secret key instead.");
+@property (nonatomic, readonly) STPPaymentMethodCardCheckResult addressPostalCodeCheck DEPRECATED_MSG_ATTRIBUTE("Card check values are no longer returned to clients using publishable keys. Retrieve them on your server using yoursecret key instead.");
 
 /**
  If a CVC was provided, results of the check.
 
 
- @deprecated Card check values are no longer returned to clients using publishable keys. Retrieve them on your server using you secret key instead.
+ @deprecated Card check values are no longer returned to clients using publishable keys. Retrieve them on your server using yoursecret key instead.
  */
-@property (nonatomic, readonly) STPPaymentMethodCardCheckResult cvcCheck DEPRECATED_MSG_ATTRIBUTE("Card check values are no longer returned to clients using publishable keys. Retrieve them on your server using you secret key instead.");
+@property (nonatomic, readonly) STPPaymentMethodCardCheckResult cvcCheck DEPRECATED_MSG_ATTRIBUTE("Card check values are no longer returned to clients using publishable keys. Retrieve them on your server using yoursecret key instead.");
 
 @end
 

--- a/Stripe/PublicHeaders/STPSetupIntent.h
+++ b/Stripe/PublicHeaders/STPSetupIntent.h
@@ -53,13 +53,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) BOOL livemode;
 
 /**
- Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
- 
- @see https://stripe.com/docs/api#metadata
- */
-@property (nonatomic, nullable, readonly) NSDictionary<NSString*, NSString *> *metadata;
-
-/**
  If present, this property tells you what actions you need to take in order for your customer to set up this payment method.
  */
 @property (nonatomic, nullable, readonly) STPIntentAction *nextAction;
@@ -88,6 +81,17 @@ NS_ASSUME_NONNULL_BEGIN
  The setup error encountered in the previous SetupIntent confirmation.
  */
 @property (nonatomic, nullable, readonly) STPSetupIntentLastSetupError *lastSetupError;
+
+#pragma mark - Deprecated
+
+/**
+ Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+ 
+ @deprecated Metadata is not  returned to clients using publishable keys. Retrieve them on your server using you secret key instead.
+ 
+ @see https://stripe.com/docs/api#metadata
+ */
+@property (nonatomic, nullable, readonly) NSDictionary<NSString*, NSString *> *metadata DEPRECATED_MSG_ATTRIBUTE("Metadata is not longer to clients using publishable keys. Retrieve them on your server using you secret key instead.");
 
 @end
 

--- a/Stripe/PublicHeaders/STPSetupIntent.h
+++ b/Stripe/PublicHeaders/STPSetupIntent.h
@@ -87,11 +87,11 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
  
- @deprecated Metadata is not  returned to clients using publishable keys. Retrieve them on your server using you secret key instead.
+ @deprecated Metadata is not  returned to clients using publishable keys. Retrieve them on your server using yoursecret key instead.
  
  @see https://stripe.com/docs/api#metadata
  */
-@property (nonatomic, nullable, readonly) NSDictionary<NSString*, NSString *> *metadata DEPRECATED_MSG_ATTRIBUTE("Metadata is not longer to clients using publishable keys. Retrieve them on your server using you secret key instead.");
+@property (nonatomic, nullable, readonly) NSDictionary<NSString*, NSString *> *metadata DEPRECATED_MSG_ATTRIBUTE("Metadata is not longer to clients using publishable keys. Retrieve them on your server using yoursecret key instead.");
 
 @end
 

--- a/Stripe/PublicHeaders/STPSource.h
+++ b/Stripe/PublicHeaders/STPSource.h
@@ -136,11 +136,11 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  A set of key/value pairs associated with the source object.
  
- @deprecated Metadata is no longer returned to clients using publishable keys. Retrieve them on your server using you secret key instead.
+ @deprecated Metadata is no longer returned to clients using publishable keys. Retrieve them on your server using yoursecret key instead.
  
  @see https://stripe.com/docs/api#metadata
  */
-@property (nonatomic, nullable, readonly) NSDictionary<NSString*, NSString *> *metadata DEPRECATED_MSG_ATTRIBUTE("Metadata is no longer returned to clients using publishable keys. Retrieve them on your server using you secret key instead.");
+@property (nonatomic, nullable, readonly) NSDictionary<NSString*, NSString *> *metadata DEPRECATED_MSG_ATTRIBUTE("Metadata is no longer returned to clients using publishable keys. Retrieve them on your server using yoursecret key instead.");
 
 @end
 

--- a/Stripe/PublicHeaders/STPSource.h
+++ b/Stripe/PublicHeaders/STPSource.h
@@ -65,15 +65,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) BOOL livemode;
 
 /**
- A set of key/value pairs associated with the source object.
- 
- @note This field will only be populated when retrieved using an ephemeral key.
-
- @see https://stripe.com/docs/api#metadata
- */
-@property (nonatomic, copy, nullable, readonly) NSDictionary<NSString *, NSString *> *metadata;
-
-/**
  Information about the owner of the payment instrument.
  */
 @property (nonatomic, nullable, readonly) STPSourceOwner *owner;
@@ -139,6 +130,17 @@ NS_ASSUME_NONNULL_BEGIN
  contents of the `details` dictionary.
  */
 @property (nonatomic, nullable, readonly) STPSourceWeChatPayDetails *weChatPayDetails;
+
+#pragma mark - Deprecated
+
+/**
+ A set of key/value pairs associated with the source object.
+ 
+ @deprecated Metadata is no longer returned to clients using publishable keys. Retrieve them on your server using you secret key instead.
+ 
+ @see https://stripe.com/docs/api#metadata
+ */
+@property (nonatomic, nullable, readonly) NSDictionary<NSString*, NSString *> *metadata DEPRECATED_MSG_ATTRIBUTE("Metadata is no longer returned to clients using publishable keys. Retrieve them on your server using you secret key instead.");
 
 @end
 

--- a/Stripe/STPPaymentMethodParams.m
+++ b/Stripe/STPPaymentMethodParams.m
@@ -151,7 +151,6 @@ billingDetails:(STPPaymentMethodBillingDetails *)billingDetails
             STPPaymentMethodEPSParams *eps = [[STPPaymentMethodEPSParams alloc] init];
             params.eps = eps;
             params.billingDetails = paymentMethod.billingDetails;
-            params.metadata = paymentMethod.metadata;
             break;
         }
         case STPPaymentMethodTypeFPX:
@@ -161,7 +160,6 @@ billingDetails:(STPPaymentMethodBillingDetails *)billingDetails
             fpx.rawBankString = paymentMethod.fpx.bankIdentifierCode;
             params.fpx = fpx;
             params.billingDetails = paymentMethod.billingDetails;
-            params.metadata = paymentMethod.metadata;
             break;
         }
         case STPPaymentMethodTypeiDEAL:
@@ -171,7 +169,6 @@ billingDetails:(STPPaymentMethodBillingDetails *)billingDetails
             params.iDEAL = iDEAL;
             params.iDEAL.bankName = paymentMethod.iDEAL.bankName;
             params.billingDetails = paymentMethod.billingDetails;
-            params.metadata = paymentMethod.metadata;
             break;
         }
         case STPPaymentMethodTypeGiropay:
@@ -180,7 +177,6 @@ billingDetails:(STPPaymentMethodBillingDetails *)billingDetails
             STPPaymentMethodGiropayParams *giropay = [[STPPaymentMethodGiropayParams alloc] init];
             params.giropay = giropay;
             params.billingDetails = paymentMethod.billingDetails;
-            params.metadata = paymentMethod.metadata;
             break;
         }
         case STPPaymentMethodTypePrzelewy24:
@@ -189,7 +185,6 @@ billingDetails:(STPPaymentMethodBillingDetails *)billingDetails
             STPPaymentMethodPrzelewy24Params *przelewy24 = [[STPPaymentMethodPrzelewy24Params alloc] init];
             params.przelewy24 = przelewy24;
             params.billingDetails = paymentMethod.billingDetails;
-            params.metadata = paymentMethod.metadata;
             break;
         }
         case STPPaymentMethodTypeBancontact:
@@ -198,7 +193,6 @@ billingDetails:(STPPaymentMethodBillingDetails *)billingDetails
             STPPaymentMethodBancontactParams *bancontact = [[STPPaymentMethodBancontactParams alloc] init];
             params.bancontact = bancontact;
             params.billingDetails = paymentMethod.billingDetails;
-            params.metadata = paymentMethod.metadata;
             break;
         }
         case STPPaymentMethodTypeAlipay:
@@ -206,7 +200,6 @@ billingDetails:(STPPaymentMethodBillingDetails *)billingDetails
             // Careful! In the future, when we add recurring Alipay, we'll need to look at this!
             params.type = STPPaymentMethodTypeAlipay;
             params.billingDetails = paymentMethod.billingDetails;
-            params.metadata = paymentMethod.metadata;
             break;
         }
         case STPPaymentMethodTypeSEPADebit:

--- a/Tests/Tests/CardPaymentMethod.json
+++ b/Tests/Tests/CardPaymentMethod.json
@@ -57,8 +57,5 @@
   },
   "created": 123456789,
   "livemode": false,
-  "metadata": {
-    "order_id": "123456789"
-  },
   "type": "card"
 }

--- a/Tests/Tests/STPBankAccountTest.m
+++ b/Tests/Tests/STPBankAccountTest.m
@@ -139,7 +139,10 @@
     XCTAssertEqualObjects(bankAccount.currency, @"usd");
     XCTAssertEqualObjects(bankAccount.fingerprint, @"1JWtPxqbdX5Gamtc");
     XCTAssertEqualObjects(bankAccount.last4, @"6789");
-    XCTAssertEqualObjects(bankAccount.metadata, @{@"order_id": @"6735"});
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
+        XCTAssertEqualObjects(bankAccount.metadata, @{@"order_id": @"6735"}); // has non-empty value because this is from a hard-coded response json file
+#pragma clang diagnostic pop
     XCTAssertEqualObjects(bankAccount.routingNumber, @"110000000");
     XCTAssertEqual(bankAccount.status, STPBankAccountStatusNew);
 

--- a/Tests/Tests/STPCardTest.m
+++ b/Tests/Tests/STPCardTest.m
@@ -245,6 +245,7 @@
     XCTAssertEqualObjects(card.addressLine2, @"Apt 1");
     XCTAssertEqualObjects(card.addressState, @"PA");
     XCTAssertEqualObjects(card.addressZip, @"19219");
+    XCTAssertEqualObjects(card.metadata, @{@"order_id": @"6735"}); // has non-empty value because this is from a hard-coded response json file
 
 #pragma clang diagnostic pop
 
@@ -256,7 +257,6 @@
     XCTAssertEqual(card.expYear, (NSUInteger)2017);
     XCTAssertEqual(card.funding, STPCardFundingTypeCredit);
     XCTAssertEqualObjects(card.last4, @"4242");
-    XCTAssertEqualObjects(card.metadata, @{@"order_id": @"6735"});
     XCTAssertEqualObjects(card.name, @"Jane Austen");
 
     XCTAssertNotEqual(card.allResponseFields, response);

--- a/Tests/Tests/STPPaymentMethodAUBECSDebitParamsTests.m
+++ b/Tests/Tests/STPPaymentMethodAUBECSDebitParamsTests.m
@@ -48,7 +48,10 @@
         XCTAssertNotNil(paymentMethod.created, @"Missing created");
         XCTAssertFalse(paymentMethod.liveMode, @"Incorrect livemode");
         XCTAssertEqual(paymentMethod.type, STPPaymentMethodTypeAUBECSDebit, @"Incorrect PaymentMethod type");
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
         XCTAssertEqualObjects(paymentMethod.metadata, @{}, @"Metadata is not returned.");
+#pragma clang diagnostic pop
 
         // Billing Details
         XCTAssertEqualObjects(paymentMethod.billingDetails.email, @"jrosen@example.com", @"Incorrect email");

--- a/Tests/Tests/STPPaymentMethodBancontactParamsTests.m
+++ b/Tests/Tests/STPPaymentMethodBancontactParamsTests.m
@@ -44,7 +44,10 @@
         XCTAssertNotNil(paymentMethod.created, @"Missing created");
         XCTAssertFalse(paymentMethod.liveMode, @"Incorrect livemode");
         XCTAssertEqual(paymentMethod.type, STPPaymentMethodTypeBancontact, @"Incorrect PaymentMethod type");
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
         XCTAssertEqualObjects(paymentMethod.metadata, @{}, @"Metadata is not returned.");
+#pragma clang diagnostic pop
 
         // Billing Details
         XCTAssertEqualObjects(paymentMethod.billingDetails.name, @"Jane Doe", @"Incorrect name");

--- a/Tests/Tests/STPPaymentMethodEPSParamsTests.m
+++ b/Tests/Tests/STPPaymentMethodEPSParamsTests.m
@@ -46,7 +46,10 @@
         XCTAssertNotNil(paymentMethod.created, @"Missing created");
         XCTAssertFalse(paymentMethod.liveMode, @"Incorrect livemode");
         XCTAssertEqual(paymentMethod.type, STPPaymentMethodTypeEPS, @"Incorrect PaymentMethod type");
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
         XCTAssertEqualObjects(paymentMethod.metadata, @{}, @"Metadata is not returned.");
+#pragma clang diagnostic pop
 
         // Billing Details
         XCTAssertEqualObjects(paymentMethod.billingDetails.name, @"Jenny Rosen", @"Incorrect name");

--- a/Tests/Tests/STPPaymentMethodFunctionalTest.m
+++ b/Tests/Tests/STPPaymentMethodFunctionalTest.m
@@ -57,7 +57,10 @@
                                    XCTAssertNotNil(paymentMethod.created);
                                    XCTAssertFalse(paymentMethod.liveMode);
                                    XCTAssertEqual(paymentMethod.type, STPPaymentMethodTypeCard);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
                                    XCTAssertEqualObjects(paymentMethod.metadata, @{}, @"Metadata is not returned.");
+#pragma clang diagnostic pop
 
                                    // Billing Details
                                    XCTAssertEqualObjects(paymentMethod.billingDetails.email, @"email@email.com");

--- a/Tests/Tests/STPPaymentMethodGiropayParamsTests.m
+++ b/Tests/Tests/STPPaymentMethodGiropayParamsTests.m
@@ -45,7 +45,10 @@
         XCTAssertNotNil(paymentMethod.created, @"Missing created");
         XCTAssertFalse(paymentMethod.liveMode, @"Incorrect livemode");
         XCTAssertEqual(paymentMethod.type, STPPaymentMethodTypeGiropay, @"Incorrect PaymentMethod type");
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
         XCTAssertEqualObjects(paymentMethod.metadata, @{}, @"Metadata is not returned.");
+#pragma clang diagnostic pop
 
         // Billing Details
         XCTAssertEqualObjects(paymentMethod.billingDetails.name, @"Jenny Rosen", @"Incorrect name");

--- a/Tests/Tests/STPPaymentMethodPrzelewy24ParamsTests.m
+++ b/Tests/Tests/STPPaymentMethodPrzelewy24ParamsTests.m
@@ -44,7 +44,10 @@
         XCTAssertNotNil(paymentMethod.created, @"Missing created");
         XCTAssertFalse(paymentMethod.liveMode, @"Incorrect livemode");
         XCTAssertEqual(paymentMethod.type, STPPaymentMethodTypePrzelewy24, @"Incorrect PaymentMethod type");
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
         XCTAssertEqualObjects(paymentMethod.metadata, @{}, @"Metadata is not returned.");
+#pragma clang diagnostic pop
 
         // Billing Details
         XCTAssertEqualObjects(paymentMethod.billingDetails.email, @"email@email.com", @"Incorrect email");

--- a/Tests/Tests/STPPaymentMethodTest.m
+++ b/Tests/Tests/STPPaymentMethodTest.m
@@ -135,7 +135,10 @@
     XCTAssertNotNil(paymentMethod.billingDetails);
     XCTAssertNotNil(paymentMethod.card);
     XCTAssertNil(paymentMethod.customerId);
-    XCTAssertEqualObjects(paymentMethod.metadata, @{@"order_id": @"123456789"});
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
+    XCTAssertEqualObjects(paymentMethod.metadata, @{@"order_id": @"123456789"}); // has non-empty value because this is from a hard-coded response json file
+#pragma clang diagnostic pop
     
     XCTAssertNotEqual(paymentMethod.allResponseFields, response, @"should have own copy of fields");
     XCTAssertEqualObjects(paymentMethod.allResponseFields, response, @"fields values should match");

--- a/Tests/Tests/STPPaymentMethodTest.m
+++ b/Tests/Tests/STPPaymentMethodTest.m
@@ -134,12 +134,7 @@
     XCTAssertEqual(paymentMethod.type, STPPaymentMethodTypeCard);
     XCTAssertNotNil(paymentMethod.billingDetails);
     XCTAssertNotNil(paymentMethod.card);
-    XCTAssertNil(paymentMethod.customerId);
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated"
-    XCTAssertEqualObjects(paymentMethod.metadata, @{@"order_id": @"123456789"}); // has non-empty value because this is from a hard-coded response json file
-#pragma clang diagnostic pop
-    
+    XCTAssertNil(paymentMethod.customerId);    
     XCTAssertNotEqual(paymentMethod.allResponseFields, response, @"should have own copy of fields");
     XCTAssertEqualObjects(paymentMethod.allResponseFields, response, @"fields values should match");
 }

--- a/Tests/Tests/STPSetupIntentTest.m
+++ b/Tests/Tests/STPSetupIntentTest.m
@@ -61,7 +61,10 @@
     XCTAssertEqualObjects(setupIntent.clientSecret, @"seti_123456789_secret_123456789");
     XCTAssertEqualObjects(setupIntent.created, [NSDate dateWithTimeIntervalSince1970:123456789]);
     XCTAssertEqualObjects(setupIntent.customerID, @"cus_123456");
-    XCTAssertEqualObjects(setupIntent.metadata, @{@"user_id": @"guest_1234567"});
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
+        XCTAssertEqualObjects(setupIntent.metadata, @{@"user_id": @"guest_1234567"}); // has non-empty value because this is from a hard-coded response json file
+#pragma clang diagnostic pop
     XCTAssertEqualObjects(setupIntent.paymentMethodID, @"pm_123456");
     XCTAssertEqualObjects(setupIntent.stripeDescription, @"My Sample SetupIntent");
     XCTAssertFalse(setupIntent.livemode);

--- a/Tests/Tests/STPSetupIntentTest.m
+++ b/Tests/Tests/STPSetupIntentTest.m
@@ -61,10 +61,6 @@
     XCTAssertEqualObjects(setupIntent.clientSecret, @"seti_123456789_secret_123456789");
     XCTAssertEqualObjects(setupIntent.created, [NSDate dateWithTimeIntervalSince1970:123456789]);
     XCTAssertEqualObjects(setupIntent.customerID, @"cus_123456");
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated"
-        XCTAssertEqualObjects(setupIntent.metadata, @{@"user_id": @"guest_1234567"}); // has non-empty value because this is from a hard-coded response json file
-#pragma clang diagnostic pop
     XCTAssertEqualObjects(setupIntent.paymentMethodID, @"pm_123456");
     XCTAssertEqualObjects(setupIntent.stripeDescription, @"My Sample SetupIntent");
     XCTAssertFalse(setupIntent.livemode);

--- a/Tests/Tests/STPSourceFunctionalTest.m
+++ b/Tests/Tests/STPSourceFunctionalTest.m
@@ -39,7 +39,10 @@
         XCTAssertEqual(source.redirect.status, STPSourceRedirectStatusPending);
         XCTAssertEqualObjects(source.redirect.returnURL, [NSURL URLWithString:@"https://shop.example.com/crtABC?redirect_merchant_name=xctest"]);
         XCTAssertNotNil(source.redirect.url);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
         XCTAssertEqualObjects(source.metadata, @{}, @"Metadata is not returned.");
+#pragma clang diagnostic pop
 
         [expectation fulfill];
     }];
@@ -79,7 +82,10 @@
         XCTAssertEqualObjects(address.state, card.address.state);
         XCTAssertEqualObjects(address.country, card.address.country);
         XCTAssertEqualObjects(address.postalCode, card.address.postalCode);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
         XCTAssertEqualObjects(source.metadata, @{}, @"Metadata is not returned.");
+#pragma clang diagnostic pop
 
         [expectation fulfill];
     }];
@@ -105,7 +111,10 @@
         XCTAssertEqual(source.redirect.status, STPSourceRedirectStatusPending);
         XCTAssertEqualObjects(source.redirect.returnURL, [NSURL URLWithString:@"https://shop.example.com/crtABC?redirect_merchant_name=xctest"]);
         XCTAssertNotNil(source.redirect.url);
-        XCTAssertEqualObjects(source.metadata, @{});
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
+        XCTAssertEqualObjects(source.metadata, @{}, @"Metadata is not returned.");
+#pragma clang diagnostic pop
 
         [expectation fulfill];
     }];
@@ -134,7 +143,10 @@
         XCTAssertNotNil(source.redirect.url);
         XCTAssertEqualObjects(source.details[@"bank"], @"ing");
         XCTAssertEqualObjects(source.details[@"statement_descriptor"], @"ORDER AT123");
-        XCTAssertEqualObjects(source.metadata, @{});
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
+        XCTAssertEqualObjects(source.metadata, @{}, @"Metadata is not returned.");
+#pragma clang diagnostic pop
 
         [expectation fulfill];
     }];
@@ -162,7 +174,10 @@
         XCTAssertNotNil(source.redirect.url);
         XCTAssertNil(source.details[@"bank"]);
         XCTAssertNil(source.details[@"statement_descriptor"]);
-        XCTAssertEqualObjects(source.metadata, @{});
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
+        XCTAssertEqualObjects(source.metadata, @{}, @"Metadata is not returned.");
+#pragma clang diagnostic pop
 
         [expectation fulfill];
     }];
@@ -190,7 +205,10 @@
         XCTAssertNotNil(source.redirect.url);
         XCTAssertNil(source.details[@"bank"]);
         XCTAssertNil(source.details[@"statement_descriptor"]);
-        XCTAssertEqualObjects(source.metadata, @{});
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
+        XCTAssertEqualObjects(source.metadata, @{}, @"Metadata is not returned.");
+#pragma clang diagnostic pop
 
         [expectation fulfill];
     }];
@@ -220,7 +238,10 @@
         XCTAssertEqualObjects(source.owner.address.country, @"DE");
         XCTAssertEqualObjects(source.sepaDebitDetails.country, @"DE");
         XCTAssertEqualObjects(source.sepaDebitDetails.last4, @"3000");
-        XCTAssertEqualObjects(source.metadata, @{});
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
+        XCTAssertEqualObjects(source.metadata, @{}, @"Metadata is not returned.");
+#pragma clang diagnostic pop
 
         [expectation fulfill];
     }];
@@ -250,7 +271,10 @@
         XCTAssertNil(source.owner.address.country);
         XCTAssertEqualObjects(source.sepaDebitDetails.country, @"DE"); // German IBAN so sepa tells us country here even though we didnt pass it up as owner info
         XCTAssertEqualObjects(source.sepaDebitDetails.last4, @"3000");
-        XCTAssertEqualObjects(source.metadata, @{});
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
+        XCTAssertEqualObjects(source.metadata, @{}, @"Metadata is not returned.");
+#pragma clang diagnostic pop
 
         [expectation fulfill];
     }];
@@ -275,7 +299,10 @@
         XCTAssertEqual(source.redirect.status, STPSourceRedirectStatusPending);
         XCTAssertEqualObjects(source.redirect.returnURL, [NSURL URLWithString:@"https://shop.example.com/crtABC?redirect_merchant_name=xctest"]);
         XCTAssertNotNil(source.redirect.url);
-        XCTAssertEqualObjects(source.metadata, @{});
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
+        XCTAssertEqualObjects(source.metadata, @{}, @"Metadata is not returned.");
+#pragma clang diagnostic pop
         XCTAssertEqualObjects(source.details[@"country"], @"DE");
 
         [expectation fulfill];
@@ -326,7 +353,10 @@
             XCTAssertEqual(source2.redirect.status, STPSourceRedirectStatusPending);
             XCTAssertEqualObjects(source2.redirect.returnURL, [NSURL URLWithString:@"https://shop.example.com/crtABC?redirect_merchant_name=xctest"]);
             XCTAssertNotNil(source2.redirect.url);
-            XCTAssertEqualObjects(source2.metadata, @{});
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
+            XCTAssertEqualObjects(source2.metadata, @{}, @"Metadata is not returned.");
+#pragma clang diagnostic pop
             [threeDSExp fulfill];
         }];
     }];
@@ -404,7 +434,10 @@
         XCTAssertEqual(source.redirect.status, STPSourceRedirectStatusPending);
         XCTAssertEqualObjects(source.redirect.returnURL, [NSURL URLWithString:@"https://shop.example.com/crtABC?redirect_merchant_name=xctest"]);
         XCTAssertNotNil(source.redirect.url);
-        XCTAssertEqualObjects(source.metadata, @{});
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
+        XCTAssertEqualObjects(source.metadata, @{}, @"Metadata is not returned.");
+#pragma clang diagnostic pop
         [expectation fulfill];
     }];
 
@@ -433,7 +466,10 @@
         XCTAssertEqual(source.redirect.status, STPSourceRedirectStatusPending);
         XCTAssertEqualObjects(source.redirect.returnURL, [NSURL URLWithString:@"https://shop.example.com/crtABC?redirect_merchant_name=xctest"]);
         XCTAssertNotNil(source.redirect.url);
-        XCTAssertEqualObjects(source.metadata, @{});
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
+        XCTAssertEqualObjects(source.metadata, @{}, @"Metadata is not returned.");
+#pragma clang diagnostic pop
         [expectation fulfill];
     }];
 
@@ -486,7 +522,10 @@
         XCTAssertEqual(source.redirect.status, STPSourceRedirectStatusPending);
         XCTAssertEqualObjects(source.redirect.returnURL, [NSURL URLWithString:@"https://shop.example.com/crtABC?redirect_merchant_name=xctest"]);
         XCTAssertNotNil(source.redirect.url);
-        XCTAssertEqualObjects(source.metadata, @{});
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
+        XCTAssertEqualObjects(source.metadata, @{}, @"Metadata is not returned.");
+#pragma clang diagnostic pop
         XCTAssertEqualObjects(source.allResponseFields[@"statement_descriptor"], @"ORDER AT123");
 
         [expectation fulfill];
@@ -513,7 +552,10 @@
         XCTAssertEqual(source.redirect.status, STPSourceRedirectStatusPending);
         XCTAssertEqualObjects(source.redirect.returnURL, [NSURL URLWithString:@"https://shop.example.com/crtABC?redirect_merchant_name=xctest"]);
         XCTAssertNotNil(source.redirect.url);
-        XCTAssertEqualObjects(source.metadata, @{});
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
+        XCTAssertEqualObjects(source.metadata, @{}, @"Metadata is not returned.");
+#pragma clang diagnostic pop
         XCTAssertNil(source.allResponseFields[@"statement_descriptor"]);
 
         [expectation fulfill];
@@ -537,7 +579,10 @@
         XCTAssertEqual(source.redirect.status, STPSourceRedirectStatusPending);
         XCTAssertEqualObjects(source.redirect.returnURL, [NSURL URLWithString:@"https://shop.example.com/crtABC?redirect_merchant_name=xctest"]);
         XCTAssertNotNil(source.redirect.url);
-        XCTAssertEqualObjects(source.metadata, @{});
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
+        XCTAssertEqualObjects(source.metadata, @{}, @"Metadata is not returned.");
+#pragma clang diagnostic pop
 
         [expectation fulfill];
     }];

--- a/Tests/Tests/STPSourceTest.m
+++ b/Tests/Tests/STPSourceTest.m
@@ -344,7 +344,10 @@
     XCTAssertEqualObjects(source.currency, @"eur");
     XCTAssertEqual(source.flow, STPSourceFlowRedirect);
     XCTAssertEqual(source.livemode, NO);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
     XCTAssertEqualObjects(source.metadata, @{});
+#pragma clang diagnostic pop
     XCTAssert(source.owner);  // STPSourceOwnerTest
     XCTAssert(source.receiver);  // STPSourceReceiverTest
     XCTAssert(source.redirect);  // STPSourceRedirectTest
@@ -369,7 +372,10 @@
     XCTAssertEqualObjects(source.currency, @"usd");
     XCTAssertEqual(source.flow, STPSourceFlowRedirect);
     XCTAssertEqual(source.livemode, YES);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
     XCTAssertNil(source.metadata);
+#pragma clang diagnostic pop
     XCTAssert(source.owner);  // STPSourceOwnerTest
     XCTAssertNil(source.receiver);  // STPSourceReceiverTest
     XCTAssert(source.redirect);  // STPSourceRedirectTest
@@ -394,7 +400,10 @@
     XCTAssertNil(source.currency);
     XCTAssertEqual(source.flow, STPSourceFlowNone);
     XCTAssertEqual(source.livemode, NO);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
     XCTAssertEqualObjects(source.metadata, @{});
+#pragma clang diagnostic pop
     XCTAssert(source.owner);  // STPSourceOwnerTest
     XCTAssertNil(source.receiver);  // STPSourceReceiverTest
     XCTAssertNil(source.redirect);  // STPSourceRedirectTest
@@ -419,7 +428,10 @@
     XCTAssertEqualObjects(source.currency, @"eur");
     XCTAssertEqual(source.flow, STPSourceFlowRedirect);
     XCTAssertEqual(source.livemode, YES);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
     XCTAssertNil(source.metadata);
+#pragma clang diagnostic pop
     XCTAssert(source.owner);  // STPSourceOwnerTest
     XCTAssertNil(source.receiver);  // STPSourceReceiverTest
     XCTAssert(source.redirect);  // STPSourceRedirectTest
@@ -444,7 +456,10 @@
     XCTAssertEqualObjects(source.currency, @"eur");
     XCTAssertEqual(source.flow, STPSourceFlowNone);
     XCTAssertEqual(source.livemode, NO);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
     XCTAssertNil(source.metadata);
+#pragma clang diagnostic pop
     XCTAssertEqualObjects(source.owner.name, @"Jenny Rosen");
     XCTAssert(source.owner);  // STPSourceOwnerTest
     XCTAssertNil(source.receiver);  // STPSourceReceiverTest

--- a/Tests/Tests/SetupIntent.json
+++ b/Tests/Tests/SetupIntent.json
@@ -54,9 +54,6 @@
       "type": "invalid_request_error"
   },
   "livemode": false,
-  "metadata": {
-    "user_id": "guest_1234567"
-  },
   "next_action": {
       "type": "redirect_to_url",
       "redirect_to_url": {


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
metadata fields on retrieved API objects have been marked as deprecated with no replacement.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Metadata fields are no longer returned to client libraries and must be fetched using a secret key on your server.

## Testing
<!-- How was the code tested? Be as specific as possible. -->
Automated tests are confirming no metadata responses
