### PR TITLE
Use nonGenericDescription for CustomerSheet errors

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsViewController.swift
@@ -224,12 +224,8 @@ class CustomerSavedPaymentMethodsViewController: UIViewController {
         switchContentIfNecessary(to: contentViewController, containerView: paymentContainerView)
 
         // Error
-        switch mode {
-        case .addingNewWithSetupIntent, .addingNewPaymentMethodAttachToCustomer:
-            errorLabel.text = error?.localizedDescription
-        case .selectingSaved:
-            errorLabel.text = error?.nonGenericDescription
-        }
+        errorLabel.text = error?.nonGenericDescription
+
         UIView.animate(withDuration: PaymentSheetUI.defaultAnimationDuration) {
             self.errorLabel.setHiddenIfNecessary(self.error == nil)
         }


### PR DESCRIPTION
## Summary
We were incorrectly using `localizedDescription`, and should have been calling `nonGenericDescription` to get the nonGenericDescription from `userInfo`

## Motivation
Private beta feedback

## Testing
Manually tested by setting up temporary backend w/ hardcoded setup intent.


Screenshot before fix:
![Screenshot 2023-06-01 at 4 37 57 PM](https://github.com/stripe/stripe-ios/assets/99628984/39c23682-3184-4ff8-b3a2-2ed0b8e55dff)

Screenshot w/ fix applied:
![Screenshot 2023-06-01 at 4 36 54 PM](https://github.com/stripe/stripe-ios/assets/99628984/8d5e7eae-5cbd-4ffc-9b09-4e63adebf3b2)

