### PR TITLE
Fix SPM warning about unhandled Stripe3DS2.bundle

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
       name: "Stripe",
       dependencies: ["Stripe3DS2"],
       path: "Stripe",
-        exclude: ["BuildConfigurations", "Info.plist", "PublicHeaders/Stripe/Stripe3DS2-Prefix.pch"],
+        exclude: ["BuildConfigurations", "Info.plist", "PublicHeaders/Stripe/Stripe3DS2-Prefix.pch", "ExternalResources/Stripe3DS2.bundle"],
         resources: [
           .process("Info.plist"),
           .process("Resources/Images"),


### PR DESCRIPTION
## Summary
We didn't ignore the Stripe3DS2.bundle after moving the resources into the dynamic Stripe3DS2.xcframework.

## Motivation
This caused an "unhandled file" warning when using the Stripe package with Swift Package Manager. https://github.com/stripe/stripe-ios/issues/1658#issuecomment-709626803

## Testing
Tested in Xcode 12.