### PR TITLE
[Identity] Fix initialScrollViewBottomInsect

### DIFF
--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Views/IdentityFlowView.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Views/IdentityFlowView.swift
@@ -115,7 +115,7 @@ class IdentityFlowView: UIView {
     private var contentViewModel: ContentViewModel?
     private var buttons: [Button] = []
     private var buttonTapActions: [() -> Void] = []
-    private var initialScrollViewBottomInsect: CGFloat?
+    private var initialScrollViewBottomInsect: CGFloat = 0
 
     // MARK: - Init
 
@@ -154,7 +154,7 @@ class IdentityFlowView: UIView {
 
         // Adjust bottom inset to make space for keyboard
         let bottomInset =
-            isKeyboardHidden ? initialScrollViewBottomInsect! : (endFrame.height - frame.height + scrollView.frame.maxY)
+            isKeyboardHidden ? initialScrollViewBottomInsect : (endFrame.height - frame.height + scrollView.frame.maxY)
         scrollView.contentInset.bottom = bottomInset
         scrollView.verticalScrollIndicatorInsets.bottom = bottomInset
         scrollView.horizontalScrollIndicatorInsets.bottom = bottomInset


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Set initialScrollViewBottomInsect to 0 instead of making it optional to avoid crash on emulators.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
On emulators, `isKeyboardHidden` is still true when a certain text field is highlighted(see below) as user can type on the physical keyboard. This would resulting in checking the uninitialized `initialScrollViewBottomInsect`, which would cause a crash. Initializing it to 0 would prevent the crash.



![simulator_screenshot_ACDA530D-BE5D-4130-8A56-30DF3FBEC608](https://user-images.githubusercontent.com/79880926/227397765-1053b631-a381-4f18-8009-b13ba2827cac.png)

## Testing
<!-- How was the code tested? Be as specific as possible. -->
Manually verified

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
