### PR TITLE
[StripeUICore][Identity] Disable dropdown with single element

### DIFF
--- a/StripeIdentity/StripeIdentity/Source/Elements/IdNumberElement.swift
+++ b/StripeIdentity/StripeIdentity/Source/Elements/IdNumberElement.swift
@@ -32,7 +32,8 @@ class IdNumberElement: ContainerElement {
         country = DropdownFieldElement.Address.makeCountry(
             label: String.Localized.country,
             countryCodes: countryCodes,
-            locale: locale
+            locale: locale,
+            disableDropdownWithSingleCountry: true
         )
 
         let defaultCountrySpec = countryToIDNumberTypes[countryCodes[country.selectedIndex]]

--- a/StripeUICore/StripeUICore/Source/Elements/DropdownFieldElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/DropdownFieldElement.swift
@@ -64,11 +64,14 @@ import UIKit
     private(set) lazy var pickerFieldView: PickerFieldView = {
         let pickerFieldView = PickerFieldView(
             label: label,
-            shouldShowChevron: true,
+            shouldShowChevron: disableDropdownWithSingleElement ? items.count != 1 : true,
             pickerView: pickerView,
             delegate: self,
             theme: theme
         )
+        if disableDropdownWithSingleElement && items.count == 1 {
+            pickerFieldView.isUserInteractionEnabled = false
+        }
         return pickerFieldView
     }()
 
@@ -76,6 +79,7 @@ import UIKit
     private let label: String?
     private let theme: ElementsUITheme
     private var previouslySelectedIndex: Int
+    private let disableDropdownWithSingleElement: Bool
 
     /**
      - Parameters:
@@ -94,6 +98,7 @@ import UIKit
         defaultIndex: Int = 0,
         label: String?,
         theme: ElementsUITheme = .default,
+        disableDropdownWithSingleElement: Bool = false,
         didUpdate: DidUpdateSelectedIndex? = nil
     ) {
         assert(!items.isEmpty, "`items` must contain at least one item")
@@ -101,6 +106,7 @@ import UIKit
         self.label = label
         self.theme = theme
         self.items = items
+        self.disableDropdownWithSingleElement = disableDropdownWithSingleElement
         self.didUpdate = didUpdate
 
         // Default to defaultIndex, if in bounds

--- a/StripeUICore/StripeUICore/Source/Elements/Factories/DropdownFieldElement+AddressFactory.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Factories/DropdownFieldElement+AddressFactory.swift
@@ -21,7 +21,8 @@ import Foundation
             countryCodes: [String],
             theme: ElementsUITheme = .default,
             defaultCountry: String? = nil,
-            locale: Locale = Locale.current
+            locale: Locale = Locale.current,
+            disableDropdownWithSingleCountry: Bool = false
         ) -> DropdownFieldElement {
             let dropdownItems: [DropdownItem] = countryCodes.map {
                 let flagEmoji = String.countryFlagEmoji(for: $0) ?? ""              // 🇺🇸
@@ -38,7 +39,8 @@ import Foundation
                 items: dropdownItems,
                 defaultIndex: defaultCountryIndex,
                 label: String.Localized.country_or_region,
-                theme: theme
+                theme: theme,
+                disableDropdownWithSingleElement: disableDropdownWithSingleCountry
             )
         }
     }

--- a/StripeUICore/StripeUICoreTests/Unit/Elements/DropdownFieldElementTest.swift
+++ b/StripeUICore/StripeUICoreTests/Unit/Elements/DropdownFieldElementTest.swift
@@ -33,6 +33,16 @@ final class DropdownFieldElementTest: XCTestCase {
         XCTAssertEqual(element.selectedIndex, 0)
     }
 
+    func testDisableDropdownWithSingleElement() {
+        let multipleElements = DropdownFieldElement(items: items, defaultIndex: -1, label: "", disableDropdownWithSingleElement: true)
+
+        XCTAssertEqual(multipleElements.pickerFieldView.isUserInteractionEnabled, true)
+
+        let singleElement = DropdownFieldElement(items: [DropdownFieldElement.DropdownItem(pickerDisplayName: "Item", labelDisplayName: "Item", accessibilityValue: "Item", rawData: "Item")], defaultIndex: -1, label: "", disableDropdownWithSingleElement: true)
+
+        XCTAssertEqual(singleElement.pickerFieldView.isUserInteractionEnabled, false)
+    }
+
     func testDidUpdate() {
         var index: Int?
         let element = DropdownFieldElement(items: items, label: "", didUpdate: { index = $0 })


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Add the option to disable dropdown when [items] only have one element, and apply it to the address extension

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Better UX

## Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Unitest
- [x] manual

## Screenshots
| single element  | multiple elements |
| ------------- | ------------- |
| ![single](https://user-images.githubusercontent.com/79880926/220229417-2e53f135-3bc5-4329-b4ad-0c77626007d9.png)  |![multi](https://user-images.githubusercontent.com/79880926/220229414-12fc4293-72c5-4cfc-9a9d-cf264e9dbcdf.gif) |

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
