### PR TITLE
Financial Connections: added support for skipping success pane

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundMainView.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundMainView.swift
@@ -16,50 +16,65 @@ struct PlaygroundMainView: View {
         ZStack {
             VStack {
                 Form {
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("What do you want to use Financial Connections for?")
-                            .font(.headline)
-                        Picker("Flow?", selection: $viewModel.flow) {
-                            ForEach(PlaygroundMainViewModel.Flow.allCases) {
-                                Text($0.rawValue.capitalized)
-                                    .tag($0)
+                    Section {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("What do you want to use Financial Connections for?")
+                                .font(.headline)
+                            Picker("Flow?", selection: $viewModel.flow) {
+                                ForEach(PlaygroundMainViewModel.Flow.allCases) {
+                                    Text($0.rawValue.capitalized)
+                                        .tag($0)
+                                }
+                            }
+                            .pickerStyle(.segmented)
+                            Text("'Payments' has manual entry enabled.")
+                                .font(.caption)
+                                .italic()
+                        }
+
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("How do you want it to look like?")
+                                .font(.headline)
+                            Picker("Enable Native?", selection: $viewModel.nativeSelection) {
+                                ForEach(PlaygroundMainViewModel.NativeSelection.allCases) {
+                                    Text($0.rawValue.capitalized)
+                                        .tag($0)
+                                }
+                            }
+                            .pickerStyle(.segmented)
+                            Text("'Automatic' will let the server choose between 'Web' or 'Native'.")
+                                .font(.caption)
+                                .italic()
+                        }
+
+                        if !viewModel.enableAppToApp
+                            && (viewModel.customPublicKey.isEmpty || viewModel.customSecretKey.isEmpty)
+                        {
+                            if #available(iOS 14.0, *) {
+                                Toggle("Enable Test Mode", isOn: $viewModel.enableTestMode)
+                                    // test mode color
+                                    .toggleStyle(
+                                        SwitchToggleStyle(
+                                            tint: Color(red: 231 / 255.0, green: 151 / 255.0, blue: 104 / 255.0)
+                                        )
+                                    )
+                            } else {
+                                Toggle("Enable Test Mode", isOn: $viewModel.enableTestMode)
                             }
                         }
-                        .pickerStyle(.segmented)
-                        Text("'Payments' has manual entry enabled.")
-                            .font(.caption)
-                            .italic()
-                    }
 
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("How do you want it to look like?")
-                            .font(.headline)
-                        Picker("Enable Native?", selection: $viewModel.nativeSelection) {
-                            ForEach(PlaygroundMainViewModel.NativeSelection.allCases) {
-                                Text($0.rawValue.capitalized)
-                                    .tag($0)
-                            }
+                        if viewModel.customPublicKey.isEmpty || viewModel.customSecretKey.isEmpty {
+                            Toggle("Enable App To App (livemode only)", isOn: $viewModel.enableAppToApp)
                         }
-                        .pickerStyle(.segmented)
-                        Text("'Automatic' will let the server choose between 'Web' or 'Native'.")
-                            .font(.caption)
-                            .italic()
+
+                        Button(action: viewModel.didSelectClearCaches) {
+                            Text("Clear Caches")
+                        }
                     }
 
-                    Toggle("Enable App To App", isOn: $viewModel.enableAppToApp)
-
-                    if #available(iOS 14.0, *) {
-                        Toggle("Enable Test Mode", isOn: $viewModel.enableTestMode)
-                            // test mode color
-                            .toggleStyle(
-                                SwitchToggleStyle(tint: Color(red: 231 / 255.0, green: 151 / 255.0, blue: 104 / 255.0))
-                            )
-                    } else {
-                        Toggle("Enable Test Mode", isOn: $viewModel.enableTestMode)
-                    }
-
-                    Button(action: viewModel.didSelectClearCaches) {
-                        Text("Clear Caches")
+                    Section(header: Text("CUSTOM KEYS")) {
+                        TextField("Public Key (pk_)", text: $viewModel.customPublicKey)
+                        TextField("Secret Key (sk_)", text: $viewModel.customSecretKey)
                     }
                 }
                 VStack {

--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundMainViewModel.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundMainViewModel.swift
@@ -65,6 +65,17 @@ final class PlaygroundMainViewModel: ObservableObject {
         }
     }
 
+    @Published var customPublicKey: String = PlaygroundUserDefaults.customPublicKey {
+        didSet {
+            PlaygroundUserDefaults.customPublicKey = customPublicKey
+        }
+    }
+    @Published var customSecretKey: String = PlaygroundUserDefaults.customSecretKey {
+        didSet {
+            PlaygroundUserDefaults.customSecretKey = customSecretKey
+        }
+    }
+
     @Published var isLoading: Bool = false
 
     init() {
@@ -86,7 +97,9 @@ final class PlaygroundMainViewModel: ObservableObject {
         SetupPlayground(
             enableAppToApp: enableAppToApp,
             enableTestMode: enableTestMode,
-            flow: flow.rawValue
+            flow: flow.rawValue,
+            customPublicKey: customPublicKey,
+            customSecretKey: customSecretKey
         ) { [weak self] setupPlaygroundResponse in
             if let setupPlaygroundResponse = setupPlaygroundResponse {
                 PresentFinancialConnectionsSheet(
@@ -125,6 +138,8 @@ private func SetupPlayground(
     enableAppToApp: Bool,
     enableTestMode: Bool,
     flow: String,
+    customPublicKey: String,
+    customSecretKey: String,
     completionHandler: @escaping ([String: String]?) -> Void
 ) {
     let baseURL = "https://financial-connections-playground-ios.glitch.me"
@@ -138,6 +153,8 @@ private func SetupPlayground(
         requestBody["enable_test_mode"] = enableTestMode
         requestBody["enable_app_to_app"] = enableAppToApp
         requestBody["flow"] = flow
+        requestBody["custom_public_key"] = customPublicKey
+        requestBody["custom_secret_key"] = customSecretKey
         return try! JSONSerialization.data(
             withJSONObject: requestBody,
             options: .prettyPrinted

--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/helpers/PlaygroundUserDefaults.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/helpers/PlaygroundUserDefaults.swift
@@ -33,6 +33,18 @@ final class PlaygroundUserDefaults {
         defaultValue: false
     )
     static var enableTestMode: Bool
+
+    @UserDefault(
+        key: "FINANCIAL_CONNECTIONS_EXAMPLE_APP_CUSTOM_PUBLIC_KEY",
+        defaultValue: ""
+    )
+    static var customPublicKey: String
+
+    @UserDefault(
+        key: "FINANCIAL_CONNECTIONS_EXAMPLE_APP_CUSTOM_SECRET_KEY",
+        defaultValue: ""
+    )
+    static var customSecretKey: String
 }
 
 @propertyWrapper

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsSessionManifest.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsSessionManifest.swift
@@ -77,4 +77,5 @@ struct FinancialConnectionsSessionManifest: Decodable {
     let features: [String: Bool]?
     let experimentAssignments: [String: String]?
     let assignmentEventId: String?
+    let skipSuccessPane: Bool?
 }


### PR DESCRIPTION
## Summary

This PR:
1. Adds "custom public key" and "customer secret key" text fields to the playground (this is so we can test custom merchants)
2. adds support for skip_success_pane

Links:
- https://docs.google.com/document/d/1yTpXDZYQEPms2oRvcjtUdYl2ycsF0XysRQJZq8brmro/edit#heading=h.5b205kqez27g
- https://stripe.slack.com/archives/C01DNBVURH9/p1674066056911119
- https://git.corp.stripe.com/stripe-internal/pay-server/pull/565204

## Testing

Test mode video below. Also tested on live mode.

https://user-images.githubusercontent.com/105514761/215833313-4d0f9975-9321-45d5-b5a3-5e3872cbcad9.mov
