### PR TITLE
[FC] Integrate PagerDuty on e2e test failures. 

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -218,6 +218,12 @@ workflows:
         - test_repetition_mode: retry_on_failure
         - maximum_test_repetitions: "5"
         - scheme: FinancialConnections Example
+    - pagerduty@0:
+        is_always_run: true
+        run_if: .IsBuildFailed
+        inputs:
+          - event_description: iOS E2E tests failing! $BITRISE_BUILD_URL.
+          - integration_key: $AUX_PAGERDUTY_INTEGRATION_KEY
     - slack@3:
         is_always_run: true
         run_if: .IsBuildFailed


### PR DESCRIPTION
## Summary
- Adds PagerDuty Bitrise step to iOS E2E tests.
- See PagerDuty Integration [here](https://not-a-startup.pagerduty.com/services/PBS6Z8C/integrations/PSNGA60). 
- More details in this [doc](https://docs.google.com/document/d/1dTmcPAoXxWGPdYuwKBtWbS9Gqahm97GemwBiSvrhIng/edit#).