### PR TITLE
Stop validating amount in deferred flow

### DIFF
--- a/Stripe/StripeiOSTests/PaymentSheet+APITest.swift
+++ b/Stripe/StripeiOSTests/PaymentSheet+APITest.swift
@@ -760,12 +760,13 @@ class PaymentSheetAPITest: XCTestCase {
         waitForExpectations(timeout: 10)
     }
 
-    func testDeferredConfirm_paymentintent_amount_doesnt_match_intent_config() {
+    func testDeferredConfirm_paymentintent_client_side_confirm_validates() {
         // More validation tests are in PaymentSheetDeferredValidatorTests; this tests we perform validation in the paymentintent confirm flow
         let e = expectation(description: "confirm completes")
-        let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1080, currency: "USD")) { _, _, intentCreationCallback in
+        let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1050, currency: "USD")) { _, _, intentCreationCallback in
             STPTestingAPIClient.shared().createPaymentIntent(withParams: [
                 "amount": 1050,
+                "currency": "GBP", // Different currency than IntentConfiguration
             ]) { pi, _ in
                 intentCreationCallback(.success(pi ?? ""))
             }
@@ -782,7 +783,7 @@ class PaymentSheetAPITest: XCTestCase {
                 XCTFail()
                 return
             }
-            XCTAssertEqual((error as CustomDebugStringConvertible).debugDescription, "An error occured in PaymentSheet. Your PaymentIntent amount (1050) does not match the PaymentSheet.IntentConfiguration amount (1080).")
+            XCTAssertEqual((error as CustomDebugStringConvertible).debugDescription, "An error occured in PaymentSheet. Your PaymentIntent currency (GBP) does not match the PaymentSheet.IntentConfiguration currency (USD).")
         }
         waitForExpectations(timeout: 10)
     }

--- a/Stripe/StripeiOSTests/PaymentSheetDeferredValidatorTests.swift
+++ b/Stripe/StripeiOSTests/PaymentSheetDeferredValidatorTests.swift
@@ -46,16 +46,6 @@ final class PaymentSheetDeferredValidatorTests: XCTestCase {
         }
     }
 
-    func testPaymentIntentMismatchedAmount() throws {
-        let pi = STPFixtures.makePaymentIntent(amount: 1000, currency: "USD")
-        let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 100, currency: "USD"), confirmHandler: confirmHandler)
-        XCTAssertThrowsError(try PaymentSheetDeferredValidator.validate(paymentIntent: pi,
-                                                                        intentConfiguration: intentConfig,
-                                                                        isFlowController: false)) { error in
-            XCTAssertEqual("\(error)", "An error occured in PaymentSheet. Your PaymentIntent amount (1000) does not match the PaymentSheet.IntentConfiguration amount (100).")
-        }
-    }
-
     func testPaymentIntentMismatchedCaptureMethod() throws {
         let pi = STPFixtures.makePaymentIntent(amount: 100, currency: "USD", captureMethod: "manual")
         let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 100, currency: "USD", captureMethod: .automatic), confirmHandler: confirmHandler)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetDeferredValidator.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetDeferredValidator.swift
@@ -9,20 +9,18 @@ import Foundation
 import StripePayments
 
 struct PaymentSheetDeferredValidator {
+    /// Note: We don't validate amount (for any payment method) because there are use cases where the amount can change slightly between PM collection and confirmation.
     static func validate(paymentIntent: STPPaymentIntent,
                          intentConfiguration: PaymentSheet.IntentConfiguration,
                          isFlowController: Bool) throws {
-        guard case let .payment(amount, currency, setupFutureUsage, captureMethod) = intentConfiguration.mode else {
+        guard case let .payment(_, currency, setupFutureUsage, captureMethod) = intentConfiguration.mode else {
             throw PaymentSheetError.unknown(debugDescription: "You returned a PaymentIntent client secret but used a PaymentSheet.IntentConfiguration in setup mode.")
         }
         guard paymentIntent.currency.uppercased() == currency.uppercased() else {
-            throw PaymentSheetError.unknown(debugDescription: "Your PaymentIntent currency (\(paymentIntent.currency)) does not match the PaymentSheet.IntentConfiguration currency (\(currency)).")
+            throw PaymentSheetError.unknown(debugDescription: "Your PaymentIntent currency (\(paymentIntent.currency.uppercased())) does not match the PaymentSheet.IntentConfiguration currency (\(currency.uppercased())).")
         }
         guard paymentIntent.setupFutureUsage == setupFutureUsage else {
             throw PaymentSheetError.unknown(debugDescription: "Your PaymentIntent setupFutureUsage (\(paymentIntent.setupFutureUsage)) does not match the PaymentSheet.IntentConfiguration setupFutureUsage (\(String(describing: setupFutureUsage))).")
-        }
-        guard paymentIntent.amount == amount else {
-            throw PaymentSheetError.unknown(debugDescription: "Your PaymentIntent amount (\(paymentIntent.amount)) does not match the PaymentSheet.IntentConfiguration amount (\(amount)).")
         }
         guard paymentIntent.captureMethod == captureMethod else {
             throw PaymentSheetError.unknown(debugDescription: "Your PaymentIntent captureMethod (\(paymentIntent.captureMethod)) does not match the PaymentSheet.IntentConfiguration amount (\(captureMethod)).")


### PR DESCRIPTION
## Motivation
We don't validate amount (for any payment method) because there are use cases where the amount can change slightly between PM collection and confirmation.

## Testing
See unit tests

## Changelog
Could be considered user facing, but feels too small of a change for CHANGELOG. Feel free to disagree and I can add something.
