### PR TITLE
Remove listing achv2 saved payment methods in customer sheet

### DIFF
--- a/Stripe/StripeiOSTests/CustomerAdapterTests.swift
+++ b/Stripe/StripeiOSTests/CustomerAdapterTests.swift
@@ -109,8 +109,8 @@ class CustomerAdapterTests: APIStubbedTestCase {
         let expectedPaymentMethods = [STPFixtures.paymentMethod()]
         let expectedPaymentMethodsJSON = [STPFixtures.paymentMethodJSON()]
         let apiClient = stubbedAPIClient()
-//      Expect two calls: Once for US bank accounts, another for cards
-        stubListPaymentMethods(key: exampleKey, paymentMethodJSONs: expectedPaymentMethodsJSON, expectedCount: 2, apiClient: apiClient)
+        // Expect 1 call per PM: cards
+        stubListPaymentMethods(key: exampleKey, paymentMethodJSONs: expectedPaymentMethodsJSON, expectedCount: 1, apiClient: apiClient)
         let ekm = MockEphemeralKeyEndpoint(exampleKey)
         let sut = StripeCustomerAdapter(customerEphemeralKeyProvider: ekm.getEphemeralKey, apiClient: apiClient)
         let pms = try await sut.fetchPaymentMethods()
@@ -124,8 +124,8 @@ class CustomerAdapterTests: APIStubbedTestCase {
         let expectedPaymentMethods = [STPFixtures.paymentMethod()]
         let expectedPaymentMethodsJSON = [STPFixtures.paymentMethodJSON()]
         let apiClient = stubbedAPIClient()
-//      Expect two calls: Once for US bank accounts, another for cards
-        stubListPaymentMethods(key: exampleKey, paymentMethodJSONs: expectedPaymentMethodsJSON, expectedCount: 2, apiClient: apiClient)
+        // Expect 1 call per PM: cards
+        stubListPaymentMethods(key: exampleKey, paymentMethodJSONs: expectedPaymentMethodsJSON, expectedCount: 1, apiClient: apiClient)
         let ekm = MockEphemeralKeyEndpoint(exampleKey)
         let sut = StripeCustomerAdapter(customerEphemeralKeyProvider: ekm.getEphemeralKey, apiClient: apiClient)
         let pms = try await sut.fetchPaymentMethods()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerAdapter/CustomerAdapter.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerAdapter/CustomerAdapter.swift
@@ -132,7 +132,7 @@ import UIKit
         let customerEphemeralKey = try await customerEphemeralKey
         return try await withCheckedThrowingContinuation({ continuation in
             // List the Customer's saved PaymentMethods
-            let savedPaymentMethodTypes: [STPPaymentMethodType] = [.card, .USBankAccount]  // hardcoded for now
+            let savedPaymentMethodTypes: [STPPaymentMethodType] = [.card]  // hardcoded for now
             apiClient.listPaymentMethods(
                 forCustomer: customerEphemeralKey.id,
                 using: customerEphemeralKey.ephemeralKeySecret,


### PR DESCRIPTION
## Summary
Remove listing achv2 saved payment methods in customer sheet

## Motivation
We don't have full support for achv2 in customer sheet, so we need to remove this.

## Testing
Loaded customer w/ achv2 saved payment methods.

