### PR TITLE
Fix address element memory leak

### DIFF
--- a/StripeUICore/StripeUICore/Source/Elements/Factories/Address/AddressSectionElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Factories/Address/AddressSectionElement.swift
@@ -94,7 +94,7 @@ import UIKit
     
     // MARK: Element protocol
     public let elements: [Element]
-    public var delegate: ElementDelegate?
+    public weak var delegate: ElementDelegate?
     public lazy var view: UIView = {
         let vStack = UIStackView(arrangedSubviews: [addressSection.view, sameAsCheckbox.view].compactMap { $0 })
         vStack.axis = .vertical


### PR DESCRIPTION
## Summary
Address memory leak identified in #2101 

## Motivation
Seems that we have a strong reference to our delegate, which is the FormElement.  Seems like the right thing to do is to make this variable weak.

## Testing
Executed address element in test playground and opened up memory debugging tools to ensure we are not retaining instances of AddressSectionElement.
