### PR TITLE
Fix Emerge Tools

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -305,6 +305,7 @@ workflows:
         title: Set Bundler to use local vendor directory
     - git-clone@6:
         inputs:
+        - merge_pr: 'no'
         - fetch_tags: 'yes'
     - cache-pull@2: {}
     - bundler@0: {}

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -320,8 +320,7 @@ workflows:
         title: Fetch full branch history
     - script@1:
         inputs:
-        - content: bundle exec ruby Tests/installation_tests/size_test/size_report.rb
-            master $BITRISE_GIT_BRANCH
+        - content: bundle exec fastlane size_report
         title: Generate size report
   ui-tests:
     steps:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -199,7 +199,7 @@ platform :ios do
 
   lane :size_report do
     Dir.chdir('..') do
-      sh("bundle exec ruby Tests/installation_tests/size_test/size_report.rb master #{ENV['BITRISE_GIT_BRANCH']}")
+      sh("bundle exec ruby Tests/installation_tests/size_test/size_report.rb #{ENV['BITRISE_GIT_BRANCH']} master")
       unless ENV['EMERGE_API_TOKEN'].nil?
         archive_path = Dir.pwd + '/build/size_tests/'
         arguments = { repo_name: "#{ENV['BITRISEIO_GIT_REPOSITORY_OWNER']}/#{ENV['BITRISEIO_GIT_REPOSITORY_SLUG']}",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -203,7 +203,7 @@ platform :ios do
       unless ENV['EMERGE_API_TOKEN'].nil?
         archive_path = Dir.pwd + '/build/size_tests/'
         arguments = { repo_name: "#{ENV['BITRISEIO_GIT_REPOSITORY_OWNER']}/#{ENV['BITRISEIO_GIT_REPOSITORY_SLUG']}",
-                      sha: `git rev-parse HEAD`.to_s,
+                      sha: `#{ENV['BITRISE_GIT_COMMIT']}`.to_s,
                       build_type: 'release' }
         unless ENV['BITRISE_PULL_REQUEST'].nil?
           arguments[:pr_number] = ENV['BITRISE_PULL_REQUEST']

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -203,7 +203,7 @@ platform :ios do
       unless ENV['EMERGE_API_TOKEN'].nil?
         archive_path = Dir.pwd + '/build/size_tests/'
         arguments = { repo_name: "#{ENV['BITRISEIO_GIT_REPOSITORY_OWNER']}/#{ENV['BITRISEIO_GIT_REPOSITORY_SLUG']}",
-                      sha: `#{ENV['BITRISE_GIT_COMMIT']}`.to_s,
+                      sha: "#{ENV['BITRISE_GIT_COMMIT']}",
                       build_type: 'release' }
         unless ENV['BITRISE_PULL_REQUEST'].nil?
           arguments[:pr_number] = ENV['BITRISE_PULL_REQUEST']

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -199,6 +199,7 @@ platform :ios do
 
   lane :size_report do
     Dir.chdir('..') do
+      sh("bundle exec ruby Tests/installation_tests/size_test/size_report.rb master #{ENV['BITRISE_GIT_BRANCH']}")
       unless ENV['EMERGE_API_TOKEN'].nil?
         archive_path = Dir.pwd + '/build/size_tests/'
         arguments = { repo_name: "#{ENV['BITRISEIO_GIT_REPOSITORY_OWNER']}/#{ENV['BITRISEIO_GIT_REPOSITORY_SLUG']}",


### PR DESCRIPTION
## Summary
A few issues:
* We forgot to call `fastlane` for our size_report job after moving to Bitrise.
* We need to send the correct `HEAD` ref to Emerge Tools in this job.
* The branch arguments were swapped for the size_report job, so the size diffs have been inverted over the past month or so.

## Testing
CI