### PR TITLE
Fix typo

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/AddressViewController/AddressViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/AddressViewController/AddressViewController.swift
@@ -20,6 +20,7 @@ public protocol AddressViewControllerDelegate: AnyObject {
 
 /// A view controller that collects a name and an address, with full localization and autocomplete.
 /// - Note: It uses `navigationItem` and can push a view controller, so it must be shown inside a `UINavigationController`.
+/// - Seealso: https://stripe.com/docs/elements/address-element?platform=ios
 @objc(STPAddressViewController)
 public class AddressViewController: UIViewController {
     // MARK: - Public properties

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/AddressViewController/AddressViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/AddressViewController/AddressViewController.swift
@@ -179,10 +179,6 @@ public class AddressViewController: UIViewController {
         ])
 
         loadSpecsIfNeeded()
-    }
-
-    override public func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
         registerForKeyboardNotifications()
     }
 
@@ -197,14 +193,12 @@ public class AddressViewController: UIViewController {
 
     public override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        NotificationCenter.default.removeObserver(self)
     }
 }
 
 // MARK: - Keyboard handling
 extension AddressViewController {
     private func registerForKeyboardNotifications() {
-        NotificationCenter.default.removeObserver(self)
         NotificationCenter.default.addObserver(self, selector: #selector(adjustForKeyboard), name: UIResponder.keyboardWillHideNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(adjustForKeyboard), name: UIResponder.keyboardWillChangeFrameNotification, object: nil)
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetError.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetError.swift
@@ -35,7 +35,7 @@ extension PaymentSheetError: CustomDebugStringConvertible {
     }
 
     public var debugDescription: String {
-        return "An error ocurred in PaymentSheet. " + {
+        return "An error occured in PaymentSheet. " + {
             switch self {
             case .noPaymentMethodTypesAvailable(let intentPaymentMethods):
                 return "None of the payment methods on the PaymentIntent/SetupIntent can be used in PaymentSheet: \(intentPaymentMethods). You may need to set `allowsDelayedPaymentMethods` or `allowsPaymentMethodsRequiringShippingAddress` in your PaymentSheet.Configuration object."


### PR DESCRIPTION
## Summary
Fixes a typo and improves a docstring while I'm at it.

## Testing
Manually tested keyboard dismiss/show behavior on the AddressViewController, including when the AutocompleteVC is pushed on/off.  