### PR TITLE
Remove invalid exclude from Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
     .target(
       name: "Stripe3DS2",
       path: "Stripe3DS2/Stripe3DS2",
-      exclude: ["BuildConfigurations", "Info.plist", "Resources/CertificateFiles", "include/Stripe3DS2-Prefix.pch"],
+      exclude: ["Info.plist", "Resources/CertificateFiles", "include/Stripe3DS2-Prefix.pch"],
       resources: [
           .process("Info.plist"),
           .process("Resources")


### PR DESCRIPTION
## Summary
Xcode 13 now shows issues with packages in the issue navigator.
One issue popped up for this SDK, namely that there is an invalid exclude in the Package.swift, this PR removes it.

## Motivation
This change will make stripe compile with no warnings in Xcode 13

## Testing
No explicit testing other than CI