### PR TITLE
Add notify_ci step to legacy tests

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -263,6 +263,7 @@ workflows:
     - prep_all
     after_run:
     - upload_logs
+    - notify_ci
     meta:
       bitrise.io:
         stack: osx-xcode-13.3.x
@@ -279,6 +280,7 @@ workflows:
     - prep_all
     after_run:
     - upload_logs
+    - notify_ci
   lint-tests:
     steps:
     - fastlane@3:


### PR DESCRIPTION
## Summary
This step was missing after the bitrise migration

## Motivation
This is necessary to alert when these tests fail.

## Testing
CI

