### PR TITLE
Conform PaymentSheetError to CustomDebugStringConvertible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## X.Y.Z 2022-xx-xx
 * [Changed] Using [Tuist](https://tuist.io) to generate Xcode projects. From now on, only release versions of the SDK will include Xcode project files, in case you want to build a non release revision from source, you can follow [these instructions](https://docs.tuist.io/tutorial/get-started) to generate the project files. For Carthage users, this also means that you will only be able to depend on release versions.
 
+### PaymentSheet
+* [Added] `PaymentSheetError` now conforms to `CustomDebugStringConvertible` and has a more useful description when no payment method types are available.
+
 ## 23.3.1 2022-12-12
 * [Fixed] Fixed a bug where 3 decimal place currencies were not being formatted properly.
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
@@ -114,7 +114,7 @@ public class PaymentSheet {
                 // Verify that there are payment method types available for the intent and configuration.
                 let paymentMethodTypes = PaymentMethodType.filteredPaymentMethodTypes(from: intent, configuration: self.configuration)
                 guard !paymentMethodTypes.isEmpty else {
-                    completion(.failed(error: PaymentSheetError.noPaymentMethodTypesAvailable))
+                    completion(.failed(error: PaymentSheetError.noPaymentMethodTypesAvailable(paymentIntentPaymentMethods: intent.recommendedPaymentMethodTypes)))
                     return
                 }
                 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
@@ -114,7 +114,7 @@ public class PaymentSheet {
                 // Verify that there are payment method types available for the intent and configuration.
                 let paymentMethodTypes = PaymentMethodType.filteredPaymentMethodTypes(from: intent, configuration: self.configuration)
                 guard !paymentMethodTypes.isEmpty else {
-                    completion(.failed(error: PaymentSheetError.noPaymentMethodTypesAvailable(paymentIntentPaymentMethods: intent.recommendedPaymentMethodTypes)))
+                    completion(.failed(error: PaymentSheetError.noPaymentMethodTypesAvailable(intentPaymentMethods: intent.recommendedPaymentMethodTypes)))
                     return
                 }
                 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetError.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetError.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 @_spi(STP) import StripeCore
+import StripePayments
 
 /// Errors specific to PaymentSheet itself
 ///
@@ -18,7 +19,7 @@ public enum PaymentSheetError: Error {
     case unknown(debugDescription: String)
     
     /// No payment method types available error.
-    case noPaymentMethodTypesAvailable
+    case noPaymentMethodTypesAvailable(paymentIntentPaymentMethods: [STPPaymentMethodType])
 
     /// Localized description of the error
     public var localizedDescription: String {
@@ -26,19 +27,21 @@ public enum PaymentSheetError: Error {
     }
 }
 
-extension PaymentSheetError {
+extension PaymentSheetError: CustomDebugStringConvertible {
     /// Returns true if the error is un-fixable; e.g. no amount of retrying or customer action will result in something different
     static func isUnrecoverable(error: Error) -> Bool {
         // TODO: Expired ephemeral key
         return false
     }
     
-    var debugDescription: String {
-        switch self {
-        case .noPaymentMethodTypesAvailable:
-            return "No payment method types available"
-        case .unknown(let debugDescription):
-            return debugDescription
-        }
+    public var debugDescription: String {
+        return "An error ocurred in PaymentSheet. " + {
+            switch self {
+            case .noPaymentMethodTypesAvailable(let paymentIntentPaymentMethods):
+                return "No payment method types are available. You may need to set `allowsDelayedPaymentMethods` or `allowsPaymentMethodsRequiringShippingAddress` in your PaymentSheet.Configuration object. The PaymentIntent has the following types: \(paymentIntentPaymentMethods)"
+            case .unknown(let debugDescription):
+                return debugDescription
+            }
+        }()
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetError.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetError.swift
@@ -19,7 +19,7 @@ public enum PaymentSheetError: Error {
     case unknown(debugDescription: String)
     
     /// No payment method types available error.
-    case noPaymentMethodTypesAvailable(paymentIntentPaymentMethods: [STPPaymentMethodType])
+    case noPaymentMethodTypesAvailable(intentPaymentMethods: [STPPaymentMethodType])
 
     /// Localized description of the error
     public var localizedDescription: String {
@@ -37,8 +37,8 @@ extension PaymentSheetError: CustomDebugStringConvertible {
     public var debugDescription: String {
         return "An error ocurred in PaymentSheet. " + {
             switch self {
-            case .noPaymentMethodTypesAvailable(let paymentIntentPaymentMethods):
-                return "No payment method types are available. You may need to set `allowsDelayedPaymentMethods` or `allowsPaymentMethodsRequiringShippingAddress` in your PaymentSheet.Configuration object. The PaymentIntent has the following types: \(paymentIntentPaymentMethods)"
+            case .noPaymentMethodTypesAvailable(let intentPaymentMethods):
+                return "None of the payment methods on the PaymentIntent/SetupIntent can be used in PaymentSheet: \(intentPaymentMethods). You may need to set `allowsDelayedPaymentMethods` or `allowsPaymentMethodsRequiringShippingAddress` in your PaymentSheet.Configuration object."
             case .unknown(let debugDescription):
                 return debugDescription
             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -186,7 +186,7 @@ extension PaymentSheet {
                         from: intent,
                         configuration: configuration)
                     guard !paymentMethodTypes.isEmpty else {
-                        completion(.failure(PaymentSheetError.noPaymentMethodTypesAvailable))
+                        completion(.failure(PaymentSheetError.noPaymentMethodTypesAvailable(paymentIntentPaymentMethods: intent.recommendedPaymentMethodTypes)))
                         return
                     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -186,7 +186,7 @@ extension PaymentSheet {
                         from: intent,
                         configuration: configuration)
                     guard !paymentMethodTypes.isEmpty else {
-                        completion(.failure(PaymentSheetError.noPaymentMethodTypesAvailable(paymentIntentPaymentMethods: intent.recommendedPaymentMethodTypes)))
+                        completion(.failure(PaymentSheetError.noPaymentMethodTypesAvailable(intentPaymentMethods: intent.recommendedPaymentMethodTypes)))
                         return
                     }
 


### PR DESCRIPTION
## Summary
Conform PaymentSheetError to CustomDebugStringConvertible and adds more detailed debug descriptions.

## Motivation
It seems like we intended to do this but forgot.  

Conforming to `CustomDebugStringConvertible` lets us provide the string used when calling print, debugPrint, and po in the debugger.

You can see other *Error types conform to it in other SDKs e.g. `IdentityVerificationSheetError`.

## Testing
I manually tested:
```
print(PaymentSheetError.unknown(debugDescription: "The client secret is missing"))
print(PaymentSheetError.noPaymentMethodTypesAvailable(paymentIntentPaymentMethods: [.USBankAccount, .UPI]))
```

This produces the following output **before**:
```
unknown(debugDescription: "The client secret is missing")
noPaymentMethodTypesAvailable
```
and **after**:
```
An error ocurred in PaymentSheet. The client secret is missing
An error ocurred in PaymentSheet. No payment method types are available. You may need to set `allowsDelayedPaymentMethods` or `allowsPaymentMethodsRequiringShippingAddress` in your PaymentSheet.Configuration object. The PaymentIntent has the following types: [USBankAccount, UPI]
```

## Changelog
See CHANGELOG.md