### PR TITLE
Remove /elements/sessions (LUXE) filtering of payment methods

### DIFF
--- a/Stripe/StripeiOSTests/PaymentSheetPaymentMethodTypeTest.swift
+++ b/Stripe/StripeiOSTests/PaymentSheetPaymentMethodTypeTest.swift
@@ -637,63 +637,6 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
             )
         )
     }
-    func testArrayToString() {
-        let paymentMethodTypes: [PaymentSheet.PaymentMethodType] = [.card, .dynamic("llammaPay")]
-
-        let strList = paymentMethodTypes.stringList()
-
-        XCTAssertEqual(strList, "[\"card\",\"llammaPay\"]")
-    }
-    func testArrayToString_empty() {
-        let paymentMethodTypes: [PaymentSheet.PaymentMethodType] = []
-
-        let strList = paymentMethodTypes.stringList()
-
-        XCTAssertEqual(strList, "[]")
-    }
-    func testSymmetricDifference_same() {
-        let paymentMethodTypes1: [PaymentSheet.PaymentMethodType] = [.card, .dynamic("llammaPay")]
-        let paymentMethodTypes2: [PaymentSheet.PaymentMethodType] = [.card, .dynamic("llammaPay")]
-
-        let result = paymentMethodTypes1.symmetricDifference(paymentMethodTypes2)
-
-        XCTAssertEqual(result, [])
-    }
-    func testSymmetricDifference_difference1() {
-        let paymentMethodTypes1: [PaymentSheet.PaymentMethodType] = [
-            .card, .dynamic("llammaPay"), .dynamic("wechatpay"),
-        ]
-        let paymentMethodTypes2: [PaymentSheet.PaymentMethodType] = [.card, .dynamic("llammaPay")]
-
-        let result = paymentMethodTypes1.symmetricDifference(paymentMethodTypes2)
-
-        XCTAssertEqual(result, [.dynamic("wechatpay")])
-    }
-    func testSymmetricDifference_difference2() {
-        let paymentMethodTypes1: [PaymentSheet.PaymentMethodType] = [.card, .dynamic("llammaPay")]
-        let paymentMethodTypes2: [PaymentSheet.PaymentMethodType] = [
-            .card, .dynamic("llammaPay"), .dynamic("wechatpay"),
-        ]
-
-        let result = paymentMethodTypes1.symmetricDifference(paymentMethodTypes2)
-
-        XCTAssertEqual(result, [.dynamic("wechatpay")])
-    }
-    func testSymmetricDifference_differenceInBoth() {
-        let paymentMethodTypes1: [PaymentSheet.PaymentMethodType] = [
-            .card, .dynamic("llammaPay"), .dynamic("wechatpay"),
-        ]
-        let paymentMethodTypes2: [PaymentSheet.PaymentMethodType] = [
-            .card, .dynamic("llammaPay"), .dynamic("affirm"),
-        ]
-
-        let result = paymentMethodTypes1.symmetricDifference(paymentMethodTypes2)
-
-        XCTAssertTrue(
-            result == [.dynamic("wechatpay"), .dynamic("affirm")]
-                || result == [.dynamic("affirm"), .dynamic("wechatpay")]
-        )
-    }
 
     private func constructPI(
         paymentMethodTypes: [String],

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
@@ -123,8 +123,6 @@ import Foundation
 
     // MARK: - LUXE
     case luxeSerializeFailure = "luxe_serialize_failure"
-    case luxeClientFilteredPaymentMethods = "luxe_client_filtered_payment_methods"
-    case luxeClientFilteredPaymentMethodsNone = "luxe_client_filtered_payment_methods_none"
 
     case luxeImageSelectorIconDownloaded = "luxe_image_selector_icon_downloaded"
     case luxeImageSelectorIconFromBundle = "luxe_image_selector_icon_from_bundle"

--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/STPAnalyticsClient+LUXE.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/STPAnalyticsClient+LUXE.swift
@@ -11,12 +11,6 @@ extension STPAnalyticsClient {
     func logLUXESerializeFailure() {
         self.logPaymentSheetEvent(event: .luxeSerializeFailure)
     }
-    func logClientFilteredPaymentMethods(clientFilteredPaymentMethods: String) {
-        self.logPaymentSheetEvent(event: .luxeClientFilteredPaymentMethods, params: ["client_filtered_payment_methods": clientFilteredPaymentMethods])
-    }
-    func logClientFilteredPaymentMethodsNone() {
-        self.logPaymentSheetEvent(event: .luxeClientFilteredPaymentMethodsNone)
-    }
     func logImageSelectorIconDownloadedIfNeeded(paymentMethod: PaymentSheet.PaymentMethodType) {
         guard case .dynamic(let name) = paymentMethod else {
             return

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -204,7 +204,7 @@ extension PaymentSheet {
                 }
             }
 
-            let paymentTypes = recommendedPaymentMethodTypes.filter {
+            return recommendedPaymentMethodTypes.filter {
                 PaymentSheet.PaymentMethodType.supportsAdding(
                     paymentMethod: $0,
                     configuration: configuration,
@@ -213,20 +213,6 @@ extension PaymentSheet {
                         ? PaymentSheet.supportedLinkPaymentMethods : PaymentSheet.supportedPaymentMethods
                 )
             }
-
-            let serverFilteredPaymentMethods = Self.recommendedPaymentMethodTypes(
-                from: intent
-            ).filter({ $0 != .USBankAccount && $0 != .link })
-            let paymentTypesFiltered = paymentTypes.filter({ $0 != .USBankAccount && $0 != .link })
-            if serverFilteredPaymentMethods != paymentTypesFiltered {
-                let result = serverFilteredPaymentMethods.symmetricDifference(paymentTypes)
-                STPAnalyticsClient.sharedClient.logClientFilteredPaymentMethods(
-                    clientFilteredPaymentMethods: result.stringList()
-                )
-            } else {
-                STPAnalyticsClient.sharedClient.logClientFilteredPaymentMethodsNone()
-            }
-            return paymentTypes
         }
 
         /// Returns whether or not PaymentSheet, with the given `PaymentMethodRequirementProvider`s, should make the given `paymentMethod` available to add.
@@ -491,24 +477,5 @@ extension STPPaymentMethodParams {
                 return label
             }
         }
-    }
-}
-
-extension Array where Element == PaymentSheet.PaymentMethodType {
-    func stringList() -> String {
-        var stringList: [String] = []
-        for paymentType in self {
-            let type = PaymentSheet.PaymentMethodType.string(from: paymentType) ?? "unknown"
-            stringList.append(type)
-        }
-        guard let data = try? JSONSerialization.data(withJSONObject: stringList, options: []) else {
-            return "[]"
-        }
-        return String(data: data, encoding: .utf8) ?? "[]"
-    }
-    func symmetricDifference(_ other: Array) -> Array where Element == PaymentSheet.PaymentMethodType {
-        let set1 = Set(self)
-        let set2 = Set(other)
-        return Array(set1.symmetricDifference(set2))
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -330,13 +330,7 @@ extension PaymentSheet {
                 }
                 intentPromise.resolve(with: .paymentIntent(paymentIntent))
             }
-            let additionalParameters = [
-                "merchant_support_async": configuration.allowsDelayedPaymentMethods,
-                "merchant_support_shipping": configuration.allowsPaymentMethodsRequiringShippingAddress,
-            ]
-            configuration.apiClient.retrievePaymentIntentWithPreferences(
-                withClientSecret: clientSecret,
-                additionalParameters: additionalParameters) { result in
+            configuration.apiClient.retrievePaymentIntentWithPreferences(withClientSecret: clientSecret) { result in
                 switch result {
                 case .success(let paymentIntent):
                     paymentIntentHandlerCompletionBlock(paymentIntent)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAPIClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAPIClient+PaymentSheet.swift
@@ -94,7 +94,6 @@ extension STPAPIClient {
 
     func retrievePaymentIntentWithPreferences(
         withClientSecret secret: String,
-        additionalParameters: [String: Any] = [:],
         completion: @escaping STPPaymentIntentWithPreferencesCompletionBlock
     ) {
         var parameters: [String: Any] = [:]
@@ -107,9 +106,6 @@ extension STPAPIClient {
         parameters["client_secret"] = secret
         parameters["type"] = "payment_intent"
         parameters["expand"] = ["payment_method_preference.payment_intent.payment_method"]
-        for (apKey, apValue) in additionalParameters {
-            parameters[apKey] = apValue
-        }
         parameters["locale"] = Locale.current.toLanguageTag()
 
         APIRequest<STPPaymentIntent>.getWith(self,


### PR DESCRIPTION
## Summary
Disable server-side filtering by removing the "merchant_support_*" parameters in the `v1/elements/sessions` call.  

The endpoint doesn't filter unless "merchant_support_async" is passed in, see: https://git.corp.stripe.com/stripe-internal/pay-server/blob/95e8cc37c1a07a6a864d046d1937ff57d1a29d72/lib/lpm_ui_platform/command/filter/filter_mobile_lpms.rb#L55-L58 

## Motivation
We never fully transitioned to server-side filtering, and today filter on both the client and the server redundantly.  

We're going to encounter cases where we need to change the filtering logic. Since we don't plan to complete the transition, we'll revert server-side filtering and go back to having the client be solely responsible for filtering.

## Testing
Relying on existing tests.

## Changelog
No user facing change.