### PR TITLE
Remove shipping address requirement for affirm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## X.Y.Z 2023-XX-YY
+### PaymentSheet
+* [Fixed] Affirm no longer requires shipping details.
+
 ## 23.9.2 2023-06-20
 ### Payments
 * [Fixed] Fixed a bug causing Cash App Pay SetupIntents to incorrectly state they were canceled when they succeeded.

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -386,6 +386,11 @@ extension PlaygroundController {
             self.clientSecret = json["intentClientSecret"]
             self.ephemeralKey = json["customerEphemeralKeySecret"]
             self.customerID = json["customerId"]
+            print(self.clientSecret)
+            print(self.customerID)
+            self.ephemeralKey = "ek_test_YWNjdF8xSHZUSTdMdTVvM1AxOFpwLFZ2b2RpYm1OWTlFdENUWVNXeEVBVWRDV0NFV0J4cng_00mIpuhG8O"
+            self.clientSecret = "pi_3NMDS8Lu5o3P18Zp0gG8qvq6_secret_Kev9VIJhMqNsG9elAlEYqXzez"
+            self.customerID = "cus_O8UPWqkXNgic71"
             self.paymentMethodTypes = json["paymentMethodTypes"]?.components(separatedBy: ",")
             self.amount = Int(json["amount"] ?? "")
             StripeAPI.defaultPublishableKey = json["publishableKey"]

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -486,7 +486,6 @@ class PaymentSheetStandardLPMUITests: PaymentSheetUITestCase {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
         settings.customerMode = .new
         settings.apmsEnabled = .off
-        settings.shippingInfo = .onWithDefaults
         loadPlayground(
             app,
             settings

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -306,7 +306,7 @@ extension PaymentSheet {
                     case .blik, .card, .cardPresent, .UPI, .weChatPay:
                         return []
                     case .alipay, .EPS, .FPX, .giropay, .grabPay, .netBanking, .payPal, .przelewy24, .klarna,
-                        .linkInstantDebit, .bancontact, .iDEAL, .cashApp:
+                            .linkInstantDebit, .bancontact, .iDEAL, .cashApp, .affirm:
                         return [.returnURL]
                     case .USBankAccount:
                         return [
@@ -317,7 +317,7 @@ extension PaymentSheet {
                         return [.userSupportsDelayedPaymentMethods]
                     case .bacsDebit, .sofort:
                         return [.returnURL, .userSupportsDelayedPaymentMethods]
-                    case .afterpayClearpay, .affirm:
+                    case .afterpayClearpay:
                         return [.returnURL, .shippingAddress]
                     case .link, .unknown:
                         return [.unsupported]


### PR DESCRIPTION
## Summary
Remove shipping address requirement for affirm

## Motivation
Shipping is not actually required:
> We recommend passing [shipping](https://stripe.com/docs/api/payment_intents/create#create_payment_intent-shipping) and [billing](https://stripe.com/docs/api/payment_methods/create#create_payment_method-billing_details) details to improve conversion rates, although these are not required.
https://stripe.com/docs/payments/affirm/accept-a-payment?platform=web

https://jira.corp.stripe.com/browse/RUN_BNPL-2333

## Testing
Updated E2E affirm test

## Changelog
### PaymentSheet
* [Fixed] Affirm no longer requires shipping details.