### PR TITLE
Financial Connections: fixed an end-to-end test breaking

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
@@ -291,7 +291,10 @@ final class FinancialConnectionsUITests: XCTestCase {
         }
         institutionButton.tap()
 
-        let prepaneContinueButton = app.webViews.buttons["Continue"]
+        let prepaneContinueButton = app.webViews
+            .buttons
+            .containing(NSPredicate(format: "label CONTAINS 'Continue'"))
+            .firstMatch
         XCTAssertTrue(prepaneContinueButton.waitForExistence(timeout: 60.0))
         prepaneContinueButton.tap()
 


### PR DESCRIPTION
## Summary

^

failure: https://stripe.slack.com/archives/C04G5PZM71T/p1675977162907139

the context is that server-driven prepane PR changed "alt" text for the "Continue" button's image and now the testing API thinks the button is called "Continue Continue"

<img width="350" alt="Screen Shot 2023-02-09 at 4 57 24 PM" src="https://user-images.githubusercontent.com/105514761/217948650-3f4413f5-7adc-4003-abb1-3a8e0d3d0eee.png">

## Testing

```
Test Case '-[FinancialConnectionsUITests.FinancialConnectionsUITests testDataLiveModeOAuthWebAuthFlow]' passed (29.401 seconds).
```
