### PR TITLE
[Identity] Improve the DocumentScanner's timeout algorithm

### DIFF
--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/DocumentCaptureViewController.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/DocumentCaptureViewController.swift
@@ -504,7 +504,7 @@ extension DocumentCaptureViewController: ImageScanningSessionDelegate {
         if case let .scanning(_, scanningState?) = imageScanningSession.state, scanningState.matchesDocument(type: documentType, side: documentSide) && scannerOutputOptional == nil {
             imageScanningSession.startTimeoutTimer(expectedClassification: documentSide)
         }
-            
+
         // If this isn't the classification we're looking for, update the state
         // to display a different message to the user
         guard let scannerOutput = scannerOutputOptional,

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/DocumentCaptureViewController.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/DocumentCaptureViewController.swift
@@ -499,6 +499,12 @@ extension DocumentCaptureViewController: ImageScanningSessionDelegate {
         exifMetadata: CameraExifMetadata?,
         expectedClassification documentSide: DocumentSide
     ) {
+        // If scanningState matches, but scannerOutputOptional is nil, it means the previous frame
+        // is a match, but the current frame is not match, reset the timer.
+        if case let .scanning(_, scanningState?) = imageScanningSession.state, scanningState.matchesDocument(type: documentType, side: documentSide) && scannerOutputOptional == nil {
+            imageScanningSession.startTimeoutTimer(expectedClassification: documentSide)
+        }
+            
         // If this isn't the classification we're looking for, update the state
         // to display a different message to the user
         guard let scannerOutput = scannerOutputOptional,

--- a/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/ViewControllers/DocumentCaptureViewControllerTest.swift
+++ b/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/ViewControllers/DocumentCaptureViewControllerTest.swift
@@ -277,18 +277,18 @@ final class DocumentCaptureViewControllerTest: XCTestCase {
             expectedButtonState: .disabled
         )
     }
-    
+
     func testResetTimeoutDuringScanning() {
         // Mock that existing sacnningState already found a desired classification
         let vc = makeViewController(
             state: .scanning(.front, .passport),
             documentType: .passport
         )
-        
+
         // Mock that scanner found non-desired classification
         mockCameraFrameCaptured(vc)
         mockConcurrencyManager.respondToScan(output: nil)
-        
+
         // verify imageScanningSession.startTimeoutTimer is reset and a new valid timer is set
         XCTAssertEqual(vc.imageScanningSession.timeoutTimer?.isValid, true)
     }

--- a/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/ViewControllers/DocumentCaptureViewControllerTest.swift
+++ b/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/ViewControllers/DocumentCaptureViewControllerTest.swift
@@ -277,6 +277,21 @@ final class DocumentCaptureViewControllerTest: XCTestCase {
             expectedButtonState: .disabled
         )
     }
+    
+    func testResetTimeoutDuringScanning() {
+        // Mock that existing sacnningState already found a desired classification
+        let vc = makeViewController(
+            state: .scanning(.front, .passport),
+            documentType: .passport
+        )
+        
+        // Mock that scanner found non-desired classification
+        mockCameraFrameCaptured(vc)
+        mockConcurrencyManager.respondToScan(output: nil)
+        
+        // verify imageScanningSession.startTimeoutTimer is reset and a new valid timer is set
+        XCTAssertEqual(vc.imageScanningSession.timeoutTimer?.isValid, true)
+    }
 
     func testSaveDataFrontAndTransition() {
         let frontFileData = (VerificationPageDataUpdateMock.default.collectedData?.idDocumentFront)!


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Introduce an improved timeout logic in `DocumentCaptureViewController` that when the state transfers from found to non-found, reset the timer.
So that user has more time to complete the flow from scratch again, this logic is similar to the web flow logic.
Note: iOS's `SelfieCaptureViewController` already has a similar timeout reset logic, so the same change is not applied.


Similar Android change: https://github.com/stripe/stripe-android/pull/6688, which applies similar change to both document and selfie

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Improve scan success rate
## Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Manually verified

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
