### PR TITLE
Support preserving previous customer input for all PaymentSheet fields

### DIFF
--- a/Stripe/StripeiOSTests/PaymentSheetFormFactoryTest.swift
+++ b/Stripe/StripeiOSTests/PaymentSheetFormFactoryTest.swift
@@ -105,7 +105,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         )
         XCTAssertEqual(updatedParams?.paymentMethodParams.rawTypeString, "mock_payment_method")
         XCTAssertEqual(updatedParams?.paymentMethodParams.type, .unknown)
-        
+
         // Using the params as previous customer input...
         let name_with_previous_customer_input = PaymentSheetFormFactory(
             intent: .paymentIntent(STPFixtures.paymentIntent()),
@@ -137,7 +137,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         )
         XCTAssertEqual(updatedParams?.paymentMethodParams.rawTypeString, "mock_payment_method")
         XCTAssertEqual(updatedParams?.paymentMethodParams.type, .unknown)
-        
+
         // Using the params as previous customer input...
         let name_with_previous_customer_input = PaymentSheetFormFactory(
             intent: .paymentIntent(STPFixtures.paymentIntent()),
@@ -234,7 +234,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         XCTAssertNil(updatedParams?.paymentMethodParams.billingDetails?.email)
         XCTAssertEqual(updatedParams?.paymentMethodParams.rawTypeString, "mock_payment_method")
         XCTAssertEqual(updatedParams?.paymentMethodParams.type, .unknown)
-        
+
         // Using the params as previous customer input...
         let email_with_previous_customer_input = PaymentSheetFormFactory(
             intent: .paymentIntent(STPFixtures.paymentIntent()),
@@ -266,7 +266,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         )
         XCTAssertEqual(updatedParams?.paymentMethodParams.rawTypeString, "mock_payment_method")
         XCTAssertEqual(updatedParams?.paymentMethodParams.type, .unknown)
-        
+
         // Using the params as previous customer input...
         let email_with_previous_customer_input = PaymentSheetFormFactory(
             intent: .paymentIntent(STPFixtures.paymentIntent()),
@@ -327,7 +327,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
             updatedParams?.paymentMethodParams.billingDetails?.phone,
             "+15555555555"
         )
-        
+
         // Using the params as previous customer input...
         let phone_with_previous_customer_input = PaymentSheetFormFactory(
             intent: .paymentIntent(STPFixtures.paymentIntent()),
@@ -404,7 +404,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         )
         XCTAssertEqual(updatedParams?.paymentMethodParams.rawTypeString, "sepa_debit")
         XCTAssertEqual(updatedParams?.paymentMethodParams.type, .SEPADebit)
-        
+
         // Given a dropdown...
         let dropdown = PaymentSheetFormFactory(
             intent: .paymentIntent(STPFixtures.paymentIntent()),
@@ -421,7 +421,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
             paymentMethod: .dynamic("sepa_debit"),
             previousCustomerInput: previousCustomerInput
         ).makeDropdown(for: selectorSpec)
-        
+
         // ...should result in a valid element filled out with the previous customer input
         XCTAssertEqual(dropdown_with_previous_customer_input.element.selectedIndex, 1)
         XCTAssertEqual(dropdown_with_previous_customer_input.validationState, .valid)
@@ -586,7 +586,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         )
         XCTAssertEqual(updatedParams?.paymentMethodParams.rawTypeString, "au_becs_debit")
         XCTAssertEqual(updatedParams?.paymentMethodParams.type, .AUBECSDebit)
-        
+
         // Using the params as previous customer input...
         let bsb_with_previous_input = PaymentSheetFormFactory(
             intent: .paymentIntent(STPFixtures.paymentIntent()),
@@ -666,7 +666,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         )
         XCTAssertEqual(updatedParams?.paymentMethodParams.rawTypeString, "au_becs_debit")
         XCTAssertEqual(updatedParams?.paymentMethodParams.type, .AUBECSDebit)
-        
+
         // Using the params as previous customer input...
         let form_with_previous_input = PaymentSheetFormFactory(
             intent: .paymentIntent(STPFixtures.paymentIntent()),
@@ -715,7 +715,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         )
         XCTAssertEqual(updatedParams?.paymentMethodParams.rawTypeString, "au_becs_debit")
         XCTAssertEqual(updatedParams?.paymentMethodParams.type, .AUBECSDebit)
-        
+
         // Using the params as previous customer input...
         let form_with_previous_input = PaymentSheetFormFactory(
             intent: .paymentIntent(STPFixtures.paymentIntent()),
@@ -856,7 +856,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         XCTAssert(updatedParams?.paymentMethodParams.additionalAPIParameters.isEmpty ?? false)
         XCTAssertEqual(updatedParams?.paymentMethodParams.rawTypeString, "sofort")
         XCTAssertEqual(updatedParams?.paymentMethodParams.type, .sofort)
-        
+
         // Using the params as previous customer input...
         let country_with_previous_input = PaymentSheetFormFactory(
             intent: .paymentIntent(STPFixtures.paymentIntent()),
@@ -896,7 +896,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         )
         XCTAssertEqual(updatedParams?.paymentMethodParams.rawTypeString, "sofort")
         XCTAssertEqual(updatedParams?.paymentMethodParams.type, .sofort)
-        
+
         // Using the params as previous customer input...
         let country_with_previous_input = makeCountry(previousCustomerInput: updatedParams)
         // ...should result in a valid, filled out element
@@ -940,7 +940,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         XCTAssert(updatedParams?.paymentMethodParams.additionalAPIParameters.isEmpty ?? false)
         XCTAssertEqual(updatedParams?.paymentMethodParams.rawTypeString, "sepa_debit")
         XCTAssertEqual(updatedParams?.paymentMethodParams.type, .SEPADebit)
-        
+
         // Using the params as previous customer input...
         let form_with_previous_input = makeForm(previousCustomerInput: updatedParams)
         // ...should result in a valid, filled out element
@@ -985,7 +985,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         )
         XCTAssertEqual(updatedParams?.paymentMethodParams.rawTypeString, "sepa_debit")
         XCTAssertEqual(updatedParams?.paymentMethodParams.type, .SEPADebit)
-        
+
         // Using the params as previous customer input...
         let form_with_previous_input = makeForm(previousCustomerInput: updatedParams)
         // ...should result in a valid, filled out element
@@ -1702,7 +1702,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         let emptyAddressSectionElement = AddressSectionElement()
         XCTAssertEqual(addressSectionElement.element.addressDetails, emptyAddressSectionElement.addressDetails)
     }
-    
+
     func testAppliesPreviousCustomerInput_klarna_country() {
         func makeKlarnaCountry(apiPath: String?, previousCustomerInput: IntentConfirmParams?) -> PaymentMethodElementWrapper<DropdownFieldElement> {
             let factory = PaymentSheetFormFactory(

--- a/Stripe/StripeiOSTests/PaymentSheetFormFactoryTest.swift
+++ b/Stripe/StripeiOSTests/PaymentSheetFormFactoryTest.swift
@@ -105,6 +105,17 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         )
         XCTAssertEqual(updatedParams?.paymentMethodParams.rawTypeString, "mock_payment_method")
         XCTAssertEqual(updatedParams?.paymentMethodParams.type, .unknown)
+        
+        // Using the params as previous customer input...
+        let name_with_previous_customer_input = PaymentSheetFormFactory(
+            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            configuration: configuration,
+            paymentMethod: .dynamic("mock_payment_method"),
+            previousCustomerInput: updatedParams
+        ).makeName(apiPath: "custom_location[name]")
+        // ...should result in a valid element filled out with the previous customer input
+        XCTAssertEqual(name_with_previous_customer_input.element.text, "someName")
+        XCTAssertEqual(name_with_previous_customer_input.validationState, .valid)
     }
 
     func testNameValueWrittenToDefaultLocation() {
@@ -126,6 +137,17 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         )
         XCTAssertEqual(updatedParams?.paymentMethodParams.rawTypeString, "mock_payment_method")
         XCTAssertEqual(updatedParams?.paymentMethodParams.type, .unknown)
+        
+        // Using the params as previous customer input...
+        let name_with_previous_customer_input = PaymentSheetFormFactory(
+            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            configuration: configuration,
+            paymentMethod: .dynamic("mock_payment_method"),
+            previousCustomerInput: updatedParams
+        ).makeName()
+        // ...should result in a valid element filled out with the previous customer input
+        XCTAssertEqual(name_with_previous_customer_input.element.text, "someName")
+        XCTAssertEqual(name_with_previous_customer_input.validationState, .valid)
     }
 
     func testNameValueWrittenToLocationDefinedAPIPath() {
@@ -212,6 +234,17 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         XCTAssertNil(updatedParams?.paymentMethodParams.billingDetails?.email)
         XCTAssertEqual(updatedParams?.paymentMethodParams.rawTypeString, "mock_payment_method")
         XCTAssertEqual(updatedParams?.paymentMethodParams.type, .unknown)
+        
+        // Using the params as previous customer input...
+        let email_with_previous_customer_input = PaymentSheetFormFactory(
+            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            configuration: configuration,
+            paymentMethod: .dynamic("mock_payment_method"),
+            previousCustomerInput: updatedParams
+        ).makeName(apiPath: "custom_location[email]")
+        // ...should result in a valid element filled out with the previous customer input
+        XCTAssertEqual(email_with_previous_customer_input.element.text, "email@stripe.com")
+        XCTAssertEqual(email_with_previous_customer_input.validationState, .valid)
     }
 
     func testEmailValueWrittenToDefaultLocation() {
@@ -233,6 +266,17 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         )
         XCTAssertEqual(updatedParams?.paymentMethodParams.rawTypeString, "mock_payment_method")
         XCTAssertEqual(updatedParams?.paymentMethodParams.type, .unknown)
+        
+        // Using the params as previous customer input...
+        let email_with_previous_customer_input = PaymentSheetFormFactory(
+            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            configuration: configuration,
+            paymentMethod: .dynamic("mock_payment_method"),
+            previousCustomerInput: updatedParams
+        ).makeEmail()
+        // ...should result in a valid element filled out with the previous customer input
+        XCTAssertEqual(email_with_previous_customer_input.element.text, "email@stripe.com")
+        XCTAssertEqual(email_with_previous_customer_input.validationState, .valid)
     }
 
     func testEmailValueWrittenToLocationDefinedAPIPath() {
@@ -283,6 +327,17 @@ class PaymentSheetFormFactoryTest: XCTestCase {
             updatedParams?.paymentMethodParams.billingDetails?.phone,
             "+15555555555"
         )
+        
+        // Using the params as previous customer input...
+        let phone_with_previous_customer_input = PaymentSheetFormFactory(
+            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            configuration: configuration,
+            paymentMethod: .dynamic("mock_payment_method"),
+            previousCustomerInput: updatedParams
+        ).makePhone()
+        // ...should result in a valid element filled out with the previous customer input
+        XCTAssertEqual(phone_with_previous_customer_input.element.selectedCountryCode, "US")
+        XCTAssertEqual(phone_with_previous_customer_input.validationState, .valid)
     }
 
     func testEmailValueWrittenToLocationUndefinedAPIPath() {
@@ -742,14 +797,27 @@ class PaymentSheetFormFactoryTest: XCTestCase {
             paymentMethod: .dynamic("sofort")
         )
         let country = factory.makeCountry(countryCodes: ["AT", "BE"], apiPath: nil)
+        (country as! PaymentMethodElementWrapper<DropdownFieldElement>).element.select(index: 1) // select a different index than the default of 0
 
         let params = IntentConfirmParams(type: .dynamic("sofort"))
         let updatedParams = country.updateParams(params: params)
 
-        XCTAssertEqual(updatedParams?.paymentMethodParams.billingDetails?.address?.country, "AT")
+        XCTAssertEqual(updatedParams?.paymentMethodParams.billingDetails?.address?.country, "BE")
         XCTAssert(updatedParams?.paymentMethodParams.additionalAPIParameters.isEmpty ?? false)
         XCTAssertEqual(updatedParams?.paymentMethodParams.rawTypeString, "sofort")
         XCTAssertEqual(updatedParams?.paymentMethodParams.type, .sofort)
+        
+        // Using the params as previous customer input...
+        let country_with_previous_input = PaymentSheetFormFactory(
+            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            configuration: configuration,
+            paymentMethod: .dynamic("sofort"),
+            previousCustomerInput: updatedParams
+        ).makeCountry(countryCodes: ["AT", "BE"], apiPath: nil)
+        // ...should result in a valid, filled out element
+        XCTAssert(country_with_previous_input.validationState == .valid)
+        let updatedParams_with_previous_input = country_with_previous_input.updateParams(params: .init(type: .dynamic("sofort")))
+        XCTAssertEqual(updatedParams_with_previous_input?.paymentMethodParams.billingDetails?.address?.country, "BE")
     }
 
     func testMakeFormElement_Country_withAPIPath() {
@@ -760,6 +828,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
             paymentMethod: .dynamic("sofort")
         )
         let country = factory.makeCountry(countryCodes: ["AT", "BE"], apiPath: "sofort[country]")
+        (country as! PaymentMethodElementWrapper<DropdownFieldElement>).element.select(index: 1) // select a different index than the default of 0
 
         let params = IntentConfirmParams(type: .dynamic("sofort"))
         let updatedParams = country.updateParams(params: params)
@@ -768,10 +837,25 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         XCTAssertEqual(
             updatedParams?.paymentMethodParams.additionalAPIParameters["sofort[country]"]
                 as! String,
-            "AT"
+            "BE"
         )
         XCTAssertEqual(updatedParams?.paymentMethodParams.rawTypeString, "sofort")
         XCTAssertEqual(updatedParams?.paymentMethodParams.type, .sofort)
+        
+        // Using the params as previous customer input...
+        let country_with_previous_input = PaymentSheetFormFactory(
+            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            configuration: configuration,
+            paymentMethod: .dynamic("sofort"),
+            previousCustomerInput: updatedParams
+        ).makeCountry(countryCodes: ["AT", "BE"], apiPath: nil)
+        // ...should result in a valid, filled out element
+        XCTAssert(country_with_previous_input.validationState == .valid)
+        let updatedParams_with_previous_input = country_with_previous_input.updateParams(params: .init(type: .dynamic("sofort")))
+        XCTAssertEqual(
+            updatedParams_with_previous_input?.paymentMethodParams.additionalAPIParameters["sofort[country]"] as! String,
+            "BE"
+        )
     }
 
     func testMakeFormElement_Iban_UndefinedAPIPath() {

--- a/Stripe/StripeiOSTests/PaymentSheetFormFactoryTest.swift
+++ b/Stripe/StripeiOSTests/PaymentSheetFormFactoryTest.swift
@@ -666,6 +666,18 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         )
         XCTAssertEqual(updatedParams?.paymentMethodParams.rawTypeString, "au_becs_debit")
         XCTAssertEqual(updatedParams?.paymentMethodParams.type, .AUBECSDebit)
+        
+        // Using the params as previous customer input...
+        let form_with_previous_input = PaymentSheetFormFactory(
+            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            configuration: configuration,
+            paymentMethod: .dynamic("au_becs_debit"),
+            previousCustomerInput: updatedParams
+        ).makeFormElementFromSpec(spec: spec)
+        // ...should result in a valid, filled out element
+        XCTAssert(form_with_previous_input.validationState == .valid)
+        let updatedParams_with_previous_input = form_with_previous_input.updateParams(params: .init(type: .dynamic("au_becs_debit")))
+        XCTAssertEqual(updatedParams_with_previous_input?.paymentMethodParams.auBECSDebit?.accountNumber, "000123456")
     }
 
     func testMakeFormElement_AUBECSAccountNumber_DefinedAPIPath() {
@@ -703,6 +715,23 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         )
         XCTAssertEqual(updatedParams?.paymentMethodParams.rawTypeString, "au_becs_debit")
         XCTAssertEqual(updatedParams?.paymentMethodParams.type, .AUBECSDebit)
+        
+        // Using the params as previous customer input...
+        let form_with_previous_input = PaymentSheetFormFactory(
+            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            configuration: configuration,
+            paymentMethod: .dynamic("au_becs_debit"),
+            previousCustomerInput: updatedParams
+        ).makeFormElementFromSpec(spec: spec)
+        // ...should result in a valid, filled out element
+        XCTAssert(form_with_previous_input.validationState == .valid)
+        let updatedParams_with_previous_input = form_with_previous_input.updateParams(params: .init(type: .dynamic("au_becs_debit")))
+        XCTAssertEqual(
+            updatedParams_with_previous_input?.paymentMethodParams.additionalAPIParameters[
+                "au_becs_debit[account_number]"
+            ] as! String,
+            "000123456"
+        )
     }
 
     func testMakeFormElement_AUBECSAccountNumber() {

--- a/Stripe/StripeiOSTests/PaymentSheetFormFactoryTest.swift
+++ b/Stripe/StripeiOSTests/PaymentSheetFormFactoryTest.swift
@@ -404,6 +404,27 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         )
         XCTAssertEqual(updatedParams?.paymentMethodParams.rawTypeString, "sepa_debit")
         XCTAssertEqual(updatedParams?.paymentMethodParams.type, .SEPADebit)
+        
+        // Given a dropdown...
+        let dropdown = PaymentSheetFormFactory(
+            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            configuration: configuration,
+            paymentMethod: .dynamic("sepa_debit")
+        ).makeDropdown(for: selectorSpec)
+        // ...with a selection *different* from the default of 0
+        dropdown.element.select(index: 1)
+        // ...using the params as previous customer input to create a new dropdown...
+        let previousCustomerInput = dropdown.updateParams(params: IntentConfirmParams(type: .dynamic("sepa_debit")))
+        let dropdown_with_previous_customer_input = PaymentSheetFormFactory(
+            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            configuration: configuration,
+            paymentMethod: .dynamic("sepa_debit"),
+            previousCustomerInput: previousCustomerInput
+        ).makeDropdown(for: selectorSpec)
+        
+        // ...should result in a valid element filled out with the previous customer input
+        XCTAssertEqual(dropdown_with_previous_customer_input.element.selectedIndex, 1)
+        XCTAssertEqual(dropdown_with_previous_customer_input.validationState, .valid)
     }
 
     func testMakeFormElement_KlarnaCountry_UndefinedAPIPath() {

--- a/Stripe/StripeiOSTests/PaymentSheetFormFactoryTest.swift
+++ b/Stripe/StripeiOSTests/PaymentSheetFormFactoryTest.swift
@@ -872,12 +872,17 @@ class PaymentSheetFormFactoryTest: XCTestCase {
 
     func testMakeFormElement_Country_withAPIPath() {
         let configuration = PaymentSheet.Configuration()
-        let factory = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
-            configuration: configuration,
-            paymentMethod: .dynamic("sofort")
-        )
-        let country = factory.makeCountry(countryCodes: ["AT", "BE"], apiPath: "sofort[country]")
+        func makeCountry(previousCustomerInput: IntentConfirmParams?) -> PaymentMethodElement {
+            let factory = PaymentSheetFormFactory(
+                intent: .paymentIntent(STPFixtures.paymentIntent()),
+                configuration: configuration,
+                paymentMethod: .dynamic("sofort"),
+                previousCustomerInput: previousCustomerInput
+            )
+            let country = factory.makeCountry(countryCodes: ["AT", "BE"], apiPath: "sofort[country]")
+            return country
+        }
+        let country = makeCountry(previousCustomerInput: nil)
         (country as! PaymentMethodElementWrapper<DropdownFieldElement>).element.select(index: 1) // select a different index than the default of 0
 
         let params = IntentConfirmParams(type: .dynamic("sofort"))
@@ -893,12 +898,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         XCTAssertEqual(updatedParams?.paymentMethodParams.type, .sofort)
         
         // Using the params as previous customer input...
-        let country_with_previous_input = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
-            configuration: configuration,
-            paymentMethod: .dynamic("sofort"),
-            previousCustomerInput: updatedParams
-        ).makeCountry(countryCodes: ["AT", "BE"], apiPath: nil)
+        let country_with_previous_input = makeCountry(previousCustomerInput: updatedParams)
         // ...should result in a valid, filled out element
         XCTAssert(country_with_previous_input.validationState == .valid)
         let updatedParams_with_previous_input = country_with_previous_input.updateParams(params: .init(type: .dynamic("sofort")))

--- a/Stripe/StripeiOSTests/PaymentSheetFormFactoryTest.swift
+++ b/Stripe/StripeiOSTests/PaymentSheetFormFactoryTest.swift
@@ -429,6 +429,17 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         )
         XCTAssertEqual(updatedParams?.paymentMethodParams.rawTypeString, "au_becs_debit")
         XCTAssertEqual(updatedParams?.paymentMethodParams.type, .AUBECSDebit)
+        // Using the params as previous customer input...
+        let bsb_with_previous_input = PaymentSheetFormFactory(
+            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            configuration: configuration,
+            paymentMethod: .dynamic("au_becs_debit"),
+            previousCustomerInput: updatedParams
+        ).makeBSB()
+        // ...should result in a valid, filled out element
+        XCTAssert(bsb_with_previous_input.validationState == .valid)
+        let updatedParams_with_previous_input = bsb_with_previous_input.updateParams(params: .init(type: .dynamic("au_becs_debit")))
+        XCTAssertEqual(updatedParams_with_previous_input?.paymentMethodParams.auBECSDebit?.bsbNumber, "000000")
     }
 
     func testMakeFormElement_BSBNumber_withAPIPath() {
@@ -452,6 +463,21 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         )
         XCTAssertEqual(updatedParams?.paymentMethodParams.rawTypeString, "au_becs_debit")
         XCTAssertEqual(updatedParams?.paymentMethodParams.type, .AUBECSDebit)
+        // Using the params as previous customer input...
+        let bsb_with_previous_input = PaymentSheetFormFactory(
+            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            configuration: configuration,
+            paymentMethod: .dynamic("au_becs_debit"),
+            previousCustomerInput: updatedParams
+        ).makeBSB(apiPath: "custom_path[bsb_number]")
+        // ...should result in a valid, filled out element
+        XCTAssert(bsb_with_previous_input.validationState == .valid)
+        let updatedParams_with_previous_input = bsb_with_previous_input.updateParams(params: .init(type: .dynamic("au_becs_debit")))
+        XCTAssertEqual(
+            updatedParams_with_previous_input?.paymentMethodParams.additionalAPIParameters["custom_path[bsb_number]"]
+                as! String,
+            "000000"
+        )
     }
 
     func testMakeFormElement_BSBNumber_UndefinedAPIPath() {
@@ -484,6 +510,18 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         )
         XCTAssertEqual(updatedParams?.paymentMethodParams.rawTypeString, "au_becs_debit")
         XCTAssertEqual(updatedParams?.paymentMethodParams.type, .AUBECSDebit)
+        
+        // Using the params as previous customer input...
+        let bsb_with_previous_input = PaymentSheetFormFactory(
+            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            configuration: configuration,
+            paymentMethod: .dynamic("au_becs_debit"),
+            previousCustomerInput: updatedParams
+        ).makeBSB()
+        // ...should result in a valid, filled out element
+        XCTAssert(bsb_with_previous_input.validationState == .valid)
+        let updatedParams_with_previous_input = bsb_with_previous_input.updateParams(params: .init(type: .dynamic("au_becs_debit")))
+        XCTAssertEqual(updatedParams_with_previous_input?.paymentMethodParams.auBECSDebit?.bsbNumber, "000000")
     }
 
     func testMakeFormElement_BSBNumber_DefinedAPIPath() {

--- a/Stripe/StripeiOSTests/STPFixtures+Swift.swift
+++ b/Stripe/StripeiOSTests/STPFixtures+Swift.swift
@@ -31,13 +31,14 @@ extension STPFixtures {
     static func paymentIntent(
         paymentMethodTypes: [String],
         orderedPaymentMethodTypes: [String]? = nil,
-        setupFutureUsage: STPPaymentIntentSetupFutureUsage = .none
+        setupFutureUsage: STPPaymentIntentSetupFutureUsage = .none,
+        currency: String = "usd"
     ) -> STPPaymentIntent {
         var apiResponse: [AnyHashable: Any?] = [
             "id": "123",
             "client_secret": "sec",
             "amount": 10,
-            "currency": "usd",
+            "currency": currency,
             "status": "requires_payment_method",
             "livemode": false,
             "created": 1652736692.0,

--- a/Stripe/StripeiOSTests/TextFieldElement+IBANTest.swift
+++ b/Stripe/StripeiOSTests/TextFieldElement+IBANTest.swift
@@ -47,7 +47,7 @@ class TextFieldElementIBANTest: XCTestCase {
             "AT861904300235473202": .valid,
         ]
 
-        let config = TextFieldElement.IBANConfiguration()
+        let config = TextFieldElement.IBANConfiguration(defaultValue: nil)
         for (text, expected) in testcases {
             let actual = config.validate(text: text, isOptional: false)
             XCTAssertTrue(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/TextField/TextFieldElement+IBAN.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/TextField/TextFieldElement+IBAN.swift
@@ -12,8 +12,8 @@ import Foundation
 import UIKit
 
 extension TextFieldElement {
-    static func makeIBAN(theme: ElementsUITheme = .default) -> TextFieldElement {
-        return TextFieldElement(configuration: IBANConfiguration(), theme: theme)
+    static func makeIBAN(defaultValue: String? = nil, theme: ElementsUITheme = .default) -> TextFieldElement {
+        return TextFieldElement(configuration: IBANConfiguration(defaultValue: defaultValue), theme: theme)
     }
 
     // MARK: - IBANError
@@ -57,6 +57,7 @@ extension TextFieldElement {
      */
     struct IBANConfiguration: TextFieldElementConfiguration {
         let label: String = STPLocalizedString("IBAN", "Label for an IBAN field")
+        let defaultValue: String?
         func maxLength(for text: String) -> Int {
             return 34
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
@@ -33,7 +33,7 @@ extension PaymentSheetFormFactory {
 
         let previousCardInput = previousCustomerInput?.paymentMethodParams.card
         let cardDefaultValues = CardSection.DefaultValues(
-            name: defaultBillingDetails.name,
+            name: defaultBillingDetails().name,
             pan: previousCardInput?.number,
             cvc: previousCardInput?.cvc,
             expiry: "\(previousCardInput?.expMonth?.stringValue ?? "")\(previousCardInput?.expYear?.stringValue ?? "")"

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+FormSpec.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+FormSpec.swift
@@ -179,7 +179,7 @@ extension PaymentSheetFormFactory {
         case .unknown: return nil
         }
     }
-    
+
     func makeDropdown(for selectorSpec: FormSpec.SelectorSpec) -> PaymentMethodElementWrapper<DropdownFieldElement> {
         assert(selectorSpec.apiPath?["v1"] != nil) // If there's no api path, the dropdown selection is unused!
         let dropdownItems: [DropdownFieldElement.DropdownItem] = selectorSpec.items.map {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+FormSpec.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+FormSpec.swift
@@ -122,22 +122,7 @@ extension PaymentSheetFormFactory {
                 ? makeEmail(apiPath: spec.apiPath?["v1"])
                 : nil
         case .selector(let selectorSpec):
-            let dropdownItems: [DropdownFieldElement.DropdownItem] = selectorSpec.items.map {
-                .init(pickerDisplayName: $0.displayText, labelDisplayName: $0.displayText, accessibilityValue: $0.displayText, rawData: $0.apiValue ?? $0.displayText)
-            }
-            let dropdownField = DropdownFieldElement(
-                items: dropdownItems,
-                label: selectorSpec.translationId.localizedValue,
-                theme: theme
-            )
-            return PaymentMethodElementWrapper(dropdownField) { dropdown, params in
-                let selectedValue = dropdown.selectedItem.rawData
-                // TODO: Determine how to handle multiple versions
-                if let apiPathKey = selectorSpec.apiPath?["v1"] {
-                    params.paymentMethodParams.additionalAPIParameters[apiPathKey] = selectedValue
-                }
-                return params
-            }
+            return makeDropdown(for: selectorSpec)
         case .billing_address(let countrySpec):
             return configuration.billingDetailsCollectionConfiguration.address != .never
                 ? makeBillingAddressSection(countries: countrySpec.allowedCountryCodes)
@@ -192,6 +177,30 @@ extension PaymentSheetFormFactory {
                 ? makeBillingAddressSection(collectionMode: .noCountry, countries: nil)
                 : nil
         case .unknown: return nil
+        }
+    }
+    
+    func makeDropdown(for selectorSpec: FormSpec.SelectorSpec) -> PaymentMethodElementWrapper<DropdownFieldElement> {
+        assert(selectorSpec.apiPath?["v1"] != nil) // If there's no api path, the dropdown selection is unused!
+        let dropdownItems: [DropdownFieldElement.DropdownItem] = selectorSpec.items.map {
+            .init(pickerDisplayName: $0.displayText, labelDisplayName: $0.displayText, accessibilityValue: $0.displayText, rawData: $0.apiValue ?? $0.displayText)
+        }
+        let previousCustomerInputIndex = dropdownItems.firstIndex { item in
+            item.rawData == getPreviousCustomerInput(for: selectorSpec.apiPath?["v1"])
+        }
+        let dropdownField = DropdownFieldElement(
+            items: dropdownItems,
+            defaultIndex: previousCustomerInputIndex ?? 0,
+            label: selectorSpec.translationId.localizedValue,
+            theme: theme
+        )
+        return PaymentMethodElementWrapper(dropdownField) { dropdown, params in
+            let selectedValue = dropdown.selectedItem.rawData
+            // TODO: Determine how to handle multiple versions
+            if let apiPathKey = selectorSpec.apiPath?["v1"] {
+                params.paymentMethodParams.additionalAPIParameters[apiPathKey] = selectedValue
+            }
+            return params
         }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -143,6 +143,14 @@ class PaymentSheetFormFactory {
 
 extension PaymentSheetFormFactory {
     // MARK: - DRY Helper funcs
+    
+    /// Fields generated from form specs i.e. LUXE can write their values to arbitrary keys (`apiPath`)  in `additionalAPIParameters`.
+    func getPreviousCustomerInput(for apiPath: String?) -> String? {
+        guard let apiPath = apiPath else {
+            return nil
+        }
+        return previousCustomerInput?.paymentMethodParams.additionalAPIParameters[apiPath] as? String
+    }
 
     func makeName(label: String? = nil, apiPath: String? = nil) -> PaymentMethodElementWrapper<TextFieldElement> {
         let element = TextFieldElement.makeName(
@@ -185,7 +193,8 @@ extension PaymentSheetFormFactory {
     }
 
     func makeBSB(apiPath: String? = nil) -> PaymentMethodElementWrapper<TextFieldElement> {
-        let element = TextFieldElement.Account.makeBSB(defaultValue: nil, theme: theme)
+        let defaultValue = getPreviousCustomerInput(for: apiPath) ?? previousCustomerInput?.paymentMethodParams.auBECSDebit?.bsbNumber
+        let element = TextFieldElement.Account.makeBSB(defaultValue: defaultValue, theme: theme)
         return PaymentMethodElementWrapper(element) { textField, params in
             let bsbNumberText = BSBNumber(number: textField.text).bsbNumberText()
             if let apiPath = apiPath {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -504,24 +504,24 @@ extension PaymentSheetFormFactory {
     func makeDefaultsApplierWrapper<T: PaymentMethodElement>(for element: T) -> PaymentMethodElementWrapper<T> {
         return PaymentMethodElementWrapper(
             element,
-            defaultsApplier: { [configuration, defaultBillingDetails] _, params in
+            defaultsApplier: { [configuration] _, params in
                 // Only apply defaults when the flag is on.
                 guard configuration.billingDetailsCollectionConfiguration.attachDefaultsToPaymentMethod else {
                     return params
                 }
 
-                if let name = defaultBillingDetails.name {
+                if let name = configuration.defaultBillingDetails.name {
                     params.paymentMethodParams.nonnil_billingDetails.name = name
                 }
-                if let phone = defaultBillingDetails.phone {
+                if let phone = configuration.defaultBillingDetails.phone {
                     params.paymentMethodParams.nonnil_billingDetails.phone = phone
                 }
-                if let email = defaultBillingDetails.email {
+                if let email = configuration.defaultBillingDetails.email {
                     params.paymentMethodParams.nonnil_billingDetails.email = email
                 }
-                if defaultBillingDetails.address != .init() {
+                if configuration.defaultBillingDetails.address != .init() {
                     params.paymentMethodParams.nonnil_billingDetails.address =
-                        STPPaymentMethodAddress(address: defaultBillingDetails.address)
+                    STPPaymentMethodAddress(address: configuration.defaultBillingDetails.address)
                 }
                 return params
             },

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -143,7 +143,7 @@ extension PaymentSheetFormFactory {
         details.address.city = previous?.address?.city ?? configuration.address.city
         details.address.state = previous?.address?.state ?? configuration.address.state
         details.address.postalCode = previous?.address?.postalCode ?? configuration.address.postalCode
-        details.address.country = getPreviousCustomerInput(for: nameAPIPath ?? "") ?? previous?.address?.country ?? configuration.address.country
+        details.address.country = getPreviousCustomerInput(for: countryAPIPath ?? "") ?? previous?.address?.country ?? configuration.address.country
         return details
     }
     

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -35,26 +35,6 @@ class PaymentSheetFormFactory {
     let linkAccount: PaymentSheetLinkAccount?
     let previousCustomerInput: IntentConfirmParams?
 
-    /// For each field in PaymentSheet.BillingDetails, determines the default value by looking at (in order of preference):
-    /// 1. the given API Path (only for name, email, and country fields),
-    /// 2. `previousCustomerInput`
-    /// 3. the merchant provided`configuration`
-    func defaultBillingDetails(nameAPIPath: String? = nil, emailAPIPath: String? = nil, countryAPIPath: String? = nil) -> PaymentSheet.BillingDetails {
-        let previous = previousCustomerInput?.paymentMethodParams.billingDetails
-        let configuration = configuration.defaultBillingDetails
-        var details = PaymentSheet.BillingDetails()
-        details.name = getPreviousCustomerInput(for: nameAPIPath ?? "") ?? previous?.name ?? configuration.name
-        details.phone = previous?.phone ?? configuration.phone
-        details.email = getPreviousCustomerInput(for: emailAPIPath ?? "") ?? previous?.email ?? configuration.email
-        details.address.line1 = previous?.address?.line1 ?? configuration.address.line1
-        details.address.line2 = previous?.address?.line2 ?? configuration.address.line2
-        details.address.city = previous?.address?.city ?? configuration.address.city
-        details.address.state = previous?.address?.state ?? configuration.address.state
-        details.address.postalCode = previous?.address?.postalCode ?? configuration.address.postalCode
-        details.address.country = getPreviousCustomerInput(for: nameAPIPath ?? "") ?? previous?.address?.country ?? configuration.address.country
-        return details
-    }
-
     var canSaveToLink: Bool {
         return (intent.supportsLinkCard && paymentMethod == .card && saveMode != .merchantRequired)
     }
@@ -146,6 +126,26 @@ class PaymentSheetFormFactory {
 
 extension PaymentSheetFormFactory {
     // MARK: - DRY Helper funcs
+    
+    /// For each field in PaymentSheet.BillingDetails, determines the default value by looking at (in order of preference):
+    /// 1. the given API Path (only for name, email, and country fields),
+    /// 2. `previousCustomerInput`
+    /// 3. the merchant provided`configuration`
+    func defaultBillingDetails(nameAPIPath: String? = nil, emailAPIPath: String? = nil, countryAPIPath: String? = nil) -> PaymentSheet.BillingDetails {
+        let previous = previousCustomerInput?.paymentMethodParams.billingDetails
+        let configuration = configuration.defaultBillingDetails
+        var details = PaymentSheet.BillingDetails()
+        details.name = getPreviousCustomerInput(for: nameAPIPath ?? "") ?? previous?.name ?? configuration.name
+        details.phone = previous?.phone ?? configuration.phone
+        details.email = getPreviousCustomerInput(for: emailAPIPath ?? "") ?? previous?.email ?? configuration.email
+        details.address.line1 = previous?.address?.line1 ?? configuration.address.line1
+        details.address.line2 = previous?.address?.line2 ?? configuration.address.line2
+        details.address.city = previous?.address?.city ?? configuration.address.city
+        details.address.state = previous?.address?.state ?? configuration.address.state
+        details.address.postalCode = previous?.address?.postalCode ?? configuration.address.postalCode
+        details.address.country = getPreviousCustomerInput(for: nameAPIPath ?? "") ?? previous?.address?.country ?? configuration.address.country
+        return details
+    }
     
     /// Fields generated from form specs i.e. LUXE can write their values to arbitrary keys (`apiPath`)  in `additionalAPIParameters`.
     func getPreviousCustomerInput(for apiPath: String?) -> String? {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -212,7 +212,8 @@ extension PaymentSheetFormFactory {
     }
 
     func makeAUBECSAccountNumber(apiPath: String? = nil) -> PaymentMethodElementWrapper<TextFieldElement> {
-        let element = TextFieldElement.Account.makeAUBECSAccountNumber(defaultValue: nil, theme: theme)
+        let defaultValue = getPreviousCustomerInput(for: apiPath) ?? previousCustomerInput?.paymentMethodParams.auBECSDebit?.accountNumber
+        let element = TextFieldElement.Account.makeAUBECSAccountNumber(defaultValue: defaultValue, theme: theme)
         return PaymentMethodElementWrapper(element) { textField, params in
             if let apiPath = apiPath {
                 params.paymentMethodParams.additionalAPIParameters[apiPath] = textField.text

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -401,7 +401,8 @@ extension PaymentSheetFormFactory {
     }
 
     func makeIban(apiPath: String? = nil) -> PaymentMethodElementWrapper<TextFieldElement> {
-        return PaymentMethodElementWrapper(TextFieldElement.makeIBAN(theme: theme)) { iban, params in
+        let defaultValue = getPreviousCustomerInput(for: apiPath) ?? previousCustomerInput?.paymentMethodParams.sepaDebit?.iban
+        return PaymentMethodElementWrapper(TextFieldElement.makeIBAN(defaultValue: defaultValue, theme: theme)) { iban, params in
             if let apiPath = apiPath {
                 params.paymentMethodParams.additionalAPIParameters[apiPath] = iban.text
             } else {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -126,7 +126,7 @@ class PaymentSheetFormFactory {
 
 extension PaymentSheetFormFactory {
     // MARK: - DRY Helper funcs
-    
+
     /// For each field in PaymentSheet.BillingDetails, determines the default value by looking at (in order of preference):
     /// 1. the given API Path (only for name, email, and country fields),
     /// 2. `previousCustomerInput`
@@ -146,7 +146,7 @@ extension PaymentSheetFormFactory {
         details.address.country = getPreviousCustomerInput(for: countryAPIPath ?? "") ?? previous?.address?.country ?? configuration.address.country
         return details
     }
-    
+
     /// Fields generated from form specs i.e. LUXE can write their values to arbitrary keys (`apiPath`)  in `additionalAPIParameters`.
     func getPreviousCustomerInput(for apiPath: String?) -> String? {
         guard let apiPath = apiPath else {


### PR DESCRIPTION
## Summary
follow-on to https://github.com/stripe/stripe-ios/pull/2415

This PR adds support for preserving previous customer input for all payment method forms possible today.

## Testing
I've added tests for each field.  

Unfortunately, I can't figure out a way to ensure that we've covered *all* possible fields that can be displayed by the SDK.  Ideally, such a test would break when we **add** new fields, too, until the developer adds support for preserving previous customer input. 

## Changelog
no user facing changes
