### PR TITLE
Fix VerificationClientSecret

### DIFF
--- a/StripeIdentity/StripeIdentity/Source/VerificationClientSecret.swift
+++ b/StripeIdentity/StripeIdentity/Source/VerificationClientSecret.swift
@@ -45,6 +45,6 @@ extension VerificationClientSecret {
         }
 
         verificationSessionId = "\(components[0])_\(components[1])"
-        urlToken = String(components[3])
+        urlToken = String(components[4])
     }
 }

--- a/StripeIdentity/StripeIdentity/Source/VerificationClientSecret.swift
+++ b/StripeIdentity/StripeIdentity/Source/VerificationClientSecret.swift
@@ -15,7 +15,7 @@ struct VerificationClientSecret {
 }
 
 extension VerificationClientSecret {
-    private static let expectedComponentsCount = 4
+    private static let expectedComponentsCount = 5
 
     /**
      Initialize from string.
@@ -38,8 +38,9 @@ extension VerificationClientSecret {
                 !components[1].isEmpty &&
                 (components[1].rangeOfCharacter(from: CharacterSet.alphanumerics.inverted) == nil) &&
                 components[2] == "secret" &&
-                !components[3].isEmpty &&
-                (components[3].rangeOfCharacter(from: CharacterSet.alphanumerics.inverted) == nil) else {
+                (components[3] == "test" || components[3] == "live") &&
+                !components[4].isEmpty &&
+                (components[4].rangeOfCharacter(from: CharacterSet.alphanumerics.inverted) == nil) else {
             return nil
         }
 

--- a/StripeIdentity/StripeIdentityTests/Unit/VerificationClientSecretTest.swift
+++ b/StripeIdentity/StripeIdentityTests/Unit/VerificationClientSecretTest.swift
@@ -13,10 +13,14 @@ import XCTest
 final class VerificationClientSecretTest: XCTestCase {
 
     func testValidSecrets() {
-        verifySecret(secretString: "vi_abc123_secret_xyz456", expectedSessionId: "vi_abc123", expectedUrlToken: "xyz456")
-        verifySecret(secretString: " vi_abc123_secret_xyz456 ", expectedSessionId: "vi_abc123", expectedUrlToken: "xyz456")
-        verifySecret(secretString: "vs_abc123_secret_xyz456", expectedSessionId: "vs_abc123", expectedUrlToken: "xyz456")
-        verifySecret(secretString: " vs_abc123_secret_xyz456 ", expectedSessionId: "vs_abc123", expectedUrlToken: "xyz456")
+        verifySecret(secretString: "vi_abc123_secret_test_xyz456", expectedSessionId: "vi_abc123", expectedUrlToken: "xyz456")
+        verifySecret(secretString: " vi_abc123_secret_test_xyz456 ", expectedSessionId: "vi_abc123", expectedUrlToken: "xyz456")
+        verifySecret(secretString: "vi_abc123_secret_live_xyz456", expectedSessionId: "vi_abc123", expectedUrlToken: "xyz456")
+        verifySecret(secretString: " vi_abc123_secret_live_xyz456 ", expectedSessionId: "vi_abc123", expectedUrlToken: "xyz456")
+        verifySecret(secretString: "vs_abc123_secret_test_xyz456", expectedSessionId: "vs_abc123", expectedUrlToken: "xyz456")
+        verifySecret(secretString: " vs_abc123_secret_test_xyz456 ", expectedSessionId: "vs_abc123", expectedUrlToken: "xyz456")
+        verifySecret(secretString: "vs_abc123_secret_live_xyz456", expectedSessionId: "vs_abc123", expectedUrlToken: "xyz456")
+        verifySecret(secretString: " vs_abc123_secret_live_xyz456 ", expectedSessionId: "vs_abc123", expectedUrlToken: "xyz456")
     }
 
     func testInvalidSecrets() {


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
VerificationClientSecret initializer was modified because the format of client_secret used in StripeIdentity has changed.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
