### PR TITLE
Repurposes LinkPaymentViewController for Instant Debits

### DIFF
--- a/Stripe/StripeiOSTests/STPAPIClient+LinkAccountSessionTest.swift
+++ b/Stripe/StripeiOSTests/STPAPIClient+LinkAccountSessionTest.swift
@@ -5,7 +5,7 @@
 //  Created by Yuki Tokuhiro on 4/26/23.
 //
 
-@testable import StripePayments
+@testable @_spi(STP) import StripePayments
 import XCTest
 
 final class STPAPIClient_LinkAccountSessionTest: XCTestCase {

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/en.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/en.lproj/Localizable.strings
@@ -40,6 +40,9 @@
 /* Text providing link to terms for ACH payments */
 "By continuing, you agree to authorize payments pursuant to <terms>these terms</terms>." = "By continuing, you agree to authorize payments pursuant to <terms>these terms</terms>.";
 
+/* Mandate text displayed when paying via Link instant debit. */
+"By continuing, you agree to authorize payments pursuant to these <terms>terms</terms>." = "By continuing, you agree to authorize payments pursuant to these <terms>terms</terms>.";
+
 /* Cash App mandate text */
 "By continuing, you authorize %@ to debit your Cash App account for this payment and future payments in accordance with %@'s terms, until this authorization is revoked. You can change this anytime in your Cash App Settings." = "By continuing, you authorize %1$@ to debit your Cash App account for this payment and future payments in accordance with %2$@'s terms, until this authorization is revoked. You can change this anytime in your Cash App Settings.";
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
@@ -268,6 +268,28 @@ extension STPAPIClient {
         )
     }
 
+    func generatedLinkAccountSessionManifest(
+        with clientSecret: String,
+        completion: @escaping (Result<Manifest, Error>) -> Void
+    ) {
+        let future: Future<Manifest> = self.post(
+            resource: "link_account_sessions/generate_hosted_url",
+            parameters: [
+                "client_secret": clientSecret,
+                "fullscreen": true,
+                "hide_close_button": true,
+            ]
+        )
+        future.observe { result in
+            switch result {
+            case .success(let manifest):
+                completion(.success(manifest))
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+
     func createLinkAccountSession(
         for consumerSessionClientSecret: String,
         consumerAccountPublishableKey: String?,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/ACH/InstantDebitsOnlyFinancialConnectionsAuthManager.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/ACH/InstantDebitsOnlyFinancialConnectionsAuthManager.swift
@@ -1,0 +1,175 @@
+//
+//  InstantDebitsOnlyFinancialConnectionsAuthManager.swift
+//  StripePaymentSheet
+//
+//  Created by Vardges Avetisyan on 6/12/23.
+//
+
+import AuthenticationServices
+import UIKit
+
+@_spi(STP) import StripeCore
+
+struct Manifest: Decodable {
+    let hostedAuthURL: URL
+    let successURL: URL
+    let cancelURL: URL
+
+    enum CodingKeys: String, CodingKey {
+        case hostedAuthURL = "hosted_auth_url"
+        case successURL = "success_url"
+        case cancelURL = "cancel_url"
+    }
+}
+
+/// For internal SDK use only
+final class InstantDebitsOnlyAuthenticationSessionManager: NSObject {
+
+    // MARK: - Types
+
+    struct RedactedPaymentDetails {
+        let paymentMethodID: String
+        let bankName: String?
+        let bankIconCode: String?
+        let last4: String?
+    }
+
+    enum Result {
+        case success(details: RedactedPaymentDetails)
+        case canceled
+    }
+
+    enum Error: Swift.Error, LocalizedError {
+        case failedToStart
+        case noURL
+        case unexpectedURL
+        case noPaymentMethodID
+        case canceled
+
+        var errorDescription: String? {
+            return NSError.stp_unexpectedErrorMessage()
+        }
+    }
+
+    // MARK: - Properties
+
+    private var authSession: ASWebAuthenticationSession?
+    private var window: UIWindow?
+
+    // MARK: - Init
+
+    init(window: UIWindow?) {
+        self.window = window
+    }
+
+    // MARK: - Public
+
+    private func hostedAuthURL(for manifest: Manifest) -> URL {
+        // Adds a parameter for the flow to return payment method id
+        return URL(string: manifest.hostedAuthURL.absoluteString + "&return_payment_method=true")!
+    }
+
+    func start(manifest: Manifest) -> Promise<InstantDebitsOnlyAuthenticationSessionManager.Result> {
+        let promise = Promise<InstantDebitsOnlyAuthenticationSessionManager.Result>()
+
+        let authSession = ASWebAuthenticationSession(
+            url: hostedAuthURL(for: manifest),
+            callbackURLScheme: manifest.successURL.scheme,
+            completionHandler: { returnUrl, error in
+
+                if let error = error {
+                    if let authenticationSessionError = error as? ASWebAuthenticationSessionError {
+                        switch authenticationSessionError.code {
+                        case .canceledLogin:
+                            promise.resolve(with: .canceled)
+                        default:
+                            promise.reject(with: authenticationSessionError)
+                        }
+                    } else {
+                        promise.reject(with: error)
+                    }
+                    return
+                }
+
+                guard let returnUrl = returnUrl else {
+                    promise.reject(with: InstantDebitsOnlyAuthenticationSessionManager.Error.noURL)
+                    return
+                }
+
+                if returnUrl.matchesSchemeHostAndPath(of: manifest.successURL) {
+                    if let paymentMethodID = Self.extractValue(from: returnUrl, key: "payment_method_id") {
+                        let details = RedactedPaymentDetails(paymentMethodID: paymentMethodID,
+                                                             bankName: Self.extractValue(from: returnUrl, key: "bank_name")?.replacingOccurrences(of: "+", with: " "),
+                                                             bankIconCode: Self.extractValue(from: returnUrl, key: "bank_icon_code"),
+                                                             last4: Self.extractValue(from: returnUrl, key: "last4"))
+                        promise.fullfill(with: .success(.success(details: details)))
+                    } else {
+                        promise.reject(with: InstantDebitsOnlyAuthenticationSessionManager.Error.noPaymentMethodID)
+                    }
+                } else if returnUrl.matchesSchemeHostAndPath(of: manifest.cancelURL) {
+                    promise.reject(with: InstantDebitsOnlyAuthenticationSessionManager.Error.canceled)
+                } else {
+                    promise.reject(with: InstantDebitsOnlyAuthenticationSessionManager.Error.noURL)
+                }
+            }
+        )
+        authSession.presentationContextProvider = self
+        authSession.prefersEphemeralWebBrowserSession = true
+
+        self.authSession = authSession
+        if #available(iOS 13.4, *) {
+            if !authSession.canStart {
+                promise.reject(
+                    with: InstantDebitsOnlyAuthenticationSessionManager.Error.failedToStart
+                )
+                return promise
+            }
+        }
+
+        if !authSession.start() {
+            promise.reject(with: InstantDebitsOnlyAuthenticationSessionManager.Error.failedToStart)
+            return promise
+        }
+
+        return promise
+    }
+}
+
+// MARK: - ASWebAuthenticationPresentationContextProviding
+
+/// :nodoc:
+
+extension InstantDebitsOnlyAuthenticationSessionManager: ASWebAuthenticationPresentationContextProviding {
+
+    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        return self.window ?? ASPresentationAnchor()
+    }
+}
+
+// MARK: - Utils
+
+extension InstantDebitsOnlyAuthenticationSessionManager {
+
+    private static func extractValue(from url: URL, key: String) -> String? {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            assertionFailure("Invalid URL")
+            return nil
+        }
+
+        return components
+            .queryItems?
+            .first(where: { $0.name == key })?
+            .value?.removingPercentEncoding
+    }
+}
+
+private extension URL {
+
+    func matchesSchemeHostAndPath(of otherURL: URL) -> Bool {
+        return (
+            self.scheme == otherURL.scheme &&
+            self.host == otherURL.host &&
+            self.path == otherURL.path
+        )
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/InstantDebitsOnlyViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/InstantDebitsOnlyViewController.swift
@@ -1,0 +1,238 @@
+//
+//  PayWithLinkViewController-InstantDebitsOnly.swift
+//  StripePaymentSheet
+//
+//  Created by Vardges Avetisyan on 6/8/23.
+//
+
+import Foundation
+import PassKit
+import SafariServices
+import UIKit
+
+@_spi(STP) import StripeApplePay
+@_spi(STP) import StripeCore
+@_spi(STP) import StripePayments
+@_spi(STP) import StripeUICore
+
+@available(iOSApplicationExtension, unavailable)
+@available(macCatalystApplicationExtension, unavailable)
+protocol InstantDebitsOnlyViewControllerDelegate: AnyObject {
+
+    func instantDebitsOnlyViewControllerDidProducePaymentMethod(_ controller: InstantDebitsOnlyViewController, with paymentMethodId: String)
+
+    func instantDebitsOnlyViewControllerDidCancel(_ controller: InstantDebitsOnlyViewController)
+
+    func instantDebitsOnlyViewControllerDidFail(_ controller: InstantDebitsOnlyViewController, error: Error)
+
+    func instantDebitsOnlyViewControllerDidComplete(_ controller: InstantDebitsOnlyViewController)
+}
+
+@available(iOSApplicationExtension, unavailable)
+@available(macCatalystApplicationExtension, unavailable)
+final class InstantDebitsOnlyViewController: UIViewController {
+
+    lazy var navigationBar: SheetNavigationBar = {
+        let navigationBar = SheetNavigationBar(isTestMode: configuration.apiClient.isTestmode,
+                                               appearance: PaymentSheet.Appearance.default)
+        navigationBar.delegate = self
+        return navigationBar
+    }()
+    var requiresFullScreen: Bool
+
+    weak var delegate: InstantDebitsOnlyViewControllerDelegate?
+    private lazy var bankInfoView = LinkBankAccountInfoView(frame: .zero)
+    private var paymentMethodId: String?
+
+    private lazy var instantDebitMandateView = LinkInstantDebitMandateView(delegate: self)
+    private lazy var connectionsAuthManager: InstantDebitsOnlyAuthenticationSessionManager = {
+        return InstantDebitsOnlyAuthenticationSessionManager(window: view.window)
+    }()
+
+    private lazy var confirmButton = ConfirmButton.makeLinkButton(
+        callToAction: .custom(title: String.Localized.continue),
+        compact: false
+    ) { [weak self] in
+        guard let self = self else { return }
+        self.delegate?.instantDebitsOnlyViewControllerDidComplete(self)
+    }
+
+    private lazy var cancelButton: Button = {
+        let button = Button(
+            configuration: .linkSecondary(),
+            title: String.Localized.cancel
+        )
+        button.addTarget(self, action: #selector(cancelButtonTapped(_:)), for: .touchUpInside)
+        return button
+    }()
+
+    private lazy var separator = SeparatorLabel(text: String.Localized.or)
+
+    private lazy var mandateContainerView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [
+            instantDebitMandateView,
+        ])
+        stackView.axis = .vertical
+        stackView.spacing = LinkUI.contentSpacing
+        return stackView
+    }()
+
+    private lazy var errorLabel: UILabel = {
+        let label = ElementsUI.makeErrorLabel(theme: LinkUI.appearance.asElementsTheme)
+        label.textAlignment = .center
+        label.isHidden = true
+        return label
+    }()
+
+    private lazy var containerView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [
+            bankInfoView,
+            mandateContainerView,
+            errorLabel,
+            confirmButton,
+        ])
+        stackView.axis = .vertical
+        stackView.spacing = LinkUI.contentSpacing
+        stackView.setCustomSpacing(LinkUI.extraLargeContentSpacing, after: mandateContainerView)
+        stackView.isLayoutMarginsRelativeArrangement = true
+        stackView.directionalLayoutMargins = LinkUI.contentMargins
+        return stackView
+    }()
+
+    private lazy var dynamicHeightContainer: DynamicHeightContainerView = {
+        let view = DynamicHeightContainerView(pinnedDirection: .bottom)
+        return view
+    }()
+
+    private let manifest: Manifest
+    private let configuration: PaymentSheet.Configuration
+
+    init(
+        manifest: Manifest,
+        configuration: PaymentSheet.Configuration
+    ) {
+        self.manifest = manifest
+        self.requiresFullScreen = false
+        self.configuration = configuration
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+        updateUI(animated: false)
+    }
+
+    func setupUI() {
+        containerView.addArrangedSubview(cancelButton)
+
+        dynamicHeightContainer.addPinnedSubview(containerView)
+        dynamicHeightContainer.updateHeight()
+
+        view.addAndPinSubview(dynamicHeightContainer)
+        containerView.alpha = 0.0
+
+        containerView.toggleArrangedSubview(bankInfoView, shouldShow: false, animated: false)
+    }
+
+    func updateUI(animated: Bool) {
+        mandateContainerView.toggleArrangedSubview(
+            instantDebitMandateView,
+            shouldShow: true,
+            animated: animated
+        )
+    }
+
+    func setBankAccountInfo(details: InstantDebitsOnlyAuthenticationSessionManager.RedactedPaymentDetails) {
+        bankInfoView.setBankAccountInfo(iconCode: details.bankIconCode, bankName: details.bankName, last4: details.last4)
+        containerView.toggleArrangedSubview(bankInfoView, shouldShow: true, animated: false)
+    }
+
+    func updateErrorLabel(for error: Error?) {
+        errorLabel.text = error?.nonGenericDescription
+        containerView.toggleArrangedSubview(errorLabel, shouldShow: error != nil, animated: true)
+    }
+
+    @objc
+    func cancelButtonTapped(_ sender: Button) {
+        delegate?.instantDebitsOnlyViewControllerDidCancel(self)
+    }
+
+    func startInstantDebitsOnlyWebFlow() {
+        paymentMethodId = nil
+        confirmButton.update(state: .processing)
+        connectionsAuthManager.start(manifest: manifest).observe { [weak self] result in
+            guard let self = self else { return }
+            self.containerView.alpha = 1.0
+            switch result {
+            case .success(let successResult):
+                switch successResult {
+                case .success(let details):
+                    self.paymentMethodId = details.paymentMethodID
+                    self.confirmButton.update(state: .enabled)
+                    self.delegate?.instantDebitsOnlyViewControllerDidProducePaymentMethod(self, with: details.paymentMethodID)
+                    self.setBankAccountInfo(details: details)
+                case.canceled:
+                    self.confirmButton.update(state: .disabled)
+                    self.delegate?.instantDebitsOnlyViewControllerDidCancel(self)
+                }
+            case .failure(let error):
+                self.confirmButton.update(state: .disabled)
+                self.delegate?.instantDebitsOnlyViewControllerDidFail(self, error: error)
+            }
+        }
+    }
+}
+
+// MARK: - BottomSheetContentViewController
+
+@available(iOSApplicationExtension, unavailable)
+@available(macCatalystApplicationExtension, unavailable)
+extension InstantDebitsOnlyViewController: BottomSheetContentViewController {
+
+    var isDismissable: Bool {
+        return paymentMethodId == nil
+    }
+
+    var allowsDragToDismiss: Bool {
+        return isDismissable
+    }
+
+    func didTapOrSwipeToDismiss() {
+        if isDismissable {
+            delegate?.instantDebitsOnlyViewControllerDidCancel(self)
+        }
+    }
+}
+
+// MARK: - SheetNavigationBarDelegate
+
+@available(iOSApplicationExtension, unavailable)
+@available(macCatalystApplicationExtension, unavailable)
+extension InstantDebitsOnlyViewController: SheetNavigationBarDelegate {
+    func sheetNavigationBarDidClose(_ sheetNavigationBar: SheetNavigationBar) {
+        delegate?.instantDebitsOnlyViewControllerDidCancel(self)
+    }
+
+    func sheetNavigationBarDidBack(_ sheetNavigationBar: SheetNavigationBar) {
+        // no-op
+    }
+}
+
+// MARK: - LinkInstantDebitMandateViewDelegate
+
+@available(iOSApplicationExtension, unavailable)
+@available(macCatalystApplicationExtension, unavailable)
+extension InstantDebitsOnlyViewController: LinkInstantDebitMandateViewDelegate {
+
+    func instantDebitMandateView(_ mandateView: LinkInstantDebitMandateView, didTapOnLinkWithURL url: URL) {
+        let safariVC = SFSafariViewController(url: url)
+        safariVC.dismissButtonStyle = .close
+        safariVC.modalPresentationStyle = .overFullScreen
+        present(safariVC, animated: true)
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/Button+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/Button+Link.swift
@@ -1,0 +1,69 @@
+//
+//  Button+Link.swift
+//  StripePaymentSheet
+//
+//  Created by Ramon Torres on 12/1/21.
+//  Copyright © 2021 Stripe, Inc. All rights reserved.
+//
+
+@_spi(STP) import StripeUICore
+import UIKit
+
+extension Button.Configuration {
+
+    static func linkPrimary() -> Self {
+        var configuration: Button.Configuration = .primary()
+        configuration.font = LinkUI.font(forTextStyle: .bodyEmphasized)
+        configuration.insets = LinkUI.buttonMargins
+        configuration.cornerRadius = LinkUI.cornerRadius
+
+        // Colors
+        configuration.foregroundColor = .linkPrimaryButtonForeground
+        configuration.backgroundColor = .linkBrand
+        configuration.disabledBackgroundColor = .linkBrand
+
+        configuration.colorTransforms.disabledForeground = .setAlpha(amount: 0.5)
+        configuration.colorTransforms.highlightedForeground = .darken(amount: 0.2)
+
+        return configuration
+    }
+
+    static func linkSecondary() -> Self {
+        var configuration: Button.Configuration = .linkPrimary()
+
+        // Colors
+        configuration.foregroundColor = .linkSecondaryButtonForeground
+        configuration.backgroundColor = .linkSecondaryButtonBackground
+        configuration.disabledBackgroundColor = .linkSecondaryButtonBackground
+
+        return configuration
+    }
+
+    static func linkPlain() -> Self {
+        var configuration: Button.Configuration = .plain()
+        configuration.font = LinkUI.font(forTextStyle: .body)
+        configuration.foregroundColor = .linkBrandDark
+        configuration.disabledForegroundColor = nil
+        configuration.colorTransforms.highlightedForeground = .setAlpha(amount: 0.4)
+        configuration.colorTransforms.disabledForeground = .setAlpha(amount: 0.3)
+        return configuration
+    }
+
+    static func linkBordered() -> Self {
+        var configuration: Button.Configuration = .plain()
+        configuration.font = LinkUI.font(forTextStyle: .detailEmphasized)
+        configuration.insets = .insets(top: 4, leading: 12, bottom: 4, trailing: 12)
+        configuration.borderWidth = 1
+        configuration.cornerRadius = LinkUI.mediumCornerRadius
+
+        // Colors
+        configuration.foregroundColor = .label
+        configuration.backgroundColor = .clear
+        configuration.borderColor = .linkControlBorder
+
+        configuration.colorTransforms.highlightedForeground = .setAlpha(amount: 0.5)
+        configuration.colorTransforms.highlightedBorder = .setAlpha(amount: 0.5)
+
+        return configuration
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Views/LinkBankAccountInfoView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Views/LinkBankAccountInfoView.swift
@@ -1,0 +1,95 @@
+//
+//  LinkBankAccountInfoView.swift
+//  StripePaymentSheet
+//
+//  Created by Vardges Avetisyan on 6/22/23.
+//
+
+@_spi(STP) import StripeUICore
+import UIKit
+
+final class LinkBankAccountInfoView: UIView {
+    struct Constants {
+        static let contentSpacing: CGFloat = 4
+        static let iconSize = CGSize(width: 30, height: 20)
+        static let maxFontSize: CGFloat = 20
+    }
+
+    private lazy var bankIconView: UIImageView = {
+        let iconView = UIImageView()
+        iconView.contentMode = .scaleAspectFill
+        iconView.tintColor = .systemGray2
+        return iconView
+    }()
+
+    private let primaryLabel: UILabel = {
+        let label = UILabel()
+        label.adjustsFontForContentSizeCategory = true
+        label.font = LinkUI.font(forTextStyle: .bodyEmphasized, maximumPointSize: Constants.maxFontSize)
+        label.textColor = .linkPrimaryText
+        return label
+    }()
+
+    private let secondaryLabel: UILabel = {
+        let label = UILabel()
+        label.font = LinkUI.font(forTextStyle: .caption, maximumPointSize: Constants.maxFontSize)
+        label.textColor = .linkSecondaryText
+        return label
+    }()
+
+    private lazy var iconContainerView: UIView = {
+        let view = UIView()
+        bankIconView.translatesAutoresizingMaskIntoConstraints = false
+
+        view.addSubview(bankIconView)
+
+        NSLayoutConstraint.activate([
+            bankIconView.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor),
+            bankIconView.topAnchor.constraint(greaterThanOrEqualTo: view.topAnchor),
+            bankIconView.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor),
+            bankIconView.bottomAnchor.constraint(lessThanOrEqualTo: view.bottomAnchor),
+            bankIconView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            bankIconView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+        ])
+
+        return view
+    }()
+
+    private lazy var stackView: UIStackView = {
+        let labelStackView = UIStackView(arrangedSubviews: [
+            primaryLabel,
+            secondaryLabel,
+        ])
+        labelStackView.axis = .vertical
+        labelStackView.alignment = .leading
+        labelStackView.spacing = 2
+
+        let stackView = UIStackView(arrangedSubviews: [
+            iconContainerView,
+            labelStackView,
+        ])
+
+        stackView.spacing = Constants.contentSpacing
+        stackView.distribution = .fillProportionally
+        stackView.alignment = .center
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        addAndPinSubview(stackView)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func setBankAccountInfo(iconCode: String?, bankName: String?, last4: String?) {
+        bankIconView.image = PaymentSheetImageLibrary.bankIcon(for: iconCode)
+        primaryLabel.text = bankName
+        if let last4 = last4 {
+            secondaryLabel.text = "••••\(last4)"
+        }
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Views/LinkInstantDebitMandateView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Views/LinkInstantDebitMandateView.swift
@@ -1,0 +1,117 @@
+//
+//  LinkInstantDebitMandateView.swift
+//  StripePaymentSheet
+//
+//  Created by Ramon Torres on 2/17/22.
+//  Copyright © 2022 Stripe, Inc. All rights reserved.
+//
+
+@_spi(STP) import StripePaymentsUI
+@_spi(STP) import StripeUICore
+import UIKit
+
+protocol LinkInstantDebitMandateViewDelegate: AnyObject {
+    /// Called when the user taps on a link.
+    ///
+    /// - Parameters:
+    ///   - mandateView: The view that the user interacted with.
+    ///   - url: URL of the link.
+    func instantDebitMandateView(_ mandateView: LinkInstantDebitMandateView, didTapOnLinkWithURL url: URL)
+}
+
+/// For internal SDK use only
+@objc(STP_Internal_LinkInstantDebitMandateViewDelegate)
+final class LinkInstantDebitMandateView: UIView {
+    struct Constants {
+        static let lineHeight: CGFloat = 1.5
+    }
+
+    // TODO(vardges): Update with final URLs
+    private let links: [String: URL] = [
+        "terms": URL(string: "https://stripe.com/ach-payments/authorization")!
+    ]
+
+    weak var delegate: LinkInstantDebitMandateViewDelegate?
+
+    private lazy var textView: UITextView = {
+        let textView = UITextView()
+        textView.isScrollEnabled = false
+        textView.isEditable = false
+        textView.backgroundColor = .clear
+        textView.attributedText = formattedLegalText()
+        textView.textColor = .linkSecondaryText
+        textView.textAlignment = .center
+        textView.textContainerInset = .zero
+        textView.textContainer.lineFragmentPadding = 0
+        textView.delegate = self
+        textView.clipsToBounds = false
+        textView.adjustsFontForContentSizeCategory = true
+        textView.linkTextAttributes = [
+            .foregroundColor: UIColor.linkBrandDark
+        ]
+        textView.font = LinkUI.font(forTextStyle: .caption)
+        return textView
+    }()
+
+    init(delegate: LinkInstantDebitMandateViewDelegate? = nil) {
+        super.init(frame: .zero)
+        self.delegate = delegate
+        addAndPinSubview(textView)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func formattedLegalText() -> NSAttributedString {
+        let string = STPLocalizedString(
+            "By continuing, you agree to authorize payments pursuant to these <terms>terms</terms>.",
+            "Mandate text displayed when paying via Link instant debit."
+        )
+
+        let formattedString = NSMutableAttributedString()
+
+        STPStringUtils.parseRanges(from: string, withTags: Set<String>(links.keys)) { string, matches in
+            formattedString.append(NSAttributedString(string: string))
+
+            for (tag, range) in matches {
+                guard range.rangeValue.location != NSNotFound else {
+                    assertionFailure("Tag '<\(tag)>' not found")
+                    continue
+                }
+
+                if let url = links[tag] {
+                    formattedString.addAttributes([.link: url], range: range.rangeValue)
+                }
+            }
+        }
+
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineSpacing = LinkUI.lineSpacing(
+            fromRelativeHeight: Constants.lineHeight,
+            textStyle: .caption
+        )
+
+        formattedString.addAttributes([.paragraphStyle: paragraphStyle], range: formattedString.extent)
+
+        return formattedString
+    }
+
+}
+
+extension LinkInstantDebitMandateView: UITextViewDelegate {
+
+    func textView(
+        _ textView: UITextView,
+        shouldInteractWith URL: URL,
+        in characterRange: NSRange,
+        interaction: UITextItemInteraction
+    ) -> Bool {
+        if interaction == .invokeDefaultAction {
+            delegate?.instantDebitMandateView(self, didTapOnLinkWithURL: URL)
+        }
+
+        return false
+    }
+
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkPaymentController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkPaymentController.swift
@@ -100,7 +100,7 @@ import UIKit
 
         let instantDebitsController: InstantDebitsOnlyViewController = try await withCheckedThrowingContinuation { [self] continuation in
             let apiClient = self.configuration.apiClient
-            let parameters = [
+            let parameters: [String: Any] = [
                 "attach_required": false,
                 "product": "instant_debits",
             ]

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkPaymentController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkPaymentController.swift
@@ -20,9 +20,29 @@ import UIKit
     private let mode: PaymentSheet.InitializationMode
     private let configuration: PaymentSheet.Configuration
 
-    private var intent: Intent?
     private var payWithLinkContinuation: CheckedContinuation<Void, Swift.Error>?
-    private var paymentOption: PaymentOption?
+    private var paymentMethodId: String?
+
+    private lazy var loadingViewController: LoadingViewController = {
+        let loadingViewController = LoadingViewController(
+            delegate: self,
+            appearance: PaymentSheet.Appearance.default,
+            isTestMode: configuration.apiClient.isTestmode,
+            loadingViewHeight: 244
+        )
+        return loadingViewController
+    }()
+
+    /// The parent view controller to present
+    private lazy var bottomSheetViewController: BottomSheetViewController = {
+        let vc = BottomSheetViewController(
+            contentViewController: loadingViewController,
+            appearance: PaymentSheet.Appearance.default,
+            isTestMode: configuration.apiClient.isTestmode,
+            didCancelNative3DS2: {}
+        )
+        return vc
+    }()
 
     /// Initializes a new `LinkPaymentController` instance.
     /// - Parameter paymentIntentClientSecret: The [client secret](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-client_secret) of a Stripe PaymentIntent object
@@ -76,33 +96,80 @@ import UIKit
     /// - Throws: Either `LinkPaymentController.Error.canceled`, meaning the customer canceled the flow, or an error describing what went wrong.
     @MainActor
     @_spi(LinkOnly) public func present(from presentingViewController: UIViewController) async throws {
-        let linkController: PayWithLinkWebController = try await withCheckedThrowingContinuation { [self] continuation in
-            PaymentSheetLoader.load(mode: mode, configuration: configuration) { result in
-                switch result {
-                case .success(let intent, _, let isLinkEnabled):
-                    guard isLinkEnabled else {
-                        continuation.resume(throwing: LinkPaymentController.Error.unavailable)
-                        return
-                    }
-                    self.intent = intent
-                    let linkController = PayWithLinkWebController(
-                        intent: intent,
-                        configuration: self.configuration,
-                        shouldOfferApplePay: false,
-                        shouldFinishOnClose: true,
-                        callToAction: .customWithLock(title: String.Localized.continue)
-                    )
-                    continuation.resume(returning: linkController)
-                case .failure(let error):
-                    continuation.resume(throwing: error)
+        presentingViewController.presentAsBottomSheet(bottomSheetViewController, appearance: PaymentSheet.Appearance.default)
+
+        let instantDebitsController: InstantDebitsOnlyViewController = try await withCheckedThrowingContinuation { [self] continuation in
+            let apiClient = self.configuration.apiClient
+            let parameters = [
+                "attach_required": false,
+                "product": "instant_debits",
+            ]
+            switch mode {
+            case .paymentIntentClientSecret(let clientSecret):
+                guard let paymentIntentId = STPPaymentIntent.id(fromClientSecret: clientSecret) else {
+                    continuation.resume(throwing: PaymentSheetError.unknown(debugDescription: "Invalid client secret"))
+                    return
                 }
+                apiClient.createLinkAccountSession(paymentIntentID: paymentIntentId,
+                                                   clientSecret: clientSecret,
+                                                   paymentMethodType: .link,
+                                                   customerName: configuration.defaultBillingDetails.name,
+                                                   customerEmailAddress: configuration.defaultBillingDetails.email,
+                                                   additionalParameteres: parameters) { [weak self] linkAccountSession, error in
+                    self?.generateManifest(continuation: continuation, error: error, linkAccountSession: linkAccountSession)
+                }
+            case .setupIntentClientSecret(let clientSecret):
+                guard let setupIntentId = STPSetupIntent.id(fromClientSecret: clientSecret) else {
+                    continuation.resume(throwing: PaymentSheetError.unknown(debugDescription: "Invalid client secret"))
+                    return
+                }
+                apiClient.createLinkAccountSession(setupIntentID: setupIntentId,
+                                                   clientSecret: clientSecret,
+                                                   paymentMethodType: .link,
+                                                   customerName: configuration.defaultBillingDetails.name,
+                                                   customerEmailAddress: configuration.defaultBillingDetails.email,
+                                                   additionalParameteres: parameters) { [weak self] linkAccountSession, error in
+                    self?.generateManifest(continuation: continuation, error: error, linkAccountSession: linkAccountSession)
+                }
+            case .deferredIntent:
+                continuation.resume(throwing: PaymentSheetError.unknown(debugDescription: "Link payment controller is not implemented for deferred intent yet."))
             }
         }
-        linkController.payWithLinkDelegate = self
-        defer { linkController.cancel() }
+        defer {
+            // reset the stack
+            bottomSheetViewController.contentStack = [loadingViewController]
+            bottomSheetViewController.dismiss(animated: true)
+        }
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Swift.Error>) in
             payWithLinkContinuation = continuation
-            linkController.present(over: presentingViewController)
+            bottomSheetViewController.contentStack = [instantDebitsController]
+            instantDebitsController.startInstantDebitsOnlyWebFlow()
+        }
+    }
+
+    private func generateManifest(continuation: CheckedContinuation<InstantDebitsOnlyViewController, Swift.Error>,
+                                  error: Swift.Error?,
+                                  linkAccountSession: LinkAccountSession?) {
+        if let error = error {
+            continuation.resume(throwing: error)
+            return
+        }
+
+        guard let linkAccountSession = linkAccountSession else {
+            continuation.resume(throwing: PaymentSheetError.unknown(debugDescription: "Failed to create link account session"))
+            return
+        }
+
+        configuration.apiClient.generatedLinkAccountSessionManifest(with: linkAccountSession.clientSecret) { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .success(let manifest):
+                let instantDebitsViewController = InstantDebitsOnlyViewController(manifest: manifest, configuration: self.configuration)
+                instantDebitsViewController.delegate = self
+                continuation.resume(returning: instantDebitsViewController)
+            case .failure(let error):
+                continuation.resume(throwing: error)
+            }
         }
     }
 
@@ -131,46 +198,50 @@ import UIKit
     /// - Throws: Either `LinkPaymentController.Error.canceled`, meaning the customer canceled the flow, or an error describing what went wrong.
     @MainActor
     @_spi(LinkOnly) public func confirm(from presentingViewController: UIViewController) async throws {
-        if (intent == nil || paymentOption == nil) && LinkAccountService().hasSessionCookie {
-            // If the customer has a Link cookie, `present` may not need to have been called - try to load here
-            paymentOption = try await withCheckedThrowingContinuation { [self] continuation in
-                PaymentSheetLoader.load(mode: mode, configuration: configuration) { result in
-                    switch result {
-                    case .success(let intent, _, let isLinkEnabled):
-                        guard isLinkEnabled else {
-                            continuation.resume(throwing: Error.unavailable)
-                            return
-                        }
-                        self.intent = intent
-                        // TODO(bmelts): can we reliably determine the customer's previously used funding source (if any)?
-                        continuation.resume(returning: .link(option: .wallet))
-                    case .failure(let error):
-                        continuation.resume(throwing: error)
-                    }
-                }
-            }
-        }
-        guard let intent = intent, let paymentOption = paymentOption else {
+        guard let paymentMethodId = paymentMethodId else {
             assertionFailure("`confirm` should not be called without the customer authorizing Link. Make sure to call `present` first if your customer hasn't previously selected Link as a payment method.")
             throw PaymentSheetError.unknown(debugDescription: "confirm called without authorizing Link")
         }
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Swift.Error>) in
-            PaymentSheet.confirm(
-                configuration: configuration,
-                authenticationContext: AuthenticationContext(presentingViewController: presentingViewController, appearance: .default),
-                intent: intent,
-                paymentOption: paymentOption,
-                paymentHandler: STPPaymentHandler(apiClient: configuration.apiClient),
-                isFlowController: false
-            ) { result in
-                switch result {
-                case .completed:
-                    continuation.resume()
-                case .canceled:
-                    continuation.resume(throwing: Error.canceled)
-                case .failed(let error):
-                    continuation.resume(throwing: error)
+            switch mode {
+            case .paymentIntentClientSecret(let clientSecret):
+                let paymentIntentParams = STPPaymentIntentParams(clientSecret: clientSecret, paymentMethodType: .link)
+                paymentIntentParams.paymentMethodId = paymentMethodId
+                paymentIntentParams.mandateData = STPMandateDataParams.makeWithInferredValues()
+                STPPaymentHandler.shared().confirmPayment(
+                    paymentIntentParams, with: AuthenticationContext(presentingViewController: presentingViewController, appearance: .default)
+                ) { (status, _, error) in
+                    switch status {
+                    case .canceled:
+                        continuation.resume(throwing: Error.canceled)
+                    case .failed:
+                        continuation.resume(throwing: error ?? Error.canceled)
+                    case .succeeded:
+                        continuation.resume()
+                    @unknown default:
+                        fatalError()
+                    }
                 }
+            case .setupIntentClientSecret(let clientSecret):
+                let setupIntentParams = STPSetupIntentConfirmParams(clientSecret: clientSecret, paymentMethodType: .link)
+                setupIntentParams.paymentMethodID = paymentMethodId
+                setupIntentParams.mandateData = STPMandateDataParams.makeWithInferredValues()
+                STPPaymentHandler.shared().confirmSetupIntent(
+                    setupIntentParams, with: AuthenticationContext(presentingViewController: presentingViewController, appearance: .default)
+                ) { (status, _, error) in
+                    switch status {
+                    case .canceled:
+                        continuation.resume(throwing: Error.canceled)
+                    case .failed:
+                        continuation.resume(throwing: error ?? Error.canceled)
+                    case .succeeded:
+                        continuation.resume()
+                    @unknown default:
+                        fatalError()
+                    }
+                }
+            case .deferredIntent:
+                continuation.resume(throwing: PaymentSheetError.unknown(debugDescription: "Link payment confirmation is not implemented for deferred intent yet."))
             }
         }
     }
@@ -196,13 +267,32 @@ import UIKit
 
 @available(iOSApplicationExtension, unavailable)
 @available(macCatalystApplicationExtension, unavailable)
-extension LinkPaymentController: PayWithLinkWebControllerDelegate {
-    func payWithLinkWebControllerDidComplete(_ payWithLinkWebController: PayWithLinkWebController, intent: Intent, with paymentOption: PaymentOption) {
-        self.intent = intent
-        self.paymentOption = paymentOption
+extension LinkPaymentController: InstantDebitsOnlyViewControllerDelegate {
+
+    func instantDebitsOnlyViewControllerDidProducePaymentMethod(_ controller: InstantDebitsOnlyViewController, with paymentMethodId: String) {
+        self.paymentMethodId = paymentMethodId
     }
 
-    func payWithLinkWebControllerDidCancel(_ payWithLinkWebController: PayWithLinkWebController) {
+    func instantDebitsOnlyViewControllerDidCancel(_ controller: InstantDebitsOnlyViewController) {
+        payWithLinkContinuation?.resume(throwing: Error.canceled)
+    }
+
+    func instantDebitsOnlyViewControllerDidFail(_ controller: InstantDebitsOnlyViewController, error: Swift.Error) {
+        payWithLinkContinuation?.resume(throwing: error)
+    }
+
+    func instantDebitsOnlyViewControllerDidComplete(
+        _ controller: InstantDebitsOnlyViewController
+    ) {
+        payWithLinkContinuation?.resume(returning: ())
+    }
+}
+
+@available(iOSApplicationExtension, unavailable)
+@available(macCatalystApplicationExtension, unavailable)
+@_spi(LinkOnly)
+extension LinkPaymentController: LoadingViewControllerDelegate {
+    func shouldDismiss(_ loadingViewController: LoadingViewController) {
         payWithLinkContinuation?.resume(throwing: Error.canceled)
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/ConfirmButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/ConfirmButton.swift
@@ -17,6 +17,42 @@ import UIKit
 private let spinnerMoveToCenterAnimationDuration = 0.35
 private let checkmarkStrokeDuration = 0.2
 
+//
+//  ConfirmButton+Link.swift
+//  StripePaymentSheet
+//
+//  Created by Ramon Torres on 1/12/22.
+//  Copyright © 2022 Stripe, Inc. All rights reserved.
+//
+extension ConfirmButton {
+
+    static func makeLinkButton(
+        callToAction: CallToActionType,
+        compact: Bool = false,
+        didTap: @escaping () -> Void
+    ) -> ConfirmButton {
+        let button = ConfirmButton(
+            callToAction: callToAction,
+            appearance: LinkUI.appearance,
+            didTap: didTap
+        )
+
+        // Override the background color of the `.succeeded` state. Make it match
+        // the background color of the `.enabled` state.
+        button.succeededBackgroundColor = (
+            LinkUI.appearance.primaryButton.backgroundColor ??
+            LinkUI.appearance.colors.primary
+        )
+
+        button.directionalLayoutMargins = compact
+            ? LinkUI.compactButtonMargins
+            : LinkUI.buttonMargins
+
+        return button
+    }
+
+}
+
 /// Buy button or Apple Pay
 /// For internal SDK use only
 @objc(STP_Internal_ConfirmButton)

--- a/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+LinkAccountSession.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+LinkAccountSession.swift
@@ -8,17 +8,23 @@
 import Foundation
 @_spi(STP) import StripeCore
 
-typealias STPLinkAccountSessionBlock = (LinkAccountSession?, Error?) -> Void
-typealias STPLinkAccountSessionsAttachPaymentIntentBlock = (STPPaymentIntent?, Error?) -> Void
-typealias STPLinkAccountSessionsAttachSetupIntentBlock = (STPSetupIntent?, Error?) -> Void
+@_spi(STP)
+public typealias STPLinkAccountSessionBlock = (LinkAccountSession?, Error?) -> Void
+@_spi(STP)
+public typealias STPLinkAccountSessionsAttachPaymentIntentBlock = (STPPaymentIntent?, Error?) -> Void
+@_spi(STP)
+public typealias STPLinkAccountSessionsAttachSetupIntentBlock = (STPSetupIntent?, Error?) -> Void
 
-extension STPAPIClient {
+@_spi(STP)
+public extension STPAPIClient {
+
     func createLinkAccountSession(
         setupIntentID: String,
         clientSecret: String,
         paymentMethodType: STPPaymentMethodType,
         customerName: String?,
         customerEmailAddress: String?,
+        additionalParameteres: [String: Any] = [:],
         completion: @escaping STPLinkAccountSessionBlock
     ) {
         let endpoint: String = "setup_intents/\(setupIntentID)/link_account_sessions"
@@ -28,6 +34,7 @@ extension STPAPIClient {
             paymentMethodType: paymentMethodType,
             customerName: customerName,
             customerEmailAddress: customerEmailAddress,
+            additionalParameteres: additionalParameteres,
             completion: completion
         )
     }
@@ -38,6 +45,7 @@ extension STPAPIClient {
         paymentMethodType: STPPaymentMethodType,
         customerName: String?,
         customerEmailAddress: String?,
+        additionalParameteres: [String: Any] = [:],
         completion: @escaping STPLinkAccountSessionBlock
     ) {
         let endpoint: String = "payment_intents/\(paymentIntentID)/link_account_sessions"
@@ -47,6 +55,7 @@ extension STPAPIClient {
             paymentMethodType: paymentMethodType,
             customerName: customerName,
             customerEmailAddress: customerEmailAddress,
+            additionalParameteres: additionalParameteres,
             completion: completion
         )
     }
@@ -82,11 +91,12 @@ extension STPAPIClient {
         paymentMethodType: STPPaymentMethodType,
         customerName: String?,
         customerEmailAddress: String?,
+        additionalParameteres: [String: Any],
         completion: @escaping STPLinkAccountSessionBlock
     ) {
-        var parameters: [String: Any] = [
-            "client_secret": clientSecret,
-        ]
+        var parameters = additionalParameteres
+        parameters["client_secret"] = clientSecret
+
         if let paymentMethodType = STPPaymentMethod.string(from: paymentMethodType) {
             parameters["payment_method_data[type]"] = paymentMethodType
         }


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Refactors LinkPaymentViewController to be used for Instant Debits Only flow.
## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
We want this dedicated LinkOnly entry point to be used for instant debits only flow on mobile. The flow calls into a hosted webflow link generation API, gets the link, opens in a secure webview. Upon completion parses URL params. Uses the returned payment method ID to confirm the payment.
## Testing
<!-- How was the code tested? Be as specific as possible. -->


https://github.com/stripe/stripe-ios/assets/92807969/18fafb4b-efe4-4de5-a226-4fef5df302d5



Tested against my devbox. Will follow up with the playground entry point to test this.
## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
