### PR TITLE
Rename FORCE_SUCCESS

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -11,7 +11,7 @@
 //  This exposes internal functionality which may cause unexpected behavior if used directly.
 import Contacts
 import PassKit
-@_spi(STP) @_spi(ExperimentalPaymentSheetDecouplingAPI) import StripePaymentSheet
+@_spi(STP) @_spi(ExperimentalPaymentSheetDecouplingAPI) @_spi(PaymentSheetSkipConfirmation) import StripePaymentSheet
 import SwiftUI
 import UIKit
 
@@ -705,7 +705,7 @@ extension PaymentSheetTestPlayground {
         switch integrationType {
         case .deferred_mp:
             // multiprocessor
-            intentCreationCallback(.success(PaymentSheet.IntentConfiguration.FORCE_SUCCESS))
+            intentCreationCallback(.success(PaymentSheet.IntentConfiguration.COMPLETE_WITHOUT_CONFIRMING_INTENT))
             return
         case .deferred_csc:
             if integrationType == .deferred_csc {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+DeferredAPI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+DeferredAPI.swift
@@ -40,7 +40,7 @@ extension PaymentSheet {
                 let clientSecret = try await fetchIntentClientSecretFromMerchant(intentConfig: intentConfig,
                                                                                  paymentMethod: paymentMethod,
                                                                                  shouldSavePaymentMethod: confirmType.shouldSave)
-                guard clientSecret != IntentConfiguration.FORCE_SUCCESS else {
+                guard clientSecret != IntentConfiguration.COMPLETE_WITHOUT_CONFIRMING_INTENT else {
                     // Force close PaymentSheet and early exit
                     completion(.completed)
                     STPAnalyticsClient.sharedClient.logPaymentSheetEvent(event: .paymentSheetForceSuccess)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetIntentConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetIntentConfiguration.swift
@@ -15,7 +15,7 @@ import Foundation
     /// - Seealso: https://stripe.com/docs/payments/finalize-payments-on-the-server
     struct IntentConfiguration {
 
-        /// Pass this into `intentCreationCallback` to force PaymentSheet to show success, dismiss the sheet without confirming payment, and return a PaymentSheetResult of `completed`.
+        /// Pass this into `intentCreationCallback` to force PaymentSheet to show success, dismiss the sheet without confirming the intent, and return a PaymentSheetResult of `completed`.
         /// - Note: ⚠️ Only for advanced users, not required for most integrations.
         @_spi(PaymentSheetSkipConfirmation) public static let COMPLETE_WITHOUT_CONFIRMING_INTENT = "COMPLETE_WITHOUT_CONFIRMING_INTENT"
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetIntentConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetIntentConfiguration.swift
@@ -15,9 +15,9 @@ import Foundation
     /// - Seealso: https://stripe.com/docs/payments/finalize-payments-on-the-server
     struct IntentConfiguration {
 
-        /// Pass this into `intentCreationCallback` to force PaymentSheet to show success and dismiss.
-        /// - Note: Only for advanced users, not required for most integrations.
-        @_spi(STP) public static let FORCE_SUCCESS = "FORCE_SUCCESS"
+        /// Pass this into `intentCreationCallback` to force PaymentSheet to show success, dismiss the sheet without confirming payment, and return a PaymentSheetResult of `completed`.
+        /// - Note: ⚠️ Only for advanced users, not required for most integrations.
+        @_spi(PaymentSheetSkipConfirmation) public static let COMPLETE_WITHOUT_CONFIRMING_INTENT = "COMPLETE_WITHOUT_CONFIRMING_INTENT"
 
         /// Called when the customer confirms payment.
         /// Your implementation should follow the [guide](https://stripe.com/docs/payments/finalize-payments-on-the-server) to create (and optionally confirm) PaymentIntent or SetupIntent on your server and call the `intentCreationCallback` with its client secret or an error if one occurred.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetIntentConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetIntentConfiguration.swift
@@ -15,8 +15,9 @@ import Foundation
     /// - Seealso: https://stripe.com/docs/payments/finalize-payments-on-the-server
     struct IntentConfiguration {
 
-        /// Pass this into `intentCreationCallback` to force PaymentSheet to show success, dismiss the sheet without confirming the intent, and return a PaymentSheetResult of `completed`.
-        /// - Note: ⚠️ Only for advanced users, not required for most integrations.
+        /// Pass this into `intentCreationCallback` to force PaymentSheet to show success, dismiss the sheet, and return a PaymentSheetResult of `completed`.
+        /// - Note: ⚠️ If provided, the SDK performs no action to complete the payment or setup - it doesn't confirm a PaymentIntent or SetupIntent or handle next actions.
+        ///   You should only use this if your integration can't create a PaymentIntent or SetupIntent. It is your responsibility to ensure that you only pass this value if the payment or set up is successful. 
         @_spi(PaymentSheetSkipConfirmation) public static let COMPLETE_WITHOUT_CONFIRMING_INTENT = "COMPLETE_WITHOUT_CONFIRMING_INTENT"
 
         /// Called when the customer confirms payment.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
@@ -61,7 +61,7 @@ extension STPApplePayContext {
                 intentConfig.confirmHandler(stpPaymentMethod, shouldSavePaymentMethod) { result in
                     switch result {
                     case .success(let clientSecret):
-                        guard clientSecret != PaymentSheet.IntentConfiguration.FORCE_SUCCESS else {
+                        guard clientSecret != PaymentSheet.IntentConfiguration.COMPLETE_WITHOUT_CONFIRMING_INTENT else {
                             completion(STPApplePayContext.FORCE_SUCCESS, nil)
                             return
                         }


### PR DESCRIPTION
## Summary
- Renames `FORCE_SUCCESS` to `COMPLETE_WITHOUT_CONFIRMING_INTENT` and puts it under SPI protection `PaymentSheetSkipConfirmation`.

## Motivation
API review

## Testing
Ensured the project compiled

## Changelog
N/A

cc @tillh-stripe let's do this on Android