### PR TITLE
Attempt to fix Apple Pay callback for server-confirmed PaymentIntents

### DIFF
--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Views/IdentityHTMLView/HTMLViewWithIconLabels.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Views/IdentityHTMLView/HTMLViewWithIconLabels.swift
@@ -136,15 +136,12 @@ extension HTMLViewWithIconLabels {
         addAndPinSubview(vStack)
         vStack.addArrangedSubview(separatorView)
         vStack.addArrangedSubview(textView)
+        vStack.setCustomSpacing(Styling.separatorVerticalSpacing, after: separatorView)
     }
 
     fileprivate func installConstraints() {
         NSLayoutConstraint.activate([
             separatorView.heightAnchor.constraint(equalToConstant: IdentityUI.separatorHeight),
-            separatorView.bottomAnchor.constraint(
-                equalTo: textView.topAnchor,
-                constant: -Styling.separatorVerticalSpacing
-            ),
             separatorView.leadingAnchor.constraint(equalTo: vStack.leadingAnchor),
             separatorView.trailingAnchor.constraint(equalTo: vStack.trailingAnchor),
             textView.leadingAnchor.constraint(equalTo: vStack.leadingAnchor),


### PR DESCRIPTION
## Summary
Added the ability to pass `nil` to both `clientSecret` *and* `intentCreationError` on the Apple Pay callback.

## Motivation
When using server-confirmed PaymentIntents, there is nothing for this delegate to do in an Apple Pay situation where the payment has already been completed. Currently, passing `nil` to both parameters leaves the application in a no-op state and the Apple Pay sheet just times out even though the payment was processed successfully in the background.

Why not just confirm the intent on the client? Because when using pending updates with subscriptions, there is no option to do this. It means that using Apple Pay to pay for a change in subscription *will* mess up your subscription if the payment fails, which is what pending updates are meant to prevent. I discussed this on the Stripe developer Discord before submitting this.

## Testing
I tested it manually by simply unlocking the dependency and running the code in XCode. It works as expected. I have no idea how to properly test this as I never worked with Carthage, so I couldn't get it to run at all. This is more of a suggestion than a viable PR.
