### PR TITLE
Generate and delete project files during release

### DIFF
--- a/ci_scripts/cleanup_project_files_from_repo.rb
+++ b/ci_scripts/cleanup_project_files_from_repo.rb
@@ -1,0 +1,25 @@
+#!/usr/bin/env ruby
+
+require_relative 'common'
+
+def cleanup_project_files_from_repo(version, github_client)
+  branchname = "releases/#{version}_cleanup"
+  run_command("git checkout -b #{branchname}")
+  run_command('ci_scripts/delete_project_files.rb')
+  run_command("git add Stripe.xcworkspace -f &&
+    git add Stripe*/*.xcodeproj -f &&
+    git add Example/**/*.xcodeproj -f &&
+    git add Testers/**/*.xcodeproj -f &&
+    git commit -m \"Remove generated project files for v#{@version}\"")
+  run_command("git push origin #{branchname}")
+  github_client.create_pull_request(
+    'stripe/stripe-ios',
+    'master',
+    branchname,
+    "Remove generated project files for v#{@version}",
+    "Remove generated project files for v#{@version}"
+  )
+
+  rputs 'Request review on the PR and merge it.'
+  notify_user
+end

--- a/ci_scripts/common.rb
+++ b/ci_scripts/common.rb
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+
+require 'colorize'
+require 'English'
+
+def rputs(string)
+  puts string.red
+end
+
+def run_command(command, raise_on_failure = true)
+  puts "> #{command}".blue
+  system(command.to_s)
+  return unless $CHILD_STATUS.exitstatus != 0
+
+  rputs "Command failed: #{command} \a"
+  raise if raise_on_failure
+end

--- a/ci_scripts/create_release.rb
+++ b/ci_scripts/create_release.rb
@@ -22,6 +22,12 @@ def create_branch
   run_command("git checkout -b #{@branchname}")
 end
 
+def regenerate_project_files
+  run_command('ci_scripts/delete_project_files.rb')
+  puts 'Generating project files'
+  run_command('tuist generate -n')
+end
+
 def update_version
   # Overwrite the VERSION file with version
   File.open('VERSION', 'w') do |f|
@@ -49,8 +55,16 @@ end
 
 def commit_changes
   # Commit and push the changes
+  # Xcode project files are added to ensure compatibility with Carthage,
+  # -f is used because this files are included in .gitignore.
   # Manually add the docs directory to pick up any new docs files generated as part of release
-  run_command("git add -u && git add docs && git commit -m \"Update version to #{@version}\"")
+  run_command("git add Stripe.xcworkspace -f &&
+    git add Stripe*/*.xcodeproj -f &&
+    git add Example/**/*.xcodeproj -f &&
+    git add Testers/**/*.xcodeproj -f &&
+    git add -u &&
+    git add docs &&
+    git commit -m \"Update version to #{@version}\"")
 end
 
 def push_changes
@@ -115,6 +129,7 @@ end
 
 steps = [
   method(:create_branch),
+  method(:regenerate_project_files),
   method(:update_version),
   method(:update_placeholders),
   method(:build_documentation),

--- a/ci_scripts/delete_project_files.rb
+++ b/ci_scripts/delete_project_files.rb
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+
+require_relative 'common'
+
+run_command('rm -f .package.resolved', false)
+run_command('rm -rf Stripe.xcworkspace', false)
+run_command('find Stripe* -type d -name "*.xcodeproj" -exec rm -r {} +', false)
+run_command('find Example -type d -name "*.xcodeproj" -exec rm -r {} +', false)
+run_command('find Testers -type d -name "*.xcodeproj" -exec rm -r {} +', false)

--- a/ci_scripts/deploy_release.rb
+++ b/ci_scripts/deploy_release.rb
@@ -6,6 +6,8 @@ require_relative 'release_common'
 
 @changelog = changelog(@version)
 
+@cleanup_branchname = "releases/#{@version}_cleanup"
+
 def export_builds
   # Compile the build products: bundle install && ./ci_scripts/export_builds.rb
   run_command('ci_scripts/export_builds.rb')
@@ -93,6 +95,29 @@ def reply_email
   rputs 'https://go/mobile-sdk-updates-list'
   puts "Deploy complete: https://github.com/stripe/stripe-ios/releases/tag/#{@version}".magenta
   notify_user
+end
+
+def cleanup_project_files
+  rputs 'Cleanup generated project files from repo'
+  run_command("git checkout -b #{@cleanup_branchname}")
+  run_command('ci_scripts/delete_project_files.rb')
+  run_command("git add -u && git commit -m \"Remove generated project files for v#{@version}\"")
+  run_command("git push origin #{@cleanup_branchname}")
+end
+
+def create_cleanup_pr
+  unless @is_dry_run
+    pr = @github_client.create_pull_request(
+      'stripe/stripe-ios',
+      'master',
+      @cleanup_branchname,
+      "Remove generated project files for v#{@version}"
+    )
+
+    rputs "Cleanup PR created at #{pr.html_url}"
+    rputs 'Request review on the PR and merge it.'
+    notify_user
+  end
 
   puts 'Done! Have a nice day!'.green
 end
@@ -109,6 +134,8 @@ steps = [
   method(:push_spm_mirror),
   method(:sync_owner_list),
   method(:changelog_done),
-  method(:reply_email)
+  method(:reply_email),
+  method(:cleanup_project_files),
+  method(:create_cleanup_pr)
 ]
 execute_steps(steps, @step_index)

--- a/ci_scripts/release_common.rb
+++ b/ci_scripts/release_common.rb
@@ -2,17 +2,17 @@
 
 # This is a support file for the other release scripts.
 
+require_relative 'common'
 require 'fileutils'
 require 'optparse'
 require 'colorize'
 require 'octokit'
 require 'erb'
 
-
 # This should generally be the minimum Xcode version supported by the App Store, as the
 # compiled XCFrameworks won't be usable on older versions.
 # We sometimes bump this if an Xcode bug or deprecation forces us to upgrade early.
-MIN_SUPPORTED_XCODE_VERSION = '13.2.1'
+MIN_SUPPORTED_XCODE_VERSION = '13.2.1'.freeze
 
 SCRIPT_DIR = __dir__
 abort 'Unable to find SCRIPT_DIR' if SCRIPT_DIR.nil? || SCRIPT_DIR.empty?
@@ -28,17 +28,17 @@ Dir.chdir(ROOT_DIR)
 OptionParser.new do |opts|
   opts.banner = "Release scripts\n Usage: script.rb [options]"
 
-  opts.on("--version VERSION",
-    "Version to release (e.g. 21.2.0)") do |t|
+  opts.on('--version VERSION',
+          'Version to release (e.g. 21.2.0)') do |t|
     @specified_version = t
   end
 
-  opts.on("--dry-run", "Don't do any real deployment, just build") do |s|
+  opts.on('--dry-run', "Don't do any real deployment, just build") do |s|
     @is_dry_run = s
   end
 
-  opts.on("--continue-from NUMBER",
-    "Continue from a specified step") do |t|
+  opts.on('--continue-from NUMBER',
+          'Continue from a specified step') do |t|
     @step_index = t.to_i
   end
 end.parse!
@@ -49,10 +49,10 @@ def File.join_if_safe(arg1, *otherArgs)
 
   # Check for empty or nil strings
   args.each do |arg|
-    raise "Cannot join nil or empty string." if arg.nil? || arg.empty?
+    raise 'Cannot join nil or empty string.' if arg.nil? || arg.empty?
   end
 
-  return File.join(args)
+  File.join(args)
 end
 
 def prompt_user(prompt)
@@ -61,7 +61,7 @@ def prompt_user(prompt)
 end
 
 def notify_user
-  prompt_user "Press enter to continue..."
+  prompt_user 'Press enter to continue...'
 end
 
 def open_url(url)
@@ -69,21 +69,10 @@ def open_url(url)
 end
 
 def get_current_release_version_of_repo(repo)
-  begin
-    latest_version = Octokit.latest_release(repo)
-    latest_version.tag_name
-  rescue
-    raise "No releases found."
-  end
-end
-
-def run_command(command)
-  puts "> #{command}".blue
-  system("#{command}")
-  if $?.exitstatus != 0
-    rputs "Command failed: #{command} \a"
-    raise
-  end
+  latest_version = Octokit.latest_release(repo)
+  latest_version.tag_name
+rescue StandardError
+  raise 'No releases found.'
 end
 
 def changelog(version)
@@ -125,10 +114,6 @@ def version_from_file
     version = f.read.chomp
   end
   version
-end
-
-def rputs(string)
-  puts string.red
 end
 
 def github_login


### PR DESCRIPTION
## Summary
In order to support Carthage, project files need to be included in the repository, in order to do that without always having them there, I'm adding steps as part of the release process to generate the files and commit them in the released version, and then follow up with another PR that deletes them again.
As discussed before, this should be a good enough compromise that gives enough support for Carthage while keeping the overhead to a minimum on our side.

## Motivation
https://paper.dropbox.com/doc/Eliminate-Xcode-Project-Files--BtejXTVe6C_T2pnkquWC6sqCAg-2QD9baK8ePqcQfTJUtvSw

## Testing
Ran the relevant steps on the create_release and deploy_release scripts, verified that the release PR included the project files and that the follow up PR deleted them.

## Changelog
A follow up PR will add changelog and readme changes once all PRs are merged.