### PR TITLE
Don't export TestUtils schemes

### DIFF
--- a/Tests/installation_tests/carthage/setup.sh
+++ b/Tests/installation_tests/carthage/setup.sh
@@ -40,7 +40,7 @@ info "Executing carthage bootstrap..."
 
 cd "${script_dir}" || die "Executing \`cd\` failed"
 
-carthage bootstrap --platform ios --configuration Debug --no-use-binaries --cache-builds --use-xcframeworks
+carthage bootstrap --platform ios --no-use-binaries --cache-builds --use-xcframeworks
 
 carthage_exit_code="$?"
 

--- a/Tuist/ProjectDescriptionHelpers/Tuist+Stripe.swift
+++ b/Tuist/ProjectDescriptionHelpers/Tuist+Stripe.swift
@@ -333,15 +333,21 @@ extension Project {
                 )
             )
         )
-        if testUtilsOptions != nil {
-            schemes.append(
-                Scheme(
-                    name: "\(name)TestUtils",
-                    shared: false,
-                    buildAction: .buildAction(targets: ["\(name)TestUtils"])
-                )
-            )
-        }
+// We shouldn't create schemes for TestUtils: There isn't a clear use for them,
+// and they cause issues with Carthage.
+// Marking them as `shared: false` doesn't appear to work: Tuist still generates
+// the xcscheme file, then Xcode deletes it as soon as you inspect the Manage Schemes page.
+// This won't work for the Carthage case, where Xcode won't even be opened before Carthage
+// attempts to build them.
+//        if testUtilsOptions != nil {
+//            schemes.append(
+//                Scheme(
+//                    name: "\(name)TestUtils",
+//                    shared: false,
+//                    buildAction: .buildAction(targets: ["\(name)TestUtils"])
+//                )
+//            )
+//        }
         return schemes
     }
 

--- a/Tuist/ProjectDescriptionHelpers/Tuist+Stripe.swift
+++ b/Tuist/ProjectDescriptionHelpers/Tuist+Stripe.swift
@@ -337,6 +337,7 @@ extension Project {
             schemes.append(
                 Scheme(
                     name: "\(name)TestUtils",
+                    shared: false,
                     buildAction: .buildAction(targets: ["\(name)TestUtils"])
                 )
             )


### PR DESCRIPTION
## Summary
TestUtils schemes are being picked up by Carthage, which slows down builds and causes issues on Xcode 14.3. Don't export schemes for these — there's no reason to build them separately, as they're already implicitly built when running tests.

I tried setting `shared: false`, but it doesn't seem to be processed properly by Tuist. Left a comment with more explanation, maybe we can investigate more in the future.

Also fix the Carthage tests to build all configurations — the linked issue was only happening when building for Release.

## Motivation
https://github.com/stripe/stripe-ios/issues/2446

## Testing
CI, manually installing with Carthage on Xcode 14.3.