### PR TITLE
FC Networking: Introduced a reusable OTP view and utilized it in all the OTP panes

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationBodyView.swift
@@ -11,39 +11,10 @@ import Foundation
 import UIKit
 
 @available(iOSApplicationExtension, unavailable)
-protocol NetworkingLinkStepUpVerificationBodyViewDelegate: AnyObject {
-    func networkingLinkStepUpVerificationBodyView(
-        _ view: NetworkingLinkStepUpVerificationBodyView,
-        didEnterValidOTPCode otpCode: String
-    )
-}
-
-@available(iOSApplicationExtension, unavailable)
 final class NetworkingLinkStepUpVerificationBodyView: UIView {
 
     private let email: String
     private let didSelectResendCode: () -> Void
-    weak var delegate: NetworkingLinkStepUpVerificationBodyViewDelegate?
-
-    private(set) lazy var otpTextField: UITextField = {
-       let textField = InsetTextField()
-        textField.textColor = .textPrimary
-        textField.placeholder = "OTP"
-        textField.keyboardType = .numberPad
-        textField.layer.cornerRadius = 8
-        textField.layer.borderColor = UIColor.textBrand.cgColor
-        textField.layer.borderWidth = 2.0
-        textField.addTarget(
-            self,
-            action: #selector(otpTextFieldDidChange),
-            for: .editingChanged
-        )
-        NSLayoutConstraint.activate([
-            textField.heightAnchor.constraint(equalToConstant: 56)
-        ])
-
-        return textField
-    }()
 
     private lazy var footnoteHorizontalStackView: UIStackView = {
         let footnoteHorizontalStackView = UIStackView()
@@ -55,6 +26,7 @@ final class NetworkingLinkStepUpVerificationBodyView: UIView {
 
     init(
         email: String,
+        otpView: UIView,
         didSelectResendCode: @escaping () -> Void
     ) {
         self.email = email
@@ -62,7 +34,7 @@ final class NetworkingLinkStepUpVerificationBodyView: UIView {
         super.init(frame: .zero)
         let verticalStackView = UIStackView(
             arrangedSubviews: [
-                otpTextField,
+                otpView,
                 footnoteHorizontalStackView,
             ]
         )
@@ -75,19 +47,6 @@ final class NetworkingLinkStepUpVerificationBodyView: UIView {
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-    @objc private func otpTextFieldDidChange() {
-        guard let otp = otpTextField.text else {
-            return
-        }
-
-        if otp.count == 6 && Int(otp) != nil {
-            delegate?.networkingLinkStepUpVerificationBodyView(
-                self,
-                didEnterValidOTPCode: otp
-            )
-        }
     }
 
     func isResendingCode(_ isResendingCode: Bool) {
@@ -187,6 +146,7 @@ private struct NetworkingLinkStepUpVerificationBodyViewUIViewRepresentable: UIVi
     func makeUIView(context: Context) -> NetworkingLinkStepUpVerificationBodyView {
         NetworkingLinkStepUpVerificationBodyView(
             email: "test@stripe.com",
+            otpView: UIView(),
             didSelectResendCode: {}
         )
     }
@@ -208,31 +168,3 @@ struct NetworkingLinkStepUpVerificationBodyView_Previews: PreviewProvider {
 }
 
 #endif
-
-private class InsetTextField: UITextField { // TODO(kgaidis): cleanup/delete after using Stripe's components
-
-    private let padding = UIEdgeInsets(
-        top: 0,
-        left: 10,
-        bottom: 0,
-        right: 10
-    )
-
-    override open func textRect(
-        forBounds bounds: CGRect
-    ) -> CGRect {
-        return bounds.inset(by: padding)
-    }
-
-    override open func placeholderRect(
-        forBounds bounds: CGRect
-    ) -> CGRect {
-        return bounds.inset(by: padding)
-    }
-
-    override open func editingRect(
-        forBounds bounds: CGRect
-    ) -> CGRect {
-        return bounds.inset(by: padding)
-    }
-}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationDataSource.swift
@@ -46,6 +46,7 @@ final class NetworkingLinkStepUpVerificationDataSourceImplementation: Networking
             emailAddress: consumerSession.emailAddress,
             customEmailType: "NETWORKED_CONNECTIONS_OTP_EMAIL",
             connectionsMerchantName: manifest.businessName,
+            pane: .networkingLinkStepUpVerification,
             consumerSession: nil,
             apiClient: apiClient,
             clientSecret: clientSecret,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationDataSource.swift
@@ -46,6 +46,7 @@ final class NetworkingLinkStepUpVerificationDataSourceImplementation: Networking
             emailAddress: consumerSession.emailAddress,
             customEmailType: "NETWORKED_CONNECTIONS_OTP_EMAIL",
             connectionsMerchantName: manifest.businessName,
+            consumerSession: nil,
             apiClient: apiClient,
             clientSecret: clientSecret,
             analyticsClient: analyticsClient

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationDataSource.swift
@@ -11,10 +11,8 @@ import Foundation
 protocol NetworkingLinkStepUpVerificationDataSource: AnyObject {
     var consumerSession: ConsumerSessionData { get }
     var analyticsClient: FinancialConnectionsAnalyticsClient { get }
+    var networkingOTPDataSource: NetworkingOTPDataSource { get }
 
-    func lookupConsumerSession() -> Future<LookupConsumerSessionResponse>
-    func startVerificationSession() -> Future<ConsumerSessionResponse>
-    func confirmVerificationSession(otpCode: String) -> Future<ConsumerSessionResponse>
     func markLinkStepUpAuthenticationVerified() -> Future<FinancialConnectionsSessionManifest>
     func selectNetworkedAccount() -> Future<FinancialConnectionsInstitutionList>
 }
@@ -27,6 +25,7 @@ final class NetworkingLinkStepUpVerificationDataSourceImplementation: Networking
     private let apiClient: FinancialConnectionsAPIClient
     private let clientSecret: String
     let analyticsClient: FinancialConnectionsAnalyticsClient
+    let networkingOTPDataSource: NetworkingOTPDataSource
 
     init(
         consumerSession: ConsumerSessionData,
@@ -42,41 +41,17 @@ final class NetworkingLinkStepUpVerificationDataSourceImplementation: Networking
         self.apiClient = apiClient
         self.clientSecret = clientSecret
         self.analyticsClient = analyticsClient
-    }
-
-    func lookupConsumerSession() -> Future<LookupConsumerSessionResponse> {
-        return apiClient
-            .consumerSessionLookup(
-                emailAddress: consumerSession.emailAddress
-            )
-            .chained { [weak self] lookupConsumerSessionResponse in
-                if let consumerSession = lookupConsumerSessionResponse.consumerSession {
-                    self?.consumerSession = consumerSession
-                }
-                return Promise(value: lookupConsumerSessionResponse)
-            }
-    }
-
-    func startVerificationSession() -> Future<ConsumerSessionResponse> {
-        return apiClient.consumerSessionStartVerification(
-            emailAddress: consumerSession.emailAddress,
+        let networkingOTPDataSource = NetworkingOTPDataSourceImplementation(
             otpType: "EMAIL",
+            emailAddress: consumerSession.emailAddress,
             customEmailType: "NETWORKED_CONNECTIONS_OTP_EMAIL",
             connectionsMerchantName: manifest.businessName,
-            consumerSessionClientSecret: consumerSession.clientSecret
+            apiClient: apiClient,
+            clientSecret: clientSecret,
+            analyticsClient: analyticsClient
         )
-        .chained { [weak self] consumerSessionResponse in
-            self?.consumerSession = consumerSessionResponse.consumerSession
-            return Promise(value: consumerSessionResponse)
-        }
-    }
-
-    func confirmVerificationSession(otpCode: String) -> Future<ConsumerSessionResponse> {
-        return apiClient.consumerSessionConfirmVerification(
-            otpCode: otpCode,
-            otpType: "EMAIL",
-            consumerSessionClientSecret: consumerSession.clientSecret
-        )
+        self.networkingOTPDataSource = networkingOTPDataSource
+        networkingOTPDataSource.delegate = self
     }
 
     func markLinkStepUpAuthenticationVerified() -> Future<FinancialConnectionsSessionManifest> {
@@ -89,5 +64,17 @@ final class NetworkingLinkStepUpVerificationDataSourceImplementation: Networking
             clientSecret: clientSecret,
             consumerSessionClientSecret: consumerSession.clientSecret
         )
+    }
+}
+
+// MARK: - NetworkingOTPDataSourceDelegate
+
+extension NetworkingLinkStepUpVerificationDataSourceImplementation: NetworkingOTPDataSourceDelegate {
+
+    func networkingOTPDataSource(
+        _ dataSource: NetworkingOTPDataSource,
+        didUpdateConsumerSession consumerSession: ConsumerSessionData
+    ) {
+        self.consumerSession = consumerSession
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationViewController.swift
@@ -168,6 +168,10 @@ extension NetworkingLinkStepUpVerificationViewController: NetworkingOTPViewDeleg
         handleFailure(error: error, errorName: "LookupConsumerSessionError")
     }
 
+    func networkingOTPViewWillStartVerification(_ view: NetworkingOTPView) {
+        // no-op
+    }
+
     func networkingOTPView(_ view: NetworkingOTPView, didStartVerification consumerSession: ConsumerSessionData) {
         // it's important to call this BEFORE we call `showContent` because of `didShowContent`
         if !didShowContent {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationBodyView.swift
@@ -11,52 +11,13 @@ import Foundation
 import UIKit
 
 @available(iOSApplicationExtension, unavailable)
-protocol NetworkingLinkVerificationBodyViewDelegate: AnyObject {
-    func networkingLinkVerificationBodyView(
-        _ view: NetworkingLinkVerificationBodyView,
-        didEnterValidOTPCode otpCode: String
-    )
-}
-
-@available(iOSApplicationExtension, unavailable)
 final class NetworkingLinkVerificationBodyView: UIView {
 
-    weak var delegate: NetworkingLinkVerificationBodyViewDelegate?
-
-    private lazy var otpVerticalStackView: UIStackView = {
-        let otpVerticalStackView = UIStackView(
-            arrangedSubviews: [
-                otpTextField,
-            ]
-        )
-        otpVerticalStackView.axis = .vertical
-        otpVerticalStackView.spacing = 8
-        return otpVerticalStackView
-    }()
-    // TODO(kgaidis): make changes to `OneTimeCodeTextField` to
-    // make the font larger
-    private(set) lazy var otpTextField: OneTimeCodeTextField = {
-        let otpTextField = OneTimeCodeTextField(numberOfDigits: 6, theme: theme)
-        otpTextField.tintColor = .textBrand
-        otpTextField.addTarget(self, action: #selector(otpTextFieldDidChange), for: .valueChanged)
-        return otpTextField
-    }()
-    private lazy var theme: ElementsUITheme = {
-        var theme: ElementsUITheme = .default
-        theme.colors = {
-            var colors = ElementsUITheme.Color()
-            colors.border = .borderNeutral
-            return colors
-        }()
-        return theme
-    }()
-    private var lastErrorView: UIView?
-
-    init(email: String) {
+    init(email: String, otpView: UIView) {
         super.init(frame: .zero)
         let verticalStackView = UIStackView(
             arrangedSubviews: [
-                otpVerticalStackView,
+                otpView,
                 CreateEmailLabel(email: email),
             ]
         )
@@ -67,26 +28,6 @@ final class NetworkingLinkVerificationBodyView: UIView {
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-    @objc private func otpTextFieldDidChange() {
-        showErrorText(nil) // clear the error
-
-        if otpTextField.isComplete {
-            delegate?.networkingLinkVerificationBodyView(self, didEnterValidOTPCode: otpTextField.value)
-        }
-    }
-
-    func showErrorText(_ errorText: String?) {
-        lastErrorView?.removeFromSuperview()
-        lastErrorView = nil
-
-        if let errorText = errorText {
-            // TODO(kgaidis): rename & move `ManualEntryErrorView` to be more generic
-            let errorView = ManualEntryErrorView(text: errorText)
-            self.lastErrorView = errorView
-            otpVerticalStackView.addArrangedSubview(errorView)
-        }
     }
 }
 
@@ -107,7 +48,8 @@ private struct NetworkingLinkVerificationBodyViewUIViewRepresentable: UIViewRepr
 
     func makeUIView(context: Context) -> NetworkingLinkVerificationBodyView {
         NetworkingLinkVerificationBodyView(
-            email: "test@stripe.com"
+            email: "test@stripe.com",
+            otpView: UIView()
         )
     }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationDataSource.swift
@@ -47,6 +47,7 @@ final class NetworkingLinkVerificationDataSourceImplementation: NetworkingLinkVe
             emailAddress: accountholderCustomerEmailAddress,
             customEmailType: nil,
             connectionsMerchantName: nil,
+            pane: .networkingLinkVerification,
             consumerSession: nil,
             apiClient: apiClient,
             clientSecret: clientSecret,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationDataSource.swift
@@ -47,6 +47,7 @@ final class NetworkingLinkVerificationDataSourceImplementation: NetworkingLinkVe
             emailAddress: accountholderCustomerEmailAddress,
             customEmailType: nil,
             connectionsMerchantName: nil,
+            consumerSession: nil,
             apiClient: apiClient,
             clientSecret: clientSecret,
             analyticsClient: analyticsClient

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationDataSource.swift
@@ -45,6 +45,8 @@ final class NetworkingLinkVerificationDataSourceImplementation: NetworkingLinkVe
         let networkingOTPDataSource = NetworkingOTPDataSourceImplementation(
             otpType: "SMS",
             emailAddress: accountholderCustomerEmailAddress,
+            customEmailType: nil,
+            connectionsMerchantName: nil,
             apiClient: apiClient,
             clientSecret: clientSecret,
             analyticsClient: analyticsClient
@@ -71,7 +73,7 @@ final class NetworkingLinkVerificationDataSourceImplementation: NetworkingLinkVe
 // MARK: - NetworkingOTPDataSourceDelegate
 
 extension NetworkingLinkVerificationDataSourceImplementation: NetworkingOTPDataSourceDelegate {
-    
+
     func networkingOTPDataSource(_ dataSource: NetworkingOTPDataSource, didUpdateConsumerSession consumerSession: ConsumerSessionData) {
         self.consumerSession = consumerSession
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationDataSource.swift
@@ -13,10 +13,8 @@ protocol NetworkingLinkVerificationDataSource: AnyObject {
     var manifest: FinancialConnectionsSessionManifest { get }
     var analyticsClient: FinancialConnectionsAnalyticsClient { get }
     var consumerSession: ConsumerSessionData? { get }
+    var networkingOTPDataSource: NetworkingOTPDataSource { get }
 
-    func lookupConsumerSession() -> Future<LookupConsumerSessionResponse>
-    func startVerificationSession() -> Future<ConsumerSessionResponse>
-    func confirmVerificationSession(otpCode: String) -> Future<ConsumerSessionResponse>
     func markLinkVerified() -> Future<FinancialConnectionsSessionManifest>
     func fetchNetworkedAccounts() -> Future<FinancialConnectionsNetworkedAccountsResponse>
 }
@@ -28,6 +26,7 @@ final class NetworkingLinkVerificationDataSourceImplementation: NetworkingLinkVe
     private let apiClient: FinancialConnectionsAPIClient
     private let clientSecret: String
     let analyticsClient: FinancialConnectionsAnalyticsClient
+    let networkingOTPDataSource: NetworkingOTPDataSource
 
     private(set) var consumerSession: ConsumerSessionData?
 
@@ -43,42 +42,15 @@ final class NetworkingLinkVerificationDataSourceImplementation: NetworkingLinkVe
         self.apiClient = apiClient
         self.clientSecret = clientSecret
         self.analyticsClient = analyticsClient
-    }
-
-    func lookupConsumerSession() -> Future<LookupConsumerSessionResponse> {
-        apiClient
-            .consumerSessionLookup(
-                emailAddress: accountholderCustomerEmailAddress
-            )
-            .chained { [weak self] lookupConsumerSessionResponse in
-                self?.consumerSession = lookupConsumerSessionResponse.consumerSession
-                return Promise(value: lookupConsumerSessionResponse)
-            }
-    }
-
-    func startVerificationSession() -> Future<ConsumerSessionResponse> {
-        guard let consumerSessionClientSecret = consumerSession?.clientSecret else {
-            return Promise(error: FinancialConnectionsSheetError.unknown(debugDescription: "invalid startVerificationSession call: no consumerSession.clientSecret"))
-        }
-        return apiClient.consumerSessionStartVerification(
-            emailAddress: self.accountholderCustomerEmailAddress,
+        let networkingOTPDataSource = NetworkingOTPDataSourceImplementation(
             otpType: "SMS",
-            customEmailType: nil,
-            connectionsMerchantName: nil,
-            consumerSessionClientSecret: consumerSessionClientSecret
+            emailAddress: accountholderCustomerEmailAddress,
+            apiClient: apiClient,
+            clientSecret: clientSecret,
+            analyticsClient: analyticsClient
         )
-
-    }
-
-    func confirmVerificationSession(otpCode: String) -> Future<ConsumerSessionResponse> {
-        guard let consumerSessionClientSecret = consumerSession?.clientSecret else {
-            return Promise(error: FinancialConnectionsSheetError.unknown(debugDescription: "invalid confirmVerificationSession state: no consumerSessionClientSecret"))
-        }
-        return apiClient.consumerSessionConfirmVerification(
-            otpCode: otpCode,
-            otpType: "SMS",
-            consumerSessionClientSecret: consumerSessionClientSecret
-        )
+        self.networkingOTPDataSource = networkingOTPDataSource
+        networkingOTPDataSource.delegate = self
     }
 
     func markLinkVerified() -> Future<FinancialConnectionsSessionManifest> {
@@ -93,5 +65,14 @@ final class NetworkingLinkVerificationDataSourceImplementation: NetworkingLinkVe
             clientSecret: clientSecret,
             consumerSessionClientSecret: consumerSessionClientSecret
         )
+    }
+}
+
+// MARK: - NetworkingOTPDataSourceDelegate
+
+extension NetworkingLinkVerificationDataSourceImplementation: NetworkingOTPDataSourceDelegate {
+    
+    func networkingOTPDataSource(_ dataSource: NetworkingOTPDataSource, didUpdateConsumerSession consumerSession: ConsumerSessionData) {
+        self.consumerSession = consumerSession
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationViewController.swift
@@ -146,6 +146,10 @@ extension NetworkingLinkVerificationViewController: NetworkingOTPViewDelegate {
         showLoadingView(false) // started in networkingOTPViewWillStartConsumerLookup
     }
 
+    func networkingOTPViewWillStartVerification(_ view: NetworkingOTPView) {
+        // no-op
+    }
+
     func networkingOTPView(_ view: NetworkingOTPView, didStartVerification consumerSession: ConsumerSessionData) {
         showLoadingView(false) // started in networkingOTPViewWillStartConsumerLookup
         showContent(redactedPhoneNumber: consumerSession.redactedPhoneNumber)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationViewController.swift
@@ -112,11 +112,11 @@ final class NetworkingLinkVerificationViewController: UIViewController {
 
 @available(iOSApplicationExtension, unavailable)
 extension NetworkingLinkVerificationViewController: NetworkingOTPViewDelegate {
-    
+
     func networkingOTPViewWillStartConsumerLookup(_ view: NetworkingOTPView) {
         showLoadingView(true)
     }
-    
+
     func networkingOTPViewConsumerNotFound(_ view: NetworkingOTPView) {
         dataSource.analyticsClient.log(
             eventName: "networking.verification.error",
@@ -128,7 +128,7 @@ extension NetworkingLinkVerificationViewController: NetworkingOTPViewDelegate {
         delegate?.networkingLinkVerificationViewController(self, didRequestNextPane: .institutionPicker, consumerSession: nil)
         showLoadingView(false) // started in networkingOTPViewWillStartConsumerLookup
     }
-    
+
     func networkingOTPView(_ view: NetworkingOTPView, didFailConsumerLookup error: Error) {
         dataSource.analyticsClient.logUnexpectedError(
             error,
@@ -145,15 +145,15 @@ extension NetworkingLinkVerificationViewController: NetworkingOTPViewDelegate {
         delegate?.networkingLinkVerificationViewController(self, didReceiveTerminalError: error)
         showLoadingView(false) // started in networkingOTPViewWillStartConsumerLookup
     }
-    
+
     func networkingOTPView(_ view: NetworkingOTPView, didStartVerification consumerSession: ConsumerSessionData) {
         showLoadingView(false) // started in networkingOTPViewWillStartConsumerLookup
         showContent(redactedPhoneNumber: consumerSession.redactedPhoneNumber)
     }
-    
+
     func networkingOTPView(_ view: NetworkingOTPView, didFailToStartVerification error: Error) {
         showLoadingView(false) // started in networkingOTPViewWillStartConsumerLookup
-        
+
         dataSource.analyticsClient.logUnexpectedError(
             error,
             errorName: "StartVerificationSessionError",
@@ -168,7 +168,7 @@ extension NetworkingLinkVerificationViewController: NetworkingOTPViewDelegate {
         )
         delegate?.networkingLinkVerificationViewController(self, didReceiveTerminalError: error)
     }
-    
+
     func networkingOTPViewDidConfirmVerification(_ view: NetworkingOTPView) {
         dataSource.markLinkVerified()
             .observe { [weak self] result in
@@ -226,8 +226,8 @@ extension NetworkingLinkVerificationViewController: NetworkingOTPViewDelegate {
                 }
             }
     }
-    
+
     func networkingOTPView(_ view: NetworkingOTPView, didTerminallyFailToConfirmVerification error: Error) {
         delegate?.networkingLinkVerificationViewController(self, didReceiveTerminalError: error)
-    }   
+    }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationViewController.swift
@@ -36,9 +36,16 @@ final class NetworkingLinkVerificationViewController: UIViewController {
         return activityIndicator
     }()
     private lazy var bodyView: NetworkingLinkVerificationBodyView = {
-        let bodyView = NetworkingLinkVerificationBodyView(email: dataSource.accountholderCustomerEmailAddress)
-        bodyView.delegate = self
+        let bodyView = NetworkingLinkVerificationBodyView(
+            email: dataSource.accountholderCustomerEmailAddress,
+            otpView: otpView
+        )
         return bodyView
+    }()
+    private lazy var otpView: NetworkingOTPView = {
+        let otpView = NetworkingOTPView(dataSource: dataSource.networkingOTPDataSource)
+        otpView.delegate = self
+        return otpView
     }()
 
     init(dataSource: NetworkingLinkVerificationDataSource) {
@@ -53,65 +60,7 @@ final class NetworkingLinkVerificationViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .customBackgroundColor
-
-        showLoadingView(true)
-        dataSource.lookupConsumerSession()
-            .observe { [weak self] result in
-                guard let self = self else { return }
-                switch result {
-                case .success(let lookupConsumerSessionResponse):
-                    if lookupConsumerSessionResponse.exists {
-                        self.dataSource.startVerificationSession()
-                            .observe { [weak self] result in
-                                guard let self = self else { return }
-                                self.showLoadingView(false)
-                                switch result {
-                                case .success(let consumerSessionResponse):
-                                    self.showContent(redactedPhoneNumber: consumerSessionResponse.consumerSession.redactedPhoneNumber)
-                                case .failure(let error):
-                                    self.dataSource.analyticsClient.logUnexpectedError(
-                                        error,
-                                        errorName: "StartVerificationSessionError",
-                                        pane: .networkingLinkVerification
-                                    )
-                                    self.dataSource.analyticsClient.log(
-                                        eventName: "networking.verification.error",
-                                        parameters: [
-                                            "error": "StartVerificationSession"
-                                        ],
-                                        pane: .networkingLinkVerification
-                                    )
-                                    self.delegate?.networkingLinkVerificationViewController(self, didReceiveTerminalError: error)
-                                }
-                            }
-                    } else {
-                        self.dataSource.analyticsClient.log(
-                            eventName: "networking.verification.error",
-                            parameters: [
-                                "error": "ConsumerNotFoundError"
-                            ],
-                            pane: .networkingLinkVerification
-                        )
-                        self.delegate?.networkingLinkVerificationViewController(self, didRequestNextPane: .institutionPicker, consumerSession: nil)
-                        self.showLoadingView(false)
-                    }
-                case .failure(let error):
-                    self.dataSource.analyticsClient.logUnexpectedError(
-                        error,
-                        errorName: "LookupConsumerSessionError",
-                        pane: .networkingLinkVerification
-                    )
-                    self.dataSource.analyticsClient.log(
-                        eventName: "networking.verification.error",
-                        parameters: [
-                            "error": "LookupConsumerSession"
-                        ],
-                        pane: .networkingLinkVerification
-                    )
-                    self.delegate?.networkingLinkVerificationViewController(self, didReceiveTerminalError: error)
-                    self.showLoadingView(false)
-                }
-            }
+        otpView.lookupConsumerAndStartVerification()
     }
 
     private func showContent(redactedPhoneNumber: String) {
@@ -128,8 +77,6 @@ final class NetworkingLinkVerificationViewController: UIViewController {
             footerView: nil
         )
         pane.addTo(view: view)
-
-        bodyView.otpTextField.becomeFirstResponder()
     }
 
     private func showLoadingView(_ show: Bool) {
@@ -161,102 +108,126 @@ final class NetworkingLinkVerificationViewController: UIViewController {
     }
 }
 
-// MARK: - NetworkingLinkVerificationBodyViewDelegate
+// MARK: - NetworkingOTPViewDelegate
 
 @available(iOSApplicationExtension, unavailable)
-extension NetworkingLinkVerificationViewController: NetworkingLinkVerificationBodyViewDelegate {
-
-    func networkingLinkVerificationBodyView(
-        _ bodyView: NetworkingLinkVerificationBodyView,
-        didEnterValidOTPCode otpCode: String
-    ) {
-        bodyView.otpTextField.resignFirstResponder()
-        // TODO(kgaidis): consider implementing a loading/grayed-out state for `otpTextField`
-
-        dataSource.confirmVerificationSession(otpCode: otpCode)
+extension NetworkingLinkVerificationViewController: NetworkingOTPViewDelegate {
+    
+    func networkingOTPViewWillStartConsumerLookup(_ view: NetworkingOTPView) {
+        showLoadingView(true)
+    }
+    
+    func networkingOTPViewConsumerNotFound(_ view: NetworkingOTPView) {
+        dataSource.analyticsClient.log(
+            eventName: "networking.verification.error",
+            parameters: [
+                "error": "ConsumerNotFoundError"
+            ],
+            pane: .networkingLinkVerification
+        )
+        delegate?.networkingLinkVerificationViewController(self, didRequestNextPane: .institutionPicker, consumerSession: nil)
+        showLoadingView(false) // started in networkingOTPViewWillStartConsumerLookup
+    }
+    
+    func networkingOTPView(_ view: NetworkingOTPView, didFailConsumerLookup error: Error) {
+        dataSource.analyticsClient.logUnexpectedError(
+            error,
+            errorName: "LookupConsumerSessionError",
+            pane: .networkingLinkVerification
+        )
+        dataSource.analyticsClient.log(
+            eventName: "networking.verification.error",
+            parameters: [
+                "error": "LookupConsumerSession"
+            ],
+            pane: .networkingLinkVerification
+        )
+        delegate?.networkingLinkVerificationViewController(self, didReceiveTerminalError: error)
+        showLoadingView(false) // started in networkingOTPViewWillStartConsumerLookup
+    }
+    
+    func networkingOTPView(_ view: NetworkingOTPView, didStartVerification consumerSession: ConsumerSessionData) {
+        showLoadingView(false) // started in networkingOTPViewWillStartConsumerLookup
+        showContent(redactedPhoneNumber: consumerSession.redactedPhoneNumber)
+    }
+    
+    func networkingOTPView(_ view: NetworkingOTPView, didFailToStartVerification error: Error) {
+        showLoadingView(false) // started in networkingOTPViewWillStartConsumerLookup
+        
+        dataSource.analyticsClient.logUnexpectedError(
+            error,
+            errorName: "StartVerificationSessionError",
+            pane: .networkingLinkVerification
+        )
+        dataSource.analyticsClient.log(
+            eventName: "networking.verification.error",
+            parameters: [
+                "error": "StartVerificationSession"
+            ],
+            pane: .networkingLinkVerification
+        )
+        delegate?.networkingLinkVerificationViewController(self, didReceiveTerminalError: error)
+    }
+    
+    func networkingOTPViewDidConfirmVerification(_ view: NetworkingOTPView) {
+        dataSource.markLinkVerified()
             .observe { [weak self] result in
                 guard let self = self else { return }
                 switch result {
-                case .success:
-                    self.dataSource.markLinkVerified()
+                case .success(let manifest):
+                    self.dataSource.fetchNetworkedAccounts()
                         .observe { [weak self] result in
                             guard let self = self else { return }
                             switch result {
-                            case .success(let manifest):
-                                self.dataSource.fetchNetworkedAccounts()
-                                    .observe { [weak self] result in
-                                        guard let self = self else { return }
-                                        switch result {
-                                        case .success(let networkedAccountsResponse):
-                                            let networkedAccounts = networkedAccountsResponse.data
-                                            if networkedAccounts.isEmpty {
-                                                self.dataSource.analyticsClient.log(
-                                                    eventName: "networking.verification.success_no_accounts",
-                                                    pane: .networkingLinkVerification
-                                                )
-                                                self.requestNextPane(manifest.nextPane)
-                                            } else {
-                                                self.dataSource.analyticsClient.log(
-                                                    eventName: "networking.verification.success",
-                                                    pane: .networkingLinkVerification
-                                                )
-                                                self.requestNextPane(.linkAccountPicker)
-                                            }
-                                        case .failure(let error):
-                                            self.dataSource
-                                                .analyticsClient
-                                                .logUnexpectedError(
-                                                    error,
-                                                    errorName: "FetchNetworkedAccountsError",
-                                                    pane: .networkingLinkVerification
-                                                )
-                                            self.dataSource
-                                                .analyticsClient
-                                                .log(
-                                                    eventName: "networking.verification.error",
-                                                    parameters: [
-                                                        "error": "NetworkedAccountsRetrieveMethodError",
-                                                    ],
-                                                    pane: .networkingLinkVerification
-                                                )
-                                            self.requestNextPane(manifest.nextPane)
-                                        }
-                                    }
+                            case .success(let networkedAccountsResponse):
+                                let networkedAccounts = networkedAccountsResponse.data
+                                if networkedAccounts.isEmpty {
+                                    self.dataSource.analyticsClient.log(
+                                        eventName: "networking.verification.success_no_accounts",
+                                        pane: .networkingLinkVerification
+                                    )
+                                    self.requestNextPane(manifest.nextPane)
+                                } else {
+                                    self.dataSource.analyticsClient.log(
+                                        eventName: "networking.verification.success",
+                                        pane: .networkingLinkVerification
+                                    )
+                                    self.requestNextPane(.linkAccountPicker)
+                                }
                             case .failure(let error):
                                 self.dataSource
                                     .analyticsClient
                                     .logUnexpectedError(
                                         error,
-                                        errorName: "MarkLinkVerifiedError",
+                                        errorName: "FetchNetworkedAccountsError",
                                         pane: .networkingLinkVerification
                                     )
-                                self.delegate?.networkingLinkVerificationViewController(self, didReceiveTerminalError: error)
+                                self.dataSource
+                                    .analyticsClient
+                                    .log(
+                                        eventName: "networking.verification.error",
+                                        parameters: [
+                                            "error": "NetworkedAccountsRetrieveMethodError",
+                                        ],
+                                        pane: .networkingLinkVerification
+                                    )
+                                self.requestNextPane(manifest.nextPane)
                             }
                         }
                 case .failure(let error):
-                    if let errorMessage = AuthFlowHelpers.networkingOTPErrorMessage(fromError: error, otpType: "SMS") {
-                        self.dataSource
-                            .analyticsClient
-                            .logExpectedError(
-                                error,
-                                errorName: "ConfirmVerificationSessionError",
-                                pane: .networkingLinkVerification
-                            )
-
-                        bodyView.otpTextField.performInvalidCodeAnimation(shouldClearValue: false)
-                        bodyView.showErrorText(errorMessage)
-                    } else {
-                        self.dataSource
-                            .analyticsClient
-                            .logUnexpectedError(
-                                error,
-                                errorName: "ConfirmVerificationSessionError",
-                                pane: .networkingLinkVerification
-                            )
-
-                        self.delegate?.networkingLinkVerificationViewController(self, didReceiveTerminalError: error)
-                    }
+                    self.dataSource
+                        .analyticsClient
+                        .logUnexpectedError(
+                            error,
+                            errorName: "MarkLinkVerifiedError",
+                            pane: .networkingLinkVerification
+                        )
+                    self.delegate?.networkingLinkVerificationViewController(self, didReceiveTerminalError: error)
                 }
             }
     }
+    
+    func networkingOTPView(_ view: NetworkingOTPView, didTerminallyFailToConfirmVerification error: Error) {
+        delegate?.networkingLinkVerificationViewController(self, didReceiveTerminalError: error)
+    }   
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkBodyView.swift
@@ -11,43 +11,13 @@ import Foundation
 import UIKit
 
 @available(iOSApplicationExtension, unavailable)
-protocol NetworkingSaveToLinkVerificationBodyViewDelegate: AnyObject {
-    func networkingSaveToLinkVerificationBodyView(
-        _ view: NetworkingSaveToLinkVerificationBodyView,
-        didEnterValidOTPCode otpCode: String
-    )
-}
-
-@available(iOSApplicationExtension, unavailable)
 final class NetworkingSaveToLinkVerificationBodyView: UIView {
 
-    weak var delegate: NetworkingSaveToLinkVerificationBodyViewDelegate?
-
-    private(set) lazy var otpTextField: UITextField = {
-       let textField = InsetTextField()
-        textField.textColor = .textPrimary
-        textField.placeholder = "OTP"
-        textField.keyboardType = .numberPad
-        textField.layer.cornerRadius = 8
-        textField.layer.borderColor = UIColor.textBrand.cgColor
-        textField.layer.borderWidth = 2.0
-        textField.addTarget(
-            self,
-            action: #selector(otpTextFieldDidChange),
-            for: .editingChanged
-        )
-        NSLayoutConstraint.activate([
-            textField.heightAnchor.constraint(equalToConstant: 56)
-        ])
-
-        return textField
-    }()
-
-    init(email: String) {
+    init(email: String, otpView: UIView) {
         super.init(frame: .zero)
         let verticalStackView = UIStackView(
             arrangedSubviews: [
-                otpTextField,
+                otpView,
                 CreateEmailLabel(email: email),
             ]
         )
@@ -58,19 +28,6 @@ final class NetworkingSaveToLinkVerificationBodyView: UIView {
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-    @objc private func otpTextFieldDidChange() {
-        guard let otp = otpTextField.text else {
-            return
-        }
-
-        if otp.count == 6 && Int(otp) != nil {
-            delegate?.networkingSaveToLinkVerificationBodyView(
-                self,
-                didEnterValidOTPCode: otp
-            )
-        }
     }
 }
 
@@ -91,7 +48,8 @@ private struct NetworkingSaveToLinkVerificationBodyViewUIViewRepresentable: UIVi
 
     func makeUIView(context: Context) -> NetworkingSaveToLinkVerificationBodyView {
         NetworkingSaveToLinkVerificationBodyView(
-            email: "test@stripe.com"
+            email: "test@stripe.com",
+            otpView: UIView()
         )
     }
 
@@ -112,31 +70,3 @@ struct NetworkingSaveToLinkVerificationBodyView_Previews: PreviewProvider {
 }
 
 #endif
-
-private class InsetTextField: UITextField { // TODO(kgaidis): cleanup/delete after using Stripe's components
-
-    private let padding = UIEdgeInsets(
-        top: 0,
-        left: 10,
-        bottom: 0,
-        right: 10
-    )
-
-    override open func textRect(
-        forBounds bounds: CGRect
-    ) -> CGRect {
-        return bounds.inset(by: padding)
-    }
-
-    override open func placeholderRect(
-        forBounds bounds: CGRect
-    ) -> CGRect {
-        return bounds.inset(by: padding)
-    }
-
-    override open func editingRect(
-        forBounds bounds: CGRect
-    ) -> CGRect {
-        return bounds.inset(by: padding)
-    }
-}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationDataSource.swift
@@ -45,6 +45,7 @@ final class NetworkingSaveToLinkVerificationDataSourceImplementation: Networking
             emailAddress: consumerSession.emailAddress,
             customEmailType: nil,
             connectionsMerchantName: nil,
+            pane: .networkingSaveToLinkVerification,
             consumerSession: consumerSession,
             apiClient: apiClient,
             clientSecret: clientSecret,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationDataSource.swift
@@ -11,6 +11,7 @@ import Foundation
 protocol NetworkingSaveToLinkVerificationDataSource: AnyObject {
     var consumerSession: ConsumerSessionData { get }
     var analyticsClient: FinancialConnectionsAnalyticsClient { get }
+    var networkingOTPDataSource: NetworkingOTPDataSource { get }
 
     func startVerificationSession() -> Future<ConsumerSessionResponse>
     func confirmVerificationSession(otpCode: String) -> Future<ConsumerSessionResponse>
@@ -25,6 +26,7 @@ final class NetworkingSaveToLinkVerificationDataSourceImplementation: Networking
     private let apiClient: FinancialConnectionsAPIClient
     private let clientSecret: String
     let analyticsClient: FinancialConnectionsAnalyticsClient
+    let networkingOTPDataSource: NetworkingOTPDataSource
 
     init(
         consumerSession: ConsumerSessionData,
@@ -38,6 +40,18 @@ final class NetworkingSaveToLinkVerificationDataSourceImplementation: Networking
         self.apiClient = apiClient
         self.clientSecret = clientSecret
         self.analyticsClient = analyticsClient
+        let networkingOTPDataSource = NetworkingOTPDataSourceImplementation(
+            otpType: "SMS",
+            emailAddress: consumerSession.emailAddress,
+            customEmailType: nil,
+            connectionsMerchantName: nil,
+            consumerSession: consumerSession,
+            apiClient: apiClient,
+            clientSecret: clientSecret,
+            analyticsClient: analyticsClient
+        )
+        self.networkingOTPDataSource = networkingOTPDataSource
+        networkingOTPDataSource.delegate = self
     }
 
     func startVerificationSession() -> Future<ConsumerSessionResponse> {
@@ -88,5 +102,14 @@ final class NetworkingSaveToLinkVerificationDataSourceImplementation: Networking
         .chained { _ in
             return Promise(value: ())
         }
+    }
+}
+
+// MARK: - NetworkingOTPDataSourceDelegate
+
+extension NetworkingSaveToLinkVerificationDataSourceImplementation: NetworkingOTPDataSourceDelegate {
+
+    func networkingOTPDataSource(_ dataSource: NetworkingOTPDataSource, didUpdateConsumerSession consumerSession: ConsumerSessionData) {
+        self.consumerSession = consumerSession
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPDataSource.swift
@@ -8,6 +8,10 @@
 import Foundation
 @_spi(STP) import StripeCore
 
+protocol NetworkingOTPDataSourceDelegate: AnyObject {
+    func networkingOTPDataSource(_ dataSource: NetworkingOTPDataSource, didUpdateConsumerSession consumerSession: ConsumerSessionData)
+}
+
 protocol NetworkingOTPDataSource: AnyObject {
     var otpType: String { get }
     var emailAddress: String { get }
@@ -26,8 +30,15 @@ final class NetworkingOTPDataSourceImplementation: NetworkingOTPDataSource {
     private let apiClient: FinancialConnectionsAPIClient
     private let clientSecret: String
     let analyticsClient: FinancialConnectionsAnalyticsClient
+    weak var delegate: NetworkingOTPDataSourceDelegate?
 
-    private(set) var consumerSession: ConsumerSessionData?
+    private(set) var consumerSession: ConsumerSessionData? {
+        didSet {
+            if let consumerSession = consumerSession {
+                delegate?.networkingOTPDataSource(self, didUpdateConsumerSession: consumerSession)
+            }
+        }
+    }
 
     init(
         otpType: String,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPDataSource.swift
@@ -27,6 +27,8 @@ final class NetworkingOTPDataSourceImplementation: NetworkingOTPDataSource {
 
     let otpType: String
     let emailAddress: String
+    let customEmailType: String?
+    let connectionsMerchantName: String?
     private let apiClient: FinancialConnectionsAPIClient
     private let clientSecret: String
     let analyticsClient: FinancialConnectionsAnalyticsClient
@@ -43,12 +45,16 @@ final class NetworkingOTPDataSourceImplementation: NetworkingOTPDataSource {
     init(
         otpType: String,
         emailAddress: String,
+        customEmailType: String?,
+        connectionsMerchantName: String?,
         apiClient: FinancialConnectionsAPIClient,
         clientSecret: String,
         analyticsClient: FinancialConnectionsAnalyticsClient
     ) {
         self.otpType = otpType
         self.emailAddress = emailAddress
+        self.customEmailType = customEmailType
+        self.connectionsMerchantName = connectionsMerchantName
         self.apiClient = apiClient
         self.clientSecret = clientSecret
         self.analyticsClient = analyticsClient
@@ -72,8 +78,8 @@ final class NetworkingOTPDataSourceImplementation: NetworkingOTPDataSource {
         return apiClient.consumerSessionStartVerification(
             emailAddress: emailAddress,
             otpType: otpType,
-            customEmailType: nil,
-            connectionsMerchantName: nil,
+            customEmailType: customEmailType,
+            connectionsMerchantName: connectionsMerchantName,
             consumerSessionClientSecret: consumerSessionClientSecret
         ).chained { [weak self] consumerSessionResponse in
             self?.consumerSession = consumerSessionResponse.consumerSession

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPDataSource.swift
@@ -1,0 +1,86 @@
+//
+//  NetworkingOTPDataSource.swift
+//  StripeFinancialConnections
+//
+//  Created by Krisjanis Gaidis on 2/28/23.
+//
+
+import Foundation
+@_spi(STP) import StripeCore
+
+protocol NetworkingOTPDataSource: AnyObject {
+    var otpType: String { get }
+    var emailAddress: String { get }
+    var analyticsClient: FinancialConnectionsAnalyticsClient { get }
+    var consumerSession: ConsumerSessionData? { get }
+
+    func lookupConsumerSession() -> Future<LookupConsumerSessionResponse>
+    func startVerificationSession() -> Future<ConsumerSessionResponse>
+    func confirmVerificationSession(otpCode: String) -> Future<ConsumerSessionResponse>
+}
+
+final class NetworkingOTPDataSourceImplementation: NetworkingOTPDataSource {
+
+    let otpType: String
+    let emailAddress: String
+    private let apiClient: FinancialConnectionsAPIClient
+    private let clientSecret: String
+    let analyticsClient: FinancialConnectionsAnalyticsClient
+
+    private(set) var consumerSession: ConsumerSessionData?
+
+    init(
+        otpType: String,
+        emailAddress: String,
+        apiClient: FinancialConnectionsAPIClient,
+        clientSecret: String,
+        analyticsClient: FinancialConnectionsAnalyticsClient
+    ) {
+        self.otpType = otpType
+        self.emailAddress = emailAddress
+        self.apiClient = apiClient
+        self.clientSecret = clientSecret
+        self.analyticsClient = analyticsClient
+    }
+
+    func lookupConsumerSession() -> Future<LookupConsumerSessionResponse> {
+        apiClient
+            .consumerSessionLookup(
+                emailAddress: emailAddress
+            )
+            .chained { [weak self] lookupConsumerSessionResponse in
+                self?.consumerSession = lookupConsumerSessionResponse.consumerSession
+                return Promise(value: lookupConsumerSessionResponse)
+            }
+    }
+
+    func startVerificationSession() -> Future<ConsumerSessionResponse> {
+        guard let consumerSessionClientSecret = consumerSession?.clientSecret else {
+            return Promise(error: FinancialConnectionsSheetError.unknown(debugDescription: "invalid startVerificationSession call: no consumerSession.clientSecret"))
+        }
+        return apiClient.consumerSessionStartVerification(
+            emailAddress: emailAddress,
+            otpType: otpType,
+            customEmailType: nil,
+            connectionsMerchantName: nil,
+            consumerSessionClientSecret: consumerSessionClientSecret
+        ).chained { [weak self] consumerSessionResponse in
+            self?.consumerSession = consumerSessionResponse.consumerSession
+            return Promise(value: consumerSessionResponse)
+        }
+    }
+
+    func confirmVerificationSession(otpCode: String) -> Future<ConsumerSessionResponse> {
+        guard let consumerSessionClientSecret = consumerSession?.clientSecret else {
+            return Promise(error: FinancialConnectionsSheetError.unknown(debugDescription: "invalid confirmVerificationSession state: no consumerSessionClientSecret"))
+        }
+        return apiClient.consumerSessionConfirmVerification(
+            otpCode: otpCode,
+            otpType: otpType,
+            consumerSessionClientSecret: consumerSessionClientSecret
+        ).chained { [weak self] consumerSessionResponse in
+            self?.consumerSession = consumerSessionResponse.consumerSession
+            return Promise(value: consumerSessionResponse)
+        }
+    }
+}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPDataSource.swift
@@ -14,9 +14,8 @@ protocol NetworkingOTPDataSourceDelegate: AnyObject {
 
 protocol NetworkingOTPDataSource: AnyObject {
     var otpType: String { get }
-    var emailAddress: String { get }
     var analyticsClient: FinancialConnectionsAnalyticsClient { get }
-    var consumerSession: ConsumerSessionData? { get }
+    var pane: FinancialConnectionsSessionManifest.NextPane { get }
 
     func lookupConsumerSession() -> Future<LookupConsumerSessionResponse>
     func startVerificationSession() -> Future<ConsumerSessionResponse>
@@ -26,27 +25,28 @@ protocol NetworkingOTPDataSource: AnyObject {
 final class NetworkingOTPDataSourceImplementation: NetworkingOTPDataSource {
 
     let otpType: String
-    let emailAddress: String
-    let customEmailType: String?
-    let connectionsMerchantName: String?
-    private let apiClient: FinancialConnectionsAPIClient
-    private let clientSecret: String
-    let analyticsClient: FinancialConnectionsAnalyticsClient
-    weak var delegate: NetworkingOTPDataSourceDelegate?
-
-    private(set) var consumerSession: ConsumerSessionData? {
+    private let emailAddress: String
+    private let customEmailType: String?
+    private let connectionsMerchantName: String?
+    private var consumerSession: ConsumerSessionData? {
         didSet {
             if let consumerSession = consumerSession {
                 delegate?.networkingOTPDataSource(self, didUpdateConsumerSession: consumerSession)
             }
         }
     }
+    let pane: FinancialConnectionsSessionManifest.NextPane
+    private let apiClient: FinancialConnectionsAPIClient
+    private let clientSecret: String
+    let analyticsClient: FinancialConnectionsAnalyticsClient
+    weak var delegate: NetworkingOTPDataSourceDelegate?
 
     init(
         otpType: String,
         emailAddress: String,
         customEmailType: String?,
         connectionsMerchantName: String?,
+        pane: FinancialConnectionsSessionManifest.NextPane,
         consumerSession: ConsumerSessionData?,
         apiClient: FinancialConnectionsAPIClient,
         clientSecret: String,
@@ -56,6 +56,7 @@ final class NetworkingOTPDataSourceImplementation: NetworkingOTPDataSource {
         self.emailAddress = emailAddress
         self.customEmailType = customEmailType
         self.connectionsMerchantName = connectionsMerchantName
+        self.pane = pane
         self.consumerSession = consumerSession
         self.apiClient = apiClient
         self.clientSecret = clientSecret

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPDataSource.swift
@@ -47,6 +47,7 @@ final class NetworkingOTPDataSourceImplementation: NetworkingOTPDataSource {
         emailAddress: String,
         customEmailType: String?,
         connectionsMerchantName: String?,
+        consumerSession: ConsumerSessionData?,
         apiClient: FinancialConnectionsAPIClient,
         clientSecret: String,
         analyticsClient: FinancialConnectionsAnalyticsClient
@@ -55,6 +56,7 @@ final class NetworkingOTPDataSourceImplementation: NetworkingOTPDataSource {
         self.emailAddress = emailAddress
         self.customEmailType = customEmailType
         self.connectionsMerchantName = connectionsMerchantName
+        self.consumerSession = consumerSession
         self.apiClient = apiClient
         self.clientSecret = clientSecret
         self.analyticsClient = analyticsClient

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
@@ -121,6 +121,7 @@ final class NetworkingOTPView: UIView {
     
     private func userDidEnterValidOTPCode(_ otpCode: String) {
         otpTextField.resignFirstResponder()
+        // TODO(kgaidis): consider implementing a loading/grayed-out state for `otpTextField`
         
         dataSource.confirmVerificationSession(otpCode: otpCode)
             .observe { [weak self] result in

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
@@ -15,20 +15,20 @@ protocol NetworkingOTPViewDelegate: AnyObject {
     func networkingOTPViewWillStartConsumerLookup(_ view: NetworkingOTPView)
     func networkingOTPViewConsumerNotFound(_ view: NetworkingOTPView)
     func networkingOTPView(_ view: NetworkingOTPView, didFailConsumerLookup error: Error)
-    
+
     func networkingOTPView(_ view: NetworkingOTPView, didStartVerification consumerSession: ConsumerSessionData)
     func networkingOTPView(_ view: NetworkingOTPView, didFailToStartVerification error: Error)
-    
+
     func networkingOTPViewDidConfirmVerification(_ view: NetworkingOTPView)
     func networkingOTPView(_ view: NetworkingOTPView, didTerminallyFailToConfirmVerification error: Error)
 }
 
 @available(iOSApplicationExtension, unavailable)
 final class NetworkingOTPView: UIView {
-    
+
     private let dataSource: NetworkingOTPDataSource
     weak var delegate: NetworkingOTPViewDelegate?
-    
+
     private lazy var verticalStackView: UIStackView = {
         let otpVerticalStackView = UIStackView(
             arrangedSubviews: [
@@ -57,17 +57,17 @@ final class NetworkingOTPView: UIView {
         return theme
     }()
     private var lastErrorView: UIView?
-    
+
     init(dataSource: NetworkingOTPDataSource) {
         self.dataSource = dataSource
         super.init(frame: .zero)
         addAndPinSubview(verticalStackView)
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     @objc private func otpTextFieldDidChange() {
         showErrorText(nil) // clear the error
 
@@ -87,7 +87,7 @@ final class NetworkingOTPView: UIView {
             verticalStackView.addArrangedSubview(errorView)
         }
     }
-    
+
     func lookupConsumerAndStartVerification() {
         delegate?.networkingOTPViewWillStartConsumerLookup(self)
         dataSource.lookupConsumerSession()
@@ -102,7 +102,7 @@ final class NetworkingOTPView: UIView {
                                 switch result {
                                 case .success(let consumerSessionResponse):
                                     self.delegate?.networkingOTPView(self, didStartVerification: consumerSessionResponse.consumerSession)
-                                    
+
                                     // call this AFTER the delegate to ensure that the delegate-handler
                                     // adds the OTP view to the view-hierarchy
                                     self.otpTextField.becomeFirstResponder()
@@ -118,11 +118,11 @@ final class NetworkingOTPView: UIView {
                 }
             }
     }
-    
+
     private func userDidEnterValidOTPCode(_ otpCode: String) {
         otpTextField.resignFirstResponder()
         // TODO(kgaidis): consider implementing a loading/grayed-out state for `otpTextField`
-        
+
         dataSource.confirmVerificationSession(otpCode: otpCode)
             .observe { [weak self] result in
                 guard let self = self else { return }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
@@ -1,0 +1,156 @@
+//
+//  NetworkingOTPView.swift
+//  StripeFinancialConnections
+//
+//  Created by Krisjanis Gaidis on 2/28/23.
+//
+
+import Foundation
+@_spi(STP) import StripeCore
+@_spi(STP) import StripeUICore
+import UIKit
+
+@available(iOSApplicationExtension, unavailable)
+protocol NetworkingOTPViewDelegate: AnyObject {
+    func networkingOTPViewWillStartConsumerLookup(_ view: NetworkingOTPView)
+    func networkingOTPViewConsumerNotFound(_ view: NetworkingOTPView)
+    func networkingOTPView(_ view: NetworkingOTPView, didFailConsumerLookup error: Error)
+    
+    func networkingOTPView(_ view: NetworkingOTPView, didStartVerification consumerSession: ConsumerSessionData)
+    func networkingOTPView(_ view: NetworkingOTPView, didFailToStartVerification error: Error)
+    
+    func networkingOTPViewDidConfirmVerification(_ view: NetworkingOTPView)
+    func networkingOTPView(_ view: NetworkingOTPView, didTerminallyFailToConfirmVerification error: Error)
+}
+
+@available(iOSApplicationExtension, unavailable)
+final class NetworkingOTPView: UIView {
+    
+    private let dataSource: NetworkingOTPDataSource
+    weak var delegate: NetworkingOTPViewDelegate?
+    
+    private lazy var verticalStackView: UIStackView = {
+        let otpVerticalStackView = UIStackView(
+            arrangedSubviews: [
+                otpTextField,
+            ]
+        )
+        otpVerticalStackView.axis = .vertical
+        otpVerticalStackView.spacing = 8
+        return otpVerticalStackView
+    }()
+    // TODO(kgaidis): make changes to `OneTimeCodeTextField` to
+    // make the font larger
+    private(set) lazy var otpTextField: OneTimeCodeTextField = {
+        let otpTextField = OneTimeCodeTextField(numberOfDigits: 6, theme: theme)
+        otpTextField.tintColor = .textBrand
+        otpTextField.addTarget(self, action: #selector(otpTextFieldDidChange), for: .valueChanged)
+        return otpTextField
+    }()
+    private lazy var theme: ElementsUITheme = {
+        var theme: ElementsUITheme = .default
+        theme.colors = {
+            var colors = ElementsUITheme.Color()
+            colors.border = .borderNeutral
+            return colors
+        }()
+        return theme
+    }()
+    private var lastErrorView: UIView?
+    
+    init(dataSource: NetworkingOTPDataSource) {
+        self.dataSource = dataSource
+        super.init(frame: .zero)
+        addAndPinSubview(verticalStackView)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    @objc private func otpTextFieldDidChange() {
+        showErrorText(nil) // clear the error
+
+        if otpTextField.isComplete {
+            userDidEnterValidOTPCode(otpTextField.value)
+        }
+    }
+
+    private func showErrorText(_ errorText: String?) {
+        lastErrorView?.removeFromSuperview()
+        lastErrorView = nil
+
+        if let errorText = errorText {
+            // TODO(kgaidis): rename & move `ManualEntryErrorView` to be more generic
+            let errorView = ManualEntryErrorView(text: errorText)
+            self.lastErrorView = errorView
+            verticalStackView.addArrangedSubview(errorView)
+        }
+    }
+    
+    func lookupConsumerAndStartVerification() {
+        delegate?.networkingOTPViewWillStartConsumerLookup(self)
+        dataSource.lookupConsumerSession()
+            .observe { [weak self] result in
+                guard let self = self else { return }
+                switch result {
+                case .success(let lookupConsumerSessionResponse):
+                    if lookupConsumerSessionResponse.exists {
+                        self.dataSource.startVerificationSession()
+                            .observe { [weak self] result in
+                                guard let self = self else { return }
+                                switch result {
+                                case .success(let consumerSessionResponse):
+                                    self.delegate?.networkingOTPView(self, didStartVerification: consumerSessionResponse.consumerSession)
+                                    
+                                    // call this AFTER the delegate to ensure that the delegate-handler
+                                    // adds the OTP view to the view-hierarchy
+                                    self.otpTextField.becomeFirstResponder()
+                                case .failure(let error):
+                                    self.delegate?.networkingOTPView(self, didFailToStartVerification: error)
+                                }
+                            }
+                    } else {
+                        self.delegate?.networkingOTPViewConsumerNotFound(self)
+                    }
+                case .failure(let error):
+                    self.delegate?.networkingOTPView(self, didFailConsumerLookup: error)
+                }
+            }
+    }
+    
+    private func userDidEnterValidOTPCode(_ otpCode: String) {
+        otpTextField.resignFirstResponder()
+        
+        dataSource.confirmVerificationSession(otpCode: otpCode)
+            .observe { [weak self] result in
+                guard let self = self else { return }
+                switch result {
+                case .success:
+                    self.delegate?.networkingOTPViewDidConfirmVerification(self)
+                case .failure(let error):
+                    if let errorMessage = AuthFlowHelpers.networkingOTPErrorMessage(fromError: error, otpType: self.dataSource.otpType) {
+                        self.dataSource
+                            .analyticsClient
+                            .logExpectedError(
+                                error,
+                                errorName: "ConfirmVerificationSessionError",
+                                pane: .networkingLinkVerification // TODO(kgaidis): adjust the pane
+                            )
+
+                        self.otpTextField.performInvalidCodeAnimation(shouldClearValue: false)
+                        self.showErrorText(errorMessage)
+                    } else {
+                        self.dataSource
+                            .analyticsClient
+                            .logUnexpectedError(
+                                error,
+                                errorName: "ConfirmVerificationSessionError",
+                                pane: .networkingLinkVerification
+                            )
+                        self.delegate?.networkingOTPView(self, didTerminallyFailToConfirmVerification: error)
+                    }
+                }
+            }
+    }
+}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
@@ -142,7 +142,7 @@ final class NetworkingOTPView: UIView {
                             .logExpectedError(
                                 error,
                                 errorName: "ConfirmVerificationSessionError",
-                                pane: .networkingLinkVerification // TODO(kgaidis): adjust the pane
+                                pane: self.dataSource.pane
                             )
 
                         self.otpTextField.performInvalidCodeAnimation(shouldClearValue: false)
@@ -153,7 +153,7 @@ final class NetworkingOTPView: UIView {
                             .logUnexpectedError(
                                 error,
                                 errorName: "ConfirmVerificationSessionError",
-                                pane: .networkingLinkVerification // TODO(kgaidis): adjust the pane
+                                pane: self.dataSource.pane
                             )
                         self.delegate?.networkingOTPView(self, didTerminallyFailToConfirmVerification: error)
                     }


### PR DESCRIPTION
## Summary

(Sorry for this being a large PR, part of the reason was that I wasn't sure how to define the interface of `NetworkingOTPView` without seeing it in-action across the 3 verification panes)

This PR introduces two key new classe:
1) `NetworkingOTPView`
2) `NetworkingOTPDataSource`

`NetworkingOTPView` represents this:

<img width="369" alt="screen_shot_2023-02-28_at_5 09 58_pm" src="https://user-images.githubusercontent.com/105514761/222492427-4a7b0a57-a391-4447-9926-40a803b61773.png">

`NetworkingOTPDataSource` abstracts 3 API calls:
- lookup
- startVerification
- finishVerification

The purpose of this new set of classes is to reuse OTP logic across the 3 different verification panes (SignUp verification, LoginVerification, StepUpVerification).

The purpose of this PR is NOT to "polish" these panes with 100% correct logic, _but_ it does kind-of help with that.

## Testing

### SignUpVerification

https://user-images.githubusercontent.com/105514761/222493473-fdab21ef-3a40-4b39-a013-0226f6043152.mp4

### LoginVerification and StepUpVerification

https://user-images.githubusercontent.com/105514761/222493773-be97d6ec-315c-490c-909e-844542bbab86.mp4

