### PR TITLE
Financial Connections: fixed an issue where pane parameter sometimes was not set for some analytics.

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsAnalyticsClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsAnalyticsClient.swift
@@ -28,12 +28,14 @@ final class FinancialConnectionsAnalyticsClient {
     public func log(
         eventName: String,
         parameters: [String: Any] = [:],
-        pane: FinancialConnectionsSessionManifest.NextPane? = nil
+        pane: FinancialConnectionsSessionManifest.NextPane
     ) {
         let eventName = "linked_accounts.\(eventName)"
 
         var parameters = parameters
-        parameters["pane"] = pane?.rawValue
+        // !!! BE CAREFUL MODIFYING "PANE" ANALYTICS CODE
+        // ITS CRITICAL FOR PANE CONVERSION !!!
+        parameters["pane"] = pane.rawValue
         parameters = parameters.merging(
             additionalParameters,
             uniquingKeysWith: { eventParameter, _ in
@@ -51,6 +53,7 @@ final class FinancialConnectionsAnalyticsClient {
             "Do not pass NextPane enum. Use the raw value."
         )
 
+        assert((parameters["pane"] as? String) != nil, "We expect pane to be set as a String for all analytics events.")
         analyticsClient.log(eventName: eventName, parameters: parameters)
     }
 
@@ -72,13 +75,13 @@ final class FinancialConnectionsAnalyticsClient {
 extension FinancialConnectionsAnalyticsClient {
 
     func logPaneLoaded(pane: FinancialConnectionsSessionManifest.NextPane) {
-        log(eventName: "pane.loaded", parameters: ["pane": pane.rawValue])
+        log(eventName: "pane.loaded", pane: pane)
     }
 
     func logExpectedError(
         _ error: Error,
         errorName: String,
-        pane: FinancialConnectionsSessionManifest.NextPane?
+        pane: FinancialConnectionsSessionManifest.NextPane
     ) {
         log(
             error: error,
@@ -91,7 +94,7 @@ extension FinancialConnectionsAnalyticsClient {
     func logUnexpectedError(
         _ error: Error,
         errorName: String,
-        pane: FinancialConnectionsSessionManifest.NextPane?
+        pane: FinancialConnectionsSessionManifest.NextPane
     ) {
         log(
             error: error,
@@ -105,10 +108,9 @@ extension FinancialConnectionsAnalyticsClient {
         error: Error,
         errorName: String,
         eventName: String,
-        pane: FinancialConnectionsSessionManifest.NextPane?
+        pane: FinancialConnectionsSessionManifest.NextPane
     ) {
         var parameters: [String: Any] = [:]
-        parameters["pane"] = pane?.rawValue
         parameters["error"] = errorName
         if let stripeError = error as? StripeError,
             case .apiError(let apiError) = stripeError
@@ -130,13 +132,13 @@ extension FinancialConnectionsAnalyticsClient {
             }() as String
             parameters["code"] = (error as NSError).code
         }
-        log(eventName: eventName, parameters: parameters)
+        log(eventName: eventName, parameters: parameters, pane: pane)
     }
 
     func logMerchantDataAccessLearnMore(pane: FinancialConnectionsSessionManifest.NextPane) {
         log(
             eventName: "click.data_access.learn_more",
-            parameters: ["pane": pane.rawValue]
+            pane: pane
         )
     }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/FinancialConnectionsNavigationController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/FinancialConnectionsNavigationController.swift
@@ -56,9 +56,9 @@ class FinancialConnectionsNavigationController: UINavigationController {
                 // simplify analytics logging (same event, different parameters)
                 eventName: "click.nav_bar.back",
                 parameters: [
-                    "pane": FinancialConnectionsAnalyticsClient.paneFromViewController(fromViewController).rawValue,
                     "source": source,
-                ]
+                ],
+                pane: FinancialConnectionsAnalyticsClient.paneFromViewController(fromViewController)
             )
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerViewController.swift
@@ -84,7 +84,7 @@ final class AccountPickerViewController: UIViewController {
                     .analyticsClient
                     .log(
                         eventName: "click.link_accounts",
-                        parameters: ["pane": FinancialConnectionsSessionManifest.NextPane.accountPicker.rawValue]
+                        pane: .accountPicker
                     )
 
                 self.didSelectLinkAccounts()
@@ -142,7 +142,8 @@ final class AccountPickerViewController: UIViewController {
                                 parameters: [
                                     "duration": Date().timeIntervalSince(pollingStartDate).milliseconds,
                                     "authSessionId": self.dataSource.authSession.id,
-                                ]
+                                ],
+                                pane: .accountPicker
                             )
                     }
                     self.dataSource

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AttachLinkedPaymentAccount/AttachLinkedPaymentAccountViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AttachLinkedPaymentAccount/AttachLinkedPaymentAccountViewController.swift
@@ -107,7 +107,8 @@ final class AttachLinkedPaymentAccountViewController: UIViewController {
                             parameters: [
                                 "duration": Date().timeIntervalSince(pollingStartDate).milliseconds,
                                 "authSessionId": self.dataSource.authSessionId ?? "unknown",
-                            ]
+                            ],
+                            pane: .attachLinkedPaymentAccount
                         )
 
                     self.delegate?.attachLinkedPaymentAccountViewController(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentViewController.swift
@@ -107,7 +107,7 @@ class ConsentViewController: UIViewController {
     private func didSelectAgree() {
         dataSource.analyticsClient.log(
             eventName: "click.agree",
-            parameters: ["pane": FinancialConnectionsSessionManifest.NextPane.consent.rawValue]
+            pane: .consent
         )
 
         footerView.setIsLoading(true)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionPickerViewController.swift
@@ -207,11 +207,11 @@ extension InstitutionPickerViewController {
                             .log(
                                 eventName: "search.succeeded",
                                 parameters: [
-                                    "pane": FinancialConnectionsSessionManifest.NextPane.institutionPicker.rawValue,
                                     "query": searchQuery,
                                     "duration": Date().timeIntervalSince(lastInstitutionSearchFetchDate).milliseconds,
                                     "result_count": institutionList.data.count,
-                                ]
+                                ],
+                                pane: .institutionPicker
                             )
                     case .failure(let error):
                         self.institutionSearchTableView.loadInstitutions([])
@@ -269,9 +269,9 @@ extension InstitutionPickerViewController: FeaturedInstitutionGridViewDelegate {
         dataSource.analyticsClient.log(
             eventName: "search.featured_institution_selected",
             parameters: [
-                "pane": FinancialConnectionsSessionManifest.NextPane.institutionPicker.rawValue,
                 "institution_id": institution.id,
-            ]
+            ],
+            pane: .institutionPicker
         )
         didSelectInstitution(institution)
     }
@@ -289,9 +289,9 @@ extension InstitutionPickerViewController: InstitutionSearchTableViewDelegate {
         dataSource.analyticsClient.log(
             eventName: "search.search_result_selected",
             parameters: [
-                "pane": FinancialConnectionsSessionManifest.NextPane.institutionPicker.rawValue,
                 "institution_id": institution.id,
-            ]
+            ],
+            pane: .institutionPicker
         )
         didSelectInstitution(institution)
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -67,12 +67,8 @@ class NativeFlowController {
     @objc private func didSelectNavigationBarCloseButton() {
         dataManager.analyticsClient.log(
             eventName: "click.nav_bar.close",
-            parameters: [
-                "pane":
-                    FinancialConnectionsAnalyticsClient
-                    .paneFromViewController(navigationController.topViewController)
-                    .rawValue,
-            ]
+            pane: FinancialConnectionsAnalyticsClient
+                .paneFromViewController(navigationController.topViewController)
         )
 
         let showConfirmationAlert =
@@ -352,7 +348,12 @@ extension NativeFlowController {
         }
         dataManager
             .analyticsClient
-            .log(eventName: "complete", parameters: parameters)
+            .log(
+                eventName: "complete",
+                parameters: parameters,
+                pane: FinancialConnectionsAnalyticsClient
+                    .paneFromViewController(navigationController.topViewController)
+            )
     }
 }
 
@@ -1065,7 +1066,7 @@ private func CreatePaneViewController(
             .analyticsClient
             .log(
                 eventName: "pane.launched",
-                parameters: ["pane": pane.rawValue]
+                pane: pane
             )
     } else {
         dataManager

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/AuthFlowHelpers.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/AuthFlowHelpers.swift
@@ -45,7 +45,7 @@ final class AuthFlowHelpers {
             analyticsClient
                 .log(
                     eventName: eventName,
-                    parameters: ["pane": pane.rawValue]
+                    pane: pane
                 )
         }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Success/SuccessViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Success/SuccessViewController.swift
@@ -64,7 +64,7 @@ final class SuccessViewController: UIViewController {
                         .analyticsClient
                         .log(
                             eventName: "click.disconnect_link",
-                            parameters: ["pane": FinancialConnectionsSessionManifest.NextPane.success.rawValue]
+                            pane: .success
                         )
                 },
                 didSelectMerchantDataAccessLearnMore: { [weak self] in
@@ -86,7 +86,7 @@ final class SuccessViewController: UIViewController {
                         .analyticsClient
                         .log(
                             eventName: "click.done",
-                            parameters: ["pane": FinancialConnectionsSessionManifest.NextPane.success.rawValue]
+                            pane: .success
                         )
                     self.delegate?.successViewControllerDidSelectDone(self)
                 }


### PR DESCRIPTION
## Summary

This [PR change](https://github.com/stripe/stripe-ios/commit/eef3060fa906b19bdd18fadd13625232fe4d1fe6#diff-7bde6f18d1a87908b49f4681c27ab8b122a3e4d30c96c5b8722715b64da5eedcR36) created a problem where "pane" parameter is _sometimes_ not logged. This PR ensures "pane" parameter is always logged.

## Testing

Walking through the flow and seeing some critical events having "pane:"

pane.launched has pane:

```
["is_stripe_direct": false, "product": "payment_flows", "event_name": "linked_accounts.pane.launched", "sdk_version": "23.9.1", "pane": "consent", "navigator_language": "en_US", "account_holder_id": "bcaccthld_1NIemaL6p1bboFUQ2wAfMJyn", "livemode": true, "sdk_platform": "ios", "las_client_secret": "", "is_webview": false, "event_id": "C166A009-705D-4B4D-875D-9899857C7CA3", "allow_manual_entry": true, "single_account": true, "os_version": "16.1", "app_version": "1.1", "created": 1686691784.735907, "platform_info": ["app_bundle_id": "com.stripe.example.Connections-Example", "install": "X"], "client_id": "mobile-clients-linked-accounts", "device_type": "arm64", "key": "", "app_name": "FinancialConnectionsExample"]
```

pane.loaded has pane:

```
["sdk_platform": "ios", "event_name": "linked_accounts.pane.loaded", "device_type": "arm64", "sdk_version": "23.9.1", "allow_manual_entry": true, "os_version": "16.1", "app_version": "1.1", "client_id": "mobile-clients-linked-accounts", "is_webview": false, "navigator_language": "en_US", "pane": "consent", "las_client_secret": "", "livemode": true, "product": "payment_flows", "single_account": true, "account_holder_id": "bcaccthld_1NIemaL6p1bboFUQ2wAfMJyn", "event_id": "1DFB9BF1-CA6B-41D7-9300-3066E8536BCC", "created": 1686691784.760275, "key": "", "app_name": "FinancialConnectionsExample", "platform_info": ["app_bundle_id": "com.stripe.example.Connections-Example", "install": "X"], "is_stripe_direct": false]
```

error has pane:

```
LOG ANALYTICS: ["sdk_platform": "ios", "event_name": "linked_accounts.error.unexpected", "navigator_language": "en_US", "created": 1686692431.8194408, "code": -1009, "os_version": "16.1", "event_id": "8210CABC-9D9C-47C6-AF19-207983383665", "single_account": true, "livemode": true, "is_stripe_direct": false, "is_webview": false, "las_client_secret": "fcsess_client_secret_jidEQJurFaax4epUcBgGlkRc", "app_name": "FinancialConnectionsExample", "platform_info": ["app_bundle_id": "com.stripe.example.Connections-Example", "install": "X"], "error_type": "NSURLErrorDomain", "account_holder_id": "bcaccthld_1NIemaL6p1bboFUQ2wAfMJyn", "pane": "consent", "client_id": "mobile-clients-linked-accounts", "allow_manual_entry": true, "device_type": "arm64", "app_version": "1.1", "error_message": "The Internet connection appears to be offline.", "sdk_version": "23.9.1", "product": "payment_flows", "key": "", "error": "Conse
```

Also checked splunk for real time pane events.

Ran end-to-end tests via `bitrise run financial-connections-stability-tests` which check pretty much all flows and possibilities. If they pass, and don't crash due to asserts, its nearly impossible that pane events are not logged anywhere.

```
FinancialConnectionsNetworkingUITests
    ✓ testNativeNetworkingTestMode (74.274 seconds)
FinancialConnectionsUITests
    ✓ testDataLiveModeOAuthNativeAuthFlow (28.854 seconds)
    ✓ testDataLiveModeOAuthWebAuthFlow (24.320 seconds)
    ✓ testDataTestModeOAuthNativeAuthFlow (20.968 seconds)
    ✓ testPaymentTestModeLegacyNativeAuthFlow (23.216 seconds)
    ✓ testPaymentTestModeManualEntryNativeAuthFlow (27.235 seconds)
    ✓ testSearchInLiveModeNativeAuthFlow (24.654 seconds)

------------------------------------------------------------------------------+
|            bitrise summary: financial-connections-stability-tests            |
+---+---------------------------------------------------------------+----------+
|   | title                                                         | time (s) |
+---+---------------------------------------------------------------+----------+
| ✓ | Start Xcode simulator                                         | 3.97 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Set CONFIGURATION_BUILD_DIR                                   | 0.88 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Set CONFIGURATION_TEMP_DIR                                    | 0.75 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Set Bundler to use local vendor directory                     | 1.32 sec |
+---+---------------------------------------------------------------+----------+
| - | Git Clone Repository (Skipped)                                | 1.17 sec |
+---+---------------------------------------------------------------+----------+
| Update available: 6 (6.2.3) -> 8.0.1                                         |
|                                                                              |
| Release notes are available below                                            |
| https://github.com/bitrise-steplib/steps-git-clone/releases                  |
+---+---------------------------------------------------------------+----------+
| - | tuist (Skipped)                                               | 0.78 sec |
+---+---------------------------------------------------------------+----------+
| - | Bitrise.io Cache:Pull (Skipped)                               | 0.64 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Bundler                                                       | 1.53 sec |
+---+---------------------------------------------------------------+----------+
| - | Bitrise.io Cache:Push (Skipped)                               | 0.66 sec |
+---+---------------------------------------------------------------+----------+
| - | Restore SPM Cache (Skipped)                                   | 0.63 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Xcode Test for iOS                                            | 5.7 min  |
+---+---------------------------------------------------------------+----------+
| - | Create a PagerDuty alert (Skipped)                            | 0.57 sec |
+---+---------------------------------------------------------------+----------+
| - | Send a Slack message (Skipped)                                | 0.53 sec |
+---+---------------------------------------------------------------+----------+
| - | Deploy to Bitrise.io - Build Artifacts, Test Repo... (Skipped)| 0.77 sec |
+---+---------------------------------------------------------------+----------+
| Total runtime: 5.9 min                                                       |
+------------------------------------------------------------------------------+
```