### PR TITLE
Redact uk_-format keys

### DIFF
--- a/StripeCore/StripeCore/Source/API Bindings/STPAPIClient.swift
+++ b/StripeCore/StripeCore/Source/API Bindings/STPAPIClient.swift
@@ -48,7 +48,7 @@ import UIKit
             return nil
         }
 
-        return publishableKey.isSecretKey ? "[REDACTED_LIVE_KEY]" : publishableKey
+        return (publishableKey.isSecretKey || publishableKeyIsUserKey) ? "[REDACTED_LIVE_KEY]" : publishableKey
     }
 
     // Stored STPPaymentConfiguration: Type checking handled in STPAPIClient+Payments.swift.

--- a/StripeCore/StripeCoreTests/Analytics/STPAnalyticsClientTest.swift
+++ b/StripeCore/StripeCoreTests/Analytics/STPAnalyticsClientTest.swift
@@ -24,6 +24,14 @@ class STPAnalyticsClientTest: XCTestCase {
 
         XCTAssertEqual("[REDACTED_LIVE_KEY]", payload["publishable_key"] as? String)
     }
+    
+    func testShouldRedactUserKeyFromLog() {
+        let analyticsClient = STPAnalyticsClient()
+
+        let payload = analyticsClient.commonPayload(STPAPIClient(publishableKey: "uk_live_foo"))
+
+        XCTAssertEqual("[REDACTED_LIVE_KEY]", payload["publishable_key"] as? String)
+    }
 
     func testShouldNotRedactLiveKeyFromLog() {
         let analyticsClient = STPAnalyticsClient()


### PR DESCRIPTION
## Summary
Redact `uk_` keys.

## Motivation
These shouldn't be logged to the analytics service.

## Testing
Added a test.