### PR TITLE
FC Networking: fixed an issue where tap area for skip button in WarmUp pane wasn't as large as we want.

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupBodyView.swift
@@ -11,7 +11,7 @@ import Foundation
 import UIKit
 
 @available(iOSApplicationExtension, unavailable)
-final class NetworkingLinkLoginWarmupBodyView: UIView {
+final class NetworkingLinkLoginWarmupBodyView: HitTestView {
 
     private let didSelectContinue: () -> Void
 
@@ -22,7 +22,7 @@ final class NetworkingLinkLoginWarmupBodyView: UIView {
     ) {
         self.didSelectContinue = didSelectContinue
         super.init(frame: .zero)
-        let verticalStackView = UIStackView(
+        let verticalStackView = HitTestStackView(
             arrangedSubviews: [
                 CreateContinueButton(
                     email: email,


### PR DESCRIPTION
## Summary

Feedback " Continue without signing in tap area is small sometimes hard to hit" from [document](https://docs.google.com/document/d/1TIAPlrpCNQWPo3uBOTs77qPPBdnTGNaHlM9XnfSz684/edit#).

It was difficult to tap unless right on:

https://user-images.githubusercontent.com/105514761/232615455-ac725c44-8187-49ef-aac2-000c7b7995a1.mov

## Testing

After fix its much easier to tap from the bottom (this also makes sense from the stand-point of view hierarchy):

https://user-images.githubusercontent.com/105514761/232614929-39c73753-cc82-476d-8c77-a1b1f8aeb478.mov

