### PR TITLE
Build on all branches

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -14,7 +14,7 @@ app:
       is_expand: false
     FASTLANE_LANE: ios integration_all
 trigger_map:
-- push_branch: master
+- push_branch: "*"
   pipeline: main-trigger-pipeline
 - pull_request_source_branch: "*"
   pipeline: main-trigger-pipeline


### PR DESCRIPTION
## Summary
Build all branches when pushed, instead of only building branches with PRs attached.

## Motivation
I noticed that our other repos do this, and it's nice to have slightly faster results.

## Testing
CI