### PR TITLE
Updates the default height of a floating input to meet WCAG 2.5.5 Target Size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* [Changed] Increases the default height of floating inputs to meet WCAG guidelines
+
 ## 22.4.0 2022-05-23
 ### PaymentSheet
 * [Added] The ability to customize the appearance of the PaymentSheet using `PaymentSheet.Appearance`.

--- a/Stripe/STPFloatingPlaceholderTextField.swift
+++ b/Stripe/STPFloatingPlaceholderTextField.swift
@@ -14,7 +14,7 @@ import UIKit
 class STPFloatingPlaceholderTextField: UITextField {
 
     struct LayoutConstants {
-        static let defaultHeight: CGFloat = 40
+        static let defaultHeight: CGFloat = 44
 
         static let horizontalMargin: CGFloat = 11
         static let horizontalSpacing: CGFloat = 4


### PR DESCRIPTION
## Summary
Updates the default height of a floating input to meet [WCAG 2.5.5 Target Size](https://www.w3.org/TR/WCAG21/#target-size)

## Motivation
We are working through accessibility testing on our app, the `STPCardFormView` fails initial tests as the inputs are too small.

_It's possible this needs changing in other areas of the stripe UI framework, however, I'm a new contributor and I do not know the codebase that well - any pointers to get this across the line would be great._