### PR TITLE
Fix clear button in address autocomplete

### DIFF
--- a/StripeUICore/StripeUICore/Source/Elements/TextField/TextFieldView.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/TextField/TextFieldView.swift
@@ -207,10 +207,6 @@ class TextFieldView: UIView {
 
         // Update accessory view
         accessoryView = viewModel.accessoryView
-
-        // Manually call layoutIfNeeded to avoid unintentional animations
-        // in next layout pass
-        layoutIfNeeded()
     }
     
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/StripeUICore/StripeUICore/Source/Elements/TextField/TextFieldView.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/TextField/TextFieldView.swift
@@ -60,6 +60,10 @@ class TextFieldView: UIView {
     /// This could contain the logos of networks, banks, etc.
     var accessoryView: UIView? {
         didSet {
+            // For some reason, the stackview chooses to stretch accessoryContainerView if its
+            // content is nil instead of the text field, so we hide it.
+            accessoryContainerView.setHiddenIfNecessary(accessoryView == nil)
+
             guard oldValue != accessoryView else {
                 return
             }
@@ -203,9 +207,6 @@ class TextFieldView: UIView {
 
         // Update accessory view
         accessoryView = viewModel.accessoryView
-        // For some reason, the stackview chooses to stretch accessoryContainerView if its
-        // content is nil instead of the text field, so we hide it.
-        accessoryContainerView.setHiddenIfNecessary(accessoryView == nil)
 
         // Manually call layoutIfNeeded to avoid unintentional animations
         // in next layout pass

--- a/StripeUICore/StripeUICore/Source/Elements/TextField/TextFieldView.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/TextField/TextFieldView.swift
@@ -100,6 +100,7 @@ class TextFieldView: UIView {
         self.delegate = delegate
         super.init(frame: .zero)
         isAccessibilityElement = true
+        translatesAutoresizingMaskIntoConstraints = false
         installConstraints()
         updateUI(with: viewModel)
     }
@@ -207,6 +208,10 @@ class TextFieldView: UIView {
 
         // Update accessory view
         accessoryView = viewModel.accessoryView
+
+        // Manually call layoutIfNeeded to avoid unintentional animations
+        // in next layout pass
+        layoutIfNeeded()
     }
     
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/StripeUICore/StripeUICore/Source/Elements/TextField/TextFieldView.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/TextField/TextFieldView.swift
@@ -68,8 +68,6 @@ class TextFieldView: UIView {
                 accessoryContainerView.addAndPinSubview(accessoryView)
                 accessoryView.setContentHuggingPriority(.required, for: .horizontal)
             }
-            // For some reason, the stackview chooses to stretch accessoryContainerView if its content is nil instead of the text field, so we hide it.
-            accessoryContainerView.setHiddenIfNecessary(accessoryView == nil)
         }
     }
 
@@ -205,6 +203,10 @@ class TextFieldView: UIView {
 
         // Update accessory view
         accessoryView = viewModel.accessoryView
+        // For some reason, the stackview chooses to stretch accessoryContainerView if its
+        // content is nil instead of the text field, so we hide it.
+        accessoryContainerView.setHiddenIfNecessary(accessoryView == nil)
+
         // Manually call layoutIfNeeded to avoid unintentional animations
         // in next layout pass
         layoutIfNeeded()


### PR DESCRIPTION
## Summary
This was a regression introduced in https://github.com/stripe/stripe-ios/pull/2079.
The issue was that the `setHidden` call was made on `didSet` but the `accessoryView` was always `nil` so that was never reached, so I moved it.

![Simulator Screen Shot - iPhone 12 mini - 2022-11-22 at 15 32 39](https://user-images.githubusercontent.com/114543737/203442066-1c6ba746-af44-4f94-8374-6471336acdf0.png)

## Motivation
Fix regression introduced in https://github.com/stripe/stripe-ios/pull/2079.

## Testing
Verify visually.
I tried adding a snapshot test, but I found no way of setting the text in the autocomplete field, and didn't seem worth it to spend much time looking for another way to do it for a very simple fix.

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
