### PR TITLE
Financial Connections: changed networking sign up pane typography

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/FinancialConnectionsFont.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/FinancialConnectionsFont.swift
@@ -83,6 +83,7 @@ struct FinancialConnectionsFont {
         case small
         case smallEmphasized
         case mediumEmphasized
+        case large
         case largeEmphasized
     }
     static func label(_ token: LabelToken) -> FinancialConnectionsFont {
@@ -105,6 +106,11 @@ struct FinancialConnectionsFont {
             font = UIFont.systemFont(ofSize: 14, weight: .semibold)
             lineHeight = 20
             appleTextStyle = .footnote
+        case .large:
+            // 16 size / 24 line height / 400 weight
+            font = UIFont.systemFont(ofSize: 16, weight: .regular)
+            lineHeight = 24
+            appleTextStyle = .body
         case .largeEmphasized:
             // 16 size / 24 line height / 600 weight
             font = UIFont.systemFont(ofSize: 16, weight: .semibold)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupBodyFormView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupBodyFormView.swift
@@ -68,7 +68,7 @@ final class NetworkingLinkSignupBodyFormView: UIView {
         theme.shadow = nil
         theme.fonts = {
             var fonts = ElementsUITheme.Font()
-            fonts.subheadline = .stripeFont(forTextStyle: .body)
+            fonts.subheadline = FinancialConnectionsFont.label(.large).uiFont
             return fonts
         }()
         theme.colors = {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupBodyView.swift
@@ -88,7 +88,7 @@ private func CreateBulletPointView(
                 let extraPaddingView = UIStackView(arrangedSubviews: [imageView])
                 extraPaddingView.isLayoutMarginsRelativeArrangement = true
                 extraPaddingView.directionalLayoutMargins = NSDirectionalEdgeInsets(
-                    top: 3,
+                    top: labelView.topPadding,
                     leading: 0,
                     bottom: 0,
                     trailing: 0

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupFooterView.swift
@@ -23,17 +23,17 @@ class NetworkingLinkSignupFooterView: HitTestView {
     private lazy var footerVerticalStackView: UIStackView = {
         let verticalStackView = UIStackView()
         verticalStackView.axis = .vertical
-        verticalStackView.spacing = 16
+        verticalStackView.spacing = 24
         verticalStackView.addArrangedSubview(aboveCtaLabel)
         verticalStackView.addArrangedSubview(buttonVerticalStack)
         return verticalStackView
     }()
 
-    private lazy var aboveCtaLabel: ClickableLabel = {
-        let termsAndPrivacyPolicyLabel = ClickableLabel(
-            font: UIFont.stripeFont(forTextStyle: .detail),
-            boldFont: UIFont.stripeFont(forTextStyle: .detailEmphasized),
-            linkFont: UIFont.stripeFont(forTextStyle: .detailEmphasized),
+    private lazy var aboveCtaLabel: AttributedTextView = {
+        let termsAndPrivacyPolicyLabel = AttributedTextView(
+            font: .body(.small),
+            boldFont: .body(.smallEmphasized),
+            linkFont: .body(.smallEmphasized),
             textColor: .textSecondary,
             alignCenter: true
         )


### PR DESCRIPTION
## Summary

^ see title

Designs:
- https://www.figma.com/file/ikSIQS9Lw0qIr3PSeyyrPP/Connections-V2.5?type=design&node-id=1636-89037&mode=design&t=lhMvUW7TshC52WLx-0

Font references:
- https://sail.stripe.me/foundations/typography/
- https://www.figma.com/file/WAFvoybps5uk3FL4tftaee/Sail?type=design&node-id=26-370&mode=design&t=Hd2oiFSiURfCMlmn-0

## Testing

| Before | After |
| --- | --- |
| ![signup-before](https://github.com/stripe/stripe-ios/assets/105514761/5ce0a407-b1aa-4065-969c-35e948aed437) | ![signup-after](https://github.com/stripe/stripe-ios/assets/105514761/82e4f70d-e7b6-4f54-8a81-365d3ec9d373) |

