### PR TITLE
Fix error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## X.Y.Z 2022-xx-xx
+### PaymentSheet
+* [Fixed] Fixed user facing error messages for card related errors.
+
 ## 23.1.1 2022-11-07
 ### Payments
 * [Fixed] Fixed an issue with linking the StripePayments SDK in certain configurations.

--- a/StripeCore/StripeCore/Source/Helpers/STPError.swift
+++ b/StripeCore/StripeCore/Source/Helpers/STPError.swift
@@ -193,13 +193,16 @@ extension NSError {
                     userInfo[STPError.cardErrorCodeKey] = cardErrorCode.rawValue
                 }
 
-                let localizedMessage = Utils.localizedMessage(
-                    fromAPIErrorCode: stripeErrorCode,
-                    declineCode: declineCode as? String
-                )
+                // If the server didn't send an error message, use a local one.
+                if stripeErrorMessage == nil {
+                    let localizedMessage = Utils.localizedMessage(
+                        fromAPIErrorCode: stripeErrorCode,
+                        declineCode: declineCode as? String
+                    )
 
-                if let localizedMessage = localizedMessage {
-                    userInfo[NSLocalizedDescriptionKey] = localizedMessage
+                    if let localizedMessage = localizedMessage {
+                        userInfo[NSLocalizedDescriptionKey] = localizedMessage
+                    }
                 }
             }
         }

--- a/StripeCore/StripeCoreTests/API Bindings/STPAPIClient+ErrorResponseTest.swift
+++ b/StripeCore/StripeCoreTests/API Bindings/STPAPIClient+ErrorResponseTest.swift
@@ -10,8 +10,37 @@
 import XCTest
 
 class STPAPIClient_ErrorResponseTest: XCTestCase {
-    /// Response is an error, error code is a known error code, so the `localizedDescription` should be overridden by a default error code .
-    func testResponse_WithKnownErrorCode() throws {
+    /// Response is an error, error code is a known error code, and no message is present,
+    /// `localizedDescription` is filled by a default error message.
+    func testResponse_WithKnownErrorCode_noMessage() throws {
+        let response = [
+            "error": [
+                "type": "card_error",
+                "code": "incorrect_number",
+            ]
+        ]
+
+        let responseData = try JSONSerialization.data(withJSONObject: response, options: [])
+        let result: Result<EmptyResponse, Error> = STPAPIClient.decodeResponse(
+            data: responseData,
+            error: nil,
+            response: nil
+        )
+
+        switch result {
+        case .failure(let error):
+            XCTAssertEqual(
+                error.localizedDescription,
+                NSError.stp_cardErrorInvalidNumberUserMessage()
+            )
+        case .success:
+            XCTFail("The request should not have succeeded")
+        }
+    }
+
+    /// Response is an error, error code is a known error code, and message is present,
+    /// `localizedDescription` is filled with the provided message.
+    func testResponse_WithKnownErrorCode_messagePresent() throws {
         let response = [
             "error": [
                 "type": "card_error",
@@ -31,7 +60,7 @@ class STPAPIClient_ErrorResponseTest: XCTestCase {
         case .failure(let error):
             XCTAssertEqual(
                 error.localizedDescription,
-                NSError.stp_cardErrorInvalidNumberUserMessage()
+                "some message"
             )
         case .success:
             XCTFail("The request should not have succeeded")

--- a/Tests/Tests/StripeErrorTest.swift
+++ b/Tests/Tests/StripeErrorTest.swift
@@ -154,9 +154,10 @@ class StripeErrorTest: XCTestCase {
         let error = NSError.stp_error(fromStripeResponse: response)!
         XCTAssertEqual(error.domain, STPError.stripeDomain)
         XCTAssertEqual(error.code, STPErrorCode.invalidRequestError.rawValue)
+        // Error type is not `card_error`, so `NSLocalizedDescription` will be a generic error.
         XCTAssertEqual(
             error.userInfo[NSLocalizedDescriptionKey] as! String,
-            NSError.stp_cardErrorInvalidNumberUserMessage())
+            NSError.stp_unexpectedErrorMessage())
         XCTAssertEqual(
             error.userInfo[STPError.cardErrorCodeKey] as! String, STPError.incorrectNumber)
         XCTAssertEqual(
@@ -180,7 +181,7 @@ class StripeErrorTest: XCTestCase {
         XCTAssertEqual(error.code, STPErrorCode.cardError.rawValue)
         XCTAssertEqual(
             error.userInfo[NSLocalizedDescriptionKey] as! String,
-            NSError.stp_cardErrorInvalidNumberUserMessage())
+            "Your card number is incorrect.")
         XCTAssertEqual(
             error.userInfo[STPError.cardErrorCodeKey] as! String, STPError.incorrectNumber)
         XCTAssertEqual(
@@ -195,7 +196,6 @@ class StripeErrorTest: XCTestCase {
         let response = [
             "error": [
                 "type": "card_error",
-                "message": "Your card has insufficient funds.",
                 "code": "card_declined",
                 "decline_code": "insufficient_funds",
             ]
@@ -207,6 +207,7 @@ class StripeErrorTest: XCTestCase {
         XCTAssertEqual(error.domain, STPError.stripeDomain)
         XCTAssertEqual(error.code, STPErrorCode.cardError.rawValue)
         XCTAssertEqual(error.userInfo[STPError.cardErrorCodeKey] as? String, STPCardErrorCode.cardDeclined.rawValue)
+        // Response didn't include a message, so a built in message will be used.
         XCTAssertEqual(error.userInfo[NSLocalizedDescriptionKey] as? String, NSError.stp_cardErrorDeclinedUserMessage())
         XCTAssertEqual(error.userInfo[STPError.stripeDeclineCodeKey] as? String, "insufficient_funds")
     }


### PR DESCRIPTION
## Summary
Fixes card related error messages defaulting to local messages instead of using the server provided messages.

## Motivation
https://github.com/stripe/stripe-ios/issues/2072

## Testing
- Visually verified the errors displayed on the payment sheet playground app
- Added unit tests

## Changelog
[Fixed] Fixed user facing error messages for card related errors.