### PR TITLE
[Link] Streamline the add PM flow for Link Bank only businesses

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/ACH/LinkFinancialConnectionsAuthManager.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/ACH/LinkFinancialConnectionsAuthManager.swift
@@ -10,7 +10,6 @@ import UIKit
 import AuthenticationServices
 
 @_spi(STP) import StripeCore
-@_spi(STP) import StripePayments
 
 /// For internal SDK use only
 @objc(STP_Internal_LinkFinancialConnectionsAuthManager)

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/ACH/LinkFinancialConnectionsAuthManager.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/ACH/LinkFinancialConnectionsAuthManager.swift
@@ -10,6 +10,7 @@ import UIKit
 import AuthenticationServices
 
 @_spi(STP) import StripeCore
+@_spi(STP) import StripePayments
 
 /// For internal SDK use only
 @objc(STP_Internal_LinkFinancialConnectionsAuthManager)
@@ -18,14 +19,12 @@ final class LinkFinancialConnectionsAuthManager: NSObject {
         static let linkedAccountIDQueryParameterName = "linked_account"
     }
 
-    enum AuthenticationResult {
-        case success(linkedAccountID: String)
+    enum Error: Swift.Error, LocalizedError {
         case canceled
-        case failure(Error)
-    }
-
-    enum AuthenticationError: Error, LocalizedError {
-        case unknown(_ debugDescription: String)
+        case failedToStart
+        case noLinkedAccountID
+        case noURL
+        case unexpectedURL
 
         var errorDescription: String? {
             return NSError.stp_unexpectedErrorMessage()
@@ -44,8 +43,6 @@ final class LinkFinancialConnectionsAuthManager: NSObject {
         }
     }
 
-    typealias CompletionBlock = (AuthenticationResult) -> Void
-
     let linkAccount: PaymentSheetLinkAccount
     let window: UIWindow?
 
@@ -54,96 +51,79 @@ final class LinkFinancialConnectionsAuthManager: NSObject {
         self.window = window
     }
 
-    func start(
-        clientSecret: String,
-        completion: @escaping CompletionBlock
-    ) {
-        generateHostedURL(withClientSecret: clientSecret).observe { [weak self] result in
-            switch result {
-            case .success(let manifest):
-                self?.authenticate(withManifest: manifest, completion: completion)
-            case .failure(let error):
-                completion(.failure(error))
-            }
-        }
+    /// Initiate a Financial Connections session for Link Instant Debits.
+    /// - Parameter clientSecret: The client secret of the consumer's Link account session.
+    /// - Returns: The ID for the newly linked account.
+    /// - Throws: Either `Error.canceled`, meaning the user canceled the flow, or an error describing what went wrong.
+    func start(clientSecret: String) async throws -> String {
+        let manifest = try await generateHostedURL(withClientSecret: clientSecret)
+        return try await authenticate(withManifest: manifest)
     }
 
 }
 
 extension LinkFinancialConnectionsAuthManager {
 
-    private func generateHostedURL(withClientSecret clientSecret: String) -> Promise<Manifest> {
-        return linkAccount.apiClient.post(
-            resource: "link_account_sessions/generate_hosted_url",
-            parameters: [
-                "client_secret": clientSecret,
-                "fullscreen": true,
-                "hide_close_button": true
-            ],
-            ephemeralKeySecret: linkAccount.publishableKey
-        )
-    }
-
-    private func authenticate(
-        withManifest manifest: Manifest,
-        completion: @escaping CompletionBlock
-    ) {
-        let authSession = ASWebAuthenticationSession(
-            url: manifest.hostedAuthURL,
-            callbackURLScheme: manifest.successURL.scheme,
-            completionHandler: { url, error in
-                if let error = error {
-                    if let authenticationSessionError = error as? ASWebAuthenticationSessionError {
-                        switch authenticationSessionError.code {
-                        case .canceledLogin:
-                            completion(.canceled)
-                        default:
-                            completion(.failure(authenticationSessionError))
-                        }
-                    } else {
-                        completion(.failure(error))
-                    }
-                    return
-                }
-
-                guard let url = url else {
-                    completion(.failure(
-                        AuthenticationError.unknown("Unexpected `nil` URL")
-                    ))
-                    return
-                }
-
-                if url.matchesSchemeHostAndPath(of: manifest.successURL) {
-                    if let linkedAccountID = Self.extractLinkedAccountID(from: url) {
-                        completion(.success(linkedAccountID: linkedAccountID))
-                    } else {
-                        completion(.failure(
-                            AuthenticationError.unknown("URL is missing the linked account ID")
-                        ))
-                    }
-                } else if url.matchesSchemeHostAndPath(of: manifest.cancelURL) {
-                    completion(.canceled)
-                } else {
-                    completion(.failure(
-                        AuthenticationError.unknown("Unexpected URL")
-                    ))
-                }
-            }
-        )
-
-        authSession.presentationContextProvider = self
-        authSession.prefersEphemeralWebBrowserSession = true
-
-        if #available(iOS 13.4, *) {
-            guard authSession.canStart else {
-                completion(.failure(
-                    AuthenticationError.unknown("Failed to start session")
-                ))
-                return
+    private func generateHostedURL(withClientSecret clientSecret: String) async throws -> Manifest {
+        return try await withCheckedThrowingContinuation { continuation in
+            linkAccount.apiClient.post(
+                resource: "link_account_sessions/generate_hosted_url",
+                parameters: [
+                    "client_secret": clientSecret,
+                    "fullscreen": true,
+                    "hide_close_button": true
+                ],
+                ephemeralKeySecret: linkAccount.publishableKey
+            ).observe { result in
+                continuation.resume(with: result)
             }
         }
+    }
 
-        authSession.start()
+    private func authenticate(withManifest manifest: Manifest) async throws -> String {
+        try await withCheckedThrowingContinuation { continuation in
+            let authSession = ASWebAuthenticationSession(
+                url: manifest.hostedAuthURL,
+                callbackURLScheme: manifest.successURL.scheme,
+                completionHandler: { url, error in
+                    if let error = error {
+                        if let authenticationSessionError = error as? ASWebAuthenticationSessionError,
+                            authenticationSessionError.code == .canceledLogin
+                        {
+                            return continuation.resume(throwing: Error.canceled)
+                        }
+                        return continuation.resume(throwing: error)
+                    }
+
+                    guard let url = url else {
+                        return continuation.resume(throwing: Error.noURL)
+                    }
+
+                    if url.matchesSchemeHostAndPath(of: manifest.successURL) {
+                        if let linkedAccountID = Self.extractLinkedAccountID(from: url) {
+                            return continuation.resume(returning: linkedAccountID)
+                        } else {
+                            return continuation.resume(throwing: Error.noLinkedAccountID)
+                        }
+                    } else if url.matchesSchemeHostAndPath(of: manifest.cancelURL) {
+                        return continuation.resume(throwing: Error.canceled)
+                    } else {
+                        return continuation.resume(throwing: Error.unexpectedURL)
+                    }
+                }
+            )
+
+            authSession.presentationContextProvider = self
+            authSession.prefersEphemeralWebBrowserSession = true
+
+            if #available(iOS 13.4, *) {
+                guard authSession.canStart else {
+                    return continuation.resume(throwing: Error.failedToStart)
+                }
+            }
+
+            authSession.start()
+        }
     }
 
 }

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Components/PaymentMethodPicker/LinkPaymentMethodPicker.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Components/PaymentMethodPicker/LinkPaymentMethodPicker.swift
@@ -224,6 +224,10 @@ extension LinkPaymentMethodPicker {
         cell.isLoading = false
     }
 
+    func setAddPaymentMethodButtonEnabled(_ enabled: Bool) {
+        addPaymentMethodButton.isEnabled = enabled
+    }
+
     private func reloadDataIfNeeded() {
         if needsDataReload {
             reloadData()

--- a/StripePaymentSheet/StripePaymentSheet/Internal/Link/Extensions/Intent+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Internal/Link/Extensions/Intent+Link.swift
@@ -17,6 +17,10 @@ extension Intent {
         return supportsLink && (linkFundingSources?.contains(.card) ?? false)
     }
 
+    var onlySupportsLinkBank: Bool {
+        return supportsLink && (linkFundingSources == [.bankAccount])
+    }
+
     var callToAction: ConfirmButton.CallToActionType {
         switch self {
         case .paymentIntent(let paymentIntent):

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentMethodType.swift
@@ -173,9 +173,10 @@ extension PaymentSheet {
         static func filteredPaymentMethodTypes(from intent: Intent, configuration: Configuration) -> [PaymentMethodType] {
             var recommendedPaymentMethodTypes = Self.recommendedPaymentMethodTypes(from: intent)
             if configuration.linkPaymentMethodsOnly {
-                // If we're in the Link modal, manually add instant debit
-                // as an option and let the support calls decide if it's allowed
-                recommendedPaymentMethodTypes.append(.linkInstantDebit)
+                // If we're in the Link modal, manually add Link payment methods
+                // and let the support calls decide if they're allowed
+                recommendedPaymentMethodTypes.append(.card) // Link Card
+                recommendedPaymentMethodTypes.append(.linkInstantDebit) // Link Bank
             }
 
             let paymentTypes = recommendedPaymentMethodTypes.filter {


### PR DESCRIPTION
## Summary
Go straight into the bank connection flow when adding a Link payment method on a business that only supports Link Bank. Also converts the bank connection manager to use Swift Concurrency where possible.

## Motivation
This fulfills [LINK_CX-1214](https://jira.corp.stripe.com/browse/LINK_CX-1214). In order to keep behavior consistent in both places, I've hoisted up the code used in the `NewPaymentViewController` into the `coordinator`. This necessitated some refactor work, and I was getting pretty sick of the Great Pyramid of Completion Handlers, so it seemed like a good opportunity to convert as much of it as possible to use Swift Concurrency. The concurrency is abstracted away at this point – all current interactions with it go through a completion handler-based wrapper, to avoid refactor creep – but in the future we'll be able to leverage the `async` method directly.

Unfortunately `ASWebAuthenticationSession` has no `async` API available, so that part's still kind of a mess. But not meaningfully more than it was previously. (It may be helpful to hide whitespace diffs when reviewing.)

## Testing
Manual exercise of success/cancel/error flows with single and multiple funding sources.
