### PR TITLE
STPPaymentCardTextField postalCodeField accessibility label

### DIFF
--- a/Stripe/STPPaymentCardTextField.swift
+++ b/Stripe/STPPaymentCardTextField.swift
@@ -699,6 +699,7 @@ open class STPPaymentCardTextField: UIControl, UIKeyInput, STPFormTextFieldDeleg
         postalCodeField.alpha = 0
         postalCodeField.isAccessibilityElement = false
         postalCodeField.keyboardType = .numbersAndPunctuation
+        postalCodeField.accessibilityLabel = defaultPostalFieldPlaceholder(forCountryCode: countryCode)
         self.postalCodeField = postalCodeField
         // Placeholder is set by country code setter
 
@@ -785,9 +786,12 @@ open class STPPaymentCardTextField: UIControl, UIKeyInput, STPFormTextFieldDeleg
 
     func updatePostalFieldPlaceholder() {
         if postalCodePlaceholder == nil {
-            postalCodeField.placeholder = defaultPostalFieldPlaceholder(forCountryCode: countryCode)
+            let placeholder = defaultPostalFieldPlaceholder(forCountryCode: countryCode)
+            postalCodeField.placeholder = placeholder
+            postalCodeField.accessibilityLabel = placeholder
         } else {
             postalCodeField.placeholder = postalCodePlaceholder
+            postalCodeField.accessibilityLabel = postalCodePlaceholder
         }
     }
 


### PR DESCRIPTION
## Summary
Add missed accessibility label for `STPPaymentCardTextField.postalCodeField` with value equals to field's placeholder by analogy with other fields.

## Motivation
The motivation is to make missed field accessible.

The issue with missed `accessibilityLabel` is reproducible in `UI Examples` project with `Card Field` demo.

## Testing
The change is trivial and doesn't seem that need automated testing coverage. Also, AFAIK project doesn't contain tests on accessibility fields.
