### PR TITLE
Use localizedModel instead of name 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Payments
 * [Fixed] Fixed amounts in COP being formatted incorrectly.
 * [Fixed] Fixed BLIK payment bindings not handling next actions correctly.
+* [Changed] Removed usage of `UIDevice.currentDevice.name`.
 
 ### Identity
 * [Added] Added a retake photo button on selfie scanning screen.

--- a/Stripe3DS2/Stripe3DS2/STDSDeviceInformationParameter.m
+++ b/Stripe3DS2/Stripe3DS2/STDSDeviceInformationParameter.m
@@ -224,7 +224,7 @@ static const NSString * const kParameterNilCode = @"RE04";
     return [[STDSDeviceInformationParameter alloc] initWithIdentifier:@"C009"
                                                       permissionCheck:nil
                                                            valueCheck:^id _Nullable{
-                                                               return [UIDevice currentDevice].name;
+                                                               return [UIDevice currentDevice].localizedModel;
                                                            }];
 }
 


### PR DESCRIPTION
## Summary
Instead of using name we are moving to localizedModel as to not block merchants from obtaining the entitlement to read `UIDevice.currentDevice.name`.

## Motivation
https://github.com/stripe/stripe-ios/issues/2398

## Testing
Existing tests

## Changelog
See diff