### PR TITLE
bugfix: wrong zh-Hans text for the label for text field to enter card…

### DIFF
--- a/Stripe/Resources/Localizations/zh-Hans.lproj/Localizable.strings
+++ b/Stripe/Resources/Localizations/zh-Hans.lproj/Localizable.strings
@@ -161,7 +161,7 @@
 "Loading…" = "正在加载……";
 
 /* label for text field to enter card expiry */
-"MM/YY" = "年年/月月";
+"MM/YY" = "月月/年年";
 
 /* Title for payment options section */
 "MORE OPTIONS" = "更多选择";


### PR DESCRIPTION
## Summary
Wrong text for the label for text field to enter card expiry.
MM/YY the correct Chinese is "月月/年年".

![Xnip2020-09-22_10-07-16](https://user-images.githubusercontent.com/1787428/93839194-c8bc7080-fcbe-11ea-857c-3dd94a8fe262.jpg)
![Xnip2020-09-22_10-09-10](https://user-images.githubusercontent.com/1787428/93839205-ceb25180-fcbe-11ea-913c-fe76ad58021e.jpg)

## Motivation
https://github.com/cythb/stripe-ios/blob/75ae62b04b5d479532da75c7f56b44b47f8e8f91/Stripe/Resources/Localizations/zh-Hans.lproj/Localizable.strings#L164

## Testing
<!-- How was the code tested? Be as specific as possible. -->
