### PR TITLE
Refactor TextFieldView hitTest to except multiple subviews, make Rota…

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Views/RotatingCardBrandsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Views/RotatingCardBrandsView.swift
@@ -17,7 +17,6 @@ import UIKit
 /// For internal SDK use only
 @objc(STP_Internal_RotatingCardBrandsView)
 class RotatingCardBrandsView: UIView {
-
     static let MaxStaticBrands: Int = 3
     static let LogoSpacing: CGFloat = 3
 
@@ -179,7 +178,16 @@ class RotatingCardBrandsView: UIView {
             self.stackView = stackView
         }
     }
-
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        isUserInteractionEnabled = false
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     override func didMoveToWindow() {
         super.didMoveToWindow()
         if window != nil {

--- a/StripeUICore/StripeUICore/Source/Elements/TextField/TextFieldView.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/TextField/TextFieldView.swift
@@ -112,14 +112,14 @@ class TextFieldView: UIView {
         guard isUserInteractionEnabled, !isHidden, self.point(inside: point, with: event) else {
             return nil
         }
-        
-        // Check if the clear button was tapped, if so foward hit to the view
-        let convertedPoint = clearButton.convert(point, from: self)
-        if let hitView = clearButton.hitTest(convertedPoint, with: event) {
-            return hitView
+        // We override hitTest to forward all events within our bounds to the textfield
+        // ...except for these subviews:
+        for interactableSubview in [clearButton, accessoryView].compactMap({ $0 }) {
+            let convertedPoint = interactableSubview.convert(point, from: self)
+            if let hitView = interactableSubview.hitTest(convertedPoint, with: event) {
+                return hitView
+            }
         }
-        
-        // Forward all events within our bounds to the textfield
         return textField
     }
     


### PR DESCRIPTION
…tingCardsBrandView non-interactable


## Motivation
In the future I will add an interactable accessory view to TextFieldView, so I'm cleaning up the code here.

## Testing
Manually tapped on all variations of subviews I could find in TextFieldView and made sure they did the right thing.
- the CVC icon, the rotating card brands icon, and error view -> tap gets forwarded to textfield
- clear button -> tap gets forwarded to clear button

## Changelog
No user facing change