### PR TITLE
Financial Connections: cleaned up UI tests and added a manual entry test

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
@@ -51,7 +51,7 @@ final class FinancialConnectionsUITests: XCTestCase {
         XCTAssertTrue(showAuthFlowButton.waitForExistence(timeout: 60.0))
         showAuthFlowButton.tap()
 
-        let consentAgreeButton = app.buttons["Agree"]
+        let consentAgreeButton = app.buttons["consent_agree_button"]
         XCTAssertTrue(consentAgreeButton.waitForExistence(timeout: 120.0))  // glitch app can take time to lload
         consentAgreeButton.tap()
 
@@ -107,7 +107,7 @@ final class FinancialConnectionsUITests: XCTestCase {
         XCTAssertTrue(showAuthFlowButton.waitForExistence(timeout: 60.0))
         showAuthFlowButton.tap()
 
-        let consentAgreeButton = app.buttons["Agree"]
+        let consentAgreeButton = app.buttons["consent_agree_button"]
         XCTAssertTrue(consentAgreeButton.waitForExistence(timeout: 120.0))  // glitch app can take time to lload
         consentAgreeButton.tap()
 
@@ -165,7 +165,7 @@ final class FinancialConnectionsUITests: XCTestCase {
         XCTAssertTrue(showAuthFlowButton.waitForExistence(timeout: 60.0))
         showAuthFlowButton.tap()
 
-        let consentAgreeButton = app.buttons["Agree"]
+        let consentAgreeButton = app.buttons["consent_agree_button"]
         XCTAssertTrue(consentAgreeButton.waitForExistence(timeout: 120.0))  // glitch app can take time to lload
         consentAgreeButton.tap()
 
@@ -257,7 +257,7 @@ final class FinancialConnectionsUITests: XCTestCase {
         XCTAssertTrue(showAuthFlowButton.waitForExistence(timeout: 60.0))
         showAuthFlowButton.tap()
 
-        let consentAgreeButton = app.webViews.buttons["Agree"]
+        let consentAgreeButton = app.webViews.buttons["consent_agree_button"]
         XCTAssertTrue(consentAgreeButton.waitForExistence(timeout: 120.0))  // glitch app can take time to load
         consentAgreeButton.tap()
 

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
@@ -61,11 +61,7 @@ final class FinancialConnectionsUITests: XCTestCase {
         app.launch()
 
         app.fc_playgroundCell.tap()
-
-        let dataSegmentPickerButton = app.segmentedControls.buttons["Payments"]
-        XCTAssertTrue(dataSegmentPickerButton.waitForExistence(timeout: 60.0))
-        dataSegmentPickerButton.tap()
-
+        app.fc_playgroundPaymentFlowButton.tap()
         app.fc_playgroundNativeButton.tap()
 
         let enableTestModeSwitch = app.fc_playgroundEnableTestModeSwitch
@@ -92,6 +88,57 @@ final class FinancialConnectionsUITests: XCTestCase {
             app.fc_playgroundSuccessAlertView.staticTexts.containing(NSPredicate(format: "label CONTAINS 'StripeBank'")).firstMatch
                 .exists
         )
+    }
+
+    func testPaymentTestModeManualEntryNativeAuthFlow() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        app.fc_playgroundCell.tap()
+        app.fc_playgroundPaymentFlowButton.tap()
+        app.fc_playgroundNativeButton.tap()
+
+        let enableTestModeSwitch = app.fc_playgroundEnableTestModeSwitch
+        if (enableTestModeSwitch.value as? String) == "0" {
+            enableTestModeSwitch.tap()
+        }
+
+        app.fc_playgroundShowAuthFlowButton.tap()
+
+        let manuallyVerifyLabel = app.otherElements["consent_manually_verify_label"]
+        XCTAssertTrue(manuallyVerifyLabel.waitForExistence(timeout: 120.0))
+        manuallyVerifyLabel.tap()
+
+        let manualEntryRoutingNumberTextField = app.textFields["manual_entry_routing_number_text_field"]
+        XCTAssertTrue(manualEntryRoutingNumberTextField.waitForExistence(timeout: 60.0))
+        manualEntryRoutingNumberTextField.tap()
+        manualEntryRoutingNumberTextField.typeText("110000000")
+
+        app.scrollViews.firstMatch.swipeUp() // dismiss keyboard
+
+        let manualEntryAccountNumberTextField = app.textFields["manual_entry_account_number_text_field"]
+        XCTAssertTrue(manualEntryAccountNumberTextField.waitForExistence(timeout: 60.0))
+        manualEntryAccountNumberTextField.tap()
+        manualEntryAccountNumberTextField.typeText("000123456789")
+
+        app.scrollViews.firstMatch.swipeUp() // dismiss keyboard
+
+        let manualEntryAccountNumberConfirmationTextField = app.textFields["manual_entry_account_number_confirmation_text_field"]
+        XCTAssertTrue(manualEntryAccountNumberConfirmationTextField.waitForExistence(timeout: 60.0))
+        manualEntryAccountNumberConfirmationTextField.tap()
+        manualEntryAccountNumberConfirmationTextField.typeText("000123456789")
+
+        app.scrollViews.firstMatch.swipeUp() // dismiss keyboard
+
+        let manualEntryContinueButton = app.buttons["manual_entry_continue_button"]
+        XCTAssertTrue(manualEntryContinueButton.waitForExistence(timeout: 120.0))
+        manualEntryContinueButton.tap()
+
+        let manualEntrySuccessDoneButton = app.buttons["manual_entry_success_done_button"]
+        XCTAssertTrue(manualEntrySuccessDoneButton.waitForExistence(timeout: 120.0))
+        manualEntrySuccessDoneButton.tap()
+
+        XCTAssert(app.fc_playgroundSuccessAlertView.exists)
     }
 
     // note that this does NOT complete the Auth Flow, but its a decent check on

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
@@ -33,15 +33,15 @@ final class FinancialConnectionsUITests: XCTestCase {
         XCTAssertTrue(playgroundCell.waitForExistence(timeout: 60.0))
         playgroundCell.tap()
 
-        let dataSegmentPickerButton = app.collectionViews.buttons["Data"]
+        let dataSegmentPickerButton = app.segmentedControls.buttons["Data"]
         XCTAssertTrue(dataSegmentPickerButton.waitForExistence(timeout: 60.0))
         dataSegmentPickerButton.tap()
 
-        let nativeSegmentPickerButton = app.collectionViews.buttons["Native"]
+        let nativeSegmentPickerButton = app.segmentedControls.buttons["Native"]
         XCTAssertTrue(nativeSegmentPickerButton.waitForExistence(timeout: 60.0))
         nativeSegmentPickerButton.tap()
 
-        let enableTestModeSwitch = app.collectionViews.switches["Enable Test Mode"]
+        let enableTestModeSwitch = app.switches["Enable Test Mode"].firstMatch
         XCTAssertTrue(enableTestModeSwitch.waitForExistence(timeout: 60.0))
         if (enableTestModeSwitch.value as? String) == "0" {
             enableTestModeSwitch.tap()
@@ -89,15 +89,15 @@ final class FinancialConnectionsUITests: XCTestCase {
         XCTAssertTrue(playgroundCell.waitForExistence(timeout: 60.0))
         playgroundCell.tap()
 
-        let dataSegmentPickerButton = app.collectionViews.buttons["Payments"]
+        let dataSegmentPickerButton = app.segmentedControls.buttons["Payments"]
         XCTAssertTrue(dataSegmentPickerButton.waitForExistence(timeout: 60.0))
         dataSegmentPickerButton.tap()
 
-        let nativeSegmentPickerButton = app.collectionViews.buttons["Native"]
+        let nativeSegmentPickerButton = app.segmentedControls.buttons["Native"]
         XCTAssertTrue(nativeSegmentPickerButton.waitForExistence(timeout: 60.0))
         nativeSegmentPickerButton.tap()
 
-        let enableTestModeSwitch = app.collectionViews.switches["Enable Test Mode"]
+        let enableTestModeSwitch = app.switches["Enable Test Mode"].firstMatch
         XCTAssertTrue(enableTestModeSwitch.waitForExistence(timeout: 60.0))
         if (enableTestModeSwitch.value as? String) == "0" {
             enableTestModeSwitch.tap()
@@ -147,15 +147,15 @@ final class FinancialConnectionsUITests: XCTestCase {
         XCTAssertTrue(playgroundCell.waitForExistence(timeout: 60.0))
         playgroundCell.tap()
 
-        let dataSegmentPickerButton = app.collectionViews.buttons["Data"]
+        let dataSegmentPickerButton = app.segmentedControls.buttons["Data"]
         XCTAssertTrue(dataSegmentPickerButton.waitForExistence(timeout: 60.0))
         dataSegmentPickerButton.tap()
 
-        let nativeSegmentPickerButton = app.collectionViews.buttons["Native"]
+        let nativeSegmentPickerButton = app.segmentedControls.buttons["Native"]
         XCTAssertTrue(nativeSegmentPickerButton.waitForExistence(timeout: 60.0))
         nativeSegmentPickerButton.tap()
 
-        let enableTestModeSwitch = app.collectionViews.switches["Enable Test Mode"]
+        let enableTestModeSwitch = app.switches["Enable Test Mode"].firstMatch
         XCTAssertTrue(enableTestModeSwitch.waitForExistence(timeout: 60.0))
         if (enableTestModeSwitch.value as? String) == "1" {
             enableTestModeSwitch.tap()
@@ -239,15 +239,15 @@ final class FinancialConnectionsUITests: XCTestCase {
         XCTAssertTrue(playgroundCell.waitForExistence(timeout: 60.0))
         playgroundCell.tap()
 
-        let dataSegmentPickerButton = app.collectionViews.buttons["Data"]
+        let dataSegmentPickerButton = app.segmentedControls.buttons["Data"]
         XCTAssertTrue(dataSegmentPickerButton.waitForExistence(timeout: 60.0))
         dataSegmentPickerButton.tap()
 
-        let nativeSegmentPickerButton = app.collectionViews.buttons["Web"]
+        let nativeSegmentPickerButton = app.segmentedControls.buttons["Web"]
         XCTAssertTrue(nativeSegmentPickerButton.waitForExistence(timeout: 60.0))
         nativeSegmentPickerButton.tap()
 
-        let enableTestModeSwitch = app.collectionViews.switches["Enable Test Mode"]
+        let enableTestModeSwitch = app.switches["Enable Test Mode"].firstMatch
         XCTAssertTrue(enableTestModeSwitch.waitForExistence(timeout: 60.0))
         if (enableTestModeSwitch.value as? String) == "1" {
             enableTestModeSwitch.tap()
@@ -257,7 +257,7 @@ final class FinancialConnectionsUITests: XCTestCase {
         XCTAssertTrue(showAuthFlowButton.waitForExistence(timeout: 60.0))
         showAuthFlowButton.tap()
 
-        let consentAgreeButton = app.webViews.buttons["consent_agree_button"]
+        let consentAgreeButton = app.webViews.buttons["Agree"]
         XCTAssertTrue(consentAgreeButton.waitForExistence(timeout: 120.0))  // glitch app can take time to load
         consentAgreeButton.tap()
 

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
@@ -28,35 +28,30 @@ final class FinancialConnectionsUITests: XCTestCase {
     func testDataTestModeOAuthNativeAuthFlow() throws {
         let app = XCUIApplication()
         app.launch()
-        
+
         app.fc_playgroundCell.tap()
         app.fc_playgroundDataFlowButton.tap()
         app.fc_playgroundNativeButton.tap()
-        
+
         let enableTestModeSwitch = app.fc_playgroundEnableTestModeSwitch
         if (enableTestModeSwitch.value as? String) == "0" {
             enableTestModeSwitch.tap()
         }
 
         app.fc_playgroundShowAuthFlowButton.tap()
-        app.fc_consentAgreeButton.tap()
+        app.fc_nativeConsentAgreeButton.tap()
 
         let featuredLegacyTestInstitution = app.collectionViews.staticTexts["Test OAuth Institution"]
         XCTAssertTrue(featuredLegacyTestInstitution.waitForExistence(timeout: 60.0))
         featuredLegacyTestInstitution.tap()
 
-        app.fc_prepaneContinueButton.tap()
+        app.fc_nativePrepaneContinueButton.tap()
+        app.fc_nativeAccountPickerLinkAccountsButton.tap()
+        app.fc_nativeSuccessDoneButton.tap()
 
-        let accountPickerLinkAccountsButton = app.buttons["account_picker_link_accounts_button"]
-        XCTAssertTrue(accountPickerLinkAccountsButton.waitForExistence(timeout: 120.0))  // wait for accounts to fetch
-        accountPickerLinkAccountsButton.tap()
-
-        app.fc_successDoneButton.tap()
-
-        let playgroundSuccessAlertView = app.fc_playgroundSuccessAlertView
         // ensure alert body contains "Stripe Bank" (AKA one bank is linked)
         XCTAssert(
-            playgroundSuccessAlertView.staticTexts.containing(NSPredicate(format: "label CONTAINS 'StripeBank'")).firstMatch
+            app.fc_playgroundSuccessAlertView.staticTexts.containing(NSPredicate(format: "label CONTAINS 'StripeBank'")).firstMatch
                 .exists
         )
     }
@@ -65,31 +60,21 @@ final class FinancialConnectionsUITests: XCTestCase {
         let app = XCUIApplication()
         app.launch()
 
-        let playgroundCell = app.tables.staticTexts["Playground"]
-        XCTAssertTrue(playgroundCell.waitForExistence(timeout: 60.0))
         app.fc_playgroundCell.tap()
 
         let dataSegmentPickerButton = app.segmentedControls.buttons["Payments"]
         XCTAssertTrue(dataSegmentPickerButton.waitForExistence(timeout: 60.0))
         dataSegmentPickerButton.tap()
 
-        let nativeSegmentPickerButton = app.segmentedControls.buttons["Native"]
-        XCTAssertTrue(nativeSegmentPickerButton.waitForExistence(timeout: 60.0))
-        nativeSegmentPickerButton.tap()
+        app.fc_playgroundNativeButton.tap()
 
-        let enableTestModeSwitch = app.switches["Enable Test Mode"].firstMatch
-        XCTAssertTrue(enableTestModeSwitch.waitForExistence(timeout: 60.0))
+        let enableTestModeSwitch = app.fc_playgroundEnableTestModeSwitch
         if (enableTestModeSwitch.value as? String) == "0" {
             enableTestModeSwitch.tap()
         }
 
-        let showAuthFlowButton = app.buttons["Show Auth Flow"]
-        XCTAssertTrue(showAuthFlowButton.waitForExistence(timeout: 60.0))
-        showAuthFlowButton.tap()
-
-        let consentAgreeButton = app.buttons["consent_agree_button"]
-        XCTAssertTrue(consentAgreeButton.waitForExistence(timeout: 120.0))  // glitch app can take time to lload
-        consentAgreeButton.tap()
+        app.fc_playgroundShowAuthFlowButton.tap()
+        app.fc_nativeConsentAgreeButton.tap()
 
         let featuredLegacyTestInstitution = app.collectionViews.staticTexts["Test Institution"]
         XCTAssertTrue(featuredLegacyTestInstitution.waitForExistence(timeout: 60.0))
@@ -99,20 +84,12 @@ final class FinancialConnectionsUITests: XCTestCase {
         XCTAssertTrue(successAccountRow.waitForExistence(timeout: 60.0))
         successAccountRow.tap()
 
-        let accountPickerLinkAccountButton = app.buttons["Link account"]
-        XCTAssertTrue(accountPickerLinkAccountButton.waitForExistence(timeout: 120.0))  // wait for accounts to fetch
-        accountPickerLinkAccountButton.tap()
-
-        let successPaneDoneButton = app.buttons["Done"]
-        XCTAssertTrue(successPaneDoneButton.waitForExistence(timeout: 120.0))  // wait for accounts to link
-        successPaneDoneButton.tap()
-
-        let playgroundSuccessAlert = app.alerts["Success"]
-        XCTAssertTrue(playgroundSuccessAlert.waitForExistence(timeout: 60.0))
+        app.fc_nativeAccountPickerLinkAccountsButton.tap()
+        app.fc_nativeSuccessDoneButton.tap()
 
         // ensure alert body contains "Stripe Bank" (AKA one bank is linked)
         XCTAssert(
-            playgroundSuccessAlert.staticTexts.containing(NSPredicate(format: "label CONTAINS 'StripeBank'")).firstMatch
+            app.fc_playgroundSuccessAlertView.staticTexts.containing(NSPredicate(format: "label CONTAINS 'StripeBank'")).firstMatch
                 .exists
         )
     }
@@ -123,31 +100,17 @@ final class FinancialConnectionsUITests: XCTestCase {
         let app = XCUIApplication()
         app.launch()
 
-        let playgroundCell = app.tables.staticTexts["Playground"]
-        XCTAssertTrue(playgroundCell.waitForExistence(timeout: 60.0))
-        playgroundCell.tap()
+        app.fc_playgroundCell.tap()
+        app.fc_playgroundDataFlowButton.tap()
+        app.fc_playgroundNativeButton.tap()
 
-        let dataSegmentPickerButton = app.segmentedControls.buttons["Data"]
-        XCTAssertTrue(dataSegmentPickerButton.waitForExistence(timeout: 60.0))
-        dataSegmentPickerButton.tap()
-
-        let nativeSegmentPickerButton = app.segmentedControls.buttons["Native"]
-        XCTAssertTrue(nativeSegmentPickerButton.waitForExistence(timeout: 60.0))
-        nativeSegmentPickerButton.tap()
-
-        let enableTestModeSwitch = app.switches["Enable Test Mode"].firstMatch
-        XCTAssertTrue(enableTestModeSwitch.waitForExistence(timeout: 60.0))
+        let enableTestModeSwitch = app.fc_playgroundEnableTestModeSwitch
         if (enableTestModeSwitch.value as? String) == "1" {
             enableTestModeSwitch.tap()
         }
 
-        let showAuthFlowButton = app.buttons["Show Auth Flow"]
-        XCTAssertTrue(showAuthFlowButton.waitForExistence(timeout: 60.0))
-        showAuthFlowButton.tap()
-
-        let consentAgreeButton = app.buttons["consent_agree_button"]
-        XCTAssertTrue(consentAgreeButton.waitForExistence(timeout: 120.0))  // glitch app can take time to lload
-        consentAgreeButton.tap()
+        app.fc_playgroundShowAuthFlowButton.tap()
+        app.fc_nativeConsentAgreeButton.tap()
 
         // find + tap an institution; we add extra institutions in case
         // they don't get featured
@@ -179,9 +142,7 @@ final class FinancialConnectionsUITests: XCTestCase {
         }
         institutionButton.tap()
 
-        let prepaneContinueButton = app.buttons["Continue"]
-        XCTAssertTrue(prepaneContinueButton.waitForExistence(timeout: 60.0))
-        prepaneContinueButton.tap()
+        app.fc_nativePrepaneContinueButton.tap()
 
         // check that the WebView loaded
         let institutionWebViewText = app.webViews
@@ -215,27 +176,19 @@ final class FinancialConnectionsUITests: XCTestCase {
         let app = XCUIApplication()
         app.launch()
 
-        let playgroundCell = app.tables.staticTexts["Playground"]
-        XCTAssertTrue(playgroundCell.waitForExistence(timeout: 60.0))
-        playgroundCell.tap()
+        app.fc_playgroundCell.tap()
+        app.fc_playgroundDataFlowButton.tap()
 
-        let dataSegmentPickerButton = app.segmentedControls.buttons["Data"]
-        XCTAssertTrue(dataSegmentPickerButton.waitForExistence(timeout: 60.0))
-        dataSegmentPickerButton.tap()
+        let webSegmentPickerButton = app.segmentedControls.buttons["Web"]
+        XCTAssertTrue(webSegmentPickerButton.waitForExistence(timeout: 60.0))
+        webSegmentPickerButton.tap()
 
-        let nativeSegmentPickerButton = app.segmentedControls.buttons["Web"]
-        XCTAssertTrue(nativeSegmentPickerButton.waitForExistence(timeout: 60.0))
-        nativeSegmentPickerButton.tap()
-
-        let enableTestModeSwitch = app.switches["Enable Test Mode"].firstMatch
-        XCTAssertTrue(enableTestModeSwitch.waitForExistence(timeout: 60.0))
+        let enableTestModeSwitch = app.fc_playgroundEnableTestModeSwitch
         if (enableTestModeSwitch.value as? String) == "1" {
             enableTestModeSwitch.tap()
         }
 
-        let showAuthFlowButton = app.buttons["Show Auth Flow"]
-        XCTAssertTrue(showAuthFlowButton.waitForExistence(timeout: 60.0))
-        showAuthFlowButton.tap()
+        app.fc_playgroundShowAuthFlowButton.tap()
 
         let consentAgreeButton = app.webViews.buttons["Agree"]
         XCTAssertTrue(consentAgreeButton.waitForExistence(timeout: 120.0))  // glitch app can take time to load

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
@@ -28,55 +28,35 @@ final class FinancialConnectionsUITests: XCTestCase {
     func testDataTestModeOAuthNativeAuthFlow() throws {
         let app = XCUIApplication()
         app.launch()
-
-        let playgroundCell = app.tables.staticTexts["Playground"]
-        XCTAssertTrue(playgroundCell.waitForExistence(timeout: 60.0))
-        playgroundCell.tap()
-
-        let dataSegmentPickerButton = app.segmentedControls.buttons["Data"]
-        XCTAssertTrue(dataSegmentPickerButton.waitForExistence(timeout: 60.0))
-        dataSegmentPickerButton.tap()
-
-        let nativeSegmentPickerButton = app.segmentedControls.buttons["Native"]
-        XCTAssertTrue(nativeSegmentPickerButton.waitForExistence(timeout: 60.0))
-        nativeSegmentPickerButton.tap()
-
-        let enableTestModeSwitch = app.switches["Enable Test Mode"].firstMatch
-        XCTAssertTrue(enableTestModeSwitch.waitForExistence(timeout: 60.0))
+        
+        app.fc_playgroundCell.tap()
+        app.fc_playgroundDataFlowButton.tap()
+        app.fc_playgroundNativeButton.tap()
+        
+        let enableTestModeSwitch = app.fc_playgroundEnableTestModeSwitch
         if (enableTestModeSwitch.value as? String) == "0" {
             enableTestModeSwitch.tap()
         }
 
-        let showAuthFlowButton = app.buttons["Show Auth Flow"]
-        XCTAssertTrue(showAuthFlowButton.waitForExistence(timeout: 60.0))
-        showAuthFlowButton.tap()
-
-        let consentAgreeButton = app.buttons["consent_agree_button"]
-        XCTAssertTrue(consentAgreeButton.waitForExistence(timeout: 120.0))  // glitch app can take time to lload
-        consentAgreeButton.tap()
+        app.fc_playgroundShowAuthFlowButton.tap()
+        app.fc_consentAgreeButton.tap()
 
         let featuredLegacyTestInstitution = app.collectionViews.staticTexts["Test OAuth Institution"]
         XCTAssertTrue(featuredLegacyTestInstitution.waitForExistence(timeout: 60.0))
         featuredLegacyTestInstitution.tap()
 
-        let prepaneContinueButton = app.buttons["Continue"]
-        XCTAssertTrue(prepaneContinueButton.waitForExistence(timeout: 60.0))
-        prepaneContinueButton.tap()
+        app.fc_prepaneContinueButton.tap()
 
-        let accountPickerLinkAccountsButton = app.buttons["Link accounts"]
+        let accountPickerLinkAccountsButton = app.buttons["account_picker_link_accounts_button"]
         XCTAssertTrue(accountPickerLinkAccountsButton.waitForExistence(timeout: 120.0))  // wait for accounts to fetch
         accountPickerLinkAccountsButton.tap()
 
-        let successPaneDoneButton = app.buttons["Done"]
-        XCTAssertTrue(successPaneDoneButton.waitForExistence(timeout: 120.0))  // wait for accounts to link
-        successPaneDoneButton.tap()
+        app.fc_successDoneButton.tap()
 
-        let playgroundSuccessAlert = app.alerts["Success"]
-        XCTAssertTrue(playgroundSuccessAlert.waitForExistence(timeout: 60.0))
-
+        let playgroundSuccessAlertView = app.fc_playgroundSuccessAlertView
         // ensure alert body contains "Stripe Bank" (AKA one bank is linked)
         XCTAssert(
-            playgroundSuccessAlert.staticTexts.containing(NSPredicate(format: "label CONTAINS 'StripeBank'")).firstMatch
+            playgroundSuccessAlertView.staticTexts.containing(NSPredicate(format: "label CONTAINS 'StripeBank'")).firstMatch
                 .exists
         )
     }
@@ -87,7 +67,7 @@ final class FinancialConnectionsUITests: XCTestCase {
 
         let playgroundCell = app.tables.staticTexts["Playground"]
         XCTAssertTrue(playgroundCell.waitForExistence(timeout: 60.0))
-        playgroundCell.tap()
+        app.fc_playgroundCell.tap()
 
         let dataSegmentPickerButton = app.segmentedControls.buttons["Payments"]
         XCTAssertTrue(dataSegmentPickerButton.waitForExistence(timeout: 60.0))

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIApplication+Extensions.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIApplication+Extensions.swift
@@ -9,66 +9,68 @@ import Foundation
 import XCTest
 
 extension XCUIApplication {
-    
+
     // MARK: - Example App Helpers
-    
+
     var fc_playgroundCell: XCUIElement {
         let playgroundCell = tables.staticTexts["Playground"]
         XCTAssertTrue(playgroundCell.waitForExistence(timeout: 10.0))
         return playgroundCell
     }
-    
+
     var fc_playgroundDataFlowButton: XCUIElement {
         let playgroundDataFlowButton = segmentedControls.buttons["Data"]
         XCTAssertTrue(playgroundDataFlowButton.waitForExistence(timeout: 60.0))
         return playgroundDataFlowButton
     }
-    
+
     var fc_playgroundNativeButton: XCUIElement {
         let playgroundNativeButton = segmentedControls.buttons["Native"]
         XCTAssertTrue(playgroundNativeButton.waitForExistence(timeout: 60.0))
         return playgroundNativeButton
     }
-    
+
     var fc_playgroundEnableTestModeSwitch: XCUIElement {
         let enableTestModeSwitch = switches["Enable Test Mode"].firstMatch
         XCTAssertTrue(enableTestModeSwitch.waitForExistence(timeout: 60.0))
         return enableTestModeSwitch
     }
-    
+
     var fc_playgroundShowAuthFlowButton: XCUIElement {
         let showAuthFlowButton = buttons["Show Auth Flow"]
         XCTAssertTrue(showAuthFlowButton.waitForExistence(timeout: 60.0))
         return showAuthFlowButton
     }
-    
+
     var fc_playgroundSuccessAlertView: XCUIElement {
         let playgroundSuccessAlertView = alerts["Success"]
         XCTAssertTrue(playgroundSuccessAlertView.waitForExistence(timeout: 60.0))
         return playgroundSuccessAlertView
     }
-    
+
     // MARK: - SDK Helpers
 
-    var fc_consentAgreeButton: XCUIElement {
+    var fc_nativeConsentAgreeButton: XCUIElement {
         let consentAgreeButton = buttons["consent_agree_button"]
         XCTAssertTrue(consentAgreeButton.waitForExistence(timeout: 120.0))  // glitch app can take time to lload
         return consentAgreeButton
     }
-    
-    var fc_prepaneContinueButton: XCUIElement {
+
+    var fc_nativePrepaneContinueButton: XCUIElement {
         let prepaneContinueButton = buttons["prepane_continue_button"]
         XCTAssertTrue(prepaneContinueButton.waitForExistence(timeout: 60.0))
         return prepaneContinueButton
     }
-    
-    var fc_successDoneButton: XCUIElement {
+
+    var fc_nativeAccountPickerLinkAccountsButton: XCUIElement {
+        let accountPickerLinkAccountsButton = buttons["account_picker_link_accounts_button"]
+        XCTAssertTrue(accountPickerLinkAccountsButton.waitForExistence(timeout: 120.0))  // wait for accounts to fetch
+        return accountPickerLinkAccountsButton
+    }
+
+    var fc_nativeSuccessDoneButton: XCUIElement {
         let successDoneButton = buttons["success_done_button"]
         XCTAssertTrue(successDoneButton.waitForExistence(timeout: 120.0))  // wait for accounts to link
         return successDoneButton
     }
-    
-    
-        
-    // ...
 }

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIApplication+Extensions.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIApplication+Extensions.swift
@@ -1,0 +1,74 @@
+//
+//  XCUIApplication+Extensions.swift
+//  FinancialConnections Example
+//
+//  Created by Krisjanis Gaidis on 4/26/23.
+//
+
+import Foundation
+import XCTest
+
+extension XCUIApplication {
+    
+    // MARK: - Example App Helpers
+    
+    var fc_playgroundCell: XCUIElement {
+        let playgroundCell = tables.staticTexts["Playground"]
+        XCTAssertTrue(playgroundCell.waitForExistence(timeout: 10.0))
+        return playgroundCell
+    }
+    
+    var fc_playgroundDataFlowButton: XCUIElement {
+        let playgroundDataFlowButton = segmentedControls.buttons["Data"]
+        XCTAssertTrue(playgroundDataFlowButton.waitForExistence(timeout: 60.0))
+        return playgroundDataFlowButton
+    }
+    
+    var fc_playgroundNativeButton: XCUIElement {
+        let playgroundNativeButton = segmentedControls.buttons["Native"]
+        XCTAssertTrue(playgroundNativeButton.waitForExistence(timeout: 60.0))
+        return playgroundNativeButton
+    }
+    
+    var fc_playgroundEnableTestModeSwitch: XCUIElement {
+        let enableTestModeSwitch = switches["Enable Test Mode"].firstMatch
+        XCTAssertTrue(enableTestModeSwitch.waitForExistence(timeout: 60.0))
+        return enableTestModeSwitch
+    }
+    
+    var fc_playgroundShowAuthFlowButton: XCUIElement {
+        let showAuthFlowButton = buttons["Show Auth Flow"]
+        XCTAssertTrue(showAuthFlowButton.waitForExistence(timeout: 60.0))
+        return showAuthFlowButton
+    }
+    
+    var fc_playgroundSuccessAlertView: XCUIElement {
+        let playgroundSuccessAlertView = alerts["Success"]
+        XCTAssertTrue(playgroundSuccessAlertView.waitForExistence(timeout: 60.0))
+        return playgroundSuccessAlertView
+    }
+    
+    // MARK: - SDK Helpers
+
+    var fc_consentAgreeButton: XCUIElement {
+        let consentAgreeButton = buttons["consent_agree_button"]
+        XCTAssertTrue(consentAgreeButton.waitForExistence(timeout: 120.0))  // glitch app can take time to lload
+        return consentAgreeButton
+    }
+    
+    var fc_prepaneContinueButton: XCUIElement {
+        let prepaneContinueButton = buttons["prepane_continue_button"]
+        XCTAssertTrue(prepaneContinueButton.waitForExistence(timeout: 60.0))
+        return prepaneContinueButton
+    }
+    
+    var fc_successDoneButton: XCUIElement {
+        let successDoneButton = buttons["success_done_button"]
+        XCTAssertTrue(successDoneButton.waitForExistence(timeout: 120.0))  // wait for accounts to link
+        return successDoneButton
+    }
+    
+    
+        
+    // ...
+}

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIApplication+Extensions.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIApplication+Extensions.swift
@@ -24,6 +24,12 @@ extension XCUIApplication {
         return playgroundDataFlowButton
     }
 
+    var fc_playgroundPaymentFlowButton: XCUIElement {
+        let playgroundPaymentFlowButton = segmentedControls.buttons["Payments"]
+        XCTAssertTrue(playgroundPaymentFlowButton.waitForExistence(timeout: 60.0))
+        return playgroundPaymentFlowButton
+    }
+
     var fc_playgroundNativeButton: XCUIElement {
         let playgroundNativeButton = segmentedControls.buttons["Native"]
         XCTAssertTrue(playgroundNativeButton.waitForExistence(timeout: 60.0))

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerFooterView.swift
@@ -23,6 +23,7 @@ final class AccountPickerFooterView: UIView {
         NSLayoutConstraint.activate([
             linkAccountsButton.heightAnchor.constraint(equalToConstant: 56)
         ])
+        linkAccountsButton.accessibilityIdentifier = "account_picker_link_accounts_button"
         return linkAccountsButton
     }()
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentFooterView.swift
@@ -24,6 +24,7 @@ class ConsentFooterView: HitTestView {
         NSLayoutConstraint.activate([
             agreeButton.heightAnchor.constraint(equalToConstant: 56)
         ])
+        agreeButton.accessibilityIdentifier = "consent_agree_button"
         return agreeButton
     }()
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentFooterView.swift
@@ -73,6 +73,7 @@ class ConsentFooterView: HitTestView {
                 belowCtaText,
                 action: didSelectURL
             )
+            manuallyVerifyLabel.accessibilityIdentifier = "consent_manually_verify_label"
             verticalStackView.addArrangedSubview(manuallyVerifyLabel)
             verticalStackView.setCustomSpacing(24, after: agreeButton)
         }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/ManualEntry/ManualEntryFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/ManualEntry/ManualEntryFooterView.swift
@@ -21,6 +21,7 @@ final class ManualEntryFooterView: UIView {
         NSLayoutConstraint.activate([
             continueButton.heightAnchor.constraint(equalToConstant: 56)
         ])
+        continueButton.accessibilityIdentifier = "manual_entry_continue_button"
         return continueButton
     }()
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/ManualEntry/ManualEntryFormView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/ManualEntry/ManualEntryFormView.swift
@@ -56,6 +56,7 @@ final class ManualEntryFormView: UIView {
             action: #selector(textFieldTextDidChange),
             for: .editingChanged
         )
+        routingNumberTextField.textField.accessibilityIdentifier = "manual_entry_routing_number_text_field"
         return routingNumberTextField
     }()
     private lazy var accountNumberTextField: ManualEntryTextField = {
@@ -74,6 +75,7 @@ final class ManualEntryFormView: UIView {
             for: .editingChanged
         )
         accountNumberTextField.delegate = self
+        accountNumberTextField.textField.accessibilityIdentifier = "manual_entry_account_number_text_field"
         return accountNumberTextField
     }()
     private lazy var accountNumberConfirmationTextField: ManualEntryTextField = {
@@ -90,6 +92,7 @@ final class ManualEntryFormView: UIView {
             for: .editingChanged
         )
         accountNumberConfirmationTextField.delegate = self
+        accountNumberConfirmationTextField.textField.accessibilityIdentifier = "manual_entry_account_number_confirmation_text_field"
         return accountNumberConfirmationTextField
     }()
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/ManualEntrySuccess/ManualEntrySuccessViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/ManualEntrySuccess/ManualEntrySuccessViewController.swift
@@ -98,6 +98,7 @@ private func CreateFooterView(_ buttonTarget: ManualEntrySuccessViewController) 
     NSLayoutConstraint.activate([
         doneButton.heightAnchor.constraint(equalToConstant: 56)
     ])
+    doneButton.accessibilityIdentifier = "manual_entry_success_done_button"
     let verticalStackView = UIStackView(
         arrangedSubviews: [
             doneButton

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PrepaneView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PrepaneView.swift
@@ -134,6 +134,7 @@ private func CreateFooterView(
     NSLayoutConstraint.activate([
         continueButton.heightAnchor.constraint(equalToConstant: 56)
     ])
+    continueButton.accessibilityIdentifier = "prepane_continue_button"
 
     let footerStackView = UIStackView()
     footerStackView.axis = .vertical

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Success/SuccessFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Success/SuccessFooterView.swift
@@ -23,6 +23,7 @@ final class SuccessFooterView: UIView {
         NSLayoutConstraint.activate([
             doneButton.heightAnchor.constraint(equalToConstant: 56)
         ])
+        doneButton.accessibilityIdentifier = "success_done_button"
         return doneButton
     }()
 


### PR DESCRIPTION
## Summary

^ cleaned up UI tests and added a manual entry test

## Testing

new manual entry test:

https://user-images.githubusercontent.com/105514761/234675631-1a9d765d-43bd-4412-b2c5-19f2cb967c75.mp4

Ran `bitrise run financial-connections-stability-tests`:

```
FinancialConnectionsUITests
    ✓ testDataLiveModeOAuthNativeAuthFlow (29.561 seconds)
    ✓ testDataLiveModeOAuthWebAuthFlow (28.031 seconds)
    ✓ testDataTestModeOAuthNativeAuthFlow (21.002 seconds)
    ✓ testPaymentTestModeLegacyNativeAuthFlow (24.202 seconds)
    ✓ testPaymentTestModeManualEntryNativeAuthFlow (28.232 seconds)


	 Executed 5 tests, with 0 failures (0 unexpected) in 131.028 (131.034) seconds

▸ Test Succeeded



+------------------------------------------------------------------------------+
|            bitrise summary: financial-connections-stability-tests            |
+---+---------------------------------------------------------------+----------+
|   | title                                                         | time (s) |
+---+---------------------------------------------------------------+----------+
| ✓ | Start Xcode simulator                                         | 3.15 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Set CONFIGURATION_BUILD_DIR                                   | 0.63 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Set CONFIGURATION_TEMP_DIR                                    | 0.59 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Set Bundler to use local vendor directory                     | 0.71 sec |
+---+---------------------------------------------------------------+----------+
| - | Git Clone Repository (Skipped)                                | 0.63 sec |
+---+---------------------------------------------------------------+----------+
| Update available: 6 (6.2.3) -> 8.0.1                                         |
|                                                                              |
| Release notes are available below                                            |
| https://github.com/bitrise-steplib/steps-git-clone/releases                  |
+---+---------------------------------------------------------------+----------+
| - | tuist (Skipped)                                               | 0.49 sec |
+---+---------------------------------------------------------------+----------+
| - | Bitrise.io Cache:Pull (Skipped)                               | 0.46 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Bundler                                                       | 0.93 sec |
+---+---------------------------------------------------------------+----------+
| - | Bitrise.io Cache:Push (Skipped)                               | 0.47 sec |
+---+---------------------------------------------------------------+----------+
| - | Restore SPM Cache (Skipped)                                   | 0.46 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Xcode Test for iOS                                            | 2.5 min  |
+---+---------------------------------------------------------------+----------+
| - | Create a PagerDuty alert (Skipped)                            | 0.47 sec |
+---+---------------------------------------------------------------+----------+
| - | Send a Slack message (Skipped)                                | 0.44 sec |
+---+---------------------------------------------------------------+----------+
| - | Deploy to Bitrise.io - Build Artifacts, Test Repo... (Skipped)| 0.67 sec |
+---+---------------------------------------------------------------+----------+
| Total runtime: 2.7 min                                                       |
+------------------------------------------------------------------------------+
```