### PR TITLE
Financial Connections: added support for subtitle for DataAccessNotice displayed in a bottom sheet

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsBulletPoint.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsBulletPoint.swift
@@ -1,0 +1,20 @@
+//
+//  FinancialConnectionsBulletPoint.swift
+//  StripeFinancialConnections
+//
+//  Created by Krisjanis Gaidis on 1/19/23.
+//
+
+import Foundation
+
+struct FinancialConnectionsBulletPoint: Decodable {
+    let icon: FinancialConnectionsImage?
+    let title: String?
+    let content: String?
+
+    init(icon: FinancialConnectionsImage, title: String? = nil, content: String? = nil) {
+        self.icon = icon
+        self.title = title
+        self.content = content
+    }
+}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsConsent.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsConsent.swift
@@ -1,0 +1,23 @@
+//
+//  FinancialConnectionsConsent.swift
+//  StripeFinancialConnections
+//
+//  Created by Krisjanis Gaidis on 1/19/23.
+//
+
+import Foundation
+
+struct FinancialConnectionsConsent: Decodable {
+    let title: String
+    let body: Body
+    let aboveCta: String
+    let cta: String
+    let belowCta: String?
+
+    let dataAccessNotice: FinancialConnectionsDataAccessNotice
+    let legalDetailsNotice: FinancialConnectionsLegalDetailsNotice
+
+    struct Body: Decodable {
+        let bullets: [FinancialConnectionsBulletPoint]
+    }
+}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsDataAccessNotice.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsDataAccessNotice.swift
@@ -1,18 +1,17 @@
 //
-//  ConsentBottomSheetModel.swift
+//  FinancialConnectionsDataAccessNotice.swift
 //  StripeFinancialConnections
 //
-//  Created by Krisjanis Gaidis on 11/17/22.
-//  Copyright © 2022 Stripe, Inc. All rights reserved.
+//  Created by Krisjanis Gaidis on 1/19/23.
 //
 
 import Foundation
 
-struct ConsentBottomSheetModel {
+struct FinancialConnectionsDataAccessNotice: Decodable {
     let title: String
     let subtitle: String?
     let body: Body
-    let extraNotice: String?
+    let connectedAccountNotice: String?
     let learnMore: String
     let cta: String
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsLegalDetailsNotice.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsLegalDetailsNotice.swift
@@ -1,18 +1,15 @@
 //
-//  ConsentBottomSheetModel.swift
+//  FinancialConnectionsLegalDetailsNotice.swift
 //  StripeFinancialConnections
 //
-//  Created by Krisjanis Gaidis on 11/17/22.
-//  Copyright © 2022 Stripe, Inc. All rights reserved.
+//  Created by Krisjanis Gaidis on 1/19/23.
 //
 
 import Foundation
 
-struct ConsentBottomSheetModel {
+struct FinancialConnectionsLegalDetailsNotice: Decodable {
     let title: String
-    let subtitle: String?
     let body: Body
-    let extraNotice: String?
     let learnMore: String
     let cta: String
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsSynchronize.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsSynchronize.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 struct FinancialConnectionsSynchronize: Decodable {
-
     let manifest: FinancialConnectionsSessionManifest
     let text: Text?
     let visual: VisualUpdate?
@@ -20,56 +19,5 @@ struct FinancialConnectionsSynchronize: Decodable {
     struct VisualUpdate: Decodable {
         let reducedBranding: Bool
         let merchantLogo: [String]
-    }
-}
-
-struct FinancialConnectionsConsent: Decodable {
-
-    let title: String
-    let body: Body
-    let aboveCta: String
-    let cta: String
-    let belowCta: String?
-
-    let dataAccessNotice: FinancialConnectionsDataAccessNotice
-    let legalDetailsNotice: FinancialConnectionsLegalDetailsNotice
-
-    struct Body: Decodable {
-        let bullets: [FinancialConnectionsBulletPoint]
-    }
-}
-
-struct FinancialConnectionsDataAccessNotice: Decodable {
-    let title: String
-    let body: Body
-    let connectedAccountNotice: String?
-    let learnMore: String
-    let cta: String
-
-    struct Body: Decodable {
-        let bullets: [FinancialConnectionsBulletPoint]
-    }
-}
-
-struct FinancialConnectionsLegalDetailsNotice: Decodable {
-    let title: String
-    let body: Body
-    let learnMore: String
-    let cta: String
-
-    struct Body: Decodable {
-        let bullets: [FinancialConnectionsBulletPoint]
-    }
-}
-
-struct FinancialConnectionsBulletPoint: Decodable {
-    let icon: FinancialConnectionsImage?
-    let title: String?
-    let content: String?
-
-    init(icon: FinancialConnectionsImage, title: String? = nil, content: String? = nil) {
-        self.icon = icon
-        self.title = title
-        self.content = content
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentViewController.swift
@@ -150,6 +150,7 @@ class ConsentViewController: UIViewController {
                 let dataAccessNoticeModel = dataSource.consent.dataAccessNotice
                 let consentBottomSheetModel = ConsentBottomSheetModel(
                     title: dataAccessNoticeModel.title,
+                    subtitle: dataAccessNoticeModel.subtitle,
                     body: ConsentBottomSheetModel.Body(
                         bullets: dataAccessNoticeModel.body.bullets
                     ),
@@ -167,6 +168,7 @@ class ConsentViewController: UIViewController {
                 let legalDetailsNoticeModel = dataSource.consent.legalDetailsNotice
                 let consentBottomSheetModel = ConsentBottomSheetModel(
                     title: legalDetailsNoticeModel.title,
+                    subtitle: nil,
                     body: ConsentBottomSheetModel.Body(
                         bullets: legalDetailsNoticeModel.body.bullets
                     ),

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/ConsentBottomSheetView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/ConsentBottomSheetView.swift
@@ -29,6 +29,7 @@ final class ConsentBottomSheetView: UIView {
             arrangedSubviews: [
                 CreateContentView(
                     headerTitle: model.title,
+                    headerSubtitle: model.subtitle,
                     bulletItems: model.body.bullets,
                     extraNotice: model.extraNotice,
                     learnMoreText: model.learnMore,
@@ -81,6 +82,7 @@ final class ConsentBottomSheetView: UIView {
 @available(iOSApplicationExtension, unavailable)
 private func CreateContentView(
     headerTitle: String,
+    headerSubtitle: String?,
     bulletItems: [FinancialConnectionsBulletPoint],
     extraNotice: String?,
     learnMoreText: String,
@@ -91,7 +93,8 @@ private func CreateContentView(
             var subviews: [UIView] = []
             subviews.append(
                 CreateHeaderView(
-                    text: headerTitle,
+                    title: headerTitle,
+                    subtitle: headerSubtitle,
                     didSelectURL: didSelectURL
                 )
             )
@@ -131,17 +134,34 @@ private func CreateContentView(
 
 @available(iOSApplicationExtension, unavailable)
 private func CreateHeaderView(
-    text: String,
+    title: String,
+    subtitle: String?,
     didSelectURL: @escaping (URL) -> Void
 ) -> UIView {
+    let verticalStack = UIStackView()
+    verticalStack.axis = .vertical
+    verticalStack.spacing = 4
+
     let headerLabel = ClickableLabel(
         font: .stripeFont(forTextStyle: .heading),
         boldFont: .stripeFont(forTextStyle: .heading),
         linkFont: .stripeFont(forTextStyle: .heading),
         textColor: .textPrimary
     )
-    headerLabel.setText(text, action: didSelectURL)
-    return headerLabel
+    headerLabel.setText(title, action: didSelectURL)
+    verticalStack.addArrangedSubview(headerLabel)
+
+    if let subtitle = subtitle {
+        let subtitleLabel = ClickableLabel(
+            font: .stripeFont(forTextStyle: .body),
+            boldFont: .stripeFont(forTextStyle: .bodyEmphasized),
+            linkFont: .stripeFont(forTextStyle: .bodyEmphasized),
+            textColor: .textPrimary
+        )
+        subtitleLabel.setText(subtitle, action: didSelectURL)
+        verticalStack.addArrangedSubview(subtitleLabel)
+    }
+    return verticalStack
 }
 
 @available(iOSApplicationExtension, unavailable)
@@ -221,19 +241,20 @@ private struct ConsentBottomSheetViewUIViewRepresentable: UIViewRepresentable {
     func makeUIView(context: Context) -> ConsentBottomSheetView {
         ConsentBottomSheetView(
             model: ConsentBottomSheetModel(
-                title: "",
+                title: "When will [Merchant] use your data?",
+                subtitle: "[Merchant] will use your account and routing number, balances and transactions when:",
                 body: ConsentBottomSheetModel.Body(
                     bullets: [
                         FinancialConnectionsBulletPoint(
                             icon: FinancialConnectionsImage(default: nil),
-                            title: "...",
-                            content: "..."
+                            title: nil,
+                            content: "Transferring money between your bank account and Merchant"
                         ),
                     ]
                 ),
                 extraNotice: nil,
-                learnMore: "...",
-                cta: "..."
+                learnMore: "[Learn more](https://www.stripe.com)",
+                cta: "Got it"
             ),
             didSelectOK: {},
             didSelectURL: { _ in }


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

Adds a subtitle to the DataAccessNotice

Backend PR: https://git.corp.stripe.com/stripe-internal/pay-server/pull/562130/files
[Figma](https://www.figma.com/file/xhr2eikB7Mz72uf8J2rfjm/Cash-App---comprehensive-changes?node-id=0%3A1&t=d70rHtT7Km7Pc9oF-0)

## Testing

### PR Notice

![Simulator Screen Shot - iPhone 14 Pro - 2023-01-19 at 17 39 13](https://user-images.githubusercontent.com/105514761/213578413-d0de25e7-3b05-434c-8f1d-5cad32edff92.png)

### Regular Notice (double check that nothing is broken)

![regular_notice](https://user-images.githubusercontent.com/105514761/213578429-d0e79438-1de9-4597-b648-5675e066dff4.png)

### Legal Notice (double check that nothing is broken)

![legal_notice](https://user-images.githubusercontent.com/105514761/213578465-42308d25-66a8-40d2-b8b5-e38859589406.png)
