### PR TITLE
Adds missing header imports

### DIFF
--- a/Stripe3DS2/Stripe3DS2/STDSImageLoader.h
+++ b/Stripe3DS2/Stripe3DS2/STDSImageLoader.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Stripe3DS2/Stripe3DS2/STDSSecTypeUtilities.m
+++ b/Stripe3DS2/Stripe3DS2/STDSSecTypeUtilities.m
@@ -9,6 +9,7 @@
 #import "STDSSecTypeUtilities.h"
 
 #import <CommonCrypto/CommonCrypto.h>
+#import <CommonCrypto/CommonRandom.h>
 #import <Security/Security.h>
 
 #import "STDSBundleLocator.h"

--- a/Stripe3DS2/Stripe3DS2/include/STDSChallengeStatusReceiver.h
+++ b/Stripe3DS2/Stripe3DS2/include/STDSChallengeStatusReceiver.h
@@ -7,6 +7,8 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
 @class STDSTransaction, STDSCompletionEvent, STDSRuntimeErrorEvent, STDSProtocolErrorEvent;
 
 NS_ASSUME_NONNULL_BEGIN


### PR DESCRIPTION
## Summary
This change adds some missing header imports

* `STDSImageLoader.h`: Referenced `UIImage` without importing UIKit
* `STDSChallengeStatusReceiver.h`: Referenced `UIViewController` without importing UIKit
* `STDSSecTypeUtilities.m`: Referenced `CCRandomGenerateBytes` without importing `CommonRandom.h`

## Testing
* Ensured compilation succeeded
* Ran unit tests
