### PR TITLE
Make Cash App Pay poll for setup intents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## x.x.x x-x-x
+### Payments
+* [Fixed] Fixed a bug which was causing Cash App Pay SetupIntents to incorrectly state they were canclled when they succeeded.
+
 ## 23.9.1 2023-06-12
 ### PaymentSheet
 * [Fixed] Fixed validating the IntentConfiguration matches the PaymentIntent/SetupIntent when it was already confirmed on the server. Note: server-side confirmation is in private beta.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## x.x.x x-x-x
 ### Payments
-* [Fixed] Fixed a bug which was causing Cash App Pay SetupIntents to incorrectly state they were canclled when they succeeded.
+* [Fixed] Fixed a bug causing Cash App Pay SetupIntents to incorrectly state they were canclled when they succeeded.
 
 ### AddressElement
 * [Fixed] A bug that was causing `addressViewControllerDidFinish` to return a non-nil `AddressDetails` when the user cancels out of the AddressElement when default values are provided.

--- a/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
@@ -1517,10 +1517,11 @@ public class STPPaymentHandler: NSObject {
                                 currentAction.complete(with: .succeeded, error: nil)
                             } else {
                                 // If this is a web-based 3DS2 transaction that is still in requires_action, we may just need to refresh the SI a few more times.
+                                // Also retry a few times for Cash App, the redirect flow is fast and sometimes the intent doesn't update quick enough
+                                let shouldRetryForCard = retrievedSetupIntent?.paymentMethod?.type == .card && retrievedSetupIntent?.nextAction?.type == .useStripeSDK
+                                let shouldRetryForCashApp = retrievedSetupIntent?.paymentMethod?.type == .cashApp
                                 if retryCount > 0
-                                    && retrievedSetupIntent?.paymentMethod?.type == .card
-                                    && retrievedSetupIntent?.nextAction?.type == .useStripeSDK
-                                {
+                                    && (shouldRetryForCard || shouldRetryForCashApp) {
                                     self._retryWithExponentialDelay(retryCount: retryCount) {
                                         self._retrieveAndCheckIntentForCurrentAction(
                                             retryCount: retryCount - 1


### PR DESCRIPTION
## Summary
- The original polling logic only applied to PaymentIntents, resulting in some SetupIntents showing canclled when they in fact succeeded.

## Motivation
Customer reported issue

## Testing
Manual

## Changelog
See diff