### PR TITLE
FC Networking: in warmup pane, we now use manifest to go to next pane when skipping

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupDataSource.swift
@@ -12,7 +12,7 @@ protocol NetworkingLinkLoginWarmupDataSource: AnyObject {
     var manifest: FinancialConnectionsSessionManifest { get }
     var analyticsClient: FinancialConnectionsAnalyticsClient { get }
 
-    func disableNetworking() -> Future<Void>
+    func disableNetworking() -> Future<FinancialConnectionsSessionManifest>
 }
 
 final class NetworkingLinkLoginWarmupDataSourceImplementation: NetworkingLinkLoginWarmupDataSource {
@@ -34,13 +34,10 @@ final class NetworkingLinkLoginWarmupDataSourceImplementation: NetworkingLinkLog
         self.analyticsClient = analyticsClient
     }
 
-    func disableNetworking() -> Future<Void> {
+    func disableNetworking() -> Future<FinancialConnectionsSessionManifest> {
         return apiClient.disableNetworking(
             disabledReason: nil,
             clientSecret: clientSecret
         )
-        .chained { _ in
-            return Promise(value: ())
-        }
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupViewController.swift
@@ -14,8 +14,9 @@ protocol NetworkingLinkLoginWarmupViewControllerDelegate: AnyObject {
     func networkingLinkLoginWarmupViewControllerDidSelectContinue(
         _ viewController: NetworkingLinkLoginWarmupViewController
     )
-    func networkingLinkLoginWarmupViewControllerDidSelectSkip(
-        _ viewController: NetworkingLinkLoginWarmupViewController
+    func networkingLinkLoginWarmupViewController(
+        _ viewController: NetworkingLinkLoginWarmupViewController,
+        didSelectSkipWithManifest manifest: FinancialConnectionsSessionManifest
     )
     func networkingLinkLoginWarmupViewController(_ viewController: NetworkingLinkLoginWarmupViewController, didReceiveTerminalError error: Error)
 }
@@ -82,8 +83,11 @@ final class NetworkingLinkLoginWarmupViewController: UIViewController {
             .observe { [weak self] result in
                 guard let self = self else { return }
                 switch result {
-                case .success:
-                    self.delegate?.networkingLinkLoginWarmupViewControllerDidSelectSkip(self)
+                case .success(let manifest):
+                    self.delegate?.networkingLinkLoginWarmupViewController(
+                        self,
+                        didSelectSkipWithManifest: manifest
+                    )
                 case .failure(let error):
                     self.delegate?.networkingLinkLoginWarmupViewController(self, didReceiveTerminalError: error)
                 }


### PR DESCRIPTION
## Summary

In Networking Warm Up Pane, recently Stripe.js changed logic to use the manifest, instead of hard-coding the pane. This PR updates the code to also do that.

## Testing

Here we can see that skipping in the warmup pane still leads to the institution picker (what was previously hard-coded).


https://user-images.githubusercontent.com/105514761/228983417-30515d9a-7470-4d56-91de-c81840e38666.mov

