### PR TITLE
Moved changelog entry to correct section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ### CardScan
 * [Added] Added a README.md for the `CardScanSheet` integration.
 
+### PaymentSheet
+* [Added] Added parameters to customize the primary button and Apple Pay button labels. They can be found under `PaymentSheet.Configuration.primaryButtonLabel` and `PaymentSheet.ApplePayConfiguration.buttonType` respectively.
+
 ## 23.0.0 2022-10-24
 ### Payments
 * [Changed] Reduced the size of the SDK by splitting the `Stripe` module into `StripePaymentSheet`, `StripePayments`, and `StripePaymentsUI`. Some manual changes may be required. Migration instructions are available at [https://stripe.com/docs/mobile/ios/sdk-23-migration](https://stripe.com/docs/mobile/ios/sdk-23-migration).
@@ -20,7 +23,6 @@
 ### PaymentSheet
 * [Fixed] Fixed a validation issue where cards expiring at the end of the current month were incorrectly treated as expired.
 * [Fixed] Fixed a visual bug in iOS 16 where advancing between text fields would momentarily dismiss the keyboard.
-* [Added] Added parameters to customize the primary button and Apple Pay button labels. They can be found under `PaymentSheet.Configuration.primaryButtonLabel` and `PaymentSheet.ApplePayConfiguration.buttonType` respectively.
 
 ## 22.8.4 2022-10-12
 ### PaymentSheet


### PR DESCRIPTION
## Summary
The changelog entry moved to the previous release section after rebasing because the PR was originally created on the previous release, fixing that.

## Motivation
Fix changelog before release.

## Testing
Look at preview.
