### PR TITLE
Make currency have a default value of nil in decoupled setup mode

### DIFF
--- a/Stripe/StripeiOSTests/PaymentSheet+APITest.swift
+++ b/Stripe/StripeiOSTests/PaymentSheet+APITest.swift
@@ -186,6 +186,8 @@ class PaymentSheetAPITest: XCTestCase {
             .init(mode: .setup(currency: "USD"), confirmHandler: confirmHandler),
             // Setup config with explicit PM types
             .init(mode: .setup(currency: "USD"), paymentMethodTypes: ["card"], confirmHandler: confirmHandler),
+            // Setup config w/o currency
+            .init(mode: .setup(), confirmHandler: confirmHandler),
         ]
         loadExpectation.expectedFulfillmentCount = intentConfigTestcases.count
         for (index, intentConfig) in intentConfigTestcases.enumerated() {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetIntentConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetIntentConfiguration.swift
@@ -108,7 +108,7 @@ import Foundation
             /// Use this if your integration creates a SetupIntent
             case setup(
                 /// Three-letter ISO currency code. Optional - setting this ensures only valid payment methods are displayed.
-                currency: String?,
+                currency: String? = nil,
                 /// Indicates how the payment method is intended to be used in the future.
                 /// - Seealso: https://stripe.com/docs/api/setup_intents/create#create_setup_intent-usage
                 setupFutureUsage: SetupFutureUsage = .offSession


### PR DESCRIPTION
## Summary
Make currency have a default value of nil in decoupled setup mode

## Motivation
It's already optional. No need to make merchants explicitly specify nil.

## Testing
Added a unit test

## Changelog
not breaking