### PR TITLE
Connect billing details elements for non LUXE PMs

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
@@ -36,7 +36,7 @@ extension PaymentSheetFormFactory {
             defaultName: configuration.defaultBillingDetails.name,
             theme: theme)
 
-        let billingAddressSection: PaymentMethodElement? = {
+        let billingAddressSection: PaymentMethodElementWrapper<AddressSectionElement>? = {
             switch configuration.billingDetailsCollectionConfiguration.address {
             case .automatic:
                 return makeBillingAddressSection(collectionMode: .countryAndPostal(), countries: nil)
@@ -46,6 +46,15 @@ extension PaymentSheetFormFactory {
                 return nil
             }
         }()
+
+        let phoneElement = contactInformationSection?.elements.compactMap {
+            $0 as? PaymentMethodElementWrapper<PhoneNumberElement>
+        }.first
+
+        connectBillingDetailsFields(
+            countryElement: nil,
+            addressElement: billingAddressSection,
+            phoneElement: phoneElement)
 
         let cardFormElement = FormElement(
             elements: [

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+FormSpec.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+FormSpec.swift
@@ -80,9 +80,9 @@ extension PaymentSheetFormFactory {
         }
 
         connectBillingDetailsFields(
-            countryElement: countryElement,
-            addressElement: billingAddressElement,
-            phoneElement: phoneElement)
+            countryElement: countryElement as? PaymentMethodElementWrapper<DropdownFieldElement>,
+            addressElement: billingAddressElement as? PaymentMethodElementWrapper<AddressSectionElement>,
+            phoneElement: phoneElement as? PaymentMethodElementWrapper<PhoneNumberElement>)
 
         return elements
     }
@@ -192,58 +192,6 @@ extension PaymentSheetFormFactory {
                 ? makeBillingAddressSection(collectionMode: .noCountry, countries: nil)
                 : nil
         case .unknown: return nil
-        }
-    }
-
-    private func connectBillingDetailsFields(
-        countryElement: Element?,
-        addressElement: Element?,
-        phoneElement: Element?
-    ) {
-        // Using a closure because a function would require capturing self, which will be deallocated by the time
-        // the closures below are called.
-        let defaultBillingDetails = configuration.defaultBillingDetails
-        let updatePhone = { (phoneElement: PhoneNumberElement, countryCode: String) in
-            // Only update the phone country if:
-            // 1. It's different from the selected one,
-            // 2. A default phone number was not provided.
-            // 3. The phone field hasn't been modified yet.
-            guard countryCode != phoneElement.selectedCountryCode
-                    && defaultBillingDetails.phone == nil
-                    && !phoneElement.hasBeenModified
-            else {
-                return
-            }
-
-            phoneElement.selectedCountryCode = countryCode
-        }
-
-        if let countryElement = countryElement as? PaymentMethodElementWrapper<DropdownFieldElement> {
-            countryElement.element.didUpdate = { [updatePhone] _ in
-                let countryCode = countryElement.element.selectedItem.rawData
-                if let phoneElement = phoneElement as? PaymentMethodElementWrapper<PhoneNumberElement> {
-                    updatePhone(phoneElement.element, countryCode)
-                }
-                if let addressElement = addressElement as? PaymentMethodElementWrapper<AddressSectionElement> {
-                    addressElement.element.selectedCountryCode = countryCode
-                }
-            }
-
-            if let addressElement = addressElement as? PaymentMethodElementWrapper<AddressSectionElement>,
-               addressElement.element.selectedCountryCode != countryElement.element.selectedItem.rawData
-            {
-                addressElement.element.selectedCountryCode = countryElement.element.selectedItem.rawData
-            }
-        }
-
-        if let addressElement = addressElement as? PaymentMethodElementWrapper<AddressSectionElement> {
-            addressElement.element.didUpdate = { [updatePhone] addressDetails in
-                if let countryCode = addressDetails.address.country,
-                   let phoneElement = phoneElement as? PaymentMethodElementWrapper<PhoneNumberElement>
-                {
-                    updatePhone(phoneElement.element, countryCode)
-                }
-            }
         }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+UPI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+UPI.swift
@@ -22,6 +22,13 @@ extension PaymentSheetFormFactory {
         let billingAddressElement = configuration.billingDetailsCollectionConfiguration.address == .full
             ? makeBillingAddressSection(countries: nil)
             : nil
+        let phoneElement = contactInformationElement?.elements.compactMap {
+            $0 as? PaymentMethodElementWrapper<PhoneNumberElement>
+        }.first
+        connectBillingDetailsFields(
+            countryElement: nil,
+            addressElement: billingAddressElement,
+            phoneElement: phoneElement)
 
         let allElements: [Element?] = [
             makeUPIHeader(),


### PR DESCRIPTION
## Summary
Connecting billing details elements for non LUXE PMs so the phone country can change when the billing country changes.
I previously created this helper for LUXE and now I'm using it for all PMs.

## Motivation
Part of BDCC

## Testing
Checked that phone number country changed when country changed only when the field didn't have a default value and had not been modified.

