### PR TITLE
Success animation should always be white

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Views/ConfirmButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Views/ConfirmButton.swift
@@ -523,7 +523,7 @@ class ConfirmButton: UIView {
 
             if status == .succeeded {
                 // always use hardcoded color for foreground color when in success state
-                return background.contrastingColor
+                return .white
             }
             
             // if foreground is set prefer that over a dynamic constrasting color in all othe states


### PR DESCRIPTION
## Summary
The confirm button always turns systemGreen during the success animation, so the success checkmark should always be white.

## Motivation
https://github.com/stripe/stripe-ios/issues/2089

## Testing
PaymentSheet Example