### PR TITLE
Don't validate the PI/SI in PaymentSheet deferred flow when doing ser…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## X.Y.Z 2023-xx-yy
+### PaymentSheet
+* [Fixed] Fixed validating the IntentConfiguration matches the PaymentIntent/SetupIntent when it was already confirmed on the server. Note: server-side confirmation is in private beta.
+
 ## 23.9.0 2023-05-30
 ### PaymentSheet
 * [Changed] The private beta API for https://stripe.com/docs/payments/finalize-payments-on-the-server has changed:

--- a/Stripe/StripeiOSTests/PaymentSheet+APITest.swift
+++ b/Stripe/StripeiOSTests/PaymentSheet+APITest.swift
@@ -786,7 +786,7 @@ class PaymentSheetAPITest: XCTestCase {
         }
         waitForExpectations(timeout: 10)
     }
-    
+
     func testDeferredConfirm_paymentintent_server_side_confirm_doesnt_validate() {
         // More validation tests are in PaymentSheetDeferredValidatorTests; this tests we **don't** perform validation in the paymentintent server-side confirm flow
         let e = expectation(description: "confirm completes")
@@ -794,7 +794,7 @@ class PaymentSheetAPITest: XCTestCase {
             STPTestingAPIClient.shared().createPaymentIntent(withParams: [
                 "amount": 1050,
                 "confirm": true,
-                "payment_method": paymentMethod.stripeId
+                "payment_method": paymentMethod.stripeId,
             ]) { pi, _ in
                 intentCreationCallback(.success(pi ?? ""))
             }
@@ -815,7 +815,7 @@ class PaymentSheetAPITest: XCTestCase {
         }
         waitForExpectations(timeout: 10)
     }
-    
+
     func testDeferredConfirm_setupintent_usage_doesnt_match_intent_config() {
         // More validation tests are in PaymentSheetDeferredValidatorTests; this tests we perform validation in the setupintent confirm flow
         let e = expectation(description: "confirm completes")
@@ -842,7 +842,7 @@ class PaymentSheetAPITest: XCTestCase {
         }
         waitForExpectations(timeout: 10)
     }
-    
+
     func testDeferredConfirm_setupintent_server_side_confirm_doesnt_validate() {
         // More validation tests are in PaymentSheetDeferredValidatorTests; this tests we **don't** perform validation in the SetupIntent server-side confirm flow
         let e = expectation(description: "confirm completes")

--- a/Stripe/StripeiOSTests/PaymentSheet+APITest.swift
+++ b/Stripe/StripeiOSTests/PaymentSheet+APITest.swift
@@ -777,22 +777,24 @@ class PaymentSheetAPITest: XCTestCase {
             paymentOption: .new(confirmParams: self.valid_card_checkbox_selected),
             paymentHandler: paymentHandler
         ) { result in
-                e.fulfill()
-                guard case let .failed(error) = result else {
-                    XCTFail()
-                    return
-                }
-                XCTAssertEqual((error as CustomDebugStringConvertible).debugDescription, "An error occured in PaymentSheet. Your PaymentIntent amount (1050) does not match the PaymentSheet.IntentConfiguration amount (1080).")
+            e.fulfill()
+            guard case let .failed(error) = result else {
+                XCTFail()
+                return
             }
+            XCTAssertEqual((error as CustomDebugStringConvertible).debugDescription, "An error occured in PaymentSheet. Your PaymentIntent amount (1050) does not match the PaymentSheet.IntentConfiguration amount (1080).")
+        }
         waitForExpectations(timeout: 10)
     }
-
-    func testDeferredConfirm_setupintent_usage_doesnt_match_intent_config() {
-        // More validation tests are in PaymentSheetDeferredValidatorTests; this tests we perform validation in the setupintent confirm flow
+    
+    func testDeferredConfirm_paymentintent_server_side_confirm_doesnt_validate() {
+        // More validation tests are in PaymentSheetDeferredValidatorTests; this tests we **don't** perform validation in the paymentintent server-side confirm flow
         let e = expectation(description: "confirm completes")
-        let intentConfig = PaymentSheet.IntentConfiguration(mode: .setup(currency: "USD")) { _, _, intentCreationCallback in
-            STPTestingAPIClient.shared().createSetupIntent(withParams: [
-                "usage": "on_session",
+        let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1080, currency: "USD")) { paymentMethod, _, intentCreationCallback in
+            STPTestingAPIClient.shared().createPaymentIntent(withParams: [
+                "amount": 1050,
+                "confirm": true,
+                "payment_method": paymentMethod.stripeId
             ]) { pi, _ in
                 intentCreationCallback(.success(pi ?? ""))
             }
@@ -804,13 +806,69 @@ class PaymentSheetAPITest: XCTestCase {
             paymentOption: .new(confirmParams: self.valid_card_checkbox_selected),
             paymentHandler: paymentHandler
         ) { result in
-                e.fulfill()
-                guard case let .failed(error) = result else {
-                    XCTFail()
-                    return
-                }
-                XCTAssertEqual((error as CustomDebugStringConvertible).debugDescription, "An error occured in PaymentSheet. Your SetupIntent usage (onSession) does not match the PaymentSheet.IntentConfiguration setupFutureUsage (offSession).")
+            e.fulfill()
+            // The result is completed, even though the IntentConfiguration and PaymentIntent amounts are not the same
+            guard case .completed = result else {
+                XCTFail()
+                return
             }
+        }
+        waitForExpectations(timeout: 10)
+    }
+    
+    func testDeferredConfirm_setupintent_usage_doesnt_match_intent_config() {
+        // More validation tests are in PaymentSheetDeferredValidatorTests; this tests we perform validation in the setupintent confirm flow
+        let e = expectation(description: "confirm completes")
+        let intentConfig = PaymentSheet.IntentConfiguration(mode: .setup(currency: "USD")) { _, _, intentCreationCallback in
+            STPTestingAPIClient.shared().createSetupIntent(withParams: [
+                "usage": "on_session",
+            ]) { si, _ in
+                intentCreationCallback(.success(si ?? ""))
+            }
+        }
+        PaymentSheet.confirm(
+            configuration: configuration,
+            authenticationContext: self,
+            intent: .deferredIntent(elementsSession: ._testCardValue(), intentConfig: intentConfig),
+            paymentOption: .new(confirmParams: self.valid_card_checkbox_selected),
+            paymentHandler: paymentHandler
+        ) { result in
+            e.fulfill()
+            guard case let .failed(error) = result else {
+                XCTFail()
+                return
+            }
+            XCTAssertEqual((error as CustomDebugStringConvertible).debugDescription, "An error occured in PaymentSheet. Your SetupIntent usage (onSession) does not match the PaymentSheet.IntentConfiguration setupFutureUsage (offSession).")
+        }
+        waitForExpectations(timeout: 10)
+    }
+    
+    func testDeferredConfirm_setupintent_server_side_confirm_doesnt_validate() {
+        // More validation tests are in PaymentSheetDeferredValidatorTests; this tests we **don't** perform validation in the SetupIntent server-side confirm flow
+        let e = expectation(description: "confirm completes")
+        let intentConfig = PaymentSheet.IntentConfiguration(mode: .setup(currency: "USD")) { paymentMethod, _, intentCreationCallback in
+            STPTestingAPIClient.shared().createSetupIntent(withParams: [
+                "usage": "on_session",
+                "payment_method": paymentMethod.stripeId,
+                "confirm": true,
+            ]) { si, _ in
+                intentCreationCallback(.success(si ?? ""))
+            }
+        }
+        PaymentSheet.confirm(
+            configuration: configuration,
+            authenticationContext: self,
+            intent: .deferredIntent(elementsSession: ._testCardValue(), intentConfig: intentConfig),
+            paymentOption: .new(confirmParams: self.valid_card_checkbox_selected),
+            paymentHandler: paymentHandler
+        ) { result in
+            e.fulfill()
+            // The result is completed, even though the IntentConfiguration and SetupIntent setup_future_usage values are not the same
+            guard case .completed = result else {
+                XCTFail()
+                return
+            }
+        }
         waitForExpectations(timeout: 10)
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+DeferredAPI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+DeferredAPI.swift
@@ -52,12 +52,10 @@ extension PaymentSheet {
                 switch intentConfig.mode {
                 case .payment:
                     let paymentIntent = try await configuration.apiClient.retrievePaymentIntent(clientSecret: clientSecret, expand: ["payment_method"])
-                    try PaymentSheetDeferredValidator.validate(paymentIntent: paymentIntent,
-                                                               intentConfiguration: intentConfig,
-                                                               isFlowController: isFlowController)
                     // Check if it needs confirmation
                     if [STPPaymentIntentStatus.requiresPaymentMethod, STPPaymentIntentStatus.requiresConfirmation].contains(paymentIntent.status) {
                         // 4a. Client-side confirmation
+                        try PaymentSheetDeferredValidator.validate(paymentIntent: paymentIntent, intentConfiguration: intentConfig, isFlowController: isFlowController)
                         let paymentIntentParams = makePaymentIntentParams(
                             confirmPaymentMethodType: confirmType,
                             paymentIntent: paymentIntent,
@@ -81,9 +79,9 @@ extension PaymentSheet {
                     }
                 case .setup:
                     let setupIntent = try await configuration.apiClient.retrieveSetupIntent(clientSecret: clientSecret, expand: ["payment_method"])
-                    try PaymentSheetDeferredValidator.validate(setupIntent: setupIntent, intentConfiguration: intentConfig)
                     if [STPSetupIntentStatus.requiresPaymentMethod, STPSetupIntentStatus.requiresConfirmation].contains(setupIntent.status) {
                         // 4a. Client-side confirmation
+                        try PaymentSheetDeferredValidator.validate(setupIntent: setupIntent, intentConfiguration: intentConfig)
                         let setupIntentParams = makeSetupIntentParams(
                             confirmPaymentMethodType: confirmType,
                             setupIntent: setupIntent,


### PR DESCRIPTION
…ver-side confirm


## Motivation
Say the merchant, for whatever reason, uses a different value (amount, SFU, etc) when creating the intent and then immediately confirms it on the server. The intent doesn’t require any other action, so it’s immediately succeeded.

Next, our client-side validator will regard the intent as invalid and display failure even though the intent has been confirmed. The end user thinks something went wrong and will try again, resulting in a double charge

## Testing
Added unit tests 

## Changelog
### PaymentSheet 
* [Fixed] Fixed validating the IntentConfiguration matches the PaymentIntent/SetupIntent when it was already confirmed on the server. Note: server-side confirmation is in private beta.