### PR TITLE
Add payment handler stubbed mocked tests back to project

### DIFF
--- a/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe.xcodeproj/project.pbxproj
@@ -278,6 +278,8 @@
 		6B48785627BDB7B100B7632D /* STPPaymentMethodAffirmTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B48785527BDB7B100B7632D /* STPPaymentMethodAffirmTests.swift */; };
 		6B80425827D1AC5D007CAFC1 /* STPAPIClientStubbedTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B80425727D1AC5D007CAFC1 /* STPAPIClientStubbedTest.swift */; };
 		6BB54EFD27ECF1E500069F06 /* STPPaymentMethodUSBankAccountParamsStubbedTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB54EFC27ECF1E500069F06 /* STPPaymentMethodUSBankAccountParamsStubbedTest.swift */; };
+		6BC4DC9C2937DD670022403B /* STPPaymentHandlerStubbedMockedFilesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BC4DC9B2937DD670022403B /* STPPaymentHandlerStubbedMockedFilesTests.swift */; };
+		6BC4DCA12937DF4F0022403B /* MockFiles in Resources */ = {isa = PBXBuildFile; fileRef = 6BC4DCA02937DF4F0022403B /* MockFiles */; };
 		6BF391B32832D64500FBB32D /* PaymentSheetPaymentMethodTypeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BF391B22832D64500FBB32D /* PaymentSheetPaymentMethodTypeTest.swift */; };
 		8B39128220E2F99600098401 /* EPSSource.json in Resources */ = {isa = PBXBuildFile; fileRef = 8B39128120E2F99600098401 /* EPSSource.json */; };
 		8B39128320E2F9A100098401 /* BancontactSource.json in Resources */ = {isa = PBXBuildFile; fileRef = 8B39127F20E2F6A500098401 /* BancontactSource.json */; };
@@ -805,6 +807,8 @@
 		6B48785527BDB7B100B7632D /* STPPaymentMethodAffirmTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPPaymentMethodAffirmTests.swift; sourceTree = "<group>"; };
 		6B80425727D1AC5D007CAFC1 /* STPAPIClientStubbedTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPAPIClientStubbedTest.swift; sourceTree = "<group>"; };
 		6BB54EFC27ECF1E500069F06 /* STPPaymentMethodUSBankAccountParamsStubbedTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = STPPaymentMethodUSBankAccountParamsStubbedTest.swift; sourceTree = "<group>"; };
+		6BC4DC9B2937DD670022403B /* STPPaymentHandlerStubbedMockedFilesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = STPPaymentHandlerStubbedMockedFilesTests.swift; sourceTree = "<group>"; };
+		6BC4DCA02937DF4F0022403B /* MockFiles */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = MockFiles; path = Tests/MockFiles; sourceTree = SOURCE_ROOT; };
 		6BF391B22832D64500FBB32D /* PaymentSheetPaymentMethodTypeTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSheetPaymentMethodTypeTest.swift; sourceTree = "<group>"; };
 		7E0B1132203572FB00271AD3 /* fi */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = fi; path = Localizations/fi.lproj/Localizable.strings; sourceTree = "<group>"; };
 		8B013C881F1E784A00DD831B /* STPPaymentConfigurationTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STPPaymentConfigurationTest.m; sourceTree = "<group>"; };
@@ -1557,6 +1561,7 @@
 		C18867D81E8B093300A77634 /* Unit */ = {
 			isa = PBXGroup;
 			children = (
+				6BC4DCA02937DF4F0022403B /* MockFiles */,
 				D092E37E27C5B91F00B72609 /* AnalyticsHelperTests.swift */,
 				B6D98972251C07FA00C3D894 /* APIRequestTest.swift */,
 				D0D59740280A29D900AAAB1E /* CardExpiryDateTests.swift */,
@@ -1653,6 +1658,7 @@
 				F14C872E1D4FCDBA00C7CC6A /* STPPaymentContextApplePayTest.m */,
 				3111C3FD252BC79E00207E32 /* STPPaymentContextApplePayTest.swift */,
 				36F9A11E25F6A3D600591514 /* STPPaymentHandlerTests.swift */,
+				6BC4DC9B2937DD670022403B /* STPPaymentHandlerStubbedMockedFilesTests.swift */,
 				36E295CD2522B2D500CF5C06 /* STPPaymentIntentEnumsTest.swift */,
 				36ADAE222523AC7700302DFB /* STPPaymentIntentLastPaymentErrorTest.swift */,
 				3111C3F0252BC79C00207E32 /* STPPaymentIntentParamsTest.swift */,
@@ -2019,6 +2025,7 @@
 				8BD2133E1F045D31007F6FD1 /* SEPADebitSource.json in Resources */,
 				B3BDCADF20F0142C0034F7F5 /* PaymentIntent.json in Resources */,
 				B613DD3E22C54BA800C7603F /* SetupIntent.json in Resources */,
+				6BC4DCA12937DF4F0022403B /* MockFiles in Resources */,
 				B632989F2295BDD90007D287 /* ApplePayPaymentMethod.json in Resources */,
 				8BD213371F044B57007F6FD1 /* BankAccount.json in Resources */,
 				C1C02CCC1ECCD0ED00DF5643 /* EphemeralKey.json in Resources */,
@@ -2272,6 +2279,7 @@
 				C1CFCB751ED5E12400BE45DF /* STPFileTest.m in Sources */,
 				8B5B4B441EFDD925005CF475 /* STPSourceOwnerTest.m in Sources */,
 				8B82C5CA1F2BC78F009639F7 /* STPApplePayPaymentOptionTest.m in Sources */,
+				6BC4DC9C2937DD670022403B /* STPPaymentHandlerStubbedMockedFilesTests.swift in Sources */,
 				B3BDCACF20EEF4640034F7F5 /* STPPaymentIntentFunctionalTest.m in Sources */,
 				3111C35725279C3B00207E32 /* STPSwiftFixtures.swift in Sources */,
 				3111C627252D3DCF00207E32 /* STPPaymentIntentTest.swift in Sources */,

--- a/Tests/Tests/STPPaymentHandlerStubbedMockedFilesTests.swift
+++ b/Tests/Tests/STPPaymentHandlerStubbedMockedFilesTests.swift
@@ -6,12 +6,16 @@
 //
 
 import OHHTTPStubs
+import OHHTTPStubsSwift
 import StripeCoreTestUtils
 import XCTest
 
 @testable@_spi(STP) import Stripe
 @testable@_spi(STP) import StripeApplePay
 @testable@_spi(STP) import StripeCore
+@testable@_spi(STP) import StripePaymentSheet
+@testable@_spi(STP) import StripePayments
+@testable@_spi(STP) import StripePaymentsUI
 
 class STPPaymentHandlerStubbedMockedFilesTests: APIStubbedTestCase, STPAuthenticationContext {
     override func setUp() {
@@ -252,7 +256,7 @@ class STPPaymentHandlerStubbedMockedFilesTests: APIStubbedTestCase, STPAuthentic
             }]
             """.data(using: .utf8)!
         let formSpec = try! JSONSerialization.jsonObject(with: updatedSpecJson) as! [NSDictionary]
-        FormSpecProvider.shared.load(from: formSpec)
+        FormSpecProvider.shared.loadFrom(formSpec)
         guard let affirmUpdated = FormSpecProvider.shared.formSpec(for: "affirm") else {
             XCTFail()
             return


### PR DESCRIPTION
## Summary
Seems like these tests got removed during the great reshuffle

## Motivation
We need these mock tests :)

## Testing
Executed unit tests in xcode
