### PR TITLE
[StripeUiCore] Capitalize name config 

### DIFF
--- a/StripeUICore/StripeUICore/Source/Elements/Factories/TextFieldElement+Factory.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Factories/TextFieldElement+Factory.swift
@@ -46,7 +46,7 @@ import UIKit
         }
 
         public func keyboardProperties(for text: String) -> TextFieldElement.KeyboardProperties {
-            return .init(type: .namePhonePad, textContentType: textContentType, autocapitalization: .words)
+            return .init(type: .default, textContentType: textContentType, autocapitalization: .words)
         }
 
         private static func label(for type: NameType) -> String {


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
`.namePhonePad` doesn't support autocapitalization type `.words`, use `.default` instead.
Please see details at [this](https://stackoverflow.com/a/36365399) SO thread


## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
Manually verified

# Recordings
| Before  | After |
| ------------- | ------------- |
| ![before](https://user-images.githubusercontent.com/79880926/220209818-da01acda-219c-4d4b-b513-203ce9101690.gif)  | ![after](https://user-images.githubusercontent.com/79880926/220209808-bdc51538-21c7-47f9-9a31-c1349d93aafc.gif) |




## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
