### PR TITLE
Fix luxe specs not being loaded in the decoupled flow

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -380,7 +380,7 @@ extension PaymentSheet {
                             // Overwrite the form specs that were already loaded from disk
                             switch intent {
                             case .paymentIntent(let paymentIntent):
-                                _ = FormSpecProvider.shared.loadFrom(paymentIntent.allResponseFields["payment_method_specs"] ?? [:])
+                                _ = FormSpecProvider.shared.loadFrom(paymentIntent.allResponseFields["payment_method_specs"] ?? [String: Any]())
                             case .setupIntent:
                                 break // Not supported
                             case .deferredIntent(elementsSession: let elementsSession, intentConfig: _):

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -377,11 +377,14 @@ extension PaymentSheet {
                         )
 
                         loadSpecsPromise.observe { _ in
-                            if case .paymentIntent(let paymentIntent) = intent {
-                                if let payment_method_specs = paymentIntent.allResponseFields["payment_method_specs"] {
-                                    // Over-write the form specs that were already loaded from disk
-                                    _ = FormSpecProvider.shared.loadFrom(payment_method_specs)
-                                }
+                            // Overwrite the form specs that were already loaded from disk
+                            switch intent {
+                            case .paymentIntent(let paymentIntent):
+                                _ = FormSpecProvider.shared.loadFrom(paymentIntent.allResponseFields["payment_method_specs"] ?? [:])
+                            case .setupIntent:
+                                break // Not supported
+                            case .deferredIntent(elementsSession: let elementsSession, intentConfig: _):
+                                _ = FormSpecProvider.shared.loadFrom(elementsSession.paymentMethodSpecs as Any)
                             }
                             linkAccountPromise.observe { linkAccountResult in
                                 switch linkAccountResult {


### PR DESCRIPTION
## Summary
- Fix luxe specs not being loaded in the decoupled flow
- Also fixed not reporting an error if the luxe specs are not present

## Impact
There are only 3 LUXE PMs: 
- revolut_pay
- mobilepay
- zip

These all have the form specs hardcoded in the SDK already, they're just missing the icons.  So the net effect of this bug is just that the icons are blank.

## Motivation
I just happened to come across this bug while looking at something else.

## Testing
Manually tested. We need to overhaul the loader and the "ElementsSession response hidden inside a PaymentIntent" hack before this can be reasonably unit tested. 

## Changelog
I highly doubt there are any users affected.
