### PR TITLE
Update Ru Localization. Long text for CVC/CVV code

### DIFF
--- a/Stripe/Resources/Localizations/ru.lproj/Localizable.strings
+++ b/Stripe/Resources/Localizations/ru.lproj/Localizable.strings
@@ -101,10 +101,10 @@
 "County" = "Графство";
 
 /* Label for entering CVC in text field */
-"CVC" = "Код CVV/CVC";
+"CVC" = "Код CVC";
 
 /* Label for entering CVV in text field */
-"CVV" = "Код CVV/CVC";
+"CVV" = "Код CVV";
 
 /* Title for delivery info form */
 "Delivery" = "Доставка";


### PR DESCRIPTION
Long text for CVC/CVV code causes infinite loop on iPhone SE (with Russian lang). When trying to add bank card, after entering pan – app stuck.
`class STPPaymentCardTextField` line 1130
```
        case .expiration:
          while hPadding < STPPaymentCardTextFieldMinimumPadding {
```
method `cvcFieldWidth()` returns too big width (because of long placeholder text)

## Summary
<!-- Simple summary of what was changed. -->

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
