### PR TITLE
Adding revolut pay as a payment method into payment sheet

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentMethodType.swift
@@ -17,6 +17,8 @@ extension PaymentSheet {
 
         func supportsAddingRequirements() -> [PaymentMethodTypeRequirement] {
             switch(self) {
+            case .dynamic("revolut_pay"):
+                return [.returnURL]
             default:
                 return [.unavailable]
             }
@@ -72,6 +74,8 @@ extension PaymentSheet {
         var displayName: String {
             if let stpPaymentMethodType = stpPaymentMethodType {
                 return stpPaymentMethodType.displayName
+            } else if case .dynamic("revolut_pay") = self {
+                return "Revolut Pay"
             } else if case .dynamic(let name) = self {
                 //TODO: We should introduce a display name in our model rather than presenting the payment method type
                 return name

--- a/StripePaymentSheet/StripePaymentSheet/Resources/JSON/form_specs.json
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/JSON/form_specs.json
@@ -436,6 +436,32 @@
     }
 },
 {
+    "type": "revolut_pay",
+    "async": false,
+    "selector_icon": {
+        "light_theme_png": "https://js.stripe.com/v3/fingerprinted/img/payment-methods/icon-pm-revolutpay@3x-71e94e0b505ece2af665eb0503be405d.png",
+        "dark_theme_png": "https://js.stripe.com/v3/fingerprinted/img/payment-methods/icon-pm-revolutpay_dark@3x-60943829a069f1c3ac619e4da0ab1ef0.png",
+        "light_theme_svg": "https://js.stripe.com/v3/fingerprinted/img/payment-methods/revolutPay-1f86fe1f353d59bea0e62ff027bfdb30.svg"
+    },
+    "fields": [
+    ],
+    "next_action_spec": {
+        "confirm_response_status_specs": {
+            "requires_action": {
+                "type": "redirect_to_url"
+            }
+        },
+        "post_confirm_handling_pi_status_specs": {
+            "succeeded": {
+                "type": "finished"
+            },
+            "requires_action": {
+                "type": "canceled"
+            }
+        }
+    }
+},
+{
     "type": "card",
     "async": false,
     "fields": [


### PR DESCRIPTION
## Summary
Add payment method to payment sheet w/ default lpm ui configuration

## Motivation
Support for mobile pay in payment sheet

## Testing
Feature is behind a feature gate for specific merchants.  Tested w/ updating v6 endpoint w/ test merchant.

