### PR TITLE
Remove podspec references to non-existent resources

### DIFF
--- a/StripeFinancialConnections.podspec
+++ b/StripeFinancialConnections.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
     s.dependency   'StripeCore', "#{s.version}"
     s.dependency   'StripeUICore', "#{s.version}"
     s.source_files                   = 'StripeFinancialConnections/StripeFinancialConnections/**/*.swift'
-    s.ios.resource_bundle            = { 'StripeFinancialConnections' => 'StripeFinancialConnections/StripeFinancialConnections/Resources/**/*.{lproj,xcassets,png}' }
+    s.ios.resource_bundle            = { 'StripeFinancialConnections' => 'StripeFinancialConnections/StripeFinancialConnections/Resources/**/*.{lproj,png}' }
 end

--- a/StripeUICore.podspec
+++ b/StripeUICore.podspec
@@ -18,6 +18,6 @@ Pod::Spec.new do |s|
   s.swift_version		               = '5.0'
   s.weak_framework                 = 'SwiftUI'
   s.source_files                   = 'StripeUICore/StripeUICore/**/*.swift'
-  s.ios.resource_bundle            = { 'StripeUICore' => 'StripeUICore/StripeUICore/Resources/**/*.{lproj,png,xcassets,json}' }
+  s.ios.resource_bundle            = { 'StripeUICore' => 'StripeUICore/StripeUICore/Resources/**/*.{lproj,png,json}' }
   s.dependency                       'StripeCore', "#{s.version}"
 end


### PR DESCRIPTION
## Summary
Removed non-existent references to `*.xcassets` in the StripeFinancialConnections and StripeUICore podspecs

## Motivation
Fixes https://github.com/stripe/stripe-ios/issues/2019

## Testing
n/a

## Changelog
n/a
