### PR TITLE
Use iPad's form sheet presentation for macCatalyst

### DIFF
--- a/Stripe/PaymentMethodTypeCollectionView.swift
+++ b/Stripe/PaymentMethodTypeCollectionView.swift
@@ -107,7 +107,15 @@ extension PaymentMethodTypeCollectionView: UICollectionViewDataSource, UICollect
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        // Fixed size cells for iPad
+        // Fixed size cells for iPads and macCatalyst.
+        if #available(iOS 14.0, macCatalyst 14.0, *) {
+            guard UIDevice.current.userInterfaceIdiom != .pad && UIDevice.current.userInterfaceIdiom != .mac else {
+                return CGSize(width: 100, height: PaymentMethodTypeCollectionView.cellHeight)
+            }
+        } else {
+            guard UIDevice.current.userInterfaceIdiom != .pad else { return CGSize(width: 100, height: PaymentMethodTypeCollectionView.cellHeight) }
+        }
+
         guard UIDevice.current.userInterfaceIdiom != .pad else { return CGSize(width: 100, height: PaymentMethodTypeCollectionView.cellHeight) }
         
         // When there are 2 PMs, make them span the width of the collection view

--- a/Stripe/UIViewController+BottomSheet.swift
+++ b/Stripe/UIViewController+BottomSheet.swift
@@ -13,9 +13,28 @@ extension UIViewController {
     func presentAsBottomSheet(
         _ viewControllerToPresent: BottomSheetPresentable,
         appearance: PaymentSheet.Appearance,
-        completion: (() -> ())? = nil
+        completion: (() -> Void)? = nil
     ) {
-        if UIDevice.current.userInterfaceIdiom == .pad {
+        // Whether to present the bottomsheet as a form sheet on larger devices, or as bottom sheet
+        // on smaller devices.
+        let presentAsForm: Bool
+        if #available(iOS 14.0, macCatalyst 14.0, *) {
+            if UIDevice.current.userInterfaceIdiom == .pad
+                || UIDevice.current.userInterfaceIdiom == .mac
+            {
+                presentAsForm = true
+            } else {
+                presentAsForm = false
+            }
+        } else {
+            if UIDevice.current.userInterfaceIdiom == .pad {
+                presentAsForm = true
+            } else {
+                presentAsForm = false
+            }
+        }
+
+        if presentAsForm {
             viewControllerToPresent.modalPresentationStyle = .formSheet
             if let vc = viewControllerToPresent as? BottomSheetViewController {
                 viewControllerToPresent.presentationController?.delegate = vc
@@ -26,7 +45,7 @@ extension UIViewController {
             BottomSheetTransitioningDelegate.appearance = appearance
             viewControllerToPresent.transitioningDelegate = BottomSheetTransitioningDelegate.default
         }
-        
+
         present(viewControllerToPresent, animated: true, completion: completion)
     }
 }


### PR DESCRIPTION
## Summary
Adds macCatalyst support when presenting bottom sheets so that they look similar to how they look on iPad.

## Motivation
iPads seem to have a different presentation style based on the fact that they have a larger screen. This same logic applies to macCatalyst apps, which run on macOS devices which have historically also had larger screens.

## Testing
Ran our sample catalyst app with this change and saw that the view controller was presented as a form instead of a bottom sheet.

## Changelog
* [Fixed] [Add support for macCatalyst to use the form sheet presentation, like in iPad](https://github.com/stripe/stripe-ios/issues/2023)