### PR TITLE
Financial Connections: removed linked label

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerLabelRowView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerLabelRowView.swift
@@ -54,8 +54,6 @@ final class AccountPickerLabelRowView: UIView {
         return subtitleLabel
     }()
 
-    private var linkedView: UIView?
-
     init() {
         super.init(frame: .zero)
         labelStackView.addArrangedSubview(
@@ -87,8 +85,7 @@ final class AccountPickerLabelRowView: UIView {
     func setLeadingTitle(
         _ leadingTitle: String,
         trailingTitle: String?,
-        subtitle: String?,
-        isLinked: Bool
+        subtitle: String?
     ) {
         leadingTitleLabel.text = leadingTitle
         trailingTitleLabel.text = trailingTitle
@@ -97,39 +94,6 @@ final class AccountPickerLabelRowView: UIView {
         if let subtitle = subtitle {
             subtitleLabel.text = subtitle
             labelStackView.addArrangedSubview(subtitleLabel)
-        }
-
-        linkedView?.removeFromSuperview()
-        linkedView = nil
-        if isLinked {
-            let linkedLabel = UILabel()
-            linkedLabel.text = STPLocalizedString(
-                "Linked",
-                "An indicator next to a bank account that educates the user that this bank account is already connected (or linked). This indicator appears in a screen that allows users to select which bank accounts they want to use to pay for something."
-            )
-            linkedLabel.font = .stripeFont(forTextStyle: .captionTightEmphasized)
-            linkedLabel.textColor = .textSuccess
-            linkedLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
-            linkedLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-
-            // stack views make re-sizing and adding padding really easy
-            // so we don't NEED a stack view for a single label but it
-            // simplifies work
-            let linkedLabelStackView = UIStackView(
-                arrangedSubviews: [linkedLabel]
-            )
-            linkedLabelStackView.isLayoutMarginsRelativeArrangement = true
-            linkedLabelStackView.directionalLayoutMargins = NSDirectionalEdgeInsets(
-                top: 2,
-                leading: 6,
-                bottom: 2,
-                trailing: 6
-            )
-            linkedLabelStackView.layer.cornerRadius = 4
-            linkedLabelStackView.backgroundColor = .success100
-            topLevelHorizontalStackView.addArrangedSubview(linkedLabelStackView)
-
-            self.linkedView = linkedLabelStackView
         }
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerSelectionListView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerSelectionListView.swift
@@ -76,8 +76,7 @@ final class AccountPickerSelectionListView: UIView {
                 ),
                 trailingTitle: nil,
                 subtitle: nil,
-                isSelected: (enabledAccounts.count == selectedAccounts.count),
-                isLinked: false
+                isSelected: (enabledAccounts.count == selectedAccounts.count)
             )
             verticalStackView.addArrangedSubview(allAccountsCellView)
         }
@@ -107,8 +106,7 @@ final class AccountPickerSelectionListView: UIView {
                 rowTitles.leadingTitle,
                 trailingTitle: rowTitles.trailingTitle,
                 subtitle: AccountPickerHelpers.rowSubtitle(forAccount: account),
-                isSelected: selectedAccounts.contains(where: { $0.id == account.id }),
-                isLinked: account.linkedAccountId != nil
+                isSelected: selectedAccounts.contains(where: { $0.id == account.id })
             )
             verticalStackView.addArrangedSubview(accountCellView)
         }
@@ -126,8 +124,7 @@ final class AccountPickerSelectionListView: UIView {
                 AccountPickerHelpers.rowTitles(forAccount: disabledAccount).leadingTitle,
                 trailingTitle: "••••\(disabledAccount.displayableAccountNumbers ?? "")",
                 subtitle: disabledAccount.allowSelectionMessage,
-                isSelected: false,
-                isLinked: false
+                isSelected: false
             )
             verticalStackView.addArrangedSubview(accountCellView)
         }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerSelectionRowView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerSelectionRowView.swift
@@ -87,14 +87,12 @@ final class AccountPickerSelectionRowView: UIView {
         _ leadingTitle: String,
         trailingTitle: String?,
         subtitle: String?,
-        isSelected: Bool,
-        isLinked: Bool
+        isSelected: Bool
     ) {
         labelRowView.setLeadingTitle(
             leadingTitle,
             trailingTitle: trailingTitle,
-            subtitle: subtitle,
-            isLinked: isLinked
+            subtitle: subtitle
         )
         self.isSelected = isSelected
     }
@@ -152,8 +150,7 @@ private struct AccountPickerSelectionRowViewUIViewRepresentable: UIViewRepresent
             leadingTitle,
             trailingTitle: trailingTitle,
             subtitle: subtitle,
-            isSelected: isSelected,
-            isLinked: isLinked
+            isSelected: isSelected
         )
         return view
     }
@@ -163,8 +160,7 @@ private struct AccountPickerSelectionRowViewUIViewRepresentable: UIViewRepresent
             leadingTitle,
             trailingTitle: trailingTitle,
             subtitle: subtitle,
-            isSelected: isSelected,
-            isLinked: isLinked
+            isSelected: isSelected
         )
     }
 }


### PR DESCRIPTION
## Summary

Original request:
> Remove "Linked" pill in account picker 

## Testing

| Before      | After |
| ----------- | ----------- |
| ![before](https://user-images.githubusercontent.com/105514761/216346709-6c565ea9-aa89-4d6e-967b-8de1623d3c9c.png)      | ![after](https://user-images.githubusercontent.com/105514761/216346730-c6a59ce6-cbfa-4069-bcb0-a2330ebfb870.png)       |




