### PR TITLE
Financial Connections Networking: added V0 of NetworkingLinkSignup pane

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
@@ -73,6 +73,23 @@ protocol FinancialConnectionsAPIClient {
         eventNamespace: String,
         eventName: String
     ) -> Future<EmptyResponse>
+
+    // MARK: - Networking
+
+    func saveAccountsToLink(
+        emailAddress: String,
+        phoneNumber: String,
+        country: String,
+        selectedAccountIds: [String],
+        consumerSessionClientSecret: String?,
+        clientSecret: String
+    ) -> Future<FinancialConnectionsSessionManifest>
+
+    // MARK: - Link API's
+
+    func consumerSessionLookup(
+        emailAddress: String
+    ) -> Future<LookupConsumerSessionResponse>
 }
 
 extension STPAPIClient: FinancialConnectionsAPIClient {
@@ -388,6 +405,46 @@ extension STPAPIClient: FinancialConnectionsAPIClient {
             parameters: body
         )
     }
+
+    // MARK: - Networking
+
+    func saveAccountsToLink(
+        emailAddress: String,
+        phoneNumber: String,
+        country: String,
+        selectedAccountIds: [String],
+        consumerSessionClientSecret: String?,
+        clientSecret: String
+    ) -> Future<FinancialConnectionsSessionManifest> {
+        var body: [String: Any] = [
+            "client_secret": clientSecret,
+            "email_address":
+                emailAddress
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .lowercased(),
+            "phone_number": phoneNumber,
+            "country": country,
+            "locale": Locale.current.identifier,
+            "selected_accounts": selectedAccountIds,
+        ]
+        body["consumer_session_client_secret"] = consumerSessionClientSecret
+        return post(resource: APIEndpointSaveAccountsToLink, parameters: body)
+    }
+
+    // MARK: - Link API's [TODO(kgaidis): delete these later]
+
+    func consumerSessionLookup(
+        emailAddress: String
+    ) -> Future<LookupConsumerSessionResponse> {
+        let parameters: [String: Any] = [
+            "request_surface": "web_connections",  // TODO(kgaidis): request backend to add ios_connections
+            "email_address":
+                emailAddress
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .lowercased(),
+        ]
+        return post(resource: "consumers/sessions/lookup", parameters: parameters)
+    }
 }
 
 private let APIEndpointListAccounts = "link_account_sessions/list_accounts"
@@ -406,3 +463,5 @@ private let APIEndpointAuthSessionsAuthorized = "connections/auth_sessions/autho
 private let APIEndpointAuthSessionsAccounts = "connections/auth_sessions/accounts"
 private let APIEndpointAuthSessionsSelectedAccounts = "connections/auth_sessions/selected_accounts"
 private let APIEndpointAuthSessionsEvents = "connections/auth_sessions/events"
+// Networking
+private let APIEndpointSaveAccountsToLink = "link_account_sessions/save_accounts_to_link"

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/ConsumerSession/ConsumerSessionModels.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/ConsumerSession/ConsumerSessionModels.swift
@@ -1,0 +1,20 @@
+//
+//  LookupConsumerSessionResponse.swift
+//  StripeFinancialConnections
+//
+//  Created by Krisjanis Gaidis on 1/25/23.
+//
+
+import Foundation
+
+struct ConsumerSession: Decodable {
+    let clientSecret: String
+    let emailAddress: String
+    let redactedPhoneNumber: String
+}
+
+struct LookupConsumerSessionResponse: Decodable {
+    let consumerSession: ConsumerSession?
+    let exists: Bool
+    let accountId: String?
+}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsAnalyticsClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsAnalyticsClient.swift
@@ -25,9 +25,16 @@ final class FinancialConnectionsAnalyticsClient {
         additionalParameters["navigator_language"] = Locale.current.identifier
     }
 
-    public func log(eventName: String, parameters: [String: Any] = [:]) {
+    public func log(
+        eventName: String,
+        parameters: [String: Any] = [:],
+        pane: FinancialConnectionsSessionManifest.NextPane? = nil
+    ) {
         let eventName = "linked_accounts.\(eventName)"
-        let parameters = parameters.merging(
+
+        var parameters = parameters
+        parameters["pane"] = pane?.rawValue
+        parameters = parameters.merging(
             additionalParameters,
             uniquingKeysWith: { eventParameter, _ in
                 // prioritize event `parameters` over `additionalParameters`

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsAnalyticsClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsAnalyticsClient.swift
@@ -168,6 +168,8 @@ extension FinancialConnectionsAnalyticsClient {
             return .resetFlow
         case is TerminalErrorViewController:
             return .terminalError
+        case is NetworkingLinkSignupViewController:
+            return .networkingLinkSignupPane
         default:
             return .unparsable
         }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -539,6 +539,23 @@ extension NativeFlowController: ResetFlowViewControllerDelegate {
     }
 }
 
+// MARK: - NetworkingLinkSignupViewControllerDelegate
+
+@available(iOSApplicationExtension, unavailable)
+extension NativeFlowController: NetworkingLinkSignupViewControllerDelegate {
+
+    func networkingLinkSignupViewControllerDidSelectNotNow(
+        _ viewController: NetworkingLinkSignupViewController
+    ) {
+        let successViewController = CreatePaneViewController(
+            pane: .success,
+            nativeFlowController: self,
+            dataManager: dataManager
+        )
+        pushViewController(successViewController, animated: true)
+    }
+}
+
 // MARK: - TerminalErrorViewControllerDelegate
 
 @available(iOSApplicationExtension, unavailable)
@@ -690,8 +707,17 @@ private func CreatePaneViewController(
             viewController = nil
         }
     case .networkingLinkSignupPane:
-        assertionFailure("Not supported")
-        viewController = nil
+        let networkingLinkSignupDataSource = NetworkingLinkSignupDataSourceImplementation(
+            manifest: dataManager.manifest,
+            apiClient: dataManager.apiClient,
+            clientSecret: dataManager.clientSecret,
+            analyticsClient: dataManager.analyticsClient
+        )
+        let networkingLinkSignupViewController = NetworkingLinkSignupViewController(
+            dataSource: networkingLinkSignupDataSource
+        )
+        networkingLinkSignupViewController.delegate = nativeFlowController
+        viewController = networkingLinkSignupViewController
     case .networkingLinkVerification:
         assertionFailure("Not supported")
         viewController = nil

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -544,7 +544,7 @@ extension NativeFlowController: ResetFlowViewControllerDelegate {
 @available(iOSApplicationExtension, unavailable)
 extension NativeFlowController: NetworkingLinkSignupViewControllerDelegate {
 
-    func networkingLinkSignupViewControllerDidSelectNotNow(
+    func networkingLinkSignupViewControllerDidFinish(
         _ viewController: NetworkingLinkSignupViewController
     ) {
         let successViewController = CreatePaneViewController(
@@ -707,17 +707,23 @@ private func CreatePaneViewController(
             viewController = nil
         }
     case .networkingLinkSignupPane:
-        let networkingLinkSignupDataSource = NetworkingLinkSignupDataSourceImplementation(
-            manifest: dataManager.manifest,
-            apiClient: dataManager.apiClient,
-            clientSecret: dataManager.clientSecret,
-            analyticsClient: dataManager.analyticsClient
-        )
-        let networkingLinkSignupViewController = NetworkingLinkSignupViewController(
-            dataSource: networkingLinkSignupDataSource
-        )
-        networkingLinkSignupViewController.delegate = nativeFlowController
-        viewController = networkingLinkSignupViewController
+        if let linkedAccountIds = dataManager.linkedAccounts?.map({ $0.id }) {
+            let networkingLinkSignupDataSource = NetworkingLinkSignupDataSourceImplementation(
+                manifest: dataManager.manifest,
+                selectedAccountIds: linkedAccountIds,
+                apiClient: dataManager.apiClient,
+                clientSecret: dataManager.clientSecret,
+                analyticsClient: dataManager.analyticsClient
+            )
+            let networkingLinkSignupViewController = NetworkingLinkSignupViewController(
+                dataSource: networkingLinkSignupDataSource
+            )
+            networkingLinkSignupViewController.delegate = nativeFlowController
+            viewController = networkingLinkSignupViewController
+        } else {
+            assertionFailure("Code logic error. Missing parameters for \(pane).")
+            viewController = nil
+        }
     case .networkingLinkVerification:
         assertionFailure("Not supported")
         viewController = nil

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupBodyFormView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupBodyFormView.swift
@@ -1,0 +1,112 @@
+//
+//  NetworkingLinkSignupBodyFormView.swift
+//  StripeFinancialConnections
+//
+//  Created by Krisjanis Gaidis on 1/24/23.
+//
+
+import Foundation
+@_spi(STP) import StripeCore
+@_spi(STP) import StripeUICore
+import UIKit
+
+@available(iOSApplicationExtension, unavailable)
+final class NetworkingLinkSignupBodyFormView: UIView {
+    
+    private(set) lazy var emailAddressTextField: UITextField = {
+       let emailAddressTextField = InsetTextField()
+        emailAddressTextField.placeholder = "Email address (needs to end with .com)"
+        emailAddressTextField.layer.cornerRadius = 8
+        emailAddressTextField.layer.borderColor = UIColor.textBrand.cgColor
+        emailAddressTextField.layer.borderWidth = 2.0
+        NSLayoutConstraint.activate([
+            emailAddressTextField.heightAnchor.constraint(equalToConstant: 56)
+        ])
+        return emailAddressTextField
+    }()
+    
+    private(set) lazy var phoneNumberTextField: UITextField = {
+       let phoneNumberTextField = InsetTextField()
+        phoneNumberTextField.placeholder = "Phone number"
+        phoneNumberTextField.layer.cornerRadius = 8
+        phoneNumberTextField.layer.borderColor = UIColor.textBrand.cgColor
+        phoneNumberTextField.layer.borderWidth = 2.0
+        NSLayoutConstraint.activate([
+            phoneNumberTextField.heightAnchor.constraint(equalToConstant: 56)
+        ])
+        return phoneNumberTextField
+    }()
+    
+    init() {
+        super.init(frame: .zero)
+        let verticalStackView = UIStackView(
+            arrangedSubviews: [
+                emailAddressTextField,
+                phoneNumberTextField
+            ]
+        )
+        verticalStackView.axis = .vertical
+        verticalStackView.spacing = 12
+        addAndPinSubview(verticalStackView)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+#if DEBUG
+
+import SwiftUI
+
+@available(iOSApplicationExtension, unavailable)
+private struct NetworkingLinkSignupBodyFormViewUIViewRepresentable: UIViewRepresentable {
+
+    func makeUIView(context: Context) -> NetworkingLinkSignupBodyFormView {
+        NetworkingLinkSignupBodyFormView()
+    }
+
+    func updateUIView(_ uiView: NetworkingLinkSignupBodyFormView, context: Context) {}
+}
+
+@available(iOSApplicationExtension, unavailable)
+struct NetworkingLinkSignupBodyFormView_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack(alignment: .leading) {
+            NetworkingLinkSignupBodyFormViewUIViewRepresentable()
+                .frame(maxHeight: 200)
+                .padding()
+            Spacer()
+        }
+    }
+}
+
+#endif
+
+private class InsetTextField: UITextField {
+    
+    private let padding = UIEdgeInsets(
+        top: 0,
+        left: 10,
+        bottom: 0,
+        right: 10
+    )
+    
+    override open func textRect(
+        forBounds bounds: CGRect
+    ) -> CGRect {
+        return bounds.inset(by: padding)
+    }
+    
+    override open func placeholderRect(
+        forBounds bounds: CGRect
+    ) -> CGRect {
+        return bounds.inset(by: padding)
+    }
+    
+    override open func editingRect(
+        forBounds bounds: CGRect
+    ) -> CGRect {
+        return bounds.inset(by: padding)
+    }
+}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupBodyFormView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupBodyFormView.swift
@@ -11,47 +11,111 @@ import Foundation
 import UIKit
 
 @available(iOSApplicationExtension, unavailable)
+protocol NetworkingLinkSignupBodyFormViewDelegate: AnyObject {
+    func networkingLinkSignupBodyFormViewDidEnterValidEmail(_ view: NetworkingLinkSignupBodyFormView)
+}
+
+@available(iOSApplicationExtension, unavailable)
 final class NetworkingLinkSignupBodyFormView: UIView {
-    
+
+    weak var delegate: NetworkingLinkSignupBodyFormViewDelegate?
+
+    private lazy var verticalStackView: UIStackView = {
+        let verticalStackView = UIStackView(
+            arrangedSubviews: [
+                emailAddressTextField
+            ]
+        )
+        verticalStackView.axis = .vertical
+        verticalStackView.spacing = 12
+        return verticalStackView
+    }()
     private(set) lazy var emailAddressTextField: UITextField = {
-       let emailAddressTextField = InsetTextField()
+        let emailAddressTextField = InsetTextField()
         emailAddressTextField.placeholder = "Email address (needs to end with .com)"
         emailAddressTextField.layer.cornerRadius = 8
         emailAddressTextField.layer.borderColor = UIColor.textBrand.cgColor
         emailAddressTextField.layer.borderWidth = 2.0
+        emailAddressTextField.delegate = self
+        emailAddressTextField.addTarget(
+            self,
+            action: #selector(emailAddressTextFieldDidChange),
+            for: .editingChanged
+        )
         NSLayoutConstraint.activate([
             emailAddressTextField.heightAnchor.constraint(equalToConstant: 56)
         ])
         return emailAddressTextField
     }()
-    
     private(set) lazy var phoneNumberTextField: UITextField = {
-       let phoneNumberTextField = InsetTextField()
+        let phoneNumberTextField = InsetTextField()
         phoneNumberTextField.placeholder = "Phone number"
         phoneNumberTextField.layer.cornerRadius = 8
         phoneNumberTextField.layer.borderColor = UIColor.textBrand.cgColor
         phoneNumberTextField.layer.borderWidth = 2.0
+        phoneNumberTextField.delegate = self
+        phoneNumberTextField.addTarget(
+            self,
+            action: #selector(phoneNumberTextFieldDidChange),
+            for: .editingChanged
+        )
         NSLayoutConstraint.activate([
             phoneNumberTextField.heightAnchor.constraint(equalToConstant: 56)
         ])
         return phoneNumberTextField
     }()
-    
+
     init() {
         super.init(frame: .zero)
-        let verticalStackView = UIStackView(
-            arrangedSubviews: [
-                emailAddressTextField,
-                phoneNumberTextField
-            ]
-        )
-        verticalStackView.axis = .vertical
-        verticalStackView.spacing = 12
         addAndPinSubview(verticalStackView)
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    func showPhoneNumberTextFieldIfNeeded() {
+        guard phoneNumberTextField.superview == nil else {
+            return  // already added
+        }
+        verticalStackView.addArrangedSubview(phoneNumberTextField)
+        // TODO(kgaidis): also add a little label together with phone numebr text field
+    }
+
+    @objc private func emailAddressTextFieldDidChange() {
+        guard let emailAddress = emailAddressTextField.text else {
+            return
+        }
+
+        // TODO(kgaidis): validate e-mail
+
+        if emailAddress.hasSuffix(".com") {
+            delegate?.networkingLinkSignupBodyFormViewDidEnterValidEmail(self)
+        }
+    }
+
+    @objc private func phoneNumberTextFieldDidChange() {
+        print("\(phoneNumberTextField.text!)")
+    }
+}
+
+@available(iOSApplicationExtension, unavailable)
+extension NetworkingLinkSignupBodyFormView: UITextFieldDelegate {
+
+    func textField(
+        _ textField: UITextField,
+        shouldChangeCharactersIn range: NSRange,
+        replacementString string: String
+    ) -> Bool {
+        return true
+    }
+
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+
+    }
+
+    func textFieldDidEndEditing(_ textField: UITextField) {
+
     }
 }
 
@@ -84,26 +148,26 @@ struct NetworkingLinkSignupBodyFormView_Previews: PreviewProvider {
 #endif
 
 private class InsetTextField: UITextField {
-    
+
     private let padding = UIEdgeInsets(
         top: 0,
         left: 10,
         bottom: 0,
         right: 10
     )
-    
+
     override open func textRect(
         forBounds bounds: CGRect
     ) -> CGRect {
         return bounds.inset(by: padding)
     }
-    
+
     override open func placeholderRect(
         forBounds bounds: CGRect
     ) -> CGRect {
         return bounds.inset(by: padding)
     }
-    
+
     override open func editingRect(
         forBounds bounds: CGRect
     ) -> CGRect {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupBodyView.swift
@@ -1,0 +1,138 @@
+//
+//  NetworkingLinkSignupContentView.swift
+//  StripeFinancialConnections
+//
+//  Created by Krisjanis Gaidis on 1/24/23.
+//
+
+import Foundation
+@_spi(STP) import StripeCore
+@_spi(STP) import StripeUICore
+import UIKit
+
+@available(iOSApplicationExtension, unavailable)
+final class NetworkingLinkSignupBodyView: UIView {
+    
+    init(
+        bulletPoints: [FinancialConnectionsBulletPoint],
+        formView: UIView,
+        didSelectURL: @escaping (URL) -> Void
+    ) {
+        super.init(frame: .zero)
+        let verticalStackView = UIStackView(
+            arrangedSubviews: [
+                CreateMultipleBulletPointView(
+                    bulletPoints: bulletPoints,
+                    didSelectURL: didSelectURL
+                ),
+                formView
+            ]
+        )
+        verticalStackView.axis = .vertical
+        verticalStackView.spacing = 24
+        addAndPinSubview(verticalStackView)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+@available(iOSApplicationExtension, unavailable)
+private func CreateMultipleBulletPointView(
+    bulletPoints: [FinancialConnectionsBulletPoint],
+    didSelectURL: @escaping (URL) -> Void
+) -> UIView {
+    let verticalStackView = HitTestStackView()
+    verticalStackView.axis = .vertical
+    verticalStackView.spacing = 12
+    bulletPoints.forEach { bulletPoint in
+        let bulletPointView = CreateBulletPointView(
+            title: bulletPoint.title,
+            content: bulletPoint.content,
+            iconUrl: bulletPoint.icon?.default,
+            action: didSelectURL
+        )
+        verticalStackView.addArrangedSubview(bulletPointView)
+    }
+    return verticalStackView
+}
+
+@available(iOSApplicationExtension, unavailable)
+private func CreateBulletPointView(
+    title: String?,
+    content: String?,
+    iconUrl: String?,
+    action: @escaping (URL) -> Void
+) -> UIView {
+    let imageView = UIImageView()
+    imageView.contentMode = .scaleAspectFit
+    imageView.setImage(with: iconUrl)
+    imageView.translatesAutoresizingMaskIntoConstraints = false
+    NSLayoutConstraint.activate([
+        imageView.widthAnchor.constraint(equalToConstant: 16),
+        imageView.heightAnchor.constraint(equalToConstant: 16),
+    ])
+
+    let labelView = BulletPointLabelView(
+        title: title,
+        content: content,
+        didSelectURL: action
+    )
+
+    let horizontalStackView = HitTestStackView(
+        arrangedSubviews: [
+            imageView,
+            labelView,
+        ]
+    )
+    horizontalStackView.axis = .horizontal
+    horizontalStackView.spacing = 10
+    horizontalStackView.alignment = .top
+    return horizontalStackView
+}
+
+#if DEBUG
+
+import SwiftUI
+
+@available(iOSApplicationExtension, unavailable)
+private struct NetworkingLinkSignupBodyViewUIViewRepresentable: UIViewRepresentable {
+
+    func makeUIView(context: Context) -> NetworkingLinkSignupBodyView {
+        NetworkingLinkSignupBodyView(
+            bulletPoints: [
+                FinancialConnectionsBulletPoint(
+                    icon: FinancialConnectionsImage(
+                        default:
+                            "https://b.stripecdn.com/connections-statics-srv/assets/SailIcon--reserve-primary-3x.png"
+                    ),
+                    content:
+                        "Connect your account faster on [Merchant] and thousands of sites."
+                ),
+                FinancialConnectionsBulletPoint(
+                    icon: FinancialConnectionsImage(default: "https://b.stripecdn.com/connections-statics-srv/assets/SailIcon--reserve-primary-3x.png"),
+                    content: "Link with Stripe encrypts your data and never shares your login details."
+                ),
+            ],
+            formView: UIView(),
+            didSelectURL: { _ in }
+        )
+    }
+
+    func updateUIView(_ uiView: NetworkingLinkSignupBodyView, context: Context) {}
+}
+
+@available(iOSApplicationExtension, unavailable)
+struct NetworkingLinkSignupBodyView_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack(alignment: .leading) {
+            NetworkingLinkSignupBodyViewUIViewRepresentable()
+                .frame(maxHeight: 200)
+                .padding()
+            Spacer()
+        }
+    }
+}
+
+#endif

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupBodyView.swift
@@ -12,7 +12,7 @@ import UIKit
 
 @available(iOSApplicationExtension, unavailable)
 final class NetworkingLinkSignupBodyView: UIView {
-    
+
     init(
         bulletPoints: [FinancialConnectionsBulletPoint],
         formView: UIView,
@@ -25,14 +25,14 @@ final class NetworkingLinkSignupBodyView: UIView {
                     bulletPoints: bulletPoints,
                     didSelectURL: didSelectURL
                 ),
-                formView
+                formView,
             ]
         )
         verticalStackView.axis = .vertical
         verticalStackView.spacing = 24
         addAndPinSubview(verticalStackView)
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -111,7 +111,10 @@ private struct NetworkingLinkSignupBodyViewUIViewRepresentable: UIViewRepresenta
                         "Connect your account faster on [Merchant] and thousands of sites."
                 ),
                 FinancialConnectionsBulletPoint(
-                    icon: FinancialConnectionsImage(default: "https://b.stripecdn.com/connections-statics-srv/assets/SailIcon--reserve-primary-3x.png"),
+                    icon: FinancialConnectionsImage(
+                        default:
+                            "https://b.stripecdn.com/connections-statics-srv/assets/SailIcon--reserve-primary-3x.png"
+                    ),
                     content: "Link with Stripe encrypts your data and never shares your login details."
                 ),
             ],

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupDataSource.swift
@@ -1,0 +1,34 @@
+//
+//  NetworkingLinkSignupDataSource.swift
+//  StripeFinancialConnections
+//
+//  Created by Krisjanis Gaidis on 1/17/23.
+//
+
+import Foundation
+@_spi(STP) import StripeCore
+
+protocol NetworkingLinkSignupDataSource: AnyObject {
+    var manifest: FinancialConnectionsSessionManifest { get }
+    var analyticsClient: FinancialConnectionsAnalyticsClient { get }
+}
+
+final class NetworkingLinkSignupDataSourceImplementation: NetworkingLinkSignupDataSource {
+
+    let manifest: FinancialConnectionsSessionManifest
+    private let apiClient: FinancialConnectionsAPIClient
+    private let clientSecret: String
+    let analyticsClient: FinancialConnectionsAnalyticsClient
+
+    init(
+        manifest: FinancialConnectionsSessionManifest,
+        apiClient: FinancialConnectionsAPIClient,
+        clientSecret: String,
+        analyticsClient: FinancialConnectionsAnalyticsClient
+    ) {
+        self.manifest = manifest
+        self.apiClient = apiClient
+        self.clientSecret = clientSecret
+        self.analyticsClient = analyticsClient
+    }
+}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupDataSource.swift
@@ -11,25 +11,51 @@ import Foundation
 protocol NetworkingLinkSignupDataSource: AnyObject {
     var manifest: FinancialConnectionsSessionManifest { get }
     var analyticsClient: FinancialConnectionsAnalyticsClient { get }
+
+    func lookup(emailAddress: String) -> Future<LookupConsumerSessionResponse>
+    func saveToLink(emailAddress: String, phoneNumber: String, countryCode: String) -> Future<Void>
 }
 
 final class NetworkingLinkSignupDataSourceImplementation: NetworkingLinkSignupDataSource {
 
     let manifest: FinancialConnectionsSessionManifest
+    private let selectedAccountIds: [String]
     private let apiClient: FinancialConnectionsAPIClient
     private let clientSecret: String
     let analyticsClient: FinancialConnectionsAnalyticsClient
 
+    // we get this after starting verification
+    private var consumerSessionClientSecret: String?
+
     init(
         manifest: FinancialConnectionsSessionManifest,
+        selectedAccountIds: [String],
         apiClient: FinancialConnectionsAPIClient,
         clientSecret: String,
         analyticsClient: FinancialConnectionsAnalyticsClient
     ) {
         self.manifest = manifest
+        self.selectedAccountIds = selectedAccountIds
         self.apiClient = apiClient
         self.clientSecret = clientSecret
         self.analyticsClient = analyticsClient
     }
 
+    func lookup(emailAddress: String) -> Future<LookupConsumerSessionResponse> {
+        return apiClient.consumerSessionLookup(emailAddress: emailAddress)
+    }
+
+    func saveToLink(emailAddress: String, phoneNumber: String, countryCode: String) -> Future<Void> {
+        return apiClient.saveAccountsToLink(
+            emailAddress: emailAddress,
+            phoneNumber: phoneNumber,  // TODO(kgaidis): double-check how we only support US phone numbers? // ex. "+12345642332"
+            country: countryCode,  // ex. "US"
+            selectedAccountIds: selectedAccountIds,
+            consumerSessionClientSecret: nil,
+            clientSecret: clientSecret
+        )
+        .chained { _ in
+            return Promise(value: ())
+        }
+    }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupDataSource.swift
@@ -31,4 +31,5 @@ final class NetworkingLinkSignupDataSourceImplementation: NetworkingLinkSignupDa
         self.clientSecret = clientSecret
         self.analyticsClient = analyticsClient
     }
+
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupFooterView.swift
@@ -1,0 +1,132 @@
+//
+//  NetworkingLinkSignupFooterView.swift
+//  StripeFinancialConnections
+//
+//  Created by Krisjanis Gaidis on 1/17/23.
+//
+
+import Foundation
+@_spi(STP) import StripeCore
+@_spi(STP) import StripeUICore
+import UIKit
+
+@available(iOSApplicationExtension, unavailable)
+class NetworkingLinkSignupFooterView: HitTestView {
+
+    private let agreeButtonText: String
+    private let didSelectAgree: () -> Void
+
+    private lazy var agreeButton: StripeUICore.Button = {
+        let agreeButton = Button(configuration: .financialConnectionsPrimary)
+        agreeButton.title = agreeButtonText
+        agreeButton.addTarget(self, action: #selector(didSelectAgreeButton), for: .touchUpInside)
+        agreeButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            agreeButton.heightAnchor.constraint(equalToConstant: 56)
+        ])
+        return agreeButton
+    }()
+
+    init(
+        aboveCtaText: String,
+        ctaText: String,
+        belowCtaText: String?,
+        didSelectAgree: @escaping () -> Void,
+        didSelectURL: @escaping (URL) -> Void
+    ) {
+        self.agreeButtonText = ctaText
+        self.didSelectAgree = didSelectAgree
+        super.init(frame: .zero)
+        backgroundColor = .customBackgroundColor
+
+        let termsAndPrivacyPolicyLabel = ClickableLabel(
+            font: UIFont.stripeFont(forTextStyle: .detail),
+            boldFont: UIFont.stripeFont(forTextStyle: .detailEmphasized),
+            linkFont: UIFont.stripeFont(forTextStyle: .detailEmphasized),
+            textColor: .textSecondary,
+            alignCenter: true
+        )
+        termsAndPrivacyPolicyLabel.setText(
+            aboveCtaText,
+            action: didSelectURL
+        )
+
+        let verticalStackView = HitTestStackView(
+            arrangedSubviews: [
+                termsAndPrivacyPolicyLabel,
+                agreeButton,
+            ]
+        )
+        verticalStackView.axis = .vertical
+        verticalStackView.spacing = 20
+
+        if let belowCtaText = belowCtaText {
+            let manuallyVerifyLabel = ClickableLabel(
+                font: UIFont.stripeFont(forTextStyle: .detail),
+                boldFont: UIFont.stripeFont(forTextStyle: .detailEmphasized),
+                linkFont: UIFont.stripeFont(forTextStyle: .detailEmphasized),
+                textColor: .textSecondary,
+                alignCenter: true
+            )
+            manuallyVerifyLabel.setText(
+                belowCtaText,
+                action: didSelectURL
+            )
+            verticalStackView.addArrangedSubview(manuallyVerifyLabel)
+            verticalStackView.setCustomSpacing(24, after: agreeButton)
+        }
+
+        addAndPinSubview(verticalStackView)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    @objc private func didSelectAgreeButton() {
+        didSelectAgree()
+    }
+
+    func setIsLoading(_ isLoading: Bool) {
+        agreeButton.isLoading = isLoading
+    }
+}
+
+#if DEBUG
+
+import SwiftUI
+
+@available(iOSApplicationExtension, unavailable)
+private struct NetworkingLinkSignupFooterViewUIViewRepresentable: UIViewRepresentable {
+
+    func makeUIView(context: Context) -> NetworkingLinkSignupFooterView {
+        NetworkingLinkSignupFooterView(
+            aboveCtaText:
+                "You agree to Stripe's [Terms](https://stripe.com/legal/end-users#linked-financial-account-terms) and [Privacy Policy](https://stripe.com/privacy). [Learn more](https://stripe.com/privacy-center/legal#linking-financial-accounts)",
+            ctaText: "Agree",
+            belowCtaText: "[Manually verify instead](https://www.stripe.com) (takes 1-2 business days)",
+            didSelectAgree: {},
+            didSelectURL: { _ in }
+        )
+    }
+
+    func updateUIView(_ uiView: NetworkingLinkSignupFooterView, context: Context) {
+        uiView.sizeToFit()
+    }
+}
+
+@available(iOSApplicationExtension, unavailable)
+struct NetworkingLinkSignupFooterView_Previews: PreviewProvider {
+    static var previews: some View {
+        if #available(iOS 14.0, *) {
+            VStack {
+                NetworkingLinkSignupFooterViewUIViewRepresentable()
+                    .frame(maxHeight: 200)
+                Spacer()
+            }
+            .padding()
+        }
+    }
+}
+
+#endif

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupFooterView.swift
@@ -48,7 +48,6 @@ class NetworkingLinkSignupFooterView: HitTestView {
         let verticalStackView = UIStackView()
         verticalStackView.axis = .vertical
         verticalStackView.spacing = 12
-        verticalStackView.addArrangedSubview(saveToLinkButton)
         verticalStackView.addArrangedSubview(notNowButton)
         return verticalStackView
     }()
@@ -98,6 +97,15 @@ class NetworkingLinkSignupFooterView: HitTestView {
         fatalError("init(coder:) has not been implemented")
     }
 
+    func showSaveToLinkButtonIfNeeded() {
+        guard saveToLinkButton.superview == nil else {
+            return  // already added
+        }
+        notNowButton.removeFromSuperview()
+        buttonVerticalStack.addArrangedSubview(saveToLinkButton)
+        buttonVerticalStack.addArrangedSubview(notNowButton)
+    }
+
     @objc private func didSelectSaveToLinkButton() {
         didSelectSaveToLink()
     }
@@ -107,6 +115,7 @@ class NetworkingLinkSignupFooterView: HitTestView {
     }
 
     func setIsLoading(_ isLoading: Bool) {
+        // TODO(kgaidis): remove if not necessary
         saveToLinkButton.isLoading = isLoading
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupFooterView.swift
@@ -85,7 +85,7 @@ class NetworkingLinkSignupFooterView: HitTestView {
         self.aboveCtaText = aboveCtaText
         self.saveToLinkButtonText = saveToLinkButtonText
         self.notNowButtonText = notNowButtonText
-        self.didSelectSaveToLink = didSelectNotNow
+        self.didSelectSaveToLink = didSelectSaveToLink
         self.didSelectNotNow = didSelectNotNow
         self.didSelectURL = didSelectURL
         super.init(frame: .zero)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupFooterView.swift
@@ -13,32 +13,23 @@ import UIKit
 @available(iOSApplicationExtension, unavailable)
 class NetworkingLinkSignupFooterView: HitTestView {
 
-    private let agreeButtonText: String
-    private let didSelectAgree: () -> Void
+    private let aboveCtaText: String
+    private let saveToLinkButtonText: String
+    private let notNowButtonText: String
+    private let didSelectSaveToLink: () -> Void
+    private let didSelectNotNow: () -> Void
+    private let didSelectURL: (URL) -> Void
 
-    private lazy var agreeButton: StripeUICore.Button = {
-        let agreeButton = Button(configuration: .financialConnectionsPrimary)
-        agreeButton.title = agreeButtonText
-        agreeButton.addTarget(self, action: #selector(didSelectAgreeButton), for: .touchUpInside)
-        agreeButton.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            agreeButton.heightAnchor.constraint(equalToConstant: 56)
-        ])
-        return agreeButton
+    private lazy var footerVerticalStackView: UIStackView = {
+        let verticalStackView = UIStackView()
+        verticalStackView.axis = .vertical
+        verticalStackView.spacing = 16
+        verticalStackView.addArrangedSubview(aboveCtaLabel)
+        verticalStackView.addArrangedSubview(buttonVerticalStack)
+        return verticalStackView
     }()
 
-    init(
-        aboveCtaText: String,
-        ctaText: String,
-        belowCtaText: String?,
-        didSelectAgree: @escaping () -> Void,
-        didSelectURL: @escaping (URL) -> Void
-    ) {
-        self.agreeButtonText = ctaText
-        self.didSelectAgree = didSelectAgree
-        super.init(frame: .zero)
-        backgroundColor = .customBackgroundColor
-
+    private lazy var aboveCtaLabel: ClickableLabel = {
         let termsAndPrivacyPolicyLabel = ClickableLabel(
             font: UIFont.stripeFont(forTextStyle: .detail),
             boldFont: UIFont.stripeFont(forTextStyle: .detailEmphasized),
@@ -50,45 +41,73 @@ class NetworkingLinkSignupFooterView: HitTestView {
             aboveCtaText,
             action: didSelectURL
         )
+        return termsAndPrivacyPolicyLabel
+    }()
 
-        let verticalStackView = HitTestStackView(
-            arrangedSubviews: [
-                termsAndPrivacyPolicyLabel,
-                agreeButton,
-            ]
-        )
+    private lazy var buttonVerticalStack: UIStackView = {
+        let verticalStackView = UIStackView()
         verticalStackView.axis = .vertical
-        verticalStackView.spacing = 20
+        verticalStackView.spacing = 12
+        verticalStackView.addArrangedSubview(saveToLinkButton)
+        verticalStackView.addArrangedSubview(notNowButton)
+        return verticalStackView
+    }()
 
-        if let belowCtaText = belowCtaText {
-            let manuallyVerifyLabel = ClickableLabel(
-                font: UIFont.stripeFont(forTextStyle: .detail),
-                boldFont: UIFont.stripeFont(forTextStyle: .detailEmphasized),
-                linkFont: UIFont.stripeFont(forTextStyle: .detailEmphasized),
-                textColor: .textSecondary,
-                alignCenter: true
-            )
-            manuallyVerifyLabel.setText(
-                belowCtaText,
-                action: didSelectURL
-            )
-            verticalStackView.addArrangedSubview(manuallyVerifyLabel)
-            verticalStackView.setCustomSpacing(24, after: agreeButton)
-        }
+    private lazy var saveToLinkButton: StripeUICore.Button = {
+        let saveToLinkButton = Button(configuration: .primary())  // Button(configuration: .financialConnectionsPrimary)
+        saveToLinkButton.title = saveToLinkButtonText
+        saveToLinkButton.addTarget(self, action: #selector(didSelectSaveToLinkButton), for: .touchUpInside)
+        saveToLinkButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            saveToLinkButton.heightAnchor.constraint(equalToConstant: 56)
+        ])
+        return saveToLinkButton
+    }()
 
-        addAndPinSubview(verticalStackView)
+    private lazy var notNowButton: StripeUICore.Button = {
+        let saveToLinkButton = Button(configuration: .secondary())  // Button(configuration: .financialConnectionsSecondary)
+        saveToLinkButton.title = notNowButtonText
+        saveToLinkButton.addTarget(self, action: #selector(didSelectNotNowButton), for: .touchUpInside)
+        saveToLinkButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            saveToLinkButton.heightAnchor.constraint(equalToConstant: 56)
+        ])
+        return saveToLinkButton
+    }()
+
+    init(
+        aboveCtaText: String = "Stripe's [Terms](www.stripe.com) and [Privacy Policy](www.stripe.com)",
+        saveToLinkButtonText: String = "Save to Link",
+        notNowButtonText: String = "Not now",
+        didSelectSaveToLink: @escaping () -> Void,
+        didSelectNotNow: @escaping () -> Void,
+        didSelectURL: @escaping (URL) -> Void
+    ) {
+        self.aboveCtaText = aboveCtaText
+        self.saveToLinkButtonText = saveToLinkButtonText
+        self.notNowButtonText = notNowButtonText
+        self.didSelectSaveToLink = didSelectNotNow
+        self.didSelectNotNow = didSelectNotNow
+        self.didSelectURL = didSelectURL
+        super.init(frame: .zero)
+        backgroundColor = .customBackgroundColor
+        addAndPinSubview(footerVerticalStackView)
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    @objc private func didSelectAgreeButton() {
-        didSelectAgree()
+    @objc private func didSelectSaveToLinkButton() {
+        didSelectSaveToLink()
+    }
+
+    @objc private func didSelectNotNowButton() {
+        didSelectNotNow()
     }
 
     func setIsLoading(_ isLoading: Bool) {
-        agreeButton.isLoading = isLoading
+        saveToLinkButton.isLoading = isLoading
     }
 }
 
@@ -101,11 +120,8 @@ private struct NetworkingLinkSignupFooterViewUIViewRepresentable: UIViewRepresen
 
     func makeUIView(context: Context) -> NetworkingLinkSignupFooterView {
         NetworkingLinkSignupFooterView(
-            aboveCtaText:
-                "You agree to Stripe's [Terms](https://stripe.com/legal/end-users#linked-financial-account-terms) and [Privacy Policy](https://stripe.com/privacy). [Learn more](https://stripe.com/privacy-center/legal#linking-financial-accounts)",
-            ctaText: "Agree",
-            belowCtaText: "[Manually verify instead](https://www.stripe.com) (takes 1-2 business days)",
-            didSelectAgree: {},
+            didSelectSaveToLink: {},
+            didSelectNotNow: {},
             didSelectURL: { _ in }
         )
     }
@@ -115,17 +131,17 @@ private struct NetworkingLinkSignupFooterViewUIViewRepresentable: UIViewRepresen
     }
 }
 
+@available(iOS 14.0, *)
 @available(iOSApplicationExtension, unavailable)
 struct NetworkingLinkSignupFooterView_Previews: PreviewProvider {
     static var previews: some View {
-        if #available(iOS 14.0, *) {
-            VStack {
-                NetworkingLinkSignupFooterViewUIViewRepresentable()
-                    .frame(maxHeight: 200)
-                Spacer()
-            }
-            .padding()
+        VStack {
+            NetworkingLinkSignupFooterViewUIViewRepresentable()
+                .frame(maxHeight: 200)
+            Spacer()
         }
+        .padding()
+        .frame(maxWidth: .infinity)
     }
 }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
@@ -1,0 +1,57 @@
+//
+//  NetworkingLinkSignupViewController.swift
+//  StripeFinancialConnections
+//
+//  Created by Krisjanis Gaidis on 1/17/23.
+//
+
+import Foundation
+import UIKit
+
+@available(iOSApplicationExtension, unavailable)
+protocol NetworkingLinkSignupViewControllerDelegate: AnyObject {
+    func networkingLinkSignupViewControllerDidSelectNotNow(
+        _ viewController: NetworkingLinkSignupViewController
+    )
+}
+
+@available(iOSApplicationExtension, unavailable)
+final class NetworkingLinkSignupViewController: UIViewController {
+
+    private let dataSoure: NetworkingLinkSignupDataSource
+    weak var delegate: NetworkingLinkSignupViewControllerDelegate?
+
+    init(dataSource: NetworkingLinkSignupDataSource) {
+        self.dataSoure = dataSource
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .customBackgroundColor
+
+        let pane = PaneWithHeaderLayoutView(
+            title: "Save your account to Link",
+            contentView: UIView(),
+            footerView: NetworkingLinkSignupFooterView(
+                aboveCtaText: "",
+                ctaText: "Not Now",
+                belowCtaText: nil,
+                didSelectAgree: { [weak self] in
+                    guard let self = self else {
+                        return
+                    }
+                    self.delegate?.networkingLinkSignupViewControllerDidSelectNotNow(self)
+                },
+                didSelectURL: { _ in
+
+                }
+            )
+        )
+        pane.addTo(view: view)
+    }
+}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
@@ -22,7 +22,9 @@ final class NetworkingLinkSignupViewController: UIViewController {
     weak var delegate: NetworkingLinkSignupViewControllerDelegate?
 
     private lazy var formView: NetworkingLinkSignupBodyFormView = {
-        return NetworkingLinkSignupBodyFormView()
+        let formView = NetworkingLinkSignupBodyFormView()
+        formView.delegate = self
+        return formView
     }()
     private lazy var footerView: NetworkingLinkSignupFooterView = {
         return NetworkingLinkSignupFooterView(
@@ -33,6 +35,8 @@ final class NetworkingLinkSignupViewController: UIViewController {
                 guard let self = self else {
                     return
                 }
+                // TODO(kgaidis): log `click.not_now`
+                // TODO(kgaidis): go to success pane
                 self.delegate?.networkingLinkSignupViewControllerDidSelectNotNow(self)
             },
             didSelectURL: { [weak self] url in
@@ -86,5 +90,29 @@ final class NetworkingLinkSignupViewController: UIViewController {
 
     private func didSelectURLInTextFromBackend(_ url: URL) {
 
+    }
+}
+
+@available(iOSApplicationExtension, unavailable)
+extension NetworkingLinkSignupViewController: NetworkingLinkSignupBodyFormViewDelegate {
+
+    func networkingLinkSignupBodyFormViewDidEnterValidEmail(_ view: NetworkingLinkSignupBodyFormView) {
+        guard let emailAddress = view.emailAddressTextField.text else {
+            return
+        }
+        print(emailAddress)
+
+        // TODO(kgaidis): first check whether a user with this `emailAddress` already exists...
+        //                this is done via `startVerificationSession` call
+        //                if it exists, we will log `networking.returning_consumer`
+        //                and also go to `networking_save_to_link_verification`
+        //                ...we also need to handle errors
+
+        // if this user with `emailAddress` does NOT exist, we:
+        // - TODO(kgaidis): show the Save to Link button
+
+        dataSoure.analyticsClient.log(eventName: "networking.new_consumer", pane: .networkingLinkSignupPane)
+        formView.showPhoneNumberTextFieldIfNeeded()
+        footerView.showSaveToLinkButtonIfNeeded()
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
@@ -21,6 +21,26 @@ final class NetworkingLinkSignupViewController: UIViewController {
     private let dataSoure: NetworkingLinkSignupDataSource
     weak var delegate: NetworkingLinkSignupViewControllerDelegate?
 
+    private lazy var formView: NetworkingLinkSignupBodyFormView = {
+        return NetworkingLinkSignupBodyFormView()
+    }()
+    private lazy var footerView: NetworkingLinkSignupFooterView = {
+        return NetworkingLinkSignupFooterView(
+            didSelectSaveToLink: {
+
+            },
+            didSelectNotNow: { [weak self] in
+                guard let self = self else {
+                    return
+                }
+                self.delegate?.networkingLinkSignupViewControllerDidSelectNotNow(self)
+            },
+            didSelectURL: { [weak self] url in
+                self?.didSelectURLInTextFromBackend(url)
+            }
+        )
+    }()
+
     init(dataSource: NetworkingLinkSignupDataSource) {
         self.dataSoure = dataSource
         super.init(nibName: nil, bundle: nil)
@@ -36,22 +56,35 @@ final class NetworkingLinkSignupViewController: UIViewController {
 
         let pane = PaneWithHeaderLayoutView(
             title: "Save your account to Link",
-            contentView: UIView(),
-            footerView: NetworkingLinkSignupFooterView(
-                aboveCtaText: "",
-                ctaText: "Not Now",
-                belowCtaText: nil,
-                didSelectAgree: { [weak self] in
-                    guard let self = self else {
-                        return
-                    }
-                    self.delegate?.networkingLinkSignupViewControllerDidSelectNotNow(self)
-                },
-                didSelectURL: { _ in
-
+            contentView: NetworkingLinkSignupBodyView(
+                bulletPoints: [
+                    FinancialConnectionsBulletPoint(
+                        icon: FinancialConnectionsImage(
+                            default:
+                                "https://b.stripecdn.com/connections-statics-srv/assets/SailIcon--reserve-primary-3x.png"
+                        ),
+                        content:
+                            "Connect your account faster on [Merchant] and thousands of sites."
+                    ),
+                    FinancialConnectionsBulletPoint(
+                        icon: FinancialConnectionsImage(
+                            default:
+                                "https://b.stripecdn.com/connections-statics-srv/assets/SailIcon--reserve-primary-3x.png"
+                        ),
+                        content: "Link with Stripe encrypts your data and never shares your login details."
+                    ),
+                ],
+                formView: formView,
+                didSelectURL: { [weak self] url in
+                    self?.didSelectURLInTextFromBackend(url)
                 }
-            )
+            ),
+            footerView: footerView
         )
         pane.addTo(view: view)
+    }
+
+    private func didSelectURLInTextFromBackend(_ url: URL) {
+
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
@@ -11,6 +11,7 @@ import Foundation
 @testable import StripeFinancialConnections
 
 class EmptyFinancialConnectionsAPIClient: FinancialConnectionsAPIClient {
+
     func fetchFinancialConnectionsAccounts(clientSecret: String, startingAfterAccountId: String?) -> Promise<
         StripeAPI.FinancialConnectionsSession.AccountList
     > {
@@ -102,5 +103,22 @@ class EmptyFinancialConnectionsAPIClient: FinancialConnectionsAPIClient {
         eventName: String
     ) -> Future<EmptyResponse> {
         return Promise<EmptyResponse>()
+    }
+
+    func saveAccountsToLink(
+        emailAddress: String,
+        phoneNumber: String,
+        country: String,
+        selectedAccountIds: [String],
+        consumerSessionClientSecret: String?,
+        clientSecret: String
+    ) -> Future<StripeFinancialConnections.FinancialConnectionsSessionManifest> {
+        return Promise<StripeFinancialConnections.FinancialConnectionsSessionManifest>()
+    }
+
+    func consumerSessionLookup(
+        emailAddress: String
+    ) -> Future<StripeFinancialConnections.LookupConsumerSessionResponse> {
+        return Promise<StripeFinancialConnections.LookupConsumerSessionResponse>()
     }
 }


### PR DESCRIPTION
## Summary

^ this PR adds support for NetworkingLinkSignup pane. One can now sign-up to Link in test mode OR live mode (tested both).

### NOTE: THIS HAS LOTS OF TODO's, THAT'S EXPECTED; IT'S JUST THE FIRST-LAYER PASS & GOAL IS TO CODE ALL THE PANES BEFORE POLISHING (SO WE CAN FIND ISSUES ASAP)

## Testing

Tested test-mode and live-mode, but here's a video of test mode:

https://user-images.githubusercontent.com/105514761/215586030-e5f89a50-75bf-4751-b281-17dd74e5bca9.mov
