### PR TITLE
FC: Detect banking app installed case

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthDataSource.swift
@@ -19,7 +19,7 @@ protocol PartnerAuthDataSource: AnyObject {
     func authorizeAuthSession(_ authSession: FinancialConnectionsAuthSession) -> Future<FinancialConnectionsAuthSession>
     func cancelPendingAuthSessionIfNeeded()
     func recordAuthSessionEvent(eventName: String, authSessionId: String)
-    func clearReturnURL(authSession: FinancialConnectionsAuthSession, urlString: String) -> Future<FinancialConnectionsAuthSession>
+    func clearReturnURL(authSession: FinancialConnectionsAuthSession, authURL: String) -> Future<FinancialConnectionsAuthSession>
 }
 
 final class PartnerAuthDataSourceImplementation: PartnerAuthDataSource {
@@ -64,7 +64,7 @@ final class PartnerAuthDataSourceImplementation: PartnerAuthDataSource {
         }
     }
 
-    func clearReturnURL(authSession: FinancialConnectionsAuthSession, urlString: String) -> Future<FinancialConnectionsAuthSession> {
+    func clearReturnURL(authSession: FinancialConnectionsAuthSession, authURL: String) -> Future<FinancialConnectionsAuthSession> {
         let promise = Promise<FinancialConnectionsAuthSession>()
 
         apiClient
@@ -79,7 +79,7 @@ final class PartnerAuthDataSourceImplementation: PartnerAuthDataSource {
                                                                         nextPane: authSession.nextPane,
                                                                         showPartnerDisclosure: authSession.showPartnerDisclosure,
                                                                         skipAccountSelection: authSession.skipAccountSelection,
-                                                                        url: urlString,
+                                                                        url: authURL,
                                                                         isOauth: authSession.isOauth,
                                                                         display: authSession.display)
                     self.pendingAuthSession = copiedSession

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthViewController.swift
@@ -404,24 +404,24 @@ final class PartnerAuthViewController: UIViewController {
 
         self.subscribeToURLAndAppActiveNotifications()
         UIApplication.shared.open(url, options: [UIApplication.OpenExternalURLOptionsKey.universalLinksOnly: true]) { (success) in
-            if !success {
-                self.clearStateAndUnsubscribeFromNotifications()
+            if success { return }
+            // This means banking app is not installed
+            self.clearStateAndUnsubscribeFromNotifications()
 
-                self.showEstablishingConnectionLoadingView(true)
-                self.dataSource
-                    .clearReturnURL(authSession: authSession, urlString: urlString)
-                    .observe(on: .main) { [weak self] result in
-                        guard let self = self else { return }
-                        // order is important so be careful of moving
-                        self.showEstablishingConnectionLoadingView(false)
-                        switch result {
-                        case .success(let authSession):
-                            self.openInstitutionAuthenticationWebView(authSession: authSession)
-                        case .failure(let error):
-                            self.showErrorView(error)
-                        }
+            self.showEstablishingConnectionLoadingView(true)
+            self.dataSource
+                .clearReturnURL(authSession: authSession, authURL: urlString)
+                .observe(on: .main) { [weak self] result in
+                    guard let self = self else { return }
+                    // order is important so be careful of moving
+                    self.showEstablishingConnectionLoadingView(false)
+                    switch result {
+                    case .success(let authSession):
+                        self.openInstitutionAuthenticationWebView(authSession: authSession)
+                    case .failure(let error):
+                        self.showErrorView(error)
                     }
-            }
+                }
         }
     }
 


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Don't open auth urls in safari if app is not installed
## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Makes for a better UX.

This one is a bit tricky. When we detect the app is not installed, we clear app return url from server then open the non native redirect link.

## Testing
<!-- How was the code tested? Be as specific as possible. -->
See how I first go with app installed, then delete and try again and it opens in webview
https://user-images.githubusercontent.com/92807969/226878470-735358bd-a5c2-41af-ab93-21e84b320543.MP4


