### PR TITLE
Clean up PaymentSheet availability logging

### DIFF
--- a/Stripe/StripeiOSTests/PaymentSheetPaymentMethodTypeTest.swift
+++ b/Stripe/StripeiOSTests/PaymentSheetPaymentMethodTypeTest.swift
@@ -170,7 +170,7 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
                     ),
                     supportedPaymentMethods: sepaFamily.map { $0.stpPaymentMethodType! }
                 ),
-                .missingRequirements([.unavailable, .userSupportsDelayedPaymentMethods])
+                .missingRequirements([.unsupportedForSetup, .userSupportsDelayedPaymentMethods])
             )
 
             // ...and can't be set up
@@ -181,7 +181,7 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
                     intent: .setupIntent(STPFixtures.setupIntent()),
                     supportedPaymentMethods: sepaFamily.map { $0.stpPaymentMethodType! }
                 ),
-                .missingRequirements([.unavailable, .userSupportsDelayedPaymentMethods])
+                .missingRequirements([.unsupportedForSetup, .userSupportsDelayedPaymentMethods])
             )
         }
     }
@@ -617,16 +617,23 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
         var configuration = PaymentSheet.Configuration()
         configuration.returnURL = "http://return-to-url"
 
-        for intent in [Intent.setupIntent(setupIntent), Intent.paymentIntent(paymentIntent)] {
-            XCTAssertEqual(
-                PaymentSheet.PaymentMethodType.supportsAdding(
-                    paymentMethod: paymentMethod,
-                    configuration: configuration,
-                    intent: intent
-                ),
-                .missingRequirements([.unavailable])
-            )
-        }
+        XCTAssertEqual(
+            PaymentSheet.PaymentMethodType.supportsAdding(
+                paymentMethod: paymentMethod,
+                configuration: configuration,
+                intent: Intent.setupIntent(setupIntent)
+            ),
+            .missingRequirements([.unsupportedForSetup])
+        )
+        
+        XCTAssertEqual(
+            PaymentSheet.PaymentMethodType.supportsAdding(
+                paymentMethod: paymentMethod,
+                configuration: configuration,
+                intent: Intent.paymentIntent(paymentIntent)
+            ),
+            .missingRequirements([.unsupported])
+        )
     }
 
     func testSupport() {

--- a/Stripe/StripeiOSTests/PaymentSheetPaymentMethodTypeTest.swift
+++ b/Stripe/StripeiOSTests/PaymentSheetPaymentMethodTypeTest.swift
@@ -625,7 +625,7 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
             ),
             .missingRequirements([.unsupportedForSetup])
         )
-        
+
         XCTAssertEqual(
             PaymentSheet.PaymentMethodType.supportsAdding(
                 paymentMethod: paymentMethod,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
@@ -32,7 +32,8 @@ class AddPaymentMethodViewController: UIViewController {
     lazy var paymentMethodTypes: [PaymentSheet.PaymentMethodType] = {
         let paymentMethodTypes = PaymentSheet.PaymentMethodType.filteredPaymentMethodTypes(
             from: intent,
-            configuration: configuration
+            configuration: configuration,
+            logAvailability: true
         )
         assert(!paymentMethodTypes.isEmpty, "At least one payment method type must be available.")
         return paymentMethodTypes

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -227,7 +227,7 @@ extension PaymentSheet {
                 if logAvailability && availabilityStatus != .supported {
                     // This payment method is being filtered out, log the reason/s why
                     #if DEBUG
-                    print("[Stripe SDK]: PaymentSheet could not offer \(paymentMethodType.displayName):\n* \(availabilityStatus.debugDescription)")
+                    print("[Stripe SDK]: PaymentSheet could not offer \(paymentMethodType.displayName):\n\t* \(availabilityStatus.debugDescription)")
                     #endif
                 }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -24,14 +24,14 @@ extension PaymentSheet {
             case .dynamic("zip"):
                 return [.returnURL]
             default:
-                return [.unavailable]
+                return [.unsupported]
             }
         }
 
         func supportsSaveAndReuseRequirements() -> [PaymentMethodTypeRequirement] {
             switch self {
             default:
-                return [.unavailable]
+                return [.unsupportedForSetup]
             }
         }
 
@@ -227,7 +227,7 @@ extension PaymentSheet {
                 if availabilityStatus != .supported {
                     // This payment method is being filtered out, log the reason/s why
                     #if DEBUG
-                    print("[Stripe SDK]: \(paymentMethodType.displayName) is not being displayed because one or more requirements are not being met or this payment method is not supported by PaymentSheet. \(availabilityStatus.description)\n")
+                    print("[Stripe SDK]: PaymentSheet could not offer \(paymentMethodType.displayName):\n* \(availabilityStatus.debugDescription)")
                     #endif
                 }
 
@@ -286,18 +286,18 @@ extension PaymentSheet {
                     case .iDEAL, .bancontact, .sofort:
                         // SEPA-family PMs are disallowed until we can reuse them for PI+sfu and SI.
                         // n.b. While iDEAL and bancontact are themselves not delayed, they turn into SEPA upon save, which IS delayed.
-                        return [.returnURL, .userSupportsDelayedPaymentMethods, .unavailable]
+                        return [.returnURL, .userSupportsDelayedPaymentMethods, .unsupportedForSetup]
                     case .SEPADebit:
                         // SEPA-family PMs are disallowed until we can reuse them for PI+sfu and SI.
-                        return [.userSupportsDelayedPaymentMethods, .unavailable]
+                        return [.userSupportsDelayedPaymentMethods, .unsupportedForSetup]
                     case .bacsDebit:
                         return [.returnURL, .userSupportsDelayedPaymentMethods]
                     case .AUBECSDebit, .cardPresent, .blik, .weChatPay, .grabPay, .FPX, .giropay, .przelewy24, .EPS,
                         .netBanking, .OXXO, .afterpayClearpay, .UPI, .boleto, .klarna, .link, .linkInstantDebit,
                         .affirm, .cashApp, .unknown:
-                        return [.unavailable]
+                        return [.unsupportedForSetup]
                     @unknown default:
-                        return [.unavailable]
+                        return [.unsupportedForSetup]
                     }
                 }()
             } else {
@@ -320,9 +320,9 @@ extension PaymentSheet {
                     case .afterpayClearpay, .affirm:
                         return [.returnURL, .shippingAddress]
                     case .link, .unknown:
-                        return [.unavailable]
+                        return [.unsupported]
                     @unknown default:
-                        return [.unavailable]
+                        return [.unsupported]
                     }
                 }()
             }
@@ -369,7 +369,7 @@ extension PaymentSheet {
                 case .USBankAccount:
                     return [.userSupportsDelayedPaymentMethods]
                 default:
-                    return [.unavailable]
+                    return [.unsupportedForReuse]
                 }
             }()
             return Self.configurationSupports(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -203,7 +203,7 @@ extension PaymentSheet {
         ///   - intent: An `intent` to extract `PaymentMethodType`s from.
         ///   - configuration: A `PaymentSheet` configuration.
         /// - Returns: An ordered list of `PaymentMethodType`s, including only the ones supported by this configuration.
-        static func filteredPaymentMethodTypes(from intent: Intent, configuration: Configuration) -> [PaymentMethodType]
+        static func filteredPaymentMethodTypes(from intent: Intent, configuration: Configuration, logAvailability: Bool = false) -> [PaymentMethodType]
         {
             var recommendedPaymentMethodTypes = Self.recommendedPaymentMethodTypes(from: intent)
             if configuration.linkPaymentMethodsOnly {
@@ -224,7 +224,7 @@ extension PaymentSheet {
                         ? PaymentSheet.supportedLinkPaymentMethods : PaymentSheet.supportedPaymentMethods
                 )
 
-                if availabilityStatus != .supported {
+                if logAvailability && availabilityStatus != .supported {
                     // This payment method is being filtered out, log the reason/s why
                     #if DEBUG
                     print("[Stripe SDK]: PaymentSheet could not offer \(paymentMethodType.displayName):\n* \(availabilityStatus.debugDescription)")

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
@@ -121,10 +121,10 @@ extension PaymentSheet {
 
         /// A special case that indicates the payment method is unsupported by PaymentSheet when using SetupIntents or SFU
         case unsupportedForSetup
-        
+
         /// A special case that indicates the payment method is unsupported by PaymentSheet for later reuse
         case unsupportedForReuse
-        
+
         /// Indicates that a payment method requires a return URL
         case returnURL
 
@@ -183,7 +183,7 @@ extension PaymentSheet {
             case .unactivated:
                 return "This payment method is enabled for test mode, but is not activated for live mode. Visit the Stripe Dashboard to activate the payment method. https://support.stripe.com/questions/activate-a-new-payment-method"
             case .missingRequirements(let missingRequirements):
-                return missingRequirements.map {$0.debugDescription}.joined(separator: "\n\t* ")
+                return missingRequirements.map { $0.debugDescription }.joined(separator: "\n\t* ")
             }
         }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
@@ -114,9 +114,15 @@ typealias PaymentMethodTypeRequirement = PaymentSheet.PaymentMethodTypeRequireme
 extension PaymentSheet {
     enum PaymentMethodTypeRequirement: Comparable {
 
-        /// A special case that indicates the payment method is unavailable
-        case unavailable
+        /// A special case that indicates the payment method is always unsupported by PaymentSheet
+        case unsupported
 
+        /// A special case that indicates the payment method is unsupported by PaymentSheet when using SetupIntents or SFU
+        case unsupportedForSetup
+        
+        /// A special case that indicates the payment method is unsupported by PaymentSheet for later reuse
+        case unsupportedForReuse
+        
         /// Indicates that a payment method requires a return URL
         case returnURL
 
@@ -135,18 +141,22 @@ extension PaymentSheet {
         /// A helpful description for developers to better understand requirements so they can debug why payment methods are not present
         var debugDescription: String {
             switch self {
-            case .unavailable:
-                return "unavailable: This payment method is not available."
+            case .unsupported:
+                return "This payment method is not currently supported by PaymentSheet."
+            case .unsupportedForSetup:
+                return "This payment method is not currently supported by PaymentSheet when using a PaymentIntent with the `setupFutureUsage` parameter, or when using a SetupIntent."
+            case .unsupportedForReuse:
+                return "PaymentSheet does not currently support reusing this saved payment method."
             case .returnURL:
-                return "returnURL: A return URL must be set, see https://stripe.com/docs/payments/accept-a-payment?platform=ios&ui=payment-sheet#ios-set-up-return-url"
+                return "A return URL must be set, see https://stripe.com/docs/payments/accept-a-payment?platform=ios&ui=payment-sheet#ios-set-up-return-url"
             case .shippingAddress:
-                return "shippingAddress: A shipping address must be present on the Intent or collected through the Address Element and populated on PaymentSheet.Configuration.shippingDetails. See https://stripe.com/docs/api/payment_intents/object#payment_intent_object-shipping and https://stripe.com/docs/elements/address-element/collect-addresses?platform=ios#ios-pre-fill-billing"
+                return "A shipping address must be present on the Intent or collected through the Address Element and populated on PaymentSheet.Configuration.shippingDetails. See https://stripe.com/docs/api/payment_intents/object#payment_intent_object-shipping and https://stripe.com/docs/elements/address-element/collect-addresses?platform=ios#ios-pre-fill-billing"
             case .userSupportsDelayedPaymentMethods:
-                return "userSupportsDelayedPaymentMethods: PaymentSheet.Configuration.allowsDelayedPaymentMethods must be set to true."
+                return "PaymentSheet.Configuration.allowsDelayedPaymentMethods must be set to true."
             case .financialConnectionsSDK:
-                return "financialConnectionsSDK: The FinancialConnections SDK must be linked."
+                return "The FinancialConnections SDK must be linked."
             case .validUSBankVerificationMethod:
-                return "validUSBankVerificationMethod: Requires a valid US bank verification method."
+                return "Requires a valid US bank verification method."
             }
         }
 
@@ -162,16 +172,16 @@ extension PaymentSheet {
         /// This payment method has requirements not met by the configuration or intent
         case missingRequirements(Set<PaymentMethodTypeRequirement>)
 
-        var description: String {
+        var debugDescription: String {
             switch self {
             case .supported:
                 return "Supported by PaymentSheet."
             case .notSupported:
-                return "Not currently supported by PaymentSheet."
+                return "This payment method is not currently supported by PaymentSheet."
             case .unactivated:
-                return "Activated for test mode but not activated for live mode:. Visit the Stripe Dashboard to activate the payment method. https://support.stripe.com/questions/activate-a-new-payment-method"
+                return "This payment method is enabled for test mode, but is not activated for live mode. Visit the Stripe Dashboard to activate the payment method. https://support.stripe.com/questions/activate-a-new-payment-method"
             case .missingRequirements(let missingRequirements):
-                return "\(missingRequirements.reduce("") { $0 + $1.debugDescription }) "
+                return missingRequirements.map {$0.debugDescription}.joined(separator: "\n* ")
             }
         }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
@@ -181,7 +181,7 @@ extension PaymentSheet {
             case .unactivated:
                 return "This payment method is enabled for test mode, but is not activated for live mode. Visit the Stripe Dashboard to activate the payment method. https://support.stripe.com/questions/activate-a-new-payment-method"
             case .missingRequirements(let missingRequirements):
-                return missingRequirements.map {$0.debugDescription}.joined(separator: "\n* ")
+                return missingRequirements.map {$0.debugDescription}.joined(separator: "\n\t* ")
             }
         }
 


### PR DESCRIPTION
## Summary
Cleaning up this logging to make it a little easier to determine why payment methods are unavailable.

Before:
```

[Stripe SDK]: Link is not being displayed because one or more requirements are not being met or this payment method is not supported by PaymentSheet. Not currently supported by PaymentSheet.

[Stripe SDK]: US Bank Account is not being displayed because one or more requirements are not being met or this payment method is not supported by PaymentSheet. userSupportsDelayedPaymentMethods: PaymentSheet.Configuration.allowsDelayedPaymentMethods must be set to true.validUSBankVerificationMethod: Requires a valid US bank verification method. 

[Stripe SDK]: Cash App Pay is not being displayed because one or more requirements are not being met or this payment method is not supported by PaymentSheet. unavailable: This payment method is not available. 
```
After:
```
[Stripe SDK]: PaymentSheet could not offer Cash App Pay:
    * This payment method is not currently supported by PaymentSheet when using a PaymentIntent with the `setupFutureUsage` parameter, or when using a SetupIntent.
[Stripe SDK]: PaymentSheet could not offer US Bank Account:
    * PaymentSheet.Configuration.allowsDelayedPaymentMethods must be set to true.
[Stripe SDK]: PaymentSheet could not offer Alipay:
    * This payment method is not currently supported by PaymentSheet.
```

## Motivation
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-2187

## Testing
Manually