### PR TITLE
FC Networking: V0 of NetworkingSaveToLinkVerification pane

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
@@ -80,9 +80,9 @@ protocol FinancialConnectionsAPIClient {
     // MARK: - Networking
 
     func saveAccountsToLink(
-        emailAddress: String,
-        phoneNumber: String,
-        country: String,
+        emailAddress: String?,
+        phoneNumber: String?,
+        country: String?,
         selectedAccountIds: [String],
         consumerSessionClientSecret: String?,
         clientSecret: String
@@ -453,24 +453,24 @@ extension STPAPIClient: FinancialConnectionsAPIClient {
     // MARK: - Networking
 
     func saveAccountsToLink(
-        emailAddress: String,
-        phoneNumber: String,
-        country: String,
+        emailAddress: String?,
+        phoneNumber: String?,
+        country: String?,
         selectedAccountIds: [String],
         consumerSessionClientSecret: String?,
         clientSecret: String
     ) -> Future<FinancialConnectionsSessionManifest> {
         var body: [String: Any] = [
             "client_secret": clientSecret,
-            "email_address":
-                emailAddress
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-                .lowercased(),
-            "phone_number": phoneNumber,
-            "country": country,
-            "locale": Locale.current.identifier,
             "selected_accounts": selectedAccountIds,
+            "expand": ["active_auth_session"],
         ]
+        body["email_address"] = emailAddress?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        body["phone_number"] = phoneNumber
+        body["country"] = country
+        body["locale"] = (phoneNumber != nil) ? Locale.current.identifier : nil
         body["consumer_session_client_secret"] = consumerSessionClientSecret
         return post(resource: APIEndpointSaveAccountsToLink, parameters: body)
     }
@@ -481,6 +481,7 @@ extension STPAPIClient: FinancialConnectionsAPIClient {
     ) -> Future<FinancialConnectionsSessionManifest> {
         var body: [String: Any] = [
             "client_secret": clientSecret,
+            "expand": ["active_auth_session"],
         ]
         body["disabled_reason"] = disabledReason
         return post(resource: APIEndpointDisableNetworking, parameters: body)
@@ -491,6 +492,7 @@ extension STPAPIClient: FinancialConnectionsAPIClient {
     ) -> Future<FinancialConnectionsSessionManifest> {
         let parameters: [String: Any] = [
             "client_secret": clientSecret,
+            "expand": ["active_auth_session"],
         ]
         return post(resource: APIEndpointLinkVerified, parameters: parameters)
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsSessionManifest.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsSessionManifest.swift
@@ -28,6 +28,7 @@ struct FinancialConnectionsSessionManifest: Decodable {
         case networkingLinkLoginWarmup = "networking_link_login_warmup"
         case networkingLinkSignupPane = "networking_link_signup_pane"
         case networkingLinkVerification = "networking_link_verification"
+        case networkingSaveToLinkVerification = "networking_save_to_link_verification"
         case partnerAuth = "partner_auth"
         case success = "success"
         case unexpectedError = "unexpected_error"

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsAnalyticsClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsAnalyticsClient.swift
@@ -181,6 +181,8 @@ extension FinancialConnectionsAnalyticsClient {
             return .networkingLinkLoginWarmup
         case is NetworkingLinkVerificationViewController:
             return .networkingLinkVerification
+        case is NetworkingSaveToLinkVerificationViewController:
+            return .networkingSaveToLinkVerification
         case is LinkAccountPickerViewController:
             return .linkAccountPicker
         default:

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -846,11 +846,11 @@ private func CreatePaneViewController(
     case .networkingSaveToLinkVerification:
         if
             let consumerSession = dataManager.consumerSession,
-            let selectedAccountIds = dataManager.linkedAccounts?.map({ $0.id })
+            let selectedAccountId = dataManager.linkedAccounts?.map({ $0.id }).first
         {
             let networkingSaveToLinkVerificationDataSource = NetworkingSaveToLinkVerificationDataSourceImplementation(
                 consumerSession: consumerSession,
-                selectedAccountIds: selectedAccountIds,
+                selectedAccountId: selectedAccountId,
                 apiClient: dataManager.apiClient,
                 clientSecret: dataManager.clientSecret,
                 analyticsClient: dataManager.analyticsClient

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -81,6 +81,7 @@ class NativeFlowController {
                 || navigationController.topViewController is AttachLinkedPaymentAccountViewController
                 || navigationController.topViewController is NetworkingLinkSignupViewController
                 || navigationController.topViewController is NetworkingLinkVerificationViewController
+                || navigationController.topViewController is NetworkingSaveToLinkVerificationViewController
                 || navigationController.topViewController is LinkAccountPickerViewController)
         closeAuthFlow(showConfirmationAlert: showConfirmationAlert, error: nil)
     }
@@ -534,7 +535,7 @@ extension NativeFlowController: ResetFlowViewControllerDelegate {
 
 @available(iOSApplicationExtension, unavailable)
 extension NativeFlowController: NetworkingLinkSignupViewControllerDelegate {
-    
+
     func networkingLinkSignupViewController(
         _ viewController: NetworkingLinkSignupViewController,
         foundReturningConsumerWithSession consumerSession: ConsumerSessionData
@@ -542,7 +543,7 @@ extension NativeFlowController: NetworkingLinkSignupViewControllerDelegate {
         dataManager.consumerSession = consumerSession
         pushPane(.networkingSaveToLinkVerification, animated: true)
     }
-    
+
     func networkingLinkSignupViewControllerDidFinish(
         _ viewController: NetworkingLinkSignupViewController
     ) {
@@ -679,7 +680,7 @@ extension NativeFlowController: NetworkingSaveToLinkVerificationViewControllerDe
         // TODO(kgaidis): use the error to show a notice on success pane that saving to link failed...
         pushPane(.success, animated: true)
     }
-    
+
     func networkingSaveToLinkVerificationViewController(
         _ viewController: NetworkingSaveToLinkVerificationViewController,
         didReceiveTerminalError error: Error

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -534,7 +534,15 @@ extension NativeFlowController: ResetFlowViewControllerDelegate {
 
 @available(iOSApplicationExtension, unavailable)
 extension NativeFlowController: NetworkingLinkSignupViewControllerDelegate {
-
+    
+    func networkingLinkSignupViewController(
+        _ viewController: NetworkingLinkSignupViewController,
+        foundReturningConsumerWithSession consumerSession: ConsumerSessionData
+    ) {
+        dataManager.consumerSession = consumerSession
+        pushPane(.networkingSaveToLinkVerification, animated: true)
+    }
+    
     func networkingLinkSignupViewControllerDidFinish(
         _ viewController: NetworkingLinkSignupViewController
     ) {
@@ -810,6 +818,24 @@ private func CreatePaneViewController(
             let networkingLinkVerificationViewController = NetworkingLinkVerificationViewController(dataSource: networkingLinkVerificationDataSource)
             networkingLinkVerificationViewController.delegate = nativeFlowController
             viewController = networkingLinkVerificationViewController
+        } else {
+            assertionFailure("Code logic error. Missing parameters for \(pane).")
+            viewController = nil
+        }
+    case .networkingSaveToLinkVerification:
+        if let accountholderCustomerEmailAddress = dataManager.consumerSession?.emailAddress {
+            let networkingSaveToLinkVerificationDataSource = NetworkingSaveToLinkVerificationDataSourceImplementation(
+                accountholderCustomerEmailAddress: accountholderCustomerEmailAddress,
+                manifest: dataManager.manifest,
+                apiClient: dataManager.apiClient,
+                clientSecret: dataManager.clientSecret,
+                analyticsClient: dataManager.analyticsClient
+            )
+            let networkingSaveToLinkVerificationViewController = NetworkingSaveToLinkVerificationViewController(
+                dataSource: networkingSaveToLinkVerificationDataSource
+            )
+            // networkingLinkVerificationViewController.delegate = nativeFlowController TODO(kgaidis): set the delegate
+            viewController = networkingSaveToLinkVerificationViewController
         } else {
             assertionFailure("Code logic error. Missing parameters for \(pane).")
             viewController = nil

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupFooterView.swift
@@ -53,7 +53,7 @@ class NetworkingLinkSignupFooterView: HitTestView {
     }()
 
     private lazy var saveToLinkButton: StripeUICore.Button = {
-        let saveToLinkButton = Button(configuration: .primary())  // Button(configuration: .financialConnectionsPrimary)
+        let saveToLinkButton = Button(configuration: .financialConnectionsPrimary)
         saveToLinkButton.title = saveToLinkButtonText
         saveToLinkButton.addTarget(self, action: #selector(didSelectSaveToLinkButton), for: .touchUpInside)
         saveToLinkButton.translatesAutoresizingMaskIntoConstraints = false
@@ -64,7 +64,7 @@ class NetworkingLinkSignupFooterView: HitTestView {
     }()
 
     private lazy var notNowButton: StripeUICore.Button = {
-        let saveToLinkButton = Button(configuration: .secondary())  // Button(configuration: .financialConnectionsSecondary)
+        let saveToLinkButton = Button(configuration: .financialConnectionsSecondary)
         saveToLinkButton.title = notNowButtonText
         saveToLinkButton.addTarget(self, action: #selector(didSelectNotNowButton), for: .touchUpInside)
         saveToLinkButton.translatesAutoresizingMaskIntoConstraints = false

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
@@ -11,6 +11,10 @@ import UIKit
 
 @available(iOSApplicationExtension, unavailable)
 protocol NetworkingLinkSignupViewControllerDelegate: AnyObject {
+    func networkingLinkSignupViewController(
+        _ viewController: NetworkingLinkSignupViewController,
+        foundReturningConsumerWithSession consumerSession: ConsumerSessionData
+    )
     func networkingLinkSignupViewControllerDidFinish(
         _ viewController: NetworkingLinkSignupViewController
     )
@@ -142,7 +146,12 @@ extension NetworkingLinkSignupViewController: NetworkingLinkSignupBodyFormViewDe
                             eventName: "networking.returning_consumer",
                             pane: .networkingLinkSignupPane
                         )
-                        // TODO(kgaidis): push pane manually to `networking_save_to_link_verification`
+                        if let consumerSession = response.consumerSession {
+                            // TODO(kgaidis): check whether its fair to assume that we will always have a consumer sesion here
+                            self.delegate?.networkingLinkSignupViewController(self, foundReturningConsumerWithSession: consumerSession)
+                        } else {
+                            // TODO(kgaidis): show terminal error?
+                        }
                     } else {
                         self.dataSource.analyticsClient.log(
                             eventName: "networking.new_consumer",

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkBodyView.swift
@@ -1,0 +1,142 @@
+//
+//  NetworkingSaveToLinkBodyView.swift
+//  StripeFinancialConnections
+//
+//  Created by Krisjanis Gaidis on 2/14/23.
+//
+
+import Foundation
+@_spi(STP) import StripeCore
+@_spi(STP) import StripeUICore
+import UIKit
+
+@available(iOSApplicationExtension, unavailable)
+protocol NetworkingSaveToLinkVerificationBodyViewDelegate: AnyObject {
+    func networkingSaveToLinkVerificationBodyView(
+        _ view: NetworkingSaveToLinkVerificationBodyView,
+        didEnterValidOTPCode otpCode: String
+    )
+}
+
+@available(iOSApplicationExtension, unavailable)
+final class NetworkingSaveToLinkVerificationBodyView: UIView {
+
+    weak var delegate: NetworkingSaveToLinkVerificationBodyViewDelegate?
+
+    private(set) lazy var otpTextField: UITextField = {
+       let textField = InsetTextField()
+        textField.textColor = .textPrimary
+        textField.placeholder = "OTP"
+        textField.keyboardType = .numberPad
+        textField.layer.cornerRadius = 8
+        textField.layer.borderColor = UIColor.textBrand.cgColor
+        textField.layer.borderWidth = 2.0
+        textField.addTarget(
+            self,
+            action: #selector(otpTextFieldDidChange),
+            for: .editingChanged
+        )
+        NSLayoutConstraint.activate([
+            textField.heightAnchor.constraint(equalToConstant: 56)
+        ])
+
+        return textField
+    }()
+
+    init(email: String) {
+        super.init(frame: .zero)
+        let verticalStackView = UIStackView(
+            arrangedSubviews: [
+                otpTextField,
+                CreateEmailLabel(email: email),
+            ]
+        )
+        verticalStackView.axis = .vertical
+        verticalStackView.spacing = 20
+        addAndPinSubview(verticalStackView)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    @objc private func otpTextFieldDidChange() {
+        guard let otp = otpTextField.text else {
+            return
+        }
+
+        if otp.count == 6 && Int(otp) != nil {
+            delegate?.networkingSaveToLinkVerificationBodyView(
+                self,
+                didEnterValidOTPCode: otp
+            )
+        }
+    }
+}
+
+private func CreateEmailLabel(email: String) -> UIView {
+    let emailLabel = UILabel()
+    emailLabel.text = "Signing in as \(email)" // TODO(kgaidis): wrap with localizable strings
+    emailLabel.font = .stripeFont(forTextStyle: .captionTight)
+    emailLabel.textColor = .textSecondary
+    return emailLabel
+}
+
+#if DEBUG
+
+import SwiftUI
+
+@available(iOSApplicationExtension, unavailable)
+private struct NetworkingSaveToLinkVerificationBodyViewUIViewRepresentable: UIViewRepresentable {
+
+    func makeUIView(context: Context) -> NetworkingSaveToLinkVerificationBodyView {
+        NetworkingSaveToLinkVerificationBodyView(
+            email: "test@stripe.com"
+        )
+    }
+
+    func updateUIView(_ uiView: NetworkingSaveToLinkVerificationBodyView, context: Context) {}
+}
+
+@available(iOSApplicationExtension, unavailable)
+struct NetworkingSaveToLinkVerificationBodyView_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack(alignment: .leading) {
+            Spacer()
+            NetworkingSaveToLinkVerificationBodyViewUIViewRepresentable()
+                .frame(maxHeight: 100)
+                .padding()
+            Spacer()
+        }
+    }
+}
+
+#endif
+
+private class InsetTextField: UITextField { // TODO(kgaidis): cleanup/delete after using Stripe's components
+
+    private let padding = UIEdgeInsets(
+        top: 0,
+        left: 10,
+        bottom: 0,
+        right: 10
+    )
+
+    override open func textRect(
+        forBounds bounds: CGRect
+    ) -> CGRect {
+        return bounds.inset(by: padding)
+    }
+
+    override open func placeholderRect(
+        forBounds bounds: CGRect
+    ) -> CGRect {
+        return bounds.inset(by: padding)
+    }
+
+    override open func editingRect(
+        forBounds bounds: CGRect
+    ) -> CGRect {
+        return bounds.inset(by: padding)
+    }
+}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkBodyView.swift
@@ -76,7 +76,7 @@ final class NetworkingSaveToLinkVerificationBodyView: UIView {
 
 private func CreateEmailLabel(email: String) -> UIView {
     let emailLabel = UILabel()
-    emailLabel.text = "Signing in as \(email)" // TODO(kgaidis): wrap with localizable strings
+    emailLabel.text = String(format: STPLocalizedString("Signing in as %@", "A footnote that explains to the user that they are signing in as a user with a specific e-mail. '%@' is replaced with an e-mail, for example, 'Signing in as test@test.com'"), email)
     emailLabel.font = .stripeFont(forTextStyle: .captionTight)
     emailLabel.textColor = .textSecondary
     return emailLabel

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkFooterView.swift
@@ -1,0 +1,85 @@
+//
+//  NetworkingSaveToLinkFooterView.swift
+//  StripeFinancialConnections
+//
+//  Created by Krisjanis Gaidis on 2/15/23.
+//
+
+import Foundation
+@_spi(STP) import StripeCore
+@_spi(STP) import StripeUICore
+import UIKit
+
+@available(iOSApplicationExtension, unavailable)
+class NetworkingSaveToLinkFooterView: HitTestView {
+
+    private let didSelectNotNow: () -> Void
+
+    private lazy var buttonVerticalStack: UIStackView = {
+        let verticalStackView = UIStackView()
+        verticalStackView.axis = .vertical
+        verticalStackView.spacing = 12
+        verticalStackView.addArrangedSubview(notNowButton)
+        return verticalStackView
+    }()
+
+    private lazy var notNowButton: StripeUICore.Button = {
+        let saveToLinkButton = Button(configuration: .financialConnectionsSecondary)
+        saveToLinkButton.title = STPLocalizedString("Not now", "Title of a button that allows users to skip the current screen.")
+        saveToLinkButton.addTarget(self, action: #selector(didSelectNotNowButton), for: .touchUpInside)
+        saveToLinkButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            saveToLinkButton.heightAnchor.constraint(equalToConstant: 56)
+        ])
+        return saveToLinkButton
+    }()
+
+    init(didSelectNotNow: @escaping () -> Void) {
+        self.didSelectNotNow = didSelectNotNow
+        super.init(frame: .zero)
+        backgroundColor = .customBackgroundColor
+        addAndPinSubview(buttonVerticalStack)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    @objc private func didSelectNotNowButton() {
+        didSelectNotNow()
+    }
+}
+
+#if DEBUG
+
+import SwiftUI
+
+@available(iOSApplicationExtension, unavailable)
+private struct NetworkingSaveToLinkFooterViewUIViewRepresentable: UIViewRepresentable {
+
+    func makeUIView(context: Context) -> NetworkingSaveToLinkFooterView {
+        NetworkingSaveToLinkFooterView(
+            didSelectNotNow: {}
+        )
+    }
+
+    func updateUIView(_ uiView: NetworkingSaveToLinkFooterView, context: Context) {
+        uiView.sizeToFit()
+    }
+}
+
+@available(iOS 14.0, *)
+@available(iOSApplicationExtension, unavailable)
+struct NetworkingSaveToLinkFooterView_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack {
+            NetworkingSaveToLinkFooterViewUIViewRepresentable()
+                .frame(maxHeight: 200)
+            Spacer()
+        }
+        .padding()
+        .frame(maxWidth: .infinity)
+    }
+}
+
+#endif

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationDataSource.swift
@@ -1,0 +1,95 @@
+//
+//  NetworkingSaveToLinkVerificationDataSource.swift
+//  StripeFinancialConnections
+//
+//  Created by Krisjanis Gaidis on 2/14/23.
+//
+
+import Foundation
+@_spi(STP) import StripeCore
+
+protocol NetworkingSaveToLinkVerificationDataSource: AnyObject {
+    var accountholderCustomerEmailAddress: String { get }
+    var manifest: FinancialConnectionsSessionManifest { get }
+    var analyticsClient: FinancialConnectionsAnalyticsClient { get }
+    var consumerSession: ConsumerSessionData? { get }
+
+    func startVerificationSession() -> Future<ConsumerSessionResponse>
+    func confirmVerificationSession(otpCode: String) -> Future<ConsumerSessionResponse>
+    func markLinkVerified() -> Future<FinancialConnectionsSessionManifest>
+    func fetchNetworkedAccounts() -> Future<FinancialConnectionsNetworkedAccountsResponse>
+}
+
+final class NetworkingSaveToLinkVerificationDataSourceImplementation: NetworkingSaveToLinkVerificationDataSource {
+
+    let accountholderCustomerEmailAddress: String
+    let manifest: FinancialConnectionsSessionManifest
+    private let apiClient: FinancialConnectionsAPIClient
+    private let clientSecret: String
+    let analyticsClient: FinancialConnectionsAnalyticsClient
+
+    private(set) var consumerSession: ConsumerSessionData?
+
+    init(
+        accountholderCustomerEmailAddress: String,
+        manifest: FinancialConnectionsSessionManifest,
+        apiClient: FinancialConnectionsAPIClient,
+        clientSecret: String,
+        analyticsClient: FinancialConnectionsAnalyticsClient
+    ) {
+        self.accountholderCustomerEmailAddress = accountholderCustomerEmailAddress
+        self.manifest = manifest
+        self.apiClient = apiClient
+        self.clientSecret = clientSecret
+        self.analyticsClient = analyticsClient
+    }
+
+    func startVerificationSession() -> Future<ConsumerSessionResponse> {
+        apiClient
+            .consumerSessionLookup(
+                emailAddress: accountholderCustomerEmailAddress
+            )
+            .chained { [weak self] (lookupConsumerSessionResponse: LookupConsumerSessionResponse) in
+                guard let self = self else {
+                    return Promise(error: FinancialConnectionsSheetError.unknown(debugDescription: "data source deallocated"))
+                }
+                if let consumerSession = lookupConsumerSessionResponse.consumerSession {
+                    self.consumerSession = consumerSession
+                    return self.apiClient.consumerSessionStartVerification(
+                        emailAddress: self.accountholderCustomerEmailAddress,
+                        otpType: "SMS",
+                        customEmailType: nil,
+                        connectionsMerchantName: nil,
+                        consumerSessionClientSecret: consumerSession.clientSecret
+                    )
+                } else {
+                    return Promise(error: FinancialConnectionsSheetError.unknown(debugDescription: "invalid consumerSessionLookup response: no consumerSession.clientSecret"))
+                }
+            }
+    }
+
+    func confirmVerificationSession(otpCode: String) -> Future<ConsumerSessionResponse> {
+        guard let consumerSessionClientSecret = consumerSession?.clientSecret else {
+            return Promise(error: FinancialConnectionsSheetError.unknown(debugDescription: "invalid confirmVerificationSession state: no consumerSessionClientSecret"))
+        }
+        return apiClient.consumerSessionConfirmVerification(
+            otpCode: otpCode,
+            otpType: "SMS",
+            consumerSessionClientSecret: consumerSessionClientSecret
+        )
+    }
+
+    func markLinkVerified() -> Future<FinancialConnectionsSessionManifest> {
+        return apiClient.markLinkVerified(clientSecret: clientSecret)
+    }
+
+    func fetchNetworkedAccounts() -> Future<FinancialConnectionsNetworkedAccountsResponse> {
+        guard let consumerSessionClientSecret = consumerSession?.clientSecret else {
+            return Promise(error: FinancialConnectionsSheetError.unknown(debugDescription: "invalid confirmVerificationSession state: no consumerSessionClientSecret"))
+        }
+        return apiClient.fetchNetworkedAccounts(
+            clientSecret: clientSecret,
+            consumerSessionClientSecret: consumerSessionClientSecret
+        )
+    }
+}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationDataSource.swift
@@ -21,20 +21,20 @@ protocol NetworkingSaveToLinkVerificationDataSource: AnyObject {
 final class NetworkingSaveToLinkVerificationDataSourceImplementation: NetworkingSaveToLinkVerificationDataSource {
 
     private(set) var consumerSession: ConsumerSessionData
-    private let selectedAccountIds: [String]
+    private let selectedAccountId: String
     private let apiClient: FinancialConnectionsAPIClient
     private let clientSecret: String
     let analyticsClient: FinancialConnectionsAnalyticsClient
 
     init(
         consumerSession: ConsumerSessionData,
-        selectedAccountIds: [String],
+        selectedAccountId: String,
         apiClient: FinancialConnectionsAPIClient,
         clientSecret: String,
         analyticsClient: FinancialConnectionsAnalyticsClient
     ) {
         self.consumerSession = consumerSession
-        self.selectedAccountIds = selectedAccountIds
+        self.selectedAccountId = selectedAccountId
         self.apiClient = apiClient
         self.clientSecret = clientSecret
         self.analyticsClient = analyticsClient
@@ -81,7 +81,7 @@ final class NetworkingSaveToLinkVerificationDataSourceImplementation: Networking
             emailAddress: nil,
             phoneNumber: nil,
             country: nil,
-            selectedAccountIds: selectedAccountIds,
+            selectedAccountIds: [selectedAccountId],
             consumerSessionClientSecret: consumerSession.clientSecret,
             clientSecret: clientSecret
         )

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationViewController.swift
@@ -86,7 +86,12 @@ final class NetworkingSaveToLinkVerificationViewController: UIViewController {
                 "The subtitle/description of a screen where users are informed that they have received a One-Type-Password (OTP) to their phone."
             ),
             contentView: bodyView,
-            footerView: nil
+            footerView: NetworkingSaveToLinkFooterView(
+                didSelectNotNow: { [weak self] in
+                    guard let self = self else { return }
+                    self.delegate?.networkingSaveToLinkVerificationViewControllerDidFinish(self, error: nil)
+                }
+            )
         )
         pane.addTo(view: view)
     }
@@ -124,7 +129,7 @@ extension NetworkingSaveToLinkVerificationViewController: NetworkingSaveToLinkVe
                 switch result {
                 case .success:
                     view.otpTextField.text = "SUCCESS! CALLING saveToLink AND markLinkVerified..."
-                    
+
                     self.dataSource.saveToLink()
                         .observe { [weak self] result in
                             guard let self = self else { return }
@@ -153,7 +158,7 @@ extension NetworkingSaveToLinkVerificationViewController: NetworkingSaveToLinkVe
                                 self.delegate?.networkingSaveToLinkVerificationViewControllerDidFinish(self, error: error)
                             }
                         }
-                    
+
                     self.dataSource.markLinkVerified()
                         .observe { _ in
                             // we ignore result

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationViewController.swift
@@ -1,0 +1,197 @@
+//
+//  NetworkingSaveToLinkVerification.swift
+//  StripeFinancialConnections
+//
+//  Created by Krisjanis Gaidis on 2/14/23.
+//
+
+import Foundation
+@_spi(STP) import StripeCore
+@_spi(STP) import StripeUICore
+import UIKit
+
+@available(iOSApplicationExtension, unavailable)
+protocol NetworkingSaveToLinkVerificationViewControllerDelegate: AnyObject {
+    func networkingSaveToLinkVerificationViewController(
+        _ viewController: NetworkingSaveToLinkVerificationViewController,
+        didRequestNextPane nextPane: FinancialConnectionsSessionManifest.NextPane,
+        consumerSession: ConsumerSessionData
+    )
+    func networkingSaveToLinkVerificationViewController(
+        _ viewController: NetworkingSaveToLinkVerificationViewController,
+        didReceiveTerminalError error: Error
+    )
+}
+
+@available(iOSApplicationExtension, unavailable)
+final class NetworkingSaveToLinkVerificationViewController: UIViewController {
+
+    private let dataSource: NetworkingSaveToLinkVerificationDataSource
+    weak var delegate: NetworkingSaveToLinkVerificationViewControllerDelegate?
+
+    private lazy var loadingView: ActivityIndicator = {
+        let activityIndicator = ActivityIndicator(size: .large)
+        activityIndicator.color = .textDisabled
+        activityIndicator.backgroundColor = .customBackgroundColor
+        return activityIndicator
+    }()
+    private lazy var bodyView: NetworkingSaveToLinkVerificationBodyView = {
+        let bodyView = NetworkingSaveToLinkVerificationBodyView(email: dataSource.accountholderCustomerEmailAddress)
+        bodyView.delegate = self
+        return bodyView
+    }()
+
+    init(dataSource: NetworkingSaveToLinkVerificationDataSource) {
+        self.dataSource = dataSource
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .customBackgroundColor
+
+        showLoadingView(true)
+        dataSource.startVerificationSession()
+            .observe { [weak self] result in
+                guard let self = self else { return }
+                self.showLoadingView(false)
+                switch result {
+                case .success(let consumerSessionResponse):
+                    self.showContent(redactedPhoneNumber: consumerSessionResponse.consumerSession.redactedPhoneNumber)
+                case .failure(let error):
+                    self.dataSource.analyticsClient.log(
+                        eventName: "networking.verification.error",
+                        parameters: [
+                            // TODO(kgaidis): figure out a proper way to log this error
+                            "error": "here"
+                        ],
+                        pane: .networkingSaveToLinkVerification
+                    )
+                    self.delegate?.networkingSaveToLinkVerificationViewController(self, didReceiveTerminalError: error)
+                }
+            }
+    }
+
+    private func showContent(redactedPhoneNumber: String) {
+        let pane = PaneWithHeaderLayoutView(
+            title: STPLocalizedString(
+                "Sign in to Link",
+                "The title of a screen where users are informed that they can sign-in-to Link."
+            ),
+            subtitle: STPLocalizedString(
+                "Enter the code sent to \(redactedPhoneNumber)",
+                "The subtitle/description of a screen where users are informed that they have received a One-Type-Password (OTP) to their phone."
+            ),
+            contentView: bodyView,
+            footerView: nil
+        )
+        pane.addTo(view: view)
+    }
+
+    private func showLoadingView(_ show: Bool) {
+        if show && loadingView.superview == nil {
+            // first-time we are showing this, so add the view to hierarchy
+            view.addAndPinSubview(loadingView)
+        }
+
+        loadingView.isHidden = !show
+        if show {
+            loadingView.startAnimating()
+        } else {
+            loadingView.stopAnimating()
+        }
+        view.bringSubviewToFront(loadingView)  // defensive programming to avoid loadingView being hiddden
+    }
+
+    private func requestNextPane(_ pane: FinancialConnectionsSessionManifest.NextPane) {
+        if let consumerSession = dataSource.consumerSession {
+            delegate?.networkingSaveToLinkVerificationViewController(
+                self,
+                didRequestNextPane: pane,
+                consumerSession: consumerSession
+            )
+        } else {
+            assertionFailure("logic error: did not have consumerSession")
+            delegate?.networkingSaveToLinkVerificationViewController(self, didReceiveTerminalError: FinancialConnectionsSheetError.unknown(debugDescription: "logic error: did not have consumerSession"))
+        }
+    }
+}
+
+// MARK: - NetworkingSaveToLinkVerificationBodyViewDelegate
+
+@available(iOSApplicationExtension, unavailable)
+extension NetworkingSaveToLinkVerificationViewController: NetworkingSaveToLinkVerificationBodyViewDelegate {
+
+    func networkingSaveToLinkVerificationBodyView(
+        _ view: NetworkingSaveToLinkVerificationBodyView,
+        didEnterValidOTPCode otpCode: String
+    ) {
+        view.otpTextField.text = "CONFIRMING OTP..."
+
+        dataSource.confirmVerificationSession(otpCode: otpCode)
+            .observe { [weak self] result in
+                guard let self = self else { return }
+                switch result {
+                case .success:
+                    view.otpTextField.text = "SUCCESS! CALLING markLinkVerified..."
+
+                    self.dataSource.markLinkVerified()
+                        .observe { [weak self] result in
+                            guard let self = self else { return }
+                            switch result {
+                            case .success(let manifest):
+                                view.otpTextField.text = "markLinkVerified SUCCESS! Wait on accounts..."
+
+                                self.dataSource.fetchNetworkedAccounts()
+                                    .observe { [weak self] result in
+                                        guard let self = self else { return }
+                                        switch result {
+                                        case .success(let networkedAccountsResponse):
+                                            let networkedAccounts = networkedAccountsResponse.data
+                                            if networkedAccounts.isEmpty {
+                                                self.dataSource.analyticsClient.log(
+                                                    eventName: "networking.verification.success_no_accounts",
+                                                    pane: .networkingSaveToLinkVerification
+                                                )
+                                                self.requestNextPane(manifest.nextPane)
+                                            } else {
+                                                self.dataSource.analyticsClient.log(
+                                                    eventName: "networking.verification.success",
+                                                    pane: .networkingSaveToLinkVerification
+                                                )
+                                                self.requestNextPane(.linkAccountPicker)
+                                            }
+                                        case .failure(let error):
+                                            // TODO(kgaidis): log the error using the standard error logging too
+                                            self.dataSource
+                                                .analyticsClient
+                                                .log(
+                                                    eventName: "networking.verification.error",
+                                                    parameters: [
+                                                        "error": "NetworkedAccountsRetrieveMethodError",
+                                                    ],
+                                                    pane: .networkingSaveToLinkVerification
+                                                )
+                                            print(error) // TODO(kgaidis): remove print
+                                            self.requestNextPane(manifest.nextPane)
+                                        }
+                                    }
+                            case .failure(let error):
+                                print(error) // TODO(kgaidis): remove print
+                                view.otpTextField.text = "markLinkVerified FAILURE: \(error.localizedDescription)"
+                                // TODO(kgaidis): go to terminal error but double-check
+                                self.delegate?.networkingSaveToLinkVerificationViewController(self, didReceiveTerminalError: error)
+                            }
+                        }
+                case .failure(let error):
+                    print(error) // TODO(kgaidis): remove print
+                    view.otpTextField.text = "FAILURE...\(error.localizedDescription)"
+                    // TODO(kgaidis): display various known errors, or if unknown error, show terminal error
+                }
+            }
+    }
+}

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
@@ -109,9 +109,9 @@ class EmptyFinancialConnectionsAPIClient: FinancialConnectionsAPIClient {
     }
 
     func saveAccountsToLink(
-        emailAddress: String,
-        phoneNumber: String,
-        country: String,
+        emailAddress: String?,
+        phoneNumber: String?,
+        country: String?,
         selectedAccountIds: [String],
         consumerSessionClientSecret: String?,
         clientSecret: String


### PR DESCRIPTION
## Summary

^ see title

Note that this has a bunch of copied logic from `NetworkingLinkVerification` pane. That is per-design. The plan is:
1. Create the 3 verification panes that have OTP by copying code
2. Learn through the process
3. Then, refactor & combine (IF needed) after the lessons

Note that _all_ these panes _do_ have differences. It's a matter of figuring out what is the sweet-spot for reusability.

## Testing

![Simulator Screen Shot - iPhone 14 Pro - 2023-02-15 at 14 56 21](https://user-images.githubusercontent.com/105514761/219139130-c4c92192-b2c4-4905-b836-afaed25550a1.png)

https://user-images.githubusercontent.com/105514761/219139092-98f021ac-4a11-4ab2-99e8-fbc9f33386c4.mp4
