### PR TITLE
Financial Connections: added a new PaneNotFound error and added better analytics logging for FinancialConnectionsSheetErrors

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsAnalyticsClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsAnalyticsClient.swift
@@ -111,7 +111,16 @@ extension FinancialConnectionsAnalyticsClient {
             parameters["code"] = apiError.code
         } else {
             parameters["error_type"] = (error as NSError).domain
-            parameters["error_message"] = (error as NSError).localizedDescription
+            parameters["error_message"] = {
+                if let sheetError = error as? FinancialConnectionsSheetError {
+                    switch sheetError {
+                    case .unknown(let debugDescription):
+                        return debugDescription
+                    }
+                } else {
+                    return (error as NSError).localizedDescription
+                }
+            }() as String
             parameters["code"] = (error as NSError).code
         }
         log(eventName: eventName, parameters: parameters)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -765,6 +765,16 @@ private func CreatePaneViewController(
                 eventName: "pane.launched",
                 parameters: ["pane": pane.rawValue]
             )
+    } else {
+        dataManager
+            .analyticsClient
+            .logUnexpectedError(
+                FinancialConnectionsSheetError.unknown(
+                    debugDescription: "Pane Not Found: either app state is invalid, or an unsupported pane was requested."
+                ),
+                errorName: "PaneNotFound",
+                pane: pane
+            )
     }
 
     return viewController


### PR DESCRIPTION
## Summary

^ we've had issues where it was difficult to debug certain scenarios, and this adds extra logging to help debug those scenarios

## Testing


I forced the analytics event by adding bad code:

```
LOG ANALYTICS: ["app_version": "1.1", "livemode": false, "error_type": "StripeFinancialConnections.FinancialConnectionsSheetError", "sdk_version": "23.6.2", "single_account": true, "app_name": "FinancialConnectionsExample", "error": "PaneNotFound", "os_version": "16.1", "navigator_language": "en_US", "error_message": "Pane Not Found: either app state is invalid, or an unsupported pane was requested.", "allow_manual_entry": true, "device_type": "arm64", "client_id": "mobile-clients-linked-accounts", "key": "pk_test_qHiXaJRKU0hYOrWRtdUg6hB7", "sdk_platform": "ios", "platform_info": ["install": "X", "app_bundle_id": "com.stripe.example.Connections-Example"], "pane": "link_consent", "is_stripe_direct": false, "event_name": "linked_accounts.error.unexpected", "las_client_secret": "fcsess_client_secret_9lACnMRB6F6RZv2bUylGwQ2F", "account_holder_id": "bcaccthld_1N0UW8ClCIKljWvsr1NzMRPT", "product": "payment_flows", "is_webview": false, "event_id": "045B40B4-FD21-4911-BE25-4C2E33D36FCF", "code": 0, "created": 168236

```

Here is also Before/After of me changing FinancialConnectionsSheetError message...

Before:

```
(lldb) po parameters
▿ 5 elements
  ▿ 0 : 2 elements
    - key : "error"
    - value : "PaneNotFound"
  ▿ 1 : 2 elements
    - key : "error_type"
    - value : "StripeFinancialConnections.FinancialConnectionsSheetError"
  ▿ 2 : 2 elements
    - key : "error_message"
    - value : "The operation couldn’t be completed. (StripeFinancialConnections.FinancialConnectionsSheetError error 0.)"
  ▿ 3 : 2 elements
    - key : "pane"
    - value : "link_consent"
  ▿ 4 : 2 elements
    - key : "code"
    - value : 0
```

After:

```
▿ 5 elements
  ▿ 0 : 2 elements
    - key : "error_message"
    - value : "Pane Not Found: either app state is invalid, or an unsupported pane was requested."
  ▿ 1 : 2 elements
    - key : "pane"
    - value : "link_consent"
  ▿ 2 : 2 elements
    - key : "error"
    - value : "PaneNotFound"
  ▿ 3 : 2 elements
    - key : "error_type"
    - value : "StripeFinancialConnections.FinancialConnectionsSheetError"
  ▿ 4 : 2 elements
    - key : "code"
    - value : 0
```


