### PR TITLE
Fix a few AddressElement bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## x.x.x x-x-x
+### AddressElement
+* [Fixed] A bug that was causing `addressViewControllerDidFinish` to return a non-nil `AddressDetails` when the user closes the AddressElement when default values are provided.
+
 ## 23.9.1 2023-06-12
 ### PaymentSheet
 * [Fixed] Fixed validating the IntentConfiguration matches the PaymentIntent/SetupIntent when it was already confirmed on the server. Note: server-side confirmation is in private beta.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## x.x.x x-x-x
 ### AddressElement
 * [Fixed] A bug that was causing `addressViewControllerDidFinish` to return a non-nil `AddressDetails` when the user closes the AddressElement when default values are provided.
+* [Fixed] A bug that prevented the auto complete view from being presented when the AddressElement was created with default values.
 
 ## 23.9.1 2023-06-12
 ### PaymentSheet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## x.x.x x-x-x
 ### AddressElement
-* [Fixed] A bug that was causing `addressViewControllerDidFinish` to return a non-nil `AddressDetails` when the user closes the AddressElement when default values are provided.
+* [Fixed] A bug that was causing `addressViewControllerDidFinish` to return a non-nil `AddressDetails` when the user cancels out of the AddressElement when default values are provided.
 * [Fixed] A bug that prevented the auto complete view from being presented when the AddressElement was created with default values.
 
 ## 23.9.1 2023-06-12

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheet+AddressTests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheet+AddressTests.swift
@@ -282,7 +282,7 @@ NZ
         app.typeText("California")
         app.textFields["ZIP"].tap()
         app.typeText("94102")
-        app.buttons["Close"].tap()
+        app.buttons["Save address"].tap()
 
         // ...and then using PaymentSheet.FlowController...
         app.buttons["Payment method"].waitForExistenceAndTap()
@@ -298,7 +298,7 @@ NZ
         app.textFields["Country or region"].waitForExistenceAndTap()
         app.pickerWheels.firstMatch.adjust(toPickerWheelValue: "🇨🇦 Canada")
         app.toolbars.buttons["Done"].tap()
-        app.buttons["Close"].tap()
+        app.buttons["Save address"].tap()
 
         // ...should update PaymentSheet.FlowController
         app.buttons["Payment method"].waitForExistenceAndTap()
@@ -319,7 +319,7 @@ NZ
         app.textFields["Country or region"].waitForExistenceAndTap()
         app.pickerWheels.firstMatch.adjust(toPickerWheelValue: "🇺🇸 United States")
         app.toolbars.buttons["Done"].tap()
-        app.buttons["Close"].tap()
+        app.buttons["Save address"].tap()
 
         // ...should not affect your billing address...
         app.buttons["Payment method"].waitForExistenceAndTap()

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheet+AddressTests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheet+AddressTests.swift
@@ -108,7 +108,7 @@ US
         XCTAssertTrue(shippingButton.waitForExistence(timeout: 4.0))
         shippingButton.tap()
 
-        // Autocomplete should be presenteable
+        // Autocomplete should be presentable
         XCTAssertTrue(app.buttons["autocomplete_affordance"].waitForExistenceAndTap(timeout: 4.0))
         XCTAssertTrue(app.buttons["Enter address manually"].waitForExistenceAndTap(timeout: 4.0))
 

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheet+AddressTests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheet+AddressTests.swift
@@ -108,7 +108,12 @@ US
         XCTAssertTrue(shippingButton.waitForExistence(timeout: 4.0))
         shippingButton.tap()
 
+        // Autocomplete should be presenteable
+        XCTAssertTrue(app.buttons["autocomplete_affordance"].waitForExistenceAndTap(timeout: 4.0))
+        XCTAssertTrue(app.buttons["Enter address manually"].waitForExistenceAndTap(timeout: 4.0))
+
         // The Save address button should be enabled
+        XCTAssertTrue(app.buttons["Save address"].waitForExistence(timeout: 4.0))
         let saveAddressButton = app.buttons["Save address"]
         XCTAssertTrue(saveAddressButton.isEnabled)
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/AddressViewController/AddressViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/AddressViewController/AddressViewController.swift
@@ -246,7 +246,7 @@ extension AddressViewController {
     }
 
     @objc func didTapCloseButton() {
-        delegate?.addressViewControllerDidFinish(self, with: addressDetails)
+        delegate?.addressViewControllerDidFinish(self, with: nil)
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/AddressViewController/AddressViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/AddressViewController/AddressViewController.swift
@@ -273,14 +273,11 @@ extension AddressViewController {
             defaults: .init(from: defaultValues),
             collectionMode: configuration.defaultValues.address != .init() ? .all(autocompletableCountries: configuration.autocompleteCountries) : .autoCompletable,
             additionalFields: .init(from: additionalFields),
-            theme: configuration.appearance.asElementsTheme
+            theme: configuration.appearance.asElementsTheme,
+            presentAutoComplete: { [weak self] in
+                self?.presentAutocomplete()
+            }
         )
-        addressSection?.didTapAutocompleteButton = { [weak self] in
-            self?.presentAutocomplete()
-        }
-        addressSection?.autoCompleteLine?.didTap = { [weak self] in
-            self?.presentAutocomplete()
-        }
     }
 
     private func loadUI() {

--- a/StripeUICore/StripeUICore/Source/Elements/Factories/Address/AddressSectionElement+DummyAddressLine.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Factories/Address/AddressSectionElement+DummyAddressLine.swift
@@ -35,7 +35,7 @@ extension AddressSectionElement {
         public var validationState: ElementValidationState {
             return .invalid(error: TextFieldElement.Error.empty, shouldDisplay: false)
         }
-        public var didTap: () -> Void = {}
+        let didTap: () -> Void
         public let theme: ElementsUITheme
         private lazy var autocompleteLineTapRecognizer: UITapGestureRecognizer = {
             let tap = UITapGestureRecognizer(target: self, action: #selector(_didTap))
@@ -60,8 +60,9 @@ extension AddressSectionElement {
             return true
         }
 
-        public init(theme: ElementsUITheme) {
+        public init(theme: ElementsUITheme, didTap: @escaping () -> Void = {}) {
             self.theme = theme
+            self.didTap = didTap
             super.init()
         }
     }

--- a/StripeUICore/StripeUICore/Source/Elements/Factories/Address/AddressSectionElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Factories/Address/AddressSectionElement.swift
@@ -172,7 +172,8 @@ import UIKit
         defaults: AddressDetails = .empty,
         collectionMode: CollectionMode = .all(),
         additionalFields: AdditionalFields = .init(),
-        theme: ElementsUITheme = .default
+        theme: ElementsUITheme = .default,
+        presentAutoComplete: @escaping () -> Void = { }
     ) {
         let dropdownCountries = countries?.map { $0.uppercased() } ?? addressSpecProvider.countries
         let countryCodes = locale.sortedByTheirLocalizedNames(dropdownCountries)
@@ -188,6 +189,9 @@ import UIKit
         self.defaults = defaults
         self.addressSpecProvider = addressSpecProvider
         self.theme = theme
+        self.didTapAutocompleteButton = presentAutoComplete
+        autoCompleteLine?.didTap = presentAutoComplete
+
         let initialCountry = countryCodes[country.selectedIndex]
 
         // Initialize additional fields

--- a/StripeUICore/StripeUICore/Source/Elements/Factories/Address/AddressSectionElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Factories/Address/AddressSectionElement.swift
@@ -150,7 +150,7 @@ import UIKit
     let addressSpecProvider: AddressSpecProvider
     let theme: ElementsUITheme
     private(set) var defaults: AddressDetails
-    public var didTapAutocompleteButton: () -> Void = { }
+    let didTapAutocompleteButton: () -> Void
     public var didUpdate: DidUpdateAddress?
 
     // MARK: - Implementation
@@ -312,8 +312,7 @@ import UIKit
         }
 
         if collectionMode == .autoCompletable {
-            autoCompleteLine = autoCompleteLine ?? DummyAddressLine(theme: theme)
-            autoCompleteLine?.didTap = didTapAutocompleteButton
+            autoCompleteLine = autoCompleteLine ?? DummyAddressLine(theme: theme, didTap: didTapAutocompleteButton)
         } else {
             autoCompleteLine = nil
         }

--- a/StripeUICore/StripeUICore/Source/Elements/Factories/Address/AddressSectionElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Factories/Address/AddressSectionElement.swift
@@ -190,7 +190,6 @@ import UIKit
         self.addressSpecProvider = addressSpecProvider
         self.theme = theme
         self.didTapAutocompleteButton = presentAutoComplete
-        autoCompleteLine?.didTap = presentAutoComplete
 
         let initialCountry = countryCodes[country.selectedIndex]
 
@@ -314,6 +313,7 @@ import UIKit
 
         if collectionMode == .autoCompletable {
             autoCompleteLine = autoCompleteLine ?? DummyAddressLine(theme: theme)
+            autoCompleteLine?.didTap = didTapAutocompleteButton
         } else {
             autoCompleteLine = nil
         }


### PR DESCRIPTION
## Summary
- Always return nil when the user closes the address element
- Fixes a race condition when setting the auto complete tap target. The auto complete line was being init before we set the tap target result in us init'ing the auto complete line with an empty closure.

## Motivation
- https://jira.corp.stripe.com/browse/RUN_MOBILESDK-1940
- https://github.com/stripe/stripe-ios/issues/2658

## Testing
- Manual

## Changelog
See diff