### PR TITLE
Reduce redundant builds in export_builds

### DIFF
--- a/Stripe.xcodeproj/xcshareddata/xcschemes/AllStripeFrameworks.xcscheme
+++ b/Stripe.xcodeproj/xcshareddata/xcschemes/AllStripeFrameworks.xcscheme
@@ -1,0 +1,221 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1400"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "04CDB4411A5F2E1800B854EE"
+               BuildableName = "Stripe.framework"
+               BlueprintName = "StripeiOS"
+               ReferencedContainer = "container:Stripe.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3181D72C273A00BE00525C02"
+               BuildableName = "StripeApplePay.framework"
+               BlueprintName = "StripeApplePay"
+               ReferencedContainer = "container:StripeApplePay/StripeApplePay.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E63B66F82742EEBF00CFEDBA"
+               BuildableName = "StripeCameraCore.framework"
+               BlueprintName = "StripeCameraCore"
+               ReferencedContainer = "container:StripeCameraCore/StripeCameraCore.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3B2F4DF62739CCFD008618CD"
+               BuildableName = "StripeCardScan.framework"
+               BlueprintName = "StripeCardScan"
+               ReferencedContainer = "container:StripeCardScan/StripeCardScan.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E69D63FA26855B250090B43D"
+               BuildableName = "StripeCore.framework"
+               BlueprintName = "StripeCore"
+               ReferencedContainer = "container:StripeCore/StripeCore.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3139D27B286E34C400C9744B"
+               BuildableName = "StripePaymentsUI.framework"
+               BlueprintName = "StripePaymentsUI"
+               ReferencedContainer = "container:StripePaymentsUI/StripePaymentsUI.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3139D259286E34A700C9744B"
+               BuildableName = "StripePayments.framework"
+               BlueprintName = "StripePayments"
+               ReferencedContainer = "container:StripePayments/StripePayments.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3139D29D286E34DF00C9744B"
+               BuildableName = "StripePaymentSheet.framework"
+               BlueprintName = "StripePaymentSheet"
+               ReferencedContainer = "container:StripePaymentSheet/StripePaymentSheet.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E6AFFA9526E93FB50067462F"
+               BuildableName = "StripeUICore.framework"
+               BlueprintName = "StripeUICore"
+               ReferencedContainer = "container:StripeUICore/StripeUICore.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E6E146A626950E1E007BDCD8"
+               BuildableName = "StripeIdentity.framework"
+               BlueprintName = "StripeIdentity"
+               ReferencedContainer = "container:StripeIdentity/StripeIdentity.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3C4D2005273AED0800BC6444"
+               BuildableName = "StripeFinancialConnections.framework"
+               BlueprintName = "StripeFinancialConnections"
+               ReferencedContainer = "container:StripeFinancialConnections/StripeFinancialConnections.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "36DDBE9F21EFEE9700CB47C9"
+               BuildableName = "Stripe3DS2.framework"
+               BlueprintName = "Stripe3DS2"
+               ReferencedContainer = "container:Stripe3DS2/Stripe3DS2.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "04CDB4411A5F2E1800B854EE"
+            BuildableName = "Stripe.framework"
+            BlueprintName = "StripeiOS"
+            ReferencedContainer = "container:Stripe.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Stripe.xcodeproj/xcshareddata/xcschemes/AllStripeFrameworksCatalyst.xcscheme
+++ b/Stripe.xcodeproj/xcshareddata/xcschemes/AllStripeFrameworksCatalyst.xcscheme
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1400"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "04CDB4411A5F2E1800B854EE"
+               BuildableName = "Stripe.framework"
+               BlueprintName = "StripeiOS"
+               ReferencedContainer = "container:Stripe.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "36DDBE9F21EFEE9700CB47C9"
+               BuildableName = "Stripe3DS2.framework"
+               BlueprintName = "Stripe3DS2"
+               ReferencedContainer = "container:Stripe3DS2/Stripe3DS2.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3181D72C273A00BE00525C02"
+               BuildableName = "StripeApplePay.framework"
+               BlueprintName = "StripeApplePay"
+               ReferencedContainer = "container:StripeApplePay/StripeApplePay.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3139D259286E34A700C9744B"
+               BuildableName = "StripePayments.framework"
+               BlueprintName = "StripePayments"
+               ReferencedContainer = "container:StripePayments/StripePayments.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3139D27B286E34C400C9744B"
+               BuildableName = "StripePaymentsUI.framework"
+               BlueprintName = "StripePaymentsUI"
+               ReferencedContainer = "container:StripePaymentsUI/StripePaymentsUI.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E6AFFA9526E93FB50067462F"
+               BuildableName = "StripeUICore.framework"
+               BlueprintName = "StripeUICore"
+               ReferencedContainer = "container:StripeUICore/StripeUICore.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E69D63FA26855B250090B43D"
+               BuildableName = "StripeCore.framework"
+               BlueprintName = "StripeCore"
+               ReferencedContainer = "container:StripeCore/StripeCore.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3139D29D286E34DF00C9744B"
+               BuildableName = "StripePaymentSheet.framework"
+               BlueprintName = "StripePaymentSheet"
+               ReferencedContainer = "container:StripePaymentSheet/StripePaymentSheet.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "04CDB4411A5F2E1800B854EE"
+            BuildableName = "Stripe.framework"
+            BlueprintName = "StripeiOS"
+            ReferencedContainer = "container:Stripe.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ci_scripts/export_builds.rb
+++ b/ci_scripts/export_builds.rb
@@ -32,6 +32,9 @@ script_dir = __dir__
 root_dir = File.expand_path(File.join_if_safe(script_dir, '..'), Dir.getwd)
 modules = YAML.load_file('modules.yaml')['modules']
 
+# Package up 3DS2 too
+modules.append({ 'scheme' => 'Stripe3DS2', 'framework_name' => 'Stripe3DS2', 'supports_catalyst' => true })
+
 # Clean build directory
 build_dir = File.join_if_safe(root_dir, 'build')
 
@@ -39,9 +42,6 @@ info 'Cleaning build directory...'
 
 FileUtils.rm_rf(build_dir)
 Dir.mkdir(build_dir)
-
-# Compile and package dynamic framework
-info 'Compiling and packaging dynamic framework...'
 
 Dir.chdir(root_dir) do
   info 'Building all frameworks...'
@@ -94,7 +94,7 @@ Dir.chdir(root_dir) do
   puts `xcodebuild clean archive \
       -quiet \
       -workspace "Stripe.xcworkspace" \
-      -scheme "AllStripeFrameworks" \
+      -scheme "AllStripeFrameworksCatalyst" \
       -configuration "Release" \
       -archivePath "#{build_dir}/StripeFrameworks-mac.xcarchive" \
       -sdk macosx \
@@ -132,13 +132,6 @@ Dir.chdir(root_dir) do
 end # Dir.chdir
 
 Zip::File.open(File.join_if_safe(build_dir, 'Stripe.xcframework.zip'), create: true) do |zipfile|
-  # Add Stripe3DS2.xcframework to zip
-  stripe3ds2_build_build_dir = File.join_if_safe(root_dir, 'build-3ds2')
-  Dir.glob("#{stripe3ds2_build_build_dir}/Stripe3DS2.xcframework/**/*").each do |file|
-    file_name = Pathname.new(file).relative_path_from(Pathname.new(stripe3ds2_build_build_dir))
-    zipfile.add(file_name, file)
-  end
-
   # Add module framework directories to zip
   modules.each do |m|
     framework_name = m['framework_name']

--- a/ci_scripts/export_builds.rb
+++ b/ci_scripts/export_builds.rb
@@ -20,136 +20,120 @@ def File.join_if_safe(arg1, *otherArgs)
 
   # Check for empty or nil strings
   args.each do |arg|
-    raise "Cannot join nil or empty string." if arg.nil? || arg.empty?
+    raise 'Cannot join nil or empty string.' if arg.nil? || arg.empty?
   end
 
-  return File.join(args)
+  File.join(args)
 end
 
 # MARK: - Main
 
 script_dir = __dir__
-root_dir = File.expand_path(File.join_if_safe(script_dir, ".."), Dir.getwd)
-modules = YAML.load_file("modules.yaml")['modules']
+root_dir = File.expand_path(File.join_if_safe(script_dir, '..'), Dir.getwd)
+modules = YAML.load_file('modules.yaml')['modules']
 
 # Clean build directory
-build_dir = File.join_if_safe(root_dir, "build")
+build_dir = File.join_if_safe(root_dir, 'build')
 
-info "Cleaning build directory..."
+info 'Cleaning build directory...'
 
 FileUtils.rm_rf(build_dir)
 Dir.mkdir(build_dir)
 
 # Compile and package dynamic framework
-info "Compiling and packaging dynamic framework..."
+info 'Compiling and packaging dynamic framework...'
 
 Dir.chdir(root_dir) do
-  # Build Stripe3DS2
-  info "Building Stripe3DS2..."
+  info 'Building all frameworks...'
 
-  `#{root_dir}/stripe3ds2-support/ci_scripts/build_dynamic_xcframework.sh`
+  info 'Building iOS...'
 
-  exit_code=$?.exitstatus
-  if exit_code != 0
-    die "Stripe3DS2 build exited with non-zero status code: #{exit_code}"
-  end
+  # Build for iOS
+  puts `xcodebuild clean archive \
+    -quiet \
+    -workspace "Stripe.xcworkspace" \
+    -scheme "AllStripeFrameworks" \
+    -configuration "Release" \
+    -archivePath "#{build_dir}/StripeFrameworks-iOS.xcarchive" \
+    -sdk iphoneos \
+    -destination 'generic/platform=iOS' \
+    SYMROOT="#{build_dir}/StripeFrameworks-framework-ios" \
+    OBJROOT="#{build_dir}/StripeFrameworks-framework-ios" \
+    SUPPORTS_MACCATALYST=NO \
+    BUILD_LIBRARIES_FOR_DISTRIBUTION=YES \
+    SWIFT_ACTIVE_COMPILATION_CONDITIONS=STRIPE_BUILD_PACKAGE \
+    SKIP_INSTALL=NO`
+
+  exit_code = $?.exitstatus
+  die "xcodebuild exited with non-zero status code: #{exit_code}" if exit_code != 0
+
+  info 'Building Simulator...'
+
+  # Build for Simulator
+  puts `xcodebuild clean archive \
+    -quiet \
+    -workspace "Stripe.xcworkspace" \
+    -scheme "AllStripeFrameworks" \
+    -destination 'generic/platform=iOS Simulator' \
+    -configuration "Release" \
+    -archivePath "#{build_dir}/StripeFrameworks-sim.xcarchive" \
+    -sdk iphonesimulator \
+    SYMROOT="#{build_dir}/StripeFrameworks-framework-sim" \
+    OBJROOT="#{build_dir}/StripeFrameworks-framework-sim" \
+    SUPPORTS_MACCATALYST=NO \
+    BUILD_LIBRARIES_FOR_DISTRIBUTION=YES \
+    SWIFT_ACTIVE_COMPILATION_CONDITIONS=STRIPE_BUILD_PACKAGE \
+    SKIP_INSTALL=NO`
+
+  exit_code = $?.exitstatus
+  die "xcodebuild exited with non-zero status code: #{exit_code}" if exit_code != 0
+
+  info 'Building Catalyst...'
+
+  # Build for MacOS
+  puts `xcodebuild clean archive \
+      -quiet \
+      -workspace "Stripe.xcworkspace" \
+      -scheme "AllStripeFrameworks" \
+      -configuration "Release" \
+      -archivePath "#{build_dir}/StripeFrameworks-mac.xcarchive" \
+      -sdk macosx \
+      -destination 'generic/platform=macOS,variant=Mac Catalyst' \
+      SYMROOT="#{build_dir}/StripeFrameworks-framework-mac" \
+      OBJROOT="#{build_dir}/StripeFrameworks-framework-mac" \
+      SUPPORTS_MACCATALYST=YES \
+      BUILD_LIBRARIES_FOR_DISTRIBUTION=YES \
+      SWIFT_ACTIVE_COMPILATION_CONDITIONS=STRIPE_BUILD_PACKAGE \
+      SKIP_INSTALL=NO`
+
+  exit_code = $?.exitstatus
+  die "xcodebuild exited with non-zero status code: #{exit_code}" if exit_code != 0
 
   modules.each do |m|
     scheme = m['scheme']
     framework_name = m['framework_name']
     supports_catalyst = m['supports_catalyst']
     platform_frameworks = []
-    die "Module is missing scheme" if scheme.nil? || scheme.empty?
-    die "Module is missing framework_name" if framework_name.nil? || framework_name.empty?
+    die 'Module is missing scheme' if scheme.nil? || scheme.empty?
+    die 'Module is missing framework_name' if framework_name.nil? || framework_name.empty?
 
-    info "Building #{scheme}..."
+    platform_frameworks.append("-framework \"#{build_dir}/StripeFrameworks-iOS.xcarchive/Products/Library/Frameworks/#{framework_name}.framework\"")
 
-    info "Building iOS..."
-
-    # Build for iOS
-    puts `xcodebuild clean archive \
-      -quiet \
-      -workspace "Stripe.xcworkspace" \
-      -scheme "#{scheme}" \
-      -configuration "Release" \
-      -archivePath "#{build_dir}/#{framework_name}-iOS.xcarchive" \
-      -sdk iphoneos \
-      -destination 'generic/platform=iOS' \
-      SYMROOT="#{build_dir}/#{framework_name}-framework-ios" \
-      OBJROOT="#{build_dir}/#{framework_name}-framework-ios" \
-      SUPPORTS_MACCATALYST=NO \
-      BUILD_LIBRARIES_FOR_DISTRIBUTION=YES \
-      SWIFT_ACTIVE_COMPILATION_CONDITIONS=STRIPE_BUILD_PACKAGE \
-      SKIP_INSTALL=NO`
-
-    exit_code=$?.exitstatus
-    if exit_code != 0
-      die "xcodebuild exited with non-zero status code: #{exit_code}"
-    end
-
-    platform_frameworks.append("-framework \"#{build_dir}/#{framework_name}-iOS.xcarchive/Products/Library/Frameworks/#{framework_name}.framework\"")
-    
-    info "Building Simulator..."
-
-    # Build for Simulator
-    puts `xcodebuild clean archive \
-      -quiet \
-      -workspace "Stripe.xcworkspace" \
-      -scheme "#{scheme}" \
-      -destination 'generic/platform=iOS Simulator' \
-      -configuration "Release" \
-      -archivePath "#{build_dir}/#{framework_name}-sim.xcarchive" \
-      -sdk iphonesimulator \
-      SYMROOT="#{build_dir}/#{framework_name}-framework-sim" \
-      OBJROOT="#{build_dir}/#{framework_name}-framework-sim" \
-      SUPPORTS_MACCATALYST=NO \
-      BUILD_LIBRARIES_FOR_DISTRIBUTION=YES \
-      SWIFT_ACTIVE_COMPILATION_CONDITIONS=STRIPE_BUILD_PACKAGE \
-      SKIP_INSTALL=NO`
-
-    exit_code=$?.exitstatus
-    if exit_code != 0
-      die "xcodebuild exited with non-zero status code: #{exit_code}"
-    end
-    
-    platform_frameworks.append("-framework \"#{build_dir}/#{framework_name}-sim.xcarchive/Products/Library/Frameworks/#{framework_name}.framework\"")
+    platform_frameworks.append("-framework \"#{build_dir}/StripeFrameworks-sim.xcarchive/Products/Library/Frameworks/#{framework_name}.framework\"")
 
     if supports_catalyst
-        info "Building Catalyst..."
-
-        # Build for MacOS
-        puts `xcodebuild clean archive \
-          -quiet \
-          -workspace "Stripe.xcworkspace" \
-          -scheme "#{scheme}" \
-          -configuration "Release" \
-          -archivePath "#{build_dir}/#{framework_name}-mac.xcarchive" \
-          -sdk macosx \
-          -destination 'generic/platform=macOS,variant=Mac Catalyst' \
-          SYMROOT="#{build_dir}/#{framework_name}-framework-mac" \
-          OBJROOT="#{build_dir}/#{framework_name}-framework-mac" \
-          SUPPORTS_MACCATALYST=YES \
-          BUILD_LIBRARIES_FOR_DISTRIBUTION=YES \
-          SWIFT_ACTIVE_COMPILATION_CONDITIONS=STRIPE_BUILD_PACKAGE \
-          SKIP_INSTALL=NO`
-
-        exit_code=$?.exitstatus
-        if exit_code != 0
-          die "xcodebuild exited with non-zero status code: #{exit_code}"
-        end
-        platform_frameworks.append("-framework \"#{build_dir}/#{framework_name}-mac.xcarchive/Products/Library/Frameworks/#{framework_name}.framework\"")
+      platform_frameworks.append("-framework \"#{build_dir}/StripeFrameworks-mac.xcarchive/Products/Library/Frameworks/#{framework_name}.framework\"")
     end
 
     puts `xcodebuild -create-xcframework \
     #{platform_frameworks.join(' ')} \
     -output "#{build_dir}/#{framework_name}.xcframework"`
-
   end # modules.each
 end # Dir.chdir
 
-Zip::File.open(File.join_if_safe(build_dir, "Stripe.xcframework.zip"), create: true) do |zipfile|
+Zip::File.open(File.join_if_safe(build_dir, 'Stripe.xcframework.zip'), create: true) do |zipfile|
   # Add Stripe3DS2.xcframework to zip
-  stripe3ds2_build_build_dir = File.join_if_safe(root_dir, "build-3ds2")
+  stripe3ds2_build_build_dir = File.join_if_safe(root_dir, 'build-3ds2')
   Dir.glob("#{stripe3ds2_build_build_dir}/Stripe3DS2.xcframework/**/*").each do |file|
     file_name = Pathname.new(file).relative_path_from(Pathname.new(stripe3ds2_build_build_dir))
     zipfile.add(file_name, file)


### PR DESCRIPTION
## Summary
When export_builds.rb builds a framework, it also builds all dependent frameworks. This means a dependent framework (like StripeCore) is rebuilt for every framework using it.

Instead of doing this, we'll create a shared scheme in Xcode for all frameworks. (Plus a special one for Catalyst, as not all modules support Catalyst.) We'll build that scheme once per platform, then package up the results according to the modules.yaml.

## Motivation
Speed up deploy process.

## Testing
Ran locally and tested output, CI