### PR TITLE
Add support for providing metadata with Apple Pay

### DIFF
--- a/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+ApplePay.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+ApplePay.swift
@@ -58,6 +58,20 @@ extension STPAPIClient {
         with payment: PKPayment,
         completion: @escaping STPPaymentMethodCompletionBlock
     ) {
+        createPaymentMethod(with: payment, metadata: [:], completion: completion)
+    }
+
+    /// Converts a PKPayment object into a Stripe Payment Method using the Stripe API.
+    /// - Parameters:
+    ///   - payment:     The user's encrypted payment information as returned from a PKPaymentAuthorizationController. Cannot be nil.
+    ///   - metadata:    Additional data to be included with the payment method
+    ///   - completion:  The callback to run with the returned Stripe source (and any errors that may have occurred).
+    @objc(createPaymentMethodWithPayment:metadata:completion:)
+    public func createPaymentMethod(
+        with payment: PKPayment,
+        metadata: [String: String],
+        completion: @escaping STPPaymentMethodCompletionBlock
+    ) {
         createToken(with: payment) { token, error in
             if token?.tokenId == nil || error != nil {
                 completion(nil, error ?? NSError.stp_genericConnectionError())
@@ -68,12 +82,11 @@ extension STPAPIClient {
                 let paymentMethodParams = STPPaymentMethodParams(
                     card: cardParams,
                     billingDetails: billingDetails,
-                    metadata: nil
+                    metadata: metadata
                 )
                 self.createPaymentMethod(with: paymentMethodParams, completion: completion)
             }
         }
-
     }
 
     class func billingDetails(from payment: PKPayment) -> STPPaymentMethodBillingDetails? {


### PR DESCRIPTION
## Summary
Added support for providing metadata when creating a payment method with Apple Pay

## Motivation
This [feature request](https://github.com/stripe/stripe-ios/issues/2468)

## Testing
I was not actually able to test the code change. I don't have iOS 16.1 simulators installed for some reason, so I was not able to run the tests. However, the changes are extremely simple and minor. 

NOTE: I'm not saying the code doesn't need to be tested, but just saying the likelihood of tests not passing are, in all likelihood, very minimal, and it will be easy for anyone at Stripe to quickly run the tests and make sure they pass.

## Changelog
I would not consider this a _**notable**_ change. The use case for developers other than myself is likely very small as most other developers would be using STPApplePayContext for Apple Pay payments rather than rolling their own implementation like we are planning on doing.