### PR TITLE
Link Refactor: Complete PI/SI using PaymentMethod from Link return URL

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkPaymentController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkPaymentController.swift
@@ -197,24 +197,21 @@ import UIKit
 @available(iOSApplicationExtension, unavailable)
 @available(macCatalystApplicationExtension, unavailable)
 extension LinkPaymentController: PayWithLinkWebControllerDelegate {
-    func payWithLinkWebControllerDidConfirm(_ payWithLinkWebController: PayWithLinkWebController, intent: Intent, with paymentOption: PaymentOption, completion: @escaping (PaymentSheetResult) -> Void) {
+    func payWithLinkWebControllerDidComplete(_ payWithLinkWebController: PayWithLinkWebController, intent: Intent, with paymentOption: PaymentOption) {
         self.intent = intent
         self.paymentOption = paymentOption
-        completion(.completed)
+//        TODO: Do PaymentSheet thing, then do this as the completion with the result:
+//        switch result {
+//        case .canceled:
+//            payWithLinkContinuation?.resume(throwing: Error.canceled)
+//        case .failed(let error):
+//            payWithLinkContinuation?.resume(throwing: error)
+//        case .completed:
+//            payWithLinkContinuation?.resume()
+//        }
     }
 
     func payWithLinkWebControllerDidCancel(_ payWithLinkWebController: PayWithLinkWebController) {
         payWithLinkContinuation?.resume(throwing: Error.canceled)
-    }
-
-    func payWithLinkWebControllerDidFinish(_ payWithLinkWebController: PayWithLinkWebController, result: PaymentSheetResult) {
-        switch result {
-        case .canceled:
-            payWithLinkContinuation?.resume(throwing: Error.canceled)
-        case .failed(let error):
-            payWithLinkContinuation?.resume(throwing: error)
-        case .completed:
-            payWithLinkContinuation?.resume()
-        }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkPaymentController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkPaymentController.swift
@@ -200,15 +200,6 @@ extension LinkPaymentController: PayWithLinkWebControllerDelegate {
     func payWithLinkWebControllerDidComplete(_ payWithLinkWebController: PayWithLinkWebController, intent: Intent, with paymentOption: PaymentOption) {
         self.intent = intent
         self.paymentOption = paymentOption
-//        TODO: Do PaymentSheet thing, then do this as the completion with the result:
-//        switch result {
-//        case .canceled:
-//            payWithLinkContinuation?.resume(throwing: Error.canceled)
-//        case .failed(let error):
-//            payWithLinkContinuation?.resume(throwing: error)
-//        case .completed:
-//            payWithLinkContinuation?.resume()
-//        }
     }
 
     func payWithLinkWebControllerDidCancel(_ payWithLinkWebController: PayWithLinkWebController) {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithLinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithLinkController.swift
@@ -64,11 +64,10 @@ final class PayWithLinkController {
 @available(macCatalystApplicationExtension, unavailable)
 extension PayWithLinkController: PayWithLinkWebControllerDelegate {
 
-    func payWithLinkWebControllerDidConfirm(
+    func payWithLinkWebControllerDidComplete(
         _ payWithLinkWebController: PayWithLinkWebController,
         intent: Intent,
-        with paymentOption: PaymentOption,
-        completion: @escaping (PaymentSheetResult) -> Void
+        with paymentOption: PaymentOption
     ) {
         PaymentSheet.confirm(
             configuration: configuration,
@@ -76,18 +75,14 @@ extension PayWithLinkController: PayWithLinkWebControllerDelegate {
             intent: intent,
             paymentOption: paymentOption,
             paymentHandler: paymentHandler,
-            isFlowController: false,
-            completion: completion
-        )
+            isFlowController: false) { result in
+                self.completion?(result)
+                self.selfRetainer = nil
+            }
     }
 
     func payWithLinkWebControllerDidCancel(_ payWithLinkWebController: PayWithLinkWebController) {
         completion?(.canceled)
-        selfRetainer = nil
-    }
-
-    func payWithLinkWebControllerDidFinish(_ payWithLinkWebController: PayWithLinkWebController, result: PaymentSheetResult) {
-        completion?(result)
         selfRetainer = nil
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PaymentSheet-LinkConfirmOption.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PaymentSheet-LinkConfirmOption.swift
@@ -35,6 +35,11 @@ extension PaymentSheet {
             account: PaymentSheetLinkAccount,
             paymentMethodParams: STPPaymentMethodParams
         )
+        
+        /// Confirm with Payment Method.
+        case withPaymentMethod(
+            paymentMethod: STPPaymentMethod
+        )
     }
 
 }
@@ -53,6 +58,8 @@ extension PaymentSheet.LinkConfirmOption {
             return account
         case .withPaymentMethodParams(let account, _):
             return account
+        case .withPaymentMethod(_):
+            return nil
         }
     }
 
@@ -64,6 +71,8 @@ extension PaymentSheet.LinkConfirmOption {
             return paymentMethodParams.paymentSheetLabel
         case .withPaymentMethodParams(_, let paymentMethodParams):
             return paymentMethodParams.paymentSheetLabel
+        case .withPaymentMethod(let paymentMethod):
+            return paymentMethod.paymentSheetLabel
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PaymentSheet-LinkConfirmOption.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PaymentSheet-LinkConfirmOption.swift
@@ -35,7 +35,7 @@ extension PaymentSheet {
             account: PaymentSheetLinkAccount,
             paymentMethodParams: STPPaymentMethodParams
         )
-        
+
         /// Confirm with Payment Method.
         case withPaymentMethod(
             paymentMethod: STPPaymentMethod
@@ -58,7 +58,7 @@ extension PaymentSheet.LinkConfirmOption {
             return account
         case .withPaymentMethodParams(let account, _):
             return account
-        case .withPaymentMethod(_):
+        case .withPaymentMethod:
             return nil
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
@@ -350,7 +350,6 @@ extension PaymentSheet: PayWithLinkWebControllerDelegate {
     }
 
     func payWithLinkWebControllerDidCancel(_ payWithLinkWebController: PayWithLinkWebController) {
-        payWithLinkWebController.cancel()
     }
 
     private func findPaymentSheetViewController() -> PaymentSheetViewController? {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
@@ -339,47 +339,18 @@ extension PaymentSheet: LoadingViewControllerDelegate {
 @available(macCatalystApplicationExtension, unavailable)
 extension PaymentSheet: PayWithLinkWebControllerDelegate {
 
-    func payWithLinkWebControllerDidConfirm(
+    func payWithLinkWebControllerDidComplete(
         _ PayWithLinkWebController: PayWithLinkWebController,
         intent: Intent,
-        with paymentOption: PaymentOption,
-        completion: @escaping (PaymentSheetResult) -> Void
+        with paymentOption: PaymentOption
     ) {
-        PaymentSheet.confirm(
-            configuration: self.configuration,
-            authenticationContext: self.bottomSheetViewController,
-            intent: intent,
-            paymentOption: paymentOption,
-            paymentHandler: self.paymentHandler,
-            isFlowController: false)
-        { result in
-            if case let .failed(error) = result {
-                self.mostRecentError = error
-            }
-
-            STPAnalyticsClient.sharedClient.logPaymentSheetPayment(
-                isCustom: false,
-                paymentMethod: paymentOption.analyticsValue,
-                result: result,
-                linkEnabled: intent.supportsLink,
-                activeLinkSession: LinkAccountContext.shared.account?.sessionState == .verified,
-                currency: intent.currency,
-                intentConfig: intent.intentConfig
-            )
-
-            completion(result)
-        }
+        let psvc = self.findPaymentSheetViewController()
+        psvc?.pay(with: paymentOption)
+//      TODO: Analytic for Link payment succeeded
     }
 
     func payWithLinkWebControllerDidCancel(_ payWithLinkWebController: PayWithLinkWebController) {
         payWithLinkWebController.cancel()
-    }
-
-    func payWithLinkWebControllerDidFinish(
-        _ PayWithLinkWebController: PayWithLinkWebController,
-        result: PaymentSheetResult
-    ) {
-        completion?(result)
     }
 
     private func findPaymentSheetViewController() -> PaymentSheetViewController? {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -445,7 +445,7 @@ class PaymentSheetViewController: UIViewController {
         }
     }
 
-    private func pay(with paymentOption: PaymentOption) {
+    func pay(with paymentOption: PaymentOption) {
         view.endEditing(true)
         isPaymentInFlight = true
         // Clear any errors

--- a/StripePayments/StripePayments/Source/API Bindings/Models/Shared/STPMandateOnlineParams.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/Shared/STPMandateOnlineParams.swift
@@ -19,7 +19,7 @@ public class STPMandateOnlineParams: NSObject {
 
     @objc public var additionalAPIParameters: [AnyHashable: Any] = [:]
 
-    @objc internal var inferFromClient: NSNumber?
+    @objc @_spi(STP) public var inferFromClient: NSNumber?
 
     /// Initializes an STPMandateOnlineParams.
     /// - Parameter ipAddress: The IP address from which the Mandate was accepted by the customer.


### PR DESCRIPTION
## Summary
When we receive a PaymentMethod from Link, use it to confirm the PaymentIntent.

## Motivation
Switching to the Link pop-up.

## Testing
PaymentSheet Playground, will add UI tests when enabled on the backend