### PR TITLE
Fix flaky STPRedirectContext test

### DIFF
--- a/Tests/Tests/STPRedirectContextTest.m
+++ b/Tests/Tests/STPRedirectContextTest.m
@@ -590,7 +590,7 @@
                                  completion:[OCMArg isNil]]);
     XCTestExpectation *expectation = [self expectationWithDescription:@"Completion block called"];
     
-    // Hack: Wait for the Safari thread to call us back before unsubscribing. Otherwise the Safari thread doesn't get the unsubscribe request in time and calls us anyway, crashing the app.
+    // Hack: Wait ~100ms to call sut back before unsubscribing from notifications. Otherwise the Safari thread doesn't get the unsubscribe request in time and calls the deallocated sut, crashing the app.
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         [expectation fulfill];
     });

--- a/Tests/Tests/STPRedirectContextTest.m
+++ b/Tests/Tests/STPRedirectContextTest.m
@@ -588,7 +588,7 @@
     OCMVerify([mockVC presentViewController:[OCMArg isKindOfClass:[SFSafariViewController class]]
                                    animated:YES
                                  completion:[OCMArg isNil]]);
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Completion block called"];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Waiting 100ms for SafariServices"];
     
     // Hack: Wait ~100ms to call sut back before unsubscribing from notifications. Otherwise the Safari thread doesn't get the unsubscribe request in time and calls the deallocated sut, crashing the app.
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{

--- a/Tests/Tests/STPRedirectContextTest.m
+++ b/Tests/Tests/STPRedirectContextTest.m
@@ -588,7 +588,14 @@
     OCMVerify([mockVC presentViewController:[OCMArg isKindOfClass:[SFSafariViewController class]]
                                    animated:YES
                                  completion:[OCMArg isNil]]);
-
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Completion block called"];
+    
+    // Hack: Wait for the Safari thread to call us back before unsubscribing. Otherwise the Safari thread doesn't get the unsubscribe request in time and calls us anyway, crashing the app.
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        [expectation fulfill];
+    });
+        
+    [self waitForExpectationsWithTimeout:1 handler:nil];
     [sut unsubscribeFromNotifications];
 }
 


### PR DESCRIPTION
## Summary
This is just a guess, but it appears to solve the crash when running the test in a 1000x loop.

## Testing
CI