### PR TITLE
Dont double fetch the Intent in the decoupled server-side confirmation flow

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPAPIClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPAPIClient+PaymentSheet.swift
@@ -96,9 +96,9 @@ extension STPAPIClient {
     }
 
     /// Async helper version of `retrievePaymentIntent`
-    func retrievePaymentIntent(clientSecret: String) async throws -> STPPaymentIntent {
+    func retrievePaymentIntent(clientSecret: String, expand: [String]) async throws -> STPPaymentIntent {
         return try await withCheckedThrowingContinuation { continuation in
-            retrievePaymentIntent(withClientSecret: clientSecret) { paymentIntent, error in
+            retrievePaymentIntent(withClientSecret: clientSecret, expand: expand) { paymentIntent, error in
                 guard let paymentIntent = paymentIntent else {
                     continuation.resume(throwing: error ?? NSError.stp_genericFailedToParseResponseError())
                     return
@@ -109,9 +109,9 @@ extension STPAPIClient {
     }
 
     /// Async helper version of `retrieveSetupIntent`
-    func retrieveSetupIntent(clientSecret: String) async throws -> STPSetupIntent {
+    func retrieveSetupIntent(clientSecret: String, expand: [String]) async throws -> STPSetupIntent {
         return try await withCheckedThrowingContinuation { continuation in
-            retrieveSetupIntent(withClientSecret: clientSecret) { setupIntent, error in
+            retrieveSetupIntent(withClientSecret: clientSecret, expand: expand) { setupIntent, error in
                 guard let setupIntent = setupIntent else {
                     continuation.resume(throwing: error ?? NSError.stp_genericFailedToParseResponseError())
                     return

--- a/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
@@ -308,7 +308,7 @@ public class STPPaymentHandler: NSObject {
             }
         }
     }
-    
+
     /// (Internal) Handles any `nextAction` required to authenticate the PaymentIntent.
     /// Call this method if you are using server-side confirmation.  - seealso: https://stripe.com/docs/payments/accept-a-payment?platform=ios&ui=custom
     /// - Parameters:
@@ -334,7 +334,7 @@ public class STPPaymentHandler: NSObject {
             assert(paymentIntent.paymentMethod != nil, "A PaymentIntent w/ attached paymentMethod must be retrieved w/ an expanded PaymentMethod")
         }
         Self.inProgress = true
-        
+
         weak var weakSelf = self
         // wrappedCompletion ensures we perform some final logic before calling the completion block.
         let wrappedCompletion: STPPaymentHandlerActionPaymentIntentCompletionBlock = {
@@ -354,7 +354,7 @@ public class STPPaymentHandler: NSObject {
                 paymentIntent.status == .succeeded || paymentIntent.status == .requiresCapture || paymentIntent.status == .requiresConfirmation
                 || (paymentIntent.status == .processing && STPPaymentHandler._isProcessingIntentSuccess(for: paymentIntent.paymentMethod?.type ?? .unknown))
                 || (paymentIntent.status == .requiresAction && strongSelf.isNextActionSuccessState(nextAction: paymentIntent.nextAction))
-                
+
                 if error == nil && successIntentState {
                     completion(.succeeded, paymentIntent, nil)
                 } else {
@@ -369,7 +369,7 @@ public class STPPaymentHandler: NSObject {
             }
             completion(status, paymentIntent, error)
         }
-        
+
         if paymentIntent.status == .requiresConfirmation {
             // The caller forgot to confirm the paymentIntent on the backend before calling this method
             wrappedCompletion(
@@ -527,7 +527,7 @@ public class STPPaymentHandler: NSObject {
             }
         }
     }
-    
+
     /// Handles any `nextAction` required to authenticate the SetupIntent.
     /// Call this method if you are confirming the SetupIntent on your backend and get a status of requires_action.
     /// - Parameters:

--- a/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
@@ -516,7 +516,7 @@ public class STPPaymentHandler: NSObject {
             return
         }
 
-        apiClient.retrieveSetupIntent(withClientSecret: setupIntentClientSecret) { [weak self] setupIntent, error in
+        apiClient.retrieveSetupIntent(withClientSecret: setupIntentClientSecret, expand: ["payment_method"]) { [weak self] setupIntent, error in
             guard let self else {
                 return
             }


### PR DESCRIPTION
## Summary
STPPaymentHandler's two public `handleNextAction` methods first retrieve the PI/SI before continuing.  This PR adds 2 internal variants that _take_ a PI/SI, instead of retrieving it.

## Motivation
Follow-up to https://github.com/stripe/stripe-ios/pull/2545 - avoids double fetching the Intent.

## Testing
Relying on existing tests to catch regressions.

## Changelog
No user facing changes.
