### PR TITLE
Defer setting country code to update postal code field visibility

### DIFF
--- a/Stripe/STPCardFormView.swift
+++ b/Stripe/STPCardFormView.swift
@@ -314,7 +314,9 @@ public class STPCardFormView: STPFormView {
         expiryField.addObserver(self)
         billingAddressSubForm.formSection.rows.forEach({ $0.forEach({ $0.addObserver(self) }) })
         button?.addTarget(self, action: #selector(scanButtonTapped), for: .touchUpInside)
-        countryCode = countryField.inputValue
+        defer {
+            countryCode = countryField.inputValue
+        }
         
         switch style {
         


### PR DESCRIPTION
## Summary
When country code is set on STPCardFormView, the visibility of postalCodeField will be set based on whether or not postal code is required in that country. However, it is done after user has chosen a country from the country picker. If the device region is a country that has no postal code, the postal code field will be visible at the beginning. This commit defer setting the country code so that the postal code visibility can be set for the region of the device.

## Motivation
My device has chosen Hong Kong as the region, and Hong Kong does not need a postal code. However the postal code field is shown when the payment sheet is shown. I need to open the country picker and select Hong Kong again to hide the postal code field. After I looked into the code, `HK` is already declared as no postal code required:

```
class func countriesWithNoPostalCodes() -> [AnyHashable]? {
    return [
        "AE",
        "AG",
        "AN",
        "AO",
        "AW",
        "BF",
        "BI",
        "BJ",
        "BO",
        "BS",
        "BW",
        "BZ",
        "CD",
        "CF",
        "CG",
        "CI",
        "CK",
        "CM",
        "DJ",
        "DM",
        "ER",
        "FJ",
        "GD",
        "GH",
        "GM",
        "GN",
        "GQ",
        "GY",
        "HK",
        "IE",
        "JM",
        "KE",
        "KI",
        "KM",
        "KN",
        "KP",
        "LC",
        "ML",
        "MO",
        "MR",
        "MS",
        "MU",
        "MW",
        "NR",
        "NU",
        "PA",
        "QA",
        "RW",
        "SB",
        "SC",
        "SL",
        "SO",
        "SR",
        "ST",
        "SY",
        "TF",
        "TK",
        "TL",
        "TO",
        "TT",
        "TV",
        "TZ",
        "UG",
        "VU",
        "YE",
        "ZA",
        "ZW",
    ]
}
```

Then I look into the logic of toggling the visibility of the postal code field, it is done by the `didSet` method of `countryCode` in `STPCardFormView.swift`.

```
var countryCode: String? {
    didSet {
        postalCodeField.countryCode = countryCode
        set(
            textField: postalCodeField,
            isHidden: !STPPostalCodeValidator.postalCodeIsRequired(forCountryCode: countryCode),
            animated: window != nil)
        stateField?.placeholder = STPLocalizationUtils.localizedStateString(for: countryCode)
    }
}
```

However, the `didSet` method will not be called at initialization. It is called after user has chosen a country from the country picker. So in order to call the `didSet` method for the initial region, I added a `defer` call when setting the country code in initializer.

## Testing
Select a country without postal code, e.g. Hong Kong in the iOS device settings. Then make Stripe payment by opening a PaymentSheet. The postal code should be hidden.
