### PR TITLE
Add xcode 13 tests to main pipeline

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -38,6 +38,7 @@ stages:
   stage-trigger-run-all:
     workflows:
     - framework-tests: {}
+    - framework-tests-xcode-13: {}
     - install-tests-non-carthage: {}
     - lint-tests: {}
     - size-report: {}
@@ -238,6 +239,22 @@ workflows:
     before_run:
     - prep_all
     after_run: []
+  framework-tests-xcode-13:
+    steps:
+    - fastlane@3:
+        inputs:
+        - lane: legacy_tests_14
+        title: fastlane legacy_tests_14
+    envs:
+    - DEFAULT_TEST_DEVICE: "platform=iOS Simulator,name=iPhone 8,OS=14.5"
+    before_run:
+    - prep_all
+    after_run:
+    - upload_logs
+    meta:
+      bitrise.io:
+        stack: osx-xcode-13.2.x
+        machine_type_id: g2-m1.8core
   install-tests-non-carthage:
     steps:
     - fastlane@3:


### PR DESCRIPTION
## Summary
Now that we are not resource constrained, we can add xcode 13 tests to the main pipeline.

## Motivation
We want to catch issues from the oldest supported version of xcode during PR.

## Testing
CI
