### PR TITLE
Force PKR currency to 2 decimals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [Changed] The private beta API for https://stripe.com/docs/payments/finalize-payments-on-the-server has changed:
   * If you use `IntentConfiguration(..., confirmHandler:)`, the confirm handler now has an additional `shouldSavePaymentMethod: Bool` parameter that you should ignore.
   * If you use `IntentConfiguration(..., confirmHandlerForServerSideConfirmation:)`, use `IntentConfiguration(..., confirmHandler:)` instead. Additionally, the confirm handler's first parameter is now an `STPPaymentMethod` object instead of a String id. Use `paymentMethod.stripeId` to get its id and send it to your server.
+* [Fixed] Fixed PKR currency formatting.
 
 ## 23.8.0 2023-05-08
 ### Identity

--- a/Stripe/StripeiOSTests/NSDecimalNumber+StripeTest.swift
+++ b/Stripe/StripeiOSTests/NSDecimalNumber+StripeTest.swift
@@ -22,7 +22,10 @@ class NSDecimalNumberStripeTest: XCTestCase {
         "aud",
         "sek",
         "sgd",
+
+        // Special cases:
         "cop",
+        "pkr",
     ]
 
     private let noDecimalPointCurrencies = [

--- a/StripePayments/StripePayments/Source/Internal/Categories/NSDecimalNumber+Stripe_Currency.swift
+++ b/StripePayments/StripePayments/Source/Internal/Categories/NSDecimalNumber+Stripe_Currency.swift
@@ -13,6 +13,7 @@ extension NSDecimalNumber {
     // This maps the currency code to the number of decimal digits.
     static let decimalCountSpecialCases = [
         "COP": 2,
+        "PKR": 2,
     ]
 
     @objc @_spi(STP) public class func stp_decimalNumber(


### PR DESCRIPTION
## Summary
PKR technically has 2 decimal places, but in practice decimals have been discontinued and the NumberFormatter formats to no decimals. This is the same issue we had with COP a few months ago.

## Motivation
https://github.com/stripe/stripe-ios/issues/2601

## Testing
* Added test
* Visually verified
![image](https://github.com/stripe/stripe-ios/assets/114543737/626b8ac4-2c84-4bae-8b2b-01b84693018c)


## Changelog
* [Fixed] Fixed PKR currency formatting.