### PR TITLE
Financial Connections: fixed all usages of Locale.current to use a better-formatted locale string/tag

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
@@ -168,7 +168,7 @@ extension STPAPIClient: FinancialConnectionsAPIClient {
                 mobileParameters["app_return_url"] = returnURL
                 return mobileParameters
             }(),
-            "locale": Locale.current.identifier,
+            "locale": Locale.current.toLanguageTag(),
         ]
         return self.post(
             resource: "financial_connections/sessions/synchronize",
@@ -476,7 +476,7 @@ extension STPAPIClient: FinancialConnectionsAPIClient {
             .lowercased()
         body["phone_number"] = phoneNumber
         body["country"] = country
-        body["locale"] = (phoneNumber != nil) ? Locale.current.identifier : nil
+        body["locale"] = (phoneNumber != nil) ? Locale.current.toLanguageTag() : nil
         body["consumer_session_client_secret"] = consumerSessionClientSecret
         return post(resource: APIEndpointSaveAccountsToLink, parameters: body)
     }
@@ -566,7 +566,7 @@ extension STPAPIClient: FinancialConnectionsAPIClient {
             "credentials": [
                 "consumer_session_client_secret": consumerSessionClientSecret,
             ],
-            "locale": Locale.current.identifier,
+            "locale": Locale.current.toLanguageTag(),
         ]
         parameters["custom_email_type"] = customEmailType
         parameters["connections_merchant_name"] = connectionsMerchantName

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsAnalyticsClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsAnalyticsClient.swift
@@ -22,7 +22,7 @@ final class FinancialConnectionsAnalyticsClient {
     ) {
         self.analyticsClient = analyticsClient
         additionalParameters["is_webview"] = false
-        additionalParameters["navigator_language"] = Locale.current.identifier
+        additionalParameters["navigator_language"] = Locale.current.toLanguageTag()
     }
 
     public func log(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/Locale+Extensions.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/Locale+Extensions.swift
@@ -1,0 +1,33 @@
+//
+//  Locale+Extensions.swift
+//  StripeFinancialConnections
+//
+//  Created by Krisjanis Gaidis on 6/20/23.
+//
+
+import Foundation
+
+extension Locale {
+
+    /// Returns the BCP 47(-ish) language tag representing the locale.
+    ///
+    /// The language tag is expected to be well-formed as log as the locale identifier contains a
+    /// valid language code. For example:
+    ///
+    /// ```
+    /// let locale = Locale(identifier: "fr_CA")
+    /// locale.toLanguageTag() // -> "fr-CA"
+    /// ```
+    ///
+    /// The following example returns `"-ES"`, even though `"und-ES"` will be the appropriate BCP 47 tag:
+    ///
+    /// ```
+    /// let locale = Locale(identifier: "_ES")
+    /// locale.toLanguageTag() // -> "-ES"
+    /// ```
+    ///
+    /// All system iOS and macOS locales are expected to contain valid language codes.
+    func toLanguageTag() -> String {
+        return Locale.canonicalLanguageIdentifier(from: self.identifier)
+    }
+}


### PR DESCRIPTION
## Summary

We experienced an issue where backend was not accepting of an iOS locale identifier. To fix, here we use a better tag.

For example, instead of returning "en_US" we will now return "en-US."

## Testing


Run end-to-end tests `bitrise run financial-connections-stability-tests`:

```
FinancialConnectionsNetworkingUITests
    ✓ testNativeNetworkingTestMode (72.060 seconds)
FinancialConnectionsUITests
    ✓ testDataLiveModeOAuthNativeAuthFlow (27.424 seconds)
    ✓ testDataLiveModeOAuthWebAuthFlow (24.690 seconds)
    ✓ testDataTestModeOAuthNativeAuthFlow (20.247 seconds)
    ✓ testPaymentTestModeLegacyNativeAuthFlow (23.061 seconds)
    ✓ testPaymentTestModeManualEntryNativeAuthFlow (27.499 seconds)
    ✓ testSearchInLiveModeNativeAuthFlow (24.049 seconds)


+------------------------------------------------------------------------------+
|            bitrise summary: financial-connections-stability-tests            |
+---+---------------------------------------------------------------+----------+
|   | title                                                         | time (s) |
+---+---------------------------------------------------------------+----------+
| ✓ | Start Xcode simulator                                         | 2.86 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Set CONFIGURATION_BUILD_DIR                                   | 0.54 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Set CONFIGURATION_TEMP_DIR                                    | 0.50 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Set Bundler to use local vendor directory                     | 0.77 sec |
+---+---------------------------------------------------------------+----------+
| - | Git Clone Repository (Skipped)                                | 0.62 sec |
+---+---------------------------------------------------------------+----------+
| Update available: 6 (6.2.3) -> 8.1.0                                         |
|                                                                              |
| Release notes are available below                                            |
| https://github.com/bitrise-steplib/steps-git-clone/releases                  |
+---+---------------------------------------------------------------+----------+
| - | tuist (Skipped)                                               | 0.46 sec |
+---+---------------------------------------------------------------+----------+
| - | Bitrise.io Cache:Pull (Skipped)                               | 0.43 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Bundler                                                       | 1.00 sec |
+---+---------------------------------------------------------------+----------+
| - | Bitrise.io Cache:Push (Skipped)                               | 0.49 sec |
+---+---------------------------------------------------------------+----------+
| - | Restore SPM Cache (Skipped)                                   | 0.45 sec |
+---+---------------------------------------------------------------+----------+
| ✓ | Xcode Test for iOS                                            | 4.1 min  |
+---+---------------------------------------------------------------+----------+
| - | Create a PagerDuty alert (Skipped)                            | 0.51 sec |
+---+---------------------------------------------------------------+----------+
| - | Send a Slack message (Skipped)                                | 0.43 sec |
+---+---------------------------------------------------------------+----------+
| - | Deploy to Bitrise.io - Build Artifacts, Test Repo... (Skipped)| 0.64 sec |
+---+---------------------------------------------------------------+----------+
| Total runtime: 4.3 min                                                       |
+------------------------------------------------------------------------------+
```

Example synchronize parameters via debugger:

```
(lldb) po parameters

  ▿ 3 : 2 elements
    - key : "locale"
    - value : "en-US"
```

Example consumer session start paramters via debugger:


```
(lldb) po parameters

  ▿ 3 : 2 elements
    - key : "locale"
    - value : "en-US"
```

