### PR TITLE
Make AddressViewController API public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## X.Y.Z 2022-xx-xx
 ### PaymentSheet
+* [Added] Added `AddressViewController`, a customizable view controller that collects local and international addresses for your customers. See https://stripe.com/docs/elements/address-element?platform=ios.
 * [Fixed] Fixed user facing error messages for card related errors.
 
 ## 23.1.1 2022-11-07

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -9,8 +9,7 @@
 //  an example of what you should do in a real app!
 //  Note: Do not import Stripe using `@_spi(STP)` in production.
 //  This exposes internal functionality which may cause unexpected behavior if used directly.
-@_spi(STP) import StripePaymentSheet
-@_spi(STP) import StripeCore
+import StripePaymentSheet
 import Contacts
 import UIKit
 import SwiftUI

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/AddressViewController/AddressViewController+Configuration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/AddressViewController/AddressViewController+Configuration.swift
@@ -11,8 +11,7 @@ import Foundation
 @_spi(STP) import StripeUICore
 @_spi(STP) import StripePaymentsUI
 
-@_spi(STP) public extension AddressViewController {
-    /// 🏗 Under construction
+public extension AddressViewController {
     /// The customer data collected by `AddressViewController`
     struct AddressDetails {
         /// The customer's address
@@ -68,7 +67,6 @@ import Foundation
         }
     }
     
-    /// 🏗 Under construction
     /// Configuration for an `AddressViewController` instance.
     struct Configuration {
         /// Initializes a Configuration
@@ -83,9 +81,8 @@ import Foundation
             self.title = title ?? .Localized.shipping_address
         }
         
-        /// 🏗 Under construction
         /// Configuration related to the collection of additional fields beyond the physical address.
-        @_spi(STP) public struct AdditionalFields {
+        public struct AdditionalFields {
             /// Whether a field should be hidden, optional, or required.
             public enum FieldConfiguration {
                 /// The field is not displayed.
@@ -110,7 +107,6 @@ import Foundation
             }
         }
         
-        /// 🏗 Under construction
         /// Default values for the fields collected by `AddressViewController`
         public struct DefaultAddressDetails {
             /// The customer's address

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/AddressViewController/AddressViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/AddressViewController/AddressViewController.swift
@@ -11,19 +11,17 @@ import UIKit
 @_spi(STP) import StripeCore
 @_spi(STP) import StripeUICore
 
-/// 🏗 Under construction
 /// A delegate for `AddressViewController`
-@_spi(STP) public protocol AddressViewControllerDelegate: AnyObject {
+public protocol AddressViewControllerDelegate: AnyObject {
     /// Called when the customer finishes entering their address or cancels. Your implemententation should dismiss the view controller.
     /// - Parameter address: A valid address or nil if the customer cancels the flow.
     func addressViewControllerDidFinish(_ addressViewController: AddressViewController, with address: AddressViewController.AddressDetails?)
 }
 
-/// 🏗 Under construction
 /// A view controller that collects a name and an address, with full localization and autocomplete.
 /// - Note: It uses `navigationItem` and can push a view controller, so it must be shown inside a `UINavigationController`.
-@objc(STP_Internal_AddressViewController)
-@_spi(STP) public class AddressViewController: UIViewController {
+@objc(STPAddressViewController)
+public class AddressViewController: UIViewController {
     // MARK: - Public properties
     /// Configuration containing e.g. appearance styling properties, default values, etc.
     public let configuration: Configuration
@@ -132,7 +130,7 @@ import UIKit
     /// - Note: Make sure you put this in a `UINavigationController` before presenting or pushing it.
     /// - Parameter configuration: The configuration for this `AddressViewController` e.g., to style the appearance.
     /// - Parameter delegate: This is called after the customer completes entering their address or cancels the sheet.
-    @_spi(STP) public convenience init(
+    public convenience init(
         configuration: Configuration,
         delegate: AddressViewControllerDelegate
     ) {
@@ -356,7 +354,7 @@ extension AddressViewController {
 }
 
 // MARK: - ElementDelegate
- extension AddressViewController: ElementDelegate {
+ @_spi(STP) extension AddressViewController: ElementDelegate {
      @_spi(STP) public func didUpdate(element: Element) {
          guard let addressSection = addressSection else { assertionFailure(); return }
          self.latestError = nil // clear error on new input

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentSheetConfiguration.swift
@@ -147,11 +147,10 @@ extension PaymentSheet {
         /// Describes the appearance of PaymentSheet
         public var appearance = PaymentSheet.Appearance.default
         
-        /// 🏗 Under construction
         /// A closure that returns the customer's shipping details.
         /// This is used to display a "Billing address is same as shipping" checkbox if `defaultBillingDetails` is not provided
         /// If `name` and `line1` are populated, it's also [attached to the PaymentIntent](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-shipping) during payment.
-        @_spi(STP) public var shippingDetails: () -> AddressViewController.AddressDetails? = { return nil }
+        public var shippingDetails: () -> AddressViewController.AddressDetails? = { return nil }
         
         /// Initializes a Configuration with default values
         public init() {}


### PR DESCRIPTION
## Summary
Make AddressViewController API public

## Motivation
Address Element GA

## Changelog
* [Added] Added `AddressViewController`, a customizable view controller that collects local and international addresses for your customers. See https://stripe.com/docs/elements/address-element?platform=ios.
