### PR TITLE
[RUN_MOBILESDK-1847] Handle 3 decimal place currencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## X.Y.Z 2022-xx-xx
+
+* [Fixed] Fixed a bug where 3 decimal place currencies were not being formatted properly.
+
 ### PaymentSheet
 * [Fixed] Fixed an issue that caused animations of the card logos in the Card input field to glitch.
 * [Fixed] Fixed a layout issue in the "Save my info" checkbox.
-
-### Payments
-* [Fixed] Fixed a bug where 3 decimal place currencies were not being formatted properly.
 
 ## 23.3.0 2022-12-05
 ### PaymentSheet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## PaymentSheet
 * [Fixed] Fixed an issue that caused animations of the card logos in the Card input field to glitch.
 * [Fixed] Fixed a layout issue in the "Save my info" checkbox.
+* [Fixed] Fixed a bug where 3 decimal place currencies were not being formatted properly.
 
 ## 23.3.0 2022-12-05
 ### PaymentSheet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## X.Y.Z 2022-xx-xx
-## PaymentSheet
+### PaymentSheet
 * [Fixed] Fixed an issue that caused animations of the card logos in the Card input field to glitch.
 * [Fixed] Fixed a layout issue in the "Save my info" checkbox.
+
+### Payments
 * [Fixed] Fixed a bug where 3 decimal place currencies were not being formatted properly.
 
 ## 23.3.0 2022-12-05

--- a/StripePayments/StripePayments/Internal/Categories/NSDecimalNumber+Stripe_Currency.swift
+++ b/StripePayments/StripePayments/Internal/Categories/NSDecimalNumber+Stripe_Currency.swift
@@ -18,6 +18,11 @@ extension NSDecimalNumber {
         if noDecimalCurrencies.contains(currency?.lowercased() ?? "") {
             return number
         }
+        
+        if self.stp_currenciesWithThreeDecimals().contains(currency?.lowercased() ?? "") {
+            return number.multiplying(byPowerOf10: -3)
+        }
+        
         return number.multiplying(byPowerOf10: -2)
     }
 
@@ -47,7 +52,19 @@ extension NSDecimalNumber {
             "vuv",
             "xaf",
             "xof",
-            "xpf",
+            "xpf"
+        ]
+    }
+    
+    class func stp_currenciesWithThreeDecimals() -> [String] {
+        return [
+            "bhd",
+            "iqd",
+            "jod",
+            "kwd",
+            "lyd",
+            "omr",
+            "tnd"
         ]
     }
 }

--- a/StripePayments/StripePayments/Internal/Categories/NSDecimalNumber+Stripe_Currency.swift
+++ b/StripePayments/StripePayments/Internal/Categories/NSDecimalNumber+Stripe_Currency.swift
@@ -59,10 +59,8 @@ extension NSDecimalNumber {
     class func stp_currenciesWithThreeDecimals() -> [String] {
         return [
             "bhd",
-            "iqd",
             "jod",
             "kwd",
-            "lyd",
             "omr",
             "tnd"
         ]

--- a/StripePayments/StripePayments/Internal/Categories/NSDecimalNumber+Stripe_Currency.swift
+++ b/StripePayments/StripePayments/Internal/Categories/NSDecimalNumber+Stripe_Currency.swift
@@ -9,60 +9,33 @@
 import Foundation
 
 extension NSDecimalNumber {
+    
     @objc @_spi(STP) public class func stp_decimalNumber(
         withAmount amount: Int,
         currency: String?
     ) -> NSDecimalNumber {
-        let noDecimalCurrencies = self.stp_currenciesWithNoDecimal()
         let number = self.init(mantissa: UInt64(amount), exponent: 0, isNegative: false)
-        if noDecimalCurrencies.contains(currency?.lowercased() ?? "") {
-            return number
-        }
-        
-        if self.stp_currenciesWithThreeDecimals().contains(currency?.lowercased() ?? "") {
-            return number.multiplying(byPowerOf10: -3)
-        }
-        
-        return number.multiplying(byPowerOf10: -2)
+        let decimalCount = decimalCount(for: currency)
+        return number.multiplying(byPowerOf10: -Int16(decimalCount))
     }
 
     @objc @_spi(STP) public func stp_amount(withCurrency currency: String?) -> Int {
-        let noDecimalCurrencies = NSDecimalNumber.stp_currenciesWithNoDecimal()
-
         var ourNumber = self
-        if !(noDecimalCurrencies.contains(currency?.lowercased() ?? "")) {
-            ourNumber = multiplying(byPowerOf10: 2)
-        }
+        let decimalCount = NSDecimalNumber.decimalCount(for: currency)
+        ourNumber = multiplying(byPowerOf10: Int16(decimalCount))
         return Int(ourNumber.doubleValue)
     }
-
-    class func stp_currenciesWithNoDecimal() -> [String] {
-        return [
-            "bif",
-            "clp",
-            "djf",
-            "gnf",
-            "jpy",
-            "kmf",
-            "krw",
-            "mga",
-            "pyg",
-            "rwf",
-            "vnd",
-            "vuv",
-            "xaf",
-            "xof",
-            "xpf"
-        ]
-    }
     
-    class func stp_currenciesWithThreeDecimals() -> [String] {
-        return [
-            "bhd",
-            "jod",
-            "kwd",
-            "omr",
-            "tnd"
-        ]
+    private class func decimalCount(for currency: String?) -> Int {
+        let currencyLocaleIdentifier = Locale.availableIdentifiers.first(where: {
+            let locale = Locale(identifier: $0)
+            return locale.currencyCode?.lowercased() == currency?.lowercased()
+        })
+        
+        let currencyFormatter = NumberFormatter()
+        currencyFormatter.numberStyle = .currency
+        currencyFormatter.locale = Locale(identifier: currencyLocaleIdentifier ?? "")
+        
+        return currencyFormatter.maximumFractionDigits
     }
 }

--- a/Tests/Tests/NSDecimalNumber+StripeTest.swift
+++ b/Tests/Tests/NSDecimalNumber+StripeTest.swift
@@ -14,17 +14,59 @@
 
 class NSDecimalNumberStripeTest: XCTestCase {
     func testDecimalAmount_hasDecimal() {
-        let decimalNumber = NSDecimalNumber.stp_decimalNumber(withAmount: 1000, currency: "usd")
-        XCTAssertEqual(decimalNumber, NSDecimalNumber(string: "10.00"))
+        // an incomplete list of 2 decimal point currencies
+        let twoDecimalPointCurrencies = [
+            "usd",
+            "dkk",
+            "eur",
+            "aud",
+            "sek",
+            "sgd"
+        ]
+        
+        for twoDecimalPointCurrency in twoDecimalPointCurrencies {
+            let decimalNumber = NSDecimalNumber.stp_decimalNumber(withAmount: 1000, currency: twoDecimalPointCurrency)
+            XCTAssertEqual(decimalNumber, NSDecimalNumber(string: "10.00"))
+        }
     }
 
     func testDecimalAmount_noDecimal() {
-        let decimalNumber = NSDecimalNumber.stp_decimalNumber(withAmount: 1000, currency: "jpy")
-        XCTAssertEqual(decimalNumber, NSDecimalNumber(string: "1000"))
+        let noDecimalPointCurrencies = [
+            "bif",
+            "clp",
+            "djf",
+            "gnf",
+            "jpy",
+            "kmf",
+            "krw",
+            "mga",
+            "pyg",
+            "rwf",
+            "vnd",
+            "vuv",
+            "xaf",
+            "xof",
+            "xpf"
+        ]
+
+        for currency in noDecimalPointCurrencies {
+            let decimalNumber = NSDecimalNumber.stp_decimalNumber(withAmount: 1000, currency: currency)
+            XCTAssertEqual(decimalNumber, NSDecimalNumber(string: "1000"))
+        }
     }
     
     func testDecimalAmount_threeDecimal() {
-        let decimalNumber = NSDecimalNumber.stp_decimalNumber(withAmount: 92000, currency: "kwd")
-        XCTAssertEqual(decimalNumber, NSDecimalNumber(string: "92"))
+        let threeDecimalCurrencies = [
+            "bhd",
+            "jod",
+            "kwd",
+            "omr",
+            "tnd"
+        ]
+        
+        for currency in threeDecimalCurrencies {
+            let decimalNumber = NSDecimalNumber.stp_decimalNumber(withAmount: 92000, currency: currency)
+            XCTAssertEqual(decimalNumber, NSDecimalNumber(string: "92"))
+        }
     }
 }

--- a/Tests/Tests/NSDecimalNumber+StripeTest.swift
+++ b/Tests/Tests/NSDecimalNumber+StripeTest.swift
@@ -13,17 +13,44 @@
 @testable@_spi(STP) import StripePaymentsUI
 
 class NSDecimalNumberStripeTest: XCTestCase {
-    func testDecimalAmount_hasDecimal() {
-        // an incomplete list of 2 decimal point currencies
-        let twoDecimalPointCurrencies = [
-            "usd",
-            "dkk",
-            "eur",
-            "aud",
-            "sek",
-            "sgd"
-        ]
-        
+    // an incomplete list of 2 decimal point currencies
+    private let twoDecimalPointCurrencies = [
+        "usd",
+        "dkk",
+        "eur",
+        "aud",
+        "sek",
+        "sgd"
+    ]
+    
+    private let noDecimalPointCurrencies = [
+        "bif",
+        "clp",
+        "djf",
+        "gnf",
+        "jpy",
+        "kmf",
+        "krw",
+        "mga",
+        "pyg",
+        "rwf",
+        "vnd",
+        "vuv",
+        "xaf",
+        "xof",
+        "xpf"
+    ]
+    
+    private let threeDecimalCurrencies = [
+        "bhd",
+        "jod",
+        "kwd",
+        "omr",
+        "tnd"
+    ]
+    
+    
+    func testDecimalAmount_twoDecimal() {
         for twoDecimalPointCurrency in twoDecimalPointCurrencies {
             let decimalNumber = NSDecimalNumber.stp_decimalNumber(withAmount: 1000, currency: twoDecimalPointCurrency)
             XCTAssertEqual(decimalNumber, NSDecimalNumber(string: "10.00"))
@@ -31,24 +58,6 @@ class NSDecimalNumberStripeTest: XCTestCase {
     }
 
     func testDecimalAmount_noDecimal() {
-        let noDecimalPointCurrencies = [
-            "bif",
-            "clp",
-            "djf",
-            "gnf",
-            "jpy",
-            "kmf",
-            "krw",
-            "mga",
-            "pyg",
-            "rwf",
-            "vnd",
-            "vuv",
-            "xaf",
-            "xof",
-            "xpf"
-        ]
-
         for currency in noDecimalPointCurrencies {
             let decimalNumber = NSDecimalNumber.stp_decimalNumber(withAmount: 1000, currency: currency)
             XCTAssertEqual(decimalNumber, NSDecimalNumber(string: "1000"))
@@ -56,17 +65,33 @@ class NSDecimalNumberStripeTest: XCTestCase {
     }
     
     func testDecimalAmount_threeDecimal() {
-        let threeDecimalCurrencies = [
-            "bhd",
-            "jod",
-            "kwd",
-            "omr",
-            "tnd"
-        ]
-        
         for currency in threeDecimalCurrencies {
             let decimalNumber = NSDecimalNumber.stp_decimalNumber(withAmount: 92000, currency: currency)
             XCTAssertEqual(decimalNumber, NSDecimalNumber(string: "92"))
+        }
+    }
+    
+    func testAmount_twoDecimal() {
+        for twoDecimalPointCurrency in twoDecimalPointCurrencies {
+            let amount = NSDecimalNumber(value: 1000)
+            let decimalNumber = amount.stp_amount(withCurrency: twoDecimalPointCurrency)
+            XCTAssertEqual(decimalNumber, 100000)
+        }
+    }
+    
+    func testAmount_noDecimal() {
+        for noDecimalPointCurrency in noDecimalPointCurrencies {
+            let amount = NSDecimalNumber(value: 1000)
+            let decimalNumber = amount.stp_amount(withCurrency: noDecimalPointCurrency)
+            XCTAssertEqual(decimalNumber, 1000)
+        }
+    }
+    
+    func testAmount_threeDecimal() {
+        for threeDecimalPointCurrency in threeDecimalCurrencies {
+            let amount = NSDecimalNumber(value: 1000)
+            let decimalNumber = amount.stp_amount(withCurrency: threeDecimalPointCurrency)
+            XCTAssertEqual(decimalNumber, 1000000)
         }
     }
 }

--- a/Tests/Tests/NSDecimalNumber+StripeTest.swift
+++ b/Tests/Tests/NSDecimalNumber+StripeTest.swift
@@ -22,4 +22,9 @@ class NSDecimalNumberStripeTest: XCTestCase {
         let decimalNumber = NSDecimalNumber.stp_decimalNumber(withAmount: 1000, currency: "jpy")
         XCTAssertEqual(decimalNumber, NSDecimalNumber(string: "1000"))
     }
+    
+    func testDecimalAmount_threeDecimal() {
+        let decimalNumber = NSDecimalNumber.stp_decimalNumber(withAmount: 92000, currency: "kwd")
+        XCTAssertEqual(decimalNumber, NSDecimalNumber(string: "92"))
+    }
 }


### PR DESCRIPTION
## Summary
Some currencies have 3 decimal places and it doesn't look like we were handling it anywhere.

Before this change KWD with an amount of `92000` was being presented as 920 KWD rather than 92 KWD.


## Motivation
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-1847

## Testing
New unit test

## Changelog
- See diff