### PR TITLE
Adds cancellation error in STPRedirectContext completion block

### DIFF
--- a/Stripe/STPRedirectContext.m
+++ b/Stripe/STPRedirectContext.m
@@ -215,8 +215,20 @@ typedef void (^STPBoolCompletionBlock)(BOOL success);
 #pragma mark - SFSafariViewControllerDelegate -
 
 - (void)safariViewControllerDidFinish:(__unused SFSafariViewController *)controller {
+    NSError *manuallyClosedError = nil;
+    if (self.returnURL != nil
+        && self.state == STPRedirectContextStateInProgress
+        && self.completionError == nil
+        ) {
+        manuallyClosedError = [NSError errorWithDomain:StripeDomain
+                                                  code:STPCancellationError
+                                              userInfo:@{
+                                                  STPErrorMessageKey: @"User manually closed SFSafariViewController before redirect was completed."
+                                              }
+                               ];
+    }
     stpDispatchToMainThreadIfNecessary(^{
-        [self handleRedirectCompletionWithError:nil
+        [self handleRedirectCompletionWithError:manuallyClosedError
                     shouldDismissViewController:NO];
     });
 }


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
If we detect an SFSafariViewController dismissal that wasn't prompted by STPRedirectContext itself, we mark it as a cancellation error when we call the completion block.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://github.com/stripe/stripe-ios/issues/1621

## Testing
<!-- How was the code tested? Be as specific as possible. -->
Tested with sample app
