### PR TITLE
Fix multiple CI issues related to Tuist

### DIFF
--- a/Tests/installation_tests/carthage/setup.sh
+++ b/Tests/installation_tests/carthage/setup.sh
@@ -11,6 +11,14 @@ function die {
   exit 1
 }
 
+# Commit generated xcode project files.
+git add Stripe.xcworkspace -f &&
+  git add Stripe*/*.xcodeproj -f &&
+  git add Example/**/*.xcodeproj -f &&
+  git add Testers/**/*.xcodeproj -f &&
+  git add -u &&
+  git commit -m "Commit xcode project files temporarily"
+
 # Clean carthage artifacts
 info "Cleaning carthage artifacts..."
 
@@ -35,6 +43,9 @@ cd "${script_dir}" || die "Executing \`cd\` failed"
 carthage bootstrap --platform ios --configuration Debug --no-use-binaries --cache-builds --use-xcframeworks
 
 carthage_exit_code="$?"
+
+# Undo the temporarily committed xcode project files.
+git reset HEAD~
 
 if [[ "${carthage_exit_code}" != 0 ]]; then
   die "Executing carthage bootstrap failed with status code: ${carthage_exit_code}"

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -93,6 +93,10 @@ workflows:
         title: Set bundler to ignore development and test gems
     - git-clone@6: {}
     - cache-pull@2: {}
+    - tuist@0:
+        run_if: .IsCI
+        inputs:
+        - command: generate -n
     - bundler@0: {}
     - cache-push@2:
         inputs:

--- a/ci_scripts/deploy_release.rb
+++ b/ci_scripts/deploy_release.rb
@@ -102,11 +102,11 @@ def cleanup_project_files
   run_command("git checkout -b #{@cleanup_branchname}")
   run_command('ci_scripts/delete_project_files.rb')
   run_command("git add -u && git commit -m \"Remove generated project files for v#{@version}\"")
-  run_command("git push origin #{@cleanup_branchname}")
 end
 
 def create_cleanup_pr
   unless @is_dry_run
+    run_command("git push origin #{@cleanup_branchname}")
     pr = @github_client.create_pull_request(
       'stripe/stripe-ios',
       'master',


### PR DESCRIPTION
## Summary
Fixes multiple CI issues related to Tuist.
- data-theorem-sast workflow failed because tuist was not run (it didn't have prep-all as a before step).
- deploy-dry-run failed because it tried to push without a user token, fixed by not trying to push on dry run.
- carthage-install-test failed because it was using the git revision, which didn't include the project files, fixed by temporarily committing the project files before running the test.

## Motivation
Fix CI

## Testing
CI
