### PR TITLE
Fix translation always returning en in some cases

### DIFF
--- a/Stripe/STPLocalizationUtils.m
+++ b/Stripe/STPLocalizationUtils.m
@@ -31,20 +31,15 @@
      preferred language and our strings are in es.
      */
     
-    static BOOL useMainBundle = NO;
-    
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        if (![[STPBundleLocator stripeResourcesBundle].preferredLocalizations.firstObject isEqualToString:[NSBundle mainBundle].preferredLocalizations.firstObject]) {
-            useMainBundle = YES;
-        }
-    });
-    
-    NSBundle *bundle = useMainBundle ? [NSBundle mainBundle] : [STPBundleLocator stripeResourcesBundle];
+    static NSString *notFound = @"9F6091AAA1FE474AA22333F38DD1CD51";
 
-    NSString *translation = [bundle localizedStringForKey:key value:nil table:nil];
-    
-    return translation;
+    NSString *userTranslation = [[NSBundle mainBundle] localizedStringForKey:key value:notFound table:nil];
+    if (![userTranslation isEqualToString:notFound]) {
+        return userTranslation;
+    }
+
+    NSString *stripeTranslation = [[STPBundleLocator stripeResourcesBundle] localizedStringForKey:key value:nil table:nil];
+    return stripeTranslation;
 }
 
 + (NSString *)localizedNameString {


### PR DESCRIPTION
## Summary
The way of determining if a translation should be taken from the app bundle or the framework bundle is slightly different. Instead of checking the preferred localisations, the app bundle is always used as the default localisation provider and the framework bundle as a backup. 
Letting iOS decides which language should be used in regard to the locale, instead of manually comparing language codes and regions, fixes the issue.

## Motivation
In the app we are working on, we have translations for different languages with the region designator. For example we do not support `fr` or `nl` but `fr-CH` or `nl-NL`. 
I noticed that, when we use the Stripe controller to add a credit card we get the default `en` translation for the title instead of the localised string.
I dug a little bit and, with the phone in `fr`, I discovered that 
```
[[STPBundleLocator stripeResourcesBundle] preferredLocalizations]
```
 is returning `fr` but 
```
[[NSBundle mainBundle] preferredLocalizations]
``` 
is returning `fr-CH` and since those two strings are not exactly the same, we get the english translation.

## Testing
- The examples provided in the repo are still working as expected. I checked with the phone in en, fr and fr-CA.
- The translation of the credit card controller in our app is now working as expected
- I tried the run the tests but some dependencies associated to them are not building
