### PR TITLE
Stop sending payment_method in analytics

### DIFF
--- a/Stripe/StripeiOSTests/STPAnalyticsClientPaymentSheetTest.swift
+++ b/Stripe/StripeiOSTests/STPAnalyticsClientPaymentSheetTest.swift
@@ -132,7 +132,6 @@ class STPAnalyticsClientPaymentSheetTest: XCTestCase {
             result: .completed,
             linkEnabled: false,
             activeLinkSession: false,
-            paymentOption: .applePay,
             currency: "USD"
         )
 
@@ -144,7 +143,6 @@ class STPAnalyticsClientPaymentSheetTest: XCTestCase {
             result: .failed(error: PaymentSheetError.unknown(debugDescription: "Error")),
             linkEnabled: false,
             activeLinkSession: false,
-            paymentOption: .applePay,
             currency: "USD"
         )
 
@@ -225,7 +223,6 @@ class STPAnalyticsClientPaymentSheetTest: XCTestCase {
             result: .completed,
             linkEnabled: false,
             activeLinkSession: false,
-            paymentOption: .applePay,
             currency: "USD"
         )
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
@@ -361,7 +361,6 @@ extension PaymentSheet: PayWithLinkViewControllerDelegate {
                 result: result,
                 linkEnabled: intent.supportsLink,
                 activeLinkSession: LinkAccountContext.shared.account?.sessionState == .verified,
-                paymentOption: paymentOption,
                 currency: intent.currency
             )
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -22,20 +22,6 @@ extension PaymentSheet {
         case saved(paymentMethod: STPPaymentMethod)
         case new(confirmParams: IntentConfirmParams)
         case link(option: LinkConfirmOption)
-
-        var name: String {
-            switch self {
-
-            case .applePay:
-                return "applepay"
-            case .saved(paymentMethod: let paymentMethod):
-                return paymentMethod.type.displayName.lowercased()
-            case .new(confirmParams: let confirmParams):
-                return confirmParams.paymentMethodType.displayName.lowercased()
-            case .link:
-                return "link"
-            }
-        }
     }
 
     /// A class that presents the individual steps of a payment flow
@@ -286,7 +272,6 @@ extension PaymentSheet {
                     result: result,
                     linkEnabled: intent.supportsLink,
                     activeLinkSession: LinkAccountContext.shared.account?.sessionState == .verified,
-                    paymentOption: paymentOption,
                     currency: intent.currency
                 )
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
@@ -28,7 +28,6 @@ extension STPAnalyticsClient {
         result: PaymentSheetResult,
         linkEnabled: Bool,
         activeLinkSession: Bool,
-        paymentOption: PaymentOption,
         currency: String?
     ) {
         var success = false
@@ -51,8 +50,7 @@ extension STPAnalyticsClient {
             duration: AnalyticsHelper.shared.getDuration(for: .checkout),
             linkEnabled: linkEnabled,
             activeLinkSession: activeLinkSession,
-            currency: currency,
-            params: ["payment_method": paymentOption.name.lowercased()]
+            currency: currency
         )
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -451,7 +451,6 @@ class PaymentSheetViewController: UIViewController {
                     result: result,
                     linkEnabled: self.intent.supportsLink,
                     activeLinkSession: LinkAccountContext.shared.account?.sessionState == .verified,
-                    paymentOption: paymentOption,
                     currency: self.intent.currency
                 )
 


### PR DESCRIPTION
## Summary
We can use `source_type` instead!

## Motivation
Don't duplicate columns

## Testing
Manually verified
