### PR TITLE
Generate inferred mandate data for paypal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## x.x.x yyyy-mm-dd
+### Payments
+* [Fixed] Including inferred mandate data for Paypal.
+
 ## 23.5.0 2023-03-13
 ### Payments
 * [Added] API bindings support for Cash App Pay. See the docs [here](https://stripe.com/docs/payments/cash-app-pay/accept-a-payment?platform=mobile).

--- a/Stripe/StripeiOSTests/STPSetupIntentConfirmParamsTest.swift
+++ b/Stripe/StripeiOSTests/STPSetupIntentConfirmParamsTest.swift
@@ -46,7 +46,7 @@ class STPSetupIntentConfirmParamsTest: XCTestCase {
         // card type should have no default mandateData
         XCTAssertNil(params.mandateData)
 
-        for type in ["sepa_debit", "au_becs_debit", "bacs_debit"] {
+        for type in ["sepa_debit", "au_becs_debit", "bacs_debit", "paypal", "cashapp"] {
             params.mandateData = nil
             params.paymentMethodParams?.rawTypeString = type
             // Mandate-required type should have mandateData

--- a/StripePayments/StripePayments/Source/API Bindings/Models/SetupIntents/STPSetupIntentConfirmParams.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/SetupIntents/STPSetupIntentConfirmParams.swift
@@ -69,7 +69,7 @@ public class STPSetupIntentConfirmParams: NSObject, NSCopying, STPFormEncodable 
             }
             switch paymentMethodType {
             case .AUBECSDebit, .bacsDebit, .bancontact, .iDEAL, .SEPADebit, .EPS, .sofort, .link, .USBankAccount,
-                .cashApp:
+                    .cashApp, .payPal:
                 return .makeWithInferredValues()
             default: break
             }


### PR DESCRIPTION
## Summary
Mandate data was not being added to setup intents, which requires it, adding it to the list of PMs that should infer mandate data from the client.

## Motivation
Issue reported on Slack.

## Testing
Added to unit test.

## Changelog
[Fixed] Including inferred mandate data for Paypal.