### PR TITLE
Add support for ACHv2 to decoupled flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ### Payments
 * [Fixed] STPPaymentHandler.handleNextAction allows payment methods that are delayed or require further customer action like like SEPA Debit or OXXO.
 
+### PaymentSheet
+* [Added] Added ACHv2 support to the decoupled flow. Note: the decoupled flow is in Private Beta.
+
 ## 23.7.0 2023-04-24
 ### PaymentSheet
 * [Fixed] Fixed disabled text color, using a lower opacity version of the original color instead of the previous `.tertiaryLabel`.

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -351,6 +351,12 @@ class PaymentSheetTestPlayground: UIViewController {
 
         // Enable experimental payment methods.
 //        PaymentSheet.supportedPaymentMethods += [.link]
+        PaymentSheet.enableACHV2InDeferredFlow = true // TODO(https://jira.corp.stripe.com/browse/BANKCON-6731) Remove this.
+        
+        // Hack to ensure we don't force the native flow unless we're in a UI test
+        if ProcessInfo.processInfo.environment["UITesting"] == nil {
+            UserDefaults.standard.removeObject(forKey: "FINANCIAL_CONNECTIONS_EXAMPLE_APP_ENABLE_NATIVE")
+        }
 
         checkoutButton.addTarget(self, action: #selector(didTapCheckoutButton), for: .touchUpInside)
         checkoutButton.isEnabled = false

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -352,7 +352,7 @@ class PaymentSheetTestPlayground: UIViewController {
         // Enable experimental payment methods.
 //        PaymentSheet.supportedPaymentMethods += [.link]
         PaymentSheet.enableACHV2InDeferredFlow = true // TODO(https://jira.corp.stripe.com/browse/BANKCON-6731) Remove this.
-        
+
         // Hack to ensure we don't force the native flow unless we're in a UI test
         if ProcessInfo.processInfo.environment["UITesting"] == nil {
             UserDefaults.standard.removeObject(forKey: "FINANCIAL_CONNECTIONS_EXAMPLE_APP_ENABLE_NATIVE")

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -356,6 +356,9 @@ class PaymentSheetTestPlayground: UIViewController {
         // Hack to ensure we don't force the native flow unless we're in a UI test
         if ProcessInfo.processInfo.environment["UITesting"] == nil {
             UserDefaults.standard.removeObject(forKey: "FINANCIAL_CONNECTIONS_EXAMPLE_APP_ENABLE_NATIVE")
+        } else {
+            // This makes the Financial Connections SDK use the native UI instead of webview. Native is much easier to test.
+            UserDefaults.standard.set(true, forKey: "FINANCIAL_CONNECTIONS_EXAMPLE_APP_ENABLE_NATIVE")
         }
 
         checkoutButton.addTarget(self, action: #selector(didTapCheckoutButton), for: .touchUpInside)

--- a/Example/PaymentSheet Example/PaymentSheetUITest/MockFiles/elements_sessions_paymentMethod_200.json
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/MockFiles/elements_sessions_paymentMethod_200.json
@@ -72,6 +72,7 @@
     },
     "type": "payment_intent"
   },
+  "session_id": "123",
   "shipping_address_settings": {
     "autocomplete_allowed": false
   },

--- a/Example/PaymentSheet Example/PaymentSheetUITest/MockFiles/elements_sessions_paymentMethod_link_200.json
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/MockFiles/elements_sessions_paymentMethod_link_200.json
@@ -96,6 +96,7 @@
     },
     "type": "payment_intent"
   },
+  "session_id": "123",
   "shipping_address_settings": {
     "autocomplete_allowed": true
   },

--- a/Example/PaymentSheet Example/PaymentSheetUITest/MockFiles/elements_sessions_paymentMethod_savedPM_200.json
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/MockFiles/elements_sessions_paymentMethod_savedPM_200.json
@@ -101,6 +101,7 @@
     },
     "type": "payment_intent"
   },
+  "session_id": "123",
   "shipping_address_settings": {
     "autocomplete_allowed": false
   },

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetSnapshotTests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetSnapshotTests.swift
@@ -1050,7 +1050,11 @@ class PaymentSheetSnapshotTests: FBSnapshotTestCase {
         }
         testWindow.rootViewController = navController
 
-        paymentSheet.present(from: vc, completion: { _ in })
+        paymentSheet.present(from: vc) { result in
+            if case let .failed(error) = result {
+                XCTFail("Presentation failed: \(error)")
+            }
+        }
 
         // Payment sheet usually takes anywhere between 50ms-200ms (but once in a while 2-3 seconds).
         // to present with the expected content. When the sheet is presented, it initially shows a loading screen,

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -24,14 +24,7 @@ class PaymentSheetUITest: XCTestCase {
             // This makes the Financial Connections SDK trigger the (testmode) production flow instead of a stub. See FinancialConnectionsSDKAvailability.isUnitTestOrUITest.
             "USE_PRODUCTION_FINANCIAL_CONNECTIONS_SDK": "true",
         ]
-        // This makes the Financial Connections SDK use the native UI instead of webview. Native is much easier to test.
-        UserDefaults.standard.set(true, forKey: "FINANCIAL_CONNECTIONS_EXAMPLE_APP_ENABLE_NATIVE")
         app.launch()
-    }
-
-    override func tearDown() {
-        super.tearDown()
-        UserDefaults.standard.removeObject(forKey: "FINANCIAL_CONNECTIONS_EXAMPLE_APP_ENABLE_NATIVE")
     }
 
     func testPaymentSheetStandard() throws {
@@ -1883,9 +1876,9 @@ extension PaymentSheetUITest {
         continueButton.tap()
 
         // Go through connections flow
-        app.buttons["Agree"].tap()
+        app.buttons["Agree and continue"].tap()
         app.staticTexts["Test Institution"].forceTapElement()
-        app.staticTexts["Success"].tap()
+        app.staticTexts["Success"].waitForExistenceAndTap(timeout: 10)
         app.buttons["Link account"].tap()
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10))
         app.buttons.matching(identifier: "Done").allElementsBoundByIndex.last?.tap()

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -22,13 +22,13 @@ class PaymentSheetUITest: XCTestCase {
         app.launchEnvironment = [
             "UITesting": "true",
             // This makes the Financial Connections SDK trigger the (testmode) production flow instead of a stub. See FinancialConnectionsSDKAvailability.isUnitTestOrUITest.
-            "USE_PRODUCTION_FINANCIAL_CONNECTIONS_SDK": "true"
+            "USE_PRODUCTION_FINANCIAL_CONNECTIONS_SDK": "true",
         ]
         // This makes the Financial Connections SDK use the native UI instead of webview. Native is much easier to test.
         UserDefaults.standard.set(true, forKey: "FINANCIAL_CONNECTIONS_EXAMPLE_APP_ENABLE_NATIVE")
         app.launch()
     }
-    
+
     override func tearDown() {
         super.tearDown()
         UserDefaults.standard.removeObject(forKey: "FINANCIAL_CONNECTIONS_EXAMPLE_APP_ENABLE_NATIVE")
@@ -624,11 +624,11 @@ class PaymentSheetUITest: XCTestCase {
 
         // no pay button tap because linked account is stubbed/fake in UI test
     }
-    
+
     func testPaymentIntent_USBankAccount() {
         _testUSBankAccount(mode: "Pay", initMode: "Normal")
     }
-    
+
     func testSetupIntent_USBankAccount() {
         _testUSBankAccount(mode: "Setup", initMode: "Normal")
     }
@@ -894,23 +894,23 @@ extension PaymentSheetUITest {
 
         payWithApplePay()
     }
-    
+
     func testDeferredIntentPaymentIntent_USBankAccount_ClientSideConfirmation() {
         _testUSBankAccount(mode: "Pay", initMode: "Deferred", confirmMode: "Client")
     }
-    
+
     func testDeferredIntentPaymentIntent_USBankAccount_ServerSideConfirmation() {
         _testUSBankAccount(mode: "Pay", initMode: "Deferred", confirmMode: "Server")
     }
-    
+
     func testDeferredIntentSetupIntent_USBankAccount_ClientSideConfirmation() {
         _testUSBankAccount(mode: "Setup", initMode: "Deferred", confirmMode: "Client")
     }
-    
+
     func testDeferredIntentSetupIntent_USBankAccount_ServerSideConfirmation() {
         _testUSBankAccount(mode: "Setup", initMode: "Deferred", confirmMode: "Server")
     }
-    
+
 /* Disable Link test
     func testDeferredIntentLinkSignIn_ClientSideConfirmation() throws {
         loadPlayground(
@@ -1865,14 +1865,14 @@ extension PaymentSheetUITest {
         }
         loadPlayground(app, settings: settings)
         app.buttons["Checkout (Complete)"].tap()
-        
+
         // Select US Bank Account
         guard let usBankAccount = scroll(collectionView: app.collectionViews.firstMatch, toFindCellWithId: "US Bank Account") else {
             XCTFail()
             return
         }
         usBankAccount.tap()
-        
+
         // Fill out name and email fields
         let continueButton = app.buttons["Continue"]
         XCTAssertFalse(continueButton.isEnabled)
@@ -1881,7 +1881,7 @@ extension PaymentSheetUITest {
         app.typeText("test@example.com" + XCUIKeyboardKey.return.rawValue)
         XCTAssertTrue(continueButton.isEnabled)
         continueButton.tap()
-        
+
         // Go through connections flow
         app.buttons["Agree"].tap()
         app.staticTexts["Test Institution"].forceTapElement()
@@ -1889,14 +1889,14 @@ extension PaymentSheetUITest {
         app.buttons["Link account"].tap()
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10))
         app.buttons.matching(identifier: "Done").allElementsBoundByIndex.last?.tap()
-        
+
         // Confirm
         let confirmButtonText = mode == "Pay" ? "Pay $50.99" : "Set up"
         app.buttons[confirmButtonText].tap()
         let successText = app.staticTexts["Success!"]
         XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
         app.buttons["OK"].tap()
-        
+
         // Reload and pay with the now-saved us bank account
         reload(app)
         app.buttons["Checkout (Complete)"].tap()
@@ -1905,7 +1905,7 @@ extension PaymentSheetUITest {
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10))
         app.buttons["OK"].tap()
     }
-    
+
     private func payWithApplePay() {
         let applePay = XCUIApplication(bundleIdentifier: "com.apple.PassbookUIService")
         _ = applePay.wait(for: .runningForeground, timeout: 10)

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -19,8 +19,19 @@ class PaymentSheetUITest: XCTestCase {
         continueAfterFailure = false
 
         app = XCUIApplication()
-        app.launchEnvironment = ["UITesting": "true"]
+        app.launchEnvironment = [
+            "UITesting": "true",
+            // This makes the Financial Connections SDK trigger the (testmode) production flow instead of a stub. See FinancialConnectionsSDKAvailability.isUnitTestOrUITest.
+            "USE_PRODUCTION_FINANCIAL_CONNECTIONS_SDK": "true"
+        ]
+        // This makes the Financial Connections SDK use the native UI instead of webview. Native is much easier to test.
+        UserDefaults.standard.set(true, forKey: "FINANCIAL_CONNECTIONS_EXAMPLE_APP_ENABLE_NATIVE")
         app.launch()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        UserDefaults.standard.removeObject(forKey: "FINANCIAL_CONNECTIONS_EXAMPLE_APP_ENABLE_NATIVE")
     }
 
     func testPaymentSheetStandard() throws {
@@ -554,6 +565,8 @@ class PaymentSheetUITest: XCTestCase {
     }
 
     func testUSBankAccountPaymentMethod() throws {
+        app.launchEnvironment = app.launchEnvironment.merging(["USE_PRODUCTION_FINANCIAL_CONNECTIONS_SDK": "false"]) { (_, new) in new }
+        app.launch()
         loadPlayground(
             app,
             settings: [
@@ -610,6 +623,14 @@ class PaymentSheetUITest: XCTestCase {
         )
 
         // no pay button tap because linked account is stubbed/fake in UI test
+    }
+    
+    func testPaymentIntent_USBankAccount() {
+        _testUSBankAccount(mode: "Pay", initMode: "Normal")
+    }
+    
+    func testSetupIntent_USBankAccount() {
+        _testUSBankAccount(mode: "Setup", initMode: "Normal")
     }
 
     func testUPIPaymentMethod() throws {
@@ -873,6 +894,23 @@ extension PaymentSheetUITest {
 
         payWithApplePay()
     }
+    
+    func testDeferredIntentPaymentIntent_USBankAccount_ClientSideConfirmation() {
+        _testUSBankAccount(mode: "Pay", initMode: "Deferred", confirmMode: "Client")
+    }
+    
+    func testDeferredIntentPaymentIntent_USBankAccount_ServerSideConfirmation() {
+        _testUSBankAccount(mode: "Pay", initMode: "Deferred", confirmMode: "Server")
+    }
+    
+    func testDeferredIntentSetupIntent_USBankAccount_ClientSideConfirmation() {
+        _testUSBankAccount(mode: "Setup", initMode: "Deferred", confirmMode: "Client")
+    }
+    
+    func testDeferredIntentSetupIntent_USBankAccount_ServerSideConfirmation() {
+        _testUSBankAccount(mode: "Setup", initMode: "Deferred", confirmMode: "Server")
+    }
+    
 /* Disable Link test
     func testDeferredIntentLinkSignIn_ClientSideConfirmation() throws {
         loadPlayground(
@@ -1814,6 +1852,60 @@ extension PaymentSheetUITest {
 
 // MARK: Helpers
 extension PaymentSheetUITest {
+    func _testUSBankAccount(mode: String, initMode: String, confirmMode: String? = nil) {
+        var settings = [
+            "customer_mode": "new",
+            "automatic_payment_methods": "off",
+            "allows_delayed_pms": "true",
+            "init_mode": initMode,
+            "mode": mode,
+        ]
+        if let confirmMode {
+            settings["confirm_mode"] = confirmMode
+        }
+        loadPlayground(app, settings: settings)
+        app.buttons["Checkout (Complete)"].tap()
+        
+        // Select US Bank Account
+        guard let usBankAccount = scroll(collectionView: app.collectionViews.firstMatch, toFindCellWithId: "US Bank Account") else {
+            XCTFail()
+            return
+        }
+        usBankAccount.tap()
+        
+        // Fill out name and email fields
+        let continueButton = app.buttons["Continue"]
+        XCTAssertFalse(continueButton.isEnabled)
+        app.textFields["Full name"].tap()
+        app.typeText("John Doe" + XCUIKeyboardKey.return.rawValue)
+        app.typeText("test@example.com" + XCUIKeyboardKey.return.rawValue)
+        XCTAssertTrue(continueButton.isEnabled)
+        continueButton.tap()
+        
+        // Go through connections flow
+        app.buttons["Agree"].tap()
+        app.staticTexts["Test Institution"].forceTapElement()
+        app.staticTexts["Success"].tap()
+        app.buttons["Link account"].tap()
+        XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10))
+        app.buttons.matching(identifier: "Done").allElementsBoundByIndex.last?.tap()
+        
+        // Confirm
+        let confirmButtonText = mode == "Pay" ? "Pay $50.99" : "Set up"
+        app.buttons[confirmButtonText].tap()
+        let successText = app.staticTexts["Success!"]
+        XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
+        app.buttons["OK"].tap()
+        
+        // Reload and pay with the now-saved us bank account
+        reload(app)
+        app.buttons["Checkout (Complete)"].tap()
+        XCTAssertTrue(app.buttons["••••6789"].waitForExistenceAndTap())
+        app.buttons[confirmButtonText].tap()
+        XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10))
+        app.buttons["OK"].tap()
+    }
+    
     private func payWithApplePay() {
         let applePay = XCUIApplication(bundleIdentifier: "com.apple.PassbookUIService")
         _ = applePay.wait(for: .runningForeground, timeout: 10)

--- a/Stripe/StripeiOSTests/STPAPIClient+LinkAccountSessionTest.swift
+++ b/Stripe/StripeiOSTests/STPAPIClient+LinkAccountSessionTest.swift
@@ -13,7 +13,7 @@ final class STPAPIClient_LinkAccountSessionTest: XCTestCase {
     func testCreateLinkAccountSessionForDeferredIntent() {
         let e = expectation(description: "create link account session")
         let apiClient = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
-        apiClient.createLinkAccountSessionForDeferredIntent(sessionId: "mobile_test_\(UUID().uuidString)", onBehalfOf: nil) { linkAccountSession, error in
+        apiClient.createLinkAccountSessionForDeferredIntent(sessionId: "mobile_test_\(UUID().uuidString)", amount: nil, currency: nil, onBehalfOf: nil) { linkAccountSession, error in
             XCTAssertNil(error)
             XCTAssertNotNil(linkAccountSession)
             e.fulfill()

--- a/Stripe/StripeiOSTests/STPAPIClient+LinkAccountSessionTest.swift
+++ b/Stripe/StripeiOSTests/STPAPIClient+LinkAccountSessionTest.swift
@@ -1,0 +1,23 @@
+//
+//  STPAPIClient+LinkAccountSessionTest.swift
+//  StripeiOSTests
+//
+//  Created by Yuki Tokuhiro on 4/26/23.
+//
+
+import XCTest
+@testable import StripePayments
+
+final class STPAPIClient_LinkAccountSessionTest: XCTestCase {
+    
+    func testCreateLinkAccountSessionForDeferredIntent() {
+        let e = expectation(description: "create link account session")
+        let apiClient = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
+        apiClient.createLinkAccountSessionForDeferredIntent(sessionId: "mobile_test_\(UUID().uuidString)", onBehalfOf: nil) { linkAccountSession, error in
+            XCTAssertNil(error)
+            XCTAssertNotNil(linkAccountSession)
+            e.fulfill()
+        }
+        waitForExpectations(timeout: 10)
+    }
+}

--- a/Stripe/StripeiOSTests/STPAPIClient+LinkAccountSessionTest.swift
+++ b/Stripe/StripeiOSTests/STPAPIClient+LinkAccountSessionTest.swift
@@ -5,11 +5,11 @@
 //  Created by Yuki Tokuhiro on 4/26/23.
 //
 
-import XCTest
 @testable import StripePayments
+import XCTest
 
 final class STPAPIClient_LinkAccountSessionTest: XCTestCase {
-    
+
     func testCreateLinkAccountSessionForDeferredIntent() {
         let e = expectation(description: "create link account session")
         let apiClient = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPElementsSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPElementsSession.swift
@@ -10,6 +10,8 @@ import Foundation
 
 /// The response returned by v1/elements/sessions
 @_spi(STP) public final class STPElementsSession: NSObject {
+    /// Elements Session ID for analytics purposes, looks like "elements_session_1234"
+    public let sessionID: String
 
     /// The ordered payment method preference for this ElementsSession.
     public let orderedPaymentMethodTypes: [STPPaymentMethodType]
@@ -33,6 +35,7 @@ import Foundation
         let props: [String] = [
             // Object
             String(format: "%@: %p", NSStringFromClass(STPElementsSession.self), self),
+            "sessionID = \(sessionID)",
             "orderedPaymentMethodTypes = \(String(describing: orderedPaymentMethodTypes))",
             "unactivatedPaymentMethodTypes = \(String(describing: unactivatedPaymentMethodTypes))",
             "linkSettings = \(String(describing: linkSettings))",
@@ -45,6 +48,7 @@ import Foundation
 
     private init(
         allResponseFields: [AnyHashable: Any],
+        sessionID: String,
         orderedPaymentMethodTypes: [STPPaymentMethodType],
         unactivatedPaymentMethodTypes: [STPPaymentMethodType],
         countryCode: String?,
@@ -52,6 +56,7 @@ import Foundation
         paymentMethodSpecs: [[AnyHashable: Any]]?
     ) {
         self.allResponseFields = allResponseFields
+        self.sessionID = sessionID
         self.orderedPaymentMethodTypes = orderedPaymentMethodTypes
         self.unactivatedPaymentMethodTypes = unactivatedPaymentMethodTypes
         self.countryCode = countryCode
@@ -66,7 +71,8 @@ extension STPElementsSession: STPAPIResponseDecodable {
     public static func decodedObject(fromAPIResponse response: [AnyHashable: Any]?) -> Self? {
         guard let dict = response,
             let paymentMethodPrefDict = dict["payment_method_preference"] as? [AnyHashable: Any],
-            let paymentMethodTypeStrings = paymentMethodPrefDict["ordered_payment_method_types"] as? [String]
+            let paymentMethodTypeStrings = paymentMethodPrefDict["ordered_payment_method_types"] as? [String],
+            let sessionID = dict["session_id"] as? String
         else {
             return nil
         }
@@ -74,6 +80,7 @@ extension STPElementsSession: STPAPIResponseDecodable {
 
         return STPElementsSession(
             allResponseFields: dict,
+            sessionID: sessionID,
             orderedPaymentMethodTypes: paymentMethodTypeStrings.map({ STPPaymentMethod.type(from: $0) }),
             unactivatedPaymentMethodTypes: unactivatedPaymentMethodTypeStrings.map({ STPPaymentMethod.type(from: $0) }),
             countryCode: paymentMethodPrefDict["country_code"] as? String,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
@@ -369,11 +369,21 @@ class AddPaymentMethodViewController: UIViewController {
                 financialConnectionsCompletion: financialConnectionsCompletion
             )
         case let .deferredIntent(elementsSession, intentConfig):
-            // I observed a blank webview unless the session ID is unique per attempt, so append a UUID.
-            let sessionId = elementsSession.sessionID + "--" + UUID().uuidString
+            let amount: Int?
+            let currency: String?
+            switch intentConfig.mode {
+            case let .payment(amount: _amount, currency: _currency, _, _):
+                amount = _amount
+                currency = _currency
+            case let .setup(currency: _currency, _):
+                amount = nil
+                currency = _currency
+            }
             client.collectBankAccountForDeferredIntent(
-                sessionId: sessionId,
+                sessionId: elementsSession.sessionID,
                 returnURL: configuration.returnURL,
+                amount: amount,
+                currency: currency,
                 onBehalfOf: intentConfig.onBehalfOf,
                 from: viewController,
                 financialConnectionsCompletion: financialConnectionsCompletion

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
@@ -368,8 +368,16 @@ class AddPaymentMethodViewController: UIViewController {
                 from: viewController,
                 financialConnectionsCompletion: financialConnectionsCompletion
             )
-        case .deferredIntent:
-            fatalError("TODO(DeferredIntent): Support ACHv2")
+        case let .deferredIntent(elementsSession, intentConfig):
+            // I observed a blank webview unless the session ID is unique per attempt, so append a UUID.
+            let sessionId = elementsSession.sessionID + "--" + UUID().uuidString
+            client.collectBankAccountForDeferredIntent(
+                sessionId: sessionId,
+                returnURL: configuration.returnURL,
+                onBehalfOf: intentConfig.onBehalfOf,
+                from: viewController,
+                financialConnectionsCompletion: financialConnectionsCompletion
+            )
         }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -249,11 +249,6 @@ extension PaymentSheet {
             intent: Intent,
             supportedPaymentMethods: [STPPaymentMethodType] = PaymentSheet.supportedPaymentMethods
         ) -> PaymentMethodAvailabilityStatus {
-            if paymentMethod == .USBankAccount, case .deferredIntent = intent {
-                // TODO(DeferredIntent): Support ACHv2
-                return .notSupported
-            }
-
             guard let stpPaymentMethodType = paymentMethod.stpPaymentMethodType else {
                 // if the payment method cannot be represented as a `STPPaymentMethodType` attempt to read it
                 // as a dynamic payment method

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -253,7 +253,7 @@ extension PaymentSheet {
                 // TODO(DeferredIntent): Remove this code when https://jira.corp.stripe.com/browse/BANKCON-6731 is complete
                 return .notSupported
             }
-            
+
             guard let stpPaymentMethodType = paymentMethod.stpPaymentMethodType else {
                 // if the payment method cannot be represented as a `STPPaymentMethodType` attempt to read it
                 // as a dynamic payment method

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -249,6 +249,11 @@ extension PaymentSheet {
             intent: Intent,
             supportedPaymentMethods: [STPPaymentMethodType] = PaymentSheet.supportedPaymentMethods
         ) -> PaymentMethodAvailabilityStatus {
+            if paymentMethod == .USBankAccount, case .deferredIntent = intent, !PaymentSheet.enableACHV2InDeferredFlow {
+                // TODO(DeferredIntent): Remove this code when https://jira.corp.stripe.com/browse/BANKCON-6731 is complete
+                return .notSupported
+            }
+            
             guard let stpPaymentMethodType = paymentMethod.stpPaymentMethodType else {
                 // if the payment method cannot be represented as a `STPPaymentMethodType` attempt to read it
                 // as a dynamic payment method

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -479,14 +479,11 @@ extension PaymentSheet {
             }
 
         case .deferredIntent(let intentConfig):
-            let deferredIntentHandlerCompletionBlock: ((STPElementsSession) -> Void) = { elementsSession in
-                intentPromise.resolve(with: .deferredIntent(elementsSession: elementsSession, intentConfig: intentConfig))
-            }
 
             configuration.apiClient.retrieveElementsSession(withIntentConfig: intentConfig) { result in
                 switch result {
                 case .success(let elementsSession):
-                    deferredIntentHandlerCompletionBlock(elementsSession)
+                    intentPromise.resolve(with: .deferredIntent(elementsSession: elementsSession, intentConfig: intentConfig))
                 case .failure(let error):
                     intentPromise.reject(with: error)
                 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+DeferredAPI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+DeferredAPI.swift
@@ -22,7 +22,6 @@ extension PaymentSheet {
         guard let paymentMethodParams = paymentMethodParams else {
             throw PaymentSheetError.unknown(debugDescription: "paymentMethodParams unexpectedly nil")
         }
-
         return try await apiClient.createPaymentMethod(with: paymentMethodParams)
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
@@ -27,6 +27,8 @@ extension PaymentSheet {
         .UPI,
         .cashApp,
     ]
+    /// Whether to enable ACHv2 in the deferred flow.  To be deleted when https://jira.corp.stripe.com/browse/BANKCON-6731 is completed.
+    @_spi(STP) public static var enableACHV2InDeferredFlow: Bool = false
 
     /// An unordered list of paymentMethodtypes that can be used with Link in PaymentSheet
     /// - Note: This is a var because it depends on the authenticated Link user

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
@@ -146,7 +146,7 @@ extension PaymentSheet {
             case .userSupportsDelayedPaymentMethods:
                 return "userSupportsDelayedPaymentMethods: PaymentSheet.Configuration.allowsDelayedPaymentMethods must be set to true."
             case .financialConnectionsSDK:
-                return "financialConnectionsSDK: The FinancialConnections SDK must be linked."
+                return "financialConnectionsSDK: The FinancialConnections SDK must be linked. See https://stripe.com/docs/payments/accept-a-payment?platform=ios&ui=payment-sheet#ios-ach"
             case .validUSBankVerificationMethod:
                 return "validUSBankVerificationMethod: Requires a valid US bank verification method."
             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
@@ -92,8 +92,8 @@ extension Intent: PaymentMethodRequirementProvider {
             }
             return reqs
         case .deferredIntent:
-            // TODO(DeferredIntent): Allow ACHv2
-            return []
+            // Verification method is always 'automatic'
+            return [.validUSBankVerificationMethod]
         }
     }
 }

--- a/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+LinkAccountSession.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+LinkAccountSession.swift
@@ -53,16 +53,19 @@ extension STPAPIClient {
 
     func createLinkAccountSessionForDeferredIntent(
         sessionId: String,
+        amount: Int?,
+        currency: String?,
         onBehalfOf: String?,
         completion: @escaping STPLinkAccountSessionBlock
     ) {
         let endpoint: String = "connections/link_account_sessions_for_deferred_payment"
         var parameters: [String: Any] = [
             "unique_id": sessionId,
+            "verification_method": STPPaymentMethodOptions.USBankAccount.VerificationMethod.automatic.rawValue, // Hardcoded b/c the merchant can't choose in the deferred flow
         ]
-        if let onBehalfOf {
-            parameters["on_behalf_of"] = onBehalfOf
-        }
+        parameters["amount"] = amount
+        parameters["currency"] = currency
+        parameters["on_behalf_of"] = onBehalfOf
         APIRequest<LinkAccountSession>.post(
             with: self,
             endpoint: endpoint,

--- a/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+LinkAccountSession.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+LinkAccountSession.swift
@@ -50,7 +50,7 @@ extension STPAPIClient {
             completion: completion
         )
     }
-    
+
     func createLinkAccountSessionForDeferredIntent(
         sessionId: String,
         onBehalfOf: String?,
@@ -82,7 +82,7 @@ extension STPAPIClient {
         completion: @escaping STPLinkAccountSessionBlock
     ) {
         var parameters: [String: Any] = [
-            "client_secret": clientSecret
+            "client_secret": clientSecret,
         ]
         if let paymentMethodType = STPPaymentMethod.string(from: paymentMethodType) {
             parameters["payment_method_data[type]"] = paymentMethodType

--- a/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+LinkAccountSession.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+LinkAccountSession.swift
@@ -49,7 +49,27 @@ extension STPAPIClient {
             customerEmailAddress: customerEmailAddress,
             completion: completion
         )
-
+    }
+    
+    func createLinkAccountSessionForDeferredIntent(
+        sessionId: String,
+        onBehalfOf: String?,
+        completion: @escaping STPLinkAccountSessionBlock
+    ) {
+        let endpoint: String = "connections/link_account_sessions_for_deferred_payment"
+        var parameters: [String: Any] = [
+            "unique_id": sessionId,
+        ]
+        if let onBehalfOf {
+            parameters["on_behalf_of"] = onBehalfOf
+        }
+        APIRequest<LinkAccountSession>.post(
+            with: self,
+            endpoint: endpoint,
+            parameters: parameters
+        ) { linkAccountSession, _, error in
+            completion(linkAccountSession, error)
+        }
     }
 
     // MARK: - Helper

--- a/StripePayments/StripePayments/Source/Helpers/STPBankAccountCollector.swift
+++ b/StripePayments/StripePayments/Source/Helpers/STPBankAccountCollector.swift
@@ -236,7 +236,7 @@ public class STPBankAccountCollector: NSObject {
             completion: linkAccountSessionCallback
         )
     }
-
+    
     // MARK: Helper
     private func attachLinkAccountSessionToPaymentIntent(
         paymentIntentID: String,
@@ -457,6 +457,44 @@ public class STPBankAccountCollector: NSObject {
                 return
             }
             completion(setupIntent, nil)
+        }
+    }
+    
+    // MARK: - Collect Bank Account - Deferred Intent
+    @_spi(STP) public func collectBankAccountForDeferredIntent(
+        sessionId: String,
+        returnURL: String?,
+        onBehalfOf: String?,
+        from viewController: UIViewController,
+        financialConnectionsCompletion: @escaping (
+            FinancialConnectionsSDKResult?, LinkAccountSession?, NSError?
+        ) -> Void
+    ) {
+        guard
+            let financialConnectionsAPI = FinancialConnectionsSDKAvailability.financialConnections()
+        else {
+            assertionFailure("FinancialConnections SDK has not been linked into your project")
+            financialConnectionsCompletion(nil, nil, error(for: .financialConnectionsSDKNotLinked))
+            return
+        }
+        
+        apiClient.createLinkAccountSessionForDeferredIntent(sessionId: sessionId, onBehalfOf: onBehalfOf) { linkAccountSession, error in
+            if let error = error {
+                financialConnectionsCompletion(nil, nil, self.error(for: .unexpectedError, userInfo: [NSUnderlyingErrorKey: error]))
+                return
+            }
+            guard let linkAccountSession = linkAccountSession else {
+                financialConnectionsCompletion(nil, nil, NSError.stp_genericFailedToParseResponseError())
+                return
+            }
+            financialConnectionsAPI.presentFinancialConnectionsSheet(
+                apiClient: self.apiClient,
+                clientSecret: linkAccountSession.clientSecret,
+                returnURL: returnURL,
+                from: viewController
+            ) { result in
+                financialConnectionsCompletion(result, linkAccountSession, nil)
+            }
         }
     }
 }

--- a/StripePayments/StripePayments/Source/Helpers/STPBankAccountCollector.swift
+++ b/StripePayments/StripePayments/Source/Helpers/STPBankAccountCollector.swift
@@ -464,6 +464,8 @@ public class STPBankAccountCollector: NSObject {
     @_spi(STP) public func collectBankAccountForDeferredIntent(
         sessionId: String,
         returnURL: String?,
+        amount: Int?,
+        currency: String?,
         onBehalfOf: String?,
         from viewController: UIViewController,
         financialConnectionsCompletion: @escaping (
@@ -478,7 +480,12 @@ public class STPBankAccountCollector: NSObject {
             return
         }
 
-        apiClient.createLinkAccountSessionForDeferredIntent(sessionId: sessionId, onBehalfOf: onBehalfOf) { linkAccountSession, error in
+        apiClient.createLinkAccountSessionForDeferredIntent(
+            sessionId: sessionId,
+            amount: amount,
+            currency: currency,
+            onBehalfOf: onBehalfOf
+        ) { linkAccountSession, error in
             if let error = error {
                 financialConnectionsCompletion(nil, nil, self.error(for: .unexpectedError, userInfo: [NSUnderlyingErrorKey: error]))
                 return

--- a/StripePayments/StripePayments/Source/Helpers/STPBankAccountCollector.swift
+++ b/StripePayments/StripePayments/Source/Helpers/STPBankAccountCollector.swift
@@ -236,7 +236,7 @@ public class STPBankAccountCollector: NSObject {
             completion: linkAccountSessionCallback
         )
     }
-    
+
     // MARK: Helper
     private func attachLinkAccountSessionToPaymentIntent(
         paymentIntentID: String,
@@ -459,7 +459,7 @@ public class STPBankAccountCollector: NSObject {
             completion(setupIntent, nil)
         }
     }
-    
+
     // MARK: - Collect Bank Account - Deferred Intent
     @_spi(STP) public func collectBankAccountForDeferredIntent(
         sessionId: String,
@@ -477,7 +477,7 @@ public class STPBankAccountCollector: NSObject {
             financialConnectionsCompletion(nil, nil, error(for: .financialConnectionsSDKNotLinked))
             return
         }
-        
+
         apiClient.createLinkAccountSessionForDeferredIntent(sessionId: sessionId, onBehalfOf: onBehalfOf) { linkAccountSession, error in
             if let error = error {
                 financialConnectionsCompletion(nil, nil, self.error(for: .unexpectedError, userInfo: [NSUnderlyingErrorKey: error]))

--- a/StripePayments/StripePayments/Source/Internal/Helpers/ConnectionsSDKAvailability.swift
+++ b/StripePayments/StripePayments/Source/Internal/Helpers/ConnectionsSDKAvailability.swift
@@ -19,8 +19,8 @@ import UIKit
 
     static let isUnitOrUITest: Bool = {
         #if targetEnvironment(simulator)
-            return NSClassFromString("XCTest") != nil
-                || ProcessInfo.processInfo.environment["UITesting"] != nil
+        let useProductionSDK = ProcessInfo.processInfo.environment["USE_PRODUCTION_FINANCIAL_CONNECTIONS_SDK"] == "true"
+        return !useProductionSDK && (NSClassFromString("XCTest") != nil || ProcessInfo.processInfo.environment["UITesting"] != nil)
         #else
             return false
         #endif


### PR DESCRIPTION
## Summary
Add support for ACHv2 to decoupled flow. 

## Testing
- Adds 4 UI tests for combinations of [Payment, Setup] and [Client-side confirmation, Server-side confirmation].
- Adds 2 UI tests for Payment, Setup in normal mode. 
- [ ] Once I get approval, I'll manually kick off a UI test run before merging.

## Changelog
### PaymentSheet
 [Added] Added ACHv2 support to the decoupled flow. Note: the decoupled flow is in Private Beta.
