### PR TITLE
Financial Connections: added support for reduced_branding

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsSynchronize.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsSynchronize.swift
@@ -11,9 +11,14 @@ struct FinancialConnectionsSynchronize: Decodable {
     
     let manifest: FinancialConnectionsSessionManifest
     let text: Text?
+    let visual: VisualUpdate?
     
     struct Text: Decodable {
         let consentPane: FinancialConnectionsConsent?
+    }
+    
+    struct VisualUpdate: Decodable {
+        let reducedBranding: Bool
     }
 }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/FinancialConnectionsNavigationController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/FinancialConnectionsNavigationController.swift
@@ -136,46 +136,50 @@ extension FinancialConnectionsNavigationController {
     static func configureNavigationItemForNative(
         _ navigationItem: UINavigationItem?,
         closeItem: UIBarButtonItem,
+        shouldHideStripeLogo: Bool,
         shouldLeftAlignStripeLogo: Bool
     ) {
-        let stripeLogoView: UIView = {
-            let stripeLogoImageView = UIImageView(
-                image: {
-                    if shouldLeftAlignStripeLogo {
-                        return Image
-                            .stripe_logo
-                            .makeImage(template: true)
-                            .withInsets(UIEdgeInsets(top: 0, left: 3, bottom: 0, right: 0))
-                    } else {
-                        return Image
-                            .stripe_logo
-                            .makeImage(template: true)
-                    }
-                }()
-            )
-            stripeLogoImageView.tintColor = UIColor.textBrand
-            stripeLogoImageView.contentMode = .scaleAspectFit
-            stripeLogoImageView.sizeToFit()
-            stripeLogoImageView.frame = CGRect(
-                x: 0,
-                y: 0,
-                width: stripeLogoImageView.bounds.width * (16 / stripeLogoImageView.bounds.height),
-                height: 16
-            )
-            // If `titleView` is directly set to the `UIImageView`
-            // we can't control the sizing...so we create a `containerView`
-            // so we can control `UIImageView` sizing.
-            let containerView = UIView()
-            containerView.frame = stripeLogoImageView.bounds
-            containerView.addSubview(stripeLogoImageView)
+        if !shouldHideStripeLogo {
+            let stripeLogoView: UIView = {
+                let stripeLogoImageView = UIImageView(
+                    image: {
+                        if shouldLeftAlignStripeLogo {
+                            return Image
+                                .stripe_logo
+                                .makeImage(template: true)
+                                .withInsets(UIEdgeInsets(top: 0, left: 3, bottom: 0, right: 0))
+                        } else {
+                            return Image
+                                .stripe_logo
+                                .makeImage(template: true)
+                        }
+                    }()
+                )
+                stripeLogoImageView.tintColor = UIColor.textBrand
+                stripeLogoImageView.contentMode = .scaleAspectFit
+                stripeLogoImageView.sizeToFit()
+                stripeLogoImageView.frame = CGRect(
+                    x: 0,
+                    y: 0,
+                    width: stripeLogoImageView.bounds.width * (16 / stripeLogoImageView.bounds.height),
+                    height: 16
+                )
+                // If `titleView` is directly set to the `UIImageView`
+                // we can't control the sizing...so we create a `containerView`
+                // so we can control `UIImageView` sizing.
+                let containerView = UIView()
+                containerView.frame = stripeLogoImageView.bounds
+                containerView.addSubview(stripeLogoImageView)
+                
+                stripeLogoImageView.center = containerView.center
+                return containerView
+            }()
             
-            stripeLogoImageView.center = containerView.center
-            return containerView
-        }()
-        if shouldLeftAlignStripeLogo {
-            navigationItem?.leftBarButtonItem = UIBarButtonItem(customView: stripeLogoView)
-        } else {
-            navigationItem?.titleView = stripeLogoView
+            if shouldLeftAlignStripeLogo {
+                navigationItem?.leftBarButtonItem = UIBarButtonItem(customView: stripeLogoView)
+            } else {
+                navigationItem?.titleView = stripeLogoView
+            }
         }
         navigationItem?.backButtonTitle = ""
         navigationItem?.rightBarButtonItem = closeItem

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostController.swift
@@ -92,6 +92,7 @@ extension HostController: HostViewControllerDelegate {
 
         let dataManager = NativeFlowAPIDataManager(
             manifest: synchronizePayload.manifest,
+            visualUpdate: synchronizePayload.visual,
             returnURL: returnURL,
             consentPaneModel: consentPaneModel,
             apiClient: api,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -91,6 +91,7 @@ extension NativeFlowController {
             FinancialConnectionsNavigationController.configureNavigationItemForNative(
                 viewController.navigationItem,
                 closeItem: navigationBarCloseBarButtonItem,
+                shouldHideStripeLogo: (dataManager.visualUpdate?.reducedBranding ?? false),
                 shouldLeftAlignStripeLogo: viewControllers.first == viewController && viewController is ConsentViewController
             )
         }
@@ -102,6 +103,7 @@ extension NativeFlowController {
             FinancialConnectionsNavigationController.configureNavigationItemForNative(
                 viewController.navigationItem,
                 closeItem: navigationBarCloseBarButtonItem,
+                shouldHideStripeLogo: (dataManager.visualUpdate?.reducedBranding ?? false),
                 shouldLeftAlignStripeLogo: false // if we `push`, this is not the first VC
             )
             navigationController.pushViewController(viewController, animated: animated)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowDataManager.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowDataManager.swift
@@ -10,6 +10,7 @@ import Foundation
 
 protocol NativeFlowDataManager: AnyObject {
     var manifest: FinancialConnectionsSessionManifest { get set }
+    var visualUpdate: FinancialConnectionsSynchronize.VisualUpdate? { get }
     var returnURL: String? { get }
     var consentPaneModel: FinancialConnectionsConsent { get }
     var apiClient: FinancialConnectionsAPIClient { get }
@@ -34,6 +35,7 @@ class NativeFlowAPIDataManager: NativeFlowDataManager {
             didUpdateManifest()
         }
     }
+    let visualUpdate: FinancialConnectionsSynchronize.VisualUpdate?
     let returnURL: String?
     let consentPaneModel: FinancialConnectionsConsent
     let apiClient: FinancialConnectionsAPIClient
@@ -49,6 +51,7 @@ class NativeFlowAPIDataManager: NativeFlowDataManager {
 
     init(
         manifest: FinancialConnectionsSessionManifest,
+        visualUpdate: FinancialConnectionsSynchronize.VisualUpdate?,
         returnURL: String?,
         consentPaneModel: FinancialConnectionsConsent,
         apiClient: FinancialConnectionsAPIClient,
@@ -56,6 +59,7 @@ class NativeFlowAPIDataManager: NativeFlowDataManager {
         analyticsClient: FinancialConnectionsAnalyticsClient
     ) {
         self.manifest = manifest
+        self.visualUpdate = visualUpdate
         self.returnURL = returnURL
         self.consentPaneModel = consentPaneModel
         self.apiClient = apiClient


### PR DESCRIPTION
## Summary

^ adds support for `reduced_branding` flag which hides logo in navigation bar

Links for context:
- https://stripe.slack.com/archives/C02KW8G938W/p1670955745288589?thread_ts=1670955422.450539&cid=C02KW8G938W
- https://jira.corp.stripe.com/browse/BANKCON-5899
- https://jira.corp.stripe.com/browse/BANKCON-5586
- https://www.figma.com/file/pU6S60e08Rgv0dvycCxMT8/Connections---Mobile?node-id=2884%3A52462&t=rzvAXP5ys05asf6D-0
- https://git.corp.stripe.com/stripe-internal/stripe-js-v3/pull/13083
- https://github.com/stripe/stripe-android/pull/5949
- https://amp.corp.stripe.com/feature-flags/flag/bank_connections_enable_visual_features_in_synchronize_method/rollouts/ffrp_N0wFXcGgwweAOc

## Testing

<img width="352" alt="Screen Shot 2022-12-20 at 2 27 47 PM" src="https://user-images.githubusercontent.com/105514761/208750476-39f25b06-237d-4e1c-a4ae-a8c1f7f63db6.png">


# Logo Visible (BEFORE)

https://user-images.githubusercontent.com/105514761/208525216-935fd81c-5259-4f7f-a903-e9a6f56c7e34.mov

# Logo NOT Visible (AFTER)

https://user-images.githubusercontent.com/105514761/208525246-9cb86098-95c5-4774-8e1e-51c859215e18.mov
