### PR TITLE
FC Networking: polish around LinkAccountPicker

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsPartnerAccount.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsPartnerAccount.swift
@@ -18,6 +18,7 @@ struct FinancialConnectionsPartnerAccount: Decodable {
     let supportedPaymentMethodTypes: [FinancialConnectionsPaymentMethodType]
     let allowSelection: Bool?
     let allowSelectionMessage: String?
+    let status: String?
 
     var allowSelectionNonOptional: Bool {
         return allowSelection ?? true

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerFooterView.swift
@@ -113,6 +113,7 @@ private func CreateDataAccessDisclosureView(
                 isStripeDirect: isStripeDirect,
                 businessName: businessName,
                 permissions: permissions,
+                isNetworking: false,
                 didSelectLearnMore: didSelectLearnMore
             ),
         ]

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerBodyView.swift
@@ -51,7 +51,7 @@ final class LinkAccountPickerBodyView: UIView {
         // list all accounts
         accounts.forEach { account in
             let accountRowView = LinkAccountPickerRowView(
-                isDisabled: false,
+                isDisabled: account.status != "active",
                 didSelect: { [weak self] in
                     guard let self = self else { return }
                     self.delegate?.linkAccountPickerBodyView(
@@ -60,6 +60,7 @@ final class LinkAccountPickerBodyView: UIView {
                     )
                 }
             )
+            // TODO(kgaidis): when we implement repair logic, this will have new text
             let rowTitles = AccountPickerHelpers.rowTitles(forAccount: account)
             accountRowView.configure(
                 institutionImageUrl: nil, // TODO(kgaidis): get image url from backend
@@ -101,7 +102,20 @@ private struct LinkAccountPickerBodyViewUIViewRepresentable: UIViewRepresentable
                     currency: "USD",
                     supportedPaymentMethodTypes: [.usBankAccount],
                     allowSelection: true,
-                    allowSelectionMessage: nil
+                    allowSelectionMessage: nil,
+                    status: "active"
+                ),
+                FinancialConnectionsPartnerAccount(
+                    id: "abc",
+                    name: "Advantage Plus Checking",
+                    displayableAccountNumbers: "1324",
+                    linkedAccountId: nil,
+                    balanceAmount: 100000,
+                    currency: "USD",
+                    supportedPaymentMethodTypes: [.usBankAccount],
+                    allowSelection: true,
+                    allowSelectionMessage: nil,
+                    status: "disabled"
                 ),
             ]
         )
@@ -118,7 +132,7 @@ struct LinkAccountPickerBodyView_Previews: PreviewProvider {
         VStack(alignment: .leading) {
             Spacer()
             LinkAccountPickerBodyViewUIViewRepresentable()
-                .frame(maxHeight: 120)
+                .frame(maxHeight: 200)
                 .padding()
             Spacer()
         }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerFooterView.swift
@@ -84,6 +84,7 @@ private func CreateDataAccessDisclosureView(
                 isStripeDirect: isStripeDirect,
                 businessName: businessName,
                 permissions: permissions,
+                isNetworking: true,
                 didSelectLearnMore: didSelectLearnMore
             ),
         ]

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
@@ -173,7 +173,7 @@ final class LinkAccountPickerViewController: UIViewController {
                         } else {
                             // this shouldn't happen, but in case it does, we navigate to `institutionPicker` so user
                             // could still have a chance at successfully connecting their account
-                            self.delegate?.linkAccountPickerViewController(self, didRequestNextPane: .institutionPicker)
+                            self.delegate?.linkAccountPickerViewController(self, didRequestNextPane: .institutionPicker) // TODO(kgaidis): double check whether this fall-back is fine...maybe we add support for success pane having no institution...
                         }
                     case .failure(let error):
                         self.dataSource

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
@@ -45,7 +45,7 @@ final class LinkAccountPickerViewController: UIViewController {
     private weak var bodyView: LinkAccountPickerBodyView?
     private lazy var footerView: LinkAccountPickerFooterView = {
         return LinkAccountPickerFooterView(
-            isStripeDirect: dataSource.manifest.isStripeDirect ?? false,
+            isStripeDirect: false,
             businessName: businessName,
             permissions: dataSource.manifest.permissions,
             singleAccount: dataSource.manifest.singleAccount,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/MerchantDataAccessView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/MerchantDataAccessView.swift
@@ -18,6 +18,7 @@ final class MerchantDataAccessView: HitTestView {
         isStripeDirect: Bool,
         businessName: String?,
         permissions: [StripeAPI.FinancialConnectionsAccount.Permissions],
+        isNetworking: Bool,
         didSelectLearnMore: @escaping () -> Void
     ) {
         super.init(frame: .zero)
@@ -64,7 +65,16 @@ final class MerchantDataAccessView: HitTestView {
         let learnMoreString = "[\(String.Localized.learn_more)](\(learnMoreUrlString))"
 
         let finalString: String
-        if isStripeDirect {
+        if isNetworking {
+            let localizedPermissionFullString = String(
+                format: STPLocalizedString(
+                    "%@ through Link.",
+                    "A sentence that describes what users banking data is accessible to Link. For example, the full sentence may say 'Account details, transactions, balances through Link.'"
+                ),
+                permissionString
+            )
+            finalString = "\(leadingString) \(localizedPermissionFullString) \(learnMoreString)"
+        } else if isStripeDirect {
             finalString = "\(leadingString) \(permissionString). \(learnMoreString)"
         } else {
             let localizedPermissionFullString = String(
@@ -167,6 +177,7 @@ private struct MerchantDataAccessViewUIViewRepresentable: UIViewRepresentable {
             isStripeDirect: isStripeDirect,
             businessName: businessName,
             permissions: permissions,
+            isNetworking: false,
             didSelectLearnMore: {}
         )
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Success/SuccessBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Success/SuccessBodyView.swift
@@ -109,6 +109,7 @@ private func CreateDataAccessDisclosureView(
                 isStripeDirect: isStripeDirect,
                 businessName: businessName,
                 permissions: permissions,
+                isNetworking: false,
                 didSelectLearnMore: didSelectLearnMore
             ),
         ]


### PR DESCRIPTION
## Summary

Two things:
1. Corrected data access language in LinkAccountPicker to say "with Link" instead of "with Stripe"
2. Added support for disabled accounts

## Testing

### Corrected Data Merchant Access 

![iOS_After_MerchantDataAccess](https://user-images.githubusercontent.com/105514761/222780961-5aa47562-d22b-4526-b29b-aa96595fe670.png)


### Disabled Account via SwiftUI Previews

![Screen Shot 2023-03-03 at 11 57 51 AM](https://user-images.githubusercontent.com/105514761/222780879-269e13e0-858a-4640-8b5e-e89c00c2cb6f.png)

