### PR TITLE
Add new analytic payload items for conversion tracking

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Intent.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Intent.swift
@@ -66,6 +66,15 @@ enum Intent {
 
         return false
     }
+    
+    var currency: String? {
+        switch self {
+        case .paymentIntent(let pi):
+            return pi.currency
+        case .setupIntent:
+            return nil
+        }
+    }
 }
 
 // MARK: - IntentClientSecret

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentSheet.swift
@@ -361,7 +361,8 @@ extension PaymentSheet: PayWithLinkViewControllerDelegate {
                 result: result,
                 linkEnabled: intent.supportsLink,
                 activeLinkSession: LinkAccountContext.shared.account?.sessionState == .verified,
-                paymentOption: paymentOption
+                paymentOption: paymentOption,
+                currency: intent.currency
             )
 
             completion(result)

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentSheet.swift
@@ -360,7 +360,8 @@ extension PaymentSheet: PayWithLinkViewControllerDelegate {
                 paymentMethod: paymentOption.analyticsValue,
                 result: result,
                 linkEnabled: intent.supportsLink,
-                activeLinkSession: LinkAccountContext.shared.account?.sessionState == .verified
+                activeLinkSession: LinkAccountContext.shared.account?.sessionState == .verified,
+                paymentOption: paymentOption
             )
 
             completion(result)

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentSheetFlowController.swift
@@ -22,6 +22,20 @@ extension PaymentSheet {
         case saved(paymentMethod: STPPaymentMethod)
         case new(confirmParams: IntentConfirmParams)
         case link(option: LinkConfirmOption)
+        
+        var name: String {
+            switch self {
+                
+            case .applePay:
+                return "applepay"
+            case .saved(paymentMethod: let paymentMethod):
+                return paymentMethod.type.displayName.lowercased()
+            case .new(confirmParams: let confirmParams):
+                return confirmParams.paymentMethodType.displayName.lowercased()
+            case .link(option: _):
+                return "link"
+            }
+        }
     }
 
     /// A class that presents the individual steps of a payment flow
@@ -271,7 +285,8 @@ extension PaymentSheet {
                     paymentMethod: paymentOption.analyticsValue,
                     result: result,
                     linkEnabled: intent.supportsLink,
-                    activeLinkSession: LinkAccountContext.shared.account?.sessionState == .verified
+                    activeLinkSession: LinkAccountContext.shared.account?.sessionState == .verified,
+                    paymentOption: paymentOption
                 )
 
                 if case .completed = result, case .link = paymentOption {

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentSheetFlowController.swift
@@ -286,7 +286,8 @@ extension PaymentSheet {
                     result: result,
                     linkEnabled: intent.supportsLink,
                     activeLinkSession: LinkAccountContext.shared.account?.sessionState == .verified,
-                    paymentOption: paymentOption
+                    paymentOption: paymentOption,
+                    currency: intent.currency
                 )
 
                 if case .completed = result, case .link = paymentOption {

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
@@ -42,9 +42,7 @@ extension STPAnalyticsClient {
             success = true
         }
 
-        let logParams =  ["payment_method": paymentOption.name.lowercased(),
-                          "locale": Locale.autoupdatingCurrent.identifier,
-                          "currency": currency]
+        let logParams =  ["payment_method": paymentOption.name.lowercased()]
         
         logPaymentSheetEvent(
             event: paymentSheetPaymentEventValue(
@@ -55,7 +53,7 @@ extension STPAnalyticsClient {
             duration: AnalyticsHelper.shared.getDuration(for: .checkout),
             linkEnabled: linkEnabled,
             activeLinkSession: activeLinkSession,
-            params: logParams as [String : Any]
+            currency: currency, params: logParams as [String : Any]
         )
     }
 
@@ -63,13 +61,15 @@ extension STPAnalyticsClient {
         isCustom: Bool,
         paymentMethod: AnalyticsPaymentMethodType,
         linkEnabled: Bool,
-        activeLinkSession: Bool
+        activeLinkSession: Bool,
+        currency: String?
     ) {
         AnalyticsHelper.shared.startTimeMeasurement(.checkout)
         logPaymentSheetEvent(
             event: paymentSheetShowEventValue(isCustom: isCustom, paymentMethod: paymentMethod),
             linkEnabled: linkEnabled,
-            activeLinkSession: activeLinkSession
+            activeLinkSession: activeLinkSession,
+            currency: currency
         )
     }
     
@@ -223,6 +223,7 @@ extension STPAnalyticsClient {
         linkEnabled: Bool? = nil,
         activeLinkSession: Bool? = nil,
         configuration: PaymentSheet.Configuration? = nil,
+        currency: String? = nil,
         params: [String: Any] = [:]
     ) {
         var additionalParams = [:] as [String: Any]
@@ -235,6 +236,8 @@ extension STPAnalyticsClient {
         additionalParams["active_link_session"] = activeLinkSession
         additionalParams["session_id"] = AnalyticsHelper.shared.sessionID
         additionalParams["mpe_config"] = configuration?.analyticPayload
+        additionalParams["locale"] = Locale.autoupdatingCurrent.identifier
+        additionalParams["currency"] = currency
         for (param, param_value) in params {
             additionalParams[param] = param_value
         }

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
@@ -27,7 +27,8 @@ extension STPAnalyticsClient {
         paymentMethod: AnalyticsPaymentMethodType,
         result: PaymentSheetResult,
         linkEnabled: Bool,
-        activeLinkSession: Bool
+        activeLinkSession: Bool,
+        paymentOption: PaymentOption
     ) {
         var success = false
         switch result {
@@ -48,7 +49,8 @@ extension STPAnalyticsClient {
             ),
             duration: AnalyticsHelper.shared.getDuration(for: .checkout),
             linkEnabled: linkEnabled,
-            activeLinkSession: activeLinkSession
+            activeLinkSession: activeLinkSession,
+            params: ["selected_lpm": paymentOption.name.lowercased()]
         )
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
@@ -28,7 +28,8 @@ extension STPAnalyticsClient {
         result: PaymentSheetResult,
         linkEnabled: Bool,
         activeLinkSession: Bool,
-        paymentOption: PaymentOption
+        paymentOption: PaymentOption,
+        currency: String?
     ) {
         var success = false
         switch result {
@@ -41,6 +42,10 @@ extension STPAnalyticsClient {
             success = true
         }
 
+        let logParams =  ["payment_method": paymentOption.name.lowercased(),
+                          "locale": Locale.autoupdatingCurrent.identifier,
+                          "currency": currency]
+        
         logPaymentSheetEvent(
             event: paymentSheetPaymentEventValue(
                 isCustom: isCustom,
@@ -50,7 +55,7 @@ extension STPAnalyticsClient {
             duration: AnalyticsHelper.shared.getDuration(for: .checkout),
             linkEnabled: linkEnabled,
             activeLinkSession: activeLinkSession,
-            params: ["selected_lpm": paymentOption.name.lowercased()]
+            params: logParams as [String : Any]
         )
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
@@ -41,8 +41,6 @@ extension STPAnalyticsClient {
         case .completed:
             success = true
         }
-
-        let logParams =  ["payment_method": paymentOption.name.lowercased()]
         
         logPaymentSheetEvent(
             event: paymentSheetPaymentEventValue(
@@ -53,7 +51,8 @@ extension STPAnalyticsClient {
             duration: AnalyticsHelper.shared.getDuration(for: .checkout),
             linkEnabled: linkEnabled,
             activeLinkSession: activeLinkSession,
-            currency: currency, params: logParams as [String : Any]
+            currency: currency,
+            params: ["payment_method": paymentOption.name.lowercased()]
         )
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/ViewControllers/ChoosePaymentOptionViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/ViewControllers/ChoosePaymentOptionViewController.swift
@@ -206,7 +206,8 @@ class ChoosePaymentOptionViewController: UIViewController {
             isCustom: true,
             paymentMethod: mode.analyticsValue,
             linkEnabled: intent.supportsLink,
-            activeLinkSession: LinkAccountContext.shared.account?.sessionState == .verified
+            activeLinkSession: LinkAccountContext.shared.account?.sessionState == .verified,
+            currency: intent.currency
         )
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -239,7 +239,8 @@ class PaymentSheetViewController: UIViewController {
             isCustom: false,
             paymentMethod: mode.analyticsValue,
             linkEnabled: intent.supportsLink,
-            activeLinkSession: LinkAccountContext.shared.account?.sessionState == .verified
+            activeLinkSession: LinkAccountContext.shared.account?.sessionState == .verified,
+            currency: intent.currency
         )
     }
     

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -449,7 +449,8 @@ class PaymentSheetViewController: UIViewController {
                     result: result,
                     linkEnabled: self.intent.supportsLink,
                     activeLinkSession: LinkAccountContext.shared.account?.sessionState == .verified,
-                    paymentOption: paymentOption
+                    paymentOption: paymentOption,
+                    currency: self.intent.currency
                 )
 
                 self.isPaymentInFlight = false

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -448,7 +448,8 @@ class PaymentSheetViewController: UIViewController {
                     paymentMethod: paymentOption.analyticsValue,
                     result: result,
                     linkEnabled: self.intent.supportsLink,
-                    activeLinkSession: LinkAccountContext.shared.account?.sessionState == .verified
+                    activeLinkSession: LinkAccountContext.shared.account?.sessionState == .verified,
+                    paymentOption: paymentOption
                 )
 
                 self.isPaymentInFlight = false

--- a/Tests/Tests/STPAnalyticsClientPaymentSheetTest.swift
+++ b/Tests/Tests/STPAnalyticsClientPaymentSheetTest.swift
@@ -110,7 +110,8 @@ class STPAnalyticsClientPaymentSheetTest: XCTestCase {
             isCustom: true,
             paymentMethod: .newPM,
             linkEnabled: false,
-            activeLinkSession: false
+            activeLinkSession: false,
+            currency: "USD"
         )
 
         let event2 = XCTestExpectation(description: "mc_complete_sheet_savedpm_show")
@@ -119,7 +120,8 @@ class STPAnalyticsClientPaymentSheetTest: XCTestCase {
             isCustom: false,
             paymentMethod: .savedPM,
             linkEnabled: false,
-            activeLinkSession: false
+            activeLinkSession: false,
+            currency: "USD"
         )
 
         let event3 = XCTestExpectation(description: "mc_complete_payment_savedpm_success")
@@ -129,7 +131,9 @@ class STPAnalyticsClientPaymentSheetTest: XCTestCase {
             paymentMethod: .savedPM,
             result: .completed,
             linkEnabled: false,
-            activeLinkSession: false
+            activeLinkSession: false,
+            paymentOption: .applePay,
+            currency: "USD"
         )
 
         let event4 = XCTestExpectation(description: "mc_custom_payment_applepay_failure")
@@ -139,7 +143,9 @@ class STPAnalyticsClientPaymentSheetTest: XCTestCase {
             paymentMethod: .applePay,
             result: .failed(error: PaymentSheetError.unknown(debugDescription: "Error")),
             linkEnabled: false,
-            activeLinkSession: false
+            activeLinkSession: false,
+            paymentOption: .applePay,
+            currency: "USD"
         )
 
         let event5 = XCTestExpectation(description: "mc_custom_paymentoption_applepay_select")
@@ -209,7 +215,8 @@ class STPAnalyticsClientPaymentSheetTest: XCTestCase {
             isCustom: false,
             paymentMethod: .newPM,
             linkEnabled: false,
-            activeLinkSession: false
+            activeLinkSession: false,
+            currency: "USD"
         )
 
         client.logPaymentSheetPayment(
@@ -217,7 +224,9 @@ class STPAnalyticsClientPaymentSheetTest: XCTestCase {
             paymentMethod: .savedPM,
             result: .completed,
             linkEnabled: false,
-            activeLinkSession: false
+            activeLinkSession: false,
+            paymentOption: .applePay,
+            currency: "USD"
         )
 
         let duration = client.lastPayload?["duration"] as? TimeInterval


### PR DESCRIPTION
## Summary
- Logs payment method on confirm calls. It doesn't seem to make sense to log payment method on show or init events as the selected PM can change. Seems like that would lead to some false positives. We may want to find a way to track how a user progresses through the form for a given payment method(?)
- Logs currency for show and confirm events. Didn't log for init events as the `intent` isn't always available to read the currency from.
- Logs locale for init, show, and confirm events

Will need to add a new column in the analytics table for these new payload parameters.

## Motivation
https://paper.dropbox.com/doc/PaymentSheet-conversion-tracking--BtJHMy0MyLX9QEphcDLwR0CWAg-yntdTWBj58b0dcdpJjGYT

## Testing
Manual

## Changelog
N/A
