### PR TITLE
Update Klarna supported countries

### DIFF
--- a/Stripe/StripeiOSTests/KlarnaHelperTest.swift
+++ b/Stripe/StripeiOSTests/KlarnaHelperTest.swift
@@ -17,7 +17,7 @@ import XCTest
 class KlarnaHelperTest: XCTestCase {
 
     func testAvailableCountries_eur() {
-        let expected = ["AT", "FI", "DE", "NL", "BE", "ES", "IT", "FR"]
+        let expected = ["AT", "FI", "DE", "NL", "BE", "ES", "IT", "FR", "GR", "IE", "PT"]
         XCTAssertEqual(expected, KlarnaHelper.availableCountries(currency: "eur"))
     }
 
@@ -46,13 +46,39 @@ class KlarnaHelperTest: XCTestCase {
         XCTAssertEqual(expected, KlarnaHelper.availableCountries(currency: "usd"))
     }
 
-    func testAvailableCountries_aus() {
-        XCTAssertTrue(KlarnaHelper.availableCountries(currency: "aus").isEmpty)
+    func testAvailableCountries_aud() {
+        let expected = ["AU"]
+        XCTAssertEqual(expected, KlarnaHelper.availableCountries(currency: "aud"))
+    }
+
+    func testAvailableCountries_cad() {
+        let expected = ["CA"]
+        XCTAssertEqual(expected, KlarnaHelper.availableCountries(currency: "cad"))
+    }
+
+    func testAvailableCountries_czk() {
+        let expected = ["CZ"]
+        XCTAssertEqual(expected, KlarnaHelper.availableCountries(currency: "czk"))
+    }
+
+    func testAvailableCountries_nzd() {
+        let expected = ["NZ"]
+        XCTAssertEqual(expected, KlarnaHelper.availableCountries(currency: "nzd"))
+    }
+
+    func testAvailableCountries_pln() {
+        let expected = ["PL"]
+        XCTAssertEqual(expected, KlarnaHelper.availableCountries(currency: "pln"))
+    }
+
+    func testAvailableCountries_chf() {
+        let expected = ["CH"]
+        XCTAssertEqual(expected, KlarnaHelper.availableCountries(currency: "chf"))
     }
 
     func testCanBuyNow_shouldReturnTrue() {
         // https://site-admin.stripe.com/docs/payments/klarna#payment-options
-        let canBuyNow = ["de_AT", "nl_BE", "de_DE", "it_IT", "nl_NL", "es_ES", "sv_SE"]
+        let canBuyNow = ["de_AT", "nl_BE", "de_DE", "it_IT", "nl_NL", "es_ES", "sv_SE", "en_CA", "en_AU", "pl_PL", "es_PT", "de_CH"]
 
         for country in canBuyNow {
             XCTAssertTrue(KlarnaHelper.canBuyNow(locale: Locale(identifier: country)))

--- a/Stripe/StripeiOSTests/KlarnaHelperTest.swift
+++ b/Stripe/StripeiOSTests/KlarnaHelperTest.swift
@@ -78,7 +78,7 @@ class KlarnaHelperTest: XCTestCase {
 
     func testCanBuyNow_shouldReturnTrue() {
         // https://site-admin.stripe.com/docs/payments/klarna#payment-options
-        let canBuyNow = ["de_AT", "nl_BE", "de_DE", "it_IT", "nl_NL", "es_ES", "sv_SE", "en_CA", "en_AU", "pl_PL", "es_PT", "de_CH"]
+        let canBuyNow = ["de_AT", "nl_BE", "de_DE", "it_IT", "nl_NL", "es_ES", "sv_SE", "en_CA", "en_AU", "pl_PL", "es_PT", "de_CH", "fr_CA"]
 
         for country in canBuyNow {
             XCTAssertTrue(KlarnaHelper.canBuyNow(locale: Locale(identifier: country)))

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/KlarnaHelper.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/KlarnaHelper.swift
@@ -27,7 +27,7 @@ struct KlarnaHelper {
             "czk": ["CZ"],
             "nzd": ["NZ"],
             "pln": ["PL"],
-            "chf": ["CH"]
+            "chf": ["CH"],
         ]
         return currencyToCountry[currency.lowercased()] ?? []
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/KlarnaHelper.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/KlarnaHelper.swift
@@ -16,12 +16,18 @@ struct KlarnaHelper {
     /// - Returns: the list of countries this PI can take payment from for Klarna.
     static func availableCountries(currency: String) -> [String] {
         let currencyToCountry = [
-            "eur": ["AT", "FI", "DE", "NL", "BE", "ES", "IT", "FR"],
+            "eur": ["AT", "FI", "DE", "NL", "BE", "ES", "IT", "FR", "GR", "IE", "PT"],
             "dkk": ["DK"],
             "nok": ["NO"],
             "sek": ["SE"],
             "gbp": ["GB"],
             "usd": ["US"],
+            "aud": ["AU"],
+            "cad": ["CA"],
+            "czk": ["CZ"],
+            "nzd": ["NZ"],
+            "pln": ["PL"],
+            "chf": ["CH"]
         ]
         return currencyToCountry[currency.lowercased()] ?? []
     }
@@ -32,7 +38,7 @@ struct KlarnaHelper {
     static func canBuyNow(locale: Locale = Locale.current) -> Bool {
         // A list of countries Klarna supports "buy now" from
         // https://site-admin.stripe.com/docs/payments/klarna#payment-options
-        let buyNowAvailable = ["AT", "BE", "DE", "IT", "NL", "ES", "SE"]
+        let buyNowAvailable = ["AT", "BE", "DE", "IT", "NL", "ES", "SE", "CA", "AU", "PL", "PT", "CH"]
         return buyNowAvailable.contains(locale.regionCode?.uppercased() ?? "US")
     }
 }


### PR DESCRIPTION
## Summary
Updates the list of supported Klarna currency mappings to the latest found here: https://stripe.com/docs/payments/klarna

## Motivation
https://www.linkedin.com/posts/stripe_were-expanding-support-for-more-buy-now-activity-7052340412929245184-b-v9?utm_source=share&utm_medium=member_desktop

## Testing
Manual

## Changelog
N/A