### PR TITLE
FC Networking: small fixes around sign up, and attaching accounts

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AttachLinkedPaymentAccount/AttachLinkedPaymentAccountDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AttachLinkedPaymentAccount/AttachLinkedPaymentAccountDataSource.swift
@@ -27,6 +27,7 @@ final class AttachLinkedPaymentAccountDataSourceImplementation: AttachLinkedPaym
     private let linkedAccountId: String
     let analyticsClient: FinancialConnectionsAnalyticsClient
     let authSessionId: String?
+    private let consumerSessionClientSecret: String?
 
     init(
         apiClient: FinancialConnectionsAPIClient,
@@ -35,7 +36,8 @@ final class AttachLinkedPaymentAccountDataSourceImplementation: AttachLinkedPaym
         institution: FinancialConnectionsInstitution,
         linkedAccountId: String,
         analyticsClient: FinancialConnectionsAnalyticsClient,
-        authSessionId: String?
+        authSessionId: String?,
+        consumerSessionClientSecret: String?
     ) {
         self.apiClient = apiClient
         self.clientSecret = clientSecret
@@ -44,13 +46,14 @@ final class AttachLinkedPaymentAccountDataSourceImplementation: AttachLinkedPaym
         self.linkedAccountId = linkedAccountId
         self.analyticsClient = analyticsClient
         self.authSessionId = authSessionId
+        self.consumerSessionClientSecret = consumerSessionClientSecret
     }
 
     func attachLinkedAccountIdToLinkAccountSession() -> Future<FinancialConnectionsPaymentAccountResource> {
         return apiClient.attachLinkedAccountIdToLinkAccountSession(
             clientSecret: clientSecret,
             linkedAccountId: linkedAccountId,
-            consumerSessionClientSecret: nil  // used for Link
+            consumerSessionClientSecret: consumerSessionClientSecret  // used for Link
         )
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -775,7 +775,8 @@ private func CreatePaneViewController(
                 institution: institution,
                 linkedAccountId: linkedAccountId,
                 analyticsClient: dataManager.analyticsClient,
-                authSessionId: dataManager.authSession?.id
+                authSessionId: dataManager.authSession?.id,
+                consumerSessionClientSecret: dataManager.consumerSession?.clientSecret
             )
             let attachedLinkedPaymentAccountViewController = AttachLinkedPaymentAccountViewController(
                 dataSource: dataSource

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
@@ -123,9 +123,10 @@ final class NetworkingLinkSignupViewController: UIViewController {
                 eventName: "click.save_to_link",
                 pane: .networkingLinkSignupPane
             )
+
         dataSource.saveToLink(
             emailAddress: formView.emailElement.emailAddressString ?? "",
-            phoneNumber: formView.phoneNumberElement.phoneNumber?.number ?? "",
+            phoneNumber: formView.phoneNumberElement.phoneNumber?.string(as: .e164) ?? "",
             countryCode: formView.phoneNumberElement.phoneNumber?.countryCode ?? "US"
         )
         .observe { [weak self] result in


### PR DESCRIPTION
## Summary

Two fixes:
1. Fixed how we were passing a phone number (the phone number can't just be `4015006000`, it needs to be `+1401500600`.
2. Added `consumerSessionClientSecret` 

## Testing

I went through the flow several times to get these working + verify it (its going to a feature branch).