### PR TITLE
Fix slow compilation of AddressSectionElement.updateAddressFields

### DIFF
--- a/StripeUICore/StripeUICore/Source/Elements/Factories/Address/AddressSectionElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Factories/Address/AddressSectionElement.swift
@@ -321,7 +321,7 @@ import UIKit
         spec.makePostalElement(countryCode: countryCode, defaultValue: address.postalCode, theme: theme) : nil
 
         // Order the address fields according to `fieldOrdering`
-        let addressFields: [TextOrDropdownElement?] = fieldOrdering.reduce([]) { partialResult, fieldType in
+        let addressFields: [Element?] = fieldOrdering.reduce([]) { partialResult, fieldType in
             // This should be a flatMap but I'm having trouble satisfying the compiler
             switch fieldType {
             case .line:
@@ -334,8 +334,10 @@ import UIKit
                 return partialResult + [postalCode]
             }
         }
-        // Set the new address fields, including any additional fields
-        addressSection.elements = ([name] + [country] + [autoCompleteLine] + addressFields + [phone]).compactMap { $0 }
+
+        let initialElements: [Element?] = [name, country, autoCompleteLine]
+        let phoneElement: [Element?] = [phone]
+        addressSection.elements = (initialElements + addressFields + phoneElement).compactMap { $0 }
     }
 
     /// Returns `true` iff all **displayed** address fields match the given `address`, treating `nil` and "" as equal.


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

AddressSectionElement.updateAddressFields is currently extremely slow to compile taking around ~8004.12ms to compile. This is due to array concatenation of different derived types. By providing swift with base class type information for elements this drastically speeds up compilation resulting in compilation for this function now taking ~14.67ms. 

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Decrease compilation time of the Stripe package, gaining 7ish seconds of our CI time back per run. 

## Testing
<!-- How was the code tested? Be as specific as possible. -->
To validate the difference run the following on the master branch and this branch respectively. 

Perform a clean build from terminal using the following: 
`xcodebuild -workspace Stripe.xcworkspace  -scheme "PaymentSheet Example" clean build -xcconfig Example/PaymentSheet\ Example/BuildConfigurations/PaymentSheet-Example-Debug.xcconfig -destination "platform=iOS Simulator,name=iPhone 8,OS=15.2"  -derivedDataPath /tmp/ddata OTHER_SWIFT_FLAGS="-Xfrontend -debug-time-function-bodies" | grep ".[0-9]ms" | grep -v "^0.[0-9]ms" | sort -nr > ~/Desktop/timer.txt`

`open ~/Desktop/timer.txt`

Search for `updateAddressFields` (on master this will be the first entry)

compare 

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
