### PR TITLE
Unpublicize PaymentSheet.PaymentMethodType - making it public was a typo

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -13,7 +13,7 @@ import Foundation
 import UIKit
 
 extension PaymentSheet {
-    public enum PaymentMethodType: Equatable, Hashable {
+    enum PaymentMethodType: Equatable, Hashable {
 
         func supportsAddingRequirements() -> [PaymentMethodTypeRequirement] {
             switch self {


### PR DESCRIPTION
## Motivation
This type is not useful to users and was mistakenly made public.

## Changelog
I'm opting not to add anything to the CHANGELOG because I'm guessing this has zero usage.  This type is not useful to users and was mistakenly made public.
