### PR TITLE
Possibility to focus invisible card info fields with Voice Over

### DIFF
--- a/Stripe/STPPaymentCardTextField.swift
+++ b/Stripe/STPPaymentCardTextField.swift
@@ -710,6 +710,8 @@ open class STPPaymentCardTextField: UIControl, UIKeyInput, STPFormTextFieldDeleg
         addSubview(self.fieldsView)
         for field in allFields {
             self.fieldsView.addSubview(field)
+            
+            field.accessibilityCustomActions = [makeNextFieldAccessibilityCustomAction()]
         }
 
         addSubview(brandImageView)
@@ -2016,6 +2018,25 @@ open class STPPaymentCardTextField: UIControl, UIKeyInput, STPFormTextFieldDeleg
             "viewModel.hasCompleteMetadataForCardNumber",
         ])
     }
+    
+    // MARK: accessibility custom actions
+    
+    private func makeNextFieldAccessibilityCustomAction() -> UIAccessibilityCustomAction {
+        return UIAccessibilityCustomAction(
+            name: STPLocalizedString(
+                "Next", "accessibility custom action name for next text field entry"),
+            target: self,
+            selector: #selector(activateNextField))
+    }
+    
+    @objc private func activateNextField() -> Bool {
+        let nextFirstResponder = nextFirstResponderField()
+        nextFirstResponder.becomeFirstResponder()
+        UIAccessibility.post(notification: .layoutChanged, argument: nextFirstResponder)
+        
+        return true
+    }
+
 }
 
 /// This protocol allows a delegate to be notified when a payment text field's


### PR DESCRIPTION
## Summary
Add “Next“ custom action on input field which will move focus to next field doesn’t matter if it is visible on the screen or not. 

There is small amount of additive-only changes which reuse code for finding next appropriate field and relayout the fields of dynamic width.

Please see how the implementation works in "UI Examples" project:

https://user-images.githubusercontent.com/72379517/124762351-78578c00-df3b-11eb-816b-2718ed3e71f9.MP4

## Motivation
User cannot focus next hidden field in case if focused one is expanded and shifts next field out of screen bounds.

Please see the issue in "UI Examples" project:

https://user-images.githubusercontent.com/72379517/124763028-3549e880-df3c-11eb-9c58-85dafd075c41.MP4

## Testing
Voice Over is not available on simulator, so custom actions could be tested only manually. Please see the screencast with implemented behavior above.
