### PR TITLE
Switch legacy_tests_13 to use x86_64 builder

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -233,6 +233,10 @@ workflows:
     - prep_all
     after_run:
     - upload_logs
+    meta:
+      bitrise.io:
+        stack: osx-xcode-13.3.x
+        machine_type_id: g2.12core
   legacy-tests-14:
     steps:
     - fastlane@3:


### PR DESCRIPTION
## Summary
We're seeing some issues in CI where Rosetta doesn't work early in the boot process, so the iOS 13 simulator runtime's `liblaunch_sim.dylib` (which is only available for x86_64) can't be loaded. Let's make our lives a little easier by running these tests natively instead of using Rosetta on an M1 VM.

## Testing
CI, manually kicked off the legacy_tests_13 job: https://app.bitrise.io/build/504b6a5a-1131-4682-a6f0-bde056087792