### PR TITLE
Financial Connections: changed success pane typography

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/FinancialConnectionsFont.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/FinancialConnectionsFont.swift
@@ -82,6 +82,7 @@ struct FinancialConnectionsFont {
     enum LabelToken {
         case small
         case smallEmphasized
+        case mediumEmphasized
         case largeEmphasized
     }
     static func label(_ token: LabelToken) -> FinancialConnectionsFont {
@@ -99,6 +100,11 @@ struct FinancialConnectionsFont {
             font = UIFont.systemFont(ofSize: 12, weight: .semibold)
             lineHeight = 16
             appleTextStyle = .caption1
+        case .mediumEmphasized:
+            // 14 size / 20 line height / 600 weight
+            font = UIFont.systemFont(ofSize: 14, weight: .semibold)
+            lineHeight = 20
+            appleTextStyle = .footnote
         case .largeEmphasized:
             // 16 size / 24 line height / 600 weight
             font = UIFont.systemFont(ofSize: 16, weight: .semibold)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Success/SuccessAccountListView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Success/SuccessAccountListView.swift
@@ -31,10 +31,11 @@ final class SuccessAccountListView: UIView {
 }
 
 private func CreateAccountCountView(institution: FinancialConnectionsInstitution, numberOfAccounts: Int) -> UIView {
-    let numberOfAccountsLabel = UILabel()
+    let numberOfAccountsLabel = AttributedLabel(
+        font: .label(.mediumEmphasized),
+        textColor: .textSecondary
+    )
     numberOfAccountsLabel.textAlignment = .right
-    numberOfAccountsLabel.font = .stripeFont(forTextStyle: .captionEmphasized)
-    numberOfAccountsLabel.textColor = .textSecondary
     numberOfAccountsLabel.text = String(
         format: STPLocalizedString(
             "%d accounts",
@@ -45,7 +46,7 @@ private func CreateAccountCountView(institution: FinancialConnectionsInstitution
 
     let horizontalStackView = UIStackView(
         arrangedSubviews: [
-            CreateIconWithLabelView(instituion: institution, text: institution.name),
+            CreateIconWithLabelView(institution: institution, text: institution.name),
             numberOfAccountsLabel,
         ]
     )
@@ -79,15 +80,16 @@ private func CreateAccountRowView(
 
     horizontalStackView.addArrangedSubview(
         CreateIconWithLabelView(
-            instituion: institution,
+            institution: institution,
             text: account.name
         )
     )
 
     if let displayableAccountNumbers = account.displayableAccountNumbers {
-        let displayableAccountNumberLabel = UILabel()
-        displayableAccountNumberLabel.font = .stripeFont(forTextStyle: .captionEmphasized)
-        displayableAccountNumberLabel.textColor = .textSecondary
+        let displayableAccountNumberLabel = AttributedLabel(
+            font: .label(.mediumEmphasized),
+            textColor: .textSecondary
+        )
         displayableAccountNumberLabel.text = "••••\(displayableAccountNumbers)"
         // compress `account.name` instead of account number if text is long
         displayableAccountNumberLabel.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
@@ -97,13 +99,14 @@ private func CreateAccountRowView(
     return horizontalStackView
 }
 
-private func CreateIconWithLabelView(instituion: FinancialConnectionsInstitution, text: String) -> UIView {
+private func CreateIconWithLabelView(institution: FinancialConnectionsInstitution, text: String) -> UIView {
     let institutionIconView = InstitutionIconView(size: .small)
-    institutionIconView.setImageUrl(instituion.icon?.default)
+    institutionIconView.setImageUrl(institution.icon?.default)
 
-    let label = UILabel()
-    label.font = .stripeFont(forTextStyle: .captionEmphasized)
-    label.textColor = .textPrimary
+    let label = AttributedLabel(
+        font: .label(.mediumEmphasized),
+        textColor: .textPrimary
+    )
     label.text = text
     label.translatesAutoresizingMaskIntoConstraints = false
     label.setContentHuggingPriority(.defaultHigh, for: .horizontal)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Success/SuccessBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Success/SuccessBodyView.swift
@@ -113,8 +113,8 @@ private func CreateDataAccessDisclosureView(
                 businessName: businessName,
                 permissions: permissions,
                 isNetworking: isNetworking,
-                font: .body(.small),
-                boldFont: .body(.smallEmphasized),
+                font: .label(.small),
+                boldFont: .label(.smallEmphasized),
                 alignCenter: false,
                 didSelectLearnMore: didSelectLearnMore
             ),
@@ -154,10 +154,10 @@ private func CreateDisconnectAccountLabel(
         isEndUserFacing: isEndUserFacing
     )
 
-    let disconnectAccountLabel = ClickableLabel(
-        font: .stripeFont(forTextStyle: .captionTight),
-        boldFont: .stripeFont(forTextStyle: .captionTightEmphasized),
-        linkFont: .stripeFont(forTextStyle: .captionTightEmphasized),
+    let disconnectAccountLabel = AttributedTextView(
+        font: .body(.small),
+        boldFont: .body(.smallEmphasized),
+        linkFont: .body(.smallEmphasized),
         textColor: .textSecondary
     )
     disconnectAccountLabel.setText(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Success/SuccessFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Success/SuccessFooterView.swift
@@ -36,7 +36,7 @@ final class SuccessFooterView: UIView {
 
         let footerStackView = UIStackView()
         footerStackView.axis = .vertical
-        footerStackView.spacing = 12
+        footerStackView.spacing = 24
 
         if showFailedToLinkNotice {
             let saveToLinkFailedNoticeView = CreateSaveToLinkFailedNoticeView(
@@ -44,13 +44,7 @@ final class SuccessFooterView: UIView {
             )
             footerStackView.addArrangedSubview(saveToLinkFailedNoticeView)
         }
-
-        let footerButtonStackView = UIStackView()
-        footerButtonStackView.axis = .vertical
-        footerButtonStackView.spacing = 12
-        footerButtonStackView.addArrangedSubview(doneButton)
-        footerStackView.addArrangedSubview(footerButtonStackView)
-
+        footerStackView.addArrangedSubview(doneButton)
         addAndPinSubviewToSafeArea(footerStackView)
     }
 
@@ -70,9 +64,9 @@ final class SuccessFooterView: UIView {
 private func CreateSaveToLinkFailedNoticeView(
     businessName: String?
 ) -> UIView {
-    let errorLabelFont = UIFont.stripeFont(forTextStyle: .captionEmphasized)
+    let errorLabelFont = FinancialConnectionsFont.label(.smallEmphasized)
     let warningIconWidthAndHeight: CGFloat = 12
-    let warningIconInsets = (errorLabelFont.lineHeight - warningIconWidthAndHeight) / 2
+    let warningIconInsets = errorLabelFont.topPadding
     let warningIconImageView = UIImageView()
     warningIconImageView.image = Image.warning_triangle.makeImage()
         .withTintColor(.textCritical)
@@ -89,9 +83,10 @@ private func CreateSaveToLinkFailedNoticeView(
         warningIconImageView.heightAnchor.constraint(equalToConstant: warningIconWidthAndHeight),
     ])
 
-    let errorLabel = UILabel()
-    errorLabel.font = .stripeFont(forTextStyle: .captionEmphasized)
-    errorLabel.textColor = .textPrimary
+    let errorLabel = AttributedLabel(
+        font: .label(.smallEmphasized),
+        textColor: .textPrimary
+    )
     errorLabel.numberOfLines = 0
     errorLabel.text = {
         if let businessName = businessName {


### PR DESCRIPTION
## Summary

Changed success pane typography.

Designs:
- https://www.figma.com/file/ikSIQS9Lw0qIr3PSeyyrPP/Connections-V2.5?type=design&node-id=1636-89037&mode=design&t=lhMvUW7TshC52WLx-0

Font references:
- https://sail.stripe.me/foundations/typography/
- https://www.figma.com/file/WAFvoybps5uk3FL4tftaee/Sail?type=design&node-id=26-370&mode=design&t=Hd2oiFSiURfCMlmn-0

## Testing

| Before | After |
| --- | --- |
| ![before](https://github.com/stripe/stripe-ios/assets/105514761/f7f90fff-c3ca-4346-9e16-638483eb462f) | ![after](https://github.com/stripe/stripe-ios/assets/105514761/a6fa3f28-fadd-4c46-806f-242e7bb6cc9c) |

