### PR TITLE
Add a setting to disable autoreload in the playground

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -169,7 +169,7 @@ struct PaymentSheetButtons: View {
                         if playgroundController.isLoading {
                             ProgressView()
                         } else {
-                            
+
                                 if playgroundController.settings != playgroundController.currentlyRenderedSettings {
                                     StaleView()
                                 }

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -169,10 +169,9 @@ struct PaymentSheetButtons: View {
                         if playgroundController.isLoading {
                             ProgressView()
                         } else {
-
-                                if playgroundController.settings != playgroundController.currentlyRenderedSettings {
-                                    StaleView()
-                                }
+                            if playgroundController.settings != playgroundController.currentlyRenderedSettings {
+                                StaleView()
+                            }
                             Button {
                                 reloadPlaygroundController()
                             } label: {

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -227,7 +227,7 @@ struct StaleView: View {
             .font(.subheadline.smallCaps().bold())
             .padding(.horizontal, 4.0)
             .padding(.bottom, 2.0)
-            .background(Color.gray)
+            .background(Color.red)
             .foregroundColor(.white)
             .cornerRadius(8.0)
     }

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -65,6 +65,7 @@ struct PaymentSheetTestPlayground: View {
                         SettingView(setting: $playgroundController.settings.allowsDelayedPMs)
                         SettingView(setting: $playgroundController.settings.defaultBillingAddress)
                         SettingView(setting: $playgroundController.settings.linkEnabled)
+                        SettingView(setting: $playgroundController.settings.autoreload)
                         TextField("Custom CTA", text: customCTABinding)
                     }
                     Divider()
@@ -121,6 +122,9 @@ struct PaymentSheetButtons: View {
                         if playgroundController.isLoading {
                             ProgressView()
                         } else {
+                            if playgroundController.settings != playgroundController.currentlyRenderedSettings {
+                                StaleView()
+                            }
                             Button {
                                 reloadPlaygroundController()
                             } label: {
@@ -165,6 +169,10 @@ struct PaymentSheetButtons: View {
                         if playgroundController.isLoading {
                             ProgressView()
                         } else {
+                            
+                                if playgroundController.settings != playgroundController.currentlyRenderedSettings {
+                                    StaleView()
+                                }
                             Button {
                                 reloadPlaygroundController()
                             } label: {
@@ -211,6 +219,18 @@ struct PaymentSheetButtons: View {
                 }
             }
         }
+    }
+}
+
+struct StaleView: View {
+    var body: some View {
+        Text("Stale")
+            .font(.subheadline.smallCaps().bold())
+            .padding(.horizontal, 4.0)
+            .padding(.bottom, 2.0)
+            .background(Color.gray)
+            .foregroundColor(.white)
+            .cornerRadius(8.0)
     }
 }
 

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -187,7 +187,6 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
         case off
     }
 
-
     var uiStyle: UIStyle
     var mode: Mode
     var integrationType: IntegrationType

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -180,6 +180,13 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
         case never
         case full
     }
+    enum Autoreload: String, PickerEnum {
+        static var enumName: String { "Autoreload" }
+
+        case on
+        case off
+    }
+
 
     var uiStyle: UIStyle
     var mode: Mode
@@ -197,6 +204,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
     var linkEnabled: LinkEnabled
     var customCtaLabel: String?
     var checkoutEndpoint: String?
+    var autoreload: Autoreload
 
     var attachDefaults: BillingDetailsAttachDefaults
     var collectName: BillingDetailsName
@@ -221,6 +229,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
             linkEnabled: .off,
             customCtaLabel: nil,
             checkoutEndpoint: Self.defaultCheckoutEndpoint,
+            autoreload: .on,
             attachDefaults: .off,
             collectName: .automatic,
             collectEmail: .automatic,


### PR DESCRIPTION
## Summary
Add a setting to disable autoreload in the playground and an indicator to show if the PaymentSheet state is stale.
<img width="373" alt="CleanShot 2023-06-05 at 13 14 09@2x" src="https://github.com/stripe/stripe-ios/assets/52758633/5d1195fa-4b41-47bf-908e-663b789e5e16">

## Motivation
@wooj-stripe asked

## Testing
Xcode SwiftUI preview

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
