### PR TITLE
Use the previous add params for encoding

### DIFF
--- a/StripeCore/StripeCore/Source/API Bindings/STPAPIClient.swift
+++ b/StripeCore/StripeCore/Source/API Bindings/STPAPIClient.swift
@@ -376,12 +376,9 @@ extension STPAPIClient {
         completion: @escaping (Result<T, Error>) -> Void
     ) {
         var request = configuredRequest(for: url)
-        var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: true)!
         switch method {
         case .get:
-            let query = URLEncoder.queryString(from: parameters)
-            urlComponents.query = query
-            request.url = urlComponents.url!
+            request.stp_addParameters(toURL: parameters)
         case .post:
             let formData = URLEncoder.queryString(from: parameters).data(using: .utf8)
             request.httpBody = formData


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Switches back to using the previous way of adding GET params to URLRequests.
## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Current approach was double percent encoding parameters. URLComponent expects the query set on it not to be percent encoded.
## Testing
<!-- How was the code tested? Be as specific as possible. -->
<img width="542" alt="Screenshot 2023-01-27 at 2 23 42 PM" src="https://user-images.githubusercontent.com/92807969/215179878-ea87261d-6577-42dd-9af1-b5b4764a0c5e.png">

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
[Fixed] Double encoding of GET parameters.