### PR TITLE
FC Networking: in sign up pane, disabled phone label animating.

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundMainView.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundMainView.swift
@@ -88,6 +88,10 @@ struct PlaygroundMainView: View {
                         TextField("Public Key (pk_)", text: $viewModel.customPublicKey)
                         TextField("Secret Key (sk_)", text: $viewModel.customSecretKey)
                     }
+
+                    // extra space so keyboard doesn't cover the "CUSTOM KEYS" section
+                    // (SwiftUI, depending on iOS version, doesn't handle keyboard)
+                    Spacer(minLength: 300)
                 }
                 VStack {
                     Button(action: viewModel.didSelectShow) {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
@@ -67,7 +67,7 @@ final class NetworkingLinkSignupViewController: UIViewController {
 
         showLoadingView(true)
     }
-    
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         // delay executing logic until `viewDidAppear` because
@@ -98,7 +98,7 @@ final class NetworkingLinkSignupViewController: UIViewController {
                 }
         }
     }
-    
+
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         if willNavigateToReturningConsumer {
@@ -235,7 +235,7 @@ final class NetworkingLinkSignupViewController: UIViewController {
         let isPhoneNumberValid = formView.phoneNumberElement.validationState.isValid
         footerView?.enableSaveToLinkButton(isEmailValid && isPhoneNumberValid)
     }
-    
+
     private func foundReturningConsumer(withSession consumerSession: ConsumerSessionData) {
         willNavigateToReturningConsumer = true
         delegate?.networkingLinkSignupViewController(
@@ -290,7 +290,10 @@ extension NetworkingLinkSignupViewController: NetworkingLinkSignupBodyFormViewDe
                             let didPrefillPhoneNumber = (self.formView.phoneNumberElement.phoneNumber?.number ?? "").count > 1
                             // if the phone number is pre-filled, we don't focus on the phone number field
                             if !didPrefillPhoneNumber {
-                                self.formView.beginEditingPhoneNumberField()
+                                // this disables the "Phone" label animating (we don't want that animation here)
+                                UIView.performWithoutAnimation {
+                                    self.formView.beginEditingPhoneNumberField()
+                                }
                             } else {
                                 // user is done with e-mail AND phone number, so dismiss the keyboard
                                 // so they can see the "Save to Link" button


### PR DESCRIPTION
## Summary

[bug bash](https://docs.google.com/document/d/1TIAPlrpCNQWPo3uBOTs77qPPBdnTGNaHlM9XnfSz684/edit#heading=h.uvzt26y6fkii): "Phone label animates in weirdly (reduces in size)"

## Testing

notice the phone label no longer animates, but field still does:

https://user-images.githubusercontent.com/105514761/235233019-fb15f493-2e7c-4f45-bbfc-592c5d4424a0.mp4
