### PR TITLE
Fix mandate blocking payment if it is rendered after the view control…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Payments
 * [Fixed] Fixed UnionPay cards appearing as invalid in some cases.
 
+### PaymentSheet
+* [Fixed] Fixed a bug that prevents users from using SEPA Debit w/ PaymentIntents or SetupIntents and Paypal in PaymentIntent+setup_future_usage or SetupIntent.
+
 ## 23.6.1 2023-04-17
 ### All
 * Xcode 13 is [no longer supported by Apple](https://developer.apple.com/news/upcoming-requirements/). Please upgrade to Xcode 14.1 or later.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
@@ -298,6 +298,7 @@ class AddPaymentMethodViewController: UIViewController {
             paymentMethodFormElement = makeElement(for: selectedPaymentMethodType)
         }
         updateUI()
+        sendEventToSubviews(.viewDidAppear, from: view)
     }
 
     func didTapCallToActionButton(behavior: OverrideableBuyButtonBehavior, from viewController: UIViewController) {


### PR DESCRIPTION
…ler first appears.

## Summary
https://github.com/stripe/stripe-ios/pull/2424 added `SimpleMandateElement `, which requires its view to have been displayed before producing a valid payment option.  

However, it failed to tell `SimpleMandateElement` that it has appeared if it was rendered **after** the view controller (AddPaymentMethodViewController) first appears, so the mandate always block the customer from paying.

## Motivation
#ir-covering-silences

## Testing
* Tested the PMs that use SimpleMandateElement - SEPA, Paypal+SetupIntent, Paypal+PaymentIntent+SFU, in PaymentSheet & PaymentSheet.FlowController

## Changelog
[Fixed] Fixed a bug that prevents users from using SEPA Debit w/ PaymentIntents or SetupIntents and Paypal in PaymentIntent+setup_future_usage or SetupIntent.
