### PR TITLE
Change behavior of STPBinController.mostSpecificBINRange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## x.x.x yyyy-mm-dd
+
+### Payments
+* [Fixed] Fixed UnionPay cards appearing as invalid in some cases.
+
 ## 23.6.1 2023-04-17
 ### All
 * Xcode 13 is [no longer supported by Apple](https://developer.apple.com/news/upcoming-requirements/). Please upgrade to Xcode 14.1 or later.

--- a/Stripe/StripeiOSTests/STPBinRangeTest.swift
+++ b/Stripe/StripeiOSTests/STPBinRangeTest.swift
@@ -155,4 +155,31 @@ class STPBinRangeTest: XCTestCase {
         XCTAssertEqual(binRange?.brand, .visa)
         XCTAssertEqual(binRange?.panLength, 16)
     }
+
+    func testMostSpecificBinRangePrefersKnownBrand() {
+        // 624478 is a real world case that returns ranges for UnionPay and NYCE, the latter being handled as unknown.
+        let mockedRanges = [
+            STPBINRange(
+                panLength: 16,
+                brand: .unionPay,
+                accountRangeLow: "6244780000000000",
+                accountRangeHigh: "6244789999999999",
+                country: "HK"
+            ),
+            STPBINRange(
+                panLength: 16,
+                brand: .unknown,
+                accountRangeLow: "6244780000000000",
+                accountRangeHigh: "6244789999999999",
+                country: "CN"
+            ),
+        ]
+        STPBINController.shared.sRetrievedRanges["624478"] = mockedRanges
+        STPBINController.shared.sAllRanges += mockedRanges
+
+        let binRange = STPBINController.shared.mostSpecificBINRange(forNumber: "624478")
+        XCTAssertEqual(binRange.accountRangeLow, "6244780000000000")
+        XCTAssertEqual(binRange.accountRangeHigh, "6244789999999999")
+        XCTAssertEqual(binRange.brand, .unionPay)
+    }
 }

--- a/StripePayments/StripePayments/Source/Helpers/STPBINController.swift
+++ b/StripePayments/StripePayments/Source/Helpers/STPBINController.swift
@@ -94,9 +94,21 @@ extension STPBINRange {
     }
 
     func compare(_ other: STPBINRange) -> ComparisonResult {
-        return NSNumber(value: accountRangeLow.count).compare(
+        let result = NSNumber(value: accountRangeLow.count).compare(
             NSNumber(value: other.accountRangeLow.count)
         )
+
+        // If they are the same range unknown brands go first.
+        if result == .orderedSame {
+            if brand == .unknown && other.brand != .unknown {
+                return .orderedAscending
+            } else if brand != .unknown && other.brand == .unknown {
+                return .orderedDescending
+            }
+        }
+
+        return result
+
     }
 }
 

--- a/StripePayments/StripePayments/Source/Helpers/STPBINController.swift
+++ b/StripePayments/StripePayments/Source/Helpers/STPBINController.swift
@@ -386,7 +386,7 @@ extension STPBINRange {
         return binRanges
     }()
 
-    private var sAllRanges: [STPBINRange] = {
+    var sAllRanges: [STPBINRange] = {
         return STPBINRangeInitialRanges
     }()
 


### PR DESCRIPTION
## Summary
There is an issue reported in https://jira.corp.stripe.com/browse/RUN_MOBILESDK-2271 where a UnionPay card shows as invalid, this happens because the Metadata Service returns two potential ranges for this BIN, one of them handled as unknown by the client:

```
{
  "data": [
    {
      "account_range_high": "6244789999999999",
      "account_range_low": "6244780000000000",
      "brand": "UNIONPAY",
      "country": "HK",
      "funding": "CREDIT",
      "pan_length": 16
    },
    {
      "account_range_high": "6244789999999999",
      "account_range_low": "6244780000000000",
      "brand": "NYCE",
      "country": "CN",
      "funding": "DEBIT",
      "pan_length": 16
    }
  ]
}
```

Given the logic in mostSpecificBINRange, where we sort the BIN ranges and take the last, I'm making it so known brands come after unknown brands, i.e. giving preference to known brands.
This might change with the efforts for card brand choice.

## Motivation
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-2271

## Testing
- Added test
- Visually tested

## Changelog
* [Fixed] Fixed UnionPay cards appearing as invalid in some cases.