### PR TITLE
Fix DocC nightly run issues

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -91,11 +91,11 @@ workflows:
     - prep_all
     after_run:
     - notify_ci
-  build-docs:
+  check-docs:
     steps:
     - script@1:
         inputs:
-        - content: bundle exec ./ci_scripts/build_documentation.rb --publish
+        - content: bundle exec ./ci_scripts/build_documentation.rb
         title: Build documentation
     before_run:
     - prep_all

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -44,7 +44,7 @@ stages:
   stage-releases-run-all:
     workflows:
     - framework-tests: {}
-    - build-docs: {}
+    - deploy-docs: {}
     - install-tests-non-carthage: {}
     - lint-tests: {}
     - size-report: {}
@@ -59,7 +59,7 @@ stages:
     workflows:
     - basic-integration-tests: {}
     - ui-tests: {}
-    - build-docs: {}
+    - check-docs: {}
     - legacy-tests-13: {}
     - legacy-tests-14: {}
     - carthage-install-test: {}
@@ -93,13 +93,42 @@ workflows:
     - notify_ci
   build-docs:
     steps:
-    - activate-ssh-key@4: {}
     - script@1:
         inputs:
         - content: bundle exec ./ci_scripts/build_documentation.rb --publish
         title: Build documentation
     before_run:
     - prep_all
+    after_run:
+    - notify_ci
+  deploy-docs:
+    steps:
+    - activate-ssh-key@4: {}
+    - script@1:
+        inputs:
+        - content: bundle config set path 'vendor/bundle'
+        is_always_run: true
+        title: Set Bundler to use local vendor directory
+    - git-clone@6:
+        inputs:
+        - merge_pr: 'no'
+        - fetch_tags: 'yes'
+    - cache-pull@2: {}
+    - bundler@0: {}
+    - cache-push@2:
+        inputs:
+        - compress_archive: 'true'
+        - cache_paths: |
+            vendor
+            SourcePackages
+    - script@1:
+        inputs:
+        - content: git fetch origin
+        title: Fetch full branch history
+    - script@1:
+        inputs:
+        - content: bundle exec ./ci_scripts/build_documentation.rb --publish
+        title: Build documentation
   data-theorem-sast:
     steps:
     - script@1:

--- a/ci_scripts/create_release.rb
+++ b/ci_scripts/create_release.rb
@@ -54,7 +54,6 @@ def commit_changes
     git add Example/**/*.xcodeproj -f &&
     git add Testers/**/*.xcodeproj -f &&
     git add -u &&
-    git add docs &&
     git commit -m \"Update version to #{@version}\"")
 end
 

--- a/ci_scripts/deploy_release.rb
+++ b/ci_scripts/deploy_release.rb
@@ -2,6 +2,19 @@
 
 require_relative 'release_common'
 
+# This should generally be the minimum Xcode version supported by the App Store, as the
+# compiled XCFrameworks won't be usable on older versions.
+# We sometimes bump this if an Xcode bug or deprecation forces us to upgrade early.
+MIN_SUPPORTED_XCODE_VERSION = '13.2.1'.freeze
+
+# Verify that xcode-select -p returns the correct version for building Stripe.xcframework.
+unless `xcodebuild -version`.include?("Xcode #{MIN_SUPPORTED_XCODE_VERSION}")
+  rputs "Xcode #{MIN_SUPPORTED_XCODE_VERSION} is required to build Stripe.xcframework."
+  rputs 'Use `xcode-select -s` to select the correct version, or download it from https://developer.apple.com/download/more/.'
+  rputs "If you believe this is no longer the correct version, update `MIN_SUPPORTED_XCODE_VERSION` in `#{__FILE__}`."
+  abort
+end
+
 @version = version_from_file
 
 @changelog = changelog(@version)
@@ -11,10 +24,6 @@ require_relative 'release_common'
 def export_builds
   # Compile the build products: bundle install && ./ci_scripts/export_builds.rb
   run_command('ci_scripts/export_builds.rb')
-end
-
-def pod_lint
-  pod_lint_common
 end
 
 def changedoc_approve
@@ -139,7 +148,6 @@ end
 
 steps = [
   method(:export_builds),
-  method(:pod_lint),
   method(:changedoc_approve),
   method(:approve_pr),
   method(:create_docs_pr),

--- a/ci_scripts/release_common.rb
+++ b/ci_scripts/release_common.rb
@@ -9,11 +9,6 @@ require 'colorize'
 require 'octokit'
 require 'erb'
 
-# This should generally be the minimum Xcode version supported by the App Store, as the
-# compiled XCFrameworks won't be usable on older versions.
-# We sometimes bump this if an Xcode bug or deprecation forces us to upgrade early.
-MIN_SUPPORTED_XCODE_VERSION = '13.2.1'.freeze
-
 SCRIPT_DIR = __dir__
 abort 'Unable to find SCRIPT_DIR' if SCRIPT_DIR.nil? || SCRIPT_DIR.empty?
 
@@ -148,11 +143,3 @@ def execute_steps(steps, step_index)
 end
 
 @github_client = github_login unless @is_dry_run
-
-# Verify that xcode-select -p returns the correct version for building Stripe.xcframework.
-unless `xcodebuild -version`.include?("Xcode #{MIN_SUPPORTED_XCODE_VERSION}")
-  rputs "Xcode #{MIN_SUPPORTED_XCODE_VERSION} is required to build Stripe.xcframework and propose the deploy."
-  rputs 'Use `xcode-select -s` to select the correct version, or download it from https://developer.apple.com/download/more/.'
-  rputs "If you believe this is no longer the correct version, update `MIN_SUPPORTED_XCODE_VERSION` in `#{__FILE__}`."
-  abort
-end


### PR DESCRIPTION
## Summary
* Fix the nightly docs job to check the docs without publishing. Pull the full git repo during the docs deploy job.
* Remove a broken (and unnecessary) `pod lib lint` step
* Only check the Xcode version for deploying release artifacts, as the proposer no longer needs a specific Xcode version

## Testing
CI, will run the jobs separately to test