### PR TITLE
[Identity] Translate labels of different country's ID

### DIFF
--- a/StripeIdentity/StripeIdentity/Resources/Localizations/en.lproj/Localizable.strings
+++ b/StripeIdentity/StripeIdentity/Resources/Localizations/en.lproj/Localizable.strings
@@ -84,8 +84,17 @@
 /* Description of passport image */
 "Image of passport" = "Image of passport";
 
+/* Label for the ID field to collect individual CPF for Brazilian ID */
+"Individual CPF" = "Individual CPF";
+
+/* Label for the ID field to collect last 4 of social security number for US ID */
+"Last 4 of Social Security number" = "Last 4 of Social Security number";
+
 /* Status while screen is loading */
 "Loading" = "Loading";
+
+/* Label for the ID field to collect NRIC or FIN for Singaporean ID */
+"NRIC or FIN" = "NRIC or FIN";
 
 /* Title of ID document scanning screen when scanning a passport */
 "Passport" = "Passport";

--- a/StripeIdentity/StripeIdentity/Source/Elements/IdentityElementsFactory.swift
+++ b/StripeIdentity/StripeIdentity/Source/Elements/IdentityElementsFactory.swift
@@ -25,9 +25,9 @@ struct IdentityElementsFactory {
     let dateFormatter: DateFormatter
 
     static let supportedCountryToIDNumberTypes: [String: IdentityElementsFactory.IDNumberSpec] = [
-        "US": .init(type: .US_SSN_LAST4, label: "Last 4 of Social Security number"),
-        "BR": .init(type: .BR_CPF, label: "Individual CPF"),
-        "SG": .init(type: .SG_NRIC_OR_FIN, label: "NRIC or FIN"),
+        "US": .init(type: .US_SSN_LAST4, label: String.Localized.last_4_of_ssn),
+        "BR": .init(type: .BR_CPF, label: String.Localized.individual_cpf),
+        "SG": .init(type: .SG_NRIC_OR_FIN, label: String.Localized.nric_or_fin),
     ]
 
     init(

--- a/StripeIdentity/StripeIdentity/Source/Helpers/String+Localized.swift
+++ b/StripeIdentity/StripeIdentity/Source/Helpers/String+Localized.swift
@@ -45,21 +45,21 @@ extension String.Localized {
             "Label for the personal id number field in the hosted verification details collection form for countries without an exception"
         )
     }
-    
+
     static var last_4_of_ssn: String {
         STPLocalizedString(
             "Last 4 of Social Security number",
             "Label for the ID field to collect last 4 of social security number for US ID"
         )
     }
-    
+
     static var individual_cpf: String {
         STPLocalizedString(
             "Individual CPF",
             "Label for the ID field to collect individual CPF for Brazilian ID"
         )
     }
-    
+
     static var nric_or_fin: String {
         STPLocalizedString(
             "NRIC or FIN",

--- a/StripeIdentity/StripeIdentity/Source/Helpers/String+Localized.swift
+++ b/StripeIdentity/StripeIdentity/Source/Helpers/String+Localized.swift
@@ -45,6 +45,27 @@ extension String.Localized {
             "Label for the personal id number field in the hosted verification details collection form for countries without an exception"
         )
     }
+    
+    static var last_4_of_ssn: String {
+        STPLocalizedString(
+            "Last 4 of Social Security number",
+            "Label for the ID field to collect last 4 of social security number for US ID"
+        )
+    }
+    
+    static var individual_cpf: String {
+        STPLocalizedString(
+            "Individual CPF",
+            "Label for the ID field to collect individual CPF for Brazilian ID"
+        )
+    }
+    
+    static var nric_or_fin: String {
+        STPLocalizedString(
+            "NRIC or FIN",
+            "Label for the ID field to collect NRIC or FIN for Singaporean ID"
+        )
+    }
 
     // MARK: - Document Upload
 


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Add the  labels of country ID to Localized strings

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
