### PR TITLE
Remove references to non-existent resources in Stripe podspec

### DIFF
--- a/Stripe.podspec
+++ b/Stripe.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target          = '13.0'
   s.weak_framework                 = 'SwiftUI'
   s.source_files                   = 'Stripe/*.swift'
-  s.ios.resource_bundle            = { 'Stripe' => 'Stripe/Resources/**/*.{lproj,json,png,xcassets}' }
+  s.ios.resource_bundle            = { 'Stripe' => 'Stripe/Resources/**/*.{lproj,png}' }
   s.dependency                       'StripeCore', s.version.to_s
   s.dependency                       'StripeUICore', s.version.to_s
   s.dependency                       'StripeApplePay', s.version.to_s


### PR DESCRIPTION
## Summary
Removed non-existent references to `*.json` and `*.xcassets` in the Stripe podspec

```
ls Stripe/Resources/**/*.json | wc -l    
zsh: no matches found: Stripe/Resources/**/*.json
       0
       
ls Stripe/Resources/**/*.xcassets | wc -l
zsh: no matches found: Stripe/Resources/**/*.xcassets
       0  
```

## Motivation
Same as https://github.com/stripe/stripe-ios/pull/2020

## Testing
n/a

## Changelog
n/a