### PR TITLE
[Identity] Fix IDNumber submit crash

### DIFF
--- a/StripeIdentity/StripeIdentity/Source/Elements/IdNumberElement.swift
+++ b/StripeIdentity/StripeIdentity/Source/Elements/IdNumberElement.swift
@@ -20,7 +20,7 @@ class IdNumberElement: ContainerElement {
 
     let countryCodes: [String]
     let country: DropdownFieldElement
-    let id: TextFieldElement
+    var id: TextFieldElement
 
     init(countryToIDNumberTypes: [String: IdentityElementsFactory.IDNumberSpec], locale: Locale) {
 
@@ -53,12 +53,12 @@ class IdNumberElement: ContainerElement {
         // Change ID input based on country selection
         country.didUpdate = { index in
             let selectedCountryCode = self.countryCodes[index]
-            let id = TextFieldElement(
+            self.id = TextFieldElement(
                 configuration: IDNumberTextFieldConfiguration(
                     spec: countryToIDNumberTypes[selectedCountryCode]
                 )
             )
-            section.elements = [self.country, id]
+            section.elements = [self.country, self.id]
         }
 
         section.delegate = self


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
We incorrectly assigned a new `TextFieldElement` when country is changed, causing the input value not being picked up when button is clicked. Should update the one in `self`.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fix crash


## Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] manually verified

## Recordings
| Before  | After |
| ------------- | ------------- |
| ![idBefore](https://user-images.githubusercontent.com/79880926/221072547-5dee518c-0516-4757-9ef4-8b9c04b7a6b6.gif)  | ![idAfter](https://user-images.githubusercontent.com/79880926/221072558-e9b8e242-e5cb-4e33-998e-1cd7a49d152a.gif) |

 





## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
