### PR TITLE
Run tuist only in CI

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -325,6 +325,7 @@ workflows:
         inputs:
         - clone_depth: '1'
     - tuist@0:
+        run_if: .IsCI
         inputs:
         - command: generate -n
     - cache-pull@2: {}


### PR DESCRIPTION
## Summary
Running the Tuist step only in CI.
This step first installs Tuist, which requires root permissions so it asks for the user's password, this is annoying when running locally and should be unnecessary since developers should have already generated projects in their workspace.
I will also look into contributing to the step to skip installing Tuist if it's already installed, but for now this should be enough.

## Motivation
Got feedback that being requested for the password was annoying.

## Testing
- Ran a workflow locally and Tuist wasn't installed.
- CI
