### PR TITLE
[Link] Make sure add payment button always matches the default selected method

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Controllers/PayWithLinkViewController-NewPaymentViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Controllers/PayWithLinkViewController-NewPaymentViewController.swift
@@ -180,7 +180,7 @@ extension PayWithLinkViewController {
                     constant: -LinkUI.contentMargins.trailing)
             ])
 
-            confirmButton.update(state: .disabled)
+            didUpdate(addPaymentMethodVC)
         }
 
         func confirm() {


### PR DESCRIPTION
Previously it used whatever the global default was ("Pay"), rather than what was being presented to the user. This meant that if the only option was incompatible with that, the user would be stuck.

## Motivation
|Before|After|
|-------|------|
|![Screen Shot 2022-10-24 at 9 35 57 AM](https://user-images.githubusercontent.com/105328383/199318150-44befe51-fcbb-4fd8-ad34-6ad8f2df2c8d.png)|![Screen Shot 2022-11-01 at 12 03 15 PM](https://user-images.githubusercontent.com/105328383/199318172-6cb72237-54d5-46b9-ac9b-5d9d33758454.png)|
