### PR TITLE
Invoke merchant callback on main thread

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -695,10 +695,7 @@ extension PaymentSheetTestPlayground {
     // Client-side confirmation handler
     func confirmHandler(_ paymentMethodID: String,
                         _ intentCreationCallback: @escaping (Result<String, Error>) -> Void) {
-        // Client-side confirmation, simulate a delay like we are doing validation on our backend
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-            intentCreationCallback(.success(self.clientSecret!))
-        }
+        intentCreationCallback(.success(self.clientSecret!))
     }
 
     // Server-side confirmation handler

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -695,7 +695,9 @@ extension PaymentSheetTestPlayground {
     // Client-side confirmation handler
     func confirmHandler(_ paymentMethodID: String,
                         _ intentCreationCallback: @escaping (Result<String, Error>) -> Void) {
-        intentCreationCallback(.success(self.clientSecret!))
+        DispatchQueue.global(qos: .background).async {
+            intentCreationCallback(.success(self.clientSecret!))
+        }
     }
 
     // Server-side confirmation handler

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -897,365 +897,364 @@ extension PaymentSheetUITest {
     }
 
     // MARK: Deferred tests (server-side)
-    // TODO(porter) re-enable
 
-//    func testDeferredPaymentIntent_ServerSideConfirmation() {
-//        loadPlayground(
-//            app,
-//            settings: [
-//                "init_mode": "Deferred",
-//                "confirm_mode": "Server",
-//            ]
-//        )
-//
-//        app.buttons["Checkout (Complete)"].tap()
-//        try? fillCardData(app, container: nil)
-//
-//        app.buttons["Pay $50.99"].tap()
-//
-//        let successText = app.staticTexts["Success!"]
-//        XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
-//    }
-//
-//    func testDeferredPaymentIntent_SeverSideConfirmation_LostCardDecline() {
-//        loadPlayground(
-//            app,
-//            settings: [
-//                "init_mode": "Deferred",
-//                "confirm_mode": "Server",
-//            ]
-//        )
-//
-//        app.buttons["Checkout (Complete)"].tap()
-//        try? fillCardData(app, container: nil, cardNumber: "4000000000009987")
-//
-//        app.buttons["Pay $50.99"].tap()
-//
-//        // Error comes from our backend and isn't pretty
-//        let predicate = NSPredicate(format: "label CONTAINS 'ServerSideConfirmationError error'")
-//        let declineText = app.staticTexts.containing(predicate).firstMatch
-//        XCTAssertTrue(declineText.waitForExistence(timeout: 10.0))
-//    }
-//
-//    func testDeferredSetupIntent_ServerSideConfirmation() {
-//        loadPlayground(
-//            app,
-//            settings: [
-//                "init_mode": "Deferred",
-//                "mode": "Setup",
-//                "confirm_mode": "Server",
-//            ]
-//        )
-//
-//        app.buttons["Checkout (Complete)"].tap()
-//        try? fillCardData(app, container: nil)
-//
-//        app.buttons["Set up"].tap()
-//
-//        let successText = app.staticTexts["Success!"]
-//        XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
-//    }
-//
-//    func testDeferredPaymentIntent_FlowController_ServerSideConfirmation() {
-//        loadPlayground(
-//            app,
-//            settings: [
-//                "init_mode": "Deferred",
-//                "confirm_mode": "Server",
-//            ]
-//        )
-//
-//        let selectButton = app.buttons["present_saved_pms"]
-//        XCTAssertTrue(selectButton.waitForExistence(timeout: 10.0))
-//        selectButton.tap()
-//        let selectText = app.staticTexts["Select your payment method"]
-//        XCTAssertTrue(selectText.waitForExistence(timeout: 10.0))
-//
-//        let addCardButton = app.buttons["+ Add"]
-//        XCTAssertTrue(addCardButton.waitForExistence(timeout: 4.0))
-//        addCardButton.tap()
-//
-//        try? fillCardData(app, container: nil)
-//
-//        app.buttons["Continue"].tap()
-//        app.buttons["Checkout (Custom)"].tap()
-//
-//        let successText = app.staticTexts["Success!"]
-//        XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
-//    }
-//
-//    func testDeferredSetupIntent_FlowController_ServerSideConfirmation() {
-//        loadPlayground(
-//            app,
-//            settings: [
-//                "init_mode": "Deferred",
-//                "mode": "Setup",
-//                "confirm_mode": "Server",
-//            ]
-//        )
-//
-//        let selectButton = app.buttons["present_saved_pms"]
-//        XCTAssertTrue(selectButton.waitForExistence(timeout: 10.0))
-//        selectButton.tap()
-//        let selectText = app.staticTexts["Select your payment method"]
-//        XCTAssertTrue(selectText.waitForExistence(timeout: 10.0))
-//
-//        let addCardButton = app.buttons["+ Add"]
-//        XCTAssertTrue(addCardButton.waitForExistence(timeout: 4.0))
-//        addCardButton.tap()
-//
-//        try? fillCardData(app, container: nil)
-//
-//        app.buttons["Continue"].tap()
-//        app.buttons["Checkout (Custom)"].tap()
-//
-//        let successText = app.staticTexts["Success!"]
-//        XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
-//    }
-//
-//    func testDeferferedIntentLinkSignup_ServerSideConfirmation() throws {
-//        loadPlayground(
-//            app,
-//            settings: [
-//                "customer_mode": "new",
-//                "automatic_payment_methods": "off",
-//                "link": "on",
-//                "init_mode": "Deferred",
-//                "confirm_mode": "Server",
-//            ]
-//        )
-//
-//        app.buttons["Checkout (Complete)"].tap()
-//
-//        let payWithLinkButton = app.buttons["Pay with Link"]
-//        XCTAssertTrue(payWithLinkButton.waitForExistence(timeout: 10))
-//        payWithLinkButton.tap()
-//
-//        let modal = app.otherElements["Stripe.Link.PayWithLinkViewController"]
-//        XCTAssertTrue(modal.waitForExistence(timeout: 10))
-//
-//        let emailField = modal.textFields["Email"]
-//        XCTAssertTrue(emailField.waitForExistence(timeout: 10))
-//        emailField.tap()
-//        emailField.typeText("mobile-payments-sdk-ci+\(UUID())@stripe.com")
-//
-//        let phoneField = modal.textFields["Phone"]
-//        XCTAssert(phoneField.waitForExistence(timeout: 10))
-//        phoneField.tap()
-//        phoneField.typeText("3105551234")
-//
-//        // The name field is only required for non-US countries. Only fill it out if it exists.
-//        let nameField = modal.textFields["Name"]
-//        if nameField.exists {
-//            nameField.tap()
-//            nameField.typeText("Jane Done")
-//        }
-//
-//        modal.buttons["Join Link"].tap()
-//
-//        // Because we are presenting view controllers with `modalPresentationStyle = .overFullScreen`,
-//        // there are currently 2 card forms on screen. Specifying a container helps the `fillCardData()`
-//        // method operate on the correct card form.
-//        try fillCardData(app, container: modal)
-//
-//        // Pay!
-//        let payButton = modal.buttons["Pay $50.99"]
-//        expectation(for: NSPredicate(format: "enabled == true"), evaluatedWith: payButton, handler: nil)
-//        waitForExpectations(timeout: 10, handler: nil)
-//        payButton.tap()
-//
-//        let successText = app.staticTexts["Success!"]
-//        XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
-//    }
-//
-//    func testDeferredPaymentIntent_ApplePay_ServerSideConfirmation() {
-//        loadPlayground(
-//            app,
-//            settings: [
-//                "init_mode": "Deferred",
-//                "confirm_mode": "Server",
-//            ]
-//        )
-//
-//        app.buttons["Checkout (Complete)"].tap()
-//        let applePayButton = app.buttons["apple_pay_button"]
-//        XCTAssertTrue(applePayButton.waitForExistence(timeout: 4.0))
-//        applePayButton.tap()
-//
-//        payWithApplePay()
-//    }
-//
-//    func testPaymentSheetCustomSaveAndRemoveCard_DeferredIntent_ServerSideConfirmation() throws {
-//        loadPlayground(
-//            app,
-//            settings: [
-//                "customer_mode": "new",
-//                "apple_pay": "off",  // disable Apple Pay
-//                // This test case is testing a feature not available when Link is on,
-//                // so we must manually turn off Link.
-//                "automatic_payment_methods": "off",
-//                "link": "off",
-//                "init_mode": "Deferred",
-//                "confirm_mode": "Server",
-//            ]
-//        )
-//
-//        var paymentMethodButton = app.buttons["Select Payment Method"]
-//        XCTAssertTrue(paymentMethodButton.waitForExistence(timeout: 60.0))
-//        paymentMethodButton.tap()
-//        try! fillCardData(app)
-//
-//        // toggle save this card on and off
-//        var saveThisCardToggle = app.switches["Save this card for future Example, Inc. payments"]
-//        let expectDefaultSelectionOn = Locale.current.regionCode == "US"
-//        if expectDefaultSelectionOn {
-//            XCTAssertTrue(saveThisCardToggle.isSelected)
-//        } else {
-//            XCTAssertFalse(saveThisCardToggle.isSelected)
-//        }
-//        saveThisCardToggle.tap()
-//        if expectDefaultSelectionOn {
-//            XCTAssertFalse(saveThisCardToggle.isSelected)
-//        } else {
-//            XCTAssertTrue(saveThisCardToggle.isSelected)
-//            saveThisCardToggle.tap()  // toggle back off
-//        }
-//        XCTAssertFalse(saveThisCardToggle.isSelected)
-//
-//        // Complete payment
-//        app.buttons["Continue"].tap()
-//        app.buttons["Checkout (Custom)"].tap()
-//        var successText = app.alerts.staticTexts["Success!"]
-//        XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
-//        app.alerts.scrollViews.otherElements.buttons["OK"].tap()
-//
-//        // Reload w/ same customer
-//        reload(app)
-//        XCTAssertTrue(paymentMethodButton.waitForExistence(timeout: 60.0))
-//        paymentMethodButton.tap()
-//        try! fillCardData(app)  // If the previous card was saved, we'll be on the 'saved pms' screen and this will fail
-//        // toggle save this card on
-//        saveThisCardToggle = app.switches["Save this card for future Example, Inc. payments"]
-//        if !expectDefaultSelectionOn {
-//            saveThisCardToggle.tap()
-//        }
-//        XCTAssertTrue(saveThisCardToggle.isSelected)
-//
-//        // Complete payment
-//        app.buttons["Continue"].tap()
-//        app.buttons["Checkout (Custom)"].tap()
-//        successText = app.alerts.staticTexts["Success!"]
-//        XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
-//        app.alerts.scrollViews.otherElements.buttons["OK"].tap()
-//
-//        // Reload w/ same customer
-//        reload(app)
-//
-//        // return to payment method selector
-//        paymentMethodButton = app.staticTexts["••••4242"]  // The card should be saved now
-//        XCTAssertTrue(paymentMethodButton.waitForExistence(timeout: 60.0))
-//        paymentMethodButton.tap()
-//
-//        let editButton = app.staticTexts["Edit"]
-//        XCTAssertTrue(editButton.waitForExistence(timeout: 60.0))
-//        editButton.tap()
-//
-//        let removeButton = app.buttons["Remove"]
-//        XCTAssertTrue(removeButton.waitForExistence(timeout: 60.0))
-//        removeButton.tap()
-//
-//        let confirmRemoval = app.alerts.buttons["Remove"]
-//        XCTAssertTrue(confirmRemoval.waitForExistence(timeout: 60.0))
-//        confirmRemoval.tap()
-//
-//        XCTAssertTrue(app.cells.count == 1)
-//    }
-//
-//    func testDeferredIntentLinkSignIn_SeverSideConfirmation() throws {
-//        loadPlayground(
-//            app,
-//            settings: [
-//                "customer_mode": "new",
-//                "automatic_payment_methods": "off",
-//                "link": "on",
-//                "init_mode": "Deferred",
-//                "confirm_mode": "Server",
-//            ]
-//        )
-//
-//        app.buttons["Checkout (Complete)"].tap()
-//
-//        let payWithLinkButton = app.buttons["Pay with Link"]
-//        XCTAssertTrue(payWithLinkButton.waitForExistence(timeout: 10))
-//        payWithLinkButton.tap()
-//
-//        try loginAndPay()
-//    }
-//
-//    func testDeferredIntentLinkSignIn_ServerSideConfirmation_LostCardDecline() throws {
-//        loadPlayground(
-//            app,
-//            settings: [
-//                "customer_mode": "new",
-//                "automatic_payment_methods": "off",
-//                "link": "on",
-//                "init_mode": "Deferred",
-//                "confirm_mode": "Server",
-//            ]
-//        )
-//
-//        app.buttons["Checkout (Complete)"].tap()
-//
-//        let payWithLinkButton = app.buttons["Pay with Link"]
-//        XCTAssertTrue(payWithLinkButton.waitForExistence(timeout: 10))
-//        payWithLinkButton.tap()
-//
-//        try linkLogin()
-//
-//        let modal = app.otherElements["Stripe.Link.PayWithLinkViewController"]
-//        let paymentMethodPicker = app.otherElements["Stripe.Link.PaymentMethodPicker"]
-//        if paymentMethodPicker.waitForExistence(timeout: 10) {
-//            paymentMethodPicker.tap()
-//            paymentMethodPicker.buttons["Add a payment method"].tap()
-//        }
-//
-//        try fillCardData(app, container: modal, cardNumber: "4000000000009987")
-//
-//        let payButton = modal.buttons["Pay $50.99"]
-//        expectation(for: NSPredicate(format: "enabled == true"), evaluatedWith: payButton, handler: nil)
-//        waitForExpectations(timeout: 10, handler: nil)
-//        payButton.tap()
-//
-//        // Error comes from our backend and isn't pretty
-//        let predicate = NSPredicate(format: "label CONTAINS 'ServerSideConfirmationError error'")
-//        let declineText = app.staticTexts.containing(predicate).firstMatch
-//        XCTAssertTrue(declineText.waitForExistence(timeout: 10.0))
-//    }
-//
-//    func testDeferredIntentLinkCustomFlow_SeverSideConfirmation() throws {
-//        loadPlayground(
-//            app,
-//            settings: [
-//                "customer_mode": "new",
-//                "automatic_payment_methods": "off",
-//                "link": "on",
-//                "init_mode": "Deferred",
-//                "confirm_mode": "Server",
-//            ]
-//        )
-//
-//        let paymentMethodButton = app.buttons["Select Payment Method"]
-//        XCTAssertTrue(paymentMethodButton.waitForExistence(timeout: 10.0))
-//        paymentMethodButton.tap()
-//
-//        let addCardButton = app.buttons["Link"]
-//        XCTAssertTrue(addCardButton.waitForExistence(timeout: 10.0))
-//        addCardButton.tap()
-//
-//        app.buttons["Checkout (Custom)"].tap()
-//
-//        try loginAndPay()
-//    }
+    func testDeferredPaymentIntent_ServerSideConfirmation() {
+        loadPlayground(
+            app,
+            settings: [
+                "init_mode": "Deferred",
+                "confirm_mode": "Server",
+            ]
+        )
+
+        app.buttons["Checkout (Complete)"].tap()
+        try? fillCardData(app, container: nil)
+
+        app.buttons["Pay $50.99"].tap()
+
+        let successText = app.staticTexts["Success!"]
+        XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
+    }
+
+    func testDeferredPaymentIntent_SeverSideConfirmation_LostCardDecline() {
+        loadPlayground(
+            app,
+            settings: [
+                "init_mode": "Deferred",
+                "confirm_mode": "Server",
+            ]
+        )
+
+        app.buttons["Checkout (Complete)"].tap()
+        try? fillCardData(app, container: nil, cardNumber: "4000000000009987")
+
+        app.buttons["Pay $50.99"].tap()
+
+        // Error comes from our backend and isn't pretty
+        let predicate = NSPredicate(format: "label CONTAINS 'ServerSideConfirmationError error'")
+        let declineText = app.staticTexts.containing(predicate).firstMatch
+        XCTAssertTrue(declineText.waitForExistence(timeout: 10.0))
+    }
+
+    func testDeferredSetupIntent_ServerSideConfirmation() {
+        loadPlayground(
+            app,
+            settings: [
+                "init_mode": "Deferred",
+                "mode": "Setup",
+                "confirm_mode": "Server",
+            ]
+        )
+
+        app.buttons["Checkout (Complete)"].tap()
+        try? fillCardData(app, container: nil)
+
+        app.buttons["Set up"].tap()
+
+        let successText = app.staticTexts["Success!"]
+        XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
+    }
+
+    func testDeferredPaymentIntent_FlowController_ServerSideConfirmation() {
+        loadPlayground(
+            app,
+            settings: [
+                "init_mode": "Deferred",
+                "confirm_mode": "Server",
+            ]
+        )
+
+        let selectButton = app.buttons["present_saved_pms"]
+        XCTAssertTrue(selectButton.waitForExistence(timeout: 10.0))
+        selectButton.tap()
+        let selectText = app.staticTexts["Select your payment method"]
+        XCTAssertTrue(selectText.waitForExistence(timeout: 10.0))
+
+        let addCardButton = app.buttons["+ Add"]
+        XCTAssertTrue(addCardButton.waitForExistence(timeout: 4.0))
+        addCardButton.tap()
+
+        try? fillCardData(app, container: nil)
+
+        app.buttons["Continue"].tap()
+        app.buttons["Checkout (Custom)"].tap()
+
+        let successText = app.staticTexts["Success!"]
+        XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
+    }
+
+    func testDeferredSetupIntent_FlowController_ServerSideConfirmation() {
+        loadPlayground(
+            app,
+            settings: [
+                "init_mode": "Deferred",
+                "mode": "Setup",
+                "confirm_mode": "Server",
+            ]
+        )
+
+        let selectButton = app.buttons["present_saved_pms"]
+        XCTAssertTrue(selectButton.waitForExistence(timeout: 10.0))
+        selectButton.tap()
+        let selectText = app.staticTexts["Select your payment method"]
+        XCTAssertTrue(selectText.waitForExistence(timeout: 10.0))
+
+        let addCardButton = app.buttons["+ Add"]
+        XCTAssertTrue(addCardButton.waitForExistence(timeout: 4.0))
+        addCardButton.tap()
+
+        try? fillCardData(app, container: nil)
+
+        app.buttons["Continue"].tap()
+        app.buttons["Checkout (Custom)"].tap()
+
+        let successText = app.staticTexts["Success!"]
+        XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
+    }
+
+    func testDeferferedIntentLinkSignup_ServerSideConfirmation() throws {
+        loadPlayground(
+            app,
+            settings: [
+                "customer_mode": "new",
+                "automatic_payment_methods": "off",
+                "link": "on",
+                "init_mode": "Deferred",
+                "confirm_mode": "Server",
+            ]
+        )
+
+        app.buttons["Checkout (Complete)"].tap()
+
+        let payWithLinkButton = app.buttons["Pay with Link"]
+        XCTAssertTrue(payWithLinkButton.waitForExistence(timeout: 10))
+        payWithLinkButton.tap()
+
+        let modal = app.otherElements["Stripe.Link.PayWithLinkViewController"]
+        XCTAssertTrue(modal.waitForExistence(timeout: 10))
+
+        let emailField = modal.textFields["Email"]
+        XCTAssertTrue(emailField.waitForExistence(timeout: 10))
+        emailField.tap()
+        emailField.typeText("mobile-payments-sdk-ci+\(UUID())@stripe.com")
+
+        let phoneField = modal.textFields["Phone"]
+        XCTAssert(phoneField.waitForExistence(timeout: 10))
+        phoneField.tap()
+        phoneField.typeText("3105551234")
+
+        // The name field is only required for non-US countries. Only fill it out if it exists.
+        let nameField = modal.textFields["Name"]
+        if nameField.exists {
+            nameField.tap()
+            nameField.typeText("Jane Done")
+        }
+
+        modal.buttons["Join Link"].tap()
+
+        // Because we are presenting view controllers with `modalPresentationStyle = .overFullScreen`,
+        // there are currently 2 card forms on screen. Specifying a container helps the `fillCardData()`
+        // method operate on the correct card form.
+        try fillCardData(app, container: modal)
+
+        // Pay!
+        let payButton = modal.buttons["Pay $50.99"]
+        expectation(for: NSPredicate(format: "enabled == true"), evaluatedWith: payButton, handler: nil)
+        waitForExpectations(timeout: 10, handler: nil)
+        payButton.tap()
+
+        let successText = app.staticTexts["Success!"]
+        XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
+    }
+
+    func testDeferredPaymentIntent_ApplePay_ServerSideConfirmation() {
+        loadPlayground(
+            app,
+            settings: [
+                "init_mode": "Deferred",
+                "confirm_mode": "Server",
+            ]
+        )
+
+        app.buttons["Checkout (Complete)"].tap()
+        let applePayButton = app.buttons["apple_pay_button"]
+        XCTAssertTrue(applePayButton.waitForExistence(timeout: 4.0))
+        applePayButton.tap()
+
+        payWithApplePay()
+    }
+
+    func testPaymentSheetCustomSaveAndRemoveCard_DeferredIntent_ServerSideConfirmation() throws {
+        loadPlayground(
+            app,
+            settings: [
+                "customer_mode": "new",
+                "apple_pay": "off",  // disable Apple Pay
+                // This test case is testing a feature not available when Link is on,
+                // so we must manually turn off Link.
+                "automatic_payment_methods": "off",
+                "link": "off",
+                "init_mode": "Deferred",
+                "confirm_mode": "Server",
+            ]
+        )
+
+        var paymentMethodButton = app.buttons["Select Payment Method"]
+        XCTAssertTrue(paymentMethodButton.waitForExistence(timeout: 60.0))
+        paymentMethodButton.tap()
+        try! fillCardData(app)
+
+        // toggle save this card on and off
+        var saveThisCardToggle = app.switches["Save this card for future Example, Inc. payments"]
+        let expectDefaultSelectionOn = Locale.current.regionCode == "US"
+        if expectDefaultSelectionOn {
+            XCTAssertTrue(saveThisCardToggle.isSelected)
+        } else {
+            XCTAssertFalse(saveThisCardToggle.isSelected)
+        }
+        saveThisCardToggle.tap()
+        if expectDefaultSelectionOn {
+            XCTAssertFalse(saveThisCardToggle.isSelected)
+        } else {
+            XCTAssertTrue(saveThisCardToggle.isSelected)
+            saveThisCardToggle.tap()  // toggle back off
+        }
+        XCTAssertFalse(saveThisCardToggle.isSelected)
+
+        // Complete payment
+        app.buttons["Continue"].tap()
+        app.buttons["Checkout (Custom)"].tap()
+        var successText = app.alerts.staticTexts["Success!"]
+        XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
+        app.alerts.scrollViews.otherElements.buttons["OK"].tap()
+
+        // Reload w/ same customer
+        reload(app)
+        XCTAssertTrue(paymentMethodButton.waitForExistence(timeout: 60.0))
+        paymentMethodButton.tap()
+        try! fillCardData(app)  // If the previous card was saved, we'll be on the 'saved pms' screen and this will fail
+        // toggle save this card on
+        saveThisCardToggle = app.switches["Save this card for future Example, Inc. payments"]
+        if !expectDefaultSelectionOn {
+            saveThisCardToggle.tap()
+        }
+        XCTAssertTrue(saveThisCardToggle.isSelected)
+
+        // Complete payment
+        app.buttons["Continue"].tap()
+        app.buttons["Checkout (Custom)"].tap()
+        successText = app.alerts.staticTexts["Success!"]
+        XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
+        app.alerts.scrollViews.otherElements.buttons["OK"].tap()
+
+        // Reload w/ same customer
+        reload(app)
+
+        // return to payment method selector
+        paymentMethodButton = app.staticTexts["••••4242"]  // The card should be saved now
+        XCTAssertTrue(paymentMethodButton.waitForExistence(timeout: 60.0))
+        paymentMethodButton.tap()
+
+        let editButton = app.staticTexts["Edit"]
+        XCTAssertTrue(editButton.waitForExistence(timeout: 60.0))
+        editButton.tap()
+
+        let removeButton = app.buttons["Remove"]
+        XCTAssertTrue(removeButton.waitForExistence(timeout: 60.0))
+        removeButton.tap()
+
+        let confirmRemoval = app.alerts.buttons["Remove"]
+        XCTAssertTrue(confirmRemoval.waitForExistence(timeout: 60.0))
+        confirmRemoval.tap()
+
+        XCTAssertTrue(app.cells.count == 1)
+    }
+
+    func testDeferredIntentLinkSignIn_SeverSideConfirmation() throws {
+        loadPlayground(
+            app,
+            settings: [
+                "customer_mode": "new",
+                "automatic_payment_methods": "off",
+                "link": "on",
+                "init_mode": "Deferred",
+                "confirm_mode": "Server",
+            ]
+        )
+
+        app.buttons["Checkout (Complete)"].tap()
+
+        let payWithLinkButton = app.buttons["Pay with Link"]
+        XCTAssertTrue(payWithLinkButton.waitForExistence(timeout: 10))
+        payWithLinkButton.tap()
+
+        try loginAndPay()
+    }
+
+    func testDeferredIntentLinkSignIn_ServerSideConfirmation_LostCardDecline() throws {
+        loadPlayground(
+            app,
+            settings: [
+                "customer_mode": "new",
+                "automatic_payment_methods": "off",
+                "link": "on",
+                "init_mode": "Deferred",
+                "confirm_mode": "Server",
+            ]
+        )
+
+        app.buttons["Checkout (Complete)"].tap()
+
+        let payWithLinkButton = app.buttons["Pay with Link"]
+        XCTAssertTrue(payWithLinkButton.waitForExistence(timeout: 10))
+        payWithLinkButton.tap()
+
+        try linkLogin()
+
+        let modal = app.otherElements["Stripe.Link.PayWithLinkViewController"]
+        let paymentMethodPicker = app.otherElements["Stripe.Link.PaymentMethodPicker"]
+        if paymentMethodPicker.waitForExistence(timeout: 10) {
+            paymentMethodPicker.tap()
+            paymentMethodPicker.buttons["Add a payment method"].tap()
+        }
+
+        try fillCardData(app, container: modal, cardNumber: "4000000000009987")
+
+        let payButton = modal.buttons["Pay $50.99"]
+        expectation(for: NSPredicate(format: "enabled == true"), evaluatedWith: payButton, handler: nil)
+        waitForExpectations(timeout: 10, handler: nil)
+        payButton.tap()
+
+        // Error comes from our backend and isn't pretty
+        let predicate = NSPredicate(format: "label CONTAINS 'ServerSideConfirmationError error'")
+        let declineText = app.staticTexts.containing(predicate).firstMatch
+        XCTAssertTrue(declineText.waitForExistence(timeout: 10.0))
+    }
+
+    func testDeferredIntentLinkCustomFlow_SeverSideConfirmation() throws {
+        loadPlayground(
+            app,
+            settings: [
+                "customer_mode": "new",
+                "automatic_payment_methods": "off",
+                "link": "on",
+                "init_mode": "Deferred",
+                "confirm_mode": "Server",
+            ]
+        )
+
+        let paymentMethodButton = app.buttons["Select Payment Method"]
+        XCTAssertTrue(paymentMethodButton.waitForExistence(timeout: 10.0))
+        paymentMethodButton.tap()
+
+        let addCardButton = app.buttons["Link"]
+        XCTAssertTrue(addCardButton.waitForExistence(timeout: 10.0))
+        addCardButton.tap()
+
+        app.buttons["Checkout (Custom)"].tap()
+
+        try loginAndPay()
+    }
 }
 
 // MARK: - Link

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+DeferredAPI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+DeferredAPI.swift
@@ -97,13 +97,17 @@ extension PaymentSheet {
       try await withCheckedThrowingContinuation { continuation in
 
           if let confirmHandlerForServerSideConfirmation = intentConfig.confirmHandlerForServerSideConfirmation {
-              confirmHandlerForServerSideConfirmation(paymentMethodID, shouldSavePaymentMethod, { result in
-                  continuation.resume(with: result)
-              })
+              DispatchQueue.main.async {
+                  confirmHandlerForServerSideConfirmation(paymentMethodID, shouldSavePaymentMethod, { result in
+                      continuation.resume(with: result)
+                  })
+              }
           } else if let confirmHandler = intentConfig.confirmHandler {
-              confirmHandler(paymentMethodID, { result in
-                  continuation.resume(with: result)
-              })
+              DispatchQueue.main.async {
+                  confirmHandler(paymentMethodID, { result in
+                      continuation.resume(with: result)
+                  })
+              }
           }
       }
     }


### PR DESCRIPTION
## Summary
- Our SSC tests were failing on CI due to UI modifications happening in the merchant app (playground app) occurring off the main thread.

```
Main Thread Checker: UI API called on a background thread: -[UISegmentedControl selectedSegmentIndex]
PID: 7251, TID: 52484, Thread name: (none), Queue name: com.apple.root.user-initiated-qos.cooperative, QoS: 25
Backtrace:
4   PaymentSheetExample                 0x000000010433e2e4 $s19PaymentSheetExample0aB14TestPlaygroundC19merchantCountryCodeAC08MerchantgH0Ovg + 244
5   PaymentSheetExample                 0x00000001043412d4 $s19PaymentSheetExample0aB14TestPlaygroundC39confirmHandlerForServerSideConfirmationyySS_Sbys6ResultOySSs5Error_pGctF + 952
6   PaymentSheetExample                 0x0000000104340f0c $s19PaymentSheetExample0aB14TestPlaygroundC12intentConfig06StripeaB00aB0C19IntentConfigurationVvgySS_Sbys6ResultOySSs5Error_pGctcACcfu5_ySS_SbyAMctcfu6_ + 100
7   StripePaymentSheet                  0x0000000106501140 $s18StripePaymentSheet0bC0C35fetchIntentClientSecretFromMerchant12intentConfig15paymentMethodID010shouldSavebM0SSAC0E13ConfigurationV_SSSbtYaKFZyScCySSs5Error_pGXEfU_ + 460
8   libswift_Concurrency.dylib          0x00000001af04d67c $ss31withCheckedThrowingContinuation8function_xSS_yScCyxs5Error_pGXEtYaKlFySccyxsAC_pGXEfU_TA + 156
9   libswift_Concurrency.dylib          0x00000001af04d714 $ss30withUnsafeThrowingContinuationyxySccyxs5Error_pGXEYaKlF + 120
10  libswift_Concurrency.dylib          0x00000001af0754f8 _ZN5swift34runJobInEstablishedExecutorContextEPNS_3JobE + 336
11  libswift_Concurrency.dylib          0x00000001af076170 _ZL17swift_job_runImplPN5swift3JobENS_11ExecutorRefE + 80
12  libdispatch.dylib                   0x0000000180138e8c _dispatch_continuation_pop + 152
13  libdispatch.dylib                   0x00000001801382e4 _dispatch_async_redirect_invoke + 872
14  libdispatch.dylib                   0x0000000180148a7c _dispatch_root_queue_drain + 440
15  libdispatch.dylib                   0x00000001801495b8 _dispatch_worker_thread2 + 224
16  libsystem_pthread.dylib             0x00000001af2568c0 _pthread_wqthread + 224
17  libsystem_pthread.dylib             0x00000001af2556c0 start_wqthread + 8
```

These were also manifesting as purple memory errors in Xcode but they were not causing failures:
<img width="590" alt="CleanShot 2023-03-14 at 05 42 19@2x" src="https://user-images.githubusercontent.com/88012362/224990602-c667d911-c557-49fb-89ca-10b0b9d6601c.png">

## Motivation
Fix tests

## Testing

https://app.bitrise.io/build/e5b00c14-b957-4a5a-8e04-9b4f1c2c6970
https://app.bitrise.io/build/cad1f580-0b1c-4cf9-a95b-a8b218810114


## Changelog
N/A