### PR TITLE
Fix not setting moto for Dashboard 

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Intent.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Intent.swift
@@ -222,6 +222,7 @@ extension STPConfirmPaymentMethodOptions {
             cardOptions = cardOptions ?? STPConfirmCardOptions()
             cardOptions?.additionalAPIParameters["setup_future_usage"] = sfuValue
         case .USBankAccount:
+            // Note: the SFU value passed in the STPConfirmUSBankAccountOptions init will be overwritten by `additionalAPIParameters`. See https://jira.corp.stripe.com/browse/RUN_MOBILESDK-1737
             usBankAccountOptions = usBankAccountOptions ?? STPConfirmUSBankAccountOptions(setupFutureUsage: .none)
             usBankAccountOptions?.additionalAPIParameters["setup_future_usage"] = sfuValue
         default:

--- a/Tests/Tests/PaymentSheet+APITest.swift
+++ b/Tests/Tests/PaymentSheet+APITest.swift
@@ -39,17 +39,6 @@ class PaymentSheetAPITest: XCTestCase {
         }
         return config
     }()
-    var newCardPaymentOption: PaymentOption {
-        let cardParams = STPPaymentMethodCardParams()
-        cardParams.number = "4242424242424242"
-        cardParams.cvc = "123"
-        cardParams.expYear = 22
-        cardParams.expMonth = 12
-        return .new(confirmParams: IntentConfirmParams(
-            params: .init(card: cardParams, billingDetails: .init(), metadata: nil),
-            type: .card
-        ))
-    }
 
     override class func setUp() {
         super.setUp()
@@ -125,11 +114,27 @@ class PaymentSheetAPITest: XCTestCase {
                         )
                         XCTAssertEqual(paymentMethods, [])
                         // 2. Confirm the intent with a new card
+                        let cardParams = STPPaymentMethodCardParams()
+                        cardParams.number = "4242424242424242"
+                        cardParams.cvc = "123"
+                        cardParams.expYear = 22
+                        cardParams.expMonth = 12
+                        let newCardPaymentOption: PaymentSheet.PaymentOption = .new(
+                            confirmParams: .init(
+                                params: .init(
+                                    card: cardParams,
+                                    billingDetails: .init(),
+                                    metadata: nil
+                                ),
+                                type: .card
+                            )
+                        )
+
                         PaymentSheet.confirm(
                             configuration: self.configuration,
                             authenticationContext: self,
                             intent: paymentIntent,
-                            paymentOption: self.newCardPaymentOption,
+                            paymentOption: newCardPaymentOption,
                             paymentHandler: self.paymentHandler
                         ) { result in
                             switch result {
@@ -398,48 +403,6 @@ class PaymentSheetAPITest: XCTestCase {
 
         let params = STPFormEncoder.dictionary(forObject: paymentIntentParams)
         XCTAssertEqual((params["payment_method_options"] as! [String: Any]).count, 0)
-    }
-    
-    func testMakeDashboardParamsSetsMoto() {
-        let mockPaymentIntent = STPFixtures.paymentIntent()
-        let mockPaymentMethod = STPFixtures.paymentMethod()
-        
-        let cardParams = STPPaymentMethodCardParams()
-        cardParams.number = "4242424242424242"
-        cardParams.cvc = "123"
-        cardParams.expYear = 22
-        cardParams.expMonth = 12
-        let intentConfirmParams = IntentConfirmParams(
-            params: .init(card: cardParams, billingDetails: .init(), metadata: nil),
-            type: .card
-        )
-        var configuration = configuration
-        configuration.customer = .init(id: "cus_123", ephemeralKeySecret: "ek_123")
-        let dashboardPaymentIntentConfirmParams = intentConfirmParams.makeDashboardParams(
-            paymentIntentClientSecret: mockPaymentIntent.clientSecret,
-            paymentMethodID: mockPaymentMethod.stripeId,
-            configuration: configuration
-        )
-        
-        let z = STPFormEncoder.dictionary(forObject: dashboardPaymentIntentConfirmParams)
-        
-//        let intent = Intent.paymentIntent(mockPaymentIntent)
-//        let e = expectation(description: "confirm")
-//
-//        // Overwrite configuration to mimick Dashboard's use of uk_
-//        var configuration = configuration
-//        configuration.apiClient = STPAPIClient(publishableKey: "uk_123")
-//
-//        PaymentSheet.confirm(
-//            configuration: configuration,
-//            authenticationContext: self,
-//            intent: intent,
-//            paymentOption: newCardPaymentOption,
-//            paymentHandler: paymentHandler
-//        ) { result in
-//            e.fulfill()
-//        }
-//        waitForExpectations(timeout: 10)
     }
 }
 

--- a/Tests/Tests/PaymentSheet+APITest.swift
+++ b/Tests/Tests/PaymentSheet+APITest.swift
@@ -39,6 +39,17 @@ class PaymentSheetAPITest: XCTestCase {
         }
         return config
     }()
+    var newCardPaymentOption: PaymentOption {
+        let cardParams = STPPaymentMethodCardParams()
+        cardParams.number = "4242424242424242"
+        cardParams.cvc = "123"
+        cardParams.expYear = 22
+        cardParams.expMonth = 12
+        return .new(confirmParams: IntentConfirmParams(
+            params: .init(card: cardParams, billingDetails: .init(), metadata: nil),
+            type: .card
+        ))
+    }
 
     override class func setUp() {
         super.setUp()
@@ -114,27 +125,11 @@ class PaymentSheetAPITest: XCTestCase {
                         )
                         XCTAssertEqual(paymentMethods, [])
                         // 2. Confirm the intent with a new card
-                        let cardParams = STPPaymentMethodCardParams()
-                        cardParams.number = "4242424242424242"
-                        cardParams.cvc = "123"
-                        cardParams.expYear = 22
-                        cardParams.expMonth = 12
-                        let newCardPaymentOption: PaymentSheet.PaymentOption = .new(
-                            confirmParams: .init(
-                                params: .init(
-                                    card: cardParams,
-                                    billingDetails: .init(),
-                                    metadata: nil
-                                ),
-                                type: .card
-                            )
-                        )
-
                         PaymentSheet.confirm(
                             configuration: self.configuration,
                             authenticationContext: self,
                             intent: paymentIntent,
-                            paymentOption: newCardPaymentOption,
+                            paymentOption: self.newCardPaymentOption,
                             paymentHandler: self.paymentHandler
                         ) { result in
                             switch result {
@@ -403,6 +398,48 @@ class PaymentSheetAPITest: XCTestCase {
 
         let params = STPFormEncoder.dictionary(forObject: paymentIntentParams)
         XCTAssertEqual((params["payment_method_options"] as! [String: Any]).count, 0)
+    }
+    
+    func testMakeDashboardParamsSetsMoto() {
+        let mockPaymentIntent = STPFixtures.paymentIntent()
+        let mockPaymentMethod = STPFixtures.paymentMethod()
+        
+        let cardParams = STPPaymentMethodCardParams()
+        cardParams.number = "4242424242424242"
+        cardParams.cvc = "123"
+        cardParams.expYear = 22
+        cardParams.expMonth = 12
+        let intentConfirmParams = IntentConfirmParams(
+            params: .init(card: cardParams, billingDetails: .init(), metadata: nil),
+            type: .card
+        )
+        var configuration = configuration
+        configuration.customer = .init(id: "cus_123", ephemeralKeySecret: "ek_123")
+        let dashboardPaymentIntentConfirmParams = intentConfirmParams.makeDashboardParams(
+            paymentIntentClientSecret: mockPaymentIntent.clientSecret,
+            paymentMethodID: mockPaymentMethod.stripeId,
+            configuration: configuration
+        )
+        
+        let z = STPFormEncoder.dictionary(forObject: dashboardPaymentIntentConfirmParams)
+        
+//        let intent = Intent.paymentIntent(mockPaymentIntent)
+//        let e = expectation(description: "confirm")
+//
+//        // Overwrite configuration to mimick Dashboard's use of uk_
+//        var configuration = configuration
+//        configuration.apiClient = STPAPIClient(publishableKey: "uk_123")
+//
+//        PaymentSheet.confirm(
+//            configuration: configuration,
+//            authenticationContext: self,
+//            intent: intent,
+//            paymentOption: newCardPaymentOption,
+//            paymentHandler: paymentHandler
+//        ) { result in
+//            e.fulfill()
+//        }
+//        waitForExpectations(timeout: 10)
     }
 }
 


### PR DESCRIPTION
## Summary
`payment_method_options.card.moto` broke in https://github.com/stripe-ios/stripe-ios-private/pull/1413 - the call to `setSetupFutureUsageIfNecessary` adds an additionalAPIParameter of ["card": ["setup_future_usage": ...]] that overwrites moto.

## Motivation
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-1768

## Testing
Manually tested. I tried adding some Dashboard tests but ran into trouble mimicking Dashboard's particular configuration (how they create PIs, use "uk_" keys and Stripe-Account header). 

## Changelog
No user-facing change - this should only affect Dashboard.
