### PR TITLE
Refactor PaymentSheet deferred confirm code 

### DIFF
--- a/Stripe/StripeiOSTests/PaymentSheet+APITest.swift
+++ b/Stripe/StripeiOSTests/PaymentSheet+APITest.swift
@@ -15,7 +15,7 @@ import XCTest
 @testable@_spi(STP) @_spi(ExperimentalPaymentSheetDecouplingAPI) import StripePaymentSheet
 
 class PaymentSheetAPITest: XCTestCase {
-
+    
     let apiClient = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
     lazy var paymentHandler: STPPaymentHandler = {
         return STPPaymentHandler(
@@ -39,7 +39,7 @@ class PaymentSheetAPITest: XCTestCase {
         }
         return config
     }()
-
+    
     lazy var newCardPaymentOption: PaymentSheet.PaymentOption = {
         let cardParams = STPPaymentMethodCardParams()
         cardParams.number = "4242424242424242"
@@ -56,25 +56,25 @@ class PaymentSheetAPITest: XCTestCase {
                 type: .card
             )
         )
-
+        
         return newCardPaymentOption
     }()
-
+    
     override class func setUp() {
         super.setUp()
         // `PaymentSheet.load()` uses the `LinkAccountService` to lookup the Link user account.
         // Override the default cookie store since Keychain is not available in this test case.
         LinkAccountService.defaultCookieStore = LinkInMemoryCookieStore()
     }
-
+    
     // MARK: - load and confirm tests
-
+    
     func testPaymentSheetLoadAndConfirmWithPaymentIntent() {
         let expectation = XCTestExpectation(description: "Retrieve Payment Intent With Preferences")
         let types = ["ideal", "card", "bancontact", "sofort"]
         let expected = [.card, .iDEAL, .bancontact, .sofort]
             .filter { PaymentSheet.supportedPaymentMethods.contains($0) }
-
+        
         // 0. Create a PI on our test backend
         fetchPaymentIntent(types: types) { result in
             switch result {
@@ -92,7 +92,7 @@ class PaymentSheetAPITest: XCTestCase {
                         )
                         XCTAssertEqual(paymentMethods, [])
                         // 2. Confirm the intent with a new card
-
+                        
                         PaymentSheet.confirm(
                             configuration: self.configuration,
                             authenticationContext: self,
@@ -132,14 +132,14 @@ class PaymentSheetAPITest: XCTestCase {
                         print(error)
                     }
                 }
-
+                
             case .failure(let error):
                 print(error)
             }
         }
         wait(for: [expectation], timeout: STPTestingNetworkRequestTimeout)
     }
-
+    
     func testPaymentSheetLoadWithSetupIntent() {
         let expectation = XCTestExpectation(description: "Retrieve Setup Intent With Preferences")
         let types = ["ideal", "card", "bancontact", "sofort"]
@@ -163,19 +163,19 @@ class PaymentSheetAPITest: XCTestCase {
                         print(error)
                     }
                 }
-
+                
             case .failure(let error):
                 print(error)
             }
         }
         wait(for: [expectation], timeout: STPTestingNetworkRequestTimeout)
     }
-
+    
     func testPaymentSheetLoadAndConfirmWithDeferredIntent() {
         let loadExpectation = XCTestExpectation(description: "Load PaymentSheet")
         let confirmExpectation = XCTestExpectation(description: "Confirm deferred intent")
         let callbackExpectation = XCTestExpectation(description: "Confirm callback invoked")
-
+        
         let types = ["card", "cashapp"]
         let expected: [STPPaymentMethodType] = [.card, .cashApp]
         let confirmHandler: PaymentSheet.IntentConfiguration.ConfirmHandler = {_, intentCreationCallback in
@@ -210,7 +210,7 @@ class PaymentSheetAPITest: XCTestCase {
                     XCTFail()
                     return
                 }
-
+                
                 PaymentSheet.confirm(configuration: self.configuration,
                                      authenticationContext: self,
                                      intent: .deferredIntent(elementsSession: elementsSession,
@@ -226,20 +226,20 @@ class PaymentSheetAPITest: XCTestCase {
                         XCTFail("Failed to confirm: \(error)")
                     }
                 }
-
+                
             case .failure(let error):
                 print(error)
             }
         }
-
+        
         wait(for: [loadExpectation, confirmExpectation, callbackExpectation], timeout: STPTestingNetworkRequestTimeout)
     }
-
+    
     func testPaymentSheetLoadAndConfirmWithDeferredIntent_serverSideConfirmation() {
         let loadExpectation = XCTestExpectation(description: "Load PaymentSheet")
         let confirmExpectation = XCTestExpectation(description: "Confirm deferred intent")
         let callbackExpectation = XCTestExpectation(description: "Confirm callback invoked")
-
+        
         let types = ["card", "cashapp"]
         let expected: [STPPaymentMethodType] = [.card, .cashApp]
         let serverSideConfirmHandler: PaymentSheet.IntentConfiguration.ConfirmHandlerForServerSideConfirmation = {paymentMethodID, _, intentCreationCallback in
@@ -277,7 +277,7 @@ class PaymentSheetAPITest: XCTestCase {
                     XCTFail()
                     return
                 }
-
+                
                 PaymentSheet.confirm(configuration: self.configuration,
                                      authenticationContext: self,
                                      intent: .deferredIntent(elementsSession: elementsSession,
@@ -293,15 +293,15 @@ class PaymentSheetAPITest: XCTestCase {
                         XCTFail("Failed to confirm: \(error)")
                     }
                 }
-
+                
             case .failure(let error):
                 print(error)
             }
         }
-
+        
         wait(for: [loadExpectation, confirmExpectation, callbackExpectation], timeout: STPTestingNetworkRequestTimeout)
     }
-
+    
     func testPaymentSheetLoadAndConfirmWithPaymentIntentAttachedPaymentMethod() {
         let expectation = XCTestExpectation(
             description: "Load PaymentIntent with an attached payment method"
@@ -315,7 +315,7 @@ class PaymentSheetAPITest: XCTestCase {
                 XCTFail()
                 return
             }
-
+            
             // 1. Load the PI
             PaymentSheet.load(
                 mode: .paymentIntentClientSecret(clientSecret),
@@ -366,7 +366,7 @@ class PaymentSheetAPITest: XCTestCase {
         }
         wait(for: [expectation], timeout: STPTestingNetworkRequestTimeout)
     }
-
+    
     func testPaymentSheetLoadWithSetupIntentAttachedPaymentMethod() {
         let expectation = XCTestExpectation(
             description: "Load SetupIntent with an attached payment method"
@@ -379,7 +379,7 @@ class PaymentSheetAPITest: XCTestCase {
                 expectation.fulfill()
                 return
             }
-
+            
             PaymentSheet.load(
                 mode: .setupIntentClientSecret(clientSecret),
                 configuration: self.configuration
@@ -393,9 +393,334 @@ class PaymentSheetAPITest: XCTestCase {
         }
         wait(for: [expectation], timeout: STPTestingNetworkRequestTimeout)
     }
+    
+    // MARK: - Deferred confirm tests
+    struct TestCase {
+        let name: String
+        let isPaymentIntent: Bool
+        let input_paymentOption: PaymentOption
+        let expected_shouldSavePaymentMethod: Bool
+        let expected_result: PaymentSheetResult
+    }
+    struct ExpectedError: LocalizedError {
+        var errorDescription: String?
+    }
+    var valid_card_checkbox_selected: IntentConfirmParams {
+        let intentConfirmParams = IntentConfirmParams(params: ._testValidCardValue(), type: .card)
+        intentConfirmParams.saveForFutureUseCheckboxState = .selected
+        return intentConfirmParams
+    }
+    var valid_card_checkbox_deselected: IntentConfirmParams {
+        let intentConfirmParams = IntentConfirmParams(params: ._testValidCardValue(), type: .card)
+        intentConfirmParams.saveForFutureUseCheckboxState = .deselected
+        return intentConfirmParams
+    }
+    func createValidSavedPaymentMethod() -> STPPaymentMethod {
+        var validSavedPM: STPPaymentMethod? = nil
+        let createPMExpectation = expectation(description: "Create PM")
+        apiClient.createPaymentMethod(with: ._testValidCardValue()) { paymentMethod, error in
+            guard let paymentMethod = paymentMethod else {
+                XCTFail(String(describing: error))
+                return
+            }
+            validSavedPM = paymentMethod
+            createPMExpectation.fulfill()
+        }
+        waitForExpectations(timeout: 10)
+        return validSavedPM!
+    }
+    
+    func testDeferredConfirm_valid_new_card_and_save_checkbox_selected() {
+        _testDeferredConfirm(
+            inputPaymentOption: .new(confirmParams: valid_card_checkbox_selected),
+            expectedShouldSavePaymentMethod: true,
+            expectedResult: .completed,
+            isPaymentIntent: true,
+            isServerSideConfirm: false // Client-side confirmation
 
+        )
+        _testDeferredConfirm(
+            inputPaymentOption: .new(confirmParams: valid_card_checkbox_selected),
+            expectedShouldSavePaymentMethod: true,
+            expectedResult: .completed,
+            isPaymentIntent: true,
+            isServerSideConfirm: true // Server-side confirmation
+        )
+    }
+    
+    func testDeferredConfirm_valid_new_card_and_save_checkbox_deselected() {
+        _testDeferredConfirm(
+            inputPaymentOption: .new(confirmParams: valid_card_checkbox_deselected),
+            expectedShouldSavePaymentMethod: false,
+            expectedResult: .completed,
+            isPaymentIntent: true, // PaymentIntent
+            isServerSideConfirm: false // Client-side confirmation
+        )
+        _testDeferredConfirm(
+            inputPaymentOption: .new(confirmParams: valid_card_checkbox_deselected),
+            expectedShouldSavePaymentMethod: false,
+            expectedResult: .completed,
+            isPaymentIntent: true, // PaymentIntent
+            isServerSideConfirm: true // Server-side confirmation
+        )
+    }
+    
+    func testDeferredConfirm_valid_saved_card() {
+        _testDeferredConfirm(
+            inputPaymentOption: .saved(paymentMethod: createValidSavedPaymentMethod()),
+            expectedShouldSavePaymentMethod: false,
+            expectedResult: .completed,
+            isPaymentIntent: true, // PaymentIntent
+            isServerSideConfirm: false // Client-side confirmation
+        )
+        _testDeferredConfirm(
+            inputPaymentOption: .saved(paymentMethod: createValidSavedPaymentMethod()),
+            expectedShouldSavePaymentMethod: false,
+            expectedResult: .completed,
+            isPaymentIntent: true, // PaymentIntent
+            isServerSideConfirm: true // Server-side confirmation
+        )
+        _testDeferredConfirm(
+            inputPaymentOption: .saved(paymentMethod: createValidSavedPaymentMethod()),
+            expectedShouldSavePaymentMethod: false,
+            expectedResult: .completed,
+            isPaymentIntent: false, // SetupIntent
+            isServerSideConfirm: false // Client-side confirmation
+        )
+        _testDeferredConfirm(
+            inputPaymentOption: .saved(paymentMethod: createValidSavedPaymentMethod()),
+            expectedShouldSavePaymentMethod: false,
+            expectedResult: .completed,
+            isPaymentIntent: false, // SetupIntent
+            isServerSideConfirm: true // Server-side confirmation
+        )
+    }
+    
+    func testDeferredConfirm_new_expired_card() {
+        // Note: This fails when the PM is created
+        let invalid_exp_year_card = IntentConfirmParams(params: .init(card: STPFixtures.paymentMethodCardParams(), billingDetails: nil, metadata: nil), type: .card)
+        _testDeferredConfirm(
+            inputPaymentOption: .new(confirmParams: invalid_exp_year_card),
+            expectedShouldSavePaymentMethod: false,
+            expectedResult: .failed(error: ExpectedError(errorDescription: "Your card's expiration year is invalid.")),
+            isPaymentIntent: true, // PaymentIntent
+            isServerSideConfirm: false // Client-side confirmation
+        )
+        _testDeferredConfirm(
+            inputPaymentOption: .new(confirmParams: invalid_exp_year_card),
+            expectedShouldSavePaymentMethod: false,
+            expectedResult: .failed(error: ExpectedError(errorDescription: "Your card's expiration year is invalid.")),
+            isPaymentIntent: true, // PaymentIntent
+            isServerSideConfirm: true // Server-side confirmation
+        )
+        _testDeferredConfirm(
+            inputPaymentOption: .new(confirmParams: invalid_exp_year_card),
+            expectedShouldSavePaymentMethod: false,
+            expectedResult: .failed(error: ExpectedError(errorDescription: "Your card's expiration year is invalid.")),
+            isPaymentIntent: false, // SetupIntent
+            isServerSideConfirm: false // Client-side confirmation
+        )
+        _testDeferredConfirm(
+            inputPaymentOption: .new(confirmParams: invalid_exp_year_card),
+            expectedShouldSavePaymentMethod: false,
+            expectedResult: .failed(error: ExpectedError(errorDescription: "Your card's expiration year is invalid.")),
+            isPaymentIntent: false, // SetupIntent
+            isServerSideConfirm: true // Server-side confirmation
+        )
+    }
+    
+    func testDeferredConfirm_new_insufficient_funds_card() {
+        // Note: This fails when the intent is confirmed
+        let insufficient_funds_new_PM = IntentConfirmParams(params: ._testCardValue(number: "4000000000009995"), type: .card)
+        _testDeferredConfirm(
+            inputPaymentOption: .new(confirmParams: insufficient_funds_new_PM),
+            expectedShouldSavePaymentMethod: false,
+            expectedResult: .failed(error: ExpectedError(errorDescription: "Your card has insufficient funds.")),
+            isPaymentIntent: true, // PaymentIntent
+            isServerSideConfirm: false // Client-side confirmation
+        )
+        _testDeferredConfirm(
+            inputPaymentOption: .new(confirmParams: insufficient_funds_new_PM),
+            expectedShouldSavePaymentMethod: false,
+            expectedResult: .failed(error: ExpectedError(errorDescription: "Your card has insufficient funds.")),
+            isPaymentIntent: true, // PaymentIntent
+            isServerSideConfirm: true // Server-side confirmation
+        )
+        _testDeferredConfirm(
+            inputPaymentOption: .new(confirmParams: insufficient_funds_new_PM),
+            expectedShouldSavePaymentMethod: false,
+            expectedResult: .failed(error: ExpectedError(errorDescription: "Your card has insufficient funds.")),
+            isPaymentIntent: false, // SetupIntent
+            isServerSideConfirm: false // Client-side confirmation
+        )
+        _testDeferredConfirm(
+            inputPaymentOption: .new(confirmParams: insufficient_funds_new_PM),
+            expectedShouldSavePaymentMethod: false,
+            expectedResult: .failed(error: ExpectedError(errorDescription: "Your card has insufficient funds.")),
+            isPaymentIntent: false, // SetupIntent
+            isServerSideConfirm: true // Server-side confirmation
+        )
+    }
+    
+    func testDeferredConfirm_saved_insufficient_funds_card() {
+        let insufficient_funds_saved_PM = STPPaymentMethod(stripeId: "pm_card_visa_chargeDeclinedInsufficientFunds")
+        _testDeferredConfirm(
+            inputPaymentOption: .saved(paymentMethod: insufficient_funds_saved_PM),
+            expectedShouldSavePaymentMethod: false,
+            expectedResult: .failed(error: ExpectedError(errorDescription: "Your card has insufficient funds.")),
+            isPaymentIntent: true, // PaymentIntent
+            isServerSideConfirm: false // Client-side confirmation
+        )
+        _testDeferredConfirm(
+            inputPaymentOption: .saved(paymentMethod: insufficient_funds_saved_PM),
+            expectedShouldSavePaymentMethod: false,
+            expectedResult: .failed(error: ExpectedError(errorDescription: "Your card has insufficient funds.")),
+            isPaymentIntent: true, // PaymentIntent
+            isServerSideConfirm: true // Server-side confirmation
+        )
+        _testDeferredConfirm(
+            inputPaymentOption: .saved(paymentMethod: insufficient_funds_saved_PM),
+            expectedShouldSavePaymentMethod: false,
+            expectedResult: .failed(error: ExpectedError(errorDescription: "Your card has insufficient funds.")),
+            isPaymentIntent: false, // SetupIntent
+            isServerSideConfirm: false // Client-side confirmation
+        )
+        _testDeferredConfirm(
+            inputPaymentOption: .saved(paymentMethod: insufficient_funds_saved_PM),
+            expectedShouldSavePaymentMethod: false,
+            expectedResult: .failed(error: ExpectedError(errorDescription: "Your card has insufficient funds.")),
+            isPaymentIntent: false, // SetupIntent
+            isServerSideConfirm: true // Server-side confirmation
+        )
+    }
+    
+    func _testDeferredConfirm(
+        inputPaymentOption: PaymentOption,
+        expectedShouldSavePaymentMethod: Bool,
+        expectedResult: PaymentSheetResult,
+        isPaymentIntent: Bool,
+        isServerSideConfirm: Bool
+    ) {
+        let expectation = expectation(description: "")
+        var sut_paymentMethodID: String = "" // The PM that the sut gave us
+        var merchant_clientSecret: String? = nil
+        let client_confirmHandler: PaymentSheet.IntentConfiguration.ConfirmHandler = { paymentMethodID, intentCreationCallback in
+            sut_paymentMethodID = paymentMethodID
+            let createIntentCompletion: (String?, Error?) -> Void = { clientSecret, error in
+                if let clientSecret {
+                    merchant_clientSecret = clientSecret
+                    intentCreationCallback(.success(clientSecret))
+                } else {
+                    intentCreationCallback(.failure(error ?? NSError()))
+                }
+            }
+            if isPaymentIntent {
+                STPTestingAPIClient.shared().createPaymentIntent(withParams: [
+                    "amount": 1050,
+                ], completion: createIntentCompletion)
+            } else {
+                STPTestingAPIClient.shared().createSetupIntent(withParams: [:
+                ], completion: createIntentCompletion)
+            }
+        }
+        let server_confirmHandler: PaymentSheet.IntentConfiguration.ConfirmHandlerForServerSideConfirmation = { paymentMethodID, shouldSavePaymentMethod, intentCreationCallback in
+            XCTAssertEqual(shouldSavePaymentMethod, expectedShouldSavePaymentMethod)
+            sut_paymentMethodID = paymentMethodID
+            let createIntentCompletion: (String?, Error?) -> Void = { clientSecret, error in
+                if let clientSecret {
+                    merchant_clientSecret = clientSecret
+                    intentCreationCallback(.success(clientSecret))
+                } else {
+                    intentCreationCallback(.failure(error ?? NSError()))
+                }
+            }
+            if isPaymentIntent {
+                STPTestingAPIClient.shared().createPaymentIntent(withParams: [
+                    "amount": 1050,
+                    "payment_method": paymentMethodID,
+                    "confirm": true,
+                    "payment_method_options[card][setup_future_usage]": expectedShouldSavePaymentMethod ? "off_session" : "",
+                ], completion: createIntentCompletion)
+            } else {
+                STPTestingAPIClient.shared().createSetupIntent(withParams: [
+                    "confirm": "true",
+                    "payment_method": paymentMethodID,
+                    "payment_method_types": ["card"],
+                    "return_url": "foo://z",
+                ], completion: createIntentCompletion)
+            }
+        }
+        let intentConfigMode: PaymentSheet.IntentConfiguration.Mode = {
+            if isPaymentIntent {
+                return .payment(amount: 1050, currency: "USD")
+            } else {
+                return .setup(currency: nil)
+            }
+        }()
+        let intentConfig: PaymentSheet.IntentConfiguration = {
+            if isServerSideConfirm {
+                return .init(mode: intentConfigMode, confirmHandlerForServerSideConfirmation: server_confirmHandler)
+            } else {
+                return .init(mode: intentConfigMode, confirmHandler: client_confirmHandler)
+            }
+        }()
+        let intent: Intent = .deferredIntent(
+            elementsSession: ._testCardValue(),
+            intentConfig: intentConfig
+        )
+        var configuration = self.configuration
+        configuration.customer = .init(id: "", ephemeralKeySecret: "")
+        PaymentSheet.confirm(
+            configuration: configuration,
+            authenticationContext: self,
+            intent: intent,
+            paymentOption: inputPaymentOption,
+            paymentHandler: self.paymentHandler
+        ) { result in
+            XCTAssertTrue(Thread.isMainThread)
+            switch (result, expectedResult) {
+            case (.completed, .completed):
+                if isPaymentIntent {
+                    self.apiClient.retrievePaymentIntent(withClientSecret: merchant_clientSecret!) { intent, error in
+                        expectation.fulfill()
+                        guard let intent else { XCTFail("Failed to retrieve Intent"); return }
+                        // The PM passed to the merchant should match the PM on the succeeded intent
+                        XCTAssertEqual(intent.paymentMethodId, sut_paymentMethodID)
+                        // The PI should succeed
+                        XCTAssertEqual(intent.status, STPPaymentIntentStatus.succeeded)
+                        // The PI's sfu value should match `expectedShouldSavePaymentMethod`
+                        let cardSFU = (intent.paymentMethodOptions?.allResponseFields["card"] as? [String: Any])?["setup_future_usage"] as? String
+                        if expectedShouldSavePaymentMethod {
+                            XCTAssertEqual(cardSFU, "off_session")
+                        } else {
+                            XCTAssertNil(cardSFU)
+                        }
+                    }
+                } else {
+                    self.apiClient.retrieveSetupIntent(withClientSecret: merchant_clientSecret!) { intent, error in
+                        expectation.fulfill()
+                        guard let intent else { XCTFail("Failed to retrieve Intent"); return }
+                        // The PM passed to the merchant should match the PM on the succeeded intent
+                        XCTAssertEqual(intent.paymentMethodID, sut_paymentMethodID)
+                        // The PI should succeed
+                        XCTAssertEqual(intent.status, STPSetupIntentStatus.succeeded)
+                    }
+                }
+            case (.canceled, .canceled):
+                expectation.fulfill()
+            case (.failed(let resultError), .failed(let expectedError)):
+                // Hack: Use hasSuffix b/c the test backend prepends "Error creating PaymentIntent:" to its returned error string
+                XCTAssertTrue(resultError.localizedDescription.hasSuffix(expectedError.localizedDescription))
+                expectation.fulfill()
+            default:
+                XCTFail("Result did not match. Expected \(expectedResult) but got \(result)")
+            }
+        }
+        waitForExpectations(timeout: 10)
+    }
+    
     // MARK: - update tests
-
+    
     func testUpdate() {
         var intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1000, currency: "USD")) { _, _ in
             // These tests don't confirm, so this is unused
@@ -417,7 +742,7 @@ class PaymentSheetAPITest: XCTestCase {
                     XCTAssertTrue(sut.viewController.intent.isSettingUp)
                     XCTAssertFalse(sut.viewController.intent.isPaymentIntent)
                     firstUpdateExpectation.fulfill()
-
+                    
                     // ...updating the intent config multiple times should succeed...
                     intentConfig.mode = .payment(amount: 100, currency: "USD", setupFutureUsage: nil)
                     sut.update(intentConfiguration: intentConfig) { error in
@@ -434,12 +759,12 @@ class PaymentSheetAPITest: XCTestCase {
         }
         waitForExpectations(timeout: 10)
     }
-
+    
     func testUpdateFails() {
         var intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1000, currency: "USD")) { _, _ in
             // These tests don't confirm, so this is unused
         }
-
+        
         let failedUpdateExpectation = expectation(description: "First update fails")
         let secondUpdateExpectation = expectation(description: "Second update succeeds")
         PaymentSheet.FlowController.create(intentConfiguration: intentConfig, configuration: configuration) { result in
@@ -453,7 +778,7 @@ class PaymentSheetAPITest: XCTestCase {
                     XCTAssertNil(sut.paymentOption)
                     failedUpdateExpectation.fulfill()
                     // Note: `confirm` has an assertionFailure if paymentOption is nil, so we don't check it here.
-
+                    
                     // ...updating should succeed after failing to update
                     intentConfig.mode = .setup(currency: "USD", setupFutureUsage: .offSession)
                     sut.update(intentConfiguration: intentConfig) { error in
@@ -469,12 +794,12 @@ class PaymentSheetAPITest: XCTestCase {
         }
         waitForExpectations(timeout: 10)
     }
-
+    
     func testUpdateIgnoresInFlightUpdate() {
         var intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1000, currency: "USD")) { _, _ in
             // These tests don't confirm, so this is unused
         }
-
+        
         let firstUpdateExpectation = expectation(description: "First update should not invoke callback")
         firstUpdateExpectation.isInverted = true
         let secondUpdateExpectation = expectation(description: "Second update succeeds")
@@ -486,7 +811,7 @@ class PaymentSheetAPITest: XCTestCase {
                 flowController.update(intentConfiguration: intentConfig) { _ in
                     firstUpdateExpectation.fulfill()
                 }
-
+                
                 intentConfig.mode = .setup(currency: "USD", setupFutureUsage: .offSession)
                 flowController.update(intentConfiguration: intentConfig) { error in
                     XCTAssertNil(error)
@@ -500,9 +825,9 @@ class PaymentSheetAPITest: XCTestCase {
         }
         waitForExpectations(timeout: 10)
     }
-
+    
     // MARK: - other tests
-
+    
     func testMakeShippingParamsReturnsNilIfPaymentIntentHasDifferentShipping() {
         // Given a PI with shipping...
         let pi = STPFixtures.paymentIntent()
@@ -514,7 +839,8 @@ class PaymentSheetAPITest: XCTestCase {
         var config = configuration
         // ...PaymentSheet should set shipping params on /confirm
         XCTAssertNotNil(PaymentSheet.makeShippingParams(for: pi, configuration: config))
-
+        XCTAssertNotNil(PaymentSheet.makePaymentIntentParams(confirmPaymentMethodType: .saved(STPFixtures.paymentMethod()), paymentIntent: pi, configuration: config).shipping)
+        
         // However, if the PI and config have the same shipping...
         config.shippingDetails = {
             return .init(
@@ -532,8 +858,9 @@ class PaymentSheetAPITest: XCTestCase {
         }
         // ...PaymentSheet should not set shipping params on /confirm
         XCTAssertNil(PaymentSheet.makeShippingParams(for: pi, configuration: config))
+        XCTAssertNil(PaymentSheet.makePaymentIntentParams(confirmPaymentMethodType: .saved(STPFixtures.paymentMethod()), paymentIntent: pi, configuration: config).shipping)
     }
-
+    
     /// Setting SFU to `true` when a customer is set should set the parameter to `off_session`.
     func testPaymentIntentParamsWithSFUTrueAndCustomer() {
         let paymentIntentParams = STPPaymentIntentParams(clientSecret: "")
@@ -543,7 +870,7 @@ class PaymentSheetAPITest: XCTestCase {
             paymentMethodType: PaymentSheet.PaymentMethodType.card,
             customer: .init(id: "", ephemeralKeySecret: "")
         )
-
+        
         let params = STPFormEncoder.dictionary(forObject: paymentIntentParams)
         guard
             let paymentMethodOptions = params["payment_method_options"] as? [String: Any],
@@ -553,10 +880,10 @@ class PaymentSheetAPITest: XCTestCase {
             XCTFail("Incorrect params")
             return
         }
-
+        
         XCTAssertEqual(setupFutureUsage, "off_session")
     }
-
+    
     /// Setting SFU to `false` when a customer is set should set the parameter to an empty string.
     func testPaymentIntentParamsWithSFUFalseAndCustomer() {
         let paymentIntentParams = STPPaymentIntentParams(clientSecret: "")
@@ -566,7 +893,7 @@ class PaymentSheetAPITest: XCTestCase {
             paymentMethodType: PaymentSheet.PaymentMethodType.card,
             customer: .init(id: "", ephemeralKeySecret: "")
         )
-
+        
         let params = STPFormEncoder.dictionary(forObject: paymentIntentParams)
         guard
             let paymentMethodOptions = params["payment_method_options"] as? [String: Any],
@@ -576,10 +903,10 @@ class PaymentSheetAPITest: XCTestCase {
             XCTFail("Incorrect params")
             return
         }
-
+        
         XCTAssertEqual(setupFutureUsage, "")
     }
-
+    
     /// Setting SFU to `true` when no customer is set shouldn't set the parameter.
     func testPaymentIntentParamsWithSFUTrueAndNoCustomer() {
         let paymentIntentParams = STPPaymentIntentParams(clientSecret: "")
@@ -589,11 +916,11 @@ class PaymentSheetAPITest: XCTestCase {
             paymentMethodType: PaymentSheet.PaymentMethodType.card,
             customer: nil
         )
-
+        
         let params = STPFormEncoder.dictionary(forObject: paymentIntentParams)
         XCTAssertEqual((params["payment_method_options"] as! [String: Any]).count, 0)
     }
-
+    
     /// Setting SFU to `false` when no customer is set shouldn't set the parameter.
     func testPaymentIntentParamsWithSFUFalseAndNoCustomer() {
         let paymentIntentParams = STPPaymentIntentParams(clientSecret: "")
@@ -603,13 +930,104 @@ class PaymentSheetAPITest: XCTestCase {
             paymentMethodType: PaymentSheet.PaymentMethodType.card,
             customer: nil
         )
-
+        
         let params = STPFormEncoder.dictionary(forObject: paymentIntentParams)
         XCTAssertEqual((params["payment_method_options"] as! [String: Any]).count, 0)
     }
-
+    
+    func testMakeIntentParams_always_sets_paymentMethodType() {
+        let examplePaymentMethodParams = STPPaymentMethodParams(card: STPFixtures.paymentMethodCardParams(), billingDetails: nil, metadata: nil)
+        let examplePaymentMethod = STPFixtures.paymentMethod()
+        var configuration = PaymentSheet.Configuration._testValue_MostPermissive()
+        configuration.customer = .init(id: "id", ephemeralKeySecret: "ek")
+        let confirmTypes: [PaymentSheet.ConfirmPaymentMethodType] = [
+            .new(params: examplePaymentMethodParams, shouldSave: false),
+            .new(params: examplePaymentMethodParams, paymentMethod: examplePaymentMethod, shouldSave: false),
+            .saved(examplePaymentMethod),
+        ]
+        for confirmType in confirmTypes {
+            let pi_params = PaymentSheet.makePaymentIntentParams(
+                confirmPaymentMethodType: confirmType,
+                paymentIntent: STPFixtures.paymentIntent(),
+                configuration: configuration
+            )
+            XCTAssertEqual(pi_params.paymentMethodType, .card)
+            XCTAssertEqual(pi_params.returnURL, configuration.returnURL)
+            if pi_params.paymentMethodParams == nil {
+                XCTAssertEqual(pi_params.paymentMethodId, examplePaymentMethod.stripeId)
+            }
+            let si_params = PaymentSheet.makeSetupIntentParams(
+                confirmPaymentMethodType: confirmType,
+                setupIntent: STPFixtures.setupIntent(),
+                configuration: configuration
+            )
+            XCTAssertEqual(si_params.paymentMethodType, .card)
+            XCTAssertEqual(si_params.returnURL, configuration.returnURL)
+            if si_params.paymentMethodParams == nil {
+                XCTAssertEqual(si_params.paymentMethodID, examplePaymentMethod.stripeId)
+            }
+        }
+    }
+    
+    func testMakeIntentParams_paypal_sets_mandate() {
+        let paypalPaymentMethodParams = STPPaymentMethodParams(payPal: .init(), billingDetails: nil, metadata: nil)
+        let paypalPaymentMethod = STPPaymentMethod.decodedObject(fromAPIResponse: ["id": "pm_123", "type": "paypal"])!
+        var configuration = PaymentSheet.Configuration._testValue_MostPermissive()
+        configuration.customer = .init(id: "id", ephemeralKeySecret: "ek")
+        // Confirming w/ a new Paypal PM...
+        let confirmTypes: [PaymentSheet.ConfirmPaymentMethodType] = [
+            .new(params: paypalPaymentMethodParams, shouldSave: false),
+            .new(params: paypalPaymentMethodParams, paymentMethod: paypalPaymentMethod, shouldSave: false),
+        ]
+        
+        for confirmType in confirmTypes {
+            // Params for pi without SFU supplied...
+            let params_for_pi_without_sfu = PaymentSheet.makePaymentIntentParams(
+                confirmPaymentMethodType: confirmType,
+                paymentIntent: STPFixtures.makePaymentIntent(),
+                configuration: configuration
+            )
+            // ...shouldn't have mandate data
+            XCTAssertNil(params_for_pi_without_sfu.mandateData)
+            // Params for pi with SFU supplied...
+            let params_for_pi_with_sfu = PaymentSheet.makePaymentIntentParams(
+                confirmPaymentMethodType: confirmType,
+                paymentIntent: STPFixtures.makePaymentIntent(setupFutureUsage: .offSession),
+                configuration: configuration
+            )
+            // ...should have mandate data
+            XCTAssertNotNil(params_for_pi_with_sfu.mandateData)
+            XCTAssert(params_for_pi_with_sfu.mandateData != nil)
+            // Params for si
+            let params_for_si_with_sfu = PaymentSheet.makeSetupIntentParams(
+                confirmPaymentMethodType: confirmType,
+                setupIntent: STPFixtures.setupIntent(),
+                configuration: configuration
+            )
+            // ...should have mandate data
+            XCTAssertNotNil(params_for_si_with_sfu.mandateData)
+        }
+    }
+    
     // MARK: - helper methods
-
+    func fetchPaymentIntent(
+        types: [String],
+        currency: String = "eur",
+        paymentMethodID: String? = nil,
+        confirm: Bool = false
+    ) async throws -> String {
+        try await withCheckedThrowingContinuation() { continuation in
+            fetchPaymentIntent(
+                types: types,
+                currency: currency,
+                paymentMethodID: paymentMethodID,
+                confirm: confirm
+            ) { result in
+                continuation.resume(with: result)
+            }
+        }
+    }
+    
     func fetchPaymentIntent(
         types: [String],
         currency: String = "eur",
@@ -625,23 +1043,23 @@ class PaymentSheetAPITest: XCTestCase {
         if let paymentMethodID = paymentMethodID {
             params["payment_method"] = paymentMethodID
         }
-
+        
         STPTestingAPIClient
             .shared()
             .createPaymentIntent(
                 withParams: params
             ) { clientSecret, error in
                 guard let clientSecret = clientSecret,
-                    error == nil
+                      error == nil
                 else {
                     completion(.failure(error!))
                     return
                 }
-
+                
                 completion(.success(clientSecret))
             }
     }
-
+    
     func fetchSetupIntent(types: [String], completion: @escaping (Result<(String), Error>) -> Void)
     {
         STPTestingAPIClient
@@ -652,16 +1070,15 @@ class PaymentSheetAPITest: XCTestCase {
                 ]
             ) { clientSecret, error in
                 guard let clientSecret = clientSecret,
-                    error == nil
+                      error == nil
                 else {
                     completion(.failure(error!))
                     return
                 }
-
+                
                 completion(.success(clientSecret))
             }
     }
-
 }
 
 extension PaymentSheetAPITest: STPAuthenticationContext {

--- a/Stripe/StripeiOSTests/PaymentSheet+APITest.swift
+++ b/Stripe/StripeiOSTests/PaymentSheet+APITest.swift
@@ -15,7 +15,7 @@ import XCTest
 @testable@_spi(STP) @_spi(ExperimentalPaymentSheetDecouplingAPI) import StripePaymentSheet
 
 class PaymentSheetAPITest: XCTestCase {
-    
+
     let apiClient = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
     lazy var paymentHandler: STPPaymentHandler = {
         return STPPaymentHandler(
@@ -39,7 +39,7 @@ class PaymentSheetAPITest: XCTestCase {
         }
         return config
     }()
-    
+
     lazy var newCardPaymentOption: PaymentSheet.PaymentOption = {
         let cardParams = STPPaymentMethodCardParams()
         cardParams.number = "4242424242424242"
@@ -56,25 +56,25 @@ class PaymentSheetAPITest: XCTestCase {
                 type: .card
             )
         )
-        
+
         return newCardPaymentOption
     }()
-    
+
     override class func setUp() {
         super.setUp()
         // `PaymentSheet.load()` uses the `LinkAccountService` to lookup the Link user account.
         // Override the default cookie store since Keychain is not available in this test case.
         LinkAccountService.defaultCookieStore = LinkInMemoryCookieStore()
     }
-    
+
     // MARK: - load and confirm tests
-    
+
     func testPaymentSheetLoadAndConfirmWithPaymentIntent() {
         let expectation = XCTestExpectation(description: "Retrieve Payment Intent With Preferences")
         let types = ["ideal", "card", "bancontact", "sofort"]
         let expected = [.card, .iDEAL, .bancontact, .sofort]
             .filter { PaymentSheet.supportedPaymentMethods.contains($0) }
-        
+
         // 0. Create a PI on our test backend
         fetchPaymentIntent(types: types) { result in
             switch result {
@@ -92,7 +92,7 @@ class PaymentSheetAPITest: XCTestCase {
                         )
                         XCTAssertEqual(paymentMethods, [])
                         // 2. Confirm the intent with a new card
-                        
+
                         PaymentSheet.confirm(
                             configuration: self.configuration,
                             authenticationContext: self,
@@ -132,14 +132,14 @@ class PaymentSheetAPITest: XCTestCase {
                         print(error)
                     }
                 }
-                
+
             case .failure(let error):
                 print(error)
             }
         }
         wait(for: [expectation], timeout: STPTestingNetworkRequestTimeout)
     }
-    
+
     func testPaymentSheetLoadWithSetupIntent() {
         let expectation = XCTestExpectation(description: "Retrieve Setup Intent With Preferences")
         let types = ["ideal", "card", "bancontact", "sofort"]
@@ -163,19 +163,19 @@ class PaymentSheetAPITest: XCTestCase {
                         print(error)
                     }
                 }
-                
+
             case .failure(let error):
                 print(error)
             }
         }
         wait(for: [expectation], timeout: STPTestingNetworkRequestTimeout)
     }
-    
+
     func testPaymentSheetLoadAndConfirmWithDeferredIntent() {
         let loadExpectation = XCTestExpectation(description: "Load PaymentSheet")
         let confirmExpectation = XCTestExpectation(description: "Confirm deferred intent")
         let callbackExpectation = XCTestExpectation(description: "Confirm callback invoked")
-        
+
         let types = ["card", "cashapp"]
         let expected: [STPPaymentMethodType] = [.card, .cashApp]
         let confirmHandler: PaymentSheet.IntentConfiguration.ConfirmHandler = {_, intentCreationCallback in
@@ -210,7 +210,7 @@ class PaymentSheetAPITest: XCTestCase {
                     XCTFail()
                     return
                 }
-                
+
                 PaymentSheet.confirm(configuration: self.configuration,
                                      authenticationContext: self,
                                      intent: .deferredIntent(elementsSession: elementsSession,
@@ -226,20 +226,20 @@ class PaymentSheetAPITest: XCTestCase {
                         XCTFail("Failed to confirm: \(error)")
                     }
                 }
-                
+
             case .failure(let error):
                 print(error)
             }
         }
-        
+
         wait(for: [loadExpectation, confirmExpectation, callbackExpectation], timeout: STPTestingNetworkRequestTimeout)
     }
-    
+
     func testPaymentSheetLoadAndConfirmWithDeferredIntent_serverSideConfirmation() {
         let loadExpectation = XCTestExpectation(description: "Load PaymentSheet")
         let confirmExpectation = XCTestExpectation(description: "Confirm deferred intent")
         let callbackExpectation = XCTestExpectation(description: "Confirm callback invoked")
-        
+
         let types = ["card", "cashapp"]
         let expected: [STPPaymentMethodType] = [.card, .cashApp]
         let serverSideConfirmHandler: PaymentSheet.IntentConfiguration.ConfirmHandlerForServerSideConfirmation = {paymentMethodID, _, intentCreationCallback in
@@ -277,7 +277,7 @@ class PaymentSheetAPITest: XCTestCase {
                     XCTFail()
                     return
                 }
-                
+
                 PaymentSheet.confirm(configuration: self.configuration,
                                      authenticationContext: self,
                                      intent: .deferredIntent(elementsSession: elementsSession,
@@ -293,15 +293,15 @@ class PaymentSheetAPITest: XCTestCase {
                         XCTFail("Failed to confirm: \(error)")
                     }
                 }
-                
+
             case .failure(let error):
                 print(error)
             }
         }
-        
+
         wait(for: [loadExpectation, confirmExpectation, callbackExpectation], timeout: STPTestingNetworkRequestTimeout)
     }
-    
+
     func testPaymentSheetLoadAndConfirmWithPaymentIntentAttachedPaymentMethod() {
         let expectation = XCTestExpectation(
             description: "Load PaymentIntent with an attached payment method"
@@ -315,7 +315,7 @@ class PaymentSheetAPITest: XCTestCase {
                 XCTFail()
                 return
             }
-            
+
             // 1. Load the PI
             PaymentSheet.load(
                 mode: .paymentIntentClientSecret(clientSecret),
@@ -366,7 +366,7 @@ class PaymentSheetAPITest: XCTestCase {
         }
         wait(for: [expectation], timeout: STPTestingNetworkRequestTimeout)
     }
-    
+
     func testPaymentSheetLoadWithSetupIntentAttachedPaymentMethod() {
         let expectation = XCTestExpectation(
             description: "Load SetupIntent with an attached payment method"
@@ -379,7 +379,7 @@ class PaymentSheetAPITest: XCTestCase {
                 expectation.fulfill()
                 return
             }
-            
+
             PaymentSheet.load(
                 mode: .setupIntentClientSecret(clientSecret),
                 configuration: self.configuration
@@ -393,7 +393,7 @@ class PaymentSheetAPITest: XCTestCase {
         }
         wait(for: [expectation], timeout: STPTestingNetworkRequestTimeout)
     }
-    
+
     // MARK: - Deferred confirm tests
     struct TestCase {
         let name: String
@@ -416,7 +416,7 @@ class PaymentSheetAPITest: XCTestCase {
         return intentConfirmParams
     }
     func createValidSavedPaymentMethod() -> STPPaymentMethod {
-        var validSavedPM: STPPaymentMethod? = nil
+        var validSavedPM: STPPaymentMethod?
         let createPMExpectation = expectation(description: "Create PM")
         apiClient.createPaymentMethod(with: ._testValidCardValue()) { paymentMethod, error in
             guard let paymentMethod = paymentMethod else {
@@ -429,7 +429,7 @@ class PaymentSheetAPITest: XCTestCase {
         waitForExpectations(timeout: 10)
         return validSavedPM!
     }
-    
+
     func testDeferredConfirm_valid_new_card_and_save_checkbox_selected() {
         _testDeferredConfirm(
             inputPaymentOption: .new(confirmParams: valid_card_checkbox_selected),
@@ -447,7 +447,7 @@ class PaymentSheetAPITest: XCTestCase {
             isServerSideConfirm: true // Server-side confirmation
         )
     }
-    
+
     func testDeferredConfirm_valid_new_card_and_save_checkbox_deselected() {
         _testDeferredConfirm(
             inputPaymentOption: .new(confirmParams: valid_card_checkbox_deselected),
@@ -464,7 +464,7 @@ class PaymentSheetAPITest: XCTestCase {
             isServerSideConfirm: true // Server-side confirmation
         )
     }
-    
+
     func testDeferredConfirm_valid_saved_card() {
         _testDeferredConfirm(
             inputPaymentOption: .saved(paymentMethod: createValidSavedPaymentMethod()),
@@ -495,7 +495,7 @@ class PaymentSheetAPITest: XCTestCase {
             isServerSideConfirm: true // Server-side confirmation
         )
     }
-    
+
     func testDeferredConfirm_new_expired_card() {
         // Note: This fails when the PM is created
         let invalid_exp_year_card = IntentConfirmParams(params: .init(card: STPFixtures.paymentMethodCardParams(), billingDetails: nil, metadata: nil), type: .card)
@@ -528,7 +528,7 @@ class PaymentSheetAPITest: XCTestCase {
             isServerSideConfirm: true // Server-side confirmation
         )
     }
-    
+
     func testDeferredConfirm_new_insufficient_funds_card() {
         // Note: This fails when the intent is confirmed
         let insufficient_funds_new_PM = IntentConfirmParams(params: ._testCardValue(number: "4000000000009995"), type: .card)
@@ -561,7 +561,7 @@ class PaymentSheetAPITest: XCTestCase {
             isServerSideConfirm: true // Server-side confirmation
         )
     }
-    
+
     func testDeferredConfirm_saved_insufficient_funds_card() {
         let insufficient_funds_saved_PM = STPPaymentMethod(stripeId: "pm_card_visa_chargeDeclinedInsufficientFunds")
         _testDeferredConfirm(
@@ -593,7 +593,7 @@ class PaymentSheetAPITest: XCTestCase {
             isServerSideConfirm: true // Server-side confirmation
         )
     }
-    
+
     func _testDeferredConfirm(
         inputPaymentOption: PaymentOption,
         expectedShouldSavePaymentMethod: Bool,
@@ -603,7 +603,7 @@ class PaymentSheetAPITest: XCTestCase {
     ) {
         let expectation = expectation(description: "")
         var sut_paymentMethodID: String = "" // The PM that the sut gave us
-        var merchant_clientSecret: String? = nil
+        var merchant_clientSecret: String?
         let client_confirmHandler: PaymentSheet.IntentConfiguration.ConfirmHandler = { paymentMethodID, intentCreationCallback in
             sut_paymentMethodID = paymentMethodID
             let createIntentCompletion: (String?, Error?) -> Void = { clientSecret, error in
@@ -681,7 +681,7 @@ class PaymentSheetAPITest: XCTestCase {
             switch (result, expectedResult) {
             case (.completed, .completed):
                 if isPaymentIntent {
-                    self.apiClient.retrievePaymentIntent(withClientSecret: merchant_clientSecret!) { intent, error in
+                    self.apiClient.retrievePaymentIntent(withClientSecret: merchant_clientSecret!) { intent, _ in
                         expectation.fulfill()
                         guard let intent else { XCTFail("Failed to retrieve Intent"); return }
                         // The PM passed to the merchant should match the PM on the succeeded intent
@@ -697,7 +697,7 @@ class PaymentSheetAPITest: XCTestCase {
                         }
                     }
                 } else {
-                    self.apiClient.retrieveSetupIntent(withClientSecret: merchant_clientSecret!) { intent, error in
+                    self.apiClient.retrieveSetupIntent(withClientSecret: merchant_clientSecret!) { intent, _ in
                         expectation.fulfill()
                         guard let intent else { XCTFail("Failed to retrieve Intent"); return }
                         // The PM passed to the merchant should match the PM on the succeeded intent
@@ -718,9 +718,9 @@ class PaymentSheetAPITest: XCTestCase {
         }
         waitForExpectations(timeout: 10)
     }
-    
+
     // MARK: - update tests
-    
+
     func testUpdate() {
         var intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1000, currency: "USD")) { _, _ in
             // These tests don't confirm, so this is unused
@@ -742,7 +742,7 @@ class PaymentSheetAPITest: XCTestCase {
                     XCTAssertTrue(sut.viewController.intent.isSettingUp)
                     XCTAssertFalse(sut.viewController.intent.isPaymentIntent)
                     firstUpdateExpectation.fulfill()
-                    
+
                     // ...updating the intent config multiple times should succeed...
                     intentConfig.mode = .payment(amount: 100, currency: "USD", setupFutureUsage: nil)
                     sut.update(intentConfiguration: intentConfig) { error in
@@ -759,12 +759,12 @@ class PaymentSheetAPITest: XCTestCase {
         }
         waitForExpectations(timeout: 10)
     }
-    
+
     func testUpdateFails() {
         var intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1000, currency: "USD")) { _, _ in
             // These tests don't confirm, so this is unused
         }
-        
+
         let failedUpdateExpectation = expectation(description: "First update fails")
         let secondUpdateExpectation = expectation(description: "Second update succeeds")
         PaymentSheet.FlowController.create(intentConfiguration: intentConfig, configuration: configuration) { result in
@@ -778,7 +778,7 @@ class PaymentSheetAPITest: XCTestCase {
                     XCTAssertNil(sut.paymentOption)
                     failedUpdateExpectation.fulfill()
                     // Note: `confirm` has an assertionFailure if paymentOption is nil, so we don't check it here.
-                    
+
                     // ...updating should succeed after failing to update
                     intentConfig.mode = .setup(currency: "USD", setupFutureUsage: .offSession)
                     sut.update(intentConfiguration: intentConfig) { error in
@@ -794,12 +794,12 @@ class PaymentSheetAPITest: XCTestCase {
         }
         waitForExpectations(timeout: 10)
     }
-    
+
     func testUpdateIgnoresInFlightUpdate() {
         var intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1000, currency: "USD")) { _, _ in
             // These tests don't confirm, so this is unused
         }
-        
+
         let firstUpdateExpectation = expectation(description: "First update should not invoke callback")
         firstUpdateExpectation.isInverted = true
         let secondUpdateExpectation = expectation(description: "Second update succeeds")
@@ -811,7 +811,7 @@ class PaymentSheetAPITest: XCTestCase {
                 flowController.update(intentConfiguration: intentConfig) { _ in
                     firstUpdateExpectation.fulfill()
                 }
-                
+
                 intentConfig.mode = .setup(currency: "USD", setupFutureUsage: .offSession)
                 flowController.update(intentConfiguration: intentConfig) { error in
                     XCTAssertNil(error)
@@ -825,9 +825,9 @@ class PaymentSheetAPITest: XCTestCase {
         }
         waitForExpectations(timeout: 10)
     }
-    
+
     // MARK: - other tests
-    
+
     func testMakeShippingParamsReturnsNilIfPaymentIntentHasDifferentShipping() {
         // Given a PI with shipping...
         let pi = STPFixtures.paymentIntent()
@@ -840,7 +840,7 @@ class PaymentSheetAPITest: XCTestCase {
         // ...PaymentSheet should set shipping params on /confirm
         XCTAssertNotNil(PaymentSheet.makeShippingParams(for: pi, configuration: config))
         XCTAssertNotNil(PaymentSheet.makePaymentIntentParams(confirmPaymentMethodType: .saved(STPFixtures.paymentMethod()), paymentIntent: pi, configuration: config).shipping)
-        
+
         // However, if the PI and config have the same shipping...
         config.shippingDetails = {
             return .init(
@@ -860,7 +860,7 @@ class PaymentSheetAPITest: XCTestCase {
         XCTAssertNil(PaymentSheet.makeShippingParams(for: pi, configuration: config))
         XCTAssertNil(PaymentSheet.makePaymentIntentParams(confirmPaymentMethodType: .saved(STPFixtures.paymentMethod()), paymentIntent: pi, configuration: config).shipping)
     }
-    
+
     /// Setting SFU to `true` when a customer is set should set the parameter to `off_session`.
     func testPaymentIntentParamsWithSFUTrueAndCustomer() {
         let paymentIntentParams = STPPaymentIntentParams(clientSecret: "")
@@ -870,7 +870,7 @@ class PaymentSheetAPITest: XCTestCase {
             paymentMethodType: PaymentSheet.PaymentMethodType.card,
             customer: .init(id: "", ephemeralKeySecret: "")
         )
-        
+
         let params = STPFormEncoder.dictionary(forObject: paymentIntentParams)
         guard
             let paymentMethodOptions = params["payment_method_options"] as? [String: Any],
@@ -880,10 +880,10 @@ class PaymentSheetAPITest: XCTestCase {
             XCTFail("Incorrect params")
             return
         }
-        
+
         XCTAssertEqual(setupFutureUsage, "off_session")
     }
-    
+
     /// Setting SFU to `false` when a customer is set should set the parameter to an empty string.
     func testPaymentIntentParamsWithSFUFalseAndCustomer() {
         let paymentIntentParams = STPPaymentIntentParams(clientSecret: "")
@@ -893,7 +893,7 @@ class PaymentSheetAPITest: XCTestCase {
             paymentMethodType: PaymentSheet.PaymentMethodType.card,
             customer: .init(id: "", ephemeralKeySecret: "")
         )
-        
+
         let params = STPFormEncoder.dictionary(forObject: paymentIntentParams)
         guard
             let paymentMethodOptions = params["payment_method_options"] as? [String: Any],
@@ -903,10 +903,10 @@ class PaymentSheetAPITest: XCTestCase {
             XCTFail("Incorrect params")
             return
         }
-        
+
         XCTAssertEqual(setupFutureUsage, "")
     }
-    
+
     /// Setting SFU to `true` when no customer is set shouldn't set the parameter.
     func testPaymentIntentParamsWithSFUTrueAndNoCustomer() {
         let paymentIntentParams = STPPaymentIntentParams(clientSecret: "")
@@ -916,11 +916,11 @@ class PaymentSheetAPITest: XCTestCase {
             paymentMethodType: PaymentSheet.PaymentMethodType.card,
             customer: nil
         )
-        
+
         let params = STPFormEncoder.dictionary(forObject: paymentIntentParams)
         XCTAssertEqual((params["payment_method_options"] as! [String: Any]).count, 0)
     }
-    
+
     /// Setting SFU to `false` when no customer is set shouldn't set the parameter.
     func testPaymentIntentParamsWithSFUFalseAndNoCustomer() {
         let paymentIntentParams = STPPaymentIntentParams(clientSecret: "")
@@ -930,11 +930,11 @@ class PaymentSheetAPITest: XCTestCase {
             paymentMethodType: PaymentSheet.PaymentMethodType.card,
             customer: nil
         )
-        
+
         let params = STPFormEncoder.dictionary(forObject: paymentIntentParams)
         XCTAssertEqual((params["payment_method_options"] as! [String: Any]).count, 0)
     }
-    
+
     func testMakeIntentParams_always_sets_paymentMethodType() {
         let examplePaymentMethodParams = STPPaymentMethodParams(card: STPFixtures.paymentMethodCardParams(), billingDetails: nil, metadata: nil)
         let examplePaymentMethod = STPFixtures.paymentMethod()
@@ -968,7 +968,7 @@ class PaymentSheetAPITest: XCTestCase {
             }
         }
     }
-    
+
     func testMakeIntentParams_paypal_sets_mandate() {
         let paypalPaymentMethodParams = STPPaymentMethodParams(payPal: .init(), billingDetails: nil, metadata: nil)
         let paypalPaymentMethod = STPPaymentMethod.decodedObject(fromAPIResponse: ["id": "pm_123", "type": "paypal"])!
@@ -979,7 +979,7 @@ class PaymentSheetAPITest: XCTestCase {
             .new(params: paypalPaymentMethodParams, shouldSave: false),
             .new(params: paypalPaymentMethodParams, paymentMethod: paypalPaymentMethod, shouldSave: false),
         ]
-        
+
         for confirmType in confirmTypes {
             // Params for pi without SFU supplied...
             let params_for_pi_without_sfu = PaymentSheet.makePaymentIntentParams(
@@ -1008,7 +1008,7 @@ class PaymentSheetAPITest: XCTestCase {
             XCTAssertNotNil(params_for_si_with_sfu.mandateData)
         }
     }
-    
+
     // MARK: - helper methods
     func fetchPaymentIntent(
         types: [String],
@@ -1016,7 +1016,7 @@ class PaymentSheetAPITest: XCTestCase {
         paymentMethodID: String? = nil,
         confirm: Bool = false
     ) async throws -> String {
-        try await withCheckedThrowingContinuation() { continuation in
+        try await withCheckedThrowingContinuation { continuation in
             fetchPaymentIntent(
                 types: types,
                 currency: currency,
@@ -1027,7 +1027,7 @@ class PaymentSheetAPITest: XCTestCase {
             }
         }
     }
-    
+
     func fetchPaymentIntent(
         types: [String],
         currency: String = "eur",
@@ -1043,7 +1043,7 @@ class PaymentSheetAPITest: XCTestCase {
         if let paymentMethodID = paymentMethodID {
             params["payment_method"] = paymentMethodID
         }
-        
+
         STPTestingAPIClient
             .shared()
             .createPaymentIntent(
@@ -1055,11 +1055,11 @@ class PaymentSheetAPITest: XCTestCase {
                     completion(.failure(error!))
                     return
                 }
-                
+
                 completion(.success(clientSecret))
             }
     }
-    
+
     func fetchSetupIntent(types: [String], completion: @escaping (Result<(String), Error>) -> Void)
     {
         STPTestingAPIClient
@@ -1075,7 +1075,7 @@ class PaymentSheetAPITest: XCTestCase {
                     completion(.failure(error!))
                     return
                 }
-                
+
                 completion(.success(clientSecret))
             }
     }

--- a/Stripe/StripeiOSTests/PaymentSheet+APITest.swift
+++ b/Stripe/StripeiOSTests/PaymentSheet+APITest.swift
@@ -611,7 +611,7 @@ class PaymentSheetAPITest: XCTestCase {
                     merchant_clientSecret = clientSecret
                     intentCreationCallback(.success(clientSecret))
                 } else {
-                    intentCreationCallback(.failure(error ?? NSError()))
+                    intentCreationCallback(.failure(error ?? ExpectedError()))
                 }
             }
             if isPaymentIntent {
@@ -631,7 +631,7 @@ class PaymentSheetAPITest: XCTestCase {
                     merchant_clientSecret = clientSecret
                     intentCreationCallback(.success(clientSecret))
                 } else {
-                    intentCreationCallback(.failure(error ?? NSError()))
+                    intentCreationCallback(.failure(error ?? ExpectedError()))
                 }
             }
             if isPaymentIntent {

--- a/Stripe/StripeiOSTests/STPFixtures+Swift.swift
+++ b/Stripe/StripeiOSTests/STPFixtures+Swift.swift
@@ -70,7 +70,7 @@ extension STPPaymentMethodParams {
     static func _testValidCardValue() -> STPPaymentMethodParams {
         return _testCardValue()
     }
-    
+
     static func _testCardValue(number: String = "4242424242424242") -> STPPaymentMethodParams {
         let cardParams = STPPaymentMethodCardParams()
         cardParams.number = number
@@ -88,4 +88,3 @@ extension STPElementsSession {
         return elementsSession
     }
 }
-

--- a/Stripe/StripeiOSTests/STPFixtures+Swift.swift
+++ b/Stripe/StripeiOSTests/STPFixtures+Swift.swift
@@ -65,3 +65,27 @@ extension PaymentSheet.Configuration {
         return configuration
     }
 }
+
+extension STPPaymentMethodParams {
+    static func _testValidCardValue() -> STPPaymentMethodParams {
+        return _testCardValue()
+    }
+    
+    static func _testCardValue(number: String = "4242424242424242") -> STPPaymentMethodParams {
+        let cardParams = STPPaymentMethodCardParams()
+        cardParams.number = number
+        cardParams.cvc = "123"
+        cardParams.expYear = (Calendar.current.dateComponents([.year], from: Date()).year! + 1) as NSNumber
+        cardParams.expMonth = 01
+        return STPPaymentMethodParams(card: cardParams, billingDetails: nil, metadata: nil)
+    }
+}
+
+extension STPElementsSession {
+    static func _testCardValue() -> STPElementsSession {
+        let elementsSessionJson = STPTestUtils.jsonNamed("ElementsSession")!
+        let elementsSession = STPElementsSession.decodedObject(fromAPIResponse: elementsSessionJson)!
+        return elementsSession
+    }
+}
+

--- a/Stripe/StripeiOSTests/STPPaymentHandlerFunctionalTest.swift
+++ b/Stripe/StripeiOSTests/STPPaymentHandlerFunctionalTest.swift
@@ -21,14 +21,8 @@ final class STPPaymentHandlerFunctionalSwiftTest: XCTestCase, STPAuthenticationC
 
     func test_card_payment_intent_server_side_confirmation() {
         let apiClient = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
-        let cardParams = STPPaymentMethodCardParams()
-        cardParams.number = "4242424242424242"
-        cardParams.cvc = "123"
-        cardParams.expYear = (Calendar.current.dateComponents([.year], from: Date()).year! + 1) as NSNumber
-        cardParams.expMonth = 01
-
         let e = self.expectation(description: "")
-        apiClient.createPaymentMethod(with: .init(card: cardParams, billingDetails: nil, metadata: nil)) { paymentMethod, error in
+        apiClient.createPaymentMethod(with: ._testValidCardValue()) { paymentMethod, error in
             guard let paymentMethod = paymentMethod else {
                 XCTFail(String(describing: error))
                 return
@@ -114,14 +108,9 @@ final class STPPaymentHandlerFunctionalSwiftTest: XCTestCase, STPAuthenticationC
 
     func test_card_setup_intent_server_side_confirmation() {
         let apiClient = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
-        let cardParams = STPPaymentMethodCardParams()
-        cardParams.number = "4242424242424242"
-        cardParams.cvc = "123"
-        cardParams.expYear = Calendar.current.dateComponents([.year], from: Date()).year! + 1 as NSNumber
-        cardParams.expMonth = 01
 
         let e = self.expectation(description: "")
-        apiClient.createPaymentMethod(with: .init(card: cardParams, billingDetails: nil, metadata: nil)) { paymentMethod, error in
+        apiClient.createPaymentMethod(with: ._testValidCardValue()) { paymentMethod, error in
             guard let paymentMethod = paymentMethod else {
                 XCTFail(String(describing: error))
                 return

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfirmParams.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfirmParams.swift
@@ -70,44 +70,6 @@ class IntentConfirmParams {
         self.paymentMethodParams = params
     }
 
-    func makeParams(
-        paymentIntentClientSecret: String,
-        configuration: PaymentSheet.Configuration,
-        paymentMethodID: String?
-    ) -> STPPaymentIntentParams {
-        let params: STPPaymentIntentParams
-        // If a payment method ID was provided use that, otherwise use the payment method params
-        if let paymentMethodID = paymentMethodID {
-            params = STPPaymentIntentParams(clientSecret: paymentIntentClientSecret, paymentMethodType: paymentMethodParams.type)
-            params.paymentMethodId = paymentMethodID
-        } else {
-            params = STPPaymentIntentParams(clientSecret: paymentIntentClientSecret)
-            params.paymentMethodParams = paymentMethodParams
-        }
-
-        let options = STPConfirmPaymentMethodOptions()
-        options.setSetupFutureUsageIfNecessary(
-            saveForFutureUseCheckboxState == .selected,
-            paymentMethodType: paymentMethodType,
-            customer: configuration.customer
-        )
-        params.paymentMethodOptions = options
-        return params
-    }
-
-    func makeParams(setupIntentClientSecret: String, paymentMethodID: String?) -> STPSetupIntentConfirmParams {
-        let params: STPSetupIntentConfirmParams
-        // If a payment method ID was provided use that, otherwise use the payment method params
-        if let paymentMethodID = paymentMethodID {
-            params = STPSetupIntentConfirmParams(clientSecret: setupIntentClientSecret, paymentMethodType: paymentMethodParams.type)
-            params.paymentMethodID = paymentMethodID
-        } else {
-            params = STPSetupIntentConfirmParams(clientSecret: setupIntentClientSecret)
-            params.paymentMethodParams = paymentMethodParams
-        }
-        return params
-    }
-
     func makeDashboardParams(
         paymentIntentClientSecret: String,
         paymentMethodID: String,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -557,12 +557,12 @@ extension PaymentSheet {
         }
         return params
     }
-    
+
     enum ConfirmPaymentMethodType {
         case saved(STPPaymentMethod)
         /// - paymentMethod: Pass this if you created a PaymentMethod already (e.g. for the deferred flow).
         case new(params: STPPaymentMethodParams, paymentMethod: STPPaymentMethod? = nil, shouldSave: Bool)
-        
+
         var shouldSave: Bool {
             switch self {
             case .saved:
@@ -572,7 +572,7 @@ extension PaymentSheet {
             }
         }
     }
-    
+
     static func makePaymentIntentParams(
         confirmPaymentMethodType: ConfirmPaymentMethodType,
         paymentIntent: STPPaymentIntent,
@@ -598,7 +598,7 @@ extension PaymentSheet {
                 params.paymentMethodParams = paymentMethodParams
                 paymentMethodType = paymentMethodParams.type
             }
-            
+
             // Paypal requires mandate_data if setting up
             if params.paymentMethodType == .payPal
                 && paymentIntent.setupFutureUsage == .offSession
@@ -614,7 +614,7 @@ extension PaymentSheet {
         params.shipping = makeShippingParams(for: paymentIntent, configuration: configuration)
         return params
     }
-    
+
     static func makeSetupIntentParams(
         confirmPaymentMethodType: ConfirmPaymentMethodType,
         setupIntent: STPSetupIntent,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+DeferredAPI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+DeferredAPI.swift
@@ -35,7 +35,7 @@ extension PaymentSheet {
                     paymentMethod = try await configuration.apiClient.createPaymentMethod(with: params)
                     confirmType = .new(params: params, paymentMethod: paymentMethod, shouldSave: shouldSave)
                 }
-                
+
                 // 2. Get Intent client secret from merchant
                 let clientSecret = try await fetchIntentClientSecretFromMerchant(intentConfig: intentConfig,
                                                                                  paymentMethodID: paymentMethod.stripeId,
@@ -46,7 +46,7 @@ extension PaymentSheet {
                     STPAnalyticsClient.sharedClient.logPaymentSheetEvent(event: .paymentSheetForceSuccess)
                     return
                 }
-                
+
                 // 3. Retrieve the PaymentIntent or SetupIntent
                 switch intentConfig.mode {
                 case .payment:
@@ -106,9 +106,9 @@ extension PaymentSheet {
             }
         }
     }
-    
+
     // MARK: - Helper methods
-    
+
     /// Convenience method that converts a STPPayymentHandlerActionStatus + error into a PaymentSheetResult
     static func makePaymentSheetResult(for status: STPPaymentHandlerActionStatus, error: Error?) -> PaymentSheetResult {
         switch status {
@@ -123,12 +123,12 @@ extension PaymentSheet {
             return .failed(error: PaymentSheetError.unknown(debugDescription: "Unrecognized STPPaymentHandlerActionStatus status"))
         }
     }
-    
+
     static func fetchIntentClientSecretFromMerchant(intentConfig: IntentConfiguration,
                                                     paymentMethodID: String,
                                                     shouldSavePaymentMethod: Bool) async throws -> String {
         try await withCheckedThrowingContinuation { continuation in
-            
+
             if let confirmHandlerForServerSideConfirmation = intentConfig.confirmHandlerForServerSideConfirmation {
                 DispatchQueue.main.async {
                     confirmHandlerForServerSideConfirmation(paymentMethodID, shouldSavePaymentMethod, { result in

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+DeferredAPI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+DeferredAPI.swift
@@ -12,98 +12,105 @@ import Foundation
 @available(iOSApplicationExtension, unavailable)
 @available(macCatalystApplicationExtension, unavailable)
 extension PaymentSheet {
-    static func createPaymentMethodIfNeeded(apiClient: STPAPIClient,
-                                            paymentMethod: STPPaymentMethod?,
-                                            paymentMethodParams: STPPaymentMethodParams?) async throws -> STPPaymentMethod {
-        if let paymentMethod = paymentMethod {
-            return paymentMethod
-        }
-
-        guard let paymentMethodParams = paymentMethodParams else {
-            throw PaymentSheetError.unknown(debugDescription: "paymentMethodParams unexpectedly nil")
-        }
-        return try await apiClient.createPaymentMethod(with: paymentMethodParams)
-    }
-
-    static func handleDeferredIntentConfirmation(deferredIntentContext: DeferredIntentContext,
-                                                 paymentMethod: STPPaymentMethod?,
-                                                 paymentMethodParams: STPPaymentMethodParams?,
-                                                 shouldSavePaymentMethod: Bool) {
+    static func handleDeferredIntentConfirmation(
+        confirmType: ConfirmPaymentMethodType,
+        configuration: PaymentSheet.Configuration,
+        intentConfig: PaymentSheet.IntentConfiguration,
+        authenticationContext: STPAuthenticationContext,
+        paymentHandler: STPPaymentHandler,
+        completion: @escaping (PaymentSheetResult) -> Void
+    ) {
         // Hack: Add deferred to analytics product usage as a hack to get it into the payment_user_agent string in the request to create a PaymentMethod
         STPAnalyticsClient.sharedClient.addClass(toProductUsageIfNecessary: IntentConfiguration.self)
-        Task {
+        Task { @MainActor in
             do {
+                var confirmType = confirmType
                 // 1. Create PM if necessary
-                let paymentMethod = try await createPaymentMethodIfNeeded(apiClient: deferredIntentContext.configuration.apiClient,
-                                                                           paymentMethod: paymentMethod,
-                                                                           paymentMethodParams: paymentMethodParams)
+                let paymentMethod: STPPaymentMethod
+                switch confirmType {
+                case let .saved(savedPaymentMethod):
+                    paymentMethod = savedPaymentMethod
+                case let .new(params, newPaymentMethod, shouldSave):
+                    assert(newPaymentMethod == nil)
+                    paymentMethod = try await configuration.apiClient.createPaymentMethod(with: params)
+                    confirmType = .new(params: params, paymentMethod: paymentMethod, shouldSave: shouldSave)
+                }
+                
                 // 2. Get Intent client secret from merchant
-                let clientSecret = try await fetchIntentClientSecretFromMerchant(intentConfig: deferredIntentContext.intentConfig,
+                let clientSecret = try await fetchIntentClientSecretFromMerchant(intentConfig: intentConfig,
                                                                                  paymentMethodID: paymentMethod.stripeId,
-                                                                                 shouldSavePaymentMethod: shouldSavePaymentMethod)
+                                                                                 shouldSavePaymentMethod: confirmType.shouldSave)
                 guard clientSecret != IntentConfiguration.FORCE_SUCCESS else {
                     // Force close PaymentSheet and early exit
-                    deferredIntentContext.completion(.completed)
+                    completion(.completed)
                     STPAnalyticsClient.sharedClient.logPaymentSheetEvent(event: .paymentSheetForceSuccess)
                     return
                 }
-
+                
                 // 3. Retrieve the PaymentIntent or SetupIntent
-                switch deferredIntentContext.intentConfig.mode {
+                switch intentConfig.mode {
                 case .payment:
-                    let paymentIntent = try await deferredIntentContext.configuration.apiClient.retrievePaymentIntent(clientSecret: clientSecret, expand: ["payment_method"])
+                    let paymentIntent = try await configuration.apiClient.retrievePaymentIntent(clientSecret: clientSecret, expand: ["payment_method"])
                     // Check if it needs confirmation
                     if [STPPaymentIntentStatus.requiresPaymentMethod, STPPaymentIntentStatus.requiresConfirmation].contains(paymentIntent.status) {
                         // 4a. Client-side confirmation
-                        confirm(configuration: deferredIntentContext.configuration,
-                                authenticationContext: deferredIntentContext.authenticationContext,
-                                intent: .paymentIntent(paymentIntent),
-                                paymentOption: deferredIntentContext.paymentOption,
-                                paymentHandler: deferredIntentContext.paymentHandler,
-                                paymentMethodID: paymentMethod.stripeId,
-                                completion: deferredIntentContext.completion)
-                    } else {
-                       // 4b. Server-side confirmation
-                        deferredIntentContext.paymentHandler.handleNextAction(
-                            for: paymentIntent,
-                            with: deferredIntentContext.authenticationContext,
-                            returnURL: deferredIntentContext.configuration.returnURL
+                        let paymentIntentParams = makePaymentIntentParams(
+                            confirmPaymentMethodType: confirmType,
+                            paymentIntent: paymentIntent,
+                            configuration: configuration
+                        )
+                        paymentHandler.confirmPayment(
+                            paymentIntentParams,
+                            with: authenticationContext
                         ) { status, _, error in
-                            deferredIntentContext.completion(paymentSheetResult(forPaymentHandlerActionStatus: status, error: error))
+                            completion(makePaymentSheetResult(for: status, error: error))
+                        }
+                    } else {
+                        // 4b. Server-side confirmation
+                        paymentHandler.handleNextAction(
+                            for: paymentIntent,
+                            with: authenticationContext,
+                            returnURL: configuration.returnURL
+                        ) { status, _, error in
+                            completion(makePaymentSheetResult(for: status, error: error))
                         }
                     }
                 case .setup:
-                    let setupIntent = try await deferredIntentContext.configuration.apiClient.retrieveSetupIntent(clientSecret: clientSecret, expand: ["payment_method"])
+                    let setupIntent = try await configuration.apiClient.retrieveSetupIntent(clientSecret: clientSecret, expand: ["payment_method"])
                     if [STPSetupIntentStatus.requiresPaymentMethod, STPSetupIntentStatus.requiresConfirmation].contains(setupIntent.status) {
                         // 4a. Client-side confirmation
-                        confirm(configuration: deferredIntentContext.configuration,
-                                authenticationContext: deferredIntentContext.authenticationContext,
-                                intent: .setupIntent(setupIntent),
-                                paymentOption: deferredIntentContext.paymentOption,
-                                paymentHandler: deferredIntentContext.paymentHandler,
-                                paymentMethodID: paymentMethod.stripeId,
-                                completion: deferredIntentContext.completion)
+                        let setupIntentParams = makeSetupIntentParams(
+                            confirmPaymentMethodType: confirmType,
+                            setupIntent: setupIntent,
+                            configuration: configuration
+                        )
+                        paymentHandler.confirmSetupIntent(
+                            setupIntentParams,
+                            with: authenticationContext
+                        ) { status, _, error in
+                            completion(makePaymentSheetResult(for: status, error: error))
+                        }
                     } else {
                         // 4b. Server-side confirmation
-                        deferredIntentContext.paymentHandler.handleNextAction(
+                        paymentHandler.handleNextAction(
                             for: setupIntent,
-                            with: deferredIntentContext.authenticationContext,
-                            returnURL: deferredIntentContext.configuration.returnURL
+                            with: authenticationContext,
+                            returnURL: configuration.returnURL
                         ) { status, _, error in
-                            deferredIntentContext.completion(paymentSheetResult(forPaymentHandlerActionStatus: status, error: error))
+                            completion(makePaymentSheetResult(for: status, error: error))
                         }
                     }
                 }
             } catch {
-                deferredIntentContext.completion(.failed(error: error))
+                completion(.failed(error: error))
             }
         }
     }
-
+    
     // MARK: - Helper methods
-
+    
     /// Convenience method that converts a STPPayymentHandlerActionStatus + error into a PaymentSheetResult
-    static func paymentSheetResult(forPaymentHandlerActionStatus status: STPPaymentHandlerActionStatus, error: Error?) -> PaymentSheetResult {
+    static func makePaymentSheetResult(for status: STPPaymentHandlerActionStatus, error: Error?) -> PaymentSheetResult {
         switch status {
         case .succeeded:
             return .completed
@@ -116,53 +123,24 @@ extension PaymentSheet {
             return .failed(error: PaymentSheetError.unknown(debugDescription: "Unrecognized STPPaymentHandlerActionStatus status"))
         }
     }
-
+    
     static func fetchIntentClientSecretFromMerchant(intentConfig: IntentConfiguration,
                                                     paymentMethodID: String,
                                                     shouldSavePaymentMethod: Bool) async throws -> String {
-      try await withCheckedThrowingContinuation { continuation in
-
-          if let confirmHandlerForServerSideConfirmation = intentConfig.confirmHandlerForServerSideConfirmation {
-              DispatchQueue.main.async {
-                  confirmHandlerForServerSideConfirmation(paymentMethodID, shouldSavePaymentMethod, { result in
-                      continuation.resume(with: result)
-                  })
-              }
-          } else if let confirmHandler = intentConfig.confirmHandler {
-              DispatchQueue.main.async {
-                  confirmHandler(paymentMethodID, { result in
-                      continuation.resume(with: result)
-                  })
-              }
-          }
-      }
-    }
-}
-
-/// Convenience class to avoid passing long argument lists when confirming deferred intents
-class DeferredIntentContext {
-    let configuration: PaymentSheet.Configuration
-    let intentConfig: PaymentSheet.IntentConfiguration
-    let paymentOption: PaymentOption
-    let authenticationContext: STPAuthenticationContext
-    let paymentHandler: STPPaymentHandler
-    let completion: PaymentSheetResultCompletionBlock
-
-    init(configuration: PaymentSheet.Configuration,
-         intentConfig: PaymentSheet.IntentConfiguration,
-         paymentOption: PaymentOption,
-         authenticationContext: STPAuthenticationContext,
-         paymentHandler: STPPaymentHandler,
-         completion: @escaping PaymentSheetResultCompletionBlock) {
-        self.configuration = configuration
-        self.intentConfig = intentConfig
-        self.paymentOption = paymentOption
-        self.authenticationContext = authenticationContext
-        self.paymentHandler = paymentHandler
-        // Always invoke completion handler on main thread
-        self.completion = { result in
-            DispatchQueue.main.async {
-                completion(result)
+        try await withCheckedThrowingContinuation { continuation in
+            
+            if let confirmHandlerForServerSideConfirmation = intentConfig.confirmHandlerForServerSideConfirmation {
+                DispatchQueue.main.async {
+                    confirmHandlerForServerSideConfirmation(paymentMethodID, shouldSavePaymentMethod, { result in
+                        continuation.resume(with: result)
+                    })
+                }
+            } else if let confirmHandler = intentConfig.confirmHandler {
+                DispatchQueue.main.async {
+                    confirmHandler(paymentMethodID, { result in
+                        continuation.resume(with: result)
+                    })
+                }
             }
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/SavedPaymentMethods/SavedPaymentMethodsSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/SavedPaymentMethods/SavedPaymentMethodsSheet+API.swift
@@ -38,7 +38,8 @@ extension SavedPaymentMethodsSheet {
             }
         if case .new(let confirmParams) = paymentOption,
            case .setupIntent(let setupIntent) = intent {
-            let setupIntentParams = confirmParams.makeParams(setupIntentClientSecret: setupIntent.clientSecret, paymentMethodID: nil)
+            let setupIntentParams = STPSetupIntentConfirmParams(clientSecret: setupIntent.clientSecret)
+            setupIntentParams.paymentMethodParams = confirmParams.paymentMethodParams
             setupIntentParams.returnURL = configuration.returnURL
             setupIntentParams.additionalAPIParameters = [ "expand": ["payment_method"]]
             paymentHandler.confirmSetupIntent(

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentIntents/STPPaymentIntentParams.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentIntents/STPPaymentIntentParams.swift
@@ -116,7 +116,7 @@ public class STPPaymentIntentParams: NSObject {
     @objc public var useStripeSDK: NSNumber?
 
     internal var _paymentMethodType: STPPaymentMethodType?
-    internal var paymentMethodType: STPPaymentMethodType? {
+    @_spi(STP) public var paymentMethodType: STPPaymentMethodType? {
         if let type = _paymentMethodType {
             return type
         }

--- a/StripePayments/StripePayments/Source/API Bindings/Models/SetupIntents/STPSetupIntentConfirmParams.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/SetupIntents/STPSetupIntentConfirmParams.swift
@@ -82,7 +82,7 @@ public class STPSetupIntentConfirmParams: NSObject, NSCopying, STPFormEncodable 
     private var _mandateData: STPMandateDataParams?
 
     internal var _paymentMethodType: STPPaymentMethodType?
-    internal var paymentMethodType: STPPaymentMethodType? {
+    @_spi(STP) public var paymentMethodType: STPPaymentMethodType? {
         if let type = _paymentMethodType {
             return type
         }


### PR DESCRIPTION
## Summary
- DRY's all the code that creates confirm parameters for intents into `makePaymentIntent`
- Makes `handleDeferredIntent` use ^ to confirm, rather than calling back to `PaymentSheet.confirm`
- Adds a bunch of tests for this deferred confirm flow

## Motivation
The previous codepath went like `confirm` -> `handleDeferredIntent...` -> `confirm` when confirming client-side.  This let us easily reuse code in the `confirm` method but the recursion was hard to follow and was making it hard to add analytics around server-side/client-side confirm. 

## Testing
- Added a lot of success & failure tests for the deferred confirm flow 
- Added unit tests for `makeIntentParams` helper method.

## Changelog
No user facing changes