### PR TITLE
Adding MobilePay as a payment method into payment sheet

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentMethodType.swift
@@ -19,6 +19,8 @@ extension PaymentSheet {
             switch(self) {
             case .dynamic("revolut_pay"):
                 return [.returnURL]
+            case .dynamic("mobilepay"):
+                return [.returnURL]
             default:
                 return [.unavailable]
             }
@@ -76,6 +78,8 @@ extension PaymentSheet {
                 return stpPaymentMethodType.displayName
             } else if case .dynamic("revolut_pay") = self {
                 return "Revolut Pay"
+            } else if case .dynamic("mobilepay") = self {
+                return "MobilePay"
             } else if case .dynamic(let name) = self {
                 //TODO: We should introduce a display name in our model rather than presenting the payment method type
                 return name

--- a/StripePaymentSheet/StripePaymentSheet/Resources/JSON/form_specs.json
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/JSON/form_specs.json
@@ -462,6 +462,31 @@
     }
 },
 {
+  "type": "mobilepay",
+  "async": false,
+  "selector_icon": {
+    "light_theme_png": "https://js.stripe.com/v3/fingerprinted/img/payment-methods/icon-pm-mobilepay@3x-23fda467d59a37d21796b2e4abc45c11.png",
+    "light_theme_svg": "https://js.stripe.com/v3/fingerprinted/img/payment-methods/mobilepay-8473098c2f914f0376b4526d75438513.svg"
+  },
+  "fields": [],
+  "next_action_spec": {
+    "confirm_response_status_specs": {
+      "requires_action": {
+        "type": "redirect_to_url",
+        "native_mobile_redirect_strategy" : "follow_redirects"
+      }
+    },
+    "post_confirm_handling_pi_status_specs": {
+      "succeeded": {
+        "type": "finished"
+      },
+      "requires_action": {
+        "type": "canceled"
+      }
+    }
+  }
+},
+{
     "type": "card",
     "async": false,
     "fields": [


### PR DESCRIPTION
## Summary
Adding MobilePay as a payment method into payment sheet

## Motivation
Support for mobile pay

Submitting this PR ahould allow the LUXE team to support the MobilePay beta on iOS.  There should not be any future client side code changes, so we believe that now is an appropriate time to push iOS changes into the client.  Merchants will not see this payment method unless they:
        1. Are gated into server side feature gate
        2. Request for this payment method in the when creating a payment intent

## Testing
Tested against dev box
Dogfooded with mobile pay team in production