### PR TITLE
Vend entire PM

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -707,7 +707,7 @@ extension PaymentSheetTestPlayground: EndpointSelectorViewControllerDelegate {
 extension PaymentSheetTestPlayground {
 
     // Client-side confirmation handler
-    func confirmHandler(_ paymentMethodID: String,
+    func confirmHandler(_ paymentMethod: STPPaymentMethod,
                         _ intentCreationCallback: @escaping (Result<String, Error>) -> Void) {
         DispatchQueue.global(qos: .background).async {
             intentCreationCallback(.success(self.clientSecret!))

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetSnapshotTests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetSnapshotTests.swift
@@ -1130,7 +1130,7 @@ class PaymentSheetSnapshotTests: FBSnapshotTestCase {
         stubCustomers()
     }
 
-    func confirmHandler(_ paymentMethodID: String,
+    func confirmHandler(_ paymentMethod: STPPaymentMethod,
                         _ intentCreationCallback: (Result<String, Error>) -> Void) {
         // no-op
     }

--- a/Stripe/StripeiOSTests/PaymentSheet+APITest.swift
+++ b/Stripe/StripeiOSTests/PaymentSheet+APITest.swift
@@ -604,8 +604,8 @@ class PaymentSheetAPITest: XCTestCase {
         let expectation = expectation(description: "")
         var sut_paymentMethodID: String = "" // The PM that the sut gave us
         var merchant_clientSecret: String?
-        let client_confirmHandler: PaymentSheet.IntentConfiguration.ConfirmHandler = { paymentMethodID, intentCreationCallback in
-            sut_paymentMethodID = paymentMethodID
+        let client_confirmHandler: PaymentSheet.IntentConfiguration.ConfirmHandler = { paymentMethod, intentCreationCallback in
+            sut_paymentMethodID = paymentMethod.stripeId
             let createIntentCompletion: (String?, Error?) -> Void = { clientSecret, error in
                 if let clientSecret {
                     merchant_clientSecret = clientSecret

--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/StripePaymentSheet+Exports.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/StripePaymentSheet+Exports.swift
@@ -9,3 +9,4 @@
 import Foundation
 
 @_exported import StripeCore
+@_exported import StripePayments

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+DeferredAPI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+DeferredAPI.swift
@@ -38,7 +38,7 @@ extension PaymentSheet {
 
                 // 2. Get Intent client secret from merchant
                 let clientSecret = try await fetchIntentClientSecretFromMerchant(intentConfig: intentConfig,
-                                                                                 paymentMethodID: paymentMethod.stripeId,
+                                                                                 paymentMethod: paymentMethod,
                                                                                  shouldSavePaymentMethod: confirmType.shouldSave)
                 guard clientSecret != IntentConfiguration.FORCE_SUCCESS else {
                     // Force close PaymentSheet and early exit
@@ -125,19 +125,19 @@ extension PaymentSheet {
     }
 
     static func fetchIntentClientSecretFromMerchant(intentConfig: IntentConfiguration,
-                                                    paymentMethodID: String,
+                                                    paymentMethod: STPPaymentMethod,
                                                     shouldSavePaymentMethod: Bool) async throws -> String {
         try await withCheckedThrowingContinuation { continuation in
 
             if let confirmHandlerForServerSideConfirmation = intentConfig.confirmHandlerForServerSideConfirmation {
                 DispatchQueue.main.async {
-                    confirmHandlerForServerSideConfirmation(paymentMethodID, shouldSavePaymentMethod, { result in
+                    confirmHandlerForServerSideConfirmation(paymentMethod.stripeId, shouldSavePaymentMethod, { result in
                         continuation.resume(with: result)
                     })
                 }
             } else if let confirmHandler = intentConfig.confirmHandler {
                 DispatchQueue.main.async {
-                    confirmHandler(paymentMethodID, { result in
+                    confirmHandler(paymentMethod, { result in
                         continuation.resume(with: result)
                     })
                 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetIntentConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetIntentConfiguration.swift
@@ -23,6 +23,7 @@ import Foundation
         /// - Note: You must create the PaymentIntent or SetupIntent with the same values used as the `IntentConfiguration` e.g. the same amount, currency, etc.
         /// - Parameters:
         ///   - paymentMethod: The `STPPaymentMethod` representing the customer's payment details.
+        ///   If your server needs the payment method, send `paymentMethod.stripeId` to your server and have it fetch the PaymentMethod object. Otherwise, you can ignore this. Don't send other properties besides the ID to your server.
         ///   - intentCreationCallback: Call this with the `client_secret` of the PaymentIntent or SetupIntent created by your server or the error that occurred. If you're using PaymentSheet, the error's localizedDescription will be displayed to the customer in the sheet. If you're using PaymentSheet.FlowController, the `confirm` method fails with the error.
         public typealias ConfirmHandler = (
             _ paymentMethod: STPPaymentMethod,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetIntentConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetIntentConfiguration.swift
@@ -22,11 +22,10 @@ import Foundation
         /// Your implementation should create a PaymentIntent or SetupIntent on your server and call the `intentCreationCallback` with its client secret or an error if one occurred.
         /// - Note: You must create the PaymentIntent or SetupIntent with the same values used as the `IntentConfiguration` e.g. the same amount, currency, etc.
         /// - Parameters:
-        ///   - paymentMethodId: The id of the PaymentMethod representing the customer's payment details.
-        ///     If you need to inspect payment method details, you can fetch the PaymentMethod object using this id on your server. Otherwise, you can ignore this.
+        ///   - paymentMethod: The `STPPaymentMethod` representing the customer's payment details.
         ///   - intentCreationCallback: Call this with the `client_secret` of the PaymentIntent or SetupIntent created by your server or the error that occurred. If you're using PaymentSheet, the error's localizedDescription will be displayed to the customer in the sheet. If you're using PaymentSheet.FlowController, the `confirm` method fails with the error.
         public typealias ConfirmHandler = (
-            _ paymentMethodID: String,
+            _ paymentMethod: STPPaymentMethod,
             _ intentCreationCallback: @escaping ((Result<String, Error>) -> Void)
         ) -> Void
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
@@ -52,8 +52,9 @@ extension STPApplePayContext {
             case .setupIntent(let setupIntent):
                 completion(setupIntent.clientSecret, nil)
             case .deferredIntent(_, let intentConfig):
-                if let confirmHandler = intentConfig.confirmHandler {
-                    confirmHandler(paymentMethod.id, { result in
+                if let confirmHandler = intentConfig.confirmHandler,
+                   let stpPaymentMethod = STPPaymentMethod.decodedObject(fromAPIResponse: paymentMethod.allResponseFields) {
+                    confirmHandler(stpPaymentMethod, { result in
                         switch result {
                         case .success(let clientSecret):
                             completion(clientSecret, nil)


### PR DESCRIPTION
## Summary
- Instead of vending the payment method ID we vend the entire payment method object

## Motivation
https://docs.google.com/document/d/1J8N62Cldh1TQ51uO18IXE349FJTrm7_dzzURAKzNKQ0/edit#heading=h.570u4leviueu

## Testing
- Manual
- Existing tests updated

## Changelog
N/A
