### PR TITLE
FC Networking: disabled focusing phone field IF the email has been prefilled

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
@@ -288,9 +288,22 @@ extension NetworkingLinkSignupViewController: NetworkingLinkSignupBodyFormViewDe
                             let didPrefillPhoneNumber = (self.formView.phoneNumberElement.phoneNumber?.number ?? "").count > 1
                             // if the phone number is pre-filled, we don't focus on the phone number field
                             if !didPrefillPhoneNumber {
-                                // this disables the "Phone" label animating (we don't want that animation here)
-                                UIView.performWithoutAnimation {
-                                    self.formView.beginEditingPhoneNumberField()
+                                let didPrefillEmailAddress = {
+                                    if
+                                        let accountholderCustomerEmailAddress = self.dataSource.manifest.accountholderCustomerEmailAddress,
+                                        !accountholderCustomerEmailAddress.isEmpty
+                                    {
+                                        return true
+                                    } else {
+                                        return false
+                                    }
+                                }()
+                                // we don't want to auto-focus the phone number field if we pre-filled the email
+                                if !didPrefillEmailAddress {
+                                    // this disables the "Phone" label animating (we don't want that animation here)
+                                    UIView.performWithoutAnimation {
+                                        self.formView.beginEditingPhoneNumberField()
+                                    }
                                 }
                             } else {
                                 // user is done with e-mail AND phone number, so dismiss the keyboard


### PR DESCRIPTION
## Summary

Since we don't auto-focus email on sign up screen showing, we also don't auto-focus on phone (if email is prefilled). [Doc context in comment thread].(https://docs.google.com/document/d/1TIAPlrpCNQWPo3uBOTs77qPPBdnTGNaHlM9XnfSz684/edit?disco=AAAAv5sTijw)

## Testing

Video that shows that when we DON'T prefill email, it still focuses to the next field automatically:

https://user-images.githubusercontent.com/105514761/235523391-5cdb705b-3017-4373-aa34-49be6b0f448b.mp4

---

Video that shows that when we DO prefill email, it does NOT auto-focus the phone field (which is what we want from doc):

https://user-images.githubusercontent.com/105514761/235523459-2821116a-255d-4cdc-84a2-601d4874e27a.mp4
