### PR TITLE
Financial Connections: changed account picker typography

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerFooterView.swift
@@ -43,17 +43,21 @@ final class AccountPickerFooterView: UIView {
 
         let verticalStackView = HitTestStackView(
             arrangedSubviews: [
-                CreateDataAccessDisclosureView(
+                MerchantDataAccessView(
                     isStripeDirect: isStripeDirect,
                     businessName: businessName,
                     permissions: permissions,
+                    isNetworking: false,
+                    font: .body(.small),
+                    boldFont: .body(.smallEmphasized),
+                    alignCenter: true,
                     didSelectLearnMore: didSelectMerchantDataAccessLearnMore
                 ),
                 linkAccountsButton,
             ]
         )
         verticalStackView.axis = .vertical
-        verticalStackView.spacing = 20
+        verticalStackView.spacing = 24
         addSubview(verticalStackView)
         addAndPinSubviewToSafeArea(verticalStackView)
 
@@ -99,34 +103,4 @@ final class AccountPickerFooterView: UIView {
             }
         }
     }
-}
-
-@available(iOSApplicationExtension, unavailable)
-private func CreateDataAccessDisclosureView(
-    isStripeDirect: Bool,
-    businessName: String?,
-    permissions: [StripeAPI.FinancialConnectionsAccount.Permissions],
-    didSelectLearnMore: @escaping () -> Void
-) -> UIView {
-    let stackView = HitTestStackView(
-        arrangedSubviews: [
-            MerchantDataAccessView(
-                isStripeDirect: isStripeDirect,
-                businessName: businessName,
-                permissions: permissions,
-                isNetworking: false,
-                didSelectLearnMore: didSelectLearnMore
-            ),
-        ]
-    )
-    stackView.isLayoutMarginsRelativeArrangement = true
-    stackView.directionalLayoutMargins = NSDirectionalEdgeInsets(
-        top: 10,
-        leading: 12,
-        bottom: 10,
-        trailing: 12
-    )
-    stackView.backgroundColor = .backgroundContainer
-    stackView.layer.cornerRadius = 8
-    return stackView
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerLabelRowView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerLabelRowView.swift
@@ -11,17 +11,7 @@ import UIKit
 
 final class AccountPickerLabelRowView: UIView {
 
-    private lazy var topLevelHorizontalStackView: UIStackView = {
-        let topLevelHorizontalStackView = UIStackView()
-        topLevelHorizontalStackView.axis = .horizontal
-        topLevelHorizontalStackView.spacing = 8
-        topLevelHorizontalStackView.distribution = .fill
-        topLevelHorizontalStackView.alignment = .center
-        topLevelHorizontalStackView.setContentHuggingPriority(.defaultHigh, for: .horizontal)
-        return topLevelHorizontalStackView
-    }()
-
-    private lazy var labelStackView: UIStackView = {
+    private lazy var verticalLabelStackView: UIStackView = {
         let labelStackView = UIStackView()
         labelStackView.axis = .vertical
         labelStackView.spacing = 0
@@ -29,34 +19,37 @@ final class AccountPickerLabelRowView: UIView {
         return labelStackView
     }()
 
-    private lazy var leadingTitleLabel: UILabel = {
-        let leadingTitleLabel = UILabel()
-        leadingTitleLabel.font = .stripeFont(forTextStyle: .bodyEmphasized)
-        leadingTitleLabel.textColor = .textPrimary
+    private lazy var leadingTitleLabel: AttributedLabel = {
+        let leadingTitleLabel = AttributedLabel(
+            font: .label(.largeEmphasized),
+            textColor: .textPrimary
+        )
         leadingTitleLabel.lineBreakMode = .byCharWrapping
         leadingTitleLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         leadingTitleLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
         return leadingTitleLabel
     }()
 
-    private lazy var trailingTitleLabel: UILabel = {
-        let trailingTitleLabel = UILabel()
-        trailingTitleLabel.font = .stripeFont(forTextStyle: .bodyEmphasized)
-        trailingTitleLabel.textColor = .textPrimary
+    private lazy var trailingTitleLabel: AttributedLabel = {
+        let trailingTitleLabel = AttributedLabel(
+            font: .label(.largeEmphasized),
+            textColor: .textPrimary
+        )
         trailingTitleLabel.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
         return trailingTitleLabel
     }()
 
-    private lazy var subtitleLabel: UILabel = {
-        let subtitleLabel = UILabel()
-        subtitleLabel.font = .stripeFont(forTextStyle: .captionTightEmphasized)
-        subtitleLabel.textColor = .textSecondary
+    private lazy var subtitleLabel: AttributedLabel = {
+        let subtitleLabel = AttributedLabel(
+            font: .label(.small),
+            textColor: .textSecondary
+        )
         return subtitleLabel
     }()
 
     init() {
         super.init(frame: .zero)
-        labelStackView.addArrangedSubview(
+        verticalLabelStackView.addArrangedSubview(
             {
                 let horizontalStackView = UIStackView(
                     arrangedSubviews: [
@@ -73,9 +66,7 @@ final class AccountPickerLabelRowView: UIView {
                 return horizontalStackView
             }()
         )
-
-        topLevelHorizontalStackView.addArrangedSubview(labelStackView)
-        addAndPinSubview(topLevelHorizontalStackView)
+        addAndPinSubview(verticalLabelStackView)
     }
 
     required init?(coder: NSCoder) {
@@ -93,7 +84,7 @@ final class AccountPickerLabelRowView: UIView {
         subtitleLabel.removeFromSuperview()
         if let subtitle = subtitle {
             subtitleLabel.text = subtitle
-            labelStackView.addArrangedSubview(subtitleLabel)
+            verticalLabelStackView.addArrangedSubview(subtitleLabel)
         }
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerFooterView.swift
@@ -44,17 +44,21 @@ final class LinkAccountPickerFooterView: UIView {
 
         let verticalStackView = HitTestStackView(
             arrangedSubviews: [
-                CreateDataAccessDisclosureView(
+                MerchantDataAccessView(
                     isStripeDirect: isStripeDirect,
                     businessName: businessName,
                     permissions: permissions,
+                    isNetworking: true,
+                    font: .body(.small),
+                    boldFont: .body(.smallEmphasized),
+                    alignCenter: true,
                     didSelectLearnMore: didSelectMerchantDataAccessLearnMore
                 ),
                 connectAccountButton,
             ]
         )
         verticalStackView.axis = .vertical
-        verticalStackView.spacing = 20
+        verticalStackView.spacing = 24
         addAndPinSubview(verticalStackView)
     }
 
@@ -69,37 +73,4 @@ final class LinkAccountPickerFooterView: UIView {
     func enableButton(_ enableButton: Bool) {
         connectAccountButton.isEnabled = enableButton
     }
-}
-
-@available(iOSApplicationExtension, unavailable)
-private func CreateDataAccessDisclosureView(
-    isStripeDirect: Bool,
-    businessName: String?,
-    permissions: [StripeAPI.FinancialConnectionsAccount.Permissions],
-    didSelectLearnMore: @escaping () -> Void
-) -> UIView {
-    let stackView = HitTestStackView(
-        arrangedSubviews: [
-            MerchantDataAccessView(
-                isStripeDirect: isStripeDirect,
-                businessName: businessName,
-                permissions: permissions,
-                isNetworking: true,
-                font: .body(.small),
-                boldFont: .body(.smallEmphasized),
-                alignCenter: true,
-                didSelectLearnMore: didSelectLearnMore
-            ),
-        ]
-    )
-    stackView.isLayoutMarginsRelativeArrangement = true
-    stackView.directionalLayoutMargins = NSDirectionalEdgeInsets(
-        top: 10,
-        leading: 12,
-        bottom: 10,
-        trailing: 12
-    )
-    stackView.backgroundColor = .backgroundContainer
-    stackView.layer.cornerRadius = 8
-    return stackView
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerFooterView.swift
@@ -85,6 +85,9 @@ private func CreateDataAccessDisclosureView(
                 businessName: businessName,
                 permissions: permissions,
                 isNetworking: true,
+                font: .body(.small),
+                boldFont: .body(.smallEmphasized),
+                alignCenter: true,
                 didSelectLearnMore: didSelectLearnMore
             ),
         ]

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerNewAccountRowView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerNewAccountRowView.swift
@@ -50,9 +50,14 @@ private func CreateIconView() -> UIView {
         .withTintColor(.textBrand, renderingMode: .alwaysOriginal)
     let paddedView = UIStackView(arrangedSubviews: [iconImageView])
     paddedView.backgroundColor = .textBrand.withAlphaComponent(0.1)
-    paddedView.layer.cornerRadius = diameter / 2
+    paddedView.layer.cornerRadius = 6
     paddedView.isLayoutMarginsRelativeArrangement = true
-    paddedView.directionalLayoutMargins = NSDirectionalEdgeInsets(top: 6, leading: 6, bottom: 6, trailing: 6)
+    paddedView.directionalLayoutMargins = NSDirectionalEdgeInsets(
+        top: 6,
+        leading: 6,
+        bottom: 6,
+        trailing: 6
+    )
     NSLayoutConstraint.activate([
         paddedView.widthAnchor.constraint(equalToConstant: diameter),
         paddedView.heightAnchor.constraint(equalToConstant: diameter),
@@ -61,13 +66,14 @@ private func CreateIconView() -> UIView {
 }
 
 private func CreateTitleLabelView() -> UIView {
-    let titleLabel = UILabel()
+    let titleLabel = AttributedLabel(
+        font: .label(.largeEmphasized),
+        textColor: .textBrand
+    )
     titleLabel.text = STPLocalizedString(
         "New bank account",
         "A button that allows users to add an additional bank account for future payments."
     )
-    titleLabel.font = .stripeFont(forTextStyle: .bodyEmphasized)
-    titleLabel.textColor = .textBrand
     titleLabel.lineBreakMode = .byCharWrapping
     return titleLabel
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/AttributedLabel.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/AttributedLabel.swift
@@ -14,6 +14,14 @@ final class AttributedLabel: UILabel {
     private let customFont: FinancialConnectionsFont
     private let customTextColor: UIColor
 
+    // one can accidentally forget to call `setText` instead of `text` so
+    // this makes it convenient to use `AttributedLabel`
+    override var text: String? {
+        didSet {
+            setText(text ?? "")
+        }
+    }
+
     init(font: FinancialConnectionsFont, textColor: UIColor) {
         self.customFont = font
         self.customTextColor = textColor
@@ -29,6 +37,7 @@ final class AttributedLabel: UILabel {
     override func drawText(in rect: CGRect) {
         guard
             let attributedText = self.attributedText,
+            attributedText.length > 0, // `attributes(at:effectiveRange)` crashes if empty string
             let font = attributedText.attributes(at: 0, effectiveRange: nil)[.font] as? UIFont,
             let paragraphStyle = attributedText.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle
         else {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/AttributedTextView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/AttributedTextView.swift
@@ -192,6 +192,7 @@ private class VerticalCenterLayoutManager: NSLayoutManager {
         let range = characterRange(forGlyphRange: glyphsToShow, actualGlyphRange: nil)
         guard
             let attributedString = textStorage?.attributedSubstring(from: range),
+            attributedString.length > 0, // `attributes(at:effectiveRange)` crashes if empty string
             let font = attributedString.attributes(at: 0, effectiveRange: nil)[.font] as? UIFont,
             let paragraphStyle = attributedString.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle
         else {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/MerchantDataAccessView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/MerchantDataAccessView.swift
@@ -19,6 +19,9 @@ final class MerchantDataAccessView: HitTestView {
         businessName: String?,
         permissions: [StripeAPI.FinancialConnectionsAccount.Permissions],
         isNetworking: Bool,
+        font: FinancialConnectionsFont,
+        boldFont: FinancialConnectionsFont,
+        alignCenter: Bool,
         didSelectLearnMore: @escaping () -> Void
     ) {
         super.init(frame: .zero)
@@ -30,20 +33,20 @@ final class MerchantDataAccessView: HitTestView {
                 "Data accessible to Stripe:",
                 "This text is a lead-up to a disclosure that lists all of the bank data that Stripe will have access to. For example, the full text may read 'Data accessible to Stripe: Account details, transactions.'"
             )
-            leadingString = "**\(localizedLeadingString)**"
+            leadingString = localizedLeadingString
         } else {
             if let businessName = businessName {
                 let localizedLeadingString = STPLocalizedString(
                     "Data accessible to %@:",
                     "This text is a lead-up to a disclosure that lists all of the bank data that a merchant (ex. Coca-Cola) will have access to. For example, the full text may read 'Data accessible to Coca-Cola: Account details, transactions.'"
                 )
-                leadingString = "**\(String(format: localizedLeadingString, businessName))**"
+                leadingString = String(format: localizedLeadingString, businessName)
             } else {
                 let localizedLeadingString = STPLocalizedString(
                     "Data accessible to this business:",
                     "This text is a lead-up to a disclosure that lists all of the bank data that a business will have access to. For example, the full text may read 'Data accessible to this business: Account details, transactions.'"
                 )
-                leadingString = "**\(localizedLeadingString)**"
+                leadingString = localizedLeadingString
             }
         }
 
@@ -87,11 +90,12 @@ final class MerchantDataAccessView: HitTestView {
             finalString = "\(leadingString) \(localizedPermissionFullString) \(learnMoreString)"
         }
 
-        let label = ClickableLabel(
-            font: .stripeFont(forTextStyle: .captionTight),
-            boldFont: .stripeFont(forTextStyle: .captionTightEmphasized),
-            linkFont: .stripeFont(forTextStyle: .captionTightEmphasized),
-            textColor: .textSecondary
+        let label = AttributedTextView(
+            font: font,
+            boldFont: boldFont,
+            linkFont: boldFont,
+            textColor: .textSecondary,
+            alignCenter: alignCenter
         )
         label.setText(
             finalString,
@@ -188,6 +192,9 @@ private struct MerchantDataAccessViewUIViewRepresentable: UIViewRepresentable {
             businessName: businessName,
             permissions: permissions,
             isNetworking: false,
+            font: .body(.small),
+            boldFont: .body(.smallEmphasized),
+            alignCenter: Bool.random(),
             didSelectLearnMore: {}
         )
     }
@@ -198,81 +205,74 @@ private struct MerchantDataAccessViewUIViewRepresentable: UIViewRepresentable {
 @available(iOSApplicationExtension, unavailable)
 struct MerchantDataAccessView_Previews: PreviewProvider {
     static var previews: some View {
-        VStack(spacing: 20) {
-            MerchantDataAccessViewUIViewRepresentable(
-                isStripeDirect: true,
-                businessName: nil,
-                permissions: [.accountNumbers]
-            )
-            .frame(height: 30)
+        ScrollView {
+            VStack(spacing: 20) {
+                Group {
+                    MerchantDataAccessViewUIViewRepresentable(
+                        isStripeDirect: true,
+                        businessName: nil,
+                        permissions: [.accountNumbers]
+                    )
 
-            MerchantDataAccessViewUIViewRepresentable(
-                isStripeDirect: false,
-                businessName: "Rocket Rides",
-                permissions: [.accountNumbers]
-            )
-            .frame(height: 30)
+                    MerchantDataAccessViewUIViewRepresentable(
+                        isStripeDirect: false,
+                        businessName: "Rocket Rides",
+                        permissions: [.accountNumbers]
+                    )
 
-            MerchantDataAccessViewUIViewRepresentable(
-                isStripeDirect: false,
-                businessName: nil,
-                permissions: [.accountNumbers]
-            )
-            .frame(height: 30)
+                    MerchantDataAccessViewUIViewRepresentable(
+                        isStripeDirect: false,
+                        businessName: nil,
+                        permissions: [.accountNumbers]
+                    )
 
-            MerchantDataAccessViewUIViewRepresentable(
-                isStripeDirect: false,
-                businessName: "Rocket Rides",
-                permissions: [.accountNumbers]
-            )
-            .frame(height: 30)
+                    MerchantDataAccessViewUIViewRepresentable(
+                        isStripeDirect: false,
+                        businessName: "Rocket Rides",
+                        permissions: [.accountNumbers]
+                    )
 
-            MerchantDataAccessViewUIViewRepresentable(
-                isStripeDirect: false,
-                businessName: "Rocket Rides",
-                permissions: [.accountNumbers, .paymentMethod]
-            )
-            .frame(height: 30)
+                    MerchantDataAccessViewUIViewRepresentable(
+                        isStripeDirect: false,
+                        businessName: "Rocket Rides",
+                        permissions: [.accountNumbers, .paymentMethod]
+                    )
 
-            MerchantDataAccessViewUIViewRepresentable(
-                isStripeDirect: false,
-                businessName: "Rocket Rides",
-                permissions: [.transactions, .ownership]
-            )
-            .frame(height: 50)
+                    MerchantDataAccessViewUIViewRepresentable(
+                        isStripeDirect: false,
+                        businessName: "Rocket Rides",
+                        permissions: [.transactions, .ownership]
+                    )
 
-            MerchantDataAccessViewUIViewRepresentable(
-                isStripeDirect: false,
-                businessName: "Rocket Rides",
-                permissions: [.transactions, .ownership, .balances]
-            )
-            .frame(height: 50)
+                    MerchantDataAccessViewUIViewRepresentable(
+                        isStripeDirect: false,
+                        businessName: "Rocket Rides",
+                        permissions: [.transactions, .ownership, .balances]
+                    )
 
-            MerchantDataAccessViewUIViewRepresentable(
-                isStripeDirect: false,
-                businessName: "Rocket Rides",
-                permissions: [.accountNumbers, .paymentMethod, .transactions, .ownership, .balances]
-            )
-            .frame(height: 50)
+                    MerchantDataAccessViewUIViewRepresentable(
+                        isStripeDirect: false,
+                        businessName: "Rocket Rides",
+                        permissions: [.accountNumbers, .paymentMethod, .transactions, .ownership, .balances]
+                    )
 
-            MerchantDataAccessViewUIViewRepresentable(
-                isStripeDirect: false,
-                businessName: "Rocket Rides",
-                permissions: [.unparsable]
-            )
-            .frame(height: 30)
+                    MerchantDataAccessViewUIViewRepresentable(
+                        isStripeDirect: false,
+                        businessName: "Rocket Rides",
+                        permissions: [.unparsable]
+                    )
 
-            MerchantDataAccessViewUIViewRepresentable(
-                isStripeDirect: true,
-                businessName: nil,
-                permissions: []
-            )
-            .frame(height: 30)
+                    MerchantDataAccessViewUIViewRepresentable(
+                        isStripeDirect: true,
+                        businessName: nil,
+                        permissions: []
+                    )
+                }
+                .frame(height: 60)
+                .padding(.horizontal)
+            }
         }
-        .padding()
-        .padding()
-        .padding()
-        .padding()
+
     }
 }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Success/SuccessBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Success/SuccessBodyView.swift
@@ -113,6 +113,9 @@ private func CreateDataAccessDisclosureView(
                 businessName: businessName,
                 permissions: permissions,
                 isNetworking: isNetworking,
+                font: .body(.small),
+                boldFont: .body(.smallEmphasized),
+                alignCenter: false,
                 didSelectLearnMore: didSelectLearnMore
             ),
         ]


### PR DESCRIPTION
## Summary

Changed account picker (non-networking and networking) typography.

Designs:
- https://www.figma.com/file/ikSIQS9Lw0qIr3PSeyyrPP/Connections-V2.5?type=design&node-id=1636-89037&mode=design&t=lhMvUW7TshC52WLx-0

Font references:
- https://sail.stripe.me/foundations/typography/
- https://www.figma.com/file/WAFvoybps5uk3FL4tftaee/Sail?type=design&node-id=26-370&mode=design&t=Hd2oiFSiURfCMlmn-0

## Testing


### Classic

| Before | After |
| --- | --- | 
| ![before-account-picker](https://github.com/stripe/stripe-ios/assets/105514761/f201d81f-ffdc-40bf-8375-f1f8e11055e5) | ![after](https://github.com/stripe/stripe-ios/assets/105514761/95310655-e45c-4601-9a6f-743617ea9170) |

### Networking

| Before | After |
| --- | --- | 
| ![networking-before](https://github.com/stripe/stripe-ios/assets/105514761/17175511-32c2-45ef-937e-2c958a644d31) | ![networking-after](https://github.com/stripe/stripe-ios/assets/105514761/5342ddc8-0d3a-4191-931f-c86d82901ecb) |
