### PR TITLE
Write loadPaymentMethodInfo stubbed timeout test

### DIFF
--- a/StripeCore/StripeCoreTestUtils/APIStubbedTestCase.swift
+++ b/StripeCore/StripeCoreTestUtils/APIStubbedTestCase.swift
@@ -24,8 +24,8 @@ open class APIStubbedTestCase: XCTestCase {
         HTTPStubs.removeAllStubs()
     }
 
-    public func stubbedAPIClient() -> STPAPIClient {
-        return APIStubbedTestCase.stubbedAPIClient()
+    public func stubbedAPIClient(configuration: URLSessionConfiguration? = nil) -> STPAPIClient {
+        return APIStubbedTestCase.stubbedAPIClient(configuration: configuration)
     }
 
     static public func stubAllOutgoingRequests() {
@@ -38,10 +38,10 @@ open class APIStubbedTestCase: XCTestCase {
         }
     }
 
-    static public func stubbedAPIClient() -> STPAPIClient {
+    static public func stubbedAPIClient(configuration: URLSessionConfiguration? = nil) -> STPAPIClient {
         let apiClient = STPAPIClient()
-        let urlSessionConfig = stubbedURLSessionConfig()
-        apiClient.urlSession = URLSession(configuration: urlSessionConfig)
+        let config = configuration ?? APIStubbedTestCase.stubbedURLSessionConfig()
+        apiClient.urlSession = URLSession(configuration: config)
         return apiClient
     }
 

--- a/StripePaymentSheet/Project.swift
+++ b/StripePaymentSheet/Project.swift
@@ -13,6 +13,9 @@ let project = Project.stripeFramework(
         .project(target: "StripePaymentsUI", path: "//StripePaymentsUI"),
     ],
     unitTestOptions: .testOptions(
+        resources: .init(resources: [
+            .folderReference(path: "StripePaymentSheetTests/Resources/MockFiles")
+        ]),
         dependencies: [
             .project(target: "StripeCoreTestUtils", path: "//StripeCore"),
         ],

--- a/StripePaymentSheet/Project.swift
+++ b/StripePaymentSheet/Project.swift
@@ -13,6 +13,9 @@ let project = Project.stripeFramework(
         .project(target: "StripePaymentsUI", path: "//StripePaymentsUI"),
     ],
     unitTestOptions: .testOptions(
+        dependencies: [
+            .project(target: "StripeCoreTestUtils", path: "//StripeCore"),
+        ],
         includesSnapshots: true,
         usesStubs: true
     )

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/CustomerSheet/CustomerSheetTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/CustomerSheet/CustomerSheetTests.swift
@@ -65,9 +65,6 @@ class CustomerSheetTests: APIStubbedTestCase {
     }
 
     func testLoadPaymentMethodInfo_CallToPaymentMethodsTimesOut() throws {
-        let customerId = "cus_123"
-        let ephemeralKey = "ek_456"
-        let setupIntentClientSecret = "si_789"
         let fastTimeoutIntervalForRequest: TimeInterval = 1
         let timeGreaterThanTimeoutIntervalForRequest: UInt32 = 3
 
@@ -76,9 +73,9 @@ class CustomerSheetTests: APIStubbedTestCase {
         let stubbedAPIClient = stubbedAPIClient(configuration: stubbedURLSessionConfig)
 
         let customerAdapter = StripeCustomerAdapter(customerEphemeralKeyProvider: {
-            .init(customerId: customerId, ephemeralKeySecret: ephemeralKey)
+            .init(customerId: "cus_123", ephemeralKeySecret: "ek_456")
         }, setupIntentClientSecretProvider: {
-            return setupIntentClientSecret
+            return "si_789"
         }, apiClient: stubbedAPIClient)
 
         stub { urlRequest in

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/CustomerSheet/CustomerSheetTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/CustomerSheet/CustomerSheetTests.swift
@@ -1,0 +1,58 @@
+//
+//  CustomerSheetTests.swift
+//  StripePaymentSheetTests
+//
+
+import Foundation
+
+@_spi(STP) @testable import StripeCore
+@_spi(STP) @testable import StripePayments
+@_spi(PrivateBetaCustomerSheet) @testable import StripePaymentSheet
+
+import OHHTTPStubs
+import OHHTTPStubsSwift
+import StripeCoreTestUtils
+import XCTest
+
+class CustomerSheetTests: APIStubbedTestCase {
+
+    func testLoadPaymentMethodInfo_CallToPaymentMethodsTimesOut() throws {
+        let customerId = "cus_123"
+        let ephemeralKey = "ek_456"
+        let setupIntentClientSecret = "si_789"
+        let fastTimeoutIntervalForRequest: TimeInterval = 1
+        let timeGreaterThanTimeoutIntervalForRequest: UInt32 = 3
+
+        let stubbedURLSessionConfig = APIStubbedTestCase.stubbedURLSessionConfig()
+        stubbedURLSessionConfig.timeoutIntervalForRequest = fastTimeoutIntervalForRequest
+        let stubbedAPIClient = stubbedAPIClient(configuration: stubbedURLSessionConfig)
+
+        let customerAdapter = StripeCustomerAdapter(customerEphemeralKeyProvider: {
+            .init(customerId: customerId, ephemeralKeySecret: ephemeralKey)
+        }, setupIntentClientSecretProvider: {
+            return setupIntentClientSecret
+        }, apiClient: stubbedAPIClient)
+
+        stub { urlRequest in
+            return urlRequest.url?.absoluteString.contains("/v1/payment_methods") ?? false
+        } response: { _ in
+            sleep(timeGreaterThanTimeoutIntervalForRequest)
+            let data = "{}".data(using: .utf8)!
+            return HTTPStubsResponse(data: data, statusCode: 200, headers: nil)
+        }
+
+        let loadPaymentMethodCalled = expectation(description: "load called")
+        let customerSheet = CustomerSheet(configuration: CustomerSheet.Configuration(), customer: customerAdapter)
+        customerSheet.loadPaymentMethodInfo { result in
+            guard case .failure(let error) = result,
+            let nserror = error as NSError?,
+                nserror.code == NSURLErrorTimedOut,
+            nserror.domain == NSURLErrorDomain else {
+                return
+            }
+            loadPaymentMethodCalled.fulfill()
+        }
+        wait(for: [loadPaymentMethodCalled], timeout: 5.0)
+    }
+}
+

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/CustomerSheet/CustomerSheetTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/CustomerSheet/CustomerSheetTests.swift
@@ -55,4 +55,3 @@ class CustomerSheetTests: APIStubbedTestCase {
         wait(for: [loadPaymentMethodCalled], timeout: 5.0)
     }
 }
-

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/CustomerSheet/CustomerSheetTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/CustomerSheet/CustomerSheetTests.swift
@@ -16,6 +16,29 @@ import XCTest
 
 class CustomerSheetTests: APIStubbedTestCase {
 
+    func testLoadPaymentMethodInfo_newCustomer() throws {
+        let stubbedAPIClient = stubbedAPIClient()
+        stubNewCustomerResponse()
+
+        let customerAdapter = StripeCustomerAdapter(customerEphemeralKeyProvider: {
+            .init(customerId: "cus_123", ephemeralKeySecret: "ek_456")
+        }, setupIntentClientSecretProvider: {
+            return "si_789"
+        }, apiClient: stubbedAPIClient)
+
+        let loadPaymentMethodInfo = expectation(description: "loadPaymentMethodInfo completed")
+        let customerSheet = CustomerSheet(configuration: CustomerSheet.Configuration(), customer: customerAdapter)
+        customerSheet.loadPaymentMethodInfo { result in
+            guard case .success((let paymentMethods, let selectedPaymentMethod)) = result else {
+                XCTFail()
+                return
+            }
+            XCTAssertEqual(paymentMethods.count, 0)
+            XCTAssert(selectedPaymentMethod == nil)
+            loadPaymentMethodInfo.fulfill()
+        }
+        wait(for: [loadPaymentMethodInfo], timeout: 5.0)
+    }
 
     func testLoadPaymentMethodInfo_singleCard() throws {
         let stubbedAPIClient = stubbedAPIClient()

--- a/StripePaymentSheet/StripePaymentSheetTests/Resources/MockFiles/saved_payment_methods_200.json
+++ b/StripePaymentSheet/StripePaymentSheetTests/Resources/MockFiles/saved_payment_methods_200.json
@@ -1,0 +1,8 @@
+{
+  "object": "list",
+  "data": [
+
+  ],
+  "has_more": false,
+  "url": "/v1/payment_methods"
+}

--- a/StripePaymentSheet/StripePaymentSheetTests/Resources/MockFiles/saved_payment_methods_withCard_200.json
+++ b/StripePaymentSheet/StripePaymentSheetTests/Resources/MockFiles/saved_payment_methods_withCard_200.json
@@ -1,0 +1,53 @@
+{
+  "object": "list",
+  "data": [
+    {
+      "id": "pm_1Kn1111131111111111111",
+      "object": "payment_method",
+      "billing_details": {
+        "address": {
+          "city": null,
+          "country": "US",
+          "line1": null,
+          "line2": null,
+          "postal_code": "44444",
+          "state": null
+        },
+        "email": null,
+        "name": null,
+        "phone": null
+      },
+      "card": {
+        "brand": "visa",
+        "checks": {
+          "address_line1_check": null,
+          "address_postal_code_check": "pass",
+          "cvc_check": "pass"
+        },
+        "country": "US",
+        "exp_month": 4,
+        "exp_year": 2024,
+        "fingerprint": "LzD7111111JQs7",
+        "funding": "credit",
+        "generated_from": null,
+        "last4": "4242",
+        "networks": {
+          "available": [
+            "visa"
+          ],
+          "preferred": null
+        },
+        "three_d_secure_usage": {
+          "supported": true
+        },
+        "wallet": null
+      },
+      "created": 1649802371,
+      "customer": "cus_LUrr1111111P",
+      "livemode": false,
+      "type": "card"
+    }
+  ],
+  "has_more": false,
+  "url": "/v1/payment_methods"
+}


### PR DESCRIPTION
## Summary
Adding stubbed test for testing timed out network requests made in the context of LoadPaymentMethodInfo.  If we're okay with this approach, I will add more test cases.

## Motivation
Investigating potential infinite loop with presenting customer sheet.

## Testing
Executed unit tests and print statements.
