### PR TITLE
Fix the theme of button items in the navigation bar

### DIFF
--- a/Stripe/STPCoreViewController.swift
+++ b/Stripe/STPCoreViewController.swift
@@ -89,14 +89,13 @@ public class STPCoreViewController: UIViewController {
   @objc
   public override func viewDidLoad() {
     super.viewDidLoad()
-
     createAndSetupViews()
-    updateAppearance()
   }
   /// :nodoc:
   @objc
   public override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
+    updateAppearance()
   }
   /// :nodoc:
   @objc


### PR DESCRIPTION
## Summary
Accessing `navigationController` property of `UIViewController` from `viewDidLoad` will always return `nil`. So, `navigationController?.navigationBar.stp_theme ?? theme` in `updateAppearance` in `STPCoreViewController` will always use `theme` property and not the theme that has been set on the navigation bar.

## Motivation
I wanted to customize the navigation bar items with a different theme than the default one, but without success because of the bug described above.

## Testing
<!-- How was the code tested? Be as specific as possible. -->
