### PR TITLE
Apply swift-format to StripePaymentSheet

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Analytics/AnalyticsHelper.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Analytics/AnalyticsHelper.swift
@@ -22,7 +22,9 @@ final class AnalyticsHelper {
 
     private var startTimes: [TimeMeasurement: Date] = [:]
 
-    init(timeProvider: @escaping () -> Date = Date.init) {
+    init(
+        timeProvider: @escaping () -> Date = Date.init
+    ) {
         self.timeProvider = timeProvider
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Analytics/STPAnalyticsClient+Address.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Analytics/STPAnalyticsClient+Address.swift
@@ -10,7 +10,7 @@ import Foundation
 @_spi(STP) import StripeCore
 
 extension STPAnalyticsClient {
-    
+
     func logAddressControllerEvent(
         event: STPAnalyticEvent,
         addressAnalyticData: AddressAnalyticData?,
@@ -20,34 +20,55 @@ extension STPAnalyticsClient {
         if isSimulatorOrTest {
             additionalParams["is_development"] = true
         }
-        
+
         additionalParams["address_data_blob"] = addressAnalyticData?.analyticsPayload
-        
-        let analytic = AddressAnalytic(event: event,
-                                       productUsage: productUsage,
-                                       params: additionalParams)
-        
+
+        let analytic = AddressAnalytic(
+            event: event,
+            productUsage: productUsage,
+            params: additionalParams
+        )
+
         log(analytic: analytic, apiClient: apiClient)
     }
 
     // MARK: - Address
 
     func logAddressShow(defaultCountryCode: String, apiClient: STPAPIClient) {
-        assert(apiClient.publishableKey?.nonEmpty != nil) // A publishable key is required to be set at this point so we can send it in our analytics payload
-        let analyticData = AddressAnalyticData(addressCountryCode: defaultCountryCode,
-                                               autoCompleteResultedSelected: nil,
-                                               editDistance: nil)
-        
-        self.logAddressControllerEvent(event: .addressShow, addressAnalyticData: analyticData, apiClient: apiClient)
+        // A publishable key is required to be set at this point so we can send it in our analytics payload
+        assert(apiClient.publishableKey?.nonEmpty != nil)
+        let analyticData = AddressAnalyticData(
+            addressCountryCode: defaultCountryCode,
+            autoCompleteResultedSelected: nil,
+            editDistance: nil
+        )
+
+        self.logAddressControllerEvent(
+            event: .addressShow,
+            addressAnalyticData: analyticData,
+            apiClient: apiClient
+        )
     }
 
-    func logAddressCompleted(addressCountyCode: String, autoCompleteResultedSelected: Bool, editDistance: Int?, apiClient: STPAPIClient) {
-        assert(apiClient.publishableKey?.nonEmpty != nil) // A publishable key is required to be set at this point so we can send it in our analytics payload
-        let analyticData = AddressAnalyticData(addressCountryCode: addressCountyCode,
-                                               autoCompleteResultedSelected: autoCompleteResultedSelected,
-                                               editDistance: editDistance)
-        
-        self.logAddressControllerEvent(event: .addressCompleted, addressAnalyticData: analyticData, apiClient: apiClient)
+    func logAddressCompleted(
+        addressCountyCode: String,
+        autoCompleteResultedSelected: Bool,
+        editDistance: Int?,
+        apiClient: STPAPIClient
+    ) {
+        // A publishable key is required to be set at this point so we can send it in our analytics payload
+        assert(apiClient.publishableKey?.nonEmpty != nil)
+        let analyticData = AddressAnalyticData(
+            addressCountryCode: addressCountyCode,
+            autoCompleteResultedSelected: autoCompleteResultedSelected,
+            editDistance: editDistance
+        )
+
+        self.logAddressControllerEvent(
+            event: .addressCompleted,
+            addressAnalyticData: analyticData,
+            apiClient: apiClient
+        )
     }
 }
 
@@ -55,16 +76,20 @@ struct AddressAnalyticData {
     let addressCountryCode: String
     let autoCompleteResultedSelected: Bool?
     let editDistance: Int?
-    
+
     var analyticsPayload: [String: Any?] {
-        return ["address_country_code": addressCountryCode,
-                "auto_complete_result_selected": autoCompleteResultedSelected,
-                "edit_distance": editDistance]
+        return [
+            "address_country_code": addressCountryCode,
+            "auto_complete_result_selected": autoCompleteResultedSelected,
+            "edit_distance": editDistance,
+        ]
     }
 }
 
 extension PaymentSheet.Address {
-    init(from address: AddressViewController.AddressDetails.Address) {
+    init(
+        from address: AddressViewController.AddressDetails.Address
+    ) {
         line1 = address.line1
         line2 = address.line2
         city = address.city
@@ -72,7 +97,7 @@ extension PaymentSheet.Address {
         country = address.country
         postalCode = address.postalCode
     }
-    
+
     func editDistance(from otherAddress: PaymentSheet.Address) -> Int {
         var editDistance = 0
         editDistance += (line1 ?? "").editDistance(to: otherAddress.line1 ?? "")
@@ -81,7 +106,7 @@ extension PaymentSheet.Address {
         editDistance += (state ?? "").editDistance(to: otherAddress.state ?? "")
         editDistance += (country ?? "").editDistance(to: otherAddress.country ?? "")
         editDistance += (postalCode ?? "").editDistance(to: otherAddress.postalCode ?? "")
-        
+
         return editDistance
     }
 }
@@ -89,5 +114,5 @@ extension PaymentSheet.Address {
 struct AddressAnalytic: Analytic {
     let event: STPAnalyticEvent
     let productUsage: Set<String>
-    let params: [String : Any]
+    let params: [String: Any]
 }

--- a/StripePaymentSheet/StripePaymentSheet/Analytics/STPAnalyticsClient+LUXE.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Analytics/STPAnalyticsClient+LUXE.swift
@@ -12,7 +12,10 @@ extension STPAnalyticsClient {
         self.logPaymentSheetEvent(event: .luxeSerializeFailure)
     }
     func logClientFilteredPaymentMethods(clientFilteredPaymentMethods: String) {
-        self.logPaymentSheetEvent(event: .luxeClientFilteredPaymentMethods, params: ["client_filtered_payment_methods": clientFilteredPaymentMethods])
+        self.logPaymentSheetEvent(
+            event: .luxeClientFilteredPaymentMethods,
+            params: ["client_filtered_payment_methods": clientFilteredPaymentMethods]
+        )
     }
     func logClientFilteredPaymentMethodsNone() {
         self.logPaymentSheetEvent(event: .luxeClientFilteredPaymentMethodsNone)
@@ -21,18 +24,27 @@ extension STPAnalyticsClient {
         guard case .dynamic(let name) = paymentMethod else {
             return
         }
-        self.logPaymentSheetEvent(event: .luxeImageSelectorIconDownloaded, params: ["payment_method": name])
+        self.logPaymentSheetEvent(
+            event: .luxeImageSelectorIconDownloaded,
+            params: ["payment_method": name]
+        )
     }
     func logImageSelectorIconFromBundleIfNeeded(paymentMethod: PaymentSheet.PaymentMethodType) {
         guard case .dynamic(let name) = paymentMethod else {
             return
         }
-        self.logPaymentSheetEvent(event: .luxeImageSelectorIconFromBundle, params: ["payment_method": name])
+        self.logPaymentSheetEvent(
+            event: .luxeImageSelectorIconFromBundle,
+            params: ["payment_method": name]
+        )
     }
     func logImageSelectorIconNotFoundIfNeeded(paymentMethod: PaymentSheet.PaymentMethodType) {
         guard case .dynamic(let name) = paymentMethod else {
             return
         }
-        self.logPaymentSheetEvent(event: .luxeImageSelectorIconNotFound, params: ["payment_method": name])
+        self.logPaymentSheetEvent(
+            event: .luxeImageSelectorIconNotFound,
+            params: ["payment_method": name]
+        )
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Categories/Data+SHA256.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Categories/Data+SHA256.swift
@@ -6,21 +6,21 @@
 //  Copyright © 2022 Stripe, Inc. All rights reserved.
 //
 
-import Foundation
 import CommonCrypto
+import Foundation
 
 // Adapted from https://stackoverflow.com/questions/25388747/sha256-in-swift
 extension Data {
-    
+
     var sha256: String {
         return digest().base64EncodedString()
     }
-    
+
     private func digest() -> Data {
         let digestLength = Int(CC_SHA256_DIGEST_LENGTH)
         var hash = [UInt8](repeating: 0, count: digestLength)
         CC_SHA256([UInt8](self), UInt32(self.count), &hash)
-        
+
         return Data(bytes: hash, count: digestLength)
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Categories/Date+Distance.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Categories/Date+Distance.swift
@@ -9,14 +9,18 @@
 import Foundation
 
 extension Date {
-    
+
     public func compatibleDistance(to other: Date) -> TimeInterval {
         if #available(iOS 13.0, *) {
             return self.distance(to: other)
         }
-        
+
         return TimeInterval(
-            Calendar.autoupdatingCurrent.dateComponents([Calendar.Component.second], from: self, to: other).second ?? 0
+            Calendar.autoupdatingCurrent.dateComponents(
+                [Calendar.Component.second],
+                from: self,
+                to: other
+            ).second ?? 0
         )
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Categories/STPPaymentMethod+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Categories/STPPaymentMethod+PaymentSheet.swift
@@ -7,9 +7,9 @@
 //
 
 import Foundation
+@_spi(STP) import StripeCore
 @_spi(STP) import StripePayments
 @_spi(STP) import StripePaymentsUI
-@_spi(STP) import StripeCore
 
 extension STPPaymentMethod {
     var paymentSheetLabel: String {
@@ -24,7 +24,7 @@ extension STPPaymentMethod {
             return type.displayName
         }
     }
-    
+
     public override var accessibilityLabel: String? {
         get {
             switch type {
@@ -34,14 +34,18 @@ extension STPPaymentMethod {
                 }
                 let brand = STPCardBrandUtilities.stringFrom(card.brand) ?? ""
                 let last4 = card.last4 ?? ""
-                let last4Spaced = last4.map{ String($0) }.joined(separator: " ")
+                let last4Spaced = last4.map { String($0) }.joined(separator: " ")
                 let localized = String.Localized.card_brand_ending_in_last_4
                 return String(format: localized, brand, last4Spaced)
             case .USBankAccount:
                 guard let usBankAccount = self.usBankAccount else {
                     return nil
                 }
-                return String(format: String.Localized.bank_name_account_ending_in_last_4, usBankAccount.bankName, usBankAccount.last4)
+                return String(
+                    format: String.Localized.bank_name_account_ending_in_last_4,
+                    usBankAccount.bankName,
+                    usBankAccount.last4
+                )
             default:
                 return nil
             }

--- a/StripePaymentSheet/StripePaymentSheet/Categories/String+Localized.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Categories/String+Localized.swift
@@ -5,9 +5,9 @@
 //  Copyright © 2022 Stripe, Inc. All rights reserved.
 //
 
+import Foundation
 @_spi(STP) import StripeCore
 @_spi(STP) import StripeUICore
-import Foundation
 
 // Localized strings that are used in multiple contexts. Collected here to avoid re-translation
 // We use snake case to make long names easier to read.
@@ -18,7 +18,7 @@ extension String.Localized {
             "Text for a button that, when tapped, displays another screen where the customer can add payment method details"
         )
     }
-    
+
     static var pay_another_way: String {
         STPLocalizedString(
             "Pay another way",
@@ -26,7 +26,9 @@ extension String.Localized {
         )
     }
 
-    static func pay_faster_at_$merchant_and_thousands_of_merchants(merchantDisplayName: String) -> String {
+    static func pay_faster_at_$merchant_and_thousands_of_merchants(
+        merchantDisplayName: String
+    ) -> String {
         String(
             format: STPLocalizedString(
                 "Pay faster at %@ and thousands of merchants.",
@@ -39,12 +41,16 @@ extension String.Localized {
             merchantDisplayName
         )
     }
-    
+
     static var save_for_future_payments: String {
-        STPLocalizedString("Save for future payments", "The label of a switch indicating whether to save the payment method for future payments.")
+        STPLocalizedString(
+            "Save for future payments",
+            "The label of a switch indicating whether to save the payment method for future payments."
+        )
     }
-    
-    static func save_this_card_for_future_$merchant_payments(merchantDisplayName: String) -> String {
+
+    static func save_this_card_for_future_$merchant_payments(merchantDisplayName: String) -> String
+    {
         String(
             format: STPLocalizedString(
                 "Save this card for future %@ payments",
@@ -53,17 +59,17 @@ extension String.Localized {
             merchantDisplayName
         )
     }
-    
+
     static var ideal_bank: String {
         STPLocalizedString("iDEAL Bank", "iDEAL bank section title for iDEAL form entry.")
     }
-    
+
     static var pay_with_payment_method: String {
         // TODO(ramont): Re-translate this string as some of the existing translations
         // contain punctuation or don't read as a sentence.
         STPLocalizedString("Pay with %@", "Pay with {payment method}")
     }
-    
+
     static var back: String {
         STPLocalizedString("Back", "Text for back button")
     }
@@ -84,13 +90,17 @@ extension String.Localized {
             "Accessibility label for an action or a button that shows a menu."
         )
     }
-    
+
     static var enter_address_manually: String {
-        STPLocalizedString("Enter address manually", "Text for a button that allows manual entry of an address")
+        STPLocalizedString(
+            "Enter address manually",
+            "Text for a button that allows manual entry of an address"
+        )
     }
-    
+
     static func does_not_support_shipping_to(countryCode: String) -> String {
-        let countryDisplayName = Locale.autoupdatingCurrent.localizedString(forRegionCode: countryCode) ?? countryCode
+        let countryDisplayName =
+            Locale.autoupdatingCurrent.localizedString(forRegionCode: countryCode) ?? countryCode
         return String(
             format: STPLocalizedString(
                 "Shipping to %@ is not supported.",
@@ -109,7 +119,7 @@ extension String.Localized {
             "Separator label between two options"
         )
     }
-    
+
     static var add_a_payment_method: String {
         STPLocalizedString(
             "Add a payment method",
@@ -120,35 +130,35 @@ extension String.Localized {
     static var save_address: String {
         STPLocalizedString("Save address", "Title for address entry section")
     }
-    
+
     static var approve_payment: String {
         STPLocalizedString(
             "Approve payment",
             "Text on a screen asking the user to approve a payment"
         )
     }
-    
+
     static var cancel_pay_another_way: String {
         STPLocalizedString(
             "Cancel and pay another way",
             "Button text on a screen asking the user to approve a payment"
         )
     }
-    
+
     static var open_upi_app: String {
         STPLocalizedString(
             "Open your UPI app to approve your payment within %@",
             "Countdown timer text on a screen asking the user to approve a payment"
         )
     }
-    
+
     static var payment_failed: String {
         STPLocalizedString(
             "Payment failed",
             "Text on a screen that indicates a payment has failed"
         )
     }
-    
+
     static var please_go_back: String {
         STPLocalizedString(
             "Please go back and select another payment method",

--- a/StripePaymentSheet/StripePaymentSheet/Categories/String+StripePaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Categories/String+StripePaymentSheet.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 
-
 extension String {
     var sha256: String? {
         guard let stringData = self.data(using: .utf8) else {

--- a/StripePaymentSheet/StripePaymentSheet/Categories/UserDefaults+Stripe.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Categories/UserDefaults+Stripe.swift
@@ -12,7 +12,8 @@ extension UserDefaults {
     /// Canonical list of all UserDefaults keys the SDK uses
     enum StripeKeys: String {
         /// The key for a dictionary of Customer id to their last selected payment method ID
-        case customerToLastSelectedPaymentMethod = "com.stripe.lib:STPStripeCustomerToLastSelectedPaymentMethodKey"
+        case customerToLastSelectedPaymentMethod =
+            "com.stripe.lib:STPStripeCustomerToLastSelectedPaymentMethodKey"
     }
 
     var customerToLastSelectedPaymentMethod: [String: String]? {
@@ -27,4 +28,3 @@ extension UserDefaults {
     }
 
 }
-

--- a/StripePaymentSheet/StripePaymentSheet/Helpers/BoolReference.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Helpers/BoolReference.swift
@@ -16,5 +16,5 @@ final class BoolReference {
         }
     }
 
-    var didUpdate: ((Bool)->Void)? = nil
+    var didUpdate: ((Bool) -> Void)? = nil
 }

--- a/StripePaymentSheet/StripePaymentSheet/Helpers/DefaultPaymentMethodStore.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Helpers/DefaultPaymentMethodStore.swift
@@ -25,7 +25,9 @@ final class DefaultPaymentMethodStore {
             }
         }
 
-        init(value: String) {
+        init(
+            value: String
+        ) {
             switch value {
             case "apple_pay":
                 self = .applePay
@@ -41,8 +43,12 @@ final class DefaultPaymentMethodStore {
     /// - Parameters:
     ///   - identifier: Payment method identifier.
     ///   - customerID: ID of the customer. Pass `nil` for anonymous users.
-    static func setDefaultPaymentMethod(_ identifier: PaymentMethodIdentifier, forCustomer customerID: String?) {
-        var customerToDefaultPaymentMethodID = UserDefaults.standard.customerToLastSelectedPaymentMethod ?? [:]
+    static func setDefaultPaymentMethod(
+        _ identifier: PaymentMethodIdentifier,
+        forCustomer customerID: String?
+    ) {
+        var customerToDefaultPaymentMethodID =
+            UserDefaults.standard.customerToLastSelectedPaymentMethod ?? [:]
 
         let key = customerID ?? ""
         customerToDefaultPaymentMethodID[key] = identifier.value

--- a/StripePaymentSheet/StripePaymentSheet/Helpers/Images.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Helpers/Images.swift
@@ -56,11 +56,11 @@ enum Image: String, CaseIterable, ImageMaker {
     case icon_link_success = "icon_link_success"
     case icon_link_error = "icon_link_error"
     case link_carousel_logo = "link_carousel_logo"
-    
+
     // Affirm Images
     case affirm_copy = "affirm_mark"
     case affirm_copy_dark = "affirm_mark_dark"
-    
+
     // Polling / UPI
     case polling_error = "polling_error_icon"
 }

--- a/StripePaymentSheet/StripePaymentSheet/Helpers/IntentStatusPoller.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Helpers/IntentStatusPoller.swift
@@ -18,14 +18,14 @@ class IntentStatusPoller {
     let apiClient: STPAPIClient
     let clientSecret: String
     let maxRetries: Int
-    
+
     private var lastStatus: STPPaymentIntentStatus = .unknown
     private var retryCount = 0
     private let pollingQueue = DispatchQueue(label: "com.stripe.intent.status.queue")
     private var nextPollWorkItem: DispatchWorkItem?
-    
+
     weak var delegate: IntentStatusPollerDelegate?
-    
+
     var isPolling: Bool = false {
         didSet {
             // Start polling if we weren't already polling
@@ -36,46 +36,52 @@ class IntentStatusPoller {
             }
         }
     }
-    
-    init(apiClient: STPAPIClient, clientSecret: String, maxRetries: Int) {
+
+    init(
+        apiClient: STPAPIClient,
+        clientSecret: String,
+        maxRetries: Int
+    ) {
         self.apiClient = apiClient
         self.clientSecret = clientSecret
         self.maxRetries = maxRetries
     }
-    
+
     // MARK: Public APIs
-    
+
     public func beginPolling() {
         isPolling = true
     }
-    
+
     public func suspendPolling() {
         isPolling = false
     }
-    
+
     public func forcePoll() {
         fetchStatus(forcePoll: true)
     }
-    
+
     // MARK: Private functions
-    
+
     private func fetchStatus(forcePoll: Bool = false) {
         guard forcePoll || (isPolling && retryCount < maxRetries) else { return }
         retryCount += 1
-        
-        apiClient.retrievePaymentIntent(withClientSecret: clientSecret) { [weak self] paymentIntent, error in
+
+        apiClient.retrievePaymentIntent(withClientSecret: clientSecret) {
+            [weak self] paymentIntent, error in
             guard let isPolling = self?.isPolling else {
                 return
             }
 
             // If latest status is different than last known status notify our delegate
             if let paymentIntent = paymentIntent,
-               paymentIntent.status != self?.lastStatus,
-               isPolling {
+                paymentIntent.status != self?.lastStatus,
+                isPolling
+            {
                 self?.lastStatus = paymentIntent.status
                 self?.delegate?.didUpdate(paymentIntent: paymentIntent)
             }
-            
+
             // If we are polling and have retries left, schedule a status fetch
             if isPolling, let maxRetries = self?.maxRetries, let retryCount = self?.retryCount {
                 self?.retryWithExponentialDelay(retryCount: maxRetries - retryCount) {
@@ -84,17 +90,17 @@ class IntentStatusPoller {
             }
         }
     }
-    
-    private func retryWithExponentialDelay(retryCount: Int, block: @escaping () -> ()) {
+
+    private func retryWithExponentialDelay(retryCount: Int, block: @escaping () -> Void) {
         // Add some backoff time
         let delayTime = TimeInterval(
             pow(Double(1 + maxRetries - retryCount), Double(2))
         )
-        
+
         nextPollWorkItem = DispatchWorkItem {
             block()
         }
-        
+
         guard let nextPollWorkItem = nextPollWorkItem else { return }
         pollingQueue.asyncAfter(deadline: .now() + delayTime, execute: nextPollWorkItem)
     }

--- a/StripePaymentSheet/StripePaymentSheet/Helpers/PaymentSheetLinkAccount.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Helpers/PaymentSheetLinkAccount.swift
@@ -6,10 +6,10 @@
 //  Copyright © 2021 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
 @_spi(STP) import StripeCore
-@_spi(STP) import StripeUICore
 @_spi(STP) import StripePayments
+@_spi(STP) import StripeUICore
+import UIKit
 
 protocol PaymentSheetLinkAccountInfoProtocol {
     var email: String { get }
@@ -38,11 +38,11 @@ class PaymentSheetLinkAccount: PaymentSheetLinkAccountInfoProtocol {
     private(set) var publishableKey: String?
 
     let email: String
-    
+
     var redactedPhoneNumber: String? {
         return currentSession?.redactedPhoneNumber
     }
-    
+
     var isRegistered: Bool {
         return currentSession != nil
     }
@@ -54,7 +54,8 @@ class PaymentSheetLinkAccount: PaymentSheetLinkAccountInfoProtocol {
     var sessionState: SessionState {
         if let currentSession = currentSession {
             // sms verification is not required if we are in the signup flow
-            return currentSession.hasVerifiedSMSSession || currentSession.isVerifiedForSignup ? .verified : .requiresVerification
+            return currentSession.hasVerifiedSMSSession || currentSession.isVerifiedForSignup
+                ? .verified : .requiresVerification
         } else {
             return .requiresSignUp
         }
@@ -94,7 +95,7 @@ class PaymentSheetLinkAccount: PaymentSheetLinkAccountInfoProtocol {
             completion: completion
         )
     }
-    
+
     func signUp(
         with phoneNumber: String,
         legalName: String?,
@@ -105,9 +106,13 @@ class PaymentSheetLinkAccount: PaymentSheetLinkAccountInfoProtocol {
         guard case .requiresSignUp = sessionState else {
             assertionFailure()
             DispatchQueue.main.async {
-                completion(.failure(
-                    PaymentSheetError.unknown(debugDescription: "Don't call sign up if not needed")
-                ))
+                completion(
+                    .failure(
+                        PaymentSheetError.unknown(
+                            debugDescription: "Don't call sign up if not needed"
+                        )
+                    )
+                )
             }
             return
         }
@@ -132,7 +137,7 @@ class PaymentSheetLinkAccount: PaymentSheetLinkAccountInfoProtocol {
             }
         }
     }
-    
+
     func startVerification(completion: @escaping (Result<Bool, Error>) -> Void) {
         guard case .requiresVerification = sessionState else {
             DispatchQueue.main.async {
@@ -144,9 +149,13 @@ class PaymentSheetLinkAccount: PaymentSheetLinkAccountInfoProtocol {
         guard let session = currentSession else {
             assertionFailure()
             DispatchQueue.main.async {
-                completion(.failure(
-                    PaymentSheetError.unknown(debugDescription: "Don't call verify if not needed")
-                ))
+                completion(
+                    .failure(
+                        PaymentSheetError.unknown(
+                            debugDescription: "Don't call verify if not needed"
+                        )
+                    )
+                )
             }
             return
         }
@@ -165,16 +174,21 @@ class PaymentSheetLinkAccount: PaymentSheetLinkAccountInfoProtocol {
             }
         }
     }
-    
+
     func verify(with oneTimePasscode: String, completion: @escaping (Result<Void, Error>) -> Void) {
         guard case .requiresVerification = sessionState,
-              hasStartedSMSVerification,
-              let session = currentSession else {
+            hasStartedSMSVerification,
+            let session = currentSession
+        else {
             assertionFailure()
             DispatchQueue.main.async {
-                completion(.failure(
-                    PaymentSheetError.unknown(debugDescription: "Don't call verify if not needed")
-                ))
+                completion(
+                    .failure(
+                        PaymentSheetError.unknown(
+                            debugDescription: "Don't call verify if not needed"
+                        )
+                    )
+                )
             }
             return
         }
@@ -194,15 +208,19 @@ class PaymentSheetLinkAccount: PaymentSheetLinkAccountInfoProtocol {
             }
         }
     }
-    
+
     func createLinkAccountSession(
         completion: @escaping (Result<LinkAccountSession, Error>) -> Void
     ) {
         guard let session = currentSession else {
             assertionFailure()
-            completion(.failure(
-                PaymentSheetError.unknown(debugDescription: "Linking account session without valid consumer session")
-            ))
+            completion(
+                .failure(
+                    PaymentSheetError.unknown(
+                        debugDescription: "Linking account session without valid consumer session"
+                    )
+                )
+            )
             return
         }
 
@@ -221,12 +239,17 @@ class PaymentSheetLinkAccount: PaymentSheetLinkAccountInfoProtocol {
         guard let session = currentSession else {
             assertionFailure()
             completion(
-                .failure(PaymentSheetError.unknown(debugDescription: "Saving to Link without valid session"))
+                .failure(
+                    PaymentSheetError.unknown(
+                        debugDescription: "Saving to Link without valid session"
+                    )
+                )
             )
             return
         }
 
-        retryingOnAuthError(completion: completion) { [apiClient, publishableKey] completionWrapper in
+        retryingOnAuthError(completion: completion) {
+            [apiClient, publishableKey] completionWrapper in
             session.createPaymentDetails(
                 paymentMethodParams: paymentMethodParams,
                 with: apiClient,
@@ -235,14 +258,20 @@ class PaymentSheetLinkAccount: PaymentSheetLinkAccountInfoProtocol {
             )
         }
     }
-    
+
     func createPaymentDetails(
         linkedAccountId: String,
         completion: @escaping (Result<ConsumerPaymentDetails, Error>) -> Void
     ) {
         guard let session = currentSession else {
             assertionFailure()
-            completion(.failure(PaymentSheetError.unknown(debugDescription: "Saving to Link without valid session")))
+            completion(
+                .failure(
+                    PaymentSheetError.unknown(
+                        debugDescription: "Saving to Link without valid session"
+                    )
+                )
+            )
             return
         }
         retryingOnAuthError(completion: completion) { [publishableKey] completionWrapper in
@@ -253,17 +282,24 @@ class PaymentSheetLinkAccount: PaymentSheetLinkAccountInfoProtocol {
             )
         }
     }
-    
+
     func listPaymentDetails(
         completion: @escaping (Result<[ConsumerPaymentDetails], Error>) -> Void
     ) {
         guard let session = currentSession else {
             assertionFailure()
-            completion(.failure(PaymentSheetError.unknown(debugDescription: "Paying with Link without valid session")))
+            completion(
+                .failure(
+                    PaymentSheetError.unknown(
+                        debugDescription: "Paying with Link without valid session"
+                    )
+                )
+            )
             return
         }
 
-        retryingOnAuthError(completion: completion) { [apiClient, publishableKey] completionWrapper in
+        retryingOnAuthError(completion: completion) {
+            [apiClient, publishableKey] completionWrapper in
             session.listPaymentDetails(
                 with: apiClient,
                 consumerAccountPublishableKey: publishableKey,
@@ -275,12 +311,17 @@ class PaymentSheetLinkAccount: PaymentSheetLinkAccountInfoProtocol {
     func deletePaymentDetails(id: String, completion: @escaping (Result<Void, Error>) -> Void) {
         guard let session = currentSession else {
             assertionFailure()
-            return completion(.failure(PaymentSheetError.unknown(
-                debugDescription: "Deleting Link payment details without valid session")
-            ))
+            return completion(
+                .failure(
+                    PaymentSheetError.unknown(
+                        debugDescription: "Deleting Link payment details without valid session"
+                    )
+                )
+            )
         }
 
-        retryingOnAuthError(completion: completion) { [apiClient, publishableKey] completionWrapper in
+        retryingOnAuthError(completion: completion) {
+            [apiClient, publishableKey] completionWrapper in
             session.deletePaymentDetails(
                 with: apiClient,
                 id: id,
@@ -297,12 +338,17 @@ class PaymentSheetLinkAccount: PaymentSheetLinkAccountInfoProtocol {
     ) {
         guard let session = currentSession else {
             assertionFailure()
-            return completion(.failure(PaymentSheetError.unknown(
-                debugDescription: "Updating Link payment details without valid session")
-            ))
+            return completion(
+                .failure(
+                    PaymentSheetError.unknown(
+                        debugDescription: "Updating Link payment details without valid session"
+                    )
+                )
+            )
         }
 
-        retryingOnAuthError(completion: completion) { [apiClient, publishableKey] completionWrapper in
+        retryingOnAuthError(completion: completion) {
+            [apiClient, publishableKey] completionWrapper in
             session.updatePaymentDetails(
                 with: apiClient,
                 id: id,
@@ -330,9 +376,9 @@ class PaymentSheetLinkAccount: PaymentSheetLinkAccountInfoProtocol {
 
         // Delete cookie.
         cookieStore.delete(key: .session)
-        
+
         markEmailAsLoggedOut()
-        
+
         // Forget current session.
         self.currentSession = nil
     }
@@ -352,34 +398,31 @@ class PaymentSheetLinkAccount: PaymentSheetLinkAccountInfoProtocol {
 extension PaymentSheetLinkAccount: Equatable {
 
     static func == (lhs: PaymentSheetLinkAccount, rhs: PaymentSheetLinkAccount) -> Bool {
-        return (
-            lhs.email == rhs.email &&
-            lhs.currentSession == rhs.currentSession &&
-            lhs.publishableKey == rhs.publishableKey
-        )
+        return
+            (lhs.email == rhs.email && lhs.currentSession == rhs.currentSession
+            && lhs.publishableKey == rhs.publishableKey)
     }
 
 }
 
 // MARK: - Session refresh
 
-private extension PaymentSheetLinkAccount {
+extension PaymentSheetLinkAccount {
 
-    typealias CompletionBlock<T> = (Result<T, Error>) -> Void
+    fileprivate typealias CompletionBlock<T> = (Result<T, Error>) -> Void
 
-    func retryingOnAuthError<T>(
+    fileprivate func retryingOnAuthError<T>(
         completion: @escaping CompletionBlock<T>,
         apiCall: @escaping (@escaping CompletionBlock<T>) -> Void
     ) {
-        apiCall() { [weak self] result in
+        apiCall { [weak self] result in
             switch result {
             case .success(_):
                 completion(result)
             case .failure(let error as NSError):
-                let isAuthError = (
-                    error.domain == STPError.stripeDomain &&
-                    error.code == STPErrorCode.authenticationError.rawValue
-                )
+                let isAuthError =
+                    (error.domain == STPError.stripeDomain
+                        && error.code == STPErrorCode.authenticationError.rawValue)
 
                 if isAuthError {
                     self?.refreshSession { refreshSessionResult in
@@ -397,14 +440,14 @@ private extension PaymentSheetLinkAccount {
         }
     }
 
-    func refreshSession(
+    fileprivate func refreshSession(
         completion: @escaping (Result<Void, Error>) -> Void
     ) {
         // The consumer session lookup endpoint currently serves as our endpoint for
         // refreshing the session. To refresh the session, we need to call this endpoint
         // without providing an email address.
         ConsumerSession.lookupSession(
-            for: nil, // No email address
+            for: nil,  // No email address
             with: apiClient,
             cookieStore: cookieStore
         ) { [weak self] result in
@@ -421,7 +464,11 @@ private extension PaymentSheetLinkAccount {
                     )
                 case .noAvailableLookupParams:
                     completion(
-                        .failure(PaymentSheetError.unknown(debugDescription: "The client secret is missing"))
+                        .failure(
+                            PaymentSheetError.unknown(
+                                debugDescription: "The client secret is missing"
+                            )
+                        )
                     )
                 }
             case .failure(let error):
@@ -443,7 +490,9 @@ extension PaymentSheetLinkAccount {
     ///
     /// - Parameter paymentDetails: Payment details
     /// - Returns: Payment method params for paying with Link.
-    func makePaymentMethodParams(from paymentDetails: ConsumerPaymentDetails) -> STPPaymentMethodParams? {
+    func makePaymentMethodParams(
+        from paymentDetails: ConsumerPaymentDetails
+    ) -> STPPaymentMethodParams? {
         guard let currentSession = currentSession else {
             assertionFailure("Cannot make payment method params without an active session.")
             return nil
@@ -471,8 +520,10 @@ extension PaymentSheetLinkAccount {
     /// Returns a set containing the Payment Details types that the user is able to use for confirming the given `intent`.
     /// - Parameter intent: The Intent that the user is trying to confirm.
     /// - Returns: A set containing the supported Payment Details types.
-    func supportedPaymentDetailsTypes(for intent: Intent) -> Set<ConsumerPaymentDetails.DetailsType> {
-        guard let currentSession = currentSession, let fundingSources = intent.linkFundingSources else {
+    func supportedPaymentDetailsTypes(for intent: Intent) -> Set<ConsumerPaymentDetails.DetailsType>
+    {
+        guard let currentSession = currentSession, let fundingSources = intent.linkFundingSources
+        else {
             return []
         }
 
@@ -516,21 +567,21 @@ extension PaymentSheetLinkAccount {
 
 // MARK: - Helpers
 
-private extension PaymentSheetLinkAccount {
+extension PaymentSheetLinkAccount {
 
     /// On *testmode* we use special email addresses for testing multiple funding sources. This method returns `true`
     /// if the given `email` is one of such email addresses.
     ///
     /// - Parameter email: Email.
     /// - Returns: Whether or not should enable multiple funding sources on test mode.
-    static func emailSupportsMultipleFundingSourcesOnTestMode(_ email: String) -> Bool {
+    fileprivate static func emailSupportsMultipleFundingSourcesOnTestMode(_ email: String) -> Bool {
         return email.contains("+multiple_funding_sources@")
     }
 
 }
 
-private extension LinkSettings.FundingSource {
-    var detailsType: ConsumerPaymentDetails.DetailsType? {
+extension LinkSettings.FundingSource {
+    fileprivate var detailsType: ConsumerPaymentDetails.DetailsType? {
         switch self {
         case .card:
             return .card

--- a/StripePaymentSheet/StripePaymentSheet/Helpers/STPCameraView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Helpers/STPCameraView.swift
@@ -30,9 +30,14 @@ class STPCameraView: UIView {
         CATransaction.begin()
         CATransaction.setValue(
             kCFBooleanTrue,
-            forKey: kCATransactionDisableActions)
+            forKey: kCATransactionDisableActions
+        )
         flashLayer?.frame = CGRect(
-            x: 0, y: 0, width: layer.bounds.size.width, height: layer.bounds.size.height)
+            x: 0,
+            y: 0,
+            width: layer.bounds.size.width,
+            height: layer.bounds.size.height
+        )
         flashLayer?.opacity = 1.0
         CATransaction.commit()
         DispatchQueue.main.async(execute: {
@@ -45,7 +50,9 @@ class STPCameraView: UIView {
         })
     }
 
-    override init(frame: CGRect) {
+    override init(
+        frame: CGRect
+    ) {
         super.init(frame: frame)
         flashLayer = CALayer()
         if let flashLayer = flashLayer {
@@ -62,7 +69,9 @@ class STPCameraView: UIView {
         return AVCaptureVideoPreviewLayer.self
     }
 
-    required init?(coder aDecoder: NSCoder) {
+    required init?(
+        coder aDecoder: NSCoder
+    ) {
         super.init(coder: aDecoder)
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Helpers/STPCardScanner.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Helpers/STPCardScanner.swift
@@ -8,11 +8,11 @@
 
 import AVFoundation
 import Foundation
+@_spi(STP) import StripeCore
+@_spi(STP) import StripePayments
+@_spi(STP) import StripePaymentsUI
 import UIKit
 import Vision
-@_spi(STP) import StripeCore
-@_spi(STP) import StripePaymentsUI
-@_spi(STP) import StripePayments
 
 enum STPCardScannerError: Int {
     /// Camera not available.
@@ -22,13 +22,17 @@ enum STPCardScannerError: Int {
 @available(iOS 13, macCatalyst 14, *)
 @objc protocol STPCardScannerDelegate: NSObjectProtocol {
     @objc(cardScanner:didFinishWithCardParams:error:) func cardScanner(
-        _ scanner: STPCardScanner, didFinishWith cardParams: STPPaymentMethodCardParams?,
-        error: Error?)
+        _ scanner: STPCardScanner,
+        didFinishWith cardParams: STPPaymentMethodCardParams?,
+        error: Error?
+    )
 }
 
 @available(iOS 13, macCatalyst 14, *)
 @objc(STPCardScanner)
-class STPCardScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, STPCardScanningProtocol {
+class STPCardScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate,
+    STPCardScanningProtocol
+{
     // iOS will kill the app if it tries to request the camera without an NSCameraUsageDescription
     static let cardScanningAvailableCameraHasUsageDescription = {
         return
@@ -58,7 +62,11 @@ class STPCardScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, ST
             // This is an optimization for portrait mode: The card will be centered in the screen,
             // so we can ignore the top and bottom. We'll use the whole frame in landscape.
             let kSTPCardScanningScreenCenter = CGRect(
-                x: 0, y: CGFloat(0.3), width: 1, height: CGFloat(0.4))
+                x: 0,
+                y: CGFloat(0.3),
+                width: 1,
+                height: CGFloat(0.4)
+            )
 
             // iOS camera image data is returned in LandcapeLeft orientation by default. We'll flip it as needed:
             switch newDeviceOrientation {
@@ -75,6 +83,7 @@ class STPCardScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, ST
                 textOrientation = .down
                 regionOfInterest = CGRect(x: 0, y: 0, width: 1, height: 1)
             case .portrait, .faceUp, .faceDown, .unknown:
+                // swift-format-ignore: NoCasesWithOnlyFallthrough
                 fallthrough
             default:
                 videoOrientation = .portrait
@@ -88,7 +97,9 @@ class STPCardScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, ST
     override init() {
     }
 
-    init(delegate: STPCardScannerDelegate?) {
+    init(
+        delegate: STPCardScannerDelegate?
+    ) {
         super.init()
         self.delegate = delegate
         captureSessionQueue = DispatchQueue(label: "com.stripe.CardScanning.CaptureSessionQueue")
@@ -158,7 +169,8 @@ class STPCardScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, ST
         return NSError(
             domain: STPCardScannerErrorDomain,
             code: STPCardScannerError.cameraNotAvailable.rawValue,
-            userInfo: userInfo)
+            userInfo: userInfo
+        )
     }
 
     deinit {
@@ -190,7 +202,10 @@ class STPCardScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, ST
         })
 
         let captureDevice = AVCaptureDevice.default(
-            .builtInWideAngleCamera, for: .video, position: .back)
+            .builtInWideAngleCamera,
+            for: .video,
+            position: .back
+        )
         self.captureDevice = captureDevice
 
         captureSession = AVCaptureSession()
@@ -249,7 +264,8 @@ class STPCardScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, ST
 
     // MARK: Processing
     func captureOutput(
-        _ output: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer,
+        _ output: AVCaptureOutput,
+        didOutput sampleBuffer: CMSampleBuffer,
         from connection: AVCaptureConnection
     ) {
         if !isScanning {
@@ -265,7 +281,10 @@ class STPCardScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, ST
         var handler: VNImageRequestHandler?
         if let pixelBuffer = pixelBuffer {
             handler = VNImageRequestHandler(
-                cvPixelBuffer: pixelBuffer, orientation: textOrientation, options: [:])
+                cvPixelBuffer: pixelBuffer,
+                orientation: textOrientation,
+                options: [:]
+            )
         }
         do {
             try handler?.perform([textRequest].compactMap { $0 })
@@ -286,15 +305,19 @@ class STPCardScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, ST
             }
             for recognizedText in candidates {
                 let possibleNumber = STPCardValidator.sanitizedNumericString(
-                    for: recognizedText.string)
+                    for: recognizedText.string
+                )
+                // This probably isn't something we're interested in, so don't bother processing it.
                 if possibleNumber.count < 4 {
-                    continue  // This probably isn't something we're interested in, so don't bother processing it.
+                    continue
                 }
 
                 // First strategy: We check if Vision sent us a number in a group on its own. If that fails, we'll try
                 // to catch it later when we iterate over all the numbers.
                 if STPCardValidator.validationState(
-                    forNumber: possibleNumber, validatingCardBrand: true)
+                    forNumber: possibleNumber,
+                    validatingCardBrand: true
+                )
                     == .valid
                 {
                     addDetectedNumber(possibleNumber)
@@ -303,9 +326,11 @@ class STPCardScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, ST
                 {
                     // Try to parse anything that looks like an expiration date.
                     let expirationString = STPStringUtils.expirationDateString(
-                        from: recognizedText.string)
+                        from: recognizedText.string
+                    )
                     let sanitizedExpiration = STPCardValidator.sanitizedNumericString(
-                        for: expirationString ?? "")
+                        for: expirationString ?? ""
+                    )
                     let month = (sanitizedExpiration as NSString).substring(to: 2)
                     let year = (sanitizedExpiration as NSString).substring(from: 2)
 
@@ -343,13 +368,16 @@ class STPCardScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, ST
 
             // Then we'll add valid matches. It's okay if we add a number a second time after doing so above, as the success of that first pass means it's more likely to be a good match.
             if STPCardValidator.validationState(
-                forNumber: potentialCardString, validatingCardBrand: true)
+                forNumber: potentialCardString,
+                validatingCardBrand: true
+            )
                 == .valid
             {
                 addDetectedNumber(potentialCardString)
             } else if STPCardValidator.validationState(
-                forNumber: potentialAmexString, validatingCardBrand: true) == .valid
-            {
+                forNumber: potentialAmexString,
+                validatingCardBrand: true
+            ) == .valid {
                 addDetectedNumber(potentialAmexString)
             }
         }
@@ -369,7 +397,8 @@ class STPCardScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, ST
             })
             videoDataOutputQueue?.asyncAfter(
                 deadline: DispatchTime.now() + Double(
-                    Int64(kSTPCardScanningTimeout * Double(NSEC_PER_SEC)))
+                    Int64(kSTPCardScanningTimeout * Double(NSEC_PER_SEC))
+                )
                     / Double(NSEC_PER_SEC),
                 execute: {
                     let strongSelf = weakSelf
@@ -377,7 +406,8 @@ class STPCardScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, ST
                         strongSelf?.didTimeout = true
                         strongSelf?.finishIfReady()
                     }
-                })
+                }
+            )
         }
 
         if (detectedNumbers?.count(for: number) ?? 0) >= kSTPCardScanningMinimumValidScans {
@@ -401,7 +431,8 @@ class STPCardScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, ST
         let detectedExpirations = self.detectedExpirations
 
         let topNumber = (detectedNumbers?.allObjects as NSArray?)?.sortedArray(comparator: {
-            obj1, obj2 in
+            obj1,
+            obj2 in
             let c1 = detectedNumbers?.count(for: obj1) ?? 0
             let c2 = detectedNumbers?.count(for: obj2) ?? 0
             if c1 < c2 {
@@ -413,7 +444,8 @@ class STPCardScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, ST
             }
         }).last
         let topExpiration = (detectedExpirations?.allObjects as NSArray?)?.sortedArray(comparator: {
-            obj1, obj2 in
+            obj1,
+            obj2 in
             let c1 = detectedExpirations?.count(for: obj1) ?? 0
             let c2 = detectedExpirations?.count(for: obj2) ?? 0
             if c1 < c2 {
@@ -436,9 +468,11 @@ class STPCardScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, ST
             params.number = topNumber as? String
             if let topExpiration = topExpiration {
                 params.expMonth = NSNumber(
-                    value: Int((topExpiration as! NSString).substring(to: 2)) ?? 0)
+                    value: Int((topExpiration as! NSString).substring(to: 2)) ?? 0
+                )
                 params.expYear = NSNumber(
-                    value: Int((topExpiration as! NSString).substring(from: 2)) ?? 0)
+                    value: Int((topExpiration as! NSString).substring(from: 2)) ?? 0
+                )
             }
             finish(with: params, error: nil)
         }

--- a/StripePaymentSheet/StripePaymentSheet/Helpers/STPImageLibrary.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Helpers/STPImageLibrary.swift
@@ -7,33 +7,32 @@
 //
 
 import Foundation
-import UIKit
 @_spi(STP) import StripePaymentsUI
 @_spi(STP) import StripeUICore
+import UIKit
 
 class PaymentSheetImageLibrary {
-    
+
     /// An icon representing Afterpay.
     @objc
     public class func afterpayLogo(locale: Locale = Locale.current) -> UIImage {
         switch (locale.languageCode, locale.regionCode) {
-            case ("en", "GB"):
-                return self.safeImageNamed("clearpay_mark", templateIfAvailable: true)
-            default:
-               return self.safeImageNamed("afterpay_mark", templateIfAvailable: true)
+        case ("en", "GB"):
+            return self.safeImageNamed("clearpay_mark", templateIfAvailable: true)
+        default:
+            return self.safeImageNamed("afterpay_mark", templateIfAvailable: true)
         }
     }
-    
+
     /// This returns the appropriate icon for the affirm logo
     @objc
     public class func affirmLogo() -> UIImage {
-        if isDarkMode(){
+        if isDarkMode() {
             return Image.affirm_copy_dark.makeImage()
         }
         return Image.affirm_copy.makeImage()
     }
-    
-    
+
     static let BankIconCodeRegexes: [String: [String]] = [
         "boa": [#"Bank of America"#],
         "capitalone": [#"Capital One"#],
@@ -49,7 +48,7 @@ class PaymentSheetImageLibrary {
         "usaa": [#"USAA FEDERAL SAVINGS BANK"#, #"USAA Bank"#],
         "usbank": [#"U\.?S\.? BANK"#, #"US Bank"#],
         "wellsfargo": [#"Wells Fargo"#],
-    ];
+    ]
 
     class func bankIconCode(for bankName: String?) -> String {
         guard let bankName = bankName else {
@@ -57,26 +56,27 @@ class PaymentSheetImageLibrary {
         }
         for (iconCode, regexes) in BankIconCodeRegexes {
             for pattern in regexes {
-                if bankName.range(of: pattern, options: [.regularExpression, .caseInsensitive]) != nil {
+                if bankName.range(of: pattern, options: [.regularExpression, .caseInsensitive])
+                    != nil
+                {
                     return iconCode
                 }
             }
         }
         return "default"
     }
-    
+
     class func bankIcon(for bank: String?) -> UIImage {
         guard let bank = bank else {
             return STPImageLibrary.bankIcon()
         }
         let icon = safeImageNamed("bank_icon_\(bank.lowercased())")
         if icon.size == .zero {
-            return STPImageLibrary.bankIcon() // use generic
+            return STPImageLibrary.bankIcon()  // use generic
         }
         return icon
     }
 }
-
 
 // MARK: - v2 Images
 

--- a/StripePaymentSheet/StripePaymentSheet/Helpers/STPLocalizedString.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Helpers/STPLocalizedString.swift
@@ -9,5 +9,8 @@ import Foundation
 @_spi(STP) import StripeCore
 
 @inline(__always) func STPLocalizedString(_ key: String, _ comment: String?) -> String {
-    return STPLocalizationUtils.localizedStripeString(forKey: key, bundleLocator: StripePaymentSheetBundleLocator.self)
+    return STPLocalizationUtils.localizedStripeString(
+        forKey: key,
+        bundleLocator: StripePaymentSheetBundleLocator.self
+    )
 }

--- a/StripePaymentSheet/StripePaymentSheet/Helpers/STPStringUtils.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Helpers/STPStringUtils.swift
@@ -49,11 +49,14 @@ extension STPStringUtils {
 
         if let endingTagRange = endingTagRange {
             finalString = (finalString as NSString?)?.replacingCharacters(
-                in: endingTagRange, with: "")
+                in: endingTagRange,
+                with: ""
+            )
         }
         let finalTagRange = NSRange(
             location: startingTagRange?.location ?? 0,
-            length: (endingTagRange?.location ?? 0) - (startingTagRange?.location ?? 0))
+            length: (endingTagRange?.location ?? 0) - (startingTagRange?.location ?? 0)
+        )
 
         completion(finalString, finalTagRange)
     }
@@ -89,7 +92,8 @@ extension STPStringUtils {
                 } else {
                     let interiorRange = NSRange(
                         location: tagRange.location + tag.count + 2,
-                        length: tagRange.length)
+                        length: tagRange.length
+                    )
                     interiorRangesToTags[NSValue(range: interiorRange)] = tag
                 }
             }
@@ -113,7 +117,8 @@ extension STPStringUtils {
                 let beginningTagLength = (tag?.count ?? 0) + 2
                 let beginningTagRange = NSRange(
                     location: interiorTagRange.location - beginningTagLength,
-                    length: beginningTagLength)
+                    length: beginningTagLength
+                )
 
                 if let subRange = Range<String.Index>(beginningTagRange, in: modifiedString) {
                     modifiedString.removeSubrange(subRange)
@@ -124,7 +129,8 @@ extension STPStringUtils {
                 let endingTagLength = beginningTagLength + 1
                 let endingTagRange = NSRange(
                     location: interiorTagRange.location + interiorTagRange.length,
-                    length: endingTagLength)
+                    length: endingTagLength
+                )
 
                 if let subRange = Range<String.Index>(endingTagRange, in: modifiedString) {
                     modifiedString.removeSubrange(subRange)

--- a/StripePaymentSheet/StripePaymentSheet/Helpers/StripePaymentSheet+Exports.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Helpers/StripePaymentSheet+Exports.swift
@@ -7,5 +7,4 @@
 //
 
 import Foundation
-
 @_exported import StripeCore

--- a/StripePaymentSheet/StripePaymentSheet/Helpers/StripePaymentSheetBundleLocator.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Helpers/StripePaymentSheetBundleLocator.swift
@@ -13,7 +13,7 @@ import Foundation
     public static let internalClass: AnyClass = StripePaymentSheetBundleLocator.self
     public static let bundleName = "StripePaymentSheet"
     #if SWIFT_PACKAGE
-    public static let spmResourcesBundle = Bundle.module
+        public static let spmResourcesBundle = Bundle.module
     #endif
     public static let resourcesBundle = StripePaymentSheetBundleLocator.computeResourcesBundle()
 }

--- a/StripePaymentSheet/StripePaymentSheet/Internal/API Bindings/Link/ConsumerSession+LookupResponse.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/API Bindings/Link/ConsumerSession+LookupResponse.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2021 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
 @_spi(STP) import StripePayments
+import UIKit
 
 extension ConsumerSession {
     struct Preferences {
@@ -16,40 +16,44 @@ extension ConsumerSession {
 
     class LookupResponse: NSObject, STPAPIResponseDecodable {
         let allResponseFields: [AnyHashable: Any]
-        
+
         enum ResponseType {
             case found(
                 consumerSession: ConsumerSession,
                 preferences: ConsumerSession.Preferences
             )
-            
+
             // errorMessage can be used internally to differentiate between
             // a not found because of an unrecognized email or a not found
             // due to an invalid cookie
             case notFound(errorMessage: String)
-            
+
             /// Lookup call was not provided an email and no cookies stored
             case noAvailableLookupParams
         }
-        
+
         let responseType: ResponseType
-        
-        init(_ responseType: ResponseType,
-             allResponseFields: [AnyHashable: Any]) {
+
+        init(
+            _ responseType: ResponseType,
+            allResponseFields: [AnyHashable: Any]
+        ) {
             self.responseType = responseType
             self.allResponseFields = allResponseFields
             super.init()
         }
-        
-        static func decodedObject(fromAPIResponse response: [AnyHashable : Any]?) -> Self? {
+
+        static func decodedObject(fromAPIResponse response: [AnyHashable: Any]?) -> Self? {
             guard let response = response,
-                  let exists = response["exists"] as? Bool else {
+                let exists = response["exists"] as? Bool
+            else {
                 return nil
             }
 
             if exists {
                 if let consumerSession = ConsumerSession.decodedObject(fromAPIResponse: response),
-                   let publishableKey = response["publishable_key"] as? String {
+                    let publishableKey = response["publishable_key"] as? String
+                {
                     return LookupResponse(
                         .found(
                             consumerSession: consumerSession,
@@ -62,8 +66,10 @@ extension ConsumerSession {
                 }
             } else {
                 if let errorMessage = response["error_message"] as? String {
-                    return LookupResponse(.notFound(errorMessage: errorMessage),
-                                          allResponseFields: response) as? Self
+                    return LookupResponse(
+                        .notFound(errorMessage: errorMessage),
+                        allResponseFields: response
+                    ) as? Self
                 } else {
                     return nil
                 }

--- a/StripePaymentSheet/StripePaymentSheet/Internal/API Bindings/Link/ConsumerSession-SignupResponse.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/API Bindings/Link/ConsumerSession-SignupResponse.swift
@@ -29,7 +29,7 @@ extension ConsumerSession {
             super.init()
         }
 
-        static func decodedObject(fromAPIResponse response: [AnyHashable : Any]?) -> Self? {
+        static func decodedObject(fromAPIResponse response: [AnyHashable: Any]?) -> Self? {
             guard
                 let response = response,
                 let consumerSession = ConsumerSession.decodedObject(fromAPIResponse: response),

--- a/StripePaymentSheet/StripePaymentSheet/Internal/API Bindings/Link/ConsumerSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/API Bindings/Link/ConsumerSession.swift
@@ -6,24 +6,23 @@
 //  Copyright © 2021 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
-
 @_spi(STP) import StripeCore
 @_spi(STP) import StripePayments
+import UIKit
 
 /// For internal SDK use only
 @objc(STP_Internal_ConsumerSession)
 class ConsumerSession: NSObject, STPAPIResponseDecodable {
-    
+
     let clientSecret: String
     let emailAddress: String
     let redactedPhoneNumber: String
     let verificationSessions: [VerificationSession]
     let authSessionClientSecret: String?
-    
+
     let supportedPaymentDetailsTypes: [ConsumerPaymentDetails.DetailsType]?
-    
-    let allResponseFields: [AnyHashable : Any]
+
+    let allResponseFields: [AnyHashable: Any]
 
     init(
         clientSecret: String,
@@ -32,7 +31,7 @@ class ConsumerSession: NSObject, STPAPIResponseDecodable {
         verificationSessions: [VerificationSession],
         authSessionClientSecret: String?,
         supportedPaymentDetailsTypes: [ConsumerPaymentDetails.DetailsType]?,
-        allResponseFields: [AnyHashable : Any]
+        allResponseFields: [AnyHashable: Any]
     ) {
         self.clientSecret = clientSecret
         self.emailAddress = emailAddress
@@ -43,17 +42,17 @@ class ConsumerSession: NSObject, STPAPIResponseDecodable {
         self.allResponseFields = allResponseFields
         super.init()
     }
-    
-    static func decodedObject(fromAPIResponse response: [AnyHashable : Any]?) -> Self? {
+
+    static func decodedObject(fromAPIResponse response: [AnyHashable: Any]?) -> Self? {
         guard let response = response,
-              let dict = response["consumer_session"] as? [AnyHashable: Any],
-              let clientSecret = dict["client_secret"] as? String,
-              let emailAddress = dict["email_address"] as? String,
-              let redactedPhoneNumber = dict["redacted_phone_number"] as? String
+            let dict = response["consumer_session"] as? [AnyHashable: Any],
+            let clientSecret = dict["client_secret"] as? String,
+            let emailAddress = dict["email_address"] as? String,
+            let redactedPhoneNumber = dict["redacted_phone_number"] as? String
         else {
             return nil
         }
-        
+
         var verificationSessions = [VerificationSession]()
         if let sessions = dict["verification_sessions"] as? [[AnyHashable: Any]] {
             for session in sessions {
@@ -71,13 +70,15 @@ class ConsumerSession: NSObject, STPAPIResponseDecodable {
             ConsumerPaymentDetails.DetailsType(rawValue: $0.lowercased())
         }
 
-        return ConsumerSession(clientSecret: clientSecret,
-                               emailAddress: emailAddress,
-                               redactedPhoneNumber: redactedPhoneNumber,
-                               verificationSessions: verificationSessions,
-                               authSessionClientSecret: authSessionClientSecret,
-                               supportedPaymentDetailsTypes: supportedPaymentDetailsTypes,
-                               allResponseFields: dict) as? Self
+        return ConsumerSession(
+            clientSecret: clientSecret,
+            emailAddress: emailAddress,
+            redactedPhoneNumber: redactedPhoneNumber,
+            verificationSessions: verificationSessions,
+            authSessionClientSecret: authSessionClientSecret,
+            supportedPaymentDetailsTypes: supportedPaymentDetailsTypes,
+            allResponseFields: dict
+        ) as? Self
     }
 
 }
@@ -97,14 +98,13 @@ extension ConsumerSession {
     }
 
     var hasStartedSMSVerification: Bool {
-        verificationSessions.contains( where: { $0.type == .sms && $0.state == .started })
+        verificationSessions.contains(where: { $0.type == .sms && $0.state == .started })
     }
 
     var isVerifiedForSignup: Bool {
         verificationSessions.isVerifiedForSignup
     }
 }
-
 
 // MARK: - API methods
 extension ConsumerSession {
@@ -115,7 +115,11 @@ extension ConsumerSession {
         cookieStore: LinkCookieStore = LinkSecureCookieStore.shared,
         completion: @escaping (Result<ConsumerSession.LookupResponse, Error>) -> Void
     ) {
-        apiClient.lookupConsumerSession(for: email, cookieStore: cookieStore, completion: completion)
+        apiClient.lookupConsumerSession(
+            for: email,
+            cookieStore: cookieStore,
+            completion: completion
+        )
     }
 
     class func signUp(
@@ -148,8 +152,9 @@ extension ConsumerSession {
         completion: @escaping (Result<ConsumerPaymentDetails, Error>) -> Void
     ) {
         guard paymentMethodParams.type == .card,
-              let billingDetails = paymentMethodParams.billingDetails,
-              let cardParams = paymentMethodParams.card else {
+            let billingDetails = paymentMethodParams.billingDetails,
+            let cardParams = paymentMethodParams.card
+        else {
             DispatchQueue.main.async {
                 assertionFailure()
                 completion(.failure(NSError.stp_genericConnectionError()))
@@ -163,7 +168,8 @@ extension ConsumerSession {
             billingEmailAddress: emailAddress,
             billingDetails: billingDetails,
             consumerAccountPublishableKey: consumerAccountPublishableKey,
-            completion: completion)
+            completion: completion
+        )
     }
 
     func createPaymentDetails(
@@ -176,7 +182,8 @@ extension ConsumerSession {
             for: clientSecret,
             linkedAccountId: linkedAccountId,
             consumerAccountPublishableKey: consumerAccountPublishableKey,
-            completion: completion)
+            completion: completion
+        )
     }
 
     func startVerification(
@@ -193,7 +200,8 @@ extension ConsumerSession {
             locale: locale,
             cookieStore: cookieStore,
             consumerAccountPublishableKey: consumerAccountPublishableKey,
-            completion: completion)
+            completion: completion
+        )
     }
 
     func confirmSMSVerification(
@@ -208,9 +216,10 @@ extension ConsumerSession {
             with: code,
             cookieStore: cookieStore,
             consumerAccountPublishableKey: consumerAccountPublishableKey,
-            completion: completion)
+            completion: completion
+        )
     }
-    
+
     func createLinkAccountSession(
         with apiClient: STPAPIClient = STPAPIClient.shared,
         consumerAccountPublishableKey: String?,
@@ -219,7 +228,8 @@ extension ConsumerSession {
         apiClient.createLinkAccountSession(
             for: clientSecret,
             consumerAccountPublishableKey: consumerAccountPublishableKey,
-            completion: completion)
+            completion: completion
+        )
     }
 
     func listPaymentDetails(
@@ -230,7 +240,8 @@ extension ConsumerSession {
         apiClient.listPaymentDetails(
             for: clientSecret,
             consumerAccountPublishableKey: consumerAccountPublishableKey,
-            completion: completion)
+            completion: completion
+        )
     }
 
     func deletePaymentDetails(
@@ -243,7 +254,8 @@ extension ConsumerSession {
             for: clientSecret,
             id: id,
             consumerAccountPublishableKey: consumerAccountPublishableKey,
-            completion: completion)
+            completion: completion
+        )
     }
 
     func updatePaymentDetails(
@@ -254,10 +266,12 @@ extension ConsumerSession {
         completion: @escaping (Result<ConsumerPaymentDetails, Error>) -> Void
     ) {
         apiClient.updatePaymentDetails(
-            for: clientSecret, id: id,
+            for: clientSecret,
+            id: id,
             updateParams: updateParams,
             consumerAccountPublishableKey: consumerAccountPublishableKey,
-            completion: completion)
+            completion: completion
+        )
     }
 
     func logout(
@@ -271,7 +285,8 @@ extension ConsumerSession {
             consumerSessionClientSecret: clientSecret,
             cookieStore: cookieStore,
             consumerAccountPublishableKey: consumerAccountPublishableKey,
-            completion: completion)
+            completion: completion
+        )
     }
 
 }

--- a/StripePaymentSheet/StripePaymentSheet/Internal/API Bindings/Link/CookieStore/LinkSecureCookieStore.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/API Bindings/Link/CookieStore/LinkSecureCookieStore.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2021 Stripe, Inc. All rights reserved.
 //
 
-import Security
 import Foundation
+import Security
 
 /// A secure cookie store backed by Keychain.
 final class LinkSecureCookieStore: LinkCookieStore {
@@ -21,10 +21,14 @@ final class LinkSecureCookieStore: LinkCookieStore {
             return
         }
 
-        let query = queryForKey(key, additionalParams: [
-            kSecValueData as String: data,
-            kSecAttrSynchronizable as String: allowSync ? kCFBooleanTrue as Any : kCFBooleanFalse as Any
-        ])
+        let query = queryForKey(
+            key,
+            additionalParams: [
+                kSecValueData as String: data,
+                kSecAttrSynchronizable as String: allowSync
+                    ? kCFBooleanTrue as Any : kCFBooleanFalse as Any,
+            ]
+        )
 
         delete(key: key)
         let status = SecItemAdd(query as CFDictionary, nil)
@@ -42,22 +46,24 @@ final class LinkSecureCookieStore: LinkCookieStore {
     }
 
     func read(key: LinkCookieKey) -> String? {
-        let query = queryForKey(key, additionalParams: [
-            kSecReturnData as String: kCFBooleanTrue as Any,
-            kSecMatchLimit as String: kSecMatchLimitOne,
-            kSecAttrSynchronizable as String: kSecAttrSynchronizableAny
-        ])
+        let query = queryForKey(
+            key,
+            additionalParams: [
+                kSecReturnData as String: kCFBooleanTrue as Any,
+                kSecMatchLimit as String: kSecMatchLimitOne,
+                kSecAttrSynchronizable as String: kSecAttrSynchronizableAny,
+            ]
+        )
 
         var result: AnyObject?
 
         let status = SecItemCopyMatching(query as CFDictionary, &result)
         // Disable this check for UI tests
-        
+
         assert(
             status == noErr || status == errSecItemNotFound,
             "Unexpected status code \(status)"
         )
-        
 
         guard
             status == noErr,
@@ -70,9 +76,12 @@ final class LinkSecureCookieStore: LinkCookieStore {
     }
 
     func delete(key: LinkCookieKey) {
-        let query = queryForKey(key, additionalParams: [
-            kSecAttrSynchronizable as String: kSecAttrSynchronizableAny
-        ])
+        let query = queryForKey(
+            key,
+            additionalParams: [
+                kSecAttrSynchronizable as String: kSecAttrSynchronizableAny
+            ]
+        )
 
         let status = SecItemDelete(query as CFDictionary)
         assert(
@@ -85,10 +94,11 @@ final class LinkSecureCookieStore: LinkCookieStore {
         _ key: LinkCookieKey,
         additionalParams: [String: Any]? = nil
     ) -> [String: Any] {
-        var query = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrAccount as String: key.rawValue
-        ] as [String : Any]
+        var query =
+            [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrAccount as String: key.rawValue,
+            ] as [String: Any]
 
         additionalParams?.forEach({ (key, value) in
             query[key] = value

--- a/StripePaymentSheet/StripePaymentSheet/Internal/API Bindings/Link/PaymentDetails.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/API Bindings/Link/PaymentDetails.swift
@@ -6,18 +6,18 @@
 //  Copyright © 2021 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
 @_spi(STP) import StripeCore
 @_spi(STP) import StripePayments
 @_spi(STP) import StripePaymentsUI
+import UIKit
 
-typealias ConsumerSessionWithPaymentDetails = (session: ConsumerSession, paymentDetails: [ConsumerPaymentDetails])
+typealias ConsumerSessionWithPaymentDetails = (
+    session: ConsumerSession, paymentDetails: [ConsumerPaymentDetails]
+)
 
-/**
- PaymentDetails response for Link accounts
- 
- For internal SDK use only
- */
+/// PaymentDetails response for Link accounts
+///
+/// For internal SDK use only
 @objc(STP_Internal_ConsumerPaymentDetails)
 class ConsumerPaymentDetails: NSObject, STPAPIResponseDecodable {
 
@@ -26,56 +26,66 @@ class ConsumerPaymentDetails: NSObject, STPAPIResponseDecodable {
     var isDefault: Bool
 
     // TODO(csabol) : Billing address
-    
-    let allResponseFields: [AnyHashable : Any]
 
-    init(stripeID: String,
-         details: Details,
-         isDefault: Bool,
-         allResponseFields: [AnyHashable: Any]) {
+    let allResponseFields: [AnyHashable: Any]
+
+    init(
+        stripeID: String,
+        details: Details,
+        isDefault: Bool,
+        allResponseFields: [AnyHashable: Any]
+    ) {
         self.stripeID = stripeID
         self.details = details
         self.isDefault = isDefault
         self.allResponseFields = allResponseFields
         super.init()
     }
-    
-    static func decodedObject(fromAPIResponse response: [AnyHashable : Any]?) -> Self? {
-        guard let dict = response?["redacted_payment_details"] as? [AnyHashable: Any] ?? response, // When this is from a list endpoint it isn't nested in redacted_payment_details
-              let stripeID = dict["id"] as? String,
-              let details = Details(dict),
-              let isDefault = dict["is_default"] as? Bool else {
+
+    static func decodedObject(fromAPIResponse response: [AnyHashable: Any]?) -> Self? {
+        // When this is from a list endpoint it isn't nested in redacted_payment_details
+        guard let dict = response?["redacted_payment_details"] as? [AnyHashable: Any] ?? response,
+            let stripeID = dict["id"] as? String,
+            let details = Details(dict),
+            let isDefault = dict["is_default"] as? Bool
+        else {
             return nil
         }
-        
-        return ConsumerPaymentDetails(stripeID: stripeID,
-                                      details: details,
-                                      isDefault: isDefault,
-                                      allResponseFields: dict) as? Self
+
+        return ConsumerPaymentDetails(
+            stripeID: stripeID,
+            details: details,
+            isDefault: isDefault,
+            allResponseFields: dict
+        ) as? Self
     }
-    
-    
+
     class ShareResponse: NSObject, STPAPIResponseDecodable {
         let paymentMethodID: String
-        let allResponseFields: [AnyHashable : Any]
-        
-        init(paymentMethodID: String,
-             allResponseFields: [AnyHashable: Any]) {
+        let allResponseFields: [AnyHashable: Any]
+
+        init(
+            paymentMethodID: String,
+            allResponseFields: [AnyHashable: Any]
+        ) {
             self.paymentMethodID = paymentMethodID
             self.allResponseFields = allResponseFields
             super.init()
         }
-        
-        static func decodedObject(fromAPIResponse response: [AnyHashable : Any]?) -> Self? {
+
+        static func decodedObject(fromAPIResponse response: [AnyHashable: Any]?) -> Self? {
             guard let dict = response,
-                  let id = dict["payment_method"] as? String else {
+                let id = dict["payment_method"] as? String
+            else {
                 return nil
             }
-            return ShareResponse(paymentMethodID: id,
-                                 allResponseFields: dict) as? Self
+            return ShareResponse(
+                paymentMethodID: id,
+                allResponseFields: dict
+            ) as? Self
         }
     }
-    
+
 }
 
 // MARK: - Details
@@ -85,13 +95,15 @@ extension ConsumerPaymentDetails {
         case card
         case bankAccount = "bank_account"
     }
-    
+
     enum Details {
-       
+
         case card(card: Card)
         case bankAccount(bankAccount: BankAccount)
-        
-        init?(_ response: [AnyHashable: Any]) {
+
+        init?(
+            _ response: [AnyHashable: Any]
+        ) {
             guard let typeString = response["type"] as? String else {
                 return nil
             }
@@ -145,7 +157,10 @@ extension ConsumerPaymentDetails.Details {
 
         var allResponseFields: [AnyHashable: Any]
 
-        init(cvcCheck: State, allResponseFields: [AnyHashable: Any]) {
+        init(
+            cvcCheck: State,
+            allResponseFields: [AnyHashable: Any]
+        ) {
             self.cvcCheck = cvcCheck
             self.allResponseFields = allResponseFields
             super.init()
@@ -163,7 +178,8 @@ extension ConsumerPaymentDetails.Details {
 
             return CardChecks(
                 cvcCheck: cvcCheckState,
-                allResponseFields: dict) as? Self
+                allResponseFields: dict
+            ) as? Self
         }
     }
 }
@@ -171,24 +187,26 @@ extension ConsumerPaymentDetails.Details {
 // MARK: - Details.Card
 extension ConsumerPaymentDetails.Details {
     class Card: NSObject, STPAPIResponseDecodable {
-        
+
         let expiryYear: Int
         let expiryMonth: Int
         let brand: STPCardBrand
         let last4: String
         let checks: CardChecks?
-        
-        let allResponseFields: [AnyHashable : Any]
-        
+
+        let allResponseFields: [AnyHashable: Any]
+
         /// A frontend convenience property, i.e. not part of the API Object
         var cvc: String? = nil
-        
-        required init(expiryYear: Int,
-                      expiryMonth: Int,
-                      brand: String,
-                      last4: String,
-                      checks: CardChecks?,
-                      allResponseFields: [AnyHashable: Any]) {
+
+        required init(
+            expiryYear: Int,
+            expiryMonth: Int,
+            brand: String,
+            last4: String,
+            checks: CardChecks?,
+            allResponseFields: [AnyHashable: Any]
+        ) {
             self.expiryYear = expiryYear
             self.expiryMonth = expiryMonth
             self.brand = STPPaymentMethodCard.brand(from: brand.lowercased())
@@ -197,17 +215,20 @@ extension ConsumerPaymentDetails.Details {
             self.allResponseFields = allResponseFields
             super.init()
         }
-        
-        static func decodedObject(fromAPIResponse response: [AnyHashable : Any]?) -> Self? {
+
+        static func decodedObject(fromAPIResponse response: [AnyHashable: Any]?) -> Self? {
             guard let dict = response?["card_details"] as? [AnyHashable: Any],
-                  let expiryYear = dict["exp_year"] as? Int,
-                  let expiryMonth = dict["exp_month"] as? Int,
-                  let brand = dict["brand"] as? String,
-                  let last4 = dict["last4"] as? String else {
+                let expiryYear = dict["exp_year"] as? Int,
+                let expiryMonth = dict["exp_month"] as? Int,
+                let brand = dict["brand"] as? String,
+                let last4 = dict["last4"] as? String
+            else {
                 return nil
             }
 
-            let checks = CardChecks.decodedObject(fromAPIResponse: dict["checks"] as? [AnyHashable: Any])
+            let checks = CardChecks.decodedObject(
+                fromAPIResponse: dict["checks"] as? [AnyHashable: Any]
+            )
 
             return Card(
                 expiryYear: expiryYear,
@@ -246,17 +267,19 @@ extension ConsumerPaymentDetails.Details.Card {
 // MARK: - Details.BankAccount
 extension ConsumerPaymentDetails.Details {
     class BankAccount: NSObject, STPAPIResponseDecodable {
-        
+
         let iconCode: String?
         let name: String
         let last4: String
-        
-        let allResponseFields: [AnyHashable : Any]
-        
-        init(iconCode: String?,
-             name: String,
-             last4: String,
-             allResponseFields: [AnyHashable: Any]) {
+
+        let allResponseFields: [AnyHashable: Any]
+
+        init(
+            iconCode: String?,
+            name: String,
+            last4: String,
+            allResponseFields: [AnyHashable: Any]
+        ) {
             self.iconCode = iconCode
             self.name = name
             self.last4 = last4
@@ -264,17 +287,20 @@ extension ConsumerPaymentDetails.Details {
             super.init()
         }
 
-        static func decodedObject(fromAPIResponse response: [AnyHashable : Any]?) -> Self? {
+        static func decodedObject(fromAPIResponse response: [AnyHashable: Any]?) -> Self? {
             guard let dict = response?["bank_account_details"] as? [AnyHashable: Any],
-                  let name = dict["bank_name"] as? String,
-                  let last4 = dict["last4"] as? String else {
-                      return nil
-                  }
-            
-            return BankAccount(iconCode: dict["bank_icon_code"] as? String,
-                               name: name,
-                               last4: last4,
-                               allResponseFields: dict) as? Self
+                let name = dict["bank_name"] as? String,
+                let last4 = dict["last4"] as? String
+            else {
+                return nil
+            }
+
+            return BankAccount(
+                iconCode: dict["bank_icon_code"] as? String,
+                name: name,
+                last4: last4,
+                allResponseFields: dict
+            ) as? Self
         }
     }
 }
@@ -282,34 +308,37 @@ extension ConsumerPaymentDetails.Details {
 // MARK: - List Deserializer
 /// :nodoc:
 extension ConsumerPaymentDetails {
-    /**
-     Helper class to deserialize a list of ConsumerPaymentDetails from API responses
-     */
+    /// Helper class to deserialize a list of ConsumerPaymentDetails from API responses
     class ListDeserializer: NSObject, STPAPIResponseDecodable {
-        let allResponseFields: [AnyHashable : Any]
+        let allResponseFields: [AnyHashable: Any]
         let paymentDetails: [ConsumerPaymentDetails]
-        
-        required init(paymentDetails: [ConsumerPaymentDetails],
-                      allResponseFields: [AnyHashable: Any]) {
+
+        required init(
+            paymentDetails: [ConsumerPaymentDetails],
+            allResponseFields: [AnyHashable: Any]
+        ) {
             self.paymentDetails = paymentDetails
             self.allResponseFields = allResponseFields
             super.init()
         }
 
-        static func decodedObject(fromAPIResponse response: [AnyHashable : Any]?) -> Self? {
+        static func decodedObject(fromAPIResponse response: [AnyHashable: Any]?) -> Self? {
             guard let response = response,
-                  let data = response["redacted_payment_details"] as? [[AnyHashable: Any]] else {
+                let data = response["redacted_payment_details"] as? [[AnyHashable: Any]]
+            else {
                 return nil
             }
-            
+
             var paymentDetails = [ConsumerPaymentDetails]()
             for entry in data {
-                if let paymentDetail = ConsumerPaymentDetails.decodedObject(fromAPIResponse: entry) {
+                if let paymentDetail = ConsumerPaymentDetails.decodedObject(fromAPIResponse: entry)
+                {
                     paymentDetails.append(paymentDetail)
                 }
             }
-            
-            return ListDeserializer(paymentDetails: paymentDetails, allResponseFields: response) as? Self
+
+            return ListDeserializer(paymentDetails: paymentDetails, allResponseFields: response)
+                as? Self
         }
     }
 }
@@ -323,7 +352,7 @@ extension ConsumerPaymentDetails {
             return "••••\(bank.last4)"
         }
     }
-    
+
     var cvc: String? {
         switch details {
         case .card(let card):

--- a/StripePaymentSheet/StripePaymentSheet/Internal/API Bindings/Link/VerificationSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/API Bindings/Link/VerificationSession.swift
@@ -6,27 +6,28 @@
 //  Copyright © 2021 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
 @_spi(STP) import StripePayments
+import UIKit
 
 extension ConsumerSession {
     class VerificationSession: NSObject, STPAPIResponseDecodable {
-        internal init(type: VerificationSession.SessionType,
-                      state: VerificationSession.SessionState,
-                      allResponseFields: [AnyHashable : Any]) {
+        internal init(
+            type: VerificationSession.SessionType,
+            state: VerificationSession.SessionState,
+            allResponseFields: [AnyHashable: Any]
+        ) {
             self.type = type
             self.state = state
             self.allResponseFields = allResponseFields
         }
-        
-        
+
         enum SessionType: String {
             case unknown = ""
             case signup = "signup"
             case email = "email"
             case sms = "sms"
         }
-        
+
         enum SessionState: String {
             case unknown = ""
             case started = "started"
@@ -35,28 +36,30 @@ extension ConsumerSession {
             case canceled = "canceled"
             case expired = "expired"
         }
-        
+
         let type: SessionType
         let state: SessionState
-        
-        let allResponseFields: [AnyHashable : Any]
-        
-        static func decodedObject(fromAPIResponse response: [AnyHashable : Any]?) -> Self? {
+
+        let allResponseFields: [AnyHashable: Any]
+
+        static func decodedObject(fromAPIResponse response: [AnyHashable: Any]?) -> Self? {
             guard let response = response,
-                  let typeString = (response["type"] as? String)?.lowercased(),
-                  let statusString = (response["state"] as? String)?.lowercased() else {
+                let typeString = (response["type"] as? String)?.lowercased(),
+                let statusString = (response["state"] as? String)?.lowercased()
+            else {
                 return nil
             }
-            
+
             let type: SessionType = SessionType(rawValue: typeString) ?? .unknown
             let state: SessionState = SessionState(rawValue: statusString) ?? .unknown
-            
-            return VerificationSession(type: type,
-                                       state: state,
-                                       allResponseFields: response) as? Self
+
+            return VerificationSession(
+                type: type,
+                state: state,
+                allResponseFields: response
+            ) as? Self
         }
-        
-        
+
     }
 }
 
@@ -64,7 +67,7 @@ extension Sequence where Iterator.Element == ConsumerSession.VerificationSession
     var containsVerifiedSMSSession: Bool {
         return contains(where: { $0.type == .sms && $0.state == .verified })
     }
-    
+
     var isVerifiedForSignup: Bool {
         return contains(where: { $0.type == .signup && $0.state == .started })
     }

--- a/StripePaymentSheet/StripePaymentSheet/Internal/API Bindings/VO/CardExpiryDate.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/API Bindings/VO/CardExpiryDate.swift
@@ -21,7 +21,9 @@ struct CardExpiryDate {
     }
 
     /// Creates a `CardExpiryDate` struct from a 4 digit string in `MMyy` format.
-    init?(_ string: String?) {
+    init?(
+        _ string: String?
+    ) {
         guard
             let string = string,
             string.count == 4,
@@ -43,7 +45,10 @@ struct CardExpiryDate {
     /// - Parameters:
     ///   - month: Month.
     ///   - year: Year.
-    init(month: Int, year: Int) {
+    init(
+        month: Int,
+        year: Int
+    ) {
         self.month = month
         self.year = Self.normalizeYear(year)
     }
@@ -69,9 +74,6 @@ struct CardExpiryDate {
 
 extension CardExpiryDate: Equatable {
     static func == (lhs: Self, rhs: Self) -> Bool {
-        return (
-            lhs.month == rhs.month &&
-            lhs.year == rhs.year
-        )
+        return (lhs.month == rhs.month && lhs.year == rhs.year)
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Basic UI/Inputs/OneTimeCodeTextField-TextStorage.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Basic UI/Inputs/OneTimeCodeTextField-TextStorage.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2022 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
 @_spi(STP) import StripePayments
+import UIKit
 
 extension OneTimeCodeTextField {
     final class TextStorage {
@@ -42,7 +42,9 @@ extension OneTimeCodeTextField {
 
         private let allowedCharacters: CharacterSet = .init(charactersIn: "0123456789")
 
-        init(capacity: Int) {
+        init(
+            capacity: Int
+        ) {
             self.capacity = capacity
         }
 
@@ -107,14 +109,16 @@ extension OneTimeCodeTextField {
     final class TextPosition: UITextPosition {
         let index: Int
 
-        init(_ index: Int) {
+        init(
+            _ index: Int
+        ) {
             self.index = index
         }
 
         override var description: String {
             let props: [String] = [
                 String(format: "%@: %p", NSStringFromClass(type(of: self)), self),
-                "index = \(String(describing: index))"
+                "index = \(String(describing: index))",
             ]
             return "<\(props.joined(separator: "; "))>"
         }
@@ -165,7 +169,10 @@ extension OneTimeCodeTextField {
             return _end
         }
 
-        convenience init?(start: UITextPosition, end: UITextPosition) {
+        convenience init?(
+            start: UITextPosition,
+            end: UITextPosition
+        ) {
             guard
                 let start = start as? TextPosition,
                 let end = end as? TextPosition
@@ -176,7 +183,10 @@ extension OneTimeCodeTextField {
             self.init(start: start, end: end)
         }
 
-        init(start: TextPosition, end: TextPosition) {
+        init(
+            start: TextPosition,
+            end: TextPosition
+        ) {
             self._start = start
             self._end = end
         }
@@ -185,7 +195,7 @@ extension OneTimeCodeTextField {
             let props: [String] = [
                 String(format: "%@: %p", NSStringFromClass(type(of: self)), self),
                 "start = \(String(describing: start))",
-                "end = \(String(describing: end))"
+                "end = \(String(describing: end))",
             ]
             return "<\(props.joined(separator: "; "))>"
         }
@@ -208,7 +218,10 @@ extension OneTimeCodeTextField {
             let lowerBound = min(_start.index, _end.index)
             let upperBound = max(_start.index, _end.index)
 
-            let beginIndex = string.index(string.startIndex, offsetBy: min(lowerBound, string.count))
+            let beginIndex = string.index(
+                string.startIndex,
+                offsetBy: min(lowerBound, string.count)
+            )
             let endIndex = string.index(string.startIndex, offsetBy: min(upperBound, string.count))
 
             return beginIndex..<endIndex

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Basic UI/Inputs/OneTimeCodeTextField.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Basic UI/Inputs/OneTimeCodeTextField.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2021 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
 @_spi(STP) import StripeUICore
+import UIKit
 
 /// A field for collecting one-time codes (OTCs).
 /// For internal SDK use only
@@ -71,7 +71,9 @@ final class OneTimeCodeTextField: UIControl {
 
     private let feedbackGenerator = UINotificationFeedbackGenerator()
 
-    init(numberOfDigits: Int = 6) {
+    init(
+        numberOfDigits: Int = 6
+    ) {
         self.numberOfDigits = numberOfDigits
         self.textStorage = TextStorage(capacity: numberOfDigits)
         super.init(frame: .zero)
@@ -97,7 +99,9 @@ final class OneTimeCodeTextField: UIControl {
         )
     }
 
-    required init?(coder: NSCoder) {
+    required init?(
+        coder: NSCoder
+    ) {
         fatalError("init(coder:) has not been implemented")
     }
 
@@ -132,7 +136,8 @@ final class OneTimeCodeTextField: UIControl {
         super.touchesEnded(touches, with: event)
 
         guard let point = touches.first?.location(in: self),
-              bounds.contains(point) else {
+            bounds.contains(point)
+        else {
             return
         }
 
@@ -147,9 +152,9 @@ final class OneTimeCodeTextField: UIControl {
 
 // MARK: - Private methods
 
-private extension OneTimeCodeTextField {
+extension OneTimeCodeTextField {
 
-    func setupUI() {
+    fileprivate func setupUI() {
         let stackView = UIStackView(arrangedSubviews: arrangedDigitViews())
         stackView.spacing = shouldGroupDigits ? Constants.groupSpacing : Constants.itemSpacing
         stackView.alignment = .center
@@ -158,7 +163,7 @@ private extension OneTimeCodeTextField {
         addAndPinSubview(stackView)
     }
 
-    func arrangedDigitViews() -> [UIView] {
+    fileprivate func arrangedDigitViews() -> [UIView] {
         guard shouldGroupDigits else {
             // No grouping, simply return all the digit views.
             return digitViews
@@ -180,12 +185,12 @@ private extension OneTimeCodeTextField {
         }
     }
 
-    func update() {
+    fileprivate func update() {
         updateDigitViews()
         updateAccessibilityProperties()
     }
 
-    func updateDigitViews() {
+    fileprivate func updateDigitViews() {
         let digits: [Character] = .init(value)
 
         let selectedRange = selectedTextRange as? TextRange
@@ -196,15 +201,16 @@ private extension OneTimeCodeTextField {
         }
     }
 
-    func updateAccessibilityProperties() {
+    fileprivate func updateAccessibilityProperties() {
         accessibilityValue = value
 
-        accessibilityHint = isFirstResponder
+        accessibilityHint =
+            isFirstResponder
             ? nil
             : STPLocalizedString("Double tap to edit", "Accessibility hint for a text field")
     }
 
-    func toggleMenu() {
+    fileprivate func toggleMenu() {
         if UIMenuController.shared.isMenuVisible {
             hideMenu()
         } else {
@@ -212,7 +218,7 @@ private extension OneTimeCodeTextField {
         }
     }
 
-    func showMenu() {
+    fileprivate func showMenu() {
         let menuRect: CGRect = {
             guard let activeDigitView = digitViews.first(where: { $0.isActive }) else {
                 return bounds
@@ -224,11 +230,11 @@ private extension OneTimeCodeTextField {
         UIMenuController.shared.showMenu(from: self, rect: menuRect)
     }
 
-    func hideMenu() {
+    fileprivate func hideMenu() {
         UIMenuController.shared.hideMenu()
     }
 
-    @objc func applicationWillEnterForeground(_ notification: Notification) {
+    @objc fileprivate func applicationWillEnterForeground(_ notification: Notification) {
         // Forcing an update when the application enters foreground ensures that
         // the caret resumes blinking. This is something that iOS currently does for
         // long-running animation such as caret blinking on UITextField and
@@ -276,7 +282,9 @@ extension OneTimeCodeTextField {
             jumpAnimation.duration = duration
             jumpAnimation.values = [0, -8, 2, 0]
             jumpAnimation.keyTimes = [0.0, 0.33, 0.66, 1.0]
-            jumpAnimation.timingFunctions = [timingFunction, timingFunction, timingFunction, timingFunction]
+            jumpAnimation.timingFunctions = [
+                timingFunction, timingFunction, timingFunction, timingFunction,
+            ]
 
             let borderColorAnimation = CABasicAnimation(keyPath: "borderColor")
             borderColorAnimation.beginTime = beginTime + (CFTimeInterval(index) * staggerDelay)
@@ -366,7 +374,7 @@ extension OneTimeCodeTextField: UITextInput {
         return nil
     }
 
-    var markedTextStyle: [NSAttributedString.Key : Any]? {
+    var markedTextStyle: [NSAttributedString.Key: Any]? {
         get {
             return nil
         }
@@ -403,7 +411,8 @@ extension OneTimeCodeTextField: UITextInput {
         // We don't support marked text
     }
 
-    func textRange(from fromPosition: UITextPosition, to toPosition: UITextPosition) -> UITextRange? {
+    func textRange(from fromPosition: UITextPosition, to toPosition: UITextPosition) -> UITextRange?
+    {
         guard
             let fromPosition = fromPosition as? TextPosition,
             let toPosition = toPosition as? TextPosition
@@ -470,7 +479,10 @@ extension OneTimeCodeTextField: UITextInput {
         return toPosition.index - from.index
     }
 
-    func position(within range: UITextRange, farthestIn direction: UITextLayoutDirection) -> UITextPosition? {
+    func position(
+        within range: UITextRange,
+        farthestIn direction: UITextLayoutDirection
+    ) -> UITextPosition? {
         guard let range = range as? TextRange else {
             return nil
         }
@@ -582,9 +594,9 @@ extension OneTimeCodeTextField: UITextInput {
 
 // MARK: - Digit View
 
-private extension OneTimeCodeTextField {
+extension OneTimeCodeTextField {
 
-    final class DigitView: UIView {
+    fileprivate final class DigitView: UIView {
         struct Constants {
             static let dotSize: CGFloat = 8
             static let borderWidth: CGFloat = 1
@@ -668,7 +680,9 @@ private extension OneTimeCodeTextField {
             updateColors()
         }
 
-        required init?(coder: NSCoder) {
+        required init?(
+            coder: NSCoder
+        ) {
             fatalError("init(coder:) has not been implemented")
         }
 
@@ -725,7 +739,9 @@ private extension OneTimeCodeTextField {
 
             let blinkingAnimation = CAKeyframeAnimation(keyPath: "opacity")
             // Matches caret animation of iOS >= 13
-            blinkingAnimation.keyTimes = [0, 0.5, 0.5375, 0.575, 0.6125, 0.65, 0.85, 0.8875, 0.925, 0.9625, 1]
+            blinkingAnimation.keyTimes = [
+                0, 0.5, 0.5375, 0.575, 0.6125, 0.65, 0.85, 0.8875, 0.925, 0.9625, 1,
+            ]
             blinkingAnimation.values = [1, 1, 0.75, 0.5, 0.25, 0, 0, 0.25, 0.5, 0.75, 1]
             blinkingAnimation.duration = 1
             blinkingAnimation.repeatCount = .infinity

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Basic UI/SeparatorLabel.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Basic UI/SeparatorLabel.swift
@@ -34,7 +34,7 @@ final class SeparatorLabel: UIView {
             label.font = newValue
         }
     }
-    
+
     var textColor: UIColor {
         get {
             return label.textColor
@@ -52,7 +52,7 @@ final class SeparatorLabel: UIView {
             label.adjustsFontForContentSizeCategory = newValue
         }
     }
-    
+
     var separatorColor: UIColor? {
         get {
             return leftLineView.backgroundColor
@@ -86,17 +86,23 @@ final class SeparatorLabel: UIView {
         return view
     }()
 
-    convenience init(text: String) {
+    convenience init(
+        text: String
+    ) {
         self.init(frame: .zero)
         self.text = text
     }
 
-    override init(frame: CGRect) {
+    override init(
+        frame: CGRect
+    ) {
         super.init(frame: frame)
         setup()
     }
 
-    required init?(coder: NSCoder) {
+    required init?(
+        coder: NSCoder
+    ) {
         super.init(coder: coder)
         setup()
     }
@@ -117,9 +123,13 @@ final class SeparatorLabel: UIView {
             label.bottomAnchor.constraint(equalTo: bottomAnchor),
             label.centerXAnchor.constraint(equalTo: centerXAnchor),
             label.leadingAnchor.constraint(
-                equalTo: leftLineView.trailingAnchor, constant: Constants.spacing),
+                equalTo: leftLineView.trailingAnchor,
+                constant: Constants.spacing
+            ),
             label.trailingAnchor.constraint(
-                equalTo: rightLineView.leadingAnchor, constant: -Constants.spacing),
+                equalTo: rightLineView.leadingAnchor,
+                constant: -Constants.spacing
+            ),
 
             // Right line
             rightLineView.heightAnchor.constraint(equalToConstant: 1),

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/ACH/LinkFinancialConnectionsAuthManager.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/ACH/LinkFinancialConnectionsAuthManager.swift
@@ -6,10 +6,9 @@
 //  Copyright © 2022 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
 import AuthenticationServices
-
 @_spi(STP) import StripeCore
+import UIKit
 
 /// For internal SDK use only
 @objc(STP_Internal_LinkFinancialConnectionsAuthManager)
@@ -49,7 +48,10 @@ final class LinkFinancialConnectionsAuthManager: NSObject {
     let linkAccount: PaymentSheetLinkAccount
     let window: UIWindow?
 
-    init(linkAccount: PaymentSheetLinkAccount, window: UIWindow?) {
+    init(
+        linkAccount: PaymentSheetLinkAccount,
+        window: UIWindow?
+    ) {
         self.linkAccount = linkAccount
         self.window = window
     }
@@ -78,7 +80,7 @@ extension LinkFinancialConnectionsAuthManager {
             parameters: [
                 "client_secret": clientSecret,
                 "fullscreen": true,
-                "hide_close_button": true
+                "hide_close_button": true,
             ],
             ephemeralKeySecret: linkAccount.publishableKey
         )
@@ -107,9 +109,11 @@ extension LinkFinancialConnectionsAuthManager {
                 }
 
                 guard let url = url else {
-                    completion(.failure(
-                        AuthenticationError.unknown("Unexpected `nil` URL")
-                    ))
+                    completion(
+                        .failure(
+                            AuthenticationError.unknown("Unexpected `nil` URL")
+                        )
+                    )
                     return
                 }
 
@@ -117,16 +121,20 @@ extension LinkFinancialConnectionsAuthManager {
                     if let linkedAccountID = Self.extractLinkedAccountID(from: url) {
                         completion(.success(linkedAccountID: linkedAccountID))
                     } else {
-                        completion(.failure(
-                            AuthenticationError.unknown("URL is missing the linked account ID")
-                        ))
+                        completion(
+                            .failure(
+                                AuthenticationError.unknown("URL is missing the linked account ID")
+                            )
+                        )
                     }
                 } else if url.matchesSchemeHostAndPath(of: manifest.cancelURL) {
                     completion(.canceled)
                 } else {
-                    completion(.failure(
-                        AuthenticationError.unknown("Unexpected URL")
-                    ))
+                    completion(
+                        .failure(
+                            AuthenticationError.unknown("Unexpected URL")
+                        )
+                    )
                 }
             }
         )
@@ -136,9 +144,11 @@ extension LinkFinancialConnectionsAuthManager {
 
         if #available(iOS 13.4, *) {
             guard authSession.canStart else {
-                completion(.failure(
-                    AuthenticationError.unknown("Failed to start session")
-                ))
+                completion(
+                    .failure(
+                        AuthenticationError.unknown("Failed to start session")
+                    )
+                )
                 return
             }
         }
@@ -177,14 +187,12 @@ extension LinkFinancialConnectionsAuthManager {
 
 }
 
-private extension URL {
+extension URL {
 
-    func matchesSchemeHostAndPath(of otherURL: URL) -> Bool {
-        return (
-            self.scheme == otherURL.scheme &&
-            self.host == otherURL.host &&
-            self.path == otherURL.path
-        )
+    fileprivate func matchesSchemeHostAndPath(of otherURL: URL) -> Bool {
+        return
+            (self.scheme == otherURL.scheme && self.host == otherURL.host
+            && self.path == otherURL.path)
     }
 
 }

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Components/Badge/LinkBadgeView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Components/Badge/LinkBadgeView.swift
@@ -6,16 +6,20 @@
 //  Copyright © 2022 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
-
 @_spi(STP) import StripeUICore
+import UIKit
 
 /// For internal SDK use only
 @objc(STP_Internal_LinkBadgeView)
 final class LinkBadgeView: UIView {
     struct Constants {
         static let spacing: CGFloat = 4
-        static let margins: NSDirectionalEdgeInsets = .insets(top: 2, leading: 4, bottom: 2, trailing: 4)
+        static let margins: NSDirectionalEdgeInsets = .insets(
+            top: 2,
+            leading: 4,
+            bottom: 2,
+            trailing: 4
+        )
         static let iconSize: CGSize = .init(width: 12, height: 12)
         static let maxFontSize: CGFloat = 16
     }
@@ -49,7 +53,7 @@ final class LinkBadgeView: UIView {
 
         NSLayoutConstraint.activate([
             imageView.widthAnchor.constraint(equalToConstant: Constants.iconSize.width),
-            imageView.heightAnchor.constraint(equalToConstant: Constants.iconSize.height)
+            imageView.heightAnchor.constraint(equalToConstant: Constants.iconSize.height),
         ])
 
         return imageView
@@ -58,7 +62,10 @@ final class LinkBadgeView: UIView {
     private lazy var textLabel: UILabel = {
         let label = UILabel()
         label.textColor = type.foregroundColor
-        label.font = LinkUI.font(forTextStyle: .captionEmphasized, maximumPointSize: Constants.maxFontSize)
+        label.font = LinkUI.font(
+            forTextStyle: .captionEmphasized,
+            maximumPointSize: Constants.maxFontSize
+        )
         label.adjustsFontForContentSizeCategory = true
         return label
     }()
@@ -67,18 +74,25 @@ final class LinkBadgeView: UIView {
         return CGSize(width: UIView.noIntrinsicMetric, height: 20)
     }
 
-    convenience init(type: BadgeType, text: String) {
+    convenience init(
+        type: BadgeType,
+        text: String
+    ) {
         self.init(type: type)
         self.text = text
     }
 
-    init(type: BadgeType) {
+    init(
+        type: BadgeType
+    ) {
         self.type = type
         super.init(frame: .zero)
         setupUI()
     }
 
-    required init?(coder: NSCoder) {
+    required init?(
+        coder: NSCoder
+    ) {
         fatalError("init(coder:) has not been implemented")
     }
 
@@ -101,9 +115,9 @@ final class LinkBadgeView: UIView {
 
 }
 
-private extension LinkBadgeView.BadgeType {
+extension LinkBadgeView.BadgeType {
 
-    var icon: UIImage? {
+    fileprivate var icon: UIImage? {
         switch self {
         case .neutral:
             return nil
@@ -112,7 +126,7 @@ private extension LinkBadgeView.BadgeType {
         }
     }
 
-    var backgroundColor: UIColor {
+    fileprivate var backgroundColor: UIColor {
         switch self {
         case .neutral:
             return .linkNeutralBackground
@@ -121,7 +135,7 @@ private extension LinkBadgeView.BadgeType {
         }
     }
 
-    var foregroundColor: UIColor {
+    fileprivate var foregroundColor: UIColor {
         switch self {
         case .neutral:
             return .linkNeutralForeground

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Components/NavigationBar/LinkNavigationBar.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Components/NavigationBar/LinkNavigationBar.swift
@@ -6,12 +6,11 @@
 //  Copyright © 2022 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
-
 @_spi(STP) import StripeCore
-@_spi(STP) import StripeUICore
 @_spi(STP) import StripePayments
 @_spi(STP) import StripePaymentsUI
+@_spi(STP) import StripeUICore
+import UIKit
 
 /// For internal SDK use only
 @objc(STP_Internal_LinkNavigationBar)
@@ -99,7 +98,8 @@ final class LinkNavigationBar: UIView {
     }()
 
     override var intrinsicContentSize: CGSize {
-        let baseHeight: CGFloat = isLarge
+        let baseHeight: CGFloat =
+            isLarge
             ? Constants.largeHeight
             : Constants.defaultHeight
         return CGSize(
@@ -135,7 +135,10 @@ final class LinkNavigationBar: UIView {
             closeButton.widthAnchor.constraint(equalToConstant: Constants.buttonSize.width),
             closeButton.heightAnchor.constraint(equalToConstant: Constants.buttonSize.height),
             // Logo
-            logoView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: Constants.logoVerticalOffset),
+            logoView.topAnchor.constraint(
+                equalTo: safeAreaLayoutGuide.topAnchor,
+                constant: Constants.logoVerticalOffset
+            ),
             logoView.centerXAnchor.constraint(equalTo: safeAreaLayoutGuide.centerXAnchor),
             logoView.bottomAnchor.constraint(lessThanOrEqualTo: layoutMarginsGuide.bottomAnchor),
             // Email label
@@ -159,7 +162,9 @@ final class LinkNavigationBar: UIView {
         update()
     }
 
-    required init?(coder: NSCoder) {
+    required init?(
+        coder: NSCoder
+    ) {
         fatalError("init(coder:) has not been implemented")
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Components/Notice/LinkNoticeView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Components/Notice/LinkNoticeView.swift
@@ -6,9 +6,8 @@
 //  Copyright © 2022 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
-
 @_spi(STP) import StripeUICore
+import UIKit
 
 /// A view for displaying text notices.
 ///
@@ -53,25 +52,32 @@ final class LinkNoticeView: UIView {
         return label
     }()
 
-    convenience init(type: NoticeType, text: String) {
+    convenience init(
+        type: NoticeType,
+        text: String
+    ) {
         self.init(type: type)
         self.text = text
     }
 
-    init(type: NoticeType) {
+    init(
+        type: NoticeType
+    ) {
         self.type = type
         super.init(frame: .zero)
         setupUI()
     }
 
-    required init?(coder: NSCoder) {
+    required init?(
+        coder: NSCoder
+    ) {
         fatalError("init(coder:) has not been implemented")
     }
 
     private func setupUI() {
         let stackView = UIStackView(arrangedSubviews: [
             iconView,
-            textLabel
+            textLabel,
         ])
 
         stackView.axis = .horizontal
@@ -87,23 +93,23 @@ final class LinkNoticeView: UIView {
 
 }
 
-private extension LinkNoticeView.NoticeType {
+extension LinkNoticeView.NoticeType {
 
-    var icon: UIImage {
+    fileprivate var icon: UIImage {
         switch self {
         case .error:
             return Image.icon_link_error.makeImage(template: true)
         }
     }
 
-    var backgroundColor: UIColor {
+    fileprivate var backgroundColor: UIColor {
         switch self {
         case .error:
             return .linkDangerBackground
         }
     }
 
-    var foregroundColor: UIColor {
+    fileprivate var foregroundColor: UIColor {
         switch self {
         case .error:
             return .linkDangerForeground

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Components/PaymentMethodPicker/LinkPaymentMethodPicker-AddButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Components/PaymentMethodPicker/LinkPaymentMethodPicker-AddButton.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2021 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
 @_spi(STP) import StripeCore
 @_spi(STP) import StripeUICore
+import UIKit
 
 extension LinkPaymentMethodPicker {
 
@@ -17,7 +17,9 @@ extension LinkPaymentMethodPicker {
             static let iconSize: CGSize = .init(width: 24, height: 24)
         }
 
-        private let iconView: UIImageView = UIImageView(image: Image.icon_add_bordered.makeImage(template: true))
+        private let iconView: UIImageView = UIImageView(
+            image: Image.icon_add_bordered.makeImage(template: true)
+        )
 
         private lazy var textLabel: UILabel = {
             let label = UILabel()
@@ -47,7 +49,9 @@ extension LinkPaymentMethodPicker {
             update()
         }
 
-        required init?(coder: NSCoder) {
+        required init?(
+            coder: NSCoder
+        ) {
             fatalError("init(coder:) has not been implemented")
         }
 
@@ -78,7 +82,7 @@ extension LinkPaymentMethodPicker {
                 stackView.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor),
                 stackView.bottomAnchor.constraint(equalTo: layoutMarginsGuide.bottomAnchor),
                 stackView.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
-                stackView.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor)
+                stackView.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),
             ])
         }
 

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Components/PaymentMethodPicker/LinkPaymentMethodPicker-Cell.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Components/PaymentMethodPicker/LinkPaymentMethodPicker-Cell.swift
@@ -6,20 +6,28 @@
 //  Copyright © 2021 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
 @_spi(STP) import StripeCore
 @_spi(STP) import StripeUICore
+import UIKit
 
 protocol LinkPaymentMethodPickerCellDelegate: AnyObject {
     func savedPaymentPickerCellDidSelect(_ cell: LinkPaymentMethodPicker.Cell)
-    func savedPaymentPickerCell(_ cell: LinkPaymentMethodPicker.Cell, didTapMenuButton button: UIButton)
+    func savedPaymentPickerCell(
+        _ cell: LinkPaymentMethodPicker.Cell,
+        didTapMenuButton button: UIButton
+    )
 }
 
 extension LinkPaymentMethodPicker {
 
     final class Cell: UIControl {
         struct Constants {
-            static let margins = NSDirectionalEdgeInsets(top: 16, leading: 20, bottom: 16, trailing: 20)
+            static let margins = NSDirectionalEdgeInsets(
+                top: 16,
+                leading: 20,
+                bottom: 16,
+                trailing: 20
+            )
             static let contentSpacing: CGFloat = 12
             static let contentIndentation: CGFloat = 34
             static let menuSpacing: CGFloat = 8
@@ -84,10 +92,13 @@ extension LinkPaymentMethodPicker {
             return iconView
         }()
 
-        private let unavailableBadge = LinkBadgeView(type: .error, text: STPLocalizedString(
-            "Unavailable for this purchase",
-            "Label shown when a payment method cannot be used for the current transaction."
-        ))
+        private let unavailableBadge = LinkBadgeView(
+            type: .error,
+            text: STPLocalizedString(
+                "Unavailable for this purchase",
+                "Label shown when a payment method cannot be used for the current transaction."
+            )
+        )
 
         private lazy var menuButton: UIButton = {
             let button = UIButton(type: .system)
@@ -118,7 +129,9 @@ extension LinkPaymentMethodPicker {
             return separator
         }()
 
-        override init(frame: CGRect) {
+        override init(
+            frame: CGRect
+        ) {
             super.init(frame: frame)
 
             isAccessibilityElement = true
@@ -127,12 +140,16 @@ extension LinkPaymentMethodPicker {
             setupUI()
         }
 
-        required init?(coder: NSCoder) {
+        required init?(
+            coder: NSCoder
+        ) {
             fatalError("init(coder:) has not been implemented")
         }
 
         private func setupUI() {
-            let rightStackView = UIStackView(arrangedSubviews: [defaultBadge, alertIconView, activityIndicator, menuButton])
+            let rightStackView = UIStackView(arrangedSubviews: [
+                defaultBadge, alertIconView, activityIndicator, menuButton,
+            ])
             rightStackView.spacing = LinkUI.smallContentSpacing
             rightStackView.distribution = .equalSpacing
             rightStackView.alignment = .center
@@ -162,20 +179,31 @@ extension LinkPaymentMethodPicker {
 
                 // Menu button
                 menuButton.widthAnchor.constraint(equalToConstant: Constants.menuButtonSize.width),
-                menuButton.heightAnchor.constraint(equalToConstant: Constants.menuButtonSize.height),
+                menuButton.heightAnchor.constraint(
+                    equalToConstant: Constants.menuButtonSize.height
+                ),
 
                 // Loader
-                activityIndicator.widthAnchor.constraint(equalToConstant: Constants.menuButtonSize.width),
-                activityIndicator.heightAnchor.constraint(equalToConstant: Constants.menuButtonSize.height),
+                activityIndicator.widthAnchor.constraint(
+                    equalToConstant: Constants.menuButtonSize.width
+                ),
+                activityIndicator.heightAnchor.constraint(
+                    equalToConstant: Constants.menuButtonSize.height
+                ),
 
                 // Icon
                 alertIconView.widthAnchor.constraint(equalToConstant: Constants.iconViewSize.width),
-                alertIconView.heightAnchor.constraint(equalToConstant: Constants.iconViewSize.height),
+                alertIconView.heightAnchor.constraint(
+                    equalToConstant: Constants.iconViewSize.height
+                ),
 
                 // Container
                 container.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor),
                 container.bottomAnchor.constraint(equalTo: layoutMarginsGuide.bottomAnchor),
-                container.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor, constant: Constants.contentIndentation),
+                container.leadingAnchor.constraint(
+                    equalTo: layoutMarginsGuide.leadingAnchor,
+                    constant: Constants.contentIndentation
+                ),
                 container.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),
                 // Make stackView fill the container
                 stackView.trailingAnchor.constraint(equalTo: container.trailingAnchor),

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Components/PaymentMethodPicker/LinkPaymentMethodPicker-CellContentView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Components/PaymentMethodPicker/LinkPaymentMethodPicker-CellContentView.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2021 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
-@_spi(STP) import StripeUICore
 @_spi(STP) import StripePaymentsUI
+@_spi(STP) import StripeUICore
+import UIKit
 
 extension LinkPaymentMethodPicker {
 
@@ -30,7 +30,9 @@ extension LinkPaymentMethodPicker {
                     secondaryLabel.text = nil
                     secondaryLabel.isHidden = true
                 case .bankAccount(let bankAccount):
-                    bankIconView.image = PaymentSheetImageLibrary.bankIcon(for: bankAccount.iconCode)
+                    bankIconView.image = PaymentSheetImageLibrary.bankIcon(
+                        for: bankAccount.iconCode
+                    )
                     cardBrandView.isHidden = true
                     bankIconView.isHidden = false
                     primaryLabel.text = bankAccount.name
@@ -45,61 +47,71 @@ extension LinkPaymentMethodPicker {
                 }
             }
         }
-        
+
         private lazy var bankIconView: UIImageView = {
             let iconView = UIImageView()
             iconView.contentMode = .scaleAspectFit
             return iconView
         }()
-        
+
         private lazy var cardBrandView: CardBrandView = CardBrandView(centerHorizontally: true)
-        
+
         private let primaryLabel: UILabel = {
             let label = UILabel()
             label.adjustsFontForContentSizeCategory = true
-            label.font = LinkUI.font(forTextStyle: .bodyEmphasized, maximumPointSize: Constants.maxFontSize)
+            label.font = LinkUI.font(
+                forTextStyle: .bodyEmphasized,
+                maximumPointSize: Constants.maxFontSize
+            )
             label.textColor = .linkPrimaryText
             return label
         }()
-        
+
         private let secondaryLabel: UILabel = {
             let label = UILabel()
-            label.font = LinkUI.font(forTextStyle: .caption, maximumPointSize: Constants.maxFontSize)
+            label.font = LinkUI.font(
+                forTextStyle: .caption,
+                maximumPointSize: Constants.maxFontSize
+            )
             label.textColor = .linkSecondaryText
             return label
         }()
-                
+
         private lazy var iconContainerView: UIView = {
             let view = UIView()
             bankIconView.translatesAutoresizingMaskIntoConstraints = false
             cardBrandView.translatesAutoresizingMaskIntoConstraints = false
-            
+
             view.addSubview(bankIconView)
             view.addSubview(cardBrandView)
-            
+
             let cardBrandSize = cardBrandView.size(for: Constants.iconSize)
             NSLayoutConstraint.activate([
-                view.widthAnchor.constraint(equalToConstant: max(Constants.iconSize.width, cardBrandSize.width)),
-                view.heightAnchor.constraint(equalToConstant: max(Constants.iconSize.height, cardBrandSize.height)),
-                
+                view.widthAnchor.constraint(
+                    equalToConstant: max(Constants.iconSize.width, cardBrandSize.width)
+                ),
+                view.heightAnchor.constraint(
+                    equalToConstant: max(Constants.iconSize.height, cardBrandSize.height)
+                ),
+
                 bankIconView.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor),
                 bankIconView.topAnchor.constraint(greaterThanOrEqualTo: view.topAnchor),
                 bankIconView.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor),
                 bankIconView.bottomAnchor.constraint(lessThanOrEqualTo: view.bottomAnchor),
                 bankIconView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
                 bankIconView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
-                
+
                 cardBrandView.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor),
                 cardBrandView.topAnchor.constraint(greaterThanOrEqualTo: view.topAnchor),
                 cardBrandView.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor),
                 cardBrandView.bottomAnchor.constraint(lessThanOrEqualTo: view.bottomAnchor),
                 cardBrandView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
                 cardBrandView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
-                
+
                 cardBrandView.widthAnchor.constraint(equalToConstant: cardBrandSize.width),
                 cardBrandView.heightAnchor.constraint(equalToConstant: cardBrandSize.height),
             ])
-                        
+
             return view
         }()
 
@@ -111,7 +123,6 @@ extension LinkPaymentMethodPicker {
             labelStackView.axis = .vertical
             labelStackView.alignment = .leading
             labelStackView.spacing = 0
-            
 
             let stackView = UIStackView(arrangedSubviews: [
                 iconContainerView,
@@ -124,12 +135,16 @@ extension LinkPaymentMethodPicker {
             return stackView
         }()
 
-        override init(frame: CGRect) {
+        override init(
+            frame: CGRect
+        ) {
             super.init(frame: frame)
             addAndPinSubview(stackView)
         }
 
-        required init?(coder: NSCoder) {
+        required init?(
+            coder: NSCoder
+        ) {
             fatalError("init(coder:) has not been implemented")
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Components/PaymentMethodPicker/LinkPaymentMethodPicker-Header.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Components/PaymentMethodPicker/LinkPaymentMethodPicker-Header.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2021 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
 @_spi(STP) import StripeUICore
+import UIKit
 
 extension LinkPaymentMethodPicker {
 
@@ -15,8 +15,18 @@ extension LinkPaymentMethodPicker {
         struct Constants {
             static let contentSpacing: CGFloat = 16
             static let chevronSize: CGSize = .init(width: 24, height: 24)
-            static let collapsedInsets = NSDirectionalEdgeInsets(top: 20, leading: 20, bottom: 20, trailing: 20)
-            static let expandedInsets = NSDirectionalEdgeInsets(top: 20, leading: 20, bottom: 4, trailing: 20)
+            static let collapsedInsets = NSDirectionalEdgeInsets(
+                top: 20,
+                leading: 20,
+                bottom: 20,
+                trailing: 20
+            )
+            static let expandedInsets = NSDirectionalEdgeInsets(
+                top: 20,
+                leading: 20,
+                bottom: 4,
+                trailing: 20
+            )
         }
 
         /// The selected payment method.
@@ -49,7 +59,10 @@ extension LinkPaymentMethodPicker {
             let label = UILabel()
             label.font = LinkUI.font(forTextStyle: .body)
             label.textColor = .linkSecondaryText
-            label.text = STPLocalizedString("Payment", "Label for a section displaying payment details.")
+            label.text = STPLocalizedString(
+                "Payment",
+                "Label for a section displaying payment details."
+            )
             label.adjustsFontForContentSizeCategory = true
             return label
         }()
@@ -76,12 +89,14 @@ extension LinkPaymentMethodPicker {
         }()
 
         private lazy var chevron: UIImageView = {
-            let chevron = UIImageView(image: StripeUICore.Image.icon_chevron_down.makeImage(template: true))
+            let chevron = UIImageView(
+                image: StripeUICore.Image.icon_chevron_down.makeImage(template: true)
+            )
             chevron.contentMode = .center
 
             NSLayoutConstraint.activate([
                 chevron.widthAnchor.constraint(equalToConstant: Constants.chevronSize.width),
-                chevron.heightAnchor.constraint(equalToConstant: Constants.chevronSize.height)
+                chevron.heightAnchor.constraint(equalToConstant: Constants.chevronSize.height),
             ])
 
             return chevron
@@ -90,7 +105,7 @@ extension LinkPaymentMethodPicker {
         private lazy var paymentInfoStackView: UIStackView = {
             let stackView = UIStackView(arrangedSubviews: [
                 payWithLabel,
-                contentView
+                contentView,
             ])
 
             stackView.alignment = .center
@@ -104,7 +119,7 @@ extension LinkPaymentMethodPicker {
             let stackView = UIStackView(arrangedSubviews: [
                 paymentInfoStackView,
                 headingLabel,
-                chevron
+                chevron,
             ])
 
             stackView.axis = .horizontal
@@ -117,7 +132,9 @@ extension LinkPaymentMethodPicker {
             return stackView
         }()
 
-        override init(frame: CGRect) {
+        override init(
+            frame: CGRect
+        ) {
             super.init(frame: .zero)
 
             addSubview(stackView)
@@ -137,7 +154,9 @@ extension LinkPaymentMethodPicker {
             updateAccessibilityContent()
         }
 
-        required init?(coder: NSCoder) {
+        required init?(
+            coder: NSCoder
+        ) {
             fatalError("init(coder:) has not been implemented")
         }
 

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Components/PaymentMethodPicker/LinkPaymentMethodPicker-RadioButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Components/PaymentMethodPicker/LinkPaymentMethodPicker-RadioButton.swift
@@ -49,7 +49,12 @@ extension LinkPaymentMethodPicker {
             let innerCircle = CALayer()
             innerCircle.backgroundColor = UIColor.white.cgColor
             innerCircle.cornerRadius = Constants.innerDiameter / 2
-            innerCircle.bounds = CGRect(x: 0, y: 0, width: Constants.innerDiameter, height: Constants.innerDiameter)
+            innerCircle.bounds = CGRect(
+                x: 0,
+                y: 0,
+                width: Constants.innerDiameter,
+                height: Constants.innerDiameter
+            )
             innerCircle.anchorPoint = CGPoint(x: 0.5, y: 0.5)
 
             // Add and center inner circle
@@ -71,7 +76,9 @@ extension LinkPaymentMethodPicker {
             applyStyling()
         }
 
-        required init?(coder: NSCoder) {
+        required init?(
+            coder: NSCoder
+        ) {
             super.init(coder: coder)
             applyStyling()
         }

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Components/PaymentMethodPicker/LinkPaymentMethodPicker.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Components/PaymentMethodPicker/LinkPaymentMethodPicker.swift
@@ -6,9 +6,8 @@
 //  Copyright © 2021 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
-
 @_spi(STP) import StripeUICore
+import UIKit
 
 protocol LinkPaymentMethodPickerDelegate: AnyObject {
     func paymentMethodPickerDidChange(_ picker: LinkPaymentMethodPicker)
@@ -66,7 +65,7 @@ final class LinkPaymentMethodPicker: UIView {
     private lazy var stackView: UIStackView = {
         let stackView = UIStackView(arrangedSubviews: [
             headerView,
-            listView
+            listView,
         ])
 
         stackView.axis = .vertical
@@ -94,13 +93,17 @@ final class LinkPaymentMethodPicker: UIView {
 
     private let addPaymentMethodButton = AddButton()
 
-    override init(frame: CGRect) {
+    override init(
+        frame: CGRect
+    ) {
         super.init(frame: .zero)
         addAndPinSubview(stackView)
         setup()
     }
 
-    required init?(coder: NSCoder) {
+    required init?(
+        coder: NSCoder
+    ) {
         fatalError("init(coder:) has not been implemented")
     }
 
@@ -120,7 +123,11 @@ final class LinkPaymentMethodPicker: UIView {
         listView.isHidden = true
         listView.layer.zPosition = 0
 
-        addPaymentMethodButton.addTarget(self, action: #selector(onAddPaymentButtonTapped(_:)), for: .touchUpInside)
+        addPaymentMethodButton.addTarget(
+            self,
+            action: #selector(onAddPaymentButtonTapped(_:)),
+            for: .touchUpInside
+        )
     }
 
     override func layoutSubviews() {
@@ -158,14 +165,14 @@ final class LinkPaymentMethodPicker: UIView {
 
 }
 
-private extension LinkPaymentMethodPicker {
+extension LinkPaymentMethodPicker {
 
-    @objc func onHeaderTapped(_ sender: Header) {
+    @objc fileprivate func onHeaderTapped(_ sender: Header) {
         setExpanded(!sender.isExpanded, animated: true)
         impactFeedbackGenerator.impactOccurred()
     }
 
-    @objc func onAddPaymentButtonTapped(_ sender: AddButton) {
+    @objc fileprivate func onAddPaymentButtonTapped(_ sender: AddButton) {
         delegate?.paymentDetailsPickerDidTapOnAddPayment(self)
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Components/Toast/LinkToast.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Components/Toast/LinkToast.swift
@@ -6,10 +6,9 @@
 //  Copyright © 2021 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
-
 @_spi(STP) import StripeCore
 @_spi(STP) import StripeUICore
+import UIKit
 
 /// A view for displaying a brief message to the user.
 /// For internal SDK use only
@@ -47,14 +46,19 @@ final class LinkToast: UIView {
     /// - Parameters:
     ///   - type: Toast type.
     ///   - text: Text to show.
-    init(type: ToastType, text: String) {
+    init(
+        type: ToastType,
+        text: String
+    ) {
         self.toastType = type
         self.text = text
         super.init(frame: .zero)
         setup()
     }
 
-    required init?(coder: NSCoder) {
+    required init?(
+        coder: NSCoder
+    ) {
         fatalError("init(coder:) has not been implemented")
     }
 
@@ -79,7 +83,7 @@ final class LinkToast: UIView {
             stackView.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor),
             stackView.bottomAnchor.constraint(equalTo: layoutMarginsGuide.bottomAnchor),
             stackView.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
-            stackView.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor)
+            stackView.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),
         ])
     }
 
@@ -110,8 +114,12 @@ extension LinkToast {
 
             // Pin edges
             topAnchor.constraint(equalTo: presentingView.safeAreaLayoutGuide.topAnchor),
-            leadingAnchor.constraint(greaterThanOrEqualTo: presentingView.layoutMarginsGuide.leadingAnchor),
-            trailingAnchor.constraint(lessThanOrEqualTo: presentingView.layoutMarginsGuide.trailingAnchor)
+            leadingAnchor.constraint(
+                greaterThanOrEqualTo: presentingView.layoutMarginsGuide.leadingAnchor
+            ),
+            trailingAnchor.constraint(
+                lessThanOrEqualTo: presentingView.layoutMarginsGuide.trailingAnchor
+            ),
         ])
 
         alpha = 0
@@ -148,7 +156,10 @@ extension LinkToast {
             options: .curveEaseOut
         ) {
             self.alpha = 0
-            self.transform = CGAffineTransform(translationX: 0, y: -Constants.animationTravelDistance)
+            self.transform = CGAffineTransform(
+                translationX: 0,
+                y: -Constants.animationTravelDistance
+            )
         } completion: { _ in
             self.removeFromSuperview()
         }

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Controllers/PayWithLinkViewController-BaseViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Controllers/PayWithLinkViewController-BaseViewController.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2021 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
 @_spi(STP) import StripeCore
 @_spi(STP) import StripeUICore
+import UIKit
 
 extension PayWithLinkViewController {
 
@@ -47,12 +47,16 @@ extension PayWithLinkViewController {
 
         private(set) lazy var contentView = UIView()
 
-        init(context: Context) {
+        init(
+            context: Context
+        ) {
             self.context = context
             super.init(nibName: nil, bundle: nil)
         }
 
-        required init?(coder: NSCoder) {
+        required init?(
+            coder: NSCoder
+        ) {
             fatalError("init(coder:) has not been implemented")
         }
 
@@ -75,7 +79,7 @@ extension PayWithLinkViewController {
                 contentView.topAnchor.constraint(equalTo: customNavigationBar.bottomAnchor),
                 contentView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
                 contentView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-                contentView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+                contentView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             ])
         }
 
@@ -105,14 +109,20 @@ extension PayWithLinkViewController {
 
         @objc
         func onMenuButtonTapped(_ sender: UIButton) {
-            let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-            actionSheet.addAction(UIAlertAction(
-                title: STPLocalizedString("Log out of Link", "Title of the logout action."),
-                style: .destructive,
-                handler: { [weak self] _ in
-                    self?.coordinator?.logout(cancel: true)
-                }
-            ))
+            let actionSheet = UIAlertController(
+                title: nil,
+                message: nil,
+                preferredStyle: .actionSheet
+            )
+            actionSheet.addAction(
+                UIAlertAction(
+                    title: STPLocalizedString("Log out of Link", "Title of the logout action."),
+                    style: .destructive,
+                    handler: { [weak self] _ in
+                        self?.coordinator?.logout(cancel: true)
+                    }
+                )
+            )
             actionSheet.addAction(UIAlertAction(title: String.Localized.cancel, style: .cancel))
 
             // iPad support

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Controllers/PayWithLinkViewController-LoaderViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Controllers/PayWithLinkViewController-LoaderViewController.swift
@@ -6,9 +6,8 @@
 //  Copyright © 2021 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
-
 @_spi(STP) import StripeUICore
+import UIKit
 
 extension PayWithLinkViewController {
 

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Controllers/PayWithLinkViewController-NewPaymentViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Controllers/PayWithLinkViewController-NewPaymentViewController.swift
@@ -6,18 +6,18 @@
 //  Copyright © 2021 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
 import PassKit
 @_spi(STP) import StripeCore
-@_spi(STP) import StripeUICore
 @_spi(STP) import StripePayments
+@_spi(STP) import StripeUICore
+import UIKit
 
 extension PayWithLinkViewController {
 
     /// For internal SDK use only
     @objc(STP_Internal_NewPaymentViewController)
     final class NewPaymentViewController: BaseViewController {
-        struct  Constants {
+        struct Constants {
             static let applePayButtonHeight: CGFloat = 48
         }
 
@@ -47,11 +47,13 @@ extension PayWithLinkViewController {
         }
 
         private lazy var cancelButton: Button = {
-            let buttonTitle = isAddingFirstPaymentMethod
+            let buttonTitle =
+                isAddingFirstPaymentMethod
                 ? String.Localized.pay_another_way
                 : String.Localized.cancel
 
-            let configuration: Button.Configuration = shouldShowApplePayButton
+            let configuration: Button.Configuration =
+                shouldShowApplePayButton
                 ? .linkPlain()
                 : .linkSecondary()
 
@@ -63,12 +65,17 @@ extension PayWithLinkViewController {
         private lazy var separator = SeparatorLabel(text: String.Localized.or)
 
         private lazy var applePayButton: PKPaymentButton = {
-            let button = PKPaymentButton(paymentButtonType: .plain, paymentButtonStyle: .compatibleAutomatic)
+            let button = PKPaymentButton(
+                paymentButtonType: .plain,
+                paymentButtonStyle: .compatibleAutomatic
+            )
             button.addTarget(self, action: #selector(applePayButtonTapped(_:)), for: .touchUpInside)
             button.cornerRadius = LinkUI.cornerRadius
 
             NSLayoutConstraint.activate([
-                button.heightAnchor.constraint(greaterThanOrEqualToConstant: Constants.applePayButtonHeight)
+                button.heightAnchor.constraint(
+                    greaterThanOrEqualToConstant: Constants.applePayButtonHeight
+                )
             ])
 
             return button
@@ -92,7 +99,7 @@ extension PayWithLinkViewController {
             var configuration = context.configuration
             configuration.linkPaymentMethodsOnly = true
             configuration.appearance = LinkUI.appearance
-            
+
             return AddPaymentMethodViewController(
                 intent: context.intent,
                 configuration: configuration,
@@ -105,11 +112,9 @@ extension PayWithLinkViewController {
         private let feedbackGenerator = UINotificationFeedbackGenerator()
 
         private var shouldShowApplePayButton: Bool {
-            return (
-                isAddingFirstPaymentMethod &&
-                context.shouldOfferApplePay &&
-                context.configuration.isApplePayEnabled
-            )
+            return
+                (isAddingFirstPaymentMethod && context.shouldOfferApplePay
+                && context.configuration.isApplePayEnabled)
         }
 
         init(
@@ -122,7 +127,9 @@ extension PayWithLinkViewController {
             super.init(context: context)
         }
 
-        required init?(coder: NSCoder) {
+        required init?(
+            coder: NSCoder
+        ) {
             fatalError("init(coder:) has not been implemented")
         }
 
@@ -139,14 +146,17 @@ extension PayWithLinkViewController {
                 titleLabel,
                 addPaymentMethodVC.view,
                 errorLabel,
-                buttonContainer
+                buttonContainer,
             ])
 
             stackView.axis = .vertical
             stackView.spacing = LinkUI.contentSpacing
             stackView.alignment = .center
             stackView.setCustomSpacing(LinkUI.extraLargeContentSpacing, after: titleLabel)
-            stackView.setCustomSpacing(LinkUI.extraLargeContentSpacing, after: addPaymentMethodVC.view)
+            stackView.setCustomSpacing(
+                LinkUI.extraLargeContentSpacing,
+                after: addPaymentMethodVC.view
+            )
             stackView.translatesAutoresizingMaskIntoConstraints = false
 
             let scrollView = LinkKeyboardAvoidingScrollView()
@@ -156,28 +166,40 @@ extension PayWithLinkViewController {
             contentView.addAndPinSubview(scrollView)
 
             NSLayoutConstraint.activate([
-                stackView.topAnchor.constraint(equalTo: scrollView.topAnchor, constant: preferredContentMargins.top),
-                stackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor, constant: -preferredContentMargins.bottom),
+                stackView.topAnchor.constraint(
+                    equalTo: scrollView.topAnchor,
+                    constant: preferredContentMargins.top
+                ),
+                stackView.bottomAnchor.constraint(
+                    equalTo: scrollView.bottomAnchor,
+                    constant: -preferredContentMargins.bottom
+                ),
                 stackView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
                 stackView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
                 stackView.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
 
                 titleLabel.leadingAnchor.constraint(
                     equalTo: stackView.safeAreaLayoutGuide.leadingAnchor,
-                    constant: preferredContentMargins.leading),
+                    constant: preferredContentMargins.leading
+                ),
                 titleLabel.trailingAnchor.constraint(
                     equalTo: stackView.safeAreaLayoutGuide.trailingAnchor,
-                    constant: -preferredContentMargins.trailing),
+                    constant: -preferredContentMargins.trailing
+                ),
 
                 addPaymentMethodVC.view.leadingAnchor.constraint(equalTo: stackView.leadingAnchor),
-                addPaymentMethodVC.view.trailingAnchor.constraint(equalTo: stackView.trailingAnchor),
+                addPaymentMethodVC.view.trailingAnchor.constraint(
+                    equalTo: stackView.trailingAnchor
+                ),
 
                 buttonContainer.leadingAnchor.constraint(
                     equalTo: stackView.safeAreaLayoutGuide.leadingAnchor,
-                    constant: LinkUI.contentMargins.leading),
+                    constant: LinkUI.contentMargins.leading
+                ),
                 buttonContainer.trailingAnchor.constraint(
                     equalTo: stackView.safeAreaLayoutGuide.trailingAnchor,
-                    constant: -LinkUI.contentMargins.trailing)
+                    constant: -LinkUI.contentMargins.trailing
+                ),
             ])
 
             didUpdate(addPaymentMethodVC)
@@ -193,9 +215,10 @@ extension PayWithLinkViewController {
                 didSelectAddBankAccount(addPaymentMethodVC)
                 return
             }
-            
+
             guard let newPaymentOption = addPaymentMethodVC.paymentOption,
-                  case .new(let confirmParams) = newPaymentOption else {
+                case .new(let confirmParams) = newPaymentOption
+            else {
                 assertionFailure()
                 return
             }
@@ -203,7 +226,8 @@ extension PayWithLinkViewController {
             feedbackGenerator.prepare()
             confirmButton.update(state: .processing)
 
-            linkAccount.createPaymentDetails(with: confirmParams.paymentMethodParams) { [weak self] result in
+            linkAccount.createPaymentDetails(with: confirmParams.paymentMethodParams) {
+                [weak self] result in
                 guard let self = self else {
                     return
                 }
@@ -213,29 +237,31 @@ extension PayWithLinkViewController {
                     if case .card(let card) = paymentDetails.details {
                         card.cvc = confirmParams.paymentMethodParams.card?.cvc
                     }
-                    
-                    self.coordinator?.confirm(with: self.linkAccount,
-                                              paymentDetails: paymentDetails,
-                                              completion: { [weak self] result in
-                        let state: ConfirmButton.Status
-                        
-                        switch result {
-                        case .completed:
-                            state = .succeeded
-                        case .canceled:
-                            state = .enabled
-                        case .failed(let error):
-                            state = .enabled
-                            self?.updateErrorLabel(for: error)
-                        }
 
-                        self?.feedbackGenerator.notificationOccurred(.success)
-                        self?.confirmButton.update(state: state, animated: true) {
-                            if state == .succeeded {
-                                self?.coordinator?.finish(withResult: result)
+                    self.coordinator?.confirm(
+                        with: self.linkAccount,
+                        paymentDetails: paymentDetails,
+                        completion: { [weak self] result in
+                            let state: ConfirmButton.Status
+
+                            switch result {
+                            case .completed:
+                                state = .succeeded
+                            case .canceled:
+                                state = .enabled
+                            case .failed(let error):
+                                state = .enabled
+                                self?.updateErrorLabel(for: error)
+                            }
+
+                            self?.feedbackGenerator.notificationOccurred(.success)
+                            self?.confirmButton.update(state: state, animated: true) {
+                                if state == .succeeded {
+                                    self?.coordinator?.finish(withResult: result)
+                                }
                             }
                         }
-                    })
+                    )
                 case .failure(let error):
                     self.feedbackGenerator.notificationOccurred(.error)
                     self.confirmButton.update(state: .enabled, animated: true)
@@ -252,7 +278,7 @@ extension PayWithLinkViewController {
                 window: view.window
             )
 
-            linkAccount.createLinkAccountSession() { [weak self] result in
+            linkAccount.createLinkAccountSession { [weak self] result in
                 guard let self = self else { return }
 
                 switch result {
@@ -272,13 +298,13 @@ extension PayWithLinkViewController {
                                     // Store last added payment details so we can automatically select it on wallet
                                     self.context.lastAddedPaymentDetails = paymentDetails
                                     self.coordinator?.accountUpdated(self.linkAccount)
-                                    // Do not update confirmButton -- leave in processing while coordinator updates
+                                // Do not update confirmButton -- leave in processing while coordinator updates
                                 case .failure(let error):
                                     self.updateErrorLabel(for: error)
                                     self.confirmButton.update(state: .enabled)
                                 }
                             }
-                        case.canceled:
+                        case .canceled:
                             self.confirmButton.update(state: .enabled)
                         case .failure(let error):
                             self.updateErrorLabel(for: error)
@@ -290,7 +316,7 @@ extension PayWithLinkViewController {
                 }
             }
         }
-        
+
         func updateErrorLabel(for error: Error?) {
             errorLabel.text = error?.nonGenericDescription
             UIView.animate(withDuration: PaymentSheetUI.defaultAnimationDuration) {
@@ -316,11 +342,16 @@ extension PayWithLinkViewController {
 
 }
 
-extension PayWithLinkViewController.NewPaymentViewController: AddPaymentMethodViewControllerDelegate {
+extension PayWithLinkViewController.NewPaymentViewController: AddPaymentMethodViewControllerDelegate
+{
 
     func didUpdate(_ viewController: AddPaymentMethodViewController) {
         if viewController.selectedPaymentMethodType == .linkInstantDebit {
-            confirmButton.update(state: .enabled, style: .stripe, callToAction: .add(paymentMethodType: .linkInstantDebit))
+            confirmButton.update(
+                state: .enabled,
+                style: .stripe,
+                callToAction: .add(paymentMethodType: .linkInstantDebit)
+            )
         } else {
             confirmButton.update(
                 state: viewController.paymentOption != nil ? .enabled : .disabled,

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Controllers/PayWithLinkViewController-SignUpViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Controllers/PayWithLinkViewController-SignUpViewController.swift
@@ -6,11 +6,10 @@
 //  Copyright © 2021 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
 import SafariServices
-
 @_spi(STP) import StripeCore
 @_spi(STP) import StripeUICore
+import UIKit
 
 extension PayWithLinkViewController {
 
@@ -47,7 +46,10 @@ extension PayWithLinkViewController {
             return label
         }()
 
-        private lazy var emailElement = LinkEmailElement(defaultValue: viewModel.emailAddress, theme: LinkUI.appearance.asElementsTheme)
+        private lazy var emailElement = LinkEmailElement(
+            defaultValue: viewModel.emailAddress,
+            theme: LinkUI.appearance.asElementsTheme
+        )
 
         private lazy var phoneNumberElement = PhoneNumberElement(
             defaultCountryCode: context.configuration.defaultBillingDetails.address.country,
@@ -63,11 +65,20 @@ extension PayWithLinkViewController {
             theme: LinkUI.appearance.asElementsTheme
         )
 
-        private lazy var emailSection = SectionElement(elements: [emailElement], theme: LinkUI.appearance.asElementsTheme)
+        private lazy var emailSection = SectionElement(
+            elements: [emailElement],
+            theme: LinkUI.appearance.asElementsTheme
+        )
 
-        private lazy var phoneNumberSection = SectionElement(elements: [phoneNumberElement], theme: LinkUI.appearance.asElementsTheme)
+        private lazy var phoneNumberSection = SectionElement(
+            elements: [phoneNumberElement],
+            theme: LinkUI.appearance.asElementsTheme
+        )
 
-        private lazy var nameSection = SectionElement(elements: [nameElement], theme: LinkUI.appearance.asElementsTheme)
+        private lazy var nameSection = SectionElement(
+            elements: [nameElement],
+            theme: LinkUI.appearance.asElementsTheme
+        )
 
         private lazy var legalTermsView: LinkLegalTermsView = {
             let legalTermsView = LinkLegalTermsView(textAlignment: .center)
@@ -105,7 +116,7 @@ extension PayWithLinkViewController {
                 nameSection.view,
                 legalTermsView,
                 errorLabel,
-                signUpButton
+                signUpButton,
             ])
 
             stackView.axis = .vertical
@@ -132,7 +143,9 @@ extension PayWithLinkViewController {
             super.init(context: context)
         }
 
-        required init?(coder: NSCoder) {
+        required init?(
+            coder: NSCoder
+        ) {
             fatalError("init(coder:) has not been implemented")
         }
 
@@ -299,7 +312,8 @@ extension PayWithLinkViewController.SignUpViewController: UITextViewDelegate {
 
 extension PayWithLinkViewController.SignUpViewController: LinkLegalTermsViewDelegate {
 
-    func legalTermsView(_ legalTermsView: LinkLegalTermsView, didTapOnLinkWithURL url: URL) -> Bool {
+    func legalTermsView(_ legalTermsView: LinkLegalTermsView, didTapOnLinkWithURL url: URL) -> Bool
+    {
         let safariVC = SFSafariViewController(url: url)
         safariVC.dismissButtonStyle = .close
         safariVC.modalPresentationStyle = .overFullScreen

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Controllers/PayWithLinkViewController-SignUpViewModel.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Controllers/PayWithLinkViewController-SignUpViewModel.swift
@@ -7,10 +7,9 @@
 //
 
 import Foundation
-
 @_spi(STP) import StripeCore
-@_spi(STP) import StripeUICore
 @_spi(STP) import StripePayments
+@_spi(STP) import StripeUICore
 
 protocol PayWithLinkSignUpViewModelDelegate: AnyObject {
     func viewModelDidChange(_ viewModel: PayWithLinkViewController.SignUpViewModel)
@@ -111,7 +110,7 @@ extension PayWithLinkViewController {
 
         var shouldEnableSignUpButton: Bool {
             guard let linkAccount = linkAccount,
-                  let phoneNumber = phoneNumber
+                let phoneNumber = phoneNumber
             else {
                 return false
             }
@@ -131,7 +130,9 @@ extension PayWithLinkViewController {
 
         private let accountService: LinkAccountServiceProtocol
 
-        private let accountLookupDebouncer = OperationDebouncer(debounceTime: LinkUI.accountLookupDebounceTime)
+        private let accountLookupDebouncer = OperationDebouncer(
+            debounceTime: LinkUI.accountLookupDebounceTime
+        )
 
         private let configuration: PaymentSheet.Configuration
 
@@ -157,7 +158,8 @@ extension PayWithLinkViewController {
 
         func signUp(completion: @escaping (Result<PaymentSheetLinkAccount, Error>) -> Void) {
             guard let linkAccount = linkAccount,
-                  let phoneNumber = phoneNumber else {
+                let phoneNumber = phoneNumber
+            else {
                 assertionFailure("`signUp()` called without a link account or phone number")
                 return
             }
@@ -181,9 +183,9 @@ extension PayWithLinkViewController {
 
 }
 
-private extension PayWithLinkViewController.SignUpViewModel {
+extension PayWithLinkViewController.SignUpViewModel {
 
-    func onEmailUpdate() {
+    fileprivate func onEmailUpdate() {
         linkAccount = nil
         errorMessage = nil
 
@@ -220,7 +222,7 @@ private extension PayWithLinkViewController.SignUpViewModel {
         }
     }
 
-    func notifyUpdate() {
+    fileprivate func notifyUpdate() {
         delegate?.viewModelDidChange(self)
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Controllers/PayWithLinkViewController-UpdatePaymentViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Controllers/PayWithLinkViewController-UpdatePaymentViewController.swift
@@ -6,11 +6,10 @@
 //  Copyright © 2022 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
-
 @_spi(STP) import StripeCore
-@_spi(STP) import StripeUICore
 @_spi(STP) import StripePaymentsUI
+@_spi(STP) import StripeUICore
+import UIKit
 
 protocol UpdatePaymentViewControllerDelegate: AnyObject {
     func didUpdate(paymentMethod: ConsumerPaymentDetails)
@@ -57,21 +56,25 @@ extension PayWithLinkViewController {
         ) { [weak self] in
             self?.updateCard()
         }
-        
+
         private lazy var cancelButton: Button = {
             let button = Button(configuration: .linkSecondary(), title: String.Localized.cancel)
             button.addTarget(self, action: #selector(didSelectCancel), for: .touchUpInside)
             button.adjustsFontForContentSizeCategory = true
             return button
         }()
-        
+
         private lazy var errorLabel: UILabel = {
             return ElementsUI.makeErrorLabel(theme: LinkUI.appearance.asElementsTheme)
         }()
 
         private lazy var cardEditElement = LinkCardEditElement(paymentMethod: paymentMethod)
 
-        init(linkAccount: PaymentSheetLinkAccount, context: Context, paymentMethod: ConsumerPaymentDetails) {
+        init(
+            linkAccount: PaymentSheetLinkAccount,
+            context: Context,
+            paymentMethod: ConsumerPaymentDetails
+        ) {
             self.linkAccount = linkAccount
             self.intent = context.intent
             self.configuration = context.configuration
@@ -80,7 +83,9 @@ extension PayWithLinkViewController {
             super.init(context: context)
         }
 
-        required init?(coder: NSCoder) {
+        required init?(
+            coder: NSCoder
+        ) {
             fatalError("init(coder:) has not been implemented")
         }
 
@@ -90,14 +95,14 @@ extension PayWithLinkViewController {
             view.backgroundColor = .linkBackground
             view.directionalLayoutMargins = LinkUI.contentMargins
             errorLabel.isHidden = true
-            
+
             let stackView = UIStackView(arrangedSubviews: [
                 titleLabel,
                 cardEditElement.view,
                 errorLabel,
                 thisIsYourDefaultLabel,
                 updateButton,
-                cancelButton
+                cancelButton,
             ])
 
             stackView.axis = .vertical
@@ -115,7 +120,10 @@ extension PayWithLinkViewController {
                 thisIsYourDefaultLabel.isHidden = true
                 stackView.setCustomSpacing(LinkUI.largeContentSpacing, after: cardEditElement.view)
             } else {
-                stackView.setCustomSpacing(LinkUI.extraLargeContentSpacing, after: thisIsYourDefaultLabel)
+                stackView.setCustomSpacing(
+                    LinkUI.extraLargeContentSpacing,
+                    after: thisIsYourDefaultLabel
+                )
             }
 
             updateButton.update(state: .disabled)
@@ -125,7 +133,9 @@ extension PayWithLinkViewController {
             updateErrorLabel(for: nil)
 
             guard let params = cardEditElement.params else {
-                assertionFailure("Params are expected to be not `nil` when `updateCard()` is called.")
+                assertionFailure(
+                    "Params are expected to be not `nil` when `updateCard()` is called."
+                )
                 return
             }
 
@@ -140,7 +150,8 @@ extension PayWithLinkViewController {
                 details: .card(expiryDate: params.expiryDate, billingDetails: params.billingDetails)
             )
 
-            linkAccount.updatePaymentDetails(id: paymentMethod.stripeID, updateParams: updateParams) { [weak self] result in
+            linkAccount.updatePaymentDetails(id: paymentMethod.stripeID, updateParams: updateParams)
+            { [weak self] result in
                 switch result {
                 case .success(let updatedPaymentDetails):
                     // Updates to CVC only get applied when the intent is confirmed so we manually add them here
@@ -148,8 +159,13 @@ extension PayWithLinkViewController {
                     if case .card(let card) = updatedPaymentDetails.details {
                         card.cvc = params.cvc
                     }
-                    
-                    self?.updateButton.update(state: .succeeded, style: nil, callToAction: nil, animated: true) {
+
+                    self?.updateButton.update(
+                        state: .succeeded,
+                        style: nil,
+                        callToAction: nil,
+                        animated: true
+                    ) {
                         self?.delegate?.didUpdate(paymentMethod: updatedPaymentDetails)
                         self?.navigationController?.popViewController(animated: true)
                     }
@@ -161,11 +177,11 @@ extension PayWithLinkViewController {
                 }
             }
         }
-        
+
         @objc func didSelectCancel() {
             self.navigationController?.popViewController(animated: true)
         }
-        
+
         func updateErrorLabel(for error: Error?) {
             errorLabel.text = error?.nonGenericDescription
             errorLabel.setHiddenIfNecessary(error == nil)
@@ -176,16 +192,16 @@ extension PayWithLinkViewController {
 }
 
 extension PayWithLinkViewController.UpdatePaymentViewController: ElementDelegate {
-    
+
     func didUpdate(element: Element) {
         updateErrorLabel(for: nil)
         updateButton.update(state: cardEditElement.validationState.isValid ? .enabled : .disabled)
     }
-    
+
     func continueToNextField(element: Element) {
         updateButton.update(state: cardEditElement.validationState.isValid ? .enabled : .disabled)
     }
-    
+
 }
 
 // MARK: UpdatePaymentDetailsParams
@@ -199,9 +215,11 @@ struct UpdatePaymentDetailsParams {
     let isDefault: Bool?
     let details: DetailsType?
 
-    init(isDefault: Bool? = nil, details: DetailsType? = nil) {
+    init(
+        isDefault: Bool? = nil,
+        details: DetailsType? = nil
+    ) {
         self.isDefault = isDefault
         self.details = details
     }
 }
-

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Controllers/PayWithLinkViewController-VerifyAccountViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Controllers/PayWithLinkViewController-VerifyAccountViewController.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2022 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
 @_spi(STP) import StripeCore
 @_spi(STP) import StripeUICore
+import UIKit
 
 extension PayWithLinkViewController {
 
@@ -23,7 +23,10 @@ extension PayWithLinkViewController {
             return vc
         }()
 
-        init(linkAccount: PaymentSheetLinkAccount, context: Context) {
+        init(
+            linkAccount: PaymentSheetLinkAccount,
+            context: Context
+        ) {
             self.linkAccount = linkAccount
             super.init(context: context)
 
@@ -31,7 +34,9 @@ extension PayWithLinkViewController {
             contentView.addAndPinSubview(verificationVC.view, insets: .zero)
         }
 
-        required init?(coder: NSCoder) {
+        required init?(
+            coder: NSCoder
+        ) {
             fatalError("init(coder:) has not been implemented")
         }
 
@@ -43,7 +48,9 @@ extension PayWithLinkViewController {
 
 }
 
-extension PayWithLinkViewController.VerifyAccountViewController: LinkVerificationViewControllerDelegate {
+extension PayWithLinkViewController.VerifyAccountViewController:
+    LinkVerificationViewControllerDelegate
+{
 
     func verificationController(
         _ controller: LinkVerificationViewController,
@@ -61,13 +68,15 @@ extension PayWithLinkViewController.VerifyAccountViewController: LinkVerificatio
                 preferredStyle: .alert
             )
 
-            alertController.addAction(UIAlertAction(
-                title: String.Localized.ok,
-                style: .default,
-                handler: { [weak self] _ in
-                    self?.coordinator?.logout(cancel: false)
-                }
-            ))
+            alertController.addAction(
+                UIAlertAction(
+                    title: String.Localized.ok,
+                    style: .default,
+                    handler: { [weak self] _ in
+                        self?.coordinator?.logout(cancel: false)
+                    }
+                )
+            )
 
             navigationController?.present(alertController, animated: true)
         }

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Controllers/PayWithLinkViewController-WalletViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Controllers/PayWithLinkViewController-WalletViewController.swift
@@ -6,17 +6,16 @@
 //  Copyright © 2021 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
 import PassKit
 import SafariServices
-
 @_spi(STP) import StripeCore
 @_spi(STP) import StripeUICore
+import UIKit
 
 extension PayWithLinkViewController {
 
     final class WalletViewController: BaseViewController {
-        struct  Constants {
+        struct Constants {
             static let applePayButtonHeight: CGFloat = 48
         }
 
@@ -54,12 +53,17 @@ extension PayWithLinkViewController {
         private lazy var separator = SeparatorLabel(text: String.Localized.or)
 
         private lazy var applePayButton: PKPaymentButton = {
-            let button = PKPaymentButton(paymentButtonType: .plain, paymentButtonStyle: .compatibleAutomatic)
+            let button = PKPaymentButton(
+                paymentButtonType: .plain,
+                paymentButtonStyle: .compatibleAutomatic
+            )
             button.addTarget(self, action: #selector(applePayButtonTapped(_:)), for: .touchUpInside)
             button.cornerRadius = LinkUI.cornerRadius
 
             NSLayoutConstraint.activate([
-                button.heightAnchor.constraint(greaterThanOrEqualToConstant: Constants.applePayButtonHeight)
+                button.heightAnchor.constraint(
+                    greaterThanOrEqualToConstant: Constants.applePayButtonHeight
+                )
             ])
 
             return button
@@ -68,15 +72,21 @@ extension PayWithLinkViewController {
         private lazy var cvcElement: TextFieldElement = {
             let configuration = TextFieldElement.CVCConfiguration(cardBrandProvider: {
                 [weak self] in
-                    return self?.viewModel.cardBrand ?? .unknown
+                return self?.viewModel.cardBrand ?? .unknown
             })
 
-            return TextFieldElement(configuration: configuration, theme: LinkUI.appearance.asElementsTheme)
+            return TextFieldElement(
+                configuration: configuration,
+                theme: LinkUI.appearance.asElementsTheme
+            )
         }()
 
         private lazy var expiryDateElement: TextFieldElement = {
             let configuration = TextFieldElement.ExpiryDateConfiguration()
-            return TextFieldElement(configuration: configuration, theme: LinkUI.appearance.asElementsTheme)
+            return TextFieldElement(
+                configuration: configuration,
+                theme: LinkUI.appearance.asElementsTheme
+            )
         }()
 
         private lazy var expiredCardNoticeView: LinkNoticeView = {
@@ -88,8 +98,12 @@ extension PayWithLinkViewController {
         private lazy var cardDetailsRecollectionSection: SectionElement = {
             let sectionElement = SectionElement(
                 elements: [
-                    SectionElement.MultiElementRow([expiryDateElement, cvcElement], theme: LinkUI.appearance.asElementsTheme)
-                ], theme: LinkUI.appearance.asElementsTheme
+                    SectionElement.MultiElementRow(
+                        [expiryDateElement, cvcElement],
+                        theme: LinkUI.appearance.asElementsTheme
+                    )
+                ],
+                theme: LinkUI.appearance.asElementsTheme
             )
             sectionElement.delegate = self
             return sectionElement
@@ -99,7 +113,7 @@ extension PayWithLinkViewController {
             let stackView = UIStackView(arrangedSubviews: [
                 paymentPicker,
                 instantDebitMandateView,
-                expiredCardNoticeView
+                expiredCardNoticeView,
             ])
             stackView.axis = .vertical
             stackView.spacing = LinkUI.contentSpacing
@@ -118,12 +132,18 @@ extension PayWithLinkViewController {
                 paymentPickerContainerView,
                 cardDetailsRecollectionSection.view,
                 errorLabel,
-                confirmButton
+                confirmButton,
             ])
             stackView.axis = .vertical
             stackView.spacing = LinkUI.contentSpacing
-            stackView.setCustomSpacing(LinkUI.extraLargeContentSpacing, after: paymentPickerContainerView)
-            stackView.setCustomSpacing(LinkUI.extraLargeContentSpacing, after: cardDetailsRecollectionSection.view)
+            stackView.setCustomSpacing(
+                LinkUI.extraLargeContentSpacing,
+                after: paymentPickerContainerView
+            )
+            stackView.setCustomSpacing(
+                LinkUI.extraLargeContentSpacing,
+                after: cardDetailsRecollectionSection.view
+            )
             stackView.isLayoutMarginsRelativeArrangement = true
             stackView.directionalLayoutMargins = preferredContentMargins
             return stackView
@@ -137,11 +157,17 @@ extension PayWithLinkViewController {
             paymentMethods: [ConsumerPaymentDetails]
         ) {
             self.linkAccount = linkAccount
-            self.viewModel = WalletViewModel(linkAccount: linkAccount, context: context, paymentMethods: paymentMethods)
+            self.viewModel = WalletViewModel(
+                linkAccount: linkAccount,
+                context: context,
+                paymentMethods: paymentMethods
+            )
             super.init(context: context)
         }
 
-        required init?(coder: NSCoder) {
+        required init?(
+            coder: NSCoder
+        ) {
             fatalError("init(coder:) has not been implemented")
         }
 
@@ -197,7 +223,9 @@ extension PayWithLinkViewController {
             )
 
             UIView.performWithoutAnimation {
-                expiryDateElement.view.setHiddenIfNecessary(!viewModel.shouldRecollectCardExpiryDate)
+                expiryDateElement.view.setHiddenIfNecessary(
+                    !viewModel.shouldRecollectCardExpiryDate
+                )
                 cvcElement.view.setHiddenIfNecessary(!viewModel.shouldRecollectCardCVC)
                 cardDetailsRecollectionSection.view.layoutIfNeeded()
             }
@@ -210,7 +238,11 @@ extension PayWithLinkViewController {
 
         func updateErrorLabel(for error: Error?) {
             errorLabel.text = error?.nonGenericDescription
-            containerView.toggleArrangedSubview(errorLabel, shouldShow: error != nil, animated: true)
+            containerView.toggleArrangedSubview(
+                errorLabel,
+                shouldShow: error != nil,
+                animated: true
+            )
         }
 
         func confirm() {
@@ -219,9 +251,10 @@ extension PayWithLinkViewController {
                 return
             }
 
-            let confirmWithPaymentDetails: (ConsumerPaymentDetails) -> Void = { [self] paymentDetails in
+            let confirmWithPaymentDetails: (ConsumerPaymentDetails) -> Void = {
+                [self] paymentDetails in
                 if viewModel.shouldRecollectCardCVC {
-                    if case let .card(card) = paymentDetails.details {
+                    if case .card(let card) = paymentDetails.details {
                         card.cvc = viewModel.cvc
                     }
                 }
@@ -242,7 +275,9 @@ extension PayWithLinkViewController {
                             message: error.localizedDescription,
                             preferredStyle: .alert
                         )
-                        alertController.addAction(.init(title: String.Localized.ok, style: .default))
+                        alertController.addAction(
+                            .init(title: String.Localized.ok, style: .default)
+                        )
                         self?.present(alertController, animated: true)
                         self?.confirmButton.update(state: .enabled)
                     }
@@ -259,7 +294,8 @@ extension PayWithLinkViewController {
             updateErrorLabel(for: nil)
             confirmButton.update(state: .processing)
 
-            coordinator?.confirm(with: linkAccount, paymentDetails: paymentDetails) { [weak self] result in
+            coordinator?.confirm(with: linkAccount, paymentDetails: paymentDetails) {
+                [weak self] result in
                 switch result {
                 case .completed:
                     self?.feedbackGenerator.notificationOccurred(.success)
@@ -290,9 +326,9 @@ extension PayWithLinkViewController {
 
 }
 
-private extension PayWithLinkViewController.WalletViewController {
+extension PayWithLinkViewController.WalletViewController {
 
-    func removePaymentMethod(at index: Int) {
+    fileprivate func removePaymentMethod(at index: Int) {
         let paymentMethod = viewModel.paymentMethods[index]
 
         let alertTitle: String = {
@@ -316,34 +352,38 @@ private extension PayWithLinkViewController.WalletViewController {
             preferredStyle: .alert
         )
 
-        alertController.addAction(UIAlertAction(
-            title: String.Localized.cancel,
-            style: .cancel
-        ))
+        alertController.addAction(
+            UIAlertAction(
+                title: String.Localized.cancel,
+                style: .cancel
+            )
+        )
 
-        alertController.addAction(UIAlertAction(
-            title: String.Localized.remove,
-            style: .destructive,
-            handler: { _ in
-                self.paymentPicker.showLoader(at: index)
+        alertController.addAction(
+            UIAlertAction(
+                title: String.Localized.remove,
+                style: .destructive,
+                handler: { _ in
+                    self.paymentPicker.showLoader(at: index)
 
-                self.viewModel.deletePaymentMethod(at: index) { result in
-                    switch result {
-                    case .success:
-                        self.paymentPicker.removePaymentMethod(at: index, animated: true)
-                    case .failure(_):
-                        break
+                    self.viewModel.deletePaymentMethod(at: index) { result in
+                        switch result {
+                        case .success:
+                            self.paymentPicker.removePaymentMethod(at: index, animated: true)
+                        case .failure(_):
+                            break
+                        }
+
+                        self.paymentPicker.hideLoader(at: index)
                     }
-
-                    self.paymentPicker.hideLoader(at: index)
                 }
-            }
-        ))
+            )
+        )
 
         present(alertController, animated: true)
     }
-    
-    func updatePaymentMethod(at index: Int) {
+
+    fileprivate func updatePaymentMethod(at index: Int) {
         let paymentMethod = viewModel.paymentMethods[index]
         let updatePaymentMethodVC = PayWithLinkViewController.UpdatePaymentViewController(
             linkAccount: linkAccount,
@@ -351,7 +391,7 @@ private extension PayWithLinkViewController.WalletViewController {
             paymentMethod: paymentMethod
         )
         updatePaymentMethodVC.delegate = self
-        
+
         navigationController?.pushViewController(updatePaymentMethodVC, animated: true)
     }
 
@@ -400,7 +440,10 @@ extension PayWithLinkViewController.WalletViewController: LinkPaymentMethodPicke
         return viewModel.paymentMethods.count
     }
 
-    func paymentPicker(_ picker: LinkPaymentMethodPicker, paymentMethodAt index: Int) -> ConsumerPaymentDetails {
+    func paymentPicker(
+        _ picker: LinkPaymentMethodPicker,
+        paymentMethodAt index: Int
+    ) -> ConsumerPaymentDetails {
         return viewModel.paymentMethods[index]
     }
 
@@ -424,35 +467,43 @@ extension PayWithLinkViewController.WalletViewController: LinkPaymentMethodPicke
     ) {
         let paymentMethod = viewModel.paymentMethods[index]
 
-        let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        let alertController = UIAlertController(
+            title: nil,
+            message: nil,
+            preferredStyle: .actionSheet
+        )
         alertController.popoverPresentationController?.sourceView = pickerView
         alertController.popoverPresentationController?.sourceRect = sourceRect
 
         if !paymentMethod.isDefault {
-            alertController.addAction(UIAlertAction(
-                title: STPLocalizedString(
-                    "Set as default",
-                    "Label for a button or menu item that sets a payment method as default when tapped."
-                ),
-                style: .default,
-                handler: { [self] _ in
-                    paymentPicker.showLoader(at: index)
-                    viewModel.setDefaultPaymentMethod(at: index) { [weak self] _ in
-                        self?.paymentPicker.hideLoader(at: index)
-                        self?.paymentPicker.reloadData()
+            alertController.addAction(
+                UIAlertAction(
+                    title: STPLocalizedString(
+                        "Set as default",
+                        "Label for a button or menu item that sets a payment method as default when tapped."
+                    ),
+                    style: .default,
+                    handler: { [self] _ in
+                        paymentPicker.showLoader(at: index)
+                        viewModel.setDefaultPaymentMethod(at: index) { [weak self] _ in
+                            self?.paymentPicker.hideLoader(at: index)
+                            self?.paymentPicker.reloadData()
+                        }
                     }
-                }
-            ))
+                )
+            )
         }
 
         if case ConsumerPaymentDetails.Details.card(_) = paymentMethod.details {
-            alertController.addAction(UIAlertAction(
-                title: String.Localized.update_card,
-                style: .default,
-                handler: { _ in
-                    self.updatePaymentMethod(at: index)
-                }
-            ))
+            alertController.addAction(
+                UIAlertAction(
+                    title: String.Localized.update_card,
+                    style: .default,
+                    handler: { _ in
+                        self.updatePaymentMethod(at: index)
+                    }
+                )
+            )
         }
 
         let removeTitle: String = {
@@ -469,18 +520,22 @@ extension PayWithLinkViewController.WalletViewController: LinkPaymentMethodPicke
                 )
             }
         }()
-        alertController.addAction(UIAlertAction(
-            title: removeTitle,
-            style: .destructive,
-            handler: { _ in
-                self.removePaymentMethod(at: index)
-            }
-        ))
+        alertController.addAction(
+            UIAlertAction(
+                title: removeTitle,
+                style: .destructive,
+                handler: { _ in
+                    self.removePaymentMethod(at: index)
+                }
+            )
+        )
 
-        alertController.addAction(UIAlertAction(
-            title: String.Localized.cancel,
-            style: .cancel
-        ))
+        alertController.addAction(
+            UIAlertAction(
+                title: String.Localized.cancel,
+                style: .cancel
+            )
+        )
 
         present(alertController, animated: true)
     }
@@ -501,7 +556,10 @@ extension PayWithLinkViewController.WalletViewController: LinkPaymentMethodPicke
 
 extension PayWithLinkViewController.WalletViewController: LinkInstantDebitMandateViewDelegate {
 
-    func instantDebitMandateView(_ mandateView: LinkInstantDebitMandateView, didTapOnLinkWithURL url: URL) {
+    func instantDebitMandateView(
+        _ mandateView: LinkInstantDebitMandateView,
+        didTapOnLinkWithURL url: URL
+    ) {
         let safariVC = SFSafariViewController(url: url)
         safariVC.dismissButtonStyle = .close
         safariVC.modalPresentationStyle = .overFullScreen
@@ -513,7 +571,7 @@ extension PayWithLinkViewController.WalletViewController: LinkInstantDebitMandat
 // MARK: - UpdatePaymentViewControllerDelegate
 
 extension PayWithLinkViewController.WalletViewController: UpdatePaymentViewControllerDelegate {
-    
+
     func didUpdate(paymentMethod: ConsumerPaymentDetails) {
         if let index = viewModel.updatePaymentMethod(paymentMethod) {
             self.paymentPicker.selectedIndex = index

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Controllers/PayWithLinkViewController-WalletViewModel.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Controllers/PayWithLinkViewController-WalletViewModel.swift
@@ -7,8 +7,8 @@
 //
 
 import Foundation
-@_spi(STP) import StripeUICore
 @_spi(STP) import StripePaymentsUI
+@_spi(STP) import StripeUICore
 
 protocol PayWithLinkWalletViewModelDelegate: AnyObject {
     func viewModelDidChange(_ viewModel: PayWithLinkViewController.WalletViewModel)
@@ -98,17 +98,11 @@ extension PayWithLinkViewController {
         }
 
         var shouldShowRecollectionSection: Bool {
-            return (
-                shouldRecollectCardCVC ||
-                shouldRecollectCardExpiryDate
-            )
+            return (shouldRecollectCardCVC || shouldRecollectCardExpiryDate)
         }
 
         var shouldShowApplePayButton: Bool {
-            return (
-                context.shouldOfferApplePay &&
-                context.configuration.isApplePayEnabled
-            )
+            return (context.shouldOfferApplePay && context.configuration.isApplePayEnabled)
         }
 
         var shouldUseCompactConfirmButton: Bool {
@@ -198,7 +192,8 @@ extension PayWithLinkViewController {
             )
         }
 
-        func deletePaymentMethod(at index: Int, completion: @escaping (Result<Void, Error>) -> Void) {
+        func deletePaymentMethod(at index: Int, completion: @escaping (Result<Void, Error>) -> Void)
+        {
             let paymentMethod = paymentMethods[index]
 
             linkAccount.deletePaymentDetails(id: paymentMethod.stripeID) { [self] result in
@@ -224,7 +219,7 @@ extension PayWithLinkViewController {
                 id: paymentMethod.stripeID,
                 updateParams: UpdatePaymentDetailsParams(isDefault: true, details: nil)
             ) { [self] result in
-                if case let .success(updatedPaymentDetails) = result {
+                if case .success(let updatedPaymentDetails) = result {
                     paymentMethods.forEach({ $0.isDefault = false })
                     paymentMethods[index] = updatedPaymentDetails
                 }
@@ -234,7 +229,11 @@ extension PayWithLinkViewController {
         }
 
         func updatePaymentMethod(_ paymentMethod: ConsumerPaymentDetails) -> Int? {
-            guard let index = paymentMethods.firstIndex(where: {$0.stripeID == paymentMethod.stripeID}) else {
+            guard
+                let index = paymentMethods.firstIndex(where: {
+                    $0.stripeID == paymentMethod.stripeID
+                })
+            else {
                 return nil
             }
 
@@ -249,7 +248,8 @@ extension PayWithLinkViewController {
             return index
         }
 
-        func updateExpiryDate(completion: @escaping (Result<ConsumerPaymentDetails, Error>) -> Void) {
+        func updateExpiryDate(completion: @escaping (Result<ConsumerPaymentDetails, Error>) -> Void)
+        {
             guard
                 let id = selectedPaymentMethod?.stripeID,
                 let expiryDate = self.expiryDate
@@ -268,9 +268,9 @@ extension PayWithLinkViewController {
 
 }
 
-private extension PayWithLinkViewController.WalletViewModel {
+extension PayWithLinkViewController.WalletViewModel {
 
-    static func determineInitiallySelectedPaymentMethod(
+    fileprivate static func determineInitiallySelectedPaymentMethod(
         context: PayWithLinkViewController.Context,
         paymentMethods: [ConsumerPaymentDetails]
     ) -> Int {
@@ -292,8 +292,8 @@ private extension PayWithLinkViewController.WalletViewModel {
 }
 
 /// Helper functions for ConsumerPaymentDetails
-private extension ConsumerPaymentDetails {
-    var paymentMethodType: PaymentSheet.PaymentMethodType {
+extension ConsumerPaymentDetails {
+    fileprivate var paymentMethodType: PaymentSheet.PaymentMethodType {
         switch details {
         case .card:
             return .card

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Controllers/PayWithLinkViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Controllers/PayWithLinkViewController.swift
@@ -6,11 +6,10 @@
 //  Copyright © 2021 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
-
 @_spi(STP) import StripeCore
-@_spi(STP) import StripeUICore
 @_spi(STP) import StripePayments
+@_spi(STP) import StripeUICore
+import UIKit
 
 protocol PayWithLinkViewControllerDelegate: AnyObject {
 
@@ -110,7 +109,9 @@ final class PayWithLinkViewController: UINavigationController {
         )
     }
 
-    private init(context: Context) {
+    private init(
+        context: Context
+    ) {
         self.context = context
         super.init(nibName: nil, bundle: nil)
 
@@ -118,7 +119,9 @@ final class PayWithLinkViewController: UINavigationController {
         setRootViewController(LoaderViewController(context: context), animated: false)
     }
 
-    required init?(coder: NSCoder) {
+    required init?(
+        coder: NSCoder
+    ) {
         fatalError("init(coder:) has not been implemented")
     }
 
@@ -141,7 +144,7 @@ final class PayWithLinkViewController: UINavigationController {
         // to restore the functionality.
         interactivePopGestureRecognizer?.delegate = self
     }
-    
+
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
     }
@@ -174,7 +177,9 @@ final class PayWithLinkViewController: UINavigationController {
                 )
             }
         case .requiresVerification:
-            setRootViewController(VerifyAccountViewController(linkAccount: linkAccount, context: context))
+            setRootViewController(
+                VerifyAccountViewController(linkAccount: linkAccount, context: context)
+            )
         case .verified:
             loadAndPresentWallet()
         }
@@ -192,9 +197,9 @@ extension PayWithLinkViewController: UIGestureRecognizerDelegate {
 
 // MARK: - Utils
 
-private extension PayWithLinkViewController {
+extension PayWithLinkViewController {
 
-    func loadAndPresentWallet() {
+    fileprivate func loadAndPresentWallet() {
         setRootViewController(LoaderViewController(context: context))
 
         guard let linkAccount = linkAccount else {
@@ -224,13 +229,14 @@ private extension PayWithLinkViewController {
                 }
             case .failure(let error):
                 self.payWithLinkDelegate?.payWithLinkViewControllerDidFinish(
-                    self, result: PaymentSheetResult.failed(error: error)
+                    self,
+                    result: PaymentSheetResult.failed(error: error)
                 )
             }
         }
     }
 
-    func updateSupportedPaymentMethods() {
+    fileprivate func updateSupportedPaymentMethods() {
         PaymentSheet.supportedLinkPaymentMethods =
             linkAccount?.supportedPaymentMethodTypes(for: context.intent) ?? []
     }
@@ -239,13 +245,16 @@ private extension PayWithLinkViewController {
 
 // MARK: - Navigation
 
-private extension PayWithLinkViewController {
+extension PayWithLinkViewController {
 
-    var rootViewController: UIViewController? {
+    fileprivate var rootViewController: UIViewController? {
         return viewControllers.first
     }
 
-    func setRootViewController(_ viewController: UIViewController, animated: Bool = true) {
+    fileprivate func setRootViewController(
+        _ viewController: UIViewController,
+        animated: Bool = true
+    ) {
         if let viewController = viewController as? BaseViewController {
             viewController.coordinator = self
             viewController.customNavigationBar.linkAccount = linkAccount

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Elements/InlineSignup/LinkInlineSignupElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Elements/InlineSignup/LinkInlineSignupElement.swift
@@ -6,15 +6,21 @@
 //  Copyright © 2022 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
 @_spi(STP) import StripeUICore
+import UIKit
 
 final class LinkInlineSignupElement: Element {
 
     private let signupView: LinkInlineSignupView
 
     lazy var view: UIView = {
-        return FormView(viewModel: .init(elements: [signupView], bordered: true, theme: viewModel.configuration.appearance.asElementsTheme))
+        return FormView(
+            viewModel: .init(
+                elements: [signupView],
+                bordered: true,
+                theme: viewModel.configuration.appearance.asElementsTheme
+            )
+        )
     }()
 
     var viewModel: LinkInlineSignupViewModel {
@@ -36,15 +42,19 @@ final class LinkInlineSignupElement: Element {
         linkAccount: PaymentSheetLinkAccount?,
         country: String?
     ) {
-        self.init(viewModel: LinkInlineSignupViewModel(
-            configuration: configuration,
-            accountService: LinkAccountService(apiClient: configuration.apiClient),
-            linkAccount: linkAccount,
-            country: country
-        ))
+        self.init(
+            viewModel: LinkInlineSignupViewModel(
+                configuration: configuration,
+                accountService: LinkAccountService(apiClient: configuration.apiClient),
+                linkAccount: linkAccount,
+                country: country
+            )
+        )
     }
 
-    init(viewModel: LinkInlineSignupViewModel) {
+    init(
+        viewModel: LinkInlineSignupViewModel
+    ) {
         self.signupView = LinkInlineSignupView(viewModel: viewModel)
         self.signupView.delegate = self
     }

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Elements/InlineSignup/LinkInlineSignupView-CheckboxElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Elements/InlineSignup/LinkInlineSignupView-CheckboxElement.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2022 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
 @_spi(STP) import StripeCore
 @_spi(STP) import StripeUICore
+import UIKit
 
 extension LinkInlineSignupView {
 
@@ -48,14 +48,21 @@ extension LinkInlineSignupView {
                 merchantDisplayName: merchantName
             )
 
-            let checkbox = CheckboxButton(text: text, description: description, theme: appearanceCopy.asElementsTheme)
+            let checkbox = CheckboxButton(
+                text: text,
+                description: description,
+                theme: appearanceCopy.asElementsTheme
+            )
             checkbox.addTarget(self, action: #selector(didToggleCheckbox), for: .touchUpInside)
             checkbox.isSelected = false
 
             return checkbox
         }()
 
-        init(merchantName: String, appearance: PaymentSheet.Appearance) {
+        init(
+            merchantName: String,
+            appearance: PaymentSheet.Appearance
+        ) {
             self.merchantName = merchantName
             self.appearance = appearance
         }

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Elements/InlineSignup/LinkInlineSignupView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Elements/InlineSignup/LinkInlineSignupView.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2022 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
 import SafariServices
 @_spi(STP) import StripeUICore
+import UIKit
 
 protocol LinkInlineSignupViewDelegate: AnyObject {
     func inlineSignupViewDidUpdate(_ view: LinkInlineSignupView)
@@ -25,26 +25,30 @@ final class LinkInlineSignupView: UIView {
     private var theme: ElementsUITheme {
         return viewModel.configuration.appearance.asElementsTheme
     }
-    
+
     private(set) lazy var checkboxElement = CheckboxElement(
         merchantName: viewModel.configuration.merchantDisplayName,
         appearance: viewModel.configuration.appearance
     )
 
-    private(set) lazy var emailElement : LinkEmailElement = {
+    private(set) lazy var emailElement: LinkEmailElement = {
         let element = LinkEmailElement(defaultValue: viewModel.emailAddress, theme: theme)
         element.indicatorTintColor = theme.colors.primary
         return element
     }()
 
     private(set) lazy var nameElement: TextFieldElement = {
-        let configuration = TextFieldElement.NameConfiguration(type: .full, defaultValue: viewModel.legalName)
+        let configuration = TextFieldElement.NameConfiguration(
+            type: .full,
+            defaultValue: viewModel.legalName
+        )
         return TextFieldElement(configuration: configuration, theme: theme)
     }()
 
     private(set) lazy var phoneNumberElement = PhoneNumberElement(
         defaultCountryCode: viewModel.configuration.defaultBillingDetails.address.country,
-        defaultPhoneNumber: viewModel.configuration.defaultBillingDetails.phone, theme: theme
+        defaultPhoneNumber: viewModel.configuration.defaultBillingDetails.phone,
+        theme: theme
     )
 
     // MARK: Sections
@@ -53,14 +57,17 @@ final class LinkInlineSignupView: UIView {
 
     private lazy var nameSection = SectionElement(elements: [nameElement], theme: theme)
 
-    private lazy var phoneNumberSection = SectionElement(elements: [phoneNumberElement], theme: theme)
+    private lazy var phoneNumberSection = SectionElement(
+        elements: [phoneNumberElement],
+        theme: theme
+    )
 
     private(set) lazy var legalTermsElement: StaticElement = {
         let legalView = LinkLegalTermsView(textAlignment: .left, delegate: self)
         legalView.font = theme.fonts.caption
         legalView.textColor = theme.colors.secondaryText
         legalView.tintColor = theme.colors.primary
-        
+
         return StaticElement(
             view: legalView
         )
@@ -71,16 +78,21 @@ final class LinkInlineSignupView: UIView {
         return StaticElement(view: infoView)
     }()
 
-    private lazy var formElement = FormElement(elements: [
-        checkboxElement,
-        emailSection,
-        phoneNumberSection,
-        nameSection,
-        legalTermsElement,
-        moreInfoElement,
-    ], theme: theme)
+    private lazy var formElement = FormElement(
+        elements: [
+            checkboxElement,
+            emailSection,
+            phoneNumberSection,
+            nameSection,
+            legalTermsElement,
+            moreInfoElement,
+        ],
+        theme: theme
+    )
 
-    init(viewModel: LinkInlineSignupViewModel) {
+    init(
+        viewModel: LinkInlineSignupViewModel
+    ) {
         self.viewModel = viewModel
         super.init(frame: .zero)
         setupUI()
@@ -89,7 +101,9 @@ final class LinkInlineSignupView: UIView {
         updateUI()
     }
 
-    required init?(coder: NSCoder) {
+    required init?(
+        coder: NSCoder
+    ) {
         fatalError("init(coder:) has not been implemented")
     }
 
@@ -104,9 +118,9 @@ final class LinkInlineSignupView: UIView {
             formElement.view.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor),
             formElement.view.bottomAnchor.constraint(equalTo: layoutMarginsGuide.bottomAnchor),
             formElement.view.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
-            formElement.view.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor)
+            formElement.view.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),
         ])
-        
+
         updateAppearance()
     }
 
@@ -127,28 +141,50 @@ final class LinkInlineSignupView: UIView {
             emailElement.stopAnimating()
         }
 
-        formElement.toggleChild(emailSection, show: viewModel.shouldShowEmailField, animated: animated)
-        formElement.toggleChild(phoneNumberSection, show: viewModel.shouldShowPhoneField, animated: animated)
-        formElement.toggleChild(nameSection, show: viewModel.shouldShowNameField, animated: animated)
-        formElement.toggleChild(legalTermsElement, show: viewModel.shouldShowLegalTerms, animated: animated)
-        formElement.toggleChild(moreInfoElement, show: viewModel.shouldShowLegalTerms, animated: animated)
+        formElement.toggleChild(
+            emailSection,
+            show: viewModel.shouldShowEmailField,
+            animated: animated
+        )
+        formElement.toggleChild(
+            phoneNumberSection,
+            show: viewModel.shouldShowPhoneField,
+            animated: animated
+        )
+        formElement.toggleChild(
+            nameSection,
+            show: viewModel.shouldShowNameField,
+            animated: animated
+        )
+        formElement.toggleChild(
+            legalTermsElement,
+            show: viewModel.shouldShowLegalTerms,
+            animated: animated
+        )
+        formElement.toggleChild(
+            moreInfoElement,
+            show: viewModel.shouldShowLegalTerms,
+            animated: animated
+        )
 
         // 2-way binding
         checkboxElement.isChecked = viewModel.saveCheckboxChecked
     }
-    
+
     private func updateAppearance() {
         backgroundColor = viewModel.configuration.appearance.colors.background
         layer.cornerRadius = viewModel.configuration.appearance.cornerRadius
         // If the borders are hidden give Link a default 1.0 border that contrasts with the background color
-        if viewModel.configuration.appearance.borderWidth == 0.0 ||
-            viewModel.configuration.appearance.colors.componentBorder.rgba.alpha == 0.0 {
+        if viewModel.configuration.appearance.borderWidth == 0.0
+            || viewModel.configuration.appearance.colors.componentBorder.rgba.alpha == 0.0
+        {
             layer.borderWidth = 1.0
-            layer.borderColor = viewModel.configuration.appearance
+            layer.borderColor =
+                viewModel.configuration.appearance
                 .colors.background.contrastingColor.withAlphaComponent(0.2).cgColor
         }
     }
-    
+
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         updateAppearance()
@@ -212,7 +248,8 @@ extension LinkInlineSignupView: LinkInlineSignupViewModelDelegate {
 
 extension LinkInlineSignupView: LinkLegalTermsViewDelegate {
 
-    func legalTermsView(_ legalTermsView: LinkLegalTermsView, didTapOnLinkWithURL url: URL) -> Bool {
+    func legalTermsView(_ legalTermsView: LinkLegalTermsView, didTapOnLinkWithURL url: URL) -> Bool
+    {
         let safariVC = SFSafariViewController(url: url)
         safariVC.dismissButtonStyle = .close
         safariVC.modalPresentationStyle = .overFullScreen

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Elements/LinkCardEditElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Elements/LinkCardEditElement.swift
@@ -6,15 +6,15 @@
 //  Copyright © 2022 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
 @_spi(STP) import StripeCore
-@_spi(STP) import StripeUICore
 @_spi(STP) import StripePayments
 @_spi(STP) import StripePaymentsUI
+@_spi(STP) import StripeUICore
+import UIKit
 
 // TODO(ramont): Remove after migrating to modern bindings
-fileprivate extension ConsumerPaymentDetails {
-    var cardDetails: Details.Card? {
+extension ConsumerPaymentDetails {
+    fileprivate var cardDetails: Details.Card? {
         switch details {
         case .card(let details):
             return details
@@ -48,7 +48,8 @@ final class LinkCardEditElement: Element {
 
     var params: Params? {
         guard validationState.isValid,
-              let expiryDate = CardExpiryDate(expiryDateElement.text) else {
+            let expiryDate = CardExpiryDate(expiryDateElement.text)
+        else {
             return nil
         }
 
@@ -109,7 +110,7 @@ final class LinkCardEditElement: Element {
             elements: [
                 cardSection,
                 billingAddressSection,
-                checkboxElement
+                checkboxElement,
             ],
             theme: theme
         )
@@ -121,7 +122,7 @@ final class LinkCardEditElement: Element {
         title: String.Localized.card_information,
         elements: [
             panElement,
-            SectionElement.MultiElementRow([expiryDateElement, cvcElement], theme: theme)
+            SectionElement.MultiElementRow([expiryDateElement, cvcElement], theme: theme),
         ],
         theme: theme
     )
@@ -132,7 +133,9 @@ final class LinkCardEditElement: Element {
         theme: theme
     )
 
-    init(paymentMethod: ConsumerPaymentDetails) {
+    init(
+        paymentMethod: ConsumerPaymentDetails
+    ) {
         self.paymentMethod = paymentMethod
 
         if let expiryDate = paymentMethod.cardDetails?.expiryDate {
@@ -156,9 +159,9 @@ extension LinkCardEditElement: ElementDelegate {
 
 }
 
-private extension LinkCardEditElement {
+extension LinkCardEditElement {
 
-    struct PANConfiguration: TextFieldElementConfiguration {
+    fileprivate struct PANConfiguration: TextFieldElementConfiguration {
         let paymentMethod: ConsumerPaymentDetails
 
         var label: String {

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Elements/LinkEmailElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Elements/LinkEmailElement.swift
@@ -6,14 +6,14 @@
 //  Copyright © 2022 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
 @_spi(STP) import StripeUICore
+import UIKit
 
 class LinkEmailElement: Element {
     weak var delegate: ElementDelegate? = nil
-    
+
     private let emailAddressElement: TextFieldElement
-    
+
     private let activityIndicator: ActivityIndicator = {
         // TODO: Consider adding the activity indicator to TextFieldView
         let activityIndicator = ActivityIndicator(size: .medium)
@@ -39,15 +39,15 @@ class LinkEmailElement: Element {
     var view: UIView {
         return stackView
     }
-    
+
     public var emailAddressString: String? {
         return emailAddressElement.text
     }
-    
+
     public var validationState: ElementValidationState {
         return emailAddressElement.validationState
     }
-    
+
     public var indicatorTintColor: UIColor {
         get {
             return activityIndicator.color
@@ -57,7 +57,7 @@ class LinkEmailElement: Element {
             activityIndicator.color = newValue
         }
     }
-    
+
     public func startAnimating() {
         UIView.performWithoutAnimation {
             activityIndicator.startAnimating()
@@ -65,7 +65,7 @@ class LinkEmailElement: Element {
             stackView.layoutSubviews()
         }
     }
-    
+
     public func stopAnimating() {
         UIView.performWithoutAnimation {
             activityIndicator.stopAnimating()
@@ -73,8 +73,11 @@ class LinkEmailElement: Element {
             stackView.layoutSubviews()
         }
     }
-    
-    public init(defaultValue: String? = nil, theme: ElementsUITheme = .default) {
+
+    public init(
+        defaultValue: String? = nil,
+        theme: ElementsUITheme = .default
+    ) {
         emailAddressElement = TextFieldElement.makeEmail(defaultValue: defaultValue, theme: theme)
         emailAddressElement.delegate = self
     }
@@ -89,7 +92,7 @@ extension LinkEmailElement: ElementDelegate {
     func didUpdate(element: Element) {
         delegate?.didUpdate(element: self)
     }
-    
+
     func continueToNextField(element: Element) {
         delegate?.continueToNextField(element: self)
     }

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Extensions/Button+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Extensions/Button+Link.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2021 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
 @_spi(STP) import StripeUICore
+import UIKit
 
 extension Button.Configuration {
 
@@ -34,7 +34,7 @@ extension Button.Configuration {
         // Colors
         configuration.foregroundColor = .linkSecondaryButtonForeground
         configuration.backgroundColor = .linkSecondaryButtonBackground
-        configuration.disabledBackgroundColor = .linkSecondaryButtonBackground 
+        configuration.disabledBackgroundColor = .linkSecondaryButtonBackground
 
         return configuration
     }

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Extensions/ConfirmButton+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Extensions/ConfirmButton+Link.swift
@@ -23,12 +23,11 @@ extension ConfirmButton {
 
         // Override the background color of the `.succeeded` state. Make it match
         // the background color of the `.enabled` state.
-        button.succeededBackgroundColor = (
-            LinkUI.appearance.primaryButton.backgroundColor ??
-            LinkUI.appearance.colors.primary
-        )
+        button.succeededBackgroundColor =
+            (LinkUI.appearance.primaryButton.backgroundColor ?? LinkUI.appearance.colors.primary)
 
-        button.directionalLayoutMargins = compact
+        button.directionalLayoutMargins =
+            compact
             ? LinkUI.compactButtonMargins
             : LinkUI.buttonMargins
 

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Extensions/FormElement+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Extensions/FormElement+Link.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2022 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
 @_spi(STP) import StripeUICore
+import UIKit
 
 // TODO(ramont): Graduate to StripeUICore.
 
@@ -40,7 +40,10 @@ extension FormElement {
 
         if animated {
             child.view.alpha = 0
-            child.view.transform = CGAffineTransform(scaleX: 0.98, y: 0.98).translatedBy(x: 0, y: -10)
+            child.view.transform = CGAffineTransform(scaleX: 0.98, y: 0.98).translatedBy(
+                x: 0,
+                y: -10
+            )
             child.view.superview?.sendSubviewToBack(child.view)
             UIView.animate(withDuration: 0.2, delay: 0, options: .curveEaseOut) {
                 child.view.alpha = 1
@@ -74,7 +77,10 @@ extension FormElement {
             UIView.animate(withDuration: 0.2, delay: 0, options: .curveEaseOut) {
                 child.view.alpha = 0
                 child.view.isHidden = true
-                child.view.transform = CGAffineTransform(scaleX: 0.98, y: 0.98).translatedBy(x: 0, y: -10)
+                child.view.transform = CGAffineTransform(scaleX: 0.98, y: 0.98).translatedBy(
+                    x: 0,
+                    y: -10
+                )
                 self.view.setNeedsLayout()
                 self.view.layoutIfNeeded()
             } completion: { _ in

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Extensions/UIColor+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Extensions/UIColor+Link.swift
@@ -6,9 +6,8 @@
 //  Copyright © 2021 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
-
 @_spi(STP) import StripeUICore
+import UIKit
 
 // MARK: - Custom colors
 
@@ -72,13 +71,23 @@ extension UIColor {
     )
 
     /// Background color of the toast component.
-    static let linkToastBackground: UIColor = UIColor(red: 0.19, green: 0.19, blue: 0.24, alpha: 1.0)
+    static let linkToastBackground: UIColor = UIColor(
+        red: 0.19,
+        green: 0.19,
+        blue: 0.24,
+        alpha: 1.0
+    )
 
     /// Foreground color of the toast component.
     static let linkToastForeground: UIColor = .white
 
     /// Foreground color of the primary button.
-    static let linkPrimaryButtonForeground: UIColor = UIColor(red: 0.012, green: 0.141, blue: 0.149, alpha: 1.0)
+    static let linkPrimaryButtonForeground: UIColor = UIColor(
+        red: 0.012,
+        green: 0.141,
+        blue: 0.149,
+        alpha: 1.0
+    )
 
     /// Foreground color of the secondary button.
     static let linkSecondaryButtonForeground: UIColor = .dynamic(
@@ -155,15 +164,19 @@ extension UIColor {
         forBackgroundColor backgroundColor: UIColor,
         traitCollection: UITraitCollection = .current
     ) -> UIColor {
-        let resolvedLightModeColor = resolvedColor(with: UITraitCollection(traitsFrom: [
-            traitCollection,
-            UITraitCollection(userInterfaceStyle: .light)
-        ]))
+        let resolvedLightModeColor = resolvedColor(
+            with: UITraitCollection(traitsFrom: [
+                traitCollection,
+                UITraitCollection(userInterfaceStyle: .light),
+            ])
+        )
 
-        let resolvedDarkModeColor = resolvedColor(with: UITraitCollection(traitsFrom: [
-            traitCollection,
-            UITraitCollection(userInterfaceStyle: .dark)
-        ]))
+        let resolvedDarkModeColor = resolvedColor(
+            with: UITraitCollection(traitsFrom: [
+                traitCollection,
+                UITraitCollection(userInterfaceStyle: .dark),
+            ])
+        )
 
         let resolvedBackgroundColor = backgroundColor.resolvedColor(with: traitCollection)
 

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/LinkUI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/LinkUI.swift
@@ -1,3 +1,4 @@
+@_spi(STP) import StripeUICore
 //
 //  LinkUI.swift
 //  StripePaymentSheet
@@ -6,7 +7,6 @@
 //  Copyright © 2021 Stripe, Inc. All rights reserved.
 //
 import UIKit
-@_spi(STP) import StripeUICore
 
 enum LinkUI {
 
@@ -35,11 +35,26 @@ enum LinkUI {
 
     static let buttonMargins: NSDirectionalEdgeInsets = .insets(amount: 16)
 
-    static let compactButtonMargins: NSDirectionalEdgeInsets = .insets(top: 12, leading: 16, bottom: 12, trailing: 16)
+    static let compactButtonMargins: NSDirectionalEdgeInsets = .insets(
+        top: 12,
+        leading: 16,
+        bottom: 12,
+        trailing: 16
+    )
 
-    static let contentMargins: NSDirectionalEdgeInsets = .insets(top: 22, leading: 20, bottom: 20, trailing: 20)
+    static let contentMargins: NSDirectionalEdgeInsets = .insets(
+        top: 22,
+        leading: 20,
+        bottom: 20,
+        trailing: 20
+    )
 
-    static let contentMarginsWithLargeNav: NSDirectionalEdgeInsets = .insets(top: 32, leading: 20, bottom: 20, trailing: 20)
+    static let contentMarginsWithLargeNav: NSDirectionalEdgeInsets = .insets(
+        top: 32,
+        leading: 20,
+        bottom: 20,
+        trailing: 20
+    )
 
     // MARK: - Content spacing
 
@@ -138,7 +153,8 @@ extension LinkUI {
         }
     }
 
-    static func lineSpacing(fromRelativeHeight lineHeight: CGFloat, textStyle: TextStyle) -> CGFloat {
+    static func lineSpacing(fromRelativeHeight lineHeight: CGFloat, textStyle: TextStyle) -> CGFloat
+    {
         let font = self.font(forTextStyle: textStyle)
         return (font.pointSize * lineHeight) - font.pointSize
     }

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Services/LinkAccountService.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Services/LinkAccountService.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-
 @_spi(STP) import StripeCore
 
 /// Provides a method for looking up Link accounts by email.
@@ -28,7 +27,7 @@ protocol LinkAccountServiceProtocol {
         withEmail email: String?,
         completion: @escaping (Result<PaymentSheetLinkAccount?, Error>) -> Void
     )
-    
+
     /// Checks if we have seen this email log out before
     /// - Parameter email: true if this email has logged out before, false otherwise
     func hasEmailLoggedOut(email: String) -> Bool
@@ -68,26 +67,30 @@ final class LinkAccountService: LinkAccountServiceProtocol {
             case .success(let lookupResponse):
                 switch lookupResponse.responseType {
                 case .found(let consumerSession, let preferences):
-                    completion(.success(
-                        PaymentSheetLinkAccount(
-                            email: consumerSession.emailAddress,
-                            session: consumerSession,
-                            publishableKey: preferences.publishableKey,
-                            apiClient: apiClient,
-                            cookieStore: cookieStore
+                    completion(
+                        .success(
+                            PaymentSheetLinkAccount(
+                                email: consumerSession.emailAddress,
+                                session: consumerSession,
+                                publishableKey: preferences.publishableKey,
+                                apiClient: apiClient,
+                                cookieStore: cookieStore
+                            )
                         )
-                    ))
+                    )
                 case .notFound(_):
                     if let email = email {
-                        completion(.success(
-                            PaymentSheetLinkAccount(
-                                email: email,
-                                session: nil,
-                                publishableKey: nil,
-                                apiClient: self.apiClient,
-                                cookieStore: self.cookieStore
+                        completion(
+                            .success(
+                                PaymentSheetLinkAccount(
+                                    email: email,
+                                    session: nil,
+                                    publishableKey: nil,
+                                    apiClient: self.apiClient,
+                                    cookieStore: self.cookieStore
+                                )
                             )
-                        ))
+                        )
                     } else {
                         completion(.success(nil))
                     }
@@ -100,7 +103,7 @@ final class LinkAccountService: LinkAccountServiceProtocol {
             }
         }
     }
-    
+
     func hasEmailLoggedOut(email: String) -> Bool {
         guard let hashedEmail = email.lowercased().sha256 else {
             return false

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Utils/OperationDebouncer.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Utils/OperationDebouncer.swift
@@ -25,7 +25,10 @@ final class OperationDebouncer {
     /// - Parameters:
     ///   - debounceTime: Time to wait before executing the enqueued operation.
     ///   - dispatchQueue: The target queue on which to execute blocks.
-    init(debounceTime: DispatchTimeInterval, dispatchQueue: DispatchQueue = .main) {
+    init(
+        debounceTime: DispatchTimeInterval,
+        dispatchQueue: DispatchQueue = .main
+    ) {
         self.debounceTime = debounceTime
         self.dispatchQueue = dispatchQueue
     }

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Verification/LinkUtils.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Verification/LinkUtils.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-
 @_spi(STP) import StripeCore
 
 final class LinkUtils {
@@ -40,8 +39,11 @@ final class LinkUtils {
     }
 
     static func getLocalizedErrorMessage(from error: Error) -> String {
-        guard let errorCodeString = (error as NSError).userInfo[STPError.stripeErrorCodeKey] as? String,
-              let errorCode = ConsumerErrorCode(rawValue: errorCodeString) else {
+        guard
+            let errorCodeString = (error as NSError).userInfo[STPError.stripeErrorCodeKey]
+                as? String,
+            let errorCode = ConsumerErrorCode(rawValue: errorCodeString)
+        else {
             return error.localizedDescription
         }
 

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Verification/LinkVerificationController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Verification/LinkVerificationController.swift
@@ -18,8 +18,14 @@ final class LinkVerificationController {
     private var selfRetainer: LinkVerificationController?
     private let verificationViewController: LinkVerificationViewController
 
-    init(mode: LinkVerificationView.Mode = .modal, linkAccount: PaymentSheetLinkAccount) {
-        self.verificationViewController = LinkVerificationViewController(mode: mode, linkAccount: linkAccount)
+    init(
+        mode: LinkVerificationView.Mode = .modal,
+        linkAccount: PaymentSheetLinkAccount
+    ) {
+        self.verificationViewController = LinkVerificationViewController(
+            mode: mode,
+            linkAccount: linkAccount
+        )
         verificationViewController.delegate = self
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Verification/LinkVerificationView-Header.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Verification/LinkVerificationView-Header.swift
@@ -6,10 +6,10 @@
 //  Copyright © 2021 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
 @_spi(STP) import StripeCore
-@_spi(STP) import StripeUICore
 @_spi(STP) import StripePayments
+@_spi(STP) import StripeUICore
+import UIKit
 
 extension LinkVerificationView {
 
@@ -21,7 +21,7 @@ extension LinkVerificationView {
         private let logoView: UIImageView = {
             let logoView = UIImageView(image: Image.link_logo.makeImage(template: true))
             logoView.translatesAutoresizingMaskIntoConstraints = false
-            logoView.isAccessibilityElement = true  
+            logoView.isAccessibilityElement = true
             logoView.accessibilityTraits = .header
             logoView.accessibilityLabel = STPPaymentMethodType.link.displayName
             return logoView
@@ -54,14 +54,16 @@ extension LinkVerificationView {
                 // Button
                 closeButton.topAnchor.constraint(equalTo: topAnchor),
                 closeButton.rightAnchor.constraint(equalTo: rightAnchor),
-                closeButton.bottomAnchor.constraint(equalTo: bottomAnchor)
+                closeButton.bottomAnchor.constraint(equalTo: bottomAnchor),
             ])
 
             tintColor = .linkNavTint
             logoView.tintColor = .linkNavLogo
         }
 
-        required init?(coder: NSCoder) {
+        required init?(
+            coder: NSCoder
+        ) {
             fatalError("init(coder:) has not been implemented")
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Verification/LinkVerificationView-LogoutView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Verification/LinkVerificationView-LogoutView.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2022 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
 @_spi(STP) import StripeCore
 @_spi(STP) import StripeUICore
+import UIKit
 
 extension LinkVerificationView {
 
@@ -35,21 +35,28 @@ extension LinkVerificationView {
         }()
 
         private(set) lazy var button: Button = {
-            let button = Button(configuration: .linkPlain(), title: STPLocalizedString(
-                "Change email",
-                "Title for a button that allows the user to use a different email in the signup flow."
-            ))
+            let button = Button(
+                configuration: .linkPlain(),
+                title: STPLocalizedString(
+                    "Change email",
+                    "Title for a button that allows the user to use a different email in the signup flow."
+                )
+            )
             button.configuration.font = font
             return button
         }()
 
-        init(linkAccount: PaymentSheetLinkAccountInfoProtocol) {
+        init(
+            linkAccount: PaymentSheetLinkAccountInfoProtocol
+        ) {
             self.linkAccount = linkAccount
             super.init(frame: .zero)
             setupUI()
         }
 
-        required init?(coder: NSCoder) {
+        required init?(
+            coder: NSCoder
+        ) {
             fatalError("init(coder:) has not been implemented")
         }
 

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Verification/LinkVerificationView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Verification/LinkVerificationView.swift
@@ -6,10 +6,9 @@
 //  Copyright © 2021 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
-
 @_spi(STP) import StripeCore
 @_spi(STP) import StripeUICore
+import UIKit
 
 /// :nodoc:
 protocol LinkVerificationViewDelegate: AnyObject {
@@ -81,7 +80,11 @@ final class LinkVerificationView: UIView {
 
     private(set) lazy var codeField: OneTimeCodeTextField = {
         let codeField = OneTimeCodeTextField(numberOfDigits: 6)
-        codeField.addTarget(self, action: #selector(oneTimeCodeFieldChanged(_:)), for: .valueChanged)
+        codeField.addTarget(
+            self,
+            action: #selector(oneTimeCodeFieldChanged(_:)),
+            for: .valueChanged
+        )
         return codeField
     }()
 
@@ -103,28 +106,40 @@ final class LinkVerificationView: UIView {
     }()
 
     private lazy var resendCodeButton: Button = {
-        let button = Button(configuration: .linkBordered(), title: STPLocalizedString(
-            "Resend code",
-            "Label for a button that re-sends the a login code when tapped"
-        ))
+        let button = Button(
+            configuration: .linkBordered(),
+            title: STPLocalizedString(
+                "Resend code",
+                "Label for a button that re-sends the a login code when tapped"
+            )
+        )
         button.addTarget(self, action: #selector(resendCodeTapped(_:)), for: .touchUpInside)
         return button
     }()
 
     private lazy var logoutView: LogoutView = {
         let logoutView = LogoutView(linkAccount: linkAccount)
-        logoutView.button.addTarget(self, action: #selector(didTapOnLogout(_:)), for: .touchUpInside)
+        logoutView.button.addTarget(
+            self,
+            action: #selector(didTapOnLogout(_:)),
+            for: .touchUpInside
+        )
         return logoutView
     }()
 
-    required init(mode: Mode, linkAccount: PaymentSheetLinkAccountInfoProtocol) {
+    required init(
+        mode: Mode,
+        linkAccount: PaymentSheetLinkAccountInfoProtocol
+    ) {
         self.mode = mode
         self.linkAccount = linkAccount
         super.init(frame: .zero)
         setupUI()
     }
-    
-    required init?(coder: NSCoder) {
+
+    required init?(
+        coder: NSCoder
+    ) {
         fatalError("init(coder:) has not been implemented")
     }
 
@@ -154,9 +169,9 @@ final class LinkVerificationView: UIView {
     }
 }
 
-private extension LinkVerificationView {
+extension LinkVerificationView {
 
-    var arrangedSubViews: [UIView] {
+    fileprivate var arrangedSubViews: [UIView] {
         switch mode {
         case .modal, .inlineLogin:
             return [
@@ -164,7 +179,7 @@ private extension LinkVerificationView {
                 headingLabel,
                 bodyLabel,
                 codeFieldContainer,
-                resendCodeButton
+                resendCodeButton,
             ]
         case .embedded:
             return [
@@ -172,12 +187,12 @@ private extension LinkVerificationView {
                 bodyLabel,
                 codeFieldContainer,
                 logoutView,
-                resendCodeButton
+                resendCodeButton,
             ]
         }
     }
 
-    func setupUI() {
+    fileprivate func setupUI() {
         directionalLayoutMargins = .insets(amount: Constants.edgeMargin)
 
         let stackView = UIStackView(arrangedSubviews: arrangedSubViews)

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Verification/LinkVerificationViewController-PresentationController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Verification/LinkVerificationViewController-PresentationController.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2021 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
 @_spi(STP) import StripeUICore
+import UIKit
 
 extension LinkVerificationViewController {
 
@@ -86,7 +86,10 @@ extension LinkVerificationViewController {
 
             return CGRect(
                 x: (containerSize.width - actualSize.width) / 2,
-                y: max((containerSize.height - actualSize.height - bottomInset) / 2, Constants.padding),
+                y: max(
+                    (containerSize.height - actualSize.height - bottomInset) / 2,
+                    Constants.padding
+                ),
                 width: actualSize.width,
                 height: actualSize.height
             ).integral
@@ -107,7 +110,8 @@ extension LinkVerificationViewController {
             super.presentationTransitionWillBegin()
 
             guard let containerView = containerView,
-                  let transitionCoordinator = presentedViewController.transitionCoordinator else {
+                let transitionCoordinator = presentedViewController.transitionCoordinator
+            else {
                 return
             }
 
@@ -136,7 +140,10 @@ extension LinkVerificationViewController {
             )
         }
 
-        override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        override func viewWillTransition(
+            to size: CGSize,
+            with coordinator: UIViewControllerTransitionCoordinator
+        ) {
             super.viewWillTransition(to: size, with: coordinator)
 
             coordinator.animate { context in
@@ -146,9 +153,12 @@ extension LinkVerificationViewController {
             }
         }
 
-        override func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) {
+        override func willTransition(
+            to newCollection: UITraitCollection,
+            with coordinator: UIViewControllerTransitionCoordinator
+        ) {
             super.willTransition(to: newCollection, with: coordinator)
-            
+
             coordinator.animate { context in
                 self.presentedView?.frame = self.calculateModalFrame(
                     forContainerSize: context.containerView.bounds.size
@@ -160,17 +170,24 @@ extension LinkVerificationViewController {
             presentedViewController: UIViewController,
             presenting presentingViewController: UIViewController?
         ) {
-            super.init(presentedViewController: presentedViewController, presenting: presentingViewController)
+            super.init(
+                presentedViewController: presentedViewController,
+                presenting: presentingViewController
+            )
 
-            NotificationCenter.default.addObserver(self,
+            NotificationCenter.default.addObserver(
+                self,
                 selector: #selector(keyboardFrameChanged(_:)),
                 name: UIResponder.keyboardWillChangeFrameNotification,
-                object: nil)
+                object: nil
+            )
 
-            NotificationCenter.default.addObserver(self,
+            NotificationCenter.default.addObserver(
+                self,
                 selector: #selector(keyboardWillHide(_:)),
                 name: UIResponder.keyboardWillHideNotification,
-                object: nil)
+                object: nil
+            )
         }
 
         deinit {
@@ -188,7 +205,8 @@ extension LinkVerificationViewController.PresentationController {
         let userInfo = notification.userInfo
 
         guard let keyboardFrame = userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect,
-              let containerView = containerView else {
+            let containerView = containerView
+        else {
             return
         }
 

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Verification/LinkVerificationViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Verification/LinkVerificationViewController.swift
@@ -6,10 +6,9 @@
 //  Copyright © 2021 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
-
 @_spi(STP) import StripeCore
 @_spi(STP) import StripeUICore
+import UIKit
 
 protocol LinkVerificationViewControllerDelegate: AnyObject {
     func verificationController(
@@ -70,7 +69,9 @@ final class LinkVerificationViewController: UIViewController {
         }
     }
 
-    required init?(coder: NSCoder) {
+    required init?(
+        coder: NSCoder
+    ) {
         fatalError("init(coder:) has not been implemented")
     }
 
@@ -96,7 +97,7 @@ final class LinkVerificationViewController: UIViewController {
             verificationView.widthAnchor.constraint(equalTo: view.widthAnchor),
             // Activity indicator
             activityIndicator.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            activityIndicator.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+            activityIndicator.centerYAnchor.constraint(equalTo: view.centerYAnchor),
         ])
 
         if mode.requiresModalPresentation {
@@ -186,10 +187,12 @@ extension LinkVerificationViewController: LinkVerificationViewDelegate {
                     preferredStyle: .alert
                 )
 
-                alertController.addAction(UIAlertAction(
-                    title: String.Localized.ok,
-                    style: .default
-                ))
+                alertController.addAction(
+                    UIAlertAction(
+                        title: String.Localized.ok,
+                        style: .default
+                    )
+                )
 
                 self?.present(alertController, animated: true)
             }
@@ -236,11 +239,15 @@ extension LinkVerificationViewController {
     final class TransitioningDelegate: NSObject, UIViewControllerTransitioningDelegate {
         static let sharedDelegate: TransitioningDelegate = TransitioningDelegate()
 
-        func presentationController(forPresented presented: UIViewController,
-                                    presenting: UIViewController?,
-                                    source: UIViewController) -> UIPresentationController? {
-            return PresentationController(presentedViewController: presented,
-                                          presenting: presenting)
+        func presentationController(
+            forPresented presented: UIViewController,
+            presenting: UIViewController?,
+            source: UIViewController
+        ) -> UIPresentationController? {
+            return PresentationController(
+                presentedViewController: presented,
+                presenting: presenting
+            )
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/ViewModels/LinkInlineSignupViewModel.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/ViewModels/LinkInlineSignupViewModel.swift
@@ -8,8 +8,8 @@
 
 import Foundation
 @_spi(STP) import StripeCore
-@_spi(STP) import StripeUICore
 @_spi(STP) import StripePayments
+@_spi(STP) import StripeUICore
 
 protocol LinkInlineSignupViewModelDelegate: AnyObject {
     func signupViewModelDidUpdate(_ viewModel: LinkInlineSignupViewModel)
@@ -18,7 +18,11 @@ protocol LinkInlineSignupViewModelDelegate: AnyObject {
 final class LinkInlineSignupViewModel {
     enum Action: Equatable {
         case pay(account: PaymentSheetLinkAccount)
-        case signupAndPay(account: PaymentSheetLinkAccount, phoneNumber: PhoneNumber, legalName: String?)
+        case signupAndPay(
+            account: PaymentSheetLinkAccount,
+            phoneNumber: PhoneNumber,
+            legalName: String?
+        )
         case continueWithoutLink
     }
 
@@ -26,7 +30,9 @@ final class LinkInlineSignupViewModel {
 
     private let accountService: LinkAccountServiceProtocol
 
-    private let accountLookupDebouncer = OperationDebouncer(debounceTime: LinkUI.accountLookupDebounceTime)
+    private let accountLookupDebouncer = OperationDebouncer(
+        debounceTime: LinkUI.accountLookupDebounceTime
+    )
 
     private let country: String?
 
@@ -74,7 +80,8 @@ final class LinkInlineSignupViewModel {
                 notifyUpdate()
 
                 if let linkAccount = linkAccount,
-                   !linkAccount.isRegistered {
+                    !linkAccount.isRegistered
+                {
                     STPAnalyticsClient.sharedClient.logLinkSignupStart()
                 }
             }
@@ -88,7 +95,7 @@ final class LinkInlineSignupViewModel {
             }
         }
     }
-    
+
     private(set) var lookupFailed: Bool = false {
         didSet {
             if lookupFailed != oldValue {
@@ -127,7 +134,8 @@ final class LinkInlineSignupViewModel {
 
     var shouldShowNameField: Bool {
         guard saveCheckboxChecked,
-              let linkAccount = linkAccount else {
+            let linkAccount = linkAccount
+        else {
             return false
         }
 
@@ -136,7 +144,7 @@ final class LinkInlineSignupViewModel {
 
     var shouldShowPhoneField: Bool {
         guard saveCheckboxChecked,
-              let linkAccount = linkAccount
+            let linkAccount = linkAccount
         else {
             return false
         }
@@ -150,7 +158,7 @@ final class LinkInlineSignupViewModel {
 
     var action: Action? {
         guard saveCheckboxChecked,
-              !lookupFailed
+            !lookupFailed
         else {
             return .continueWithoutLink
         }
@@ -162,7 +170,8 @@ final class LinkInlineSignupViewModel {
         switch linkAccount.sessionState {
         case .requiresSignUp:
             guard let phoneNumber = phoneNumber,
-                  phoneNumber.isComplete else {
+                phoneNumber.isComplete
+            else {
                 return nil
             }
 
@@ -196,16 +205,16 @@ final class LinkInlineSignupViewModel {
 
 }
 
-private extension LinkInlineSignupViewModel {
+extension LinkInlineSignupViewModel {
 
-    func notifyUpdate() {
+    fileprivate func notifyUpdate() {
         delegate?.signupViewModelDidUpdate(self)
     }
 
-    func onEmailUpdate() {
+    fileprivate func onEmailUpdate() {
         linkAccount = nil
         lookupFailed = false
-        
+
         guard let emailAddress = emailAddress else {
             accountLookupDebouncer.cancel()
             isLookingUpLinkAccount = false

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Views/LinkInstantDebitMandateView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Views/LinkInstantDebitMandateView.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2022 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
-@_spi(STP) import StripeUICore
 @_spi(STP) import StripePaymentsUI
+@_spi(STP) import StripeUICore
+import UIKit
 
 protocol LinkInstantDebitMandateViewDelegate: AnyObject {
     /// Called when the user taps on a link.
@@ -16,7 +16,10 @@ protocol LinkInstantDebitMandateViewDelegate: AnyObject {
     /// - Parameters:
     ///   - mandateView: The view that the user interacted with.
     ///   - url: URL of the link.
-    func instantDebitMandateView(_ mandateView: LinkInstantDebitMandateView, didTapOnLinkWithURL url: URL)
+    func instantDebitMandateView(
+        _ mandateView: LinkInstantDebitMandateView,
+        didTapOnLinkWithURL url: URL
+    )
 }
 
 // TODO(ramont): extract common code with `LinkLegalTermsView`.
@@ -55,13 +58,17 @@ final class LinkInstantDebitMandateView: UIView {
         return textView
     }()
 
-    init(delegate: LinkInstantDebitMandateViewDelegate? = nil) {
+    init(
+        delegate: LinkInstantDebitMandateViewDelegate? = nil
+    ) {
         super.init(frame: .zero)
         self.delegate = delegate
         addAndPinSubview(textView)
     }
 
-    required init?(coder: NSCoder) {
+    required init?(
+        coder: NSCoder
+    ) {
         fatalError("init(coder:) has not been implemented")
     }
 
@@ -73,7 +80,9 @@ final class LinkInstantDebitMandateView: UIView {
 
         let formattedString = NSMutableAttributedString()
 
-        STPStringUtils.parseRanges(from: string, withTags: Set<String>(links.keys)) { string, matches in
+        STPStringUtils.parseRanges(from: string, withTags: Set<String>(links.keys)) {
+            string,
+            matches in
             formattedString.append(NSAttributedString(string: string))
 
             for (tag, range) in matches {
@@ -94,7 +103,10 @@ final class LinkInstantDebitMandateView: UIView {
             textStyle: .caption
         )
 
-        formattedString.addAttributes([.paragraphStyle: paragraphStyle], range: formattedString.extent)
+        formattedString.addAttributes(
+            [.paragraphStyle: paragraphStyle],
+            range: formattedString.extent
+        )
 
         return formattedString
     }

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Views/LinkKeyboardAvoidingScrollView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Views/LinkKeyboardAvoidingScrollView.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2022 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
 @_spi(STP) import StripeUICore
+import UIKit
 
 /// A UIScrollView subclass that actively prevents its content from being covered by the software keyboard.
 /// For internal SDK use only
@@ -17,10 +17,12 @@ final class LinkKeyboardAvoidingScrollView: UIScrollView {
     init() {
         super.init(frame: .zero)
 
-        NotificationCenter.default.addObserver(self,
+        NotificationCenter.default.addObserver(
+            self,
             selector: #selector(keyboardFrameChanged(_:)),
             name: UIResponder.keyboardWillChangeFrameNotification,
-            object: nil)
+            object: nil
+        )
     }
 
     /// Creates a new keyboard-avoiding scrollview with the given view configured as content view.
@@ -28,7 +30,9 @@ final class LinkKeyboardAvoidingScrollView: UIScrollView {
     /// This initializer adds the content view as a subview and installs the appropriate set of constraints.
     ///
     /// - Parameter contentView: The view to be used as content view.
-    convenience init(contentView: UIView) {
+    convenience init(
+        contentView: UIView
+    ) {
         self.init()
 
         contentView.translatesAutoresizingMaskIntoConstraints = false
@@ -39,11 +43,13 @@ final class LinkKeyboardAvoidingScrollView: UIScrollView {
             contentView.bottomAnchor.constraint(equalTo: bottomAnchor),
             contentView.leadingAnchor.constraint(equalTo: leadingAnchor),
             contentView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            contentView.widthAnchor.constraint(equalTo: widthAnchor)
+            contentView.widthAnchor.constraint(equalTo: widthAnchor),
         ])
     }
 
-    required init?(coder: NSCoder) {
+    required init?(
+        coder: NSCoder
+    ) {
         fatalError("init(coder:) has not been implemented")
     }
 
@@ -54,12 +60,13 @@ final class LinkKeyboardAvoidingScrollView: UIScrollView {
 
 // MARK: - Event Handling
 
-private extension LinkKeyboardAvoidingScrollView {
+extension LinkKeyboardAvoidingScrollView {
 
-    @objc func keyboardFrameChanged(_ notification: Notification) {
+    @objc fileprivate func keyboardFrameChanged(_ notification: Notification) {
         let userInfo = notification.userInfo
 
-        guard let keyboardFrame = userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect else {
+        guard let keyboardFrame = userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect
+        else {
             return
         }
 
@@ -68,7 +75,12 @@ private extension LinkKeyboardAvoidingScrollView {
 
         UIView.animateAlongsideKeyboard(notification) {
             self.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: intersection.height, right: 0)
-            self.scrollIndicatorInsets = UIEdgeInsets(top: 0, left: 0, bottom: intersection.height, right: 0)
+            self.scrollIndicatorInsets = UIEdgeInsets(
+                top: 0,
+                left: 0,
+                bottom: intersection.height,
+                right: 0
+            )
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Views/LinkLegalTermsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Views/LinkLegalTermsView.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2022 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
-@_spi(STP) import StripeUICore
 @_spi(STP) import StripePaymentsUI
+@_spi(STP) import StripeUICore
+import UIKit
 
 protocol LinkLegalTermsViewDelegate: AnyObject {
     /// Called when the user taps on a legal link.
@@ -32,7 +32,7 @@ final class LinkLegalTermsView: UIView {
 
     private let links: [String: URL] = [
         "terms": URL(string: "https://link.co/terms")!,
-        "privacy": URL(string: "https://link.co/privacy")!
+        "privacy": URL(string: "https://link.co/privacy")!,
     ]
 
     weak var delegate: LinkLegalTermsViewDelegate?
@@ -45,7 +45,7 @@ final class LinkLegalTermsView: UIView {
             textView.textColor = newValue
         }
     }
-    
+
     var font: UIFont? {
         get {
             return textView.font
@@ -71,14 +71,19 @@ final class LinkLegalTermsView: UIView {
         return textView
     }()
 
-    init(textAlignment: NSTextAlignment = .left, delegate: LinkLegalTermsViewDelegate? = nil) {
+    init(
+        textAlignment: NSTextAlignment = .left,
+        delegate: LinkLegalTermsViewDelegate? = nil
+    ) {
         super.init(frame: .zero)
         self.textView.textAlignment = textAlignment
         self.delegate = delegate
         addAndPinSubview(textView)
     }
 
-    required init?(coder: NSCoder) {
+    required init?(
+        coder: NSCoder
+    ) {
         fatalError("init(coder:) has not been implemented")
     }
 
@@ -90,7 +95,9 @@ final class LinkLegalTermsView: UIView {
 
         let formattedString = NSMutableAttributedString()
 
-        STPStringUtils.parseRanges(from: string, withTags: Set<String>(links.keys)) { string, matches in
+        STPStringUtils.parseRanges(from: string, withTags: Set<String>(links.keys)) {
+            string,
+            matches in
             formattedString.append(NSAttributedString(string: string))
 
             for (tag, range) in matches {
@@ -111,7 +118,10 @@ final class LinkLegalTermsView: UIView {
             textStyle: .caption
         )
 
-        formattedString.addAttributes([.paragraphStyle: paragraphStyle], range: formattedString.extent)
+        formattedString.addAttributes(
+            [.paragraphStyle: paragraphStyle],
+            range: formattedString.extent
+        )
 
         return formattedString
     }

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Views/LinkMoreInfoView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Views/LinkMoreInfoView.swift
@@ -6,10 +6,10 @@
 //  Copyright © 2022 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
-@_spi(STP) import StripeUICore
-@_spi(STP) import StripePaymentsUI
 @_spi(STP) import StripePayments
+@_spi(STP) import StripePaymentsUI
+@_spi(STP) import StripeUICore
+import UIKit
 
 /// For internal SDK use only
 @objc(STP_Internal_LinkMoreInfoView)
@@ -27,10 +27,12 @@ final class LinkMoreInfoView: UIView {
         imageView.accessibilityLabel = STPPaymentMethodType.link.displayName
         return imageView
     }()
-    
+
     private let theme: ElementsUITheme
 
-    init(theme: ElementsUITheme = .default) {
+    init(
+        theme: ElementsUITheme = .default
+    ) {
         self.theme = theme
         super.init(frame: .zero)
         let stackView = UIStackView(arrangedSubviews: [logoView])
@@ -48,7 +50,9 @@ final class LinkMoreInfoView: UIView {
         ])
     }
 
-    required init?(coder: NSCoder) {
+    required init?(
+        coder: NSCoder
+    ) {
         fatalError("init(coder:) has not been implemented")
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/AddressViewController/AddressViewController+Configuration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/AddressViewController/AddressViewController+Configuration.swift
@@ -8,55 +8,67 @@
 
 import Foundation
 @_spi(STP) import StripeCore
-@_spi(STP) import StripeUICore
 @_spi(STP) import StripePaymentsUI
+@_spi(STP) import StripeUICore
 
-public extension AddressViewController {
+extension AddressViewController {
     /// The customer data collected by `AddressViewController`
-    struct AddressDetails {
+    public struct AddressDetails {
         /// The customer's address
         public let address: Address
-        
+
         /// The customer's full name
         public let name: String?
-        
+
         /// The customer's phone number, in E.164 format (e.g. "+15551234567")
         public let phone: String?
-        
+
         /// Whether or not the checkbox is enabled.
         /// Seealso: `AdditionalFieldsConfiguration.checkboxLabel`
         public let isCheckboxSelected: Bool?
-        
+
         /// Initializes an AddressDetails
-        public init(address: Address, name: String? = nil, phone: String? = nil, isCheckboxSelected: Bool? = nil) {
+        public init(
+            address: Address,
+            name: String? = nil,
+            phone: String? = nil,
+            isCheckboxSelected: Bool? = nil
+        ) {
             self.address = address
             self.name = name
             self.phone = phone
             self.isCheckboxSelected = isCheckboxSelected
         }
-        
+
         /// An address collected by `AddressViewController`
         public struct Address {
             /// City, district, suburb, town, or village.
             public let city: String?
-            
+
             /// Two-letter country code (ISO 3166-1 alpha-2).
             public let country: String
-            
+
             /// Address line 1 (e.g., street, PO Box, or company name).
             public let line1: String
-            
+
             /// Address line 2 (e.g., apartment, suite, unit, or building).
             public let line2: String?
-            
+
             /// ZIP or postal code.
             public let postalCode: String?
-            
+
             /// State, county, province, or region.
             public let state: String?
-            
+
             /// Initializes an Address
-            public init(city: String? = nil, country: String, line1: String, line2: String? = nil, postalCode: String? = nil, state: String? = nil) {
+            public init(
+                city: String? = nil,
+                country: String,
+                line1: String,
+                line2: String? = nil,
+                postalCode: String? = nil,
+                state: String? = nil
+            ) {
                 self.city = city
                 self.country = country
                 self.line1 = line1
@@ -66,13 +78,18 @@ public extension AddressViewController {
             }
         }
     }
-    
+
     /// Configuration for an `AddressViewController` instance.
-    struct Configuration {
+    public struct Configuration {
         /// Initializes a Configuration
-        public init(defaultValues: DefaultAddressDetails = .init(), additionalFields: AddressViewController.Configuration.AdditionalFields = .init(), allowedCountries: [String] = [], appearance: PaymentSheet.Appearance = PaymentSheet.Appearance.default,
-                    buttonTitle: String? = nil,
-                    title: String? = nil) {
+        public init(
+            defaultValues: DefaultAddressDetails = .init(),
+            additionalFields: AddressViewController.Configuration.AdditionalFields = .init(),
+            allowedCountries: [String] = [],
+            appearance: PaymentSheet.Appearance = PaymentSheet.Appearance.default,
+            buttonTitle: String? = nil,
+            title: String? = nil
+        ) {
             self.defaultValues = defaultValues
             self.additionalFields = additionalFields
             self.allowedCountries = allowedCountries
@@ -80,7 +97,7 @@ public extension AddressViewController {
             self.buttonTitle = buttonTitle ?? .Localized.save_address
             self.title = title ?? .Localized.shipping_address
         }
-        
+
         /// Configuration related to the collection of additional fields beyond the physical address.
         public struct AdditionalFields {
             /// Whether a field should be hidden, optional, or required.
@@ -92,38 +109,46 @@ public extension AddressViewController {
                 /// The field is displayed, but the customer is required to fill it in. If the customer doesn't, the sheet displays an error and disables the continue button.
                 case required
             }
-            
+
             /// Configuration for the field that collects a phone number.
             public var phone: FieldConfiguration
-            
+
             /// The label of a checkbox displayed below other fields. If nil, the checkbox is not displayed.
             /// Defaults to nil
             public var checkboxLabel: String?
-            
+
             /// Initializes an AdditionalFields
-            public init(phone: FieldConfiguration = .hidden, checkboxLabel: String? = nil) {
+            public init(
+                phone: FieldConfiguration = .hidden,
+                checkboxLabel: String? = nil
+            ) {
                 self.phone = phone
                 self.checkboxLabel = checkboxLabel
             }
         }
-        
+
         /// Default values for the fields collected by `AddressViewController`
         public struct DefaultAddressDetails {
             /// The customer's address
             public var address: PaymentSheet.Address
-            
+
             /// The customer's full name
             public var name: String?
-            
+
             /// The customer's phone number, without formatting (e.g. "5551234567") or in E.164 format (e.g. "+15551234567")
             public var phone: String?
-            
+
             /// Whether or not your custom checkbox is initially selected.
             /// - Note: The checkbox is displayed below the other fields when `AdditionalFieldsConfiguration.checkboxLabel` is set.
             public var isCheckboxSelected: Bool?
-            
+
             /// Initializes an AddressDetails
-            public init(address: PaymentSheet.Address = .init(), name: String? = nil, phone: String? = nil, isCheckboxSelected: Bool? = nil) {
+            public init(
+                address: PaymentSheet.Address = .init(),
+                name: String? = nil,
+                phone: String? = nil,
+                isCheckboxSelected: Bool? = nil
+            ) {
                 self.address = address
                 self.name = name
                 self.phone = phone
@@ -133,29 +158,32 @@ public extension AddressViewController {
 
         /// The values to pre-populate address fields with.
         public var defaultValues: DefaultAddressDetails = .init()
-        
+
         /// Fields to collect in addition to the physical address.
         /// By default, no additional fields are collected.
         public var additionalFields: AdditionalFields = .init()
-        
+
         /// A list of two-letter country codes representing countries the customers can select.
         /// If the list is empty (the default), we display all countries.
         public var allowedCountries: [String] = []
-        
+
         /// Configuration for the look and feel of the UI
         public var appearance: PaymentSheet.Appearance = PaymentSheet.Appearance.default
-    
+
         /// The title of the primary button displayed at the bottom of the screen. Defaults to "Save address".
         public var buttonTitle: String = .Localized.save_address
-        
+
         /// The title of the view controller. Defaults to "Shipping address".
         public var title: String = .Localized.shipping_address
-        
+
         /// The APIClient instance used to make requests to Stripe
         public var apiClient: STPAPIClient = .shared
-        
+
         /// A list of two-letter country codes that support autocomplete
         /// Defaults to a list of countries that Stripe has audited to ensure a good autocomplete experience.
-        public var autocompleteCountries: [String] = ["AU", "BE", "BR", "CA", "CH", "DE", "ES", "FR", "GB", "IE", "IT", "MX", "NO", "NL", "PL", "RU", "SE", "TR", "US", "ZA"]
+        public var autocompleteCountries: [String] = [
+            "AU", "BE", "BR", "CA", "CH", "DE", "ES", "FR", "GB", "IE", "IT", "MX", "NO", "NL",
+            "PL", "RU", "SE", "TR", "US", "ZA",
+        ]
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/BottomSheet/BottomSheetPresentationAnimator.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/BottomSheet/BottomSheetPresentationAnimator.swift
@@ -18,28 +18,30 @@ class BottomSheetPresentationAnimator: NSObject {
         case presentation
         case dismissal
     }
-    
+
     private let transitionStyle: TransitionStyle
-    
-    required init(transitionStyle: TransitionStyle) {
+
+    required init(
+        transitionStyle: TransitionStyle
+    ) {
         self.transitionStyle = transitionStyle
         super.init()
     }
-    
+
     private func animatePresentation(transitionContext: UIViewControllerContextTransitioning) {
         guard
             let toVC = transitionContext.viewController(forKey: .to),
             let fromVC = transitionContext.viewController(forKey: .from)
         else { return }
-        
+
         // Calls viewWillAppear and viewWillDisappear
         fromVC.beginAppearanceTransition(false, animated: true)
         transitionContext.containerView.layoutIfNeeded()
-        
+
         // Move presented view offscreen (from the bottom)
         toVC.view.frame = transitionContext.finalFrame(for: toVC)
         toVC.view.frame.origin.y = transitionContext.containerView.frame.height
-        
+
         Self.animate({
             transitionContext.containerView.setNeedsLayout()
             transitionContext.containerView.layoutIfNeeded()
@@ -49,16 +51,16 @@ class BottomSheetPresentationAnimator: NSObject {
             transitionContext.completeTransition(didComplete)
         }
     }
-    
+
     private func animateDismissal(transitionContext: UIViewControllerContextTransitioning) {
         guard
             let toVC = transitionContext.viewController(forKey: .to),
             let fromVC = transitionContext.viewController(forKey: .from)
         else { return }
-        
+
         // Calls viewWillAppear and viewWillDisappear
         toVC.beginAppearanceTransition(true, animated: true)
-        
+
         Self.animate({
             fromVC.view.frame.origin.y = transitionContext.containerView.frame.height
         }) { didComplete in
@@ -68,14 +70,14 @@ class BottomSheetPresentationAnimator: NSObject {
             transitionContext.completeTransition(didComplete)
         }
     }
-    
+
     static func animate(
         _ animations: @escaping () -> Void,
         _ completion: ((Bool) -> Void)? = nil
     ) {
         let params = UISpringTimingParameters()
         let animator = UIViewPropertyAnimator(duration: 0, timingParameters: params)
-        
+
         animator.addAnimations(animations)
         if let completion = completion {
             animator.addCompletion { (_) in
@@ -89,13 +91,15 @@ class BottomSheetPresentationAnimator: NSObject {
 // MARK: - UIViewControllerAnimatedTransitioning Delegate
 
 extension BottomSheetPresentationAnimator: UIViewControllerAnimatedTransitioning {
-    func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?)
-    -> TimeInterval
+    func transitionDuration(
+        using transitionContext: UIViewControllerContextTransitioning?
+    )
+        -> TimeInterval
     {
         // TODO This should depend on height so that velocity is constant
         return 0.5
     }
-    
+
     func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
         switch transitionStyle {
         case .presentation:

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/BottomSheet/BottomSheetTransitioningDelegate.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/BottomSheet/BottomSheetTransitioningDelegate.swift
@@ -17,50 +17,49 @@ import UIKit
 /// ```
 @objc(STPBottomSheetTransitioningDelegate)
 class BottomSheetTransitioningDelegate: NSObject {
-    
+
     static var appearance: PaymentSheet.Appearance = PaymentSheet.Appearance.default
-    
-    /**
-     Returns an instance of the delegate, retained for the duration of presentation
-     */
+
+    /// Returns an instance of the delegate, retained for the duration of presentation
     static var `default`: BottomSheetTransitioningDelegate = {
         return BottomSheetTransitioningDelegate()
     }()
-    
+
 }
 
 @available(iOSApplicationExtension, unavailable)
 @available(macCatalystApplicationExtension, unavailable)
 extension BottomSheetTransitioningDelegate: UIViewControllerTransitioningDelegate {
-    
-    /**
-     Returns a modal presentation animator configured for the presenting state
-     */
+
+    /// Returns a modal presentation animator configured for the presenting state
     func animationController(
-        forPresented presented: UIViewController, presenting: UIViewController,
+        forPresented presented: UIViewController,
+        presenting: UIViewController,
         source: UIViewController
     ) -> UIViewControllerAnimatedTransitioning? {
         return BottomSheetPresentationAnimator(transitionStyle: .presentation)
     }
-    
-    /**
-     Returns a modal presentation animator configured for the dismissing state
-     */
-    func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+
+    /// Returns a modal presentation animator configured for the dismissing state
+    func animationController(
+        forDismissed dismissed: UIViewController
+    ) -> UIViewControllerAnimatedTransitioning? {
         return BottomSheetPresentationAnimator(transitionStyle: .dismissal)
     }
-    
-    /**
-     Returns a modal presentation controller to coordinate the transition from the presenting
-     view controller to the presented view controller.
-     */
+
+    /// Returns a modal presentation controller to coordinate the transition from the presenting
+    /// view controller to the presented view controller.
     func presentationController(
-        forPresented presented: UIViewController, presenting: UIViewController?,
+        forPresented presented: UIViewController,
+        presenting: UIViewController?,
         source: UIViewController
     ) -> UIPresentationController? {
-        let controller = BottomSheetPresentationController(presentedViewController: presented, presenting: presenting)
-        controller.forceFullHeight = (presented as? BottomSheetViewController)?.contentRequiresFullScreen ?? false
+        let controller = BottomSheetPresentationController(
+            presentedViewController: presented,
+            presenting: presenting
+        )
+        controller.forceFullHeight =
+            (presented as? BottomSheetViewController)?.contentRequiresFullScreen ?? false
         return controller
     }
 }
-

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/BottomSheet/UIViewController+BottomSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/BottomSheet/UIViewController+BottomSheet.swift
@@ -14,12 +14,13 @@ extension UIViewController {
     func presentAsBottomSheet(
         _ viewControllerToPresent: BottomSheetPresentable,
         appearance: PaymentSheet.Appearance,
-        completion: (() -> ())? = nil
+        completion: (() -> Void)? = nil
     ) {
         var presentAsFormSheet: Bool {
             // Present as form sheet in larger devices (iPad/Mac).
             if #available(iOS 14.0, macCatalyst 14.0, *) {
-                return UIDevice.current.userInterfaceIdiom == .pad || UIDevice.current.userInterfaceIdiom == .mac
+                return UIDevice.current.userInterfaceIdiom == .pad
+                    || UIDevice.current.userInterfaceIdiom == .mac
             } else {
                 return UIDevice.current.userInterfaceIdiom == .pad
             }
@@ -36,7 +37,7 @@ extension UIViewController {
             BottomSheetTransitioningDelegate.appearance = appearance
             viewControllerToPresent.transitioningDelegate = BottomSheetTransitioningDelegate.default
         }
-        
+
         present(viewControllerToPresent, animated: true, completion: completion)
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Elements/CardSectionWithScanner/CardSectionWithScannerElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Elements/CardSectionWithScanner/CardSectionWithScannerElement.swift
@@ -7,11 +7,11 @@
 //
 
 import Foundation
-import UIKit
-@_spi(STP) import StripeUICore
 @_spi(STP) import StripeCore
 @_spi(STP) import StripePayments
 @_spi(STP) import StripePaymentsUI
+@_spi(STP) import StripeUICore
+import UIKit
 
 /// A Element that contains a SectionElement for card details, whose view depends on the availability of card scanning:
 /// If card scanning is available, it uses a custom view that adds card scanning. Otherwise, it uses the default SectionElement view.
@@ -20,37 +20,51 @@ final class CardSection: ContainerElement {
     var elements: [Element] {
         return [cardSection]
     }
-    
+
     weak var delegate: ElementDelegate?
     lazy var view: UIView = {
         if #available(iOS 13.0, macCatalyst 14, *) {
-            return CardSectionWithScannerView(cardSectionView: cardSection.view, delegate: self, theme: theme)
+            return CardSectionWithScannerView(
+                cardSectionView: cardSection.view,
+                delegate: self,
+                theme: theme
+            )
         } else {
             return cardSection.view
         }
     }()
     let cardSection: SectionElement
-    
+
     // References to the underlying TextFieldElements
     let panElement: TextFieldElement
     let cvcElement: TextFieldElement
     let expiryElement: TextFieldElement
     let theme: ElementsUITheme
-    
-    init(theme: ElementsUITheme = .default) {
+
+    init(
+        theme: ElementsUITheme = .default
+    ) {
         self.theme = theme
-        let panElement = PaymentMethodElementWrapper(TextFieldElement.PANConfiguration(), theme: theme) {  field, params in
+        let panElement = PaymentMethodElementWrapper(
+            TextFieldElement.PANConfiguration(),
+            theme: theme
+        ) { field, params in
             cardParams(for: params).number = field.text
             return params
         }
-        let cvcElementConfiguration = TextFieldElement.CVCConfiguration() {
+        let cvcElementConfiguration = TextFieldElement.CVCConfiguration {
             return STPCardValidator.brand(forNumber: panElement.element.text)
         }
-        let cvcElement = PaymentMethodElementWrapper(cvcElementConfiguration, theme: theme) { field, params in
+        let cvcElement = PaymentMethodElementWrapper(cvcElementConfiguration, theme: theme) {
+            field,
+            params in
             cardParams(for: params).cvc = field.text
             return params
         }
-        let expiryElement = PaymentMethodElementWrapper(TextFieldElement.ExpiryDateConfiguration(), theme: theme) { field, params in
+        let expiryElement = PaymentMethodElementWrapper(
+            TextFieldElement.ExpiryDateConfiguration(),
+            theme: theme
+        ) { field, params in
             if let month = Int(field.text.prefix(2)) {
                 cardParams(for: params).expMonth = NSNumber(integerLiteral: month)
             }
@@ -59,7 +73,7 @@ final class CardSection: ContainerElement {
             }
             return params
         }
-        
+
         let sectionTitle: String? = {
             if #available(iOS 13.0, macCatalyst 14, *) {
                 return nil
@@ -71,16 +85,17 @@ final class CardSection: ContainerElement {
             title: sectionTitle,
             elements: [
                 panElement,
-                SectionElement.MultiElementRow([expiryElement, cvcElement], theme: theme)
-            ], theme: theme
+                SectionElement.MultiElementRow([expiryElement, cvcElement], theme: theme),
+            ],
+            theme: theme
         )
-        
+
         self.panElement = panElement.element
         self.cvcElement = cvcElement.element
         self.expiryElement = expiryElement.element
         cardSection.delegate = self
     }
-    
+
     // MARK: - ElementDelegate
     private var cardBrand: STPCardBrand = .unknown
     func didUpdate(element: Element) {
@@ -88,7 +103,7 @@ final class CardSection: ContainerElement {
         let cardBrand = STPCardValidator.brand(forNumber: panElement.text)
         if self.cardBrand != cardBrand {
             self.cardBrand = cardBrand
-            cvcElement.setText(cvcElement.text) // A hack to get the CVC to update
+            cvcElement.setText(cvcElement.text)  // A hack to get the CVC to update
         }
         delegate?.didUpdate(element: self)
     }
@@ -96,7 +111,7 @@ final class CardSection: ContainerElement {
 
 // MARK: - Helpers
 /// A DRY helper to ensure `STPPaymentMethodCardParams` is present on `intentConfirmParams.paymentMethodParams`.
-fileprivate func cardParams(for intentParams: IntentConfirmParams) -> STPPaymentMethodCardParams {
+private func cardParams(for intentParams: IntentConfirmParams) -> STPPaymentMethodCardParams {
     guard let cardParams = intentParams.paymentMethodParams.card else {
         let cardParams = STPPaymentMethodCardParams()
         intentParams.paymentMethodParams.card = cardParams
@@ -116,13 +131,14 @@ extension CardSection: CardSectionWithScannerViewDelegate {
             }
             return String(format: "%02d%02d", expMonth.intValue, expYear.intValue)
         }()
-        
+
         // Populate the fields with the card params we scanned
         panElement.setText(cardParams.number ?? "")
         expiryElement.setText(expiryString)
-        
+
         // Slightly hacky way to focus the next un-populated field
-        if let lastCompletedElement = [panElement, expiryElement].last(where: { !$0.text.isEmpty }) {
+        if let lastCompletedElement = [panElement, expiryElement].last(where: { !$0.text.isEmpty })
+        {
             lastCompletedElement.delegate?.continueToNextField(element: lastCompletedElement)
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Elements/CardSectionWithScanner/CardSectionWithScannerView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Elements/CardSectionWithScanner/CardSectionWithScannerView.swift
@@ -7,11 +7,11 @@
 //
 
 import Foundation
-import UIKit
-@_spi(STP) import StripeUICore
 @_spi(STP) import StripeCore
 @_spi(STP) import StripePayments
 @_spi(STP) import StripePaymentsUI
+@_spi(STP) import StripeUICore
+import UIKit
 
 /**
  A view that wraps a normal section and adds a "Scan card" button. Tapping the button displays a card scan view below the section.
@@ -35,36 +35,44 @@ final class CardSectionWithScannerView: UIView {
     }()
     weak var delegate: CardSectionWithScannerViewDelegate?
     private let theme: ElementsUITheme
-    
-    init(cardSectionView: UIView, delegate: CardSectionWithScannerViewDelegate, theme: ElementsUITheme = .default) {
+
+    init(
+        cardSectionView: UIView,
+        delegate: CardSectionWithScannerViewDelegate,
+        theme: ElementsUITheme = .default
+    ) {
         self.cardSectionView = cardSectionView
         self.delegate = delegate
         self.theme = theme
         super.init(frame: .zero)
         installConstraints()
     }
-    
+
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
-    
+
     fileprivate func installConstraints() {
         let sectionTitle = ElementsUI.makeSectionTitleLabel(theme: theme)
         sectionTitle.text = String.Localized.card_information
-        let cardSectionTitleAndButton = UIStackView(arrangedSubviews: [sectionTitle, cardScanButton])
-        
-        let stack = UIStackView(arrangedSubviews: [cardSectionTitleAndButton, cardSectionView, cardScanningView])
+        let cardSectionTitleAndButton = UIStackView(arrangedSubviews: [
+            sectionTitle, cardScanButton,
+        ])
+
+        let stack = UIStackView(arrangedSubviews: [
+            cardSectionTitleAndButton, cardSectionView, cardScanningView,
+        ])
         stack.axis = .vertical
         stack.spacing = ElementsUI.sectionSpacing
         stack.setCustomSpacing(ElementsUI.formSpacing, after: cardSectionView)
         addAndPinSubview(stack)
     }
-    
+
     @available(iOS 13, macCatalyst 14, *)
     @objc func didTapCardScanButton() {
         setCardScanVisible(true)
         cardScanningView.start()
         becomeFirstResponder()
     }
-    
+
     private func setCardScanVisible(_ isCardScanVisible: Bool) {
         UIView.animate(withDuration: PaymentSheetUI.defaultAnimationDuration) {
             self.cardScanButton.alpha = isCardScanVisible ? 0 : 1
@@ -72,11 +80,11 @@ final class CardSectionWithScannerView: UIView {
             self.cardScanningView.alpha = isCardScanVisible ? 1 : 0
         }
     }
-    
+
     override var canBecomeFirstResponder: Bool {
         return true
     }
-    
+
     override func resignFirstResponder() -> Bool {
         cardScanningView.stop()
         return super.resignFirstResponder()
@@ -85,7 +93,10 @@ final class CardSectionWithScannerView: UIView {
 
 @available(iOS 13, macCatalyst 14, *)
 extension CardSectionWithScannerView: STP_Internal_CardScanningViewDelegate {
-    func cardScanningView(_ cardScanningView: CardScanningView, didFinishWith cardParams: STPPaymentMethodCardParams?) {
+    func cardScanningView(
+        _ cardScanningView: CardScanningView,
+        didFinishWith cardParams: STPPaymentMethodCardParams?
+    ) {
         setCardScanVisible(false)
         if let cardParams = cardParams {
             self.delegate?.didScanCard(cardParams: cardParams)

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Elements/ConnectionsElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Elements/ConnectionsElement.swift
@@ -6,13 +6,13 @@
 //  Copyright © 2021 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
 @_spi(STP) import StripeUICore
+import UIKit
 
 /// Intentionally empty placeholder for Connections Element
 class ConnectionsElement: Element {
     var delegate: ElementDelegate? = nil
-    
+
     var view: UIView = UIView()
 }
 

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Elements/LinkEnabledPaymentMethodElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Elements/LinkEnabledPaymentMethodElement.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2022 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
 @_spi(STP) import StripeUICore
+import UIKit
 
 final class LinkEnabledPaymentMethodElement: Element {
     struct Constants {
@@ -23,7 +23,7 @@ final class LinkEnabledPaymentMethodElement: Element {
     private lazy var stackView: UIStackView = {
         let stackView = UIStackView(arrangedSubviews: [
             paymentMethodElement.view,
-            inlineSignupElement.view
+            inlineSignupElement.view,
         ])
         stackView.axis = .vertical
         stackView.spacing = Constants.spacing

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Elements/PaymentMethodElement/PaymentMethodElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Elements/PaymentMethodElement/PaymentMethodElement.swift
@@ -9,17 +9,13 @@
 @_spi(STP) import StripeUICore
 
 // MARK: - PaymentMethodElement protocol
-/**
- This allows a user of an Element to collect all fields in the Element hierarchy into an instance of `IntentConfirmParams`.
- 
- - Remark:In practice, only "leaf" Elements - text fields, drop downs, etc. - have any user data to update params with. These elements can be wrapped in `PaymentMethodElementWrapper`.
- Other elements can rely on the default implementation provided in this file.
- */
+/// This allows a user of an Element to collect all fields in the Element hierarchy into an instance of `IntentConfirmParams`.
+///
+/// - Remark:In practice, only "leaf" Elements - text fields, drop downs, etc. - have any user data to update params with. These elements can be wrapped in `PaymentMethodElementWrapper`.
+/// Other elements can rely on the default implementation provided in this file.
 protocol PaymentMethodElement: Element {
-    /**
-     Modify the params according to your input, or return nil if invalid.
-     - Note: This is called on the Element hierarchy in depth-first search order.
-     */
+    /// Modify the params according to your input, or return nil if invalid.
+    /// - Note: This is called on the Element hierarchy in depth-first search order.
     func updateParams(params: IntentConfirmParams) -> IntentConfirmParams?
 }
 

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Elements/PaymentMethodElement/PaymentMethodElementWrapper.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Elements/PaymentMethodElement/PaymentMethodElementWrapper.swift
@@ -6,37 +6,42 @@
 //  Copyright © 2022 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
 @_spi(STP) import StripeUICore
+import UIKit
 
-/**
- A class that wraps an Element and adds a `paramsUpdater` closure, provided at initialization, used to implement `PaymentMethodElement.updateParams`
- */
+/// A class that wraps an Element and adds a `paramsUpdater` closure, provided at initialization, used to implement `PaymentMethodElement.updateParams`
 class PaymentMethodElementWrapper<WrappedElementType: Element> {
     typealias ParamsUpdater = (WrappedElementType, IntentConfirmParams) -> IntentConfirmParams?
-    
+
     let element: WrappedElementType
     weak var delegate: ElementDelegate?
 
     // MARK: IntentConfirmParams updating glue
     let paramsUpdater: ParamsUpdater
-    
-    /**
-     This only exists as a workaround to make initializers with a specific Element type e.g. TextFieldElement.
-     */
-    fileprivate init(privateElement element: WrappedElementType, paramsUpdater: @escaping ParamsUpdater) {
+
+    /// This only exists as a workaround to make initializers with a specific Element type e.g. TextFieldElement.
+    fileprivate init(
+        privateElement element: WrappedElementType,
+        paramsUpdater: @escaping ParamsUpdater
+    ) {
         self.element = element
         self.paramsUpdater = paramsUpdater
         defer {
             element.delegate = self
         }
     }
-    
-    convenience init(_ element: WrappedElementType, paramsUpdater: @escaping ParamsUpdater) {
+
+    convenience init(
+        _ element: WrappedElementType,
+        paramsUpdater: @escaping ParamsUpdater
+    ) {
         self.init(privateElement: element, paramsUpdater: paramsUpdater)
     }
-    
-    convenience init(_ element: TextFieldElement, paramsUpdater: @escaping ParamsUpdater) where WrappedElementType == TextFieldElement {
+
+    convenience init(
+        _ element: TextFieldElement,
+        paramsUpdater: @escaping ParamsUpdater
+    ) where WrappedElementType == TextFieldElement {
         self.init(privateElement: element) { textField, params in
             guard case .valid = textField.validationState else {
                 return nil
@@ -44,11 +49,18 @@ class PaymentMethodElementWrapper<WrappedElementType: Element> {
             return paramsUpdater(textField, params)
         }
     }
-    convenience init(_ textFieldElementConfiguration: TextFieldElementConfiguration, theme: ElementsUITheme, paramsUpdater: @escaping ParamsUpdater) where WrappedElementType == TextFieldElement {
-        let textFieldElement = TextFieldElement(configuration: textFieldElementConfiguration, theme: theme)
+    convenience init(
+        _ textFieldElementConfiguration: TextFieldElementConfiguration,
+        theme: ElementsUITheme,
+        paramsUpdater: @escaping ParamsUpdater
+    ) where WrappedElementType == TextFieldElement {
+        let textFieldElement = TextFieldElement(
+            configuration: textFieldElementConfiguration,
+            theme: theme
+        )
         self.init(textFieldElement, paramsUpdater: paramsUpdater)
     }
-    
+
 }
 
 // MARK: - PaymentMethodElement
@@ -66,15 +78,15 @@ extension PaymentMethodElementWrapper: Element {
     var view: UIView {
         return element.view
     }
-    
+
     func beginEditing() -> Bool {
         return element.beginEditing()
     }
-    
+
     var validationState: ElementValidationState {
         return element.validationState
     }
-    
+
     var subLabelText: String? {
         return element.subLabelText
     }
@@ -85,7 +97,7 @@ extension PaymentMethodElementWrapper: ElementDelegate {
     public func didUpdate(element: Element) {
         delegate?.didUpdate(element: self)
     }
-    
+
     public func continueToNextField(element: Element) {
         delegate?.continueToNextField(element: self)
     }

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Elements/TextField/TextFieldElement+IBAN.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Elements/TextField/TextFieldElement+IBAN.swift
@@ -7,38 +7,47 @@
 //
 
 import Foundation
-import UIKit
-@_spi(STP) import StripeUICore
 @_spi(STP) import StripeCore
+@_spi(STP) import StripeUICore
+import UIKit
 
 extension TextFieldElement {
     static func makeIBAN(theme: ElementsUITheme = .default) -> TextFieldElement {
         return TextFieldElement(configuration: IBANConfiguration(), theme: theme)
     }
-    
+
     // MARK: - IBANError
-    
+
     enum IBANError: TextFieldValidationError, Equatable {
         case incomplete
         case shouldStartWithCountryCode
         case invalidCountryCode(countryCode: String)
         ///  A catch-all for things like incorrect length, invalid characters, bad checksum.
         case invalidFormat
-        
+
         var localizedDescription: String {
             switch self {
             case .incomplete:
-                return STPLocalizedString("The IBAN you entered is incomplete.", "An error message.")
+                return STPLocalizedString(
+                    "The IBAN you entered is incomplete.",
+                    "An error message."
+                )
             case .shouldStartWithCountryCode:
-                return STPLocalizedString("Your IBAN should start with a two-letter country code.", "An error message.")
+                return STPLocalizedString(
+                    "Your IBAN should start with a two-letter country code.",
+                    "An error message."
+                )
             case .invalidCountryCode(let countryCode):
-                let localized = STPLocalizedString("The IBAN you entered is invalid, \"%@\" is not a supported country code.", "An error message.")
+                let localized = STPLocalizedString(
+                    "The IBAN you entered is invalid, \"%@\" is not a supported country code.",
+                    "An error message."
+                )
                 return String(format: localized, countryCode)
             case .invalidFormat:
                 return NSError.stp_invalidBankAccountIban
             }
         }
-        
+
         func shouldDisplay(isUserEditing: Bool) -> Bool {
             switch self {
             case .incomplete, .invalidFormat:
@@ -48,13 +57,12 @@ extension TextFieldElement {
             }
         }
     }
-        
+
     // MARK: IBANConfiguration
-    /**
-     A text field configuration for an IBAN, or International Bank Account Number, as defined in ISO 13616-1.
-     
-     - Seealso: https://en.wikipedia.org/wiki/International_Bank_Account_Number
-     */
+
+    /// A text field configuration for an IBAN, or International Bank Account Number, as defined in ISO 13616-1.
+    ///
+    /// - Seealso: https://en.wikipedia.org/wiki/International_Bank_Account_Number
     struct IBANConfiguration: TextFieldElementConfiguration {
         let label: String = STPLocalizedString("IBAN", "Label for an IBAN field")
         func maxLength(for text: String) -> Int {
@@ -69,54 +77,56 @@ extension TextFieldElement {
 
         func makeDisplayText(for text: String) -> NSAttributedString {
             let firstTwoCapitalized = text.prefix(2).uppercased() + text.dropFirst(2)
-            let attributed = NSMutableAttributedString(string: firstTwoCapitalized, attributes: [.kern: 0])
+            let attributed = NSMutableAttributedString(
+                string: firstTwoCapitalized,
+                attributes: [.kern: 0]
+            )
             // Put a space between every 4th character
             for i in stride(from: 3, to: attributed.length, by: 4) {
                 attributed.addAttribute(.kern, value: 5, range: NSRange(location: i, length: 1))
             }
             return attributed
         }
-        
-        /**
-         The IBAN structure is defined in ISO 13616-1 and consists of a two-letter ISO 3166-1 country code,
-         followed by two check digits and up to thirty alphanumeric characters for a BBAN (Basic Bank Account Number)
-         which has a fixed length per country and, included within it, a bank identifier with a fixed position and a fixed length per country.
-         
-         The check digits are calculated based on the scheme defined in ISO/IEC 7064 (MOD97-10).
-         We perform the algorithm as described in https://en.wikipedia.org/wiki/International_Bank_Account_Number#Validating_the_IBAN
-         */
+
+        /// The IBAN structure is defined in ISO 13616-1 and consists of a two-letter ISO 3166-1 country code,
+        /// followed by two check digits and up to thirty alphanumeric characters for a BBAN (Basic Bank Account Number)
+        /// which has a fixed length per country and, included within it, a bank identifier with a fixed position and a fixed length per country.
+        ///
+        /// The check digits are calculated based on the scheme defined in ISO/IEC 7064 (MOD97-10).
+        /// We perform the algorithm as described in https://en.wikipedia.org/wiki/International_Bank_Account_Number#Validating_the_IBAN
         func validate(text: String, isOptional: Bool) -> ValidationState {
             let iBAN = text.uppercased()
             guard !iBAN.isEmpty else {
                 return isOptional ? .valid : .invalid(Error.empty)
             }
-            
+
             // Validate starts with a two-letter country code
             let countryValidationResult = Self.validateCountryCode(iBAN)
             guard case .valid = countryValidationResult else {
                 return countryValidationResult
             }
-            
+
             // Validate that the total IBAN length is correct
             guard iBAN.count > minLength else {
                 return .invalid(IBANError.incomplete)
             }
-            
+
             // Validate it's up to 34 alphanumeric characters long
             guard
                 iBAN.count <= maxLength(for: text),
-                iBAN.allSatisfy({ $0.isASCII && ($0.isLetter || $0.isNumber)}) else {
-                    return .invalid(IBANError.invalidFormat)
-                }
-            
+                iBAN.allSatisfy({ $0.isASCII && ($0.isLetter || $0.isNumber) })
+            else {
+                return .invalid(IBANError.invalidFormat)
+            }
+
             // Move the four initial characters to the end of the string
             // e.g. "GB1234" -> "34GB12"
             let reorderedIBAN = iBAN.dropFirst(4) + iBAN.prefix(4)
-            
+
             // Replace each letter in the string with two digits, thereby expanding the string, where A = 10, B = 11, ..., Z = 35
             // e.g., "GB82" -> "161182"
             let oneBigNumber = Self.transformToASCIIDigits(String(reorderedIBAN))
-            
+
             // Interpret the string as a decimal integer and compute the remainder of that number on division by 97
             // If the IBAN is valid, the remainder equals 1.
             // e.g., "00001011" -> Int(1011)
@@ -125,9 +135,9 @@ extension TextFieldElement {
             }
             return .valid
         }
-        
+
         // MARK: - Helper methods
-        
+
         /// Validates that the iBAN begins with a two-letter country code
         static func validateCountryCode(_ iBAN: String) -> ValidationState {
             let countryCode = String(iBAN.prefix(2))
@@ -145,20 +155,21 @@ extension TextFieldElement {
             }
             return .valid
         }
-        
+
         /// Interprets `bigNumber` as a decimal integer and compute the remainder of that number on division by 97
         /// - Note: Does not handle empty strings
         static func mod97(_ bigNumber: String) -> Int? {
             return bigNumber.reduce(0) { (previousMod, char) in
                 guard let previousMod = previousMod,
-                      let value = Int(String(char)) else {
-                          return nil
-                      }
+                    let value = Int(String(char))
+                else {
+                    return nil
+                }
                 let factor = value < 10 ? 10 : 100
                 return (factor * previousMod + value) % 97
             }
         }
-        
+
         /// Replaces each letter in the string with two digits, thereby expanding the string, where A = 10, B = 11, ..., Z = 35
         /// e.g., "GB82" -> "161182"
         /// - Note: Assumes the string is alphanumeric
@@ -180,4 +191,4 @@ extension TextFieldElement {
     }
 }
 
-fileprivate let asciiValueOfA: Int = Int(Character("A").asciiValue!)
+private let asciiValueOfA: Int = Int(Character("A").asciiValue!)

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Error+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Error+PaymentSheet.swift
@@ -10,7 +10,7 @@ import Foundation
 @_spi(STP) import StripeCore
 
 extension Error {
-    
+
     /// If the `localizedDescription` contains a generic error message this returns the raw error message within `userInfo`
     /// Otherwise returns the `localizedDescription`
     var nonGenericDescription: String {
@@ -18,10 +18,14 @@ extension Error {
             return paymentSheetError.debugDescription
         }
         // If the `localizedDescription` is not generic, return the `localizedDescription`
-        if localizedDescription != NSError.stp_unexpectedErrorMessage() { return localizedDescription }
-        
+        if localizedDescription != NSError.stp_unexpectedErrorMessage() {
+            return localizedDescription
+        }
+
         // If error message is generic, return raw value for error message instead
-        let errorMessage = (self as NSError).userInfo[STPError.errorMessageKey] as? String ?? NSError.stp_unexpectedErrorMessage()
+        let errorMessage =
+            (self as NSError).userInfo[STPError.errorMessageKey] as? String
+            ?? NSError.stp_unexpectedErrorMessage()
         return errorMessage
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/KlarnaHelper.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/KlarnaHelper.swift
@@ -10,7 +10,7 @@ import Foundation
 
 /// Helper struct that holds some Klarna specfic logic around accepted currencies and country restrictions
 struct KlarnaHelper {
-    
+
     /// Klarna can only accept payments to specfic countries based on the currency in the PI
     /// - Parameter currency: the currency on the `PaymentIntent`
     /// - Returns: the list of countries this PI can take payment from for Klarna.
@@ -21,11 +21,11 @@ struct KlarnaHelper {
             "nok": ["NO"],
             "sek": ["SE"],
             "gbp": ["GB"],
-            "usd": ["US"]
+            "usd": ["US"],
         ]
         return currencyToCountry[currency.lowercased()] ?? []
     }
-    
+
     /// Klarna only accepts "Buy Now" from certain countries
     /// Determines if Klarna accepts "Buy Now" from `locale`
     /// - Returns: True if Klarna supports buy now in `locale`

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Link/PayWithLinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Link/PayWithLinkController.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2022 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
 @_spi(STP) import StripePayments
 @_spi(STP) import StripeUICore
+import UIKit
 
 /// Standalone Link controller
 @available(iOSApplicationExtension, unavailable)
@@ -26,7 +26,10 @@ final class PayWithLinkController {
     let intent: Intent
     let configuration: PaymentSheet.Configuration
 
-    init(intent: Intent, configuration: PaymentSheet.Configuration) {
+    init(
+        intent: Intent,
+        configuration: PaymentSheet.Configuration
+    ) {
         self.intent = intent
         self.configuration = configuration
         self.paymentHandler = .init(apiClient: configuration.apiClient)
@@ -53,9 +56,13 @@ final class PayWithLinkController {
         self.selfRetainer = self
         self.completion = completion
 
-        let payWithLinkViewController = PayWithLinkViewController(intent: intent, configuration: configuration)
+        let payWithLinkViewController = PayWithLinkViewController(
+            intent: intent,
+            configuration: configuration
+        )
         payWithLinkViewController.payWithLinkDelegate = self
-        payWithLinkViewController.modalPresentationStyle = UIDevice.current.userInterfaceIdiom == .pad
+        payWithLinkViewController.modalPresentationStyle =
+            UIDevice.current.userInterfaceIdiom == .pad
             ? .formSheet
             : .overFullScreen
 
@@ -84,13 +91,17 @@ extension PayWithLinkController: PayWithLinkViewControllerDelegate {
         )
     }
 
-    func payWithLinkViewControllerDidCancel(_ payWithLinkViewController: PayWithLinkViewController) {
+    func payWithLinkViewControllerDidCancel(_ payWithLinkViewController: PayWithLinkViewController)
+    {
         payWithLinkViewController.dismiss(animated: true)
         completion?(.canceled)
         selfRetainer = nil
     }
 
-    func payWithLinkViewControllerDidFinish(_ payWithLinkViewController: PayWithLinkViewController, result: PaymentSheetResult) {
+    func payWithLinkViewControllerDidFinish(
+        _ payWithLinkViewController: PayWithLinkViewController,
+        result: PaymentSheetResult
+    ) {
         payWithLinkViewController.dismiss(animated: true)
         completion?(result)
         selfRetainer = nil

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Link/PaymentSheet-LinkConfirmOption.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Link/PaymentSheet-LinkConfirmOption.swift
@@ -7,8 +7,8 @@
 //
 
 import Foundation
-@_spi(STP) import StripeUICore
 @_spi(STP) import StripePayments
+@_spi(STP) import StripeUICore
 
 extension PaymentSheet {
 

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
@@ -7,16 +7,16 @@
 //
 
 import Foundation
-import UIKit
-@_spi(STP) import StripeUICore
 @_spi(STP) import StripeCore
 @_spi(STP) import StripePayments
+@_spi(STP) import StripeUICore
+import UIKit
+
 protocol AddPaymentMethodViewControllerDelegate: AnyObject {
     func didUpdate(_ viewController: AddPaymentMethodViewController)
     func shouldOfferLinkSignup(_ viewController: AddPaymentMethodViewController) -> Bool
     func updateErrorLabel(for: Error?)
 }
-
 
 enum OverrideableBuyButtonBehavior {
     case LinkUSBankAccount
@@ -33,7 +33,8 @@ class AddPaymentMethodViewController: UIViewController {
     lazy var paymentMethodTypes: [PaymentSheet.PaymentMethodType] = {
         let paymentMethodTypes = PaymentSheet.PaymentMethodType.filteredPaymentMethodTypes(
             from: intent,
-            configuration: configuration)
+            configuration: configuration
+        )
         assert(!paymentMethodTypes.isEmpty, "At least one payment method type must be available.")
         return paymentMethodTypes
     }()
@@ -61,8 +62,8 @@ class AddPaymentMethodViewController: UIViewController {
 
     var overrideCallToAction: ConfirmButton.CallToActionType? {
         return overrideBuyButtonBehavior != nil
-        ? ConfirmButton.CallToActionType.customWithLock(title: String.Localized.continue)
-        : nil
+            ? ConfirmButton.CallToActionType.customWithLock(title: String.Localized.continue)
+            : nil
     }
 
     var overrideCallToActionShouldEnable: Bool {
@@ -77,7 +78,9 @@ class AddPaymentMethodViewController: UIViewController {
 
     var bottomNoticeAttributedString: NSAttributedString? {
         if selectedPaymentMethodType == .USBankAccount {
-            if let usBankPaymentMethodElement = paymentMethodFormElement as? USBankAccountPaymentMethodElement {
+            if let usBankPaymentMethodElement = paymentMethodFormElement
+                as? USBankAccountPaymentMethodElement
+            {
                 return usBankPaymentMethodElement.mandateString
             }
         }
@@ -87,8 +90,9 @@ class AddPaymentMethodViewController: UIViewController {
     var overrideBuyButtonBehavior: OverrideableBuyButtonBehavior? {
         if selectedPaymentMethodType == .USBankAccount {
             if let paymentOption = paymentOption,
-               case .new = paymentOption {
-                return nil // already have PaymentOption
+                case .new = paymentOption
+            {
+                return nil  // already have PaymentOption
             } else {
                 return .LinkUSBankAccount
             }
@@ -103,7 +107,9 @@ class AddPaymentMethodViewController: UIViewController {
         // We are keeping usBankAccountInfo in memory to preserve state
         // if the user switches payment method types
         let paymentMethodElement = makeElement(for: selectedPaymentMethodType)
-        if let usBankAccountPaymentMethodElement = paymentMethodElement as? USBankAccountPaymentMethodElement {
+        if let usBankAccountPaymentMethodElement = paymentMethodElement
+            as? USBankAccountPaymentMethodElement
+        {
             usBankAccountPaymentMethodElement.presentingViewControllerDelegate = self
         } else {
             assertionFailure("Wrong type for usBankAccountFormElement")
@@ -112,7 +118,8 @@ class AddPaymentMethodViewController: UIViewController {
     }()
     private lazy var paymentMethodFormElement: PaymentMethodElement = {
         if selectedPaymentMethodType == .USBankAccount,
-        let usBankAccountFormElement = usBankAccountFormElement {
+            let usBankAccountFormElement = usBankAccountFormElement
+        {
             return usBankAccountFormElement
         }
         return makeElement(for: selectedPaymentMethodType)
@@ -124,12 +131,17 @@ class AddPaymentMethodViewController: UIViewController {
     }()
     private lazy var paymentMethodTypesView: PaymentMethodTypeCollectionView = {
         let view = PaymentMethodTypeCollectionView(
-            paymentMethodTypes: paymentMethodTypes, appearance: configuration.appearance, delegate: self)
+            paymentMethodTypes: paymentMethodTypes,
+            appearance: configuration.appearance,
+            delegate: self
+        )
         return view
     }()
     private lazy var paymentMethodDetailsContainerView: DynamicHeightContainerView = {
         // when displaying link, we aren't in the bottom/payment sheet so pin to top for height changes
-        let view = DynamicHeightContainerView(pinnedDirection: configuration.linkPaymentMethodsOnly ? .top : .bottom)
+        let view = DynamicHeightContainerView(
+            pinnedDirection: configuration.linkPaymentMethodsOnly ? .top : .bottom
+        )
         view.directionalLayoutMargins = PaymentSheetUI.defaultMargins
         view.addPinnedSubview(paymentMethodDetailsView)
         view.updateHeight()
@@ -137,7 +149,9 @@ class AddPaymentMethodViewController: UIViewController {
     }()
 
     // MARK: - Inits
-    required init?(coder: NSCoder) {
+    required init?(
+        coder: NSCoder
+    ) {
         fatalError("init(coder:) has not been implemented")
     }
 
@@ -185,15 +199,18 @@ class AddPaymentMethodViewController: UIViewController {
     deinit {
         LinkAccountContext.shared.removeObserver(self)
     }
-    
+
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         if configuration.defaultBillingDetails == .init(),
-           let addressSection = paymentMethodFormElement.getAllSubElements()
-            .compactMap({ $0 as? PaymentMethodElementWrapper<AddressSectionElement> }).first?.element {
+            let addressSection = paymentMethodFormElement.getAllSubElements()
+                .compactMap({ $0 as? PaymentMethodElementWrapper<AddressSectionElement> }).first?
+                .element
+        {
             // If we're displaying an AddressSectionElement and we don't have default billing details, update it with the latest shipping details
             let delegate = addressSection.delegate
-            addressSection.delegate = nil // Stop didUpdate delegate calls to avoid laying out while we're being presented
+            // Stop didUpdate delegate calls to avoid laying out while we're being presented
+            addressSection.delegate = nil
             if let newShippingAddress = configuration.shippingDetails()?.address {
                 addressSection.updateBillingSameAsShippingDefaultAddress(.init(newShippingAddress))
             } else {
@@ -204,7 +221,7 @@ class AddPaymentMethodViewController: UIViewController {
     }
 
     // MARK: - Internal
-    
+
     /// Returns true iff we could map the error to one of the displayed fields
     func setErrorIfNecessary(for error: Error?) -> Bool {
         // TODO
@@ -266,7 +283,8 @@ class AddPaymentMethodViewController: UIViewController {
 
     private func updateFormElement() {
         if selectedPaymentMethodType == .USBankAccount,
-        let usBankAccountFormElement = usBankAccountFormElement {
+            let usBankAccountFormElement = usBankAccountFormElement
+        {
             paymentMethodFormElement = usBankAccountFormElement
         } else {
             paymentMethodFormElement = makeElement(for: selectedPaymentMethodType)
@@ -274,61 +292,78 @@ class AddPaymentMethodViewController: UIViewController {
         updateUI()
     }
 
-    func didTapCallToActionButton(behavior: OverrideableBuyButtonBehavior, from viewController: UIViewController) {
-        switch(behavior) {
+    func didTapCallToActionButton(
+        behavior: OverrideableBuyButtonBehavior,
+        from viewController: UIViewController
+    ) {
+        switch behavior {
         case .LinkUSBankAccount:
             handleCollectBankAccount(from: viewController)
         }
     }
 
     func handleCollectBankAccount(from viewController: UIViewController) {
-        guard let usBankAccountPaymentMethodElement = self.paymentMethodFormElement as? USBankAccountPaymentMethodElement,
-        let name = usBankAccountPaymentMethodElement.name,
-        let email = usBankAccountPaymentMethodElement.email else {
+        guard
+            let usBankAccountPaymentMethodElement = self.paymentMethodFormElement
+                as? USBankAccountPaymentMethodElement,
+            let name = usBankAccountPaymentMethodElement.name,
+            let email = usBankAccountPaymentMethodElement.email
+        else {
             assertionFailure()
             return
         }
 
         let params = STPCollectBankAccountParams.collectUSBankAccountParams(
             with: name,
-            email: email)
+            email: email
+        )
         let client = STPBankAccountCollector()
-        let errorText = STPLocalizedString("Something went wrong when linking your account.\nPlease try again later.",
-                                           "Error message when an error case happens when linking your account")
+        let errorText = STPLocalizedString(
+            "Something went wrong when linking your account.\nPlease try again later.",
+            "Error message when an error case happens when linking your account"
+        )
         let genericError = PaymentSheetError.unknown(debugDescription: errorText)
 
-        let financialConnectionsCompletion: (FinancialConnectionsSDKResult?, LinkAccountSession?, NSError?) -> Void = { result, linkAccountSession, error in
-            if let _ = error {
-                self.delegate?.updateErrorLabel(for: genericError)
-                return
-            }
-            guard let financialConnectionsResult = result else {
-                self.delegate?.updateErrorLabel(for: genericError)
-                return
-            }
+        let financialConnectionsCompletion:
+            (FinancialConnectionsSDKResult?, LinkAccountSession?, NSError?) -> Void = {
+                result,
+                linkAccountSession,
+                error in
+                if let _ = error {
+                    self.delegate?.updateErrorLabel(for: genericError)
+                    return
+                }
+                guard let financialConnectionsResult = result else {
+                    self.delegate?.updateErrorLabel(for: genericError)
+                    return
+                }
 
-            switch(financialConnectionsResult) {
-            case .cancelled:
-                break
-            case .completed(let linkedBank):
-                usBankAccountPaymentMethodElement.setLinkedBank(linkedBank)
-            case .failed:
-                self.delegate?.updateErrorLabel(for: genericError)
+                switch financialConnectionsResult {
+                case .cancelled:
+                    break
+                case .completed(let linkedBank):
+                    usBankAccountPaymentMethodElement.setLinkedBank(linkedBank)
+                case .failed:
+                    self.delegate?.updateErrorLabel(for: genericError)
+                }
             }
-        }
-        switch(intent) {
+        switch intent {
         case .paymentIntent:
-            client.collectBankAccountForPayment(clientSecret: intent.clientSecret,
-                                                returnURL: configuration.returnURL,
-                                                params: params,
-                                                from: viewController,
-                                                financialConnectionsCompletion: financialConnectionsCompletion)
+            client.collectBankAccountForPayment(
+                clientSecret: intent.clientSecret,
+                returnURL: configuration.returnURL,
+                params: params,
+                from: viewController,
+                financialConnectionsCompletion: financialConnectionsCompletion
+            )
         case .setupIntent:
-            client.collectBankAccountForSetup(clientSecret: intent.clientSecret,
-                                              returnURL: configuration.returnURL,
-                                              params: params,
-                                              from: viewController,
-                                              financialConnectionsCompletion: financialConnectionsCompletion)
+            client.collectBankAccountForSetup(
+                clientSecret: intent.clientSecret,
+                returnURL: configuration.returnURL,
+                params: params,
+                from: viewController,
+                financialConnectionsCompletion: financialConnectionsCompletion
+            )
         }
     }
 }
@@ -348,7 +383,7 @@ extension AddPaymentMethodViewController: ElementDelegate {
     func continueToNextField(element: Element) {
         delegate?.didUpdate(self)
     }
-    
+
     func didUpdate(element: Element) {
         delegate?.didUpdate(self)
         animateHeightChange()

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/New Payment Method Screen/PaymentMethodTypeCollectionView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/New Payment Method Screen/PaymentMethodTypeCollectionView.swift
@@ -7,9 +7,9 @@
 //
 
 import Foundation
-import UIKit
 @_spi(STP) import StripeCore
 @_spi(STP) import StripeUICore
+import UIKit
 
 protocol PaymentMethodTypeCollectionViewDelegate: AnyObject {
     func didUpdateSelection(_ paymentMethodTypeCollectionView: PaymentMethodTypeCollectionView)
@@ -20,10 +20,13 @@ protocol PaymentMethodTypeCollectionViewDelegate: AnyObject {
 @objc(STP_Internal_PaymentMethodTypeCollectionView)
 class PaymentMethodTypeCollectionView: UICollectionView {
     // MARK: - Constants
-    internal static let paymentMethodLogoSize: CGSize = CGSize(width: UIView.noIntrinsicMetric, height: 12)
+    internal static let paymentMethodLogoSize: CGSize = CGSize(
+        width: UIView.noIntrinsicMetric,
+        height: 12
+    )
     internal static let cellHeight: CGFloat = 52
     internal static let minInteritemSpacing: CGFloat = 12
-    
+
     let reuseIdentifier: String = "PaymentMethodTypeCollectionView.PaymentTypeCell"
     private(set) var selected: PaymentSheet.PaymentMethodType {
         didSet(old) {
@@ -42,7 +45,7 @@ class PaymentMethodTypeCollectionView: UICollectionView {
         delegate: PaymentMethodTypeCollectionViewDelegate
     ) {
         assert(!paymentMethodTypes.isEmpty, "At least one payment method type must be provided.")
-        
+
         self.paymentMethodTypes = paymentMethodTypes
         self._delegate = delegate
         self.selected = paymentMethodTypes[0]
@@ -50,8 +53,11 @@ class PaymentMethodTypeCollectionView: UICollectionView {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .horizontal
         layout.sectionInset = UIEdgeInsets(
-            top: 0, left: PaymentSheetUI.defaultPadding, bottom: 0,
-            right: PaymentSheetUI.defaultPadding)
+            top: 0,
+            left: PaymentSheetUI.defaultPadding,
+            bottom: 0,
+            right: PaymentSheetUI.defaultPadding
+        )
         layout.minimumInteritemSpacing = PaymentMethodTypeCollectionView.minInteritemSpacing
         super.init(frame: .zero, collectionViewLayout: layout)
         self.dataSource = self
@@ -67,31 +73,46 @@ class PaymentMethodTypeCollectionView: UICollectionView {
         accessibilityIdentifier = "PaymentMethodTypeCollectionView"
     }
 
-    required init?(coder: NSCoder) {
+    required init?(
+        coder: NSCoder
+    ) {
         fatalError("init(coder:) has not been implemented")
     }
 
     override var intrinsicContentSize: CGSize {
-        return CGSize(width: UIView.noIntrinsicMetric, height: PaymentMethodTypeCollectionView.cellHeight)
+        return CGSize(
+            width: UIView.noIntrinsicMetric,
+            height: PaymentMethodTypeCollectionView.cellHeight
+        )
     }
 }
 
 // MARK: - UICollectionViewDataSource, UICollectionViewDelegate, UICollectionViewDelegateFlowLayout
 
-extension PaymentMethodTypeCollectionView: UICollectionViewDataSource, UICollectionViewDelegate, UICollectionViewDelegateFlowLayout {
-    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int)
+extension PaymentMethodTypeCollectionView: UICollectionViewDataSource, UICollectionViewDelegate,
+    UICollectionViewDelegateFlowLayout
+{
+    func collectionView(
+        _ collectionView: UICollectionView,
+        numberOfItemsInSection section: Int
+    )
         -> Int
     {
         return paymentMethodTypes.count
     }
 
-    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath)
+    func collectionView(
+        _ collectionView: UICollectionView,
+        cellForItemAt indexPath: IndexPath
+    )
         -> UICollectionViewCell
     {
         guard
             let cell = collectionView.dequeueReusableCell(
                 withReuseIdentifier: PaymentMethodTypeCollectionView.PaymentTypeCell
-                    .reuseIdentifier, for: indexPath)
+                    .reuseIdentifier,
+                for: indexPath
+            )
                 as? PaymentMethodTypeCollectionView.PaymentTypeCell,
             let appearance = (collectionView as? PaymentMethodTypeCollectionView)?.appearance
         else {
@@ -107,12 +128,17 @@ extension PaymentMethodTypeCollectionView: UICollectionViewDataSource, UICollect
         collectionView.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: true)
         selected = paymentMethodTypes[indexPath.item]
     }
-    
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+
+    func collectionView(
+        _ collectionView: UICollectionView,
+        layout collectionViewLayout: UICollectionViewLayout,
+        sizeForItemAt indexPath: IndexPath
+    ) -> CGSize {
         var useFixedSizeCells: Bool {
             // Prefer fixed size cells for iPads and Mac.
             if #available(iOS 14.0, macCatalyst 14.0, *) {
-                return UIDevice.current.userInterfaceIdiom == .pad || UIDevice.current.userInterfaceIdiom == .mac
+                return UIDevice.current.userInterfaceIdiom == .pad
+                    || UIDevice.current.userInterfaceIdiom == .mac
             } else {
                 return UIDevice.current.userInterfaceIdiom == .pad
             }
@@ -125,8 +151,21 @@ extension PaymentMethodTypeCollectionView: UICollectionViewDataSource, UICollect
             // When there are not 2 PMs, show 3 full cells plus 30% of the next if present
             let numberOfCellsToShow = paymentMethodTypes.count == 2 ? CGFloat(2) : CGFloat(3.3)
 
-            let cellWidth = (collectionView.frame.width - (PaymentSheetUI.defaultPadding + (PaymentMethodTypeCollectionView.minInteritemSpacing * 3.0))) / numberOfCellsToShow
-            return CGSize(width: max(cellWidth, PaymentTypeCell.minWidth(for: paymentMethodTypes[indexPath.item], appearance: appearance)), height: PaymentMethodTypeCollectionView.cellHeight)
+            let cellWidth =
+                (collectionView.frame.width
+                    - (PaymentSheetUI.defaultPadding
+                        + (PaymentMethodTypeCollectionView.minInteritemSpacing * 3.0)))
+                / numberOfCellsToShow
+            return CGSize(
+                width: max(
+                    cellWidth,
+                    PaymentTypeCell.minWidth(
+                        for: paymentMethodTypes[indexPath.item],
+                        appearance: appearance
+                    )
+                ),
+                height: PaymentMethodTypeCollectionView.cellHeight
+            )
         }
     }
 }
@@ -141,7 +180,7 @@ extension PaymentMethodTypeCollectionView {
                 update()
             }
         }
-        
+
         var appearance: PaymentSheet.Appearance = PaymentSheet.Appearance.default {
             didSet {
                 update()
@@ -151,7 +190,11 @@ extension PaymentMethodTypeCollectionView {
         private lazy var label: UILabel = {
             let label = UILabel()
             label.numberOfLines = 1
-            label.font = appearance.scaledFont(for: appearance.font.base.medium, style: .footnote, maximumPointSize: 20)
+            label.font = appearance.scaledFont(
+                for: appearance.font.base.medium,
+                style: .footnote,
+                maximumPointSize: 20
+            )
             label.adjustsFontSizeToFitWidth = true
             label.minimumScaleFactor = 0.75
             label.textColor = .label
@@ -167,7 +210,11 @@ extension PaymentMethodTypeCollectionView {
             let shadowRoundedRectangle = ShadowedRoundedRectangle(appearance: appearance)
             shadowRoundedRectangle.layer.borderWidth = 1
             shadowRoundedRectangle.layoutMargins = UIEdgeInsets(
-                top: 15, left: 24, bottom: 15, right: 24)
+                top: 15,
+                left: 24,
+                bottom: 15,
+                right: 24
+            )
             return shadowRoundedRectangle
         }()
         lazy var paymentMethodLogoWidthConstraint: NSLayoutConstraint = {
@@ -180,10 +227,15 @@ extension PaymentMethodTypeCollectionView {
         // maps payment method type to (appearnceInstance, width) to avoid recalculation
         private static var widthCache = [String: (PaymentSheet.Appearance, CGFloat)]()
 
-        class func minWidth(for paymentMethodType: PaymentSheet.PaymentMethodType, appearance: PaymentSheet.Appearance) -> CGFloat {
-            let paymentMethodTypeString = PaymentSheet.PaymentMethodType.string(from: paymentMethodType) ?? "unknown"
+        class func minWidth(
+            for paymentMethodType: PaymentSheet.PaymentMethodType,
+            appearance: PaymentSheet.Appearance
+        ) -> CGFloat {
+            let paymentMethodTypeString =
+                PaymentSheet.PaymentMethodType.string(from: paymentMethodType) ?? "unknown"
             if let (cachedAppearance, cachedWidth) = widthCache[paymentMethodTypeString],
-               cachedAppearance == appearance {
+                cachedAppearance == appearance
+            {
                 return cachedWidth
             }
             sizingInstance.paymentMethodType = paymentMethodType
@@ -193,7 +245,9 @@ extension PaymentMethodTypeCollectionView {
             return size.width
         }
 
-        override init(frame: CGRect) {
+        override init(
+            frame: CGRect
+        ) {
             super.init(frame: frame)
 
             [paymentMethodLogo, label].forEach {
@@ -204,23 +258,33 @@ extension PaymentMethodTypeCollectionView {
             isAccessibilityElement = true
             contentView.addAndPinSubview(shadowRoundedRectangle)
             shadowRoundedRectangle.frame = bounds
-            
+
             NSLayoutConstraint.activate([
                 paymentMethodLogo.topAnchor.constraint(
-                    equalTo: shadowRoundedRectangle.topAnchor, constant: 12),
+                    equalTo: shadowRoundedRectangle.topAnchor,
+                    constant: 12
+                ),
                 paymentMethodLogo.leadingAnchor.constraint(
-                    equalTo: shadowRoundedRectangle.leadingAnchor, constant: 12),
+                    equalTo: shadowRoundedRectangle.leadingAnchor,
+                    constant: 12
+                ),
                 paymentMethodLogo.heightAnchor.constraint(
-                    equalToConstant: PaymentMethodTypeCollectionView.paymentMethodLogoSize.height),
+                    equalToConstant: PaymentMethodTypeCollectionView.paymentMethodLogoSize.height
+                ),
                 paymentMethodLogoWidthConstraint,
 
                 label.topAnchor.constraint(equalTo: paymentMethodLogo.bottomAnchor, constant: 4),
                 label.bottomAnchor.constraint(
-                    equalTo: shadowRoundedRectangle.bottomAnchor, constant: -8),
+                    equalTo: shadowRoundedRectangle.bottomAnchor,
+                    constant: -8
+                ),
                 label.leadingAnchor.constraint(equalTo: paymentMethodLogo.leadingAnchor),
-                label.trailingAnchor.constraint(equalTo: shadowRoundedRectangle.trailingAnchor, constant: -12), // should be -const of paymentMethodLogo leftAnchor
+                label.trailingAnchor.constraint(
+                    equalTo: shadowRoundedRectangle.trailingAnchor,
+                    constant: -12
+                ),  // should be -const of paymentMethodLogo leftAnchor
             ])
-            
+
             contentView.layer.cornerRadius = appearance.cornerRadius
             clipsToBounds = false
             layer.masksToBounds = false
@@ -235,7 +299,9 @@ extension PaymentMethodTypeCollectionView {
                 .cgPath
         }
 
-        required init?(coder: NSCoder) {
+        required init?(
+            coder: NSCoder
+        ) {
             fatalError("init(coder:) has not been implemented")
         }
 
@@ -269,11 +335,18 @@ extension PaymentMethodTypeCollectionView {
             shadowRoundedRectangle.appearance = appearance
             label.text = paymentMethodType.displayName
 
-            label.font = appearance.scaledFont(for: appearance.font.base.medium, style: .footnote, maximumPointSize: 20)
+            label.font = appearance.scaledFont(
+                for: appearance.font.base.medium,
+                style: .footnote,
+                maximumPointSize: 20
+            )
             let currPaymentMethodType = self.paymentMethodType
-            let image = paymentMethodType.makeImage(forDarkBackground: appearance.colors.componentBackground.contrastingColor == .white) { [weak self] image in
+            let image = paymentMethodType.makeImage(
+                forDarkBackground: appearance.colors.componentBackground.contrastingColor == .white
+            ) { [weak self] image in
                 guard let strongSelf = self,
-                      currPaymentMethodType == strongSelf.paymentMethodType else {
+                    currPaymentMethodType == strongSelf.paymentMethodType
+                else {
                     return
                 }
                 DispatchQueue.main.async {
@@ -292,7 +365,7 @@ extension PaymentMethodTypeCollectionView {
             } else {
                 // Set text color
                 label.textColor = appearance.colors.componentText
-                
+
                 // Set border
                 shadowRoundedRectangle.layer.borderWidth = appearance.borderWidth
                 shadowRoundedRectangle.layer.borderColor = appearance.colors.componentBorder.cgColor
@@ -304,13 +377,17 @@ extension PaymentMethodTypeCollectionView {
         private func updateImage(_ imageParam: UIImage) {
             var image = imageParam
             // tint icon primary color for a few PMs should be tinted the appearance primary color when selected
-            if paymentMethodType.iconRequiresTinting  {
+            if paymentMethodType.iconRequiresTinting {
                 image = image.withRenderingMode(.alwaysTemplate)
-                paymentMethodLogo.tintColor = isSelected ? appearance.colors.primary : appearance.colors.componentBackground.contrastingColor
+                paymentMethodLogo.tintColor =
+                    isSelected
+                    ? appearance.colors.primary
+                    : appearance.colors.componentBackground.contrastingColor
             }
 
             paymentMethodLogo.image = image
-            paymentMethodLogoWidthConstraint.constant = paymentMethodLogoSize.height / image.size.height * image.size.width
+            paymentMethodLogoWidthConstraint.constant =
+                paymentMethodLogoSize.height / image.size.height * image.size.width
             setNeedsLayout()
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/New Payment Method Screen/WalletHeaderView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/New Payment Method Screen/WalletHeaderView.swift
@@ -8,10 +8,9 @@
 
 import Foundation
 import PassKit
-import UIKit
-
-@_spi(STP) import StripeUICore
 @_spi(STP) import StripePaymentsUI
+@_spi(STP) import StripeUICore
+import UIKit
 
 protocol WalletHeaderViewDelegate: AnyObject {
     func walletHeaderViewApplePayButtonTapped(
@@ -59,7 +58,7 @@ extension PaymentSheetViewController {
         private let appearance: PaymentSheet.Appearance
         private let applePayButtonType: PKPaymentButtonType
         private var stackView = UIStackView()
-        
+
         private lazy var payWithLinkButton: PayWithLinkButton = {
             let button = PayWithLinkButton()
             button.cornerRadius = appearance.cornerRadius
@@ -76,11 +75,13 @@ extension PaymentSheetViewController {
         private var supportsPayWithLink: Bool {
             return options.contains(.link)
         }
-        
-        init(options: WalletOptions,
-             appearance: PaymentSheet.Appearance = PaymentSheet.Appearance.default,
-             applePayButtonType: PKPaymentButtonType = .plain,
-             delegate: WalletHeaderViewDelegate?) {
+
+        init(
+            options: WalletOptions,
+            appearance: PaymentSheet.Appearance = PaymentSheet.Appearance.default,
+            applePayButtonType: PKPaymentButtonType = .plain,
+            delegate: WalletHeaderViewDelegate?
+        ) {
             self.options = options
             self.appearance = appearance
             self.applePayButtonType = applePayButtonType
@@ -92,45 +93,51 @@ extension PaymentSheetViewController {
             updateSeparatorLabel()
         }
 
-        required init?(coder: NSCoder) {
+        required init?(
+            coder: NSCoder
+        ) {
             fatalError("init(coder:) has not been implemented")
         }
 
         @objc func handleTapApplePay() {
             delegate?.walletHeaderViewApplePayButtonTapped(self)
         }
-        
+
         @objc func handleTapPayWithLink() {
             delegate?.walletHeaderViewPayWithLinkTapped(self)
         }
-        
+
         private func buildAndPinStackView() {
             stackView.removeFromSuperview()
 
             var buttons: [UIView] = []
-            
+
             if supportsApplePay {
                 buttons.append(buildApplePayButton())
             }
-            
+
             if supportsPayWithLink {
                 buttons.append(payWithLinkButton)
             }
-            
+
             stackView = UIStackView(arrangedSubviews: buttons + [separatorLabel])
             stackView.axis = .vertical
             stackView.spacing = Constants.buttonSpacing
-            
+
             if let lastButton = buttons.last {
                 stackView.setCustomSpacing(Constants.labelSpacing, after: lastButton)
             }
-            
+
             addAndPinSubview(stackView)
         }
-        
+
         private func buildApplePayButton() -> PKPaymentButton {
-            let buttonStyle: PKPaymentButtonStyle = appearance.colors.background.contrastingColor == .black ? .black : .white
-            let button = PKPaymentButton(paymentButtonType: applePayButtonType, paymentButtonStyle: buttonStyle)
+            let buttonStyle: PKPaymentButtonStyle =
+                appearance.colors.background.contrastingColor == .black ? .black : .white
+            let button = PKPaymentButton(
+                paymentButtonType: applePayButtonType,
+                paymentButtonStyle: buttonStyle
+            )
             button.addTarget(self, action: #selector(handleTapApplePay), for: .touchUpInside)
 
             NSLayoutConstraint.activate([
@@ -144,8 +151,13 @@ extension PaymentSheetViewController {
 
         private func updateSeparatorLabel() {
             separatorLabel.textColor = appearance.colors.textSecondary
-            separatorLabel.separatorColor = appearance.colors.background.contrastingColor.withAlphaComponent(0.2)
-            separatorLabel.font = appearance.scaledFont(for: appearance.font.base.regular, style: .subheadline, maximumPointSize: 21)
+            separatorLabel.separatorColor = appearance.colors.background.contrastingColor
+                .withAlphaComponent(0.2)
+            separatorLabel.font = appearance.scaledFont(
+                for: appearance.font.base.regular,
+                style: .subheadline,
+                maximumPointSize: 21
+            )
 
             if showsCardPaymentMessage {
                 separatorLabel.text = STPLocalizedString(
@@ -159,11 +171,11 @@ extension PaymentSheetViewController {
                 )
             }
         }
-        
+
         override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
             buildAndPinStackView()
             updateSeparatorLabel()
-            
+
         }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentOption+Images.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentOption+Images.swift
@@ -6,15 +6,18 @@
 //  Copyright © 2021 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
-@_spi(STP) import StripeUICore
 @_spi(STP) import StripeCore
 @_spi(STP) import StripePayments
 @_spi(STP) import StripePaymentsUI
+@_spi(STP) import StripeUICore
+import UIKit
 
 extension PaymentOption {
     /// Returns an icon representing the payment option, suitable for display on a checkout screen
-    func makeIcon(for traitCollection: UITraitCollection? = nil, updateImageHandler: DownloadManager.UpdateImageHandler?) -> UIImage {
+    func makeIcon(
+        for traitCollection: UITraitCollection? = nil,
+        updateImageHandler: DownloadManager.UpdateImageHandler?
+    ) -> UIImage {
         switch self {
         case .applePay:
             return Image.apple_pay_mark.makeImage().withRenderingMode(.alwaysOriginal)
@@ -54,7 +57,9 @@ extension STPPaymentMethod {
         case .iDEAL:
             return Image.pm_type_ideal.makeImage()
         case .USBankAccount:
-            return PaymentSheetImageLibrary.bankIcon(for: PaymentSheetImageLibrary.bankIconCode(for: usBankAccount?.bankName))
+            return PaymentSheetImageLibrary.bankIcon(
+                for: PaymentSheetImageLibrary.bankIconCode(for: usBankAccount?.bankName)
+            )
         default:
             // If there's no image specific to this PaymentMethod (eg card network logo, bank logo), default to the PaymentMethod type's icon
             return type.makeImage()
@@ -65,13 +70,13 @@ extension STPPaymentMethod {
         if type == .card, let cardBrand = card?.brand {
             return cardBrand.makeCarouselImage()
         } else if type == .USBankAccount {
-            return PaymentSheetImageLibrary.bankIcon(for: PaymentSheetImageLibrary.bankIconCode(for: usBankAccount?.bankName))
+            return PaymentSheetImageLibrary.bankIcon(
+                for: PaymentSheetImageLibrary.bankIconCode(for: usBankAccount?.bankName)
+            )
         }
         return makeIcon()
     }
 }
-
-
 
 extension STPPaymentMethodParams {
     func makeIcon(updateHandler: DownloadManager.UpdateImageHandler?) -> UIImage {
@@ -101,7 +106,7 @@ extension STPPaymentMethodParams {
 extension ConsumerPaymentDetails {
     func makeIcon() -> UIImage {
         switch details {
-            
+
         case .card(let card):
             return STPImageLibrary.cardBrandImage(for: card.brand)
         case .bankAccount(let bankAccount):
@@ -111,54 +116,56 @@ extension ConsumerPaymentDetails {
 }
 
 extension STPPaymentMethodType {
-    
+
     /// A few payment method type icons need to be tinted white or black as they do not have
     /// light/dark agnostic icons
     var iconRequiresTinting: Bool {
-        return self == .card || self == .AUBECSDebit || self == .USBankAccount || self == .linkInstantDebit
+        return self == .card || self == .AUBECSDebit || self == .USBankAccount
+            || self == .linkInstantDebit
     }
-    
+
     func makeImage(forDarkBackground: Bool = false) -> UIImage {
-        guard let image: Image = {
-            switch self {
-            case .card:
-                return .pm_type_card
-            case .iDEAL:
-                return .pm_type_ideal
-            case .bancontact:
-                return .pm_type_bancontact
-            case .SEPADebit:
-                return .pm_type_sepa
-            case .EPS:
-                return .pm_type_eps
-            case .giropay:
-                return .pm_type_giropay
-            case .przelewy24:
-                return .pm_type_p24
-            case .afterpayClearpay:
-                return .pm_type_afterpay
-            case .sofort, .klarna:
-                return .pm_type_klarna
-            case .affirm:
-                return .pm_type_affirm
-            case .payPal:
-                return .pm_type_paypal
-            case .AUBECSDebit:
-                return .pm_type_aubecsdebit
-            case .USBankAccount, .linkInstantDebit:
-                return .pm_type_us_bank
-            case .UPI:
-                return .pm_type_upi
-            default:
-                return nil
-            }
-        }() else {
+        guard
+            let image: Image = {
+                switch self {
+                case .card:
+                    return .pm_type_card
+                case .iDEAL:
+                    return .pm_type_ideal
+                case .bancontact:
+                    return .pm_type_bancontact
+                case .SEPADebit:
+                    return .pm_type_sepa
+                case .EPS:
+                    return .pm_type_eps
+                case .giropay:
+                    return .pm_type_giropay
+                case .przelewy24:
+                    return .pm_type_p24
+                case .afterpayClearpay:
+                    return .pm_type_afterpay
+                case .sofort, .klarna:
+                    return .pm_type_klarna
+                case .affirm:
+                    return .pm_type_affirm
+                case .payPal:
+                    return .pm_type_paypal
+                case .AUBECSDebit:
+                    return .pm_type_aubecsdebit
+                case .USBankAccount, .linkInstantDebit:
+                    return .pm_type_us_bank
+                case .UPI:
+                    return .pm_type_upi
+                default:
+                    return nil
+                }
+            }()
+        else {
             assertionFailure()
             return UIImage()
         }
-        
+
         // payment method type icons are light/dark agnostic except PayPal
         return image.makeImage(darkMode: self == .payPal ? forDarkBackground : false)
     }
 }
-

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentSheet+SwiftUI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentSheet+SwiftUI.swift
@@ -75,7 +75,8 @@ extension View {
 
     /// :nodoc:
     @available(
-        *, deprecated,
+        *,
+        deprecated,
         renamed: "paymentConfirmationSheet(isConfirming:paymentSheetFlowController:onCompletion:)"
     )
     public func paymentConfirmationSheet(
@@ -126,7 +127,8 @@ extension PaymentSheet {
             }.paymentSheet(
                 isPresented: $showingPaymentSheet,
                 paymentSheet: paymentSheet,
-                onCompletion: onCompletion)
+                onCompletion: onCompletion
+            )
         }
     }
 }
@@ -166,7 +168,8 @@ extension PaymentSheet.FlowController {
             }.paymentOptionsSheet(
                 isPresented: $showingPaymentSheet,
                 paymentSheetFlowController: paymentSheetFlowController,
-                onSheetDismissed: onSheetDismissed)
+                onSheetDismissed: onSheetDismissed
+            )
         }
     }
 
@@ -205,7 +208,8 @@ extension PaymentSheet.FlowController {
             }.paymentConfirmationSheet(
                 isConfirming: $showingPaymentSheet,
                 paymentSheetFlowController: paymentSheetFlowController,
-                onCompletion: onCompletion)
+                onCompletion: onCompletion
+            )
         }
     }
 }
@@ -259,7 +263,9 @@ extension PaymentSheet {
                 }
             }
 
-            init(parent: PaymentSheetPresenter) {
+            init(
+                parent: PaymentSheetPresenter
+            ) {
                 self.parent = parent
                 self.presented = parent.presented
             }
@@ -301,11 +307,10 @@ extension PaymentSheet {
             context.coordinator.presented = presented
         }
 
-
         class Coordinator {
             var parent: PaymentSheetFlowControllerPresenter
             let view = UIView()
-            
+
             var presented: Bool {
                 didSet {
                     switch (oldValue, presented) {
@@ -328,8 +333,10 @@ extension PaymentSheet {
                     }
                 }
             }
-            
-            init(parent: PaymentSheetFlowControllerPresenter) {
+
+            init(
+                parent: PaymentSheetFlowControllerPresenter
+            ) {
                 self.parent = parent
                 self.presented = parent.presented
             }

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentSheet.swift
@@ -7,11 +7,11 @@
 //
 
 import Foundation
-import UIKit
 import PassKit
 @_spi(STP) import StripeCore
 @_spi(STP) import StripePayments
 @_spi(STP) import StripePaymentsUI
+import UIKit
 
 /// The result of an attempt to confirm a PaymentIntent or SetupIntent
 @frozen public enum PaymentSheetResult {
@@ -22,10 +22,10 @@ import PassKit
     /// fulfill the order (e.g. ship the product to the customer) after receiving a successful payment event from Stripe -
     /// see https://stripe.com/docs/payments/handling-payment-events
     case completed
-    
+
     /// The customer canceled the payment or setup attempt
     case canceled
-    
+
     /// The attempt failed.
     /// - Parameter error: The error encountered by the customer. You can display its `localizedDescription` to the customer.
     case failed(error: Error)
@@ -35,39 +35,48 @@ import PassKit
 public class PaymentSheet {
     /// This contains all configurable properties of PaymentSheet
     public let configuration: Configuration
-    
+
     /// The most recent error encountered by the customer, if any.
     public private(set) var mostRecentError: Error?
-    
+
     /// Initializes a PaymentSheet
     /// - Parameter paymentIntentClientSecret: The [client secret](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-client_secret) of a Stripe PaymentIntent object
     /// - Note: This can be used to complete a payment - don't log it, store it, or expose it to anyone other than the customer.
     /// - Parameter configuration: Configuration for the PaymentSheet. e.g. your business name, Customer details, etc.
-    public convenience init(paymentIntentClientSecret: String, configuration: Configuration) {
+    public convenience init(
+        paymentIntentClientSecret: String,
+        configuration: Configuration
+    ) {
         self.init(
             intentClientSecret: .paymentIntent(clientSecret: paymentIntentClientSecret),
             configuration: configuration
         )
     }
-    
+
     /// Initializes a PaymentSheet
     /// - Parameter setupIntentClientSecret: The [client secret](https://stripe.com/docs/api/setup_intents/object#setup_intent_object-client_secret) of a Stripe SetupIntent object
     /// - Parameter configuration: Configuration for the PaymentSheet. e.g. your business name, Customer details, etc.
-    public convenience init(setupIntentClientSecret: String, configuration: Configuration) {
+    public convenience init(
+        setupIntentClientSecret: String,
+        configuration: Configuration
+    ) {
         self.init(
             intentClientSecret: .setupIntent(clientSecret: setupIntentClientSecret),
             configuration: configuration
         )
     }
-    
-    required init(intentClientSecret: IntentClientSecret, configuration: Configuration) {
+
+    required init(
+        intentClientSecret: IntentClientSecret,
+        configuration: Configuration
+    ) {
         AnalyticsHelper.shared.generateSessionID()
         STPAnalyticsClient.sharedClient.addClass(toProductUsageIfNecessary: PaymentSheet.self)
         self.intentClientSecret = intentClientSecret
         self.configuration = configuration
         STPAnalyticsClient.sharedClient.logPaymentSheetInitialized(configuration: configuration)
     }
-    
+
     /// Presents a sheet for a customer to complete their payment
     /// - Parameter presentingViewController: The view controller to present a payment sheet
     /// - Parameter completion: Called with the result of the payment after the payment sheet is dismissed
@@ -75,12 +84,14 @@ public class PaymentSheet {
     @available(macCatalystApplicationExtension, unavailable)
     public func present(
         from presentingViewController: UIViewController,
-        completion: @escaping (PaymentSheetResult) -> ()
+        completion: @escaping (PaymentSheetResult) -> Void
     ) {
         // Overwrite completion closure to retain self until called
-        let completion: (PaymentSheetResult) -> () = { status in
+        let completion: (PaymentSheetResult) -> Void = { status in
             // Dismiss if necessary
-            if let presentingViewController = self.bottomSheetViewController.presentingViewController {
+            if let presentingViewController = self.bottomSheetViewController
+                .presentingViewController
+            {
                 // Calling `dismiss()` on the presenting view controller causes
                 // the bottom sheet and any presented view controller by
                 // bottom sheet (i.e. Link) to be dismissed all at the same time.
@@ -93,7 +104,7 @@ public class PaymentSheet {
             self.completion = nil
         }
         self.completion = completion
-        
+
         // Guard against basic user error
         guard presentingViewController.presentedViewController == nil else {
             assertionFailure("presentingViewController is already presenting a view controller")
@@ -103,7 +114,7 @@ public class PaymentSheet {
             completion(.failed(error: error))
             return
         }
-        
+
         // Configure the Payment Sheet VC after loading the PI/SI, Customer, etc.
         PaymentSheet.load(
             clientSecret: intentClientSecret,
@@ -112,14 +123,18 @@ public class PaymentSheet {
             switch result {
             case .success(let intent, let savedPaymentMethods, let isLinkEnabled):
                 // Verify that there are payment method types available for the intent and configuration.
-                let paymentMethodTypes = PaymentMethodType.filteredPaymentMethodTypes(from: intent, configuration: self.configuration)
+                let paymentMethodTypes = PaymentMethodType.filteredPaymentMethodTypes(
+                    from: intent,
+                    configuration: self.configuration
+                )
                 guard !paymentMethodTypes.isEmpty else {
                     completion(.failed(error: PaymentSheetError.noPaymentMethodTypesAvailable))
                     return
                 }
-                
+
                 // Set the PaymentSheetViewController as the content of our bottom sheet
-                let isApplePayEnabled = StripeAPI.deviceSupportsApplePay() && self.configuration.applePay != nil
+                let isApplePayEnabled =
+                    StripeAPI.deviceSupportsApplePay() && self.configuration.applePay != nil
 
                 let presentPaymentSheetVC = { (justVerifiedLinkOTP: Bool) in
                     let paymentSheetVC = PaymentSheetViewController(
@@ -133,11 +148,11 @@ public class PaymentSheet {
 
                     // Workaround to silence a warning in the Catalyst target
                     #if targetEnvironment(macCatalyst)
-                    self.configuration.style.configure(paymentSheetVC)
-                    #else
-                    if #available(iOS 13.0, *) {
                         self.configuration.style.configure(paymentSheetVC)
-                    }
+                    #else
+                        if #available(iOS 13.0, *) {
+                            self.configuration.style.configure(paymentSheetVC)
+                        }
                     #endif
 
                     let updateBottomSheet: () -> Void = {
@@ -163,9 +178,12 @@ public class PaymentSheet {
                 }
 
                 if let linkAccount = LinkAccountContext.shared.account,
-                   linkAccount.sessionState == .requiresVerification,
-                   !linkAccount.hasStartedSMSVerification {
-                    let verificationController = LinkVerificationController(linkAccount: linkAccount)
+                    linkAccount.sessionState == .requiresVerification,
+                    !linkAccount.hasStartedSMSVerification
+                {
+                    let verificationController = LinkVerificationController(
+                        linkAccount: linkAccount
+                    )
                     verificationController.present(from: self.bottomSheetViewController) { result in
                         switch result {
                         case .completed:
@@ -181,8 +199,11 @@ public class PaymentSheet {
                 completion(.failed(error: error))
             }
         }
-        
-        presentingViewController.presentAsBottomSheet(bottomSheetViewController, appearance: configuration.appearance)
+
+        presentingViewController.presentAsBottomSheet(
+            bottomSheetViewController,
+            appearance: configuration.appearance
+        )
     }
 
     /// Deletes all persisted authentication state associated with a customer.
@@ -205,20 +226,25 @@ public class PaymentSheet {
     public static func resetCustomer() {
         LinkAccountService.defaultCookieStore.clear()
     }
-    
+
     // MARK: - Internal Properties
 
     /// The client secret this instance was initialized with
     let intentClientSecret: IntentClientSecret
-    
+
     /// A user-supplied completion block. Nil until `present` is called.
-    var completion: ((PaymentSheetResult) -> ())?
-    
+    var completion: ((PaymentSheetResult) -> Void)?
+
     /// The STPPaymentHandler instance
     @available(iOSApplicationExtension, unavailable)
     @available(macCatalystApplicationExtension, unavailable)
-    lazy var paymentHandler: STPPaymentHandler = { STPPaymentHandler(apiClient: configuration.apiClient, formSpecPaymentHandler: PaymentSheetFormSpecPaymentHandler()) }()
-    
+    lazy var paymentHandler: STPPaymentHandler = {
+        STPPaymentHandler(
+            apiClient: configuration.apiClient,
+            formSpecPaymentHandler: PaymentSheetFormSpecPaymentHandler()
+        )
+    }()
+
     /// The parent view controller to present
     @available(iOSApplicationExtension, unavailable)
     @available(macCatalystApplicationExtension, unavailable)
@@ -229,7 +255,7 @@ public class PaymentSheet {
             appearance: configuration.appearance,
             isTestMode: isTestMode
         )
-        
+
         let vc = BottomSheetViewController(
             contentViewController: loadingViewController,
             appearance: configuration.appearance,
@@ -244,7 +270,7 @@ public class PaymentSheet {
         }
         return vc
     }()
-    
+
 }
 
 @available(iOSApplicationExtension, unavailable)
@@ -254,42 +280,47 @@ extension PaymentSheet: PaymentSheetViewControllerDelegate {
     func paymentSheetViewControllerShouldConfirm(
         _ paymentSheetViewController: PaymentSheetViewController,
         with paymentOption: PaymentOption,
-        completion: @escaping (PaymentSheetResult) -> ()
+        completion: @escaping (PaymentSheetResult) -> Void
     ) {
         let presentingViewController = paymentSheetViewController.presentingViewController
-        let confirm: (@escaping (PaymentSheetResult) -> ()) -> () = { completion in
+        let confirm: (@escaping (PaymentSheetResult) -> Void) -> Void = { completion in
             PaymentSheet.confirm(
                 configuration: self.configuration,
                 authenticationContext: self.bottomSheetViewController,
                 intent: paymentSheetViewController.intent,
                 paymentOption: paymentOption,
-                paymentHandler: self.paymentHandler)
-            { result in
-                if case let .failed(error) = result {
+                paymentHandler: self.paymentHandler
+            ) { result in
+                if case .failed(let error) = result {
                     self.mostRecentError = error
                 }
                 completion(result)
             }
         }
-        
+
         if case .applePay = paymentOption {
             // Don't present the Apple Pay sheet on top of the Payment Sheet
             paymentSheetViewController.dismiss(animated: true) {
-                confirm() { result in
+                confirm { result in
                     if case .completed = result {
                     } else {
                         // We dismissed the Payment Sheet to show the Apple Pay sheet
                         // Bring it back if it didn't succeed
-                        presentingViewController?.presentAsBottomSheet(self.bottomSheetViewController,
-                                                                  appearance: self.configuration.appearance)
+                        presentingViewController?.presentAsBottomSheet(
+                            self.bottomSheetViewController,
+                            appearance: self.configuration.appearance
+                        )
                     }
                     completion(result)
                 }
             }
         } else {
-            verifyLinkSessionIfNeeded(with: paymentOption, intent: paymentSheetViewController.intent) { shouldConfirm in
+            verifyLinkSessionIfNeeded(
+                with: paymentOption,
+                intent: paymentSheetViewController.intent
+            ) { shouldConfirm in
                 if shouldConfirm {
-                    confirm() { result in
+                    confirm { result in
                         completion(result)
                     }
                 } else {
@@ -298,19 +329,24 @@ extension PaymentSheet: PaymentSheetViewControllerDelegate {
             }
         }
     }
-    
-    func paymentSheetViewControllerDidFinish(_ paymentSheetViewController: PaymentSheetViewController, result: PaymentSheetResult) {
+
+    func paymentSheetViewControllerDidFinish(
+        _ paymentSheetViewController: PaymentSheetViewController,
+        result: PaymentSheetResult
+    ) {
         paymentSheetViewController.dismiss(animated: true) {
             self.completion?(result)
         }
     }
-    
-    func paymentSheetViewControllerDidCancel(_ paymentSheetViewController: PaymentSheetViewController) {
+
+    func paymentSheetViewControllerDidCancel(
+        _ paymentSheetViewController: PaymentSheetViewController
+    ) {
         paymentSheetViewController.dismiss(animated: true) {
             self.completion?(.canceled)
         }
     }
-    
+
     func paymentSheetViewControllerDidSelectPayWithLink(
         _ paymentSheetViewController: PaymentSheetViewController
     ) {
@@ -349,9 +385,9 @@ extension PaymentSheet: PayWithLinkViewControllerDelegate {
             authenticationContext: self.bottomSheetViewController,
             intent: intent,
             paymentOption: paymentOption,
-            paymentHandler: self.paymentHandler)
-        { result in
-            if case let .failed(error) = result {
+            paymentHandler: self.paymentHandler
+        ) { result in
+            if case .failed(let error) = result {
                 self.mostRecentError = error
             }
 
@@ -367,10 +403,11 @@ extension PaymentSheet: PayWithLinkViewControllerDelegate {
         }
     }
 
-    func payWithLinkViewControllerDidCancel(_ payWithLinkViewController: PayWithLinkViewController) {
+    func payWithLinkViewControllerDidCancel(_ payWithLinkViewController: PayWithLinkViewController)
+    {
         payWithLinkViewController.dismiss(animated: true)
     }
-    
+
     func payWithLinkViewControllerDidFinish(
         _ payWithLinkViewController: PayWithLinkViewController,
         result: PaymentSheetResult
@@ -384,7 +421,7 @@ extension PaymentSheet: PayWithLinkViewControllerDelegate {
                 return paymentSheetVC
             }
         }
-        
+
         return nil
     }
 }
@@ -393,9 +430,9 @@ extension PaymentSheet: PayWithLinkViewControllerDelegate {
 
 @available(iOSApplicationExtension, unavailable)
 @available(macCatalystApplicationExtension, unavailable)
-private extension PaymentSheet {
+extension PaymentSheet {
 
-    func presentPayWithLinkController(
+    fileprivate func presentPayWithLinkController(
         from presentingController: UIViewController,
         intent: Intent,
         shouldOfferApplePay: Bool = false,
@@ -420,7 +457,7 @@ private extension PaymentSheet {
         presentingController.present(payWithLinkVC, animated: true, completion: completion)
     }
 
-    func verifyLinkSessionIfNeeded(
+    fileprivate func verifyLinkSessionIfNeeded(
         with paymentOption: PaymentOption,
         intent: Intent,
         completion: ((Bool) -> Void)? = nil
@@ -435,7 +472,10 @@ private extension PaymentSheet {
             return
         }
 
-        let verificationController = LinkVerificationController(mode: .inlineLogin, linkAccount: linkAccount)
+        let verificationController = LinkVerificationController(
+            mode: .inlineLogin,
+            linkAccount: linkAccount
+        )
         verificationController.present(from: bottomSheetViewController) { [weak self] result in
             self?.bottomSheetViewController.dismiss(animated: true, completion: nil)
             switch result {

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentSheetAppearance.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentSheetAppearance.swift
@@ -6,50 +6,50 @@
 //  Copyright © 2022 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
 @_spi(STP) import StripeUICore
+import UIKit
 
-public extension PaymentSheet {
-    
+extension PaymentSheet {
+
     /// Describes the appearance of PaymentSheet
-    struct Appearance: Equatable {
+    public struct Appearance: Equatable {
         /// The default appearance for PaymentSheet
         public static let `default` = Appearance()
-        
+
         /// Creates a `PaymentSheet.Appearance` with default values
         public init() {}
-        
+
         /// Describes the appearance of fonts in PaymentSheet
         public var font: Font = Font()
-        
+
         /// Describes the colors in PaymentSheet
         public var colors: Colors = Colors()
-        
+
         /// Describes the appearance of the primary button (e.g., the "Pay" button)
         public var primaryButton: PrimaryButton = PrimaryButton()
-        
+
         /// The corner radius used for buttons, inputs, tabs in PaymentSheet
         /// - Note: The behavior of this property is consistent with the behavior of corner radius on `CALayer`
         public var cornerRadius: CGFloat = 6.0
-        
+
         /// The border used for inputs and tabs in PaymentSheet
         /// - Note: The behavior of this property is consistent with the behavior of border width on `CALayer`
         public var borderWidth: CGFloat = 1.0
-        
+
         /// The shadow used for inputs and tabs in PaymentSheet
         /// - Note: Set this to `.disabled` to disable shadows
         public var shadow: Shadow = Shadow()
-        
+
         // MARK: Fonts
-        
+
         /// Describes the appearance of fonts in PaymentSheet
         public struct Font: Equatable {
-            
+
             /// Creates a `PaymentSheet.Appearance.Font` with default values
             public init() {}
-            
-            /// The scale factor for all font sizes in PaymentSheet. 
-            /// Font sizes are multiplied by this value before being displayed. For example, setting this to 1.2 increases the size of all text by 20%. 
+
+            /// The scale factor for all font sizes in PaymentSheet.
+            /// Font sizes are multiplied by this value before being displayed. For example, setting this to 1.2 increases the size of all text by 20%.
             /// - Note: This value must be greater than 0. The default value is 1.0.
             /// - Note: This is used in conjunction with the Dynamic Type accessibility text size.
             public var sizeScaleFactor: CGFloat = 1.0 {
@@ -62,129 +62,139 @@ public extension PaymentSheet {
 
             /// The font family of this font is used throughout PaymentSheet. PaymentSheet uses this font at multiple weights (e.g., regular, medium, semibold) if they exist.
             /// - Note: The size and weight of the font is ignored. To adjust font sizes, see `sizeScaleFactor`.
-            public var base: UIFont = UIFont.systemFont(ofSize: UIFont.labelFontSize, weight: .regular)
+            public var base: UIFont = UIFont.systemFont(
+                ofSize: UIFont.labelFontSize,
+                weight: .regular
+            )
         }
-        
+
         // MARK: Colors
-        
+
         /// Describes the colors in PaymentSheet
         public struct Colors: Equatable {
 
             /// Creates a `PaymentSheet.Appearance.Colors` with default values
             public init() {}
-            
+
             /// The primary color used throughout PaymentSheet
             public var primary: UIColor = .systemBlue
-            
+
             /// The color used for the background of PaymentSheet
             public var background: UIColor = .systemBackground
-            
+
             /// The color used for the background of inputs, tabs, and other components
-            public var componentBackground: UIColor = UIColor.dynamic(light: .systemBackground,
-                                                      dark: .secondarySystemBackground)
-            
+            public var componentBackground: UIColor = UIColor.dynamic(
+                light: .systemBackground,
+                dark: .secondarySystemBackground
+            )
+
             /// The border color used for inputs, tabs, and other components
             public var componentBorder: UIColor = .systemGray3
-            
+
             /// The color of the divider lines used inside inputs, tabs, and other components
             public var componentDivider: UIColor = .systemGray3
-            
+
             /// The default text color used in PaymentSheet, appearing over the background color
             public var text: UIColor = .label
-            
+
             /// The color used for text of secondary importance. For example, this color is used for the label above input fields
             public var textSecondary: UIColor = .secondaryLabel
-            
+
             /// The color of text appearing over `componentBackground`
             public var componentText: UIColor = .label
-            
+
             /// The color used for input placeholder text
             public var componentPlaceholderText: UIColor = .secondaryLabel
-            
+
             /// The color used for icons in PaymentSheet, such as the close or back icons
             public var icon: UIColor = .secondaryLabel
-            
+
             /// The color used to indicate errors or destructive actions in PaymentSheet
             public var danger: UIColor = .systemRed
         }
-        
+
         // MARK: Shadow
-        
+
         /// Represents a shadow in PaymentSheet
         public struct Shadow: Equatable {
-            
+
             /// A pre-configured `Shadow` in the disabled or off state
             public static var disabled: Shadow {
-              return Shadow(color: .clear, opacity: 0.0, offset: .zero, radius: 0)
+                return Shadow(color: .clear, opacity: 0.0, offset: .zero, radius: 0)
             }
-            
+
             /// Color of the shadow
             /// - Note: The behavior of this property is consistent with `CALayer.shadowColor`
             public var color: UIColor = .black
-            
+
             /// Opacity or alpha of the shadow
             /// - Note: The behavior of this property is consistent with `CALayer.shadowOpacity`
             public var opacity: CGFloat = CGFloat(0.05)
-            
+
             /// Offset of the shadow
             /// - Note: The behavior of this property is consistent with `CALayer.shadowOffset`
             public var offset: CGSize = CGSize(width: 0, height: 2)
-            
+
             /// Radius of the shadow
             /// - Note: The behavior of this property is consistent with `CALayer.shadowRadius`
             public var radius: CGFloat = 4
-            
+
             /// Creates a `PaymentSheet.Appearance.Shadow` with default values
             public init() {}
-            
+
             /// Creates a `Shadow` with the specified parameters
             /// - Parameters:
             ///   - color: Color of the shadow
             ///   - opacity: Opacity or opacity of the shadow
             ///   - offset: Offset of the shadow
             ///   - radius: Radius of the shadow
-            public init(color: UIColor, opacity: CGFloat, offset: CGSize, radius: CGFloat) {
+            public init(
+                color: UIColor,
+                opacity: CGFloat,
+                offset: CGSize,
+                radius: CGFloat
+            ) {
                 self.color = color
                 self.opacity = opacity
                 self.offset = offset
                 self.radius = radius
             }
         }
-        
+
         // MARK: Primary Button
-        
+
         /// Describes the appearance of the primary button (e.g., the "Pay" button)
         public struct PrimaryButton: Equatable {
-            
+
             /// Creates a `PaymentSheet.Appearance.PrimaryButton` with default values
             public init() {}
-            
+
             /// The background color of the primary button
             /// - Note: If `nil`, `appearance.colors.primary` will be used as the primary button background color
             public var backgroundColor: UIColor?
-            
+
             /// The text color of the primary button
             /// - Note: If `nil`, defaults to either white or black depending on the color of the button
             public var textColor: UIColor?
-            
+
             /// The corner radius of the primary button
             /// - Note: If `nil`, `appearance.cornerRadius` will be used as the primary button corner radius
             /// - Note: The behavior of this property is consistent with the behavior of corner radius on `CALayer`
             public var cornerRadius: CGFloat?
-            
+
             /// The border color of the primary button
             /// - Note: The behavior of this property is consistent with the behavior of border color on `CALayer`
             public var borderColor: UIColor = .quaternaryLabel
-            
+
             /// The border width of the primary button
             /// - Note: The behavior of this property is consistent with the behavior of border width on `CALayer`
             public var borderWidth: CGFloat = 1.0
-            
+
             /// The font used for the text of the primary button
             /// - Note: If `nil`, `appearance.font.base` will be used as the primary button font
             /// - Note: `appearance.font.sizeScaleFactor` does not impact the size of this font
             public var font: UIFont?
-            
+
             /// The shadow of the primary button
             /// - Note: If `nil`, `appearance.shadow` will be used as the primary button shadow
             public var shadow: Shadow?

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentSheetConfiguration.swift
@@ -7,10 +7,10 @@
 //
 
 import Foundation
-import UIKit
 import PassKit
 @_spi(STP) import StripeCore
 @_spi(STP) import StripePaymentsUI
+import UIKit
 
 // MARK: - Configuration
 extension PaymentSheet {
@@ -41,23 +41,23 @@ extension PaymentSheet {
             }
         }
     }
-    
+
     /// Options for the default state of save payment method controls
     /// @note Some jurisdictions may have rules governing the ability to default to opt-out behaviors
     public enum SavePaymentMethodOptInBehavior {
-        
+
         /// (Default) The SDK will apply opt-out behavior for supported countries.
         /// Currently, this behavior is supported in the US.
         case automatic
-        
+
         /// The control will always default to unselected and users
         /// will have to explicitly interact to save their payment method
         case requiresOptIn
-        
+
         /// The control will always default to selected and users
         /// will have to explicitly interact to not save their payment method
         case requiresOptOut
-        
+
         var isSelectedByDefault: Bool {
             switch self {
             case .automatic:
@@ -73,17 +73,17 @@ extension PaymentSheet {
 
     /// Configuration for PaymentSheet
     public struct Configuration {
-        
+
         /// If true, allows payment methods that do not move money at the end of the checkout. Defaults to false.
         /// - Description: Some payment methods can't guarantee you will receive funds from your customer at the end of the checkout because they take time to settle (eg. most bank debits, like SEPA or ACH) or require customer action to complete (e.g. OXXO, Konbini, Boleto). If this is set to true, make sure your integration listens to webhooks for notifications on whether a payment has succeeded or not.
         /// - Seealso: https://stripe.com/docs/payments/payment-methods#payment-notification
         public var allowsDelayedPaymentMethods: Bool = false
-        
+
         /// If `true`, allows payment methods that require a shipping address, like Afterpay and Affirm. Defaults to `false`.
         /// Set this to `true` if you collect shipping addresses and set `Configuration.shippingDetails` or set `shipping` details directly on the PaymentIntent.
         /// - Note: PaymentSheet considers this property `true` and allows payment methods that require a shipping address if `shipping` details are present on the PaymentIntent when PaymentSheet loads.
         public var allowsPaymentMethodsRequiringShippingAddress: Bool = false
-        
+
         /// The APIClient instance used to make requests to Stripe
         public var apiClient: STPAPIClient = STPAPIClient.shared
 
@@ -96,12 +96,11 @@ extension PaymentSheet {
             set {
                 appearance.primaryButton.backgroundColor = newValue
             }
-            
+
             get {
                 return appearance.primaryButton.backgroundColor
             }
         }
-        
 
         /// The label to use for the primary button.
         ///
@@ -114,7 +113,8 @@ extension PaymentSheet {
         /// Default value is SheetStyle.automatic
         /// @see SheetStyle
         @available(iOS 13.0, *)
-        public var style: UserInterfaceStyle {  // stored properties can't be marked @available which is why this uses the styleRawValue private var
+        // stored properties can't be marked @available which is why this uses the styleRawValue private var
+        public var style: UserInterfaceStyle {
             get {
                 return UserInterfaceStyle(rawValue: styleRawValue)!
             }
@@ -138,26 +138,26 @@ extension PaymentSheet {
 
         /// PaymentSheet pre-populates fields with the values provided.
         public var defaultBillingDetails: BillingDetails = BillingDetails()
-        
+
         /// PaymentSheet offers users an option to save some payment methods for later use.
         /// Default value is .automatic
         /// @see SavePaymentMethodOptInBehavior
         public var savePaymentMethodOptInBehavior: SavePaymentMethodOptInBehavior = .automatic
-        
+
         /// Describes the appearance of PaymentSheet
         public var appearance = PaymentSheet.Appearance.default
-        
+
         /// A closure that returns the customer's shipping details.
         /// This is used to display a "Billing address is same as shipping" checkbox if `defaultBillingDetails` is not provided
         /// If `name` and `line1` are populated, it's also [attached to the PaymentIntent](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-shipping) during payment.
         public var shippingDetails: () -> AddressViewController.AddressDetails? = { return nil }
-        
+
         /// Initializes a Configuration with default values
         public init() {}
-        
+
         // MARK: Internal
         internal var linkPaymentMethodsOnly: Bool = false
-        
+
         /// The amount of billing address details to collect
         /// Intentionally non-public.
         /// @see BillingAddressCollection
@@ -174,7 +174,10 @@ extension PaymentSheet {
         public let ephemeralKeySecret: String
 
         /// Initializes a CustomerConfiguration
-        public init(id: String, ephemeralKeySecret: String) {
+        public init(
+            id: String,
+            ephemeralKeySecret: String
+        ) {
             self.id = id
             self.ephemeralKeySecret = ephemeralKeySecret
         }
@@ -189,12 +192,12 @@ extension PaymentSheet {
         /// The two-letter ISO 3166 code of the country of your business, e.g. "US"
         /// See your account's country value here https://dashboard.stripe.com/settings/account
         public let merchantCountryCode: String
-        
+
         /// Defines the label that will be displayed in the Apple Pay button.
         /// See <https://developer.apple.com/design/human-interface-guidelines/technologies/apple-pay/buttons-and-marks/>
         /// for all available options.
         public let buttonType: PKPaymentButtonType
-        
+
         /// An array of payment summary item objects that summarize the amount of the payment. This property is identical to `PKPaymentRequest.paymentSummaryItems`.
         /// If `nil`, we display a single line item with the amount on the PaymentIntent or "Amount pending" for SetupIntents.
         /// If you're using a SetupIntent for a recurring payment, you should set this to display the amount you intend to charge, in accordance with https://developer.apple.com/design/human-interface-guidelines/technologies/apple-pay/subscriptions-and-donations
@@ -203,7 +206,7 @@ extension PaymentSheet {
 
         /// Optional handler blocks for Apple Pay
         public let customHandlers: Handlers?
-        
+
         /// Custom handler blocks for Apple Pay
         public struct Handlers {
             /// Optionally configure additional information on your PKPaymentRequest.
@@ -230,15 +233,21 @@ extension PaymentSheet {
             /// }
             /// ```
             /// WARNING: If you do not call the completion handler, your app will hang until the Apple Pay sheet times out.
-            public let authorizationResultHandler: ((PKPaymentAuthorizationResult, ((PKPaymentAuthorizationResult) -> Void)) -> Void)?
-            
+            public let authorizationResultHandler:
+                ((PKPaymentAuthorizationResult, ((PKPaymentAuthorizationResult) -> Void)) -> Void)?
+
             /// Initializes the ApplePayConfiguration Handlers.
-            public init(paymentRequestHandler: ((PKPaymentRequest) -> PKPaymentRequest)? = nil, authorizationResultHandler: ((PKPaymentAuthorizationResult, ((PKPaymentAuthorizationResult) -> Void)) -> Void)? = nil) {
+            public init(
+                paymentRequestHandler: ((PKPaymentRequest) -> PKPaymentRequest)? = nil,
+                authorizationResultHandler: (
+                    (PKPaymentAuthorizationResult, ((PKPaymentAuthorizationResult) -> Void)) -> Void
+                )? = nil
+            ) {
                 self.paymentRequestHandler = paymentRequestHandler
                 self.authorizationResultHandler = authorizationResultHandler
             }
         }
-        
+
         /// Initializes a ApplePayConfiguration
         public init(
             merchantId: String,
@@ -254,34 +263,41 @@ extension PaymentSheet {
             self.customHandlers = customHandlers
         }
     }
-    
+
     /// An address.
     public struct Address: Equatable {
         /// City, district, suburb, town, or village.
         /// - Note: The value set is displayed in the payment sheet as-is. Depending on the payment method, the customer may be required to edit this value.
         public var city: String?
-        
+
         /// Two-letter country code (ISO 3166-1 alpha-2).
         public var country: String?
-        
+
         /// Address line 1 (e.g., street, PO Box, or company name).
         /// - Note: The value set is displayed in the payment sheet as-is. Depending on the payment method, the customer may be required to edit this value.
         public var line1: String?
-        
+
         /// Address line 2 (e.g., apartment, suite, unit, or building).
         /// - Note: The value set is displayed in the payment sheet as-is. Depending on the payment method, the customer may be required to edit this value.
         public var line2: String?
-        
+
         /// ZIP or postal code.
         /// - Note: The value set is displayed in the payment sheet as-is. Depending on the payment method, the customer may be required to edit this value.
         public var postalCode: String?
-        
+
         /// State, county, province, or region.
         /// - Note: The value set is displayed in the payment sheet as-is. Depending on the payment method, the customer may be required to edit this value.
         public var state: String?
-        
+
         /// Initializes an Address
-        public init(city: String? = nil, country: String? = nil, line1: String? = nil, line2: String? = nil, postalCode: String? = nil, state: String? = nil) {
+        public init(
+            city: String? = nil,
+            country: String? = nil,
+            line1: String? = nil,
+            line2: String? = nil,
+            postalCode: String? = nil,
+            state: String? = nil
+        ) {
             self.city = city
             self.country = country
             self.line1 = line1
@@ -290,22 +306,22 @@ extension PaymentSheet {
             self.state = state
         }
     }
-    
+
     /// Billing details of a customer
     public struct BillingDetails: Equatable {
         /// The customer's billing address
         public var address: Address = Address()
-        
+
         /// The customer's email
         /// - Note: The value set is displayed in the payment sheet as-is. Depending on the payment method, the customer may be required to edit this value.
         public var email: String?
-        
+
         /// The customer's full name
         /// - Note: The value set is displayed in the payment sheet as-is. Depending on the payment method, the customer may be required to edit this value.
         public var name: String?
-        
+
         /// The customer's phone number without formatting (e.g. 5551234567)
         public var phone: String?
     }
-    
+
 }

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentSheetError.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentSheetError.swift
@@ -16,7 +16,7 @@ import Foundation
 public enum PaymentSheetError: Error {
     /// An unknown error.
     case unknown(debugDescription: String)
-    
+
     /// No payment method types available error.
     case noPaymentMethodTypesAvailable
 
@@ -32,7 +32,7 @@ extension PaymentSheetError {
         // TODO: Expired ephemeral key
         return false
     }
-    
+
     var debugDescription: String {
         switch self {
         case .noPaymentMethodTypesAvailable:

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentSheetFormFactory/FormSpec/FormSpec.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentSheetFormFactory/FormSpec/FormSpec.swift
@@ -7,9 +7,9 @@
 //
 
 import Foundation
-@_spi(STP) import StripeUICore
 @_spi(STP) import StripeCore
 @_spi(STP) import StripePayments
+@_spi(STP) import StripeUICore
 
 /// A decodable representation that can used to construct a `FormElement`
 struct FormSpec: Decodable {
@@ -44,11 +44,13 @@ struct FormSpec: Decodable {
         private enum CodingKeys: String, CodingKey {
             case type
         }
-        init(from decoder: Decoder) throws {
+        init(
+            from decoder: Decoder
+        ) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             let field_type = try container.decode(String.self, forKey: .type)
 
-            switch(field_type) {
+            switch field_type {
             case "name":
                 self = .name(try NameFieldSpec(from: decoder))
             case "email":
@@ -101,10 +103,16 @@ struct FormSpec: Decodable {
                     case urlPath
                     case returnUrlPath
                 }
-                init(from decoder: Decoder) throws {
+                init(
+                    from decoder: Decoder
+                ) throws {
                     let container = try decoder.container(keyedBy: CodingKeys.self)
-                    self.urlPath = try container.decodeIfPresent(String.self, forKey: .urlPath) ?? "next_action[redirect_to_url][url]"
-                    self.returnUrlPath = try container.decodeIfPresent(String.self, forKey: .returnUrlPath) ?? "next_action[redirect_to_url][return_url]"
+                    self.urlPath =
+                        try container.decodeIfPresent(String.self, forKey: .urlPath)
+                        ?? "next_action[redirect_to_url][url]"
+                    self.returnUrlPath =
+                        try container.decodeIfPresent(String.self, forKey: .returnUrlPath)
+                        ?? "next_action[redirect_to_url][return_url]"
                 }
             }
 
@@ -118,12 +126,14 @@ struct FormSpec: Decodable {
                 case type
             }
 
-            init(from decoder: Decoder) throws {
+            init(
+                from decoder: Decoder
+            ) throws {
                 let container = try decoder.container(keyedBy: CodingKeys.self)
 
                 let nextActionType = try container.decode(String.self, forKey: .type)
 
-                switch(nextActionType){
+                switch nextActionType {
                 case "redirect_to_url":
                     self.type = .redirect_to_url(try RedirectToURL(from: decoder))
                 case "finished":
@@ -147,11 +157,13 @@ struct FormSpec: Decodable {
                 case type
             }
 
-            init(from decoder: Decoder) throws {
+            init(
+                from decoder: Decoder
+            ) throws {
                 let container = try decoder.container(keyedBy: CodingKeys.self)
 
                 let nextActionType = try container.decode(String.self, forKey: .type)
-                switch(nextActionType) {
+                switch nextActionType {
                 case "finished":
                     self.type = .finished
                 case "canceled":
@@ -167,7 +179,8 @@ extension FormSpec {
     static func nextActionSpec(paymentIntent: STPPaymentIntent) -> FormSpec.NextActionSpec? {
         var nextActionSpec: FormSpec.NextActionSpec? = nil
         if let paymentMethod = paymentIntent.paymentMethod?.paymentSheetPaymentMethodType(),
-           let paymentMethodString = PaymentSheet.PaymentMethodType.string(from: paymentMethod) {
+            let paymentMethodString = PaymentSheet.PaymentMethodType.string(from: paymentMethod)
+        {
             nextActionSpec = FormSpecProvider.shared.nextActionSpec(for: paymentMethodString)
         }
         return nextActionSpec
@@ -177,11 +190,11 @@ extension FormSpec {
 extension FormSpec {
     struct BaseFieldSpec: Decodable, Equatable {
         /// A form URL encoded key, whose value is `PropertyItemSpec.apiValue`
-        let apiPath: [String:String]?
+        let apiPath: [String: String]?
     }
     struct NameFieldSpec: Decodable, Equatable {
         /// A form URL encoded key, whose value is `PropertyItemSpec.apiValue`
-        let apiPath: [String:String]?
+        let apiPath: [String: String]?
         /// An optional localizedId to control the label
         let translationId: LocalizedString?
     }
@@ -197,7 +210,7 @@ extension FormSpec {
         /// The list of items to display in the dropdown
         let items: [PropertyItemSpec]
         /// A form URL encoded key, whose value is `PropertyItemSpec.apiValue`
-        let apiPath: [String:String]?
+        let apiPath: [String: String]?
 
     }
 
@@ -218,7 +231,7 @@ extension FormSpec {
 extension FormSpec {
     enum LocalizedString: String, Decodable {
         case ideal_bank = "upe.labels.ideal.bank"
-        case eps_bank =  "upe.labels.eps.bank"
+        case eps_bank = "upe.labels.eps.bank"
         case p24_bank = "upe.labels.p24.bank"
 
         case nameLabel_given = "upe.labels.name.given"

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentSheetFormFactory/FormSpec/FormSpecPaymentHandler.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentSheetFormFactory/FormSpec/FormSpecPaymentHandler.swift
@@ -13,40 +13,63 @@ class PaymentSheetFormSpecPaymentHandler {}
 
 @available(iOSApplicationExtension, unavailable)
 @available(macCatalystApplicationExtension, unavailable)
-extension PaymentSheetFormSpecPaymentHandler : FormSpecPaymentHandler {
-    func handlePostConfirmPIStatusSpec(for paymentIntent: StripePayments.STPPaymentIntent?, action: StripePayments.STPPaymentHandlerPaymentIntentActionParams, paymentHandler: StripePayments.STPPaymentHandler) -> Bool {
+extension PaymentSheetFormSpecPaymentHandler: FormSpecPaymentHandler {
+    func handlePostConfirmPIStatusSpec(
+        for paymentIntent: StripePayments.STPPaymentIntent?,
+        action: StripePayments.STPPaymentHandlerPaymentIntentActionParams,
+        paymentHandler: StripePayments.STPPaymentHandler
+    ) -> Bool {
         if let spec = paymentHandler._specForPostConfirmPIStatus(paymentIntent: paymentIntent) {
-            paymentHandler._handlePostConfirmPIStatusSpec(forAction: action, paymentIntentStatusSpec: spec)
+            paymentHandler._handlePostConfirmPIStatusSpec(
+                forAction: action,
+                paymentIntentStatusSpec: spec
+            )
             return true
         }
         return false
     }
-    
-    func isPIStatusSpecFinishedForPostConfirmPIStatus(paymentIntent: StripePayments.STPPaymentIntent?, paymentHandler: STPPaymentHandler) -> Bool {
-        guard let spec = paymentHandler._specForPostConfirmPIStatus(paymentIntent: paymentIntent) else {
+
+    func isPIStatusSpecFinishedForPostConfirmPIStatus(
+        paymentIntent: StripePayments.STPPaymentIntent?,
+        paymentHandler: STPPaymentHandler
+    ) -> Bool {
+        guard let spec = paymentHandler._specForPostConfirmPIStatus(paymentIntent: paymentIntent)
+        else {
             return false
         }
         return paymentHandler._isPIStatusSpecFinished(paymentIntentStatusSpec: spec)
     }
-    
-    func handleNextActionSpec(for paymentIntent: STPPaymentIntent, action: STPPaymentHandlerPaymentIntentActionParams, paymentHandler: STPPaymentHandler) -> Bool {
-        if let paymentIntentStatusSpec = paymentHandler._specForConfirmResponse(paymentIntent: paymentIntent) {
-            paymentHandler._handleNextActionSpec(forAction: action, paymentIntentStatusSpec: paymentIntentStatusSpec)
+
+    func handleNextActionSpec(
+        for paymentIntent: STPPaymentIntent,
+        action: STPPaymentHandlerPaymentIntentActionParams,
+        paymentHandler: STPPaymentHandler
+    ) -> Bool {
+        if let paymentIntentStatusSpec = paymentHandler._specForConfirmResponse(
+            paymentIntent: paymentIntent
+        ) {
+            paymentHandler._handleNextActionSpec(
+                forAction: action,
+                paymentIntentStatusSpec: paymentIntentStatusSpec
+            )
             return true
         }
         return false
     }
-    
+
 }
 
 extension STPPaymentHandler {
-    func _specForConfirmResponse(paymentIntent: STPPaymentIntent) -> FormSpec.NextActionSpec.ConfirmResponseStatusSpecs? {
+    func _specForConfirmResponse(
+        paymentIntent: STPPaymentIntent
+    ) -> FormSpec.NextActionSpec.ConfirmResponseStatusSpecs? {
         guard let nextActionSpec = FormSpec.nextActionSpec(paymentIntent: paymentIntent) else {
             return nil
         }
 
         if let status = paymentIntent.allResponseFields["status"] as? String,
-           let spec = nextActionSpec.confirmResponseStatusSpecs[status] {
+            let spec = nextActionSpec.confirmResponseStatusSpecs[status]
+        {
             return spec
         }
         return nil
@@ -54,20 +77,28 @@ extension STPPaymentHandler {
 
     @available(iOSApplicationExtension, unavailable)
     @available(macCatalystApplicationExtension, unavailable)
-    func _handleNextActionSpec(forAction action: STPPaymentHandlerPaymentIntentActionParams, paymentIntentStatusSpec: FormSpec.NextActionSpec.ConfirmResponseStatusSpecs) {
+    func _handleNextActionSpec(
+        forAction action: STPPaymentHandlerPaymentIntentActionParams,
+        paymentIntentStatusSpec: FormSpec.NextActionSpec.ConfirmResponseStatusSpecs
+    ) {
 
         guard let paymentIntent = action.paymentIntent else {
             assert(false, "Calling _handleNextActionStateSpec without a paymentIntent")
             return
         }
 
-        switch(paymentIntentStatusSpec.type) {
+        switch paymentIntentStatusSpec.type {
         case .redirect_to_url(let redirectToUrl):
-            if let urlString = paymentIntent.allResponseFields.stp_forLUXEJSONPath(redirectToUrl.urlPath) as? String,
-               let url = URL(string: urlString) {
+            if let urlString = paymentIntent.allResponseFields.stp_forLUXEJSONPath(
+                redirectToUrl.urlPath
+            ) as? String,
+                let url = URL(string: urlString)
+            {
 
                 var returnUrl: URL? = nil
-                if let returnString = paymentIntent.allResponseFields.stp_forLUXEJSONPath(redirectToUrl.returnUrlPath) as? String {
+                if let returnString = paymentIntent.allResponseFields.stp_forLUXEJSONPath(
+                    redirectToUrl.returnUrlPath
+                ) as? String {
                     returnUrl = URL(string: returnString)
                 }
                 self._handleRedirect(to: url, withReturn: returnUrl)
@@ -78,33 +109,47 @@ extension STPPaymentHandler {
                         for: .unsupportedAuthenticationErrorCode,
                         userInfo: [
                             "STPIntentAction": action.nextAction()?.description ?? ""
-                        ]))
+                        ]
+                    )
+                )
             }
         case .finished:
             action.complete(with: .succeeded, error: nil)
         case .unknown:
-            action.complete(with: .failed, error: _error(for: .intentStatusErrorCode,
-                                                         userInfo: [
-                                                            "STPIntentAction": action.nextAction()?.description ?? ""
-                                                         ]))
+            action.complete(
+                with: .failed,
+                error: _error(
+                    for: .intentStatusErrorCode,
+                    userInfo: [
+                        "STPIntentAction": action.nextAction()?.description ?? ""
+                    ]
+                )
+            )
         }
     }
 
-    func _specForPostConfirmPIStatus(paymentIntent: STPPaymentIntent?) -> FormSpec.NextActionSpec.PostConfirmHandlingPiStatusSpecs? {
+    func _specForPostConfirmPIStatus(
+        paymentIntent: STPPaymentIntent?
+    ) -> FormSpec.NextActionSpec.PostConfirmHandlingPiStatusSpecs? {
         guard let paymentIntent = paymentIntent,
-              let nextActionSpec = FormSpec.nextActionSpec(paymentIntent: paymentIntent),
-              let responseSpec = nextActionSpec.postConfirmHandlingPiStatusSpecs,
-              !responseSpec.isEmpty else {
+            let nextActionSpec = FormSpec.nextActionSpec(paymentIntent: paymentIntent),
+            let responseSpec = nextActionSpec.postConfirmHandlingPiStatusSpecs,
+            !responseSpec.isEmpty
+        else {
             return nil
         }
         if let status = paymentIntent.allResponseFields["status"] as? String,
-           let spec = responseSpec[status] {
+            let spec = responseSpec[status]
+        {
             return spec
         }
         return nil
     }
-    func _handlePostConfirmPIStatusSpec(forAction action: STPPaymentHandlerPaymentIntentActionParams, paymentIntentStatusSpec: FormSpec.NextActionSpec.PostConfirmHandlingPiStatusSpecs) {
-        switch(paymentIntentStatusSpec.type) {
+    func _handlePostConfirmPIStatusSpec(
+        forAction action: STPPaymentHandlerPaymentIntentActionParams,
+        paymentIntentStatusSpec: FormSpec.NextActionSpec.PostConfirmHandlingPiStatusSpecs
+    ) {
+        switch paymentIntentStatusSpec.type {
         case .finished:
             action.complete(with: .succeeded, error: nil)
         case .canceled:
@@ -113,7 +158,9 @@ extension STPPaymentHandler {
             assert(false, "programming error")
         }
     }
-    func _isPIStatusSpecFinished(paymentIntentStatusSpec: FormSpec.NextActionSpec.PostConfirmHandlingPiStatusSpecs) -> Bool {
+    func _isPIStatusSpecFinished(
+        paymentIntentStatusSpec: FormSpec.NextActionSpec.PostConfirmHandlingPiStatusSpecs
+    ) -> Bool {
         return paymentIntentStatusSpec.type == .finished
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentSheetFormFactory/FormSpec/FormSpecProvider.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentSheetFormFactory/FormSpec/FormSpecProvider.swift
@@ -10,7 +10,10 @@ import Foundation
 @_spi(STP) import StripeCore
 
 // Intentionally force-unwrap since PaymentSheet requires this file to exist
-private let formSpecsURL = StripePaymentSheetBundleLocator.resourcesBundle.url(forResource: "form_specs", withExtension: ".json")!
+private let formSpecsURL = StripePaymentSheetBundleLocator.resourcesBundle.url(
+    forResource: "form_specs",
+    withExtension: ".json"
+)!
 
 /// Provides FormSpecs for a given a payment method type.
 /// - Note: You must `load(completion:)` to load the specs json file into memory before calling `formSpec(for:)`
@@ -23,7 +26,7 @@ class FormSpecProvider {
     private lazy var formSpecsUpdateQueue: DispatchQueue = {
         DispatchQueue(label: "com.stripe.Form.FormSpecProvider", qos: .userInitiated)
     }()
-    
+
     /// Loads the JSON form spec from disk into memory
     func load(completion: ((Bool) -> Void)? = nil) {
         formSpecsUpdateQueue.async { [weak self] in
@@ -32,7 +35,9 @@ class FormSpecProvider {
             do {
                 let data = try Data(contentsOf: formSpecsURL)
                 let decodedFormSpecs = try decoder.decode([FormSpec].self, from: data)
-                self?.formSpecs = Dictionary(uniqueKeysWithValues: decodedFormSpecs.map{ ($0.type, $0) })
+                self?.formSpecs = Dictionary(
+                    uniqueKeysWithValues: decodedFormSpecs.map { ($0.type, $0) }
+                )
                 completion?(true)
             } catch {
                 completion?(false)
@@ -67,7 +72,7 @@ class FormSpecProvider {
         }
         return true
     }
-    
+
     func formSpec(for paymentMethodType: String) -> FormSpec? {
         assert(!formSpecs.isEmpty, "formSpec(for:) was called before loading form specs JSON!")
         return formSpecs[paymentMethodType]

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
@@ -7,9 +7,9 @@
 //
 
 import Foundation
-import UIKit
-@_spi(STP) import StripeUICore
 @_spi(STP) import StripeCore
+@_spi(STP) import StripeUICore
+import UIKit
 
 extension PaymentSheetFormFactory {
     func makeCard(theme: ElementsUITheme = .default) -> PaymentMethodElement {
@@ -20,12 +20,17 @@ extension PaymentSheetFormFactory {
             )
         )
         let shouldDisplaySaveCheckbox: Bool = saveMode == .userSelectable && !canSaveToLink
-        let cardFormElement = FormElement(elements: [
-            CardSection(theme: theme),
-            makeBillingAddressSection(collectionMode: .countryAndPostal(),
-                                      countries: nil),
-            shouldDisplaySaveCheckbox ? saveCheckbox : nil
-        ], theme: theme)
+        let cardFormElement = FormElement(
+            elements: [
+                CardSection(theme: theme),
+                makeBillingAddressSection(
+                    collectionMode: .countryAndPostal(),
+                    countries: nil
+                ),
+                shouldDisplaySaveCheckbox ? saveCheckbox : nil,
+            ],
+            theme: theme
+        )
         if isLinkEnabled {
             return LinkEnabledPaymentMethodElement(
                 type: .card,

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+FormSpec.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+FormSpec.swift
@@ -12,7 +12,8 @@ import Foundation
 extension PaymentSheetFormFactory {
 
     func specFromJSONProvider(provider: FormSpecProvider = FormSpecProvider.shared) -> FormSpec? {
-        guard let paymentMethodType = PaymentSheet.PaymentMethodType.string(from: paymentMethod) else {
+        guard let paymentMethodType = PaymentSheet.PaymentMethodType.string(from: paymentMethod)
+        else {
             return nil
         }
         return provider.formSpec(for: paymentMethodType)
@@ -41,7 +42,12 @@ extension PaymentSheetFormFactory {
             return makeEmail(apiPath: spec.apiPath?["v1"])
         case .selector(let selectorSpec):
             let dropdownItems: [DropdownFieldElement.DropdownItem] = selectorSpec.items.map {
-                .init(pickerDisplayName: $0.displayText, labelDisplayName: $0.displayText, accessibilityLabel: $0.displayText, rawData: $0.apiValue ?? $0.displayText)
+                .init(
+                    pickerDisplayName: $0.displayText,
+                    labelDisplayName: $0.displayText,
+                    accessibilityLabel: $0.displayText,
+                    rawData: $0.apiValue ?? $0.displayText
+                )
             }
             let dropdownField = DropdownFieldElement(
                 items: dropdownItems,

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+UPI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+UPI.swift
@@ -7,22 +7,26 @@
 //
 
 import Foundation
-import UIKit
-@_spi(STP) import StripeUICore
 @_spi(STP) import StripeCore
 @_spi(STP) import StripePayments
+@_spi(STP) import StripeUICore
+import UIKit
 
 extension PaymentSheetFormFactory {
-    
+
     func makeUPI() -> FormElement {
         return FormElement(autoSectioningElements: [makeUPIHeader(), makeVPAField()], theme: theme)
     }
-    
+
     private func makeUPIHeader() -> StaticElement {
-        return makeSectionTitleLabelWith(text: STPLocalizedString("Buy using a UPI ID",
-                                                                  "Header text shown above a UPI ID text field"))
+        return makeSectionTitleLabelWith(
+            text: STPLocalizedString(
+                "Buy using a UPI ID",
+                "Header text shown above a UPI ID text field"
+            )
+        )
     }
-    
+
     private func makeVPAField() -> PaymentMethodElementWrapper<TextFieldElement> {
         return PaymentMethodElementWrapper(TextFieldElement.makeVPA(theme: theme)) { vpa, params in
             let upi = params.paymentMethodParams.upi ?? STPPaymentMethodUPIParams()

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/STPAPIClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/STPAPIClient+PaymentSheet.swift
@@ -22,12 +22,12 @@ extension STPAPIClient {
         var shared_allPaymentMethods = [STPPaymentMethod]()
         var shared_lastError: Error? = nil
         let group = DispatchGroup()
-        
+
         for type in types {
             group.enter()
             let params = [
                 "customer": customerID,
-                "type": STPPaymentMethod.string(from: type)
+                "type": STPPaymentMethod.string(from: type),
             ]
             APIRequest<STPPaymentMethodListDeserializer>.getWith(
                 self,
@@ -47,14 +47,15 @@ extension STPAPIClient {
                 }
             }
         }
-        
+
         group.notify(queue: DispatchQueue.main) {
             completion(shared_allPaymentMethods, shared_lastError)
         }
     }
-    
+
     internal func detachPaymentMethod(
-        _ paymentMethodID: String, fromCustomerUsing ephemeralKeySecret: String,
+        _ paymentMethodID: String,
+        fromCustomerUsing ephemeralKeySecret: String,
         completion: @escaping STPErrorBlock
     ) {
         let endpoint = "\(APIEndpointPaymentMethods)/\(paymentMethodID)/detach"
@@ -67,11 +68,13 @@ extension STPAPIClient {
             completion(error)
         }
     }
-    
+
     /// Retrieve a customer
     /// - seealso: https://stripe.com/docs/api#retrieve_customer
-    func retrieveCustomer(_ customerID: String,
-        using ephemeralKey: String, completion: @escaping STPCustomerCompletionBlock
+    func retrieveCustomer(
+        _ customerID: String,
+        using ephemeralKey: String,
+        completion: @escaping STPCustomerCompletionBlock
     ) {
         let endpoint = "\(APIEndpointCustomers)/\(customerID)"
         APIRequest<STPCustomer>.getWith(
@@ -86,8 +89,12 @@ extension STPAPIClient {
 }
 
 extension STPAPIClient {
-    typealias STPPaymentIntentWithPreferencesCompletionBlock = ((Result<STPPaymentIntent, Error>) -> Void)
-    typealias STPSetupIntentWithPreferencesCompletionBlock = ((Result<STPSetupIntent, Error>) -> Void)
+    typealias STPPaymentIntentWithPreferencesCompletionBlock = (
+        (Result<STPPaymentIntent, Error>) -> Void
+    )
+    typealias STPSetupIntentWithPreferencesCompletionBlock = (
+        (Result<STPSetupIntent, Error>) -> Void
+    )
 
     func retrievePaymentIntentWithPreferences(
         withClientSecret secret: String,
@@ -109,9 +116,11 @@ extension STPAPIClient {
         }
         parameters["locale"] = Locale.current.toLanguageTag()
 
-        APIRequest<STPPaymentIntent>.getWith(self,
-                                             endpoint: APIEndpointIntentWithPreferences,
-                                             parameters: parameters) { paymentIntentWithPreferences, _, error in
+        APIRequest<STPPaymentIntent>.getWith(
+            self,
+            endpoint: APIEndpointIntentWithPreferences,
+            parameters: parameters
+        ) { paymentIntentWithPreferences, _, error in
             guard let paymentIntentWithPreferences = paymentIntentWithPreferences else {
                 completion(.failure(error ?? NSError.stp_genericFailedToParseResponseError()))
                 return
@@ -127,7 +136,8 @@ extension STPAPIClient {
     ) {
         var parameters: [String: Any] = [:]
 
-        guard STPSetupIntentConfirmParams.isClientSecretValid(secret) && !publishableKeyIsUserKey else {
+        guard STPSetupIntentConfirmParams.isClientSecretValid(secret) && !publishableKeyIsUserKey
+        else {
             completion(.failure(NSError.stp_clientSecretError()))
             return
         }
@@ -137,9 +147,11 @@ extension STPAPIClient {
         parameters["expand"] = ["payment_method_preference.setup_intent.payment_method"]
         parameters["locale"] = Locale.current.toLanguageTag()
 
-        APIRequest<STPSetupIntent>.getWith(self,
-                                           endpoint: APIEndpointIntentWithPreferences,
-                                           parameters: parameters) { setupIntentWithPreferences, _, error in
+        APIRequest<STPSetupIntent>.getWith(
+            self,
+            endpoint: APIEndpointIntentWithPreferences,
+            parameters: parameters
+        ) { setupIntentWithPreferences, _, error in
 
             guard let setupIntentWithPreferences = setupIntentWithPreferences else {
                 completion(.failure(error ?? NSError.stp_genericFailedToParseResponseError()))

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
@@ -7,19 +7,23 @@
 //
 
 import Foundation
-@_spi(STP) import StripeCore
 @_spi(STP) import StripeApplePay
+@_spi(STP) import StripeCore
 @_spi(STP) import StripePayments
 
 extension STPAnalyticsClient {
     // MARK: - Log events
     func logPaymentSheetInitialized(
-        isCustom: Bool = false, configuration: PaymentSheet.Configuration
+        isCustom: Bool = false,
+        configuration: PaymentSheet.Configuration
     ) {
-        logPaymentSheetEvent(event: paymentSheetInitEventValue(
-                                isCustom: isCustom,
-                                configuration: configuration),
-                             configuration: configuration)
+        logPaymentSheetEvent(
+            event: paymentSheetInitEventValue(
+                isCustom: isCustom,
+                configuration: configuration
+            ),
+            configuration: configuration
+        )
     }
 
     func logPaymentSheetPayment(
@@ -65,64 +69,68 @@ extension STPAnalyticsClient {
             activeLinkSession: activeLinkSession
         )
     }
-    
+
     func logPaymentSheetPaymentOptionSelect(
         isCustom: Bool,
         paymentMethod: AnalyticsPaymentMethodType
     ) {
-        logPaymentSheetEvent(event: paymentSheetPaymentOptionSelectEventValue(
-                                isCustom: isCustom,
-                                paymentMethod: paymentMethod))
+        logPaymentSheetEvent(
+            event: paymentSheetPaymentOptionSelectEventValue(
+                isCustom: isCustom,
+                paymentMethod: paymentMethod
+            )
+        )
     }
 
-
     // MARK: - String builders
-    enum AnalyticsPaymentMethodType : String {
+    enum AnalyticsPaymentMethodType: String {
         case newPM = "newpm"
         case savedPM = "savedpm"
         case applePay = "applepay"
         case link = "link"
     }
-    
-    func paymentSheetInitEventValue(isCustom: Bool, configuration: PaymentSheet.Configuration)
+
+    func paymentSheetInitEventValue(
+        isCustom: Bool,
+        configuration: PaymentSheet.Configuration
+    )
         -> STPAnalyticEvent
     {
         if isCustom {
             if configuration.customer == nil && configuration.applePay == nil {
                 return .mcInitCustomDefault
             }
-            
+
             if configuration.customer != nil && configuration.applePay == nil {
                 return .mcInitCustomCustomer
             }
-            
+
             if configuration.customer == nil && configuration.applePay != nil {
                 return .mcInitCustomApplePay
             }
-            
+
             return .mcInitCustomCustomerApplePay
         } else {
             if configuration.customer == nil && configuration.applePay == nil {
                 return .mcInitCompleteDefault
             }
-            
+
             if configuration.customer != nil && configuration.applePay == nil {
                 return .mcInitCompleteCustomer
             }
-            
+
             if configuration.customer == nil && configuration.applePay != nil {
                 return .mcInitCompleteApplePay
             }
-            
+
             return .mcInitCompleteCustomerApplePay
         }
     }
-    
+
     func paymentSheetShowEventValue(
         isCustom: Bool,
         paymentMethod: AnalyticsPaymentMethodType
-    ) -> STPAnalyticEvent
-    {
+    ) -> STPAnalyticEvent {
         if isCustom {
             switch paymentMethod {
             case .newPM:
@@ -147,13 +155,12 @@ extension STPAnalyticsClient {
             }
         }
     }
-    
+
     func paymentSheetPaymentEventValue(
         isCustom: Bool,
         paymentMethod: AnalyticsPaymentMethodType,
         success: Bool
-    ) -> STPAnalyticEvent
-    {
+    ) -> STPAnalyticEvent {
         if isCustom {
             switch paymentMethod {
             case .newPM:
@@ -172,18 +179,18 @@ extension STPAnalyticsClient {
             case .savedPM:
                 return success ? .mcPaymentCompleteSavedPMSuccess : .mcPaymentCompleteSavedPMFailure
             case .applePay:
-                return success ? .mcPaymentCompleteApplePaySuccess : .mcPaymentCompleteApplePayFailure
+                return success
+                    ? .mcPaymentCompleteApplePaySuccess : .mcPaymentCompleteApplePayFailure
             case .link:
                 return success ? .mcPaymentCompleteLinkSuccess : .mcPaymentCompleteLinkFailure
             }
         }
     }
-    
+
     func paymentSheetPaymentOptionSelectEventValue(
         isCustom: Bool,
         paymentMethod: AnalyticsPaymentMethodType
-    ) -> STPAnalyticEvent
-    {
+    ) -> STPAnalyticEvent {
         if isCustom {
             switch paymentMethod {
             case .newPM:
@@ -231,13 +238,15 @@ extension STPAnalyticsClient {
         for (param, param_value) in params {
             additionalParams[param] = param_value
         }
-        let analytic = PaymentSheetAnalytic(event: event,
-                                            productUsage: productUsage,
-                                            additionalParams: additionalParams)
-        
+        let analytic = PaymentSheetAnalytic(
+            event: event,
+            productUsage: productUsage,
+            additionalParams: additionalParams
+        )
+
         log(analytic: analytic)
     }
-    
+
     var isSimulatorOrTest: Bool {
         #if targetEnvironment(simulator)
             return true
@@ -245,11 +254,11 @@ extension STPAnalyticsClient {
             return NSClassFromString("XCTest") != nil
         #endif
     }
-    
+
 }
 
 extension PaymentSheetViewController.Mode {
-    var analyticsValue : STPAnalyticsClient.AnalyticsPaymentMethodType {
+    var analyticsValue: STPAnalyticsClient.AnalyticsPaymentMethodType {
         switch self {
         case .addingNew:
             return .newPM
@@ -260,7 +269,7 @@ extension PaymentSheetViewController.Mode {
 }
 
 extension ChoosePaymentOptionViewController.Mode {
-    var analyticsValue : STPAnalyticsClient.AnalyticsPaymentMethodType {
+    var analyticsValue: STPAnalyticsClient.AnalyticsPaymentMethodType {
         switch self {
         case .addingNew:
             return .newPM
@@ -271,7 +280,7 @@ extension ChoosePaymentOptionViewController.Mode {
 }
 
 extension SavedPaymentOptionsViewController.Selection {
-    var analyticsValue : STPAnalyticsClient.AnalyticsPaymentMethodType {
+    var analyticsValue: STPAnalyticsClient.AnalyticsPaymentMethodType {
         switch self {
         case .add:
             return .newPM
@@ -286,7 +295,7 @@ extension SavedPaymentOptionsViewController.Selection {
 }
 
 extension PaymentSheet.PaymentOption {
-    var analyticsValue : STPAnalyticsClient.AnalyticsPaymentMethodType {
+    var analyticsValue: STPAnalyticsClient.AnalyticsPaymentMethodType {
         switch self {
         case .applePay:
             return .applePay
@@ -303,11 +312,11 @@ extension PaymentSheet.PaymentOption {
 struct PaymentSheetAnalytic: StripePayments.PaymentAnalytic {
     let event: STPAnalyticEvent
     let productUsage: Set<String>
-    let additionalParams: [String : Any]
+    let additionalParams: [String: Any]
 }
 
 extension PaymentSheet.Configuration {
-    
+
     /// Serializes the configuration into a safe dictionary containing no PII for analytics logging
     var analyticPayload: [String: Any] {
         var payload = [String: Any]()
@@ -316,7 +325,7 @@ extension PaymentSheet.Configuration {
         if #available(iOS 13.0, *) {
             payload["style"] = style.rawValue
         } else {
-            payload["style"] = 0 // SheetStyle.automatic.rawValue
+            payload["style"] = 0  // SheetStyle.automatic.rawValue
         }
 
         payload["customer"] = customer != nil
@@ -324,7 +333,7 @@ extension PaymentSheet.Configuration {
         payload["default_billing_details"] = defaultBillingDetails != PaymentSheet.BillingDetails()
         payload["save_payment_method_opt_in_behavior"] = savePaymentMethodOptInBehavior.description
         payload["appearance"] = appearance.analyticPayload
-        
+
         return payload
     }
 }
@@ -351,10 +360,10 @@ extension PaymentSheet.Appearance {
         payload["font"] = font != PaymentSheet.Appearance.default.font
         payload["colors"] = colors != PaymentSheet.Appearance.default.colors
         payload["primary_button"] = primaryButton != PaymentSheet.Appearance.default.primaryButton
-        
+
         // Convenience payload item to make querying high level appearance usage easier
         payload["usage"] = payload.values.contains(true)
-        
+
         return payload
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/STPPaymentIntentShippingDetailsParams+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/STPPaymentIntentShippingDetailsParams+PaymentSheet.swift
@@ -10,7 +10,9 @@ import Foundation
 @_spi(STP) import StripePayments
 
 extension STPPaymentIntentShippingDetailsParams {
-    convenience init?(paymentSheetConfiguration: PaymentSheet.Configuration) {
+    convenience init?(
+        paymentSheetConfiguration: PaymentSheet.Configuration
+    ) {
         guard let shippingDetails = paymentSheetConfiguration.shippingDetails() else {
             return nil
         }
@@ -24,7 +26,7 @@ extension STPPaymentIntentShippingDetailsParams {
         addressParams.state = address.state
         addressParams.postalCode = address.postalCode
         addressParams.country = address.country
-        
+
         self.init(address: addressParams, name: name)
         phone = shippingDetails.phone
     }

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Saved Payment Method Screen/SavedPaymentMethodCollectionView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Saved Payment Method Screen/SavedPaymentMethodCollectionView.swift
@@ -7,11 +7,11 @@
 //
 
 import Foundation
-import UIKit
 @_spi(STP) import StripeCore
-@_spi(STP) import StripeUICore
 @_spi(STP) import StripePayments
 @_spi(STP) import StripePaymentsUI
+@_spi(STP) import StripeUICore
+import UIKit
 
 // MARK: - Constants
 /// Entire cell size
@@ -24,12 +24,17 @@ private let paymentMethodLogoSize: CGSize = CGSize(width: 54, height: 40)
 /// For internal SDK use only
 @objc(STP_Internal_SavedPaymentMethodCollectionView)
 class SavedPaymentMethodCollectionView: UICollectionView {
-    init(appearance: PaymentSheet.Appearance) {
+    init(
+        appearance: PaymentSheet.Appearance
+    ) {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .horizontal
         layout.sectionInset = UIEdgeInsets(
-            top: 0, left: PaymentSheetUI.defaultPadding, bottom: 0,
-            right: PaymentSheetUI.defaultPadding)
+            top: 0,
+            left: PaymentSheetUI.defaultPadding,
+            bottom: 0,
+            right: PaymentSheetUI.defaultPadding
+        )
         layout.itemSize = cellSize
         layout.minimumInteritemSpacing = 12
         super.init(frame: .zero, collectionViewLayout: layout)
@@ -38,12 +43,16 @@ class SavedPaymentMethodCollectionView: UICollectionView {
         backgroundColor = appearance.colors.background
 
         register(
-            PaymentOptionCell.self, forCellWithReuseIdentifier: PaymentOptionCell.reuseIdentifier)
+            PaymentOptionCell.self,
+            forCellWithReuseIdentifier: PaymentOptionCell.reuseIdentifier
+        )
     }
 
     var isRemovingPaymentMethods: Bool = false
 
-    required init?(coder: NSCoder) {
+    required init?(
+        coder: NSCoder
+    ) {
         fatalError("init(coder:) has not been implemented")
     }
 
@@ -56,7 +65,8 @@ class SavedPaymentMethodCollectionView: UICollectionView {
 
 protocol PaymentOptionCellDelegate: AnyObject {
     func paymentOptionCellDidSelectRemove(
-        _ paymentOptionCell: SavedPaymentMethodCollectionView.PaymentOptionCell)
+        _ paymentOptionCell: SavedPaymentMethodCollectionView.PaymentOptionCell
+    )
 }
 
 extension SavedPaymentMethodCollectionView {
@@ -68,25 +78,42 @@ extension SavedPaymentMethodCollectionView {
 
         lazy var label: UILabel = {
             let label = UILabel()
-            label.font = appearance.scaledFont(for: appearance.font.base.medium, style: .footnote, maximumPointSize: 20)
+            label.font = appearance.scaledFont(
+                for: appearance.font.base.medium,
+                style: .footnote,
+                maximumPointSize: 20
+            )
             label.textColor = appearance.colors.text
             label.adjustsFontForContentSizeCategory = true
             return label
         }()
         let paymentMethodLogo: UIImageView = UIImageView()
-        let plus: CircleIconView = CircleIconView(icon: .icon_plus,
-                                                  fillColor: UIColor.dynamic(
-            light: .systemGray5, dark: .tertiaryLabel))
-        lazy var selectedIcon: CircleIconView = CircleIconView(icon: .icon_checkmark, fillColor: appearance.colors.primary)
+        let plus: CircleIconView = CircleIconView(
+            icon: .icon_plus,
+            fillColor: UIColor.dynamic(
+                light: .systemGray5,
+                dark: .tertiaryLabel
+            )
+        )
+        lazy var selectedIcon: CircleIconView = CircleIconView(
+            icon: .icon_checkmark,
+            fillColor: appearance.colors.primary
+        )
         lazy var shadowRoundedRectangle: ShadowedRoundedRectangle = {
             let shadowRoundedRectangle = ShadowedRoundedRectangle(appearance: appearance)
             shadowRoundedRectangle.layoutMargins = UIEdgeInsets(
-                top: 15, left: 24, bottom: 15, right: 24)
+                top: 15,
+                left: 24,
+                bottom: 15,
+                right: 24
+            )
             return shadowRoundedRectangle
         }()
         lazy var deleteButton: CircularButton = {
-            let button = CircularButton(style: .remove,
-                                        dangerColor: appearance.colors.danger)
+            let button = CircularButton(
+                style: .remove,
+                dangerColor: appearance.colors.danger
+            )
             button.backgroundColor = appearance.colors.danger
             button.isAccessibilityElement = true
             button.accessibilityLabel = String.Localized.remove
@@ -112,7 +139,9 @@ extension SavedPaymentMethodCollectionView {
 
         // MARK: - UICollectionViewCell
 
-        override init(frame: CGRect) {
+        override init(
+            frame: CGRect
+        ) {
             super.init(frame: frame)
 
             [paymentMethodLogo, plus, selectedIcon].forEach {
@@ -140,26 +169,36 @@ extension SavedPaymentMethodCollectionView {
             NSLayoutConstraint.activate([
                 shadowRoundedRectangle.topAnchor.constraint(equalTo: contentView.topAnchor),
                 shadowRoundedRectangle.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-                shadowRoundedRectangle.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+                shadowRoundedRectangle.trailingAnchor.constraint(
+                    equalTo: contentView.trailingAnchor
+                ),
                 shadowRoundedRectangle.widthAnchor.constraint(
-                    equalToConstant: roundedRectangleSize.width),
+                    equalToConstant: roundedRectangleSize.width
+                ),
                 shadowRoundedRectangle.heightAnchor.constraint(
-                    equalToConstant: roundedRectangleSize.height),
+                    equalToConstant: roundedRectangleSize.height
+                ),
 
                 label.topAnchor.constraint(
-                    equalTo: shadowRoundedRectangle.bottomAnchor, constant: 4),
+                    equalTo: shadowRoundedRectangle.bottomAnchor,
+                    constant: 4
+                ),
                 label.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
                 label.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 2),
                 label.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
 
                 paymentMethodLogo.centerXAnchor.constraint(
-                    equalTo: shadowRoundedRectangle.centerXAnchor),
+                    equalTo: shadowRoundedRectangle.centerXAnchor
+                ),
                 paymentMethodLogo.centerYAnchor.constraint(
-                    equalTo: shadowRoundedRectangle.centerYAnchor),
+                    equalTo: shadowRoundedRectangle.centerYAnchor
+                ),
                 paymentMethodLogo.widthAnchor.constraint(
-                    equalToConstant: paymentMethodLogoSize.width),
+                    equalToConstant: paymentMethodLogoSize.width
+                ),
                 paymentMethodLogo.heightAnchor.constraint(
-                    equalToConstant: paymentMethodLogoSize.height),
+                    equalToConstant: paymentMethodLogoSize.height
+                ),
 
                 plus.centerXAnchor.constraint(equalTo: shadowRoundedRectangle.centerXAnchor),
                 plus.centerYAnchor.constraint(equalTo: shadowRoundedRectangle.centerYAnchor),
@@ -169,14 +208,22 @@ extension SavedPaymentMethodCollectionView {
                 selectedIcon.widthAnchor.constraint(equalToConstant: 26),
                 selectedIcon.heightAnchor.constraint(equalToConstant: 26),
                 selectedIcon.trailingAnchor.constraint(
-                    equalTo: shadowRoundedRectangle.trailingAnchor, constant: 6),
+                    equalTo: shadowRoundedRectangle.trailingAnchor,
+                    constant: 6
+                ),
                 selectedIcon.bottomAnchor.constraint(
-                    equalTo: shadowRoundedRectangle.bottomAnchor, constant: 6),
+                    equalTo: shadowRoundedRectangle.bottomAnchor,
+                    constant: 6
+                ),
 
                 deleteButton.trailingAnchor.constraint(
-                    equalTo: shadowRoundedRectangle.trailingAnchor, constant: 6),
+                    equalTo: shadowRoundedRectangle.trailingAnchor,
+                    constant: 6
+                ),
                 deleteButton.topAnchor.constraint(
-                    equalTo: shadowRoundedRectangle.topAnchor, constant: -6),
+                    equalTo: shadowRoundedRectangle.topAnchor,
+                    constant: -6
+                ),
             ])
         }
 
@@ -184,7 +231,9 @@ extension SavedPaymentMethodCollectionView {
             super.layoutSubviews()
         }
 
-        required init?(coder: NSCoder) {
+        required init?(
+            coder: NSCoder
+        ) {
             fatalError("init(coder:) has not been implemented")
         }
 
@@ -198,15 +247,15 @@ extension SavedPaymentMethodCollectionView {
                 update()
             }
         }
-        
+
         override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
             let translatedPoint = deleteButton.convert(point, from: self)
-            
+
             // Ensures taps on the delete button are handled properly as it lives outside its cells' bounds
-            if (deleteButton.bounds.contains(translatedPoint) && !deleteButton.isHidden) {
+            if deleteButton.bounds.contains(translatedPoint) && !deleteButton.isHidden {
                 return deleteButton.hitTest(translatedPoint, with: event)
             }
-            
+
             return super.hitTest(point, with: event)
         }
 
@@ -239,7 +288,9 @@ extension SavedPaymentMethodCollectionView {
 
         func attributedTextForLabel(paymentMethod: STPPaymentMethod) -> NSAttributedString? {
             if case .USBankAccount = paymentMethod.type {
-                let iconImage = PaymentSheetImageLibrary.bankIcon(for: nil).withTintColor(.secondaryLabel)
+                let iconImage = PaymentSheetImageLibrary.bankIcon(for: nil).withTintColor(
+                    .secondaryLabel
+                )
                 let iconImageAttachment = NSTextAttachment()
                 // Inspiration from:
                 // https://stackoverflow.com/questions/26105803/center-nstextattachment-image-next-to-single-line-uilabel/45161058#45161058
@@ -247,10 +298,12 @@ extension SavedPaymentMethodCollectionView {
                 let iconHeight = iconImage.size.height * ratio
                 let iconWidth = iconImage.size.width * ratio
 
-                iconImageAttachment.bounds = CGRect(x: 0,
-                                                    y: (label.font.capHeight - iconHeight).rounded() / 2,
-                                                    width: iconWidth,
-                                                    height: iconHeight)
+                iconImageAttachment.bounds = CGRect(
+                    x: 0,
+                    y: (label.font.capHeight - iconHeight).rounded() / 2,
+                    width: iconWidth,
+                    height: iconHeight
+                )
                 iconImageAttachment.image = iconImage
                 let result = NSMutableAttributedString(string: "")
 
@@ -287,7 +340,9 @@ extension SavedPaymentMethodCollectionView {
                     label.text = STPPaymentMethodType.link.displayName
                     shadowRoundedRectangle.accessibilityIdentifier = label.text
                     shadowRoundedRectangle.accessibilityLabel = label.text
-                    paymentMethodLogo.image = PaymentOption.link(option: .wallet).makeCarouselImage(for: self)
+                    paymentMethodLogo.image = PaymentOption.link(option: .wallet).makeCarouselImage(
+                        for: self
+                    )
                     paymentMethodLogo.tintColor = UIColor.linkNavLogo.resolvedContrastingColor(
                         forBackgroundColor: appearance.colors.componentBackground
                     )
@@ -296,7 +351,8 @@ extension SavedPaymentMethodCollectionView {
                         "+ Add",
                         "Text for a button that, when tapped, displays another screen where the customer can add payment method details"
                     )
-                    shadowRoundedRectangle.accessibilityLabel = String.Localized.add_new_payment_method
+                    shadowRoundedRectangle.accessibilityLabel =
+                        String.Localized.add_new_payment_method
                     shadowRoundedRectangle.accessibilityIdentifier = "+ Add"
                     paymentMethodLogo.isHidden = true
                     plus.isHidden = false
@@ -331,7 +387,8 @@ extension SavedPaymentMethodCollectionView {
                     plus.alpha = 0.6
                     label.textColor = appearance.colors.text.disabledColor
                     shadowRoundedRectangle.layer.borderWidth = appearance.borderWidth
-                    shadowRoundedRectangle.layer.borderColor = appearance.colors.componentBorder.cgColor
+                    shadowRoundedRectangle.layer.borderColor =
+                        appearance.colors.componentBorder.cgColor
                 }
 
             } else if isSelected {
@@ -353,8 +410,13 @@ extension SavedPaymentMethodCollectionView {
                 applyDefaultStyle()
             }
             deleteButton.isAccessibilityElement = !deleteButton.isHidden
-            shadowRoundedRectangle.roundedRectangle.backgroundColor = appearance.colors.componentBackground
-            label.font = appearance.scaledFont(for: appearance.font.base.medium, style: .footnote, maximumPointSize: 20)
+            shadowRoundedRectangle.roundedRectangle.backgroundColor =
+                appearance.colors.componentBackground
+            label.font = appearance.scaledFont(
+                for: appearance.font.base.medium,
+                style: .footnote,
+                maximumPointSize: 20
+            )
 
             shadowRoundedRectangle.accessibilityTraits = {
                 if isRemovingPaymentMethods {
@@ -374,14 +436,17 @@ extension SavedPaymentMethodCollectionView {
     // A circle with an image in the middle
     class CircleIconView: UIView {
         let imageView: UIImageView
-        
+
         override var backgroundColor: UIColor? {
             didSet {
                 imageView.tintColor = backgroundColor?.contrastingColor
             }
         }
 
-        required init(icon: Image, fillColor: UIColor) {
+        required init(
+            icon: Image,
+            fillColor: UIColor
+        ) {
             imageView = UIImageView(image: icon.makeImage(template: true))
             super.init(frame: .zero)
             backgroundColor = fillColor
@@ -405,7 +470,9 @@ extension SavedPaymentMethodCollectionView {
             layer.masksToBounds = true
         }
 
-        required init?(coder: NSCoder) {
+        required init?(
+            coder: NSCoder
+        ) {
             fatalError("init(coder:) has not been implemented")
         }
 

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
@@ -7,36 +7,39 @@
 //
 
 import Foundation
-import UIKit
-
 @_spi(STP) import StripeCore
-@_spi(STP) import StripeUICore
 @_spi(STP) import StripePayments
+@_spi(STP) import StripeUICore
+import UIKit
 
 protocol SavedPaymentOptionsViewControllerDelegate: AnyObject {
     func didUpdateSelection(
         viewController: SavedPaymentOptionsViewController,
-        paymentMethodSelection: SavedPaymentOptionsViewController.Selection)
+        paymentMethodSelection: SavedPaymentOptionsViewController.Selection
+    )
     func didSelectRemove(
         viewController: SavedPaymentOptionsViewController,
-        paymentMethodSelection: SavedPaymentOptionsViewController.Selection)
+        paymentMethodSelection: SavedPaymentOptionsViewController.Selection
+    )
 }
 
 /// For internal SDK use only
 @objc(STP_Internal_SavedPaymentOptionsViewController)
 class SavedPaymentOptionsViewController: UIViewController {
     // MARK: - Types
-    /**
-     Represents the payment method the user has selected
-     */
+
     // TODO (cleanup) Replace this with didSelectX delegate methods. Turn this into a private ViewModel class
+    /// Represents the payment method the user has selected
     enum Selection {
         case applePay
         case link
         case saved(paymentMethod: STPPaymentMethod)
         case add
 
-        static func ==(lhs: Selection, rhs: DefaultPaymentMethodStore.PaymentMethodIdentifier?) -> Bool {
+        static func == (
+            lhs: Selection,
+            rhs: DefaultPaymentMethodStore.PaymentMethodIdentifier?
+        ) -> Bool {
             switch lhs {
             case .link:
                 return rhs == .link
@@ -54,7 +57,7 @@ class SavedPaymentOptionsViewController: UIViewController {
         let customerID: String?
         let showApplePay: Bool
         let showLink: Bool
-        
+
         enum AutoSelectDefaultBehavior {
             /// will only autoselect default has been stored locally
             case onlyIfMatched
@@ -63,15 +66,12 @@ class SavedPaymentOptionsViewController: UIViewController {
             /// No auto selection
             case none
         }
-        
+
         let autoSelectDefaultBehavior: AutoSelectDefaultBehavior
     }
 
     var hasRemovablePaymentMethods: Bool {
-        return (
-            configuration.customerID != nil &&
-            !savedPaymentMethods.isEmpty
-        )
+        return (configuration.customerID != nil && !savedPaymentMethods.isEmpty)
     }
 
     var isRemovingPaymentMethods: Bool {
@@ -94,7 +94,9 @@ class SavedPaymentOptionsViewController: UIViewController {
     var bottomNoticeAttributedString: NSAttributedString? {
         if case .saved(let paymentMethod) = selectedPaymentOption {
             if let _ = paymentMethod.usBankAccount {
-                return USBankAccountPaymentMethodElement.attributedMandateTextSavedPaymentMethod(theme: appearance.asElementsTheme)
+                return USBankAccountPaymentMethodElement.attributedMandateTextSavedPaymentMethod(
+                    theme: appearance.asElementsTheme
+                )
             }
         }
         return nil
@@ -115,7 +117,7 @@ class SavedPaymentOptionsViewController: UIViewController {
             return .applePay
         case .link:
             return .link(option: .wallet)
-        case let .saved(paymentMethod):
+        case .saved(let paymentMethod):
             return .saved(paymentMethod: paymentMethod)
         }
     }
@@ -176,7 +178,9 @@ class SavedPaymentOptionsViewController: UIViewController {
         updateUI()
     }
 
-    required init?(coder: NSCoder) {
+    required init?(
+        coder: NSCoder
+    ) {
         fatalError("init(coder:) has not been implemented")
     }
 
@@ -200,7 +204,9 @@ class SavedPaymentOptionsViewController: UIViewController {
 
     // MARK: - Private methods
     private func updateUI() {
-        let defaultPaymentMethod = DefaultPaymentMethodStore.defaultPaymentMethod(for: configuration.customerID)
+        let defaultPaymentMethod = DefaultPaymentMethodStore.defaultPaymentMethod(
+            for: configuration.customerID
+        )
 
         // Move default to front
         var savedPaymentMethods = self.savedPaymentMethods
@@ -224,7 +230,8 @@ class SavedPaymentOptionsViewController: UIViewController {
 
         if configuration.autoSelectDefaultBehavior != .none {
             // Select default
-            selectedViewModelIndex = viewModels.firstIndex(where: { $0 == defaultPaymentMethod })
+            selectedViewModelIndex =
+                viewModels.firstIndex(where: { $0 == defaultPaymentMethod })
                 ?? (configuration.autoSelectDefaultBehavior == .defaultFirst ? 1 : nil)
         }
 
@@ -241,7 +248,7 @@ class SavedPaymentOptionsViewController: UIViewController {
         // For some reason, the selected cell loses its selected appearance
         collectionView.selectItem(at: selectedIndexPath, animated: false, scrollPosition: .bottom)
     }
-    
+
     func unselectPaymentMethod() {
         guard let selectedIndexPath = selectedIndexPath else {
             return
@@ -256,9 +263,16 @@ class SavedPaymentOptionsViewController: UIViewController {
             return
         }
 
-        DefaultPaymentMethodStore.setDefaultPaymentMethod(.link, forCustomer: configuration.customerID)
+        DefaultPaymentMethodStore.setDefaultPaymentMethod(
+            .link,
+            forCustomer: configuration.customerID
+        )
         selectedViewModelIndex = viewModels.firstIndex(where: { $0 == .link })
-        collectionView.selectItem(at: selectedIndexPath, animated: false, scrollPosition: .centeredHorizontally)
+        collectionView.selectItem(
+            at: selectedIndexPath,
+            animated: false,
+            scrollPosition: .centeredHorizontally
+        )
     }
 }
 
@@ -267,20 +281,28 @@ class SavedPaymentOptionsViewController: UIViewController {
 extension SavedPaymentOptionsViewController: UICollectionViewDataSource, UICollectionViewDelegate,
     UICollectionViewDelegateFlowLayout
 {
-    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int)
+    func collectionView(
+        _ collectionView: UICollectionView,
+        numberOfItemsInSection section: Int
+    )
         -> Int
     {
         return viewModels.count
     }
 
-    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath)
+    func collectionView(
+        _ collectionView: UICollectionView,
+        cellForItemAt indexPath: IndexPath
+    )
         -> UICollectionViewCell
     {
         let viewModel = viewModels[indexPath.item]
         guard
             let cell = collectionView.dequeueReusableCell(
                 withReuseIdentifier: SavedPaymentMethodCollectionView.PaymentOptionCell
-                    .reuseIdentifier, for: indexPath)
+                    .reuseIdentifier,
+                for: indexPath
+            )
                 as? SavedPaymentMethodCollectionView.PaymentOptionCell
         else {
             assertionFailure()
@@ -290,11 +312,14 @@ extension SavedPaymentOptionsViewController: UICollectionViewDataSource, UIColle
         cell.delegate = self
         cell.isRemovingPaymentMethods = self.collectionView.isRemovingPaymentMethods
         cell.appearance = appearance
-        
+
         return cell
     }
 
-    func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath)
+    func collectionView(
+        _ collectionView: UICollectionView,
+        shouldSelectItemAt indexPath: IndexPath
+    )
         -> Bool
     {
         guard !self.collectionView.isRemovingPaymentMethods else {
@@ -318,9 +343,15 @@ extension SavedPaymentOptionsViewController: UICollectionViewDataSource, UIColle
             assertionFailure()
             break
         case .applePay:
-            DefaultPaymentMethodStore.setDefaultPaymentMethod(.applePay, forCustomer: configuration.customerID)
+            DefaultPaymentMethodStore.setDefaultPaymentMethod(
+                .applePay,
+                forCustomer: configuration.customerID
+            )
         case .link:
-            DefaultPaymentMethodStore.setDefaultPaymentMethod(.link, forCustomer: configuration.customerID)
+            DefaultPaymentMethodStore.setDefaultPaymentMethod(
+                .link,
+                forCustomer: configuration.customerID
+            )
         case .saved(let paymentMethod):
             DefaultPaymentMethodStore.setDefaultPaymentMethod(
                 .stripe(id: paymentMethod.stripeId),
@@ -339,14 +370,15 @@ extension SavedPaymentOptionsViewController: PaymentOptionCellDelegate {
         _ paymentOptionCell: SavedPaymentMethodCollectionView.PaymentOptionCell
     ) {
         guard let indexPath = collectionView.indexPath(for: paymentOptionCell),
-              case .saved(let paymentMethod) = viewModels[indexPath.row]
+            case .saved(let paymentMethod) = viewModels[indexPath.row]
         else {
             assertionFailure()
             return
         }
         let viewModel = viewModels[indexPath.row]
         let alert = UIAlertAction(
-            title: String.Localized.remove, style: .destructive
+            title: String.Localized.remove,
+            style: .destructive
         ) { (_) in
             self.viewModels.remove(at: indexPath.row)
             // the deletion needs to be in a performBatchUpdates so we make sure it is completed
@@ -375,15 +407,16 @@ extension SavedPaymentOptionsViewController: PaymentOptionCellDelegate {
         }
         let cancel = UIAlertAction(
             title: String.Localized.cancel,
-            style: .cancel, handler: nil
+            style: .cancel,
+            handler: nil
         )
-        
+
         let alertController = UIAlertController(
             title: paymentMethod.removalMessage.title,
             message: paymentMethod.removalMessage.message,
             preferredStyle: .alert
         )
-        
+
         alertController.addAction(cancel)
         alertController.addAction(alert)
         present(alertController, animated: true, completion: nil)

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/USBankAccount/BankAccountInfoView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/USBankAccount/BankAccountInfoView.swift
@@ -5,9 +5,9 @@
 //  Copyright © 2022 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
-@_spi(STP) import StripeUICore
 @_spi(STP) import StripePaymentsUI
+@_spi(STP) import StripeUICore
+import UIKit
 
 protocol BankAccountInfoViewDelegate {
     func didTapXIcon()
@@ -21,7 +21,7 @@ class BankAccountInfoView: UIView {
     }
 
     private let theme: ElementsUITheme
-    
+
     lazy var bankNameLabel: UILabel = {
         let label = UILabel()
         label.font = theme.fonts.subheadline
@@ -69,14 +69,19 @@ class BankAccountInfoView: UIView {
         }
     }
 
-    init(frame: CGRect, theme: ElementsUITheme = .default) {
+    init(
+        frame: CGRect,
+        theme: ElementsUITheme = .default
+    ) {
         self.theme = theme
         super.init(frame: frame)
         addViewComponents()
         addTouchCallbackForX()
     }
 
-    required init?(coder: NSCoder) {
+    required init?(
+        coder: NSCoder
+    ) {
         fatalError("init(coder:) has not been implemented")
     }
 
@@ -95,25 +100,52 @@ class BankAccountInfoView: UIView {
 
         NSLayoutConstraint.activate([
             bankIconImageView.centerYAnchor.constraint(equalTo: centerYAnchor),
-            bankIconImageView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Constants.spacing),
+            bankIconImageView.leadingAnchor.constraint(
+                equalTo: leadingAnchor,
+                constant: Constants.spacing
+            ),
 
-            bankNameLabel.leadingAnchor.constraint(equalTo: bankIconImageView.trailingAnchor, constant: Constants.spacing),
+            bankNameLabel.leadingAnchor.constraint(
+                equalTo: bankIconImageView.trailingAnchor,
+                constant: Constants.spacing
+            ),
             bankNameLabel.widthAnchor.constraint(lessThanOrEqualTo: widthAnchor, multiplier: 0.5),
             bankNameLabel.topAnchor.constraint(equalTo: topAnchor, constant: Constants.spacing),
-            bankNameLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Constants.spacing),
+            bankNameLabel.bottomAnchor.constraint(
+                equalTo: bottomAnchor,
+                constant: -Constants.spacing
+            ),
 
-            bankAccountNumberLabel.leadingAnchor.constraint(equalTo: bankNameLabel.trailingAnchor, constant: Constants.spacing),
-            bankAccountNumberLabel.topAnchor.constraint(equalTo: topAnchor, constant: Constants.spacing),
-            bankAccountNumberLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Constants.spacing),
+            bankAccountNumberLabel.leadingAnchor.constraint(
+                equalTo: bankNameLabel.trailingAnchor,
+                constant: Constants.spacing
+            ),
+            bankAccountNumberLabel.topAnchor.constraint(
+                equalTo: topAnchor,
+                constant: Constants.spacing
+            ),
+            bankAccountNumberLabel.bottomAnchor.constraint(
+                equalTo: bottomAnchor,
+                constant: -Constants.spacing
+            ),
 
-            xIconTappableArea.leadingAnchor.constraint(greaterThanOrEqualTo: bankAccountNumberLabel.trailingAnchor, constant: Constants.spacing),
+            xIconTappableArea.leadingAnchor.constraint(
+                greaterThanOrEqualTo: bankAccountNumberLabel.trailingAnchor,
+                constant: Constants.spacing
+            ),
             xIconTappableArea.trailingAnchor.constraint(equalTo: trailingAnchor),
             xIconTappableArea.widthAnchor.constraint(equalToConstant: 44.0),
             xIconTappableArea.topAnchor.constraint(equalTo: topAnchor),
             xIconTappableArea.bottomAnchor.constraint(equalTo: bottomAnchor),
 
-            xIcon.leadingAnchor.constraint(greaterThanOrEqualTo: xIconTappableArea.leadingAnchor, constant: Constants.spacing),
-            xIcon.trailingAnchor.constraint(equalTo: xIconTappableArea.trailingAnchor, constant: -Constants.spacing),
+            xIcon.leadingAnchor.constraint(
+                greaterThanOrEqualTo: xIconTappableArea.leadingAnchor,
+                constant: Constants.spacing
+            ),
+            xIcon.trailingAnchor.constraint(
+                equalTo: xIconTappableArea.trailingAnchor,
+                constant: -Constants.spacing
+            ),
             xIcon.centerYAnchor.constraint(equalTo: xIconTappableArea.centerYAnchor),
             xIcon.heightAnchor.constraint(equalToConstant: Constants.spacing),
             xIcon.widthAnchor.constraint(equalToConstant: Constants.spacing),
@@ -131,7 +163,9 @@ class BankAccountInfoView: UIView {
 
     func setBankName(text: String) {
         self.bankNameLabel.text = text
-        bankIconImageView.image = PaymentSheetImageLibrary.bankIcon(for: PaymentSheetImageLibrary.bankIconCode(for: text))
+        bankIconImageView.image = PaymentSheetImageLibrary.bankIcon(
+            for: PaymentSheetImageLibrary.bankIconCode(for: text)
+        )
     }
 
     func setLastFourOfBank(text: String) {
@@ -139,8 +173,10 @@ class BankAccountInfoView: UIView {
     }
 
     func updateUI() {
-        bankNameLabel.textColor = isUserInteractionEnabled ? theme.colors.textFieldText : .tertiaryLabel
-        bankAccountNumberLabel.textColor = isUserInteractionEnabled ? theme.colors.textFieldText : .tertiaryLabel
+        bankNameLabel.textColor =
+            isUserInteractionEnabled ? theme.colors.textFieldText : .tertiaryLabel
+        bankAccountNumberLabel.textColor =
+            isUserInteractionEnabled ? theme.colors.textFieldText : .tertiaryLabel
         bankIconImageView.alpha = isUserInteractionEnabled ? 1.0 : 0.5
         xIcon.alpha = isUserInteractionEnabled ? 1.0 : 0.5
     }

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/USBankAccount/USBankAccountPaymentMethodElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/USBankAccount/USBankAccountPaymentMethodElement.swift
@@ -5,13 +5,13 @@
 //  Copyright © 2022 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
-@_spi(STP) import StripeUICore
 @_spi(STP) import StripeCore
-@_spi(STP) import StripePaymentsUI
 @_spi(STP) import StripePayments
+@_spi(STP) import StripePaymentsUI
+@_spi(STP) import StripeUICore
+import UIKit
 
-final class USBankAccountPaymentMethodElement : Element {
+final class USBankAccountPaymentMethodElement: Element {
     var presentingViewControllerDelegate: PresentingViewControllerDelegate? = nil
 
     var delegate: ElementDelegate? = nil
@@ -30,7 +30,12 @@ final class USBankAccountPaymentMethodElement : Element {
     private let theme: ElementsUITheme
     private var linkedBank: LinkedBank? {
         didSet {
-            self.mandateString = Self.attributedMandateText(for: linkedBank, merchantName: merchantName, isSaving: savingAccount.value, theme: theme)
+            self.mandateString = Self.attributedMandateText(
+                for: linkedBank,
+                merchantName: merchantName,
+                isSaving: savingAccount.value,
+                theme: theme
+            )
         }
     }
 
@@ -46,34 +51,52 @@ final class USBankAccountPaymentMethodElement : Element {
         "terms": URL(string: "https://stripe.com/legal/ach-payments/authorization")!
     ]
 
-    static let ContinueMandateText: String = STPLocalizedString("By continuing, you agree to authorize payments pursuant to <terms>these terms</terms>.", "Text providing link to terms for ACH payments")
-    static let SaveAccountMandateText: String = STPLocalizedString("By saving your bank account for %@ you agree to authorize payments pursuant to <terms>these terms</terms>.", "Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@).")
-    static let MicrodepositCopy: String = STPLocalizedString("Stripe will deposit $0.01 to your account in 1-2 business days. Then you’ll get an email with instructions to complete payment to %@.", "Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name")
-
+    static let ContinueMandateText: String = STPLocalizedString(
+        "By continuing, you agree to authorize payments pursuant to <terms>these terms</terms>.",
+        "Text providing link to terms for ACH payments"
+    )
+    static let SaveAccountMandateText: String = STPLocalizedString(
+        "By saving your bank account for %@ you agree to authorize payments pursuant to <terms>these terms</terms>.",
+        "Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@)."
+    )
+    static let MicrodepositCopy: String = STPLocalizedString(
+        "Stripe will deposit $0.01 to your account in 1-2 business days. Then you’ll get an email with instructions to complete payment to %@.",
+        "Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name"
+    )
 
     var canLinkAccount: Bool {
-        return self.formElement.updateParams(params: IntentConfirmParams(type: .USBankAccount)) != nil
+        return self.formElement.updateParams(params: IntentConfirmParams(type: .USBankAccount))
+            != nil
     }
 
     var name: String? {
-        return self.formElement.updateParams(params: IntentConfirmParams(type: .USBankAccount))?.paymentMethodParams.nonnil_billingDetails.name
+        return self.formElement.updateParams(params: IntentConfirmParams(type: .USBankAccount))?
+            .paymentMethodParams.nonnil_billingDetails.name
     }
 
     var email: String? {
-        return self.formElement.updateParams(params: IntentConfirmParams(type: .USBankAccount))?.paymentMethodParams.nonnil_billingDetails.email
+        return self.formElement.updateParams(params: IntentConfirmParams(type: .USBankAccount))?
+            .paymentMethodParams.nonnil_billingDetails.email
     }
-    
-    init(titleElement: StaticElement,
-         nameElement: PaymentMethodElement,
-         emailElement: PaymentMethodElement,
-         checkboxElement: PaymentMethodElement?,
-         savingAccount: BoolReference,
-         merchantName: String,
-         theme: ElementsUITheme = .default) {
+
+    init(
+        titleElement: StaticElement,
+        nameElement: PaymentMethodElement,
+        emailElement: PaymentMethodElement,
+        checkboxElement: PaymentMethodElement?,
+        savingAccount: BoolReference,
+        merchantName: String,
+        theme: ElementsUITheme = .default
+    ) {
         self.bankInfoView = BankAccountInfoView(frame: .zero, theme: theme)
-        self.bankInfoSectionElement = SectionElement(title: STPLocalizedString("Bank account",
-                                                                               "Title for collected bank account information"),
-                                                     elements: [StaticElement(view: bankInfoView)], theme: theme)
+        self.bankInfoSectionElement = SectionElement(
+            title: STPLocalizedString(
+                "Bank account",
+                "Title for collected bank account information"
+            ),
+            elements: [StaticElement(view: bankInfoView)],
+            theme: theme
+        )
         self.linkedBank = nil
         self.bankInfoSectionElement.view.isHidden = true
         self.checkboxElement = checkboxElement
@@ -81,10 +104,12 @@ final class USBankAccountPaymentMethodElement : Element {
         self.merchantName = merchantName
         self.savingAccount = savingAccount
         self.theme = theme
-        var autoSectioningElements: [Element] = [titleElement,
-                                                 nameElement,
-                                                 emailElement,
-                                                 bankInfoSectionElement]
+        var autoSectioningElements: [Element] = [
+            titleElement,
+            nameElement,
+            emailElement,
+            bankInfoSectionElement,
+        ]
         if let checkboxElement = checkboxElement {
             checkboxElement.view.isHidden = true
             autoSectioningElements.append(checkboxElement)
@@ -98,7 +123,12 @@ final class USBankAccountPaymentMethodElement : Element {
                 guard let self = self else {
                     return
                 }
-                self.mandateString = Self.attributedMandateText(for: self.linkedBank, merchantName: merchantName, isSaving: value, theme: theme)
+                self.mandateString = Self.attributedMandateText(
+                    for: self.linkedBank,
+                    merchantName: merchantName,
+                    isSaving: value,
+                    theme: theme
+                )
                 self.delegate?.didUpdate(element: self)
             }
         }
@@ -107,7 +137,8 @@ final class USBankAccountPaymentMethodElement : Element {
     func setLinkedBank(_ linkedBank: LinkedBank) {
         self.linkedBank = linkedBank
         if let last4ofBankAccount = linkedBank.last4,
-           let bankName = linkedBank.bankName {
+            let bankName = linkedBank.bankName
+        {
             self.bankInfoView.setBankName(text: bankName)
             self.bankInfoView.setLastFourOfBank(text: "••••\(last4ofBankAccount)")
             formElement.setElements(linkedAccountElements, hidden: false, animated: true)
@@ -115,24 +146,31 @@ final class USBankAccountPaymentMethodElement : Element {
         self.delegate?.didUpdate(element: self)
     }
 
-    class func attributedMandateText(for linkedBank: LinkedBank?,
-                                     merchantName: String,
-                                     isSaving: Bool,
-                                     theme: ElementsUITheme = .default) -> NSMutableAttributedString? {
+    class func attributedMandateText(
+        for linkedBank: LinkedBank?,
+        merchantName: String,
+        isSaving: Bool,
+        theme: ElementsUITheme = .default
+    ) -> NSMutableAttributedString? {
         guard let linkedBank = linkedBank else {
             return nil
         }
 
-        var mandateText = isSaving ? String(format: Self.SaveAccountMandateText, merchantName) : Self.ContinueMandateText
+        var mandateText =
+            isSaving
+            ? String(format: Self.SaveAccountMandateText, merchantName) : Self.ContinueMandateText
         if !linkedBank.instantlyVerified {
-            mandateText =  String.init(format: Self.MicrodepositCopy, merchantName) + "\n" + mandateText
+            mandateText =
+                String.init(format: Self.MicrodepositCopy, merchantName) + "\n" + mandateText
         }
         let formattedString = applyLinksToString(template: mandateText, links: links)
         applyStyle(formattedString: formattedString, theme: theme)
         return formattedString
     }
 
-    class func attributedMandateTextSavedPaymentMethod(theme: ElementsUITheme = .default) -> NSMutableAttributedString {
+    class func attributedMandateTextSavedPaymentMethod(
+        theme: ElementsUITheme = .default
+    ) -> NSMutableAttributedString {
         let mandateText = Self.ContinueMandateText
         let formattedString = applyLinksToString(template: mandateText, links: links)
         applyStyle(formattedString: formattedString, theme: theme)
@@ -140,9 +178,14 @@ final class USBankAccountPaymentMethodElement : Element {
     }
 
     // TODO(wooj): Refactor this code to be common across multiple classes
-    private class func applyLinksToString(template: String, links:[String: URL]) -> NSMutableAttributedString {
+    private class func applyLinksToString(
+        template: String,
+        links: [String: URL]
+    ) -> NSMutableAttributedString {
         let formattedString = NSMutableAttributedString()
-        STPStringUtils.parseRanges(from: template, withTags: Set<String>(links.keys)) { string, matches in
+        STPStringUtils.parseRanges(from: template, withTags: Set<String>(links.keys)) {
+            string,
+            matches in
             formattedString.append(NSAttributedString(string: string))
             for (tag, range) in matches {
                 guard range.rangeValue.location != NSNotFound else {
@@ -158,14 +201,20 @@ final class USBankAccountPaymentMethodElement : Element {
         return formattedString
     }
 
-    private class func applyStyle(formattedString: NSMutableAttributedString, theme: ElementsUITheme = .default) {
+    private class func applyStyle(
+        formattedString: NSMutableAttributedString,
+        theme: ElementsUITheme = .default
+    ) {
         let style = NSMutableParagraphStyle()
         style.alignment = .center
-        formattedString.addAttributes([.paragraphStyle: style,
-                                       .font: UIFont.preferredFont(forTextStyle: .footnote),
-                                       .foregroundColor: theme.colors.secondaryText
-                                      ],
-                                      range: NSRange(location: 0, length: formattedString.length))
+        formattedString.addAttributes(
+            [
+                .paragraphStyle: style,
+                .font: UIFont.preferredFont(forTextStyle: .footnote),
+                .foregroundColor: theme.colors.secondaryText,
+            ],
+            range: NSRange(location: 0, length: formattedString.length)
+        )
     }
 }
 
@@ -178,20 +227,26 @@ extension USBankAccountPaymentMethodElement: BankAccountInfoViewDelegate {
         }
 
         guard let last4BankAccount = self.linkedBank?.last4,
-              let presentingDelegate = presentingViewControllerDelegate else {
+            let presentingDelegate = presentingViewControllerDelegate
+        else {
             completionClosure()
             return
         }
 
-        let didTapAlert = UIAlertAction(title: String.Localized.remove, style: .destructive) { (_) in
+        let didTapAlert = UIAlertAction(title: String.Localized.remove, style: .destructive) {
+            (_) in
             completionClosure()
         }
-        let didTapCancel = UIAlertAction(title: String.Localized.cancel,
-                                   style: .cancel,
-                                   handler: nil)
-        let alertController = UIAlertController(title: String.Localized.removeBankAccount,
-                                                message: String(format: String.Localized.removeBankAccountEndingIn, last4BankAccount),
-                                                preferredStyle: .alert)
+        let didTapCancel = UIAlertAction(
+            title: String.Localized.cancel,
+            style: .cancel,
+            handler: nil
+        )
+        let alertController = UIAlertController(
+            title: String.Localized.removeBankAccount,
+            message: String(format: String.Localized.removeBankAccountEndingIn, last4BankAccount),
+            preferredStyle: .alert
+        )
         alertController.addAction(didTapCancel)
         alertController.addAction(didTapAlert)
         presentingDelegate.presentViewController(viewController: alertController, completion: nil)
@@ -201,8 +256,10 @@ extension USBankAccountPaymentMethodElement: BankAccountInfoViewDelegate {
 extension USBankAccountPaymentMethodElement: PaymentMethodElement {
     func updateParams(params: IntentConfirmParams) -> IntentConfirmParams? {
         if let updatedParams = self.formElement.updateParams(params: params),
-           let linkedBank = linkedBank {
-            updatedParams.paymentMethodParams.usBankAccount?.linkAccountSessionID = linkedBank.sessionId
+            let linkedBank = linkedBank
+        {
+            updatedParams.paymentMethodParams.usBankAccount?.linkAccountSessionID =
+                linkedBank.sessionId
             updatedParams.linkedBank = linkedBank
             return updatedParams
         }

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/ViewControllers/AutoComplete/AddressSearchResult.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/ViewControllers/AutoComplete/AddressSearchResult.swift
@@ -13,19 +13,19 @@ import MapKit
 protocol AddressSearchResult {
     var title: String { get }
 
-    var titleHighlightRanges: [NSValue] { get } // NSValue-wrapped NSRanges
+    var titleHighlightRanges: [NSValue] { get }  // NSValue-wrapped NSRanges
 
     var subtitle: String { get }
 
-    var subtitleHighlightRanges: [NSValue] { get } // NSValue-wrapped NSRanges
-    
+    var subtitleHighlightRanges: [NSValue] { get }  // NSValue-wrapped NSRanges
+
     /// Converts this search result to a `PaymentSheet.Address?`
     /// - Parameter completion: Invoked with a `PaymentSheet.Address?` representation of this address search result
-    func asAddress(completion: @escaping (PaymentSheet.Address?) -> ())
+    func asAddress(completion: @escaping (PaymentSheet.Address?) -> Void)
 }
 
 extension MKLocalSearchCompletion: AddressSearchResult {
-    func asAddress(completion: @escaping (PaymentSheet.Address?) -> ()) {
+    func asAddress(completion: @escaping (PaymentSheet.Address?) -> Void) {
         let searchRequest = MKLocalSearch.Request(completion: self)
         let search = MKLocalSearch(request: searchRequest)
 
@@ -39,11 +39,13 @@ extension MKLocalSearchCompletion: AddressSearchResult {
 extension MKPlacemark {
     /// Converts this placemark into an address that can be interpreted by PaymentSheet
     var asAddress: PaymentSheet.Address {
-        return PaymentSheet.Address(city: locality,
-                                    country: isoCountryCode,
-                                    line1: name,
-                                    line2: nil, // Can't get line 2 from auto complete
-                                    postalCode: postalCode,
-                                    state: administrativeArea)
+        return PaymentSheet.Address(
+            city: locality,
+            country: isoCountryCode,
+            line1: name,
+            line2: nil,  // Can't get line 2 from auto complete
+            postalCode: postalCode,
+            state: administrativeArea
+        )
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/ViewControllers/AutoComplete/AutoCompleteViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/ViewControllers/AutoComplete/AutoCompleteViewController.swift
@@ -7,13 +7,13 @@
 //
 
 import Foundation
-import UIKit
 import MapKit
 @_spi(STP) import StripeCore
 @_spi(STP) import StripeUICore
+import UIKit
 
 protocol AutoCompleteViewControllerDelegate: AnyObject {
-    
+
     /// Called when the user has selected an address from the auto complete suggestions
     /// - Parameter address: The address selected from the search results
     func didSelectAddress(_ address: PaymentSheet.Address?)
@@ -25,32 +25,32 @@ class AutoCompleteViewController: UIViewController {
     let configuration: AddressViewController.Configuration
     let addressSpecProvider: AddressSpecProvider
     private lazy var addressSearchCompleter: MKLocalSearchCompleter = {
-       let searchCompleter = MKLocalSearchCompleter()
+        let searchCompleter = MKLocalSearchCompleter()
         searchCompleter.delegate = self
         if #available(iOS 13.0, *) {
             searchCompleter.resultTypes = .address
         }
         return searchCompleter
     }()
-    
+
     weak var delegate: AutoCompleteViewControllerDelegate?
-    
+
     private let cellReuseIdentifier = "autoCompleteCell"
     var results: [AddressSearchResult] = [] {
         didSet {
             separatorView.isHidden = results.isEmpty
             tableView.reloadData()
-            latestError = nil // reset latest error whenever we get new results
+            latestError = nil  // reset latest error whenever we get new results
         }
     }
-    
+
     private var latestError: Error? {
         didSet {
             errorLabel.text = latestError?.localizedDescription
             errorLabel.isHidden = latestError == nil
         }
     }
-    
+
     // MARK: - Views
     lazy var formView: UIView = {
         return formElement.view
@@ -60,7 +60,7 @@ class AutoCompleteViewController: UIViewController {
         stackView.directionalLayoutMargins = PaymentSheetUI.defaultMargins
         stackView.isLayoutMarginsRelativeArrangement = true
         stackView.axis = .vertical
-        
+
         return stackView
     }()
     lazy var tableView: UITableView = {
@@ -79,7 +79,7 @@ class AutoCompleteViewController: UIViewController {
         return button
     }()
     lazy var separatorView: UIView = {
-       let view = UIView()
+        let view = UIView()
         view.backgroundColor = configuration.appearance.colors.componentDivider
         view.isHidden = true
         return view
@@ -92,7 +92,7 @@ class AutoCompleteViewController: UIViewController {
     private var theme: ElementsUITheme {
         return configuration.appearance.asElementsTheme
     }
-    
+
     // MARK: - Elements
     lazy var autoCompleteLine: TextFieldElement = {
         let autoCompleteLine = TextFieldElement.Address.makeAutoCompleteLine(theme: theme)
@@ -107,7 +107,7 @@ class AutoCompleteViewController: UIViewController {
         form.delegate = self
         return form
     }()
-    
+
     // MARK: - Initializers
     required init(
         configuration: AddressViewController.Configuration,
@@ -117,27 +117,33 @@ class AutoCompleteViewController: UIViewController {
         self.addressSpecProvider = addressSpecProvider
         super.init(nibName: nil, bundle: nil)
     }
-    
-    required init?(coder: NSCoder) {
+
+    required init?(
+        coder: NSCoder
+    ) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     // MARK: - Overrides
     var stackViewBottomConstraint: NSLayoutConstraint!
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = configuration.appearance.colors.background
-        
-        let stackView = UIStackView(arrangedSubviews: [formStackView, errorLabel, separatorView, tableView, manualEntryButton])
+
+        let stackView = UIStackView(arrangedSubviews: [
+            formStackView, errorLabel, separatorView, tableView, manualEntryButton,
+        ])
         stackView.spacing = PaymentSheetUI.defaultPadding
         stackView.axis = .vertical
-        stackView.setCustomSpacing(24, after: formStackView) // hardcoded from figma value
+        stackView.setCustomSpacing(24, after: formStackView)  // hardcoded from figma value
         stackView.setCustomSpacing(0, after: separatorView)
         stackView.setCustomSpacing(0, after: tableView)
         stackView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(stackView)
 
-        stackViewBottomConstraint = stackView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+        stackViewBottomConstraint = stackView.bottomAnchor.constraint(
+            equalTo: view.safeAreaLayoutGuide.bottomAnchor
+        )
         NSLayoutConstraint.activate([
             stackViewBottomConstraint,
 
@@ -145,27 +151,43 @@ class AutoCompleteViewController: UIViewController {
             stackView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
             stackView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
             separatorView.heightAnchor.constraint(equalToConstant: 0.33),
-            manualEntryButton.heightAnchor.constraint(equalToConstant: manualEntryButton.frame.size.height)
+            manualEntryButton.heightAnchor.constraint(
+                equalToConstant: manualEntryButton.frame.size.height
+            ),
         ])
-        
+
     }
-    
+
     private func registerForKeyboardNotifications() {
         NotificationCenter.default.removeObserver(self)
-        NotificationCenter.default.addObserver(self, selector: #selector(adjustForKeyboard), name: UIResponder.keyboardWillHideNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(adjustForKeyboard), name: UIResponder.keyboardWillChangeFrameNotification, object: nil)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(adjustForKeyboard),
+            name: UIResponder.keyboardWillHideNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(adjustForKeyboard),
+            name: UIResponder.keyboardWillChangeFrameNotification,
+            object: nil
+        )
     }
-    
+
     @objc private func adjustForKeyboard(notification: Notification) {
         guard
-            let keyboardScreenEndFrame = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue
+            let keyboardScreenEndFrame =
+                (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?
+                .cgRectValue
         else {
             return
         }
 
-        view.layoutIfNeeded() // Ensures the view is laid out before animating
+        view.layoutIfNeeded()  // Ensures the view is laid out before animating
         let keyboardViewEndFrame = view.convert(keyboardScreenEndFrame, from: view.window)
-        let keyboardInViewHeight = view.safeAreaLayoutGuide.layoutFrame.intersection(keyboardViewEndFrame).height
+        let keyboardInViewHeight = view.safeAreaLayoutGuide.layoutFrame.intersection(
+            keyboardViewEndFrame
+        ).height
         if notification.name == UIResponder.keyboardWillHideNotification {
             stackViewBottomConstraint.constant = 0
         } else {
@@ -178,18 +200,18 @@ class AutoCompleteViewController: UIViewController {
             self.view.layoutIfNeeded()
         }
     }
-     
+
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         registerForKeyboardNotifications()
         autoCompleteLine.beginEditing()
     }
-    
+
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         NotificationCenter.default.removeObserver(self)
     }
-    
+
     // MARK: Private functions
     @objc private func manualEntryButtonTapped() {
         // Populate address with partial for line 1
@@ -202,7 +224,7 @@ extension AutoCompleteViewController: ElementDelegate {
     func didUpdate(element: Element) {
         addressSearchCompleter.queryFragment = autoCompleteLine.text
     }
-    
+
     func continueToNextField(element: Element) {
         // no-op
     }
@@ -213,16 +235,16 @@ extension AutoCompleteViewController: MKLocalSearchCompleterDelegate {
     func completerDidUpdateResults(_ completer: MKLocalSearchCompleter) {
         self.results = completer.results
     }
-    
+
     func completer(_ completer: MKLocalSearchCompleter, didFailWithError error: Error) {
         let nsError = error as NSError
-        
+
         // Making a query with an empty string causes a server error and doesn't update search results
         if completer.queryFragment.isEmpty && nsError.code == MKError.serverFailure.rawValue {
             results.removeAll()
             return
         }
-        
+
         self.latestError = error
     }
 }
@@ -232,39 +254,44 @@ extension AutoCompleteViewController: UITableViewDelegate, UITableViewDataSource
     func numberOfSections(in tableView: UITableView) -> Int {
         return 1
     }
-    
+
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return results.count
     }
-    
+
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: cellReuseIdentifier) ??
-             UITableViewCell(style: .subtitle, reuseIdentifier: cellReuseIdentifier)
+        let cell =
+            tableView.dequeueReusableCell(withIdentifier: cellReuseIdentifier)
+            ?? UITableViewCell(style: .subtitle, reuseIdentifier: cellReuseIdentifier)
         cell.backgroundColor = configuration.appearance.colors.background
 
         let result = results[indexPath.row]
-        cell.textLabel?.attributedText = result.title.highlightSearchString(highlightRanges: result.titleHighlightRanges,
-                                                                            textStyle: .subheadline,
-                                                                            appearance: configuration.appearance,
-                                                                             isSubtitle: false)
+        cell.textLabel?.attributedText = result.title.highlightSearchString(
+            highlightRanges: result.titleHighlightRanges,
+            textStyle: .subheadline,
+            appearance: configuration.appearance,
+            isSubtitle: false
+        )
 
-        cell.detailTextLabel?.attributedText = result.subtitle.highlightSearchString(highlightRanges: result.subtitleHighlightRanges,
-                                                                            textStyle: .footnote,
-                                                                            appearance: configuration.appearance,
-                                                                            isSubtitle: true)
-        cell.indentationWidth = 5 // hardcoded value to align with searchbar textfield
+        cell.detailTextLabel?.attributedText = result.subtitle.highlightSearchString(
+            highlightRanges: result.subtitleHighlightRanges,
+            textStyle: .footnote,
+            appearance: configuration.appearance,
+            isSubtitle: true
+        )
+        cell.indentationWidth = 5  // hardcoded value to align with searchbar textfield
 
         return cell
     }
-    
+
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return 64
     }
-    
+
     func tableView(_ tableView: UITableView, indentationLevelForRowAt indexPath: IndexPath) -> Int {
         return 1
     }
-    
+
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         results[indexPath.row].asAddress { [weak self] address in
             DispatchQueue.main.async {
@@ -272,5 +299,5 @@ extension AutoCompleteViewController: UITableViewDelegate, UITableViewDataSource
             }
         }
     }
-    
+
 }

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/ViewControllers/AutoComplete/String+AutoComplete.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/ViewControllers/AutoComplete/String+AutoComplete.swift
@@ -10,24 +10,40 @@ import Foundation
 import UIKit
 
 extension String {
-    func highlightSearchString(highlightRanges: [NSValue], textStyle: UIFont.TextStyle, appearance: PaymentSheet.Appearance, isSubtitle: Bool) -> NSAttributedString {
+    func highlightSearchString(
+        highlightRanges: [NSValue],
+        textStyle: UIFont.TextStyle,
+        appearance: PaymentSheet.Appearance,
+        isSubtitle: Bool
+    ) -> NSAttributedString {
         let attributedString = NSMutableAttributedString(string: self)
 
         attributedString.addAttribute(
             NSAttributedString.Key.font,
-            value: appearance.scaledFont(for: appearance.font.base.regular, style: textStyle, maximumPointSize: 25),
-            range: (self as NSString).range(of: self))
+            value: appearance.scaledFont(
+                for: appearance.font.base.regular,
+                style: textStyle,
+                maximumPointSize: 25
+            ),
+            range: (self as NSString).range(of: self)
+        )
 
         attributedString.addAttribute(
             NSAttributedString.Key.foregroundColor,
             value: isSubtitle ? appearance.colors.textSecondary : appearance.colors.text,
-            range: (self as NSString).range(of: self))
+            range: (self as NSString).range(of: self)
+        )
 
         for highlightRange in highlightRanges {
             attributedString.addAttribute(
                 NSAttributedString.Key.font,
-                value: appearance.scaledFont(for: appearance.font.base.bold, style: textStyle, maximumPointSize: 25),
-                range: highlightRange.rangeValue)
+                value: appearance.scaledFont(
+                    for: appearance.font.base.bold,
+                    style: textStyle,
+                    maximumPointSize: 25
+                ),
+                range: highlightRange.rangeValue
+            )
         }
 
         return attributedString
@@ -54,8 +70,8 @@ extension String {
             return sCount
         }
 
-        let line : [Int]  = Array(repeating: 0, count: oCount + 1)
-        var mat : [[Int]] = Array(repeating: line, count: sCount + 1)
+        let line: [Int] = Array(repeating: 0, count: oCount + 1)
+        var mat: [[Int]] = Array(repeating: line, count: sCount + 1)
 
         for i in 0...sCount {
             mat[i][0] = i
@@ -68,12 +84,11 @@ extension String {
         for j in 1...oCount {
             for i in 1...sCount {
                 if self[i - 1] == other[j - 1] {
-                    mat[i][j] = mat[i - 1][j - 1]       // no operation
-                }
-                else {
-                    let del = mat[i - 1][j] + 1         // deletion
-                    let ins = mat[i][j - 1] + 1         // insertion
-                    let sub = mat[i - 1][j - 1] + 1     // substitution
+                    mat[i][j] = mat[i - 1][j - 1]  // no operation
+                } else {
+                    let del = mat[i - 1][j] + 1  // deletion
+                    let ins = mat[i][j - 1] + 1  // insertion
+                    let sub = mat[i - 1][j - 1] + 1  // substitution
                     mat[i][j] = min(min(del, ins), sub)
                 }
             }

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/ViewControllers/BottomSheet3DS2ViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/ViewControllers/BottomSheet3DS2ViewController.swift
@@ -6,13 +6,14 @@
 //  Copyright © 2021 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
-@_spi(STP) import StripePaymentsUI
 @_spi(STP) import StripePayments
+@_spi(STP) import StripePaymentsUI
+import UIKit
 
 protocol BottomSheet3DS2ViewControllerDelegate: AnyObject {
     func bottomSheet3DS2ViewControllerDidCancel(
-        _ bottomSheet3DS2ViewController: BottomSheet3DS2ViewController)
+        _ bottomSheet3DS2ViewController: BottomSheet3DS2ViewController
+    )
 }
 
 /// For internal SDK use only
@@ -22,8 +23,10 @@ class BottomSheet3DS2ViewController: UIViewController {
     weak var delegate: BottomSheet3DS2ViewControllerDelegate? = nil
 
     lazy var navigationBar: SheetNavigationBar = {
-        let navBar = SheetNavigationBar(isTestMode: isTestMode,
-                                        appearance: appearance)
+        let navBar = SheetNavigationBar(
+            isTestMode: isTestMode,
+            appearance: appearance
+        )
         navBar.setStyle(.back)
         navBar.delegate = self
         return navBar
@@ -33,14 +36,20 @@ class BottomSheet3DS2ViewController: UIViewController {
     let appearance: PaymentSheet.Appearance
     let isTestMode: Bool
 
-    required init(challengeViewController: UIViewController, appearance: PaymentSheet.Appearance, isTestMode: Bool) {
+    required init(
+        challengeViewController: UIViewController,
+        appearance: PaymentSheet.Appearance,
+        isTestMode: Bool
+    ) {
         self.challengeViewController = challengeViewController
         self.appearance = appearance
         self.isTestMode = isTestMode
         super.init(nibName: nil, bundle: nil)
     }
 
-    required init?(coder: NSCoder) {
+    required init?(
+        coder: NSCoder
+    ) {
         fatalError("init(coder:) has not been implemented")
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/ViewControllers/BottomSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/ViewControllers/BottomSheetViewController.swift
@@ -7,14 +7,14 @@
 //
 
 import SafariServices
-import UIKit
 @_spi(STP) import StripeCore
-@_spi(STP) import StripeUICore
 @_spi(STP) import StripePayments
 @_spi(STP) import StripePaymentsUI
+@_spi(STP) import StripeUICore
+import UIKit
 
 protocol BottomSheetContentViewController: UIViewController {
-    
+
     /// - Note: Implementing `navigationBar` as a computed variable will result in undefined behavior.
     var navigationBar: SheetNavigationBar { get }
     var requiresFullScreen: Bool { get }
@@ -57,7 +57,7 @@ class BottomSheetViewController: UIViewController, BottomSheetPresentable {
 
     func popContentViewController() -> BottomSheetContentViewController? {
         guard contentStack.count > 1,
-              let toVC = contentStack.stp_boundSafeObject(at: 1)
+            let toVC = contentStack.stp_boundSafeObject(at: 1)
         else {
             return nil
         }
@@ -66,7 +66,7 @@ class BottomSheetViewController: UIViewController, BottomSheetPresentable {
         contentViewController = toVC
         return popped
     }
-    
+
     let isTestMode: Bool
     let appearance: PaymentSheet.Appearance
 
@@ -94,18 +94,18 @@ class BottomSheetViewController: UIViewController, BottomSheetPresentable {
             navigationBarContainerView.addArrangedSubview(contentViewController.navigationBar)
         }
     }
-    
+
     var contentRequiresFullScreen: Bool {
         return contentViewController.requiresFullScreen
     }
 
-    let didCancelNative3DS2: () -> ()
-    
+    let didCancelNative3DS2: () -> Void
+
     required init(
         contentViewController: BottomSheetContentViewController,
         appearance: PaymentSheet.Appearance,
         isTestMode: Bool,
-        didCancelNative3DS2: @escaping () -> ()
+        didCancelNative3DS2: @escaping () -> Void
     ) {
         self.contentViewController = contentViewController
         self.appearance = appearance
@@ -123,7 +123,9 @@ class BottomSheetViewController: UIViewController, BottomSheetPresentable {
         self.view.backgroundColor = appearance.colors.background
     }
 
-    required init?(coder: NSCoder) {
+    required init?(
+        coder: NSCoder
+    ) {
         fatalError("init(coder:) has not been implemented")
     }
 
@@ -136,12 +138,15 @@ class BottomSheetViewController: UIViewController, BottomSheetPresentable {
 
         view.backgroundColor = .systemBackground
         registerForKeyboardNotifications()
-        [scrollView, navigationBarContainerView].forEach({  // Note: Order important here, navigation bar should be on top
+        // Note: Order important here, navigation bar should be on top
+        [scrollView, navigationBarContainerView].forEach({
             view.addSubview($0)
             $0.translatesAutoresizingMaskIntoConstraints = false
         })
         NSLayoutConstraint.activate([
-            navigationBarContainerView.topAnchor.constraint(equalTo: view.topAnchor),  // For unknown reasons, safeAreaLayoutGuide can have incorrect padding; we'll rely on our superview instead
+            // For unknown reasons, safeAreaLayoutGuide can have incorrect padding;
+            // we'll rely on our superview instead
+            navigationBarContainerView.topAnchor.constraint(equalTo: view.topAnchor),
             navigationBarContainerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             navigationBarContainerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
 
@@ -157,25 +162,33 @@ class BottomSheetViewController: UIViewController, BottomSheetPresentable {
 
         // Give the scroll view a desired height
         let scrollViewHeightConstraint = scrollView.heightAnchor.constraint(
-            equalTo: scrollView.contentLayoutGuide.heightAnchor)
+            equalTo: scrollView.contentLayoutGuide.heightAnchor
+        )
         scrollViewHeightConstraint.priority = .fittingSizeLevel
         self.scrollViewHeightConstraint = scrollViewHeightConstraint
 
         NSLayoutConstraint.activate([
             contentContainerView.leadingAnchor.constraint(
-                equalTo: scrollView.contentLayoutGuide.leadingAnchor),
+                equalTo: scrollView.contentLayoutGuide.leadingAnchor
+            ),
             contentContainerView.trailingAnchor.constraint(
-                equalTo: scrollView.contentLayoutGuide.trailingAnchor),
+                equalTo: scrollView.contentLayoutGuide.trailingAnchor
+            ),
             contentContainerView.topAnchor.constraint(
-                equalTo: scrollView.contentLayoutGuide.topAnchor),
+                equalTo: scrollView.contentLayoutGuide.topAnchor
+            ),
             contentContainerView.bottomAnchor.constraint(
-                equalTo: scrollView.contentLayoutGuide.bottomAnchor),
+                equalTo: scrollView.contentLayoutGuide.bottomAnchor
+            ),
             contentContainerView.widthAnchor.constraint(
-                equalTo: scrollView.frameLayoutGuide.widthAnchor),
+                equalTo: scrollView.frameLayoutGuide.widthAnchor
+            ),
             scrollViewHeightConstraint,
         ])
         let hideKeyboardGesture = UITapGestureRecognizer(
-            target: self, action: #selector(didTapAnywhere))
+            target: self,
+            action: #selector(didTapAnywhere)
+        )
         hideKeyboardGesture.cancelsTouchesInView = false
         hideKeyboardGesture.delegate = self
         view.addGestureRecognizer(hideKeyboardGesture)
@@ -183,11 +196,17 @@ class BottomSheetViewController: UIViewController, BottomSheetPresentable {
 
     private func registerForKeyboardNotifications() {
         NotificationCenter.default.addObserver(
-            self, selector: #selector(keyboardDidHide),
-            name: UIResponder.keyboardWillHideNotification, object: nil)
+            self,
+            selector: #selector(keyboardDidHide),
+            name: UIResponder.keyboardWillHideNotification,
+            object: nil
+        )
         NotificationCenter.default.addObserver(
-            self, selector: #selector(keyboardDidShow),
-            name: UIResponder.keyboardWillShowNotification, object: nil)
+            self,
+            selector: #selector(keyboardDidShow),
+            name: UIResponder.keyboardWillShowNotification,
+            object: nil
+        )
     }
 
     @objc
@@ -196,24 +215,34 @@ class BottomSheetViewController: UIViewController, BottomSheetPresentable {
         let landscape = UIScreen.main.bounds.size.width > UIScreen.main.bounds.size.height
         // Handle iPad landscape edge case where `scrollRectToVisible` isn't sufficient
         if UIDevice.current.userInterfaceIdiom == .pad && landscape {
-            guard let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else { return }
-            scrollView.contentInset.bottom = view.convert(keyboardFrame.cgRectValue, from: nil).size.height
+            guard
+                let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey]
+                    as? NSValue
+            else { return }
+            scrollView.contentInset.bottom =
+                view.convert(keyboardFrame.cgRectValue, from: nil).size.height
             return
         }
-        
+
         if let firstResponder = view.firstResponder() {
-            let firstResponderFrame = scrollView.convert(firstResponder.bounds, from: firstResponder).insetBy(
+            let firstResponderFrame = scrollView.convert(
+                firstResponder.bounds,
+                from: firstResponder
+            ).insetBy(
                 dx: -Constants.keyboardAvoidanceEdgePadding,
                 dy: -Constants.keyboardAvoidanceEdgePadding
             )
             scrollView.scrollRectToVisible(firstResponderFrame, animated: true)
         }
     }
-    
+
     @objc
     private func keyboardDidHide(notification: Notification) {
         if let firstResponder = view.firstResponder() {
-            let firstResponderFrame = scrollView.convert(firstResponder.bounds, from: firstResponder).insetBy(
+            let firstResponderFrame = scrollView.convert(
+                firstResponder.bounds,
+                from: firstResponder
+            ).insetBy(
                 dx: -Constants.keyboardAvoidanceEdgePadding,
                 dy: -Constants.keyboardAvoidanceEdgePadding
             )
@@ -235,7 +264,9 @@ class BottomSheetViewController: UIViewController, BottomSheetPresentable {
 }
 
 extension BottomSheetViewController: UIAdaptivePresentationControllerDelegate {
-    func presentationControllerShouldDismiss(_ presentationController: UIPresentationController) -> Bool {
+    func presentationControllerShouldDismiss(
+        _ presentationController: UIPresentationController
+    ) -> Bool {
         // On iPad, tapping outside the sheet dismisses it without informing us - so we override this method to be informed.
         didTapOrSwipeToDismiss()
         return false
@@ -257,7 +288,7 @@ extension BottomSheetViewController: UIScrollViewDelegate {
 @available(iOSApplicationExtension, unavailable)
 @available(macCatalystApplicationExtension, unavailable)
 extension BottomSheetViewController: PaymentSheetAuthenticationContext {
-    
+
     func authenticationPresentingViewController() -> UIViewController {
         return findTopMostPresentedViewController() ?? self
     }
@@ -272,23 +303,32 @@ extension BottomSheetViewController: PaymentSheetAuthenticationContext {
     }
 
     func present(
-        _ authenticationViewController: UIViewController, completion: @escaping () -> Void
+        _ authenticationViewController: UIViewController,
+        completion: @escaping () -> Void
     ) {
         let threeDS2ViewController = BottomSheet3DS2ViewController(
-            challengeViewController: authenticationViewController, appearance: appearance, isTestMode: isTestMode)
+            challengeViewController: authenticationViewController,
+            appearance: appearance,
+            isTestMode: isTestMode
+        )
         threeDS2ViewController.delegate = self
         pushContentViewController(threeDS2ViewController)
         completion()
     }
-    
+
     func presentPollingVCForAction(_ action: STPPaymentHandlerActionParams) {
-        let pollingVC = PollingViewController(currentAction: action,
-                                                      appearance: self.appearance)
+        let pollingVC = PollingViewController(
+            currentAction: action,
+            appearance: self.appearance
+        )
         pushContentViewController(pollingVC)
     }
 
     func dismiss(_ authenticationViewController: UIViewController) {
-        guard contentViewController is BottomSheet3DS2ViewController || contentViewController is PollingViewController else {
+        guard
+            contentViewController is BottomSheet3DS2ViewController
+                || contentViewController is PollingViewController
+        else {
             return
         }
         _ = popContentViewController()
@@ -307,7 +347,10 @@ extension BottomSheetViewController: UIGestureRecognizerDelegate {
         return true
     }
 
-    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch)
+    func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldReceive touch: UITouch
+    )
         -> Bool
     {
         // I can't find another way to allow custom UIControl subclasses to receive touches

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/ViewControllers/ChoosePaymentOptionViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/ViewControllers/ChoosePaymentOptionViewController.swift
@@ -7,17 +7,19 @@
 //
 
 import Foundation
-import UIKit
 @_spi(STP) import StripeCore
-@_spi(STP) import StripeUICore
-@_spi(STP) import StripePaymentsUI
 @_spi(STP) import StripePayments
+@_spi(STP) import StripePaymentsUI
+@_spi(STP) import StripeUICore
+import UIKit
 
 protocol ChoosePaymentOptionViewControllerDelegate: AnyObject {
     func choosePaymentOptionViewControllerShouldClose(
-        _ choosePaymentOptionViewController: ChoosePaymentOptionViewController)
+        _ choosePaymentOptionViewController: ChoosePaymentOptionViewController
+    )
     func choosePaymentOptionViewControllerDidUpdateSelection(
-        _ choosePaymentOptionViewController: ChoosePaymentOptionViewController)
+        _ choosePaymentOptionViewController: ChoosePaymentOptionViewController
+    )
 }
 
 /// For internal SDK use only
@@ -48,7 +50,7 @@ class ChoosePaymentOptionViewController: UIViewController {
             guard let selectedPaymentOption = selectedPaymentOption else {
                 return .dynamic("")
             }
-            if case let .saved(paymentMethod) = selectedPaymentOption {
+            if case .saved(let paymentMethod) = selectedPaymentOption {
                 return paymentMethod.paymentSheetPaymentMethodType()
             } else if case .applePay = selectedPaymentOption {
                 return .card
@@ -61,8 +63,10 @@ class ChoosePaymentOptionViewController: UIViewController {
     }
     weak var delegate: ChoosePaymentOptionViewControllerDelegate?
     lazy var navigationBar: SheetNavigationBar = {
-        let navBar = SheetNavigationBar(isTestMode: configuration.apiClient.isTestmode,
-                                        appearance: configuration.appearance)
+        let navBar = SheetNavigationBar(
+            isTestMode: configuration.apiClient.isTestmode,
+            appearance: configuration.appearance
+        )
         navBar.delegate = self
         return navBar
     }()
@@ -86,7 +90,8 @@ class ChoosePaymentOptionViewController: UIViewController {
         return AddPaymentMethodViewController(
             intent: intent,
             configuration: configuration,
-            delegate: self)
+            delegate: self
+        )
     }()
     private let savedPaymentOptionsViewController: SavedPaymentOptionsViewController
     private lazy var headerLabel: UILabel = {
@@ -98,7 +103,7 @@ class ChoosePaymentOptionViewController: UIViewController {
     private lazy var errorLabel: UILabel = {
         return ElementsUI.makeErrorLabel(theme: configuration.appearance.asElementsTheme)
     }()
-    private lazy var confirmButton: ConfirmButton = {        
+    private lazy var confirmButton: ConfirmButton = {
         let button = ConfirmButton(
             callToAction: .add(paymentMethodType: selectedPaymentMethodType),
             appearance: configuration.appearance,
@@ -115,7 +120,9 @@ class ChoosePaymentOptionViewController: UIViewController {
 
     // MARK: - Init
 
-    required init?(coder: NSCoder) {
+    required init?(
+        coder: NSCoder
+    ) {
         fatalError("init(coder:) has not been implemented")
     }
 
@@ -130,14 +137,15 @@ class ChoosePaymentOptionViewController: UIViewController {
         self.intent = intent
         self.isApplePayEnabled = isApplePayEnabled
         self.isLinkEnabled = isLinkEnabled
-        
+
         self.configuration = configuration
         self.delegate = delegate
 
         // Default to payment selection, as long as we have saved PMs or Apple Pay or Link is enabled.
-        self.mode = savedPaymentMethods.count > 0 || isApplePayEnabled || isLinkEnabled
-                ? .selectingSaved
-                : .addingNew
+        self.mode =
+            savedPaymentMethods.count > 0 || isApplePayEnabled || isLinkEnabled
+            ? .selectingSaved
+            : .addingNew
 
         self.savedPaymentOptionsViewController = SavedPaymentOptionsViewController(
             savedPaymentMethods: savedPaymentMethods,
@@ -194,12 +202,14 @@ class ChoosePaymentOptionViewController: UIViewController {
             stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             stackView.bottomAnchor.constraint(
-                equalTo: view.bottomAnchor, constant: -PaymentSheetUI.defaultSheetMargins.bottom),
+                equalTo: view.bottomAnchor,
+                constant: -PaymentSheetUI.defaultSheetMargins.bottom
+            ),
         ])
 
         updateUI()
     }
-    
+
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         STPAnalyticsClient.sharedClient.logPaymentSheetShow(
@@ -222,18 +232,23 @@ class ChoosePaymentOptionViewController: UIViewController {
                         return .close(showAdditionalButton: true)
                     } else {
                         self.navigationBar.additionalButton.removeTarget(
-                            self, action: #selector(didSelectEditSavedPaymentMethodsButton),
-                            for: .touchUpInside)
+                            self,
+                            action: #selector(didSelectEditSavedPaymentMethodsButton),
+                            for: .touchUpInside
+                        )
                         return .close(showAdditionalButton: false)
                     }
                 case .addingNew:
                     self.navigationBar.additionalButton.removeTarget(
-                        self, action: #selector(didSelectEditSavedPaymentMethodsButton),
-                        for: .touchUpInside)
+                        self,
+                        action: #selector(didSelectEditSavedPaymentMethodsButton),
+                        for: .touchUpInside
+                    )
                     return savedPaymentOptionsViewController.hasPaymentOptions
                         ? .back : .close(showAdditionalButton: false)
                 }
-            }())
+            }()
+        )
     }
 
     // state -> view
@@ -242,8 +257,8 @@ class ChoosePaymentOptionViewController: UIViewController {
         let shouldEnableUserInteraction = !isSavingInProgress && !isVerificationInProgress
         if shouldEnableUserInteraction != view.isUserInteractionEnabled {
             sendEventToSubviews(
-                shouldEnableUserInteraction ?
-                    .shouldEnableUserInteraction : .shouldDisableUserInteraction,
+                shouldEnableUserInteraction
+                    ? .shouldEnableUserInteraction : .shouldDisableUserInteraction,
                 from: view
             )
         }
@@ -256,10 +271,14 @@ class ChoosePaymentOptionViewController: UIViewController {
         case .selectingSaved:
             headerLabel.text = STPLocalizedString(
                 "Select your payment method",
-                "Title shown above a carousel containing the customer's payment methods")
+                "Title shown above a carousel containing the customer's payment methods"
+            )
         case .addingNew:
             if addPaymentMethodViewController.paymentMethodTypes == [.card] {
-                headerLabel.text = STPLocalizedString("Add a card", "Title shown above a card entry form")
+                headerLabel.text = STPLocalizedString(
+                    "Add a card",
+                    "Title shown above a card entry form"
+                )
             } else {
                 headerLabel.text = STPLocalizedString("Choose a payment method", "TODO")
             }
@@ -311,8 +330,12 @@ class ChoosePaymentOptionViewController: UIViewController {
                         self.view.layoutIfNeeded()
                     }
                 }
-                confirmButton.update(state: savedPaymentOptionsViewController.isRemovingPaymentMethods ? .disabled : .enabled,
-                                     callToAction: .customWithLock(title: String.Localized.continue), animated: true)
+                confirmButton.update(
+                    state: savedPaymentOptionsViewController.isRemovingPaymentMethods
+                        ? .disabled : .enabled,
+                    callToAction: .customWithLock(title: String.Localized.continue),
+                    animated: true
+                )
             } else {
                 if !confirmButton.isHidden {
                     UIView.animate(withDuration: PaymentSheetUI.defaultAnimationDuration) {
@@ -346,10 +369,14 @@ class ChoosePaymentOptionViewController: UIViewController {
                 }
             }()
 
-            var callToAction: ConfirmButton.CallToActionType = .add(paymentMethodType: selectedPaymentMethodType)
+            var callToAction: ConfirmButton.CallToActionType = .add(
+                paymentMethodType: selectedPaymentMethodType
+            )
             if let overrideCallToAction = addPaymentMethodViewController.overrideCallToAction {
                 callToAction = overrideCallToAction
-                confirmButtonState = addPaymentMethodViewController.overrideCallToActionShouldEnable ? .enabled : .disabled
+                confirmButtonState =
+                    addPaymentMethodViewController.overrideCallToActionShouldEnable
+                    ? .enabled : .disabled
             }
 
             confirmButton.update(
@@ -364,15 +391,19 @@ class ChoosePaymentOptionViewController: UIViewController {
         switch mode {
         case .selectingSaved:
             if selectedPaymentMethodType.requiresMandateDisplayForSavedSelection {
-                self.bottomNoticeTextField.attributedText = savedPaymentOptionsViewController.bottomNoticeAttributedString
+                self.bottomNoticeTextField.attributedText =
+                    savedPaymentOptionsViewController.bottomNoticeAttributedString
             } else {
                 self.bottomNoticeTextField.attributedText = nil
             }
         case .addingNew:
-            self.bottomNoticeTextField.attributedText = addPaymentMethodViewController.bottomNoticeAttributedString
+            self.bottomNoticeTextField.attributedText =
+                addPaymentMethodViewController.bottomNoticeAttributedString
         }
         UIView.animate(withDuration: PaymentSheetUI.defaultAnimationDuration) {
-            self.bottomNoticeTextField.setHiddenIfNecessary(self.bottomNoticeTextField.attributedText?.length == 0)
+            self.bottomNoticeTextField.setHiddenIfNecessary(
+                self.bottomNoticeTextField.attributedText?.length == 0
+            )
         }
     }
 
@@ -382,8 +413,13 @@ class ChoosePaymentOptionViewController: UIViewController {
         case .selectingSaved:
             self.delegate?.choosePaymentOptionViewControllerShouldClose(self)
         case .addingNew:
-            if let buyButtonOverrideBehavior = addPaymentMethodViewController.overrideBuyButtonBehavior {
-                addPaymentMethodViewController.didTapCallToActionButton(behavior: buyButtonOverrideBehavior, from: self)
+            if let buyButtonOverrideBehavior = addPaymentMethodViewController
+                .overrideBuyButtonBehavior
+            {
+                addPaymentMethodViewController.didTapCallToActionButton(
+                    behavior: buyButtonOverrideBehavior,
+                    from: self
+                )
             } else {
                 self.delegate?.choosePaymentOptionViewControllerShouldClose(self)
             }
@@ -427,7 +463,10 @@ extension ChoosePaymentOptionViewController: SavedPaymentOptionsViewControllerDe
         viewController: SavedPaymentOptionsViewController,
         paymentMethodSelection: SavedPaymentOptionsViewController.Selection
     ) {
-        STPAnalyticsClient.sharedClient.logPaymentSheetPaymentOptionSelect(isCustom: true, paymentMethod: paymentMethodSelection.analyticsValue)
+        STPAnalyticsClient.sharedClient.logPaymentSheetPaymentOptionSelect(
+            isCustom: true,
+            paymentMethod: paymentMethodSelection.analyticsValue
+        )
         guard case Mode.selectingSaved = mode else {
             assertionFailure()
             return
@@ -435,7 +474,7 @@ extension ChoosePaymentOptionViewController: SavedPaymentOptionsViewControllerDe
         switch paymentMethodSelection {
         case .add:
             mode = .addingNew
-            error = nil // Clear any errors
+            error = nil  // Clear any errors
             updateUI()
         case .applePay, .link, .saved:
             delegate?.choosePaymentOptionViewControllerDidUpdateSelection(self)
@@ -456,7 +495,8 @@ extension ChoosePaymentOptionViewController: SavedPaymentOptionsViewControllerDe
             return
         }
         configuration.apiClient.detachPaymentMethod(
-            paymentMethod.stripeId, fromCustomerUsing: ephemeralKey
+            paymentMethod.stripeId,
+            fromCustomerUsing: ephemeralKey
         ) { (_) in
             // no-op
         }
@@ -483,7 +523,10 @@ extension ChoosePaymentOptionViewController: SavedPaymentOptionsViewControllerDe
         navigationBar.additionalButton.titleLabel?.font = configuration.appearance.font.base.medium
         navigationBar.additionalButton.titleLabel?.adjustsFontForContentSizeCategory = true
         navigationBar.additionalButton.addTarget(
-            self, action: #selector(didSelectEditSavedPaymentMethodsButton), for: .touchUpInside)
+            self,
+            action: #selector(didSelectEditSavedPaymentMethodsButton),
+            for: .touchUpInside
+        )
     }
 
     @objc
@@ -501,19 +544,26 @@ extension ChoosePaymentOptionViewController: AddPaymentMethodViewControllerDeleg
         error = nil  // clear error
 
         if case .link(let linkOption) = selectedPaymentOption,
-           let linkAccount = linkOption.account,
-           linkAccount.sessionState == .requiresVerification {
+            let linkAccount = linkOption.account,
+            linkAccount.sessionState == .requiresVerification
+        {
             isVerificationInProgress = true
             updateUI()
 
-            let verificationController = LinkVerificationController(mode: .inlineLogin, linkAccount: linkAccount)
-            verificationController.present(from: self, completion: { [weak self] _ in
-                // Verification result is ignored here on purpose. If verification is canceled or fails,
-                // we will simply don't block the payment. This will be revised after we redesign the inline
-                // signup UI to include verification status.
-                self?.isVerificationInProgress = false
-                self?.updateUI()
-            })
+            let verificationController = LinkVerificationController(
+                mode: .inlineLogin,
+                linkAccount: linkAccount
+            )
+            verificationController.present(
+                from: self,
+                completion: { [weak self] _ in
+                    // Verification result is ignored here on purpose. If verification is canceled or fails,
+                    // we will simply don't block the payment. This will be revised after we redesign the inline
+                    // signup UI to include verification status.
+                    self?.isVerificationInProgress = false
+                    self?.updateUI()
+                }
+            )
         } else {
             updateUI()
         }

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/ViewControllers/LoadingViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/ViewControllers/LoadingViewController.swift
@@ -7,8 +7,8 @@
 //
 
 import Foundation
-import UIKit
 @_spi(STP) import StripeUICore
+import UIKit
 
 protocol LoadingViewControllerDelegate: AnyObject {
     func shouldDismiss(_ loadingViewController: LoadingViewController)
@@ -19,12 +19,14 @@ protocol LoadingViewControllerDelegate: AnyObject {
 @objc(STP_Internal_LoadingViewController)
 class LoadingViewController: UIViewController, BottomSheetContentViewController {
     lazy var navigationBar: SheetNavigationBar = {
-        let navigationBar = SheetNavigationBar(isTestMode: isTestMode,
-                                               appearance: appearance)
+        let navigationBar = SheetNavigationBar(
+            isTestMode: isTestMode,
+            appearance: appearance
+        )
         navigationBar.delegate = self
         return navigationBar
     }()
-    
+
     let appearance: PaymentSheet.Appearance
     let isTestMode: Bool
 
@@ -40,20 +42,26 @@ class LoadingViewController: UIViewController, BottomSheetContentViewController 
     let activityIndicator = UIActivityIndicatorView(style: .medium)
     weak var delegate: LoadingViewControllerDelegate?
 
-    init(delegate: LoadingViewControllerDelegate, appearance: PaymentSheet.Appearance, isTestMode: Bool) {
+    init(
+        delegate: LoadingViewControllerDelegate,
+        appearance: PaymentSheet.Appearance,
+        isTestMode: Bool
+    ) {
         self.delegate = delegate
         self.appearance = appearance
         self.isTestMode = isTestMode
         super.init(nibName: nil, bundle: nil)
     }
 
-    required init?(coder: NSCoder) {
+    required init?(
+        coder: NSCoder
+    ) {
         fatalError("init(coder:) has not been implemented")
     }
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         activityIndicator.color = appearance.colors.background.contrastingColor
         [activityIndicator].forEach {
             view.addSubview($0)
@@ -61,9 +69,11 @@ class LoadingViewController: UIViewController, BottomSheetContentViewController 
         }
         NSLayoutConstraint.activate([
             activityIndicator.centerXAnchor.constraint(
-                equalTo: view.safeAreaLayoutGuide.centerXAnchor),
+                equalTo: view.safeAreaLayoutGuide.centerXAnchor
+            ),
             activityIndicator.centerYAnchor.constraint(
-                equalTo: view.safeAreaLayoutGuide.centerYAnchor),
+                equalTo: view.safeAreaLayoutGuide.centerYAnchor
+            ),
             view.heightAnchor.constraint(equalToConstant: loadingViewHeight),
         ])
         activityIndicator.startAnimating()

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -8,21 +8,27 @@
 
 import Foundation
 import PassKit
-import UIKit
 @_spi(STP) import StripeCore
-@_spi(STP) import StripeUICore
 @_spi(STP) import StripePayments
+@_spi(STP) import StripeUICore
+import UIKit
 
 protocol PaymentSheetViewControllerDelegate: AnyObject {
     func paymentSheetViewControllerShouldConfirm(
-        _ paymentSheetViewController: PaymentSheetViewController, with paymentOption: PaymentOption,
-        completion: @escaping (PaymentSheetResult) -> Void)
+        _ paymentSheetViewController: PaymentSheetViewController,
+        with paymentOption: PaymentOption,
+        completion: @escaping (PaymentSheetResult) -> Void
+    )
     func paymentSheetViewControllerDidFinish(
-        _ paymentSheetViewController: PaymentSheetViewController, result: PaymentSheetResult)
+        _ paymentSheetViewController: PaymentSheetViewController,
+        result: PaymentSheetResult
+    )
     func paymentSheetViewControllerDidCancel(
-        _ paymentSheetViewController: PaymentSheetViewController)
+        _ paymentSheetViewController: PaymentSheetViewController
+    )
     func paymentSheetViewControllerDidSelectPayWithLink(
-        _ paymentSheetViewController: PaymentSheetViewController)
+        _ paymentSheetViewController: PaymentSheetViewController
+    )
 }
 
 /// For internal SDK use only
@@ -44,7 +50,7 @@ class PaymentSheetViewController: UIViewController {
         case .addingNew:
             return isWalletEnabled
         case .selectingSaved:
-           // When selecting saved we only add the wallet header for Link -- ApplePay by itself is inlined
+            // When selecting saved we only add the wallet header for Link -- ApplePay by itself is inlined
             return isLinkEnabled
         }
     }
@@ -98,8 +104,10 @@ class PaymentSheetViewController: UIViewController {
         )
     }()
     internal lazy var navigationBar: SheetNavigationBar = {
-        let navBar = SheetNavigationBar(isTestMode: configuration.apiClient.isTestmode,
-                                        appearance: configuration.appearance)
+        let navBar = SheetNavigationBar(
+            isTestMode: configuration.apiClient.isTestmode,
+            appearance: configuration.appearance
+        )
         navBar.delegate = self
         return navBar
     }()
@@ -118,7 +126,8 @@ class PaymentSheetViewController: UIViewController {
             options: walletOptions,
             appearance: configuration.appearance,
             applePayButtonType: configuration.applePay?.buttonType ?? .plain,
-            delegate: self)
+            delegate: self
+        )
         return header
     }()
     private lazy var headerLabel: UILabel = {
@@ -138,7 +147,7 @@ class PaymentSheetViewController: UIViewController {
             if let customCtaLabel = configuration.primaryButtonLabel {
                 return .customWithLock(title: customCtaLabel)
             }
-            
+
             switch intent {
             case .paymentIntent(let paymentIntent):
                 return .pay(amount: paymentIntent.amount, currency: paymentIntent.currency)
@@ -160,7 +169,9 @@ class PaymentSheetViewController: UIViewController {
 
     // MARK: - Init
 
-    required init?(coder: NSCoder) {
+    required init?(
+        coder: NSCoder
+    ) {
         fatalError("init(coder:) has not been implemented")
     }
 
@@ -186,7 +197,7 @@ class PaymentSheetViewController: UIViewController {
         }
 
         super.init(nibName: nil, bundle: nil)
-        
+
         self.view.backgroundColor = configuration.appearance.colors.background
     }
 
@@ -201,7 +212,8 @@ class PaymentSheetViewController: UIViewController {
 
         // One stack view contains all our subviews
         let stackView = UIStackView(arrangedSubviews: [
-            headerLabel, walletHeader, paymentContainerView, errorLabel, buyButton, bottomNoticeTextField
+            headerLabel, walletHeader, paymentContainerView, errorLabel, buyButton,
+            bottomNoticeTextField,
         ])
         stackView.directionalLayoutMargins = PaymentSheetUI.defaultMargins
         stackView.isLayoutMarginsRelativeArrangement = true
@@ -227,7 +239,9 @@ class PaymentSheetViewController: UIViewController {
             stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             stackView.bottomAnchor.constraint(
-                equalTo: view.bottomAnchor, constant: -PaymentSheetUI.defaultSheetMargins.bottom),
+                equalTo: view.bottomAnchor,
+                constant: -PaymentSheetUI.defaultSheetMargins.bottom
+            ),
         ])
 
         updateUI(animated: false)
@@ -242,7 +256,7 @@ class PaymentSheetViewController: UIViewController {
             activeLinkSession: LinkAccountContext.shared.account?.sessionState == .verified
         )
     }
-    
+
     func set(error: Error?) {
         self.error = error
         self.errorLabel.text = error?.nonGenericDescription
@@ -263,17 +277,22 @@ class PaymentSheetViewController: UIViewController {
                         return .close(showAdditionalButton: true)
                     } else {
                         self.navigationBar.additionalButton.removeTarget(
-                            self, action: #selector(didSelectEditSavedPaymentMethodsButton),
-                            for: .touchUpInside)
+                            self,
+                            action: #selector(didSelectEditSavedPaymentMethodsButton),
+                            for: .touchUpInside
+                        )
                         return .close(showAdditionalButton: false)
                     }
                 case .addingNew:
                     self.navigationBar.additionalButton.removeTarget(
-                        self, action: #selector(didSelectEditSavedPaymentMethodsButton),
-                        for: .touchUpInside)
+                        self,
+                        action: #selector(didSelectEditSavedPaymentMethodsButton),
+                        for: .touchUpInside
+                    )
                     return savedPaymentMethods.isEmpty ? .close(showAdditionalButton: false) : .back
                 }
-            }())
+            }()
+        )
 
     }
 
@@ -283,7 +302,8 @@ class PaymentSheetViewController: UIViewController {
         let shouldEnableUserInteraction = !isPaymentInFlight
         if shouldEnableUserInteraction != view.isUserInteractionEnabled {
             sendEventToSubviews(
-                shouldEnableUserInteraction ? .shouldEnableUserInteraction : .shouldDisableUserInteraction,
+                shouldEnableUserInteraction
+                    ? .shouldEnableUserInteraction : .shouldDisableUserInteraction,
                 from: view
             )
         }
@@ -296,9 +316,8 @@ class PaymentSheetViewController: UIViewController {
 
         // Content header
         walletHeader.isHidden = !shouldShowWalletHeader
-        walletHeader.showsCardPaymentMessage = (
-            addPaymentMethodViewController.paymentMethodTypes == [.card]
-        )
+        walletHeader.showsCardPaymentMessage =
+            (addPaymentMethodViewController.paymentMethodTypes == [.card])
 
         switch mode {
         case .addingNew:
@@ -309,13 +328,16 @@ class PaymentSheetViewController: UIViewController {
             )
         case .selectingSaved:
             headerLabel.isHidden = false
-            headerLabel.text = shouldShowWalletHeader && intent.isPaymentIntent
+            headerLabel.text =
+                shouldShowWalletHeader && intent.isPaymentIntent
                 ? STPLocalizedString(
                     "Pay using",
-                    "Title shown above a section containing various payment options")
+                    "Title shown above a section containing various payment options"
+                )
                 : STPLocalizedString(
                     "Select your payment method",
-                    "Title shown above a carousel containing the customer's payment methods")
+                    "Title shown above a carousel containing the customer's payment methods"
+                )
         }
 
         // Content
@@ -360,7 +382,9 @@ class PaymentSheetViewController: UIViewController {
             buyButtonStyle = .stripe
             if let overrideCallToAction = addPaymentMethodViewController.overrideCallToAction {
                 callToAction = overrideCallToAction
-                buyButtonStatus = addPaymentMethodViewController.overrideCallToActionShouldEnable ? .enabled : .disabled
+                buyButtonStatus =
+                    addPaymentMethodViewController.overrideCallToActionShouldEnable
+                    ? .enabled : .disabled
             } else {
                 buyButtonStatus =
                     addPaymentMethodViewController.paymentOption == nil ? .disabled : .enabled
@@ -395,12 +419,16 @@ class PaymentSheetViewController: UIViewController {
     func updateBottomNotice() {
         switch mode {
         case .selectingSaved:
-            self.bottomNoticeTextField.attributedText = savedPaymentOptionsViewController.bottomNoticeAttributedString
+            self.bottomNoticeTextField.attributedText =
+                savedPaymentOptionsViewController.bottomNoticeAttributedString
         case .addingNew:
-            self.bottomNoticeTextField.attributedText = addPaymentMethodViewController.bottomNoticeAttributedString
+            self.bottomNoticeTextField.attributedText =
+                addPaymentMethodViewController.bottomNoticeAttributedString
         }
         UIView.animate(withDuration: PaymentSheetUI.defaultAnimationDuration) {
-            self.bottomNoticeTextField.setHiddenIfNecessary(self.bottomNoticeTextField.attributedText?.length == 0)
+            self.bottomNoticeTextField.setHiddenIfNecessary(
+                self.bottomNoticeTextField.attributedText?.length == 0
+            )
         }
     }
 
@@ -408,8 +436,13 @@ class PaymentSheetViewController: UIViewController {
     private func didTapBuyButton() {
         switch mode {
         case .addingNew:
-            if let buyButtonOverrideBehavior = addPaymentMethodViewController.overrideBuyButtonBehavior {
-                addPaymentMethodViewController.didTapCallToActionButton(behavior: buyButtonOverrideBehavior, from: self)
+            if let buyButtonOverrideBehavior = addPaymentMethodViewController
+                .overrideBuyButtonBehavior
+            {
+                addPaymentMethodViewController.didTapCallToActionButton(
+                    behavior: buyButtonOverrideBehavior,
+                    from: self
+                )
             } else {
                 guard let newPaymentOption = addPaymentMethodViewController.paymentOption else {
                     assertionFailure()
@@ -475,7 +508,10 @@ class PaymentSheetViewController: UIViewController {
                         UINotificationFeedbackGenerator().notificationOccurred(.success)
                         self.buyButton.update(state: .succeeded, animated: true) {
                             // Wait a bit before closing the sheet
-                            self.delegate?.paymentSheetViewControllerDidFinish(self, result: .completed)
+                            self.delegate?.paymentSheetViewControllerDidFinish(
+                                self,
+                                result: .completed
+                            )
                         }
                     }
                 }
@@ -525,7 +561,10 @@ extension PaymentSheetViewController: SavedPaymentOptionsViewControllerDelegate 
         viewController: SavedPaymentOptionsViewController,
         paymentMethodSelection: SavedPaymentOptionsViewController.Selection
     ) {
-        STPAnalyticsClient.sharedClient.logPaymentSheetPaymentOptionSelect(isCustom: false, paymentMethod: paymentMethodSelection.analyticsValue)
+        STPAnalyticsClient.sharedClient.logPaymentSheetPaymentOptionSelect(
+            isCustom: false,
+            paymentMethod: paymentMethodSelection.analyticsValue
+        )
         if case .add = paymentMethodSelection {
             mode = .addingNew
             error = nil  // Clear any errors
@@ -543,7 +582,8 @@ extension PaymentSheetViewController: SavedPaymentOptionsViewControllerDelegate 
             return
         }
         configuration.apiClient.detachPaymentMethod(
-            paymentMethod.stripeId, fromCustomerUsing: ephemeralKey
+            paymentMethod.stripeId,
+            fromCustomerUsing: ephemeralKey
         ) { (_) in
             // no-op
         }
@@ -569,7 +609,10 @@ extension PaymentSheetViewController: SavedPaymentOptionsViewControllerDelegate 
         navigationBar.additionalButton.accessibilityIdentifier = "edit_saved_button"
         navigationBar.additionalButton.titleLabel?.adjustsFontForContentSizeCategory = true
         navigationBar.additionalButton.addTarget(
-            self, action: #selector(didSelectEditSavedPaymentMethodsButton), for: .touchUpInside)
+            self,
+            action: #selector(didSelectEditSavedPaymentMethodsButton),
+            for: .touchUpInside
+        )
     }
 
     @objc

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/ViewControllers/PollingViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/ViewControllers/PollingViewController.swift
@@ -7,11 +7,11 @@
 //
 
 import Foundation
-import UIKit
 @_spi(STP) import StripeCore
-@_spi(STP) import StripeUICore
 @_spi(STP) import StripePayments
 @_spi(STP) import StripePaymentsUI
+@_spi(STP) import StripeUICore
+import UIKit
 
 /// For internal SDK use only
 @objc(STP_Internal_PollingViewController)
@@ -20,29 +20,32 @@ class PollingViewController: UIViewController {
         case polling
         case error
     }
-    
+
     // MARK: State
-    
-    private let deadline = Date().addingTimeInterval(60 * 5) // in 5 minutes
+
+    private let deadline = Date().addingTimeInterval(60 * 5)  // in 5 minutes
     private var oneSecondTimer: Timer?
     private let currentAction: STPPaymentHandlerActionParams
     private let appearance: PaymentSheet.Appearance
-    
+
     private lazy var intentPoller: IntentStatusPoller = {
         guard let currentAction = currentAction as? STPPaymentHandlerPaymentIntentActionParams,
-              let clientSecret = currentAction.paymentIntent?.clientSecret else { fatalError() }
-        
-        let intentPoller = IntentStatusPoller(apiClient: currentAction.apiClient,
-                                              clientSecret: clientSecret,
-                                              maxRetries: 12)
+            let clientSecret = currentAction.paymentIntent?.clientSecret
+        else { fatalError() }
+
+        let intentPoller = IntentStatusPoller(
+            apiClient: currentAction.apiClient,
+            clientSecret: clientSecret,
+            maxRetries: 12
+        )
         intentPoller.delegate = self
         return intentPoller
     }()
-    
+
     private var timeRemaining: TimeInterval {
         return Date().compatibleDistance(to: deadline)
     }
-    
+
     private var dateFormatter: DateComponentsFormatter {
         let formatter = DateComponentsFormatter()
         if timeRemaining > 60 {
@@ -53,20 +56,24 @@ class PollingViewController: UIViewController {
         formatter.allowedUnits = [.minute, .second]
         return formatter
     }
-    
+
     private var instructionLabelAttributedText: NSAttributedString {
         let timeRemaining = dateFormatter.string(from: timeRemaining) ?? ""
-        let attrText = NSMutableAttributedString(string: String(
-            format: .Localized.open_upi_app,
-            timeRemaining
-        ))
-        
-        attrText.addAttributes([.foregroundColor: appearance.colors.primary],
-                               range: NSString(string: attrText.string).range(of: timeRemaining))
-        
+        let attrText = NSMutableAttributedString(
+            string: String(
+                format: .Localized.open_upi_app,
+                timeRemaining
+            )
+        )
+
+        attrText.addAttributes(
+            [.foregroundColor: appearance.colors.primary],
+            range: NSString(string: attrText.string).range(of: timeRemaining)
+        )
+
         return attrText
     }
-    
+
     private var pollingState: PollingState = .polling {
         didSet {
             if oldValue != pollingState && pollingState == .error {
@@ -74,23 +81,25 @@ class PollingViewController: UIViewController {
             }
         }
     }
-    
+
     private lazy var setErrorStateWorkItem: DispatchWorkItem = {
         let workItem = DispatchWorkItem { [weak self] in
             self?.pollingState = .error
         }
-        
+
         return workItem
     }()
-    
+
     // MARK: Views
-    
+
     lazy var formStackView: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [errorImageView,
-                                                       actvityIndicator,
-                                                       titleLabel,
-                                                       instructionLabel,
-                                                       cancelButton])
+        let stackView = UIStackView(arrangedSubviews: [
+            errorImageView,
+            actvityIndicator,
+            titleLabel,
+            instructionLabel,
+            cancelButton,
+        ])
         stackView.directionalLayoutMargins = PaymentSheetUI.defaultMargins
         stackView.isLayoutMarginsRelativeArrangement = true
         stackView.axis = .vertical
@@ -101,47 +110,59 @@ class PollingViewController: UIViewController {
         stackView.setCustomSpacing(12, after: instructionLabel)
         return stackView
     }()
-    
+
     private lazy var actvityIndicator: ActivityIndicator = {
         let indicator = ActivityIndicator(size: .large)
         indicator.tintColor = appearance.colors.icon
         indicator.startAnimating()
         return indicator
     }()
-    
+
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
         label.numberOfLines = 0
         label.textAlignment = .center
         label.text = .Localized.approve_payment
         label.textColor = appearance.colors.text
-        label.font = appearance.scaledFont(for: appearance.font.base.medium, style: .body, maximumPointSize: 25)
+        label.font = appearance.scaledFont(
+            for: appearance.font.base.medium,
+            style: .body,
+            maximumPointSize: 25
+        )
         label.sizeToFit()
         return label
     }()
-    
+
     private lazy var instructionLabel: UILabel = {
         let label = UILabel()
         label.numberOfLines = 0
         label.textAlignment = .center
-        label.font = appearance.scaledFont(for: appearance.font.base.regular, style: .subheadline, maximumPointSize: 22)
+        label.font = appearance.scaledFont(
+            for: appearance.font.base.regular,
+            style: .subheadline,
+            maximumPointSize: 22
+        )
         label.textColor = appearance.colors.textSecondary
         label.attributedText = instructionLabelAttributedText
         label.sizeToFit()
         return label
     }()
-    
+
     private lazy var cancelButton: UIButton = {
         let button = UIButton(type: .system)
         button.setTitle(.Localized.cancel_pay_another_way, for: .normal)
-        button.titleLabel?.font = appearance.scaledFont(for: appearance.font.base.regular, style: .footnote, maximumPointSize: 22)
+        button.titleLabel?.font = appearance.scaledFont(
+            for: appearance.font.base.regular,
+            style: .footnote,
+            maximumPointSize: 22
+        )
         button.addTarget(self, action: #selector(didTapCancel), for: .touchUpInside)
         button.tintColor = appearance.colors.primary
         return button
     }()
-    
+
     // MARK: Error state views
-    
+
     private lazy var errorImageView: UIImageView = {
         let imageView = UIImageView(image: Image.polling_error.makeImage(template: true))
         imageView.tintColor = appearance.colors.danger
@@ -149,34 +170,41 @@ class PollingViewController: UIViewController {
         imageView.isHidden = true
         return imageView
     }()
-    
+
     // MARK: Navigation bar
-    
+
     internal lazy var navigationBar: SheetNavigationBar = {
-        let navBar = SheetNavigationBar(isTestMode: false,
-                                        appearance: appearance)
+        let navBar = SheetNavigationBar(
+            isTestMode: false,
+            appearance: appearance
+        )
         navBar.delegate = self
         navBar.setStyle(.none)
         return navBar
     }()
-    
+
     // MARK: Overrides
-    
-    init(currentAction: STPPaymentHandlerActionParams, appearance: PaymentSheet.Appearance) {
+
+    init(
+        currentAction: STPPaymentHandlerActionParams,
+        appearance: PaymentSheet.Appearance
+    ) {
         self.currentAction = currentAction
         self.appearance = appearance
         super.init(nibName: nil, bundle: nil)
     }
-    
-    required init?(coder: NSCoder) {
+
+    required init?(
+        coder: NSCoder
+    ) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         // disable swipe to dismiss
         isModalInPresentation = true
-        
+
         // Height of the polling view controller is either the height of the parent, or the height of the screen (flow controller use case)
         let height = parent?.view.frame.size.height ?? UIScreen.main.bounds.height
         let stackView = UIStackView(arrangedSubviews: [formStackView])
@@ -186,7 +214,7 @@ class PollingViewController: UIViewController {
         stackView.backgroundColor = appearance.colors.background
         view.backgroundColor = appearance.colors.background
         view.addSubview(stackView)
-        
+
         NSLayoutConstraint.activate([
             stackView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             stackView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
@@ -195,50 +223,64 @@ class PollingViewController: UIViewController {
             view.heightAnchor.constraint(equalToConstant: height - SheetNavigationBar.height),
         ])
     }
-    
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        
+
         if oneSecondTimer == nil {
-            oneSecondTimer = Timer.scheduledTimer(timeInterval: 1,
-                                  target: self,
-                                  selector: (#selector(updateTimer)),
-                                  userInfo: nil,
-                                  repeats: true)
+            oneSecondTimer = Timer.scheduledTimer(
+                timeInterval: 1,
+                target: self,
+                selector: (#selector(updateTimer)),
+                userInfo: nil,
+                repeats: true
+            )
         }
-        
+
         DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
             self.intentPoller.beginPolling()
         }
-        
-        NotificationCenter.default.addObserver(self, selector: #selector(didEnterBackground), name: UIApplication.didEnterBackgroundNotification, object: nil)
-        
-        NotificationCenter.default.addObserver(self, selector: #selector(didBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(didEnterBackground),
+            name: UIApplication.didEnterBackgroundNotification,
+            object: nil
+        )
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(didBecomeActive),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
     }
-    
+
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         intentPoller.suspendPolling()
-        
+
         NotificationCenter.default.removeObserver(self)
     }
-    
+
     // MARK: Handlers
-    
+
     @objc func didTapCancel() {
         currentAction.complete(with: .canceled, error: nil)
         dismiss()
     }
-    
+
     private func dismiss() {
-        if let authContext = currentAction.authenticationContext as? PaymentSheetAuthenticationContext {
+        if let authContext = currentAction.authenticationContext
+            as? PaymentSheetAuthenticationContext
+        {
             authContext.authenticationContextWillDismiss?(self)
             authContext.dismiss(self)
         }
-        
+
         oneSecondTimer?.invalidate()
     }
-    
+
     // MARK: App lifecycle observers
 
     @objc func didBecomeActive(_ notification: Notification) {
@@ -246,14 +288,13 @@ class PollingViewController: UIViewController {
             self.intentPoller.beginPolling()
         }
     }
-    
-    
+
     @objc func didEnterBackground(_ notification: Notification) {
         intentPoller.suspendPolling()
     }
-    
+
     // MARK: Timer handler
-    
+
     @objc func updateTimer() {
         guard timeRemaining > 0 else {
             oneSecondTimer?.invalidate()
@@ -263,9 +304,9 @@ class PollingViewController: UIViewController {
 
         instructionLabel.attributedText = instructionLabelAttributedText
     }
-    
+
     // MARK: Private helpers
-    
+
     private func moveToErrorState() {
         DispatchQueue.main.async {
             self.errorImageView.isHidden = false
@@ -279,7 +320,7 @@ class PollingViewController: UIViewController {
             self.currentAction.complete(with: .canceled, error: nil)
         }
     }
-    
+
     // Called after the 5 minute timer expires to wrap up polling
     private func finishPolling() {
         // Do one last force poll after 5 min
@@ -288,16 +329,19 @@ class PollingViewController: UIViewController {
             self.intentPoller.forcePoll()
             // If we don't get a terminal status back after 20 seconds from the previous force poll, set error state to suspend polling.
             // This could occur if network connections are unreliable
-            DispatchQueue.main.asyncAfter(deadline: .now() + 20, execute: self.setErrorStateWorkItem)
+            DispatchQueue.main.asyncAfter(
+                deadline: .now() + 20,
+                execute: self.setErrorStateWorkItem
+            )
         }
     }
-    
+
 }
 
 // MARK: BottomSheetContentViewController
 
 extension PollingViewController: BottomSheetContentViewController {
-    
+
     var allowsDragToDismiss: Bool {
         return false
     }
@@ -314,26 +358,28 @@ extension PollingViewController: BottomSheetContentViewController {
 // MARK: SheetNavigationBarDelegate
 
 extension PollingViewController: SheetNavigationBarDelegate {
-    
+
     func sheetNavigationBarDidClose(_ sheetNavigationBar: SheetNavigationBar) {
         dismiss()
     }
-    
+
     func sheetNavigationBarDidBack(_ sheetNavigationBar: SheetNavigationBar) {
         dismiss()
     }
-    
+
 }
 
 // MARK: IntentStatusPollerDelegate
 
 extension PollingViewController: IntentStatusPollerDelegate {
     func didUpdate(paymentIntent: STPPaymentIntent) {
-        guard let currentAction = currentAction as? STPPaymentHandlerPaymentIntentActionParams else { return }
-        
+        guard let currentAction = currentAction as? STPPaymentHandlerPaymentIntentActionParams
+        else { return }
+
         if paymentIntent.status == .succeeded {
-            setErrorStateWorkItem.cancel() // cancel the error work item incase it was scheduled
-            currentAction.paymentIntent = paymentIntent // update the local copy of the intent with the latest from the server
+            setErrorStateWorkItem.cancel()  // cancel the error work item incase it was scheduled
+            // update the local copy of the intent with the latest from the server
+            currentAction.paymentIntent = paymentIntent
             currentAction.complete(with: .succeeded, error: nil)
             dismiss()
         } else if paymentIntent.status != .requiresAction {

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Views/AUBECSMandate.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Views/AUBECSMandate.swift
@@ -6,14 +6,14 @@
 //  Copyright © 2022 Stripe, Inc. All rights reserved.
 //
 import Foundation
-import UIKit
 import SafariServices
-@_spi(STP) import StripeUICore
 @_spi(STP) import StripePaymentsUI
+@_spi(STP) import StripeUICore
+import UIKit
 
 @objc(STP_Internal_AUBECSLegalTermsView)
 final class AUBECSLegalTermsView: UIView {
-    
+
     private let links: [String: URL] = [
         "terms": URL(string: "https://stripe.com/au-becs-dd-service-agreement/legal")!
     ]
@@ -22,7 +22,7 @@ final class AUBECSLegalTermsView: UIView {
     private var theme: ElementsUITheme {
         return configuration.appearance.asElementsTheme
     }
-    
+
     private lazy var textView: UITextView = {
         let textView = UITextView()
         textView.isScrollEnabled = false
@@ -38,14 +38,19 @@ final class AUBECSLegalTermsView: UIView {
         return textView
     }()
 
-    init(configuration: PaymentSheet.Configuration, textAlignment: NSTextAlignment = .left) {
+    init(
+        configuration: PaymentSheet.Configuration,
+        textAlignment: NSTextAlignment = .left
+    ) {
         self.configuration = configuration
         super.init(frame: .zero)
         self.textView.textAlignment = textAlignment
         addAndPinSubview(textView)
     }
 
-    required init?(coder: NSCoder) {
+    required init?(
+        coder: NSCoder
+    ) {
         fatalError("init(coder:) has not been implemented")
     }
 
@@ -63,7 +68,9 @@ final class AUBECSLegalTermsView: UIView {
 
         let formattedString = NSMutableAttributedString()
 
-        STPStringUtils.parseRanges(from: string, withTags: Set<String>(links.keys)) { string, matches in
+        STPStringUtils.parseRanges(from: string, withTags: Set<String>(links.keys)) {
+            string,
+            matches in
             formattedString.append(NSAttributedString(string: string))
 
             for (tag, range) in matches {
@@ -83,8 +90,8 @@ final class AUBECSLegalTermsView: UIView {
 
 }
 
-private extension UIResponder {
-    var parentViewController: UIViewController? {
+extension UIResponder {
+    fileprivate var parentViewController: UIViewController? {
         return next as? UIViewController ?? next?.parentViewController
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Views/AffirmCopyLabel.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Views/AffirmCopyLabel.swift
@@ -1,3 +1,5 @@
+@_spi(STP) import StripePaymentsUI
+@_spi(STP) import StripeUICore
 //
 //  AffirmCopyLabel.swift
 //  StripePaymentSheet
@@ -6,8 +8,6 @@
 //  Copyright © 2021 Stripe, Inc. All rights reserved.
 //
 import UIKit
-@_spi(STP) import StripeUICore
-@_spi(STP) import StripePaymentsUI
 
 /// For internal SDK use only
 @objc(STP_Internal_AffirmCopyLabel)
@@ -15,11 +15,15 @@ class AffirmCopyLabel: UIView {
 
     let logo = NSTextAttachment()
 
-    convenience init(theme: ElementsUITheme = .default) {
+    convenience init(
+        theme: ElementsUITheme = .default
+    ) {
         self.init(frame: .zero)
         let affirmLabel = UILabel()
 
-        let message = NSMutableAttributedString(string: STPLocalizedString("Pay over time with %@", "Pay over time with Affirm copy"))
+        let message = NSMutableAttributedString(
+            string: STPLocalizedString("Pay over time with %@", "Pay over time with Affirm copy")
+        )
         logo.image = PaymentSheetImageLibrary.affirmLogo()
         message.replaceOccurrences(of: "%@", with: logo)
         affirmLabel.attributedText = message
@@ -29,17 +33,21 @@ class AffirmCopyLabel: UIView {
         affirmLabel.sizeToFit()
         addAndPinSubview(affirmLabel)
     }
-    
+
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         logo.image = PaymentSheetImageLibrary.affirmLogo()
     }
-    
-    override init(frame: CGRect) {
+
+    override init(
+        frame: CGRect
+    ) {
         super.init(frame: frame)
     }
-    
-    required init?(coder: NSCoder) {
+
+    required init?(
+        coder: NSCoder
+    ) {
         fatalError("init(coder:) has not been implemented")
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Views/AfterpayPriceBreakdownView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Views/AfterpayPriceBreakdownView.swift
@@ -6,11 +6,11 @@
 //  Copyright © 2021 Stripe, Inc. All rights reserved.
 //
 import Foundation
-import UIKit
 import SafariServices
-@_spi(STP) import StripeUICore
 @_spi(STP) import StripePayments
 @_spi(STP) import StripePaymentsUI
+@_spi(STP) import StripeUICore
+import UIKit
 
 /// For internal SDK use only
 @objc(STP_Internal_AfterpayPriceBreakdownView)
@@ -44,17 +44,27 @@ class AfterpayPriceBreakdownView: UIView {
     }
 
     let locale: Locale
-    
-    init(amount: Int, currency: String, locale: Locale = Locale.autoupdatingCurrent, theme: ElementsUITheme = .default) {
+
+    init(
+        amount: Int,
+        currency: String,
+        locale: Locale = Locale.autoupdatingCurrent,
+        theme: ElementsUITheme = .default
+    ) {
         self.locale = locale
         self.theme = theme
         super.init(frame: .zero)
         let numInstallments = Self.numberOfInstallments(currency: currency)
         let installmentAmount = amount / numInstallments
-        let installmentAmountDisplayString = String.localizedAmountDisplayString(for: installmentAmount, currency: currency)
-        
-        afterPayClearPayLabel.attributedText = generateAfterPayClearPayString(numInstallments: numInstallments,
-                                                                              installmentAmountString: installmentAmountDisplayString)
+        let installmentAmountDisplayString = String.localizedAmountDisplayString(
+            for: installmentAmount,
+            currency: currency
+        )
+
+        afterPayClearPayLabel.attributedText = generateAfterPayClearPayString(
+            numInstallments: numInstallments,
+            installmentAmountString: installmentAmountDisplayString
+        )
         afterPayClearPayLabel.numberOfLines = 0
         afterPayClearPayLabel.translatesAutoresizingMaskIntoConstraints = false
         afterPayClearPayLabel.isUserInteractionEnabled = true
@@ -62,17 +72,23 @@ class AfterpayPriceBreakdownView: UIView {
 
         NSLayoutConstraint.activate([
             afterPayClearPayLabel.leadingAnchor.constraint(
-                equalTo: leadingAnchor),
+                equalTo: leadingAnchor
+            ),
             afterPayClearPayLabel.topAnchor.constraint(
-                equalTo: topAnchor),
+                equalTo: topAnchor
+            ),
             afterPayClearPayLabel.bottomAnchor.constraint(equalTo: bottomAnchor),
             afterPayClearPayLabel.trailingAnchor.constraint(equalTo: trailingAnchor),
         ])
-        
-        afterPayClearPayLabel.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(didTapInfoButton)))
+
+        afterPayClearPayLabel.addGestureRecognizer(
+            UITapGestureRecognizer(target: self, action: #selector(didTapInfoButton))
+        )
     }
-    
-    required init?(coder: NSCoder) {
+
+    required init?(
+        coder: NSCoder
+    ) {
         fatalError("init(coder:) has not been implemented")
     }
 
@@ -80,23 +96,29 @@ class AfterpayPriceBreakdownView: UIView {
         super.layoutSubviews()
     }
 
-    private func generateAfterPayClearPayString(numInstallments: Int, installmentAmountString: String) -> NSMutableAttributedString {
+    private func generateAfterPayClearPayString(
+        numInstallments: Int,
+        installmentAmountString: String
+    ) -> NSMutableAttributedString {
         let amountStringAttributes = [
             NSAttributedString.Key.font: theme.fonts.subheadlineBold,
-            .foregroundColor: theme.colors.bodyText
+            .foregroundColor: theme.colors.bodyText,
         ]
         let stringAttributes = [
             NSAttributedString.Key.font: theme.fonts.subheadline,
-            .foregroundColor: theme.colors.bodyText
+            .foregroundColor: theme.colors.bodyText,
         ]
-        let template = STPLocalizedString("Pay in <num_installments/> interest-free payments of <installment_price/> with <img/>",
-                                          "Pay in templated string for afterpay/clearpay")
+        let template = STPLocalizedString(
+            "Pay in <num_installments/> interest-free payments of <installment_price/> with <img/>",
+            "Pay in templated string for afterpay/clearpay"
+        )
 
         let resultingString = NSMutableAttributedString()
         resultingString.append(NSAttributedString(string: ""))
         guard let numInstallmentsRange = template.range(of: "<num_installments/>"),
-              let installmentPrice = template.range(of: "<installment_price/>"),
-              let img = template.range(of: "<img/>") else {
+            let installmentPrice = template.range(of: "<installment_price/>"),
+            let img = template.range(of: "<img/>")
+        else {
             return resultingString
         }
 
@@ -111,35 +133,58 @@ class AfterpayPriceBreakdownView: UIView {
                     continue
                 }
                 numInstallmentsAppended = true
-                resultingString.append(NSAttributedString(string: "\(numInstallments)",
-                                                          attributes: stringAttributes))
+                resultingString.append(
+                    NSAttributedString(
+                        string: "\(numInstallments)",
+                        attributes: stringAttributes
+                    )
+                )
             } else if installmentPrice.contains(currIndex) {
                 if installmentPriceAppended {
                     continue
                 }
                 installmentPriceAppended = true
-                resultingString.append(NSAttributedString(string: installmentAmountString,
-                                                          attributes: amountStringAttributes))
+                resultingString.append(
+                    NSAttributedString(
+                        string: installmentAmountString,
+                        attributes: amountStringAttributes
+                    )
+                )
             } else if img.contains(currIndex) {
                 if imgAppended {
                     continue
                 }
                 imgAppended = true
                 let titleFont = stringAttributes[NSAttributedString.Key.font] as! UIFont
-                let clearPay = attributedStringOfImageWithoutLink(uiImage: afterpayMarkImage, font: titleFont)
-                let infoButton = attributedStringOfImageWithoutLink(uiImage: infoImage, font: titleFont)
+                let clearPay = attributedStringOfImageWithoutLink(
+                    uiImage: afterpayMarkImage,
+                    font: titleFont
+                )
+                let infoButton = attributedStringOfImageWithoutLink(
+                    uiImage: infoImage,
+                    font: titleFont
+                )
                 resultingString.append(clearPay)
-                resultingString.append(NSAttributedString(string: "\u{00A0}\u{00A0}", attributes: stringAttributes))
+                resultingString.append(
+                    NSAttributedString(string: "\u{00A0}\u{00A0}", attributes: stringAttributes)
+                )
                 resultingString.append(infoButton)
             } else {
-                resultingString.append(NSAttributedString(string: String(currCharacter),
-                                                          attributes: stringAttributes))
+                resultingString.append(
+                    NSAttributedString(
+                        string: String(currCharacter),
+                        attributes: stringAttributes
+                    )
+                )
             }
         }
         return resultingString
     }
 
-    private func attributedStringOfImageWithoutLink(uiImage: UIImage, font: UIFont) -> NSAttributedString {
+    private func attributedStringOfImageWithoutLink(
+        uiImage: UIImage,
+        font: UIFont
+    ) -> NSAttributedString {
         let imageAttachment = NSTextAttachment()
         imageAttachment.bounds = boundsOfImage(font: font, uiImage: uiImage)
         imageAttachment.image = uiImage
@@ -148,10 +193,12 @@ class AfterpayPriceBreakdownView: UIView {
 
     // https://stackoverflow.com/questions/26105803/center-nstextattachment-image-next-to-single-line-uilabel
     private func boundsOfImage(font: UIFont, uiImage: UIImage) -> CGRect {
-        return CGRect(x: 0,
-                      y: (font.capHeight - uiImage.size.height).rounded() / 2,
-                      width: uiImage.size.width,
-                      height: uiImage.size.height)
+        return CGRect(
+            x: 0,
+            y: (font.capHeight - uiImage.size.height).rounded() / 2,
+            width: uiImage.size.width,
+            height: uiImage.size.height
+        )
     }
 
     @objc
@@ -162,15 +209,15 @@ class AfterpayPriceBreakdownView: UIView {
             parentViewController?.present(safariController, animated: true)
         }
     }
-    
+
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         afterpayMarkImageView.tintColor = theme.colors.parentBackground.contrastingColor
     }
 }
 
-private extension UIResponder {
-    var parentViewController: UIViewController? {
+extension UIResponder {
+    fileprivate var parentViewController: UIViewController? {
         return next as? UIViewController ?? next?.parentViewController
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Views/Appearance+FontScaling.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Views/Appearance+FontScaling.swift
@@ -9,18 +9,23 @@
 import UIKit
 
 extension PaymentSheet.Appearance {
-    
+
     /// Computes a font scaled to be used in PaymentSheet
     /// - Parameters:
     ///   - font: The font to be scaled
     ///   - style: The style for your text
     ///   - maximumPointSize: The maximum font size to be scaled to
     /// - Returns: A font scaled to be used in PaymentSheet
-    func scaledFont(for font: UIFont, style: UIFont.TextStyle, maximumPointSize: CGFloat) -> UIFont {
-        let defaultTraitCollection = UITraitCollection(preferredContentSizeCategory: .large) // large is the default content size category
-        let fontDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: style, compatibleWith: defaultTraitCollection)
+    func scaledFont(for font: UIFont, style: UIFont.TextStyle, maximumPointSize: CGFloat) -> UIFont
+    {
+        // large is the default content size category
+        let defaultTraitCollection = UITraitCollection(preferredContentSizeCategory: .large)
+        let fontDescriptor = UIFontDescriptor.preferredFontDescriptor(
+            withTextStyle: style,
+            compatibleWith: defaultTraitCollection
+        )
         let customFont = font.withSize(fontDescriptor.pointSize * self.font.sizeScaleFactor)
-        
+
         // scale the custom font for dynamic type
         return UIFontMetrics.default.scaledFont(for: customFont, maximumPointSize: maximumPointSize)
     }

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Views/CardScanButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Views/CardScanButton.swift
@@ -6,11 +6,11 @@
 //  Copyright © 2022 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
-@_spi(STP) import StripeCore
-@_spi(STP) import StripeUICore
-@_spi(STP) import StripePaymentsUI
 import CloudKit
+@_spi(STP) import StripeCore
+@_spi(STP) import StripePaymentsUI
+@_spi(STP) import StripeUICore
+import UIKit
 
 extension UIButton {
     @available(iOS 13, macCatalyst 14, *)
@@ -22,7 +22,10 @@ extension UIButton {
 
         let scanButton = UIButton(type: .system)
         scanButton.setTitle(String.Localized.scan_card, for: .normal)
-        scanButton.setImage(UIImage(systemName: "camera.fill", withConfiguration: iconConfig), for: .normal)
+        scanButton.setImage(
+            UIImage(systemName: "camera.fill", withConfiguration: iconConfig),
+            for: .normal
+        )
         scanButton.setContentSpacing(4, withEdgeInsets: .zero)
         scanButton.tintColor = theme.colors.primary
         scanButton.titleLabel?.font = theme.fonts.sectionHeader

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Views/CardScanningView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Views/CardScanningView.swift
@@ -7,17 +7,18 @@
 //
 
 import Foundation
-import UIKit
+@_spi(STP) import StripeCore
 @_spi(STP) import StripePayments
 @_spi(STP) import StripePaymentsUI
 @_spi(STP) import StripeUICore
-@_spi(STP) import StripeCore
+import UIKit
 
 private class CardScanningEasilyTappableButton: UIButton {
     override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
         let newArea = bounds.insetBy(
             dx: -(PaymentSheetUI.minimumTapSize.width - bounds.width) / 2,
-            dy: -(PaymentSheetUI.minimumTapSize.height - bounds.height) / 2)
+            dy: -(PaymentSheetUI.minimumTapSize.height - bounds.height) / 2
+        )
         return newArea.contains(point)
     }
 }
@@ -26,7 +27,9 @@ private class CardScanningEasilyTappableButton: UIButton {
 @available(iOS 13, macCatalyst 14, *)
 @objc protocol STP_Internal_CardScanningViewDelegate: NSObjectProtocol {
     func cardScanningView(
-        _ cardScanningView: CardScanningView, didFinishWith cardParams: STPPaymentMethodCardParams?)
+        _ cardScanningView: CardScanningView,
+        didFinishWith cardParams: STPPaymentMethodCardParams?
+    )
 }
 
 /// For internal SDK use only
@@ -50,7 +53,8 @@ class CardScanningView: UIView, STPCardScannerDelegate {
     }
 
     func cardScanner(
-        _ scanner: STPCardScanner, didFinishWith cardParams: STPPaymentMethodCardParams?,
+        _ scanner: STPCardScanner,
+        didFinishWith cardParams: STPPaymentMethodCardParams?,
         error: Error?
     ) {
         if error != nil {
@@ -113,7 +117,9 @@ class CardScanningView: UIView, STPCardScannerDelegate {
         // TODO(porter): Customize card scanning view?
         let button = CircularButton(style: .close)
         button.accessibilityLabel = STPLocalizedString(
-            "Close card scanner", "Accessibility label for the button to close the card scanner.")
+            "Close card scanner",
+            "Accessibility label for the button to close the card scanner."
+        )
         button.translatesAutoresizingMaskIntoConstraints = false
         return button
     }()
@@ -128,20 +134,32 @@ class CardScanningView: UIView, STPCardScannerDelegate {
 
         cardOuterBlurView.addConstraints([
             vibrancyEffectView.bottomAnchor.constraint(
-                equalTo: cardOuterBlurView.bottomAnchor, constant: 0),
+                equalTo: cardOuterBlurView.bottomAnchor,
+                constant: 0
+            ),
             vibrancyEffectView.leftAnchor.constraint(
-                equalTo: cardOuterBlurView.leftAnchor, constant: 0),
+                equalTo: cardOuterBlurView.leftAnchor,
+                constant: 0
+            ),
             vibrancyEffectView.rightAnchor.constraint(
-                equalTo: cardOuterBlurView.rightAnchor, constant: 0),
+                equalTo: cardOuterBlurView.rightAnchor,
+                constant: 0
+            ),
             vibrancyEffectView.topAnchor.constraint(
-                equalTo: cardOuterBlurView.topAnchor, constant: 0),
+                equalTo: cardOuterBlurView.topAnchor,
+                constant: 0
+            ),
         ])
 
         vibrancyEffectView.addConstraints([
             instructionsLabel.leftAnchor.constraint(
-                equalTo: vibrancyEffectView.leftAnchor, constant: 0),
+                equalTo: vibrancyEffectView.leftAnchor,
+                constant: 0
+            ),
             instructionsLabel.rightAnchor.constraint(
-                equalTo: vibrancyEffectView.rightAnchor, constant: 0),
+                equalTo: vibrancyEffectView.rightAnchor,
+                constant: 0
+            ),
         ])
     }
 
@@ -160,14 +178,18 @@ class CardScanningView: UIView, STPCardScannerDelegate {
         self.stop()
     }
 
-    override init(frame: CGRect) {
+    override init(
+        frame: CGRect
+    ) {
         super.init(frame: frame)
         self.setupBlurView()
 
         let cameraView = STPCameraView(frame: bounds)
         cameraView.isAccessibilityElement = true
         cameraView.accessibilityLabel = STPLocalizedString(
-            "Point the camera at your card.", "Accessibility instructions for card scanning.")
+            "Point the camera at your card.",
+            "Accessibility instructions for card scanning."
+        )
         let cardScanner = STPCardScanner(delegate: self)
         cardScanner.cameraView = cameraView
         self.cardScanner = cardScanner
@@ -201,23 +223,34 @@ class CardScanningView: UIView, STPCardScannerDelegate {
                 errorLabel.centerYAnchor.constraint(equalTo: self.centerYAnchor, constant: 0),
                 errorLabel.leftAnchor.constraint(equalTo: cardOutlineView.leftAnchor, constant: 8),
                 errorLabel.rightAnchor.constraint(
-                    equalTo: cardOutlineView.rightAnchor, constant: -8),
+                    equalTo: cardOutlineView.rightAnchor,
+                    constant: -8
+                ),
 
                 closeButton.topAnchor.constraint(equalTo: self.topAnchor, constant: 8),
                 closeButton.rightAnchor.constraint(equalTo: self.rightAnchor, constant: -8),
 
                 cardOutlineView.heightAnchor.constraint(
-                    equalTo: cardOutlineView.widthAnchor, multiplier: CardScanningView.cardSizeRatio
+                    equalTo: cardOutlineView.widthAnchor,
+                    multiplier: CardScanningView.cardSizeRatio
                 ),
 
                 cardOutlineView.topAnchor.constraint(
-                    equalTo: self.topAnchor, constant: CardScanningView.cardInset),
+                    equalTo: self.topAnchor,
+                    constant: CardScanningView.cardInset
+                ),
                 cardOutlineView.leftAnchor.constraint(
-                    equalTo: self.leftAnchor, constant: CardScanningView.cardInset),
+                    equalTo: self.leftAnchor,
+                    constant: CardScanningView.cardInset
+                ),
                 cardOutlineView.rightAnchor.constraint(
-                    equalTo: self.rightAnchor, constant: -CardScanningView.cardInset),
+                    equalTo: self.rightAnchor,
+                    constant: -CardScanningView.cardInset
+                ),
                 cardOutlineView.bottomAnchor.constraint(
-                    equalTo: self.bottomAnchor, constant: -CardScanningView.cardInset),
+                    equalTo: self.bottomAnchor,
+                    constant: -CardScanningView.cardInset
+                ),
             ])
     }
 
@@ -230,8 +263,13 @@ class CardScanningView: UIView, STPCardScannerDelegate {
 
         let outerPath = UIBezierPath(
             roundedRect: CGRect(
-                x: 0, y: 0, width: self.bounds.size.width, height: self.bounds.size.height),
-            cornerRadius: CardScanningView.cornerRadius)
+                x: 0,
+                y: 0,
+                width: self.bounds.size.width,
+                height: self.bounds.size.height
+            ),
+            cornerRadius: CardScanningView.cornerRadius
+        )
         let innerPath = UIBezierPath(roundedRect: cardOutlineView.frame, cornerRadius: cornerRadius)
 
         outerPath.append(innerPath)
@@ -244,7 +282,9 @@ class CardScanningView: UIView, STPCardScannerDelegate {
         cardOuterBlurView.layer.mask = maskLayer
     }
 
-    required init?(coder aDecoder: NSCoder) {
+    required init?(
+        coder aDecoder: NSCoder
+    ) {
         super.init(coder: aDecoder)
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Views/CircularButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Views/CircularButton.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2021 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
 @_spi(STP) import StripeCore
 @_spi(STP) import StripeUICore
+import UIKit
 
 /// For internal SDK use only
 @objc(STP_Internal_CircularButton)
@@ -36,13 +36,19 @@ class CircularButton: UIControl {
         case remove
     }
 
-    required init(style: Style, iconColor: UIColor = .secondaryLabel, dangerColor: UIColor = .systemRed) {
+    required init(
+        style: Style,
+        iconColor: UIColor = .secondaryLabel,
+        dangerColor: UIColor = .systemRed
+    ) {
         self.style = style
         self.iconColor = iconColor
         super.init(frame: .zero)
 
         backgroundColor = UIColor.dynamic(
-            light: .systemBackground, dark: .systemGray2)
+            light: .systemBackground,
+            dark: .systemGray2
+        )
         layer.cornerRadius = radius
         layer.masksToBounds = false
         isAccessibilityElement = true
@@ -53,10 +59,12 @@ class CircularButton: UIControl {
         layer.shadowColor = UIColor.systemGray2.cgColor
         layer.shadowOpacity = shadowOpacity
         let path = UIBezierPath(
-            arcCenter: CGPoint(x: radius, y: radius), radius: radius,
+            arcCenter: CGPoint(x: radius, y: radius),
+            radius: radius,
             startAngle: 0,
             endAngle: CGFloat.pi * 2,
-            clockwise: true)
+            clockwise: true
+        )
         layer.shadowPath = path.cgPath
 
         addSubview(imageView)
@@ -75,7 +83,8 @@ class CircularButton: UIControl {
         case .remove:
             backgroundColor = UIColor.dynamic(
                 light: .systemBackground,
-                dark: UIColor(red: 43.0 / 255.0, green: 43.0 / 255.0, blue: 47.0 / 255.0, alpha: 1))
+                dark: UIColor(red: 43.0 / 255.0, green: 43.0 / 255.0, blue: 47.0 / 255.0, alpha: 1)
+            )
             imageView.image = Image.icon_x.makeImage(template: true)
             imageView.tintColor = dangerColor
             accessibilityLabel = String.Localized.remove
@@ -84,7 +93,9 @@ class CircularButton: UIControl {
         imageView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             imageView.centerXAnchor.constraint(
-                equalTo: centerXAnchor, constant: style == .back ? -0.5 : 0),
+                equalTo: centerXAnchor,
+                constant: style == .back ? -0.5 : 0
+            ),
             imageView.centerYAnchor.constraint(equalTo: centerYAnchor),
         ])
 
@@ -95,7 +106,8 @@ class CircularButton: UIControl {
     override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
         let newArea = bounds.insetBy(
             dx: -(PaymentSheetUI.minimumTapSize.width - bounds.width) / 2,
-            dy: -(PaymentSheetUI.minimumTapSize.height - bounds.height) / 2)
+            dy: -(PaymentSheetUI.minimumTapSize.height - bounds.height) / 2
+        )
         return newArea.contains(point)
     }
 
@@ -135,7 +147,9 @@ class CircularButton: UIControl {
         }
     }
 
-    required init?(coder: NSCoder) {
+    required init?(
+        coder: NSCoder
+    ) {
         fatalError("init(coder:) has not been implemented")
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Views/ConfirmButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Views/ConfirmButton.swift
@@ -8,11 +8,11 @@
 
 import Foundation
 import PassKit
-import UIKit
-@_spi(STP) import StripeUICore
 @_spi(STP) import StripeCore
-@_spi(STP) import StripePaymentsUI
 @_spi(STP) import StripePayments
+@_spi(STP) import StripePaymentsUI
+@_spi(STP) import StripeUICore
+import UIKit
 
 private let spinnerMoveToCenterAnimationDuration = 0.35
 private let checkmarkStrokeDuration = 0.2
@@ -22,7 +22,7 @@ private let checkmarkStrokeDuration = 0.2
 @objc(STP_Internal_ConfirmButton)
 class ConfirmButton: UIView {
     let applePayButtonType: PKPaymentButtonType
-    
+
     // MARK: Internal Properties
     enum Status {
         case enabled
@@ -43,7 +43,9 @@ class ConfirmButton: UIView {
 
     }
 
-    lazy var cornerRadius: CGFloat = appearance.primaryButton.cornerRadius ?? appearance.cornerRadius {
+    lazy var cornerRadius: CGFloat =
+        appearance.primaryButton.cornerRadius ?? appearance.cornerRadius
+    {
         didSet {
             applyCornerRadius()
         }
@@ -79,7 +81,9 @@ class ConfirmButton: UIView {
     }()
     private lazy var applePayButton: PKPaymentButton = {
         let button = PKPaymentButton(
-            paymentButtonType: applePayButtonType, paymentButtonStyle: .compatibleAutomatic)
+            paymentButtonType: applePayButtonType,
+            paymentButtonStyle: .compatibleAutomatic
+        )
         button.addTarget(self, action: #selector(handleTap), for: .touchUpInside)
         button.preservesSuperviewLayoutMargins = false
         return button
@@ -105,11 +109,25 @@ class ConfirmButton: UIView {
         self.didTap = didTap
         super.init(frame: .zero)
 
-        directionalLayoutMargins = NSDirectionalEdgeInsets(top: 10, leading: 16, bottom: 10, trailing: 16)
+        directionalLayoutMargins = NSDirectionalEdgeInsets(
+            top: 10,
+            leading: 16,
+            bottom: 10,
+            trailing: 16
+        )
         // primaryButton.backgroundColor takes priority over appearance.colors.primary
         tintColor = appearance.primaryButton.backgroundColor ?? appearance.colors.primary
-        layer.applyShadow(shadow: appearance.primaryButton.shadow?.asElementThemeShadow ?? appearance.shadow.asElementThemeShadow)
-        font = appearance.primaryButton.font ?? appearance.scaledFont(for: appearance.font.base.medium, style: .callout, maximumPointSize: 25)
+        layer.applyShadow(
+            shadow: appearance.primaryButton.shadow?.asElementThemeShadow
+                ?? appearance.shadow.asElementThemeShadow
+        )
+        font =
+            appearance.primaryButton.font
+            ?? appearance.scaledFont(
+                for: appearance.font.base.medium,
+                style: .callout,
+                maximumPointSize: 25
+            )
         buyButton.titleLabel.sizeToFit()
         addAndPinSubview(applePayButton)
         addAndPinSubview(buyButton)
@@ -118,7 +136,9 @@ class ConfirmButton: UIView {
         update()
     }
 
-    required init?(coder: NSCoder) {
+    required init?(
+        coder: NSCoder
+    ) {
         fatalError("init(coder:) has not been implemented")
     }
 
@@ -145,7 +165,8 @@ class ConfirmButton: UIView {
             style: style ?? self.style,
             callToAction: callToAction ?? self.callToAction,
             animated: animated,
-            completion: completion)
+            completion: completion
+        )
     }
 
     func update(
@@ -221,9 +242,10 @@ class ConfirmButton: UIView {
         private static let minimumButtonHeight: CGFloat = 44
         private var status: Status = .enabled
         private let appearance: PaymentSheet.Appearance
-        
+
         override var intrinsicContentSize: CGSize {
-            let height = Self.minimumLabelHeight
+            let height =
+                Self.minimumLabelHeight
                 + directionalLayoutMargins.top
                 + directionalLayoutMargins.bottom
 
@@ -243,25 +265,35 @@ class ConfirmButton: UIView {
                 highlightDimView.frame = bounds
                 if self.isHighlighted {
                     UIView.animate(
-                        withDuration: PaymentSheetUI.defaultAnimationDuration, delay: 0.2,
+                        withDuration: PaymentSheetUI.defaultAnimationDuration,
+                        delay: 0.2,
                         options: [.beginFromCurrentState],
                         animations: {
                             self.highlightDimView.alpha = 1
-                        }, completion: nil)
+                        },
+                        completion: nil
+                    )
                 } else {
                     UIView.animate(
-                        withDuration: PaymentSheetUI.quickAnimationDuration, delay: 0,
+                        withDuration: PaymentSheetUI.quickAnimationDuration,
+                        delay: 0,
                         options: [.beginFromCurrentState],
                         animations: {
                             self.highlightDimView.alpha = 0
-                        }, completion: nil)
+                        },
+                        completion: nil
+                    )
                 }
             }
         }
         lazy var titleLabel: UILabel = {
             let label = UILabel()
             label.textAlignment = .center
-            label.font = .preferredFont(forTextStyle: .callout, weight: .medium, maximumPointSize: 25)
+            label.font = .preferredFont(
+                forTextStyle: .callout,
+                weight: .medium,
+                maximumPointSize: 25
+            )
             label.textColor = .white
             label.adjustsFontForContentSizeCategory = true
             return label
@@ -294,10 +326,12 @@ class ConfirmButton: UIView {
                 foregroundColorDidChange()
             }
         }
-        
+
         var overriddenForegroundColor: UIColor?
 
-        init(appearance: PaymentSheet.Appearance = .default) {
+        init(
+            appearance: PaymentSheet.Appearance = .default
+        ) {
             self.appearance = appearance
             super.init(frame: .zero)
             preservesSuperviewLayoutMargins = true
@@ -307,7 +341,10 @@ class ConfirmButton: UIView {
             isAccessibilityElement = true
 
             // Add views
-            let views = ["titleLabel": titleLabel, "lockIcon": lockIcon, "spinnyView": spinner, "addIcon": addIcon]
+            let views = [
+                "titleLabel": titleLabel, "lockIcon": lockIcon, "spinnyView": spinner,
+                "addIcon": addIcon,
+            ]
             views.values.forEach {
                 $0.translatesAutoresizingMaskIntoConstraints = false
                 addSubview($0)
@@ -317,20 +354,24 @@ class ConfirmButton: UIView {
             highlightDimView.alpha = 0
 
             let titleLabelCenterXConstraint = titleLabel.centerXAnchor.constraint(
-                equalTo: centerXAnchor)
+                equalTo: centerXAnchor
+            )
             titleLabelCenterXConstraint.priority = .defaultLow
             NSLayoutConstraint.activate([
                 // Add icon
                 addIcon.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
                 addIcon.centerYAnchor.constraint(equalTo: centerYAnchor),
-                
+
                 // Label
                 titleLabelCenterXConstraint,
                 titleLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
                 titleLabel.leadingAnchor.constraint(greaterThanOrEqualTo: addIcon.trailingAnchor),
 
                 // Lock icon
-                lockIcon.leadingAnchor.constraint(greaterThanOrEqualTo: titleLabel.trailingAnchor, constant: 8),
+                lockIcon.leadingAnchor.constraint(
+                    greaterThanOrEqualTo: titleLabel.trailingAnchor,
+                    constant: 8
+                ),
                 lockIcon.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),
                 lockIcon.centerYAnchor.constraint(equalTo: centerYAnchor),
 
@@ -338,7 +379,7 @@ class ConfirmButton: UIView {
                 spinnerCenteredToLockConstraint,
                 spinner.centerYAnchor.constraint(equalTo: lockIcon.centerYAnchor),
                 spinner.widthAnchor.constraint(equalToConstant: spinnerSize.width),
-                spinner.heightAnchor.constraint(equalToConstant: spinnerSize.height)
+                spinner.heightAnchor.constraint(equalToConstant: spinnerSize.height),
             ])
             layer.borderColor = appearance.primaryButton.borderColor.cgColor
             overriddenForegroundColor = appearance.primaryButton.textColor
@@ -354,7 +395,9 @@ class ConfirmButton: UIView {
             updateColors()
         }
 
-        required init?(coder: NSCoder) {
+        required init?(
+            coder: NSCoder
+        ) {
             fatalError("init(coder:) has not been implemented")
         }
 
@@ -368,13 +411,18 @@ class ConfirmButton: UIView {
                     switch callToAction {
                     case .add(let paymentMethodType):
                         if paymentMethodType == .linkInstantDebit {
-                            return STPLocalizedString("Add bank account", "Button prompt to add a bank account as a payment method.")
+                            return STPLocalizedString(
+                                "Add bank account",
+                                "Button prompt to add a bank account as a payment method."
+                            )
                         } else {
                             return String.Localized.continue
                         }
-                    case let .pay(amount, currency):
+                    case .pay(let amount, let currency):
                         let localizedAmount = String.localizedAmountDisplayString(
-                            for: amount, currency: currency)
+                            for: amount,
+                            currency: currency
+                        )
                         let localized = STPLocalizedString(
                             "Pay %@",
                             "Label of a button that initiates payment when tapped"
@@ -385,9 +433,9 @@ class ConfirmButton: UIView {
                             "Set up",
                             "Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use"
                         )
-                    case let .custom(title):
+                    case .custom(let title):
                         return title
-                    case let .customWithLock(title):
+                    case .customWithLock(let title):
                         return title
                     }
                 case .processing:
@@ -399,20 +447,20 @@ class ConfirmButton: UIView {
                     return nil
                 }
             }()
-            
+
             // Show/hide lock and add icons
             switch callToAction {
-              case .add(let paymentMethodType):
+            case .add(let paymentMethodType):
                 lockIcon.isHidden = true
                 addIcon.isHidden = paymentMethodType != .linkInstantDebit
-              case .custom:
+            case .custom:
                 lockIcon.isHidden = true
                 addIcon.isHidden = true
             case .customWithLock:
                 lockIcon.isHidden = false
                 addIcon.isHidden = true
-              case .pay,
-                   .setup:
+            case .pay,
+                .setup:
                 lockIcon.isHidden = false
                 addIcon.isHidden = true
             }
@@ -446,7 +494,9 @@ class ConfirmButton: UIView {
                                 .underlineStyle: NSUnderlineStyle.single.rawValue,
                             ]
                             self.titleLabel.attributedText = NSAttributedString(
-                                string: text, attributes: attributes)
+                                string: text,
+                                attributes: attributes
+                            )
                         }
                     }
                 }
@@ -499,7 +549,9 @@ class ConfirmButton: UIView {
             spinnerCenteredConstraint.isActive = true
             setNeedsLayout()
             UIView.animate(
-                withDuration: spinnerMoveToCenterAnimationDuration, delay: 0, options: .curveEaseOut
+                withDuration: spinnerMoveToCenterAnimationDuration,
+                delay: 0,
+                options: .curveEaseOut
             ) {
                 self.layoutIfNeeded()
             } completion: { (_) in
@@ -517,7 +569,7 @@ class ConfirmButton: UIView {
                 return succeededBackgroundColor
             }
         }
-        
+
         private func foregroundColor(for status: Status) -> UIColor {
             let background = backgroundColor(for: status)
 
@@ -525,7 +577,7 @@ class ConfirmButton: UIView {
                 // always use hardcoded color for foreground color when in success state
                 return background.contrastingColor
             }
-            
+
             // if foreground is set prefer that over a dynamic constrasting color in all othe states
             return overriddenForegroundColor ?? background.contrastingColor
         }
@@ -555,18 +607,26 @@ class ConfirmButton: UIView {
             }
         }
 
-        override init(frame: CGRect) {
+        override init(
+            frame: CGRect
+        ) {
             // Circle
             let circlePath = UIBezierPath(
                 arcCenter: CGPoint(
                     x: frame.size.width / 2,
-                    y: frame.size.height / 2),
+                    y: frame.size.height / 2
+                ),
                 radius: (frame.size.width) / 2,
                 startAngle: 0.0,
                 endAngle: CGFloat.pi * 2,
-                clockwise: false)
+                clockwise: false
+            )
             circleLayer.bounds = CGRect(
-                x: 0, y: 0, width: frame.size.width, height: frame.size.width)
+                x: 0,
+                y: 0,
+                width: frame.size.width,
+                height: frame.size.width
+            )
             circleLayer.path = circlePath.cgPath
             circleLayer.fillColor = UIColor.clear.cgColor
             circleLayer.lineCap = .round
@@ -583,7 +643,11 @@ class ConfirmButton: UIView {
             checkmarkPath.addLine(to: checkPoint2)
 
             checkmarkLayer.bounds = CGRect(
-                x: 0, y: 0, width: frame.size.width, height: frame.size.width)
+                x: 0,
+                y: 0,
+                width: frame.size.width,
+                height: frame.size.width
+            )
             checkmarkLayer.path = checkmarkPath.cgPath
             checkmarkLayer.lineCap = .round
             checkmarkLayer.fillColor = UIColor.clear.cgColor
@@ -602,7 +666,9 @@ class ConfirmButton: UIView {
             colorDidChange()
         }
 
-        required init?(coder: NSCoder) {
+        required init?(
+            coder: NSCoder
+        ) {
             fatalError()
         }
 
@@ -613,7 +679,8 @@ class ConfirmButton: UIView {
             animation.fromValue = 0
             animation.toValue = 0.8
             animation.timingFunction = CAMediaTimingFunction(
-                name: CAMediaTimingFunctionName.easeOut)
+                name: CAMediaTimingFunctionName.easeOut
+            )
             circleLayer.strokeEnd = 0.8
             circleLayer.add(animation, forKey: "animateCircle")
             let rotationAnimation = CABasicAnimation(keyPath: "transform.rotation")
@@ -632,13 +699,15 @@ class ConfirmButton: UIView {
             circleAnimation.fromValue = 0.8
             circleAnimation.toValue = 1
             circleAnimation.timingFunction = CAMediaTimingFunction(
-                name: CAMediaTimingFunctionName.easeIn)
+                name: CAMediaTimingFunctionName.easeIn
+            )
             circleLayer.strokeEnd = 1.0
             circleLayer.add(circleAnimation, forKey: "animateDone")
 
             // Check the mark
             let animation = CABasicAnimation(keyPath: "strokeEnd")
-            animation.beginTime = CACurrentMediaTime() + circleAnimation.duration + 0.15  // Start after the circle closes
+            // Start after the circle closes
+            animation.beginTime = CACurrentMediaTime() + circleAnimation.duration + 0.15
             animation.fillMode = .backwards
             animation.duration = checkmarkStrokeDuration
             animation.fromValue = 0.0

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Views/ManualEntryButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Views/ManualEntryButton.swift
@@ -7,36 +7,40 @@
 //
 
 import Foundation
-import UIKit
 @_spi(STP) import StripeCore
 @_spi(STP) import StripeUICore
+import UIKit
 
 extension UIButton {
-    
+
     static func makeManualEntryButton(appearance: PaymentSheet.Appearance) -> UIButton {
         let button = UIButton(type: .system)
-        button.titleLabel?.font = appearance.scaledFont(for: appearance.font.base.regular, style: .subheadline, maximumPointSize: 20)
+        button.titleLabel?.font = appearance.scaledFont(
+            for: appearance.font.base.regular,
+            style: .subheadline,
+            maximumPointSize: 20
+        )
         button.tintColor = appearance.colors.primary
-        
+
         button.setTitle(.Localized.enter_address_manually, for: .normal)
         button.titleLabel?.sizeToFit()
-        
+
         if let titleLabelHeight = button.titleLabel?.frame.size.height {
             button.frame.size.height = titleLabelHeight * 2.25
         }
-        
+
         if #available(iOS 13.0, *) {
             button.backgroundColor = UIColor(dynamicProvider: { traitCollection in
                 if traitCollection.isDarkMode {
                     return appearance.colors.componentBackground
                 }
-                
+
                 return appearance.colors.background.darken(by: 0.07)
             })
         } else {
             button.backgroundColor = appearance.colors.background.darken(by: 0.07)
         }
-        
+
         return button
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Views/PayWithLinkButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Views/PayWithLinkButton.swift
@@ -6,12 +6,11 @@
 //  Copyright © 2021 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
-
 @_spi(STP) import StripeCore
-@_spi(STP) import StripeUICore
-@_spi(STP) import StripePaymentsUI
 @_spi(STP) import StripePayments
+@_spi(STP) import StripePaymentsUI
+@_spi(STP) import StripeUICore
+import UIKit
 
 /// A button for paying with Link.
 /// For internal SDK use only
@@ -21,7 +20,12 @@ final class PayWithLinkButton: UIControl {
     struct Constants {
         static let defaultSize: CGSize = .init(width: 200, height: 44)
         static let logoSize: CGSize = .init(width: 35, height: 16)
-        static let margins: NSDirectionalEdgeInsets = .init(top: 7, leading: 16, bottom: 7, trailing: 10)
+        static let margins: NSDirectionalEdgeInsets = .init(
+            top: 7,
+            leading: 16,
+            bottom: 7,
+            trailing: 10
+        )
         static let emailContainerMinimumCornerRadius: CGFloat = 3
         static let emailContainerInsets: NSDirectionalEdgeInsets = .insets(amount: 6)
     }
@@ -80,7 +84,7 @@ final class PayWithLinkButton: UIControl {
     private lazy var stackView: UIStackView = {
         let stackView = UIStackView(arrangedSubviews: [
             Self.makeLogoView(),
-            emailLabelContainer
+            emailLabelContainer,
         ])
         stackView.spacing = 8
         stackView.translatesAutoresizingMaskIntoConstraints = false
@@ -112,7 +116,9 @@ final class PayWithLinkButton: UIControl {
         LinkAccountContext.shared.addObserver(self, selector: #selector(onAccountChange(_:)))
     }
 
-    required init?(coder: NSCoder) {
+    required init?(
+        coder: NSCoder
+    ) {
         fatalError("init(coder:) has not been implemented")
     }
 
@@ -141,22 +147,22 @@ final class PayWithLinkButton: UIControl {
 
 // MARK: - UI
 
-private extension PayWithLinkButton {
+extension PayWithLinkButton {
 
-    static func makeLogoView() -> UIImageView {
+    fileprivate static func makeLogoView() -> UIImageView {
         let logoView = UIImageView(image: Image.link_logo.makeImage(template: true))
         logoView.translatesAutoresizingMaskIntoConstraints = false
         logoView.contentMode = .scaleAspectFill
 
         NSLayoutConstraint.activate([
             logoView.widthAnchor.constraint(equalToConstant: Constants.logoSize.width),
-            logoView.heightAnchor.constraint(equalToConstant: Constants.logoSize.height)
+            logoView.heightAnchor.constraint(equalToConstant: Constants.logoSize.height),
         ])
 
         return logoView
     }
 
-    func setupUI() {
+    fileprivate func setupUI() {
         directionalLayoutMargins = Constants.margins
 
         addSubview(logoView)
@@ -169,11 +175,11 @@ private extension PayWithLinkButton {
             stackView.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor),
             stackView.bottomAnchor.constraint(equalTo: layoutMarginsGuide.bottomAnchor),
             stackView.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
-            stackView.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor)
+            stackView.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),
         ])
     }
 
-    func updateUI() {
+    fileprivate func updateUI() {
         emailLabel.text = linkAccount?.email
         logoView.isHidden = hasValidLinkAccount
         stackView.isHidden = !hasValidLinkAccount
@@ -184,9 +190,9 @@ private extension PayWithLinkButton {
 
 // MARK: - Styling
 
-private extension PayWithLinkButton {
+extension PayWithLinkButton {
 
-    var effectiveCornerRadius: CGFloat {
+    fileprivate var effectiveCornerRadius: CGFloat {
         // Matches the formula used by `PKPaymentButton` for calculating
         // the effective corner radius. The effective corner radius is snapped
         // to half the button's height if the corner radius is
@@ -198,7 +204,7 @@ private extension PayWithLinkButton {
             : cornerRadius
     }
 
-    var effectiveEmailContainerRadius: CGFloat {
+    fileprivate var effectiveEmailContainerRadius: CGFloat {
         guard cornerRadius >= 1 else {
             // No round the container corners if `cornerRadius` is less than 1.
             return 0.0
@@ -212,7 +218,7 @@ private extension PayWithLinkButton {
         )
     }
 
-    func applyStyle() {
+    fileprivate func applyStyle() {
         // Foreground
         let foregroundColor = self.foregroundColor(for: state)
         titleLabel.textColor = foregroundColor
@@ -225,7 +231,7 @@ private extension PayWithLinkButton {
         backgroundColor = backgroundColor(for: state)
     }
 
-    func applyCornerRadius() {
+    fileprivate func applyCornerRadius() {
         if #available(iOS 13.0, *) {
             layer.cornerCurve = .continuous
             emailLabelContainer.layer.cornerCurve = .continuous
@@ -235,7 +241,7 @@ private extension PayWithLinkButton {
         emailLabelContainer.layer.cornerRadius = effectiveEmailContainerRadius
     }
 
-    func foregroundColor(for state: State) -> UIColor {
+    fileprivate func foregroundColor(for state: State) -> UIColor {
         switch state {
         case .highlighted:
             return UIColor.linkPrimaryButtonForeground.withAlphaComponent(0.8)
@@ -244,7 +250,7 @@ private extension PayWithLinkButton {
         }
     }
 
-    func backgroundColor(for state: State) -> UIColor {
+    fileprivate func backgroundColor(for state: State) -> UIColor {
         switch state {
         case .highlighted:
             return UIColor.linkBrand.darken(by: 0.2)
@@ -259,9 +265,9 @@ private extension PayWithLinkButton {
 
 // MARK: - Accessibility
 
-private extension PayWithLinkButton {
+extension PayWithLinkButton {
 
-    func updateAccessibilityContent() {
+    fileprivate func updateAccessibilityContent() {
         if isEnabled {
             accessibilityTraits = [.button]
         } else {

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Views/SepaMandateView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Views/SepaMandateView.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2021 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
 @_spi(STP) import StripeUICore
+import UIKit
 
 /// For internal SDK use only
 @objc(STP_Internal_SepaMandateView)
@@ -20,8 +20,11 @@ class SepaMandateView: UIView {
         label.numberOfLines = 0
         return label
     }()
-    
-    init(merchantDisplayName: String, theme: ElementsUITheme = .default) {
+
+    init(
+        merchantDisplayName: String,
+        theme: ElementsUITheme = .default
+    ) {
         self.theme = theme
         super.init(frame: .zero)
         let localized = STPLocalizedString(
@@ -31,11 +34,13 @@ class SepaMandateView: UIView {
         label.text = String(format: localized, merchantDisplayName)
         installConstraints()
     }
-    
-    required init?(coder: NSCoder) {
+
+    required init?(
+        coder: NSCoder
+    ) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     fileprivate func installConstraints() {
         addAndPinSubview(label)
     }

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Views/ShadowedRoundedRectangleView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Views/ShadowedRoundedRectangleView.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2021 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
 @_spi(STP) import StripeUICore
+import UIKit
 
 /// The shadowed rounded rectangle that our cells use to display content
 /// For internal SDK use only
@@ -47,7 +47,9 @@ class ShadowedRoundedRectangle: UIView {
         }
     }
 
-    required init(appearance: PaymentSheet.Appearance) {
+    required init(
+        appearance: PaymentSheet.Appearance
+    ) {
         self.appearance = appearance
         roundedRectangle = UIView()
         roundedRectangle.layer.cornerRadius = appearance.cornerRadius
@@ -83,7 +85,9 @@ class ShadowedRoundedRectangle: UIView {
         setNeedsLayout()
     }
 
-    required init?(coder: NSCoder) {
+    required init?(
+        coder: NSCoder
+    ) {
         fatalError("init(coder:) has not been implemented")
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Views/SheetNavigationBar.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Views/SheetNavigationBar.swift
@@ -7,9 +7,9 @@
 //
 
 import Foundation
-import UIKit
 @_spi(STP) import StripeCore
 @_spi(STP) import StripeUICore
+import UIKit
 
 protocol SheetNavigationBarDelegate: AnyObject {
     func sheetNavigationBarDidClose(_ sheetNavigationBar: SheetNavigationBar)
@@ -29,7 +29,7 @@ class SheetNavigationBar: UIView {
         button.accessibilityIdentifier = "UIButton.Close"
         return button
     }()
-    
+
     fileprivate lazy var backButton: UIButton = {
         let button = SheetNavigationButton(type: .custom)
         button.setImage(Image.icon_chevron_left_standalone.makeImage(template: true), for: .normal)
@@ -38,19 +38,23 @@ class SheetNavigationBar: UIView {
         button.accessibilityIdentifier = "UIButton.Back"
         return button
     }()
-    
+
     lazy var additionalButton: UIButton = {
         let button = UIButton()
         button.setTitleColor(appearance.colors.icon, for: .normal)
         button.setTitleColor(appearance.colors.icon.disabledColor, for: .disabled)
-        button.titleLabel?.font = appearance.scaledFont(for: appearance.font.base.bold, style: .footnote, maximumPointSize: 20)
+        button.titleLabel?.font = appearance.scaledFont(
+            for: appearance.font.base.bold,
+            style: .footnote,
+            maximumPointSize: 20
+        )
 
         return button
     }()
-    
+
     let testModeView = TestModeView()
     let appearance: PaymentSheet.Appearance
-    
+
     override var isUserInteractionEnabled: Bool {
         didSet {
             // Explicitly disable buttons to update their appearance
@@ -59,8 +63,11 @@ class SheetNavigationBar: UIView {
             additionalButton.isEnabled = isUserInteractionEnabled
         }
     }
-    
-    init(isTestMode: Bool, appearance: PaymentSheet.Appearance) {
+
+    init(
+        isTestMode: Bool,
+        appearance: PaymentSheet.Appearance
+    ) {
         self.appearance = appearance
         super.init(frame: .zero)
         backgroundColor = appearance.colors.background.withAlphaComponent(0.9)
@@ -71,25 +78,33 @@ class SheetNavigationBar: UIView {
 
         NSLayoutConstraint.activate([
             closeButton.leadingAnchor.constraint(
-                equalTo: leadingAnchor, constant: PaymentSheetUI.defaultPadding),
+                equalTo: leadingAnchor,
+                constant: PaymentSheetUI.defaultPadding
+            ),
             closeButton.centerYAnchor.constraint(equalTo: centerYAnchor),
 
             backButton.leadingAnchor.constraint(
-                equalTo: leadingAnchor, constant: PaymentSheetUI.defaultPadding),
+                equalTo: leadingAnchor,
+                constant: PaymentSheetUI.defaultPadding
+            ),
             backButton.centerYAnchor.constraint(equalTo: centerYAnchor),
 
             additionalButton.trailingAnchor.constraint(
-                equalTo: trailingAnchor, constant: -PaymentSheetUI.defaultPadding),
+                equalTo: trailingAnchor,
+                constant: -PaymentSheetUI.defaultPadding
+            ),
             additionalButton.centerYAnchor.constraint(equalTo: centerYAnchor),
         ])
-        
+
         if isTestMode {
             testModeView.translatesAutoresizingMaskIntoConstraints = false
             addSubview(testModeView)
-            
+
             NSLayoutConstraint.activate([
                 testModeView.leadingAnchor.constraint(
-                    equalTo: closeButton.trailingAnchor, constant: PaymentSheetUI.defaultPadding),
+                    equalTo: closeButton.trailingAnchor,
+                    constant: PaymentSheetUI.defaultPadding
+                ),
                 testModeView.centerYAnchor.constraint(equalTo: centerYAnchor),
                 testModeView.widthAnchor.constraint(equalToConstant: 82),
                 testModeView.heightAnchor.constraint(equalToConstant: 23),
@@ -102,7 +117,9 @@ class SheetNavigationBar: UIView {
         setStyle(.close(showAdditionalButton: false))
     }
 
-    required init?(coder: NSCoder) {
+    required init?(
+        coder: NSCoder
+    ) {
         fatalError("init(coder:) has not been implemented")
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Views/SheetNavigationButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Views/SheetNavigationButton.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2022 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
 @_spi(STP) import StripeCore
 @_spi(STP) import StripeUICore
+import UIKit
 
 /// A simple button that increases the tap target for small buttons used in the navigation bar of PaymentSheet
 /// For internal SDK use only
@@ -26,11 +26,15 @@ class SheetNavigationButton: UIButton {
         return largerFrame.contains(point)
     }
 
-    override init(frame: CGRect) {
+    override init(
+        frame: CGRect
+    ) {
         super.init(frame: frame)
     }
 
-    required init?(coder aDecoder: NSCoder) {
+    required init?(
+        coder aDecoder: NSCoder
+    ) {
         fatalError("init(coder:) has not been implemented")
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Views/TestModeView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Views/TestModeView.swift
@@ -7,20 +7,31 @@
 //
 
 import Foundation
-import UIKit
 @_spi(STP) import StripeCore
 @_spi(STP) import StripeUICore
+import UIKit
 
-private extension UIColor {
-    static var testModeTextColor = UIColor(red: 0.65, green: 0.41, blue: 0.07, alpha: 1.00)
-    static var testModeBackgroundColor = UIColor(red: 1.00, green: 0.87, blue: 0.58, alpha: 1.00)
+// swift-format-ignore: DontRepeatTypeInStaticProperties
+extension UIColor {
+    fileprivate static var testModeTextColor = UIColor(
+        red: 0.65,
+        green: 0.41,
+        blue: 0.07,
+        alpha: 1.00
+    )
+    fileprivate static var testModeBackgroundColor = UIColor(
+        red: 1.00,
+        green: 0.87,
+        blue: 0.58,
+        alpha: 1.00
+    )
 }
 
 /// A badge that indicates if the PaymentSheet is in test mode
 /// For internal SDK use only
 @objc(STP_Internal_TestModeView)
 class TestModeView: UIView {
-    
+
     private lazy var testLabel: UILabel = {
         let label = UILabel()
         label.text = "TEST MODE"
@@ -30,11 +41,13 @@ class TestModeView: UIView {
         let fontMetrics = UIFontMetrics(forTextStyle: .body)
         let font = UIFont.systemFont(ofSize: 12, weight: .bold)
         label.font = fontMetrics.scaledFont(for: font, maximumPointSize: 12)
-        
+
         return label
     }()
-    
-    override init(frame: CGRect) {
+
+    override init(
+        frame: CGRect
+    ) {
         super.init(frame: frame)
         backgroundColor = UIColor.testModeBackgroundColor
         layer.cornerRadius = ElementsUI.defaultCornerRadius
@@ -42,9 +55,11 @@ class TestModeView: UIView {
 
         addAndPinSubview(testLabel)
     }
-    
-    required init?(coder: NSCoder) {
+
+    required init?(
+        coder: NSCoder
+    ) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
 }

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Views/UIKit+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Views/UIKit+PaymentSheet.swift
@@ -8,17 +8,22 @@
 
 import Foundation
 import PassKit
-import UIKit
 @_spi(STP) import StripeCore
 @_spi(STP) import StripeUICore
+import UIKit
 
 enum PaymentSheetUI {
     /// The padding between views in the sheet e.g., between the bottom of the form and the Pay button
     static let defaultPadding: CGFloat = 20
     static let defaultMargins: NSDirectionalEdgeInsets = .insets(
-        leading: defaultPadding, trailing: defaultPadding)
+        leading: defaultPadding,
+        trailing: defaultPadding
+    )
     static let defaultSheetMargins: NSDirectionalEdgeInsets = .insets(
-        leading: defaultPadding, bottom: 36, trailing: defaultPadding)
+        leading: defaultPadding,
+        bottom: 36,
+        trailing: defaultPadding
+    )
     static let minimumTapSize: CGSize = CGSize(width: 44, height: 44)
     static let defaultAnimationDuration: TimeInterval = 0.2
     static let quickAnimationDuration: TimeInterval = 0.1
@@ -31,7 +36,11 @@ enum PaymentSheetUI {
         let header = UILabel()
         header.textColor = appearance.colors.text
         header.numberOfLines = 2
-        header.font = appearance.scaledFont(for: appearance.font.base.bold, style: .title3, maximumPointSize: 35)
+        header.font = appearance.scaledFont(
+            for: appearance.font.base.bold,
+            style: .title3,
+            maximumPointSize: 35
+        )
         header.accessibilityTraits = [.header]
         header.adjustsFontSizeToFitWidth = true
         header.adjustsFontForContentSizeCategory = true
@@ -51,7 +60,8 @@ extension PKPaymentButtonStyle {
 
 extension UIViewController {
     func switchContentIfNecessary(
-        to toVC: UIViewController, containerView: DynamicHeightContainerView
+        to toVC: UIViewController,
+        containerView: DynamicHeightContainerView
     ) {
         assert(children.count <= 1)
         // Swap out child view controllers if necessary
@@ -64,12 +74,13 @@ extension UIViewController {
             self.addChild(toVC)
             toVC.view.alpha = 0
             containerView.addPinnedSubview(toVC.view)
-            containerView.layoutIfNeeded()  // Lay the view out now or it animates layout from a zero size
+            // Lay the view out now or it animates layout from a zero size
+            containerView.layoutIfNeeded()
 
             // Remove the child view controller, but don't remove its view yet - keep it on screen so we can fade it out
             fromVC.willMove(toParent: nil)
             fromVC.removeFromParent()
-            
+
             animateHeightChange(
                 {
                     containerView.updateHeight()
@@ -111,7 +122,8 @@ extension UIFont {
 
         traits[.weight] = weight
 
-        attributes[.name] = nil // nil out name so we fallback on the font family to compute the correct weight
+        // nil out name so we fallback on the font family to compute the correct weight
+        attributes[.name] = nil
         attributes[.traits] = traits
         attributes[.family] = familyName
 

--- a/StripePaymentSheet/StripePaymentSheetTests/DictionaryTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/DictionaryTests.swift
@@ -6,36 +6,54 @@
 //
 
 import Foundation
+@_spi(STP)@testable import StripePaymentSheet
 import XCTest
 
-@_spi(STP) @testable import StripePaymentSheet
-
 class DictionaryTests: XCTestCase {
-    
+
     func testParseLUXEJSONPath() {
         XCTAssertEqual(Dictionary.stp_parseLUXEJSONPath(""), [])
         XCTAssertEqual(Dictionary.stp_parseLUXEJSONPath("next_action"), ["next_action"])
-        XCTAssertEqual(Dictionary.stp_parseLUXEJSONPath("next_action[k1][k2]"), ["next_action", "k1", "k2"])
+        XCTAssertEqual(
+            Dictionary.stp_parseLUXEJSONPath("next_action[k1][k2]"),
+            ["next_action", "k1", "k2"]
+        )
     }
 
     func testForLUXEJSONPath() {
-        let input: [AnyHashable: Any] = [ "next_action" : ["display_details":
-                                                            [
-                                                                "hosted_voucher_url":"https://payments.stripe.com/pm/v/test",
-                                                                "expires_at": 123456
-                                                            ]
-                                                          ],
-                                          "other_key": "value2"]
+        let input: [AnyHashable: Any] = [
+            "next_action": [
+                "display_details":
+                    [
+                        "hosted_voucher_url": "https://payments.stripe.com/pm/v/test",
+                        "expires_at": 123456,
+                    ]
+            ],
+            "other_key": "value2",
+        ]
 
         XCTAssertEqual(input.stp_forLUXEJSONPath("other_key") as? String, "value2")
-        XCTAssertEqual(input.stp_forLUXEJSONPath("next_action[display_details][hosted_voucher_url]") as? String, "https://payments.stripe.com/pm/v/test")
-        XCTAssertEqual(input.stp_forLUXEJSONPath("next_action[display_details][expires_at]") as? Int, 123456)
+        XCTAssertEqual(
+            input.stp_forLUXEJSONPath("next_action[display_details][hosted_voucher_url]")
+                as? String,
+            "https://payments.stripe.com/pm/v/test"
+        )
+        XCTAssertEqual(
+            input.stp_forLUXEJSONPath("next_action[display_details][expires_at]") as? Int,
+            123456
+        )
 
-        guard let dict = input.stp_forLUXEJSONPath("next_action[display_details]") as? [AnyHashable: Any] else {
+        guard
+            let dict = input.stp_forLUXEJSONPath("next_action[display_details]")
+                as? [AnyHashable: Any]
+        else {
             XCTFail("")
             return
         }
-        XCTAssertEqual(dict["hosted_voucher_url"] as? String, "https://payments.stripe.com/pm/v/test" )
+        XCTAssertEqual(
+            dict["hosted_voucher_url"] as? String,
+            "https://payments.stripe.com/pm/v/test"
+        )
         XCTAssertEqual(dict["expires_at"] as? Int, 123456)
 
         XCTAssertNil(input.stp_forLUXEJSONPath("next_action[display_details][doesNotExist]"))

--- a/StripePaymentSheet/StripePaymentSheetTests/STPAnalyticsClient+PaymentSheetTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/STPAnalyticsClient+PaymentSheetTests.swift
@@ -6,9 +6,9 @@
 //
 
 import Foundation
+@_spi(STP)@testable import StripeCore
+@_spi(STP)@testable import StripePaymentSheet
 import XCTest
-@_spi(STP) @testable import StripePaymentSheet
-@_spi(STP) @testable import StripeCore
 
 class STPAnalyticsClientPaymentSheetTest: XCTestCase {
     func testPaymentSheetSDKVariantPayload() throws {

--- a/StripePaymentSheet/StripePaymentSheetTests/StripePaymentSheetTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/StripePaymentSheetTests.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+
 @testable import StripePaymentSheet
 
 class StripePaymentSheetTests: XCTestCase {


### PR DESCRIPTION
## Summary
Apply swift-format to StripePaymentSheet.
Part of the effort to enable swift-format as a CI check in the stripe-ios repo.

## Motivation
Standardize code style.

## Testing
CI
