### PR TITLE
Fix issue with removing payment method in customer sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 23.9.0 2023-05-30
-### PaymentSheet
+
+	### PaymentSheet
 * [Changed] The private beta API for https://stripe.com/docs/payments/finalize-payments-on-the-server has changed:
   * If you use `IntentConfiguration(..., confirmHandler:)`, the confirm handler now has an additional `shouldSavePaymentMethod: Bool` parameter that you should ignore.
   * If you use `IntentConfiguration(..., confirmHandlerForServerSideConfirmation:)`, use `IntentConfiguration(..., confirmHandler:)` instead. Additionally, the confirm handler's first parameter is now an `STPPaymentMethod` object instead of a String id. Use `paymentMethod.stripeId` to get its id and send it to your server.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 ## 23.9.0 2023-05-30
-
-	### PaymentSheet
+### PaymentSheet
 * [Changed] The private beta API for https://stripe.com/docs/payments/finalize-payments-on-the-server has changed:
   * If you use `IntentConfiguration(..., confirmHandler:)`, the confirm handler now has an additional `shouldSavePaymentMethod: Bool` parameter that you should ignore.
   * If you use `IntentConfiguration(..., confirmHandlerForServerSideConfirmation:)`, use `IntentConfiguration(..., confirmHandler:)` instead. Additionally, the confirm handler's first parameter is now an `STPPaymentMethod` object instead of a String id. Use `paymentMethod.stripeId` to get its id and send it to your server.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewController.swift
@@ -134,7 +134,11 @@ class CustomerSavedPaymentMethodsCollectionViewController: UIViewController {
             return .saved(paymentMethod: paymentMethod)
         }
     }
-    var savedPaymentMethods: [STPPaymentMethod]
+    var savedPaymentMethods: [STPPaymentMethod] {
+        didSet {
+            updateUI(selectedSavedPaymentOption: originalSelectedSavedPaymentMethod)
+        }
+    }
 
     /// Whether or not there are any payment options we can show
     /// i.e. Are there any cells besides the Add cell?


### PR DESCRIPTION
## Summary
Fixing issue with removing payment methods with customer sheet

## Motivation
Crashing bug

## Testing
Manually tested
Add two cards, then remove the first one, then attempt to remove the second one.

without fix: 
![withBug](https://github.com/stripe/stripe-ios/assets/99628984/eefea42f-1829-4ee6-8d3c-99c5fcf5acf0)


With Fix:
![fixForAssertCrash](https://github.com/stripe/stripe-ios/assets/99628984/0f22199a-7adb-4bec-8afe-181444be8baa)

