### PR TITLE
Remove unnecessary 3DS2 assert

### DIFF
--- a/Stripe3DS2/Stripe3DS2/STDSACSNetworkingManager.m
+++ b/Stripe3DS2/Stripe3DS2/STDSACSNetworkingManager.m
@@ -54,8 +54,6 @@ static const NSTimeInterval kTimeoutInterval = 10;
 }
 
 - (void)submitChallengeRequest:(STDSChallengeRequestParameters *)request withCompletion:(void (^)(id<STDSChallengeResponse> _Nullable, NSError * _Nullable))completion {
-
-    NSAssert(_currentTask == nil, @"%@ is not intended to handle multiple concurrent tasks.", NSStringFromClass([self class]));
     if (_currentTask != nil) {
         dispatch_async(dispatch_get_main_queue(), ^{
             completion(nil, [NSError errorWithDomain:STDSStripe3DS2ErrorDomain


### PR DESCRIPTION
## Summary
This isn't a programmer error (it's easy to trigger by a user simply tapping the "Cancel" button while an event is in-flight), and NSAsserts are [not disabled by default in SPM](https://forums.swift.org/t/assertions-in-swift-packages/42692). We should just remove this assert.

## Motivation
https://github.com/stripe/stripe-ios/issues/2094

## Testing
CI, manually tapping the cancel button while loading is in progress in a livemode 3DS2 transaction.