### PR TITLE
Fix bindings for BLIK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## x.x.x yyyy-mm-dd
+### Payments
+* [Fixed] Fixed BLIK payment bindings.
+
 ## 23.5.0 2023-03-13
 ### Payments
 * [Added] API bindings support for Cash App Pay. See the docs [here](https://stripe.com/docs/payments/cash-app-pay/accept-a-payment?platform=mobile).

--- a/Example/Non-Card Payment Examples/Non-Card Payment Examples/BlikExampleViewController.swift
+++ b/Example/Non-Card Payment Examples/Non-Card Payment Examples/BlikExampleViewController.swift
@@ -107,7 +107,7 @@ extension BlikExampleViewController {
                     }
                 }
             },
-            additionalParameters: "supported_payment_methods=blik&country=pl"
+            additionalParameters: "supported_payment_methods=blik&country=pl&currency=pln"
         )
     }
 }

--- a/Example/Non-Card Payment Examples/Non-Card Payment Examples/BlikExampleViewController.swift
+++ b/Example/Non-Card Payment Examples/Non-Card Payment Examples/BlikExampleViewController.swift
@@ -1,0 +1,119 @@
+//
+//  BlikExampleViewController.swift
+//  Non-Card Payment Examples
+//
+//  Created by Eduardo Urias on 3/15/23.
+//
+
+import UIKit
+
+public class BlikExampleViewController: UIViewController {
+    @objc weak var delegate: ExampleViewControllerDelegate?
+    var inProgress: Bool = false {
+        didSet {
+            navigationController?.navigationBar.isUserInteractionEnabled = !inProgress
+            payButton.isEnabled = !inProgress
+            inProgress
+                ? activityIndicatorView.startAnimating() : activityIndicatorView.stopAnimating()
+        }
+    }
+
+    // UI
+    lazy var activityIndicatorView = {
+        return UIActivityIndicatorView(style: .medium)
+    }()
+    lazy var payButton: UIButton = {
+        let button = UIButton(type: .roundedRect)
+        button.setTitle("Pay with BLIK", for: .normal)
+        button.addTarget(self, action: #selector(didTapPayButton), for: .touchUpInside)
+        return button
+    }()
+
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .white
+        title = "BLIK"
+        [payButton, activityIndicatorView].forEach { subview in
+            view.addSubview(subview)
+            subview.translatesAutoresizingMaskIntoConstraints = false
+        }
+
+        let constraints = [
+            payButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            payButton.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+
+            activityIndicatorView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            activityIndicatorView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+        ]
+        NSLayoutConstraint.activate(constraints)
+    }
+
+    @objc func didTapPayButton() {
+        guard STPAPIClient.shared.publishableKey != nil else {
+            delegate?.exampleViewController(
+                self,
+                didFinishWithMessage: "Please set a Stripe Publishable Key in Constants.m"
+            )
+            return
+        }
+        inProgress = true
+        pay()
+    }
+}
+
+// MARK: -
+extension BlikExampleViewController {
+    @objc func pay() {
+        // 1. Create a BLIK PaymentIntent
+        MyAPIClient.shared().createPaymentIntent(
+            completion: { (_, clientSecret, error) in
+                guard let clientSecret = clientSecret else {
+                    self.delegate?.exampleViewController(self, didFinishWithError: error)
+                    return
+                }
+
+                let paymentIntentParams = STPPaymentIntentParams(clientSecret: clientSecret)
+                paymentIntentParams.paymentMethodParams = STPPaymentMethodParams(
+                    blik: STPPaymentMethodBLIKParams(),
+                    billingDetails: nil,
+                    metadata: nil
+                )
+                paymentIntentParams.returnURL = "payments-example://safepay/"
+
+                let blikOptions = STPConfirmBLIKOptions(code: "777123")
+                let confirmPaymentMethodOptions = STPConfirmPaymentMethodOptions()
+                confirmPaymentMethodOptions.blikOptions = blikOptions
+                paymentIntentParams.paymentMethodOptions = confirmPaymentMethodOptions
+
+                STPPaymentHandler.shared().confirmPayment(
+                    paymentIntentParams,
+                    with: self
+                ) { (status, _, error) in
+                    switch status {
+                    case .canceled:
+                        self.delegate?.exampleViewController(
+                            self,
+                            didFinishWithMessage: "Cancelled"
+                        )
+                    case .failed:
+                        self.delegate?.exampleViewController(self, didFinishWithError: error)
+                    case .succeeded:
+                        self.delegate?.exampleViewController(
+                            self,
+                            didFinishWithMessage: "Payment successfully created."
+                        )
+                    @unknown default:
+                        fatalError()
+                    }
+                }
+            },
+            additionalParameters: "supported_payment_methods=blik&country=pl"
+        )
+    }
+}
+
+extension BlikExampleViewController: STPAuthenticationContext {
+    public func authenticationPresentingViewController() -> UIViewController {
+        self
+    }
+}

--- a/Example/Non-Card Payment Examples/Non-Card Payment Examples/BrowseExamplesViewController.m
+++ b/Example/Non-Card Payment Examples/Non-Card Payment Examples/BrowseExamplesViewController.m
@@ -46,7 +46,7 @@
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
-    return 24;
+    return 25;
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
@@ -123,6 +123,9 @@
             break;
         case 23:
             cell.textLabel.text = @"Cash App Pay";
+            break;
+        case 24:
+            cell.textLabel.text = @"BLIK";
             break;
     }
     return cell;
@@ -278,6 +281,12 @@
         }
         case 23: {
             CashAppExampleViewController *exampleVC = [CashAppExampleViewController new];
+            exampleVC.delegate = self;
+            viewController = exampleVC;
+            break;
+        }
+        case 24: {
+            BlikExampleViewController *exampleVC = [BlikExampleViewController new];
             exampleVC.delegate = self;
             viewController = exampleVC;
             break;

--- a/Stripe/StripeiOSTests/Resources/MockFiles/paymentIntentResponse.json
+++ b/Stripe/StripeiOSTests/Resources/MockFiles/paymentIntentResponse.json
@@ -28,7 +28,8 @@
     "afterpay_clearpay",
     "klarna",
     "us_bank_account",
-    "affirm"
+    "affirm",
+    "blik"
   ],
   "processing": null,
   "receipt_email": null,

--- a/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
@@ -1740,13 +1740,13 @@ public class STPPaymentHandler: NSObject {
                 .redirectToURL,
                 .useStripeSDK,
                 .alipayHandleRedirect,
-                .BLIKAuthorize,
                 .weChatPayRedirectToApp,
                 .cashAppRedirectToApp:
                 return false
             case .OXXODisplayDetails,
                 .boletoDisplayDetails,
                 .verifyWithMicrodeposits,
+                .BLIKAuthorize,
                 .upiAwaitNotification:
                 return true
             }


### PR DESCRIPTION
## Summary
BLIK was not treated as an out-of-band payment (it requires consumer confirmation on banking app), this caused the PaymentHandler to complete with an error because it didn't expect the status to be `requires_action`.

## Motivation
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-2179

## Testing
- Added an example view controller to Non-Card Examples to test manually
- Added test

## Changelog
* [Fixed] Fixed BLIK payment bindings.