### PR TITLE
Pass return URL to STPApplePayContext

### DIFF
--- a/StripeApplePay/StripeApplePay/Source/ApplePayContext/STPApplePayContext.swift
+++ b/StripeApplePay/StripeApplePay/Source/ApplePayContext/STPApplePayContext.swift
@@ -200,6 +200,7 @@ public class STPApplePayContext: NSObject, PKPaymentAuthorizationControllerDeleg
     @_spi(STP) public var shippingDetails: StripeAPI.ShippingDetails?
     private weak var delegate: _stpinternal_STPApplePayContextDelegateBase?
     @objc var authorizationController: PKPaymentAuthorizationController?
+    @_spi(STP) public var returnUrl: String?
     // Internal state
     private var paymentState: PaymentState = .notStarted
     private var error: Error?
@@ -516,6 +517,7 @@ public class STPApplePayContext: NSObject, PKPaymentAuthorizationControllerDeleg
                             )
                             confirmParams.paymentMethod = paymentMethod.id
                             confirmParams.useStripeSdk = true
+                            confirmParams.returnUrl = self.returnUrl
 
                             StripeAPI.SetupIntent.confirm(
                                 apiClient: self.apiClient,

--- a/StripeApplePay/StripeApplePay/Source/PaymentsCore/API/Models/SetupIntentParams.swift
+++ b/StripeApplePay/StripeApplePay/Source/PaymentsCore/API/Models/SetupIntentParams.swift
@@ -16,14 +16,14 @@ extension StripeAPI {
             clientSecret: String,
             paymentMethodData: StripeAPI.PaymentMethodParams? = nil,
             paymentMethod: String? = nil,
-            returnURL: String? = nil,
+            returnUrl: String? = nil,
             useStripeSdk: Bool? = nil,
             _additionalParametersStorage: NonEncodableParameters? = nil
         ) {
             self.clientSecret = clientSecret
             self.paymentMethodData = paymentMethodData
             self.paymentMethod = paymentMethod
-            self.returnURL = returnURL
+            self.returnUrl = returnUrl
             self.useStripeSdk = useStripeSdk
             self._additionalParametersStorage = _additionalParametersStorage
         }
@@ -40,7 +40,7 @@ extension StripeAPI {
         /// The URL to redirect your customer back to after they authenticate or cancel
         /// their payment on the payment method’s app or site.
         /// This should probably be a URL that opens your iOS app.
-        @_spi(STP) public var returnURL: String?
+        @_spi(STP) public var returnUrl: String?
         /// A boolean number to indicate whether you intend to use the Stripe SDK's functionality to handle any SetupIntent next actions.
         /// If set to false, SetupIntent.nextAction will only ever contain a redirect url that can be opened in a webview or mobile browser.
         /// When set to true, the nextAction may contain information that the Stripe SDK can use to perform native authentication within your

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
@@ -130,6 +130,7 @@ extension STPApplePayContext {
         if let applePayContext = STPApplePayContext(paymentRequest: paymentRequest, delegate: delegate) {
             applePayContext.shippingDetails = makeShippingDetails(from: configuration)
             applePayContext.apiClient = configuration.apiClient
+            applePayContext.returnUrl = configuration.returnURL
             return applePayContext
         } else {
             // Delegate only deallocs when Apple Pay completes


### PR DESCRIPTION
## Summary
SetupIntents with auto PMs require a return URL, but we were not passing it for Apple Pay, causing the confirmation to fail.
This was already mitigated on the backend by removing this requirement in https://git.corp.stripe.com/stripe-internal/pay-server/pull/606610, but we still need to pass it on our side.

## Motivation
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-2268

## Testing
Verified that return URL was included in the confirm request.
