### PR TITLE
Disabling some lint rules

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -23,18 +23,18 @@ disabled_rules:
   - function_parameter_count
   - multiple_closures_with_trailing_closure
   - inclusive_language
+  - line_length
+  - xctfail_message
+  - no_fallthrough_only
+  - closure_parameter_position
   # The following rules were disabled during the initial cleanup, if it causes too much trouble to fix
   # violations in future changes they can be disabled on a case by case basis.
-  # - line_length
   # - shorthand_operator
   # - for_where  
-  # - xctfail_message
   # - empty_count
   # - overridden_super_call
   # - redundant_string_enum_value
-  # - no_fallthrough_only
   # - class_delegate_protocol
-  # - closure_parameter_position
   # - reduce_boolean
   # - unused_setter_value
   # - notification_center_detachment
@@ -65,14 +65,12 @@ opt_in_rules:
   - weak_delegate
   - discouraged_object_literal
   - unowned_variable_capture
-  - indentation_width
   - single_test_class
   # The following rules were disabled during the initial cleanup, if it causes too much trouble to fix
   # violations in future changes they can be disabled on a case by case basis.
   # - weak_delegate
   # - discouraged_object_literal
   # - unowned_variable_capture
-  # - indentation_width
   # - single_test_class
 
 excluded:


### PR DESCRIPTION
## Summary
Disabling some swiftlint rules

## Motivation
Some of these rules are too annoying, disabling them.

## Testing
CI
