### PR TITLE
Financial Connections: changed the typography in networking verification panes

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationBodyView.swift
@@ -80,27 +80,29 @@ final class NetworkingLinkStepUpVerificationBodyView: UIView {
 }
 
 private func CreateEmailLabel(email: String) -> UIView {
-    let emailLabel = UILabel()
+    let emailLabel = AttributedLabel(
+        font: .label(.medium),
+        textColor: .textSecondary
+    )
     emailLabel.text = "\(email)"
-    emailLabel.font = .stripeFont(forTextStyle: .captionTight)
-    emailLabel.textColor = .textSecondary
     return emailLabel
 }
 
 private func CreateCreateDotLabel() -> UIView {
-    let dotLabel = UILabel()
+    let dotLabel = AttributedLabel(
+        font: .label(.medium),
+        textColor: .textDisabled
+    )
     dotLabel.text = "•"
-    dotLabel.font = .stripeFont(forTextStyle: .captionTight)
-    dotLabel.textColor = .textDisabled
     return dotLabel
 }
 
 @available(iOSApplicationExtension, unavailable)
 private func CreateResendCodeLabel(isEnabled: Bool, didSelect: @escaping () -> Void) -> UIView {
-    let resendCodeLabel = ClickableLabel(
-        font: .stripeFont(forTextStyle: .captionTightEmphasized),
-        boldFont: .stripeFont(forTextStyle: .captionTightEmphasized),
-        linkFont: .stripeFont(forTextStyle: .captionTightEmphasized),
+    let resendCodeLabel = AttributedTextView(
+        font: .label(.medium),
+        boldFont: .label(.mediumEmphasized),
+        linkFont: .label(.mediumEmphasized),
         textColor: .textDisabled,
         alignCenter: false
     )

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationBodyView.swift
@@ -32,10 +32,11 @@ final class NetworkingLinkVerificationBodyView: UIView {
 }
 
 private func CreateEmailLabel(email: String) -> UIView {
-    let emailLabel = UILabel()
+    let emailLabel = AttributedLabel(
+        font: .label(.medium),
+        textColor: .textSecondary
+    )
     emailLabel.text = String(format: STPLocalizedString("Signing in as %@", "A footnote that explains the user that when they enter an one-time-password code (OTP), they will be signing in as the email in this footnote. '%@' is replaced with an email, for examle: 'Signing in as user@gmail.com'."), email)
-    emailLabel.font = .stripeFont(forTextStyle: .captionTight)
-    emailLabel.textColor = .textSecondary
     return emailLabel
 }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkBodyView.swift
@@ -32,10 +32,11 @@ final class NetworkingSaveToLinkVerificationBodyView: UIView {
 }
 
 private func CreateEmailLabel(email: String) -> UIView {
-    let emailLabel = UILabel()
+    let emailLabel = AttributedLabel(
+        font: .label(.medium),
+        textColor: .textSecondary
+    )
     emailLabel.text = String(format: STPLocalizedString("Signing in as %@", "A footnote that explains to the user that they are signing in as a user with a specific e-mail. '%@' is replaced with an e-mail, for example, 'Signing in as test@test.com'"), email)
-    emailLabel.font = .stripeFont(forTextStyle: .captionTight)
-    emailLabel.textColor = .textSecondary
     return emailLabel
 }
 


### PR DESCRIPTION
## Summary

^ see title

Designs:
- https://www.figma.com/file/ikSIQS9Lw0qIr3PSeyyrPP/Connections-V2.5?type=design&node-id=1636-89037&mode=design&t=lhMvUW7TshC52WLx-0

Font references:
- https://sail.stripe.me/foundations/typography/
- https://www.figma.com/file/WAFvoybps5uk3FL4tftaee/Sail?type=design&node-id=26-370&mode=design&t=Hd2oiFSiURfCMlmn-0

## Testing

### Returning Verification (After Sign Up)

| Before | After |
| --- | --- |
| ![before-returninguserverification](https://github.com/stripe/stripe-ios/assets/105514761/ca19482e-4695-4271-9d85-b7766663f7e6) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-05-10 at 14 14 22](https://github.com/stripe/stripe-ios/assets/105514761/5449dd1d-0d74-414f-a956-e4c4a2a7abd4) |

### Existing User Verification

| Before | After |
| --- | --- |
| ![before-warmupverification](https://github.com/stripe/stripe-ios/assets/105514761/ba8be0b1-3ea6-4f34-aa56-f70091c58b11) | ![after-signedin-verification-after](https://github.com/stripe/stripe-ios/assets/105514761/dc942238-04aa-4491-975d-834595534895) |

### Step Up Verification 
| Before | After |
| --- | --- |
| ![before-stepup-verification](https://github.com/stripe/stripe-ios/assets/105514761/1b542d13-988d-46b3-b6bb-9072d399e0d2) | ![after-stepup](https://github.com/stripe/stripe-ios/assets/105514761/1017507f-081c-4da1-82eb-a294b5e100ea) |
