### PR TITLE
Prevent confirm button from appearing when del selected on spms

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/SavedPaymentMethods/SavedPaymentMethodsCollectionViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/SavedPaymentMethods/SavedPaymentMethodsCollectionViewController.swift
@@ -306,7 +306,7 @@ class SavedPaymentMethodsCollectionViewController: UIViewController {
                 return true
             }
         } else {
-            if originalSelectedSavedPaymentMethod == nil {
+            if originalSelectedViewModelIndex == nil {
                 return false
             } else {
                 return true
@@ -399,7 +399,7 @@ extension SavedPaymentMethodsCollectionViewController: PaymentOptionCellDelegate
 
                 if let index = self.selectedViewModelIndex {
                     if indexPath.row == index {
-                        self.selectedViewModelIndex = min(1, self.viewModels.count - 1)
+                        self.selectedViewModelIndex = nil
                     } else if indexPath.row < index {
                         self.selectedViewModelIndex = index - 1
                     }


### PR DESCRIPTION
## Summary
Confirm button is appearing when exiting edit mode with spms.

Repro steps:
1. Present spms w/ a selected payment method
2. Enter edit mode
3. delete the one that was selected
4. exit edit mode

Observed:
Confirm button is visible

Expected
Confirm button is not visible


## Motivation
Visual bug

## Testing
Manual testing with playground


Before:
![removingSelected-broken](https://github.com/stripe/stripe-ios/assets/99628984/f8eb1a43-62c8-4d74-a12a-987ddce9a53a)

After:
![removingSelected-fixed](https://github.com/stripe/stripe-ios/assets/99628984/90cc40d8-3ace-46b6-b0b4-8b3ee86d31fa)
