### PR TITLE
Remove usage of `UIDevice.currentDevice.name`

### DIFF
--- a/Stripe3DS2/Stripe3DS2/STDSDeviceInformationParameter+Private.h
+++ b/Stripe3DS2/Stripe3DS2/STDSDeviceInformationParameter+Private.h
@@ -32,8 +32,6 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)advertisingID;
 /// Screen Resolution: Pixel width and pixel height
 + (instancetype)screenResolution;
-/// Device Name: User-assigned device name
-+ (instancetype)deviceName;
 /// IP Address: IP address of device
 + (instancetype)IPAddress;
 /// Latitude: Device physical location latitude

--- a/Stripe3DS2/Stripe3DS2/STDSDeviceInformationParameter.m
+++ b/Stripe3DS2/Stripe3DS2/STDSDeviceInformationParameter.m
@@ -111,7 +111,6 @@ static const NSString * const kParameterNilCode = @"RE04";
                           [STDSDeviceInformationParameter timeZone],
                           [STDSDeviceInformationParameter advertisingID],
                           [STDSDeviceInformationParameter screenResolution],
-                          [STDSDeviceInformationParameter deviceName],
                           [STDSDeviceInformationParameter IPAddress],
                           [STDSDeviceInformationParameter latitude],
                           [STDSDeviceInformationParameter longitude],
@@ -216,15 +215,6 @@ static const NSString * const kParameterNilCode = @"RE04";
                                                                CGRect boundsInPixels = [UIScreen mainScreen].nativeBounds;
                                                                return [NSString stringWithFormat:@"%ldx%ld", (long)boundsInPixels.size.width, (long)boundsInPixels.size.height];
 
-                                                           }];
-}
-
-+ (instancetype)deviceName
-{
-    return [[STDSDeviceInformationParameter alloc] initWithIdentifier:@"C009"
-                                                      permissionCheck:nil
-                                                           valueCheck:^id _Nullable{
-                                                               return [UIDevice currentDevice].name;
                                                            }];
 }
 

--- a/Stripe3DS2/Stripe3DS2Tests/STDSDeviceInformationParameterTests.m
+++ b/Stripe3DS2/Stripe3DS2Tests/STDSDeviceInformationParameterTests.m
@@ -89,7 +89,7 @@
 
 - (void)testAllParameters {
     NSArray<STDSDeviceInformationParameter *> *allParams = [STDSDeviceInformationParameter allParameters];
-    XCTAssertEqual(allParams.count, 29, @"iOS should collect 29 separate parameters.");
+    XCTAssertEqual(allParams.count, 28, @"iOS should collect 28 separate parameters.");
     NSMutableSet<NSString *> *allParamIdentifiers = [[NSMutableSet alloc] init];
     for (STDSDeviceInformationParameter *param in allParams) {
         [param collectIgnoringRestrictions:YES withHandler:^(BOOL collected, NSString * _Nonnull identifier, id _Nonnull value) {
@@ -106,7 +106,6 @@
                                                  @"C006",
                                                  @"C007",
                                                  @"C008",
-                                                 @"C009",
                                                  @"C010",
                                                  @"C011",
                                                  @"C012",
@@ -171,7 +170,6 @@
                                                                                         @"C006": [STDSDeviceInformationParameter timeZone],
                                                                                         @"C007": [STDSDeviceInformationParameter advertisingID],
                                                                                         @"C008": [STDSDeviceInformationParameter screenResolution],
-                                                                                        @"C009": [STDSDeviceInformationParameter deviceName],
                                                                                         @"C010": [STDSDeviceInformationParameter IPAddress],
                                                                                         @"C011": [STDSDeviceInformationParameter latitude],
                                                                                         @"C012": [STDSDeviceInformationParameter longitude],


### PR DESCRIPTION
## Summary
Remove usage of `UIDevice.currentDevice.name`.

## Motivation
As detailed in [this issue](https://github.com/stripe/stripe-ios/issues/2398), iOS 16 no longer returns a user specified device name like `Andrew’s iPhone 14 Pro`. Instead it just returns `iPhone`. That makes this parameter not very useful for Stripe. However apps can request an entitlement to get the full name again. But those apps are specifically prohibited from allowing that device name to be shared with third parties (Stripe). So by removing this access, app creators can now request this entitlement from Apple, and not be in violation of the rules around that entitlement.

## Testing
There are existing tests that confirmed that this `deviceName` was being included in the params. They have been updated to no longer expect it.
