### PR TITLE
Rename PersistablePaymentMethodOption -> CustomerPaymentOption

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetSnapshotTests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetSnapshotTests.swift
@@ -31,11 +31,11 @@ class StubCustomerAdapter: CustomerAdapter {
 
     }
 
-    func setSelectedPaymentMethodOption(paymentOption: StripePaymentSheet.CustomerPaymentOption?) async throws {
+    func setSelectedPaymentOption(paymentOption: CustomerPaymentOption?) async throws {
 
     }
 
-    func fetchSelectedPaymentMethodOption() async throws -> StripePaymentSheet.CustomerPaymentOption? {
+    func fetchSelectedPaymentOption() async throws -> CustomerPaymentOption? {
         return nil
     }
 

--- a/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetSnapshotTests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetSnapshotTests.swift
@@ -31,11 +31,11 @@ class StubCustomerAdapter: CustomerAdapter {
 
     }
 
-    func setSelectedPaymentMethodOption(paymentOption: StripePaymentSheet.PersistablePaymentMethodOption?) async throws {
+    func setSelectedPaymentMethodOption(paymentOption: StripePaymentSheet.CustomerPaymentOption?) async throws {
 
     }
 
-    func fetchSelectedPaymentMethodOption() async throws -> StripePaymentSheet.PersistablePaymentMethodOption? {
+    func fetchSelectedPaymentMethodOption() async throws -> StripePaymentSheet.CustomerPaymentOption? {
         return nil
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerAdapter/CustomerAdapter.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerAdapter/CustomerAdapter.swift
@@ -49,13 +49,13 @@ import UIKit
     /// To unset the default payment method, pass `nil` as the `paymentOption`.
     /// If you are implementing your own <CustomerAdapter>:
     /// Save a representation of the passed `paymentOption` as the customer's default payment method.
-    func setSelectedPaymentMethodOption(paymentOption: PersistablePaymentMethodOption?) async throws
+    func setSelectedPaymentOption(paymentOption: CustomerPaymentOption?) async throws
 
     /// Retrieve the last selected payment method for the customer.
     /// If you are implementing your own <CustomerAdapter>:
-    /// Return a PersistablePaymentMethodOption for the customer's default selected payment method.
+    /// Return a CustomerPaymentOption for the customer's default selected payment method.
     /// If no default payment method is selected, return nil.
-    func fetchSelectedPaymentMethodOption() async throws -> PersistablePaymentMethodOption?
+    func fetchSelectedPaymentOption() async throws -> CustomerPaymentOption?
 
     /// Creates a SetupIntent configured to attach a new payment method to a customer, then returns the client secret for the created SetupIntent.
     func setupIntentClientSecretForCustomerAttach() async throws -> String
@@ -174,16 +174,16 @@ import UIKit
         })
     }
 
-    open func setSelectedPaymentMethodOption(paymentOption: PersistablePaymentMethodOption?) async throws {
+    open func setSelectedPaymentOption(paymentOption: CustomerPaymentOption?) async throws {
         let customerEphemeralKey = try await customerEphemeralKey
 
-        PersistablePaymentMethodOption.setDefaultPaymentMethod(paymentOption, forCustomer: customerEphemeralKey.id)
+        CustomerPaymentOption.setDefaultPaymentMethod(paymentOption, forCustomer: customerEphemeralKey.id)
     }
 
-    open func fetchSelectedPaymentMethodOption() async throws -> PersistablePaymentMethodOption? {
+    open func fetchSelectedPaymentOption() async throws -> CustomerPaymentOption? {
         let customerEphemeralKey = try await customerEphemeralKey
 
-        return PersistablePaymentMethodOption.defaultPaymentMethod(for: customerEphemeralKey.id)
+        return CustomerPaymentOption.defaultPaymentMethod(for: customerEphemeralKey.id)
     }
 
     open func setupIntentClientSecretForCustomerAttach() async throws -> String {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerAdapter/CustomerPaymentOption.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerAdapter/CustomerPaymentOption.swift
@@ -1,17 +1,12 @@
 //
-//  PersistablePaymentMethodOption.swift
+//  CustomerPaymentOption.swift
 //  StripePaymentsUI
 //
 
 import Foundation
 
-@_spi(PrivateBetaCustomerSheet) public enum PersistablePaymentMethodOptionError: Error {
-    case unableToEncode(PersistablePaymentMethodOption)
-    case unableToDecode(String?)
-}
-
 /// A representation of a Payment Method option, used for persisting the user's default payment method.
-@_spi(PrivateBetaCustomerSheet) public enum PersistablePaymentMethodOption: Equatable {
+@_spi(PrivateBetaCustomerSheet) public enum CustomerPaymentOption: Equatable {
     /// The user's default payment method is Apple Pay.
     /// This is not a specific Apple Pay card. Stripe will present an Apple Pay sheet to the user.
     case applePay
@@ -47,7 +42,7 @@ import Foundation
     /// - Parameters:
     ///   - identifier: Payment method identifier.
     ///   - customerID: ID of the customer. Pass `nil` for anonymous users.
-    @_spi(STP) public static func setDefaultPaymentMethod(_ paymentMethodOption: PersistablePaymentMethodOption?, forCustomer customerID: String?) {
+    @_spi(STP) public static func setDefaultPaymentMethod(_ paymentMethodOption: CustomerPaymentOption?, forCustomer customerID: String?) {
         var customerToDefaultPaymentMethodID = UserDefaults.standard.customerToLastSelectedPaymentMethod ?? [:]
 
         let key = customerID ?? ""
@@ -59,13 +54,13 @@ import Foundation
     /// Returns the identifier of the default payment method for a customer.
     /// - Parameter customerID: ID of the customer. Pass `nil` for anonymous users.
     /// - Returns: Default payment method.
-    @_spi(STP) public static func defaultPaymentMethod(for customerID: String?) -> PersistablePaymentMethodOption? {
+    @_spi(STP) public static func defaultPaymentMethod(for customerID: String?) -> CustomerPaymentOption? {
         let key = customerID ?? ""
 
         guard let value = UserDefaults.standard.customerToLastSelectedPaymentMethod?[key] else {
             return nil
         }
 
-        return PersistablePaymentMethodOption(value: value)
+        return CustomerPaymentOption(value: value)
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewController.swift
@@ -17,11 +17,11 @@ protocol CustomerSavedPaymentMethodsCollectionViewControllerDelegate: AnyObject 
     func didSelectRemove(
         viewController: CustomerSavedPaymentMethodsCollectionViewController,
         paymentMethodSelection: CustomerSavedPaymentMethodsCollectionViewController.Selection,
-        originalPaymentMethodSelection: PersistablePaymentMethodOption?)
+        originalPaymentMethodSelection: CustomerPaymentOption?)
 }
 /*
  This class is largely a copy of SavedPaymentOptionsViewController, however a couple of exceptions
-  - Removes link supportPersistablePaymentMethodOption
+  - Removes link as an option
   - Does not save the selected payment method to the local device settings
   - Fetches customerId using the underlying backing STPCustomerContext
  */
@@ -39,7 +39,7 @@ class CustomerSavedPaymentMethodsCollectionViewController: UIViewController {
         case saved(paymentMethod: STPPaymentMethod)
         case add
 
-        static func ==(lhs: Selection, rhs: PersistablePaymentMethodOption?) -> Bool {
+        static func ==(lhs: Selection, rhs: CustomerPaymentOption?) -> Bool {
             switch lhs {
             case .applePay:
                 return rhs == .applePay
@@ -147,7 +147,7 @@ class CustomerSavedPaymentMethodsCollectionViewController: UIViewController {
         }
     }
     weak var delegate: CustomerSavedPaymentMethodsCollectionViewControllerDelegate?
-    let originalSelectedSavedPaymentMethod: PersistablePaymentMethodOption?
+    let originalSelectedSavedPaymentMethod: CustomerPaymentOption?
     var originalSelectedViewModelIndex: Int? {
         guard let originalSelectedSavedPaymentMethod = originalSelectedSavedPaymentMethod else {
             return nil
@@ -183,7 +183,7 @@ class CustomerSavedPaymentMethodsCollectionViewController: UIViewController {
     // MARK: - Inits
     required init(
         savedPaymentMethods: [STPPaymentMethod],
-        selectedPaymentMethodOption: PersistablePaymentMethodOption?,
+        selectedPaymentMethodOption: CustomerPaymentOption?,
         savedPaymentMethodsConfiguration: CustomerSheet.Configuration,
         customerAdapter: CustomerAdapter,
         configuration: Configuration,
@@ -224,7 +224,7 @@ class CustomerSavedPaymentMethodsCollectionViewController: UIViewController {
     }
 
     // MARK: - Private methods
-    private func updateUI(selectedSavedPaymentOption: PersistablePaymentMethodOption?) {
+    private func updateUI(selectedSavedPaymentOption: CustomerPaymentOption?) {
         // Move default to front
         var savedPaymentMethods = self.savedPaymentMethods
         if let defaultPMIndex = savedPaymentMethods.firstIndex(where: {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsViewController.swift
@@ -22,7 +22,7 @@ class CustomerSavedPaymentMethodsViewController: UIViewController {
 
     // MARK: - Read-only Properties
     let savedPaymentMethods: [STPPaymentMethod]
-    let selectedPaymentMethodOption: PersistablePaymentMethodOption?
+    let selectedPaymentMethodOption: CustomerPaymentOption?
     let isApplePayEnabled: Bool
     let configuration: CustomerSheet.Configuration
     let customerAdapter: CustomerAdapter
@@ -109,7 +109,7 @@ class CustomerSavedPaymentMethodsViewController: UIViewController {
 
     required init(
         savedPaymentMethods: [STPPaymentMethod],
-        selectedPaymentMethodOption: PersistablePaymentMethodOption?,
+        selectedPaymentMethodOption: CustomerPaymentOption?,
         configuration: CustomerSheet.Configuration,
         customerAdapter: CustomerAdapter,
         isApplePayEnabled: Bool,
@@ -563,9 +563,9 @@ class CustomerSavedPaymentMethodsViewController: UIViewController {
                                             onError: @escaping (Error) -> Void,
                                             onSuccess: @escaping () -> Void) {
         Task {
-            let persistablePaymentOption = paymentOptionSelection.persistablePaymentMethodOption()
+            let customerPaymentMethodOption = paymentOptionSelection.customerPaymentMethodOption()
             do {
-                try await customerAdapter.setSelectedPaymentMethodOption(paymentOption: persistablePaymentOption)
+                try await customerAdapter.setSelectedPaymentOption(paymentOption: customerPaymentMethodOption)
                 onSuccess()
             } catch {
                 onError(error)
@@ -665,7 +665,7 @@ extension CustomerSavedPaymentMethodsViewController: CustomerSavedPaymentMethods
     func didSelectRemove(
         viewController: CustomerSavedPaymentMethodsCollectionViewController,
         paymentMethodSelection: CustomerSavedPaymentMethodsCollectionViewController.Selection,
-        originalPaymentMethodSelection: PersistablePaymentMethodOption?) {
+        originalPaymentMethodSelection: CustomerPaymentOption?) {
             guard case .saved(let paymentMethod) = paymentMethodSelection else {
                 return
             }
@@ -682,7 +682,7 @@ extension CustomerSavedPaymentMethodsViewController: CustomerSavedPaymentMethods
                 if let originalPaymentMethodSelection = originalPaymentMethodSelection,
                    paymentMethodSelection == originalPaymentMethodSelection {
                     do {
-                        try await self.customerAdapter.setSelectedPaymentMethodOption(paymentOption: nil)
+                        try await self.customerAdapter.setSelectedPaymentOption(paymentOption: nil)
                     } catch {
                         // We are unable to persist the selectedPaymentMethodOption -- if we attempt to re-call
                         // a payment method that is no longer there, the UI should be able to handle not selecting it.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheet.swift
@@ -129,7 +129,7 @@ internal enum CustomerSheetResult {
     @available(macCatalystApplicationExtension, unavailable)
     func present(from presentingViewController: UIViewController,
                  savedPaymentMethods: [STPPaymentMethod],
-                 selectedPaymentMethodOption: PersistablePaymentMethodOption?) {
+                 selectedPaymentMethodOption: CustomerPaymentOption?) {
         let loadSpecsPromise = Promise<Void>()
         AddressSpecProvider.shared.loadAddressSpecs {
             loadSpecsPromise.resolve(with: ())
@@ -155,11 +155,11 @@ internal enum CustomerSheetResult {
 }
 
 extension CustomerSheet {
-    func loadPaymentMethodInfo(completion: @escaping (Result<([STPPaymentMethod], PersistablePaymentMethodOption?), Error>) -> Void) {
+    func loadPaymentMethodInfo(completion: @escaping (Result<([STPPaymentMethod], CustomerPaymentOption?), Error>) -> Void) {
         Task {
             do {
                 async let paymentMethodsResult = try customerAdapter.fetchPaymentMethods()
-                async let selectedPaymentMethodResult = try self.customerAdapter.fetchSelectedPaymentMethodOption()
+                async let selectedPaymentMethodResult = try self.customerAdapter.fetchSelectedPaymentOption()
                 let (paymentMethods, selectedPaymentMethod) = try await (paymentMethodsResult, selectedPaymentMethodResult)
                 completion(.success((paymentMethods, selectedPaymentMethod)))
             } catch {
@@ -212,7 +212,7 @@ extension CustomerSheet: LoadingViewControllerDelegate {
     /// You can use this to obtain the selected payment method without loading the CustomerSheet.
     public func retrievePaymentOptionSelection() async throws -> CustomerSheet.PaymentOptionSelection?
      {
-        let selectedPaymentOption = try await self.fetchSelectedPaymentMethodOption()
+        let selectedPaymentOption = try await self.fetchSelectedPaymentOption()
         switch selectedPaymentOption {
         case .applePay:
             return .applePay()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetConfiguration.swift
@@ -93,7 +93,7 @@ extension CustomerSheet {
             }
         }
 
-        func persistablePaymentMethodOption() -> PersistablePaymentMethodOption {
+        func customerPaymentMethodOption() -> CustomerPaymentOption {
             switch self {
             case .applePay:
                 return .applePay

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -324,7 +324,7 @@ extension PaymentSheet {
 
                 if case .completed = result, case .link = paymentOption {
                     // Remember Link as default payment method for users who just created an account.
-                    PersistablePaymentMethodOption.setDefaultPaymentMethod(.link, forCustomer: configuration.customer?.id)
+                    CustomerPaymentOption.setDefaultPaymentMethod(.link, forCustomer: configuration.customer?.id)
                 }
 
                 completion(result)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
@@ -36,7 +36,7 @@ class SavedPaymentOptionsViewController: UIViewController {
         case saved(paymentMethod: STPPaymentMethod)
         case add
 
-        static func ==(lhs: Selection, rhs: PersistablePaymentMethodOption?) -> Bool {
+        static func ==(lhs: Selection, rhs: CustomerPaymentOption?) -> Bool {
             switch lhs {
             case .link:
                 return rhs == .link
@@ -200,7 +200,7 @@ class SavedPaymentOptionsViewController: UIViewController {
 
     // MARK: - Private methods
     private func updateUI() {
-        let defaultPaymentMethod = PersistablePaymentMethodOption.defaultPaymentMethod(for: configuration.customerID)
+        let defaultPaymentMethod = CustomerPaymentOption.defaultPaymentMethod(for: configuration.customerID)
 
         // Move default to front
         var savedPaymentMethods = self.savedPaymentMethods
@@ -256,7 +256,7 @@ class SavedPaymentOptionsViewController: UIViewController {
             return
         }
 
-        PersistablePaymentMethodOption.setDefaultPaymentMethod(.link, forCustomer: configuration.customerID)
+        CustomerPaymentOption.setDefaultPaymentMethod(.link, forCustomer: configuration.customerID)
         selectedViewModelIndex = viewModels.firstIndex(where: { $0 == .link })
         collectionView.selectItem(at: selectedIndexPath, animated: false, scrollPosition: .centeredHorizontally)
     }
@@ -317,11 +317,11 @@ extension SavedPaymentOptionsViewController: UICollectionViewDataSource, UIColle
             // Should have been handled in shouldSelectItemAt: before we got here!
             assertionFailure()
         case .applePay:
-            PersistablePaymentMethodOption.setDefaultPaymentMethod(.applePay, forCustomer: configuration.customerID)
+            CustomerPaymentOption.setDefaultPaymentMethod(.applePay, forCustomer: configuration.customerID)
         case .link:
-            PersistablePaymentMethodOption.setDefaultPaymentMethod(.link, forCustomer: configuration.customerID)
+            CustomerPaymentOption.setDefaultPaymentMethod(.link, forCustomer: configuration.customerID)
         case .saved(let paymentMethod):
-            PersistablePaymentMethodOption.setDefaultPaymentMethod(
+            CustomerPaymentOption.setDefaultPaymentMethod(
                 .stripeId(paymentMethod.stripeId),
                 forCustomer: configuration.customerID
             )


### PR DESCRIPTION
## Summary
Rename class name based on

## Motivation
Naming discussion offline

## Testing
Compiled, mostly relying on existing ui/automated tests.

Previous pr: https://github.com/stripe/stripe-ios/pull/2594