### PR TITLE
Fix deferred client-side confirmation for mandate PMs

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfirmParams.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfirmParams.swift
@@ -77,12 +77,15 @@ class IntentConfirmParams {
         configuration: PaymentSheet.Configuration,
         paymentMethodID: String?
     ) -> STPPaymentIntentParams {
-        let params = STPPaymentIntentParams(clientSecret: paymentIntentClientSecret)
+        let params: STPPaymentIntentParams
         // If a payment method ID was provided use that, otherwise use the payment method params
         if let paymentMethodID = paymentMethodID {
+            params = STPPaymentIntentParams(clientSecret: paymentIntentClientSecret, paymentMethodType: paymentMethodParams.type)
             params.paymentMethodId = paymentMethodID
         } else {
+            params = STPPaymentIntentParams(clientSecret: paymentIntentClientSecret)
             params.paymentMethodParams = paymentMethodParams
+            return params
         }
 
         let options = paymentMethodOptions ?? STPConfirmPaymentMethodOptions()
@@ -92,16 +95,17 @@ class IntentConfirmParams {
             customer: configuration.customer
         )
         params.paymentMethodOptions = options
-
         return params
     }
 
     func makeParams(setupIntentClientSecret: String, paymentMethodID: String?) -> STPSetupIntentConfirmParams {
-        let params = STPSetupIntentConfirmParams(clientSecret: setupIntentClientSecret)
+        let params: STPSetupIntentConfirmParams
         // If a payment method ID was provided use that, otherwise use the payment method params
         if let paymentMethodID = paymentMethodID {
+            params = STPSetupIntentConfirmParams(clientSecret: setupIntentClientSecret, paymentMethodType: paymentMethodParams.type)
             params.paymentMethodID = paymentMethodID
         } else {
+            params = STPSetupIntentConfirmParams(clientSecret: setupIntentClientSecret)
             params.paymentMethodParams = paymentMethodParams
         }
         return params

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+DeferredAPI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+DeferredAPI.swift
@@ -30,7 +30,7 @@ extension PaymentSheet {
                                                  paymentMethod: STPPaymentMethod?,
                                                  paymentMethodParams: STPPaymentMethodParams?,
                                                  shouldSavePaymentMethod: Bool) {
-        // Add deferred to payment analytics user agent
+        // Hack: Add deferred to analytics product usage as a hack to get it into the payment_user_agent string in the request to create a PaymentMethod
         STPAnalyticsClient.sharedClient.addClass(toProductUsageIfNecessary: IntentConfiguration.self)
         Task {
             do {


### PR DESCRIPTION
## Summary
Fix deferred client-side confirmation for most PMs that require a mandate incl. SEPA, sofort, us bank accounts.

## Motivation
Before this change, SEPA, sofort, us bank accounts will confirm w/o a mandate attached and fail. This is because the STPPaymentIntentParams' paymentMethodType will be nil - see https://github.com/stripe/stripe-ios/blob/a7eef1421a933c8507f71b8f026d2232917fb720/StripePayments/StripePayments/Source/API%20Bindings/Models/PaymentIntents/STPPaymentIntentParams.swift#L134-L136

## Testing
Manually tested sofort and SEPA. 
