### PR TITLE
Financial Connections: made the Stripe logo bigger in navigation bar.

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/FinancialConnectionsNavigationController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/FinancialConnectionsNavigationController.swift
@@ -179,8 +179,8 @@ extension FinancialConnectionsNavigationController {
                 stripeLogoImageView.frame = CGRect(
                     x: 0,
                     y: 0,
-                    width: stripeLogoImageView.bounds.width * (16 / stripeLogoImageView.bounds.height),
-                    height: 16
+                    width: stripeLogoImageView.bounds.width * (20 / max(1, stripeLogoImageView.bounds.height)),
+                    height: 20
                 )
                 // If `titleView` is directly set to the `UIImageView`
                 // we can't control the sizing...so we create a `containerView`


### PR DESCRIPTION
## Summary

We wanted to increase the size of the logo, so this PR increases the size of the logo in navigation bar. [Slack context](https://stripe.slack.com/archives/C02KW8G938W/p1684850455502419?thread_ts=1684340861.042859&cid=C02KW8G938W).

## Testing

see screenshot below, but I also did some manual checking + end to end test running

![Simulator Screen Shot - iPhone 13 mini - 2023-05-23 at 11 15 32](https://github.com/stripe/stripe-ios/assets/105514761/b70c0eee-200c-426d-acc6-2bf6cd13aa02)
