### PR TITLE
Update SavedPaymentMethodsSheetUITest to choose apple pay on/off

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/WalletModeUITests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/WalletModeUITests.swift
@@ -21,17 +21,59 @@ class SavedPaymentMethodsSheetUITest: XCTestCase {
         app.launch()
     }
 
-    func testPaymentSheetStandard() throws {
+    func testPaymentSheetStandard_applePayOff_addCard() throws {
         app.staticTexts["SavedPaymentMethodsSheet (test playground)"].tap()
         let loadButton = app.staticTexts["Load Ephemeral Key"]
         XCTAssertTrue(loadButton.waitForExistence(timeout: 60.0))
+        app.segmentedControls["apple_pay_selector"].buttons["off"].tap()
         loadButton.tap()
+
         let selectButton = app.staticTexts["Select"]
         XCTAssertTrue(selectButton.waitForExistence(timeout: 60.0))
         selectButton.tap()
         try! fillCardData(app, postalEnabled: false)
         app.buttons["Add"].tap()
         let paymentMethodButton = app.staticTexts["Success: ••••4242"]  // The card should be saved now
+        XCTAssertTrue(paymentMethodButton.waitForExistence(timeout: 60.0))
+    }
+
+    func testPaymentSheetStandard_applePayOn_addCard() throws {
+        app.staticTexts["SavedPaymentMethodsSheet (test playground)"].tap()
+        let loadButton = app.staticTexts["Load Ephemeral Key"]
+        XCTAssertTrue(loadButton.waitForExistence(timeout: 60.0))
+        app.segmentedControls["apple_pay_selector"].buttons["on"].tap()
+        loadButton.tap()
+
+        let selectButton = app.staticTexts["Select"]
+        XCTAssertTrue(selectButton.waitForExistence(timeout: 60.0))
+        selectButton.tap()
+
+        app.staticTexts["+ Add"].tap()
+
+        try! fillCardData(app, postalEnabled: false)
+        app.buttons["Add"].tap()
+        let paymentMethodButton = app.staticTexts["Success: ••••4242"]  // The card should be saved now
+        XCTAssertTrue(paymentMethodButton.waitForExistence(timeout: 60.0))
+    }
+
+    func testPaymentSheetStandard_applePayOn_selectApplePay() throws {
+        app.staticTexts["SavedPaymentMethodsSheet (test playground)"].tap()
+        let loadButton = app.staticTexts["Load Ephemeral Key"]
+        XCTAssertTrue(loadButton.waitForExistence(timeout: 60.0))
+        app.segmentedControls["apple_pay_selector"].buttons["on"].tap()
+        loadButton.tap()
+
+        let selectButton = app.staticTexts["Select"]
+        XCTAssertTrue(selectButton.waitForExistence(timeout: 60.0))
+        selectButton.tap()
+
+        app.collectionViews.staticTexts["Apple Pay"].tap()
+
+        let confirmButton = app.buttons["Confirm"]
+        XCTAssertTrue(confirmButton.waitForExistence(timeout: 60.0))
+        confirmButton.tap()
+
+        let paymentMethodButton = app.staticTexts["Success: Apple Pay"]  // The card should be saved now
         XCTAssertTrue(paymentMethodButton.waitForExistence(timeout: 60.0))
     }
 }


### PR DESCRIPTION
## Summary
Add apple pay as an option on/off in ui tests

## Motivation
This is currently breaking

## Testing
Executed tests locally on dev box
