### PR TITLE
Identity] Support the 'closed' field in submit endpoint

### DIFF
--- a/StripeIdentity/StripeIdentity/Source/API Bindings/Models/VerificationPage/VerificationPage.swift
+++ b/StripeIdentity/StripeIdentity/Source/API Bindings/Models/VerificationPage/VerificationPage.swift
@@ -45,3 +45,9 @@ extension StripeAPI {
     }
 
 }
+
+extension StripeAPI.VerificationPage {
+    func copyWithNewMissings(newMissings: Set<StripeAPI.VerificationPageFieldType>) -> StripeAPI.VerificationPage {
+        return StripeAPI.VerificationPage(biometricConsent: self.biometricConsent, documentCapture: self.documentCapture, documentSelect: self.documentSelect, individual: self.individual, countryNotListed: self.countryNotListed, individualWelcome: self.individualWelcome, phoneOtp: self.phoneOtp, fallbackUrl: self.fallbackUrl, id: self.id, livemode: self.livemode, requirements: StripeAPI.VerificationPageRequirements(missing: newMissings), selfie: self.selfie, status: self.status, submitted: self.submitted, success: self.success, unsupportedClient: self.unsupportedClient)
+    }
+}

--- a/StripeIdentity/StripeIdentity/Source/API Bindings/Models/VerificationPageData/VerificationPageData.swift
+++ b/StripeIdentity/StripeIdentity/Source/API Bindings/Models/VerificationPageData/VerificationPageData.swift
@@ -22,6 +22,21 @@ extension StripeAPI {
         let status: Status
         /// If true, the associated VerificationSession has been submitted for processing.
         let submitted: Bool
+
+        /// If true, the associated VerificationSession has been closed and can no longer be modified.
+        /// After submitting, closed might be false if needs to fallback from phone verification to document verification.
+        let closed: Bool
     }
 
+}
+
+extension StripeAPI.VerificationPageData {
+    /// When submitted but is not closed and there is still missing requirements, need to fallback.
+    func needsFallback() -> Bool {
+        return submitted && !closed && !requirements.missing.isEmpty
+    }
+
+    func submittedAndClosed() -> Bool {
+        return submitted && closed
+    }
 }

--- a/StripeIdentity/StripeIdentity/Source/API Bindings/Models/VerificationPageDataUpdate/VerificationPageClearData.swift
+++ b/StripeIdentity/StripeIdentity/Source/API Bindings/Models/VerificationPageDataUpdate/VerificationPageClearData.swift
@@ -20,6 +20,7 @@ extension StripeAPI {
         let dob: Bool?
         let name: Bool?
         let address: Bool?
+        let phoneOtp: Bool?
     }
 }
 
@@ -36,7 +37,8 @@ extension StripeAPI.VerificationPageClearData {
             idNumber: fields.contains(.idNumber),
             dob: fields.contains(.dob),
             name: fields.contains(.name),
-            address: fields.contains(.address)
+            address: fields.contains(.address),
+            phoneOtp: fields.contains(.phoneOtp)
         )
     }
 }

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/VerificationSheetController.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/VerificationSheetController.swift
@@ -248,30 +248,31 @@ final class VerificationSheetController: VerificationSheetControllerProtocol {
         // If finished collecting, submit and transition
         if updateData.requirements.missing.isEmpty {
             apiClient.submitIdentityVerificationPage().observe(on: .main) { [weak self] submittedData in
-                self?.isVerificationPageSubmitted = (try? submittedData.get())?.submittedAndClosed() == true
+                guard let self = self else { return }
+                self.isVerificationPageSubmitted = (try? submittedData.get())?.submittedAndClosed() == true
 
                 // Checking the response of submit
                 guard case .success(let resultData) = submittedData
                 else {
-                    self?.isVerificationPageSubmitted = false
-                    self?.transitionWithVerificaionPageDataResult(submittedData, completion: completion)
+                    self.isVerificationPageSubmitted = false
+                    self.transitionWithVerificaionPageDataResult(submittedData, completion: completion)
                     return
                 }
 
-                self?.isVerificationPageSubmitted = resultData.submitted == true && resultData.closed == true
+                self.isVerificationPageSubmitted = resultData.submitted == true && resultData.closed == true
 
                 if resultData.needsFallback() {
                     // Checking the buffered VerificationPageResponse, update its missings with the new missings
-                    guard let verificationPageResponse = try? self?.verificationPageResponse?.get() else {
+                    guard let verificationPageResponse = try? self.verificationPageResponse?.get() else {
                         assertionFailure("Fail to get VerificationPageResponse is nil")
                         return
                     }
-                    self?.verificationPageResponse = .success(verificationPageResponse.copyWithNewMissings(newMissings: resultData.requirements.missing))
+                    self.verificationPageResponse = .success(verificationPageResponse.copyWithNewMissings(newMissings: resultData.requirements.missing))
                     // clear collected data
-                    self?.collectedData = StripeAPI.VerificationPageCollectedData()
+                    self.collectedData = StripeAPI.VerificationPageCollectedData()
 
                 }
-                self?.transitionWithVerificaionPageDataResult(
+                self.transitionWithVerificaionPageDataResult(
                     submittedData,
                     completion: completion
                 )

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/VerificationSheetFlowController.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/VerificationSheetFlowController.swift
@@ -250,8 +250,11 @@ extension VerificationSheetFlowController: VerificationSheetFlowControllerProtoc
         // been submitted and they can't go back to edit their input.
         let isSuccessState = nextViewController is SuccessViewController
 
+        // If it's biometric consent, it's either the first screen of a doc type verification, or the first doc-fallback screen of phone type verification, don't show go back.
+        let isBiometricConsent = nextViewController is BiometricConsentViewController
+
         // Don't display a back button, so replace the navigation stack
-        if isTransitioningFromLoading || isTransitioningFromDebug || isSuccessState {
+        if isTransitioningFromLoading || isTransitioningFromDebug || isSuccessState || isBiometricConsent {
             navigationController.setViewControllers([nextViewController], animated: shouldAnimate)
         } else {
             navigationController.pushViewController(nextViewController, animated: shouldAnimate)
@@ -328,8 +331,8 @@ extension VerificationSheetFlowController: VerificationSheetFlowControllerProtoc
         let missingRequirements =
             updateDataResponse?.requirements.missing ?? staticContent.requirements.missing
 
-        // Show success screen if submitted
-        if updateDataResponse?.submitted == true {
+        // Show success screen if submitted and closed
+        if updateDataResponse?.submittedAndClosed() == true {
             return completion(
                 SuccessViewController(
                     successContent: staticContent.success,

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/PhoneOtpViewController.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/PhoneOtpViewController.swift
@@ -100,7 +100,7 @@ class PhoneOtpViewController: IdentityFlowViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override func viewWillAppear(_ animated: Bool) {
+    override func viewDidAppear(_ animated: Bool) {
         updateUI()
         generateOtp()
     }

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/PhoneOtpViewController.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/PhoneOtpViewController.swift
@@ -80,10 +80,10 @@ class PhoneOtpViewController: IdentityFlowViewController {
         let bodyText = {
             if let localPhoneNumber = sheetController.collectedData.phone {
                 // If phone number is collected locally use the non-nil number
-                return phoneOtpContent.body.replacingOccurrences(of: "&phone_number&", with: localPhoneNumber.phoneNumber?.suffix(4) ?? "")
+                return phoneOtpContent.body.replacingOccurrences(of: "{phone_number}", with: localPhoneNumber.phoneNumber?.suffix(4) ?? "")
             } else {
                 // Otherwise use the server provided non-nil number
-                return phoneOtpContent.body.replacingOccurrences(of: "&phone_number&", with: phoneOtpContent.redactedPhoneNumber ?? "")
+                return phoneOtpContent.body.replacingOccurrences(of: "{phone_number}", with: phoneOtpContent.redactedPhoneNumber ?? "")
             }
         }()
 
@@ -100,8 +100,7 @@ class PhoneOtpViewController: IdentityFlowViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
+    override func viewWillAppear(_ animated: Bool) {
         updateUI()
         generateOtp()
     }

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/PhoneOtpViewController.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/PhoneOtpViewController.swift
@@ -100,7 +100,8 @@ class PhoneOtpViewController: IdentityFlowViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override func viewDidAppear(_ animated: Bool) {
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
         updateUI()
         generateOtp()
     }

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/PhoneOtpViewController.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/PhoneOtpViewController.swift
@@ -99,10 +99,14 @@ class PhoneOtpViewController: IdentityFlowViewController {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        updateUI()
+    }
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        updateUI()
         generateOtp()
     }
 

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/PhoneOtpViewController.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/PhoneOtpViewController.swift
@@ -99,9 +99,9 @@ class PhoneOtpViewController: IdentityFlowViewController {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
         updateUI()
         generateOtp()
     }

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Views/PhoneOtpView.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Views/PhoneOtpView.swift
@@ -95,6 +95,7 @@ class PhoneOtpView: UIView {
         ])
 
         addAndPinSubview(stackView)
+        configure(with: viewModel)
     }
 
     required init?(coder: NSCoder) {

--- a/StripeIdentity/StripeIdentityTests/Helpers/IdentityMockData.swift
+++ b/StripeIdentity/StripeIdentityTests/Helpers/IdentityMockData.swift
@@ -41,6 +41,7 @@ enum VerificationPageDataMock: String, MockData {
     case noErrors = "VerificationPageData_no_errors"
     case noErrorsNeedback = "VerificationPageData_no_errors_needback"
     case submitted = "VerificationPageData_submitted"
+    case submittedNotClosed = "VerificationPageData_submitted_not_closed"
 
     static func noErrorsWithMissings(
         with missingRequirements: Set<StripeAPI.VerificationPageFieldType>
@@ -53,7 +54,8 @@ enum VerificationPageDataMock: String, MockData {
                 missing: missingRequirements
             ),
             status: noErrorsResponse.status,
-            submitted: noErrorsResponse.submitted
+            submitted: noErrorsResponse.submitted,
+            closed: noErrorsResponse.closed
         )
     }
 }

--- a/StripeIdentity/StripeIdentityTests/Helpers/IdentityMockData.swift
+++ b/StripeIdentity/StripeIdentityTests/Helpers/IdentityMockData.swift
@@ -170,7 +170,7 @@ enum VerificationPageDataUpdateMock {
 enum PhoneOtpPageMock {
     static let`default` = StripeAPI.VerificationPageStaticContentPhoneOtpPage(
         title: "Enter verification code",
-        body: "Enter the code sent to you phone &phone_number& to continue.",
+        body: "Enter the code sent to you phone {phone_number} to continue.",
         redactedPhoneNumber: "(***)*****35",
         errorOtpMessage: "Error confirming verification code",
         resendButtonText: "Resend code",

--- a/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPageData/VerificationPageData_200.json
+++ b/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPageData/VerificationPageData_200.json
@@ -2,6 +2,7 @@
    "id": "VS_123",
    "status": "requires_input",
    "submitted": false,
+   "closed": false,
    "requirements": {
        "errors": [
            {

--- a/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPageData/VerificationPageData_no_errors.json
+++ b/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPageData/VerificationPageData_no_errors.json
@@ -2,6 +2,7 @@
    "id": "VS_123",
    "status": "requires_input",
    "submitted": false,
+   "closed": false,
    "requirements": {
        "errors": [],
        "missing": []

--- a/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPageData/VerificationPageData_no_errors_needback.json
+++ b/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPageData/VerificationPageData_no_errors_needback.json
@@ -2,6 +2,7 @@
    "id": "VS_123",
    "status": "requires_input",
    "submitted": false,
+   "closed": false,
    "requirements": {
        "errors": [],
        "missing": [

--- a/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPageData/VerificationPageData_submitted.json
+++ b/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPageData/VerificationPageData_submitted.json
@@ -2,6 +2,7 @@
    "id": "VS_123",
    "status": "requires_input",
    "submitted": true,
+   "closed": true,
    "requirements": {
        "errors": [],
        "missing": []

--- a/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPageData/VerificationPageData_submitted_not_closed.json
+++ b/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPageData/VerificationPageData_submitted_not_closed.json
@@ -1,0 +1,16 @@
+{
+   "id": "VS_123",
+   "status": "requires_input",
+   "submitted": true,
+   "closed": false,
+   "requirements": {
+       "errors": [],
+       "missing": [
+         "biometric_consent",
+         "id_document_front",
+         "id_document_back",
+         "id_document_type"
+       ]
+   },
+
+}

--- a/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/Coordinators/VerificationSheetControllerTest.swift
+++ b/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/Coordinators/VerificationSheetControllerTest.swift
@@ -172,7 +172,8 @@ final class VerificationSheetControllerTest: XCTestCase {
                     idNumber: false,
                     dob: false,
                     name: false,
-                    address: false
+                    address: false,
+                    phoneOtp: false
                 ),
                 collectedData: mockData
             )

--- a/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/ViewControllers/PhoneOtpViewControllerTest.swift
+++ b/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/ViewControllers/PhoneOtpViewControllerTest.swift
@@ -33,7 +33,7 @@ final class PhoneOtpViewControllerTest: XCTestCase {
 
         vc = PhoneOtpViewController(phoneOtpContent: phoneOtpContent, sheetController: mockSheetController)
 
-        vc.viewWillAppear(false)
+        vc.viewDidAppear(false)
     }
 
     func testGenerateCodeOnceWhenLoads() {

--- a/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/ViewControllers/PhoneOtpViewControllerTest.swift
+++ b/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/ViewControllers/PhoneOtpViewControllerTest.swift
@@ -33,6 +33,7 @@ final class PhoneOtpViewControllerTest: XCTestCase {
 
         vc = PhoneOtpViewController(phoneOtpContent: phoneOtpContent, sheetController: mockSheetController)
 
+        vc.viewWillAppear(false)
     }
 
     func testGenerateCodeOnceWhenLoads() {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Introduced a new `closed` boolean in submit API endpoint, after submitting
* When `submitted` and `closed` are `true` -> navigate to success page
* When `submitted`=`true` and `closed`=`false`, need to fallback, check `missings` and fallback accordingly - currently this only happens when `phone` type verification fallback to `document`

Android change: https://github.com/stripe/stripe-android/pull/6958
# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Support phoneV


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
