### PR TITLE
Fix Pull Request URL in Emerge Tools

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -210,7 +210,7 @@ platform :ios do
                       sha: `git rev-parse HEAD`.to_s,
                       build_type: 'release' }
         unless ENV['CIRCLE_PULL_REQUEST'].nil?
-          arguments[:pr_number] = ENV['CIRCLE_PULL_REQUEST'].partition('/').last.to_s # get the PR number from the PR URL
+          arguments[:pr_number] = ENV['CIRCLE_PULL_REQUEST'].split('/').last.to_s # get the PR number from the PR URL
           arguments[:base_sha] = `git rev-parse master`.to_s
         end
         emerge(file_path: archive_path + 'Stripe.xcarchive', **arguments)


### PR DESCRIPTION
## Summary
My Ruby is rusty: I used `partition()` here when I meant to use `split()`. [`partition()`](https://ruby-doc.org/core-3.1.2/String.html#method-i-partition) splits based on the first instance of the separator.

## Motivation
Fix Emerge Tools uploads to point to the correct PRs.

## Testing
Manually in `irb`.