### PR TITLE
Only run size-report on internal PRs

### DIFF
--- a/Tests/installation_tests/size_test/size_report.rb
+++ b/Tests/installation_tests/size_test/size_report.rb
@@ -36,6 +36,15 @@ require 'terminal-table'
 #
 ################################################################################
 
+puts "REPO: #{ENV["BITRISEIO_PULL_REQUEST_REPOSITORY_URL"]}"
+
+# Local runs don't set this env variable, defaulting to the stripe repo so the report is run.
+pr_repo_url = ENV["BITRISEIO_PULL_REQUEST_REPOSITORY_URL"] ||= 'https://github.com/stripe/stripe-ios'
+unless pr_repo_url.include? 'github.com/stripe/stripe-ios'
+  puts 'Size report can only be run on Stripe PRs, skipping.'
+  exit 0
+end
+
 # MARK: - Helpers
 
 # Redefine backtick to exit the script on failure.

--- a/Tests/installation_tests/size_test/size_report.rb
+++ b/Tests/installation_tests/size_test/size_report.rb
@@ -36,10 +36,8 @@ require 'terminal-table'
 #
 ################################################################################
 
-puts "REPO: #{ENV["BITRISEIO_PULL_REQUEST_REPOSITORY_URL"]}"
-
 # Local runs don't set this env variable, defaulting to the stripe repo so the report is run.
-pr_repo_url = ENV["BITRISEIO_PULL_REQUEST_REPOSITORY_URL"] ||= 'https://github.com/stripe/stripe-ios'
+pr_repo_url = ENV["BITRISEIO_PULL_REQUEST_REPOSITORY_URL"] ||= 'https://github.com/stripe/stripe-ios.git'
 unless pr_repo_url.include? 'github.com/stripe/stripe-ios'
   puts 'Size report can only be run on Stripe PRs, skipping.'
   exit 0


### PR DESCRIPTION
## Summary
The size report check only works on internal PRs, so only running it on internal PRs.

## Motivation
Avoid failing CI on external PRs.

## Testing
CI
