### PR TITLE
Lower max number of parallel simulators

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -506,7 +506,7 @@ workflows:
         - scheme: PaymentSheet Example
         - test_plan: PaymentSheet Example-Shard1
         - log_formatter: xcbeautify
-        - xcodebuild_options: -maximum-concurrent-test-simulator-destinations 3 -maximum-parallel-testing-workers 3
+        - xcodebuild_options: -maximum-concurrent-test-simulator-destinations 2 -maximum-parallel-testing-workers 2
     - deploy-to-bitrise-io@2: {}
     before_run:
     - prep_all
@@ -526,7 +526,7 @@ workflows:
         - scheme: PaymentSheet Example
         - test_plan: PaymentSheet Example-Shard2
         - log_formatter: xcbeautify
-        - xcodebuild_options: -maximum-concurrent-test-simulator-destinations 3 -maximum-parallel-testing-workers 3      
+        - xcodebuild_options: -maximum-concurrent-test-simulator-destinations 2 -maximum-parallel-testing-workers 2
     - deploy-to-bitrise-io@2: {}
     before_run:
     - prep_all


### PR DESCRIPTION
## Summary
Lower max number of parallel simulators

## Motivation
Attempting to make builds more stable. We really ought to have bitrise figure out limitation with xcode, but this is a quick band-aid

## Testing
None, other than running CI.