### PR TITLE
Simplify expression in STPSectionHeaderView.swift

### DIFF
--- a/Stripe/STPSectionHeaderView.swift
+++ b/Stripe/STPSectionHeaderView.swift
@@ -56,7 +56,7 @@ class STPSectionHeaderView: UIView {
         }
     }
     private weak var label: UILabel?
-    private var buttonInsets: UIEdgeInsets!
+    private let buttonInsets = UIEdgeInsets(top: 5, left: 5, bottom: 5, right: 15)
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -74,7 +74,6 @@ class STPSectionHeaderView: UIView {
         button.contentEdgeInsets = .zero
         addSubview(button)
         self.button = button
-        buttonInsets = UIEdgeInsets(top: 5, left: 5, bottom: 5, right: 15)
         backgroundColor = UIColor.clear
         updateAppearance()
     }
@@ -121,10 +120,10 @@ class STPSectionHeaderView: UIView {
         }
     }
 
-    func height(forButtonText text: String?, width: CGFloat) -> CGFloat {
+    private func height(forButtonText text: String?, width: CGFloat) -> CGFloat {
         let insets = buttonInsets
         let textSize = CGSize(
-            width: width - (insets?.left ?? 0.0) - (insets?.right ?? 0.0),
+            width: width - insets.left - insets.right,
             height: CGFloat.greatestFiniteMagnitude)
         var attributes: [NSAttributedString.Key: Any]?
         if let font1 = button?.titleLabel?.font {
@@ -137,8 +136,8 @@ class STPSectionHeaderView: UIView {
             options: .usesLineFragmentOrigin,
             attributes: attributes,
             context: nil
-        ).size
-        return (buttonSize?.height ?? 0.0) + (insets?.top ?? 0.0) + (insets?.bottom ?? 0.0)
+        ).size ?? .zero
+        return buttonSize.height + insets.top + insets.bottom
     }
 
     override func sizeThatFits(_ size: CGSize) -> CGSize {


### PR DESCRIPTION
## Summary
I've simplified an expression in this view to reduce the compile time from 13 seconds to 6 milliseconds.

## Motivation
I analyze the compile time of my projects from time to time and discovered Stripe currently has a hotspot.

After making this innocuous change, the time to compile goes from:
`12899.38ms stripe-ios/Stripe/STPSectionHeaderView.swift:124:10    instance method height(forButtonText:width:)`
to:
`6.05ms stripe-ios/Stripe/STPSectionHeaderView.swift:123:18    instance method height(forButtonText:width:)`

## Testing
The code is identical in functionality.
