### PR TITLE
Financial Connections: disabled reporting financial-connections-stability-tests successes (only failures)

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -225,6 +225,7 @@ workflows:
         - scheme: FinancialConnections Example
     - slack@3:
         is_always_run: true
+        run_if: .IsBuildFailed
         inputs:
         - webhook_url: $SLACK_KGAIDIS_TESTING_WEBHOOK_URL
         - webhook_url_on_error: $SLACK_KGAIDIS_TESTING_WEBHOOK_URL


### PR DESCRIPTION
## Summary

This changes the end-to-end tests to notify Slack only on failures (rather than both success and failure). Eventually this will be connected to pagers.

## Testing

First I had to setup my computer to be able to run the tests locally:
- Run `tuist generate`
- Install bitrise local tools. [See Installing Bitrise CLI](https://confluence.corp.stripe.com/pages/viewpage.action?pageId=433048367)...or generally `brew install bitrise`.
- Had to run `gem install bundler:2.1.2`. [See troubleshooting section](https://confluence.corp.stripe.com/pages/viewpage.action?pageId=433048367).
- Had to install `go`. [See troubleshooting section](https://confluence.corp.stripe.com/pages/viewpage.action?pageId=433048367).

I modified `SLACK_KGAIDIS_TESTING_WEBHOOK_URL` with the [actual string from secrets](https://app.bitrise.io/app/b220f4ba85d134a7/workflow_editor#!/secrets).

After setup was done, I ran: `bitrise run financial-connections-stability-tests`.

Here was a successful run and we can see that the "Send a Slack message" step got skipped:

```
+------------------------------------------------------------------------------+
|            bitrise summary: financial-connections-stability-tests            |
+---+---------------------------------------------------------------+----------+
|   | title                                                         | time (s) |
+---+---------------------------------------------------------------+----------+
| ✓ | Start Xcode simulator                                         | 2.17 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Set CONFIGURATION_BUILD_DIR                                   | 0.48 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Set CONFIGURATION_TEMP_DIR                                    | 0.49 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Set Bundler to use local vendor directory                     | 0.58 sec |
+---+---------------------------------------------------------------+----------+
| - | Git Clone Repository (Skipped)                                | 0.57 sec |
+---+---------------------------------------------------------------+----------+
| Update available: 6 (6.2.3) -> 8.0.1                                         |
|                                                                              |
| Release notes are available below                                            |
| https://github.com/bitrise-steplib/steps-git-clone/releases                  |
+---+---------------------------------------------------------------+----------+
| - | tuist (Skipped)                                               | 0.50 sec |
+---+---------------------------------------------------------------+----------+
| - | Bitrise.io Cache:Pull (Skipped)                               | 0.45 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Bundler                                                       | 0.79 sec |
+---+---------------------------------------------------------------+----------+
| - | Bitrise.io Cache:Push (Skipped)                               | 0.44 sec |
+---+---------------------------------------------------------------+----------+
| - | Restore SPM Cache (Skipped)                                   | 0.44 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Xcode Test for iOS                                            | 2.2 min  |
+---+---------------------------------------------------------------+----------+
| - | Send a Slack message (Skipped)                                | 0.52 sec |
+---+---------------------------------------------------------------+----------+
| - | Deploy to Bitrise.io - Build Artifacts, Test Repo... (Skipped)| 0.64 sec |
+---+---------------------------------------------------------------+----------+
| Total runtime: 2.3 min                                                       |
+------------------------------------------------------------------------------+
```

I then added a bug in `ConsentViewController`, where I modified `footerView` `dataSource.consent.cta` to "WRONG CTA," and got back a failure from Slack. Notice the "Send a Slack message" step was NOT skipped. And see screenshot of failure.

We can see that the bug made tests fail:
git
```
✗ testDataLiveModeOAuthNativeAuthFlow, XCTAssertTrue failed
```

https://stripe.slack.com/archives/C04G5PZM71T/p1680629372266169

```
+------------------------------------------------------------------------------+
|            bitrise summary: financial-connections-stability-tests            |
+---+---------------------------------------------------------------+----------+
|   | title                                                         | time (s) |
+---+---------------------------------------------------------------+----------+
| ✓ | Start Xcode simulator                                         | 2.47 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Set CONFIGURATION_BUILD_DIR                                   | 0.49 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Set CONFIGURATION_TEMP_DIR                                    | 0.48 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Set Bundler to use local vendor directory                     | 0.64 sec |
+---+---------------------------------------------------------------+----------+
| - | Git Clone Repository (Skipped)                                | 0.57 sec |
+---+---------------------------------------------------------------+----------+
| Update available: 6 (6.2.3) -> 8.0.1                                         |
|                                                                              |
| Release notes are available below                                            |
| https://github.com/bitrise-steplib/steps-git-clone/releases                  |
+---+---------------------------------------------------------------+----------+
| - | tuist (Skipped)                                               | 0.47 sec |
+---+---------------------------------------------------------------+----------+
| - | Bitrise.io Cache:Pull (Skipped)                               | 0.45 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Bundler                                                       | 0.89 sec |
+---+---------------------------------------------------------------+----------+
| - | Bitrise.io Cache:Push (Skipped)                               | 0.46 sec |
+---+---------------------------------------------------------------+----------+
| - | Restore SPM Cache (Skipped)                                   | 0.46 sec |
+---+---------------------------------------------------------------+----------+
| x | Xcode Test for iOS (Failed)                                   | 33.0 min |
+---+---------------------------------------------------------------+----------+
| Issue tracker: https://github.com/bitrise-steplib/steps-xcode-test/issues    |
| Source: https://github.com/bitrise-steplib/steps-xcode-test                  |
+---+---------------------------------------------------------------+----------+
| ✓ | Send a Slack message                                          | 1.25 sec |
+---+---------------------------------------------------------------+----------+
| - | Deploy to Bitrise.io - Build Artifacts, Test Repo... (Skipped)| 0.79 sec |
+---+---------------------------------------------------------------+----------+
| Total runtime: 33.2 min                                                      |
+------------------------------------------------------------------------------+
```

<img width="412" alt="Screenshot 2023-04-04 at 1 34 16 PM" src="https://user-images.githubusercontent.com/105514761/229922187-18edfdfa-658b-4c5c-88e0-822074883e3f.png">
