### PR TITLE
FC Networking: changed the OTP error to have a red-colored link rather than blue

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/ManualEntry/ManualEntryErrorView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/ManualEntry/ManualEntryErrorView.swift
@@ -37,7 +37,8 @@ final class ManualEntryErrorView: UIView {
             font: errorLabelFont,
             boldFont: .stripeFont(forTextStyle: .bodyEmphasized),
             linkFont: .stripeFont(forTextStyle: .bodyEmphasized),
-            textColor: .textCritical
+            textColor: .textCritical,
+            linkColor: .textCritical
         )
         errorLabel.setText(text)
         errorLabel.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/ClickableLabel.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/ClickableLabel.swift
@@ -32,6 +32,7 @@ final class ClickableLabel: HitTestView {
         boldFont: UIFont,
         linkFont: UIFont,
         textColor: UIColor,
+        linkColor: UIColor = .textBrand,
         alignCenter: Bool = false
     ) {
         self.font = font
@@ -49,7 +50,7 @@ final class ClickableLabel: HitTestView {
         textView.textContainerInset = .zero
         textView.textContainer.lineFragmentPadding = 0.0
         textView.linkTextAttributes = [
-            .foregroundColor: UIColor.textBrand
+            .foregroundColor: linkColor
         ]
         textView.delegate = self
         // remove clipping so when user selects an attributed


### PR DESCRIPTION
## Summary

Previous [PR had a comment](https://github.com/stripe/stripe-ios/pull/2330) (IRL) that the blue link looks weird; this PR makes it red. 

## Testing

<img width="378" alt="Screen Shot 2023-03-09 at 3 30 25 PM" src="https://user-images.githubusercontent.com/105514761/224184386-ce4793a8-fe85-418c-aad6-f58667903668.png">
