### PR TITLE
Removes invalid mandate ID confirm params

### DIFF
--- a/Stripe/PublicHeaders/Stripe/STPPaymentIntentParams.h
+++ b/Stripe/PublicHeaders/Stripe/STPPaymentIntentParams.h
@@ -132,11 +132,6 @@ STPPaymentIntentShippingDetailsParams;
 @property (nonatomic, nullable) STPMandateDataParams *mandateData;
 
 /**
- The ID of the Mandate to be used for this payment.
- */
-@property (nonatomic, nullable) NSString *mandate;
-
-/**
  Options to update the associated PaymentMethod during confirmation.
  @see STPConfirmPaymentMethodOptions
  */
@@ -165,6 +160,13 @@ STPPaymentIntentShippingDetailsParams;
  This property has been renamed to `savePaymentMethod` and deprecated.
  */
 @property (nonatomic, strong, nullable) NSNumber *saveSourceToCustomer __attribute__((deprecated("saveSourceToCustomer has been renamed to savePaymentMethod", "saveSourceToCustomer")));
+
+/**
+ The ID of the Mandate to be used for this payment.
+ 
+ @deprecated This parameter is not usable with publishable keys and will be ignored.
+ */
+@property (nonatomic, nullable) NSString *mandate DEPRECATED_MSG_ATTRIBUTE("Mandate IDs are not usable with publishable keys. Set them on your server using your secret key instead.");
 
 @end
 

--- a/Stripe/PublicHeaders/Stripe/STPSetupIntentConfirmParams.h
+++ b/Stripe/PublicHeaders/Stripe/STPSetupIntentConfirmParams.h
@@ -77,8 +77,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  The ID of the Mandate to be used for this payment.
+ 
+ @deprecated This parameter is not usable with publishable keys and will be ignored.
  */
-@property (nonatomic, nullable) NSString *mandate;
+@property (nonatomic, nullable) NSString *mandate DEPRECATED_MSG_ATTRIBUTE("Mandate IDs are not usable with publishable keys. Set them on your server using your secret key instead.");
 
 @end
 

--- a/Stripe/STPPaymentIntentParams.m
+++ b/Stripe/STPPaymentIntentParams.m
@@ -72,7 +72,6 @@
 
                        // Mandate
                        [NSString stringWithFormat:@"mandateData = %@", self.mandateData],
-                       [NSString stringWithFormat:@"mandate = %@", self.mandate],
 
                        // PaymentMethodOptions
                        [NSString stringWithFormat:@"paymentMethodOptions = @%@", self.paymentMethodOptions],
@@ -113,7 +112,7 @@
     
     if (_mandateData != nil) {
         return _mandateData;
-    } else if (self.mandate == nil && paymentMethodRequiresMandate) {
+    } else if (paymentMethodRequiresMandate) {
         // Create default infer from client mandate_data
         STPMandateDataParams *mandateData = [[STPMandateDataParams alloc] init];
         STPMandateCustomerAcceptanceParams *customerAcceptance = [[STPMandateCustomerAcceptanceParams alloc] init];
@@ -163,7 +162,6 @@
     copy.setupFutureUsage = self.setupFutureUsage;
     copy.useStripeSDK = self.useStripeSDK;
     copy.mandateData = self.mandateData;
-    copy.mandate = self.mandate;
     copy.paymentMethodOptions = self.paymentMethodOptions;
     copy.shipping = self.shipping;
     copy.additionalAPIParameters = self.additionalAPIParameters;
@@ -190,7 +188,6 @@
              NSStringFromSelector(@selector(returnURL)): @"return_url",
              NSStringFromSelector(@selector(useStripeSDK)) : @"use_stripe_sdk",
              NSStringFromSelector(@selector(mandateData)) : @"mandate_data",
-             NSStringFromSelector(@selector(mandate)) : @"mandate",
              NSStringFromSelector(@selector(paymentMethodOptions)) : @"payment_method_options",
              NSStringFromSelector(@selector(shipping)) : @"shipping",
              };

--- a/Stripe/STPSetupIntentConfirmParams.m
+++ b/Stripe/STPSetupIntentConfirmParams.m
@@ -50,7 +50,6 @@
 
                        // Mandate
                        [NSString stringWithFormat:@"mandateData = %@", self.mandateData],
-                       [NSString stringWithFormat:@"mandate = %@", self.mandate],
 
                        // Additional params set by app
                        [NSString stringWithFormat:@"additionalAPIParameters = %@", self.additionalAPIParameters],
@@ -64,7 +63,7 @@
     
     if (_mandateData != nil) {
         return _mandateData;
-    } else if (self.mandate == nil && paymentMethodRequiresMandate) {
+    } else if (paymentMethodRequiresMandate) {
         // Create default infer from client mandate_data
         STPMandateDataParams *mandateData = [[STPMandateDataParams alloc] init];
         STPMandateCustomerAcceptanceParams *customerAcceptance = [[STPMandateCustomerAcceptanceParams alloc] init];
@@ -91,7 +90,6 @@
     copy.returnURL = self.returnURL;
     copy.useStripeSDK = self.useStripeSDK;
     copy.mandateData = self.mandateData;
-    copy.mandate = self.mandate;
     copy.additionalAPIParameters = self.additionalAPIParameters;
 
     return copy;
@@ -110,9 +108,7 @@
              NSStringFromSelector(@selector(paymentMethodID)): @"payment_method",
              NSStringFromSelector(@selector(returnURL)): @"return_url",
              NSStringFromSelector(@selector(useStripeSDK)): @"use_stripe_sdk",
-             NSStringFromSelector(@selector(mandateData)): @"mandate_data",
              NSStringFromSelector(@selector(mandateData)) : @"mandate_data",
-             NSStringFromSelector(@selector(mandate)) : @"mandate",
              };
 }
 

--- a/Tests/Tests/STPPaymentIntentParamsTest.m
+++ b/Tests/Tests/STPPaymentIntentParamsTest.m
@@ -41,13 +41,13 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated"
         XCTAssertNil(params.saveSourceToCustomer);
+        XCTAssertNil(params.mandate);
 #pragma clang diagnostic pop
         XCTAssertNil(params.savePaymentMethod);
         XCTAssertNil(params.returnURL);
         XCTAssertNil(params.setupFutureUsage);
         XCTAssertNil(params.useStripeSDK);
         XCTAssertNil(params.mandateData);
-        XCTAssertNil(params.mandate);
         XCTAssertNil(params.paymentMethodOptions);
         XCTAssertNil(params.shipping);
     }
@@ -102,18 +102,12 @@
     XCTAssertNil(params.mandateData);
 
     for (NSString *type in @[@"sepa_debit", @"au_becs_debit", @"bacs_debit"]) {
-        params.mandate = nil;
         params.mandateData = nil;
         params.paymentMethodParams.rawTypeString = type;
         // Mandate-required type should have mandateData
         XCTAssertNotNil(params.mandateData);
         XCTAssertEqual(params.mandateData.customerAcceptance.onlineParams.inferFromClient, @YES);
 
-        params.mandate = @"my_mandate";
-        // Mandate-required with a mandate ID should not have default
-        XCTAssertNil(params.mandateData);
-
-        params.mandate = nil;
         params.mandateData = [[STPMandateDataParams alloc] init];
         // Default behavior should not override custom setting
         XCTAssertNotNil(params.mandateData);
@@ -155,7 +149,6 @@
     params.returnURL = @"fake://testing_only";
     params.setupFutureUsage = @(1);
     params.useStripeSDK = @YES;
-    params.mandate = @"test_mandate";
     params.mandateData = [[STPMandateDataParams alloc] init];
     params.paymentMethodOptions = [[STPConfirmPaymentMethodOptions alloc] init];
     params.additionalAPIParameters = @{@"other_param" : @"other_value"};
@@ -173,7 +166,6 @@
     XCTAssertEqualObjects(params.savePaymentMethod, paramsCopy.savePaymentMethod);
     XCTAssertEqualObjects(params.returnURL, paramsCopy.returnURL);
     XCTAssertEqualObjects(params.useStripeSDK, paramsCopy.useStripeSDK);
-    XCTAssertEqualObjects(params.mandate, paramsCopy.mandate);
     XCTAssertEqualObjects(params.paymentMethodOptions, paramsCopy.paymentMethodOptions);
     XCTAssertEqualObjects(params.additionalAPIParameters, paramsCopy.additionalAPIParameters);
 

--- a/Tests/Tests/STPPaymentMethodAUBECSDebitParamsTests.m
+++ b/Tests/Tests/STPPaymentMethodAUBECSDebitParamsTests.m
@@ -50,7 +50,7 @@
         XCTAssertEqual(paymentMethod.type, STPPaymentMethodTypeAUBECSDebit, @"Incorrect PaymentMethod type");
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated"
-        XCTAssertEqualObjects(paymentMethod.metadata, @{}, @"Metadata is not returned.");
+        XCTAssertNil(paymentMethod.metadata, @"Metadata is not returned.");
 #pragma clang diagnostic pop
 
         // Billing Details

--- a/Tests/Tests/STPPaymentMethodBancontactParamsTests.m
+++ b/Tests/Tests/STPPaymentMethodBancontactParamsTests.m
@@ -46,7 +46,7 @@
         XCTAssertEqual(paymentMethod.type, STPPaymentMethodTypeBancontact, @"Incorrect PaymentMethod type");
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated"
-        XCTAssertEqualObjects(paymentMethod.metadata, @{}, @"Metadata is not returned.");
+        XCTAssertNil(paymentMethod.metadata, @"Metadata is not returned.");
 #pragma clang diagnostic pop
 
         // Billing Details

--- a/Tests/Tests/STPPaymentMethodEPSParamsTests.m
+++ b/Tests/Tests/STPPaymentMethodEPSParamsTests.m
@@ -48,7 +48,7 @@
         XCTAssertEqual(paymentMethod.type, STPPaymentMethodTypeEPS, @"Incorrect PaymentMethod type");
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated"
-        XCTAssertEqualObjects(paymentMethod.metadata, @{}, @"Metadata is not returned.");
+        XCTAssertNil(paymentMethod.metadata, @"Metadata is not returned.");
 #pragma clang diagnostic pop
 
         // Billing Details

--- a/Tests/Tests/STPPaymentMethodFunctionalTest.m
+++ b/Tests/Tests/STPPaymentMethodFunctionalTest.m
@@ -59,7 +59,7 @@
                                    XCTAssertEqual(paymentMethod.type, STPPaymentMethodTypeCard);
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated"
-                                   XCTAssertEqualObjects(paymentMethod.metadata, @{}, @"Metadata is not returned.");
+                                   XCTAssertNil(paymentMethod.metadata, @"Metadata is not returned.");
 #pragma clang diagnostic pop
 
                                    // Billing Details

--- a/Tests/Tests/STPPaymentMethodGiropayParamsTests.m
+++ b/Tests/Tests/STPPaymentMethodGiropayParamsTests.m
@@ -47,7 +47,7 @@
         XCTAssertEqual(paymentMethod.type, STPPaymentMethodTypeGiropay, @"Incorrect PaymentMethod type");
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated"
-        XCTAssertEqualObjects(paymentMethod.metadata, @{}, @"Metadata is not returned.");
+        XCTAssertNil(paymentMethod.metadata, @"Metadata is not returned.");
 #pragma clang diagnostic pop
 
         // Billing Details

--- a/Tests/Tests/STPPaymentMethodPrzelewy24ParamsTests.m
+++ b/Tests/Tests/STPPaymentMethodPrzelewy24ParamsTests.m
@@ -46,7 +46,7 @@
         XCTAssertEqual(paymentMethod.type, STPPaymentMethodTypePrzelewy24, @"Incorrect PaymentMethod type");
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated"
-        XCTAssertEqualObjects(paymentMethod.metadata, @{}, @"Metadata is not returned.");
+        XCTAssertNil(paymentMethod.metadata, @"Metadata is not returned.");
 #pragma clang diagnostic pop
 
         // Billing Details

--- a/Tests/Tests/STPSetupIntentConfirmParamsTest.m
+++ b/Tests/Tests/STPSetupIntentConfirmParamsTest.m
@@ -35,7 +35,6 @@
         XCTAssertNil(params.returnURL);
         XCTAssertNil(params.useStripeSDK);
         XCTAssertNil(params.mandateData);
-        XCTAssertNil(params.mandate);
     }
 }
 
@@ -57,18 +56,12 @@
     XCTAssertNil(params.mandateData);
 
     for (NSString *type in @[@"sepa_debit", @"au_becs_debit", @"bacs_debit"]) {
-        params.mandate = nil;
         params.mandateData = nil;
         params.paymentMethodParams.rawTypeString = type;
         // Mandate-required type should have mandateData
         XCTAssertNotNil(params.mandateData);
         XCTAssertEqual(params.mandateData.customerAcceptance.onlineParams.inferFromClient, @YES);
 
-        params.mandate = @"my_mandate";
-        // Mandate-required with a mandate ID should not have default
-        XCTAssertNil(params.mandateData);
-
-        params.mandate = nil;
         params.mandateData = [[STPMandateDataParams alloc] init];
         // Default behavior should not override custom setting
         XCTAssertNotNil(params.mandateData);
@@ -106,7 +99,6 @@
     params.paymentMethodID = @"test_payment_method_id";
     params.returnURL = @"fake://testing_only";
     params.useStripeSDK = @YES;
-    params.mandate = @"test_mandate";
     params.mandateData = [[STPMandateDataParams alloc] init];
     params.additionalAPIParameters = @{@"other_param" : @"other_value"};
 
@@ -120,7 +112,6 @@
 
     XCTAssertEqualObjects(params.returnURL, paramsCopy.returnURL);
     XCTAssertEqualObjects(params.useStripeSDK, paramsCopy.useStripeSDK);
-    XCTAssertEqualObjects(params.mandate, paramsCopy.mandate);
     XCTAssertEqualObjects(params.additionalAPIParameters, paramsCopy.additionalAPIParameters);
 
 

--- a/Tests/Tests/STPSourceFunctionalTest.m
+++ b/Tests/Tests/STPSourceFunctionalTest.m
@@ -41,7 +41,7 @@
         XCTAssertNotNil(source.redirect.url);
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated"
-        XCTAssertEqualObjects(source.metadata, @{}, @"Metadata is not returned.");
+        XCTAssertNil(source.metadata, @"Metadata is not returned.");
 #pragma clang diagnostic pop
 
         [expectation fulfill];
@@ -84,7 +84,7 @@
         XCTAssertEqualObjects(address.postalCode, card.address.postalCode);
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated"
-        XCTAssertEqualObjects(source.metadata, @{}, @"Metadata is not returned.");
+        XCTAssertNil(source.metadata, @"Metadata is not returned.");
 #pragma clang diagnostic pop
 
         [expectation fulfill];
@@ -113,7 +113,7 @@
         XCTAssertNotNil(source.redirect.url);
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated"
-        XCTAssertEqualObjects(source.metadata, @{}, @"Metadata is not returned.");
+        XCTAssertNil(source.metadata, @"Metadata is not returned.");
 #pragma clang diagnostic pop
 
         [expectation fulfill];
@@ -145,7 +145,7 @@
         XCTAssertEqualObjects(source.details[@"statement_descriptor"], @"ORDER AT123");
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated"
-        XCTAssertEqualObjects(source.metadata, @{}, @"Metadata is not returned.");
+        XCTAssertNil(source.metadata, @"Metadata is not returned.");
 #pragma clang diagnostic pop
 
         [expectation fulfill];
@@ -176,7 +176,7 @@
         XCTAssertNil(source.details[@"statement_descriptor"]);
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated"
-        XCTAssertEqualObjects(source.metadata, @{}, @"Metadata is not returned.");
+        XCTAssertNil(source.metadata, @"Metadata is not returned.");
 #pragma clang diagnostic pop
 
         [expectation fulfill];
@@ -207,7 +207,7 @@
         XCTAssertNil(source.details[@"statement_descriptor"]);
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated"
-        XCTAssertEqualObjects(source.metadata, @{}, @"Metadata is not returned.");
+        XCTAssertNil(source.metadata, @"Metadata is not returned.");
 #pragma clang diagnostic pop
 
         [expectation fulfill];
@@ -240,7 +240,7 @@
         XCTAssertEqualObjects(source.sepaDebitDetails.last4, @"3000");
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated"
-        XCTAssertEqualObjects(source.metadata, @{}, @"Metadata is not returned.");
+        XCTAssertNil(source.metadata, @"Metadata is not returned.");
 #pragma clang diagnostic pop
 
         [expectation fulfill];
@@ -273,7 +273,7 @@
         XCTAssertEqualObjects(source.sepaDebitDetails.last4, @"3000");
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated"
-        XCTAssertEqualObjects(source.metadata, @{}, @"Metadata is not returned.");
+        XCTAssertNil(source.metadata, @"Metadata is not returned.");
 #pragma clang diagnostic pop
 
         [expectation fulfill];
@@ -301,7 +301,7 @@
         XCTAssertNotNil(source.redirect.url);
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated"
-        XCTAssertEqualObjects(source.metadata, @{}, @"Metadata is not returned.");
+        XCTAssertNil(source.metadata, @"Metadata is not returned.");
 #pragma clang diagnostic pop
         XCTAssertEqualObjects(source.details[@"country"], @"DE");
 
@@ -355,7 +355,7 @@
             XCTAssertNotNil(source2.redirect.url);
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated"
-            XCTAssertEqualObjects(source2.metadata, @{}, @"Metadata is not returned.");
+            XCTAssertNil(source2.metadata, @"Metadata is not returned.");
 #pragma clang diagnostic pop
             [threeDSExp fulfill];
         }];
@@ -436,7 +436,7 @@
         XCTAssertNotNil(source.redirect.url);
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated"
-        XCTAssertEqualObjects(source.metadata, @{}, @"Metadata is not returned.");
+        XCTAssertNil(source.metadata, @"Metadata is not returned.");
 #pragma clang diagnostic pop
         [expectation fulfill];
     }];
@@ -468,7 +468,7 @@
         XCTAssertNotNil(source.redirect.url);
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated"
-        XCTAssertEqualObjects(source.metadata, @{}, @"Metadata is not returned.");
+        XCTAssertNil(source.metadata, @"Metadata is not returned.");
 #pragma clang diagnostic pop
         [expectation fulfill];
     }];
@@ -524,7 +524,7 @@
         XCTAssertNotNil(source.redirect.url);
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated"
-        XCTAssertEqualObjects(source.metadata, @{}, @"Metadata is not returned.");
+        XCTAssertNil(source.metadata, @"Metadata is not returned.");
 #pragma clang diagnostic pop
         XCTAssertEqualObjects(source.allResponseFields[@"statement_descriptor"], @"ORDER AT123");
 
@@ -554,7 +554,7 @@
         XCTAssertNotNil(source.redirect.url);
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated"
-        XCTAssertEqualObjects(source.metadata, @{}, @"Metadata is not returned.");
+        XCTAssertNil(source.metadata, @"Metadata is not returned.");
 #pragma clang diagnostic pop
         XCTAssertNil(source.allResponseFields[@"statement_descriptor"]);
 
@@ -581,7 +581,7 @@
         XCTAssertNotNil(source.redirect.url);
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated"
-        XCTAssertEqualObjects(source.metadata, @{}, @"Metadata is not returned.");
+        XCTAssertNil(source.metadata, @"Metadata is not returned.");
 #pragma clang diagnostic pop
 
         [expectation fulfill];


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Deprecates mandate properties and removes their usage in SetupIntent and PaymentIntent confirmation

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Mandate ID is not usable with publishable keys. They must be set using a secret key.
see https://stripe.com/docs/api/setup_intents/confirm https://stripe.com/docs/api/payment_intents/confirm#confirm_payment_intent-mandate

## Testing
<!-- How was the code tested? Be as specific as possible. -->
Existing tests.
