### PR TITLE
Financial Connections: added extra logging for Partner Auth invalid URLs

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthViewController.swift
@@ -410,6 +410,17 @@ final class PartnerAuthViewController: UIViewController {
     private func openInstitutionAuthenticationWebView(authSession: FinancialConnectionsAuthSession) {
         guard let urlString = authSession.url, let url = URL(string: urlString) else {
             assertionFailure("Expected to get a URL back from authorization session.")
+            dataSource
+                .analyticsClient
+                .logUnexpectedError(
+                    FinancialConnectionsSheetError.unknown(
+                        debugDescription: "Invalid or NULL URL returned from auth session"
+                    ),
+                    errorName: "InvalidAuthSessionURL",
+                    pane: .partnerAuth
+                )
+            // navigate back to institution picker so user can try again
+            navigateBack()
             return
         }
 


### PR DESCRIPTION
## Summary

#ir-paused-cite issue where we sometimes were getting back URL's returned that are not up to URL spec


## Testing

Ensure code logic is sound by reading code + I ran the analytics code outside the `guard else` and it went fine:

```
2023-03-15 15:04:02.694360-0700 FinancialConnectionsExample[52096:3932730] LOG ANALYTICS: ["client_id": "mobile-clients-linked-accounts", "single_account": false, "error_type": "StripeFinancialConnections.FinancialConnectionsSheetError", "sdk_version": "23.5.0", "navigator_language": "en_US", "code": 0, "os_version": "16.1", "key": "pk_live_51L5WGHL6p1bboFUQaRJKytBAfODaYz1Bkyd73AMyt2dgx0RXbyCIHPBFAoFKst1D0PB0ZGNXfco4hbWg0xxW149s00MsUX0GcF", "is_webview": false, "app_name": "FinancialConnectionsExample", "event_name": "linked_accounts.error.unexpected", "account_holder_id": "bcaccthld_1Mm2QLL6p1bboFUQ6Lcykkfh", "sdk_platform": "ios", "is_stripe_direct": false, "error_message": "The operation couldn’t be completed. (StripeFinancialConnections.FinancialConnectionsSheetError error 0.)", "device_type": "arm64", "product": "external_api", "platform_info": ["install": "X", "app_bundle_id": "com.stripe.example.Connections-Example"], "app_version": "1.1", "las_client_secret": "fcsess_client_secret_pP", "error": "InvalidAuthSessionURL", "livemode": true, "pane": "part
```