### PR TITLE
Financial Connections: added livemode search end to end tests

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
@@ -295,6 +295,49 @@ final class FinancialConnectionsUITests: XCTestCase {
         let playgroundCancelAlert = app.alerts["Cancelled"]
         XCTAssertTrue(playgroundCancelAlert.waitForExistence(timeout: 60.0))
     }
+
+    func testSearchInLiveModeNativeAuthFlow() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        app.fc_playgroundCell.tap()
+        app.fc_playgroundPaymentFlowButton.tap()
+        app.fc_playgroundNativeButton.tap()
+
+        let enableTestModeSwitch = app.fc_playgroundEnableTestModeSwitch
+        if (enableTestModeSwitch.value as? String) == "1" {
+            enableTestModeSwitch.tap()
+        }
+
+        app.fc_playgroundShowAuthFlowButton.tap()
+        app.fc_nativeConsentAgreeButton.tap()
+
+        let searchBarTextField = app.textFields["search_bar_text_field"]
+        XCTAssertTrue(searchBarTextField.waitForExistence(timeout: 120.0))
+        searchBarTextField.tap()
+        searchBarTextField.typeText("Bank of America")
+
+        let bankOfAmericaSearchRow = app.tables.staticTexts["Bank of America"]
+        XCTAssertTrue(bankOfAmericaSearchRow.waitForExistence(timeout: 120.0))
+        bankOfAmericaSearchRow.tap()
+
+        XCTAssert(app.fc_nativePrepaneContinueButton.exists) // check that prepane was opened
+
+        let backButton = app.navigationBars["fc_navigation_bar"].buttons["Back"]
+        XCTAssertTrue(backButton.waitForExistence(timeout: 60.0))
+        backButton.tap()
+
+        searchBarTextField.tap()
+        searchBarTextField.typeText("testing123")
+
+        let institutionSearchFooterView = app.otherElements["institution_search_footer_view"]
+        XCTAssertTrue(institutionSearchFooterView.waitForExistence(timeout: 120.0))
+        institutionSearchFooterView.tap()
+
+        // check that manual entry screen is opened
+        let manualEntryContinueButton = app.buttons["manual_entry_continue_button"]
+        XCTAssertTrue(manualEntryContinueButton.waitForExistence(timeout: 60.0))
+    }
 }
 
 extension XCTestCase {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/FinancialConnectionsNavigationController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/FinancialConnectionsNavigationController.swift
@@ -42,6 +42,7 @@ class FinancialConnectionsNavigationController: UINavigationController {
         // before a user can fully dismiss
         isModalInPresentation = true
         listenToInteractivePopGestureRecognizer()
+        navigationBar.accessibilityIdentifier = "fc_navigation_bar"
     }
 
     private func logNavigationBackEvent(fromViewController: UIViewController, source: String) {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionSearchBar.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionSearchBar.swift
@@ -57,6 +57,7 @@ final class InstitutionSearchBar: UIView {
             action: #selector(textFieldTextDidChange),
             for: .editingChanged
         )
+        textField.accessibilityIdentifier = "search_bar_text_field"
         return textField
     }()
     private lazy var textFieldClearButton: UIButton = {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionSearchFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionSearchFooterView.swift
@@ -72,6 +72,7 @@ final class InstitutionSearchFooterView: UIView {
         }
 
         self.showTopSeparator = true
+        accessibilityIdentifier = "institution_search_footer_view"
     }
 
     required init?(coder: NSCoder) {


### PR DESCRIPTION
## Summary

This adds end-to-end tests for Native institution search. We recently modified how cells are displayed for search, and it would have been nice to have a test for it too. The test checks whether we can search & open a bank (Bank of America), and whether we can open manual entry from search too.

## Testing

The test:

https://user-images.githubusercontent.com/105514761/236900899-a3a8e730-b2ec-4f0d-a2cc-60c50d132b50.mp4

Then run `bitrise run financial-connections-stability-tests`:

```
Test Suite FinancialConnectionsUITests.xctest started
FinancialConnectionsNetworkingUITests
    ✓ testNativeNetworkingTestMode (73.521 seconds)
FinancialConnectionsUITests
    ✓ testDataLiveModeOAuthNativeAuthFlow (27.476 seconds)
    ✓ testDataLiveModeOAuthWebAuthFlow (24.797 seconds)
    ✓ testDataTestModeOAuthNativeAuthFlow (20.116 seconds)
    ✓ testPaymentTestModeLegacyNativeAuthFlow (23.651 seconds)
    ✓ testPaymentTestModeManualEntryNativeAuthFlow (27.333 seconds)
    ✓ testSearchInLiveModeNativeAuthFlow (25.172 seconds)


+------------------------------------------------------------------------------+
|            bitrise summary: financial-connections-stability-tests            |
+---+---------------------------------------------------------------+----------+
|   | title                                                         | time (s) |
+---+---------------------------------------------------------------+----------+
| ✓ | Start Xcode simulator                                         | 2.55 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Set CONFIGURATION_BUILD_DIR                                   | 0.55 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Set CONFIGURATION_TEMP_DIR                                    | 0.49 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Set Bundler to use local vendor directory                     | 0.64 sec |
+---+---------------------------------------------------------------+----------+
| - | Git Clone Repository (Skipped)                                | 0.58 sec |
+---+---------------------------------------------------------------+----------+
| Update available: 6 (6.2.3) -> 8.0.1                                         |
|                                                                              |
| Release notes are available below                                            |
| https://github.com/bitrise-steplib/steps-git-clone/releases                  |
+---+---------------------------------------------------------------+----------+
| - | tuist (Skipped)                                               | 0.47 sec |
+---+---------------------------------------------------------------+----------+
| - | Bitrise.io Cache:Pull (Skipped)                               | 0.47 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Bundler                                                       | 0.87 sec |
+---+---------------------------------------------------------------+----------+
| - | Bitrise.io Cache:Push (Skipped)                               | 0.44 sec |
+---+---------------------------------------------------------------+----------+
| - | Restore SPM Cache (Skipped)                                   | 0.44 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Xcode Test for iOS                                            | 4.1 min  |
+---+---------------------------------------------------------------+----------+
| - | Create a PagerDuty alert (Skipped)                            | 0.49 sec |
+---+---------------------------------------------------------------+----------+
| - | Send a Slack message (Skipped)                                | 0.45 sec |
+---+---------------------------------------------------------------+----------+
| - | Deploy to Bitrise.io - Build Artifacts, Test Repo... (Skipped)| 0.64 sec |
+---+---------------------------------------------------------------+----------+
| Total runtime: 4.2 min                                                       |
+------------------------------------------------------------------------------+

```