### PR TITLE
FC Networking: Polished NetworkingVerificationPane with a new OTP text field

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundMainViewModel.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundMainViewModel.swift
@@ -165,7 +165,7 @@ private func SetupPlayground(
     if !enableTestMode && email == "test@test.com" {
         assertionFailure("\(email) will not work with livemode, it will return rate limit exceeded")
     }
-    
+
     let baseURL = "https://financial-connections-playground-ios.glitch.me"
     let endpoint = "/setup_playground"
     let url = URL(string: baseURL + endpoint)!

--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundMainViewModel.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundMainViewModel.swift
@@ -162,6 +162,10 @@ private func SetupPlayground(
     customSecretKey: String,
     completionHandler: @escaping ([String: String]?) -> Void
 ) {
+    if !enableTestMode && email == "test@test.com" {
+        assertionFailure("\(email) will not work with livemode, it will return rate limit exceeded")
+    }
+    
     let baseURL = "https://financial-connections-playground-ios.glitch.me"
     let endpoint = "/setup_playground"
     let url = URL(string: baseURL + endpoint)!

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/ManualEntry/ManualEntryErrorView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/ManualEntry/ManualEntryErrorView.swift
@@ -9,6 +9,7 @@ import Foundation
 @_spi(STP) import StripeUICore
 import UIKit
 
+@available(iOSApplicationExtension, unavailable)
 final class ManualEntryErrorView: UIView {
 
     init(text: String) {
@@ -32,11 +33,13 @@ final class ManualEntryErrorView: UIView {
             warningIconImageView.heightAnchor.constraint(equalToConstant: warningIconWidthAndHeight),
         ])
 
-        let errorLabel = UILabel()
-        errorLabel.font = errorLabelFont
-        errorLabel.textColor = .textCritical
-        errorLabel.numberOfLines = 0
-        errorLabel.text = text
+        let errorLabel = ClickableLabel(
+            font: errorLabelFont,
+            boldFont: .stripeFont(forTextStyle: .bodyEmphasized),
+            linkFont: .stripeFont(forTextStyle: .bodyEmphasized),
+            textColor: .textCritical
+        )
+        errorLabel.setText(text)
         errorLabel.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
 
         let horizontalStackView = UIStackView(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/ManualEntry/ManualEntryFormView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/ManualEntry/ManualEntryFormView.swift
@@ -10,10 +10,12 @@ import Foundation
 import SwiftUI
 import UIKit
 
+@available(iOSApplicationExtension, unavailable)
 protocol ManualEntryFormViewDelegate: AnyObject {
     func manualEntryFormViewTextDidChange(_ view: ManualEntryFormView)
 }
 
+@available(iOSApplicationExtension, unavailable)
 final class ManualEntryFormView: UIView {
 
     weak var delegate: ManualEntryFormViewDelegate?
@@ -177,6 +179,7 @@ final class ManualEntryFormView: UIView {
 
 // MARK: - ManualEntryTextFieldDelegate
 
+@available(iOSApplicationExtension, unavailable)
 extension ManualEntryFormView: ManualEntryTextFieldDelegate {
 
     func manualEntryTextField(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/ManualEntry/ManualEntryTextField.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/ManualEntry/ManualEntryTextField.swift
@@ -9,6 +9,7 @@ import Foundation
 @_spi(STP) import StripeUICore
 import UIKit
 
+@available(iOSApplicationExtension, unavailable)
 protocol ManualEntryTextFieldDelegate: AnyObject {
     func manualEntryTextField(
         _ textField: ManualEntryTextField,
@@ -19,6 +20,7 @@ protocol ManualEntryTextFieldDelegate: AnyObject {
     func manualEntryTextFieldDidEndEditing(_ textField: ManualEntryTextField)
 }
 
+@available(iOSApplicationExtension, unavailable)
 final class ManualEntryTextField: UIView {
 
     private lazy var verticalStackView: UIStackView = {
@@ -151,6 +153,7 @@ final class ManualEntryTextField: UIView {
 
 // MARK: - UITextFieldDelegate
 
+@available(iOSApplicationExtension, unavailable)
 extension ManualEntryTextField: UITextFieldDelegate {
 
     func textField(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -636,9 +636,11 @@ extension NativeFlowController: NetworkingLinkVerificationViewControllerDelegate
     func networkingLinkVerificationViewController(
         _ viewController: NetworkingLinkVerificationViewController,
         didRequestNextPane nextPane: FinancialConnectionsSessionManifest.NextPane,
-        consumerSession: ConsumerSessionData
+        consumerSession: ConsumerSessionData?
     ) {
-        dataManager.consumerSession = consumerSession
+        if let consumerSession = consumerSession {
+            dataManager.consumerSession = consumerSession
+        }
         pushPane(nextPane, animated: true)
     }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationBodyView.swift
@@ -22,7 +22,7 @@ protocol NetworkingLinkVerificationBodyViewDelegate: AnyObject {
 final class NetworkingLinkVerificationBodyView: UIView {
 
     weak var delegate: NetworkingLinkVerificationBodyViewDelegate?
-    
+
     private lazy var otpVerticalStackView: UIStackView = {
         let otpVerticalStackView = UIStackView(
             arrangedSubviews: [
@@ -71,16 +71,16 @@ final class NetworkingLinkVerificationBodyView: UIView {
 
     @objc private func otpTextFieldDidChange() {
         showErrorText(nil) // clear the error
-        
+
         if otpTextField.isComplete {
             delegate?.networkingLinkVerificationBodyView(self, didEnterValidOTPCode: otpTextField.value)
         }
     }
-    
+
     func showErrorText(_ errorText: String?) {
         lastErrorView?.removeFromSuperview()
         lastErrorView = nil
-        
+
         if let errorText = errorText {
             // TODO(kgaidis): rename & move `ManualEntryErrorView` to be more generic
             let errorView = ManualEntryErrorView(text: errorText)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationBodyView.swift
@@ -92,7 +92,7 @@ final class NetworkingLinkVerificationBodyView: UIView {
 
 private func CreateEmailLabel(email: String) -> UIView {
     let emailLabel = UILabel()
-    emailLabel.text = "Signing in as \(email)" // TODO(kgaidis): wrap with localizable strings
+    emailLabel.text = String(format: STPLocalizedString("Signing in as %@", "A footnote that explains the user that when they enter an one-time-password code (OTP), they will be signing in as the email in this footnote. '%@' is replaced with an email, for examle: 'Signing in as user@gmail.com'."), email)
     emailLabel.font = .stripeFont(forTextStyle: .captionTight)
     emailLabel.textColor = .textSecondary
     return emailLabel

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationDataSource.swift
@@ -55,7 +55,7 @@ final class NetworkingLinkVerificationDataSourceImplementation: NetworkingLinkVe
                 return Promise(value: lookupConsumerSessionResponse)
             }
     }
-    
+
     func startVerificationSession() -> Future<ConsumerSessionResponse> {
         guard let consumerSessionClientSecret = consumerSession?.clientSecret else {
             return Promise(error: FinancialConnectionsSheetError.unknown(debugDescription: "invalid startVerificationSession call: no consumerSession.clientSecret"))

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationViewController.swift
@@ -230,7 +230,6 @@ extension NetworkingLinkVerificationViewController: NetworkingLinkVerificationBo
                                         errorName: "MarkLinkVerifiedError",
                                         pane: .networkingLinkVerification
                                     )
-                                // TODO(kgaidis): go to terminal error but double-check
                                 self.delegate?.networkingLinkVerificationViewController(self, didReceiveTerminalError: error)
                             }
                         }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/AuthFlowHelpers.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/AuthFlowHelpers.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import SafariServices
+@_spi(STP) import StripeCore
 
 final class AuthFlowHelpers {
 
@@ -52,6 +53,38 @@ final class AuthFlowHelpers {
             handleStripeScheme(url.host)
         } else {
             SFSafariViewController.present(url: url)
+        }
+    }
+
+    @available(iOSApplicationExtension, unavailable)
+    static func networkingOTPErrorMessage(
+        fromError error: Error,
+        otpType: String // TODO(kgaidis): move this to be type-safe after Link framework intro
+    ) -> String? {
+        if
+            let error = error as? StripeError,
+            case .apiError(let apiError) = error
+        {
+            if apiError.code == "consumer_verification_code_invalid" {
+                return STPLocalizedString("Hmm, that code didn’t work. Double check it and try again.", "Error message when one-time-passcode (OTP) is invalid.")
+            } else if
+                apiError.code == "consumer_session_expired"
+                || apiError.code == "consumer_verification_expired"
+                || apiError.code == "consumer_verification_max_attempts_exceeded"
+            {
+                let leadingMessage = STPLocalizedString("It looks like the verification code you provided is not valid anymore.", "The leading text in an error message that explains that the one-type-passcode (OTP) the user provided is invalid. This is leading text embedded inside of larger text: 'It looks like the verification code you provided is not valid anymore. Try again, or contact us.'")
+                let trailingMessage = (otpType == "EMAIL") ? STPLocalizedString("Click “Resend code” and try again, or %@.", "Text as part of an error message that shows up when user entered an invalid one-time-passcode (OTP). '%@' will be replaced by text with a link: 'contact us'") : STPLocalizedString("Try again, or %@.", "Text as part of an error message that shows up when user entered an invalid one-time-passcode (OTP). '%@' will be replaced by text with a link: 'contact us'")
+
+                let contactUsText = STPLocalizedString("contact us", "A link/button inside of text that can be tapped to visit a support website. This link will be embedded inside of larger text: 'It looks like the verification code you provided is not valid anymore. Try again, or contact us.'")
+                let contactUsUrlString = "https://support.link.co/contact/email?skipVerification=true"
+                let contactUsWithUrlText = "[\(contactUsText)](\(contactUsUrlString))"
+
+                return leadingMessage + " " + String(format: trailingMessage, contactUsWithUrlText)
+            } else {
+                return nil
+            }
+        } else {
+            return nil
         }
     }
 }


### PR DESCRIPTION
## Summary

This PR polishes NetworkingVerificationPane with a new OTP text field.

Future PR's will likely refactor some of this into reusable parts that can be reused in other verification screens.

This doc has breakdown of the screen/designs:
- https://docs.google.com/document/d/1acZD4TmxD_AgUwRwUyLWvQmBHJ0ze3gdS5v0LY76ASI/edit#heading=h.bjqww0lwyey0

## Testing

### Overall Video

https://user-images.githubusercontent.com/105514761/221676139-04beab13-c054-4e2b-8a13-5d6ddd04d857.mp4

### Testing Various Errors

![OTP_error_1](https://user-images.githubusercontent.com/105514761/221676245-55953509-3957-427f-9659-e3949a2c25bd.png)

![OTP_error_2](https://user-images.githubusercontent.com/105514761/221676251-26c62ae4-2b2c-49db-9497-75d57bee5a8e.png)

### Testing Error Link

https://user-images.githubusercontent.com/105514761/221676421-c67effd4-477d-49f2-9d21-5e2bc340b829.mp4

### Verify Manual Entry Error Looks The Same

![verify_manual_entry_errors](https://user-images.githubusercontent.com/105514761/221676549-7a56c3b4-11d5-4095-8245-df1c6769faea.png)
