### PR TITLE
Add branch check before notifying in CI

### DIFF
--- a/ci_scripts/notify_ci.rb
+++ b/ci_scripts/notify_ci.rb
@@ -6,7 +6,7 @@ require 'json'
 require 'openssl'
 require 'base64'
 
-if ENV['$BITRISE_GIT_BRANCH'] != 'master'
+if ENV['BITRISE_GIT_BRANCH'] != 'master'
   puts 'Not on main branch, skipping notification'
   exit 0
 end

--- a/ci_scripts/notify_ci.rb
+++ b/ci_scripts/notify_ci.rb
@@ -6,6 +6,11 @@ require 'json'
 require 'openssl'
 require 'base64'
 
+if ENV['$BITRISE_GIT_BRANCH'] != 'master'
+  puts 'Not on main branch, skipping notification'
+  exit 0
+end
+
 env_sdk_failure_notif_endpoint = ENV['SDK_FAILURE_NOTIFICATION_ENDPOINT']
 env_sdk_failure_notif_endpoint_hmac_key = ENV['SDK_FAILURE_NOTIFICATION_ENDPOINT_HMAC_KEY']
 


### PR DESCRIPTION
## Summary
Add a check to not notify when a CI check fails outside of the main branch.

## Motivation
CI was creating JIRA tasks for manually triggered runs, causing unnecessary noise.

## Testing
CI
