### PR TITLE
Fix invalid DocC deprecation warnings

### DIFF
--- a/ci_scripts/build_documentation.rb
+++ b/ci_scripts/build_documentation.rb
@@ -221,6 +221,15 @@ def build_index_page(modules, release_version, docs_root_directory)
   # Copy 404 redirect page
   `cp "#{$SCRIPT_DIR}/docs/404.html" "#{docs_root_directory}/docs/404.html"`
 
+  # HACK: Remove all deprecation warnings.
+  # Remove this once DocC is fixed: https://github.com/apple/swift-docc/issues/450
+  js_files = Dir.glob("#{docs_root_directory}/docs/**/*.json")
+  js_files.each do |jsf|
+    content = File.read(jsf)
+    content = content.gsub(/"deprecated":true/, '"deprecated":false')
+    File.open(jsf, 'w') { |file| file.puts content }
+  end
+
   # Clean up the bogus index.html file created by DocC
   File.delete("#{docs_root_directory}/docs/index.html")
 end


### PR DESCRIPTION
## Summary
Temporarily remove deprecation warnings from DocC output until https://github.com/apple/swift-docc/issues/450 is fixed.

## Testing
 https://github.com/stripe/stripe-ios/pull/2193