### PR TITLE
Fix `setup_future_usage` value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### PaymentSheet
 * [Added] Added `PaymentSheet.Configuration.allowsPaymentMethodsRequiringShippingAddress`. Previously, to allow payment methods that require a shipping address (e.g. Afterpay and Affirm) in PaymentSheet, you attached a shipping address to the PaymentIntent before initializing PaymentSheet. Now, you can instead set this property to `true` and set `PaymentSheet.Configuration.shippingDetails` to a closure that returns your customers' shipping address. The shipping address will be attached to the PaymentIntent when the customer completes the checkout.
 * [Fixed] Fixed user facing error messages for card related errors.
+* [Fixed] Fixed `setup_future_usage` being set to a empty string instead of being left off the payload.
 
 ## 23.1.1 2022-11-07
 ### Payments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### PaymentSheet
 * [Added] Added `PaymentSheet.Configuration.allowsPaymentMethodsRequiringShippingAddress`. Previously, to allow payment methods that require a shipping address (e.g. Afterpay and Affirm) in PaymentSheet, you attached a shipping address to the PaymentIntent before initializing PaymentSheet. Now, you can instead set this property to `true` and set `PaymentSheet.Configuration.shippingDetails` to a closure that returns your customers' shipping address. The shipping address will be attached to the PaymentIntent when the customer completes the checkout.
 * [Fixed] Fixed user facing error messages for card related errors.
-* [Fixed] Fixed `setup_future_usage` being set to a empty string instead of being left off the payload.
+* [Fixed] Fixed `setup_future_usage` value being overridden for new customers when it was already set by the Payment Intent.
 
 ## 23.1.1 2022-11-07
 ### Payments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### PaymentSheet
 * [Added] Added `PaymentSheet.Configuration.allowsPaymentMethodsRequiringShippingAddress`. Previously, to allow payment methods that require a shipping address (e.g. Afterpay and Affirm) in PaymentSheet, you attached a shipping address to the PaymentIntent before initializing PaymentSheet. Now, you can instead set this property to `true` and set `PaymentSheet.Configuration.shippingDetails` to a closure that returns your customers' shipping address. The shipping address will be attached to the PaymentIntent when the customer completes the checkout.
 * [Fixed] Fixed user facing error messages for card related errors.
-* [Fixed] Fixed `setup_future_usage` value being overridden for new customers when it was already set by the Payment Intent.
+* [Fixed] Fixed `setup_future_usage` value being set when there's no customer.
 
 ## 23.1.1 2022-11-07
 ### Payments

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Intent.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Intent.swift
@@ -194,7 +194,9 @@ extension STPConfirmPaymentMethodOptions {
         paymentMethodType: STPPaymentMethodType,
         customer: PaymentSheet.CustomerConfiguration?
     ) {
-        // When no customer is set this property cannot be set.
+        // This property cannot be set if there is no customer.
+        assert(!(shouldSave && customer == nil))
+
         // Only support card and US bank setup_future_usage in payment_method_options
         guard customer != nil && paymentMethodType == .card || paymentMethodType == .USBankAccount
         else {

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Intent.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Intent.swift
@@ -175,14 +175,15 @@ extension STPConfirmPaymentMethodOptions {
         We write payment method options SFU to set the customer’s desired save behavior
      */
     func setSetupFutureUsageIfNecessary(_ shouldSave: Bool, paymentMethodType: STPPaymentMethodType) {
-        guard paymentMethodType == .card || paymentMethodType == .USBankAccount else {
-            // Only support card and US bank setup_future_usage in payment_method_options
+        // Only set the value to `off_session` when `shouldSave` is `true`.
+        // Only support card and US bank setup_future_usage in payment_method_options.
+        guard shouldSave && (paymentMethodType == .card || paymentMethodType == .USBankAccount)
+        else {
             return
         }
 
         additionalAPIParameters[STPPaymentMethod.string(from: paymentMethodType)] = [
-            // We pass an empty string to 'unset' this value. This makes the PaymentIntent inherit the top-level setup_future_usage.
-            "setup_future_usage": shouldSave ? "off_session" : ""
+            "setup_future_usage": "off_session",
         ]
     }
     func setSetupFutureUsageIfNecessary(_ shouldSave: Bool, paymentMethodType: PaymentSheet.PaymentMethodType) {

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentSheet+API.swift
@@ -85,7 +85,8 @@ extension PaymentSheet {
                         }
                         let paymentIntentParams = confirmParams.makeDashboardParams(
                             paymentIntentClientSecret: paymentIntent.clientSecret,
-                            paymentMethodID: paymentMethod?.stripeId ?? ""
+                            paymentMethodID: paymentMethod?.stripeId ?? "",
+                            configuration: configuration
                         )
                         paymentIntentParams.shipping = makeShippingParams(for: paymentIntent, configuration: configuration)
                         paymentHandler.confirmPayment(
@@ -94,7 +95,10 @@ extension PaymentSheet {
                             completion: paymentHandlerCompletion)
                     }
                 } else {
-                    let paymentIntentParams = confirmParams.makeParams(paymentIntentClientSecret: paymentIntent.clientSecret)
+                    let paymentIntentParams = confirmParams.makeParams(
+                        paymentIntentClientSecret: paymentIntent.clientSecret,
+                        configuration: configuration
+                    )
                     paymentIntentParams.returnURL = configuration.returnURL
                     paymentIntentParams.shipping = makeShippingParams(for: paymentIntent, configuration: configuration)
                     paymentHandler.confirmPayment(paymentIntentParams,
@@ -122,7 +126,11 @@ extension PaymentSheet {
                 paymentIntentParams.shipping = makeShippingParams(for: paymentIntent, configuration: configuration)
                 // Overwrite in case payment_method_options was set previously - we don't want to save an already-saved payment method
                 paymentIntentParams.paymentMethodOptions = STPConfirmPaymentMethodOptions()
-                paymentIntentParams.paymentMethodOptions?.setSetupFutureUsageIfNecessary(false, paymentMethodType: paymentMethod.type)
+                paymentIntentParams.paymentMethodOptions?.setSetupFutureUsageIfNecessary(
+                    false,
+                    paymentMethodType: paymentMethod.type,
+                    customer: configuration.customer
+                )
                 
                 paymentHandler.confirmPayment(
                     paymentIntentParams,

--- a/Tests/Tests/STPPaymentIntentFunctionalTest.swift
+++ b/Tests/Tests/STPPaymentIntentFunctionalTest.swift
@@ -148,5 +148,5 @@ class STPPaymentIntentFunctionalTestSwift: XCTestCase {
             XCTAssertNotNil(clientSecret)
         }
     }
-    
+
 }

--- a/Tests/Tests/STPPaymentIntentFunctionalTest.swift
+++ b/Tests/Tests/STPPaymentIntentFunctionalTest.swift
@@ -148,5 +148,5 @@ class STPPaymentIntentFunctionalTestSwift: XCTestCase {
             XCTAssertNotNil(clientSecret)
         }
     }
-
+    
 }


### PR DESCRIPTION
## Summary
After discussion:
- Fixing this only for the new customer case, in which the value of `setup_future_usage` present in the Payment Intent should be preserved.
- Will further discuss what to do for the returning customer case when `setup_future_usage` is already in the Intent but the customer can uncheck the "save payment method" box.

## Motivation
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-1731

## Testing
- Reproduced the issue on my own glitch server and confirmed it didn't happen after the fix.
- Added unit test.

## Changelog
### PaymentSheet
* [Fixed] Fixed `setup_future_usage` value being set when there's no customer.