### PR TITLE
FC Networking: added support for returning an institution as part of PartnerAccount and displayed an institution icon in LinkAccountPicker.

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
@@ -270,9 +270,10 @@ extension STPAPIClient: FinancialConnectionsAPIClient {
         authSessionId: String,
         initialPollDelay: TimeInterval
     ) -> Future<FinancialConnectionsAuthSessionAccounts> {
-        let body = [
+        let body: [String: Any] = [
             "client_secret": clientSecret,
             "id": authSessionId,
+            "expand": ["data.institution"],
         ]
         let pollingHelper = APIPollingHelper(
             apiCall: { [weak self] in
@@ -281,7 +282,7 @@ extension STPAPIClient: FinancialConnectionsAPIClient {
                         error: FinancialConnectionsSheetError.unknown(debugDescription: "STPAPIClient deallocated.")
                     )
                 }
-                return self.post(resource: APIEndpointAuthSessionsAccounts, object: body)
+                return self.post(resource: APIEndpointAuthSessionsAccounts, parameters: body)
             },
             pollTimingOptions: APIPollingHelper<FinancialConnectionsAuthSessionAccounts>.PollTimingOptions(
                 initialPollDelay: initialPollDelay
@@ -299,6 +300,7 @@ extension STPAPIClient: FinancialConnectionsAPIClient {
             "client_secret": clientSecret,
             "id": authSessionId,
             "selected_accounts": selectedAccountIds,
+            "expand": ["data.institution"],
         ]
         return self.post(resource: APIEndpointAuthSessionsSelectedAccounts, parameters: body)
     }
@@ -504,9 +506,10 @@ extension STPAPIClient: FinancialConnectionsAPIClient {
         clientSecret: String,
         consumerSessionClientSecret: String
     ) -> Future<FinancialConnectionsNetworkedAccountsResponse> {
-        let parameters = [
+        let parameters: [String: Any] = [
             "client_secret": clientSecret,
             "consumer_session_client_secret": consumerSessionClientSecret,
+            "expand": ["data.institution"],
         ]
         return get(resource: APIEndpointNetworkedAccounts, parameters: parameters)
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsInstitution.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsInstitution.swift
@@ -15,14 +15,6 @@ struct FinancialConnectionsInstitution: Decodable, Hashable, Equatable {
     let url: String?
     let icon: FinancialConnectionsImage?
     let logo: FinancialConnectionsImage?
-
-    init(id: String, name: String, url: String?, smallImageUrl: String? = nil) {
-        self.id = id
-        self.name = name
-        self.url = url
-        self.icon = nil
-        self.logo = nil
-    }
 }
 
 // MARK: - Institution List

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsPartnerAccount.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsPartnerAccount.swift
@@ -19,6 +19,7 @@ struct FinancialConnectionsPartnerAccount: Decodable {
     let allowSelection: Bool?
     let allowSelectionMessage: String?
     let status: String?
+    let institution: FinancialConnectionsInstitution?
 
     var allowSelectionNonOptional: Bool {
         return allowSelection ?? true
@@ -30,11 +31,6 @@ struct FinancialConnectionsPartnerAccount: Decodable {
             return nil
         }
     }
-}
-
-struct FinancialConnectionsDisabledPartnerAccount {
-    let account: FinancialConnectionsPartnerAccount
-    let disableReason: String
 }
 
 struct FinancialConnectionsAuthSessionAccounts: Decodable {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerAccountLoadErrorView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerAccountLoadErrorView.swift
@@ -104,7 +104,9 @@ private struct AccountPickerAccountLoadErrorViewUIViewRepresentable: UIViewRepre
             institution: FinancialConnectionsInstitution(
                 id: "123",
                 name: institutionName,
-                url: nil
+                url: nil,
+                icon: nil,
+                logo: nil
             ),
             didSelectAnotherBank: {},
             didSelectTryAgain: didSelectTryAgain,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerNoAccountEligibleErrorView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerNoAccountEligibleErrorView.swift
@@ -177,7 +177,13 @@ private struct AccountPickerNoAccountEligibleErrorViewUIViewRepresentable: UIVie
 
     func makeUIView(context: Context) -> AccountPickerNoAccountEligibleErrorView {
         AccountPickerNoAccountEligibleErrorView(
-            institution: FinancialConnectionsInstitution(id: "123", name: institutionName, url: nil),
+            institution: FinancialConnectionsInstitution(
+                id: "123",
+                name: institutionName,
+                url: nil,
+                icon: nil,
+                logo: nil
+            ),
             bussinessName: businessName,
             institutionSkipAccountSelection: institutionSkipAccountSelection,
             numberOfIneligibleAccounts: numberOfIneligibleAccounts,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AttachLinkedPaymentAccount/AccountNumberRetrievalErrorView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AttachLinkedPaymentAccount/AccountNumberRetrievalErrorView.swift
@@ -87,7 +87,9 @@ private struct AccountNumberRetrievalErrorViewUIViewRepresentable: UIViewReprese
             institution: FinancialConnectionsInstitution(
                 id: "123",
                 name: institutionName,
-                url: nil
+                url: nil,
+                icon: nil,
+                logo: nil
             ),
             didSelectAnotherBank: {},
             didSelectEnterBankDetailsManually: didSelectEnterBankDetailsManually

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/FeaturedInstitutionGridView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/FeaturedInstitutionGridView.swift
@@ -120,7 +120,13 @@ private struct FeaturedInstitutionGridViewUIViewRepresentable: UIViewRepresentab
 
     func updateUIView(_ uiView: FeaturedInstitutionGridView, context: Context) {
         let institutions = (1...10).map { i in
-            FinancialConnectionsInstitution(id: "\(i)", name: "\(i)", url: nil)
+            FinancialConnectionsInstitution(
+                id: "\(i)",
+                name: "\(i)",
+                url: nil,
+                icon: nil,
+                logo: nil
+            )
         }
         uiView.loadInstitutions(institutions)
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerBodyView.swift
@@ -63,7 +63,7 @@ final class LinkAccountPickerBodyView: UIView {
             // TODO(kgaidis): when we implement repair logic, this will have new text
             let rowTitles = AccountPickerHelpers.rowTitles(forAccount: account)
             accountRowView.configure(
-                institutionImageUrl: nil, // TODO(kgaidis): get image url from backend
+                institutionImageUrl: account.institution?.icon?.default,
                 leadingTitle: rowTitles.leadingTitle,
                 trailingTitle: rowTitles.trailingTitle,
                 subtitle: AccountPickerHelpers.rowSubtitle(forAccount: account),
@@ -103,7 +103,16 @@ private struct LinkAccountPickerBodyViewUIViewRepresentable: UIViewRepresentable
                     supportedPaymentMethodTypes: [.usBankAccount],
                     allowSelection: true,
                     allowSelectionMessage: nil,
-                    status: "active"
+                    status: "active",
+                    institution: FinancialConnectionsInstitution(
+                        id: "abc",
+                        name: "N/A",
+                        url: nil,
+                        icon: FinancialConnectionsImage(
+                            default: "https://b.stripecdn.com/connections-statics-srv/assets/BrandIcon--stripe-4x.png"
+                        ),
+                        logo: nil
+                    )
                 ),
                 FinancialConnectionsPartnerAccount(
                     id: "abc",
@@ -115,7 +124,8 @@ private struct LinkAccountPickerBodyViewUIViewRepresentable: UIViewRepresentable
                     supportedPaymentMethodTypes: [.usBankAccount],
                     allowSelection: true,
                     allowSelectionMessage: nil,
-                    status: "disabled"
+                    status: "disabled",
+                    institution: nil
                 ),
             ]
         )

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/InstitutionIconView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/InstitutionIconView.swift
@@ -110,7 +110,9 @@ private struct InstitutionIconViewUIViewRepresentable: UIViewRepresentable {
     private let institution: FinancialConnectionsInstitution = FinancialConnectionsInstitution(
         id: "123",
         name: "Chase",
-        url: nil
+        url: nil,
+        icon: nil,
+        logo: nil
     )
     let size: InstitutionIconView.Size
     let showWarning: Bool


### PR DESCRIPTION
## Summary

This PR adds support for institution icons in the LinkAccountPicker:
- https://github.com/stripe/stripe-android/pull/6469
- https://docs.google.com/document/d/15UP0AtPK9IJQYSB_p2P_VOT1qoTGOKA4U-8ZTXP1di0/edit#heading=h.hl0vb671m5lm


## Testing

### Live Mode Institution Icons Show Up

![live-mode](https://user-images.githubusercontent.com/105514761/230145265-ba3b13ad-9fa5-4f7e-9674-1c7d5a4f7357.png)

### Test Mode Institutions Show Up

![test-mode](https://user-images.githubusercontent.com/105514761/230145299-d3e06e29-a48a-43da-9d74-d33372e430af.png)

### SwiftUI Previews Showing A NULL Institution and a NON-NULL

![swiftui-previews](https://user-images.githubusercontent.com/105514761/230145371-f2de010a-bdd4-46a2-9a52-b709671a335e.png)

### Added Breakpoints In All The Functions Where We Added `expand:data.institution` To Ensure They Still Work

![fetchAuthSessionAccounts](https://user-images.githubusercontent.com/105514761/230145545-3f2c7fe5-a569-4669-b64e-b428c9ecae6d.png)

![selectAuthSessionAccounts](https://user-images.githubusercontent.com/105514761/230145547-9e16b125-482b-4f4f-882b-23b7c4178d59.png)

![fetchNetworkedAccounts](https://user-images.githubusercontent.com/105514761/230145548-409a71fc-66ff-4250-856c-411387835cf7.png)

