### PR TITLE
Fix constraint error in HTMLViewWithIconLabels

### DIFF
--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Views/IdentityHTMLView/HTMLViewWithIconLabels.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Views/IdentityHTMLView/HTMLViewWithIconLabels.swift
@@ -136,15 +136,12 @@ extension HTMLViewWithIconLabels {
         addAndPinSubview(vStack)
         vStack.addArrangedSubview(separatorView)
         vStack.addArrangedSubview(textView)
+        vStack.setCustomSpacing(Styling.separatorVerticalSpacing, after: separatorView)
     }
 
     fileprivate func installConstraints() {
         NSLayoutConstraint.activate([
             separatorView.heightAnchor.constraint(equalToConstant: IdentityUI.separatorHeight),
-            separatorView.bottomAnchor.constraint(
-                equalTo: textView.topAnchor,
-                constant: -Styling.separatorVerticalSpacing
-            ),
             separatorView.leadingAnchor.constraint(equalTo: vStack.leadingAnchor),
             separatorView.trailingAnchor.constraint(equalTo: vStack.trailingAnchor),
             textView.leadingAnchor.constraint(equalTo: vStack.leadingAnchor),


### PR DESCRIPTION
## Summary
Fixes a constraint error. Edit: Explained in email to Chen Cen, but recap:

The `UIStackView` used has a spacing of 16, but a manually added constraint of 24 points between the divider and the text below - inside the stack view - caused a constraint error, as both are priority 1000. This fix uses the built-in custom spacing for the divider and removes the manually added constraint.

## Motivation
Bug, self-explanatory.

## Testing
I ran it. It no longer produces constraint errors and renders as expected (with the correct 24 point spacing).

## Changelog
n/a
