### PR TITLE
Fix early return typo from #2504

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfirmParams.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfirmParams.swift
@@ -85,7 +85,6 @@ class IntentConfirmParams {
         } else {
             params = STPPaymentIntentParams(clientSecret: paymentIntentClientSecret)
             params.paymentMethodParams = paymentMethodParams
-            return params
         }
 
         let options = paymentMethodOptions ?? STPConfirmPaymentMethodOptions()


### PR DESCRIPTION
## Summary
Fixes https://github.com/stripe/stripe-ios/pull/2504/files#diff-305ea2bdb8f8647eb2bfc2a7f506c6cecba3250c1884cbd970556c9e08379dceR88, which accidentally added an early return.


## Testing
Tested `testPaymentSheetCustomSaveAndRemoveCard()` locally (it doesn't run on PRs), the test that failed and caught this bug.

## Changelog
The bug this fixed was not released, so no changelog required.
