### PR TITLE
FC Networking: added end to end test for sign-up and sign-in flow

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundMainView.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundMainView.swift
@@ -77,11 +77,13 @@ struct PlaygroundMainView: View {
                             TextField("Email (existing Link consumer)", text: $viewModel.email)
                                 .keyboardType(.emailAddress)
                                 .autocapitalization(.none)
+                                .accessibility(identifier: "playground-email")
                         }
                     }
 
                     Section(header: Text("PERMISSIONS")) {
                         Toggle("Transactions \(viewModel.flow == .networking ? "(enable step-up verification)" : "")", isOn: $viewModel.enableTransactionsPermission)
+                            .accessibility(identifier: "playground-transactions-permission")
                     }
 
                     Section(header: Text("CUSTOM KEYS")) {

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
@@ -1,0 +1,231 @@
+//
+//  FinancialConnectionsNetworkingUITests.swift
+//  FinancialConnections Example
+//
+//  Created by Krisjanis Gaidis on 4/24/23.
+//  Copyright © 2023 Stripe, Inc. All rights reserved.
+//
+
+import XCTest
+
+final class FinancialConnectionsNetworkingUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testNativeNetworkingTestMode() throws {
+        let emailAddresss = "\(UUID().uuidString)@UITestForIOS.com"
+        executeNativeNetworkingTestModeSignUpFlowTest(emailAddress: emailAddresss)
+        executeNativeNetworkingTestModeSignInFlowTest(emailAddress: emailAddresss)
+    }
+
+    private func executeNativeNetworkingTestModeSignUpFlowTest(emailAddress: String) {
+        let app = XCUIApplication()
+        app.launch()
+
+        let playgroundCell = app.tables.staticTexts["Playground"]
+        XCTAssertTrue(playgroundCell.waitForExistence(timeout: 60.0))
+        playgroundCell.tap()
+
+        let dataSegmentPickerButton = app.segmentedControls.buttons["Networking"]
+        XCTAssertTrue(dataSegmentPickerButton.waitForExistence(timeout: 60.0))
+        dataSegmentPickerButton.tap()
+
+        let nativeSegmentPickerButton = app.segmentedControls.buttons["Native"]
+        XCTAssertTrue(nativeSegmentPickerButton.waitForExistence(timeout: 60.0))
+        nativeSegmentPickerButton.tap()
+
+        let enableTestModeSwitch = app.switches["Enable Test Mode"].firstMatch
+        XCTAssertTrue(enableTestModeSwitch.waitForExistence(timeout: 60.0))
+        if (enableTestModeSwitch.value as? String) == "0" {
+            enableTestModeSwitch.tap()
+        }
+
+        app.swipeUp() // scroll to see email field
+
+        let playgroundEmailTextField = app.textFields["playground-email"]
+        XCTAssertTrue(playgroundEmailTextField.waitForExistence(timeout: 60.0))
+        playgroundEmailTextField.tap()
+        clear(textField: playgroundEmailTextField)
+        app.keyboards.buttons["return"].tap() // dismiss keyboard (warning: ensure keyboard is visible if manually testing)
+
+        let playgroundTransactionsPermissionsSwitch = app.switches["playground-transactions-permission"]
+        XCTAssertTrue(playgroundTransactionsPermissionsSwitch.waitForExistence(timeout: 60.0))
+        if (playgroundTransactionsPermissionsSwitch.value as? String) == "0" {
+            playgroundTransactionsPermissionsSwitch.tap() // turn ON transactions
+        }
+
+        let showAuthFlowButton = app.buttons["Show Auth Flow"]
+        XCTAssertTrue(showAuthFlowButton.waitForExistence(timeout: 60.0))
+        showAuthFlowButton.tap()
+
+        let consentAgreeButton = app.buttons["Agree"]
+        XCTAssertTrue(consentAgreeButton.waitForExistence(timeout: 120.0))  // glitch app can take time to load
+        consentAgreeButton.tap()
+
+        let featuredLegacyTestInstitution = app.collectionViews.staticTexts["Test OAuth Institution"]
+        XCTAssertTrue(featuredLegacyTestInstitution.waitForExistence(timeout: 60.0))
+        featuredLegacyTestInstitution.tap()
+
+        let prepaneContinueButton = app.buttons["Continue"]
+        XCTAssertTrue(prepaneContinueButton.waitForExistence(timeout: 60.0))
+        prepaneContinueButton.tap()
+
+        let successInstitution = app.scrollViews.staticTexts["Success"]
+        XCTAssertTrue(successInstitution.waitForExistence(timeout: 60.0))
+        successInstitution.tap()
+
+        let accountPickerLinkAccountsButton = app.buttons["Link account"]
+        XCTAssertTrue(accountPickerLinkAccountsButton.waitForExistence(timeout: 120.0))  // wait for accounts to fetch
+        accountPickerLinkAccountsButton.tap()
+
+        let emailTextField = app.textFields["Email"]
+        XCTAssertTrue(emailTextField.waitForExistence(timeout: 120.0))  // wait for synchronize to complete
+        emailTextField.tap()
+        emailTextField.typeText(emailAddress)
+
+        let phoneTextField = app.textFields["Phone"]
+        XCTAssertTrue(phoneTextField.waitForExistence(timeout: 120.0))  // wait for lookup to complete
+        phoneTextField.tap()
+        phoneTextField.typeText("4015006000")
+
+        let phoneTextFieldToolbarDoneButton = app.toolbars["Toolbar"].buttons["Done"]
+        XCTAssertTrue(phoneTextFieldToolbarDoneButton.waitForExistence(timeout: 60.0))
+        phoneTextFieldToolbarDoneButton.tap()
+
+        let saveToLinkButon = app.buttons["Save to Link"]
+        XCTAssertTrue(saveToLinkButon.waitForExistence(timeout: 120.0))  // glitch app can take time to lload
+        saveToLinkButon.tap()
+
+        let successPaneDoneButton = app.buttons["Done"]
+        XCTAssertTrue(successPaneDoneButton.waitForExistence(timeout: 120.0))  // wait for accounts to link
+        // this ensures that save to Link was successful...
+        // ...we want to check AFTER success screen has rendered with the "Done" button
+        XCTAssert(!app.staticTexts.containing(NSPredicate(format: "label CONTAINS 'could not be saved to Link'")).firstMatch
+            .exists)
+        successPaneDoneButton.tap()
+
+        let playgroundSuccessAlert = app.alerts["Success"]
+        XCTAssertTrue(playgroundSuccessAlert.waitForExistence(timeout: 60.0))
+
+        // ensure alert body contains "Stripe Bank" (AKA one bank is linked)
+        XCTAssert(
+            playgroundSuccessAlert.staticTexts.containing(NSPredicate(format: "label CONTAINS 'StripeBank'")).firstMatch
+                .exists
+        )
+    }
+
+    private func executeNativeNetworkingTestModeSignInFlowTest(emailAddress: String) {
+        let app = XCUIApplication()
+        app.launch()
+
+        let playgroundCell = app.tables.staticTexts["Playground"]
+        XCTAssertTrue(playgroundCell.waitForExistence(timeout: 60.0))
+        playgroundCell.tap()
+
+        let dataSegmentPickerButton = app.segmentedControls.buttons["Networking"]
+        XCTAssertTrue(dataSegmentPickerButton.waitForExistence(timeout: 60.0))
+        dataSegmentPickerButton.tap()
+
+        let nativeSegmentPickerButton = app.segmentedControls.buttons["Native"]
+        XCTAssertTrue(nativeSegmentPickerButton.waitForExistence(timeout: 60.0))
+        nativeSegmentPickerButton.tap()
+
+        let enableTestModeSwitch = app.switches["Enable Test Mode"].firstMatch
+        XCTAssertTrue(enableTestModeSwitch.waitForExistence(timeout: 60.0))
+        if (enableTestModeSwitch.value as? String) == "0" {
+            enableTestModeSwitch.tap()
+        }
+
+        app.swipeUp() // scroll to see email field
+
+        let playgroundEmailTextField = app.textFields["playground-email"]
+        XCTAssertTrue(playgroundEmailTextField.waitForExistence(timeout: 60.0))
+        playgroundEmailTextField.tap()
+        clear(textField: playgroundEmailTextField)
+        playgroundEmailTextField.typeText(emailAddress)
+        app.keyboards.buttons["return"].tap() // dismiss keyboard (warning: ensure keyboard is visible if manually testing)
+
+        let playgroundTransactionsPermissionsSwitch = app.switches["playground-transactions-permission"]
+        XCTAssertTrue(playgroundTransactionsPermissionsSwitch.waitForExistence(timeout: 60.0))
+        if (playgroundTransactionsPermissionsSwitch.value as? String) == "0" {
+            playgroundTransactionsPermissionsSwitch.tap() // turn ON transactions
+        }
+
+        let showAuthFlowButton = app.buttons["Show Auth Flow"]
+        XCTAssertTrue(showAuthFlowButton.waitForExistence(timeout: 60.0))
+        showAuthFlowButton.tap()
+
+        let consentAgreeButton = app.buttons["Agree"]
+        XCTAssertTrue(consentAgreeButton.waitForExistence(timeout: 120.0))  // glitch app can take time to load
+        consentAgreeButton.tap()
+
+        let continueWithEmailButton = app.scrollViews.otherElements.staticTexts[emailAddress]
+        XCTAssertTrue(continueWithEmailButton.waitForExistence(timeout: 60.0))
+        continueWithEmailButton.tap()
+
+        let verificationOTPTextView = app.scrollViews.otherElements.textViews["Code field"]
+        XCTAssertTrue(verificationOTPTextView.waitForExistence(timeout: 60.0))
+        verificationOTPTextView.tap()
+        verificationOTPTextView.typeText("111111")
+
+        let successInstitution = app.scrollViews.staticTexts["Success"]
+        XCTAssertTrue(successInstitution.waitForExistence(timeout: 120.0)) // need to wait for various API calls to appear
+        successInstitution.tap()
+
+        let connectAccountButton = app.buttons["Connect account"]
+        XCTAssertTrue(connectAccountButton.waitForExistence(timeout: 60.0))
+        connectAccountButton.tap()
+
+        let stepUpVerificationOTPTextView = app.scrollViews.otherElements.textViews["Code field"]
+        XCTAssertTrue(stepUpVerificationOTPTextView.waitForExistence(timeout: 60.0))
+        stepUpVerificationOTPTextView.tap()
+        stepUpVerificationOTPTextView.typeText("111111")
+
+        let successPaneDoneButton = app.buttons["Done"]
+        XCTAssertTrue(successPaneDoneButton.waitForExistence(timeout: 120.0))  // wait for verification to succeed
+        // this ensures that save to Link was successful...
+        // ...we want to check AFTER success screen has rendered with the "Done" button
+        XCTAssert(!app.staticTexts.containing(NSPredicate(format: "label CONTAINS 'could not be saved to Link'")).firstMatch
+            .exists)
+        successPaneDoneButton.tap()
+
+        let playgroundSuccessAlert = app.alerts["Success"]
+        XCTAssertTrue(playgroundSuccessAlert.waitForExistence(timeout: 60.0))
+
+        // ensure alert body contains "Stripe Bank" (AKA one bank is linked)
+        XCTAssert(
+            playgroundSuccessAlert.staticTexts.containing(NSPredicate(format: "label CONTAINS 'StripeBank'")).firstMatch
+                .exists
+        )
+    }
+}
+
+extension XCTestCase {
+
+    fileprivate func clear(textField: XCUIElement) {
+        wait(timeout: 1.5) // wait for keyboard to appear, otherwise `textField.coordinate` may select the wrong spot
+        while
+            let text = textField.value as? String,
+            !text.isEmpty,
+            text != textField.placeholderValue
+        {
+            let middleCoordinate = textField.coordinate(withNormalizedOffset: CGVector(dx: 0.50, dy: 0.50))
+            middleCoordinate.tap()
+            let deleteString = String(repeating: XCUIKeyboardKey.delete.rawValue, count: text.count)
+            textField.typeText(deleteString)
+        }
+    }
+}

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
@@ -315,7 +315,7 @@ final class FinancialConnectionsUITests: XCTestCase {
 }
 
 extension XCTestCase {
-    fileprivate func wait(timeout: TimeInterval) {
+    func wait(timeout: TimeInterval) {
         _ = XCTWaiter.wait(for: [XCTestExpectation(description: "")], timeout: timeout)
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
@@ -67,7 +67,7 @@ final class NetworkingLinkSignupViewController: UIViewController {
 
         showLoadingView(true)
     }
-    
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         // delay executing logic until `viewDidAppear` because
@@ -98,7 +98,7 @@ final class NetworkingLinkSignupViewController: UIViewController {
                 }
         }
     }
-    
+
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         if willNavigateToReturningConsumer {
@@ -235,7 +235,7 @@ final class NetworkingLinkSignupViewController: UIViewController {
         let isPhoneNumberValid = formView.phoneNumberElement.validationState.isValid
         footerView?.enableSaveToLinkButton(isEmailValid && isPhoneNumberValid)
     }
-    
+
     private func foundReturningConsumer(withSession consumerSession: ConsumerSessionData) {
         willNavigateToReturningConsumer = true
         delegate?.networkingLinkSignupViewController(


### PR DESCRIPTION
## Summary

This PR adds an end-to-end test that tests both signing up a new user, and then also utilizing the newly signed up user as an existing user.

## Testing

I ran the tests a lot of times through many devices, and even some different iOS versions.

Then also ran `bitrise run financial-connections-stability-tests`:

```

All tests
Test Suite FinancialConnectionsUITests.xctest started
FinancialConnectionsNetworkingUITests
    ✓ testNativeNetworkingTestMode (74.395 seconds)
FinancialConnectionsUITests
    ✓ testDataLiveModeOAuthNativeAuthFlow (27.512 seconds)
    ✓ testDataLiveModeOAuthWebAuthFlow (26.021 seconds)
    ✓ testDataTestModeOAuthNativeAuthFlow (20.618 seconds)
    ✓ testPaymentTestModeLegacyNativeAuthFlow (23.007 seconds)





+------------------------------------------------------------------------------+
|            bitrise summary: financial-connections-stability-tests            |
+---+---------------------------------------------------------------+----------+
|   | title                                                         | time (s) |
+---+---------------------------------------------------------------+----------+
| ✓ | Start Xcode simulator                                         | 2.37 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Set CONFIGURATION_BUILD_DIR                                   | 0.50 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Set CONFIGURATION_TEMP_DIR                                    | 0.47 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Set Bundler to use local vendor directory                     | 0.68 sec |
+---+---------------------------------------------------------------+----------+
| - | Git Clone Repository (Skipped)                                | 0.80 sec |
+---+---------------------------------------------------------------+----------+
| Update available: 6 (6.2.3) -> 8.0.1                                         |
|                                                                              |
| Release notes are available below                                            |
| https://github.com/bitrise-steplib/steps-git-clone/releases                  |
+---+---------------------------------------------------------------+----------+
| - | tuist (Skipped)                                               | 0.48 sec |
+---+---------------------------------------------------------------+----------+
| - | Bitrise.io Cache:Pull (Skipped)                               | 0.44 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Bundler                                                       | 0.86 sec |
+---+---------------------------------------------------------------+----------+
| - | Bitrise.io Cache:Push (Skipped)                               | 0.46 sec |
+---+---------------------------------------------------------------+----------+
| - | Restore SPM Cache (Skipped)                                   | 0.48 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Xcode Test for iOS                                            | 4.6 min  |
+---+---------------------------------------------------------------+----------+
| - | Create a PagerDuty alert (Skipped)                            | 0.69 sec |
+---+---------------------------------------------------------------+----------+
| - | Send a Slack message (Skipped)                                | 0.45 sec |
+---+---------------------------------------------------------------+----------+
| - | Deploy to Bitrise.io - Build Artifacts, Test Repo... (Skipped)| 0.93 sec |
+---+---------------------------------------------------------------+----------+
| Total runtime: 4.8 min                                                       |
+------------------------------------------------------------------------------+
```


https://user-images.githubusercontent.com/105514761/234413154-84b691f2-0324-4892-a5d6-238865227089.mp4

<img width="1196" alt="ui-testing" src="https://user-images.githubusercontent.com/105514761/234413170-80299a89-66f2-4a4f-acae-3c6d9c1790bd.png">
