### PR TITLE
Expose StripeApplePay.createToken under @_spi(StripeApplePayTokenization)

### DIFF
--- a/StripeApplePay/StripeApplePay/Source/PaymentsCore/API/Models/Token.swift
+++ b/StripeApplePay/StripeApplePay/Source/PaymentsCore/API/Models/Token.swift
@@ -11,12 +11,13 @@ import PassKit
 @_spi(STP) import StripeCore
 
 extension StripeAPI {
-    struct Token: UnknownFieldsDecodable {
-        var _allResponseFieldsStorage: NonEncodableParameters?
+    // Internal note: @_spi(StripeApplePayTokenization) is intended for limited public use. See https://docs.google.com/document/d/1Z9bTUBvDDufoqTaQeI3A0Cxdsoj_D0IkxdWX-GB-RTQ
+    @_spi(StripeApplePayTokenization) public struct Token: UnknownFieldsDecodable {
+        public var _allResponseFieldsStorage: NonEncodableParameters?
 
         /// The value of the token. You can store this value on your server and use it to make charges and customers.
         /// - seealso: https://stripe.com/docs/payments/charges-api
-        let id: String
+        public let id: String
         /// Whether or not this token was created in livemode. Will be YES if you used your Live Publishable Key, and NO if you used your Test Publishable Key.
         var livemode: Bool
         /// The type of this token.

--- a/StripeApplePay/StripeApplePay/Source/PaymentsCore/API/Token+API.swift
+++ b/StripeApplePay/StripeApplePay/Source/PaymentsCore/API/Token+API.swift
@@ -15,17 +15,18 @@ extension StripeAPI.Token {
     /// - Parameters:
     ///   - token: The Stripe token from the response. Will be nil if an error occurs. - seealso: STPToken
     ///   - error: The error returned from the response, or nil if none occurs. - seealso: StripeError.h for possible values.
-    typealias TokenCompletionBlock = (Result<StripeAPI.Token, Error>) -> Void
+    @_spi(StripeApplePayTokenization) public typealias TokenCompletionBlock = (Result<StripeAPI.Token, Error>) -> Void
 
     /// Converts a PKPayment object into a Stripe token using the Stripe API.
     /// - Parameters:
     ///   - payment:     The user's encrypted payment information as returned from a PKPaymentAuthorizationController. Cannot be nil.
     ///   - completion:  The callback to run with the returned Stripe token (and any errors that may have occurred).
-    static func create(
+    @_spi(StripeApplePayTokenization) public static func create(
         apiClient: STPAPIClient = .shared,
         payment: PKPayment,
         completion: @escaping TokenCompletionBlock
     ) {
+        // Internal note: @_spi(StripeApplePayTokenization) is intended for limited public use. See https://docs.google.com/document/d/1Z9bTUBvDDufoqTaQeI3A0Cxdsoj_D0IkxdWX-GB-RTQ
         let params = payment.stp_tokenParameters(apiClient: apiClient)
         create(
             apiClient: apiClient,


### PR DESCRIPTION
## Summary
Expose StripeApplePay.createToken and Token API under `@_spi(StripeApplePayTokenization)`

## Motivation
https://docs.google.com/document/d/1Z9bTUBvDDufoqTaQeI3A0Cxdsoj_D0IkxdWX-GB-RTQ

## Testing
Manually tested, confirmed with user

## Changelog
We're not ready to make this generally available and are in direct contact with the user who needs this, so I won't note this in the changelog.