### PR TITLE
Financial Connections: wrote more UI tests to test more cases, including live mode

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
@@ -23,7 +23,7 @@ final class FinancialConnectionsUITests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 
-    func testDataTestModeNativeAuthFlow() throws {
+    func testDataTestModeOAuthNativeAuthFlow() throws {
         let app = XCUIApplication()
         app.launch()
         
@@ -53,9 +53,13 @@ final class FinancialConnectionsUITests: XCTestCase {
         XCTAssertTrue(consentAgreeButton.waitForExistence(timeout: 120.0)) // glitch app can take time to lload
         consentAgreeButton.tap()
         
-        let featuredLegacyTestInstitution = app.collectionViews.staticTexts["Test Institution"]
+        let featuredLegacyTestInstitution = app.collectionViews.staticTexts["Test OAuth Institution"]
         XCTAssertTrue(featuredLegacyTestInstitution.waitForExistence(timeout: 60.0))
         featuredLegacyTestInstitution.tap()
+        
+        let prepaneContinueButton = app.buttons["Continue"]
+        XCTAssertTrue(prepaneContinueButton.waitForExistence(timeout: 60.0))
+        prepaneContinueButton.tap()
         
         let accountPickerLinkAccountsButton = app.buttons["Link accounts"]
         XCTAssertTrue(accountPickerLinkAccountsButton.waitForExistence(timeout: 120.0)) // wait for accounts to fetch
@@ -70,5 +74,254 @@ final class FinancialConnectionsUITests: XCTestCase {
         
         // ensure alert body contains "Stripe Bank" (AKA one bank is linked)
         XCTAssert(playgroundSuccessAlert.staticTexts.containing(NSPredicate(format: "label CONTAINS 'StripeBank'")).firstMatch.exists)
+    }
+    
+    func testPaymentTestModeLegacyNativeAuthFlow() throws {
+        let app = XCUIApplication()
+        app.launch()
+        
+        let playgroundCell = app.tables.staticTexts["Playground"]
+        XCTAssertTrue(playgroundCell.waitForExistence(timeout: 60.0))
+        playgroundCell.tap()
+        
+        let dataSegmentPickerButton = app.collectionViews.buttons["Payments"]
+        XCTAssertTrue(dataSegmentPickerButton.waitForExistence(timeout: 60.0))
+        dataSegmentPickerButton.tap()
+        
+        let nativeSegmentPickerButton = app.collectionViews.buttons["Native"]
+        XCTAssertTrue(nativeSegmentPickerButton.waitForExistence(timeout: 60.0))
+        nativeSegmentPickerButton.tap()
+        
+        let enableTestModeSwitch = app.collectionViews.switches["Enable Test Mode"]
+        XCTAssertTrue(enableTestModeSwitch.waitForExistence(timeout: 60.0))
+        if (enableTestModeSwitch.value as? String) == "0" {
+            enableTestModeSwitch.tap()
+        }
+        
+        let showAuthFlowButton = app.buttons["Show Auth Flow"]
+        XCTAssertTrue(showAuthFlowButton.waitForExistence(timeout: 60.0))
+        showAuthFlowButton.tap()
+        
+        let consentAgreeButton = app.buttons["Agree"]
+        XCTAssertTrue(consentAgreeButton.waitForExistence(timeout: 120.0)) // glitch app can take time to lload
+        consentAgreeButton.tap()
+        
+        let featuredLegacyTestInstitution = app.collectionViews.staticTexts["Test Institution"]
+        XCTAssertTrue(featuredLegacyTestInstitution.waitForExistence(timeout: 60.0))
+        featuredLegacyTestInstitution.tap()
+        
+        let successAccountRow = app.scrollViews.staticTexts["Success"]
+        XCTAssertTrue(successAccountRow.waitForExistence(timeout: 60.0))
+        successAccountRow.tap()
+        
+        let accountPickerLinkAccountButton = app.buttons["Link account"]
+        XCTAssertTrue(accountPickerLinkAccountButton.waitForExistence(timeout: 120.0)) // wait for accounts to fetch
+        accountPickerLinkAccountButton.tap()
+        
+        let successPaneDoneButton = app.buttons["Done"]
+        XCTAssertTrue(successPaneDoneButton.waitForExistence(timeout: 120.0)) // wait for accounts to link
+        successPaneDoneButton.tap()
+        
+        let playgroundSuccessAlert = app.alerts["Success"]
+        XCTAssertTrue(playgroundSuccessAlert.waitForExistence(timeout: 60.0))
+        
+        // ensure alert body contains "Stripe Bank" (AKA one bank is linked)
+        XCTAssert(playgroundSuccessAlert.staticTexts.containing(NSPredicate(format: "label CONTAINS 'StripeBank'")).firstMatch.exists)
+    }
+    
+    // note that this does NOT complete the Auth Flow, but its a decent check on
+    // whether live mode is ~working
+    func testDataLiveModeOAuthNativeAuthFlow() throws {
+        let app = XCUIApplication()
+        app.launch()
+        
+        let playgroundCell = app.tables.staticTexts["Playground"]
+        XCTAssertTrue(playgroundCell.waitForExistence(timeout: 60.0))
+        playgroundCell.tap()
+        
+        let dataSegmentPickerButton = app.collectionViews.buttons["Data"]
+        XCTAssertTrue(dataSegmentPickerButton.waitForExistence(timeout: 60.0))
+        dataSegmentPickerButton.tap()
+        
+        let nativeSegmentPickerButton = app.collectionViews.buttons["Native"]
+        XCTAssertTrue(nativeSegmentPickerButton.waitForExistence(timeout: 60.0))
+        nativeSegmentPickerButton.tap()
+        
+        let enableTestModeSwitch = app.collectionViews.switches["Enable Test Mode"]
+        XCTAssertTrue(enableTestModeSwitch.waitForExistence(timeout: 60.0))
+        if (enableTestModeSwitch.value as? String) == "1" {
+            enableTestModeSwitch.tap()
+        }
+        
+        let showAuthFlowButton = app.buttons["Show Auth Flow"]
+        XCTAssertTrue(showAuthFlowButton.waitForExistence(timeout: 60.0))
+        showAuthFlowButton.tap()
+        
+        let consentAgreeButton = app.buttons["Agree"]
+        XCTAssertTrue(consentAgreeButton.waitForExistence(timeout: 120.0)) // glitch app can take time to lload
+        consentAgreeButton.tap()
+        
+        // find + tap an institution; we add extra institutions in case
+        // they don't get featured
+        let institutionButton: XCUIElement?
+        let institutionTextInWebView: String?
+        let chaseInstitutionButton = app.cells["Chase"]
+        if chaseInstitutionButton.waitForExistence(timeout: 10) {
+            institutionButton = chaseInstitutionButton
+            institutionTextInWebView = "Chase"
+        } else {
+            let bankOfAmericaInstitutionButton = app.cells["Bank of America"]
+            if bankOfAmericaInstitutionButton.waitForExistence(timeout: 10) {
+                institutionButton = bankOfAmericaInstitutionButton
+                institutionTextInWebView = "Bank of America"
+            } else {
+                let wellsFargoInstitutionButton = app.cells["Wells Fargo"]
+                if wellsFargoInstitutionButton.waitForExistence(timeout: 10) {
+                    institutionButton = wellsFargoInstitutionButton
+                    institutionTextInWebView = "Wells Fargo"
+                } else {
+                    institutionButton = nil
+                    institutionTextInWebView = nil
+                }
+            }
+        }
+        guard let institutionButton = institutionButton, let institutionTextInWebView = institutionTextInWebView else {
+            XCTFail("Couldn't find a Live Mode institution.")
+            return
+        }
+        institutionButton.tap()
+        
+        let prepaneContinueButton = app.buttons["Continue"]
+        XCTAssertTrue(prepaneContinueButton.waitForExistence(timeout: 60.0))
+        prepaneContinueButton.tap()
+        
+        // check that the WebView loaded
+        let institutionWebViewText = app.webViews
+            .staticTexts
+            .containing(NSPredicate(format: "label CONTAINS '\(institutionTextInWebView)'"))
+            .firstMatch
+        XCTAssertTrue(institutionWebViewText.waitForExistence(timeout: 120.0))
+        
+        let secureWebViewCancelButton = app.buttons["Cancel"]
+        XCTAssertTrue(secureWebViewCancelButton.waitForExistence(timeout: 60.0))
+        secureWebViewCancelButton.tap()
+        
+        let navigationBarCloseButton = app.navigationBars.buttons["close"]
+        XCTAssertTrue(navigationBarCloseButton.waitForExistence(timeout: 60.0))
+        navigationBarCloseButton.tap()
+        
+        let cancelAlert = app.alerts["Are you sure you want to cancel?"]
+        XCTAssertTrue(cancelAlert.waitForExistence(timeout: 60.0))
+        
+        let cancelAlertButon =  app.alerts.buttons["Yes, cancel"]
+        XCTAssertTrue(cancelAlertButon.waitForExistence(timeout: 60.0))
+        cancelAlertButon.tap()
+
+        let playgroundCancelAlert = app.alerts["Cancelled"]
+        XCTAssertTrue(playgroundCancelAlert.waitForExistence(timeout: 60.0))
+    }
+    
+    // note that this does NOT complete the Auth Flow, but its a decent check on
+    // whether live mode is ~working
+    func testDataLiveModeOAuthWebAuthFlow() throws {
+        let app = XCUIApplication()
+        app.launch()
+        
+        let playgroundCell = app.tables.staticTexts["Playground"]
+        XCTAssertTrue(playgroundCell.waitForExistence(timeout: 60.0))
+        playgroundCell.tap()
+        
+        let dataSegmentPickerButton = app.collectionViews.buttons["Data"]
+        XCTAssertTrue(dataSegmentPickerButton.waitForExistence(timeout: 60.0))
+        dataSegmentPickerButton.tap()
+        
+        let nativeSegmentPickerButton = app.collectionViews.buttons["Web"]
+        XCTAssertTrue(nativeSegmentPickerButton.waitForExistence(timeout: 60.0))
+        nativeSegmentPickerButton.tap()
+        
+        let enableTestModeSwitch = app.collectionViews.switches["Enable Test Mode"]
+        XCTAssertTrue(enableTestModeSwitch.waitForExistence(timeout: 60.0))
+        if (enableTestModeSwitch.value as? String) == "1" {
+            enableTestModeSwitch.tap()
+        }
+        
+        let showAuthFlowButton = app.buttons["Show Auth Flow"]
+        XCTAssertTrue(showAuthFlowButton.waitForExistence(timeout: 60.0))
+        showAuthFlowButton.tap()
+        
+        let consentAgreeButton = app.webViews.buttons["Agree"]
+        XCTAssertTrue(consentAgreeButton.waitForExistence(timeout: 120.0)) // glitch app can take time to load
+        consentAgreeButton.tap()
+        
+        // find + tap an institution; we add extra institutions in case
+        // they don't get featured
+        let institutionButton: XCUIElement?
+        let institutionTextInWebView: String?
+        let chaseInstitutionButton = app.webViews.buttons["Chase"]
+        if chaseInstitutionButton.waitForExistence(timeout: 10) {
+            institutionButton = chaseInstitutionButton
+            institutionTextInWebView = "Chase"
+        } else {
+            let bankOfAmericaInstitutionButton = app.webViews.buttons["Bank of America"]
+            if bankOfAmericaInstitutionButton.waitForExistence(timeout: 10) {
+                institutionButton = bankOfAmericaInstitutionButton
+                institutionTextInWebView = "Bank of America"
+            } else {
+                let wellsFargoInstitutionButton = app.webViews.buttons["Wells Fargo"]
+                if wellsFargoInstitutionButton.waitForExistence(timeout: 10) {
+                    institutionButton = wellsFargoInstitutionButton
+                    institutionTextInWebView = "Wells Fargo"
+                } else {
+                    institutionButton = nil
+                    institutionTextInWebView = nil
+                }
+            }
+        }
+        guard let institutionButton = institutionButton, let institutionTextInWebView = institutionTextInWebView else {
+            XCTFail("Couldn't find a Live Mode institution.")
+            return
+        }
+        institutionButton.tap()
+        
+        let prepaneContinueButton = app.webViews.buttons["Continue"]
+        XCTAssertTrue(prepaneContinueButton.waitForExistence(timeout: 60.0))
+        prepaneContinueButton.tap()
+        
+        // check that the WebView loaded
+        let institutionWebViewText = app.webViews
+            .staticTexts
+            .containing(NSPredicate(format: "label CONTAINS '\(institutionTextInWebView)'"))
+            .firstMatch
+        XCTAssertTrue(institutionWebViewText.waitForExistence(timeout: 120.0))
+        
+        let secureWebViewCancelButton = app.buttons["Cancel"]
+        XCTAssertTrue(secureWebViewCancelButton.waitForExistence(timeout: 60.0))
+        secureWebViewCancelButton.tap()
+        
+        let playgroundCancelAlert = app.alerts["Cancelled"]
+        XCTAssertTrue(playgroundCancelAlert.waitForExistence(timeout: 60.0))
+    }
+}
+
+extension XCTestCase {
+    fileprivate func wait(timeout: TimeInterval) {
+       _ = XCTWaiter.wait(for: [XCTestExpectation(description: "")], timeout: timeout)
+   }
+}
+
+extension XCUIElement {
+    
+    fileprivate func wait(
+        until expression: @escaping (XCUIElement) -> Bool,
+        timeout: TimeInterval
+    ) -> Bool {
+        let expectation = XCTNSPredicateExpectation(
+            predicate: NSPredicate { _, _ in
+                expression(self)
+            },
+            object: nil
+        )
+        let result = XCTWaiter().wait(for: [expectation], timeout: timeout)
+        return (result == .completed)
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/FeaturedInstitutionGridView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/FeaturedInstitutionGridView.swift
@@ -48,6 +48,7 @@ class FeaturedInstitutionGridView: UIView {
                 fatalError("Couldn't find cell with reuseIdentifier \(cellIdentifier)")
             }
             cell.customize(with: institution)
+            cell.accessibilityLabel = institution.name // used for UI tests
             return cell
         }
         self.dataSource = dataSource

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -380,12 +380,6 @@ workflows:
         - test_repetition_mode: retry_on_failure
         - maximum_test_repetitions: "5"
         - scheme: PaymentSheet Example
-    - xcode-test@4:
-        inputs:
-        - destination: "$DEFAULT_TEST_DEVICE"
-        - test_repetition_mode: retry_on_failure
-        - maximum_test_repetitions: "5"
-        - scheme: FinancialConnections Example
     - deploy-to-bitrise-io@2: {}
     before_run:
     - prep_all


### PR DESCRIPTION
## Summary

The UI tests succeeded every 3 hours for over 7 days. Since the reliability is good, we are now adding more UI tests to keep testing the reliability with more tests.

There are now 4 tests:
- 3 tests for native flow: 1 test mode OAuth for 'data' flows, 1 test mode legacy for 'payment' flows, 1 live mode test
- 1 live mode test for web flow

Note that the live mode tests only test opening the institution browser (it does not enter credentials). Right now there is no test that tests going through the full WEB flow - that's because Xcode UI tests were not able to recognize certain Web View elements.

## Testing

1. I replaced $SLACK_KGAIDIS_TESTING_WEBHOOK_URL with the stored secret
2. I ran `bitrise run financial-connections-stability-tests` locally

Workflow ran successfully:

```
|            bitrise summary: financial-connections-stability-tests            |
+---+---------------------------------------------------------------+----------+
|   | title                                                         | time (s) |
+---+---------------------------------------------------------------+----------+
| ✓ | Start Xcode simulator                                         | 2.76 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Set CONFIGURATION_BUILD_DIR                                   | 0.51 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Set CONFIGURATION_TEMP_DIR                                    | 0.48 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Set Bundler to use local vendor directory                     | 0.72 sec |
+---+---------------------------------------------------------------+----------+
| - | Git Clone Repository (Skipped)                                | 0.57 sec |
+---+---------------------------------------------------------------+----------+
| Update available: 6 (6.2.3) -> 7.0.0                                         |
|                                                                              |
| Release notes are available below                                            |
| https://github.com/bitrise-steplib/steps-git-clone/releases                  |
+---+---------------------------------------------------------------+----------+
| - | Run Tuist (Skipped)                                           | 0.48 sec |
+---+---------------------------------------------------------------+----------+
| - | Bitrise.io Cache:Pull (Skipped)                               | 0.41 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Bundler                                                       | 0.88 sec |
+---+---------------------------------------------------------------+----------+
| - | Bitrise.io Cache:Push (Skipped)                               | 0.48 sec |
+---+---------------------------------------------------------------+----------+
| - | Restore SPM Cache (Beta) (Skipped)                            | 0.48 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Xcode Test for iOS                                            | 2.4 min  |
+---+---------------------------------------------------------------+----------+
| ✓ | Send a Slack message                                          | 0.72 sec |
+---+---------------------------------------------------------------+----------+
| - | Deploy to Bitrise.io - Apps, Logs, Artifacts (Skipped)        | 0.61 sec |
+---+---------------------------------------------------------------+----------+
| Total runtime: 2.5 min                                                       |
+------------------------------------------------------------------------------+


Submitting anonymized usage information...
For more information visit:
https://github.com/bitrise-io/bitrise-plugins-analytics/blob/master/README.md

Bitrise build successful
```