### PR TITLE
FC Networking: added a new request surface for Link APIs

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
@@ -537,13 +537,13 @@ extension STPAPIClient: FinancialConnectionsAPIClient {
         return post(resource: APIEndpointLinkStepUpAuthenticationVerified, parameters: parameters)
     }
 
-    // MARK: - Link API's [TODO(kgaidis): delete these later]
+    // MARK: - Link API's
 
     func consumerSessionLookup(
         emailAddress: String
     ) -> Future<LookupConsumerSessionResponse> {
         let parameters: [String: Any] = [
-            "request_surface": "web_connections",  // TODO(kgaidis): request backend to add ios_connections
+            "request_surface": "ios_connections",
             "email_address":
                 emailAddress
                 .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -553,13 +553,13 @@ extension STPAPIClient: FinancialConnectionsAPIClient {
     }
 
     func consumerSessionStartVerification(
-        otpType: String, // TODO(kgaidis): consider whether this should be an enum type SMS + EMAIL
-        customEmailType: String?, // TODO(kgaidis): consider whether this should be an enum type
+        otpType: String,
+        customEmailType: String?,
         connectionsMerchantName: String?,
         consumerSessionClientSecret: String
     ) -> Future<ConsumerSessionResponse> {
         var parameters: [String: Any] = [
-            "request_surface": "web_connections",  // TODO(kgaidis): request backend to add ios_connections
+            "request_surface": "ios_connections",
             "type": otpType,
             "credentials": [
                 "consumer_session_client_secret": consumerSessionClientSecret,
@@ -573,7 +573,7 @@ extension STPAPIClient: FinancialConnectionsAPIClient {
 
     func consumerSessionConfirmVerification(
         otpCode: String,
-        otpType: String, // TODO(kgaidis): consider whether this should be an enum type SMS + EMAIL
+        otpType: String,
         consumerSessionClientSecret: String
     ) -> Future<ConsumerSessionResponse> {
         let parameters: [String: Any] = [
@@ -582,7 +582,7 @@ extension STPAPIClient: FinancialConnectionsAPIClient {
             "credentials": [
                 "consumer_session_client_secret": consumerSessionClientSecret,
             ],
-            "request_surface": "web_connections",  // TODO(kgaidis): request backend to add ios_connections
+            "request_surface": "ios_connections",
         ]
         return post(resource: "consumers/sessions/confirm_verification", parameters: parameters)
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/AuthFlowHelpers.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/AuthFlowHelpers.swift
@@ -59,7 +59,7 @@ final class AuthFlowHelpers {
     @available(iOSApplicationExtension, unavailable)
     static func networkingOTPErrorMessage(
         fromError error: Error,
-        otpType: String // TODO(kgaidis): move this to be type-safe after Link framework intro
+        otpType: String
     ) -> String? {
         if
             let error = error as? StripeError,


### PR DESCRIPTION
## Summary

[This PR](https://git.corp.stripe.com/stripe-internal/pay-server/pull/601584/files) introduced `ios_connections` request surface for Link API's. Previously we were using a `web_connections` request surface for Link API's.

## Testing

I went through the whole flow to ensure all API calls still work.


https://user-images.githubusercontent.com/105514761/230390692-56fd2d94-8d9e-42d0-9fc1-4da7c0ae1bfd.mp4


