### PR TITLE
Fix logic for removing payment method for spms

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/Resources/Base.lproj/Main.storyboard
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Resources/Base.lproj/Main.storyboard
@@ -2353,7 +2353,7 @@
                                                     <constraint firstAttribute="height" constant="1" id="y59-Mh-0ZU"/>
                                                 </constraints>
                                             </view>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="PaymentSheet.FlowController" textAlignment="justified" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nHT-Ub-Q2l">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SavedPaymentMethodSheet" textAlignment="justified" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nHT-Ub-Q2l">
                                                 <rect key="frame" x="0.0" y="51" width="413" height="20.5"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                 <nil key="textColor"/>

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/SavedPaymentMethods/SavedPaymentMethodsCollectionViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/SavedPaymentMethods/SavedPaymentMethodsCollectionViewController.swift
@@ -16,7 +16,8 @@ protocol SavedPaymentMethodsCollectionViewControllerDelegate: AnyObject {
         paymentMethodSelection: SavedPaymentMethodsCollectionViewController.Selection)
     func didSelectRemove(
         viewController: SavedPaymentMethodsCollectionViewController,
-        paymentMethodSelection: SavedPaymentMethodsCollectionViewController.Selection)
+        paymentMethodSelection: SavedPaymentMethodsCollectionViewController.Selection,
+        originalPaymentMethodSelection: PersistablePaymentMethodOption?)
 }
 /*
  This class is largely a copy of SavedPaymentOptionsViewController, however a couple of exceptions
@@ -407,7 +408,8 @@ extension SavedPaymentMethodsCollectionViewController: PaymentOptionCellDelegate
 
                 self.delegate?.didSelectRemove(
                     viewController: self,
-                    paymentMethodSelection: viewModel
+                    paymentMethodSelection: viewModel,
+                    originalPaymentMethodSelection: self.originalSelectedSavedPaymentMethod
                 )
             }
         }


### PR DESCRIPTION
## Summary
We were calling `setSelectedPaymentMethodOption(paymentOption: nil)` every time we were removing a payment method.  We should ONLY be doing this if it was the payment method was was originally selected when the sheet was being displayed.  I suspect this code was added because we were just getting things to compile/work, but this logic is not correct.

I also updated the storyboard to remove some copy/paste artifact (oops!)

## Motivation
Bad logic around removing

## Testing
Manual testing with print statements
