### PR TITLE
FC Networking: fixed dark mode issue with OTP field.

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
@@ -53,6 +53,8 @@ final class NetworkingOTPView: UIView {
         theme.colors = {
             var colors = ElementsUITheme.Color()
             colors.border = .borderNeutral
+            colors.background = .customBackgroundColor
+            colors.textFieldText = .textPrimary
             return colors
         }()
         return theme


### PR DESCRIPTION
## Summary

There was a coloring issue in dark mode with OTP. This PR fixes it.

![Simulator Screen Shot - iPhone 14 Pro - 2023-04-03 at 15 19 23](https://user-images.githubusercontent.com/105514761/229607845-0f3c7682-8347-474b-8229-4edcaa98fe78.png)

## Testing

Now the field has the expected colors in dark mode!

![Simulator Screen Shot - iPhone 14 Pro - 2023-04-03 at 15 24 53](https://user-images.githubusercontent.com/105514761/229607910-7e6ae52e-90de-4d23-bc39-d68cd74e4b40.png)

