### PR TITLE
[StripeUICore][Identity] Add an optional date formatter to DateFieldElement

### DIFF
--- a/StripeIdentity/StripeIdentity/Source/Elements/IdentityElementsFactory.swift
+++ b/StripeIdentity/StripeIdentity/Source/Elements/IdentityElementsFactory.swift
@@ -21,6 +21,8 @@ struct IdentityElementsFactory {
 
     let locale: Locale
     let addressSpecProvider: AddressSpecProvider
+    
+    let dateFormatter: DateFormatter
 
     static let supportedCountryToIDNumberTypes: [String: IdentityElementsFactory.IDNumberSpec] = [
         "US": .init(type: .US_SSN_LAST4, label: "Last 4 of Social Security number"),
@@ -34,6 +36,9 @@ struct IdentityElementsFactory {
     ) {
         self.locale = locale
         self.addressSpecProvider = addressSpecProvider
+        
+        self.dateFormatter = DateFormatter()
+        self.dateFormatter.dateFormat = "MM / dd / yyyy"
     }
 
     // MARK: Name
@@ -70,10 +75,17 @@ struct IdentityElementsFactory {
 
     // MARK: DOB
 
-    func makeDateOfBirth() -> DateFieldElement {
-        return DateFieldElement(
-            maximumDate: Date(),
-            locale: locale
+    func makeDateOfBirthSection() -> SectionElement {
+        return  SectionElement(
+            title: String.Localized.date_of_birth,
+            elements: [DateFieldElement(
+                label: "MM / DD / YYYY",
+                minimumDate: dateFormatter.date(from: "01 / 01 / 1990"),
+                maximumDate: Date(),
+                locale: locale,
+                customDateFormatter: dateFormatter
+                )
+            ]
         )
     }
 

--- a/StripeIdentity/StripeIdentity/Source/Elements/IdentityElementsFactory.swift
+++ b/StripeIdentity/StripeIdentity/Source/Elements/IdentityElementsFactory.swift
@@ -21,7 +21,7 @@ struct IdentityElementsFactory {
 
     let locale: Locale
     let addressSpecProvider: AddressSpecProvider
-    
+
     let dateFormatter: DateFormatter
 
     static let supportedCountryToIDNumberTypes: [String: IdentityElementsFactory.IDNumberSpec] = [
@@ -36,7 +36,7 @@ struct IdentityElementsFactory {
     ) {
         self.locale = locale
         self.addressSpecProvider = addressSpecProvider
-        
+
         self.dateFormatter = DateFormatter()
         self.dateFormatter.dateFormat = "MM / dd / yyyy"
     }
@@ -84,7 +84,7 @@ struct IdentityElementsFactory {
                 maximumDate: Date(),
                 locale: locale,
                 customDateFormatter: dateFormatter
-                )
+                ),
             ]
         )
     }

--- a/StripeIdentity/StripeIdentity/Source/Elements/IndividualFormElement.swift
+++ b/StripeIdentity/StripeIdentity/Source/Elements/IndividualFormElement.swift
@@ -100,10 +100,7 @@ final class IndividualFormElement: ContainerElement {
             nameElement = nil
         }
         if missing.contains(.dob) {
-            dobElement = SectionElement(
-                title: String.Localized.date_of_birth,
-                elements: [elementsFactory.makeDateOfBirth()]
-            )
+            dobElement = elementsFactory.makeDateOfBirthSection()
             elements.append(dobElement!)
         } else {
             dobElement = nil

--- a/StripeUICore/StripeUICore/Source/Elements/DateFieldElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/DateFieldElement.swift
@@ -90,10 +90,14 @@ import UIKit
         locale: Locale = .current,
         timeZone: TimeZone = .current,
         theme: ElementsUITheme = .default,
+        customDateFormatter: DateFormatter? = nil,
         didUpdate: DidUpdateSelectedDate? = nil
     ) {
         self.label = label
         self.theme = theme
+        if let customDateFormatter = customDateFormatter {
+            self.dateFormatter = customDateFormatter
+        }
         dateFormatter.locale = locale
         dateFormatter.timeZone = timeZone
 

--- a/StripeUICore/StripeUICoreTests/Unit/Elements/DateFieldElementTest.swift
+++ b/StripeUICore/StripeUICoreTests/Unit/Elements/DateFieldElementTest.swift
@@ -35,12 +35,12 @@ final class DateFieldElementTest: XCTestCase {
         let element = DateFieldElement(label: "", defaultDate: oct1_2021, minimumDate: oct3_2021)
         XCTAssertNil(element.selectedDate)
     }
-    
+
     func testCustomDateformatter() {
-        let timeZone = TimeZone(secondsFromGMT:0)
+        let timeZone = TimeZone(secondsFromGMT: 0)
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "MMddyyyy"
-        
+
         let element = DateFieldElement(timeZone: timeZone!, customDateFormatter: dateFormatter)
         // Emulate a user changing the picker and hitting done button
         element.datePickerView.date = oct3_2021

--- a/StripeUICore/StripeUICoreTests/Unit/Elements/DateFieldElementTest.swift
+++ b/StripeUICore/StripeUICoreTests/Unit/Elements/DateFieldElementTest.swift
@@ -35,6 +35,20 @@ final class DateFieldElementTest: XCTestCase {
         let element = DateFieldElement(label: "", defaultDate: oct1_2021, minimumDate: oct3_2021)
         XCTAssertNil(element.selectedDate)
     }
+    
+    func testCustomDateformatter() {
+        let timeZone = TimeZone(secondsFromGMT:0)
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "MMddyyyy"
+        
+        let element = DateFieldElement(timeZone: timeZone!, customDateFormatter: dateFormatter)
+        // Emulate a user changing the picker and hitting done button
+        element.datePickerView.date = oct3_2021
+        element.didSelectDate()
+        element.didFinish(element.pickerFieldView)
+
+        XCTAssertEqual(element.pickerFieldView.displayText, "10032021")
+    }
 
     func testDidUpdate() {
         var date: Date?


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Update the DOB DateFieldElement to accept an optional formatter
Apply the formatter for Identity and apply the min date

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Better UX

## Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Unit
- [x] Manual

# Recordings
| Before  | After |
| ------------- | ------------- |
| ![before](https://user-images.githubusercontent.com/79880926/220224068-c011d45a-4fd5-4b3f-8f21-f369d8303434.gif)  | ![after](https://user-images.githubusercontent.com/79880926/220224066-7b81ec1c-08ae-4cc9-bce3-ba16b96322d4.gif) |







## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
