### PR TITLE
Make spms re-presentable after being dismissed

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/SavedPaymentMethods/SavedPaymentMethodsSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/SavedPaymentMethods/SavedPaymentMethodsSheet.swift
@@ -39,13 +39,6 @@ internal enum SavedPaymentMethodsSheetResult {
     @available(macCatalystApplicationExtension, unavailable)
     lazy var bottomSheetViewController: BottomSheetViewController = {
         let isTestMode = configuration.apiClient.isTestmode
-        let loadingViewController = LoadingViewController(
-            delegate: self,
-            appearance: configuration.appearance,
-            isTestMode: isTestMode,
-            loadingViewHeight: 180
-        )
-
         let vc = BottomSheetViewController(
             contentViewController: loadingViewController,
             appearance: configuration.appearance,
@@ -59,7 +52,17 @@ internal enum SavedPaymentMethodsSheetResult {
         return vc
     }()
 
-    /// 
+    lazy var loadingViewController: LoadingViewController = {
+        let isTestMode = configuration.apiClient.isTestmode
+        return LoadingViewController(
+            delegate: self,
+            appearance: configuration.appearance,
+            isTestMode: isTestMode,
+            loadingViewHeight: 180
+        )
+    }()
+
+    ///
     /// Use a StripeCustomerAdapter, or build your own.
     public init(configuration: SavedPaymentMethodsSheet.Configuration,
                 customer: CustomerAdapter) {
@@ -95,6 +98,7 @@ internal enum SavedPaymentMethodsSheetResult {
                 // bottom sheet (i.e. Link) to be dismissed all at the same time.
                 presentingViewController.dismiss(animated: true)
             }
+            self.bottomSheetViewController.contentStack = [self.loadingViewController]
             self.completion = nil
         }
         self.completion = completion


### PR DESCRIPTION
## Summary
Overriding the contentStack with a loadingViewController on dismissal clears out the in memory SavedPaymentMethodsSheet.  Clearing this out of memory avoids this visual bug when attempting to re-present the sheet.

## Motivation
Visual bug

## Testing
Manual testing with payment sheet

Before:
![represent_withBug](https://github.com/stripe/stripe-ios/assets/99628984/dd9725b4-166a-4de7-99e0-82147bb52316)

After:
![represent_fixed](https://github.com/stripe/stripe-ios/assets/99628984/7763953c-6ab7-45bb-8998-42a4d740cc1a)
