### PR TITLE
Support sending cus_ to backend and add add/remove test for customersheet

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/Resources/Base.lproj/Main.storyboard
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Resources/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="R4a-Xk-VIc">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="R4a-Xk-VIc">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -1529,8 +1529,75 @@
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vnO-Ja-3nd">
                                 <rect key="frame" x="0.0" y="92" width="414" height="724"/>
                                 <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="GFg-y2-Y9j" userLabel="Other Stack View">
+                                        <rect key="frame" x="1" y="1416" width="413" height="161.5"/>
+                                        <subviews>
+                                            <button opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="252" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="j1Z-HN-58K">
+                                                <rect key="frame" x="0.0" y="0.0" width="413" height="30"/>
+                                                <color key="backgroundColor" systemColor="secondarySystemBackgroundColor"/>
+                                                <state key="normal" title="Load Ephemeral Key"/>
+                                            </button>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5Tc-Ls-d1e">
+                                                <rect key="frame" x="0.0" y="40" width="413" height="1"/>
+                                                <color key="backgroundColor" systemColor="systemFillColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="1" id="y59-Mh-0ZU"/>
+                                                </constraints>
+                                            </view>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CustomerSheet" textAlignment="justified" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nHT-Ub-Q2l">
+                                                <rect key="frame" x="0.0" y="51" width="413" height="20.5"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="a87-4F-pwf" userLabel="Payment method row">
+                                                <rect key="frame" x="0.0" y="81.5" width="413" height="50"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Payment method" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ntl-NB-EaJ">
+                                                        <rect key="frame" x="0.0" y="0.0" width="123" height="50"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <button opaque="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="1000" verticalHuggingPriority="750" verticalCompressionResistancePriority="250" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OFo-x2-vud">
+                                                        <rect key="frame" x="286" y="8" width="71" height="34"/>
+                                                        <accessibility key="accessibilityConfiguration" identifier="Payment method" label="Select Payment Method"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
+                                                        <state key="normal" title="Add"/>
+                                                        <state key="disabled" title="Loading..."/>
+                                                        <userDefinedRuntimeAttributes>
+                                                            <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="present_saved_pms"/>
+                                                        </userDefinedRuntimeAttributes>
+                                                    </button>
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="i1d-Ou-did">
+                                                        <rect key="frame" x="365" y="15" width="32" height="20"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" constant="32" id="hJh-z6-J4g"/>
+                                                            <constraint firstAttribute="height" constant="20" id="hSV-rL-D1H"/>
+                                                        </constraints>
+                                                    </imageView>
+                                                </subviews>
+                                                <constraints>
+                                                    <constraint firstItem="i1d-Ou-did" firstAttribute="centerY" secondItem="a87-4F-pwf" secondAttribute="centerY" id="0Tg-um-LO5"/>
+                                                    <constraint firstItem="ntl-NB-EaJ" firstAttribute="centerY" secondItem="a87-4F-pwf" secondAttribute="centerY" id="MeO-nm-cBb"/>
+                                                    <constraint firstItem="ntl-NB-EaJ" firstAttribute="leading" secondItem="a87-4F-pwf" secondAttribute="leading" id="Rzt-0U-3BA"/>
+                                                    <constraint firstItem="OFo-x2-vud" firstAttribute="centerY" secondItem="ntl-NB-EaJ" secondAttribute="centerY" id="VEs-pk-TNE"/>
+                                                    <constraint firstItem="OFo-x2-vud" firstAttribute="height" secondItem="a87-4F-pwf" secondAttribute="height" multiplier="0.68" id="X4l-UA-FIK"/>
+                                                    <constraint firstItem="i1d-Ou-did" firstAttribute="leading" secondItem="OFo-x2-vud" secondAttribute="trailing" constant="8" symbolic="YES" id="XHo-pc-DHw"/>
+                                                    <constraint firstItem="ntl-NB-EaJ" firstAttribute="height" secondItem="a87-4F-pwf" secondAttribute="height" id="bBi-tE-FhV"/>
+                                                    <constraint firstAttribute="trailing" secondItem="i1d-Ou-did" secondAttribute="trailing" constant="16" id="t4E-QQ-0yz"/>
+                                                </constraints>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="geL-CH-mwv">
+                                                <rect key="frame" x="0.0" y="141.5" width="413" height="20"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="20" id="18D-7H-geg"/>
+                                                </constraints>
+                                            </view>
+                                        </subviews>
+                                    </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" misplaced="YES" layoutMarginsFollowReadableWidth="YES" axis="vertical" alignment="top" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="iWh-BL-5h0" userLabel="Configuration Stack View">
-                                        <rect key="frame" x="7" y="8" width="414" height="1400"/>
+                                        <rect key="frame" x="8" y="8" width="414" height="1400"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kYS-zf-RaB">
                                                 <rect key="frame" x="0.0" y="0.0" width="353.5" height="34.5"/>
@@ -1560,7 +1627,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" spacing="8" id="CGS-a6-geB">
-                                                <rect key="frame" x="0.0" y="38.5" width="236" height="31"/>
+                                                <rect key="frame" x="0.0" y="38.5" width="313" height="31"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Customer" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fV4-be-WMI">
@@ -1570,10 +1637,14 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="pA8-Rk-fEf">
-                                                        <rect key="frame" x="83" y="0.0" width="153" height="32"/>
+                                                        <rect key="frame" x="83" y="0.0" width="230" height="32"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" constant="230" id="r1R-SC-KTl"/>
+                                                        </constraints>
                                                         <segments>
                                                             <segment title="new"/>
                                                             <segment title="returning"/>
+                                                            <segment title="id"/>
                                                         </segments>
                                                         <userDefinedRuntimeAttributes>
                                                             <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="customer_mode_selector"/>
@@ -1581,8 +1652,27 @@
                                                     </segmentedControl>
                                                 </subviews>
                                             </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="KIY-ya-3F3">
+                                                <rect key="frame" x="0.0" y="73.5" width="294" height="34"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="customerId" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rh5-b2-mAJ">
+                                                        <rect key="frame" x="0.0" y="0.0" width="86" height="34"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="AQr-oz-clv">
+                                                        <rect key="frame" x="94" y="0.0" width="200" height="34"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" constant="200" id="ZaM-Zi-9ai"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                        <textInputTraits key="textInputTraits"/>
+                                                    </textField>
+                                                </subviews>
+                                            </stackView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Client configuration" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DDf-KN-l73">
-                                                <rect key="frame" x="0.0" y="73.5" width="157" height="1218.5"/>
+                                                <rect key="frame" x="0.0" y="111.5" width="157" height="1180.5"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -1653,73 +1743,6 @@
                                             </stackView>
                                         </subviews>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="GFg-y2-Y9j" userLabel="Other Stack View">
-                                        <rect key="frame" x="1" y="1416" width="413" height="161.5"/>
-                                        <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="252" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="j1Z-HN-58K">
-                                                <rect key="frame" x="0.0" y="0.0" width="413" height="30"/>
-                                                <color key="backgroundColor" systemColor="secondarySystemBackgroundColor"/>
-                                                <state key="normal" title="Load Ephemeral Key"/>
-                                            </button>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5Tc-Ls-d1e">
-                                                <rect key="frame" x="0.0" y="40" width="413" height="1"/>
-                                                <color key="backgroundColor" systemColor="systemFillColor"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="1" id="y59-Mh-0ZU"/>
-                                                </constraints>
-                                            </view>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CustomerSheet" textAlignment="justified" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nHT-Ub-Q2l">
-                                                <rect key="frame" x="0.0" y="51" width="413" height="20.5"/>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="a87-4F-pwf" userLabel="Payment method row">
-                                                <rect key="frame" x="0.0" y="81.5" width="413" height="50"/>
-                                                <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Payment method" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ntl-NB-EaJ">
-                                                        <rect key="frame" x="0.0" y="0.0" width="123" height="50"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <button opaque="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="1000" verticalHuggingPriority="750" verticalCompressionResistancePriority="250" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OFo-x2-vud">
-                                                        <rect key="frame" x="286" y="8" width="71" height="34"/>
-                                                        <accessibility key="accessibilityConfiguration" identifier="Payment method" label="Select Payment Method"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
-                                                        <state key="normal" title="Add"/>
-                                                        <state key="disabled" title="Loading..."/>
-                                                        <userDefinedRuntimeAttributes>
-                                                            <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="present_saved_pms"/>
-                                                        </userDefinedRuntimeAttributes>
-                                                    </button>
-                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="i1d-Ou-did">
-                                                        <rect key="frame" x="365" y="15" width="32" height="20"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="width" constant="32" id="hJh-z6-J4g"/>
-                                                            <constraint firstAttribute="height" constant="20" id="hSV-rL-D1H"/>
-                                                        </constraints>
-                                                    </imageView>
-                                                </subviews>
-                                                <constraints>
-                                                    <constraint firstItem="i1d-Ou-did" firstAttribute="centerY" secondItem="a87-4F-pwf" secondAttribute="centerY" id="0Tg-um-LO5"/>
-                                                    <constraint firstItem="ntl-NB-EaJ" firstAttribute="centerY" secondItem="a87-4F-pwf" secondAttribute="centerY" id="MeO-nm-cBb"/>
-                                                    <constraint firstItem="ntl-NB-EaJ" firstAttribute="leading" secondItem="a87-4F-pwf" secondAttribute="leading" id="Rzt-0U-3BA"/>
-                                                    <constraint firstItem="OFo-x2-vud" firstAttribute="centerY" secondItem="ntl-NB-EaJ" secondAttribute="centerY" id="VEs-pk-TNE"/>
-                                                    <constraint firstItem="OFo-x2-vud" firstAttribute="height" secondItem="a87-4F-pwf" secondAttribute="height" multiplier="0.68" id="X4l-UA-FIK"/>
-                                                    <constraint firstItem="i1d-Ou-did" firstAttribute="leading" secondItem="OFo-x2-vud" secondAttribute="trailing" constant="8" symbolic="YES" id="XHo-pc-DHw"/>
-                                                    <constraint firstItem="ntl-NB-EaJ" firstAttribute="height" secondItem="a87-4F-pwf" secondAttribute="height" id="bBi-tE-FhV"/>
-                                                    <constraint firstAttribute="trailing" secondItem="i1d-Ou-did" secondAttribute="trailing" constant="16" id="t4E-QQ-0yz"/>
-                                                </constraints>
-                                            </view>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="geL-CH-mwv">
-                                                <rect key="frame" x="0.0" y="141.5" width="413" height="20"/>
-                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="20" id="18D-7H-geg"/>
-                                                </constraints>
-                                            </view>
-                                        </subviews>
-                                    </stackView>
                                 </subviews>
                                 <constraints>
                                     <constraint firstItem="iWh-BL-5h0" firstAttribute="bottom" secondItem="GFg-y2-Y9j" secondAttribute="top" constant="-16" id="JVe-t5-S9y"/>
@@ -1783,6 +1806,7 @@
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
                     <connections>
                         <outlet property="applePaySelector" destination="7q4-Hu-6Rf" id="VKB-A3-laF"/>
+                        <outlet property="customerIdTextField" destination="AQr-oz-clv" id="sd6-vf-iLT"/>
                         <outlet property="customerModeSelector" destination="pA8-Rk-fEf" id="XMp-OG-cLU"/>
                         <outlet property="headerTextForSelectionScreenTextField" destination="0RN-q7-eBK" id="gXc-yX-yKI"/>
                         <outlet property="loadButton" destination="j1Z-HN-58K" id="e77-FJ-6b5"/>
@@ -1794,7 +1818,7 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="zSK-Xo-BgE" sceneMemberID="firstResponder"/>
                 <exit id="GmB-Lw-h9m" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
-            <point key="canvasLocation" x="2590" y="840"/>
+            <point key="canvasLocation" x="2589.8550724637685" y="839.73214285714278"/>
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>

--- a/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
@@ -21,10 +21,11 @@ class CustomerSheetUITest: XCTestCase {
         app.launch()
     }
 
-    func testPaymentSheetStandard_applePayOff_addCard() throws {
+    func testCustomerSheetStandard_applePayOff_addCard() throws {
         app.staticTexts["CustomerSheet (test playground)"].tap()
         let loadButton = app.staticTexts["Load Ephemeral Key"]
         XCTAssertTrue(loadButton.waitForExistence(timeout: 60.0))
+        app.segmentedControls["customer_mode_selector"].buttons["new"].tap()
         app.segmentedControls["apple_pay_selector"].buttons["off"].tap()
         loadButton.tap()
 
@@ -37,10 +38,11 @@ class CustomerSheetUITest: XCTestCase {
         XCTAssertTrue(paymentMethodButton.waitForExistence(timeout: 60.0))
     }
 
-    func testPaymentSheetStandard_applePayOn_addCard() throws {
+    func testCustomerSheetStandard_applePayOn_addCard() throws {
         app.staticTexts["CustomerSheet (test playground)"].tap()
         let loadButton = app.staticTexts["Load Ephemeral Key"]
         XCTAssertTrue(loadButton.waitForExistence(timeout: 60.0))
+        app.segmentedControls["customer_mode_selector"].buttons["new"].tap()
         app.segmentedControls["apple_pay_selector"].buttons["on"].tap()
         loadButton.tap()
 
@@ -56,10 +58,11 @@ class CustomerSheetUITest: XCTestCase {
         XCTAssertTrue(paymentMethodButton.waitForExistence(timeout: 60.0))
     }
 
-    func testPaymentSheetStandard_applePayOn_selectApplePay() throws {
+    func testCustomerSheetStandard_applePayOn_selectApplePay() throws {
         app.staticTexts["CustomerSheet (test playground)"].tap()
         let loadButton = app.staticTexts["Load Ephemeral Key"]
         XCTAssertTrue(loadButton.waitForExistence(timeout: 60.0))
+        app.segmentedControls["customer_mode_selector"].buttons["new"].tap()
         app.segmentedControls["apple_pay_selector"].buttons["on"].tap()
         loadButton.tap()
 
@@ -75,5 +78,68 @@ class CustomerSheetUITest: XCTestCase {
 
         let paymentMethodButton = app.staticTexts["Success: Apple Pay"]  // The card should be saved now
         XCTAssertTrue(paymentMethodButton.waitForExistence(timeout: 60.0))
+    }
+
+    func testAddTwoPaymentMethods_RemoveTwoPaymentMethods() throws {
+        app.staticTexts["CustomerSheet (test playground)"].tap()
+        let loadButton = app.staticTexts["Load Ephemeral Key"]
+        XCTAssertTrue(loadButton.waitForExistence(timeout: 60.0))
+        app.segmentedControls["customer_mode_selector"].buttons["new"].tap()
+        app.segmentedControls["apple_pay_selector"].buttons["on"].tap()
+        loadButton.tap()
+
+        presentCSAndAddCardFrom(buttonLabel: "Select")
+        presentCSAndAddCardFrom(buttonLabel: "••••4242")
+
+        let selectButton = app.staticTexts["••••4242"]
+        XCTAssertTrue(selectButton.waitForExistence(timeout: 60.0))
+        selectButton.tap()
+
+        let editButton = app.staticTexts["Edit"]
+        XCTAssertTrue(editButton.waitForExistence(timeout: 60.0))
+        editButton.tap()
+
+        removeFirstPaymentMethodInList()
+        removeFirstPaymentMethodInList()
+
+        let doneButton = app.staticTexts["Done"]
+        XCTAssertTrue(doneButton.waitForExistence(timeout: 60.0))
+        doneButton.tap()
+
+        let closeButton = app.buttons["Close"]
+        XCTAssertTrue(closeButton.waitForExistence(timeout: 60.0))
+        closeButton.tap()
+
+        dismissAlertView(alertBody: "Success: payment method unset", alertTitle: "Complete", buttonToTap: "OK")
+
+        let selectButtonFinal = app.staticTexts["Select"]
+        XCTAssertTrue(selectButtonFinal.waitForExistence(timeout: 60.0))
+
+    }
+
+    func presentCSAndAddCardFrom(buttonLabel: String) {
+        let selectButton = app.staticTexts[buttonLabel]
+        XCTAssertTrue(selectButton.waitForExistence(timeout: 60.0))
+        selectButton.tap()
+
+        app.staticTexts["+ Add"].tap()
+
+        try! fillCardData(app, postalEnabled: false)
+        app.buttons["Save"].tap()
+        dismissAlertView(alertBody: "Success: ••••4242", alertTitle: "Complete", buttonToTap: "OK")
+    }
+
+    func removeFirstPaymentMethodInList() {
+        let removeButton1 = app.buttons["Remove"].firstMatch
+        removeButton1.tap()
+        dismissAlertView(alertBody: "Remove Visa ending in 4242", alertTitle: "Remove Card", buttonToTap: "Remove")
+    }
+
+    func dismissAlertView(alertBody: String, alertTitle: String, buttonToTap: String) {
+        let alertText = app.staticTexts[alertBody]
+        XCTAssertTrue(alertText.waitForExistence(timeout: 60.0))
+
+        let alert = app.alerts[alertTitle]
+        alert.buttons[buttonToTap].tap()
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewController.swift
@@ -362,7 +362,7 @@ extension CustomerSavedPaymentMethodsCollectionViewController: PaymentOptionCell
         guard let indexPath = collectionView.indexPath(for: paymentOptionCell),
               case .saved(let paymentMethod) = viewModels[indexPath.row]
         else {
-            assertionFailure()
+            assertionFailure("Please file an issue with reproduction steps at https://github.com/stripe/stripe-ios")
             return
         }
         let viewModel = viewModels[indexPath.row]


### PR DESCRIPTION
## Summary
* Updated customer sheet playground to re-use a newly created customerId.  After tapping "load" with customerMode set to "new", the segmented control automatically changes to "ID" and updates a "customerId" field.  I believe that this will encourage users of payment sheet test playground to create a new ID and use that (rather than everyone just sharing a single acct)
* Added UI test which adds two cards, and deletes them due to assertionFailure seen in beta release.

## Motivation
* Usability in customerSheet
* More tests around adding/removing cards

## Testing
* Manually tested customer sheet playground
* Executed ui tests locally.
