### PR TITLE
Financial Connections: polished bottom sheet image padding.

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/ConsentBottomSheetView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/ConsentBottomSheetView.swift
@@ -187,7 +187,18 @@ private func CreateBulletinView(
 
     let horizontalStackView = HitTestStackView(
         arrangedSubviews: [
-            imageView,
+            {
+                // add padding to the icon so its better aligned with text
+                let paddingStackView = UIStackView(arrangedSubviews: [imageView])
+                paddingStackView.isLayoutMarginsRelativeArrangement = true
+                paddingStackView.directionalLayoutMargins = NSDirectionalEdgeInsets(
+                    top: 2,
+                    leading: 0,
+                    bottom: 0,
+                    trailing: 0
+                )
+                return paddingStackView
+            }(),
             BulletPointLabelView(
                 title: title,
                 content: subtitle,
@@ -245,6 +256,11 @@ private struct ConsentBottomSheetViewUIViewRepresentable: UIViewRepresentable {
                 subtitle: "[Merchant] will use your account and routing number, balances and transactions when:",
                 body: ConsentBottomSheetModel.Body(
                     bullets: [
+                        FinancialConnectionsBulletPoint(
+                            icon: FinancialConnectionsImage(default: "https://b.stripecdn.com/connections-statics-srv/assets/SailIcon--checkCircle-green-3x.png"),
+                            title: nil,
+                            content: "Transferring money between your bank account and Merchant"
+                        ),
                         FinancialConnectionsBulletPoint(
                             icon: FinancialConnectionsImage(default: nil),
                             title: nil,


### PR DESCRIPTION
## Summary

This PR aligns the "icon" and "text" a little bit better. 

Via [bug bash request](https://docs.google.com/document/d/15pURGi0Jfw0eqAdI38BDxpR5DAUsSFK7tYB9t2jw_4k/edit#).

## Testing

| BEFORE      | AFTER |
| ----------- | ----------- |
| <img width="571" alt="BEFORE" src="https://user-images.githubusercontent.com/105514761/217905220-24ae412a-ab48-47e8-a3a6-fdfec7f9760b.png">      |  <img width="588" alt="AFTER" src="https://user-images.githubusercontent.com/105514761/217905432-5af0b888-16a8-4213-860d-4fc9f3279ee7.png">       |
