### PR TITLE
[Link] Fix duplicate Link Card payment option

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentMethodType.swift
@@ -175,8 +175,10 @@ extension PaymentSheet {
             if configuration.linkPaymentMethodsOnly {
                 // If we're in the Link modal, manually add Link payment methods
                 // and let the support calls decide if they're allowed
-                recommendedPaymentMethodTypes.append(.card) // Link Card
-                recommendedPaymentMethodTypes.append(.linkInstantDebit) // Link Bank
+                let allLinkPaymentMethods: [PaymentMethodType] = [.card, .linkInstantDebit]
+                for method in allLinkPaymentMethods where !recommendedPaymentMethodTypes.contains(method) {
+                    recommendedPaymentMethodTypes.append(method)
+                }
             }
 
             let paymentTypes = recommendedPaymentMethodTypes.filter {


### PR DESCRIPTION
## Summary
Oops.

## Motivation
<img width="354" alt="image" src="https://user-images.githubusercontent.com/105328383/202589467-7eb73150-48b1-4872-98f0-380335dec6f9.png">

## Notes
If we were able to use Swift Collections, this is an instance where [`OrderedSet`](https://github.com/apple/swift-collections/blob/main/Documentation/OrderedSet.md) would be perfect.