### PR TITLE
FC Networking: polished code and UI around the email address field of NetworkingSignUp

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -546,9 +546,18 @@ extension NativeFlowController: NetworkingLinkSignupViewControllerDelegate {
     }
 
     func networkingLinkSignupViewControllerDidFinish(
-        _ viewController: NetworkingLinkSignupViewController
+        _ viewController: NetworkingLinkSignupViewController,
+        withError error: Error?
     ) {
+        // TODO(kgaidis): show small error on success pane if error != nil
         pushPane(.success, animated: true)
+    }
+
+    func networkingLinkSignupViewController(
+        _ viewController: NetworkingLinkSignupViewController,
+        didReceiveTerminalError error: Error
+    ) {
+        showTerminalError(error)
     }
 }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/LinkEmailElement.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/LinkEmailElement.swift
@@ -1,0 +1,94 @@
+//
+//  LinkEmailElement.swift
+//  StripeFinancialConnections
+//
+//  Created by Krisjanis Gaidis on 2/21/23.
+//
+
+@_spi(STP) import StripeUICore
+import UIKit
+
+class LinkEmailElement: Element {
+    weak var delegate: ElementDelegate?
+
+    let emailAddressElement: TextFieldElement
+
+    private let activityIndicator: ActivityIndicator = {
+        let activityIndicator = ActivityIndicator(size: .medium)
+        activityIndicator.setContentCompressionResistancePriority(.required, for: .horizontal)
+        return activityIndicator
+    }()
+
+    private lazy var stackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [emailAddressElement.view, activityIndicator])
+        stackView.spacing = 0
+        stackView.axis = .horizontal
+        stackView.alignment = .center
+        stackView.isLayoutMarginsRelativeArrangement = true
+        stackView.directionalLayoutMargins = .insets(
+            top: 0,
+            leading: 0,
+            bottom: 0,
+            trailing: ElementsUI.contentViewInsets.trailing
+        )
+        return stackView
+    }()
+
+    var view: UIView {
+        return stackView
+    }
+
+    public var emailAddressString: String? {
+        return emailAddressElement.text
+    }
+
+    public var validationState: ElementValidationState {
+        return emailAddressElement.validationState
+    }
+
+    public var indicatorTintColor: UIColor {
+        get {
+            return activityIndicator.color
+        }
+
+        set {
+            activityIndicator.color = newValue
+        }
+    }
+
+    public func startAnimating() {
+        UIView.performWithoutAnimation {
+            activityIndicator.startAnimating()
+            stackView.setNeedsLayout()
+            stackView.layoutSubviews()
+        }
+    }
+
+    public func stopAnimating() {
+        UIView.performWithoutAnimation {
+            activityIndicator.stopAnimating()
+            stackView.setNeedsLayout()
+            stackView.layoutSubviews()
+        }
+    }
+
+    public init(defaultValue: String? = nil, theme: ElementsUITheme = .default) {
+        emailAddressElement = TextFieldElement.makeEmail(defaultValue: defaultValue, theme: theme)
+        emailAddressElement.delegate = self
+    }
+
+    @discardableResult
+    func beginEditing() -> Bool {
+        return emailAddressElement.beginEditing()
+    }
+}
+
+extension LinkEmailElement: ElementDelegate {
+    func didUpdate(element: Element) {
+        delegate?.didUpdate(element: self)
+    }
+
+    func continueToNextField(element: Element) {
+        delegate?.continueToNextField(element: self)
+    }
+}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupFooterView.swift
@@ -106,6 +106,10 @@ class NetworkingLinkSignupFooterView: HitTestView {
         buttonVerticalStack.addArrangedSubview(notNowButton)
     }
 
+    func enableSaveToLinkButton(_ enable: Bool) {
+        saveToLinkButton.isEnabled = enable
+    }
+
     @objc private func didSelectSaveToLinkButton() {
         didSelectSaveToLink()
     }
@@ -115,7 +119,6 @@ class NetworkingLinkSignupFooterView: HitTestView {
     }
 
     func setIsLoading(_ isLoading: Bool) {
-        // TODO(kgaidis): remove if not necessary
         saveToLinkButton.isLoading = isLoading
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
@@ -99,7 +99,7 @@ final class NetworkingLinkSignupViewController: UIViewController {
     private func didSelectSaveToLink() {
         // TODO(kgaidis): on save to link, make a network call to saveToLinkNetwork...whether SUCCESS or FAILURE...we push to success pane...
         dataSource.saveToLink(
-            emailAddress: formView.emailAddressTextField.text ?? "",
+            emailAddress: formView.emailElement.emailAddressString ?? "",
             phoneNumber: formView.phoneNumberTextField.text ?? "",
             countryCode: "US"  // TODO(kgaidis): fix the country code
         )
@@ -130,14 +130,15 @@ final class NetworkingLinkSignupViewController: UIViewController {
 
 @available(iOSApplicationExtension, unavailable)
 extension NetworkingLinkSignupViewController: NetworkingLinkSignupBodyFormViewDelegate {
-
-    func networkingLinkSignupBodyFormViewDidEnterValidEmail(_ view: NetworkingLinkSignupBodyFormView) {
-        guard let emailAddress = view.emailAddressTextField.text else {
-            return
-        }
+    
+    func networkingLinkSignupBodyFormView(
+        _ bodyFormView: NetworkingLinkSignupBodyFormView,
+        didEnterValidEmailAddress emailAddress: String
+    ) {
+        bodyFormView.emailElement.startAnimating()
         dataSource
             .lookup(emailAddress: emailAddress)
-            .observe { [weak self] result in
+            .observe { [weak self, weak bodyFormView] result in
                 guard let self = self else { return }
                 switch result {
                 case .success(let response):
@@ -168,6 +169,7 @@ extension NetworkingLinkSignupViewController: NetworkingLinkSignupBodyFormViewDe
                         pane: .networkingLinkSignupPane
                     )
                 }
+                bodyFormView?.emailElement.stopAnimating()
             }
     }
 }


### PR DESCRIPTION
## Summary

Two things:
1. Added a new/real email address field
2. Corrected/polished a bunch of logic - especially around the email address field

Note that this is _not_ the final polish of this screen, just the first step so it's easier to review. Next is logic around phone number.

[Design link](https://www.figma.com/file/pU6S60e08Rgv0dvycCxMT8/Connections---Mobile?node-id=3602%3A66700&t=vPIiKxwwfjKYTBzO-0)

## Testing

### Video of various testing

https://user-images.githubusercontent.com/105514761/220747780-bd69ad8a-67df-4bd0-8324-f1124fe74a6f.mp4

### Email prefill

https://user-images.githubusercontent.com/105514761/220747822-ab3baffd-2ef5-40c6-8daf-81b81920e9c2.mp4

### Various screenshots

![Simulator Screen Shot - iPhone 14 Pro - 2023-02-22 at 15 09 41](https://user-images.githubusercontent.com/105514761/220747859-97573cad-11b5-451e-b652-9446ebe91d47.png)
![Simulator Screen Shot - iPhone 14 Pro - 2023-02-22 at 15 09 46](https://user-images.githubusercontent.com/105514761/220747861-166de078-0746-40e9-a927-723cc9ca3a65.png)
![Simulator Screen Shot - iPhone 14 Pro - 2023-02-22 at 15 09 51](https://user-images.githubusercontent.com/105514761/220747866-0d685bea-e3dd-4e81-a514-4431f8eef6f1.png)
