### PR TITLE
Reload all cells when removing payment methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## X.X.X
 ### All
 * Xcode 13 is [no longer supported by Apple](https://developer.apple.com/news/upcoming-requirements/). Please upgrade to Xcode 14.1 or later.
+### PaymentSheet
+* [Fixed] Visual bug of the delete icon when deleting saved payment methods reported in [#2461](https://github.com/stripe/stripe-ios/issues/2461).
 
 ## 23.6.0 2023-03-27
 ### PaymentSheet

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
@@ -80,7 +80,7 @@ class SavedPaymentOptionsViewController: UIViewController {
         }
         set {
             collectionView.isRemovingPaymentMethods = newValue
-            collectionView.reloadItems(at: collectionView.indexPathsForVisibleItems)
+            collectionView.reloadData()
             if !collectionView.isRemovingPaymentMethods {
                 // re-select
                 collectionView.selectItem(


### PR DESCRIPTION
## Summary
- Fixes a bug where the delete icon was not being shown or removed in certain cases since we were not updating all cells only those visible.

Before:
![Simulator Screen Recording - iPhone 12 Pro - 2023-04-12 at 09 58 04](https://user-images.githubusercontent.com/88012362/231515624-549d346c-1ed9-4b67-b8ca-10e23f209a3a.gif)

After:
![Simulator Screen Recording - iPhone 12 Pro - 2023-04-12 at 09 57 26](https://user-images.githubusercontent.com/88012362/231515669-c06fde83-c060-447d-a748-c14a96816cca.gif)

## Motivation
https://github.com/stripe/stripe-ios/issues/2461

## Testing
Manual

## Changelog
See diff
