### PR TITLE
Financial Connections: fixed an issue where institution search wasnt scaling nicely with extra-large dynamic type.

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionSearchTableView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionSearchTableView.swift
@@ -109,7 +109,8 @@ final class InstitutionSearchTableView: UIView {
         tableView.backgroundColor = .customBackgroundColor
         tableView.separatorInset = .zero
         tableView.separatorStyle = .none
-        tableView.rowHeight = 54
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.estimatedRowHeight = 54
         tableView.contentInset = UIEdgeInsets(
             // add extra inset at the top/bottom to show the cell-selected-state separators
             top: 1.0 / UIScreen.main.nativeScale,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionSearchTableViewCell.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionSearchTableViewCell.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+@_spi(STP) import StripeUICore
 import UIKit
 
 final class InstitutionSearchTableViewCell: UITableViewCell {
@@ -30,7 +31,6 @@ final class InstitutionSearchTableViewCell: UITableViewCell {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
 
         contentView.backgroundColor = .customBackgroundColor
-        contentView.addSubview(institutionIconView)
 
         let labelStackView = UIStackView(
             arrangedSubviews: [
@@ -40,20 +40,24 @@ final class InstitutionSearchTableViewCell: UITableViewCell {
         )
         labelStackView.axis = .vertical
         labelStackView.spacing = 2
-        contentView.addSubview(labelStackView)
 
-        let horizontalPadding: CGFloat = 24.0
-        institutionIconView.translatesAutoresizingMaskIntoConstraints = false
-        labelStackView.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            institutionIconView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: horizontalPadding),
-            institutionIconView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-
-            labelStackView.leftAnchor.constraint(equalTo: institutionIconView.rightAnchor, constant: 12),
-
-            labelStackView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-            labelStackView.rightAnchor.constraint(equalTo: contentView.rightAnchor, constant: -horizontalPadding),
-        ])
+        let cellStackView = UIStackView(
+            arrangedSubviews: [
+                institutionIconView,
+                labelStackView,
+            ]
+        )
+        cellStackView.axis = .horizontal
+        cellStackView.spacing = 12
+        cellStackView.alignment = .center
+        cellStackView.isLayoutMarginsRelativeArrangement = true
+        cellStackView.directionalLayoutMargins = NSDirectionalEdgeInsets(
+            top: 10,
+            leading: 24,
+            bottom: 10,
+            trailing: 24
+        )
+        contentView.addAndPinSubview(cellStackView)
 
         self.selectedBackgroundView = CreateSelectedBackgroundView()
     }


### PR DESCRIPTION
## Summary

In institution search, we don't have UITableView automatic sized cells. If user selects a special setting to make types extra large (requires an extra toggle in dynamic type settings), then one could start seeing some visual issues of the text being as large as the cell itself. This PR fixes that by adding UITableView automatic sizing.

| Extra Large Sizing Settings | Before | After |
| --- | --- | --- |
| ![EXTRA_LARGE](https://user-images.githubusercontent.com/105514761/236545539-fd1aaabc-324e-42f4-9675-5674a62bf1a1.png) |  ![before-extra-large](https://user-images.githubusercontent.com/105514761/236545599-94678c3c-e89a-4d2e-bba7-8d632b075f06.png) | ![extra-large-after](https://user-images.githubusercontent.com/105514761/236545645-ef6505f0-788e-4463-a273-a80da5c5ee7d.png) |

## Testing

### Video testing extra large after:


https://user-images.githubusercontent.com/105514761/236545873-3e156243-ccf4-4704-a1a0-e2ca5cb94c9c.mp4

## iOS 16 iPhone 14 Pro

| Small | Regular | Large (smaller than extra large) |
| --- | --- | --- |
| ![after-small-ios16-14pro](https://user-images.githubusercontent.com/105514761/236546284-7e422fc7-93e6-4db4-8663-62b7cd4ac300.png) | ![after-regular-ios16-14pro](https://user-images.githubusercontent.com/105514761/236546289-f5a63030-3745-4bfc-b366-66004d92c07d.png) | ![after-large-iOS16-1-14pro](https://user-images.githubusercontent.com/105514761/236546281-25431114-9ac4-4409-98d8-ba217ea2b7b8.png) |

## iOS 15 iPhone SE 

| Small | Regular | Large (smaller than extra large) |
| --- | --- | --- |
|  ![after-small-ios15-iphoneSE](https://user-images.githubusercontent.com/105514761/236546600-101972ab-17bf-46e6-be04-9c40086ceb84.png) | ![after-regular-ios15-iphoneSe](https://user-images.githubusercontent.com/105514761/236546602-05ed6324-8898-4ea4-b9a8-aa230698032b.png) |  ![after-large-ios15-iphoneSE](https://user-images.githubusercontent.com/105514761/236546598-7883d7de-6004-43b3-9beb-968edfda838e.png) |

# iPad

| Regular | Large (smaller than extra large) |
| --- | --- |
| ![after-iPad-regular](https://user-images.githubusercontent.com/105514761/236546766-1f0cbfe0-7bc6-4791-9227-4cc398b92fbf.png) | ![after-iPad-large](https://user-images.githubusercontent.com/105514761/236546772-f1c5be29-bd07-49de-ac05-1cf6627cd2f7.png) |
