### PR TITLE
Use ephemeralkey instead of id to remove  pyament method

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerAdapter/CustomerAdapter.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerAdapter/CustomerAdapter.swift
@@ -164,7 +164,7 @@ import UIKit
     open func detachPaymentMethod(paymentMethodId: String) async throws {
         let customerEphemeralKey = try await customerEphemeralKey
         return try await withCheckedThrowingContinuation({ continuation in
-            apiClient.detachPaymentMethod(paymentMethodId, fromCustomerUsing: customerEphemeralKey.id) { error in
+            apiClient.detachPaymentMethod(paymentMethodId, fromCustomerUsing: customerEphemeralKey.ephemeralKeySecret) { error in
                 if let error = error {
                     continuation.resume(throwing: error)
                     return


### PR DESCRIPTION
## Summary
Fix removing payment methods by using ephemeral key instead of customer key

## Motivation
Bug with saved payment methods sheet

## Testing
Manual testing

