### PR TITLE
BOUNCER-1436: Fix ML model loading from wrong bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## X.Y.Z 2022-xx-xx
-## PaymentSheet
+### PaymentSheet
 * [Fixed] Fixed an issue that caused animations of the card logos in the Card input field to glitch.
 * [Fixed] Fixed a layout issue in the "Save my info" checkbox.
+
+### CardScan
+* [Fixed] Fixed UX model loading from the wrong bundle. [#2078](https://github.com/stripe/stripe-ios/issues/2078) (Thanks [nickm01](https://github.com/nickm01))
 
 ## 23.3.0 2022-12-05
 ### PaymentSheet

--- a/StripeCardScan/StripeCardScan/Source/CardVerify/UxAnalyzer.swift
+++ b/StripeCardScan/StripeCardScan/Source/CardVerify/UxAnalyzer.swift
@@ -6,6 +6,10 @@ import UIKit
 
 @_spi(STP) public class UxAnalyzer: CreditCardOcrImplementation {
     @AtomicProperty var uxModel: UxModel?
+    
+    static let uxResource = "UxModel"
+    static let uxExtension = "mlmodelc"
+    
     let ocr: CreditCardOcrImplementation
 
     init(
@@ -26,7 +30,7 @@ import UIKit
 
     @_spi(STP) public static func loadModelFromBundle() -> UxModel? {
         let bundle = StripeCardScanBundleLocator.resourcesBundle
-        guard let url = bundle.url(forResource: "UxModel", withExtension: "mlmodelc") else {
+        guard let url = bundle.url(forResource: UxAnalyzer.uxResource, withExtension: UxAnalyzer.uxExtension) else {
             return nil
         }
 
@@ -60,7 +64,16 @@ import UIKit
     }
 
     private func loadModel() {
-        UxModel.asyncLoad { [weak self] result in
+        guard
+            let uxModelUrl = StripeCardScanBundleLocator.resourcesBundle.url(
+                forResource: UxAnalyzer.uxResource,
+                withExtension: UxAnalyzer.uxExtension
+            )
+        else {
+            return
+        }
+        
+        UxModel.asyncLoad(contentsOf: uxModelUrl) { [weak self] result in
             switch result {
             case .success(let model):
                 self?.uxModel = model


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
UxModel was loading from the app-level bundle, not the SDK bundle. 
## Motivation
https://jira.corp.stripe.com/browse/BOUNCER-1436
https://github.com/stripe/stripe-ios/issues/2078

## Testing
<!-- How was the code tested? Be as specific as possible. -->
Created an example app outside of the repo and was able to reproduce the error described in this [issue post](https://github.com/stripe/stripe-ios/issues/2078). The changes fixed this error. 

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
