### PR TITLE
use single tms api token and expose projects ids

### DIFF
--- a/ci_scripts/download_localized_strings_from_lokalise.sh
+++ b/ci_scripts/download_localized_strings_from_lokalise.sh
@@ -13,8 +13,9 @@ if [[ -z $(which recode) ]]; then
     brew install recode
 fi
 
-API_TOKEN=$(fetch-password mobile/lokalise/token -q)
-PROJECT_ID=$(fetch-password mobile/lokalise/ios -q)
+API_TOKEN=$(fetch-password lokalise-api-token-manual -q)
+# Android-iOS-SDK
+PROJECT_ID=747824695e51bc2f4aa912.89576472
 
 # Load LOCALIZATION_DIRECTORIES & LANGUAGES variables
 source ci_scripts/localization_vars.sh

--- a/ci_scripts/upload_localized_strings_to_lokalise.sh
+++ b/ci_scripts/upload_localized_strings_to_lokalise.sh
@@ -12,8 +12,9 @@ if [[ $? -ne 0 ]]; then
     exit 1
 fi
 
-API_TOKEN=$(fetch-password mobile/lokalise/token -q)
-PROJECT_ID=$(fetch-password mobile/lokalise/ios -q)
+API_TOKEN=$(fetch-password lokalise-api-token-manual -q)
+# Android-iOS-SDK
+PROJECT_ID=747824695e51bc2f4aa912.89576472
 
 # Load LOCALIZATION_DIRECTORIES variable
 source ci_scripts/localization_vars.sh

--- a/stripe3ds2-support/ci_scripts/download_localized_strings_from_lokalise.sh
+++ b/stripe3ds2-support/ci_scripts/download_localized_strings_from_lokalise.sh
@@ -11,8 +11,9 @@ if [[ -z $(which recode) ]]; then
     brew install recode
 fi
 
-API_TOKEN=$(fetch-password mobile/lokalise/token -q)
-PROJECT_ID=$(fetch-password mobile/lokalise/ios-3ds2 -q)
+API_TOKEN=$(fetch-password lokalise-api-token-manual -q)
+# iOS 3DS2 SDK
+PROJECT_ID=614720955e51bbfda93be1.46626639
 LANGUAGES="da,de,en-GB,en,es-419,es,fi,fr-CA,fr,hu,it,ja,ko,nb,nl,nn-NO,mt,pt-BR,pt-PT,ru,sv,tr,zh-HANS,zh-HK,zh-Hant"
 # This is the custom status ID for our project with which the localizers mark completed translations
 FINAL_STATUS_ID=583

--- a/stripe3ds2-support/ci_scripts/upload_localized_strings_to_lokalise.sh
+++ b/stripe3ds2-support/ci_scripts/upload_localized_strings_to_lokalise.sh
@@ -12,8 +12,9 @@ if [[ $? -ne 0 ]]; then
     exit 1
 fi
 
-API_TOKEN=$(fetch-password mobile/lokalise/token -q)
-PROJECT_ID=$(fetch-password mobile/lokalise/ios-3ds2 -q)
+API_TOKEN=$(fetch-password lokalise-api-token-manual -q)
+# iOS 3DS2 SDK
+PROJECT_ID=614720955e51bbfda93be1.46626639
 
 lokalise2 --token $API_TOKEN \
           --project-id $PROJECT_ID \


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
- new token access is managed through LDAP https://ldapmanager.corp.stripe.com/groups/password-lokalise-api-token-manual
- no need to have encrypted values for the project ids, in fact is better to have it explicitly defined in case there's an issue (e.g better code searchibility)

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/I18NENG-2817

## Testing
<!-- How was the code tested? Be as specific as possible. -->
ran from laptop

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
