### PR TITLE
Reduce PaymentSheet UI test flake

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -1917,7 +1917,7 @@ extension PaymentSheetUITest {
         reload(app)
         app.buttons["Checkout (Complete)"].tap()
         XCTAssertTrue(app.buttons["••••6789"].waitForExistenceAndTap())
-        app.buttons[confirmButtonText].tap()
+        XCTAssertTrue(app.buttons[confirmButtonText].waitForExistenceAndTap())
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10))
         app.buttons["OK"].tap()
     }


### PR DESCRIPTION
## Summary
These tests were flaky overnight, I think it's because we're racing with the presentation of this button, especially when dismissing the Connections SDK.

## Testing
Will kick off a manual UI Tests builds.