### PR TITLE
Add gesture recognizer to customer sheet

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlayground.swift
@@ -84,6 +84,10 @@ class CustomerSheetTestPlayground: UIViewController {
         selectPaymentMethodButton.addTarget(
             self, action: #selector(didTapSelectPaymentMethodButton), for: .touchUpInside)
 
+        selectPaymentMethodImage.isUserInteractionEnabled = true
+        selectPaymentMethodImage.addGestureRecognizer(
+            UITapGestureRecognizer(target: self, action: #selector(didTapSelectPaymentMethodButton)))
+
         if let settings = CustomerSheetTestPlayground.playgroundSettings {
             loadSettingsFrom(settings: settings)
         } else if let nsUserDefaultSettings = settingsFromDefaults() {


### PR DESCRIPTION
## Summary
Add gesture recognizer to the icon in customer sheet.

## Motivation
The image is untappable, it should do the same thing as tapping on the label/button.

## Testing
manually tested.
