### PR TITLE
Fix race condition between fetching payment options and setting properties after init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## x.x.x yyyy-mm-dd
+### Basic Integration
+* [Fixed] Race condition reported in #2302
+
 ## 23.4.0 2023-02-21
 ### PaymentSheet
 * [Added] Adds support for setting up PayPal using a SetupIntent or a PaymentIntent w/ setup_future_usage=off_session. Note: PayPal is in beta.

--- a/Stripe/StripeiOS/Source/STPAddCardViewController.swift
+++ b/Stripe/StripeiOS/Source/STPAddCardViewController.swift
@@ -44,7 +44,13 @@ public class STPAddCardViewController: STPCoreTableViewController, STPAddressVie
     /// The view controller's delegate. This must be set before showing the view controller in order for it to work properly. - seealso: STPAddCardViewControllerDelegate
     @objc public weak var delegate: STPAddCardViewControllerDelegate?
     /// You can set this property to pre-fill any information you've already collected from your user. - seealso: STPUserInformation.h
-    @objc public var prefilledInformation: STPUserInformation?
+    @objc public var prefilledInformation: STPUserInformation? {
+        didSet {
+            if let address = prefilledInformation?.billingAddress {
+                addressViewModel.address = address
+            }
+        }
+    }
 
     private var _customFooterView: UIView?
     /// Provide this view controller with a footer view.

--- a/Stripe/StripeiOS/Source/STPPaymentOptionsInternalViewController.swift
+++ b/Stripe/StripeiOS/Source/STPPaymentOptionsInternalViewController.swift
@@ -90,9 +90,9 @@ class STPPaymentOptionsInternalViewController: STPCoreTableViewController, UITab
     }
 
     var addCardViewControllerCustomFooterView: UIView?
+    var prefilledInformation: STPUserInformation?
     private var configuration: STPPaymentConfiguration?
     private var apiAdapter: STPBackendAPIAdapter?
-    private var prefilledInformation: STPUserInformation?
     private var shippingAddress: STPAddress?
     private var paymentOptions: [STPPaymentOption]?
     private var apiClient: STPAPIClient = .shared

--- a/Stripe/StripeiOS/Source/STPPaymentOptionsInternalViewController.swift
+++ b/Stripe/StripeiOS/Source/STPPaymentOptionsInternalViewController.swift
@@ -63,10 +63,7 @@ class STPPaymentOptionsInternalViewController: STPCoreTableViewController, UITab
     }
 
     private var _customFooterView: UIView?
-    // @objc was added to this field in order to overcome
-    // a bug in Xcode13 w/ our unit test:
-    // testSetAfterInit_paymentOptionsViewControllerFooterView_STPPaymentOptionsInternalViewController
-    @objc var customFooterView: UIView? {
+    var customFooterView: UIView? {
         get {
             _customFooterView
         }
@@ -91,14 +88,9 @@ class STPPaymentOptionsInternalViewController: STPCoreTableViewController, UITab
             tableView?.tableFooterView = _customFooterView
         }
     }
-    // @objc was added to this field in order to overcome
-    // a bug in Xcode13 w/ our unit test:
-    // testSetAfterInit_addCardViewControllerFooterView_STPPaymentOptionsInternalViewController
-    @objc var addCardViewControllerCustomFooterView: UIView?
-    // @objc was added to this field in order to overcome
-    // a bug in xcode13 w/ our unit test:
-    // testSetAfterInit_prefilledInformation_STPPaymentOptionsInternalViewController
-    @objc var prefilledInformation: STPUserInformation?
+
+    var addCardViewControllerCustomFooterView: UIView?
+    var prefilledInformation: STPUserInformation?
     private var configuration: STPPaymentConfiguration?
     private var apiAdapter: STPBackendAPIAdapter?
     private var shippingAddress: STPAddress?

--- a/Stripe/StripeiOS/Source/STPPaymentOptionsInternalViewController.swift
+++ b/Stripe/StripeiOS/Source/STPPaymentOptionsInternalViewController.swift
@@ -63,7 +63,10 @@ class STPPaymentOptionsInternalViewController: STPCoreTableViewController, UITab
     }
 
     private var _customFooterView: UIView?
-    var customFooterView: UIView? {
+    // @objc was added to this field in order to overcome
+    // a bug in Xcode13 w/ our unit test:
+    // testSetAfterInit_paymentOptionsViewControllerFooterView_STPPaymentOptionsInternalViewController
+    @objc var customFooterView: UIView? {
         get {
             _customFooterView
         }
@@ -88,9 +91,14 @@ class STPPaymentOptionsInternalViewController: STPCoreTableViewController, UITab
             tableView?.tableFooterView = _customFooterView
         }
     }
-
-    var addCardViewControllerCustomFooterView: UIView?
-    var prefilledInformation: STPUserInformation?
+    // @objc was added to this field in order to overcome
+    // a bug in Xcode13 w/ our unit test:
+    // testSetAfterInit_addCardViewControllerFooterView_STPPaymentOptionsInternalViewController
+    @objc var addCardViewControllerCustomFooterView: UIView?
+    // @objc was added to this field in order to overcome
+    // a bug in xcode13 w/ our unit test:
+    // testSetAfterInit_prefilledInformation_STPPaymentOptionsInternalViewController
+    @objc var prefilledInformation: STPUserInformation?
     private var configuration: STPPaymentConfiguration?
     private var apiAdapter: STPBackendAPIAdapter?
     private var shippingAddress: STPAddress?

--- a/Stripe/StripeiOS/Source/STPPaymentOptionsViewController.swift
+++ b/Stripe/StripeiOS/Source/STPPaymentOptionsViewController.swift
@@ -237,7 +237,15 @@ public class STPPaymentOptionsViewController: STPCoreViewController,
     /// If you've already collected some information from your user, you can set it
     /// here and it'll be automatically filled out when possible/appropriate in any UI
     /// that the payment context creates.
-    @objc public var prefilledInformation: STPUserInformation?
+    @objc public var prefilledInformation: STPUserInformation? {
+        didSet {
+            if let payMethodsInternal = internalViewController as? STPPaymentOptionsInternalViewController {
+                payMethodsInternal.prefilledInformation = prefilledInformation
+            } else if let payMethodsInternal = internalViewController as? STPAddCardViewController {
+                payMethodsInternal.prefilledInformation = prefilledInformation
+            }
+        }
+    }
     /// @note This is no longer recommended as of v18.3.0 - the SDK automatically saves the Stripe ID of the last selected
     /// payment method using NSUserDefaults and displays it as the default pre-selected option.  You can override this behavior
     /// by setting this property.
@@ -249,13 +257,29 @@ public class STPPaymentOptionsViewController: STPCoreViewController,
     /// When the footer view needs to be resized, it will be sent a
     /// `sizeThatFits:` call. The view should respond correctly to this method in order
     /// to be sized and positioned properly.
-    @objc public var paymentOptionsViewControllerFooterView: UIView?
+    @objc public var paymentOptionsViewControllerFooterView: UIView? {
+        didSet {
+            if let payMethodsInternal = internalViewController as? STPPaymentOptionsInternalViewController {
+                payMethodsInternal.customFooterView = paymentOptionsViewControllerFooterView
+            }
+        }
+    }
+
     /// A view that will be placed as the footer of the view controller when it is
     /// showing the add card view.
     /// When the footer view needs to be resized, it will be sent a
     /// `sizeThatFits:` call. The view should respond correctly to this method in order
     /// to be sized and positioned properly.
-    @objc public var addCardViewControllerFooterView: UIView?
+    @objc public var addCardViewControllerFooterView: UIView? {
+        didSet {
+            if let payMethodsInternal = internalViewController as? STPPaymentOptionsInternalViewController {
+                payMethodsInternal.addCardViewControllerCustomFooterView = addCardViewControllerFooterView
+            } else if let payMethodsInternal = internalViewController as? STPAddCardViewController {
+                payMethodsInternal.customFooterView = addCardViewControllerFooterView
+            }
+        }
+    }
+
     /// The API Client to use to make requests.
     /// Defaults to STPAPIClient.shared
     public var apiClient: STPAPIClient = .shared

--- a/Stripe/StripeiOSTests/STPAddCardViewControllerTest.swift
+++ b/Stripe/StripeiOSTests/STPAddCardViewControllerTest.swift
@@ -91,6 +91,39 @@ class STPAddCardViewControllerTest: APIStubbedTestCase {
         XCTAssertNoThrow(sut.viewDidLoad())
     }
 
+    func testPrefilledBillingAddress_viewDidLoadHappensBeforeSettingAddress() {
+        let config = STPFixtures.paymentConfiguration()
+        config.requiredBillingAddressFields = .full
+        let sut = STPAddCardViewController(
+            configuration: config,
+            theme: STPTheme.defaultTheme
+        )
+        XCTAssertNoThrow(sut.loadView())
+        XCTAssertNoThrow(sut.viewDidLoad())
+
+        let address = STPAddress()
+        address.name = "John Smith Doe"
+        address.line1 = "55 John St"
+        address.city = "Harare"
+        address.postalCode = "10002"
+
+        let prefilledInfo = STPUserInformation()
+        prefilledInfo.billingAddress = address
+        sut.prefilledInformation = prefilledInfo
+
+        let nameCell = sut.addressViewModel.addressCells.first{ $0.type == .name }!
+        XCTAssertEqual( nameCell.contents, "John Smith Doe")
+
+        let line1Cell = sut.addressViewModel.addressCells.first{ $0.type == .line1 }!
+        XCTAssertEqual( line1Cell.contents, "55 John St")
+
+        let cityCell = sut.addressViewModel.addressCells.first{ $0.type == .city }!
+        XCTAssertEqual( cityCell.contents, "Harare")
+
+        let zipCell = sut.addressViewModel.addressCells.first{ $0.type == .zip }!
+        XCTAssertEqual( zipCell.contents, "10002")
+    }
+
     func testPrefilledBillingAddress_addAddress() {
         // Zimbabwe does not require zip codes, while the default locale for tests (US) does
         NSLocale.stp_withLocale(as: NSLocale(localeIdentifier: "en_ZW") as Locale) {

--- a/Stripe/StripeiOSTests/STPAddCardViewControllerTest.swift
+++ b/Stripe/StripeiOSTests/STPAddCardViewControllerTest.swift
@@ -111,16 +111,16 @@ class STPAddCardViewControllerTest: APIStubbedTestCase {
         prefilledInfo.billingAddress = address
         sut.prefilledInformation = prefilledInfo
 
-        let nameCell = sut.addressViewModel.addressCells.first{ $0.type == .name }!
+        let nameCell = sut.addressViewModel.addressCells.first { $0.type == .name }!
         XCTAssertEqual( nameCell.contents, "John Smith Doe")
 
-        let line1Cell = sut.addressViewModel.addressCells.first{ $0.type == .line1 }!
+        let line1Cell = sut.addressViewModel.addressCells.first { $0.type == .line1 }!
         XCTAssertEqual( line1Cell.contents, "55 John St")
 
-        let cityCell = sut.addressViewModel.addressCells.first{ $0.type == .city }!
+        let cityCell = sut.addressViewModel.addressCells.first { $0.type == .city }!
         XCTAssertEqual( cityCell.contents, "Harare")
 
-        let zipCell = sut.addressViewModel.addressCells.first{ $0.type == .zip }!
+        let zipCell = sut.addressViewModel.addressCells.first { $0.type == .zip }!
         XCTAssertEqual( zipCell.contents, "10002")
     }
 

--- a/Stripe/StripeiOSTests/STPPaymentOptionsViewControllerTest.swift
+++ b/Stripe/StripeiOSTests/STPPaymentOptionsViewControllerTest.swift
@@ -215,4 +215,132 @@ class STPPaymentOptionsViewControllerTest: XCTestCase {
         XCTAssertTrue(delegate.didFinish)
         waitForExpectations(timeout: 2, handler: nil)
     }
+
+    // Tests for race condition where the promise for fetching payment methods
+    // finishes in the context of intializing the sut, and `addCardViewControllerFooterView`
+    // is set directly after init, while internalViewController is `STPAddCardViewController`
+    func testSetAfterInit_addCardViewControllerFooterView_STPAddCardViewController() {
+        let customer = STPFixtures.customerWithNoSources()
+        let config = STPFixtures.paymentConfiguration()
+        config.applePayEnabled = false
+        let delegate = MockSTPPaymentOptionsViewControllerDelegate()
+        let sut = buildViewController(
+            with: customer,
+            paymentMethods: [],
+            configuration: config,
+            delegate: delegate
+        )
+        sut.addCardViewControllerFooterView = UIView(frame: CGRectZero)
+        guard let payMethodsInternal = sut.internalViewController as? STPAddCardViewController else {
+            XCTFail()
+            return
+        }
+        XCTAssertNotNil(payMethodsInternal.customFooterView)
+    }
+
+    // Tests for race condition where the promise for fetching payment methods
+    // finishes in the context of intializing the sut, and the `paymentOptionsViewControllerFooterView`
+    // is set directly after init, while internalViewController is `STPPaymentOptionsInternalViewController`
+    func testSetAfterInit_paymentOptionsViewControllerFooterView_STPPaymentOptionsInternalViewController() {
+        let customer = STPFixtures.customerWithSingleCardTokenSource()
+        let paymentMethods = [STPFixtures.paymentMethod()]
+        let config = STPFixtures.paymentConfiguration()
+        let delegate = MockSTPPaymentOptionsViewControllerDelegate()
+        let sut = buildViewController(
+            with: customer,
+            paymentMethods: paymentMethods.compactMap { $0 },
+            configuration: config,
+            delegate: delegate
+        )
+        sut.paymentOptionsViewControllerFooterView = UIView(frame: CGRectZero)
+        guard let payMethodsInternal = sut.internalViewController as? STPPaymentOptionsInternalViewController else {
+            XCTFail()
+            return
+        }
+        XCTAssertNotNil(payMethodsInternal.customFooterView)
+    }
+
+    // Tests for race condition where the promise for fetching payment methods
+    // finishes in the context of init the sut, and the `addCardViewControllerFooterView`
+    // is set directly after init, while internalViewController is `STPPaymentOptionsInternalViewController`
+    func testSetAfterInit_addCardViewControllerFooterView_STPPaymentOptionsInternalViewController() {
+        let customer = STPFixtures.customerWithSingleCardTokenSource()
+        let paymentMethods = [STPFixtures.paymentMethod()]
+        let config = STPFixtures.paymentConfiguration()
+        let delegate = MockSTPPaymentOptionsViewControllerDelegate()
+        let sut = buildViewController(
+            with: customer,
+            paymentMethods: paymentMethods.compactMap { $0 },
+            configuration: config,
+            delegate: delegate
+        )
+        sut.addCardViewControllerFooterView = UIView(frame: CGRectZero)
+        guard let payMethodsInternal = sut.internalViewController as? STPPaymentOptionsInternalViewController else {
+            XCTFail()
+            return
+        }
+        XCTAssertNotNil(payMethodsInternal.addCardViewControllerCustomFooterView)
+    }
+
+    // Tests for race condition where the promise for fetching payment methods
+    // finishes in the context of init the sut, and the `prefilledInformation`
+    // is set directly after init, while internalViewController is `STPPaymentOptionsInternalViewController`
+    func testSetAfterInit_prefilledInformation_STPPaymentOptionsInternalViewController() {
+        let customer = STPFixtures.customerWithSingleCardTokenSource()
+        let paymentMethods = [STPFixtures.paymentMethod()]
+        let config = STPFixtures.paymentConfiguration()
+        let delegate = MockSTPPaymentOptionsViewControllerDelegate()
+        let sut = buildViewController(
+            with: customer,
+            paymentMethods: paymentMethods.compactMap { $0 },
+            configuration: config,
+            delegate: delegate
+        )
+        let userInformation = STPUserInformation()
+        let address = STPAddress()
+        address.name = "John Doe"
+        address.line1 = "123 Main"
+        address.city = "Seattle"
+        address.state = "Washington"
+        address.postalCode = "98104"
+        address.phone = "2065551234"
+        userInformation.billingAddress = address
+        sut.prefilledInformation = userInformation
+        guard let payMethodsInternal = sut.internalViewController as? STPPaymentOptionsInternalViewController else {
+            XCTFail()
+            return
+        }
+        XCTAssertNotNil(payMethodsInternal.prefilledInformation)
+    }
+
+    // Tests for race condition where the promise for fetching payment methods
+    // finishes in the context of init the sut, and the `prefilledInformation`
+    // is set directly after init, while internalViewController is `STPAddCardViewController`
+    func testSetAfterInit_prefilledInformation_STPAddCardViewController() {
+        let customer = STPFixtures.customerWithNoSources()
+        let config = STPFixtures.paymentConfiguration()
+        config.applePayEnabled = false
+        let delegate = MockSTPPaymentOptionsViewControllerDelegate()
+        let sut = buildViewController(
+            with: customer,
+            paymentMethods: [],
+            configuration: config,
+            delegate: delegate
+        )
+        let userInformation = STPUserInformation()
+        let address = STPAddress()
+        address.name = "John Doe"
+        address.line1 = "123 Main"
+        address.city = "Seattle"
+        address.state = "Washington"
+        address.postalCode = "98104"
+        address.phone = "2065551234"
+        userInformation.billingAddress = address
+        sut.prefilledInformation = userInformation
+        guard let payMethodsInternal = sut.internalViewController as? STPAddCardViewController else {
+            XCTFail()
+            return
+        }
+        XCTAssertNotNil(payMethodsInternal.prefilledInformation)
+    }
 }

--- a/Stripe/StripeiOSTests/STPPaymentOptionsViewControllerTest.swift
+++ b/Stripe/StripeiOSTests/STPPaymentOptionsViewControllerTest.swift
@@ -253,7 +253,7 @@ class STPPaymentOptionsViewControllerTest: XCTestCase {
             delegate: delegate
         )
         sut.paymentOptionsViewControllerFooterView = UIView()
-        guard let payMethodsInternal = sut.internalViewController as? STPPaymentOptionsInternalViewController else {
+        guard let payMethodsInternal = sut.internalViewController as? AnyObject else {
             XCTFail()
             return
         }
@@ -275,7 +275,7 @@ class STPPaymentOptionsViewControllerTest: XCTestCase {
             delegate: delegate
         )
         sut.addCardViewControllerFooterView = UIView()
-        guard let payMethodsInternal = sut.internalViewController as? STPPaymentOptionsInternalViewController else {
+        guard let payMethodsInternal = sut.internalViewController as? AnyObject else {
             XCTFail()
             return
         }
@@ -306,7 +306,7 @@ class STPPaymentOptionsViewControllerTest: XCTestCase {
         address.phone = "2065551234"
         userInformation.billingAddress = address
         sut.prefilledInformation = userInformation
-        guard let payMethodsInternal = sut.internalViewController as? STPPaymentOptionsInternalViewController else {
+        guard let payMethodsInternal = sut.internalViewController as? AnyObject else {
             XCTFail()
             return
         }

--- a/Stripe/StripeiOSTests/STPPaymentOptionsViewControllerTest.swift
+++ b/Stripe/StripeiOSTests/STPPaymentOptionsViewControllerTest.swift
@@ -230,7 +230,7 @@ class STPPaymentOptionsViewControllerTest: XCTestCase {
             configuration: config,
             delegate: delegate
         )
-        sut.addCardViewControllerFooterView = UIView(frame: CGRectZero)
+        sut.addCardViewControllerFooterView = UIView()
         guard let payMethodsInternal = sut.internalViewController as? STPAddCardViewController else {
             XCTFail()
             return
@@ -252,7 +252,7 @@ class STPPaymentOptionsViewControllerTest: XCTestCase {
             configuration: config,
             delegate: delegate
         )
-        sut.paymentOptionsViewControllerFooterView = UIView(frame: CGRectZero)
+        sut.paymentOptionsViewControllerFooterView = UIView()
         guard let payMethodsInternal = sut.internalViewController as? STPPaymentOptionsInternalViewController else {
             XCTFail()
             return
@@ -274,7 +274,7 @@ class STPPaymentOptionsViewControllerTest: XCTestCase {
             configuration: config,
             delegate: delegate
         )
-        sut.addCardViewControllerFooterView = UIView(frame: CGRectZero)
+        sut.addCardViewControllerFooterView = UIView()
         guard let payMethodsInternal = sut.internalViewController as? STPPaymentOptionsInternalViewController else {
             XCTFail()
             return

--- a/Stripe/StripeiOSTests/STPPaymentOptionsViewControllerTest.swift
+++ b/Stripe/StripeiOSTests/STPPaymentOptionsViewControllerTest.swift
@@ -253,7 +253,7 @@ class STPPaymentOptionsViewControllerTest: XCTestCase {
             delegate: delegate
         )
         sut.paymentOptionsViewControllerFooterView = UIView()
-        guard let payMethodsInternal = sut.internalViewController as? AnyObject else {
+        guard let payMethodsInternal = sut.internalViewController as? STPPaymentOptionsInternalViewController else {
             XCTFail()
             return
         }
@@ -275,7 +275,7 @@ class STPPaymentOptionsViewControllerTest: XCTestCase {
             delegate: delegate
         )
         sut.addCardViewControllerFooterView = UIView()
-        guard let payMethodsInternal = sut.internalViewController as? AnyObject else {
+        guard let payMethodsInternal = sut.internalViewController as? STPPaymentOptionsInternalViewController else {
             XCTFail()
             return
         }
@@ -306,7 +306,7 @@ class STPPaymentOptionsViewControllerTest: XCTestCase {
         address.phone = "2065551234"
         userInformation.billingAddress = address
         sut.prefilledInformation = userInformation
-        guard let payMethodsInternal = sut.internalViewController as? AnyObject else {
+        guard let payMethodsInternal = sut.internalViewController as? STPPaymentOptionsInternalViewController else {
             XCTFail()
             return
         }

--- a/Stripe/StripeiOSTests/STPPaymentOptionsViewControllerTest.swift
+++ b/Stripe/StripeiOSTests/STPPaymentOptionsViewControllerTest.swift
@@ -257,7 +257,9 @@ class STPPaymentOptionsViewControllerTest: XCTestCase {
             XCTFail()
             return
         }
+#if compiler(>=5.7)
         XCTAssertNotNil(payMethodsInternal.customFooterView)
+#endif
     }
 
     // Tests for race condition where the promise for fetching payment methods
@@ -279,7 +281,9 @@ class STPPaymentOptionsViewControllerTest: XCTestCase {
             XCTFail()
             return
         }
+#if compiler(>=5.7)
         XCTAssertNotNil(payMethodsInternal.addCardViewControllerCustomFooterView)
+#endif
     }
 
     // Tests for race condition where the promise for fetching payment methods
@@ -310,7 +314,9 @@ class STPPaymentOptionsViewControllerTest: XCTestCase {
             XCTFail()
             return
         }
+#if compiler(>=5.7)
         XCTAssertNotNil(payMethodsInternal.prefilledInformation)
+#endif
     }
 
     // Tests for race condition where the promise for fetching payment methods


### PR DESCRIPTION
## Summary
Fix race condition in footer view for basic integration payment methods

## Motivation
Issue reported: #2302

## Testing
Manual testing & Added unit tests for xcode 14 only.

This gif demonstrates that the footer within `STPPaymentOptionsInternalViewController` now shows up when a user taps on the payment method, before the response has fully loaded:
![2314_footerIsShown](https://user-images.githubusercontent.com/99628984/221642431-6779e377-cfc9-4f4a-8207-08bd0bef9e74.gif)


This gif demonstrates the `STPAddCardViewController` class being displayed instead of `STPPaymentOptionsInternalViewController`, because we have configured it to have no payment methods.  It demonstrates that the prefilledInformation is being properly passed down to these subview controllers and populating the UI with that information.
![2314_addCard](https://user-images.githubusercontent.com/99628984/221643081-bfb00143-20f5-4478-a27e-768e0fd01db5.gif)


