### PR TITLE
Update card scanning links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,7 @@
 * The expiration date field's Simplified Chinese localization has been corrected. (Thanks [cythb](https://github.com/cythb)!) [#1654](https://github.com/stripe/stripe-ios/pull/1654)
 
 ## 20.0.0 2020-09-14
-* [Card scanning](https://github.com/stripe/stripe-ios#card-scanning-beta) is now built into STPAddCardViewController. Card.io support has been removed. [#1629](https://github.com/stripe/stripe-ios/pull/1629)
+* [Card scanning](https://github.com/stripe/stripe-ios#card-scanning) is now built into STPAddCardViewController. Card.io support has been removed. [#1629](https://github.com/stripe/stripe-ios/pull/1629)
 * Shrunk the SDK from 1.3MB when compressed & thinned to 0.7MB, allowing for easier App Clips integration. [#1643](https://github.com/stripe/stripe-ios/pull/1643)
 * Swift Package Manager, Apple Silicon, and Catalyst are now fully supported on Xcode 12. [#1644](https://github.com/stripe/stripe-ios/pull/1644)
 * Adds support for 19-digit cards. [#1608](https://github.com/stripe/stripe-ios/pull/1608)

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -15,7 +15,7 @@
 
 ### Migrating from versions < 20.0.0
 * The minimum iOS version is now 11.0. If you'd like to deploy for iOS 10.0, please use Stripe SDK 19.4.0.
-* Card.io is no longer supported. To enable our built-in [card scanning](https://github.com/stripe/stripe-ios#card-scanning-beta) beta, set the `cardScanningEnabled` flag on STPPaymentConfiguration.
+* Card.io is no longer supported. To enable our built-in [card scanning](https://github.com/stripe/stripe-ios#card-scanning) beta, set the `cardScanningEnabled` flag on STPPaymentConfiguration.
 * Catalyst support is out of beta, and now requires Swift Package Manager with Xcode 12 or Cocoapods 1.10.
 
 ### Migrating from versions < 19.4.0

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Table of contents
    * [Getting Started](#getting-started)
       * [Integration](#integration)
       * [Examples](#examples)
-   * [Card scanning](#card-scanning-beta)
+   * [Card scanning](#card-scanning)
    * [Contributing](#contributing)
    * [Migrating](#migrating-from-older-versions)
 <!--te-->
@@ -39,7 +39,7 @@ Table of contents
 
 **Native UI**: We provide native screens and elements to collect payment details. For example, [PaymentSheet](https://stripe.com/docs/payments/accept-a-payment?platform=ios) is a prebuilt UI that combines all the steps required to pay - collecting payment details, billing details, and confirming the payment  - into a single sheet that displays on top of your app.
 
-**Card scanning**: We support card scanning on iOS 13 and higher. See our [Card scanning](#card-scanning-beta) section.
+**Card scanning**: We support card scanning on iOS 13 and higher. See our [Card scanning](#card-scanning) section.
 
 ## Releases
 

--- a/docs/docs/docsets/Stripe.docset/Contents/Resources/Documents/index.html
+++ b/docs/docs/docsets/Stripe.docset/Contents/Resources/Documents/index.html
@@ -827,7 +827,7 @@
 <li><a href="#integration">Integration</a></li>
 <li><a href="#examples">Examples</a></li>
 </ul></li>
-<li><a href="#card-scanning-beta">Card scanning</a></li>
+<li><a href="#card-scanning">Card scanning</a></li>
 <li><a href="#contributing">Contributing</a></li>
 <li><a href="#migrating-from-older-versions">Migrating</a>
 &lt;!&ndash;te&ndash;&gt;</li>
@@ -874,7 +874,7 @@
 <li>This example demonstrates how to use <code><a href="Classes/STPAPIClient.html">STPAPIClient</a></code> to manually accept various non-card payment methods.</li>
 </ul></li>
 </ul>
-<h2 id='card-scanning-beta' class='heading'>Card scanning (Beta)</h2>
+<h2 id='card-scanning' class='heading'>Card scanning (Beta)</h2>
 
 <p>Our new <a href="https://stripe.com/payments/accept-a-payment?platform=ios">PaymentSheet</a> UI offers built-in card scanning. To enable card scanning in Basic Integration, set the <code>cardScanningEnabled</code> option on your <code><a href="Classes/STPPaymentConfiguration.html">STPPaymentConfiguration</a></code>. You&rsquo;ll also need to set <code>NSCameraUsageDescription</code> in your application&rsquo;s plist, and provide a reason for accessing the camera (e.g. &ldquo;To scan cards&rdquo;). Card scanning is supported on devices with iOS 13 or higher.</p>
 

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -827,7 +827,7 @@
 <li><a href="#integration">Integration</a></li>
 <li><a href="#examples">Examples</a></li>
 </ul></li>
-<li><a href="#card-scanning-beta">Card scanning</a></li>
+<li><a href="#card-scanning">Card scanning</a></li>
 <li><a href="#contributing">Contributing</a></li>
 <li><a href="#migrating-from-older-versions">Migrating</a>
 &lt;!&ndash;te&ndash;&gt;</li>
@@ -844,7 +844,7 @@
 
 <p><strong>Native UI</strong>: We provide native screens and elements to collect payment details. For example, <a href="https://stripe.com/docs/payments/accept-a-payment?platform=ios">PaymentSheet</a> is a prebuilt UI that combines all the steps required to pay - collecting payment details, billing details, and confirming the payment  - into a single sheet that displays on top of your app.</p>
 
-<p><strong>Card scanning</strong>: We support card scanning on iOS 13 and higher. See our <a href="#card-scanning-beta">Card scanning</a> section.</p>
+<p><strong>Card scanning</strong>: We support card scanning on iOS 13 and higher. See our <a href="#card-scanning">Card scanning</a> section.</p>
 <h2 id='releases' class='heading'>Releases</h2>
 
 <p>We support Cocoapods, Carthage, and Swift Package Manager. If you link the library manually, use a version from our <a href="https://github.com/stripe/stripe-ios/releases">releases</a> page. Make sure to embed both <code>Stripe.xcframework</code> and <code>Stripe3DS2.xcframework</code>.</p>
@@ -874,7 +874,7 @@
 <li>This example demonstrates how to use <code><a href="Classes/STPAPIClient.html">STPAPIClient</a></code> to manually accept various non-card payment methods.</li>
 </ul></li>
 </ul>
-<h2 id='card-scanning-beta' class='heading'>Card scanning (Beta)</h2>
+<h2 id='card-scanning' class='heading'>Card scanning (Beta)</h2>
 
 <p>Our new <a href="https://stripe.com/payments/accept-a-payment?platform=ios">PaymentSheet</a> UI offers built-in card scanning. To enable card scanning in Basic Integration, set the <code>cardScanningEnabled</code> option on your <code><a href="Classes/STPPaymentConfiguration.html">STPPaymentConfiguration</a></code>. You&rsquo;ll also need to set <code>NSCameraUsageDescription</code> in your application&rsquo;s plist, and provide a reason for accessing the camera (e.g. &ldquo;To scan cards&rdquo;). Card scanning is supported on devices with iOS 13 or higher.</p>
 


### PR DESCRIPTION
## Summary
Updated all documentation references of `card-scaning-beta` to `card-scanning` as the url https://github.com/stripe/stripe-ios#card-scanning-beta no longer works (should be https://github.com/stripe/stripe-ios#card-scanning).

## Motivation
I was clicking the card scanning link but to my dismay naught was happening.

## Testing
I could check the Github readme on our fork: https://github.com/Keepon-dev/stripe-ios#card-scanning