### PR TITLE
Financial Connections: implemented referral_pane for pane.launched.

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsAnalyticsClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsAnalyticsClient.swift
@@ -35,6 +35,7 @@ final class FinancialConnectionsAnalyticsClient {
         var parameters = parameters
         // !!! BE CAREFUL MODIFYING "PANE" ANALYTICS CODE
         // ITS CRITICAL FOR PANE CONVERSION !!!
+        assert(parameters["pane"] == nil, "Unexpected logic: will override 'pane' parameter.")
         parameters["pane"] = pane.rawValue
         parameters = parameters.merging(
             additionalParameters,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -1066,8 +1066,14 @@ private func CreatePaneViewController(
             .analyticsClient
             .log(
                 eventName: "pane.launched",
+                parameters: {
+                    var parameters: [String: Any] = [:]
+                    parameters["referrer_pane"] = dataManager.lastPaneLaunched?.rawValue
+                    return parameters
+                }(),
                 pane: pane
             )
+        dataManager.lastPaneLaunched = pane
     } else {
         dataManager
             .analyticsClient

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowDataManager.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowDataManager.swift
@@ -26,6 +26,7 @@ protocol NativeFlowDataManager: AnyObject {
     var accountNumberLast4: String? { get set }
     var consumerSession: ConsumerSessionData? { get set }
     var saveToLinkWithStripeSucceeded: Bool? { get set }
+    var lastPaneLaunched: FinancialConnectionsSessionManifest.NextPane? { get set }
 
     func resetState(withNewManifest newManifest: FinancialConnectionsSessionManifest)
     func completeFinancialConnectionsSession(terminalError: String?) -> Future<StripeAPI.FinancialConnectionsSession>
@@ -84,6 +85,7 @@ class NativeFlowAPIDataManager: NativeFlowDataManager {
     var accountNumberLast4: String?
     var consumerSession: ConsumerSessionData?
     var saveToLinkWithStripeSucceeded: Bool?
+    var lastPaneLaunched: FinancialConnectionsSessionManifest.NextPane?
 
     init(
         manifest: FinancialConnectionsSessionManifest,


### PR DESCRIPTION
## Summary

Analytics want us to add a referrer_pane parameter to launched event. [Slack context](https://stripe.slack.com/archives/C01DNBVURH9/p1686841902123679?thread_ts=1680887748.851119&cid=C01DNBVURH9)

## Testing

I added this debug code:

```
        if eventName == "linked_accounts.pane.launched" {
            print("^ eventName: \(eventName) pane: \(parameters["pane"] as! String) referrer_pane: \(parameters["referrer_pane"] as? String ?? "NULL")")
        }
```

And then I looked at whether the events match my expectations:

```
^ eventName: linked_accounts.pane.launched pane: consent referrer_pane: NULL
^ eventName: linked_accounts.pane.launched pane: institution_picker referrer_pane: consent
^ eventName: linked_accounts.pane.launched pane: partner_auth referrer_pane: institution_picker
^ eventName: linked_accounts.pane.launched pane: account_picker referrer_pane: partner_auth
^ eventName: linked_accounts.pane.launched pane: attach_linked_payment_account referrer_pane: account_picker
^ eventName: linked_accounts.pane.launched pane: success referrer_pane: attach_linked_payment_account
```


print out of the whole event:

```
LOG ANALYTICS: ["navigator_language": "en_US", "os_version": "16.1", "is_webview": false, "event_name": "linked_accounts.pane.launched", "sdk_platform": "ios", "livemode": false, "sdk_version": "23.9.1", "created": 1686848000.358883, "app_name": "FinancialConnectionsExample", "platform_info": ["install": "X", "app_bundle_id": "com.stripe.example.Connections-Example"], "device_type": "arm64", "pane": "success", "las_client_secret": "", "account_holder_id": "", "is_stripe_direct": false, "app_version": "1.1", "single_account": true, "allow_manual_entry": true, "event_id": "D00C5F4E-39FD-4B5F-8110-153431B28156", "client_id": "mobile-clients-linked-accounts", "key": "", "referrer_pane": "attach_linked_payment_account", "product": "payment_flows"]
```