### PR TITLE
Remove accessibilityLabel override from STPPaymentMethod extension

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Categories/STPPaymentMethod+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Categories/STPPaymentMethod+PaymentSheet.swift
@@ -25,29 +25,25 @@ extension STPPaymentMethod {
         }
     }
 
-    public override var accessibilityLabel: String? {
-        get {
-            switch type {
-            case .card:
-                guard let card = self.card else {
-                    return nil
-                }
-                let brand = STPCardBrandUtilities.stringFrom(card.brand) ?? ""
-                let last4 = card.last4 ?? ""
-                let last4Spaced = last4.map { String($0) }.joined(separator: " ")
-                let localized = String.Localized.card_brand_ending_in_last_4
-                return String(format: localized, brand, last4Spaced)
-            case .USBankAccount:
-                guard let usBankAccount = self.usBankAccount else {
-                    return nil
-                }
-                return String(format: String.Localized.bank_name_account_ending_in_last_4, usBankAccount.bankName, usBankAccount.last4)
-            default:
+    var paymentSheetAccessibilityLabel: String? {
+        switch type {
+        case .card:
+            guard let card = self.card else {
                 return nil
             }
+            let brand = STPCardBrandUtilities.stringFrom(card.brand) ?? ""
+            let last4 = card.last4 ?? ""
+            let last4Spaced = last4.map { String($0) }.joined(separator: " ")
+            let localized = String.Localized.card_brand_ending_in_last_4
+            return String(format: localized, brand, last4Spaced)
+        case .USBankAccount:
+            guard let usBankAccount = self.usBankAccount else {
+                return nil
+            }
+            return String(format: String.Localized.bank_name_account_ending_in_last_4, usBankAccount.bankName, usBankAccount.last4)
+        default:
+            return nil
         }
-        set {
-            // no-op
-        }
+
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentMethodCollectionView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentMethodCollectionView.swift
@@ -275,7 +275,7 @@ extension SavedPaymentMethodCollectionView {
                         label.text = paymentMethod.paymentSheetLabel
                     }
                     shadowRoundedRectangle.accessibilityIdentifier = label.text
-                    shadowRoundedRectangle.accessibilityLabel = paymentMethod.accessibilityLabel
+                    shadowRoundedRectangle.accessibilityLabel = paymentMethod.paymentSheetAccessibilityLabel
                     paymentMethodLogo.image = paymentMethod.makeCarouselImage(for: self)
                 case .applePay:
                     // TODO (cleanup) - get this from PaymentOptionDisplayData?


### PR DESCRIPTION
## Summary
Changes a property override (that I suspect was originally written in Objective-C, where this sort of thing was much more common/less obvious) to a computed var, resolving a build issue in Xcode 14.3.

## Motivation
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-2078

## Testing
Code builds as expected, and tests pass.

## Notes
While this is technically a public API change, I have extreme difficulty believing any user was reliant on this, and it was only public in the first place due to override visibility requirements.