### PR TITLE
Fix COP formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## x.x.x yyyy-mm-dd
+## Payments
+* [Fixed] Fixed amounts in COP being formatted incorrectly.
+
 ## 23.5.0 2023-03-13
 ### Payments
 * [Added] API bindings support for Cash App Pay. See the docs [here](https://stripe.com/docs/payments/cash-app-pay/accept-a-payment?platform=mobile).

--- a/Stripe/StripeiOSTests/NSDecimalNumber+StripeTest.swift
+++ b/Stripe/StripeiOSTests/NSDecimalNumber+StripeTest.swift
@@ -22,6 +22,7 @@ class NSDecimalNumberStripeTest: XCTestCase {
         "aud",
         "sek",
         "sgd",
+        "cop",
     ]
 
     private let noDecimalPointCurrencies = [

--- a/StripePayments/StripePayments/Source/Internal/Categories/NSDecimalNumber+Stripe_Currency.swift
+++ b/StripePayments/StripePayments/Source/Internal/Categories/NSDecimalNumber+Stripe_Currency.swift
@@ -9,6 +9,11 @@
 import Foundation
 
 extension NSDecimalNumber {
+    // The number of decimal places for some currencies varies between Stripe and NumberFormatter,
+    // This maps the currency code to the number of decimal digits.
+    static let decimalCountSpecialCases = [
+        "COP": 2,
+    ]
 
     @objc @_spi(STP) public class func stp_decimalNumber(
         withAmount amount: Int,
@@ -27,6 +32,12 @@ extension NSDecimalNumber {
     }
 
     private class func decimalCount(for currency: String?) -> Int {
+        if let currency = currency?.uppercased(),
+           let specialCase = Self.decimalCountSpecialCases[currency]
+        {
+            return specialCase
+        }
+
         let currencyLocaleIdentifier = Locale.availableIdentifiers.first(where: {
             let locale = Locale(identifier: $0)
             return locale.currencyCode?.lowercased() == currency?.lowercased()


### PR DESCRIPTION
## Summary
The COP currency is a weird case, it is officially a 2 decimal currency and that's how Stripe treats it, but in practice the decimal units have been discontinued since the 80's, as a result some formatters treat it as a 0 decimal currency, like swift's `NumberFormatter`, this causes a discrepancy where an amount of, for example, 10,000 COP, gets formatted as 1,000,000, because the Stripe amount has two trailing zeroes representing the cents.
To fix this, I added a "special cases" list with the number of decimals used by Stripe, right now that list only includes COP.

## Motivation
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-2116

## Testing
Verified visually and added unit test

## Changelog
[Fixed] Fixed amounts in COP being formatted incorrectly.