### PR TITLE
Fix StripeIdentity install tests on Carthage

### DIFF
--- a/StripeIdentity/StripeIdentity/Source/Helpers/Image.swift
+++ b/StripeIdentity/StripeIdentity/Source/Helpers/Image.swift
@@ -11,8 +11,8 @@ import Foundation
 
 /// The canonical set of all image files in the `StripeIdentity` module.
 /// This helps us avoid duplicates and automatically test that all images load properly
-enum Image: String, CaseIterable, ImageMaker {
-    typealias BundleLocator = StripeIdentityBundleLocator
+@_spi(STP) public enum Image: String, CaseIterable, ImageMaker {
+    @_spi(STP) public typealias BundleLocator = StripeIdentityBundleLocator
 
     case iconAdd = "icon_add"
     case iconCheckmark = "icon_checkmark"

--- a/StripeIdentity/StripeIdentity/Source/Helpers/StripeIdentityBundleLocator.swift
+++ b/StripeIdentity/StripeIdentity/Source/Helpers/StripeIdentityBundleLocator.swift
@@ -9,11 +9,11 @@
 import Foundation
 @_spi(STP) import StripeCore
 
-final class StripeIdentityBundleLocator: BundleLocatorProtocol {
-    static let internalClass: AnyClass = StripeIdentityBundleLocator.self
-    static let bundleName = "StripeIdentity"
+@_spi(STP) public final class StripeIdentityBundleLocator: BundleLocatorProtocol {
+    @_spi(STP) public static let internalClass: AnyClass = StripeIdentityBundleLocator.self
+    @_spi(STP) public static let bundleName = "StripeIdentity"
     #if SWIFT_PACKAGE
-        static let spmResourcesBundle = Bundle.module
+    @_spi(STP) public static let spmResourcesBundle = Bundle.module
     #endif
-    static let resourcesBundle = StripeIdentityBundleLocator.computeResourcesBundle()
+    @_spi(STP) public static let resourcesBundle = StripeIdentityBundleLocator.computeResourcesBundle()
 }

--- a/StripeIdentity/StripeIdentityTests/Snapshot/HeaderIconViewSnapshotTest.swift
+++ b/StripeIdentity/StripeIdentityTests/Snapshot/HeaderIconViewSnapshotTest.swift
@@ -11,7 +11,7 @@ import iOSSnapshotTestCase
 @_spi(STP) import StripeUICore
 import UIKit
 
-@testable import StripeIdentity
+@testable @_spi(STP) import StripeIdentity
 
 class HeaderIconViewSnapshotTest: FBSnapshotTestCase {
     let iconView = HeaderIconView()

--- a/StripeIdentity/StripeIdentityTests/Snapshot/IdentityHTMLViewSnapshotTest.swift
+++ b/StripeIdentity/StripeIdentityTests/Snapshot/IdentityHTMLViewSnapshotTest.swift
@@ -10,7 +10,7 @@ import Foundation
 import iOSSnapshotTestCase
 @_spi(STP) import StripeUICore
 
-@testable import StripeIdentity
+@testable @_spi(STP) import StripeIdentity
 
 final class IdentityHTMLViewSnapshotTest: FBSnapshotTestCase {
 

--- a/Tests/installation_tests/shared_unit_tests/StripeIdentity/StripeIdentityAssetTests.swift
+++ b/Tests/installation_tests/shared_unit_tests/StripeIdentity/StripeIdentityAssetTests.swift
@@ -7,7 +7,7 @@
 import UIKit
 import XCTest
 
-@testable import StripeIdentity
+@_spi(STP) import StripeIdentity
 
 class StripeIdentityAssetTests: XCTestCase {
 


### PR DESCRIPTION
## Summary
The Carthage install tests now build the framework for Release instead of Debug, which better matches the end user experience. But this means we can't use `@testable`, so these tests broke.

## Testing
CI, kicked off manual build: https://app.bitrise.io/build/d5980181-a21a-4d0a-a3b8-2abf65c8e306