### PR TITLE
[Link] Disable inline signup if Link doesn't support card payments

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/MockFiles/elements_sessions_paymentMethod_link_200.json
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/MockFiles/elements_sessions_paymentMethod_link_200.json
@@ -15,6 +15,9 @@
     "instant_debits_inline_institution": true,
     "link_bank_onboarding_enabled": false,
     "link_financial_incentives_experiment_enabled": false,
+    "link_funding_sources": [
+        "CARD"
+    ],
     "link_local_storage_login_enabled": true
   },
   "merchant_country": "US",

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Extensions/Intent+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Extensions/Intent+Link.swift
@@ -9,6 +9,14 @@
 @_spi(STP) import StripePayments
 
 extension Intent {
+    var supportsLink: Bool {
+        return recommendedPaymentMethodTypes.contains(.link)
+    }
+
+    var supportsLinkCard: Bool {
+        return supportsLink && (linkFundingSources?.contains(.card) ?? false)
+    }
+
     var callToAction: ConfirmButton.CallToActionType {
         switch self {
         case .paymentIntent(let paymentIntent):

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Intent.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Intent.swift
@@ -66,10 +66,6 @@ enum Intent {
 
         return false
     }
-
-    var supportsLink: Bool {
-        return recommendedPaymentMethodTypes.contains(.link)
-    }
 }
 
 // MARK: - IntentClientSecret

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -36,7 +36,7 @@ class PaymentSheetFormFactory {
 
     var canSaveToLink: Bool {
         return (
-            intent.supportsLink &&
+            intent.supportsLinkCard &&
             paymentMethod == .card &&
             saveMode != .merchantRequired
         )


### PR DESCRIPTION
## Summary
Inline Link signup should only be available if the merchant supports making credit card payments through Link.

## Motivation
Per https://paper.dropbox.com/doc/BszB8p~z7aQ_1CZXo4uMwp8KAg-PD92EmxO5ZLNodA9usMg2#:uid=940647563418880683270935 Link signup should be disabled in the case where card payments through Stripe are allowed but card payments through Link are not. This is determined by whether `"CARD"` is present in `link_funding_sources` for a given intent.
