### PR TITLE
[Link] Add initial StripeLinkCore module

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -144,6 +144,12 @@ let package = Package(
             resources: [
                 .process("Resources/Images"),
             ]
+        ),
+        .target(
+            name: "StripeLinkCore",
+            //dependencies: ["StripeCore"],
+            path: "StripeLinkCore/StripeLinkCore",
+            exclude: ["Info.plist"]
         )
     ]
 )

--- a/StripeLinkCore.podspec
+++ b/StripeLinkCore.podspec
@@ -1,0 +1,22 @@
+Pod::Spec.new do |s|
+  s.name                           = 'StripeLinkCore'
+
+  # Do not update s.version directly.
+  # Instead, update the VERSION file and run ./ci_scripts/update_version.sh
+  s.version                        = '23.4.0'
+
+  s.summary                        = 'StripeLinkCore contains shared infrastructure used by all Stripe pods. '\
+                                     'It is not meant to be used without other Stripe pods.'
+  s.license                        = { type: 'MIT', file: 'LICENSE' }
+  s.homepage                       = 'https://stripe.com/docs/mobile/ios'
+  s.authors                        = { 'Stripe' => 'support+github@stripe.com' }
+  s.source                         = { git: 'https://github.com/stripe/stripe-ios.git', tag: s.version.to_s }
+  s.frameworks                     = 'Foundation'
+  s.requires_arc                   = true
+  s.platform                       = :ios
+  s.ios.deployment_target          = '13.0'
+  s.swift_version                  = '5.0'
+  s.weak_framework                 = 'SwiftUI'
+  s.source_files                   = 'StripeLinkCore/StripeLinkCore/**/*.swift'
+  # s.dependency                       'StripeCore', s.version.to_s
+end

--- a/StripeLinkCore/Project.swift
+++ b/StripeLinkCore/Project.swift
@@ -1,0 +1,14 @@
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = Project.stripeFramework(
+    name: "StripeLinkCore",
+    dependencies: [
+        // .project(target: "StripeCore", path: "//StripeCore"),
+    ],
+    unitTestOptions: .testOptions(
+        dependencies: [
+            // .project(target: "StripeCoreTestUtils", path: "//StripeCore"),
+        ]
+    )
+)

--- a/StripeLinkCore/StripeLinkCore/Info.plist
+++ b/StripeLinkCore/StripeLinkCore/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/StripeLinkCore/StripeLinkCore/Source/Placeholder.swift
+++ b/StripeLinkCore/StripeLinkCore/Source/Placeholder.swift
@@ -1,0 +1,13 @@
+//
+//  Placeholder.swift
+//  StripeLinkCore
+//
+//  Created by Bill Meltsner on 2/23/23.
+//
+
+import Foundation
+
+/* TODO(bmelts):
+ This is a dummy placeholder swift file to make `pod lib lint` validate.
+ It will be deleted when we migrate code to `StripeLinkCore`.
+ */

--- a/StripeLinkCore/StripeLinkCore/StripeLinkCore.h
+++ b/StripeLinkCore/StripeLinkCore/StripeLinkCore.h
@@ -1,0 +1,18 @@
+//
+//  StripeLinkCore.h
+//  StripeLinkCore
+//
+//  Created by Bill Meltsner on 2/23/23.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for StripeLinkCore.
+FOUNDATION_EXPORT double StripeLinkCoreVersionNumber;
+
+//! Project version string for StripeLinkCore.
+FOUNDATION_EXPORT const unsigned char StripeLinkCoreVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <StripeLinkCore/PublicHeader.h>
+
+

--- a/StripeLinkCore/StripeLinkCoreTests/Info.plist
+++ b/StripeLinkCore/StripeLinkCoreTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/StripeLinkCore/StripeLinkCoreTests/StripeLinkCoreTests.swift
+++ b/StripeLinkCore/StripeLinkCoreTests/StripeLinkCoreTests.swift
@@ -1,0 +1,36 @@
+//
+//  StripeLinkCoreTests.swift
+//  StripeLinkCoreTests
+//
+//  Created by Bill Meltsner on 2/23/23.
+//
+
+@testable import StripeLinkCore
+import XCTest
+
+final class StripeLinkCoreTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/Workspace.swift
+++ b/Workspace.swift
@@ -11,6 +11,7 @@ let workspace = Workspace(
         "StripeCore",
         "StripeFinancialConnections",
         "StripeIdentity",
+        "StripeLinkCore",
         "StripePayments",
         "StripePaymentsUI",
         "StripePaymentSheet",
@@ -42,6 +43,7 @@ let workspace = Workspace(
                 .project(path: "StripeIdentity", target: "StripeIdentity"),
                 .project(path: "StripeFinancialConnections", target: "StripeFinancialConnections"),
                 .project(path: "Stripe3DS2", target: "Stripe3DS2"),
+                .project(path: "StripeLinkCore", target: "StripeLinkCore"),
             ])
         ),
         Scheme(
@@ -55,6 +57,7 @@ let workspace = Workspace(
                 .project(path: "StripePaymentSheet", target: "StripePaymentSheet"),
                 .project(path: "StripeUICore", target: "StripeUICore"),
                 .project(path: "Stripe3DS2", target: "Stripe3DS2"),
+                .project(path: "StripeLinkCore", target: "StripeLinkCore"),
             ])
         ),
     ],

--- a/modules.yaml
+++ b/modules.yaml
@@ -193,6 +193,11 @@ modules:
   custom_string_convertible_dir: StripeUICore/StripeUICore/Source/Categories
   supports_catalyst: true
 
+- podspec: StripeLinkCore.podspec
+  scheme: StripeLinkCore
+  framework_name: StripeLinkCore
+  supports_catalyst: true
+
 # All podspecs that get pushed to Cocoapods in the order of dependencies such
 # that a pods dependencies must appear before it in the list.
 # This is the order that podspecs will be pushed to `pod trunk`.
@@ -201,6 +206,7 @@ pod_push_order:
 - StripeUICore.podspec
 - StripeCameraCore.podspec
 - StripeApplePay.podspec
+- StripeLinkCore.podspec
 - StripePayments.podspec
 - StripePaymentsUI.podspec
 - StripePaymentSheet.podspec


### PR DESCRIPTION
## Summary
Add StripeLinkCore as a module.

## Motivation
https://docs.google.com/document/d/17jTE9n9ekPZnoQv7cJlTaAeiuq01dW6vi3w8o8vASVU/edit?pli=1#heading=h.r03jhtm7a53r

## Changelog
Once the dependencies get added, we'll need to figure out a versioning/changelog strategy for communicating this to Carthage/manual integration users, as it will require some effort from them to update.