### PR TITLE
[do not review] Allow dismissing customer sheet by retapping the selected item

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewController.swift
@@ -13,7 +13,8 @@ import UIKit
 protocol CustomerSavedPaymentMethodsCollectionViewControllerDelegate: AnyObject {
     func didUpdateSelection(
         viewController: CustomerSavedPaymentMethodsCollectionViewController,
-        paymentMethodSelection: CustomerSavedPaymentMethodsCollectionViewController.Selection)
+        paymentMethodSelection: CustomerSavedPaymentMethodsCollectionViewController.Selection,
+        didSelectSameItem: Bool)
     func didSelectRemove(
         viewController: CustomerSavedPaymentMethodsCollectionViewController,
         paymentMethodSelection: CustomerSavedPaymentMethodsCollectionViewController.Selection,
@@ -335,17 +336,18 @@ extension CustomerSavedPaymentMethodsCollectionViewController: UICollectionViewD
         }
         let viewModel = viewModels[indexPath.item]
         if case .add = viewModel {
-            delegate?.didUpdateSelection(viewController: self, paymentMethodSelection: viewModel)
+            delegate?.didUpdateSelection(viewController: self, paymentMethodSelection: viewModel, didSelectSameItem: false)
             return false
         }
         return true
     }
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        let didSelectSameItem = indexPath.item == selectedViewModelIndex
         selectedViewModelIndex = indexPath.item
         let viewModel = viewModels[indexPath.item]
 
-        delegate?.didUpdateSelection(viewController: self, paymentMethodSelection: viewModel)
+        delegate?.didUpdateSelection(viewController: self, paymentMethodSelection: viewModel, didSelectSameItem: didSelectSameItem)
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsViewController.swift
@@ -645,7 +645,8 @@ extension CustomerSavedPaymentMethodsViewController: CustomerAddPaymentMethodVie
 extension CustomerSavedPaymentMethodsViewController: CustomerSavedPaymentMethodsCollectionViewControllerDelegate {
     func didUpdateSelection(
         viewController: CustomerSavedPaymentMethodsCollectionViewController,
-        paymentMethodSelection: CustomerSavedPaymentMethodsCollectionViewController.Selection) {
+        paymentMethodSelection: CustomerSavedPaymentMethodsCollectionViewController.Selection,
+        didSelectSameItem: Bool) {
             error = nil
             switch paymentMethodSelection {
             case .add:
@@ -655,10 +656,14 @@ extension CustomerSavedPaymentMethodsViewController: CustomerSavedPaymentMethods
                     mode = .addingNewPaymentMethodAttachToCustomer
                 }
                 self.updateUI()
-            case .saved:
-                updateUI(animated: true)
-            case .applePay:
-                updateUI(animated: true)
+            case .saved, .applePay:
+                if let originallySelected = viewController.originalSelectedSavedPaymentMethod,
+                   didSelectSameItem,
+                   paymentMethodSelection == originallySelected {
+                    didTapOrSwipeToDismiss()
+                } else {
+                    self.updateUI()
+                }
             }
         }
 


### PR DESCRIPTION
## Summary -- on hold, rethinking design
Dismiss Customer Sheet if user taps the same payment method that was already selected

## Motivation
Dogfooding feedback

## Testing
Manually tested

