### PR TITLE
[Identity] Parse additional API fields for id and address

### DIFF
--- a/StripeIdentity/StripeIdentity/Source/API Bindings/IdentityAPIClient.swift
+++ b/StripeIdentity/StripeIdentity/Source/API Bindings/IdentityAPIClient.swift
@@ -35,7 +35,7 @@ final class IdentityAPIClientImpl: IdentityAPIClient {
     /// SDK is capable of using.
     ///
     /// - Note: Update this value when a new API version is ready for use in production.
-    static let productionApiVersion: Int = 2
+    static let productionApiVersion: Int = 3
 
     var betas: Set<String> {
         return ["identity_client_api=v\(apiVersion)"]

--- a/StripeIdentity/StripeIdentity/Source/API Bindings/Models/VerificationPage/VerificationPage.swift
+++ b/StripeIdentity/StripeIdentity/Source/API Bindings/Models/VerificationPage/VerificationPage.swift
@@ -22,6 +22,8 @@ extension StripeAPI {
         let biometricConsent: VerificationPageStaticContentConsentPage
         let documentCapture: VerificationPageStaticContentDocumentCapturePage
         let documentSelect: VerificationPageStaticContentDocumentSelectPage
+        var individual: VerificationPageStaticContentIndividualPage
+        var countryNotListed: VerificationPageStaticContentCountryNotListedPage
         /// The short-lived URL that can be used in the case that the client cannot support the VerificationSession.
         let fallbackUrl: String
         /// Unique identifier for the object.

--- a/StripeIdentity/StripeIdentity/Source/API Bindings/Models/VerificationPage/VerificationPageFieldType.swift
+++ b/StripeIdentity/StripeIdentity/Source/API Bindings/Models/VerificationPage/VerificationPageFieldType.swift
@@ -15,5 +15,9 @@ extension StripeAPI {
         case idDocumentBack = "id_document_back"
         case idDocumentFront = "id_document_front"
         case idDocumentType = "id_document_type"
+        case idNumber = "id_number"
+        case dob = "dob"
+        case name = "name"
+        case address = "address"
     }
 }

--- a/StripeIdentity/StripeIdentity/Source/API Bindings/Models/VerificationPage/VerificationPageStaticContentCountryNotListedPage.swift
+++ b/StripeIdentity/StripeIdentity/Source/API Bindings/Models/VerificationPage/VerificationPageStaticContentCountryNotListedPage.swift
@@ -1,0 +1,19 @@
+//
+//  VerificationPageStaticContentCountryNotListedPage.swift
+//  StripeIdentity
+//
+//  Created by Chen Cen on 2/1/23.
+//
+
+import Foundation
+@_spi(STP) import StripeCore
+
+extension StripeAPI {
+    struct VerificationPageStaticContentCountryNotListedPage: Decodable, Equatable {
+        let title: String
+        let body: String
+        let cancelButtonText: String
+        let idFromOtherCountryTextButtonText: String
+        let addressFromOtherCountryTextButtonText: String
+    }
+}

--- a/StripeIdentity/StripeIdentity/Source/API Bindings/Models/VerificationPage/VerificationPageStaticContentIndividualPage.swift
+++ b/StripeIdentity/StripeIdentity/Source/API Bindings/Models/VerificationPage/VerificationPageStaticContentIndividualPage.swift
@@ -1,0 +1,21 @@
+//
+//  VerificationPageStaticContentIndividualPage.swift
+//  StripeIdentity
+//
+//  Created by Chen Cen on 1/27/23.
+//
+
+import Foundation
+@_spi(STP) import StripeCore
+
+extension StripeAPI {
+
+    struct VerificationPageStaticContentIndividualPage: Decodable, Equatable {
+        let addressCountries: [String: String]
+        let buttonText: String
+        let title: String
+        let idNumberCountries: [String: String]
+        let idNumberCountryNotListedTextButtonText: String
+        let addressCountryNotListedTextButtonText: String
+    }
+}

--- a/StripeIdentity/StripeIdentity/Source/API Bindings/Models/VerificationPageDataUpdate/RequiredInternationalAddress.swift
+++ b/StripeIdentity/StripeIdentity/Source/API Bindings/Models/VerificationPageDataUpdate/RequiredInternationalAddress.swift
@@ -1,0 +1,19 @@
+//
+//  RequiredInternationalAddress.swift
+//  StripeIdentity
+//
+//  Created by Chen Cen on 1/27/23.
+//
+
+import Foundation
+@_spi(STP) import StripeCore
+
+extension StripeAPI {
+    struct RequiredInternationalAddress: Encodable, Equatable {
+        let line1: String
+        let line2: String?
+        let city: String?
+        let postalCode: String?
+        let country: String?
+    }
+}

--- a/StripeIdentity/StripeIdentity/Source/API Bindings/Models/VerificationPageDataUpdate/VerificationPageClearData.swift
+++ b/StripeIdentity/StripeIdentity/Source/API Bindings/Models/VerificationPageDataUpdate/VerificationPageClearData.swift
@@ -16,6 +16,10 @@ extension StripeAPI {
         let idDocumentBack: Bool?
         let idDocumentFront: Bool?
         let idDocumentType: Bool?
+        let idNumber: Bool?
+        let dob: Bool?
+        let name: Bool?
+        let address: Bool?
     }
 }
 
@@ -28,7 +32,11 @@ extension StripeAPI.VerificationPageClearData {
             face: fields.contains(.face),
             idDocumentBack: fields.contains(.idDocumentBack),
             idDocumentFront: fields.contains(.idDocumentFront),
-            idDocumentType: fields.contains(.idDocumentType)
+            idDocumentType: fields.contains(.idDocumentType),
+            idNumber: fields.contains(.idNumber),
+            dob: fields.contains(.dob),
+            name: fields.contains(.name),
+            address: fields.contains(.address)
         )
     }
 }

--- a/StripeIdentity/StripeIdentity/Source/API Bindings/Models/VerificationPageDataUpdate/VerificationPageCollectedData.swift
+++ b/StripeIdentity/StripeIdentity/Source/API Bindings/Models/VerificationPageDataUpdate/VerificationPageCollectedData.swift
@@ -17,19 +17,31 @@ extension StripeAPI {
         private(set) var idDocumentBack: VerificationPageDataDocumentFileData?
         private(set) var idDocumentFront: VerificationPageDataDocumentFileData?
         private(set) var idDocumentType: DocumentType?
+        private(set) var idNumber: VerificationPageDataIdNumber?
+        private(set) var dob: VerificationPageDataDob?
+        private(set) var name: VerificationPageDataName?
+        private(set) var address: RequiredInternationalAddress?
 
         init(
             biometricConsent: Bool? = nil,
             face: VerificationPageDataFace? = nil,
             idDocumentBack: VerificationPageDataDocumentFileData? = nil,
             idDocumentFront: VerificationPageDataDocumentFileData? = nil,
-            idDocumentType: DocumentType? = nil
+            idDocumentType: DocumentType? = nil,
+            idNumber: VerificationPageDataIdNumber? = nil,
+            dob: VerificationPageDataDob? = nil,
+            name: VerificationPageDataName? = nil,
+            address: RequiredInternationalAddress? = nil
         ) {
             self.biometricConsent = biometricConsent
             self.face = face
             self.idDocumentBack = idDocumentBack
             self.idDocumentFront = idDocumentFront
             self.idDocumentType = idDocumentType
+            self.idNumber = idNumber
+            self.dob = dob
+            self.name = name
+            self.address = address
         }
     }
 }
@@ -46,7 +58,11 @@ extension StripeAPI.VerificationPageCollectedData {
             face: otherData.face ?? self.face,
             idDocumentBack: otherData.idDocumentBack ?? self.idDocumentBack,
             idDocumentFront: otherData.idDocumentFront ?? self.idDocumentFront,
-            idDocumentType: otherData.idDocumentType ?? self.idDocumentType
+            idDocumentType: otherData.idDocumentType ?? self.idDocumentType,
+            idNumber: otherData.idNumber ?? self.idNumber,
+            dob: otherData.dob ?? self.dob,
+            name: otherData.name ?? self.name,
+            address: otherData.address ?? self.address
         )
     }
 
@@ -67,6 +83,14 @@ extension StripeAPI.VerificationPageCollectedData {
             self.idDocumentFront = nil
         case .idDocumentType:
             self.idDocumentType = nil
+        case .idNumber:
+            self.idNumber = nil
+        case .dob:
+            self.dob = nil
+        case .name:
+            self.name = nil
+        case .address:
+            self.address = nil
         }
     }
 
@@ -99,6 +123,18 @@ extension StripeAPI.VerificationPageCollectedData {
         }
         if self.idDocumentType != nil {
             ret.insert(.idDocumentType)
+        }
+        if self.idNumber != nil {
+            ret.insert(.idNumber)
+        }
+        if self.dob != nil {
+            ret.insert(.dob)
+        }
+        if self.name != nil {
+            ret.insert(.name)
+        }
+        if self.address != nil {
+            ret.insert(.address)
         }
         return ret
     }

--- a/StripeIdentity/StripeIdentity/Source/API Bindings/Models/VerificationPageDataUpdate/VerificationPageDataDob.swift
+++ b/StripeIdentity/StripeIdentity/Source/API Bindings/Models/VerificationPageDataUpdate/VerificationPageDataDob.swift
@@ -1,0 +1,17 @@
+//
+//  VerificationPageDataDob.swift
+//  StripeIdentity
+//
+//  Created by Chen Cen on 1/27/23.
+//
+
+import Foundation
+@_spi(STP) import StripeCore
+
+extension StripeAPI {
+    struct VerificationPageDataDob: Encodable, Equatable {
+        let day: String?
+        let month: String?
+        let year: String?
+    }
+}

--- a/StripeIdentity/StripeIdentity/Source/API Bindings/Models/VerificationPageDataUpdate/VerificationPageDataIdNumber.swift
+++ b/StripeIdentity/StripeIdentity/Source/API Bindings/Models/VerificationPageDataUpdate/VerificationPageDataIdNumber.swift
@@ -1,0 +1,17 @@
+//
+//  VerificationPageDataIdNumber.swift
+//  StripeIdentity
+//
+//  Created by Chen Cen on 1/27/23.
+//
+
+import Foundation
+@_spi(STP) import StripeCore
+
+extension StripeAPI {
+    struct VerificationPageDataIdNumber: Encodable, Equatable {
+        let country: String?
+        let partialValue: String?
+        let value: String?
+    }
+}

--- a/StripeIdentity/StripeIdentity/Source/API Bindings/Models/VerificationPageDataUpdate/VerificationPageDataName.swift
+++ b/StripeIdentity/StripeIdentity/Source/API Bindings/Models/VerificationPageDataUpdate/VerificationPageDataName.swift
@@ -1,0 +1,16 @@
+//
+//  VerificationPageDataName.swift
+//  StripeIdentity
+//
+//  Created by Chen Cen on 1/27/23.
+//
+
+import Foundation
+@_spi(STP) import StripeCore
+
+extension StripeAPI {
+    struct VerificationPageDataName: Encodable, Equatable {
+        let firstName: String?
+        let lastName: String?
+    }
+}

--- a/StripeIdentity/StripeIdentityTests/Helpers/IdentityMockData.swift
+++ b/StripeIdentity/StripeIdentityTests/Helpers/IdentityMockData.swift
@@ -22,6 +22,11 @@ enum VerificationPageMock: String, MockData {
     case response200 = "VerificationPage_200"
     case requireLiveCapture = "VerificationPage_require_live_capture"
     case noSelfie = "VerificationPage_no_selfie"
+    case typeDocumentRequireIdNumber = "VerificationPage_type_doc_require_idNumber"
+    case typeDocumentRequireAddress = "VerificationPage_type_doc_require_address"
+    case typeDocumentRequireIdNumberAndAddress = "VerificationPage_type_doc_require_idNumber_and_address"
+    case typeIdNumber = "VerificationPage_type_idNumber"
+    case typeAddress = "VerificationPage_type_address"
 }
 
 enum VerificationPageDataMock: String, MockData {

--- a/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_200.json
+++ b/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_200.json
@@ -8,6 +8,13 @@
         "title": "How Stripe will verify your identity",
         "scroll_to_continue_button_text": "Scroll to continue"
     },
+    "country_not_listed": {
+      "address_from_other_country_text_button_text": "Have an Address from another country?",
+      "body": "The countries not listed are not supported yet. Unfortunately, we cannot verify your identity.",
+      "cancel_button_text": "Cancel verification",
+      "id_from_other_country_text_button_text": "Have an ID from another country?",
+      "title": "We cannot verify your identity"
+    },
     "document_capture": {
         "autocapture_timeout": 10000,
         "file_purpose": "identity_private",
@@ -41,6 +48,50 @@
         "title": "Select identification type"
     },
     "fallback_url": "https://verify.stripe.com",
+    "individual": {
+      "address_countries": {
+        "AT": "Austria",
+        "AU": "Australia",
+        "BE": "Belgium",
+        "BR": "Brazil",
+        "CA": "Canada",
+        "CH": "Switzerland",
+        "CZ": "Czech Republic",
+        "DE": "Germany",
+        "DK": "Denmark",
+        "ES": "Spain",
+        "FI": "Finland",
+        "FR": "France",
+        "GB": "United Kingdom",
+        "HK": "Hong Kong",
+        "ID": "Indonesia",
+        "IE": "Ireland",
+        "IT": "Italy",
+        "LU": "Luxembourg",
+        "MT": "Malta",
+        "MX": "Mexico",
+        "MY": "Malaysia",
+        "NL": "Netherlands",
+        "NO": "Norway",
+        "PL": "Poland",
+        "PT": "Portugal",
+        "RO": "Romania",
+        "SE": "Sweden",
+        "SG": "Singapore",
+        "SK": "Slovakia",
+        "TH": "Thailand",
+        "US": "United States"
+      },
+      "address_country_not_listed_text_button_text": "My country is not listed",
+      "button_text": "Submit",
+      "id_number_countries": {
+        "BR": "Brazil",
+        "SG": "Singapore",
+        "US": "United States"
+      },
+      "id_number_country_not_listed_text_button_text": "My country is not listed",
+      "title": "Provide personal information"
+    },
     "id": "VS_123",
     "livemode": false,
     "object": "identity.verification_page",

--- a/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_no_selfie.json
+++ b/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_no_selfie.json
@@ -8,6 +8,13 @@
         "title": "How Stripe will verify your identity",
         "scroll_to_continue_button_text": "Scroll to continue"
     },
+    "country_not_listed": {
+      "address_from_other_country_text_button_text": "Have an Address from another country?",
+      "body": "The countries not listed are not supported yet. Unfortunately, we cannot verify your identity.",
+      "cancel_button_text": "Cancel verification",
+      "id_from_other_country_text_button_text": "Have an ID from another country?",
+      "title": "We cannot verify your identity"
+    },
     "document_capture": {
         "autocapture_timeout": 10000,
         "file_purpose": "identity_private",
@@ -41,6 +48,50 @@
         "title": "Select identification type"
     },
     "fallback_url": "https://verify.stripe.com",
+    "individual": {
+      "address_countries": {
+        "AT": "Austria",
+        "AU": "Australia",
+        "BE": "Belgium",
+        "BR": "Brazil",
+        "CA": "Canada",
+        "CH": "Switzerland",
+        "CZ": "Czech Republic",
+        "DE": "Germany",
+        "DK": "Denmark",
+        "ES": "Spain",
+        "FI": "Finland",
+        "FR": "France",
+        "GB": "United Kingdom",
+        "HK": "Hong Kong",
+        "ID": "Indonesia",
+        "IE": "Ireland",
+        "IT": "Italy",
+        "LU": "Luxembourg",
+        "MT": "Malta",
+        "MX": "Mexico",
+        "MY": "Malaysia",
+        "NL": "Netherlands",
+        "NO": "Norway",
+        "PL": "Poland",
+        "PT": "Portugal",
+        "RO": "Romania",
+        "SE": "Sweden",
+        "SG": "Singapore",
+        "SK": "Slovakia",
+        "TH": "Thailand",
+        "US": "United States"
+      },
+      "address_country_not_listed_text_button_text": "My country is not listed",
+      "button_text": "Submit",
+      "id_number_countries": {
+        "BR": "Brazil",
+        "SG": "Singapore",
+        "US": "United States"
+      },
+      "id_number_country_not_listed_text_button_text": "My country is not listed",
+      "title": "Provide personal information"
+    },
     "id": "VS_123",
     "livemode": false,
     "object": "identity.verification_page",

--- a/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_require_live_capture.json
+++ b/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_require_live_capture.json
@@ -8,6 +8,13 @@
         "title": "How Stripe will verify your identity",
         "scroll_to_continue_button_text": "Scroll to continue"
     },
+    "country_not_listed": {
+      "address_from_other_country_text_button_text": "Have an Address from another country?",
+      "body": "The countries not listed are not supported yet. Unfortunately, we cannot verify your identity.",
+      "cancel_button_text": "Cancel verification",
+      "id_from_other_country_text_button_text": "Have an ID from another country?",
+      "title": "We cannot verify your identity"
+    },
     "document_capture": {
         "autocapture_timeout": 10000,
         "file_purpose": "identity_private",
@@ -41,6 +48,50 @@
         "title": "Select identification type"
     },
     "fallback_url": "https://verify.stripe.com",
+    "individual": {
+      "address_countries": {
+        "AT": "Austria",
+        "AU": "Australia",
+        "BE": "Belgium",
+        "BR": "Brazil",
+        "CA": "Canada",
+        "CH": "Switzerland",
+        "CZ": "Czech Republic",
+        "DE": "Germany",
+        "DK": "Denmark",
+        "ES": "Spain",
+        "FI": "Finland",
+        "FR": "France",
+        "GB": "United Kingdom",
+        "HK": "Hong Kong",
+        "ID": "Indonesia",
+        "IE": "Ireland",
+        "IT": "Italy",
+        "LU": "Luxembourg",
+        "MT": "Malta",
+        "MX": "Mexico",
+        "MY": "Malaysia",
+        "NL": "Netherlands",
+        "NO": "Norway",
+        "PL": "Poland",
+        "PT": "Portugal",
+        "RO": "Romania",
+        "SE": "Sweden",
+        "SG": "Singapore",
+        "SK": "Slovakia",
+        "TH": "Thailand",
+        "US": "United States"
+      },
+      "address_country_not_listed_text_button_text": "My country is not listed",
+      "button_text": "Submit",
+      "id_number_countries": {
+        "BR": "Brazil",
+        "SG": "Singapore",
+        "US": "United States"
+      },
+      "id_number_country_not_listed_text_button_text": "My country is not listed",
+      "title": "Provide personal information"
+    },
     "id": "VS_123",
     "livemode": false,
     "object": "identity.verification_page",

--- a/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_type_address.json
+++ b/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_type_address.json
@@ -1,0 +1,114 @@
+{
+  "id": "vs_1MOrKBEGkPhabJTjBA2ohFAW",
+  "object": "identity.verification_page",
+  "biometric_consent": {
+    "accept_button_text": "Accept and continue",
+    "body": "<p><b>How Stripe will verify your identity</b></p><p><a href='https://stripe.com/about'>Stripe</a> will use biometric technology (on images of you and your IDs), as well as other data sources and our service providers, to confirm your identity and for fraud and security purposes. Stripe will store these images and the results of this check and share them with Tora's catfood. You can subsequently opt-out by contacting Stripe. <a href='https://stripe.com/privacy-center/legal#stripe-identity'>Learn more</a></p>",
+    "decline_button_text": "No, don't verify",
+    "privacy_policy": "Data will be stored and may be used according to the <a href='https://stripe.com/privacy'>Stripe Privacy Policy</a> and Tora's catfood Privacy Policy.",
+    "scroll_to_continue_button_text": "Scroll to continue",
+    "time_estimate": "Takes about 1–2 minutes.",
+    "title": "Tora's catfood uses Stripe to verify your identity"
+  },
+  "country_not_listed": {
+    "address_from_other_country_text_button_text": "Have an Address from another country?",
+    "body": "The countries not listed are not supported yet. Unfortunately, we cannot verify your identity.",
+    "cancel_button_text": "Cancel verification",
+    "id_from_other_country_text_button_text": "Have an ID from another country?",
+    "title": "We cannot verify your identity"
+  },
+  "document_capture": {
+    "autocapture_timeout": 8000,
+    "file_purpose": "identity_private",
+    "high_res_image_compression_quality": 0.92,
+    "high_res_image_crop_padding": 0.08,
+    "high_res_image_max_dimension": 3000,
+    "ios_id_card_back_barcode_timeout": 3000,
+    "ios_id_card_back_country_barcode_symbologies": {
+      "CA": "pdf417",
+      "US": "pdf417"
+    },
+    "low_res_image_compression_quality": 0.82,
+    "low_res_image_max_dimension": 3000,
+    "models": {
+      "id_detector_min_iou": 0.8,
+      "id_detector_min_score": 0.5,
+      "id_detector_url": "https://b.stripecdn.com/gelato-statics-srv/assets/d137be6ecc86477800ea4ef82154174092dc4c16/assets/id_detectors/tflite/2022-08-19/model.tflite"
+    },
+    "motion_blur_min_duration": 500,
+    "motion_blur_min_iou": 0.95,
+    "require_live_capture": false
+  },
+  "document_select": {
+    "body": null,
+    "button_text": "Next",
+    "id_document_type_allowlist": {
+      "driving_license": "Driver's license",
+      "id_card": "Identity card",
+      "passport": "Passport"
+    },
+    "title": "Which form of identification do you want to use?"
+  },
+  "fallback_url": "https://verify.stripe.com/start/test_YWNjdF8xTEliaExFR2tQaGFiSlRqLF9OOTlkVWhpa0hIa2s2RndYTjFxMmNwSGdxYm9hbno40100QbvpMKxr",
+  "individual": {
+    "address_countries": {
+      "AT": "Austria",
+      "AU": "Australia",
+      "BE": "Belgium",
+      "BR": "Brazil",
+      "CA": "Canada",
+      "CH": "Switzerland",
+      "CZ": "Czech Republic",
+      "DE": "Germany",
+      "DK": "Denmark",
+      "ES": "Spain",
+      "FI": "Finland",
+      "FR": "France",
+      "GB": "United Kingdom",
+      "HK": "Hong Kong",
+      "ID": "Indonesia",
+      "IE": "Ireland",
+      "IT": "Italy",
+      "LU": "Luxembourg",
+      "MT": "Malta",
+      "MX": "Mexico",
+      "MY": "Malaysia",
+      "NL": "Netherlands",
+      "NO": "Norway",
+      "PL": "Poland",
+      "PT": "Portugal",
+      "RO": "Romania",
+      "SE": "Sweden",
+      "SG": "Singapore",
+      "SK": "Slovakia",
+      "TH": "Thailand",
+      "US": "United States"
+    },
+    "address_country_not_listed_text_button_text": "My country is not listed",
+    "button_text": "Submit",
+    "id_number_countries": {
+      "BR": "Brazil",
+      "SG": "Singapore",
+      "US": "United States"
+    },
+    "id_number_country_not_listed_text_button_text": "My country is not listed",
+    "title": "Provide personal information"
+  },
+  "livemode": false,
+  "requirements": {
+    "missing": [
+      "address",
+      "dob",
+      "name"
+    ]
+  },
+  "selfie": null,
+  "status": "requires_input",
+  "submitted": false,
+  "success": {
+    "body": "<p>Thank you for providing your information. Tora's catfood will reach out if additional details are required.</p><p><b>Next steps</b></p><p>Tora's catfood will contact you regarding the outcome of your identification process.</p><p><b>More about Stripe Identity</b></p><p><a href='https://support.stripe.com/questions/common-questions-about-stripe-identity'>Common questions about Stripe Identity</a></p><p><a href='https://stripe.com/privacy-center/legal#stripe-identity'>Learn how Stripe uses data</a></p><p><a href='https://stripe.com/privacy'>Stripe Privacy Policy</a></p><p><a href='mailto:privacy@stripe.com'>Contact Stripe</a></p>",
+    "button_text": "Complete",
+    "title": "Verification submitted"
+  },
+  "unsupported_client": false
+}

--- a/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_type_doc_require_address.json
+++ b/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_type_doc_require_address.json
@@ -1,0 +1,116 @@
+{
+  "id": "vs_1MRjwTEGkPhabJTjIEKiUmmS",
+  "object": "identity.verification_page",
+  "biometric_consent": {
+    "accept_button_text": "Accept and continue",
+    "body": "<p><b>How Stripe will verify your identity</b></p><p><a href='https://stripe.com/about'>Stripe</a> will use biometric technology (on images of you and your IDs), as well as other data sources and our service providers, to confirm your identity and for fraud and security purposes. Stripe will store these images and the results of this check and share them with Tora's catfood. You can subsequently opt-out by contacting Stripe. <a href='https://stripe.com/privacy-center/legal#stripe-identity'>Learn more</a></p>",
+    "decline_button_text": "No, don't verify",
+    "privacy_policy": "Data will be stored and may be used according to the <a href='https://stripe.com/privacy'>Stripe Privacy Policy</a> and Tora's catfood Privacy Policy.",
+    "scroll_to_continue_button_text": "Scroll to continue",
+    "time_estimate": "Takes about 1–2 minutes.",
+    "title": "Tora's catfood uses Stripe to verify your identity"
+  },
+  "country_not_listed": {
+    "address_from_other_country_text_button_text": "Have an Address from another country?",
+    "body": "The countries not listed are not supported yet. Unfortunately, we cannot verify your identity.",
+    "cancel_button_text": "Cancel verification",
+    "id_from_other_country_text_button_text": "Have an ID from another country?",
+    "title": "We cannot verify your identity"
+  },
+  "document_capture": {
+    "autocapture_timeout": 8000,
+    "file_purpose": "identity_private",
+    "high_res_image_compression_quality": 0.92,
+    "high_res_image_crop_padding": 0.08,
+    "high_res_image_max_dimension": 3000,
+    "ios_id_card_back_barcode_timeout": 3000,
+    "ios_id_card_back_country_barcode_symbologies": {
+      "CA": "pdf417",
+      "US": "pdf417"
+    },
+    "low_res_image_compression_quality": 0.82,
+    "low_res_image_max_dimension": 3000,
+    "models": {
+      "id_detector_min_iou": 0.8,
+      "id_detector_min_score": 0.5,
+      "id_detector_url": "https://b.stripecdn.com/gelato-statics-srv/assets/d137be6ecc86477800ea4ef82154174092dc4c16/assets/id_detectors/tflite/2022-08-19/model.tflite"
+    },
+    "motion_blur_min_duration": 500,
+    "motion_blur_min_iou": 0.95,
+    "require_live_capture": true
+  },
+  "document_select": {
+    "body": null,
+    "button_text": "Next",
+    "id_document_type_allowlist": {
+      "driving_license": "Driver's license",
+      "id_card": "Identity card",
+      "passport": "Passport"
+    },
+    "title": "Which form of identification do you want to use?"
+  },
+  "fallback_url": "https://verify.stripe.com/start/live_YWNjdF8xTEliaExFR2tQaGFiSlRqLF9OQzhDRjQ5TXI5ZGdyM0tKWDI1RzBKMGNTQ3JyNGVU0100vUQ0sLfw",
+  "individual": {
+    "address_countries": {
+      "AT": "Austria",
+      "AU": "Australia",
+      "BE": "Belgium",
+      "BR": "Brazil",
+      "CA": "Canada",
+      "CH": "Switzerland",
+      "CZ": "Czech Republic",
+      "DE": "Germany",
+      "DK": "Denmark",
+      "ES": "Spain",
+      "FI": "Finland",
+      "FR": "France",
+      "GB": "United Kingdom",
+      "HK": "Hong Kong",
+      "ID": "Indonesia",
+      "IE": "Ireland",
+      "IT": "Italy",
+      "LU": "Luxembourg",
+      "MT": "Malta",
+      "MX": "Mexico",
+      "MY": "Malaysia",
+      "NL": "Netherlands",
+      "NO": "Norway",
+      "PL": "Poland",
+      "PT": "Portugal",
+      "RO": "Romania",
+      "SE": "Sweden",
+      "SG": "Singapore",
+      "SK": "Slovakia",
+      "TH": "Thailand",
+      "US": "United States"
+    },
+    "address_country_not_listed_text_button_text": "My country is not listed",
+    "button_text": "Submit",
+    "id_number_countries": {
+      "BR": "Brazil",
+      "SG": "Singapore",
+      "US": "United States"
+    },
+    "id_number_country_not_listed_text_button_text": "My country is not listed",
+    "title": "Provide personal information"
+  },
+  "livemode": true,
+  "requirements": {
+    "missing": [
+      "address",
+      "biometric_consent",
+      "id_document_front",
+      "id_document_back",
+      "id_document_type"
+    ]
+  },
+  "selfie": null,
+  "status": "requires_input",
+  "submitted": false,
+  "success": {
+    "body": "<p>Thank you for providing your information. Tora's catfood will reach out if additional details are required.</p><p><b>Next steps</b></p><p>Tora's catfood will contact you regarding the outcome of your identification process.</p><p><b>More about Stripe Identity</b></p><p><a href='https://support.stripe.com/questions/common-questions-about-stripe-identity'>Common questions about Stripe Identity</a></p><p><a href='https://stripe.com/privacy-center/legal#stripe-identity'>Learn how Stripe uses data</a></p><p><a href='https://stripe.com/privacy'>Stripe Privacy Policy</a></p><p><a href='mailto:privacy@stripe.com'>Contact Stripe</a></p>",
+    "button_text": "Complete",
+    "title": "Verification submitted"
+  },
+  "unsupported_client": false
+}

--- a/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_type_doc_require_idNumber.json
+++ b/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_type_doc_require_idNumber.json
@@ -1,0 +1,116 @@
+{
+  "id": "vs_1MOrPwEGkPhabJTjzCzKF4DM",
+  "object": "identity.verification_page",
+  "biometric_consent": {
+    "accept_button_text": "Accept and continue",
+    "body": "<p><b>How Stripe will verify your identity</b></p><p><a href='https://stripe.com/about'>Stripe</a> will use biometric technology (on images of you and your IDs), as well as other data sources and our service providers, to confirm your identity and for fraud and security purposes. Stripe will store these images and the results of this check and share them with Tora's catfood. You can subsequently opt-out by contacting Stripe. <a href='https://stripe.com/privacy-center/legal#stripe-identity'>Learn more</a></p>",
+    "decline_button_text": "No, don't verify",
+    "privacy_policy": "Data will be stored and may be used according to the <a href='https://stripe.com/privacy'>Stripe Privacy Policy</a> and Tora's catfood Privacy Policy.",
+    "scroll_to_continue_button_text": "Scroll to continue",
+    "time_estimate": "Takes about 1–2 minutes.",
+    "title": "Tora's catfood uses Stripe to verify your identity"
+  },
+  "country_not_listed": {
+    "address_from_other_country_text_button_text": "Have an Address from another country?",
+    "body": "The countries not listed are not supported yet. Unfortunately, we cannot verify your identity.",
+    "cancel_button_text": "Cancel verification",
+    "id_from_other_country_text_button_text": "Have an ID from another country?",
+    "title": "We cannot verify your identity"
+  },
+  "document_capture": {
+    "autocapture_timeout": 8000,
+    "file_purpose": "identity_private",
+    "high_res_image_compression_quality": 0.92,
+    "high_res_image_crop_padding": 0.08,
+    "high_res_image_max_dimension": 3000,
+    "ios_id_card_back_barcode_timeout": 3000,
+    "ios_id_card_back_country_barcode_symbologies": {
+      "CA": "pdf417",
+      "US": "pdf417"
+    },
+    "low_res_image_compression_quality": 0.82,
+    "low_res_image_max_dimension": 3000,
+    "models": {
+      "id_detector_min_iou": 0.8,
+      "id_detector_min_score": 0.5,
+      "id_detector_url": "https://b.stripecdn.com/gelato-statics-srv/assets/d137be6ecc86477800ea4ef82154174092dc4c16/assets/id_detectors/tflite/2022-08-19/model.tflite"
+    },
+    "motion_blur_min_duration": 500,
+    "motion_blur_min_iou": 0.95,
+    "require_live_capture": true
+  },
+  "document_select": {
+    "body": null,
+    "button_text": "Next",
+    "id_document_type_allowlist": {
+      "driving_license": "Driver's license",
+      "id_card": "Identity card",
+      "passport": "Passport"
+    },
+    "title": "Which form of identification do you want to use?"
+  },
+  "fallback_url": "https://verify.stripe.com/start/test_YWNjdF8xTEliaExFR2tQaGFiSlRqLF9OOTlqVW84aWdKakk3dlBuM3gwWUdiejVrTkdUSWht0100PuDMlvY6",
+  "individual": {
+    "address_countries": {
+      "AT": "Austria",
+      "AU": "Australia",
+      "BE": "Belgium",
+      "BR": "Brazil",
+      "CA": "Canada",
+      "CH": "Switzerland",
+      "CZ": "Czech Republic",
+      "DE": "Germany",
+      "DK": "Denmark",
+      "ES": "Spain",
+      "FI": "Finland",
+      "FR": "France",
+      "GB": "United Kingdom",
+      "HK": "Hong Kong",
+      "ID": "Indonesia",
+      "IE": "Ireland",
+      "IT": "Italy",
+      "LU": "Luxembourg",
+      "MT": "Malta",
+      "MX": "Mexico",
+      "MY": "Malaysia",
+      "NL": "Netherlands",
+      "NO": "Norway",
+      "PL": "Poland",
+      "PT": "Portugal",
+      "RO": "Romania",
+      "SE": "Sweden",
+      "SG": "Singapore",
+      "SK": "Slovakia",
+      "TH": "Thailand",
+      "US": "United States"
+    },
+    "address_country_not_listed_text_button_text": "My country is not listed",
+    "button_text": "Submit",
+    "id_number_countries": {
+      "BR": "Brazil",
+      "SG": "Singapore",
+      "US": "United States"
+    },
+    "id_number_country_not_listed_text_button_text": "My country is not listed",
+    "title": "Provide personal information"
+  },
+  "livemode": false,
+  "requirements": {
+    "missing": [
+      "biometric_consent",
+      "id_document_front",
+      "id_document_back",
+      "id_document_type",
+      "id_number"
+    ]
+  },
+  "selfie": null,
+  "status": "requires_input",
+  "submitted": false,
+  "success": {
+    "body": "<p>Thank you for providing your information. Tora's catfood will reach out if additional details are required.</p><p><b>Next steps</b></p><p>Tora's catfood will contact you regarding the outcome of your identification process.</p><p><b>More about Stripe Identity</b></p><p><a href='https://support.stripe.com/questions/common-questions-about-stripe-identity'>Common questions about Stripe Identity</a></p><p><a href='https://stripe.com/privacy-center/legal#stripe-identity'>Learn how Stripe uses data</a></p><p><a href='https://stripe.com/privacy'>Stripe Privacy Policy</a></p><p><a href='mailto:privacy@stripe.com'>Contact Stripe</a></p>",
+    "button_text": "Complete",
+    "title": "Verification submitted"
+  },
+  "unsupported_client": false
+}

--- a/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_type_doc_require_idNumber_and_address.json
+++ b/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_type_doc_require_idNumber_and_address.json
@@ -1,0 +1,117 @@
+{
+  "id": "vs_1MTb71EGkPhabJTjK2kJQ5xI",
+  "object": "identity.verification_page",
+  "biometric_consent": {
+    "accept_button_text": "Accept and continue",
+    "body": "<p><b>How Stripe will verify your identity</b></p><p><a href='https://stripe.com/about'>Stripe</a> will use biometric technology (on images of you and your IDs), as well as other data sources and our service providers, to confirm your identity and for fraud and security purposes. Stripe will store these images and the results of this check and share them with Tora's catfood. You can subsequently opt-out by contacting Stripe. <a href='https://stripe.com/privacy-center/legal#stripe-identity'>Learn more</a></p>",
+    "decline_button_text": "No, don't verify",
+    "privacy_policy": "Data will be stored and may be used according to the <a href='https://stripe.com/privacy'>Stripe Privacy Policy</a> and Tora's catfood Privacy Policy.",
+    "scroll_to_continue_button_text": "Scroll to continue",
+    "time_estimate": "Takes about 1–2 minutes.",
+    "title": "Tora's catfood uses Stripe to verify your identity"
+  },
+  "country_not_listed": {
+    "address_from_other_country_text_button_text": "Have an Address from another country?",
+    "body": "The countries not listed are not supported yet. Unfortunately, we cannot verify your identity.",
+    "cancel_button_text": "Cancel verification",
+    "id_from_other_country_text_button_text": "Have an ID from another country?",
+    "title": "We cannot verify your identity"
+  },
+  "document_capture": {
+    "autocapture_timeout": 8000,
+    "file_purpose": "identity_private",
+    "high_res_image_compression_quality": 0.92,
+    "high_res_image_crop_padding": 0.08,
+    "high_res_image_max_dimension": 3000,
+    "ios_id_card_back_barcode_timeout": 3000,
+    "ios_id_card_back_country_barcode_symbologies": {
+      "CA": "pdf417",
+      "US": "pdf417"
+    },
+    "low_res_image_compression_quality": 0.82,
+    "low_res_image_max_dimension": 3000,
+    "models": {
+      "id_detector_min_iou": 0.8,
+      "id_detector_min_score": 0.5,
+      "id_detector_url": "https://b.stripecdn.com/gelato-statics-srv/assets/d137be6ecc86477800ea4ef82154174092dc4c16/assets/id_detectors/tflite/2022-08-19/model.tflite"
+    },
+    "motion_blur_min_duration": 500,
+    "motion_blur_min_iou": 0.95,
+    "require_live_capture": true
+  },
+  "document_select": {
+    "body": null,
+    "button_text": "Next",
+    "id_document_type_allowlist": {
+      "driving_license": "Driver's license",
+      "id_card": "Identity card",
+      "passport": "Passport"
+    },
+    "title": "Which form of identification do you want to use?"
+  },
+  "fallback_url": "https://verify.stripe.com/start/test_YWNjdF8xTEliaExFR2tQaGFiSlRqLF9ORTNESmF3b2JCVldkRUladDZTMEw3TFk3aUt5N1BE0100D2Sn0qSX",
+  "individual": {
+    "address_countries": {
+      "AT": "Austria",
+      "AU": "Australia",
+      "BE": "Belgium",
+      "BR": "Brazil",
+      "CA": "Canada",
+      "CH": "Switzerland",
+      "CZ": "Czech Republic",
+      "DE": "Germany",
+      "DK": "Denmark",
+      "ES": "Spain",
+      "FI": "Finland",
+      "FR": "France",
+      "GB": "United Kingdom",
+      "HK": "Hong Kong",
+      "ID": "Indonesia",
+      "IE": "Ireland",
+      "IT": "Italy",
+      "LU": "Luxembourg",
+      "MT": "Malta",
+      "MX": "Mexico",
+      "MY": "Malaysia",
+      "NL": "Netherlands",
+      "NO": "Norway",
+      "PL": "Poland",
+      "PT": "Portugal",
+      "RO": "Romania",
+      "SE": "Sweden",
+      "SG": "Singapore",
+      "SK": "Slovakia",
+      "TH": "Thailand",
+      "US": "United States"
+    },
+    "address_country_not_listed_text_button_text": "My country is not listed",
+    "button_text": "Submit",
+    "id_number_countries": {
+      "BR": "Brazil",
+      "SG": "Singapore",
+      "US": "United States"
+    },
+    "id_number_country_not_listed_text_button_text": "My country is not listed",
+    "title": "Provide personal information"
+  },
+  "livemode": false,
+  "requirements": {
+    "missing": [
+      "address",
+      "biometric_consent",
+      "id_document_front",
+      "id_document_back",
+      "id_document_type",
+      "id_number"
+    ]
+  },
+  "selfie": null,
+  "status": "requires_input",
+  "submitted": false,
+  "success": {
+    "body": "<p>Thank you for providing your information. Tora's catfood will reach out if additional details are required.</p><p><b>Next steps</b></p><p>Tora's catfood will contact you regarding the outcome of your identification process.</p><p><b>More about Stripe Identity</b></p><p><a href='https://support.stripe.com/questions/common-questions-about-stripe-identity'>Common questions about Stripe Identity</a></p><p><a href='https://stripe.com/privacy-center/legal#stripe-identity'>Learn how Stripe uses data</a></p><p><a href='https://stripe.com/privacy'>Stripe Privacy Policy</a></p><p><a href='mailto:privacy@stripe.com'>Contact Stripe</a></p>",
+    "button_text": "Complete",
+    "title": "Verification submitted"
+  },
+  "unsupported_client": false
+}

--- a/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_type_idNumber.json
+++ b/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_type_idNumber.json
@@ -1,0 +1,114 @@
+{
+  "id": "vs_1MOrMgEGkPhabJTjkbUNVfh6",
+  "object": "identity.verification_page",
+  "biometric_consent": {
+    "accept_button_text": "Accept and continue",
+    "body": "<p><b>How Stripe will verify your identity</b></p><p><a href='https://stripe.com/about'>Stripe</a> will use biometric technology (on images of you and your IDs), as well as other data sources and our service providers, to confirm your identity and for fraud and security purposes. Stripe will store these images and the results of this check and share them with Tora's catfood. You can subsequently opt-out by contacting Stripe. <a href='https://stripe.com/privacy-center/legal#stripe-identity'>Learn more</a></p>",
+    "decline_button_text": "No, don't verify",
+    "privacy_policy": "Data will be stored and may be used according to the <a href='https://stripe.com/privacy'>Stripe Privacy Policy</a> and Tora's catfood Privacy Policy.",
+    "scroll_to_continue_button_text": "Scroll to continue",
+    "time_estimate": "Takes about 1–2 minutes.",
+    "title": "Tora's catfood uses Stripe to verify your identity"
+  },
+  "country_not_listed": {
+    "address_from_other_country_text_button_text": "Have an Address from another country?",
+    "body": "The countries not listed are not supported yet. Unfortunately, we cannot verify your identity.",
+    "cancel_button_text": "Cancel verification",
+    "id_from_other_country_text_button_text": "Have an ID from another country?",
+    "title": "We cannot verify your identity"
+  },
+  "document_capture": {
+    "autocapture_timeout": 8000,
+    "file_purpose": "identity_private",
+    "high_res_image_compression_quality": 0.92,
+    "high_res_image_crop_padding": 0.08,
+    "high_res_image_max_dimension": 3000,
+    "ios_id_card_back_barcode_timeout": 3000,
+    "ios_id_card_back_country_barcode_symbologies": {
+      "CA": "pdf417",
+      "US": "pdf417"
+    },
+    "low_res_image_compression_quality": 0.82,
+    "low_res_image_max_dimension": 3000,
+    "models": {
+      "id_detector_min_iou": 0.8,
+      "id_detector_min_score": 0.5,
+      "id_detector_url": "https://b.stripecdn.com/gelato-statics-srv/assets/d137be6ecc86477800ea4ef82154174092dc4c16/assets/id_detectors/tflite/2022-08-19/model.tflite"
+    },
+    "motion_blur_min_duration": 500,
+    "motion_blur_min_iou": 0.95,
+    "require_live_capture": false
+  },
+  "document_select": {
+    "body": null,
+    "button_text": "Next",
+    "id_document_type_allowlist": {
+      "driving_license": "Driver's license",
+      "id_card": "Identity card",
+      "passport": "Passport"
+    },
+    "title": "Which form of identification do you want to use?"
+  },
+  "fallback_url": "https://verify.stripe.com/start/test_YWNjdF8xTEliaExFR2tQaGFiSlRqLF9OOTlnUXJWaWJSMGg3U2NzTGlQODRHR1BhbzlTd1BT0100mJdJgeY7",
+  "individual": {
+    "address_countries": {
+      "AT": "Austria",
+      "AU": "Australia",
+      "BE": "Belgium",
+      "BR": "Brazil",
+      "CA": "Canada",
+      "CH": "Switzerland",
+      "CZ": "Czech Republic",
+      "DE": "Germany",
+      "DK": "Denmark",
+      "ES": "Spain",
+      "FI": "Finland",
+      "FR": "France",
+      "GB": "United Kingdom",
+      "HK": "Hong Kong",
+      "ID": "Indonesia",
+      "IE": "Ireland",
+      "IT": "Italy",
+      "LU": "Luxembourg",
+      "MT": "Malta",
+      "MX": "Mexico",
+      "MY": "Malaysia",
+      "NL": "Netherlands",
+      "NO": "Norway",
+      "PL": "Poland",
+      "PT": "Portugal",
+      "RO": "Romania",
+      "SE": "Sweden",
+      "SG": "Singapore",
+      "SK": "Slovakia",
+      "TH": "Thailand",
+      "US": "United States"
+    },
+    "address_country_not_listed_text_button_text": "My country is not listed",
+    "button_text": "Submit",
+    "id_number_countries": {
+      "BR": "Brazil",
+      "SG": "Singapore",
+      "US": "United States"
+    },
+    "id_number_country_not_listed_text_button_text": "My country is not listed",
+    "title": "Provide personal information"
+  },
+  "livemode": false,
+  "requirements": {
+    "missing": [
+      "dob",
+      "id_number",
+      "name"
+    ]
+  },
+  "selfie": null,
+  "status": "requires_input",
+  "submitted": false,
+  "success": {
+    "body": "<p>Thank you for providing your information. Tora's catfood will reach out if additional details are required.</p><p><b>Next steps</b></p><p>Tora's catfood will contact you regarding the outcome of your identification process.</p><p><b>More about Stripe Identity</b></p><p><a href='https://support.stripe.com/questions/common-questions-about-stripe-identity'>Common questions about Stripe Identity</a></p><p><a href='https://stripe.com/privacy-center/legal#stripe-identity'>Learn how Stripe uses data</a></p><p><a href='https://stripe.com/privacy'>Stripe Privacy Policy</a></p><p><a href='mailto:privacy@stripe.com'>Contact Stripe</a></p>",
+    "button_text": "Complete",
+    "title": "Verification submitted"
+  },
+  "unsupported_client": false
+}

--- a/StripeIdentity/StripeIdentityTests/Unit/API Bindings/IdentityAPIClientTest.swift
+++ b/StripeIdentity/StripeIdentityTests/Unit/API Bindings/IdentityAPIClientTest.swift
@@ -42,37 +42,36 @@ final class IdentityAPIClientTest: APIStubbedTestCase {
         apiClient.apiClient.urlSession = URLSession(configuration: urlSessionConfig)
     }
 
-    func testCreateVerificationPage() throws {
-        let mockVerificationPage = VerificationPageMock.response200
-        let mockResponseData = try mockVerificationPage.data()
-        let mockResponse = try mockVerificationPage.make()
+    func testCreateVerificationPageWithTypeDoc() throws {
+        try testVerificationPage(with: VerificationPageMock.response200)
+    }
 
-        stub { urlRequest in
-            XCTAssertEqual(
-                urlRequest.url?.absoluteString.hasSuffix(
-                    "v1/identity/verification_pages/\(IdentityAPIClientTest.mockId)?"
-                ),
-                true
-            )
-            XCTAssertEqual(urlRequest.httpMethod, "GET")
-            verifyHeaders(urlRequest: urlRequest)
+    func testCreateVerificationPageWithTypeDocRequireLifeCapture() throws {
+        try testVerificationPage(with: VerificationPageMock.requireLiveCapture)
+    }
 
-            return true
-        } response: { _ in
-            return HTTPStubsResponse(data: mockResponseData, statusCode: 200, headers: nil)
-        }
+    func testCreateVerificationPageWithTypeDocNoSelfie() throws {
+        try testVerificationPage(with: VerificationPageMock.noSelfie)
+    }
 
-        apiClient.getIdentityVerificationPage().observe { result in
-            switch result {
-            case .success(let response):
-                XCTAssertEqual(response, mockResponse)
-            case .failure(let error):
-                XCTFail("Request returned error \(error)")
-            }
-            self.exp.fulfill()
-        }
+    func testCreateVerificationPageWithTypeDocRequireIdNumber() throws {
+        try testVerificationPage(with: VerificationPageMock.typeDocumentRequireIdNumber)
+    }
 
-        wait(for: [exp], timeout: 1)
+    func testCreateVerificationPageWithTypeDocRequireAddress() throws {
+        try testVerificationPage(with: VerificationPageMock.typeDocumentRequireAddress)
+    }
+
+    func testCreateVerificationPageWithTypeDocRequireIdNumberAndAddress() throws {
+        try testVerificationPage(with: VerificationPageMock.typeDocumentRequireIdNumberAndAddress)
+    }
+
+    func testCreateVerificationPageWithTypeIdNumber() throws {
+        try testVerificationPage(with: VerificationPageMock.typeIdNumber)
+    }
+
+    func testCreateVerificationPageWithTypeAddress() throws {
+        try testVerificationPage(with: VerificationPageMock.typeAddress)
     }
 
     func testUpdateVerificationPageData() throws {
@@ -200,6 +199,39 @@ final class IdentityAPIClientTest: APIStubbedTestCase {
 
         wait(for: [exp], timeout: 1)
     }
+
+    private func testVerificationPage(with responseMock: VerificationPageMock) throws {
+        let mockVerificationPage = responseMock
+        let mockResponseData = try mockVerificationPage.data()
+        let mockResponse = try mockVerificationPage.make()
+
+        stub { urlRequest in
+            XCTAssertEqual(
+                urlRequest.url?.absoluteString.hasSuffix(
+                    "v1/identity/verification_pages/\(IdentityAPIClientTest.mockId)?"
+                ),
+                true
+            )
+            XCTAssertEqual(urlRequest.httpMethod, "GET")
+            verifyHeaders(urlRequest: urlRequest)
+
+            return true
+        } response: { _ in
+            return HTTPStubsResponse(data: mockResponseData, statusCode: 200, headers: nil)
+        }
+
+        apiClient.getIdentityVerificationPage().observe { result in
+            switch result {
+            case .success(let response):
+                XCTAssertEqual(response, mockResponse)
+            case .failure(let error):
+                XCTFail("Request returned error \(error)")
+            }
+            self.exp.fulfill()
+        }
+
+        wait(for: [exp], timeout: 1)
+    }
 }
 
 private func verifyHeaders(
@@ -215,7 +247,7 @@ private func verifyHeaders(
     )
     XCTAssertEqual(
         urlRequest.allHTTPHeaderFields?["Stripe-Version"],
-        "2020-08-27; identity_client_api=v2",
+        "2020-08-27; identity_client_api=v3",
         file: file,
         line: line
     )

--- a/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/Coordinators/VerificationSheetControllerTest.swift
+++ b/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/Coordinators/VerificationSheetControllerTest.swift
@@ -21,6 +21,7 @@ final class VerificationSheetControllerTest: XCTestCase {
     private var mockFlowController: VerificationSheetFlowControllerMock!
     private var controller: VerificationSheetController!
     private var mockAPIClient: IdentityAPIClientTestMock!
+    // swiftlint:disable:next weak_delegate
     private var mockDelegate: MockDelegate!
     private var mockMLModelLoader: IdentityMLModelLoaderMock!
     private var mockAnalyticsClient: MockAnalyticsClientV2!
@@ -101,7 +102,6 @@ final class VerificationSheetControllerTest: XCTestCase {
 
     func testLoadAndUpdateUI() throws {
         let mockResponse = try VerificationPageMock.response200.make()
-
         controller.loadAndUpdateUI()
 
         // Respond to request with success
@@ -141,7 +141,11 @@ final class VerificationSheetControllerTest: XCTestCase {
                     face: true,
                     idDocumentBack: true,
                     idDocumentFront: true,
-                    idDocumentType: true
+                    idDocumentType: true,
+                    idNumber: true,
+                    dob: true,
+                    name: true,
+                    address: true
                 ),
                 collectedData: mockData
             )


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
* parse `individual` and `countryNotListed` in `VerificationPage`
* support `dob`, `name`, `address`, `id_number` in `VerificationPageFieldType`, `VerificationPageCollectedData` and `VerificationPageClearData`

Please see more details in [this](https://docs.google.com/document/d/1N3GeDgdNxRsr86XdT_5lWOLEdhWST26F9t5aDgJz-3E/edit#bookmark=id.n32qfeo2i4hd) internal doc.

Similar Android change: https://github.com/stripe/stripe-android/pull/6113

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Support ID and Address

## Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
