### PR TITLE
RUN_DASHMOB-1295: Set Dashboard saved payment methods to MOTO

### DIFF
--- a/StripeCore/StripeCore/Source/API Bindings/STPAPIClient.swift
+++ b/StripeCore/StripeCore/Source/API Bindings/STPAPIClient.swift
@@ -40,11 +40,6 @@ import UIKit
     }
     var _publishableKey: String?
 
-    @_spi(STP) public var isDashboardPK: Bool {
-        // The Dashboard app's user key (uk_)
-        publishableKey?.hasPrefix("uk_") ?? false
-    }
-
     /// A publishable key that only contains publishable keys and not secret keys.
     ///
     /// If a secret key is found, returns "[REDACTED_LIVE_KEY]".

--- a/StripeCore/StripeCore/Source/API Bindings/STPAPIClient.swift
+++ b/StripeCore/StripeCore/Source/API Bindings/STPAPIClient.swift
@@ -40,6 +40,11 @@ import UIKit
     }
     var _publishableKey: String?
 
+    @_spi(STP) public var isDashboardPK: Bool {
+        // The Dashboard app's user key (uk_)
+        publishableKey?.hasPrefix("uk_") ?? false
+    }
+
     /// A publishable key that only contains publishable keys and not secret keys.
     ///
     /// If a secret key is found, returns "[REDACTED_LIVE_KEY]".

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Intent.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Intent.swift
@@ -180,11 +180,18 @@ class IntentConfirmParams {
             customer: configuration.customer
         )
         params.paymentMethodOptions = options
+
+        options.setMoto()
         
-        let cardOptions = options.cardOptions ?? STPConfirmCardOptions()
-        cardOptions.additionalAPIParameters["moto"] = true
-        options.cardOptions = cardOptions
         return params
+    }
+}
+
+extension STPConfirmPaymentMethodOptions {
+    func setMoto() {
+        let cardOptions = self.cardOptions ?? STPConfirmCardOptions()
+        cardOptions.additionalAPIParameters["moto"] = true
+        self.cardOptions = cardOptions
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Intent.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Intent.swift
@@ -193,9 +193,7 @@ extension STPConfirmPaymentMethodOptions {
         cardOptions.additionalAPIParameters["moto"] = true
         self.cardOptions = cardOptions
     }
-}
 
-extension STPConfirmPaymentMethodOptions {
     /**
      Sets `payment_method_options[x][setup_future_usage]` where x is either "card" or "us_bank_account"
      

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Intent.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/Intent.swift
@@ -182,7 +182,7 @@ class IntentConfirmParams {
         params.paymentMethodOptions = options
 
         options.setMoto()
-        
+
         return params
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentSheet+API.swift
@@ -76,7 +76,7 @@ extension PaymentSheet {
             // MARK: ↪ PaymentIntent
             case .paymentIntent(let paymentIntent):
                 // The Dashboard app cannot pass `paymentMethodParams` ie payment_method_data
-                if configuration.apiClient.isDashboardPK {
+                if configuration.apiClient.publishableKeyIsUserKey {
                     configuration.apiClient.createPaymentMethod(with: confirmParams.paymentMethodParams) {
                         paymentMethod, error in
                         if let error = error {
@@ -133,7 +133,7 @@ extension PaymentSheet {
                 )
 
                 // The Dashboard app requires MOTO
-                if configuration.apiClient.isDashboardPK {
+                if configuration.apiClient.publishableKeyIsUserKey {
                     paymentIntentParams.paymentMethodOptions?.setMoto()
                 }
 

--- a/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/PaymentSheet/PaymentSheet+API.swift
@@ -252,34 +252,6 @@ extension PaymentSheet {
         }
     }
 
-    private static func dashboardPaymentIntent(
-        configuration: PaymentSheet.Configuration,
-        authenticationContext: STPAuthenticationContext,
-        confirmParams: IntentConfirmParams,
-        paymentIntent: STPPaymentIntent,
-        paymentHandler: STPPaymentHandler,
-        completion: @escaping (PaymentSheetResult) -> Void,
-        paymentHandlerCompletion: @escaping (STPPaymentHandlerActionStatus, NSObject?, NSError?) -> Void
-    ) {
-        configuration.apiClient.createPaymentMethod(with: confirmParams.paymentMethodParams) {
-            paymentMethod, error in
-            if let error = error {
-                completion(.failed(error: error))
-                return
-            }
-            let paymentIntentParams = confirmParams.makeDashboardParams(
-                paymentIntentClientSecret: paymentIntent.clientSecret,
-                paymentMethodID: paymentMethod?.stripeId ?? "",
-                configuration: configuration
-            )
-            paymentIntentParams.shipping = makeShippingParams(for: paymentIntent, configuration: configuration)
-            paymentHandler.confirmPayment(
-                paymentIntentParams,
-                with: authenticationContext,
-                completion: paymentHandlerCompletion)
-        }
-    }
-
     /// Fetches the PaymentIntent or SetupIntent and Customer's saved PaymentMethods
     static func load(
         clientSecret: IntentClientSecret,


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

Uses the `moto` card option for saved cards for Dashboard payments.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Followup to #2137
https://jira.corp.stripe.com/browse/RUN_DASHMOB-1399

## Testing
<!-- How was the code tested? Be as specific as possible. -->

Tested the following scenarios:
- Paying with 3DS2 required card without associating payment to customer
- Paying with 3DS2 required card and saving card to customer
- Paying with saved 3DS2 required card
- Paying with saved non-3DS2 required card

#### Before

Paying with a saved 3DS2 required card resulted in an error on Dashboard.

https://user-images.githubusercontent.com/78050250/207462849-762dfebc-7498-4834-ba8b-491dde04a3ed.mp4


#### After

https://user-images.githubusercontent.com/78050250/207462873-840c37f1-9701-4759-aedc-c05cb02cd2d0.mp4


## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
