### PR TITLE
Reduce duplicate builds

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -16,8 +16,6 @@ app:
 trigger_map:
 - push_branch: "*"
   pipeline: main-trigger-pipeline
-- pull_request_source_branch: "*"
-  pipeline: main-trigger-pipeline
 pipelines:
   main-trigger-pipeline:
     stages:


### PR DESCRIPTION
## Summary
We only need the `push_branch` build, but we're also building builds on every pull request. (See https://github.com/stripe-ios/stripe-terminal-ios/blob/master/bitrise.yml#L212 for an example.)

## Testing
CI