### PR TITLE
Financial Connections: updated synchronize payload to have non-null visualupdate

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsSynchronize.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsSynchronize.swift
@@ -10,7 +10,7 @@ import Foundation
 struct FinancialConnectionsSynchronize: Decodable {
     let manifest: FinancialConnectionsSessionManifest
     let text: Text?
-    let visual: VisualUpdate?
+    let visual: VisualUpdate
 
     struct Text: Decodable {
         let consentPane: FinancialConnectionsConsent?

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostController.swift
@@ -78,8 +78,7 @@ extension HostController: HostViewControllerDelegate {
         didFetch synchronizePayload: FinancialConnectionsSynchronize
     ) {
         guard
-            let consentPaneModel = synchronizePayload.text?.consentPane,
-            let visualUpdate = synchronizePayload.visual
+            let consentPaneModel = synchronizePayload.text?.consentPane
         else {
             continueWithWebFlow(synchronizePayload.manifest)
             return
@@ -104,7 +103,7 @@ extension HostController: HostViewControllerDelegate {
 
         let dataManager = NativeFlowAPIDataManager(
             manifest: synchronizePayload.manifest,
-            visualUpdate: visualUpdate,
+            visualUpdate: synchronizePayload.visual,
             returnURL: returnURL,
             consentPaneModel: consentPaneModel,
             apiClient: api,


### PR DESCRIPTION
## Summary

^ see title

backend made this non-null: https://git.corp.stripe.com/stripe-internal/pay-server/pull/557556/files

## Testing

Build succeeded. Also successfully opened native + web flows.