### PR TITLE
Use payment method we create when confirming client side

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfirmParams.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfirmParams.swift
@@ -12,7 +12,7 @@ import UIKit
 @_spi(STP) import StripePaymentsUI
 
 /// An internal type representing both `STPPaymentIntentParams` and `STPSetupIntentParams`
-/// - Note: Assumes you're confirming with a new payment method
+/// - Note: Assumes you're confirming with a new payment method, unless a payment method ID is provided
 class IntentConfirmParams {
     /// An enum for the three possible states of the e.g. "Save this card for future payments" checkbox
     enum SaveForFutureUseCheckboxState {
@@ -74,10 +74,17 @@ class IntentConfirmParams {
 
     func makeParams(
         paymentIntentClientSecret: String,
-        configuration: PaymentSheet.Configuration
+        configuration: PaymentSheet.Configuration,
+        paymentMethodID: String?
     ) -> STPPaymentIntentParams {
         let params = STPPaymentIntentParams(clientSecret: paymentIntentClientSecret)
-        params.paymentMethodParams = paymentMethodParams
+        // If a payment method ID was provided use that, otherwise use the payment method params
+        if let paymentMethodID = paymentMethodID {
+            params.paymentMethodId = paymentMethodID
+        } else {
+            params.paymentMethodParams = paymentMethodParams
+        }
+
         let options = paymentMethodOptions ?? STPConfirmPaymentMethodOptions()
         options.setSetupFutureUsageIfNecessary(
             saveForFutureUseCheckboxState == .selected,
@@ -89,9 +96,14 @@ class IntentConfirmParams {
         return params
     }
 
-    func makeParams(setupIntentClientSecret: String) -> STPSetupIntentConfirmParams {
+    func makeParams(setupIntentClientSecret: String, paymentMethodID: String?) -> STPSetupIntentConfirmParams {
         let params = STPSetupIntentConfirmParams(clientSecret: setupIntentClientSecret)
-        params.paymentMethodParams = paymentMethodParams
+        // If a payment method ID was provided use that, otherwise use the payment method params
+        if let paymentMethodID = paymentMethodID {
+            params.paymentMethodID = paymentMethodID
+        } else {
+            params.paymentMethodParams = paymentMethodParams
+        }
         return params
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -33,6 +33,7 @@ extension PaymentSheet {
         intent: Intent,
         paymentOption: PaymentOption,
         paymentHandler: STPPaymentHandler,
+        paymentMethodID: String? = nil,
         completion: @escaping (PaymentSheetResult) -> Void
     ) {
         // Translates a STPPaymentHandler result to a PaymentResult
@@ -109,7 +110,8 @@ extension PaymentSheet {
                 } else {
                     let paymentIntentParams = confirmParams.makeParams(
                         paymentIntentClientSecret: paymentIntent.clientSecret,
-                        configuration: configuration
+                        configuration: configuration,
+                        paymentMethodID: paymentMethodID
                     )
                     paymentIntentParams.returnURL = configuration.returnURL
                     paymentIntentParams.shipping = makeShippingParams(for: paymentIntent, configuration: configuration)
@@ -128,7 +130,8 @@ extension PaymentSheet {
                 }
             // MARK: ↪ SetupIntent
             case .setupIntent(let setupIntent):
-                let setupIntentParams = confirmParams.makeParams(setupIntentClientSecret: setupIntent.clientSecret)
+                let setupIntentParams = confirmParams.makeParams(setupIntentClientSecret: setupIntent.clientSecret,
+                                                                 paymentMethodID: paymentMethodID)
                 setupIntentParams.returnURL = configuration.returnURL
                 // Paypal requires mandate_data if setting up
                 if confirmParams.paymentMethodType.stpPaymentMethodType == .payPal {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+DeferredAPI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+DeferredAPI.swift
@@ -85,6 +85,7 @@ extension PaymentSheet {
                             intent: intent,
                             paymentOption: deferredIntentContext.paymentOption,
                             paymentHandler: deferredIntentContext.paymentHandler,
+                            paymentMethodID: paymentMethod.stripeId,
                             completion: deferredIntentContext.completion)
                 }
 


### PR DESCRIPTION
## Summary
- In the deferred flow we were not using the payment method we created when confirming an intent client side. This was resulting in a new payment method being created when we confirmed the intent rather than using the one we vend back to the merchant.
- We were not setting the payment method id on the confirm params resulting in a new payment method being created
- Now when confirming an intent client side we attach the created payment method id to the confirm params to ensure it uses the same payment method as the merchant expects.

cc @yuki-stripe

## Motivation
Deferred private beta

## Testing
- Manual through inspecting the dashboard
- Difficult to test all client side since the backend contains some logic

## Changelog
N/A
