### PR TITLE
Adds SimpleMandateElement, require it to be displayed 

### DIFF
--- a/Stripe/StripeiOSTests/PaymentSheetFormFactoryTest.swift
+++ b/Stripe/StripeiOSTests/PaymentSheetFormFactoryTest.swift
@@ -1506,7 +1506,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         XCTAssertEqual(addressSectionElement.element.addressDetails, emptyAddressSectionElement.addressDetails)
     }
 
-    func testAppliesPreviousCustomerInput_for_mandate_pms() {
+    func testAppliesPreviousCustomerInput_for_mandate() {
         let expectation = expectation(description: "Load specs")
         AddressSpecProvider.shared.loadAddressSpecs {
             FormSpecProvider.shared.load { _ in
@@ -1515,6 +1515,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         }
         waitForExpectations(timeout: 1)
 
+        // Use PayPal as an example PM, since it is an empty form w/ a mandate iff PI+SFU or SI
         func makePaypalForm(isSettingUp: Bool, previousCustomerInput: IntentConfirmParams?) -> PaymentMethodElement {
             return PaymentSheetFormFactory(
                 intent: .paymentIntent(STPFixtures.paymentIntent(paymentMethodTypes: ["paypal"], setupFutureUsage: isSettingUp ? .offSession : .none)),
@@ -1555,8 +1556,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
             XCTFail("payment option should be non-nil")
             return
         }
-        // ...even though the form didn't display the mandate
-        XCTAssertFalse(paypalForm_setup_paymentOption.didDisplayMandate)
+        XCTAssertTrue(paypalForm_setup_paymentOption.didDisplayMandate)
     }
 
     // MARK: - Helpers

--- a/Stripe/StripeiOSTests/PaymentSheetFormFactoryTest.swift
+++ b/Stripe/StripeiOSTests/PaymentSheetFormFactoryTest.swift
@@ -1505,7 +1505,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         let emptyAddressSectionElement = AddressSectionElement()
         XCTAssertEqual(addressSectionElement.element.addressDetails, emptyAddressSectionElement.addressDetails)
     }
-    
+
     func testAppliesPreviousCustomerInput_for_mandate_pms() {
         let expectation = expectation(description: "Load specs")
         AddressSpecProvider.shared.loadAddressSpecs {
@@ -1514,7 +1514,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
             }
         }
         waitForExpectations(timeout: 1)
-        
+
         func makePaypalForm(isSettingUp: Bool, previousCustomerInput: IntentConfirmParams?) -> PaymentMethodElement {
             return PaymentSheetFormFactory(
                 intent: .paymentIntent(STPFixtures.paymentIntent(paymentMethodTypes: ["paypal"], setupFutureUsage: isSettingUp ? .offSession : .none)),
@@ -1523,7 +1523,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
                 previousCustomerInput: previousCustomerInput
             ).make()
         }
-        
+
         // 1. nil -> valid Payment form
         // A paypal form for *payment* without previous customer input...
         let paypalForm_payment = makePaypalForm(isSettingUp: false, previousCustomerInput: nil)
@@ -1533,7 +1533,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
             return
         }
         XCTAssertFalse(paypalForm_payment_paymentOption.didDisplayMandate)
-        
+
         // 2. valid Payment form -> invalid Setup form
         // Creating a paypal form for *setup* using the old form as previous customer input...
         var paypalForm_setup = makePaypalForm(isSettingUp: true, previousCustomerInput: paypalForm_payment_paymentOption)
@@ -1546,7 +1546,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
             return
         }
         XCTAssertTrue(paypalForm_setup_paymentOption.didDisplayMandate)
-        
+
         // 3. valid Setup form -> valid Setup form
         // Using the form's previous customer input to create another *setup* paypal form...
         paypalForm_setup = makePaypalForm(isSettingUp: true, previousCustomerInput: paypalForm_setup_paymentOption)

--- a/Stripe/StripeiOSTests/PaymentSheetFormFactoryTest.swift
+++ b/Stripe/StripeiOSTests/PaymentSheetFormFactoryTest.swift
@@ -1504,7 +1504,59 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         }
         let emptyAddressSectionElement = AddressSectionElement()
         XCTAssertEqual(addressSectionElement.element.addressDetails, emptyAddressSectionElement.addressDetails)
-
+    }
+    
+    func testAppliesPreviousCustomerInput_for_mandate_pms() {
+        let expectation = expectation(description: "Load specs")
+        AddressSpecProvider.shared.loadAddressSpecs {
+            FormSpecProvider.shared.load { _ in
+                expectation.fulfill()
+            }
+        }
+        waitForExpectations(timeout: 1)
+        
+        func makePaypalForm(isSettingUp: Bool, previousCustomerInput: IntentConfirmParams?) -> PaymentMethodElement {
+            return PaymentSheetFormFactory(
+                intent: .paymentIntent(STPFixtures.paymentIntent(paymentMethodTypes: ["paypal"], setupFutureUsage: isSettingUp ? .offSession : .none)),
+                configuration: ._testValue_MostPermissive(),
+                paymentMethod: .dynamic("paypal"),
+                previousCustomerInput: previousCustomerInput
+            ).make()
+        }
+        
+        // 1. nil -> valid Payment form
+        // A paypal form for *payment* without previous customer input...
+        let paypalForm_payment = makePaypalForm(isSettingUp: false, previousCustomerInput: nil)
+        // ...should be valid - it requires no customer input.
+        guard let paypalForm_payment_paymentOption = paypalForm_payment.updateParams(params: IntentConfirmParams(type: .dynamic("paypal"))) else {
+            XCTFail("payment option should be non-nil")
+            return
+        }
+        XCTAssertFalse(paypalForm_payment_paymentOption.didDisplayMandate)
+        
+        // 2. valid Payment form -> invalid Setup form
+        // Creating a paypal form for *setup* using the old form as previous customer input...
+        var paypalForm_setup = makePaypalForm(isSettingUp: true, previousCustomerInput: paypalForm_payment_paymentOption)
+        // ...should not be valid...
+        XCTAssertNil(paypalForm_setup.updateParams(params: IntentConfirmParams(type: .dynamic("paypal"))))
+        // ...until the customer has seen the mandate...
+        sendEventToSubviews(.viewDidAppear, from: paypalForm_setup.view)
+        guard let paypalForm_setup_paymentOption = paypalForm_setup.updateParams(params: IntentConfirmParams(type: .dynamic("paypal"))) else {
+            XCTFail("payment option should be non-nil")
+            return
+        }
+        XCTAssertTrue(paypalForm_setup_paymentOption.didDisplayMandate)
+        
+        // 3. valid Setup form -> valid Setup form
+        // Using the form's previous customer input to create another *setup* paypal form...
+        paypalForm_setup = makePaypalForm(isSettingUp: true, previousCustomerInput: paypalForm_setup_paymentOption)
+        // ...should be valid...
+        guard let paypalForm_setup_paymentOption = paypalForm_setup.updateParams(params: IntentConfirmParams(type: .dynamic("paypal"))) else {
+            XCTFail("payment option should be non-nil")
+            return
+        }
+        // ...even though the form didn't display the mandate
+        XCTAssertFalse(paypalForm_setup_paymentOption.didDisplayMandate)
     }
 
     // MARK: - Helpers

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/SimpleMandateElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/SimpleMandateElement.swift
@@ -20,14 +20,14 @@ class SimpleMandateElement: PaymentMethodElement {
             return nil
         }
     }
-    
+
     var delegate: StripeUICore.ElementDelegate?
     var view: UIView {
         return mandateTextView
     }
     let mandateTextView: SimpleMandateTextView
     let customerAlreadySawMandate: Bool
-    
+
     init(mandateText: String, customerAlreadySawMandate: Bool = false, theme: ElementsUITheme = .default) {
         mandateTextView = SimpleMandateTextView(mandateText: mandateText, theme: theme)
         self.customerAlreadySawMandate = customerAlreadySawMandate

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/SimpleMandateElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/SimpleMandateElement.swift
@@ -10,6 +10,9 @@ import UIKit
 
 class SimpleMandateElement: PaymentMethodElement {
     func updateParams(params: IntentConfirmParams) -> IntentConfirmParams? {
+        if mandateTextView.viewDidAppear {
+            params.didDisplayMandate = true
+        }
         if customerAlreadySawMandate || mandateTextView.viewDidAppear {
             // the customer must have seen the mandate for this to be valid
             return params

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/SimpleMandateElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/SimpleMandateElement.swift
@@ -10,11 +10,10 @@ import UIKit
 
 class SimpleMandateElement: PaymentMethodElement {
     func updateParams(params: IntentConfirmParams) -> IntentConfirmParams? {
-        if mandateTextView.viewDidAppear {
-            params.didDisplayMandate = true
-        }
+        // Per the contract of the `updateParams(params:)` API (see its docstring), we should only return a non-nil params if we are valid.
+        // We are only valid if the customer saw the mandate - either our view was displayed *or* the customer already saw the view
         if customerAlreadySawMandate || mandateTextView.viewDidAppear {
-            // the customer must have seen the mandate for this to be valid
+            params.didDisplayMandate = true
             return params
         } else {
             return nil

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/SimpleMandateElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/SimpleMandateElement.swift
@@ -1,0 +1,32 @@
+//
+//  SimpleMandateElement.swift
+//  StripePaymentSheet
+//
+//  Created by Yuki Tokuhiro on 3/26/23.
+//
+
+@_spi(STP) import StripeUICore
+import UIKit
+
+class SimpleMandateElement: PaymentMethodElement {
+    func updateParams(params: IntentConfirmParams) -> IntentConfirmParams? {
+        if customerAlreadySawMandate || mandateTextView.viewDidAppear {
+            // the customer must have seen the mandate for this to be valid
+            return params
+        } else {
+            return nil
+        }
+    }
+    
+    var delegate: StripeUICore.ElementDelegate?
+    var view: UIView {
+        return mandateTextView
+    }
+    let mandateTextView: SimpleMandateTextView
+    let customerAlreadySawMandate: Bool
+    
+    init(mandateText: String, customerAlreadySawMandate: Bool = false, theme: ElementsUITheme = .default) {
+        mandateTextView = SimpleMandateTextView(mandateText: mandateText, theme: theme)
+        self.customerAlreadySawMandate = customerAlreadySawMandate
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Intent.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Intent.swift
@@ -124,6 +124,8 @@ class IntentConfirmParams {
     /// True if the customer opts to save their payment method for future payments.
     /// - Note: PaymentIntent-only
     var shouldSavePaymentMethod: Bool = false
+    /// If `true`, a mandate (e.g. "By continuing you authorize Foo Corp to use your payment details for recurring payments...") was displayed to the customer.
+    var didDisplayMandate: Bool = false
     /// - Note: PaymentIntent-only
     var paymentMethodOptions: STPConfirmPaymentMethodOptions?
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
@@ -216,7 +216,7 @@ class AddPaymentMethodViewController: UIViewController {
             addressSection.delegate = delegate
         }
     }
-    
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         sendEventToSubviews(.viewDidAppear, from: view)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
@@ -216,6 +216,11 @@ class AddPaymentMethodViewController: UIViewController {
             addressSection.delegate = delegate
         }
     }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        sendEventToSubviews(.viewDidAppear, from: view)
+    }
 
     // MARK: - Internal
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/PaymentMethodTypeCollectionView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/PaymentMethodTypeCollectionView.swift
@@ -261,6 +261,8 @@ extension PaymentMethodTypeCollectionView {
                     self.label.alpha = 0.6
                 case .shouldEnableUserInteraction:
                     self.label.alpha = 1
+                default:
+                    break
                 }
             }
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -183,7 +183,7 @@ extension PaymentSheetFormFactory {
             return params
         }
     }
-    
+
     func makeMandate(mandateText: String) -> PaymentMethodElement {
         // If there was previous customer input, check if it displayed the mandate for this payment method
         let customerAlreadySawMandate = previousCustomerInput?.didDisplayMandate ?? false
@@ -229,7 +229,7 @@ extension PaymentSheetFormFactory {
         return makeMandate(mandateText: mandateText)
 
     }
-    
+
     func makePaypalMandate(intent: Intent) -> PaymentMethodElement {
         let mandateText: String = {
             if intent.isPaymentIntent {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -183,6 +183,12 @@ extension PaymentSheetFormFactory {
             return params
         }
     }
+    
+    func makeMandate(mandateText: String) -> PaymentMethodElement {
+        // If there was previous customer input, check if it displayed the mandate for this payment method
+        let customerAlreadySawMandate = previousCustomerInput?.didDisplayMandate ?? false
+        return SimpleMandateElement(mandateText: mandateText, customerAlreadySawMandate: customerAlreadySawMandate, theme: theme)
+    }
 
     func makeBSB(apiPath: String? = nil) -> PaymentMethodElementWrapper<TextFieldElement> {
         let element = TextFieldElement.Account.makeBSB(defaultValue: nil, theme: theme)
@@ -215,12 +221,12 @@ extension PaymentSheetFormFactory {
 
     func makeSepaMandate() -> PaymentMethodElement {
         let mandateText = String(format: String.Localized.sepa_mandate_text, configuration.merchantDisplayName)
-        return SimpleMandateElement(mandateText: mandateText, theme: theme)
+        return makeMandate(mandateText: mandateText)
     }
 
     func makeCashAppMandate() -> PaymentMethodElement {
         let mandateText = String(format: String.Localized.cash_app_mandate_text, configuration.merchantDisplayName)
-        return SimpleMandateElement(mandateText: mandateText, theme: theme)
+        return makeMandate(mandateText: mandateText)
 
     }
     
@@ -232,7 +238,7 @@ extension PaymentSheetFormFactory {
                 return String(format: String.Localized.paypal_mandate_text_setup, configuration.merchantDisplayName)
             }
         }()
-        return SimpleMandateElement(mandateText: mandateText, theme: theme)
+        return makeMandate(mandateText: mandateText)
     }
 
     func makeSaveCheckbox(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -213,21 +213,18 @@ extension PaymentSheetFormFactory {
         return StaticElement(view: AUBECSLegalTermsView(configuration: configuration))
     }
 
-    func makeSepaMandate() -> StaticElement {
+    func makeSepaMandate() -> PaymentMethodElement {
         let mandateText = String(format: String.Localized.sepa_mandate_text, configuration.merchantDisplayName)
-        return StaticElement(
-            view: SimpleMandateTextView(mandateText: mandateText, theme: theme)
-        )
+        return SimpleMandateElement(mandateText: mandateText, theme: theme)
     }
 
-    func makeCashAppMandate() -> StaticElement {
+    func makeCashAppMandate() -> PaymentMethodElement {
         let mandateText = String(format: String.Localized.cash_app_mandate_text, configuration.merchantDisplayName)
-        return StaticElement(
-            view: SimpleMandateTextView(mandateText: mandateText, theme: theme)
-        )
-    }
+        return SimpleMandateElement(mandateText: mandateText, theme: theme)
 
-    func makePaypalMandate(intent: Intent) -> StaticElement {
+    }
+    
+    func makePaypalMandate(intent: Intent) -> PaymentMethodElement {
         let mandateText: String = {
             if intent.isPaymentIntent {
                 return String(format: String.Localized.paypal_mandate_text_payment, configuration.merchantDisplayName)
@@ -235,9 +232,7 @@ extension PaymentSheetFormFactory {
                 return String(format: String.Localized.paypal_mandate_text_setup, configuration.merchantDisplayName)
             }
         }()
-        return StaticElement(
-            view: SimpleMandateTextView(mandateText: mandateText, theme: theme)
-        )
+        return SimpleMandateElement(mandateText: mandateText, theme: theme)
     }
 
     func makeSaveCheckbox(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentMethodCollectionView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentMethodCollectionView.swift
@@ -227,6 +227,8 @@ extension SavedPaymentMethodCollectionView {
                     self.label.alpha = 0.6
                 case .shouldEnableUserInteraction:
                     self.label.alpha = 1
+                default:
+                    break
                 }
             }
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/BankAccountInfoView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/BankAccountInfoView.swift
@@ -153,6 +153,8 @@ extension BankAccountInfoView: EventHandler {
             self.isUserInteractionEnabled = true
         case .shouldDisableUserInteraction:
             self.isUserInteractionEnabled = false
+        default:
+            break
         }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/CircularButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/CircularButton.swift
@@ -105,6 +105,8 @@ class CircularButton: UIControl {
             backgroundColor = .systemGray2
         case .shouldDisableUserInteraction:
             backgroundColor = .systemIndigo
+        default:
+            break
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/SimpleMandateTextView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/SimpleMandateTextView.swift
@@ -13,6 +13,7 @@ import UIKit
 @objc(STP_Internal_SimpleMandateTextView)
 class SimpleMandateTextView: UIView {
     private let theme: ElementsUITheme
+    var viewDidAppear: Bool = false
     lazy var label: UILabel = {
         let label = UILabel()
         label.font = theme.fonts.caption
@@ -34,5 +35,13 @@ class SimpleMandateTextView: UIView {
 
     fileprivate func installConstraints() {
         addAndPinSubview(label)
+    }
+}
+
+extension SimpleMandateTextView: EventHandler {
+    func handleEvent(_ event: StripeUICore.STPEvent) {
+        if case .viewDidAppear = event {
+           viewDidAppear = true
+        }
     }
 }

--- a/StripeUICore/StripeUICore/Source/Elements/PickerField/PickerFieldView.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/PickerField/PickerFieldView.swift
@@ -177,6 +177,8 @@ extension PickerFieldView: EventHandler {
             isUserInteractionEnabled = true
         case .shouldDisableUserInteraction:
             isUserInteractionEnabled = false
+        default:
+            break
         }
     }
 }

--- a/StripeUICore/StripeUICore/Source/Elements/Section/SectionContainerView.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Section/SectionContainerView.swift
@@ -185,6 +185,8 @@ extension SectionContainerView: EventHandler {
             isUserInteractionEnabled = true
         case .shouldDisableUserInteraction:
             isUserInteractionEnabled = false
+        default:
+            break
         }
     }
 }

--- a/StripeUICore/StripeUICore/Source/Elements/TextField/FloatingPlaceholderTextFieldView.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/TextField/FloatingPlaceholderTextFieldView.swift
@@ -182,6 +182,8 @@ extension FloatingPlaceholderTextFieldView: EventHandler {
             isUserInteractionEnabled = true
         case .shouldDisableUserInteraction:
             isUserInteractionEnabled = false
+        default:
+            break
         }
     }
 }

--- a/StripeUICore/StripeUICore/Source/Elements/TextField/TextFieldView.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/TextField/TextFieldView.swift
@@ -275,6 +275,8 @@ extension TextFieldView: EventHandler {
             isUserInteractionEnabled = true
         case .shouldDisableUserInteraction:
             isUserInteractionEnabled = false
+        default:
+            break
         }
     }
 }

--- a/StripeUICore/StripeUICore/Source/Events.swift
+++ b/StripeUICore/StripeUICore/Source/Events.swift
@@ -22,6 +22,7 @@ import UIKit
 @frozen @_spi(STP) public enum STPEvent {
     case shouldEnableUserInteraction
     case shouldDisableUserInteraction
+    case viewDidAppear
 }
 
 @_spi(STP) public protocol EventHandler {


### PR DESCRIPTION
## Summary
1. Creates a `SimpleMandateElement` that requires its view to have been displayed before producing a valid payment option.
2. Preserves "view was displayed" state in IntentConfirmParams.

## Motivation
Make `PaymentSheet.FlowController.update` flow preserve customer input when the customer is using a payment method that can require a mandate, like Paypal.  Specifically, handle edge cases around the payment method being updated to include or not include a mandate e.g. going from payment -> setup mode.  See the unit tests for details.

## Testing
See unit test

## Changelog
No user facing changes