### PR TITLE
Add an endpoint selector to TestPlayground

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example.xcodeproj/project.pbxproj
+++ b/Example/PaymentSheet Example/PaymentSheet Example.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		611CF06C27C9858200E43BB2 /* PaymentSheetSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611CF06B27C9858200E43BB2 /* PaymentSheetSnapshotTests.swift */; };
 		615EF61927DA473A00F8E0EE /* AppearancePlaygroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615EF61827DA473A00F8E0EE /* AppearancePlaygroundView.swift */; };
 		61A20BC127CA767500260BC5 /* StripeCoreTestUtils.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61A20BC027CA767500260BC5 /* StripeCoreTestUtils.framework */; };
+		6B0236B829411834007D29CC /* EndpointSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B0236B729411834007D29CC /* EndpointSelectorViewController.swift */; };
 		6B3F9F6A28078A0E00C81DDC /* StripeFinancialConnections.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6B8BD78527F555B8007463B3 /* StripeFinancialConnections.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		6B8BD78627F555B8007463B3 /* StripeFinancialConnections.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B8BD78527F555B8007463B3 /* StripeFinancialConnections.framework */; };
 		6BCAA43C281B7D78001691F1 /* MockFiles in Resources */ = {isa = PBXBuildFile; fileRef = 6BCAA43B281B7D78001691F1 /* MockFiles */; };
@@ -196,6 +197,7 @@
 		611CF06B27C9858200E43BB2 /* PaymentSheetSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSheetSnapshotTests.swift; sourceTree = "<group>"; };
 		615EF61827DA473A00F8E0EE /* AppearancePlaygroundView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppearancePlaygroundView.swift; sourceTree = "<group>"; };
 		61A20BC027CA767500260BC5 /* StripeCoreTestUtils.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = StripeCoreTestUtils.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6B0236B729411834007D29CC /* EndpointSelectorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndpointSelectorViewController.swift; sourceTree = "<group>"; };
 		6B8BD78527F555B8007463B3 /* StripeFinancialConnections.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = StripeFinancialConnections.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6BCAA43B281B7D78001691F1 /* MockFiles */ = {isa = PBXFileReference; lastKnownFileType = folder; name = MockFiles; path = PaymentSheetUITest/MockFiles; sourceTree = "<group>"; };
 		B6370756251057890094499F /* PaymentSheet Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "PaymentSheet Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -314,6 +316,7 @@
 				615EF61827DA473A00F8E0EE /* AppearancePlaygroundView.swift */,
 				B67BC53C257AB9D300B7349B /* ViewController.swift */,
 				31319EE525B21DC200C89E30 /* ExampleSwiftUIViews.swift */,
+				6B0236B729411834007D29CC /* EndpointSelectorViewController.swift */,
 			);
 			path = "PaymentSheet Example";
 			sourceTree = "<group>";
@@ -542,6 +545,7 @@
 				31319EE825B2328700C89E30 /* ExampleSwiftUICustomPaymentFlow.swift in Sources */,
 				B637075E251057890094499F /* PaymentSheetTestPlayground.swift in Sources */,
 				B637075A251057890094499F /* AppDelegate.swift in Sources */,
+				6B0236B829411834007D29CC /* EndpointSelectorViewController.swift in Sources */,
 				B68A9E32257D8E8800E904B5 /* ExampleCustomCheckoutViewController.swift in Sources */,
 				31319EE425B11FA000C89E30 /* ExampleSwiftUIPaymentSheet.swift in Sources */,
 				31319EE625B21DC200C89E30 /* ExampleSwiftUIViews.swift in Sources */,

--- a/Example/PaymentSheet Example/PaymentSheet Example/EndpointSelectorViewController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/EndpointSelectorViewController.swift
@@ -149,7 +149,7 @@ extension EndpointSelectorViewController {
 
 // MARK: - Helpers
 extension EndpointSelectorViewController {
-    func endpointFor(indexPath: IndexPath) -> String? {
+    func endpoint(for indexPath: IndexPath) -> String? {
         if indexPath.section == 0 {
             return currentCheckoutEndpoint
         }

--- a/Example/PaymentSheet Example/PaymentSheet Example/EndpointSelectorViewController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/EndpointSelectorViewController.swift
@@ -167,7 +167,7 @@ extension EndpointSelectorViewController {
         return endpointsInSection[indexPath.row]
     }
 
-    func sortedSections() -> [Dictionary<String, [String]>.Element]? {
+    func sortedSections() -> [[String: [String]].Element]? {
         guard let specs = endpointSpecs else {
             return nil
         }

--- a/Example/PaymentSheet Example/PaymentSheet Example/EndpointSelectorViewController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/EndpointSelectorViewController.swift
@@ -102,7 +102,9 @@ extension EndpointSelectorViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = UITableViewCell(style: .default, reuseIdentifier: "endpoint")
+        let reuseIdentifier = "endpointCell"
+        let cell = tableView.dequeueReusableCell(withIdentifier: reuseIdentifier) ??
+                    UITableViewCell(style: .default, reuseIdentifier: reuseIdentifier)
         guard let endpoint = endpoint(for: indexPath) else {
             return cell
         }

--- a/Example/PaymentSheet Example/PaymentSheet Example/EndpointSelectorViewController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/EndpointSelectorViewController.swift
@@ -87,10 +87,7 @@ extension EndpointSelectorViewController {
             return 0
         }
         let sectionKey = sortedSection[sectionNumberIndex].key
-        guard let endpointsInSection = specs.endpointMap[sectionKey] else {
-            return 0
-        }
-        return endpointsInSection.count
+        return specs.endpointMap[sectionKey]?.count ?? 0
     }
     override func tableView(_ tableView: UITableView, titleForHeaderInSection sectionNumber: Int) -> String? {
         if sectionNumber == 0 {

--- a/Example/PaymentSheet Example/PaymentSheet Example/EndpointSelectorViewController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/EndpointSelectorViewController.swift
@@ -1,0 +1,190 @@
+//
+//  EndpointSelector.swift
+//  PaymentSheet Example
+//
+
+import Foundation
+import UIKit
+
+protocol EndpointSelectorViewControllerDelegate: AnyObject {
+    func selected(endpoint: String) -> Void
+    func cancelTapped() -> Void
+}
+
+class EndpointSelectorViewController: UITableViewController {
+
+    let endpointSelectorEndpoint: String
+    var currentCheckoutEndpoint: String
+
+    weak var selectorDelegate: EndpointSelectorViewControllerDelegate?
+    var endpointSpecs: EndpointSpec?
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    init(delegate: EndpointSelectorViewControllerDelegate,
+         endpointSelectorEndpoint: String,
+         currentCheckoutEndpoint: String) {
+        self.selectorDelegate = delegate
+        self.endpointSelectorEndpoint = endpointSelectorEndpoint
+        self.currentCheckoutEndpoint = currentCheckoutEndpoint
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    override func viewDidLoad() {
+        loadEndpointSelector(endpoint: endpointSelectorEndpoint)
+        setBarButtonItems()
+    }
+
+    func setBarButtonItems() {
+        let barButtonItem = UIBarButtonItem(title: "Set Manually", style: .plain, target: self, action: #selector(didTapSetManually))
+        navigationItem.rightBarButtonItems = [barButtonItem]
+        let cancel = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(didTapCancel))
+        navigationItem.leftBarButtonItems = [cancel]
+    }
+
+    @objc func didTapCancel() {
+        self.selectorDelegate?.cancelTapped()
+    }
+
+    @objc func didTapSetManually() {
+        let alertController = UIAlertController(title: "Set Endpoint Manually", message: nil, preferredStyle: .alert)
+        alertController.addTextField { textField in
+            textField.text = self.currentCheckoutEndpoint
+        }
+
+        let submitAction = UIAlertAction(title: "Submit", style: .default) { [unowned alertController] _ in
+            guard let textFields = alertController.textFields,
+                  let input = textFields[0].text else {
+                return
+            }
+            self.selectorDelegate?.selected(endpoint: input)
+            self.navigationController?.popViewController(animated: true)
+        }
+        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel)
+        alertController.addAction(submitAction)
+        alertController.addAction(cancelAction)
+        present(alertController, animated: true)
+    }
+}
+
+// MARK: - TableViewController
+extension EndpointSelectorViewController {
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        guard let specs = endpointSpecs else {
+            return 2
+        }
+        return specs.endpointMap.count + 1
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection sectionNumber: Int) -> Int {
+        if sectionNumber == 0 {
+            return 1
+        }
+        let sectionNumberIndex = sectionNumber - 1
+        guard let specs = endpointSpecs,
+              let sortedSection = sortedSections() else {
+            return 0
+        }
+        let sectionKey = sortedSection[sectionNumberIndex].key
+        guard let endpointsInSection = specs.endpointMap[sectionKey] else {
+            return 0
+        }
+        return endpointsInSection.count
+    }
+    override func tableView(_ tableView: UITableView, titleForHeaderInSection sectionNumber: Int) -> String? {
+        if sectionNumber == 0 {
+            return "Current Endpoint"
+        }
+
+        let sectionNumberIndex = sectionNumber - 1
+        guard let sortedSection = sortedSections() else {
+            return "Loading..."
+        }
+        return sortedSection[sectionNumberIndex].key
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = UITableViewCell(style: .default, reuseIdentifier: "endpoint")
+        guard let endpoint = endpointFor(indexPath: indexPath) else {
+            return cell
+        }
+        cell.textLabel?.text = endpoint
+        cell.textLabel?.font = .preferredFont(forTextStyle: .caption1)
+        cell.textLabel?.numberOfLines = 0
+        return cell
+    }
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        guard let endpoint = endpointFor(indexPath: indexPath) else {
+            return
+        }
+        self.selectorDelegate?.selected(endpoint: endpoint)
+        self.navigationController?.popViewController(animated: true)
+    }
+}
+// MARK: Cheap Data provider
+extension EndpointSelectorViewController {
+    func loadEndpointSelector(endpoint: String) {
+        let request = URLRequest(url: URL(string: endpoint)!)
+        let session = URLSession.shared.dataTask(with: request) { data, response, error in
+            guard error == nil,
+                  let data = data,
+                  let specs = self.deserializeResponse(data: data) else {
+                fatalError("FAILED on endpoint selector url request")
+                return
+            }
+            self.endpointSpecs = specs
+            DispatchQueue.main.async {
+                self.tableView.reloadData()
+            }
+        }
+        session.resume()
+    }
+    func deserializeResponse(data: Data) -> EndpointSpec? {
+        let decoder = JSONDecoder()
+        do {
+            return try decoder.decode(EndpointSpec.self, from: data)
+        } catch {
+            return nil
+        }
+    }
+}
+
+// MARK: - Helpers
+extension EndpointSelectorViewController {
+    func endpointFor(indexPath: IndexPath) -> String? {
+        if indexPath.section == 0 {
+            return currentCheckoutEndpoint
+        }
+        guard let specs = endpointSpecs,
+              let sortedSection = sortedSections() else {
+            return nil
+        }
+        let sectionKey = sortedSection[indexPath.section-1].key
+        guard let endpointsInSection = specs.endpointMap[sectionKey] else {
+            return nil
+        }
+        return endpointsInSection[indexPath.row]
+    }
+
+    func sortedSections() -> [Dictionary<String, [String]>.Element]? {
+        guard let specs = endpointSpecs else {
+            return nil
+        }
+        return specs.endpointMap.sorted { k1, k2 in
+            k1.key < k2.key
+        }
+    }
+}
+
+struct EndpointSpec: Codable {
+    let endpointMap: [String: [String]]
+
+    private enum CodingKeys: String, CodingKey {
+        case endpointMap = "endpoint_map"
+    }
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.endpointMap = try container.decode([String: [String]].self, forKey: .endpointMap)
+    }
+}

--- a/Example/PaymentSheet Example/PaymentSheet Example/EndpointSelectorViewController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/EndpointSelectorViewController.swift
@@ -164,7 +164,7 @@ extension EndpointSelectorViewController {
         return endpointsInSection[indexPath.row]
     }
 
-    func sortedSections() -> [Dictionary<String, [String]>.Element]? {
+    func sortedSections() -> [String: [String]].Element]? {
         guard let specs = endpointSpecs else {
             return nil
         }

--- a/Example/PaymentSheet Example/PaymentSheet Example/EndpointSelectorViewController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/EndpointSelectorViewController.swift
@@ -166,7 +166,7 @@ extension EndpointSelectorViewController {
         return endpointsInSection[indexPath.row]
     }
 
-    func sortedSections() -> [String: [String]].Element]? {
+    func sortedSections() -> [Dictionary<String, [String]>.Element]? {
         guard let specs = endpointSpecs else {
             return nil
         }

--- a/Example/PaymentSheet Example/PaymentSheet Example/EndpointSelectorViewController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/EndpointSelectorViewController.swift
@@ -168,9 +168,7 @@ extension EndpointSelectorViewController {
         guard let specs = endpointSpecs else {
             return nil
         }
-        return specs.endpointMap.sorted { k1, k2 in
-            k1.key < k2.key
-        }
+        return specs.endpointMap.sorted { $0.key < $1.key }
     }
 }
 

--- a/Example/PaymentSheet Example/PaymentSheet Example/EndpointSelectorViewController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/EndpointSelectorViewController.swift
@@ -12,7 +12,7 @@ protocol EndpointSelectorViewControllerDelegate: AnyObject {
 }
 
 class EndpointSelectorViewController: UITableViewController {
-
+    let reuseIdentifierEndpointCell = "endpointCell"
     let endpointSelectorEndpoint: String
     var currentCheckoutEndpoint: String
 
@@ -32,6 +32,7 @@ class EndpointSelectorViewController: UITableViewController {
     }
 
     override func viewDidLoad() {
+        self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: reuseIdentifierEndpointCell)
         loadEndpointSelector(endpoint: endpointSelectorEndpoint)
         setBarButtonItems()
     }
@@ -102,9 +103,7 @@ extension EndpointSelectorViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let reuseIdentifier = "endpointCell"
-        let cell = tableView.dequeueReusableCell(withIdentifier: reuseIdentifier) ??
-                    UITableViewCell(style: .default, reuseIdentifier: reuseIdentifier)
+        let cell = tableView.dequeueReusableCell(withIdentifier: reuseIdentifierEndpointCell, for: indexPath)
         guard let endpoint = endpoint(for: indexPath) else {
             return cell
         }

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheet Example/Base.lproj/Main.storyboard
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheet Example/Base.lproj/Main.storyboard
@@ -24,7 +24,7 @@
                                         <rect key="frame" x="7" y="8" width="424.5" height="536"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jrR-tz-of1">
-                                                <rect key="frame" x="0.0" y="0.0" width="261.5" height="34.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="353.5" height="34.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Backend Configuration" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JO4-Gk-gKi">
                                                         <rect key="frame" x="0.0" y="0.0" width="182" height="34.5"/>
@@ -32,8 +32,16 @@
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" role="destructive" translatesAutoresizingMaskIntoConstraints="NO" id="7iR-MX-Gqc">
+                                                        <rect key="frame" x="182" y="0.0" width="92" height="34.5"/>
+                                                        <state key="normal" title="Button"/>
+                                                        <buttonConfiguration key="configuration" style="plain" title="Endpoint"/>
+                                                        <connections>
+                                                            <action selector="didTapEndpointConfiguration:" destination="BYZ-38-t0r" eventType="touchUpInside" id="EzL-AG-TGa"/>
+                                                        </connections>
+                                                    </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" role="destructive" translatesAutoresizingMaskIntoConstraints="NO" id="M59-S6-kSV">
-                                                        <rect key="frame" x="182" y="0.0" width="79.5" height="34.5"/>
+                                                        <rect key="frame" x="274" y="0.0" width="79.5" height="34.5"/>
                                                         <state key="normal" title="Button"/>
                                                         <buttonConfiguration key="configuration" style="plain" title="(Reset)"/>
                                                         <connections>
@@ -327,28 +335,28 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="jms-ec-kSI" userLabel="Other Stack View">
-                                        <rect key="frame" x="1" y="552" width="750" height="313"/>
+                                        <rect key="frame" x="1" y="552" width="413" height="313"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="252" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Vls-MT-OoY">
-                                                <rect key="frame" x="0.0" y="0.0" width="750" height="30"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="413" height="30"/>
                                                 <color key="backgroundColor" systemColor="secondarySystemBackgroundColor"/>
                                                 <state key="normal" title="Reload PaymentSheet"/>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8Gn-Qk-wur">
-                                                <rect key="frame" x="0.0" y="40" width="750" height="1"/>
+                                                <rect key="frame" x="0.0" y="40" width="413" height="1"/>
                                                 <color key="backgroundColor" systemColor="systemFillColor"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="1" id="I05-pn-Hpo"/>
                                                 </constraints>
                                             </view>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="PaymentSheet.FlowController" textAlignment="justified" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uDt-e8-LYu">
-                                                <rect key="frame" x="0.0" y="51" width="750" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="51" width="413" height="20.5"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Z0z-Ny-bk6" userLabel="Shipping address row">
-                                                <rect key="frame" x="0.0" y="81.5" width="750" height="50"/>
+                                                <rect key="frame" x="0.0" y="81.5" width="413" height="50"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Shipping address" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OO7-eH-azK">
                                                         <rect key="frame" x="0.0" y="0.0" width="126" height="50"/>
@@ -356,7 +364,7 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <button opaque="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="1000" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" enabled="NO" contentHorizontalAlignment="fill" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JpZ-os-9es">
-                                                        <rect key="frame" x="704" y="9" width="30" height="32"/>
+                                                        <rect key="frame" x="367" y="9" width="30" height="32"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="Shipping address">
                                                             <accessibilityTraits key="traits" button="YES"/>
                                                         </accessibility>
@@ -377,7 +385,7 @@
                                                 </constraints>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Kh7-OF-7WJ" userLabel="Payment method row">
-                                                <rect key="frame" x="0.0" y="141.5" width="750" height="50"/>
+                                                <rect key="frame" x="0.0" y="141.5" width="413" height="50"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Payment method" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pVB-4m-xhr">
                                                         <rect key="frame" x="0.0" y="0.0" width="123" height="50"/>
@@ -385,7 +393,7 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <button opaque="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="1000" verticalHuggingPriority="750" verticalCompressionResistancePriority="250" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EKp-ZG-IRr">
-                                                        <rect key="frame" x="623" y="8" width="71" height="34"/>
+                                                        <rect key="frame" x="286" y="8" width="71" height="34"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="Payment method" label="Select Payment Method"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                                                         <state key="normal" title="Add"/>
@@ -395,7 +403,7 @@
                                                         </userDefinedRuntimeAttributes>
                                                     </button>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="goU-YD-Yq5">
-                                                        <rect key="frame" x="702" y="15" width="32" height="20"/>
+                                                        <rect key="frame" x="365" y="15" width="32" height="20"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="32" id="hfL-tn-QSe"/>
                                                             <constraint firstAttribute="height" constant="20" id="x35-RU-BVf"/>
@@ -414,24 +422,24 @@
                                                 </constraints>
                                             </view>
                                             <button opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="447-yR-5wb">
-                                                <rect key="frame" x="0.0" y="201.5" width="750" height="30"/>
+                                                <rect key="frame" x="0.0" y="201.5" width="413" height="30"/>
                                                 <state key="normal" title="Checkout (Custom)"/>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mq9-Va-Cpj">
-                                                <rect key="frame" x="0.0" y="241.5" width="750" height="1"/>
+                                                <rect key="frame" x="0.0" y="241.5" width="413" height="1"/>
                                                 <color key="backgroundColor" systemColor="systemFillColor"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="1" id="p9a-er-j94"/>
                                                 </constraints>
                                             </view>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="PaymentSheet" textAlignment="justified" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SYx-vq-gAZ">
-                                                <rect key="frame" x="0.0" y="252.5" width="750" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="252.5" width="413" height="20.5"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WKM-YW-c0t">
-                                                <rect key="frame" x="0.0" y="283" width="750" height="30"/>
+                                                <rect key="frame" x="0.0" y="283" width="413" height="30"/>
                                                 <state key="normal" title="Checkout (Complete)"/>
                                             </button>
                                         </subviews>

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -15,6 +15,9 @@ import UIKit
 import SwiftUI
 import PassKit
 
+let endpointSelectorEndpoint = "https://stripe-mobile-payment-sheet-test-playground-v6.glitch.me/endpoints"
+let defaultCheckoutEndpoint = "https://stripe-mobile-payment-sheet-test-playground-v6.glitch.me/checkout"
+
 class PaymentSheetTestPlayground: UIViewController {
     static var paymentSheetPlaygroundSettings: PaymentSheetPlaygroundSettings? = nil
 
@@ -249,6 +252,7 @@ class PaymentSheetTestPlayground: UIViewController {
     var clientSecret: String?
     var ephemeralKey: String?
     var customerID: String?
+    var checkoutEndpoint: String?
     var paymentSheetFlowController: PaymentSheet.FlowController?
     var addressViewController: AddressViewController?
     var appearance = PaymentSheet.Appearance.default
@@ -291,6 +295,8 @@ class PaymentSheetTestPlayground: UIViewController {
         } else if let nsUserDefaultSettings = settingsFromDefaults() {
             loadSettingsFrom(settings: nsUserDefaultSettings)
             loadBackend()
+        } else {
+            checkoutEndpoint = defaultCheckoutEndpoint
         }
     }
 
@@ -376,6 +382,14 @@ class PaymentSheetTestPlayground: UIViewController {
         self.selectPaymentMethodButton.setNeedsLayout()
     }
 
+    @IBAction func didTapEndpointConfiguration(_ sender: Any) {
+        let endpointSelector = EndpointSelectorViewController(delegate: self,
+                                                              endpointSelectorEndpoint: endpointSelectorEndpoint,
+                                                              currentCheckoutEndpoint: checkoutEndpoint!)
+        let navController = UINavigationController(rootViewController: endpointSelector)
+        self.navigationController?.present(navController, animated: true, completion: nil)
+    }
+
     @IBAction func didTapResetConfig(_ sender: Any) {
         loadSettingsFrom(settings: PaymentSheetPlaygroundSettings.defaultValues())
     }
@@ -413,7 +427,7 @@ extension PaymentSheetTestPlayground {
         addressViewController = nil
 
         let session = URLSession.shared
-        let url = URL(string: "https://stripe-mobile-payment-sheet-test-playground-v6.glitch.me/checkout")!
+        let url = URL(string: checkoutEndpoint!)!
         let customer: String = {
             switch customerMode {
             case .guest:
@@ -508,6 +522,7 @@ struct PaymentSheetPlaygroundSettings: Codable {
     let shippingInfoSelectorValue: Int
     let linkSelectorValue: Int
     let customCtaLabel: String?
+    let checkoutEndpoint: String?
 
     static func defaultValues() -> PaymentSheetPlaygroundSettings {
         return PaymentSheetPlaygroundSettings(
@@ -522,7 +537,8 @@ struct PaymentSheetPlaygroundSettings: Codable {
             defaultBillingAddressSelectorValue: 1,
             shippingInfoSelectorValue: 0,
             linkSelectorValue: 1,
-            customCtaLabel: nil
+            customCtaLabel: nil,
+            checkoutEndpoint: defaultCheckoutEndpoint
         )
     }
 }
@@ -533,6 +549,20 @@ extension PaymentSheetTestPlayground: AddressViewControllerDelegate {
         addressViewController.dismiss(animated: true)
         self.addressDetails = address
         self.updateButtons()
+    }
+}
+
+// MARK: - EndpointSelectorViewControllerDelegate
+extension PaymentSheetTestPlayground: EndpointSelectorViewControllerDelegate {
+    func selected(endpoint: String) -> Void {
+        checkoutEndpoint = endpoint
+        serializeSettingsToNSUserDefaults()
+        loadBackend()
+        self.navigationController?.dismiss(animated: true)
+
+    }
+    func cancelTapped() -> Void {
+        self.navigationController?.dismiss(animated: true)
     }
 }
 
@@ -552,7 +582,8 @@ extension PaymentSheetTestPlayground {
             defaultBillingAddressSelectorValue: defaultBillingAddressSelector.selectedSegmentIndex,
             shippingInfoSelectorValue: shippingInfoSelector.selectedSegmentIndex,
             linkSelectorValue: linkSelector.selectedSegmentIndex,
-            customCtaLabel: customCTALabelTextField.text
+            customCtaLabel: customCTALabelTextField.text,
+            checkoutEndpoint: checkoutEndpoint
         )
         let data = try! JSONEncoder().encode(settings)
         UserDefaults.standard.set(data, forKey: PaymentSheetPlaygroundSettings.nsUserDefaultsKey)
@@ -583,6 +614,7 @@ extension PaymentSheetTestPlayground {
         automaticPaymentMethodsSelector.selectedSegmentIndex = settings.automaticPaymentMethodsSelectorValue
         linkSelector.selectedSegmentIndex = settings.linkSelectorValue
         customCTALabelTextField.text = settings.customCtaLabel
+        checkoutEndpoint = settings.checkoutEndpoint ?? defaultCheckoutEndpoint
     }
 }
 

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -252,7 +252,7 @@ class PaymentSheetTestPlayground: UIViewController {
     var clientSecret: String?
     var ephemeralKey: String?
     var customerID: String?
-    var checkoutEndpoint: String?
+    var checkoutEndpoint: String = defaultCheckoutEndpoint
     var paymentSheetFlowController: PaymentSheet.FlowController?
     var addressViewController: AddressViewController?
     var appearance = PaymentSheet.Appearance.default
@@ -295,8 +295,6 @@ class PaymentSheetTestPlayground: UIViewController {
         } else if let nsUserDefaultSettings = settingsFromDefaults() {
             loadSettingsFrom(settings: nsUserDefaultSettings)
             loadBackend()
-        } else {
-            checkoutEndpoint = defaultCheckoutEndpoint
         }
     }
 
@@ -385,7 +383,7 @@ class PaymentSheetTestPlayground: UIViewController {
     @IBAction func didTapEndpointConfiguration(_ sender: Any) {
         let endpointSelector = EndpointSelectorViewController(delegate: self,
                                                               endpointSelectorEndpoint: endpointSelectorEndpoint,
-                                                              currentCheckoutEndpoint: checkoutEndpoint!)
+                                                              currentCheckoutEndpoint: checkoutEndpoint)
         let navController = UINavigationController(rootViewController: endpointSelector)
         self.navigationController?.present(navController, animated: true, completion: nil)
     }
@@ -427,7 +425,7 @@ extension PaymentSheetTestPlayground {
         addressViewController = nil
 
         let session = URLSession.shared
-        let url = URL(string: checkoutEndpoint!)!
+        let url = URL(string: checkoutEndpoint)!
         let customer: String = {
             switch customerMode {
             case .guest:

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -15,10 +15,10 @@ import UIKit
 import SwiftUI
 import PassKit
 
-let endpointSelectorEndpoint = "https://stripe-mobile-payment-sheet-test-playground-v6.glitch.me/endpoints"
-let defaultCheckoutEndpoint = "https://stripe-mobile-payment-sheet-test-playground-v6.glitch.me/checkout"
-
 class PaymentSheetTestPlayground: UIViewController {
+    static let endpointSelectorEndpoint = "https://stripe-mobile-payment-sheet-test-playground-v6.glitch.me/endpoints"
+    static let defaultCheckoutEndpoint = "https://stripe-mobile-payment-sheet-test-playground-v6.glitch.me/checkout"
+
     static var paymentSheetPlaygroundSettings: PaymentSheetPlaygroundSettings? = nil
 
     // Configuration
@@ -382,7 +382,7 @@ class PaymentSheetTestPlayground: UIViewController {
 
     @IBAction func didTapEndpointConfiguration(_ sender: Any) {
         let endpointSelector = EndpointSelectorViewController(delegate: self,
-                                                              endpointSelectorEndpoint: endpointSelectorEndpoint,
+                                                              endpointSelectorEndpoint: Self.endpointSelectorEndpoint,
                                                               currentCheckoutEndpoint: checkoutEndpoint)
         let navController = UINavigationController(rootViewController: endpointSelector)
         self.navigationController?.present(navController, animated: true, completion: nil)
@@ -536,7 +536,7 @@ struct PaymentSheetPlaygroundSettings: Codable {
             shippingInfoSelectorValue: 0,
             linkSelectorValue: 1,
             customCtaLabel: nil,
-            checkoutEndpoint: defaultCheckoutEndpoint
+            checkoutEndpoint: PaymentSheetTestPlayground.defaultCheckoutEndpoint
         )
     }
 }
@@ -612,7 +612,7 @@ extension PaymentSheetTestPlayground {
         automaticPaymentMethodsSelector.selectedSegmentIndex = settings.automaticPaymentMethodsSelectorValue
         linkSelector.selectedSegmentIndex = settings.linkSelectorValue
         customCTALabelTextField.text = settings.customCtaLabel
-        checkoutEndpoint = settings.checkoutEndpoint ?? defaultCheckoutEndpoint
+        checkoutEndpoint = settings.checkoutEndpoint ?? PaymentSheetTestPlayground.defaultCheckoutEndpoint
     }
 }
 


### PR DESCRIPTION
## Summary
Added a way to select your endpoint by storing a list of endpoints on the -v6 endpoint:
```
app.get("/endpoints", async (req, res) => {
  let endpointMap = {
    "LPM Betas": [
      "https://pool-seen-sandal.glitch.me/checkout",
      "https://some-other-endpoint.glitch.me/checkout"
    ],
    "Shared Endpoints": [
      "https://stripe-mobile-payment-sheet-test-playground-v6.glitch.me/checkout"      
    ]
  };
  let payload = {
    "endpoint_map" : endpointMap
  }
  res.send(payload);
});
```


## Motivation
Ability to select different endpoints for dogfooding/betas/etc.

## Testing
- Emulator: Fresh install, ensuring defaults are set/loaded
- Emulator: Subsequent installs
- Reseting all defaults, etc.



![endpoint_selector](https://user-images.githubusercontent.com/99628984/206347455-cb775cab-bd8a-459f-bdf3-339d56ac436e.gif)

Annotation:
1.  Switches to GBP/GB merchant
2.  Loads backend for -v6 endpoint and creates new PI
3.  Loads payment sheet and shows two payment methods (card and paypal)
4.  Cancels payment sheet
5. Clicks on new "Endpoint" settings, which presents a modal
6.  Notice that the first section shows what the current endpoint
7.  User selects a different endpoint under section "LPM Betas", which applies these settings and dismisses the modal, and reloads automatically
8. payment sheet is presented, and since we are hitting the new endpoint which has 3 payment methods (card, paypal, and afterpay).  Then we dismiss payment sheet...
9. Finally, demonstrates that users can set the endpoint manually if they want.
