### PR TITLE
Fix a few issues with our VC logic

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetSnapshotTests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetSnapshotTests.swift
@@ -1049,10 +1049,12 @@ class PaymentSheetSnapshotTests: FBSnapshotTestCase {
             testWindow.overrideUserInterfaceStyle = .dark
         }
         testWindow.rootViewController = navController
-
-        paymentSheet.present(from: vc) { result in
-            if case let .failed(error) = result {
-                XCTFail("Presentation failed: \(error)")
+        // Wait a turn of the runloop for the RVC to attach to the window, then present PaymentSheet
+        DispatchQueue.main.async {
+            self.paymentSheet.present(from: vc) { result in
+                if case let .failed(error) = result {
+                    XCTFail("Presentation failed: \(error)")
+                }
             }
         }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
@@ -234,7 +234,7 @@ class SavedPaymentOptionsViewController: UIViewController {
     }
 
     override func viewWillAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
+        super.viewWillAppear(animated)
         guard let selectedIndexPath = collectionView.indexPathsForSelectedItems?.first else {
             return
         }


### PR DESCRIPTION
## Summary
Two issues which were causing undefined behavior in UIKit (and crashes in our snapshot tests):
* We called super.view**Did**Appear instead of super.viewWillAppear when overriding viewWillAppear, which triggered some internal issues in UIViewController.
* We also presented a VC before the UIWindow had a chance to finish setting up the provided rootViewController. This *shouldn't* be a problem, but caused UIKit to print a lot of errors around "Unbalanced calls to begin/end appearance transitions". Waiting a turn of the runloop in our test prevented this crash.

## Motivation
Fix flaky snapshot tests

## Testing
Covered by existing tests