### PR TITLE
[Identity] Support reusing a verification session

### DIFF
--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/IdentityTopLevelDestination.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/IdentityTopLevelDestination.swift
@@ -1,0 +1,19 @@
+//
+//  IdentityTopLevelDestination.swift
+//  StripeIdentity
+//
+//  Created by Chen Cen on 4/13/23.
+//
+
+import Foundation
+
+enum IdentityTopLevelDestination {
+    case consentDestination
+    case docSelectionDestination
+    case documentCaptureDestination(documentType: DocumentType)
+    case selfieCaptureDestination
+    case errorDestination
+    case individualWelcomeDestination
+    case individualDestination
+    case confirmationDestination
+}

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/VerificationSheetController.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/VerificationSheetController.swift
@@ -143,10 +143,11 @@ final class VerificationSheetController: VerificationSheetControllerProtocol {
         let returnedPromise = Promise<StripeAPI.VerificationPage>()
         // Only update `verificationPageResponse` on main
         apiClient.getIdentityVerificationPage().observe(on: .main) { [weak self] result in
-            self?.verificationPageResponse = result
+            guard let self = self else { return }
+            self.verificationPageResponse = result
             if case .success(let verificationPage) = result {
-                self?.startLoadingMLModels(from: verificationPage)
-                self?.isVerificationPageSubmitted = verificationPage.submitted
+                self.startLoadingMLModels(from: verificationPage)
+                self.isVerificationPageSubmitted = verificationPage.submitted
                 // if result success and requires address, load address spec before continue
                 if verificationPage.requirements.missing.contains(.address) {
                     AddressSpecProvider.shared.loadAddressSpecs {

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/VerificationSheetController.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/VerificationSheetController.swift
@@ -68,7 +68,7 @@ protocol VerificationSheetControllerProtocol: AnyObject {
 
     /// Transition to IndividualViewController without any API request
     func transitionToIndividual()
-    
+
     /// Clear a certain type from collected data
     func clearCollectedData(field: StripeAPI.VerificationPageFieldType)
 }
@@ -379,13 +379,13 @@ final class VerificationSheetController: VerificationSheetControllerProtocol {
             )
         }
     }
-    
+
     // MARK: - Update internal states
-    
+
     func clearCollectedData(field: StripeAPI.VerificationPageFieldType) {
         self.collectedData.clearData(field: field)
     }
-    
+
     /// Check the result of VerificationPageData and update status. Callback successPageData if successful.
     private func handleVerificationPageDataResult(
         collectedData: StripeAPI.VerificationPageCollectedData? = nil,
@@ -398,17 +398,17 @@ final class VerificationSheetController: VerificationSheetControllerProtocol {
             self.transitionWithVerificaionPageDataResult(updateDataResult, completion: completion)
             return
         }
-        
+
         // update collectedData if there are no errors.
-        if(resultData.requirements.errors.isEmpty) {
+        if resultData.requirements.errors.isEmpty {
             if let collectedData = collectedData {
                 self.collectedData.merge(collectedData)
             }
         }
-        
+
         successPageData(resultData)
     }
-    
+
     /// 1. If the save was successful, caches the collectedData
     /// 2. If all fields have been collected, submits the verification page
     /// 3. Transitions to the next screen
@@ -417,12 +417,12 @@ final class VerificationSheetController: VerificationSheetControllerProtocol {
         updateDataResult: Result<StripeAPI.VerificationPageData, Error>,
         completion: @escaping () -> Void
     ) {
-        handleVerificationPageDataResult(collectedData: collectedData, updateDataResult: updateDataResult, completion: completion) { successData in
+        handleVerificationPageDataResult(collectedData: collectedData, updateDataResult: updateDataResult, completion: completion) { _ in
             self.checkSubmitAndTransition(
                 updateDataResult: updateDataResult,
                 completion: completion
             )
-            
+
         }
     }
 
@@ -431,7 +431,7 @@ final class VerificationSheetController: VerificationSheetControllerProtocol {
     private func calculateClearData(
         dataToBeCollected: StripeAPI.VerificationPageCollectedData
     ) -> StripeAPI.VerificationPageClearData {
-        
+
         let initialMissings: Set<StripeAPI.VerificationPageFieldType>
         do {
             initialMissings = try verificationPageResponse?.get().requirements.missing ?? Set()

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/VerificationSheetController.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/VerificationSheetController.swift
@@ -68,6 +68,9 @@ protocol VerificationSheetControllerProtocol: AnyObject {
 
     /// Transition to IndividualViewController without any API request
     func transitionToIndividual()
+    
+    /// Clear a certain type from collected data
+    func clearCollectedData(field: StripeAPI.VerificationPageFieldType)
 }
 
 final class VerificationSheetController: VerificationSheetControllerProtocol {
@@ -143,6 +146,7 @@ final class VerificationSheetController: VerificationSheetControllerProtocol {
             self?.verificationPageResponse = result
             if case .success(let verificationPage) = result {
                 self?.startLoadingMLModels(from: verificationPage)
+                self?.isVerificationPageSubmitted = verificationPage.submitted
                 // if result success and requires address, load address spec before continue
                 if verificationPage.requirements.missing.contains(.address) {
                     AddressSpecProvider.shared.loadAddressSpecs {
@@ -245,17 +249,12 @@ final class VerificationSheetController: VerificationSheetControllerProtocol {
                 )
             )
         }.observe(on: .main) { result in
-            switch result {
-            case .success(let resultData):
-                guard resultData.requirements.errors.isEmpty else {
+            self.handleVerificationPageDataResult(collectedData: optionalCollectedData, updateDataResult: result) { successData in
+                guard successData.requirements.errors.isEmpty else {
                     self.transitionWithVerificaionPageDataResult(result)
                     return
                 }
-
-                if let optionalCollectedData = optionalCollectedData {
-                    self.collectedData.merge(optionalCollectedData)
-                }
-                guard !resultData.requirements.missing.contains(.idDocumentBack) else {
+                guard !successData.requirements.missing.contains(.idDocumentBack) else {
                     onCompletion(true)
                     return
                 }
@@ -264,8 +263,6 @@ final class VerificationSheetController: VerificationSheetControllerProtocol {
                 self.checkSubmitAndTransition(updateDataResult: result) {
                     onCompletion(false)
                 }
-            case .failure:
-                self.transitionWithVerificaionPageDataResult(result)
             }
         }
     }
@@ -382,7 +379,36 @@ final class VerificationSheetController: VerificationSheetControllerProtocol {
             )
         }
     }
-
+    
+    // MARK: - Update internal states
+    
+    func clearCollectedData(field: StripeAPI.VerificationPageFieldType) {
+        self.collectedData.clearData(field: field)
+    }
+    
+    /// Check the result of VerificationPageData and update status. Callback successPageData if successful.
+    private func handleVerificationPageDataResult(
+        collectedData: StripeAPI.VerificationPageCollectedData? = nil,
+        updateDataResult: Result<StripeAPI.VerificationPageData, Error>,
+        completion: @escaping () -> Void = {},
+        successPageData: @escaping (StripeAPI.VerificationPageData) -> Void
+    ) {
+        guard case .success(let resultData) = updateDataResult
+        else {
+            self.transitionWithVerificaionPageDataResult(updateDataResult, completion: completion)
+            return
+        }
+        
+        // update collectedData if there are no errors.
+        if(resultData.requirements.errors.isEmpty) {
+            if let collectedData = collectedData {
+                self.collectedData.merge(collectedData)
+            }
+        }
+        
+        successPageData(resultData)
+    }
+    
     /// 1. If the save was successful, caches the collectedData
     /// 2. If all fields have been collected, submits the verification page
     /// 3. Transitions to the next screen
@@ -391,21 +417,13 @@ final class VerificationSheetController: VerificationSheetControllerProtocol {
         updateDataResult: Result<StripeAPI.VerificationPageData, Error>,
         completion: @escaping () -> Void
     ) {
-        guard case .success(let resultData) = updateDataResult
-        else {
-            transitionWithVerificaionPageDataResult(updateDataResult, completion: completion)
-            return
+        handleVerificationPageDataResult(collectedData: collectedData, updateDataResult: updateDataResult, completion: completion) { successData in
+            self.checkSubmitAndTransition(
+                updateDataResult: updateDataResult,
+                completion: completion
+            )
+            
         }
-
-        // Only merge when updateDatResult is successful and has no errors
-        if let collectedData = collectedData, resultData.requirements.errors.isEmpty {
-            self.collectedData.merge(collectedData)
-        }
-
-        checkSubmitAndTransition(
-            updateDataResult: updateDataResult,
-            completion: completion
-        )
     }
 
     /// Calculate the clearData parameter from the collectedData to be generated by the following
@@ -413,11 +431,20 @@ final class VerificationSheetController: VerificationSheetControllerProtocol {
     private func calculateClearData(
         dataToBeCollected: StripeAPI.VerificationPageCollectedData
     ) -> StripeAPI.VerificationPageClearData {
-        return .init(
-            clearFields: Set(StripeAPI.VerificationPageFieldType.allCases).subtracting(
+        
+        let initialMissings: Set<StripeAPI.VerificationPageFieldType>
+        do {
+            initialMissings = try verificationPageResponse?.get().requirements.missing ?? Set()
+        } catch {
+            assertionFailure("verificationPageResponse is nil, using StripeAPI.VerificationPageFieldType.allCases as initialMissings")
+            initialMissings = Set(StripeAPI.VerificationPageFieldType.allCases)
+        }
+        let ret = StripeAPI.VerificationPageClearData.init(
+            clearFields: initialMissings.subtracting(
                 collectedData.collectedTypes
             ).subtracting(dataToBeCollected.collectedTypes)
         )
+        return ret
     }
 
 }

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/VerificationSheetFlowController.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/VerificationSheetFlowController.swift
@@ -320,8 +320,8 @@ extension VerificationSheetFlowController: VerificationSheetFlowControllerProtoc
                 )
             )
         }
-        
-        switch(missingRequirements.nextDestination(collectedData: sheetController.collectedData)) {
+
+        switch missingRequirements.nextDestination(collectedData: sheetController.collectedData) {
         case .consentDestination:
             return completion(
                 makeBiometricConsentViewController(
@@ -667,13 +667,11 @@ extension VerificationSheetFlowController: SFSafariViewControllerDelegate {
 
 extension Set<StripeAPI.VerificationPageFieldType> {
     func nextDestination(collectedData: StripeAPI.VerificationPageCollectedData) -> IdentityTopLevelDestination {
-        if(self.contains(.biometricConsent)) {
+        if self.contains(.biometricConsent) {
             return .consentDestination
-        }
-        else if(self.contains(.idDocumentType)) {
+        } else if self.contains(.idDocumentType) {
             return .docSelectionDestination
-        }
-        else if(!self.isDisjoint(with: [.idDocumentFront, .idDocumentBack])) {
+        } else if !self.isDisjoint(with: [.idDocumentFront, .idDocumentBack]) {
             if let unwrappedDocumentType = collectedData.idDocumentType {
                 // if idDocumentType is collected, continue capture this type
                 return .documentCaptureDestination(documentType: unwrappedDocumentType)
@@ -681,13 +679,13 @@ extension Set<StripeAPI.VerificationPageFieldType> {
                 // if idDocumentType is not collected, this is a session started half way, reacapture document type
                 return .docSelectionDestination
             }
-        } else if(self.contains(.face)) {
+        } else if self.contains(.face) {
             return .selfieCaptureDestination
-        } else if(!self.isDisjoint(with: [.name, .dob])) {
+        } else if !self.isDisjoint(with: [.name, .dob]) {
             return .individualWelcomeDestination
-        } else if(!self.isDisjoint(with: [.idNumber, .address])) {
+        } else if !self.isDisjoint(with: [.idNumber, .address]) {
             return .individualDestination
-        } else if(self.isEmpty) {
+        } else if self.isEmpty {
             return .confirmationDestination
         } else {
             return .errorDestination

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/IdentityDataCollecting.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/IdentityDataCollecting.swift
@@ -25,7 +25,7 @@ extension IdentityDataCollecting {
 
 extension IdentityDataCollecting where Self: IdentityFlowViewController {
     func clearCollectedFields() {
-        collectedFields.forEach { self.sheetController?.collectedData.clearData(field: $0) }
+        collectedFields.forEach { self.sheetController?.clearCollectedData(field: $0) }
     }
 
     func reset() {

--- a/StripeIdentity/StripeIdentityTests/Helpers/IdentityMockData.swift
+++ b/StripeIdentity/StripeIdentityTests/Helpers/IdentityMockData.swift
@@ -20,6 +20,7 @@ enum VerificationPageMock: String, MockData {
     var bundle: Bundle { return Bundle(for: ClassForBundle.self) }
 
     case response200 = "VerificationPage_200"
+    case response200Submitted = "VerificationPage_200_submitted"
     case requireLiveCapture = "VerificationPage_require_live_capture"
     case noSelfie = "VerificationPage_no_selfie"
     case typeDocumentRequireIdNumber = "VerificationPage_type_doc_require_idNumber"

--- a/StripeIdentity/StripeIdentityTests/Helpers/VerificationSheetControllerMock.swift
+++ b/StripeIdentity/StripeIdentityTests/Helpers/VerificationSheetControllerMock.swift
@@ -15,6 +15,9 @@ import XCTest
 @testable import StripeIdentity
 
 final class VerificationSheetControllerMock: VerificationSheetControllerProtocol {
+    func clearCollectedData(field: StripeCore.StripeAPI.VerificationPageFieldType) {
+        // no-op
+    }
     var verificationPageResponse: Result<StripeAPI.VerificationPage, Error>?
 
     var apiClient: IdentityAPIClient

--- a/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_200_submitted.json
+++ b/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_200_submitted.json
@@ -1,0 +1,144 @@
+{
+    "biometric_consent": {
+        "accept_button_text": "Accept and continue",
+        "body": "<p><b>How Stripe will verify your data</b></p><p>Stripe will use biometric technology (on images of you and your IDs) and other data sources to confirm your identity and for fraud and security purposes.</p><p><b><a href=\"https://stripe.com\">Learn about Stripe</a></b></p><p><b><a href=\"https://stripe.com\">Learn how Stripe Identity works</a></b></p>",
+        "decline_button_text": "No, don't verify",
+        "privacy_policy": "Data will be stored and may be used according to the Stripe <a href='https://stripe.com'>Privacy Policy</a> and <a href='https://stripe.com'>Rocket Rides</a> Privacy Policy.",
+        "time_estimate": "Takes about 1–2 minutes",
+        "title": "How Stripe will verify your identity",
+        "scroll_to_continue_button_text": "Scroll to continue"
+    },
+    "country_not_listed": {
+      "address_from_other_country_text_button_text": "Have an Address from another country?",
+      "body": "The countries not listed are not supported yet. Unfortunately, we cannot verify your identity.",
+      "cancel_button_text": "Cancel verification",
+      "id_from_other_country_text_button_text": "Have an ID from another country?",
+      "title": "We cannot verify your identity"
+    },
+    "document_capture": {
+        "autocapture_timeout": 10000,
+        "file_purpose": "identity_private",
+        "high_res_image_compression_quality": 0.92,
+        "high_res_image_crop_padding": 0.08,
+        "high_res_image_max_dimension": 2160,
+        "ios_id_card_back_barcode_timeout": 3000,
+        "ios_id_card_back_country_barcode_symbologies": {
+            "US": "pdf417",
+            "CA": "pdf417"
+        },
+        "low_res_image_compression_quality": 0.82,
+        "low_res_image_max_dimension": 800,
+        "models": {
+            "id_detector_min_iou": 0.5,
+            "id_detector_min_score": 0.4,
+            "id_detector_url": "https://some_url.com",
+        },
+        "motion_blur_min_duration": 500,
+        "motion_blur_min_iou": 0.95,
+        "require_live_capture": false
+    },
+    "document_select": {
+        "id_document_type_allowlist": {
+            "passport": "Passport",
+            "driving_license": "Driver's license",
+            "id_card": "Identity card"
+        },
+        "body": null,
+        "button_text": "Continue",
+        "title": "Select identification type"
+    },
+    "fallback_url": "https://verify.stripe.com",
+    "individual": {
+      "address_countries": {
+        "AT": "Austria",
+        "AU": "Australia",
+        "BE": "Belgium",
+        "BR": "Brazil",
+        "CA": "Canada",
+        "CH": "Switzerland",
+        "CZ": "Czech Republic",
+        "DE": "Germany",
+        "DK": "Denmark",
+        "ES": "Spain",
+        "FI": "Finland",
+        "FR": "France",
+        "GB": "United Kingdom",
+        "HK": "Hong Kong",
+        "ID": "Indonesia",
+        "IE": "Ireland",
+        "IT": "Italy",
+        "LU": "Luxembourg",
+        "MT": "Malta",
+        "MX": "Mexico",
+        "MY": "Malaysia",
+        "NL": "Netherlands",
+        "NO": "Norway",
+        "PL": "Poland",
+        "PT": "Portugal",
+        "RO": "Romania",
+        "SE": "Sweden",
+        "SG": "Singapore",
+        "SK": "Slovakia",
+        "TH": "Thailand",
+        "US": "United States"
+      },
+      "address_country_not_listed_text_button_text": "My country is not listed",
+      "button_text": "Submit",
+      "id_number_countries": {
+        "BR": "Brazil",
+        "SG": "Singapore",
+        "US": "United States"
+      },
+      "id_number_country_not_listed_text_button_text": "My country is not listed",
+      "title": "Provide personal information"
+    },
+    "individual_welcome": {
+      "body": "You’ll need to share some personal information to complete the verification. <a href='https://stripe.com/privacy-center/legal#stripe-identity'>Learn more</a>",
+      "get_started_button_text": "Get started",
+      "privacy_policy": "Data will be stored and may be used according to the <a href ='https://stripe.com/privacy'>Stripe Privacy Policy</a> and Tora's catfood Privacy Policy.",
+      "time_estimate": "Takes less than 1 minute.",
+      "title": "Tora's catfood partners with Stripe for secure Identity verification"
+    },
+    "id": "VS_123",
+    "livemode": false,
+    "object": "identity.verification_page",
+    "requirements": {
+        "missing": [
+            "biometric_consent",
+            "face",
+            "id_document_back",
+            "id_document_front",
+            "id_document_type",
+        ]
+    },
+    "selfie": {
+        "autocapture_timeout": 8000,
+        "file_purpose": "identity_private",
+        "high_res_image_compression_quality": 0.92,
+        "high_res_image_crop_padding": 0.05,
+        "high_res_image_max_dimension": 2160,
+        "low_res_image_compression_quality": 0.82,
+        "low_res_image_max_dimension": 800,
+        "max_centered_threshold_x": 0.2,
+        "max_centered_threshold_y": 0.2,
+        "max_coverage_threshold": 0.8,
+        "min_coverage_threshold": 0.07,
+        "min_edge_threshold": 0.05,
+        "models": {
+            "face_detector_min_iou": 0.5,
+            "face_detector_min_score": 0.8,
+            "face_detector_url": "https://some_url.com"
+        },
+        "num_samples": 8,
+        "sample_interval": 250,
+        "training_consent_text": "Allow Stripe to use your images to improve our biometric verification technology. You can remove Stripe's permissions at any time by contacting Stripe. <a href='https://stripe.com/privacy-center/legal#stripe-identity'>Learn how Stripe uses data</a>"
+    },
+    "status": "requires_input",
+    "submitted": true,
+    "success": {
+        "body": "<p><b>Thank you for providing your information</b></p><p>Rocket Rides will reach out if additional details are required.</p><p><b>Next steps</b></p><p>Rocket Rides will contact regarding the outcome of your identification process.</p><p><b>More about Stripe Identity</b></p><p><b><a href=\"https://stripe.com\">Learn how Stripe Identity works</a></b></p><p><b><a href=\"https://stripe.com\">Stripe's privacy policy</a></b></p><p><b><a href=\"https://stripe.com\">Frequently asked questions</a></b></p><p><b><a href=\"https://stripe.com\">Contact Stripe</a></b></p>",
+        "button_text": "Complete",
+        "title": "Verification pending"
+    },
+    "unsupported_client": false
+}

--- a/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/Coordinators/VerificationSheetControllerTest.swift
+++ b/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/Coordinators/VerificationSheetControllerTest.swift
@@ -79,7 +79,7 @@ final class VerificationSheetControllerTest: XCTestCase {
         XCTAssertTrue(mockMLModelLoader.didStartLoadingDocumentModels)
         XCTAssertTrue(mockMLModelLoader.didStartLoadingFaceModels)
     }
-    
+
     func testLoadSubmittedValidResponse() throws {
         let mockResponse = try VerificationPageMock.response200Submitted.make()
 

--- a/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/Coordinators/VerificationSheetControllerTest.swift
+++ b/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/Coordinators/VerificationSheetControllerTest.swift
@@ -79,6 +79,33 @@ final class VerificationSheetControllerTest: XCTestCase {
         XCTAssertTrue(mockMLModelLoader.didStartLoadingDocumentModels)
         XCTAssertTrue(mockMLModelLoader.didStartLoadingFaceModels)
     }
+    
+    func testLoadSubmittedValidResponse() throws {
+        let mockResponse = try VerificationPageMock.response200Submitted.make()
+
+        // Load
+        controller.load().observe { _ in
+            self.exp.fulfill()
+        }
+
+        // Verify 1 request made with secret
+        XCTAssertEqual(mockAPIClient.verificationPage.requestHistory.count, 1)
+
+        // Verify result is nil until API responds to request
+        XCTAssertNil(controller.verificationPageResponse)
+
+        // Respond to request with success
+        mockAPIClient.verificationPage.respondToRequests(with: .success(mockResponse))
+
+        // Verify completion block is called
+        wait(for: [exp], timeout: 1)
+
+        // Verify response updated on controller
+        XCTAssertEqual(try? controller.verificationPageResponse?.get(), mockResponse)
+        XCTAssertTrue(mockMLModelLoader.didStartLoadingDocumentModels)
+        XCTAssertTrue(mockMLModelLoader.didStartLoadingFaceModels)
+        XCTAssertTrue(controller.isVerificationPageSubmitted)
+    }
 
     func testLoadErrorResponse() throws {
         let mockError = NSError(domain: "", code: 0, userInfo: nil)
@@ -142,10 +169,10 @@ final class VerificationSheetControllerTest: XCTestCase {
                     idDocumentBack: true,
                     idDocumentFront: true,
                     idDocumentType: true,
-                    idNumber: true,
-                    dob: true,
-                    name: true,
-                    address: true
+                    idNumber: false,
+                    dob: false,
+                    name: false,
+                    address: false
                 ),
                 collectedData: mockData
             )

--- a/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/Coordinators/VerificationSheetFlowControllerTest.swift
+++ b/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/Coordinators/VerificationSheetFlowControllerTest.swift
@@ -169,7 +169,7 @@ final class VerificationSheetFlowControllerTest: XCTestCase {
         )
         wait(for: [exp], timeout: 1)
     }
-    
+
     func testNoSelfieConfigError() throws {
         let exp = expectation(description: "testNoSelfieConfigError")
         try nextViewController(

--- a/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/Coordinators/VerificationSheetFlowControllerTest.swift
+++ b/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/Coordinators/VerificationSheetFlowControllerTest.swift
@@ -140,46 +140,36 @@ final class VerificationSheetFlowControllerTest: XCTestCase {
         wait(for: [staticAPIErrExp, updateAPIErrExp, reqDataErrExp], timeout: 1)
     }
 
-    func testNoMoreMissingFieldsError() throws {
+    func testNoMoreMissingFieldsReturnSuccessViewController() throws {
         let exp = expectation(description: "No more missing fields")
         flowController.nextViewController(
             staticContentResult: .success(try VerificationPageMock.response200.make()),
             updateDataResult: .success(try VerificationPageDataMock.noErrors.make()),
             sheetController: mockSheetController,
             completion: { nextVC in
-                XCTAssertIs(nextVC, ErrorViewController.self)
-                XCTAssertEqual(
-                    (nextVC as? ErrorViewController)?.model,
-                    .error(VerificationSheetFlowControllerError.noScreenForRequirements([]))
-                )
+                XCTAssertIs(nextVC, SuccessViewController.self)
                 exp.fulfill()
             }
         )
         wait(for: [exp], timeout: 1)
     }
 
-    // Requires document photo but user has not selected type
-    func testDocumentPhotoNoTypeError() throws {
+    // Requires document photo without type - should return DocumentTypeSelectViewController
+    func testMissingDocFrontNoType() throws {
         // Mock that document ML models successfully loaded
         mockMLModelLoader.documentModelsPromise.resolve(with: .init(DocumentScannerMock()))
 
-        let exp = expectation(description: "testDocumentPhotoNoTypeError")
+        let exp = expectation(description: "testMissingDocFrontNoType")
         try nextViewController(
             missingRequirements: [.idDocumentFront],
             completion: { nextVC in
-                XCTAssertIs(nextVC, ErrorViewController.self)
-                XCTAssertEqual(
-                    (nextVC as? ErrorViewController)?.model,
-                    .error(
-                        VerificationSheetFlowControllerError.missingRequiredInput([.idDocumentType])
-                    )
-                )
+                XCTAssertIs(nextVC, DocumentTypeSelectViewController.self)
                 exp.fulfill()
             }
         )
         wait(for: [exp], timeout: 1)
     }
-
+    
     func testNoSelfieConfigError() throws {
         let exp = expectation(description: "testNoSelfieConfigError")
         try nextViewController(


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Add support to start a verification session halfway.

Introduce `IdentityTopLevelDestination` to abstract different screens.
Instead of navigating to `ConsentDestiantion` or `IndividualWelcomeDestiantion` on `InitialiLoadingScreen`, check the requirement and navigate from where the session is left off, the logic will also be used in test model's preview.

Similar Android change: https://github.com/stripe/stripe-android/pull/6530

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
* Support start a verification half way
* Support test mode

## Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Recordings
| Before  | After |
| ------------- | ------------- |
| ![reuseBefore](https://user-images.githubusercontent.com/79880926/232624969-8ba31b6c-aa59-400a-ab78-97d427c1bab7.gif)  | ![reuseAfter](https://user-images.githubusercontent.com/79880926/232624963-7733ef90-70c7-403c-97b3-e08165202171.gif) |







## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
