### PR TITLE
Rename success constant in ApplePayContext

### DIFF
--- a/StripeApplePay/StripeApplePay/Source/ApplePayContext/STPApplePayContext.swift
+++ b/StripeApplePay/StripeApplePay/Source/ApplePayContext/STPApplePayContext.swift
@@ -90,8 +90,9 @@ public protocol ApplePayContextDelegate: _stpinternal_STPApplePayContextDelegate
 @objc(STPApplePayContext)
 public class STPApplePayContext: NSObject, PKPaymentAuthorizationControllerDelegate {
 
-    /// A special string that can be passed in place of a intent client secret to force showing success
-    /// - Note: Only intended to be used with advanced workflows, such as multiprocessor support.
+    /// A special string that can be passed in place of a intent client secret to force showing success and return a PaymentState of `success`.
+    /// - Note: ⚠️ If provided, the SDK performs no action to complete the payment or setup - it doesn't confirm a PaymentIntent or SetupIntent or handle next actions.
+    ///   You should only use this if your integration can't create a PaymentIntent or SetupIntent. It is your responsibility to ensure that you only pass this value if the payment or set up is successful. 
     @_spi(STP) public static let COMPLETE_WITHOUT_CONFIRMING_INTENT = "COMPLETE_WITHOUT_CONFIRMING_INTENT"
 
     /// Initializes this class.

--- a/StripeApplePay/StripeApplePay/Source/ApplePayContext/STPApplePayContext.swift
+++ b/StripeApplePay/StripeApplePay/Source/ApplePayContext/STPApplePayContext.swift
@@ -92,7 +92,7 @@ public class STPApplePayContext: NSObject, PKPaymentAuthorizationControllerDeleg
 
     /// A special string that can be passed in place of a intent client secret to force showing success
     /// - Note: Only intended to be used with advanced workflows, such as multiprocessor support.
-    @_spi(STP) public static let FORCE_SUCCESS = "FORCE_SUCCESS"
+    @_spi(STP) public static let COMPLETE_WITHOUT_CONFIRMING_INTENT = "COMPLETE_WITHOUT_CONFIRMING_INTENT"
 
     /// Initializes this class.
     /// @note This may return nil if the request is invalid e.g. the user is restricted by parental controls, or can't make payments on any of the request's supported networks
@@ -497,7 +497,7 @@ public class STPApplePayContext: NSObject, PKPaymentAuthorizationControllerDeleg
                     return
                 }
 
-                guard clientSecret != STPApplePayContext.FORCE_SUCCESS else {
+                guard clientSecret != STPApplePayContext.COMPLETE_WITHOUT_CONFIRMING_INTENT else {
                     handleFinalState(.success, nil)
                     return
                 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
@@ -62,7 +62,7 @@ extension STPApplePayContext {
                     switch result {
                     case .success(let clientSecret):
                         guard clientSecret != PaymentSheet.IntentConfiguration.COMPLETE_WITHOUT_CONFIRMING_INTENT else {
-                            completion(STPApplePayContext.FORCE_SUCCESS, nil)
+                            completion(STPApplePayContext.COMPLETE_WITHOUT_CONFIRMING_INTENT, nil)
                             return
                         }
                         completion(clientSecret, nil)


### PR DESCRIPTION
## Summary
- Renames constant in ApplePayContext

## Motivation
Decoupling GA

## Testing
Project compiles

## Changelog
N/A