### PR TITLE
Restrict manual confirmation usage to FlowController

### DIFF
--- a/Stripe/StripeiOSTests/PaymentSheetDeferredValidatorTests.swift
+++ b/Stripe/StripeiOSTests/PaymentSheetDeferredValidatorTests.swift
@@ -56,6 +56,15 @@ final class PaymentSheetDeferredValidatorTests: XCTestCase {
         }
     }
 
+    func testPaymentIntentNotFlowControllerManualConfirmationMethod() throws {
+        let pi = STPFixtures.makePaymentIntent(amount: 1000, currency: "USD", confirmationMethod: "manual")
+        var intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1000, currency: "USD"), confirmHandler: confirmHandler)
+        intentConfig.isFlowController = false
+        XCTAssertThrowsError(try PaymentSheetDeferredValidator.validate(paymentIntent: pi, intentConfiguration: intentConfig)) { error in
+            XCTAssertEqual("\(error)", "An error occured in PaymentSheet. Your PaymentIntent confirmationMethod (manual) can only be used with PaymentSheet.FlowController.")
+        }
+    }
+
     func testSetupIntentMismatchedUsage() throws {
         let si = STPFixtures.makeSetupIntent(usage: "on_session")
         let intentConfig = PaymentSheet.IntentConfiguration(mode: .setup(currency: "USD", setupFutureUsage: .offSession), confirmHandler: confirmHandler)

--- a/Stripe/StripeiOSTests/PaymentSheetPaymentMethodTypeTest.swift
+++ b/Stripe/StripeiOSTests/PaymentSheetPaymentMethodTypeTest.swift
@@ -717,6 +717,7 @@ extension STPFixtures {
         setupFutureUsage: STPPaymentIntentSetupFutureUsage? = nil,
         paymentMethodOptions: STPPaymentMethodOptions? = nil,
         captureMethod: String = "automatic",
+        confirmationMethod: String = "automatic",
         shippingProvided: Bool = false
     ) -> STPPaymentIntent {
         var json = STPTestUtils.jsonNamed(STPTestJSONPaymentIntent)!
@@ -726,6 +727,7 @@ extension STPFixtures {
         json["amount"] = amount
         json["currency"] = currency
         json["capture_method"] = captureMethod
+        json["confirmation_method"] = confirmationMethod
         if let paymentMethodTypes = paymentMethodTypes {
             json["payment_method_types"] = paymentMethodTypes.map {
                 STPPaymentMethod.string(from: $0)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetDeferredValidator.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetDeferredValidator.swift
@@ -25,6 +25,9 @@ struct PaymentSheetDeferredValidator {
         guard paymentIntent.captureMethod == captureMethod else {
             throw PaymentSheetError.unknown(debugDescription: "Your PaymentIntent captureMethod (\(paymentIntent.captureMethod)) does not match the PaymentSheet.IntentConfiguration amount (\(captureMethod)).")
         }
+        if !intentConfiguration.isFlowController && paymentIntent.confirmationMethod == .manual {
+            throw PaymentSheetError.unknown(debugDescription: "Your PaymentIntent confirmationMethod (\(paymentIntent.confirmationMethod)) can only be used with PaymentSheet.FlowController.")
+        }
     }
 
     static func validate(setupIntent: STPSetupIntent, intentConfiguration: PaymentSheet.IntentConfiguration) throws {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -172,7 +172,10 @@ extension PaymentSheet {
             configuration: PaymentSheet.Configuration,
             completion: @escaping (Result<PaymentSheet.FlowController, Error>) -> Void
         ) {
-            create(mode: .deferredIntent(intentConfiguration),
+            var intentConfigCopy = intentConfiguration
+            intentConfigCopy.isFlowController = true
+
+            create(mode: .deferredIntent(intentConfigCopy),
                    configuration: configuration,
                    completion: completion
             )

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetIntentConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetIntentConfiguration.swift
@@ -65,6 +65,10 @@ import Foundation
         /// - Seealso: https://stripe.com/docs/api/payment_intents/object#payment_intent_object-on_behalf_of
         public var onBehalfOf: String?
 
+        /// Indicates if this `IntentConfiguration` is being used with `PaymentSheet.FlowController`
+        /// - Note: Only for internal SDK use
+        internal var isFlowController: Bool = false
+
         /// Controls when the funds will be captured. 
         /// - Seealso: https://stripe.com/docs/api/payment_intents/create#create_payment_intent-capture_method
         public enum CaptureMethod: String {


### PR DESCRIPTION
## Summary
- Only allow manual confirmation to be used with FlowController

## Motivation
dogfooding feedback

## Testing
- Updated unit test
- Manual

## Changelog
N/A