### PR TITLE
Switch to semver

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ From left to right: [STPAddCardViewController](https://stripe.dev/stripe-ios/doc
 We recommend installing the Stripe iOS SDK using Swift Package Manager. (File -> Swift Packages -> Add Package Dependency… in Xcode.) We also support Cocoapods and Carthage. If you link the library manually, use a version from our [releases](https://github.com/stripe/stripe-ios/releases) page.
 
 If you're reading this on GitHub.com, please make sure you are looking at the [tagged version](https://github.com/stripe/stripe-ios/tags) that corresponds to the release you have installed. Otherwise, the instructions and example code may be mismatched with your copy. You can read the latest tagged version of this README and browse the associated code on GitHub using
-[this link](https://github.com/stripe/stripe-ios/tree/v19.4.0).
+[this link](https://github.com/stripe/stripe-ios/tree/19.4.0).
 
 ## Requirements
 
@@ -74,11 +74,11 @@ Get started with our [📚 integration guides](https://stripe.com/docs/payments)
 
 There are 3 example apps included in the repository:
 
-- [UI Examples](https://github.com/stripe/stripe-ios/tree/v19.4.0/Example/UI%20Examples).
+- [UI Examples](https://github.com/stripe/stripe-ios/tree/19.4.0/Example/UI%20Examples).
   - This example lets you quickly try out the SDK's prebuilt UI components using a mock backend—just build and run!
-- [Basic Integration](https://github.com/stripe/stripe-ios/tree/v19.4.0/Example/Basic%20Integration)
+- [Basic Integration](https://github.com/stripe/stripe-ios/tree/19.4.0/Example/Basic%20Integration)
   - This example demonstrates how to build a payment flow using our prebuilt UI component integration (`STPPaymentContext`).
-- [Non-Card Payment Examples](https://github.com/stripe/stripe-ios/tree/v19.4.0/Example/Non-Card%20Payment%20Examples)
+- [Non-Card Payment Examples](https://github.com/stripe/stripe-ios/tree/19.4.0/Example/Non-Card%20Payment%20Examples)
   - This example demonstrates how to use `STPAPIClient` to accept various non-card payment methods.
 
 Check out [stripe-samples](https://github.com/stripe-samples/) for more, including:
@@ -96,7 +96,7 @@ To add card scanning capabilities to our prebuilt UI components, set the `cardSc
 <img src="https://user-images.githubusercontent.com/52758633/92628867-4d040200-f282-11ea-95d2-023d9a461d25.gif" width="222" height="458" alt="Card Scanning Demo" align="center">
 </p>
 
-Demo this in our [Basic Integration example app](https://github.com/stripe/stripe-ios/tree/v19.4.0/Example/Basic%20Integration). When you run the example app on a device, you'll see a "Scan Card" button when adding a new card.
+Demo this in our [Basic Integration example app](https://github.com/stripe/stripe-ios/tree/19.4.0/Example/Basic%20Integration). When you run the example app on a device, you'll see a "Scan Card" button when adding a new card.
 
 This feature is currently in beta. Please file bugs on our [GitHub issues page](https://github.com/stripe/stripe-ios/issues).
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ From left to right: [STPAddCardViewController](https://stripe.dev/stripe-ios/doc
 We recommend installing the Stripe iOS SDK using Swift Package Manager. (File -> Swift Packages -> Add Package Dependency… in Xcode.) We also support Cocoapods and Carthage. If you link the library manually, use a version from our [releases](https://github.com/stripe/stripe-ios/releases) page.
 
 If you're reading this on GitHub.com, please make sure you are looking at the [tagged version](https://github.com/stripe/stripe-ios/tags) that corresponds to the release you have installed. Otherwise, the instructions and example code may be mismatched with your copy. You can read the latest tagged version of this README and browse the associated code on GitHub using
-[this link](https://github.com/stripe/stripe-ios/tree/19.4.0).
+[this link](https://github.com/stripe/stripe-ios/tree/20.0.0).
 
 ## Requirements
 
@@ -74,11 +74,11 @@ Get started with our [📚 integration guides](https://stripe.com/docs/payments)
 
 There are 3 example apps included in the repository:
 
-- [UI Examples](https://github.com/stripe/stripe-ios/tree/19.4.0/Example/UI%20Examples).
+- [UI Examples](https://github.com/stripe/stripe-ios/tree/20.0.0/Example/UI%20Examples).
   - This example lets you quickly try out the SDK's prebuilt UI components using a mock backend—just build and run!
-- [Basic Integration](https://github.com/stripe/stripe-ios/tree/19.4.0/Example/Basic%20Integration)
+- [Basic Integration](https://github.com/stripe/stripe-ios/tree/20.0.0/Example/Basic%20Integration)
   - This example demonstrates how to build a payment flow using our prebuilt UI component integration (`STPPaymentContext`).
-- [Non-Card Payment Examples](https://github.com/stripe/stripe-ios/tree/19.4.0/Example/Non-Card%20Payment%20Examples)
+- [Non-Card Payment Examples](https://github.com/stripe/stripe-ios/tree/20.0.0/Example/Non-Card%20Payment%20Examples)
   - This example demonstrates how to use `STPAPIClient` to accept various non-card payment methods.
 
 Check out [stripe-samples](https://github.com/stripe-samples/) for more, including:
@@ -96,7 +96,7 @@ To add card scanning capabilities to our prebuilt UI components, set the `cardSc
 <img src="https://user-images.githubusercontent.com/52758633/92628867-4d040200-f282-11ea-95d2-023d9a461d25.gif" width="222" height="458" alt="Card Scanning Demo" align="center">
 </p>
 
-Demo this in our [Basic Integration example app](https://github.com/stripe/stripe-ios/tree/19.4.0/Example/Basic%20Integration). When you run the example app on a device, you'll see a "Scan Card" button when adding a new card.
+Demo this in our [Basic Integration example app](https://github.com/stripe/stripe-ios/tree/20.0.0/Example/Basic%20Integration). When you run the example app on a device, you'll see a "Scan Card" button when adding a new card.
 
 This feature is currently in beta. Please file bugs on our [GitHub issues page](https://github.com/stripe/stripe-ios/issues).
 

--- a/Stripe.podspec
+++ b/Stripe.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.license                        = { :type => 'MIT', :file => 'LICENSE' }
   s.homepage                       = 'https://stripe.com/docs/mobile/ios'
   s.authors                        = { 'Stripe' => 'support+github@stripe.com' }
-  s.source                         = { :git => 'https://github.com/stripe/stripe-ios.git', :tag => "v#{s.version}" }
+  s.source                         = { :git => 'https://github.com/stripe/stripe-ios.git', :tag => "#{s.version}" }
   s.frameworks                     = 'Foundation', 'Security', 'WebKit', 'PassKit', 'Contacts', 'CoreLocation'
   s.requires_arc                   = true
   s.platform                       = :ios


### PR DESCRIPTION
For Swift Package Manager and Carthage, we need to use semver. (Instead of prepending a `v` before the version.)