### PR TITLE
Use payment method we create when confirming client side 

### DIFF
--- a/Stripe/StripeiOSTests/PaymentSheet+APITest.swift
+++ b/Stripe/StripeiOSTests/PaymentSheet+APITest.swift
@@ -46,16 +46,14 @@ class PaymentSheetAPITest: XCTestCase {
         cardParams.cvc = "123"
         cardParams.expYear = 32
         cardParams.expMonth = 12
-        let newCardPaymentOption: PaymentSheet.PaymentOption = .new(
-            confirmParams: .init(
-                params: .init(
-                    card: cardParams,
-                    billingDetails: .init(),
-                    metadata: nil
-                ),
-                type: .card
-            )
-        )
+        let newCardPaymentOption: PaymentSheet.PaymentOption = .new(newPaymentMethod: .confirmParams(confirmParams: .init(
+            params: .init(
+                card: cardParams,
+                billingDetails: .init(),
+                metadata: nil
+            ),
+            type: .card
+        )))
 
         return newCardPaymentOption
     }()

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-NewPaymentViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-NewPaymentViewController.swift
@@ -204,7 +204,7 @@ extension PayWithLinkViewController {
             guard case .confirmParams(confirmParams: let confirmParams) = newPaymentMethod else {
                 fatalError("Must confirm Link with confirm params")
             }
-            
+
             linkAccount.createPaymentDetails(with: confirmParams.paymentMethodParams) { [weak self] result in
                 guard let self = self else {
                     return

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-NewPaymentViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-NewPaymentViewController.swift
@@ -193,7 +193,7 @@ extension PayWithLinkViewController {
             }
 
             guard let newPaymentOption = addPaymentMethodVC.paymentOption,
-                  case .new(let confirmParams) = newPaymentOption else {
+                  case .new(let newPaymentMethod) = newPaymentOption else {
                 assertionFailure()
                 return
             }
@@ -201,6 +201,10 @@ extension PayWithLinkViewController {
             feedbackGenerator.prepare()
             confirmButton.update(state: .processing)
 
+            guard case .confirmParams(confirmParams: let confirmParams) = newPaymentMethod else {
+                fatalError("Must confirm Link with confirm params")
+            }
+            
             linkAccount.createPaymentDetails(with: confirmParams.paymentMethodParams) { [weak self] result in
                 guard let self = self else {
                     return

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/LinkEnabledPaymentMethodElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/LinkEnabledPaymentMethodElement.swift
@@ -81,7 +81,7 @@ final class LinkEnabledPaymentMethodElement: Element {
                 )
             )
         case .continueWithoutLink:
-            return .new(confirmParams: params)
+            return .new(newPaymentMethod: .confirmParams(confirmParams: params))
         case .none:
             return nil
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
@@ -48,7 +48,7 @@ class AddPaymentMethodViewController: UIViewController {
         var params = IntentConfirmParams(type: selectedPaymentMethodType)
         params = paymentMethodFormElement.applyDefaults(params: params)
         if let params = paymentMethodFormElement.updateParams(params: params) {
-            return .new(confirmParams: params)
+            return .new(newPaymentMethod: .confirmParams(confirmParams: params))
         }
         return nil
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentOption+Images.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentOption+Images.swift
@@ -23,8 +23,13 @@ extension PaymentOption {
             return Image.apple_pay_mark.makeImage().withRenderingMode(.alwaysOriginal)
         case .saved(let paymentMethod):
             return paymentMethod.makeIcon()
-        case .new(let confirmParams):
-            return confirmParams.makeIcon(updateImageHandler: updateImageHandler)
+        case .new(let newPaymentMethod):
+            switch newPaymentMethod {
+            case .confirmParams(let confirmParams):
+                return confirmParams.makeIcon(updateImageHandler: updateImageHandler)
+            case .paymentMethod(paymentMethod: let paymentMethod):
+                return paymentMethod.makeIcon()
+            }
         case .link:
             return Image.pm_type_link.makeImage()
         }
@@ -37,8 +42,13 @@ extension PaymentOption {
             return makeIcon(for: view.traitCollection, updateImageHandler: nil)
         case .saved(let paymentMethod):
             return paymentMethod.makeCarouselImage(for: view)
-        case .new(let confirmParams):
-            return confirmParams.paymentMethodParams.makeCarouselImage(for: view)
+        case .new(let newPaymentMethod):
+            switch newPaymentMethod {
+            case .confirmParams(let confirmParams):
+                return confirmParams.paymentMethodParams.makeCarouselImage(for: view)
+            case .paymentMethod(paymentMethod: let paymentMethod):
+                return paymentMethod.makeCarouselImage(for: view)
+            }
         case .link:
             return Image.link_carousel_logo.makeImage(template: true)
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -135,12 +135,13 @@ extension PaymentSheet {
                     )
                     paymentIntentParams.returnURL = configuration.returnURL
                     paymentIntentParams.shipping = makeShippingParams(for: paymentIntent, configuration: configuration)
+                    paymentIntentParams.paymentMethodId = paymentMethod.stripeId
 
                     // The Dashboard app requires MOTO
                     if configuration.apiClient.publishableKeyIsUserKey {
                         paymentIntentParams.paymentMethodOptions?.setMoto()
                     }
-                    
+
                     // Paypal requires mandate_data if setting up
                     if paymentMethod.type == .payPal
                         && paymentIntent.setupFutureUsage == .offSession
@@ -174,6 +175,7 @@ extension PaymentSheet {
                         paymentMethodType: paymentMethod.type
                     )
                     setupIntentParams.returnURL = configuration.returnURL
+                    setupIntentParams.paymentMethodID = paymentMethod.stripeId
                     // Paypal requires mandate_data if setting up
                     if paymentMethod.type == .payPal {
                         setupIntentParams.mandateData = .makeWithInferredValues()
@@ -187,7 +189,7 @@ extension PaymentSheet {
             // MARK: ↪ Deferred Intent
             case .deferredIntent(_, let intentConfig):
                 switch newPaymentMethod {
-                    
+
                 case .confirmParams(confirmParams: let confirmParams):
                     let deferredContext = DeferredIntentContext(configuration: configuration,
                                                                 intentConfig: intentConfig,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+DeferredAPI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+DeferredAPI.swift
@@ -80,12 +80,23 @@ extension PaymentSheet {
                     // TODO(porter) Future optimization: Only fetch intent when strictly requried
                     let intent = try await deferredIntentContext.configuration.apiClient.retrieveIntent(for: deferredIntentContext.intentConfig,
                                                                                                         withClientSecret: clientSecret)
-                    confirm(configuration: deferredIntentContext.configuration,
-                            authenticationContext: deferredIntentContext.authenticationContext,
-                            intent: intent,
-                            paymentOption: deferredIntentContext.paymentOption,
-                            paymentHandler: deferredIntentContext.paymentHandler,
-                            completion: deferredIntentContext.completion)
+                    switch deferredIntentContext.paymentOption {
+                    case .applePay, .link, .saved:
+                        confirm(configuration: deferredIntentContext.configuration,
+                                authenticationContext: deferredIntentContext.authenticationContext,
+                                intent: intent,
+                                paymentOption: deferredIntentContext.paymentOption,
+                                paymentHandler: deferredIntentContext.paymentHandler,
+                                completion: deferredIntentContext.completion)
+                    case .new:
+                        // When confirming with a new payment method, confirm with the created STPPaymentMethod and not the create params
+                        confirm(configuration: deferredIntentContext.configuration,
+                                authenticationContext: deferredIntentContext.authenticationContext,
+                                intent: intent,
+                                paymentOption: .new(newPaymentMethod: .paymentMethod(paymentMethod: paymentMethod)),
+                                paymentHandler: deferredIntentContext.paymentHandler,
+                                completion: deferredIntentContext.completion)
+                    }
                 }
 
             } catch {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+DeferredAPI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+DeferredAPI.swift
@@ -89,7 +89,7 @@ extension PaymentSheet {
                                 paymentHandler: deferredIntentContext.paymentHandler,
                                 completion: deferredIntentContext.completion)
                     case .new:
-                        // When confirming with a new payment method, confirm with the created STPPaymentMethod and not the create params
+                        // When confirming with a new payment method, confirm with the created STPPaymentMethod and not the confirm params
                         confirm(configuration: deferredIntentContext.configuration,
                                 authenticationContext: deferredIntentContext.authenticationContext,
                                 intent: intent,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -23,11 +23,11 @@ extension PaymentSheet {
         case new(newPaymentMethod: NewPaymentMethod)
         case link(option: LinkConfirmOption)
     }
-    
+
     enum NewPaymentMethod {
         case confirmParams(confirmParams: IntentConfirmParams)
         case paymentMethod(paymentMethod: STPPaymentMethod)
-        
+
         var paymentSheetLabel: String {
             switch self {
             case .confirmParams(let confirmParams):
@@ -37,7 +37,7 @@ extension PaymentSheet {
             }
         }
     }
-    
+
     /// A class that presents the individual steps of a payment flow
     @available(iOSApplicationExtension, unavailable)
     @available(macCatalystApplicationExtension, unavailable)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -20,10 +20,24 @@ extension PaymentSheet {
     enum PaymentOption {
         case applePay
         case saved(paymentMethod: STPPaymentMethod)
-        case new(confirmParams: IntentConfirmParams)
+        case new(newPaymentMethod: NewPaymentMethod)
         case link(option: LinkConfirmOption)
     }
-
+    
+    enum NewPaymentMethod {
+        case confirmParams(confirmParams: IntentConfirmParams)
+        case paymentMethod(paymentMethod: STPPaymentMethod)
+        
+        var paymentSheetLabel: String {
+            switch self {
+            case .confirmParams(let confirmParams):
+                return confirmParams.paymentSheetLabel
+            case .paymentMethod(let paymentMethod):
+                return paymentMethod.paymentSheetLabel
+            }
+        }
+    }
+    
     /// A class that presents the individual steps of a payment flow
     @available(iOSApplicationExtension, unavailable)
     @available(macCatalystApplicationExtension, unavailable)
@@ -43,8 +57,8 @@ extension PaymentSheet {
                     label = String.Localized.apple_pay
                 case .saved(let paymentMethod):
                     label = paymentMethod.paymentSheetLabel
-                case .new(let confirmParams):
-                    label = confirmParams.paymentSheetLabel
+                case .new(let newPaymentMethod):
+                    label = newPaymentMethod.paymentSheetLabel
                 case .link(let option):
                     label = option.paymentSheetLabel
                 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -141,8 +141,13 @@ class PaymentSheetFlowControllerViewController: UIViewController {
             case .applePay, .saved, .link:
                 // TODO(Link): Handle link when we re-enable it
                 return nil
-            case .new(confirmParams: let params):
-                return params
+            case .new(let newPaymentMethod):
+                switch newPaymentMethod {
+                case .confirmParams(let confirmParams):
+                    return confirmParams
+                case .paymentMethod:
+                    return nil
+                }
             }
         }()
         // Default to saved payment selection mode, as long as we aren't restoring a customer's previous new payment method input


### PR DESCRIPTION
## Summary
- In the deferred flow we were not using the payment method we created when confirming an intent client side. This was resulting in a new payment method being created when we confirmed the intent rather than using the one we vend back to the merchant.
- When you would supply create payment method params and a payment method on the intent it would default to creating a new payment method with the create params overriding any assigned payment method to the intent at time of creation.
- Now when confirming an intent client side we attach the created payment method id to the confirm params to ensure it uses the same payment method as the merchant expects.

cc @yuki-stripe

## Motivation
Deferred private beta

## Testing
- Manual through inspecting the dashboard
- Difficult to test all client side since the backend contains some logic

## Changelog
N/A
