### PR TITLE
Financial Connections: added support for backend-driven Link Account Picker & networking supportability

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundMainView.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundMainView.swift
@@ -79,7 +79,7 @@ struct PlaygroundMainView: View {
                     Section(header: Text("PERMISSIONS")) {
                         Toggle("Balances", isOn: $viewModel.enableBalancesPermission)
                             .accessibility(identifier: "playground-balances-permission")
-                        
+
                         Toggle("Transactions \(viewModel.flow == .networking ? "(enable step-up verification)" : "")", isOn: $viewModel.enableTransactionsPermission)
                             .accessibility(identifier: "playground-transactions-permission")
                     }

--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundMainView.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundMainView.swift
@@ -77,6 +77,9 @@ struct PlaygroundMainView: View {
                     }
 
                     Section(header: Text("PERMISSIONS")) {
+                        Toggle("Balances", isOn: $viewModel.enableBalancesPermission)
+                            .accessibility(identifier: "playground-balances-permission")
+                        
                         Toggle("Transactions \(viewModel.flow == .networking ? "(enable step-up verification)" : "")", isOn: $viewModel.enableTransactionsPermission)
                             .accessibility(identifier: "playground-transactions-permission")
                     }

--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundMainViewModel.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundMainViewModel.swift
@@ -166,9 +166,16 @@ final class PlaygroundMainViewModel: ObservableObject {
                     case .completed(let session):
                         let accounts = session.accounts.data.filter { $0.last4 != nil }
                         let accountInfos = accounts.map { "\($0.institutionName) ....\($0.last4!)" }
+                        let sessionInfo =
+"""
+session_id=\(session.id)
+account_names=\(session.accounts.data.map({ $0.displayName ?? "N/A"}))
+account_ids=\(session.accounts.data.map({ $0.id }))
+"""
+    
                         UIAlertController.showAlert(
                             title: "Success",
-                            message: "\(accountInfos)"
+                            message: "\(accountInfos)\n\n\(sessionInfo)"
                         )
                     case .canceled:
                         UIAlertController.showAlert(

--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundMainViewModel.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundMainViewModel.swift
@@ -74,7 +74,7 @@ final class PlaygroundMainViewModel: ObservableObject {
             PlaygroundUserDefaults.enableTransactionsPermission = enableTransactionsPermission
         }
     }
-    
+
     @Published var enableBalancesPermission: Bool = PlaygroundUserDefaults.enableBalancesPermission {
         didSet {
             PlaygroundUserDefaults.enableBalancesPermission = enableBalancesPermission

--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundMainViewModel.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundMainViewModel.swift
@@ -169,10 +169,10 @@ final class PlaygroundMainViewModel: ObservableObject {
                         let sessionInfo =
 """
 session_id=\(session.id)
-account_names=\(session.accounts.data.map({ $0.displayName ?? "N/A"}))
+account_names=\(session.accounts.data.map({ $0.displayName ?? "N/A" }))
 account_ids=\(session.accounts.data.map({ $0.id }))
 """
-    
+
                         UIAlertController.showAlert(
                             title: "Success",
                             message: "\(accountInfos)\n\n\(sessionInfo)"

--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundMainViewModel.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundMainViewModel.swift
@@ -74,6 +74,12 @@ final class PlaygroundMainViewModel: ObservableObject {
             PlaygroundUserDefaults.enableTransactionsPermission = enableTransactionsPermission
         }
     }
+    
+    @Published var enableBalancesPermission: Bool = PlaygroundUserDefaults.enableBalancesPermission {
+        didSet {
+            PlaygroundUserDefaults.enableBalancesPermission = enableBalancesPermission
+        }
+    }
 
     enum CustomScenario: String, CaseIterable, Identifiable {
         case none = "none"
@@ -147,6 +153,7 @@ final class PlaygroundMainViewModel: ObservableObject {
             flow: flow.rawValue,
             email: email,
             enableTransactionsPermission: enableTransactionsPermission,
+            enableBalancesPermission: enableBalancesPermission,
             customScenario: customScenario.rawValue,
             customPublicKey: customPublicKey,
             customSecretKey: customSecretKey
@@ -200,6 +207,7 @@ private func SetupPlayground(
     flow: String,
     email: String,
     enableTransactionsPermission: Bool,
+    enableBalancesPermission: Bool,
     customScenario: String,
     customPublicKey: String,
     customSecretKey: String,
@@ -221,6 +229,7 @@ private func SetupPlayground(
         requestBody["flow"] = flow
         requestBody["email"] = email
         requestBody["enable_transactions_permission"] = enableTransactionsPermission
+        requestBody["enable_balances_permission"] = enableBalancesPermission
         requestBody["custom_scenario"] = customScenario
         requestBody["custom_public_key"] = customPublicKey
         requestBody["custom_secret_key"] = customSecretKey

--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/helpers/PlaygroundUserDefaults.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/helpers/PlaygroundUserDefaults.swift
@@ -45,6 +45,12 @@ final class PlaygroundUserDefaults {
         defaultValue: false
     )
     static var enableTransactionsPermission: Bool
+    
+    @UserDefault(
+        key: "FINANCIAL_CONNECTIONS_EXAMPLE_APP_ENABLE_BALANCES_PERMISSION",
+        defaultValue: false
+    )
+    static var enableBalancesPermission: Bool
 
     @UserDefault(
         key: "FINANCIAL_CONNECTIONS_EXAMPLE_APP_CUSTOM_SCENARIO",

--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/helpers/PlaygroundUserDefaults.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/helpers/PlaygroundUserDefaults.swift
@@ -45,7 +45,7 @@ final class PlaygroundUserDefaults {
         defaultValue: false
     )
     static var enableTransactionsPermission: Bool
-    
+
     @UserDefault(
         key: "FINANCIAL_CONNECTIONS_EXAMPLE_APP_ENABLE_BALANCES_PERMISSION",
         defaultValue: false

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsNetworkedAccountsResponse.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsNetworkedAccountsResponse.swift
@@ -28,7 +28,7 @@ struct FinancialConnectionsNetworkingAccountPicker: Decodable {
     let accounts: [FinancialConnectionsNetworkingAccountPicker.Account]
 
     struct AddNewAccount: Decodable {
-        let body: String?
+        let body: String
         let icon: FinancialConnectionsImage?
     }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsNetworkedAccountsResponse.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsNetworkedAccountsResponse.swift
@@ -1,0 +1,46 @@
+//
+//  FinancialConnectionsNetworkedAccountsResponse.swift
+//  StripeFinancialConnections
+//
+//  Created by Krisjanis Gaidis on 6/16/23.
+//
+
+import Foundation
+
+struct FinancialConnectionsNetworkedAccountsResponse: Decodable {
+    let data: [FinancialConnectionsPartnerAccount]
+    let display: Display?
+    
+    struct Display: Decodable {
+        let text: Text?
+        
+        struct Text: Decodable {
+            let returningNetworkingUserAccountPicker: FinancialConnectionsNetworkingAccountPicker?
+        }
+    }
+}
+
+struct FinancialConnectionsNetworkingAccountPicker: Decodable {
+    let title: String
+    let defaultCta: String
+    let addNewAccount: AddNewAccount
+    let accounts: [FinancialConnectionsNetworkingAccountPicker.Account]
+    
+    struct AddNewAccount: Decodable {
+        let body: String?
+        let icon: FinancialConnectionsImage
+        let nextPane: FinancialConnectionsSessionManifest.NextPane?
+    }
+    
+    struct Account: Decodable {
+        let id: String
+        let allowSelection: Bool
+        // ex. "Select to repair and connect"
+        let caption: String?
+        // ex. "Repair and connect account"
+        let selectionCta: String?
+        let icon: FinancialConnectionsImage?
+        let selectionCtaIcon: FinancialConnectionsImage?
+        let nextPaneOnSelection: FinancialConnectionsSessionManifest.NextPane?
+    }
+}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsNetworkedAccountsResponse.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsNetworkedAccountsResponse.swift
@@ -10,10 +10,10 @@ import Foundation
 struct FinancialConnectionsNetworkedAccountsResponse: Decodable {
     let data: [FinancialConnectionsPartnerAccount]
     let display: Display?
-    
+
     struct Display: Decodable {
         let text: Text?
-        
+
         struct Text: Decodable {
             let returningNetworkingUserAccountPicker: FinancialConnectionsNetworkingAccountPicker?
         }
@@ -25,13 +25,13 @@ struct FinancialConnectionsNetworkingAccountPicker: Decodable {
     let defaultCta: String
     let addNewAccount: AddNewAccount
     let accounts: [FinancialConnectionsNetworkingAccountPicker.Account]
-    
+
     struct AddNewAccount: Decodable {
         let body: String?
         let icon: FinancialConnectionsImage
         let nextPane: FinancialConnectionsSessionManifest.NextPane?
     }
-    
+
     struct Account: Decodable {
         let id: String
         let allowSelection: Bool
@@ -39,6 +39,7 @@ struct FinancialConnectionsNetworkingAccountPicker: Decodable {
         let caption: String?
         // ex. "Repair and connect account"
         let selectionCta: String?
+        // trailing icon on the account row
         let icon: FinancialConnectionsImage?
         let selectionCtaIcon: FinancialConnectionsImage?
         let nextPaneOnSelection: FinancialConnectionsSessionManifest.NextPane?

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsNetworkedAccountsResponse.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsNetworkedAccountsResponse.swift
@@ -10,6 +10,7 @@ import Foundation
 struct FinancialConnectionsNetworkedAccountsResponse: Decodable {
     let data: [FinancialConnectionsPartnerAccount]
     let display: Display?
+    let nextPaneOnAddAccount: FinancialConnectionsSessionManifest.NextPane?
 
     struct Display: Decodable {
         let text: Text?
@@ -29,7 +30,6 @@ struct FinancialConnectionsNetworkingAccountPicker: Decodable {
     struct AddNewAccount: Decodable {
         let body: String?
         let icon: FinancialConnectionsImage?
-        let nextPane: FinancialConnectionsSessionManifest.NextPane?
     }
 
     struct Account: Decodable {
@@ -42,6 +42,5 @@ struct FinancialConnectionsNetworkingAccountPicker: Decodable {
         // trailing icon on the account row
         let icon: FinancialConnectionsImage?
         let selectionCtaIcon: FinancialConnectionsImage?
-        let nextPaneOnSelection: FinancialConnectionsSessionManifest.NextPane?
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsNetworkedAccountsResponse.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsNetworkedAccountsResponse.swift
@@ -28,7 +28,7 @@ struct FinancialConnectionsNetworkingAccountPicker: Decodable {
 
     struct AddNewAccount: Decodable {
         let body: String?
-        let icon: FinancialConnectionsImage
+        let icon: FinancialConnectionsImage?
         let nextPane: FinancialConnectionsSessionManifest.NextPane?
     }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsPartnerAccount.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsPartnerAccount.swift
@@ -38,7 +38,3 @@ struct FinancialConnectionsAuthSessionAccounts: Decodable {
     let nextPane: FinancialConnectionsSessionManifest.NextPane
     let skipAccountSelection: Bool?
 }
-
-struct FinancialConnectionsNetworkedAccountsResponse: Decodable {
-    let data: [FinancialConnectionsPartnerAccount]
-}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsPartnerAccount.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsPartnerAccount.swift
@@ -20,6 +20,7 @@ struct FinancialConnectionsPartnerAccount: Decodable {
     let allowSelectionMessage: String?
     let status: String?
     let institution: FinancialConnectionsInstitution?
+    let nextPaneOnSelection: FinancialConnectionsSessionManifest.NextPane?
 
     var allowSelectionNonOptional: Bool {
         return allowSelection ?? true

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsSessionManifest.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsSessionManifest.swift
@@ -18,6 +18,7 @@ struct FinancialConnectionsSessionManifest: Decodable {
         case accountPicker = "account_picker"
         case attachLinkedPaymentAccount = "attach_linked_payment_account"
         case authOptions = "auth_options"
+        case bankAuthRepair = "bank_auth_repair"
         case consent = "consent"
         case institutionPicker = "institution_picker"
         case linkAccountPicker = "link_account_picker"

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerHelpers.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerHelpers.swift
@@ -11,6 +11,7 @@ final class AccountPickerHelpers {
     static func rowTitles(forAccount account: FinancialConnectionsPartnerAccount) -> (
         leadingTitle: String, trailingTitle: String?
     ) {
+        // TODO: think about the fact that caption changes balance ~info
         let willDisplayBalanceInfoInSubtitle = account.balanceInfo != nil
         if willDisplayBalanceInfoInSubtitle {
             return (account.name, "••••\(account.displayableAccountNumbers ?? "")")

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerHelpers.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerHelpers.swift
@@ -10,12 +10,12 @@ import UIKit
 final class AccountPickerHelpers {
     static func rowTitles(
         forAccount account: FinancialConnectionsPartnerAccount,
-        // caption, for networked accounts, _will_ hide account numbers, so we should show account numbers in the title
+        // caption, for networked accounts, will hide account numbers, so we should show account numbers in the title
         captionWillHideAccountNumbers: Bool
     ) -> (
         leadingTitle: String, trailingTitle: String?
     ) {
-        // balance info in subtitle will _hide_ account numbers, so we should show account numbers in the title
+        // balance info in subtitle will hide account numbers, so we should show account numbers in the title
         let balanceWillHideAccountNumbersInSubtitle = account.balanceInfo != nil
         if balanceWillHideAccountNumbersInSubtitle || captionWillHideAccountNumbers {
             return (account.name, "••••\(account.displayableAccountNumbers ?? "")")

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerHelpers.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerHelpers.swift
@@ -8,12 +8,16 @@
 import UIKit
 
 final class AccountPickerHelpers {
-    static func rowTitles(forAccount account: FinancialConnectionsPartnerAccount) -> (
+    static func rowTitles(
+        forAccount account: FinancialConnectionsPartnerAccount,
+        // caption, for networked accounts, _will_ hide account numbers, so we should show account numbers in the title
+        captionWillHideAccountNumbers: Bool
+    ) -> (
         leadingTitle: String, trailingTitle: String?
     ) {
-        // TODO: think about the fact that caption changes balance ~info
-        let willDisplayBalanceInfoInSubtitle = account.balanceInfo != nil
-        if willDisplayBalanceInfoInSubtitle {
+        // balance info in subtitle will _hide_ account numbers, so we should show account numbers in the title
+        let balanceWillHideAccountNumbersInSubtitle = account.balanceInfo != nil
+        if balanceWillHideAccountNumbersInSubtitle || captionWillHideAccountNumbers {
             return (account.name, "••••\(account.displayableAccountNumbers ?? "")")
         } else {
             return (account.name, nil)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerSelectionListView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerSelectionListView.swift
@@ -101,7 +101,7 @@ final class AccountPickerSelectionListView: UIView {
                     self.delegate?.accountPickerSelectionListView(self, didSelectAccounts: selectedAccounts)
                 }
             )
-            let rowTitles = AccountPickerHelpers.rowTitles(forAccount: account)
+            let rowTitles = AccountPickerHelpers.rowTitles(forAccount: account, captionWillHideAccountNumbers: false)
             accountCellView.setLeadingTitle(
                 rowTitles.leadingTitle,
                 trailingTitle: rowTitles.trailingTitle,
@@ -121,7 +121,7 @@ final class AccountPickerSelectionListView: UIView {
                 }
             )
             accountCellView.setLeadingTitle(
-                AccountPickerHelpers.rowTitles(forAccount: disabledAccount).leadingTitle,
+                AccountPickerHelpers.rowTitles(forAccount: disabledAccount, captionWillHideAccountNumbers: false).leadingTitle,
                 trailingTitle: "••••\(disabledAccount.displayableAccountNumbers ?? "")",
                 subtitle: disabledAccount.allowSelectionMessage,
                 isSelected: false

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerBodyView.swift
@@ -89,7 +89,7 @@ final class LinkAccountPickerBodyView: UIView {
         // add a 'new bank account' button row
         let newAccountRowView = LinkAccountPickerNewAccountRowView(
             title: addNewAccount.body,
-            imageUrl: addNewAccount.icon.default,
+            imageUrl: addNewAccount.icon?.default,
             didSelect: { [weak self] in
                 guard let self = self else { return }
                 self.delegate?.linkAccountPickerBodyView(
@@ -123,7 +123,7 @@ private struct LinkAccountPickerBodyViewUIViewRepresentable: UIViewRepresentable
                     ),
                     partnerAccount: FinancialConnectionsPartnerAccount(
                         id: "abc",
-                        name: "Advantage Plus Checking",
+                        name: "Advantage Plus Checking With Extra Words",
                         displayableAccountNumbers: "1324",
                         linkedAccountId: nil,
                         balanceAmount: 100000,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerBodyView.swift
@@ -15,10 +15,7 @@ protocol LinkAccountPickerBodyViewDelegate: AnyObject {
         _ view: LinkAccountPickerBodyView,
         didSelectAccount selectedAccountTuple: FinancialConnectionsAccountTuple
     )
-    func linkAccountPickerBodyView(
-        _ view: LinkAccountPickerBodyView,
-        selectedNewBankAccountAndRequestedNextPane: FinancialConnectionsSessionManifest.NextPane?
-    )
+    func linkAccountPickerBodyViewSelectedNewBankAccount(_ view: LinkAccountPickerBodyView)
 }
 
 final class LinkAccountPickerBodyView: UIView {
@@ -92,10 +89,7 @@ final class LinkAccountPickerBodyView: UIView {
             imageUrl: addNewAccount.icon?.default,
             didSelect: { [weak self] in
                 guard let self = self else { return }
-                self.delegate?.linkAccountPickerBodyView(
-                    self,
-                    selectedNewBankAccountAndRequestedNextPane: self.addNewAccount.nextPane
-                )
+                self.delegate?.linkAccountPickerBodyViewSelectedNewBankAccount(self)
             }
         )
         verticalStackView.addArrangedSubview(newAccountRowView)
@@ -118,8 +112,7 @@ private struct LinkAccountPickerBodyViewUIViewRepresentable: UIViewRepresentable
                         caption: nil,
                         selectionCta: nil,
                         icon: nil,
-                        selectionCtaIcon: nil,
-                        nextPaneOnSelection: nil
+                        selectionCtaIcon: nil
                     ),
                     partnerAccount: FinancialConnectionsPartnerAccount(
                         id: "abc",
@@ -140,7 +133,8 @@ private struct LinkAccountPickerBodyViewUIViewRepresentable: UIViewRepresentable
                                 default: "https://b.stripecdn.com/connections-statics-srv/assets/BrandIcon--stripe-4x.png"
                             ),
                             logo: nil
-                        )
+                        ),
+                        nextPaneOnSelection: .success
                     )
                 ),
                 (
@@ -152,8 +146,7 @@ private struct LinkAccountPickerBodyViewUIViewRepresentable: UIViewRepresentable
                         icon: FinancialConnectionsImage(
                             default: "https://b.stripecdn.com/connections-statics-srv/assets/SailIcon--warning-orange-3x.png"
                         ),
-                        selectionCtaIcon: nil,
-                        nextPaneOnSelection: nil
+                        selectionCtaIcon: nil
                     ),
                     partnerAccount: FinancialConnectionsPartnerAccount(
                         id: "abc",
@@ -166,7 +159,8 @@ private struct LinkAccountPickerBodyViewUIViewRepresentable: UIViewRepresentable
                         allowSelection: true,
                         allowSelectionMessage: nil,
                         status: "disabled",
-                        institution: nil
+                        institution: nil,
+                        nextPaneOnSelection: .success
                     )
                 ),
                 (
@@ -176,8 +170,7 @@ private struct LinkAccountPickerBodyViewUIViewRepresentable: UIViewRepresentable
                         caption: nil,
                         selectionCta: nil,
                         icon: nil,
-                        selectionCtaIcon: nil,
-                        nextPaneOnSelection: nil
+                        selectionCtaIcon: nil
                     ),
                     partnerAccount: FinancialConnectionsPartnerAccount(
                         id: "abc",
@@ -190,7 +183,8 @@ private struct LinkAccountPickerBodyViewUIViewRepresentable: UIViewRepresentable
                         allowSelection: true,
                         allowSelectionMessage: nil,
                         status: "disabled",
-                        institution: nil
+                        institution: nil,
+                        nextPaneOnSelection: .success
                     )
                 ),
             ],
@@ -198,8 +192,7 @@ private struct LinkAccountPickerBodyViewUIViewRepresentable: UIViewRepresentable
                 body: "New bank account",
                 icon: FinancialConnectionsImage(
                     default: "https://b.stripecdn.com/connections-statics-srv/assets/SailIcon--add-purple-3x.png"
-                ),
-                nextPane: .success
+                )
             )
         )
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerBodyView.swift
@@ -50,9 +50,8 @@ final class LinkAccountPickerBodyView: UIView {
         verticalStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
 
         accountTuples.forEach { accountTuple in
-            let accountNeedsRepair = false // (accountTuple.accountPickerAccount.nextPaneOnSelection == .bankAuthRepair)
             let accountRowView = LinkAccountPickerRowView(
-                isDisabled: !accountTuple.accountPickerAccount.allowSelection || accountNeedsRepair,
+                isDisabled: !accountTuple.accountPickerAccount.allowSelection,
                 didSelect: { [weak self] in
                     guard let self = self else { return }
                     self.delegate?.linkAccountPickerBodyView(
@@ -61,15 +60,16 @@ final class LinkAccountPickerBodyView: UIView {
                     )
                 }
             )
-            let rowTitles = AccountPickerHelpers.rowTitles(forAccount: accountTuple.partnerAccount)
+            let rowTitles = AccountPickerHelpers.rowTitles(
+                forAccount: accountTuple.partnerAccount,
+                captionWillHideAccountNumbers: accountTuple.accountPickerAccount.caption != nil
+            )
             accountRowView.configure(
                 institutionImageUrl: accountTuple.partnerAccount.institution?.icon?.default,
                 leadingTitle: rowTitles.leadingTitle,
                 trailingTitle: rowTitles.trailingTitle,
                 subtitle: {
-                    if accountNeedsRepair {
-                        return STPLocalizedString("Disconnected", "A subtitle on a button that represents a bank account. It explains to the user that this bank account is disconnected and needs to be re-added.")
-                    } else if let caption = accountTuple.accountPickerAccount.caption {
+                    if let caption = accountTuple.accountPickerAccount.caption {
                         return caption
                     } else {
                         return AccountPickerHelpers.rowSubtitle(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerBodyView.swift
@@ -24,7 +24,6 @@ protocol LinkAccountPickerBodyViewDelegate: AnyObject {
 final class LinkAccountPickerBodyView: UIView {
 
     private let accountTuples: [FinancialConnectionsAccountTuple]
-    private let accounts: [FinancialConnectionsPartnerAccount]
     private let addNewAccount: FinancialConnectionsNetworkingAccountPicker.AddNewAccount
     weak var delegate: LinkAccountPickerBodyViewDelegate?
 
@@ -40,7 +39,6 @@ final class LinkAccountPickerBodyView: UIView {
         addNewAccount: FinancialConnectionsNetworkingAccountPicker.AddNewAccount
     ) {
         self.accountTuples = accountTuples
-        self.accounts = accountTuples.map { $0.partnerAccount }
         self.addNewAccount = addNewAccount
         super.init(frame: .zero)
         addAndPinSubview(verticalStackView)
@@ -66,9 +64,7 @@ final class LinkAccountPickerBodyView: UIView {
                     )
                 }
             )
-            let rowTitles = AccountPickerHelpers.rowTitles(
-                forAccount: accountTuple.partnerAccount
-            )
+            let rowTitles = AccountPickerHelpers.rowTitles(forAccount: accountTuple.partnerAccount)
             accountRowView.configure(
                 institutionImageUrl: accountTuple.partnerAccount.institution?.icon?.default,
                 leadingTitle: rowTitles.leadingTitle,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerDataSource.swift
@@ -20,6 +20,7 @@ protocol LinkAccountPickerDataSource: AnyObject {
     var delegate: LinkAccountPickerDataSourceDelegate? { get set }
     var manifest: FinancialConnectionsSessionManifest { get }
     var selectedAccountTuple: FinancialConnectionsAccountTuple? { get }
+    var nextPaneOnAddAccount: FinancialConnectionsSessionManifest.NextPane? { get set }
     var analyticsClient: FinancialConnectionsAnalyticsClient { get }
 
     func fetchNetworkedAccounts() -> Future<FinancialConnectionsNetworkedAccountsResponse>
@@ -30,6 +31,7 @@ protocol LinkAccountPickerDataSource: AnyObject {
 final class LinkAccountPickerDataSourceImplementation: LinkAccountPickerDataSource {
 
     let manifest: FinancialConnectionsSessionManifest
+    var nextPaneOnAddAccount: FinancialConnectionsSessionManifest.NextPane?
     let analyticsClient: FinancialConnectionsAnalyticsClient
     private let apiClient: FinancialConnectionsAPIClient
     private let clientSecret: String
@@ -61,6 +63,10 @@ final class LinkAccountPickerDataSourceImplementation: LinkAccountPickerDataSour
             clientSecret: clientSecret,
             consumerSessionClientSecret: consumerSession.clientSecret
         )
+        .chained { [weak self] response in
+            self?.nextPaneOnAddAccount = response.nextPaneOnAddAccount
+            return Promise(value: response)
+        }
     }
 
     func updateSelectedAccount(_ selectedAccountTuple: FinancialConnectionsAccountTuple) {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerDataSource.swift
@@ -11,7 +11,7 @@ import Foundation
 protocol LinkAccountPickerDataSourceDelegate: AnyObject {
     func linkAccountPickerDataSource(
         _ dataSource: LinkAccountPickerDataSource,
-        didSelectAccount selectedAccount: FinancialConnectionsPartnerAccount?
+        didSelectAccount selectedAccountTuple: FinancialConnectionsAccountTuple?
     )
 }
 
@@ -19,12 +19,12 @@ protocol LinkAccountPickerDataSource: AnyObject {
 
     var delegate: LinkAccountPickerDataSourceDelegate? { get set }
     var manifest: FinancialConnectionsSessionManifest { get }
-    var selectedAccount: FinancialConnectionsPartnerAccount? { get }
+    var selectedAccountTuple: FinancialConnectionsAccountTuple? { get }
     var analyticsClient: FinancialConnectionsAnalyticsClient { get }
 
     func fetchNetworkedAccounts() -> Future<FinancialConnectionsNetworkedAccountsResponse>
     func selectNetworkedAccount(_ selectedAccount: FinancialConnectionsPartnerAccount) -> Future<FinancialConnectionsInstitutionList>
-    func updateSelectedAccount(_ selectedAccount: FinancialConnectionsPartnerAccount)
+    func updateSelectedAccount(_ selectedAccountTuple: FinancialConnectionsAccountTuple)
 }
 
 final class LinkAccountPickerDataSourceImplementation: LinkAccountPickerDataSource {
@@ -35,9 +35,9 @@ final class LinkAccountPickerDataSourceImplementation: LinkAccountPickerDataSour
     private let clientSecret: String
     private let consumerSession: ConsumerSessionData
 
-    private(set) var selectedAccount: FinancialConnectionsPartnerAccount? {
+    private(set) var selectedAccountTuple: FinancialConnectionsAccountTuple? {
         didSet {
-            delegate?.linkAccountPickerDataSource(self, didSelectAccount: selectedAccount)
+            delegate?.linkAccountPickerDataSource(self, didSelectAccount: selectedAccountTuple)
         }
     }
     weak var delegate: LinkAccountPickerDataSourceDelegate?
@@ -63,8 +63,8 @@ final class LinkAccountPickerDataSourceImplementation: LinkAccountPickerDataSour
         )
     }
 
-    func updateSelectedAccount(_ selectedAccount: FinancialConnectionsPartnerAccount) {
-        self.selectedAccount = selectedAccount
+    func updateSelectedAccount(_ selectedAccountTuple: FinancialConnectionsAccountTuple) {
+        self.selectedAccountTuple = selectedAccountTuple
     }
 
     func selectNetworkedAccount(_ selectedAccount: FinancialConnectionsPartnerAccount) -> Future<FinancialConnectionsInstitutionList> {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerFooterView.swift
@@ -70,10 +70,7 @@ final class LinkAccountPickerFooterView: UIView {
     }
 
     func didSelectedAccount(_ selectedAccountTuple: FinancialConnectionsAccountTuple?) {
-        if
-            let selectedAccountTuple = selectedAccountTuple,
-            let selectionCta = selectedAccountTuple.accountPickerAccount.selectionCta
-        {
+        if let selectionCta = selectedAccountTuple?.accountPickerAccount.selectionCta {
             connectAccountButton.title = selectionCta
         } else {
             connectAccountButton.title = defaultCta

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerFooterView.swift
@@ -11,15 +11,13 @@ import UIKit
 
 final class LinkAccountPickerFooterView: UIView {
 
+    private let defaultCta: String
     private let singleAccount: Bool
     private let didSelectConnectAccount: () -> Void
 
     private lazy var connectAccountButton: Button = {
         let connectAccountButton = Button(configuration: .financialConnectionsPrimary)
-        connectAccountButton.title = STPLocalizedString(
-            "Connect account",
-            "A button that allows users to confirm the process of saving their bank accounts for future payments. This button appears in a screen that allows users to select which bank accounts they want to use to pay for something."
-        )
+        connectAccountButton.title = defaultCta
         connectAccountButton.isEnabled = false // disable by default
         connectAccountButton.addTarget(self, action: #selector(didSelectLinkAccountsButton), for: .touchUpInside)
         connectAccountButton.translatesAutoresizingMaskIntoConstraints = false
@@ -30,6 +28,7 @@ final class LinkAccountPickerFooterView: UIView {
     }()
 
     init(
+        defaultCta: String,
         isStripeDirect: Bool,
         businessName: String?,
         permissions: [StripeAPI.FinancialConnectionsAccount.Permissions],
@@ -37,6 +36,7 @@ final class LinkAccountPickerFooterView: UIView {
         didSelectConnectAccount: @escaping () -> Void,
         didSelectMerchantDataAccessLearnMore: @escaping () -> Void
     ) {
+        self.defaultCta = defaultCta
         self.singleAccount = singleAccount
         self.didSelectConnectAccount = didSelectConnectAccount
         super.init(frame: .zero)
@@ -69,7 +69,16 @@ final class LinkAccountPickerFooterView: UIView {
         didSelectConnectAccount()
     }
 
-    func enableButton(_ enableButton: Bool) {
-        connectAccountButton.isEnabled = enableButton
+    func didSelectedAccount(_ selectedAccountTuple: FinancialConnectionsAccountTuple?) {
+        if
+            let selectedAccountTuple = selectedAccountTuple,
+            let selectionCta = selectedAccountTuple.accountPickerAccount.selectionCta
+        {
+            connectAccountButton.title = selectionCta
+        } else {
+            connectAccountButton.title = defaultCta
+        }
+
+        connectAccountButton.isEnabled = selectedAccountTuple != nil
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerNewAccountRowView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerNewAccountRowView.swift
@@ -13,16 +13,31 @@ final class LinkAccountPickerNewAccountRowView: UIView {
 
     private let didSelect: () -> Void
 
-    init(didSelect: @escaping () -> Void) {
+    init(
+        title: String?,
+        imageUrl: String?,
+        didSelect: @escaping () -> Void
+    ) {
         self.didSelect = didSelect
         super.init(frame: .zero)
 
-        let horizontalStackView = CreateHorizontalStackView(
-            arrangedSubviews: [
-                CreateIconView(),
-                CreateTitleLabelView(),
-            ]
-        )
+        let horizontalStackView = CreateHorizontalStackView()
+        if let imageUrl = imageUrl {
+            horizontalStackView.addArrangedSubview(
+                CreateIconView(imageUrl: imageUrl)
+            )
+        }
+        if let title = title {
+            horizontalStackView.addArrangedSubview(
+                CreateTitleLabelView(
+                    title: title
+//                    ?? STPLocalizedString(
+//                        "New bank account",
+//                        "A button that allows users to add an additional bank account for future payments."
+//                    )
+                )
+            )
+        }
         addAndPinSubviewToSafeArea(horizontalStackView)
 
         let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(didTapView))
@@ -42,12 +57,11 @@ final class LinkAccountPickerNewAccountRowView: UIView {
     }
 }
 
-private func CreateIconView() -> UIView {
+private func CreateIconView(imageUrl: String?) -> UIView {
     let diameter: CGFloat = 24
     let iconImageView = UIImageView()
     iconImageView.contentMode = .scaleAspectFit
-    iconImageView.image = Image.add.makeImage()
-        .withTintColor(.textBrand, renderingMode: .alwaysOriginal)
+    iconImageView.setImage(with: imageUrl)
     let paddedView = UIStackView(arrangedSubviews: [iconImageView])
     paddedView.backgroundColor = .textBrand.withAlphaComponent(0.1)
     paddedView.layer.cornerRadius = 6
@@ -65,21 +79,18 @@ private func CreateIconView() -> UIView {
     return paddedView
 }
 
-private func CreateTitleLabelView() -> UIView {
+private func CreateTitleLabelView(title: String) -> UIView {
     let titleLabel = AttributedLabel(
         font: .label(.largeEmphasized),
         textColor: .textBrand
     )
-    titleLabel.text = STPLocalizedString(
-        "New bank account",
-        "A button that allows users to add an additional bank account for future payments."
-    )
+    titleLabel.text = title
     titleLabel.lineBreakMode = .byCharWrapping
     return titleLabel
 }
 
-private func CreateHorizontalStackView(arrangedSubviews: [UIView]) -> UIStackView {
-    let horizontalStackView = UIStackView(arrangedSubviews: arrangedSubviews)
+private func CreateHorizontalStackView() -> UIStackView {
+    let horizontalStackView = UIStackView()
     horizontalStackView.axis = .horizontal
     horizontalStackView.spacing = 12
     horizontalStackView.alignment = .center
@@ -98,8 +109,16 @@ private func CreateHorizontalStackView(arrangedSubviews: [UIView]) -> UIStackVie
 import SwiftUI
 
 private struct LinkAccountPickerNewAccountRowViewUIViewRepresentable: UIViewRepresentable {
+
+    let title: String?
+    let imageUrl: String?
+
     func makeUIView(context: Context) -> LinkAccountPickerNewAccountRowView {
-        return LinkAccountPickerNewAccountRowView(didSelect: {})
+        return LinkAccountPickerNewAccountRowView(
+            title: title,
+            imageUrl: imageUrl,
+            didSelect: {}
+        )
     }
 
     func updateUIView(_ uiView: LinkAccountPickerNewAccountRowView, context: Context) {}
@@ -110,7 +129,22 @@ struct LinkAccountPickerNewAccountRowView_Previews: PreviewProvider {
         if #available(iOS 14.0, *) {
             ScrollView {
                 VStack(spacing: 10) {
-                    LinkAccountPickerNewAccountRowViewUIViewRepresentable()
+                    LinkAccountPickerNewAccountRowViewUIViewRepresentable(
+                        title: "New bank account",
+                        imageUrl: "https://b.stripecdn.com/connections-statics-srv/assets/SailIcon--add-purple-3x.png"
+                    )
+                        .frame(height: 48)
+
+                    LinkAccountPickerNewAccountRowViewUIViewRepresentable(
+                        title: "New bank account",
+                        imageUrl: nil
+                    )
+                        .frame(height: 48)
+
+                    LinkAccountPickerNewAccountRowViewUIViewRepresentable(
+                        title: nil,
+                        imageUrl: nil
+                    )
                         .frame(height: 48)
                 }
                 .padding()

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerNewAccountRowView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerNewAccountRowView.swift
@@ -14,7 +14,7 @@ final class LinkAccountPickerNewAccountRowView: UIView {
     private let didSelect: () -> Void
 
     init(
-        title: String?,
+        title: String,
         imageUrl: String?,
         didSelect: @escaping () -> Void
     ) {
@@ -27,13 +27,11 @@ final class LinkAccountPickerNewAccountRowView: UIView {
                 CreateIconView(imageUrl: imageUrl)
             )
         }
-        if let title = title {
-            horizontalStackView.addArrangedSubview(
-                CreateTitleLabelView(
-                    title: title
-                )
+        horizontalStackView.addArrangedSubview(
+            CreateTitleLabelView(
+                title: title
             )
-        }
+        )
         addAndPinSubviewToSafeArea(horizontalStackView)
 
         let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(didTapView))
@@ -53,7 +51,7 @@ final class LinkAccountPickerNewAccountRowView: UIView {
     }
 }
 
-private func CreateIconView(imageUrl: String?) -> UIView {
+private func CreateIconView(imageUrl: String) -> UIView {
     let diameter: CGFloat = 24
     let iconImageView = UIImageView()
     iconImageView.contentMode = .scaleAspectFit
@@ -106,7 +104,7 @@ import SwiftUI
 
 private struct LinkAccountPickerNewAccountRowViewUIViewRepresentable: UIViewRepresentable {
 
-    let title: String?
+    let title: String
     let imageUrl: String?
 
     func makeUIView(context: Context) -> LinkAccountPickerNewAccountRowView {
@@ -133,12 +131,6 @@ struct LinkAccountPickerNewAccountRowView_Previews: PreviewProvider {
 
                     LinkAccountPickerNewAccountRowViewUIViewRepresentable(
                         title: "New bank account",
-                        imageUrl: nil
-                    )
-                        .frame(height: 48)
-
-                    LinkAccountPickerNewAccountRowViewUIViewRepresentable(
-                        title: nil,
                         imageUrl: nil
                     )
                         .frame(height: 48)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerNewAccountRowView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerNewAccountRowView.swift
@@ -31,10 +31,6 @@ final class LinkAccountPickerNewAccountRowView: UIView {
             horizontalStackView.addArrangedSubview(
                 CreateTitleLabelView(
                     title: title
-//                    ?? STPLocalizedString(
-//                        "New bank account",
-//                        "A button that allows users to add an additional bank account for future payments."
-//                    )
                 )
             )
         }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerRowView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerRowView.swift
@@ -86,6 +86,7 @@ final class LinkAccountPickerRowView: UIView {
         trailingIconImageView = nil
         if let trailingIconImageUrl = trailingIconImageUrl {
             let trailingIconImageView = UIImageView()
+            trailingIconImageView.contentMode = .scaleAspectFit
             NSLayoutConstraint.activate([
                 trailingIconImageView.widthAnchor.constraint(equalToConstant: 16),
                 trailingIconImageView.heightAnchor.constraint(equalToConstant: 16),

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerRowView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerRowView.swift
@@ -25,6 +25,14 @@ final class LinkAccountPickerRowView: UIView {
         }
     }
 
+    private lazy var horizontalStackView: UIStackView = {
+        return CreateHorizontalStackView(
+            arrangedSubviews: [
+                institutionIconView,
+                labelRowView,
+            ]
+        )
+    }()
     private lazy var institutionIconView: InstitutionIconView = {
         let institutionIconView = InstitutionIconView(size: .small)
         return institutionIconView
@@ -32,6 +40,7 @@ final class LinkAccountPickerRowView: UIView {
     private lazy var labelRowView: AccountPickerLabelRowView = {
         return AccountPickerLabelRowView()
     }()
+    private var trailingIconImageView: UIImageView?
 
     init(
         isDisabled: Bool,
@@ -40,12 +49,6 @@ final class LinkAccountPickerRowView: UIView {
         self.didSelect = didSelect
         super.init(frame: .zero)
 
-        let horizontalStackView = CreateHorizontalStackView(
-            arrangedSubviews: [
-                institutionIconView,
-                labelRowView,
-            ]
-        )
         if isDisabled {
             horizontalStackView.alpha = 0.25
         }
@@ -68,6 +71,7 @@ final class LinkAccountPickerRowView: UIView {
         leadingTitle: String,
         trailingTitle: String?,
         subtitle: String?,
+        trailingIconImageUrl: String?,
         isSelected: Bool
     ) {
         institutionIconView.setImageUrl(institutionImageUrl)
@@ -77,6 +81,19 @@ final class LinkAccountPickerRowView: UIView {
             subtitle: subtitle
         )
         self.isSelected = isSelected
+
+        trailingIconImageView?.removeFromSuperview()
+        trailingIconImageView = nil
+        if let trailingIconImageUrl = trailingIconImageUrl {
+            let trailingIconImageView = UIImageView()
+            NSLayoutConstraint.activate([
+                trailingIconImageView.widthAnchor.constraint(equalToConstant: 16),
+                trailingIconImageView.heightAnchor.constraint(equalToConstant: 16),
+            ])
+            trailingIconImageView.setImage(with: trailingIconImageUrl)
+            self.trailingIconImageView = trailingIconImageView
+            horizontalStackView.addArrangedSubview(trailingIconImageView)
+        }
     }
 
     @objc private func didTapView() {
@@ -115,6 +132,7 @@ private struct LinkAccountPickerRowViewUIViewRepresentable: UIViewRepresentable 
     let leadingTitle: String
     let trailingTitle: String?
     let subtitle: String?
+    let trailingIconImageUrl: String?
     let isSelected: Bool
     let isDisabled: Bool
 
@@ -128,6 +146,7 @@ private struct LinkAccountPickerRowViewUIViewRepresentable: UIViewRepresentable 
             leadingTitle: leadingTitle,
             trailingTitle: trailingTitle,
             subtitle: subtitle,
+            trailingIconImageUrl: trailingIconImageUrl,
             isSelected: isSelected
         )
         return view
@@ -139,6 +158,7 @@ private struct LinkAccountPickerRowViewUIViewRepresentable: UIViewRepresentable 
             leadingTitle: leadingTitle,
             trailingTitle: trailingTitle,
             subtitle: subtitle,
+            trailingIconImageUrl: trailingIconImageUrl,
             isSelected: isSelected
         )
     }
@@ -156,6 +176,7 @@ struct LinkAccountPickerRowView_Previews: PreviewProvider {
                             leadingTitle: "Joint Checking Very Long Name To Truncate",
                             trailingTitle: "••••6789",
                             subtitle: "$2,000",
+                            trailingIconImageUrl: nil,
                             isSelected: true,
                             isDisabled: false
                         ).frame(height: 60)
@@ -164,6 +185,16 @@ struct LinkAccountPickerRowView_Previews: PreviewProvider {
                             leadingTitle: "Joint Checking",
                             trailingTitle: nil,
                             subtitle: nil,
+                            trailingIconImageUrl: nil,
+                            isSelected: false,
+                            isDisabled: false
+                        ).frame(height: 60)
+                        LinkAccountPickerRowViewUIViewRepresentable(
+                            institutionImageUrl: nil,
+                            leadingTitle: "Joint Checking Very Long Name To Truncate",
+                            trailingTitle: "••••6789",
+                            subtitle: "Select to repair and connect",
+                            trailingIconImageUrl: "https://b.stripecdn.com/connections-statics-srv/assets/SailIcon--warning-orange-3x.png",
                             isSelected: false,
                             isDisabled: false
                         ).frame(height: 60)
@@ -172,6 +203,7 @@ struct LinkAccountPickerRowView_Previews: PreviewProvider {
                             leadingTitle: "Joint Checking",
                             trailingTitle: nil,
                             subtitle: "Must be US checking account",
+                            trailingIconImageUrl: nil,
                             isSelected: false,
                             isDisabled: true
                         ).frame(height: 60)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
@@ -166,7 +166,7 @@ final class LinkAccountPickerViewController: UIViewController {
         }
 
         let nextPane = selectedAccountTuple
-            .accountPickerAccount
+            .partnerAccount
             .nextPaneOnSelection
 
         // update data model with selected account
@@ -283,17 +283,17 @@ extension LinkAccountPickerViewController: LinkAccountPickerBodyViewDelegate {
         dataSource.updateSelectedAccount(selectedAccountTuple)
     }
 
-    func linkAccountPickerBodyView(
-        _ view: LinkAccountPickerBodyView,
-        selectedNewBankAccountAndRequestedNextPane nextPane: FinancialConnectionsSessionManifest.NextPane?
-    ) {
+    func linkAccountPickerBodyViewSelectedNewBankAccount(_ view: LinkAccountPickerBodyView) {
         dataSource
             .analyticsClient
             .log(
                 eventName: "click.new_account",
                 pane: .linkAccountPicker
             )
-        delegate?.linkAccountPickerViewController(self, didRequestNextPane: nextPane ?? .institutionPicker)
+        delegate?.linkAccountPickerViewController(
+            self,
+            didRequestNextPane: dataSource.nextPaneOnAddAccount ?? .institutionPicker
+        )
     }
 }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
@@ -90,7 +90,6 @@ final class LinkAccountPickerViewController: UIViewController {
                             )
                         )
                     }
-
                 case .failure(let error):
                     self.dataSource
                         .analyticsClient

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -700,6 +700,14 @@ extension NativeFlowController: LinkAccountPickerViewControllerDelegate {
     ) {
         showTerminalError(error)
     }
+
+    func linkAccountPickerViewController(
+        _ viewController: LinkAccountPickerViewController,
+        requestedPartnerAuthWithInstitution institution: FinancialConnectionsInstitution
+    ) {
+        dataManager.institution = institution
+        pushPane(.partnerAuth, animated: true)
+    }
 }
 
 // MARK: - NetworkingSaveToLinkVerificationDelegate
@@ -779,7 +787,7 @@ private func CreatePaneViewController(
         }
     case .attachLinkedPaymentAccount:
         if let institution = dataManager.institution,
-            let linkedAccountId = dataManager.linkedAccounts?.first?.linkedAccountId
+           let linkedAccountId = dataManager.linkedAccounts?.first?.linkedAccountId
         {
             let dataSource = AttachLinkedPaymentAccountDataSourceImplementation(
                 apiClient: dataManager.apiClient,
@@ -801,6 +809,9 @@ private func CreatePaneViewController(
             assertionFailure("Code logic error. Missing parameters for \(pane).")
             viewController = nil
         }
+    case .bankAuthRepair:
+        assertionFailure("Not supported")
+        viewController = nil
     case .consent:
         let consentDataSource = ConsentDataSourceImplementation(
             manifest: dataManager.manifest,
@@ -859,7 +870,7 @@ private func CreatePaneViewController(
         viewController = manualEntryViewController
     case .manualEntrySuccess:
         if let paymentAccountResource = dataManager.paymentAccountResource,
-            let accountNumberLast4 = dataManager.accountNumberLast4
+           let accountNumberLast4 = dataManager.accountNumberLast4
         {
             let manualEntrySuccessViewController = ManualEntrySuccessViewController(
                 microdepositVerificationMethod: paymentAccountResource.microdepositVerificationMethod,
@@ -1004,7 +1015,7 @@ private func CreatePaneViewController(
         networkingLinkWarmupViewController.delegate = nativeFlowController
         viewController = networkingLinkWarmupViewController
 
-    // client-side only panes below
+        // client-side only panes below
     case .resetFlow:
         let resetFlowDataSource = ResetFlowDataSourceImplementation(
             apiClient: dataManager.apiClient,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -671,34 +671,18 @@ extension NativeFlowController: LinkAccountPickerViewControllerDelegate {
 
     func linkAccountPickerViewController(
         _ viewController: LinkAccountPickerViewController,
-        didRequestNextPane nextPane: FinancialConnectionsSessionManifest.NextPane
+        didSelectAccount selectedAccount: FinancialConnectionsPartnerAccount
     ) {
-        pushPane(nextPane, animated: true)
+        dataManager.linkedAccounts = [selectedAccount]
     }
 
     func linkAccountPickerViewController(
         _ viewController: LinkAccountPickerViewController,
-        didSelectAccount selectedAccount: FinancialConnectionsPartnerAccount,
-        institution: FinancialConnectionsInstitution
+        didRequestSuccessPaneWithInstitution institution: FinancialConnectionsInstitution
     ) {
+        assert(dataManager.linkedAccounts?.count == 1, "expected a selected account to be set")
         dataManager.institution = institution
-        dataManager.linkedAccounts = [selectedAccount]
         pushPane(.success, animated: true)
-    }
-
-    func linkAccountPickerViewController(
-        _ viewController: LinkAccountPickerViewController,
-        requestedStepUpVerificationWithSelectedAccount selectedAccount: FinancialConnectionsPartnerAccount
-    ) {
-        dataManager.linkedAccounts = [selectedAccount]
-        pushPane(.networkingLinkStepUpVerification, animated: true)
-    }
-
-    func linkAccountPickerViewController(
-        _ viewController: LinkAccountPickerViewController,
-        didReceiveTerminalError error: Error
-    ) {
-        showTerminalError(error)
     }
 
     func linkAccountPickerViewController(
@@ -707,6 +691,20 @@ extension NativeFlowController: LinkAccountPickerViewControllerDelegate {
     ) {
         dataManager.institution = institution
         pushPane(.partnerAuth, animated: true)
+    }
+
+    func linkAccountPickerViewController(
+        _ viewController: LinkAccountPickerViewController,
+        didRequestNextPane nextPane: FinancialConnectionsSessionManifest.NextPane
+    ) {
+        pushPane(nextPane, animated: true)
+    }
+
+    func linkAccountPickerViewController(
+        _ viewController: LinkAccountPickerViewController,
+        didReceiveTerminalError error: Error
+    ) {
+        showTerminalError(error)
     }
 }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -1013,7 +1013,7 @@ private func CreatePaneViewController(
         networkingLinkWarmupViewController.delegate = nativeFlowController
         viewController = networkingLinkWarmupViewController
 
-        // client-side only panes below
+    // client-side only panes below
     case .resetFlow:
         let resetFlowDataSource = ResetFlowDataSourceImplementation(
             apiClient: dataManager.apiClient,

--- a/modules.yaml
+++ b/modules.yaml
@@ -182,8 +182,8 @@ modules:
     include:
       - StripeCore
   size_report:
-    max_compressed_size: 1500
-    max_uncompressed_size: 3000
+    max_compressed_size: 3000
+    max_uncompressed_size: 5000
     max_incremental_uncompressed_size: 100
 
 - podspec: StripeUICore.podspec


### PR DESCRIPTION
## Summary

This PR adds support for "Link Account Picker" pane/screen being driven by a backend model. [Relevant document](https://docs.google.com/document/d/16T7kOE9QcIGMx_RsA90HmXwPsoPYJ0hBwdfrJmLEeU0/edit#heading=h.c9fixccnpngd).

The "Link Account Picker" pane/screen is a screen where users can select a previously linked bank account.

## Testing

Test cases:
- Repair accounts are disabled
- Step up verification works
- Basic success case works


### Test End To End Defaults

Ran end-to-end-tests which test default cases (including step-up verification) - `bitrise run financial-connections-stability-tests`:

```
FinancialConnectionsNetworkingUITests
    ✓ testNativeNetworkingTestMode (77.622 seconds)
FinancialConnectionsUITests
    ✓ testDataLiveModeOAuthNativeAuthFlow (30.413 seconds)
    ✓ testDataLiveModeOAuthWebAuthFlow (25.710 seconds)
    ✓ testDataTestModeOAuthNativeAuthFlow (23.278 seconds)
    ✓ testPaymentTestModeLegacyNativeAuthFlow (24.878 seconds)
    ✓ testPaymentTestModeManualEntryNativeAuthFlow (27.601 seconds)
    ✓ testSearchInLiveModeNativeAuthFlow (24.933 seconds)
```

### Test Various Selection States

| Test Unselected Default | Test Selecting Update Required | Test Selecting Normal |
| ----| ---- | ------ |
| ![Simulator Screenshot - iPhone 14 Pro - 2023-08-10 at 17 40 54](https://github.com/stripe/stripe-ios/assets/105514761/5e84c342-a0ee-45a3-8aad-27af6dead6a4) | ![Simulator Screenshot - iPhone 14 Pro - 2023-08-10 at 17 42 11](https://github.com/stripe/stripe-ios/assets/105514761/be9b1496-43b7-4f8c-b3f5-19df06480842) | ![Simulator Screenshot - iPhone 14 Pro - 2023-08-10 at 17 42 14](https://github.com/stripe/stripe-ios/assets/105514761/07ac87c9-4dc1-44f9-b97a-8327cfcde4a3) |


### Test Success case with step up

https://github.com/stripe/stripe-ios/assets/105514761/5d891122-1d00-4d59-bdfc-d76539f7cd25

### Test Update Required 

https://github.com/stripe/stripe-ios/assets/105514761/5dab8972-de21-4351-980a-95a288e090ef

### Test Icon On Right Side Of Networking Account Row

<img width="464" alt="Screenshot 2023-08-17 at 11 03 46 AM" src="https://github.com/stripe/stripe-ios/assets/105514761/3cf68a31-c6f9-4f1c-9178-d98d28f05f4d">

### Accounts That Need Repair Are Disabled

![Simulator Screenshot - iPhone 14 Pro - 2023-08-17 at 11 27 53](https://github.com/stripe/stripe-ios/assets/105514761/ebc1e9f0-4e17-4089-8c8b-ad1b31d8c694)

