### PR TITLE
Move CI trigger to PR instead of push

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -14,7 +14,7 @@ app:
       is_expand: false
     FASTLANE_LANE: ios integration_all
 trigger_map:
-- push_branch: "*"
+- pull_request_source_branch: '*'
   pipeline: main-trigger-pipeline
 pipelines:
   main-trigger-pipeline:


### PR DESCRIPTION
## Summary
Triggering CI on PR instead of Push

## Motivation
Apparently this is the preferred approach by Bitrise, and our current approach doesn't allow us to trigger CI on external PRs.

## Testing
CI
