### PR TITLE
Financial Connections: Added a bitrise financial-connections-stability-tests workflow

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -434,6 +434,22 @@ workflows:
       bitrise.io:
         stack: osx-xcode-13.2.x
         machine_type_id: g2-m1.8core
+  financial-connections-stability-tests:
+    before_run:
+    - prep_all
+    steps:
+    - xcode-test@4:
+        inputs:
+        - destination: $DEFAULT_TEST_DEVICE
+        - test_repetition_mode: retry_on_failure
+        - maximum_test_repetitions: '5'
+        - scheme: FinancialConnections Example
+    - slack@3:
+        is_always_run: true
+        inputs:
+        - webhook_url: $SLACK_KGAIDIS_TESTING_WEBHOOK_URL
+        - webhook_url_on_error: $SLACK_KGAIDIS_TESTING_WEBHOOK_URL
+    - deploy-to-bitrise-io@2: {}
 meta:
   bitrise.io:
     stack: osx-xcode-14.1.x-ventura


### PR DESCRIPTION
## Summary

This "workflow" runs Financial Connections UI tests. Then it slacks #kgaidis-testing channel when done.

Later, this "workflow" will be run based on a schedule.

## Testing

1. I replaced `$SLACK_KGAIDIS_TESTING_WEBHOOK_URL`  with the stored secret
2. I ran `bitrise run financial-connections-stability-tests` locally

Workflow ran successfully:

```
+------------------------------------------------------------------------------+
|            bitrise summary: financial-connections-stability-tests            |
+---+---------------------------------------------------------------+----------+
|   | title                                                         | time (s) |
+---+---------------------------------------------------------------+----------+
| ✓ | Start Xcode simulator                                         | 2.58 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Set CONFIGURATION_BUILD_DIR                                   | 0.50 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Set CONFIGURATION_TEMP_DIR                                    | 0.49 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Set Bundler to use local vendor directory                     | 0.63 sec |
+---+---------------------------------------------------------------+----------+
| - | Git Clone Repository (Skipped)                                | 0.59 sec |
+---+---------------------------------------------------------------+----------+
| - | Run Tuist (Skipped)                                           | 0.51 sec |
+---+---------------------------------------------------------------+----------+
| - | Bitrise.io Cache:Pull (Skipped)                               | 0.42 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Bundler                                                       | 0.84 sec |
+---+---------------------------------------------------------------+----------+
| - | Bitrise.io Cache:Push (Skipped)                               | 0.45 sec |
+---+---------------------------------------------------------------+----------+
| - | Restore SPM Cache (Beta) (Skipped)                            | 0.49 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Xcode Test for iOS                                            | 40.38 sec|
+---+---------------------------------------------------------------+----------+
| ✓ | Send a Slack message                                          | 0.82 sec |
+---+---------------------------------------------------------------+----------+
| - | Deploy to Bitrise.io - Apps, Logs, Artifacts (Skipped)        | 0.68 sec |
+---+---------------------------------------------------------------+----------+
| Total runtime: 49.38 sec                                                     |
+------------------------------------------------------------------------------+
```

I got Slack message:
- https://stripe.slack.com/archives/C04G5PZM71T/p1671658329861029