### PR TITLE
FC Networking: changed Link Account Picker account row to have a Disconnected label

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerBodyView.swift
@@ -50,8 +50,9 @@ final class LinkAccountPickerBodyView: UIView {
 
         // list all accounts
         accounts.forEach { account in
+            let isDisabled = (account.status != "active")
             let accountRowView = LinkAccountPickerRowView(
-                isDisabled: account.status != "active",
+                isDisabled: isDisabled,
                 didSelect: { [weak self] in
                     guard let self = self else { return }
                     self.delegate?.linkAccountPickerBodyView(
@@ -66,7 +67,7 @@ final class LinkAccountPickerBodyView: UIView {
                 institutionImageUrl: account.institution?.icon?.default,
                 leadingTitle: rowTitles.leadingTitle,
                 trailingTitle: rowTitles.trailingTitle,
-                subtitle: AccountPickerHelpers.rowSubtitle(forAccount: account),
+                subtitle: isDisabled ? STPLocalizedString("Disconnected", "A subtitle on a button that represents a bank account. It explains to the user that this bank account is disconnected and needs to be re-added.") : AccountPickerHelpers.rowSubtitle(forAccount: account),
                 isSelected: selectedAccount?.id == account.id
             )
             verticalStackView.addArrangedSubview(accountRowView)


### PR DESCRIPTION
## Summary

^ [see bug bash doc](https://docs.google.com/document/d/1TIAPlrpCNQWPo3uBOTs77qPPBdnTGNaHlM9XnfSz684/edit?disco=AAAAv5sTik4) and [see this Slack thread for recent context](https://stripe.slack.com/archives/C02KW8G938W/p1683061428586529?thread_ts=1682609438.697809&cid=C02KW8G938W)

## Testing

This should be easy to double-check by reading the code.

Tested in SwiftUI previews:

![Screenshot 2023-05-03 at 2 05 12 PM](https://user-images.githubusercontent.com/105514761/236005742-1e6a25f7-bfdc-47dd-a444-fdff6e8b1770.png)

Also double-checked that live mode non-disabled account still works:

![Simulator Screen Shot - iPhone 13 mini - 2023-05-03 at 14 06 11](https://user-images.githubusercontent.com/105514761/236005816-4799ac99-b9a4-4794-92f0-1eba8ac3bf3d.png)
