### PR TITLE
[Financial Connections]: Change ownership field to be a string

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsAccount.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsAccount.swift
@@ -53,42 +53,6 @@ public extension StripeAPI {
             public let type: ModelType
         }
         
-        public struct Owner: Codable, Equatable {
-            /// The email address of the owner.
-            public let email: String?
-            /// Unique identifier for the object.
-            public let id: String
-            /// The full name of the owner.
-            public let name: String
-            /// The ownership object that this owner belongs to.
-            public let ownership: String
-            /// The raw phone number of the owner.
-            public let phone: String?
-            /// The raw physical address of the owner.
-            public let rawAddress: String?
-            /// The timestamp of the refresh that updated this owner.
-            public let refreshedAt: Int?
-        }
-
-        public struct OwnerList: Codable, Equatable {
-            public let count: Int?
-            /// Details about each object.
-            public let data: [Owner]
-            /// True if this list has another page of items after this one that can be fetched.
-            public let hasMore: Bool
-            public let totalCount: Int?
-            /// The URL where this list can be accessed.
-            public let url: String
-        }
-        
-        public struct Ownership: Codable, Equatable {
-            /// Time at which the object was created. Measured in seconds since the Unix epoch.
-            public let created: Int
-            /// Unique identifier for the object.
-            public let id: String
-            public let owners: OwnerList
-        }
-        
         public struct OwnershipRefresh: Codable, Equatable {
             @frozen public enum Status: String, SafeEnumCodable, Equatable {
                 case failed = "failed"
@@ -146,7 +110,7 @@ public extension StripeAPI {
 
         public let balance: Balance?
         public let balanceRefresh: BalanceRefresh?
-        public let ownership: Ownership?
+        public let ownership: String?
         /// The state of the most recent attempt to refresh the account owners.
         public let ownershipRefresh: OwnershipRefresh?
         public let displayName: String?


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

Changes the ownership field to be an optional string instead of an autoexpanded object.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Assumption was made that ownership object would be autoexpanded. This is a wrong assumption. We are fixing by parsing the ownership token as a string.

## Testing
<!-- How was the code tested? Be as specific as possible. -->
Gone through the AuthFlow with ownership permission and verified parsing works.

<img width="1236" alt="Screen Shot 2022-11-16 at 3 13 58 PM" src="https://user-images.githubusercontent.com/92807969/202286377-9d87137f-c856-4c74-b025-303c70d8e98b.png">

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
[Fixed] FinancialConnections: fixed returning an error for successfully connecting an account with ownership information.