### PR TITLE
Fix DT builds on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -327,18 +327,19 @@ jobs:
       - run: "sudo gem install bundler"
       - run: "bundle config set without 'development'"
       - run: "bundle install"
-      - run:
-          name: "Submit app to Data Theorem for SAST"
-          command: bundle exec ./ci_scripts/push_dt.rb "$CIRCLE_BRANCH" "$DT_UPLOAD_API_KEY"
-      - run:
-          name: Notify on failure
-          command: "./ci_scripts/notify_ci.rb"
-          when: on_fail
+      # - run:
+      #     name: "Submit app to Data Theorem for SAST"
+      #     command: bundle exec ./ci_scripts/push_dt.rb "$CIRCLE_BRANCH" "$DT_UPLOAD_API_KEY"
+      # - run:
+      #     name: Notify on failure
+      #     command: "./ci_scripts/notify_ci.rb"
+      #     when: on_fail
 
 workflows:
   version: 2.1
   build-and-test:
     jobs:
+      - data-theorem-sast
       - size-report:
           context:
             - EmergeTools

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -327,19 +327,18 @@ jobs:
       - run: "sudo gem install bundler"
       - run: "bundle config set without 'development'"
       - run: "bundle install"
-      # - run:
-      #     name: "Submit app to Data Theorem for SAST"
-      #     command: bundle exec ./ci_scripts/push_dt.rb "$CIRCLE_BRANCH" "$DT_UPLOAD_API_KEY"
-      # - run:
-      #     name: Notify on failure
-      #     command: "./ci_scripts/notify_ci.rb"
-      #     when: on_fail
+      - run:
+          name: "Submit app to Data Theorem for SAST"
+          command: bundle exec ./ci_scripts/push_dt.rb "$CIRCLE_BRANCH" "$DT_UPLOAD_API_KEY"
+      - run:
+          name: Notify on failure
+          command: "./ci_scripts/notify_ci.rb"
+          when: on_fail
 
 workflows:
   version: 2.1
   build-and-test:
     jobs:
-      - data-theorem-sast
       - size-report:
           context:
             - EmergeTools

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -325,6 +325,7 @@ jobs:
       - macos/switch-ruby:
           version: "system" # Xcode's ipatool depends on a specific version of ruby, without this App Store archiving will fail
       - run: "sudo gem install bundler"
+      - run: "bundle config set without 'development'"
       - run: "bundle install"
       - run:
           name: "Submit app to Data Theorem for SAST"


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Skip installing development gems that require Ruby 2.7.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
DT builds use Ruby 2.6.8.

https://app.circleci.com/pipelines/github/stripe/stripe-ios/445/workflows/b2ebdda4-618c-4a6d-bc51-dc34ee98685d/jobs/2281

## Testing
<!-- How was the code tested? Be as specific as possible. -->
[CI](https://app.circleci.com/pipelines/github/stripe/stripe-ios/448/workflows/2289dedc-6207-4b26-a680-05cf9641fb64/jobs/2301).
