### PR TITLE
Send `deferred_intent_confirmation_type` in payment event

### DIFF
--- a/Stripe/StripeiOSTests/PaymentSheet+APITest.swift
+++ b/Stripe/StripeiOSTests/PaymentSheet+APITest.swift
@@ -99,7 +99,7 @@ class PaymentSheetAPITest: XCTestCase {
                             intent: paymentIntent,
                             paymentOption: self.newCardPaymentOption,
                             paymentHandler: self.paymentHandler
-                        ) { result in
+                        ) { result, _ in
                             switch result {
                             case .completed:
                                 // 3. Fetch the PI
@@ -183,7 +183,7 @@ class PaymentSheetAPITest: XCTestCase {
                                      intent: .deferredIntent(elementsSession: elementsSession,
                                                              intentConfig: intentConfig),
                                      paymentOption: self.newCardPaymentOption,
-                                     paymentHandler: self.paymentHandler) { result in
+                                     paymentHandler: self.paymentHandler) { result, _ in
                     switch result {
                     case .completed:
                         confirmExpectation.fulfill()
@@ -248,7 +248,7 @@ class PaymentSheetAPITest: XCTestCase {
                                      intent: .deferredIntent(elementsSession: elementsSession,
                                                              intentConfig: intentConfig),
                                      paymentOption: self.newCardPaymentOption,
-                                     paymentHandler: self.paymentHandler) { result in
+                                     paymentHandler: self.paymentHandler) { result, _ in
                     switch result {
                     case .completed:
                         confirmExpectation.fulfill()
@@ -297,7 +297,7 @@ class PaymentSheetAPITest: XCTestCase {
                     intent: paymentIntent,
                     paymentOption: .saved(paymentMethod: .init(stripeId: "pm_card_visa")),
                     paymentHandler: self.paymentHandler
-                ) { result in
+                ) { result, _ in
                     switch result {
                     case .completed:
                         // 3. Fetch the PI
@@ -591,7 +591,7 @@ class PaymentSheetAPITest: XCTestCase {
             intent: intent,
             paymentOption: inputPaymentOption,
             paymentHandler: self.paymentHandler
-        ) { result in
+        ) { result, _ in
             XCTAssertTrue(Thread.isMainThread)
             switch (result, expectedResult) {
             case (.completed, .completed):
@@ -651,7 +651,7 @@ class PaymentSheetAPITest: XCTestCase {
             intent: .deferredIntent(elementsSession: ._testCardValue(), intentConfig: intentConfig),
             paymentOption: .new(confirmParams: self.valid_card_checkbox_selected),
             paymentHandler: paymentHandler
-        ) { result in
+        ) { result, _ in
             e.fulfill()
             guard case let .failed(error) = result else {
                 XCTFail()
@@ -680,7 +680,7 @@ class PaymentSheetAPITest: XCTestCase {
             intent: .deferredIntent(elementsSession: ._testCardValue(), intentConfig: intentConfig),
             paymentOption: .new(confirmParams: self.valid_card_checkbox_selected),
             paymentHandler: paymentHandler
-        ) { result in
+        ) { result, _ in
             e.fulfill()
             // The result is completed, even though the IntentConfiguration and PaymentIntent amounts are not the same
             guard case .completed = result else {
@@ -707,7 +707,7 @@ class PaymentSheetAPITest: XCTestCase {
             intent: .deferredIntent(elementsSession: ._testCardValue(), intentConfig: intentConfig),
             paymentOption: .new(confirmParams: self.valid_card_checkbox_selected),
             paymentHandler: paymentHandler
-        ) { result in
+        ) { result, _ in
             e.fulfill()
             guard case let .failed(error) = result else {
                 XCTFail()
@@ -736,7 +736,7 @@ class PaymentSheetAPITest: XCTestCase {
             intent: .deferredIntent(elementsSession: ._testCardValue(), intentConfig: intentConfig),
             paymentOption: .new(confirmParams: self.valid_card_checkbox_selected),
             paymentHandler: paymentHandler
-        ) { result in
+        ) { result, _ in
             e.fulfill()
             // The result is completed, even though the IntentConfiguration and SetupIntent setup_future_usage values are not the same
             guard case .completed = result else {

--- a/Stripe/StripeiOSTests/STPAnalyticsClientPaymentSheetTest.swift
+++ b/Stripe/StripeiOSTests/STPAnalyticsClientPaymentSheetTest.swift
@@ -134,7 +134,8 @@ class STPAnalyticsClientPaymentSheetTest: XCTestCase {
             linkEnabled: false,
             activeLinkSession: false,
             linkSessionType: .ephemeral,
-            currency: "USD"
+            currency: "USD",
+            deferredIntentConfirmationType: nil
         )
 
         let event4 = XCTestExpectation(description: "mc_custom_payment_applepay_failure")
@@ -146,7 +147,8 @@ class STPAnalyticsClientPaymentSheetTest: XCTestCase {
             linkEnabled: false,
             activeLinkSession: false,
             linkSessionType: .ephemeral,
-            currency: "USD"
+            currency: "USD",
+            deferredIntentConfirmationType: nil
         )
 
         let event5 = XCTestExpectation(description: "mc_custom_paymentoption_applepay_select")
@@ -229,7 +231,8 @@ class STPAnalyticsClientPaymentSheetTest: XCTestCase {
             linkEnabled: false,
             activeLinkSession: false,
             linkSessionType: .ephemeral,
-            currency: "USD"
+            currency: "USD",
+            deferredIntentConfirmationType: nil
         )
 
         let duration = client.lastPayload?["duration"] as? TimeInterval

--- a/StripeApplePay/StripeApplePay/Source/ApplePayContext/STPApplePayContext.swift
+++ b/StripeApplePay/StripeApplePay/Source/ApplePayContext/STPApplePayContext.swift
@@ -508,6 +508,7 @@ public class STPApplePayContext: NSObject, PKPaymentAuthorizationControllerDeleg
                 }
 
                 guard clientSecret != STPApplePayContext.COMPLETE_WITHOUT_CONFIRMING_INTENT else {
+                    self.confirmType = STPApplePayContext.ConfirmType.none
                     handleFinalState(.success, nil)
                     return
                 }

--- a/StripeApplePay/StripeApplePay/Source/ApplePayContext/STPApplePayContext.swift
+++ b/StripeApplePay/StripeApplePay/Source/ApplePayContext/STPApplePayContext.swift
@@ -207,7 +207,7 @@ public class STPApplePayContext: NSObject, PKPaymentAuthorizationControllerDeleg
     private weak var delegate: _stpinternal_STPApplePayContextDelegateBase?
     @objc var authorizationController: PKPaymentAuthorizationController?
     @_spi(STP) public var returnUrl: String?
-    
+
     @_spi(STP) @frozen public enum ConfirmType {
         case client
         case server

--- a/StripeApplePay/StripeApplePay/Source/ApplePayContext/STPApplePayContext.swift
+++ b/StripeApplePay/StripeApplePay/Source/ApplePayContext/STPApplePayContext.swift
@@ -214,7 +214,7 @@ public class STPApplePayContext: NSObject, PKPaymentAuthorizationControllerDeleg
         /// The merchant backend used the special string instead of a intent client secret, so we completed the payment without confirming an intent.
         case none
     }
-    ///
+    /// Tracks where the call to confirm the PaymentIntent or SetupIntent happened.
     @_spi(STP) public var confirmType: ConfirmType?
     // Internal state
     private var paymentState: PaymentState = .notStarted

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkPaymentController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkPaymentController.swift
@@ -321,7 +321,7 @@ import UIKit
                         authenticationContext: authenticationContext,
                         paymentHandler: STPPaymentHandler.shared(),
                         isFlowController: true,
-                        mandateData: STPMandateDataParams.makeWithInferredValues()) { result in
+                        mandateData: STPMandateDataParams.makeWithInferredValues()) { result, _ in
                     switch result {
                     case .canceled:
                         continuation.resume(throwing: Error.canceled)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithLinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithLinkController.swift
@@ -15,11 +15,11 @@ import UIKit
 @available(macCatalystApplicationExtension, unavailable)
 final class PayWithLinkController {
 
-    typealias CompletionBlock = PaymentSheetResultCompletionBlock
+    typealias CompletionBlock = ((PaymentSheetResult) -> Void)
 
     private let paymentHandler: STPPaymentHandler
 
-    private var completion: PaymentSheetResultCompletionBlock?
+    private var completion: CompletionBlock?
 
     private var selfRetainer: PayWithLinkController?
 
@@ -46,7 +46,7 @@ final class PayWithLinkController {
 
     func present(
         from presentingController: UIViewController,
-        completion: @escaping PaymentSheetResultCompletionBlock
+        completion: @escaping CompletionBlock
     ) {
         // Similarly to `PKPaymentAuthorizationController`, `LinkController` should retain
         // itself while presented.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithLinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithLinkController.swift
@@ -75,10 +75,11 @@ extension PayWithLinkController: PayWithLinkWebControllerDelegate {
             intent: intent,
             paymentOption: paymentOption,
             paymentHandler: paymentHandler,
-            isFlowController: false) { result in
-                self.completion?(result)
-                self.selfRetainer = nil
-            }
+            isFlowController: false
+        ) { result, _ in
+            self.completion?(result)
+            self.selfRetainer = nil
+        }
     }
 
     func payWithLinkWebControllerDidCancel(_ payWithLinkWebController: PayWithLinkWebController) {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithLinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithLinkController.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 Stripe, Inc. All rights reserved.
 //
 
+@_spi(STP) import StripeCore
 @_spi(STP) import StripePayments
 @_spi(STP) import StripeUICore
 import UIKit
@@ -15,7 +16,7 @@ import UIKit
 @available(macCatalystApplicationExtension, unavailable)
 final class PayWithLinkController {
 
-    typealias CompletionBlock = ((PaymentSheetResult) -> Void)
+    typealias CompletionBlock = ((PaymentSheetResult, STPAnalyticsClient.DeferredIntentConfirmationType?) -> Void)
 
     private let paymentHandler: STPPaymentHandler
 
@@ -76,14 +77,14 @@ extension PayWithLinkController: PayWithLinkWebControllerDelegate {
             paymentOption: paymentOption,
             paymentHandler: paymentHandler,
             isFlowController: false
-        ) { result, _ in
-            self.completion?(result)
+        ) { result, deferredIntentConfirmationType in
+            self.completion?(result, deferredIntentConfirmationType)
             self.selfRetainer = nil
         }
     }
 
     func payWithLinkWebControllerDidCancel(_ payWithLinkWebController: PayWithLinkWebController) {
-        completion?(.canceled)
+        completion?(.canceled, nil)
         selfRetainer = nil
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -40,8 +40,8 @@ extension PaymentSheet {
                 let applePayContext = STPApplePayContext.create(
                     intent: intent,
                     configuration: configuration,
-                    completion: { result in
-                        completion(result, nil)
+                    completion: { result, deferredIntentConfirmationType in
+                        completion(result, deferredIntentConfirmationType)
                     }
                 )
             else {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -308,6 +308,7 @@ extension PaymentSheet {
                 let linkController = PayWithLinkController(intent: intent, configuration: configuration)
                 linkController.present(
                     completion: { result in
+                        // TODO(Link): Set intent confirmation type
                         completion(result, nil)
                     }
                 )

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -308,12 +308,7 @@ extension PaymentSheet {
             switch confirmOption {
             case .wallet:
                 let linkController = PayWithLinkController(intent: intent, configuration: configuration)
-                linkController.present(
-                    completion: { result in
-                        // TODO(Link): Set intent confirmation type
-                        completion(result, nil)
-                    }
-                )
+                linkController.present(completion: completion)
             case .signUp(let linkAccount, let phoneNumber, let legalName, let paymentMethodParams):
                 linkAccount.signUp(with: phoneNumber, legalName: legalName, consentAction: .checkbox) { result in
                     switch result {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -40,9 +40,7 @@ extension PaymentSheet {
                 let applePayContext = STPApplePayContext.create(
                     intent: intent,
                     configuration: configuration,
-                    completion: { result, deferredIntentConfirmationType in
-                        completion(result, deferredIntentConfirmationType)
-                    }
+                    completion: completion
                 )
             else {
                 assertionFailure(PaymentSheetError.applePayNotSupportedOrMisconfigured.debugDescription)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -29,8 +29,8 @@ extension PaymentSheet {
         completion: @escaping (PaymentSheetResult, STPAnalyticsClient.DeferredIntentConfirmationType?) -> Void
     ) {
         // Translates a STPPaymentHandler result to a PaymentResult
-        let paymentHandlerCompletion: (STPPaymentHandlerActionStatus, STPAnalyticsClient.DeferredIntentConfirmationType?, NSObject?, NSError?) -> Void = { status, deferredIntentConfirmationType, _, error in
-            completion(makePaymentSheetResult(for: status, error: error), deferredIntentConfirmationType)
+        let paymentHandlerCompletion: (STPPaymentHandlerActionStatus, NSError?) -> Void = { status, error in
+            completion(makePaymentSheetResult(for: status, error: error), nil)
         }
 
         switch paymentOption {
@@ -75,8 +75,8 @@ extension PaymentSheet {
                         paymentHandler.confirmPayment(
                             paymentIntentParams,
                             with: authenticationContext,
-                            completion: { actionStatus, intent, error in
-                                paymentHandlerCompletion(actionStatus, nil, intent, error)
+                            completion: { actionStatus, _, error in
+                                paymentHandlerCompletion(actionStatus, error)
                             }
                         )
                     }
@@ -92,8 +92,8 @@ extension PaymentSheet {
                     paymentHandler.confirmPayment(
                         params,
                         with: authenticationContext,
-                        completion: { actionStatus, intent, error in
-                            paymentHandlerCompletion(actionStatus, nil, intent, error)
+                        completion: { actionStatus, _, error in
+                            paymentHandlerCompletion(actionStatus, error)
                         }
                     )
                 }
@@ -110,8 +110,8 @@ extension PaymentSheet {
                 paymentHandler.confirmSetupIntent(
                     setupIntentParams,
                     with: authenticationContext,
-                    completion: { actionStatus, intent, error in
-                        paymentHandlerCompletion(actionStatus, nil, intent, error)
+                    completion: { actionStatus, _, error in
+                        paymentHandlerCompletion(actionStatus, error)
                     }
                 )
             // MARK: ↪ Deferred Intent
@@ -145,8 +145,8 @@ extension PaymentSheet {
                 paymentHandler.confirmPayment(
                     paymentIntentParams,
                     with: authenticationContext,
-                    completion: { actionStatus, intent, error in
-                        paymentHandlerCompletion(actionStatus, nil, intent, error)
+                    completion: { actionStatus, _, error in
+                        paymentHandlerCompletion(actionStatus, error)
                     }
                 )
             // MARK: ↪ SetupIntent
@@ -159,8 +159,8 @@ extension PaymentSheet {
                 paymentHandler.confirmSetupIntent(
                     setupIntentParams,
                     with: authenticationContext,
-                    completion: { actionStatus, intent, error in
-                        paymentHandlerCompletion(actionStatus, nil, intent, error)
+                    completion: { actionStatus, _, error in
+                        paymentHandlerCompletion(actionStatus, error)
                     }
                 )
             // MARK: ↪ Deferred Intent
@@ -187,8 +187,8 @@ extension PaymentSheet {
                     paymentHandler.confirmPayment(
                         paymentIntentParams,
                         with: authenticationContext,
-                        completion: { actionStatus, intent, error in
-                            paymentHandlerCompletion(actionStatus, nil, intent, error)
+                        completion: { actionStatus, _, error in
+                            paymentHandlerCompletion(actionStatus, error)
                         }
                     )
                 case .setupIntent(let setupIntent):
@@ -198,8 +198,8 @@ extension PaymentSheet {
                     paymentHandler.confirmSetupIntent(
                         setupIntentParams,
                         with: authenticationContext,
-                        completion: { actionStatus, intent, error in
-                            paymentHandlerCompletion(actionStatus, nil, intent, error)
+                        completion: { actionStatus, _, error in
+                            paymentHandlerCompletion(actionStatus, error)
                         }
                     )
                 case .deferredIntent(_, let intentConfig):
@@ -235,8 +235,8 @@ extension PaymentSheet {
                     paymentHandler.confirmPayment(
                         paymentIntentParams,
                         with: authenticationContext,
-                        completion: { actionStatus, intent, error in
-                            paymentHandlerCompletion(actionStatus, nil, intent, error)
+                        completion: { actionStatus, _, error in
+                            paymentHandlerCompletion(actionStatus, error)
                         }
                     )
                 case .setupIntent(let setupIntent):
@@ -247,8 +247,8 @@ extension PaymentSheet {
                     paymentHandler.confirmSetupIntent(
                         setupIntentParams,
                         with: authenticationContext,
-                        completion: { actionStatus, intent, error in
-                            paymentHandlerCompletion(actionStatus, nil, intent, error)
+                        completion: { actionStatus, _, error in
+                            paymentHandlerCompletion(actionStatus, error)
                         }
                     )
                 case .deferredIntent(_, let intentConfig):

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -237,7 +237,9 @@ extension PaymentSheet {
                     paymentHandler.confirmPayment(
                         paymentIntentParams,
                         with: authenticationContext,
-                        completion: paymentHandlerCompletion
+                        completion: { actionStatus, intent, error in
+                            paymentHandlerCompletion(actionStatus, nil, intent, error)
+                        }
                     )
                 case .setupIntent(let setupIntent):
                     let setupIntentParams = STPSetupIntentConfirmParams(clientSecret: setupIntent.clientSecret)
@@ -247,7 +249,9 @@ extension PaymentSheet {
                     paymentHandler.confirmSetupIntent(
                         setupIntentParams,
                         with: authenticationContext,
-                        completion: paymentHandlerCompletion
+                        completion: { actionStatus, intent, error in
+                            paymentHandlerCompletion(actionStatus, nil, intent, error)
+                        }
                     )
                 case .deferredIntent(_, let intentConfig):
                     handleDeferredIntentConfirmation(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+DeferredAPI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+DeferredAPI.swift
@@ -24,7 +24,7 @@ extension PaymentSheet {
     ) {
         // Hack: Add deferred to analytics product usage as a hack to get it into the payment_user_agent string in the request to create a PaymentMethod
         STPAnalyticsClient.sharedClient.addClass(toProductUsageIfNecessary: IntentConfiguration.self)
-        
+
         Task { @MainActor in
             do {
                 var confirmType = confirmType

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+DeferredAPI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+DeferredAPI.swift
@@ -20,10 +20,11 @@ extension PaymentSheet {
         paymentHandler: STPPaymentHandler,
         isFlowController: Bool,
         mandateData: STPMandateDataParams? = nil,
-        completion: @escaping (PaymentSheetResult) -> Void
+        completion: @escaping (PaymentSheetResult, STPAnalyticsClient.DeferredIntentConfirmationType?) -> Void
     ) {
         // Hack: Add deferred to analytics product usage as a hack to get it into the payment_user_agent string in the request to create a PaymentMethod
         STPAnalyticsClient.sharedClient.addClass(toProductUsageIfNecessary: IntentConfiguration.self)
+        
         Task { @MainActor in
             do {
                 var confirmType = confirmType
@@ -44,8 +45,7 @@ extension PaymentSheet {
                                                                                  shouldSavePaymentMethod: confirmType.shouldSave)
                 guard clientSecret != IntentConfiguration.COMPLETE_WITHOUT_CONFIRMING_INTENT else {
                     // Force close PaymentSheet and early exit
-                    completion(.completed)
-                    STPAnalyticsClient.sharedClient.logPaymentSheetEvent(event: .paymentSheetForceSuccess)
+                    completion(.completed, STPAnalyticsClient.DeferredIntentConfirmationType.none)
                     return
                 }
 
@@ -67,7 +67,7 @@ extension PaymentSheet {
                             paymentIntentParams,
                             with: authenticationContext
                         ) { status, _, error in
-                            completion(makePaymentSheetResult(for: status, error: error))
+                            completion(makePaymentSheetResult(for: status, error: error), .client)
                         }
                     } else {
                         // 4b. Server-side confirmation
@@ -76,7 +76,7 @@ extension PaymentSheet {
                             with: authenticationContext,
                             returnURL: configuration.returnURL
                         ) { status, _, error in
-                            completion(makePaymentSheetResult(for: status, error: error))
+                            completion(makePaymentSheetResult(for: status, error: error), .server)
                         }
                     }
                 case .setup:
@@ -94,7 +94,7 @@ extension PaymentSheet {
                             setupIntentParams,
                             with: authenticationContext
                         ) { status, _, error in
-                            completion(makePaymentSheetResult(for: status, error: error))
+                            completion(makePaymentSheetResult(for: status, error: error), .client)
                         }
                     } else {
                         // 4b. Server-side confirmation
@@ -103,12 +103,12 @@ extension PaymentSheet {
                             with: authenticationContext,
                             returnURL: configuration.returnURL
                         ) { status, _, error in
-                            completion(makePaymentSheetResult(for: status, error: error))
+                            completion(makePaymentSheetResult(for: status, error: error), .server)
                         }
                     }
                 }
             } catch {
-                completion(.failed(error: error))
+                completion(.failed(error: error), nil)
             }
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
@@ -257,10 +257,10 @@ extension PaymentSheet: PaymentSheetViewControllerDelegate {
     func paymentSheetViewControllerShouldConfirm(
         _ paymentSheetViewController: PaymentSheetViewController,
         with paymentOption: PaymentOption,
-        completion: @escaping (PaymentSheetResult) -> Void
+        completion: @escaping (PaymentSheetResult, StripeCore.STPAnalyticsClient.DeferredIntentConfirmationType?) -> Void
     ) {
         let presentingViewController = paymentSheetViewController.presentingViewController
-        let confirm: (@escaping (PaymentSheetResult) -> Void) -> Void = { completion in
+        let confirm: (@escaping (PaymentSheetResult, StripeCore.STPAnalyticsClient.DeferredIntentConfirmationType?) -> Void) -> Void = { completion in
             PaymentSheet.confirm(
                 configuration: self.configuration,
                 authenticationContext: self.bottomSheetViewController,
@@ -268,18 +268,18 @@ extension PaymentSheet: PaymentSheetViewControllerDelegate {
                 paymentOption: paymentOption,
                 paymentHandler: self.paymentHandler,
                 isFlowController: false)
-            { result in
+            { result, deferredIntentConfirmationType in
                 if case let .failed(error) = result {
                     self.mostRecentError = error
                 }
-                completion(result)
+                completion(result, deferredIntentConfirmationType)
             }
         }
 
         if case .applePay = paymentOption {
             // Don't present the Apple Pay sheet on top of the Payment Sheet
             paymentSheetViewController.dismiss(animated: true) {
-                confirm { result in
+                confirm { result, deferredIntentConfirmationType in
                     if case .completed = result {
                     } else {
                         // We dismissed the Payment Sheet to show the Apple Pay sheet
@@ -287,12 +287,12 @@ extension PaymentSheet: PaymentSheetViewControllerDelegate {
                         presentingViewController?.presentAsBottomSheet(self.bottomSheetViewController,
                                                                   appearance: self.configuration.appearance)
                     }
-                    completion(result)
+                    completion(result, deferredIntentConfirmationType)
                 }
             }
         } else {
-            confirm { result in
-                completion(result)
+            confirm { result, deferredIntentConfirmationType in
+                completion(result, deferredIntentConfirmationType)
             }
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
@@ -267,8 +267,8 @@ extension PaymentSheet: PaymentSheetViewControllerDelegate {
                 intent: paymentSheetViewController.intent,
                 paymentOption: paymentOption,
                 paymentHandler: self.paymentHandler,
-                isFlowController: false)
-            { result, deferredIntentConfirmationType in
+                isFlowController: false
+            ) { result, deferredIntentConfirmationType in
                 if case let .failed(error) = result {
                     self.mostRecentError = error
                 }
@@ -291,9 +291,7 @@ extension PaymentSheet: PaymentSheetViewControllerDelegate {
                 }
             }
         } else {
-            confirm { result, deferredIntentConfirmationType in
-                completion(result, deferredIntentConfirmationType)
-            }
+            confirm(completion)
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -296,7 +296,7 @@ extension PaymentSheet {
                 paymentOption: paymentOption,
                 paymentHandler: paymentHandler,
                 isFlowController: true
-            ) { [intent, configuration] result in
+            ) { [intent, configuration] result, deferredIntentConfirmationType in
                 STPAnalyticsClient.sharedClient.logPaymentSheetPayment(
                     isCustom: true,
                     paymentMethod: paymentOption.analyticsValue,
@@ -305,7 +305,8 @@ extension PaymentSheet {
                     activeLinkSession: LinkAccountContext.shared.account?.sessionState == .verified,
                     linkSessionType: intent.linkPopupWebviewOption,
                     currency: intent.currency,
-                    intentConfig: intent.intentConfig
+                    intentConfig: intent.intentConfig,
+                    deferredIntentConfirmationType: deferredIntentConfirmationType
                 )
 
                 if case .completed = result, case .link = paymentOption {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
@@ -31,7 +31,8 @@ extension STPAnalyticsClient {
         activeLinkSession: Bool,
         linkSessionType: LinkSettings.PopupWebviewOption?,
         currency: String?,
-        intentConfig: PaymentSheet.IntentConfiguration? = nil
+        intentConfig: PaymentSheet.IntentConfiguration? = nil,
+        deferredIntentConfirmationType: DeferredIntentConfirmationType?
     ) {
         var success = false
         switch result {
@@ -43,20 +44,23 @@ extension STPAnalyticsClient {
         case .completed:
             success = true
         }
+        
+        print(success)
+        print(deferredIntentConfirmationType?.rawValue ?? "—")
 
-        logPaymentSheetEvent(
-            event: paymentSheetPaymentEventValue(
-                isCustom: isCustom,
-                paymentMethod: paymentMethod,
-                success: success
-            ),
-            duration: AnalyticsHelper.shared.getDuration(for: .checkout),
-            linkEnabled: linkEnabled,
-            activeLinkSession: activeLinkSession,
-            linkSessionType: linkSessionType,
-            currency: currency,
-            intentConfig: intentConfig
-        )
+//        logPaymentSheetEvent(
+//            event: paymentSheetPaymentEventValue(
+//                isCustom: isCustom,
+//                paymentMethod: paymentMethod,
+//                success: success
+//            ),
+//            duration: AnalyticsHelper.shared.getDuration(for: .checkout),
+//            linkEnabled: linkEnabled,
+//            activeLinkSession: activeLinkSession,
+//            linkSessionType: linkSessionType,
+//            currency: currency,
+//            intentConfig: intentConfig
+//        )
     }
 
     func logPaymentSheetShow(
@@ -86,6 +90,12 @@ extension STPAnalyticsClient {
                              isCustom: isCustom,
                              paymentMethod: paymentMethod),
                              intentConfig: intentConfig)
+    }
+    
+    enum DeferredIntentConfirmationType: String {
+        case server = "server"
+        case client = "client"
+        case none = "none"
     }
 
     // MARK: - String builders
@@ -232,6 +242,7 @@ extension STPAnalyticsClient {
         currency: String? = nil,
         intentConfig: PaymentSheet.IntentConfiguration? = nil,
         error: Error? = nil,
+        deferredIntentConfirmationType: DeferredIntentConfirmationType? = nil,
         params: [String: Any] = [:]
     ) {
         var additionalParams = [:] as [String: Any]
@@ -251,6 +262,7 @@ extension STPAnalyticsClient {
         additionalParams["currency"] = currency
         additionalParams["is_decoupled"] = intentConfig != nil
         additionalParams["error_domain"] = (error as? NSError)?.domain
+        additionalParams["deferred_intent_confirmation_type"] = deferredIntentConfirmationType?.rawValue
 
         for (param, param_value) in params {
             additionalParams[param] = param_value

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
@@ -44,7 +44,7 @@ extension STPAnalyticsClient {
         case .completed:
             success = true
         }
-        
+
         print(success)
         print(deferredIntentConfirmationType?.rawValue ?? "—")
 
@@ -91,7 +91,7 @@ extension STPAnalyticsClient {
                              paymentMethod: paymentMethod),
                              intentConfig: intentConfig)
     }
-    
+
     enum DeferredIntentConfirmationType: String {
         case server = "server"
         case client = "client"

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
@@ -45,22 +45,19 @@ extension STPAnalyticsClient {
             success = true
         }
 
-        print(success)
-        print(deferredIntentConfirmationType?.rawValue ?? "—")
-
-//        logPaymentSheetEvent(
-//            event: paymentSheetPaymentEventValue(
-//                isCustom: isCustom,
-//                paymentMethod: paymentMethod,
-//                success: success
-//            ),
-//            duration: AnalyticsHelper.shared.getDuration(for: .checkout),
-//            linkEnabled: linkEnabled,
-//            activeLinkSession: activeLinkSession,
-//            linkSessionType: linkSessionType,
-//            currency: currency,
-//            intentConfig: intentConfig
-//        )
+        logPaymentSheetEvent(
+            event: paymentSheetPaymentEventValue(
+                isCustom: isCustom,
+                paymentMethod: paymentMethod,
+                success: success
+            ),
+            duration: AnalyticsHelper.shared.getDuration(for: .checkout),
+            linkEnabled: linkEnabled,
+            activeLinkSession: activeLinkSession,
+            linkSessionType: linkSessionType,
+            currency: currency,
+            intentConfig: intentConfig
+        )
     }
 
     func logPaymentSheetShow(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
@@ -56,7 +56,8 @@ extension STPAnalyticsClient {
             activeLinkSession: activeLinkSession,
             linkSessionType: linkSessionType,
             currency: currency,
-            intentConfig: intentConfig
+            intentConfig: intentConfig,
+            deferredIntentConfirmationType: deferredIntentConfirmationType
         )
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
@@ -76,7 +76,12 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
         error: Error?
     ) {
         let confirmType: STPAnalyticsClient.DeferredIntentConfirmationType? = {
-            guard let confirmType = context.confirmType else { return nil }
+            guard
+                let confirmType = context.confirmType,
+                case .deferredIntent = intent
+            else {
+                return nil
+            }
             switch confirmType {
             case .server:
                 return .server

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
@@ -22,7 +22,7 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
     let authorizationResultHandler:
     ((PKPaymentAuthorizationResult, @escaping ((PKPaymentAuthorizationResult) -> Void)) -> Void)?
     let intent: Intent
-    
+
     init(
         intent: Intent,
         authorizationResultHandler: (
@@ -36,7 +36,7 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
         super.init()
         self.selfRetainer = self
     }
-    
+
     func applePayContext(
         _ context: STPApplePayContext,
         didCreatePaymentMethod paymentMethod: StripeAPI.PaymentMethod,
@@ -69,7 +69,7 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
             }
         }
     }
-    
+
     func applePayContext(
         _ context: STPApplePayContext,
         didCompleteWith status: STPApplePayContext.PaymentStatus,
@@ -96,7 +96,7 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
         }
         selfRetainer = nil
     }
-    
+
     func applePayContext(
         _ context: STPApplePayContext,
         willCompleteWithResult authorizationResult: PKPaymentAuthorizationResult,
@@ -124,11 +124,11 @@ extension STPApplePayContext {
         guard let applePay = configuration.applePay else {
             return nil
         }
-        
+
         var paymentRequest = createPaymentRequest(intent: intent,
                                                   configuration: configuration,
                                                   applePay: applePay)
-        
+
         if let paymentRequestHandler = configuration.applePay?.customHandlers?.paymentRequestHandler {
             paymentRequest = paymentRequestHandler(paymentRequest)
         }
@@ -149,7 +149,7 @@ extension STPApplePayContext {
             return nil
         }
     }
-    
+
     private static func createPaymentRequest(
         intent: Intent,
         configuration: PaymentSheet.Configuration,
@@ -177,7 +177,7 @@ extension STPApplePayContext {
             }
             return paymentRequest
         }
-        
+
         func setupPaymentRequest() -> PKPaymentRequest {
             var paymentRequest: PKPaymentRequest
             paymentRequest = StripeAPI.paymentRequest(
@@ -194,10 +194,10 @@ extension STPApplePayContext {
                     PKPaymentSummaryItem(label: "\(configuration.merchantDisplayName)", amount: .one, type: .pending),
                 ]
             }
-            
+
             return paymentRequest
         }
-        
+
         switch intent {
         case .paymentIntent(let paymentIntent):
             return paymentRequest(with: paymentIntent.currency, amount: paymentIntent.amount)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -17,7 +17,7 @@ protocol PaymentSheetViewControllerDelegate: AnyObject {
     func paymentSheetViewControllerShouldConfirm(
         _ paymentSheetViewController: PaymentSheetViewController,
         with paymentOption: PaymentOption,
-        completion: @escaping (PaymentSheetResult) -> Void
+        completion: @escaping (PaymentSheetResult, STPAnalyticsClient.DeferredIntentConfirmationType?) -> Void
     )
     func paymentSheetViewControllerDidFinish(
         _ paymentSheetViewController: PaymentSheetViewController,
@@ -445,8 +445,7 @@ class PaymentSheetViewController: UIViewController {
 
         // Confirm the payment with the payment option
         let startTime = NSDate.timeIntervalSinceReferenceDate
-        self.delegate?.paymentSheetViewControllerShouldConfirm(self, with: paymentOption) {
-            result in
+        self.delegate?.paymentSheetViewControllerShouldConfirm(self, with: paymentOption) { result, deferredIntentConfirmationType in
             let elapsedTime = NSDate.timeIntervalSinceReferenceDate - startTime
             DispatchQueue.main.asyncAfter(
                 deadline: .now() + max(PaymentSheetUI.minimumFlightTime - elapsedTime, 0)
@@ -459,7 +458,8 @@ class PaymentSheetViewController: UIViewController {
                     activeLinkSession: LinkAccountContext.shared.account?.sessionState == .verified,
                     linkSessionType: self.intent.linkPopupWebviewOption,
                     currency: self.intent.currency,
-                    intentConfig: self.intent.intentConfig
+                    intentConfig: self.intent.intentConfig,
+                    deferredIntentConfirmationType: deferredIntentConfirmationType
                 )
 
                 self.isPaymentInFlight = false


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request adds tracking for the `deferred_intent_confirmation_type` similar to https://github.com/stripe/stripe-android/pull/6871 on Android.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Decoupling analytics.

## Testing
<!-- How was the code tested? Be as specific as possible. -->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
