### PR TITLE
Financial Connections: fixed an issue where an error view in dark mode could obscure UI elements

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostViewController.swift
@@ -33,8 +33,7 @@ final class HostViewController: UIViewController {
             target: self,
             action: #selector(didTapClose)
         )
-
-        item.tintColor = UIColor.dynamic(light: .systemGray2, dark: .white)
+        item.tintColor = .textDisabled
         return item
     }()
 
@@ -75,7 +74,7 @@ final class HostViewController: UIViewController {
         super.viewDidLoad()
 
         view.addSubview(loadingView)
-        view.backgroundColor = .systemBackground
+        view.backgroundColor = .customBackgroundColor
         navigationItem.rightBarButtonItem = closeItem
         loadingView.tryAgainButton.addTarget(self, action: #selector(didTapTryAgainButton), for: .touchUpInside)
         getManifest()

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/LoadingView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/LoadingView.swift
@@ -22,6 +22,7 @@ class LoadingView: UIView {
         label.textAlignment = .center
         label.numberOfLines = 0
         label.font = Styling.errorLabelFont
+        label.textColor = .textPrimary
         return label
     }()
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsWebFlowViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsWebFlowViewController.swift
@@ -63,8 +63,7 @@ final class FinancialConnectionsWebFlowViewController: UIViewController {
             target: self,
             action: #selector(didTapClose)
         )
-
-        item.tintColor = UIColor.dynamic(light: .systemGray2, dark: .white)
+        item.tintColor = .textDisabled
         return item
     }()
 
@@ -96,7 +95,7 @@ final class FinancialConnectionsWebFlowViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        view.backgroundColor = .white
+        view.backgroundColor = .customBackgroundColor
         navigationItem.rightBarButtonItem = closeItem
         loadingView.tryAgainButton.addTarget(self, action: #selector(didTapTryAgainButton), for: .touchUpInside)
         view.addSubview(loadingView)


### PR DESCRIPTION
## Summary

^ see title

I also changed teh "H

## Testing

# Sheet Presentation

### Before (not necessarily a bug, but see how it appears dark, then dismisses white)


https://user-images.githubusercontent.com/105514761/218191889-921d5d98-6a94-486b-aee4-50635ae0560c.mov



### After (not necessarily a 'fix' but aligns with what we are doing elsewhere, notice how it appears white, and dismisses white)

https://user-images.githubusercontent.com/105514761/218191208-f45a5f1f-09d1-4c04-9a11-b528d8dd4b8a.mov

# Web View Loading View

### Before

https://user-images.githubusercontent.com/105514761/218188922-378dcf5f-6228-4234-a387-6e0a6c6e1dd5.mov

### After

https://user-images.githubusercontent.com/105514761/218188783-ed07b315-294e-46f6-b68f-b4b6dcf6932a.mov
