### PR TITLE
Use background configuration for analytics client

### DIFF
--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticsClient.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticsClient.swift
@@ -26,7 +26,7 @@ import UIKit
     private var urlSession: URLSession {
         // Set up a configuration with a background session ID
         let configuration = URLSessionConfiguration.background(withIdentifier: "com.stripe.analyticsclient")
-         
+
         // Set configuration to discretionary
         configuration.isDiscretionary = true
         return URLSession(configuration: configuration)

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticsClient.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticsClient.swift
@@ -23,9 +23,14 @@ import UIKit
 
     @objc public var productUsage: Set<String> = Set()
     private var additionalInfoSet: Set<String> = Set()
-    private(set) var urlSession: URLSession = URLSession(
-        configuration: StripeAPIConfiguration.sharedUrlSessionConfiguration
-    )
+    private var urlSession: URLSession {
+        // Set up a configuration with a background session ID
+        let configuration = URLSessionConfiguration.background(withIdentifier: "com.stripe.analyticsclient")
+         
+        // Set configuration to discretionary
+        configuration.isDiscretionary = true
+        return URLSession(configuration: configuration)
+    }
 
     @objc public class func tokenType(fromParameters parameters: [AnyHashable: Any]) -> String? {
         let parameterKeys = parameters.keys


### PR DESCRIPTION
## Summary
- In the effort of being slightly better citizens we are using a background URL session with discretionary=true to achieve a slightly more efficient analytics client. This should improve our battery usage when it comes to sending analytics.
- https://developer.apple.com/library/archive/documentation/Performance/Conceptual/power_efficiency_guidelines_osx/SchedulingNetworkActivity.html
- https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1411552-isdiscretionary

## Motivation
https://docs.google.com/document/d/19e4NlRH6ON6xWpdI3uW2Hjb4fMvfkWL4rnZaVFRjew8/edit

## Testing
Manual

## Changelog
N/A
