### PR TITLE
Financial Connections: changed retreiving accounts loader copy.

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerHelpers.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerHelpers.swift
@@ -94,11 +94,11 @@ func buildRetrievingAccountsView() -> UIView {
     return ReusableInformationView(
         iconType: .loading,
         title: STPLocalizedString(
-            "Pulling up your accounts",
+            "Connecting your bank",
             "The title of the loading screen that appears when a user just logged into their bank account, and now is waiting for their bank accounts to load. Once the bank accounts are loaded, user will be able to pick the bank account they want to to use for things like payments."
         ),
         subtitle: STPLocalizedString(
-            "After this, there's just one more step.",
+            "You're almost done.",
             "The subtitle/description of the loading screen that appears when a user just logged into their bank account, and now is waiting for their bank accounts to load. Once the bank accounts are loaded, user will be able to pick the bank account they want to to use for things like payments."
         )
     )


### PR DESCRIPTION
## Summary

This PR changes the copy of retrieving accounts loader. [Doc](https://docs.google.com/document/d/1EgLzyxPlv0-Y9KNHb_b6tPIERw7gAddSv58rk4WHPjs/edit#).

This is the expectation:

<img width="626" alt="expectation" src="https://user-images.githubusercontent.com/105514761/226722203-83f38838-002a-4917-9a02-33ad1fe0c7f9.png">


## Testing

Screenshot from testing:

![Simulator Screen Shot - iPhone 14 Pro - 2023-03-21 at 15 36 42](https://user-images.githubusercontent.com/105514761/226722280-604c2336-80a9-45a2-89b1-b76468f73922.png)
