### PR TITLE
Fix klarna functional test

### DIFF
--- a/Stripe/StripeiOSTests/STPSourceFunctionalTest.m
+++ b/Stripe/StripeiOSTests/STPSourceFunctionalTest.m
@@ -604,17 +604,16 @@
     dob.day = 11;
     dob.month = 3;
     dob.year = 1952;
-    STPSourceParams *params = [STPSourceParams klarnaParamsWithReturnURL:@"https://shop.example.com/return" currency:@"GBP" purchaseCountry:@"UK" items:lineItems customPaymentMethods:@[@(STPKlarnaPaymentMethodsNone)] billingAddress:address billingFirstName:@"Arthur" billingLastName:@"Dent" billingDOB:dob];
+    STPSourceParams *params = [STPSourceParams klarnaParamsWithReturnURL:@"https://shop.example.com/return" currency:@"GBP" purchaseCountry:@"GB" items:lineItems customPaymentMethods:@[@(STPKlarnaPaymentMethodsNone)] billingAddress:address billingFirstName:@"Arthur" billingLastName:@"Dent" billingDOB:dob];
 
-    STPAPIClient *client = [[STPAPIClient alloc] initWithPublishableKey:STPTestingDefaultPublishableKey];
+    STPAPIClient *client = [[STPAPIClient alloc] initWithPublishableKey:STPTestingGBPublishableKey];
     XCTestExpectation *expectation = [self expectationWithDescription:@"Source creation"];
     [client createSourceWithParams:params completion:^(STPSource *source, NSError * error) {
         XCTAssertNil(error);
         XCTAssertNotNil(source);
         XCTAssertEqual(source.type, STPSourceTypeKlarna);
         XCTAssertEqualObjects(source.amount, @(600));
-        XCTAssertEqualObjects(source.owner.address.line1, address.line1);
-        XCTAssertEqualObjects(source.klarnaDetails.purchaseCountry, @"UK");
+        XCTAssertEqualObjects(source.klarnaDetails.purchaseCountry, @"GB");
         XCTAssertEqual(source.redirect.status, STPSourceRedirectStatusPending);
         XCTAssertEqualObjects(source.redirect.returnURL, [NSURL URLWithString:@"https://shop.example.com/return?redirect_merchant_name=xctest"]);
         XCTAssertNotNil(source.redirect.url);

--- a/Stripe/StripeiOSTests/STPTestingAPIClient.h
+++ b/Stripe/StripeiOSTests/STPTestingAPIClient.h
@@ -30,6 +30,8 @@ static NSString * const STPTestingBEPublishableKey = @"pk_test_51HZi0VArGMi59tL4
 static NSString * const STPTestingINPublishableKey = @"pk_test_51H7wmsBte6TMTRd4gph9Wm7gnQOKJwdVTCj30AhtB8MhWtlYj6v9xDn1vdCtKYGAE7cybr6fQdbQQtgvzBihE9cl00tOnrTpL9";
 // Test account in Brazil
 static NSString * const STPTestingBRPublishableKey = @"pk_test_51JYFFjJQVROkWvqT6Hy9pW7uPb6UzxT3aACZ0W3olY8KunzDE9mm6OxE5W2EHcdZk7LxN6xk9zumFbZL8zvNwixR0056FVxQmt";
+// Test account in Great Britain
+static NSString * const STPTestingGBPublishableKey = @"pk_test_51KmkHbGoesj9fw9QAZJlz1qY4dns8nFmLKc7rXiWKAIj8QU7NPFPwSY1h8mqRaFRKQ9njs9pVJoo2jhN6ZKSDA4h00mjcbGF7b";
 
 @interface STPTestingAPIClient : NSObject
 


### PR DESCRIPTION
## Summary
This was broken by https://amp.corp.stripe.com/feature-flags/flag/enable_klarna_buyer_country_validation_on_sources

## Motivation
Fix a failing test

## Testing
Ran tests
