### PR TITLE
Fix button enable/disable on filling out card params

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsViewController.swift
@@ -246,7 +246,8 @@ class CustomerSavedPaymentMethodsViewController: UIViewController {
                 showActionButton = false
             }
         case .addingNewPaymentMethodAttachToCustomer, .addingNewWithSetupIntent:
-            self.actionButton.isHidden = false
+            self.actionButton.setHiddenIfNecessary(false)
+            actionButtonStatus = addPaymentMethodViewController.paymentOption == nil ? .disabled : .enabled
         }
 
         if processingInFlight {


### PR DESCRIPTION
## Summary
Fix button enable/disable on filling out card params

## Motivation
Dogfooding feedback

## Testing
Manually tested

Gif of the change implemented:
![toUPloadForAddenabledisable](https://github.com/stripe/stripe-ios/assets/99628984/e61a4108-6c2d-43a2-af85-f2fb567e00a3)


