### PR TITLE
FC Networking: added support for a new consumer session lookup API.

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
@@ -108,11 +108,12 @@ protocol FinancialConnectionsAPIClient {
         clientSecret: String
     ) -> Future<FinancialConnectionsSessionManifest>
 
-    // MARK: - Link API's
-
     func consumerSessionLookup(
-        emailAddress: String
+        emailAddress: String,
+        clientSecret: String
     ) -> Future<LookupConsumerSessionResponse>
+
+    // MARK: - Link API's
 
     func consumerSessionStartVerification(
         otpType: String,
@@ -537,20 +538,21 @@ extension STPAPIClient: FinancialConnectionsAPIClient {
         return post(resource: APIEndpointLinkStepUpAuthenticationVerified, parameters: parameters)
     }
 
-    // MARK: - Link API's
-
     func consumerSessionLookup(
-        emailAddress: String
+        emailAddress: String,
+        clientSecret: String
     ) -> Future<LookupConsumerSessionResponse> {
         let parameters: [String: Any] = [
-            "request_surface": "ios_connections",
             "email_address":
                 emailAddress
                 .trimmingCharacters(in: .whitespacesAndNewlines)
                 .lowercased(),
+            "client_secret": clientSecret,
         ]
-        return post(resource: "consumers/sessions/lookup", parameters: parameters)
+        return post(resource: APIEndpointConsumerSessions, parameters: parameters)
     }
+
+    // MARK: - Link API's
 
     func consumerSessionStartVerification(
         otpType: String,
@@ -611,3 +613,4 @@ private let APIEndpointLinkVerified = "link_account_sessions/link_verified"
 private let APIEndpointNetworkedAccounts = "link_account_sessions/networked_accounts"
 private let APIEndpointSaveAccountsToLink = "link_account_sessions/save_accounts_to_link"
 private let APIEndpointShareNetworkedAccount = "link_account_sessions/share_networked_account"
+private let APIEndpointConsumerSessions = "connections/link_account_sessions/consumer_sessions"

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupDataSource.swift
@@ -57,7 +57,7 @@ final class NetworkingLinkSignupDataSourceImplementation: NetworkingLinkSignupDa
     }
 
     func lookup(emailAddress: String) -> Future<LookupConsumerSessionResponse> {
-        return apiClient.consumerSessionLookup(emailAddress: emailAddress)
+        return apiClient.consumerSessionLookup(emailAddress: emailAddress, clientSecret: clientSecret)
     }
 
     func saveToLink(emailAddress: String, phoneNumber: String, countryCode: String) -> Future<Void> {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationDataSource.swift
@@ -58,7 +58,8 @@ final class NetworkingSaveToLinkVerificationDataSourceImplementation: Networking
     func startVerificationSession() -> Future<ConsumerSessionResponse> {
         apiClient
             .consumerSessionLookup(
-                emailAddress: consumerSession.emailAddress
+                emailAddress: consumerSession.emailAddress,
+                clientSecret: clientSecret
             )
             .chained { [weak self] (lookupConsumerSessionResponse: LookupConsumerSessionResponse) in
                 guard let self = self else {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPDataSource.swift
@@ -66,7 +66,8 @@ final class NetworkingOTPDataSourceImplementation: NetworkingOTPDataSource {
     func lookupConsumerSession() -> Future<LookupConsumerSessionResponse> {
         apiClient
             .consumerSessionLookup(
-                emailAddress: emailAddress
+                emailAddress: emailAddress,
+                clientSecret: clientSecret
             )
             .chained { [weak self] lookupConsumerSessionResponse in
                 self?.consumerSession = lookupConsumerSessionResponse.consumerSession

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
@@ -148,7 +148,8 @@ class EmptyFinancialConnectionsAPIClient: FinancialConnectionsAPIClient {
     }
 
     func consumerSessionLookup(
-        emailAddress: String
+        emailAddress: String,
+        clientSecret: String
     ) -> Future<StripeFinancialConnections.LookupConsumerSessionResponse> {
         return Promise<StripeFinancialConnections.LookupConsumerSessionResponse>()
     }


### PR DESCRIPTION
## Summary

^ see title & [handoff document](https://docs.google.com/document/d/1461McTe886-tamgPDQrSPrgP17H816QZMBe8nVU11b4/edit#); [JIRA](https://jira.corp.stripe.com/browse/BANKCON-6537), [Slack](https://stripe.slack.com/archives/C02CCTGEZPD/p1681397620755349?thread_ts=1681340185.833879&cid=C02CCTGEZPD)

## Testing

I ran through test mode and live mode. Below you can see the test mode working in video-form. Note that this is going into a feature branch and will be run through bug bashes also.


https://user-images.githubusercontent.com/105514761/231803292-d2b6f07f-55f8-4f1c-89ff-fb502688fc69.mp4



