### PR TITLE
[Identity] Update constraint for separator in HTMLViewWithIconLabels

### DIFF
--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Views/IdentityHTMLView/HTMLViewWithIconLabels.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Views/IdentityHTMLView/HTMLViewWithIconLabels.swift
@@ -136,15 +136,12 @@ extension HTMLViewWithIconLabels {
         addAndPinSubview(vStack)
         vStack.addArrangedSubview(separatorView)
         vStack.addArrangedSubview(textView)
+        vStack.setCustomSpacing(Styling.separatorVerticalSpacing, after: separatorView)
     }
 
     fileprivate func installConstraints() {
         NSLayoutConstraint.activate([
             separatorView.heightAnchor.constraint(equalToConstant: IdentityUI.separatorHeight),
-            separatorView.bottomAnchor.constraint(
-                equalTo: textView.topAnchor,
-                constant: -Styling.separatorVerticalSpacing
-            ),
             separatorView.leadingAnchor.constraint(equalTo: vStack.leadingAnchor),
             separatorView.trailingAnchor.constraint(equalTo: vStack.trailingAnchor),
             textView.leadingAnchor.constraint(equalTo: vStack.leadingAnchor),


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
UIStackView's default spacing conflicts with the custom constraint added. Use `setCustomSpacing` instead`


## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Verified through `IdentityHTMLViewSnapshotTest`
- [x] Verified Manually

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
