### PR TITLE
Added optional func `didSelectPaymentMethod` to STPApplePayContextDelegate

### DIFF
--- a/Stripe/STPApplePayContext.swift
+++ b/Stripe/STPApplePayContext.swift
@@ -63,6 +63,16 @@ import PassKit
         didSelectShippingContact contact: PKContact,
         handler: @escaping (_ update: PKPaymentRequestShippingContactUpdate) -> Void
     )
+    
+    /// Called when the user has selected a new payment method. You should inspect the
+    /// payment method and must invoke the completion block with an updated array of PKPaymentSummaryItem objects.
+    /// @note To maintain privacy, the billing information is anonymized. For example, in the United States it only includes the city, state, and zip code.
+    /// Receive full payment and billing information in the paymentInformation passed to `applePayContext:didCreatePaymentMethod:paymentInformation:completion:`
+    @objc optional func applePayContext(
+        _ context: STPApplePayContext,
+        didSelectPaymentMethod paymentMethod: PKPaymentMethod,
+        handler: @escaping (_ update: PKPaymentRequestPaymentMethodUpdate) -> Void
+    )
 }
 
 /// A helper class that implements Apple Pay.
@@ -299,6 +309,20 @@ import PassKit
                 STPApplePayContextDelegate.applePayContext(_:didSelectShippingContact:handler:))
         ) ?? false {
             delegate?.applePayContext?(self, didSelectShippingContact: contact, handler: completion)
+        }
+    }
+    
+    /// :nodoc:
+    @objc
+    public func paymentAuthorizationController(
+        _ controller: PKPaymentAuthorizationController, didSelectPaymentMethod paymentMethod: PKPaymentMethod,
+        handler completion: @escaping (PKPaymentRequestPaymentMethodUpdate) -> Void
+    ) {
+        if delegate?.responds(
+            to: #selector(
+                STPApplePayContextDelegate.applePayContext(_:didSelectPaymentMethod:handler:))
+        ) ?? false {
+            delegate?.applePayContext?(self, didSelectPaymentMethod: paymentMethod, handler: completion)
         }
     }
 


### PR DESCRIPTION
## Summary
Implemented `paymentAuthorizationController(_:didSelectPaymentMethod:handler:)` from the `PKPaymentAuthorizationControllerDelegate`
Added `applePayContext(_:didSelectPaymentMethod:handler:` to `STPApplePayContextDelegate` and invoke it when `paymentAuthorizationController(_:didSelectPaymentMethod:handler:)` is called

## Motivation
We have a case where we don't gather the shipping address and are relying sorely on the billing one to calculate the taxes
