### PR TITLE
[Link] Migrate ConsumerPaymentDetails to modern bindings

### DIFF
--- a/Stripe/StripeiOSTests/ConsumerSessionTests.swift
+++ b/Stripe/StripeiOSTests/ConsumerSessionTests.swift
@@ -359,7 +359,7 @@ class ConsumerSessionTests: XCTestCase {
                 switch paymentDetails.details {
                 case .card(let card):
                     XCTAssertEqual(newExpiryDate, card.expiryDate)
-                case .bankAccount:
+                case .bankAccount, .unparsable:
                     XCTFail("Unexpected payment details type")
                 }
             case .failure(let error):

--- a/Stripe/StripeiOSTests/LinkCardEditElementSnapshotTests.swift
+++ b/Stripe/StripeiOSTests/LinkCardEditElementSnapshotTests.swift
@@ -63,12 +63,10 @@ extension LinkCardEditElementSnapshotTests {
                     expiryMonth: 1,
                     brand: "visa",
                     last4: "4242",
-                    checks: nil,
-                    allResponseFields: [:]
+                    checks: nil
                 )
             ),
-            isDefault: isDefault,
-            allResponseFields: [:]
+            isDefault: isDefault
         )
 
         return LinkCardEditElement(paymentMethod: paymentMethod)

--- a/Stripe/StripeiOSTests/LinkStubs.swift
+++ b/Stripe/StripeiOSTests/LinkStubs.swift
@@ -41,12 +41,10 @@ extension LinkStubs {
                         expiryMonth: 1,
                         brand: "visa",
                         last4: "4242",
-                        checks: .init(cvcCheck: .pass, allResponseFields: [:]),
-                        allResponseFields: [:]
+                        checks: .init(cvcCheck: .pass)
                     )
                 ),
-                isDefault: true,
-                allResponseFields: [:]
+                isDefault: true
             ),
             ConsumerPaymentDetails(
                 stripeID: "2",
@@ -56,12 +54,10 @@ extension LinkStubs {
                         expiryMonth: 1,
                         brand: "mastercard",
                         last4: "4444",
-                        checks: .init(cvcCheck: .fail, allResponseFields: [:]),
-                        allResponseFields: [:]
+                        checks: .init(cvcCheck: .fail)
                     )
                 ),
-                isDefault: false,
-                allResponseFields: [:]
+                isDefault: false
             ),
             ConsumerPaymentDetails(
                 stripeID: "3",
@@ -69,12 +65,10 @@ extension LinkStubs {
                     bankAccount: .init(
                         iconCode: "capitalone",
                         name: "Capital One",
-                        last4: "4242",
-                        allResponseFields: [:]
+                        last4: "4242"
                     )
                 ),
-                isDefault: false,
-                allResponseFields: [:]
+                isDefault: false
             ),
             ConsumerPaymentDetails(
                 stripeID: "4",
@@ -84,12 +78,10 @@ extension LinkStubs {
                         expiryMonth: 1,
                         brand: "american_express",
                         last4: "0005",
-                        checks: .init(cvcCheck: .fail, allResponseFields: [:]),
-                        allResponseFields: [:]
+                        checks: .init(cvcCheck: .fail)
                     )
                 ),
-                isDefault: false,
-                allResponseFields: [:]
+                isDefault: false
             ),
         ]
     }

--- a/Stripe/StripeiOSTests/PaymentSheetLinkAccountTests.swift
+++ b/Stripe/StripeiOSTests/PaymentSheetLinkAccountTests.swift
@@ -57,8 +57,7 @@ extension PaymentSheetLinkAccountTests {
             expiryMonth: 1,
             brand: "visa",
             last4: "4242",
-            checks: nil,
-            allResponseFields: [:]
+            checks: nil
         )
 
         card.cvc = cvc
@@ -66,8 +65,7 @@ extension PaymentSheetLinkAccountTests {
         return ConsumerPaymentDetails(
             stripeID: "1",
             details: .card(card: card),
-            isDefault: true,
-            allResponseFields: [:]
+            isDefault: true
         )
     }
 

--- a/StripeCore/StripeCore/Source/Coder/StripeCodable.swift
+++ b/StripeCore/StripeCore/Source/Coder/StripeCodable.swift
@@ -32,10 +32,10 @@ public protocol UnknownFieldsEncodable: Encodable {
     var _additionalParametersStorage: NonEncodableParameters? { get set }
 }
 
-/// A Codable enum that sets an "unparsable" case
+/// A Decodable enum that sets an "unparsable" case
 /// instead of failing on values that are unknown to the SDK.
 /// :nodoc:
-public protocol SafeEnumCodable: Codable {
+public protocol SafeEnumDecodable: Decodable {
     /// If the value is unparsable, the result will be available in
     /// the `allResponseFields` of the parent object.
     static var unparsable: Self { get }
@@ -44,6 +44,11 @@ public protocol SafeEnumCodable: Codable {
     // as an associated value, but Swift can't auto-generate the Codable
     // keys if we do that.
 }
+
+/// A Codable enum that sets an "unparsable" case
+/// instead of failing on values that are unknown to the SDK.
+/// :nodoc:
+public protocol SafeEnumCodable: Codable, SafeEnumDecodable {}
 
 extension UnknownFieldsDecodable {
     /// A dictionary containing all response fields from the original JSON,

--- a/StripeCore/StripeCore/Source/Coder/StripeCodable.swift
+++ b/StripeCore/StripeCore/Source/Coder/StripeCodable.swift
@@ -48,7 +48,7 @@ public protocol SafeEnumDecodable: Decodable {
 /// A Codable enum that sets an "unparsable" case
 /// instead of failing on values that are unknown to the SDK.
 /// :nodoc:
-public protocol SafeEnumCodable: Codable, SafeEnumDecodable {}
+public protocol SafeEnumCodable: Encodable, SafeEnumDecodable {}
 
 extension UnknownFieldsDecodable {
     /// A dictionary containing all response fields from the original JSON,

--- a/StripeCore/StripeCore/Source/Coder/StripeJSONDecoder.swift
+++ b/StripeCore/StripeCore/Source/Coder/StripeJSONDecoder.swift
@@ -690,15 +690,15 @@ extension STPDecodingContainerProtocol {
                 )
             }
             return convertedArray as! T
-        case is SafeEnumCodable.Type:
+        case is SafeEnumDecodable.Type:
             do {
                 let decoder = _stpinternal_JSONDecoder(jsonObject: object)
                 decoder.userInfo = userInfo
                 decoder.codingPath = codingPath
                 return try T(from: decoder)
             } catch Swift.DecodingError.dataCorrupted {
-                let enumCodableType = T.self as! (SafeEnumCodable.Type)
-                return enumCodableType.unparsable as! T
+                let enumDecodableType = T.self as! (SafeEnumDecodable.Type)
+                return enumDecodableType.unparsable as! T
             }
         default:
             let decoder = _stpinternal_JSONDecoder(jsonObject: object)

--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
@@ -502,6 +502,8 @@ extension PaymentSheetLinkAccount {
                 supportedPaymentMethodTypes.append(.card)
             case .bankAccount:
                 supportedPaymentMethodTypes.append(.linkInstantDebit)
+            case .unparsable:
+                break
             }
         }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/ConsumerSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/ConsumerSession.swift
@@ -68,7 +68,7 @@ class ConsumerSession: NSObject, STPAPIResponseDecodable {
         let supportedPaymentDetailsTypeStrings = dict["support_payment_details_types"] as? [String]
 
         let supportedPaymentDetailsTypes = supportedPaymentDetailsTypeStrings?.compactMap {
-            ConsumerPaymentDetails.DetailsType(rawValue: $0.lowercased())
+            ConsumerPaymentDetails.DetailsType(rawValue: $0)
         }
 
         return ConsumerSession(clientSecret: clientSecret,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/PaymentDetails.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/PaymentDetails.swift
@@ -18,98 +18,62 @@ typealias ConsumerSessionWithPaymentDetails = (session: ConsumerSession, payment
  
  For internal SDK use only
  */
-@objc(STP_Internal_ConsumerPaymentDetails)
-class ConsumerPaymentDetails: NSObject, STPAPIResponseDecodable {
-
+final class ConsumerPaymentDetails: Decodable {
     let stripeID: String
     let details: Details
     var isDefault: Bool
 
     // TODO(csabol) : Billing address
 
-    let allResponseFields: [AnyHashable: Any]
-
     init(stripeID: String,
          details: Details,
-         isDefault: Bool,
-         allResponseFields: [AnyHashable: Any]) {
+         isDefault: Bool) {
         self.stripeID = stripeID
         self.details = details
         self.isDefault = isDefault
-        self.allResponseFields = allResponseFields
-        super.init()
     }
 
-    static func decodedObject(fromAPIResponse response: [AnyHashable: Any]?) -> Self? {
-        guard let dict = response?["redacted_payment_details"] as? [AnyHashable: Any] ?? response, // When this is from a list endpoint it isn't nested in redacted_payment_details
-              let stripeID = dict["id"] as? String,
-              let details = Details(dict),
-              let isDefault = dict["is_default"] as? Bool else {
-            return nil
-        }
-
-        return ConsumerPaymentDetails(stripeID: stripeID,
-                                      details: details,
-                                      isDefault: isDefault,
-                                      allResponseFields: dict) as? Self
+    private enum CodingKeys: String, CodingKey {
+        case stripeID = "id"
+        case isDefault
     }
 
-    class ShareResponse: NSObject, STPAPIResponseDecodable {
-        let paymentMethodID: String
-        let allResponseFields: [AnyHashable: Any]
-
-        init(paymentMethodID: String,
-             allResponseFields: [AnyHashable: Any]) {
-            self.paymentMethodID = paymentMethodID
-            self.allResponseFields = allResponseFields
-            super.init()
-        }
-
-        static func decodedObject(fromAPIResponse response: [AnyHashable: Any]?) -> Self? {
-            guard let dict = response,
-                  let id = dict["payment_method"] as? String else {
-                return nil
-            }
-            return ShareResponse(paymentMethodID: id,
-                                 allResponseFields: dict) as? Self
-        }
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.stripeID = try container.decode(String.self, forKey: .stripeID)
+        // The payment details are included in the dictionary, so we pass the whole dict to Details
+        self.details = try decoder.singleValueContainer().decode(Details.self)
+        self.isDefault = try container.decode(Bool.self, forKey: .isDefault)
     }
-
 }
 
 // MARK: - Details
 /// :nodoc:
 extension ConsumerPaymentDetails {
-    enum DetailsType: String, CaseIterable {
-        case card
-        case bankAccount = "bank_account"
+    enum DetailsType: String, CaseIterable, Codable {
+        case card = "CARD"
+        case bankAccount = "BANK_ACCOUNT"
     }
 
-    enum Details {
-
+    enum Details: Decodable {
         case card(card: Card)
         case bankAccount(bankAccount: BankAccount)
 
-        init?(_ response: [AnyHashable: Any]) {
-            guard let typeString = response["type"] as? String else {
-                return nil
-            }
+        private enum CodingKeys: String, CodingKey {
+            case type
+            case card = "cardDetails"
+            case bankAccount = "bankAccountDetails"
+        }
 
-            switch typeString.lowercased() {
-            case "card":
-                if let card = Card.decodedObject(fromAPIResponse: response) {
-                    self = .card(card: card)
-                } else {
-                    return nil
-                }
-            case "bank_account":
-                if let bankAccount = BankAccount.decodedObject(fromAPIResponse: response) {
-                    self = .bankAccount(bankAccount: bankAccount)
-                } else {
-                    return nil
-                }
-            default:
-                return nil
+        // Our JSON structure doesn't align with Swift's expected structure for enums with associated values, so we do custom decoding.
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let type = try container.decode(DetailsType.self, forKey: CodingKeys.type)
+            switch type {
+            case .card:
+                self = .card(card: try container.decode(Card.self, forKey: CodingKeys.card))
+            case .bankAccount:
+                self = .bankAccount(bankAccount: try container.decode(BankAccount.self, forKey: CodingKeys.bankAccount))
             }
         }
     }
@@ -128,9 +92,8 @@ extension ConsumerPaymentDetails {
 
 extension ConsumerPaymentDetails.Details {
     /// For internal SDK use only
-    @objc(STP_Internal_ConsumerPaymentDetails_CardChecks)
-    class CardChecks: NSObject, STPAPIResponseDecodable {
-        enum State: String {
+    final class CardChecks: Codable {
+        enum CVCCheck: String, Codable {
             case pass = "PASS"
             case fail = "FAIL"
             case unchecked = "UNCHECKED"
@@ -140,82 +103,45 @@ extension ConsumerPaymentDetails.Details {
             case unknown = "UNKNOWN"
         }
 
-        let cvcCheck: State
+        let cvcCheck: CVCCheck
 
-        var allResponseFields: [AnyHashable: Any]
-
-        init(cvcCheck: State, allResponseFields: [AnyHashable: Any]) {
+        init(cvcCheck: CVCCheck) {
             self.cvcCheck = cvcCheck
-            self.allResponseFields = allResponseFields
-            super.init()
-        }
-
-        static func decodedObject(fromAPIResponse response: [AnyHashable: Any]?) -> Self? {
-            guard
-                let dict = response,
-                let cvcCheck = dict["cvc_check"] as? String
-            else {
-                return nil
-            }
-
-            let cvcCheckState = State(rawValue: cvcCheck.uppercased()) ?? .unknown
-
-            return CardChecks(
-                cvcCheck: cvcCheckState,
-                allResponseFields: dict) as? Self
         }
     }
 }
 
 // MARK: - Details.Card
 extension ConsumerPaymentDetails.Details {
-    class Card: NSObject, STPAPIResponseDecodable {
-
+    final class Card: Codable {
         let expiryYear: Int
         let expiryMonth: Int
-        let brand: STPCardBrand
+        let brand: String
         let last4: String
         let checks: CardChecks?
 
-        let allResponseFields: [AnyHashable: Any]
-
-        /// A frontend convenience property, i.e. not part of the API Object
-        var cvc: String?
-
-        required init(expiryYear: Int,
-                      expiryMonth: Int,
-                      brand: String,
-                      last4: String,
-                      checks: CardChecks?,
-                      allResponseFields: [AnyHashable: Any]) {
-            self.expiryYear = expiryYear
-            self.expiryMonth = expiryMonth
-            self.brand = STPPaymentMethodCard.brand(from: brand.lowercased())
-            self.last4 = last4
-            self.checks = checks
-            self.allResponseFields = allResponseFields
-            super.init()
+        private enum CodingKeys: String, CodingKey {
+            case expiryYear = "expYear"
+            case expiryMonth = "expMonth"
+            case brand
+            case last4
+            case checks
         }
 
-        static func decodedObject(fromAPIResponse response: [AnyHashable: Any]?) -> Self? {
-            guard let dict = response?["card_details"] as? [AnyHashable: Any],
-                  let expiryYear = dict["exp_year"] as? Int,
-                  let expiryMonth = dict["exp_month"] as? Int,
-                  let brand = dict["brand"] as? String,
-                  let last4 = dict["last4"] as? String else {
-                return nil
-            }
+        /// A frontend convenience property, i.e. not part of the API Object
+        /// As such this is deliberately omitted from CodingKeys
+        var cvc: String?
 
-            let checks = CardChecks.decodedObject(fromAPIResponse: dict["checks"] as? [AnyHashable: Any])
-
-            return Card(
-                expiryYear: expiryYear,
-                expiryMonth: expiryMonth,
-                brand: brand,
-                last4: last4,
-                checks: checks,
-                allResponseFields: dict
-            ) as? Self
+        init(expiryYear: Int,
+             expiryMonth: Int,
+             brand: String,
+             last4: String,
+             checks: CardChecks?) {
+            self.expiryYear = expiryYear
+            self.expiryMonth = expiryMonth
+            self.brand = brand
+            self.last4 = last4
+            self.checks = checks
         }
     }
 }
@@ -240,75 +166,31 @@ extension ConsumerPaymentDetails.Details.Card {
         return expiryDate.expired()
     }
 
+    var stpBrand: STPCardBrand {
+        return STPPaymentMethodCard.brand(from: brand)
+    }
+
 }
 
 // MARK: - Details.BankAccount
 extension ConsumerPaymentDetails.Details {
-    class BankAccount: NSObject, STPAPIResponseDecodable {
-
+    final class BankAccount: Codable {
         let iconCode: String?
         let name: String
         let last4: String
 
-        let allResponseFields: [AnyHashable: Any]
+        private enum CodingKeys: String, CodingKey {
+            case iconCode = "bankIconCode"
+            case name = "bankName"
+            case last4
+        }
 
         init(iconCode: String?,
              name: String,
-             last4: String,
-             allResponseFields: [AnyHashable: Any]) {
+             last4: String) {
             self.iconCode = iconCode
             self.name = name
             self.last4 = last4
-            self.allResponseFields = allResponseFields
-            super.init()
-        }
-
-        static func decodedObject(fromAPIResponse response: [AnyHashable: Any]?) -> Self? {
-            guard let dict = response?["bank_account_details"] as? [AnyHashable: Any],
-                  let name = dict["bank_name"] as? String,
-                  let last4 = dict["last4"] as? String else {
-                      return nil
-                  }
-
-            return BankAccount(iconCode: dict["bank_icon_code"] as? String,
-                               name: name,
-                               last4: last4,
-                               allResponseFields: dict) as? Self
-        }
-    }
-}
-
-// MARK: - List Deserializer
-/// :nodoc:
-extension ConsumerPaymentDetails {
-    /**
-     Helper class to deserialize a list of ConsumerPaymentDetails from API responses
-     */
-    class ListDeserializer: NSObject, STPAPIResponseDecodable {
-        let allResponseFields: [AnyHashable: Any]
-        let paymentDetails: [ConsumerPaymentDetails]
-
-        required init(paymentDetails: [ConsumerPaymentDetails],
-                      allResponseFields: [AnyHashable: Any]) {
-            self.paymentDetails = paymentDetails
-            self.allResponseFields = allResponseFields
-            super.init()
-        }
-
-        static func decodedObject(fromAPIResponse response: [AnyHashable: Any]?) -> Self? {
-            guard let response = response,
-                  let data = response["redacted_payment_details"] as? [[AnyHashable: Any]] else {
-                return nil
-            }
-
-            var paymentDetails = [ConsumerPaymentDetails]()
-            for entry in data {
-                if let paymentDetail = ConsumerPaymentDetails.decodedObject(fromAPIResponse: entry) {
-                    paymentDetails.append(paymentDetail)
-                }
-            }
-
-            return ListDeserializer(paymentDetails: paymentDetails, allResponseFields: response) as? Self
         }
     }
 }
@@ -336,7 +218,7 @@ extension ConsumerPaymentDetails {
         switch details {
         case .card(let card):
             // TODO(ramont): investigate why this returns optional
-            let cardBrandName = STPCardBrandUtilities.stringFrom(card.brand) ?? ""
+            let cardBrandName = STPCardBrandUtilities.stringFrom(card.stpBrand) ?? ""
             let digits = card.last4.map({ String($0) }).joined(separator: ", ")
             return String(
                 format: String.Localized.card_brand_ending_in_last_4,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/PaymentDetails.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/PaymentDetails.swift
@@ -50,14 +50,16 @@ final class ConsumerPaymentDetails: Decodable {
 // MARK: - Details
 /// :nodoc:
 extension ConsumerPaymentDetails {
-    enum DetailsType: String, CaseIterable, Codable {
+    enum DetailsType: String, CaseIterable, SafeEnumCodable {
         case card = "CARD"
         case bankAccount = "BANK_ACCOUNT"
+        case unparsable = ""
     }
 
-    enum Details: Decodable {
+    enum Details: SafeEnumDecodable {
         case card(card: Card)
         case bankAccount(bankAccount: BankAccount)
+        case unparsable
 
         private enum CodingKeys: String, CodingKey {
             case type
@@ -74,6 +76,8 @@ extension ConsumerPaymentDetails {
                 self = .card(card: try container.decode(Card.self, forKey: CodingKeys.card))
             case .bankAccount:
                 self = .bankAccount(bankAccount: try container.decode(BankAccount.self, forKey: CodingKeys.bankAccount))
+            case .unparsable:
+                self = .unparsable
             }
         }
     }
@@ -84,6 +88,8 @@ extension ConsumerPaymentDetails {
             return .card
         case .bankAccount:
             return .bankAccount
+        case .unparsable:
+            return .unparsable
         }
     }
 }
@@ -93,14 +99,14 @@ extension ConsumerPaymentDetails {
 extension ConsumerPaymentDetails.Details {
     /// For internal SDK use only
     final class CardChecks: Codable {
-        enum CVCCheck: String, Codable {
+        enum CVCCheck: String, SafeEnumCodable {
             case pass = "PASS"
             case fail = "FAIL"
             case unchecked = "UNCHECKED"
             case unavailable = "UNAVAILABLE"
             case stateInvalid = "STATE_INVALID"
             // Catch all
-            case unknown = "UNKNOWN"
+            case unparsable = ""
         }
 
         let cvcCheck: CVCCheck
@@ -202,6 +208,8 @@ extension ConsumerPaymentDetails {
             return "••••\(card.last4)"
         case .bankAccount(let bank):
             return "••••\(bank.last4)"
+        case .unparsable:
+            return ""
         }
     }
 
@@ -210,6 +218,8 @@ extension ConsumerPaymentDetails {
         case .card(let card):
             return card.cvc
         case .bankAccount:
+            return nil
+        case .unparsable:
             return nil
         }
     }
@@ -232,6 +242,8 @@ extension ConsumerPaymentDetails {
                 bank.name,
                 digits
             )
+        case .unparsable:
+            return ""
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
@@ -13,6 +13,13 @@ import Foundation
 @_spi(STP) import StripePaymentsUI
 
 extension STPAPIClient {
+    struct DetailsResponse: Decodable {
+        let redactedPaymentDetails: ConsumerPaymentDetails
+    }
+
+    struct DetailsListResponse: Decodable {
+        let redactedPaymentDetails: [ConsumerPaymentDetails]
+    }
 
     func lookupConsumerSession(
         for email: String?,
@@ -136,13 +143,9 @@ extension STPAPIClient {
             "active": false, // card details are created with active false so we don't save them until the intent confirmation succeeds
         ]
 
-        APIRequest<ConsumerPaymentDetails>.post(
-            with: self,
-            endpoint: endpoint,
-            additionalHeaders: authorizationHeader(using: consumerAccountPublishableKey),
-            parameters: parameters,
-            completion: completion
-        )
+        post(resource: endpoint, parameters: parameters, ephemeralKeySecret: consumerAccountPublishableKey) { (result: Result<DetailsResponse, Error>) in
+            completion(result.map { $0.redactedPaymentDetails })
+        }
     }
 
     func createPaymentDetails(
@@ -163,13 +166,9 @@ extension STPAPIClient {
             "is_default": true,
         ]
 
-        APIRequest<ConsumerPaymentDetails>.post(
-            with: self,
-            endpoint: endpoint,
-            additionalHeaders: authorizationHeader(using: consumerAccountPublishableKey),
-            parameters: parameters,
-            completion: completion
-        )
+        post(resource: endpoint, parameters: parameters, ephemeralKeySecret: consumerAccountPublishableKey) { (result: Result<DetailsResponse, Error>) in
+            completion(result.map { $0.redactedPaymentDetails })
+        }
     }
 
     func startVerification(
@@ -285,13 +284,8 @@ extension STPAPIClient {
             "types": ["card", "bank_account"],
         ]
 
-        APIRequest<ConsumerPaymentDetails.ListDeserializer>.post(
-            with: self,
-            endpoint: endpoint,
-            additionalHeaders: authorizationHeader(using: consumerAccountPublishableKey),
-            parameters: parameters
-        ) { result in
-            completion(result.map { $0.paymentDetails })
+        post(resource: endpoint, parameters: parameters, ephemeralKeySecret: consumerAccountPublishableKey) { (result: Result<DetailsListResponse, Error>) in
+            completion(result.map { $0.redactedPaymentDetails })
         }
     }
 
@@ -345,13 +339,9 @@ extension STPAPIClient {
             parameters["is_default"] = isDefault
         }
 
-        APIRequest<ConsumerPaymentDetails>.post(
-            with: self,
-            endpoint: endpoint,
-            additionalHeaders: authorizationHeader(using: consumerAccountPublishableKey),
-            parameters: parameters,
-            completion: completion
-        )
+        post(resource: endpoint, parameters: parameters, ephemeralKeySecret: consumerAccountPublishableKey) { (result: Result<DetailsResponse, Error>) in
+            completion(result.map { $0.redactedPaymentDetails })
+        }
     }
 
     func logout(

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/PaymentMethodPicker/LinkPaymentMethodPicker-Cell.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/PaymentMethodPicker/LinkPaymentMethodPicker-Cell.swift
@@ -202,6 +202,8 @@ extension LinkPaymentMethodPicker {
                     return card.hasExpired
                 case .bankAccount:
                     return false
+                case .unparsable:
+                    return false
                 }
             }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/PaymentMethodPicker/LinkPaymentMethodPicker-CellContentView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/PaymentMethodPicker/LinkPaymentMethodPicker-CellContentView.swift
@@ -23,7 +23,7 @@ extension LinkPaymentMethodPicker {
             didSet {
                 switch paymentMethod?.details {
                 case .card(let card):
-                    cardBrandView.cardBrand = card.brand
+                    cardBrandView.cardBrand = card.stpBrand
                     bankIconView.isHidden = true
                     cardBrandView.isHidden = false
                     primaryLabel.text = paymentMethod?.paymentSheetLabel

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/PaymentMethodPicker/LinkPaymentMethodPicker-CellContentView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/PaymentMethodPicker/LinkPaymentMethodPicker-CellContentView.swift
@@ -36,7 +36,7 @@ extension LinkPaymentMethodPicker {
                     primaryLabel.text = bankAccount.name
                     secondaryLabel.text = paymentMethod?.paymentSheetLabel
                     secondaryLabel.isHidden = false
-                case .none:
+                case .none, .unparsable:
                     cardBrandView.isHidden = true
                     bankIconView.isHidden = true
                     primaryLabel.text = nil

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewController.swift
@@ -307,6 +307,8 @@ private extension PayWithLinkViewController.WalletViewController {
                     "Are you sure you want to remove this linked account?",
                     "Title of confirmation prompt when removing a linked bank account."
                 )
+            case .unparsable:
+                return ""
             }
         }()
 
@@ -467,6 +469,8 @@ extension PayWithLinkViewController.WalletViewController: LinkPaymentMethodPicke
                     "Remove linked account",
                     "Title for a button that when tapped removes a linked bank account."
                 )
+            case .unparsable:
+                return ""
             }
         }()
         alertController.addAction(UIAlertAction(

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewModel.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewModel.swift
@@ -135,7 +135,7 @@ extension PayWithLinkViewController {
             switch selectedPaymentMethod?.details {
             case .card(let card):
                 return card.hasExpired
-            case .bankAccount, .none:
+            case .bankAccount, .unparsable, .none:
                 // Only cards have expiry date.
                 return false
             }
@@ -287,18 +287,5 @@ private extension PayWithLinkViewController.WalletViewModel {
         }
 
         return indexOfLastAddedPaymentMethod ?? indexOfDefaultPaymentMethod ?? 0
-    }
-
-}
-
-/// Helper functions for ConsumerPaymentDetails
-private extension ConsumerPaymentDetails {
-    var paymentMethodType: PaymentSheet.PaymentMethodType {
-        switch details {
-        case .card:
-            return .card
-        case .bankAccount:
-            return .linkInstantDebit
-        }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewModel.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewModel.swift
@@ -170,7 +170,7 @@ extension PayWithLinkViewController {
         var cardBrand: STPCardBrand? {
             switch selectedPaymentMethod?.details {
             case .card(let card):
-                return card.brand
+                return card.stpBrand
             default:
                 return nil
             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/LinkCardEditElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/LinkCardEditElement.swift
@@ -36,7 +36,7 @@ final class LinkCardEditElement: Element {
         return formElement.view
     }
 
-    var delegate: ElementDelegate?
+    weak var delegate: ElementDelegate?
 
     var validationState: ElementValidationState {
         return formElement.validationState

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/LinkCardEditElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/LinkCardEditElement.swift
@@ -20,6 +20,8 @@ fileprivate extension ConsumerPaymentDetails {
             return details
         case .bankAccount:
             return nil
+        case .unparsable:
+            return nil
         }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/LinkCardEditElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/LinkCardEditElement.swift
@@ -84,7 +84,7 @@ final class LinkCardEditElement: Element {
     private lazy var cvcElement = TextFieldElement(
         configuration: TextFieldElement.CVCConfiguration(
             cardBrandProvider: { [weak self] in
-                self?.paymentMethod.cardDetails?.brand ?? .unknown
+                self?.paymentMethod.cardDetails?.stpBrand ?? .unknown
             }
         ),
         theme: theme
@@ -171,7 +171,7 @@ private extension LinkCardEditElement {
 
         func accessoryView(for text: String, theme: ElementsUITheme) -> UIView? {
             paymentMethod.cardDetails.map { cardDetails in
-                let image = STPImageLibrary.cardBrandImage(for: cardDetails.brand)
+                let image = STPImageLibrary.cardBrandImage(for: cardDetails.stpBrand)
                 return UIImageView(image: image)
             }
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentOption+Images.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentOption+Images.swift
@@ -106,11 +106,12 @@ extension STPPaymentMethodParams {
 extension ConsumerPaymentDetails {
     func makeIcon() -> UIImage {
         switch details {
-
         case .card(let card):
             return STPImageLibrary.cardBrandImage(for: card.stpBrand)
         case .bankAccount(let bankAccount):
             return PaymentSheetImageLibrary.bankIcon(for: bankAccount.iconCode)
+        case .unparsable:
+            return UIImage()
         }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentOption+Images.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentOption+Images.swift
@@ -108,7 +108,7 @@ extension ConsumerPaymentDetails {
         switch details {
 
         case .card(let card):
-            return STPImageLibrary.cardBrandImage(for: card.brand)
+            return STPImageLibrary.cardBrandImage(for: card.stpBrand)
         case .bankAccount(let bankAccount):
             return PaymentSheetImageLibrary.bankIcon(for: bankAccount.iconCode)
         }


### PR DESCRIPTION
## Summary
Migrate `ConsumerPaymentDetails` (and its constituent types) off of `STPAPIResponseDecodable` and `StripePayments.APIRequest`, and onto modern `Decodable` API bindings.

## Motivation
In addition to being the way of the future, modern bindings have the advantage of not having any dependency on StripePayments, which allows us to migrate `ConsumerPaymentDetails` into a shared framework at a future date.

## Testing
Automated tests to ensure JSON parsing behaves as expected, manual exercise to ensure user-facing behavior is unchanged.

## Notes
I'm really happy with the modern bindings in my limited usage so far - much less code, much cleaner code, no Objective-C compatibility required. I hope we can migrate more of the SDK onto them!