### PR TITLE
Financial Connections: introduced FinancialConnectionsFont and ClickableLabelNew to support line spacing.

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/FinancialConnectionsFont.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/FinancialConnectionsFont.swift
@@ -1,0 +1,110 @@
+//
+//  FinancialConnectionsFont.swift
+//  StripeFinancialConnections
+//
+//  Created by Krisjanis Gaidis on 5/2/23.
+//
+
+import Foundation
+import UIKit
+
+// A wrapper around `UIFont` that allows us to specify a `lineHeight`.
+// `UIFont` does not support modifying `lineHeight` so this struct
+// helps us to easily pass around font + line height.
+struct FinancialConnectionsFont {
+
+    let uiFont: UIFont
+    let lineHeight: CGFloat
+
+    // An estimated "top padding of the font character"
+    var topPadding: CGFloat {
+        return max(0, ((lineHeight - uiFont.lineHeight) / 2)) + (uiFont.ascender - uiFont.capHeight)
+    }
+
+    enum HeadingToken {
+        case large
+    }
+    static func heading(_ token: HeadingToken) -> FinancialConnectionsFont {
+        let font: UIFont
+        let lineHeight: CGFloat
+        let appleTextStyle: UIFont.TextStyle
+        switch token {
+        case .large:
+            // 24 size / 32 line height / 600 weight
+            font = UIFont.systemFont(ofSize: 24, weight: .bold)
+            lineHeight = 32
+            appleTextStyle = .title2
+        }
+        return .create(font: font, lineHeight: lineHeight, appleTextStyle: appleTextStyle)
+    }
+
+    enum BodyToken {
+        case small
+        case smallEmphasized
+        case medium
+        case mediumEmphasized
+    }
+    static func body(_ token: BodyToken) -> FinancialConnectionsFont {
+        let font: UIFont
+        let lineHeight: CGFloat
+        let appleTextStyle: UIFont.TextStyle
+        switch token {
+        case .small:
+            // 14 size / 20 line height / 400 weight
+            font = UIFont.systemFont(ofSize: 14, weight: .regular)
+            lineHeight = 20
+            appleTextStyle = .footnote
+        case .smallEmphasized:
+            // 14 size / 20 line height / 600 weight
+            font = UIFont.systemFont(ofSize: 14, weight: .semibold)
+            lineHeight = 20
+            appleTextStyle = .footnote
+        case .medium:
+            // 16 size / 24 line height / 400 weight
+            font = UIFont.systemFont(ofSize: 16, weight: .regular)
+            lineHeight = 24
+            appleTextStyle = .body
+        case .mediumEmphasized:
+            // 16 size / 24 line height / 600 weight
+            font = UIFont.systemFont(ofSize: 16, weight: .semibold)
+            lineHeight = 24
+            appleTextStyle = .body
+        }
+        return .create(font: font, lineHeight: lineHeight, appleTextStyle: appleTextStyle)
+    }
+
+    enum LabelToken {
+        case largeEmphasized
+    }
+    static func label(_ token: LabelToken) -> FinancialConnectionsFont {
+        let font: UIFont
+        let lineHeight: CGFloat
+        let appleTextStyle: UIFont.TextStyle
+        switch token {
+        case .largeEmphasized:
+            // 16 size / 24 line height / 600 weight
+            font = UIFont.systemFont(ofSize: 16, weight: .semibold)
+            lineHeight = 24
+            appleTextStyle = .body
+        }
+        return .create(font: font, lineHeight: lineHeight, appleTextStyle: appleTextStyle)
+    }
+
+    private static func create(font: UIFont, lineHeight: CGFloat, appleTextStyle: UIFont.TextStyle) -> FinancialConnectionsFont {
+        let scaledFont = scaleFont(font, appleTextStyle: appleTextStyle)
+        return FinancialConnectionsFont(
+            uiFont: scaledFont,
+            lineHeight: scaleLineHeight(lineHeight, font: font, scaledFont: scaledFont)
+        )
+    }
+
+    private static func scaleFont(_ font: UIFont, appleTextStyle: UIFont.TextStyle) -> UIFont {
+        let metrics = UIFontMetrics(forTextStyle: appleTextStyle)
+        let scaledFont = metrics.scaledFont(for: font)
+        return scaledFont
+    }
+
+    private static func scaleLineHeight(_ lineHeight: CGFloat, font: UIFont, scaledFont: UIFont) -> CGFloat {
+        return lineHeight * (scaledFont.pointSize / max(1, font.pointSize))
+    }
+}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentBodyView.swift
@@ -13,13 +13,10 @@ import UIKit
 @available(iOSApplicationExtension, unavailable)
 class ConsentBodyView: UIView {
 
-    private let bulletItems: [FinancialConnectionsBulletPoint]
-
     init(
         bulletItems: [FinancialConnectionsBulletPoint],
         didSelectURL: @escaping (URL) -> Void
     ) {
-        self.bulletItems = bulletItems
         super.init(frame: .zero)
         backgroundColor = .customBackgroundColor
 
@@ -55,9 +52,10 @@ private func CreateLabelView(
     imageView.contentMode = .scaleAspectFit
     imageView.setImage(with: iconUrl)
     imageView.translatesAutoresizingMaskIntoConstraints = false
+    let imageDiameter: CGFloat = 16
     NSLayoutConstraint.activate([
-        imageView.widthAnchor.constraint(equalToConstant: 16),
-        imageView.heightAnchor.constraint(equalToConstant: 16),
+        imageView.widthAnchor.constraint(equalToConstant: imageDiameter),
+        imageView.heightAnchor.constraint(equalToConstant: imageDiameter),
     ])
 
     let labelView = BulletPointLabelView(
@@ -68,12 +66,26 @@ private func CreateLabelView(
 
     let horizontalStackView = HitTestStackView(
         arrangedSubviews: [
-            imageView,
+            {
+                // add padding to the `imageView` so the
+                // image is aligned with the label
+                let paddingStackView = UIStackView(
+                    arrangedSubviews: [imageView]
+                )
+                paddingStackView.isLayoutMarginsRelativeArrangement = true
+                paddingStackView.directionalLayoutMargins = NSDirectionalEdgeInsets(
+                    top: labelView.topPadding,
+                    leading: 0,
+                    bottom: 0,
+                    trailing: 0
+                )
+                return paddingStackView
+            }(),
             labelView,
         ]
     )
     horizontalStackView.axis = .horizontal
-    horizontalStackView.spacing = 10
+    horizontalStackView.spacing = 12
     horizontalStackView.alignment = .top
     return horizontalStackView
 }
@@ -97,11 +109,17 @@ private struct ConsentBodyViewUIViewRepresentable: UIViewRepresentable {
                         "Stripe will allow Goldilocks to access only the [data requested](https://www.stripe.com). We never share your login details with them."
                 ),
                 FinancialConnectionsBulletPoint(
-                    icon: FinancialConnectionsImage(default: nil),
+                    icon: FinancialConnectionsImage(
+                        default:
+                            "https://b.stripecdn.com/connections-statics-srv/assets/SailIcon--reserve-primary-3x.png"
+                    ),
                     content: "Your data is encrypted for your protection."
                 ),
                 FinancialConnectionsBulletPoint(
-                    icon: FinancialConnectionsImage(default: nil),
+                    icon: FinancialConnectionsImage(
+                        default:
+                            "https://b.stripecdn.com/connections-statics-srv/assets/SailIcon--reserve-primary-3x.png"
+                    ),
                     content: "You can [disconnect](https://www.stripe.com) your accounts at any time."
                 ),
             ],

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentFooterView.swift
@@ -40,10 +40,10 @@ class ConsentFooterView: HitTestView {
         super.init(frame: .zero)
         backgroundColor = .customBackgroundColor
 
-        let termsAndPrivacyPolicyLabel = ClickableLabel(
-            font: UIFont.stripeFont(forTextStyle: .detail),
-            boldFont: UIFont.stripeFont(forTextStyle: .detailEmphasized),
-            linkFont: UIFont.stripeFont(forTextStyle: .detailEmphasized),
+        let termsAndPrivacyPolicyLabel = ClickableLabelNew(
+            font: .body(.small),
+            boldFont: .body(.smallEmphasized),
+            linkFont: .body(.smallEmphasized),
             textColor: .textSecondary,
             alignCenter: true
         )
@@ -59,13 +59,13 @@ class ConsentFooterView: HitTestView {
             ]
         )
         verticalStackView.axis = .vertical
-        verticalStackView.spacing = 20
+        verticalStackView.spacing = 24
 
         if let belowCtaText = belowCtaText {
-            let manuallyVerifyLabel = ClickableLabel(
-                font: UIFont.stripeFont(forTextStyle: .detail),
-                boldFont: UIFont.stripeFont(forTextStyle: .detailEmphasized),
-                linkFont: UIFont.stripeFont(forTextStyle: .detailEmphasized),
+            let manuallyVerifyLabel = ClickableLabelNew(
+                font: .body(.small),
+                boldFont: .body(.smallEmphasized),
+                linkFont: .body(.smallEmphasized),
                 textColor: .textSecondary,
                 alignCenter: true
             )

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentViewController.swift
@@ -26,11 +26,11 @@ class ConsentViewController: UIViewController {
     private let dataSource: ConsentDataSource
     weak var delegate: ConsentViewControllerDelegate?
 
-    private lazy var titleLabel: ClickableLabel = {
-        let titleLabel = ClickableLabel(
-            font: .stripeFont(forTextStyle: .subtitle),
-            boldFont: .stripeFont(forTextStyle: .subtitle),
-            linkFont: .stripeFont(forTextStyle: .subtitle),
+    private lazy var titleLabel: ClickableLabelNew = {
+        let titleLabel = ClickableLabelNew(
+            font: .heading(.large),
+            boldFont: .heading(.large),
+            linkFont: .heading(.large),
             textColor: .textPrimary,
             alignCenter: dataSource.merchantLogo != nil
         )
@@ -82,21 +82,21 @@ class ConsentViewController: UIViewController {
                         ]
                     )
                     stackView.axis = .vertical
-                    stackView.spacing = 20
+                    stackView.spacing = 24
                     stackView.alignment = .center
                     return stackView
                 } else {
                     return titleLabel
                 }
             }(),
-            headerTopMargin: (dataSource.merchantLogo == nil) ? 16 : 4,
+            headerTopMargin: 16,
             contentView: ConsentBodyView(
                 bulletItems: dataSource.consent.body.bullets,
                 didSelectURL: { [weak self] url in
                     self?.didSelectURLInTextFromBackend(url)
                 }
             ),
-            headerAndContentSpacing: 28.0,
+            headerAndContentSpacing: 24.0,
             footerView: footerView
         )
         paneLayoutView.addTo(view: view)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/BulletPointLabelView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/BulletPointLabelView.swift
@@ -13,6 +13,8 @@ import UIKit
 @available(iOSApplicationExtension, unavailable)
 final class BulletPointLabelView: HitTestView {
 
+    private(set) var topPadding: CGFloat = 0
+
     init(
         title: String?,
         content: String?,
@@ -23,25 +25,31 @@ final class BulletPointLabelView: HitTestView {
         verticalLabelStackView.axis = .vertical
         verticalLabelStackView.spacing = 2
         if let title = title {
-            let primaryLabel = ClickableLabel(
-                font: .stripeFont(forTextStyle: .body),
-                boldFont: .stripeFont(forTextStyle: .bodyEmphasized),
-                linkFont: .stripeFont(forTextStyle: .bodyEmphasized),
+            let font: FinancialConnectionsFont = .body(.medium)
+            let primaryLabel = ClickableLabelNew(
+                font: font,
+                boldFont: .body(.mediumEmphasized),
+                linkFont: .body(.mediumEmphasized),
                 textColor: .textPrimary
             )
             primaryLabel.setText(title, action: didSelectURL)
             verticalLabelStackView.addArrangedSubview(primaryLabel)
+            topPadding = font.topPadding
         }
         if let content = content {
             let displayingOnlyContent = (title == nil)
-            let subtitleLabel = ClickableLabel(
-                font: .stripeFont(forTextStyle: displayingOnlyContent ? .body : .detail),
-                boldFont: .stripeFont(forTextStyle: displayingOnlyContent ? .bodyEmphasized : .detailEmphasized),
-                linkFont: .stripeFont(forTextStyle: displayingOnlyContent ? .bodyEmphasized : .detailEmphasized),
+            let font: FinancialConnectionsFont = displayingOnlyContent ? .body(.medium) : .body(.small)
+            let subtitleLabel = ClickableLabelNew(
+                font: font,
+                boldFont: displayingOnlyContent ? .body(.mediumEmphasized) : .body(.smallEmphasized),
+                linkFont: displayingOnlyContent ? .body(.mediumEmphasized) : .body(.smallEmphasized),
                 textColor: .textSecondary
             )
             subtitleLabel.setText(content, action: didSelectURL)
             verticalLabelStackView.addArrangedSubview(subtitleLabel)
+            if displayingOnlyContent {
+                topPadding = font.topPadding
+            }
         }
         addAndPinSubview(verticalLabelStackView)
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/Button+Extensions.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/Button+Extensions.swift
@@ -11,7 +11,7 @@ import Foundation
 extension Button.Configuration {
     static var financialConnectionsPrimary: Button.Configuration {
         var primaryButtonConfiguration = Button.Configuration.primary()
-        primaryButtonConfiguration.font = .stripeFont(forTextStyle: .bodyEmphasized)
+        primaryButtonConfiguration.font = FinancialConnectionsFont.label(.largeEmphasized).uiFont
         // default
         primaryButtonConfiguration.backgroundColor = .textBrand
         primaryButtonConfiguration.foregroundColor = .white
@@ -26,7 +26,7 @@ extension Button.Configuration {
 
     static var financialConnectionsSecondary: Button.Configuration {
         var secondaryButtonConfiguration = Button.Configuration.secondary()
-        secondaryButtonConfiguration.font = .stripeFont(forTextStyle: .bodyEmphasized)
+        secondaryButtonConfiguration.font = FinancialConnectionsFont.label(.largeEmphasized).uiFont
         // default
         secondaryButtonConfiguration.foregroundColor = .textPrimary
         secondaryButtonConfiguration.backgroundColor = .backgroundContainer

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/ClickableLabelNew.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/ClickableLabelNew.swift
@@ -1,0 +1,174 @@
+//
+//  ClickableLabelNew.swift
+//  StripeFinancialConnections
+//
+//  Created by Krisjanis Gaidis on 5/2/23.
+//
+
+import Foundation
+import SafariServices
+@_spi(STP) import StripeCore
+@_spi(STP) import StripeUICore
+import UIKit
+
+final class ClickableLabelNew: HitTestView {
+
+    private struct LinkDescriptor {
+        let range: NSRange
+        let urlString: String
+        let action: (URL) -> Void
+    }
+
+    private let font: FinancialConnectionsFont
+    private let boldFont: FinancialConnectionsFont
+    private let linkFont: FinancialConnectionsFont
+    private let textColor: UIColor
+    private let alignCenter: Bool
+    private let textView = IncreasedHitTestTextView()
+    private var linkURLStringToAction: [String: (URL) -> Void] = [:]
+
+    init(
+        font: FinancialConnectionsFont,
+        boldFont: FinancialConnectionsFont,
+        linkFont: FinancialConnectionsFont,
+        textColor: UIColor,
+        linkColor: UIColor = .textBrand,
+        alignCenter: Bool = false
+    ) {
+        self.font = font
+        self.boldFont = boldFont
+        self.linkFont = linkFont
+        self.textColor = textColor
+        self.alignCenter = alignCenter
+        super.init(frame: .zero)
+        textView.isScrollEnabled = false
+        textView.delaysContentTouches = false
+        textView.isEditable = false
+        textView.isSelectable = true
+        textView.backgroundColor = UIColor.clear
+        // Get rid of the extra padding added by default to UITextViews
+        textView.textContainerInset = .zero
+        textView.textContainer.lineFragmentPadding = 0.0
+        textView.linkTextAttributes = [
+            .foregroundColor: linkColor
+        ]
+        textView.delegate = self
+        // remove clipping so when user selects an attributed
+        // link, the selection area does not get clipped
+        textView.clipsToBounds = false
+        addAndPinSubview(textView)
+
+        // enable faster tap recognizing
+        if let gestureRecognizers = textView.gestureRecognizers {
+            for gestureRecognizer in gestureRecognizers {
+                if let tapGestureRecognizer = gestureRecognizer as? UITapGestureRecognizer,
+                    tapGestureRecognizer.numberOfTapsRequired == 2
+                {
+                    // double-tap gesture recognizer causes a delay
+                    // to single-tap gesture recognizer so we
+                    // disable it
+                    tapGestureRecognizer.isEnabled = false
+                }
+            }
+        }
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    /// Helper that automatically handles extracting links and, optionally, opening it via `SFSafariViewController`
+    @available(iOSApplicationExtension, unavailable)
+    func setText(
+        _ text: String,
+        action: @escaping ((URL) -> Void) = { url in
+            SFSafariViewController.present(url: url)
+        }
+    ) {
+        let textLinks = text.extractLinks()
+        setText(
+            textLinks.linklessString,
+            links: textLinks.links.map {
+                ClickableLabelNew.LinkDescriptor(
+                    range: $0.range,
+                    urlString: $0.urlString,
+                    action: action
+                )
+            }
+        )
+    }
+
+    private func setText(
+        _ text: String,
+        links: [LinkDescriptor]
+    ) {
+        let paragraphStyle = NSMutableParagraphStyle()
+        if alignCenter {
+            paragraphStyle.alignment = .center
+        }
+        paragraphStyle.minimumLineHeight = font.lineHeight
+        paragraphStyle.maximumLineHeight = font.lineHeight
+        let string = NSMutableAttributedString(
+            string: text,
+            attributes: [
+                .paragraphStyle: paragraphStyle,
+                .font: font.uiFont,
+                .foregroundColor: textColor,
+            ]
+        )
+
+        // apply link attributes
+        for link in links {
+            string.addAttribute(.link, value: link.urlString, range: link.range)
+
+            // setting font in `linkTextAttributes` does not work
+            string.addAttribute(.font, value: linkFont.uiFont, range: link.range)
+
+            linkURLStringToAction[link.urlString] = link.action
+        }
+
+        // apply bold attributes
+        string.addBoldFontAttributesByMarkdownRules(boldFont: boldFont.uiFont)
+
+        textView.attributedText = string
+    }
+}
+
+// MARK: <UITextViewDelegate>
+
+extension ClickableLabelNew: UITextViewDelegate {
+
+    func textView(
+        _ textView: UITextView,
+        shouldInteractWith URL: URL,
+        in characterRange: NSRange,
+        interaction: UITextItemInteraction
+    ) -> Bool {
+        if let linkAction = linkURLStringToAction[URL.absoluteString] {
+            linkAction(URL)
+            return false
+        } else {
+            assertionFailure("Expected every URL to have an action defined. keys:\(linkURLStringToAction); url:\(URL)")
+        }
+        return true
+    }
+
+    func textViewDidChangeSelection(_ textView: UITextView) {
+        // disable the ability to select/copy the text as a way to improve UX
+        textView.selectedTextRange = nil
+    }
+}
+
+private class IncreasedHitTestTextView: UITextView {
+
+    // increase the area of NSAttributedString taps
+    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+        // Note that increasing size here does NOT help to
+        // increase NSAttributedString implementation of how
+        // large a tap area is. As a result, this function
+        // can return `true` and the link-tap may still
+        // not happen.
+        let largerBounds = bounds.insetBy(dx: -20, dy: -20)
+        return largerBounds.contains(point)
+    }
+}


### PR DESCRIPTION
## Summary

This is the first, of many PR's, where we want to change the typography in all panes. 

This PR only modifies the Consent Pane (see test plan of all that is modified).

Two new concepts:
- `FinancialConnectionsFont` (combines UIFont and line height)
- `ClickableLabelNew` (a temporary copy-paste of `ClickableLabel` to support the new font type)

Font references:
- https://sail.stripe.me/foundations/typography/
- https://www.figma.com/file/WAFvoybps5uk3FL4tftaee/Sail?type=design&node-id=26-370&mode=design&t=Hd2oiFSiURfCMlmn-0

## Testing

The design/spacing has also been reviewed by design.

[This is what we want to achieve](https://www.figma.com/file/ikSIQS9Lw0qIr3PSeyyrPP/Connections-V2.5?type=design&node-id=1636-89037&mode=design&t=5PkZrVUywIxjEo01-0).

![Simulator Screen Shot - iPhone 14 Pro - 2023-05-04 at 16 57 05](https://user-images.githubusercontent.com/105514761/236327447-0daa4729-e92d-4420-9d67-7ddb5643832e.png)
