### PR TITLE
Fix server side confirmation for delayed and requires action pms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
-## 23.7.0 2023-04-24
+## x.x.x yyyy-mm-dd
+### Payments
+* [Fixed] STPPaymentHandler.handleNextAction allows payment methods that are delayed or require further customer action like like SEPA Debit or OXXO.
 
+## 23.7.0 2023-04-24
 ### PaymentSheet
 * [Fixed] Fixed disabled text color, using a lower opacity version of the original color instead of the previous `.tertiaryLabel`.
 

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -976,6 +976,37 @@ extension PaymentSheetUITest {
         let successText = app.staticTexts["Success!"]
         XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
     }
+    
+    func testDeferredPaymentIntent_ServerSideConfirmation_SEPA() {
+        loadPlayground(
+            app,
+            settings: [
+                "init_mode": "Deferred",
+                "confirm_mode": "Server",
+                "currency": "EUR",
+                "allows_delayed_pms": "true",
+            ]
+        )
+
+        app.buttons["Checkout (Complete)"].tap()
+        
+        guard let sepa = scroll(collectionView: app.collectionViews.firstMatch, toFindCellWithId: "SEPA Debit") else { XCTFail("Couldn't find SEPA"); return; }
+        sepa.tap()
+        
+        app.textFields["Full name"].tap()
+        app.typeText("John Doe" + XCUIKeyboardKey.return.rawValue)
+        app.typeText("test@example.com" + XCUIKeyboardKey.return.rawValue)
+        app.typeText("AT611904300234573201" + XCUIKeyboardKey.return.rawValue)
+        app.textFields["Address line 1"].tap()
+        app.typeText("510 Townsend St" + XCUIKeyboardKey.return.rawValue)
+        app.typeText("Floor 3" + XCUIKeyboardKey.return.rawValue)
+        app.typeText("San Francisco" + XCUIKeyboardKey.return.rawValue)
+        app.textFields["ZIP"].tap()
+        app.typeText("94102" + XCUIKeyboardKey.return.rawValue)
+        app.buttons["Pay €50.99"].tap()
+        let successText = app.staticTexts["Success!"]
+        XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
+    }
 
     func testDeferredPaymentIntent_SeverSideConfirmation_LostCardDecline() {
         loadPlayground(

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -677,7 +677,7 @@ extension PaymentSheetUITest {
         loadPlayground(
             app,
             settings: [
-                "init_mode": "Deferred"
+                "init_mode": "Deferred",
             ]
         )
 
@@ -694,7 +694,7 @@ extension PaymentSheetUITest {
         loadPlayground(
             app,
             settings: [
-                "init_mode": "Deferred"
+                "init_mode": "Deferred",
             ]
         )
 
@@ -729,7 +729,7 @@ extension PaymentSheetUITest {
         loadPlayground(
             app,
             settings: [
-                "init_mode": "Deferred"
+                "init_mode": "Deferred",
             ]
         )
 
@@ -838,7 +838,7 @@ extension PaymentSheetUITest {
         loadPlayground(
             app,
             settings: [
-                "init_mode": "Deferred"
+                "init_mode": "Deferred",
             ]
         )
 
@@ -976,7 +976,7 @@ extension PaymentSheetUITest {
         let successText = app.staticTexts["Success!"]
         XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
     }
-    
+
     func testDeferredPaymentIntent_ServerSideConfirmation_SEPA() {
         loadPlayground(
             app,
@@ -989,10 +989,10 @@ extension PaymentSheetUITest {
         )
 
         app.buttons["Checkout (Complete)"].tap()
-        
+
         guard let sepa = scroll(collectionView: app.collectionViews.firstMatch, toFindCellWithId: "SEPA Debit") else { XCTFail("Couldn't find SEPA"); return; }
         sepa.tap()
-        
+
         app.textFields["Full name"].tap()
         app.typeText("John Doe" + XCUIKeyboardKey.return.rawValue)
         app.typeText("test@example.com" + XCUIKeyboardKey.return.rawValue)

--- a/Stripe/StripeiOSTests/STPPaymentHandlerFunctionalTest.swift
+++ b/Stripe/StripeiOSTests/STPPaymentHandlerFunctionalTest.swift
@@ -5,9 +5,9 @@
 //  Created by Yuki Tokuhiro on 4/24/23.
 //
 
-import XCTest
 @testable import Stripe
 @_spi(STP) @testable import StripePayments
+import XCTest
 
 // You can add tests in here for payment methods that don't require customer actions (i.e. don't open webviews for customer authentication).
 // If they require customer action, use STPPaymentHandlerFunctionalTest.m instead
@@ -16,9 +16,9 @@ final class STPPaymentHandlerFunctionalSwiftTest: XCTestCase, STPAuthenticationC
     func authenticationPresentingViewController() -> UIViewController {
         return UIViewController()
     }
-    
+
     // MARK: - PaymentIntent tests
-    
+
     func test_card_payment_intent_server_side_confirmation() {
         let apiClient = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
         let cardParams = STPPaymentMethodCardParams()
@@ -26,7 +26,7 @@ final class STPPaymentHandlerFunctionalSwiftTest: XCTestCase, STPAuthenticationC
         cardParams.cvc = "123"
         cardParams.expYear = NSNumber(integerLiteral: Calendar.current.dateComponents([.year], from: Date()).year! + 1)
         cardParams.expMonth = 01
-        
+
         let e = self.expectation(description: "")
         apiClient.createPaymentMethod(with: .init(card: cardParams, billingDetails: nil, metadata: nil)) { paymentMethod, error in
             guard let paymentMethod = paymentMethod else {
@@ -46,7 +46,7 @@ final class STPPaymentHandlerFunctionalSwiftTest: XCTestCase, STPAuthenticationC
                 }
                 let sut = STPPaymentHandler(apiClient: apiClient)
                 // Note: `waitForExpectations` can deadlock if this test is async. When we can use Xcode 14.3, we can switch this test to async and use fulfillment(of:) instead of waitForExpectations
-                sut.handleNextAction(forPayment: clientSecret, with: self, returnURL: "foo://z") { status, intent, error in
+                sut.handleNextAction(forPayment: clientSecret, with: self, returnURL: "foo://z") { status, intent, _ in
                     XCTAssertEqual(sut.apiClient, apiClient) // Reference sut in the closure so it doesn't get deallocated
                     XCTAssertEqual(intent?.status, .succeeded)
                     XCTAssertEqual(status, .succeeded)
@@ -56,21 +56,21 @@ final class STPPaymentHandlerFunctionalSwiftTest: XCTestCase, STPAuthenticationC
         }
         self.waitForExpectations(timeout: 10)
     }
-    
+
     func test_sepa_debit_payment_intent_server_side_confirmation() {
         // SEPA Debit is a good payment method to test here because
         // - it's a "delayed" or "asynchronous" payment method
         // - it doesn't require customer actions (we can't simulate customer actions in XCTestCase)
-        
+
         let apiClient = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
-        
+
         let billingDetails = STPPaymentMethodBillingDetails()
         billingDetails.name = "SEPA Test Customer"
         billingDetails.email = "test@example.com"
-        
+
         let sepaDebitDetails = STPPaymentMethodSEPADebitParams()
         sepaDebitDetails.iban = "DE89370400440532013000"
-        
+
         let e = self.expectation(description: "")
         apiClient.createPaymentMethod(with: .init(sepaDebit: sepaDebitDetails, billingDetails: billingDetails, metadata: nil)) { paymentMethod, error in
             guard let paymentMethod = paymentMethod else {
@@ -89,9 +89,9 @@ final class STPPaymentHandlerFunctionalSwiftTest: XCTestCase, STPAuthenticationC
                         "online": [
                             "user_agent": "123",
                             "ip_address": "172.18.117.125",
-                        ]
-                    ]
-                ]
+                        ],
+                    ],
+                ],
             ]) { clientSecret, error in
                 guard let clientSecret = clientSecret else {
                     XCTFail()
@@ -99,7 +99,7 @@ final class STPPaymentHandlerFunctionalSwiftTest: XCTestCase, STPAuthenticationC
                 }
                 let sut = STPPaymentHandler(apiClient: apiClient)
                 // Note: `waitForExpectations` can deadlock if this test is async. When we can use Xcode 14.3, we can switch this test to async and use fulfillment(of:) instead of waitForExpectations
-                sut.handleNextAction(forPayment: clientSecret, with: self, returnURL: "foo://z") { status, intent, error in
+                sut.handleNextAction(forPayment: clientSecret, with: self, returnURL: "foo://z") { status, intent, _ in
                     XCTAssertEqual(sut.apiClient, apiClient) // Reference sut in the closure so it doesn't get deallocated
                     XCTAssertEqual(intent?.status, .processing)
                     XCTAssertEqual(status, .succeeded)
@@ -109,9 +109,9 @@ final class STPPaymentHandlerFunctionalSwiftTest: XCTestCase, STPAuthenticationC
         }
         self.waitForExpectations(timeout: 10)
     }
-        
+
     // MARK: - SetupIntent tests
-    
+
     func test_card_setup_intent_server_side_confirmation() {
         let apiClient = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
         let cardParams = STPPaymentMethodCardParams()
@@ -119,7 +119,7 @@ final class STPPaymentHandlerFunctionalSwiftTest: XCTestCase, STPAuthenticationC
         cardParams.cvc = "123"
         cardParams.expYear = NSNumber(integerLiteral: Calendar.current.dateComponents([.year], from: Date()).year! + 1)
         cardParams.expMonth = 01
-        
+
         let e = self.expectation(description: "")
         apiClient.createPaymentMethod(with: .init(card: cardParams, billingDetails: nil, metadata: nil)) { paymentMethod, error in
             guard let paymentMethod = paymentMethod else {
@@ -138,7 +138,7 @@ final class STPPaymentHandlerFunctionalSwiftTest: XCTestCase, STPAuthenticationC
                 }
                 let sut = STPPaymentHandler(apiClient: apiClient)
                 // Note: `waitForExpectations` can deadlock if this test is async. When we can use Xcode 14.3, we can switch this test to async and use fulfillment(of:) instead of waitForExpectations
-                sut.handleNextAction(forSetupIntent: clientSecret, with: self, returnURL: "foo://z") { status, intent, error in
+                sut.handleNextAction(forSetupIntent: clientSecret, with: self, returnURL: "foo://z") { status, intent, _ in
                     XCTAssertEqual(sut.apiClient, apiClient) // Reference sut in the closure so it doesn't get deallocated
                     XCTAssertEqual(intent?.status, .succeeded)
                     XCTAssertEqual(status, .succeeded)
@@ -148,21 +148,21 @@ final class STPPaymentHandlerFunctionalSwiftTest: XCTestCase, STPAuthenticationC
         }
         self.waitForExpectations(timeout: 10)
     }
-    
+
     func test_sepa_debit_setup_intent_server_side_confirmation() {
         // SEPA Debit is a good payment method to test here because
         // - it's a "delayed" or "asynchronous" payment method
         // - it doesn't require customer actions (we can't simulate customer actions in XCTestCase)
-        
+
         let apiClient = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
-        
+
         let billingDetails = STPPaymentMethodBillingDetails()
         billingDetails.name = "SEPA Test Customer"
         billingDetails.email = "test@example.com"
-        
+
         let sepaDebitDetails = STPPaymentMethodSEPADebitParams()
         sepaDebitDetails.iban = "DE89370400440532013000"
-        
+
         let e = self.expectation(description: "")
         apiClient.createPaymentMethod(with: .init(sepaDebit: sepaDebitDetails, billingDetails: billingDetails, metadata: nil)) { paymentMethod, error in
             guard let paymentMethod = paymentMethod else {
@@ -180,9 +180,9 @@ final class STPPaymentHandlerFunctionalSwiftTest: XCTestCase, STPAuthenticationC
                         "online": [
                             "user_agent": "123",
                             "ip_address": "172.18.117.125",
-                        ]
-                    ]
-                ]
+                        ],
+                    ],
+                ],
             ]) { clientSecret, error in
                 guard let clientSecret = clientSecret else {
                     XCTFail("\(String(describing: error))")
@@ -190,7 +190,7 @@ final class STPPaymentHandlerFunctionalSwiftTest: XCTestCase, STPAuthenticationC
                 }
                 let sut = STPPaymentHandler(apiClient: apiClient)
                 // Note: `waitForExpectations` can deadlock if this test is async. When we can use Xcode 14.3, we can switch this test to async and use fulfillment(of:) instead of waitForExpectations
-                sut.handleNextAction(forSetupIntent: clientSecret, with: self, returnURL: "foo://z") { status, intent, error in
+                sut.handleNextAction(forSetupIntent: clientSecret, with: self, returnURL: "foo://z") { status, intent, _ in
                     XCTAssertEqual(sut.apiClient, apiClient) // Reference sut in the closure so it doesn't get deallocated
                     XCTAssertEqual(intent?.status, .succeeded) // Note: I think this should be .processing, but testmode disagrees
                     XCTAssertEqual(status, .succeeded)

--- a/Stripe/StripeiOSTests/STPPaymentHandlerFunctionalTest.swift
+++ b/Stripe/StripeiOSTests/STPPaymentHandlerFunctionalTest.swift
@@ -24,7 +24,7 @@ final class STPPaymentHandlerFunctionalSwiftTest: XCTestCase, STPAuthenticationC
         let cardParams = STPPaymentMethodCardParams()
         cardParams.number = "4242424242424242"
         cardParams.cvc = "123"
-        cardParams.expYear = NSNumber(integerLiteral: Calendar.current.dateComponents([.year], from: Date()).year! + 1)
+        cardParams.expYear = (Calendar.current.dateComponents([.year], from: Date()).year! + 1) as NSNumber
         cardParams.expMonth = 01
 
         let e = self.expectation(description: "")
@@ -41,7 +41,7 @@ final class STPPaymentHandlerFunctionalSwiftTest: XCTestCase, STPAuthenticationC
                 "return_url": "foo://z",
             ]) { clientSecret, error in
                 guard let clientSecret = clientSecret else {
-                    XCTFail()
+                    XCTFail(String(describing: error))
                     return
                 }
                 let sut = STPPaymentHandler(apiClient: apiClient)
@@ -74,7 +74,7 @@ final class STPPaymentHandlerFunctionalSwiftTest: XCTestCase, STPAuthenticationC
         let e = self.expectation(description: "")
         apiClient.createPaymentMethod(with: .init(sepaDebit: sepaDebitDetails, billingDetails: billingDetails, metadata: nil)) { paymentMethod, error in
             guard let paymentMethod = paymentMethod else {
-                XCTFail()
+                XCTFail(String(describing: error))
                 return
             }
             STPTestingAPIClient().createPaymentIntent(withParams: [
@@ -94,7 +94,7 @@ final class STPPaymentHandlerFunctionalSwiftTest: XCTestCase, STPAuthenticationC
                 ],
             ]) { clientSecret, error in
                 guard let clientSecret = clientSecret else {
-                    XCTFail()
+                    XCTFail(String(describing: error))
                     return
                 }
                 let sut = STPPaymentHandler(apiClient: apiClient)
@@ -117,7 +117,7 @@ final class STPPaymentHandlerFunctionalSwiftTest: XCTestCase, STPAuthenticationC
         let cardParams = STPPaymentMethodCardParams()
         cardParams.number = "4242424242424242"
         cardParams.cvc = "123"
-        cardParams.expYear = NSNumber(integerLiteral: Calendar.current.dateComponents([.year], from: Date()).year! + 1)
+        cardParams.expYear = Calendar.current.dateComponents([.year], from: Date()).year! + 1 as NSNumber
         cardParams.expMonth = 01
 
         let e = self.expectation(description: "")
@@ -133,7 +133,7 @@ final class STPPaymentHandlerFunctionalSwiftTest: XCTestCase, STPAuthenticationC
                 "return_url": "foo://z",
             ]) { clientSecret, error in
                 guard let clientSecret = clientSecret else {
-                    XCTFail()
+                    XCTFail(String(describing: error))
                     return
                 }
                 let sut = STPPaymentHandler(apiClient: apiClient)

--- a/Stripe/StripeiOSTests/STPPaymentHandlerFunctionalTest.swift
+++ b/Stripe/StripeiOSTests/STPPaymentHandlerFunctionalTest.swift
@@ -1,0 +1,203 @@
+//
+//  STPPaymentHandlerFunctionalTest.swift
+//  StripeiOSTests
+//
+//  Created by Yuki Tokuhiro on 4/24/23.
+//
+
+import XCTest
+@testable import Stripe
+@_spi(STP) @testable import StripePayments
+
+// You can add tests in here for payment methods that don't require customer actions (i.e. don't open webviews for customer authentication).
+// If they require customer action, use STPPaymentHandlerFunctionalTest.m instead
+final class STPPaymentHandlerFunctionalSwiftTest: XCTestCase, STPAuthenticationContext {
+    // MARK: - STPAuthenticationContext
+    func authenticationPresentingViewController() -> UIViewController {
+        return UIViewController()
+    }
+    
+    // MARK: - PaymentIntent tests
+    
+    func test_card_payment_intent_server_side_confirmation() {
+        let apiClient = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
+        let cardParams = STPPaymentMethodCardParams()
+        cardParams.number = "4242424242424242"
+        cardParams.cvc = "123"
+        cardParams.expYear = NSNumber(integerLiteral: Calendar.current.dateComponents([.year], from: Date()).year! + 1)
+        cardParams.expMonth = 01
+        
+        let e = self.expectation(description: "")
+        apiClient.createPaymentMethod(with: .init(card: cardParams, billingDetails: nil, metadata: nil)) { paymentMethod, error in
+            guard let paymentMethod = paymentMethod else {
+                XCTFail(String(describing: error))
+                return
+            }
+            STPTestingAPIClient().createPaymentIntent(withParams: [
+                "confirm": "true",
+                "payment_method_types": ["card"],
+                "currency": "usd",
+                "payment_method": paymentMethod.stripeId,
+                "return_url": "foo://z",
+            ]) { clientSecret, error in
+                guard let clientSecret = clientSecret else {
+                    XCTFail()
+                    return
+                }
+                let sut = STPPaymentHandler(apiClient: apiClient)
+                // Note: `waitForExpectations` can deadlock if this test is async. When we can use Xcode 14.3, we can switch this test to async and use fulfillment(of:) instead of waitForExpectations
+                sut.handleNextAction(forPayment: clientSecret, with: self, returnURL: "foo://z") { status, intent, error in
+                    XCTAssertEqual(sut.apiClient, apiClient) // Reference sut in the closure so it doesn't get deallocated
+                    XCTAssertEqual(intent?.status, .succeeded)
+                    XCTAssertEqual(status, .succeeded)
+                    e.fulfill()
+                }
+            }
+        }
+        self.waitForExpectations(timeout: 10)
+    }
+    
+    func test_sepa_debit_payment_intent_server_side_confirmation() {
+        // SEPA Debit is a good payment method to test here because
+        // - it's a "delayed" or "asynchronous" payment method
+        // - it doesn't require customer actions (we can't simulate customer actions in XCTestCase)
+        
+        let apiClient = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
+        
+        let billingDetails = STPPaymentMethodBillingDetails()
+        billingDetails.name = "SEPA Test Customer"
+        billingDetails.email = "test@example.com"
+        
+        let sepaDebitDetails = STPPaymentMethodSEPADebitParams()
+        sepaDebitDetails.iban = "DE89370400440532013000"
+        
+        let e = self.expectation(description: "")
+        apiClient.createPaymentMethod(with: .init(sepaDebit: sepaDebitDetails, billingDetails: billingDetails, metadata: nil)) { paymentMethod, error in
+            guard let paymentMethod = paymentMethod else {
+                XCTFail()
+                return
+            }
+            STPTestingAPIClient().createPaymentIntent(withParams: [
+                "confirm": "true",
+                "payment_method_types": ["sepa_debit"],
+                "currency": "eur",
+                "payment_method": paymentMethod.stripeId,
+                "return_url": "foo://z",
+                "mandate_data": [
+                    "customer_acceptance": [
+                        "type": "online",
+                        "online": [
+                            "user_agent": "123",
+                            "ip_address": "172.18.117.125",
+                        ]
+                    ]
+                ]
+            ]) { clientSecret, error in
+                guard let clientSecret = clientSecret else {
+                    XCTFail()
+                    return
+                }
+                let sut = STPPaymentHandler(apiClient: apiClient)
+                // Note: `waitForExpectations` can deadlock if this test is async. When we can use Xcode 14.3, we can switch this test to async and use fulfillment(of:) instead of waitForExpectations
+                sut.handleNextAction(forPayment: clientSecret, with: self, returnURL: "foo://z") { status, intent, error in
+                    XCTAssertEqual(sut.apiClient, apiClient) // Reference sut in the closure so it doesn't get deallocated
+                    XCTAssertEqual(intent?.status, .processing)
+                    XCTAssertEqual(status, .succeeded)
+                    e.fulfill()
+                }
+            }
+        }
+        self.waitForExpectations(timeout: 10)
+    }
+        
+    // MARK: - SetupIntent tests
+    
+    func test_card_setup_intent_server_side_confirmation() {
+        let apiClient = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
+        let cardParams = STPPaymentMethodCardParams()
+        cardParams.number = "4242424242424242"
+        cardParams.cvc = "123"
+        cardParams.expYear = NSNumber(integerLiteral: Calendar.current.dateComponents([.year], from: Date()).year! + 1)
+        cardParams.expMonth = 01
+        
+        let e = self.expectation(description: "")
+        apiClient.createPaymentMethod(with: .init(card: cardParams, billingDetails: nil, metadata: nil)) { paymentMethod, error in
+            guard let paymentMethod = paymentMethod else {
+                XCTFail(String(describing: error))
+                return
+            }
+            STPTestingAPIClient().createSetupIntent(withParams: [
+                "confirm": "true",
+                "payment_method_types": ["card"],
+                "payment_method": paymentMethod.stripeId,
+                "return_url": "foo://z",
+            ]) { clientSecret, error in
+                guard let clientSecret = clientSecret else {
+                    XCTFail()
+                    return
+                }
+                let sut = STPPaymentHandler(apiClient: apiClient)
+                // Note: `waitForExpectations` can deadlock if this test is async. When we can use Xcode 14.3, we can switch this test to async and use fulfillment(of:) instead of waitForExpectations
+                sut.handleNextAction(forSetupIntent: clientSecret, with: self, returnURL: "foo://z") { status, intent, error in
+                    XCTAssertEqual(sut.apiClient, apiClient) // Reference sut in the closure so it doesn't get deallocated
+                    XCTAssertEqual(intent?.status, .succeeded)
+                    XCTAssertEqual(status, .succeeded)
+                    e.fulfill()
+                }
+            }
+        }
+        self.waitForExpectations(timeout: 10)
+    }
+    
+    func test_sepa_debit_setup_intent_server_side_confirmation() {
+        // SEPA Debit is a good payment method to test here because
+        // - it's a "delayed" or "asynchronous" payment method
+        // - it doesn't require customer actions (we can't simulate customer actions in XCTestCase)
+        
+        let apiClient = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
+        
+        let billingDetails = STPPaymentMethodBillingDetails()
+        billingDetails.name = "SEPA Test Customer"
+        billingDetails.email = "test@example.com"
+        
+        let sepaDebitDetails = STPPaymentMethodSEPADebitParams()
+        sepaDebitDetails.iban = "DE89370400440532013000"
+        
+        let e = self.expectation(description: "")
+        apiClient.createPaymentMethod(with: .init(sepaDebit: sepaDebitDetails, billingDetails: billingDetails, metadata: nil)) { paymentMethod, error in
+            guard let paymentMethod = paymentMethod else {
+                XCTFail()
+                return
+            }
+            STPTestingAPIClient().createSetupIntent(withParams: [
+                "confirm": "true",
+                "payment_method_types": ["sepa_debit"],
+                "payment_method": paymentMethod.stripeId,
+                "return_url": "foo://z",
+                "mandate_data": [
+                    "customer_acceptance": [
+                        "type": "online",
+                        "online": [
+                            "user_agent": "123",
+                            "ip_address": "172.18.117.125",
+                        ]
+                    ]
+                ]
+            ]) { clientSecret, error in
+                guard let clientSecret = clientSecret else {
+                    XCTFail("\(String(describing: error))")
+                    return
+                }
+                let sut = STPPaymentHandler(apiClient: apiClient)
+                // Note: `waitForExpectations` can deadlock if this test is async. When we can use Xcode 14.3, we can switch this test to async and use fulfillment(of:) instead of waitForExpectations
+                sut.handleNextAction(forSetupIntent: clientSecret, with: self, returnURL: "foo://z") { status, intent, error in
+                    XCTAssertEqual(sut.apiClient, apiClient) // Reference sut in the closure so it doesn't get deallocated
+                    XCTAssertEqual(intent?.status, .succeeded) // Note: I think this should be .processing, but testmode disagrees
+                    XCTAssertEqual(status, .succeeded)
+                    e.fulfill()
+                }
+            }
+        }
+        self.waitForExpectations(timeout: 10)
+    }
+}

--- a/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
@@ -730,7 +730,7 @@ public class STPPaymentHandler: NSObject {
                 error: _error(
                     for: .intentStatusErrorCode,
                     userInfo: [
-                        "STPSetupIntent": setupIntent.description
+                        "STPSetupIntent": setupIntent.description,
                     ]
                 )
             )
@@ -751,7 +751,7 @@ public class STPPaymentHandler: NSObject {
                             for: .paymentErrorCode,
                             apiErrorCode: lastSetupError.code,
                             userInfo: [
-                                NSLocalizedDescriptionKey: lastSetupError.message ?? ""
+                                NSLocalizedDescriptionKey: lastSetupError.message ?? "",
                             ]
                         )
                     )
@@ -810,7 +810,7 @@ public class STPPaymentHandler: NSObject {
                 error: _error(
                     for: .intentStatusErrorCode,
                     userInfo: [
-                        "STPPaymentIntent": paymentIntent.description
+                        "STPPaymentIntent": paymentIntent.description,
                     ]
                 )
             )
@@ -834,7 +834,7 @@ public class STPPaymentHandler: NSObject {
                             for: .paymentErrorCode,
                             apiErrorCode: lastPaymentError.code,
                             userInfo: [
-                                NSLocalizedDescriptionKey: lastPaymentError.message ?? ""
+                                NSLocalizedDescriptionKey: lastPaymentError.message ?? "",
                             ]
                         )
                     )
@@ -902,7 +902,7 @@ public class STPPaymentHandler: NSObject {
                 error: _error(
                     for: .unsupportedAuthenticationErrorCode,
                     userInfo: [
-                        "STPIntentAction": authenticationAction.description
+                        "STPIntentAction": authenticationAction.description,
                     ]
                 )
             )
@@ -916,7 +916,7 @@ public class STPPaymentHandler: NSObject {
                     error: _error(
                         for: .unsupportedAuthenticationErrorCode,
                         userInfo: [
-                            "STPIntentAction": authenticationAction.description
+                            "STPIntentAction": authenticationAction.description,
                         ]
                     )
                 )
@@ -935,7 +935,7 @@ public class STPPaymentHandler: NSObject {
                     error: _error(
                         for: .unsupportedAuthenticationErrorCode,
                         userInfo: [
-                            "STPIntentAction": authenticationAction.description
+                            "STPIntentAction": authenticationAction.description,
                         ]
                     )
                 )
@@ -954,7 +954,7 @@ public class STPPaymentHandler: NSObject {
                     error: _error(
                         for: .unsupportedAuthenticationErrorCode,
                         userInfo: [
-                            "STPIntentAction": authenticationAction.description
+                            "STPIntentAction": authenticationAction.description,
                         ]
                     )
                 )
@@ -969,7 +969,7 @@ public class STPPaymentHandler: NSObject {
                     error: _error(
                         for: .unsupportedAuthenticationErrorCode,
                         userInfo: [
-                            "STPIntentAction": authenticationAction.description
+                            "STPIntentAction": authenticationAction.description,
                         ]
                     )
                 )
@@ -984,7 +984,7 @@ public class STPPaymentHandler: NSObject {
                     error: _error(
                         for: .unsupportedAuthenticationErrorCode,
                         userInfo: [
-                            "STPIntentAction": authenticationAction.description
+                            "STPIntentAction": authenticationAction.description,
                         ]
                     )
                 )
@@ -999,7 +999,7 @@ public class STPPaymentHandler: NSObject {
                         error: _error(
                             for: .unsupportedAuthenticationErrorCode,
                             userInfo: [
-                                "STPIntentAction": authenticationAction.description
+                                "STPIntentAction": authenticationAction.description,
                             ]
                         )
                     )
@@ -1011,7 +1011,7 @@ public class STPPaymentHandler: NSObject {
                             error: _error(
                                 for: .stripe3DS2ErrorCode,
                                 userInfo: [
-                                    "description": "Failed to initialize STDSThreeDS2Service."
+                                    "description": "Failed to initialize STDSThreeDS2Service.",
                                 ]
                             )
                         )
@@ -1042,7 +1042,7 @@ public class STPPaymentHandler: NSObject {
                                     error: self._error(
                                         for: .stripe3DS2ErrorCode,
                                         userInfo: [
-                                            "exception": exception.description
+                                            "exception": exception.description,
                                         ]
                                     )
                                 )
@@ -1052,7 +1052,7 @@ public class STPPaymentHandler: NSObject {
                                 error: self._error(
                                     for: .stripe3DS2ErrorCode,
                                     userInfo: [
-                                        "exception": exception.description
+                                        "exception": exception.description,
                                     ]
                                 )
                             )
@@ -1153,7 +1153,7 @@ public class STPPaymentHandler: NSObject {
                                                             error: self._error(
                                                                 for: .stripe3DS2ErrorCode,
                                                                 userInfo: [
-                                                                    "exception": exception
+                                                                    "exception": exception,
                                                                 ]
                                                             )
                                                         )
@@ -1198,7 +1198,7 @@ public class STPPaymentHandler: NSObject {
                                         error: self._error(
                                             for: .unsupportedAuthenticationErrorCode,
                                             userInfo: [
-                                                "STPIntentAction": authenticationAction.description
+                                                "STPIntentAction": authenticationAction.description,
                                             ]
                                         )
                                     )
@@ -1218,7 +1218,7 @@ public class STPPaymentHandler: NSObject {
                             error: self._error(
                                 for: .unsupportedAuthenticationErrorCode,
                                 userInfo: [
-                                    "STPIntentAction": authenticationAction.description
+                                    "STPIntentAction": authenticationAction.description,
                                 ]
                             )
                         )
@@ -1246,7 +1246,7 @@ public class STPPaymentHandler: NSObject {
                     error: _error(
                         for: .unsupportedAuthenticationErrorCode,
                         userInfo: [
-                            "STPIntentAction": authenticationAction.description
+                            "STPIntentAction": authenticationAction.description,
                         ]
                     )
                 )
@@ -1293,7 +1293,7 @@ public class STPPaymentHandler: NSObject {
                     error: _error(
                         for: .unsupportedAuthenticationErrorCode,
                         userInfo: [
-                            "STPIntentAction": authenticationAction.description
+                            "STPIntentAction": authenticationAction.description,
                         ]
                     )
                 )
@@ -1558,7 +1558,7 @@ public class STPPaymentHandler: NSObject {
         // redirect to a native app if the app has been installed.  If Safari is not the default browser, then users not be
         // automatically navigated to the native app.
         let options: [UIApplication.OpenExternalURLOptionsKey: Any] = [
-            UIApplication.OpenExternalURLOptionsKey.universalLinksOnly: false
+            UIApplication.OpenExternalURLOptionsKey.universalLinksOnly: false,
         ]
         UIApplication.shared.open(
             url,
@@ -1630,7 +1630,7 @@ public class STPPaymentHandler: NSObject {
                         error: self._error(
                             for: .requiredAppNotAvailable,
                             userInfo: [
-                                "STPIntentAction": currentAction.description
+                                "STPIntentAction": currentAction.description,
                             ]
                         )
                     )
@@ -1725,7 +1725,7 @@ public class STPPaymentHandler: NSObject {
                 for: .requiresAuthenticationContextErrorCode,
                 userInfo: errorMessage != nil
                     ? [
-                        STPError.errorMessageKey: errorMessage ?? ""
+                        STPError.errorMessageKey: errorMessage ?? "",
                     ] : nil
             )
         }
@@ -2105,7 +2105,7 @@ extension STPPaymentHandler {
                     error: self._error(
                         for: .notAuthenticatedErrorCode,
                         userInfo: [
-                            "transaction_status": transactionStatus
+                            "transaction_status": transactionStatus,
                         ]
                     )
                 )


### PR DESCRIPTION
## Summary
Allow `processing` and `requiresNextAction` intent statuses at the end of` STPPaymentHandler.handleNextAction`. 

## Motivation
`handleNextAction` is the public API for server-side confirmation. It's supposed to support all payment methods, but today it asserts and return an error for PMs like SEPA or sofort, which are delayed PMs (i.e. the intent status is `.processing` for ~days until the money moves from the customer bank), and also PMs like OXXO, where the intent status is `.requiresAction` until the customer physically pays their voucher.

https://jira.corp.stripe.com/browse/RUN_MOBILESDK-2308

## Testing
I added tests for `handleNextAction` + card, sepa, oxxo + paymentintent, setupintent.

## Changelog
### Payments
* [Fixed] STPPaymentHandler.handleNextAction allows payment methods that are delayed or require further customer action like like SEPA Debit or OXXO.