### PR TITLE
Adding support for custom saved PaymentMethod removal message

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewController.swift
@@ -402,7 +402,7 @@ extension CustomerSavedPaymentMethodsCollectionViewController: PaymentOptionCell
 
         let alertController = UIAlertController(
             title: paymentMethod.removalMessage.title,
-            message: self.savedPaymentMethodsConfiguration.removeSavedDialogBody != nil ? self.savedPaymentMethodsConfiguration.removeSavedDialogBody : paymentMethod.removalMessage.message,
+            message: self.savedPaymentMethodsConfiguration.removeSavedPaymentMethodMessage != nil ? self.savedPaymentMethodsConfiguration.removeSavedPaymentMethodMessage : paymentMethod.removalMessage.message,
             preferredStyle: .alert
         )
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewController.swift
@@ -402,7 +402,7 @@ extension CustomerSavedPaymentMethodsCollectionViewController: PaymentOptionCell
 
         let alertController = UIAlertController(
             title: paymentMethod.removalMessage.title,
-            message: paymentMethod.removalMessage.message,
+            message: self.savedPaymentMethodsConfiguration.removeSavedDialogBody != nil ? self.savedPaymentMethodsConfiguration.removeSavedDialogBody : paymentMethod.removalMessage.message,
             preferredStyle: .alert
         )
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetConfiguration.swift
@@ -57,7 +57,7 @@ extension CustomerSheet {
         public var billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration()
 
         /// Optional configuration to display a custom message when a saved payment method is removed.
-        public var removeSavedDialogBody: String?
+        public var removeSavedPaymentMethodMessage: String?
 
         public init () {
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetConfiguration.swift
@@ -56,6 +56,9 @@ extension CustomerSheet {
         /// you **must** provide an appropriate value as part of `defaultBillingDetails`.
         public var billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration()
 
+        /// Optional configuration to display a custom message when a saved payment method is removed.
+        public var removeSavedDialogBody: String?
+
         public init () {
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
@@ -165,7 +165,7 @@ extension PaymentSheet {
         public var billingDetailsCollectionConfiguration = BillingDetailsCollectionConfiguration()
 
         /// Optional configuration to display a custom message when a saved payment method is removed.
-        public var removeSavedDialogBody: String?
+        public var removeSavedPaymentMethodMessage: String?
     }
 
     /// Configuration related to the Stripe Customer

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
@@ -108,6 +108,7 @@ extension PaymentSheet {
         /// for payment and setup intents.
         public var primaryButtonLabel: String?
 
+        
         private var styleRawValue: Int = 0  // SheetStyle.automatic.rawValue
         /// The color styling to use for PaymentSheet UI
         /// Default value is SheetStyle.automatic
@@ -163,6 +164,8 @@ extension PaymentSheet {
         /// If `never` is used for a required field for the Payment Method used during checkout,
         /// you **must** provide an appropriate value as part of `defaultBillingDetails`.
         public var billingDetailsCollectionConfiguration = BillingDetailsCollectionConfiguration()
+        
+        public var removeSavedDialogBody: String?
     }
 
     /// Configuration related to the Stripe Customer

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
@@ -108,7 +108,6 @@ extension PaymentSheet {
         /// for payment and setup intents.
         public var primaryButtonLabel: String?
 
-        
         private var styleRawValue: Int = 0  // SheetStyle.automatic.rawValue
         /// The color styling to use for PaymentSheet UI
         /// Default value is SheetStyle.automatic
@@ -164,7 +163,7 @@ extension PaymentSheet {
         /// If `never` is used for a required field for the Payment Method used during checkout,
         /// you **must** provide an appropriate value as part of `defaultBillingDetails`.
         public var billingDetailsCollectionConfiguration = BillingDetailsCollectionConfiguration()
-        
+
         public var removeSavedDialogBody: String?
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
@@ -164,6 +164,7 @@ extension PaymentSheet {
         /// you **must** provide an appropriate value as part of `defaultBillingDetails`.
         public var billingDetailsCollectionConfiguration = BillingDetailsCollectionConfiguration()
 
+        /// Optional configuration to display a custom message when a saved payment method is removed.
         public var removeSavedDialogBody: String?
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
@@ -54,7 +54,7 @@ class SavedPaymentOptionsViewController: UIViewController {
         let customerID: String?
         let showApplePay: Bool
         let showLink: Bool
-        let removeSavedDialogBody: String?
+        let removeSavedPaymentMethodMessage: String?
 
         enum AutoSelectDefaultBehavior {
             /// will only autoselect default has been stored locally
@@ -380,7 +380,7 @@ extension SavedPaymentOptionsViewController: PaymentOptionCellDelegate {
 
         let alertController = UIAlertController(
             title: paymentMethod.removalMessage.title,
-            message: configuration.removeSavedDialogBody != nil ? configuration.removeSavedDialogBody : paymentMethod.removalMessage.message,
+            message: configuration.removeSavedPaymentMethodMessage != nil ? configuration.removeSavedPaymentMethodMessage : paymentMethod.removalMessage.message,
             preferredStyle: .alert
         )
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
@@ -55,17 +55,6 @@ class SavedPaymentOptionsViewController: UIViewController {
         let showApplePay: Bool
         let showLink: Bool
         let removeSavedPaymentMethodMessage: String?
-
-        enum AutoSelectDefaultBehavior {
-            /// will only autoselect default has been stored locally
-            case onlyIfMatched
-            /// will try to use locally stored default, or revert to first available
-            case defaultFirst
-            /// No auto selection
-            case none
-        }
-
-        let autoSelectDefaultBehavior: AutoSelectDefaultBehavior
     }
 
     var hasRemovablePaymentMethods: Bool {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
@@ -54,6 +54,7 @@ class SavedPaymentOptionsViewController: UIViewController {
         let customerID: String?
         let showApplePay: Bool
         let showLink: Bool
+        let removeSavedDialogBody: String?
 
         enum AutoSelectDefaultBehavior {
             /// will only autoselect default has been stored locally
@@ -379,7 +380,7 @@ extension SavedPaymentOptionsViewController: PaymentOptionCellDelegate {
 
         let alertController = UIAlertController(
             title: paymentMethod.removalMessage.title,
-            message: paymentMethod.removalMessage.message,
+            message: configuration.removeSavedDialogBody != nil ? configuration.removeSavedDialogBody : paymentMethod.removalMessage.message,
             preferredStyle: .alert
         )
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -157,6 +157,7 @@ class PaymentSheetFlowControllerViewController: UIViewController {
                 customerID: configuration.customer?.id,
                 showApplePay: isApplePayEnabled,
                 showLink: isLinkEnabled,
+                removeSavedDialogBody: configuration.removeSavedDialogBody,
                 autoSelectDefaultBehavior: intent.supportsLink ? .onlyIfMatched : .defaultFirst
             ),
             appearance: configuration.appearance

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -157,7 +157,7 @@ class PaymentSheetFlowControllerViewController: UIViewController {
                 customerID: configuration.customer?.id,
                 showApplePay: isApplePayEnabled,
                 showLink: isLinkEnabled,
-                removeSavedDialogBody: configuration.removeSavedDialogBody,
+                removeSavedPaymentMethodMessage: configuration.removeSavedPaymentMethodMessage,
                 autoSelectDefaultBehavior: intent.supportsLink ? .onlyIfMatched : .defaultFirst
             ),
             appearance: configuration.appearance

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -157,8 +157,7 @@ class PaymentSheetFlowControllerViewController: UIViewController {
                 customerID: configuration.customer?.id,
                 showApplePay: isApplePayEnabled,
                 showLink: isLinkEnabled,
-                removeSavedPaymentMethodMessage: configuration.removeSavedPaymentMethodMessage,
-                autoSelectDefaultBehavior: intent.supportsLink ? .onlyIfMatched : .defaultFirst
+                removeSavedPaymentMethodMessage: configuration.removeSavedPaymentMethodMessage
             ),
             appearance: configuration.appearance
         )

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -88,7 +88,7 @@ class PaymentSheetViewController: UIViewController {
                 customerID: configuration.customer?.id,
                 showApplePay: showApplePay,
                 showLink: showLink,
-                removeSavedDialogBody: configuration.removeSavedDialogBody,
+                removeSavedPaymentMethodMessage: configuration.removeSavedPaymentMethodMessage,
                 autoSelectDefaultBehavior: autoSelectsDefaultPaymentMethod ? .defaultFirst : .none
             ),
             appearance: configuration.appearance,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -88,8 +88,7 @@ class PaymentSheetViewController: UIViewController {
                 customerID: configuration.customer?.id,
                 showApplePay: showApplePay,
                 showLink: showLink,
-                removeSavedPaymentMethodMessage: configuration.removeSavedPaymentMethodMessage,
-                autoSelectDefaultBehavior: autoSelectsDefaultPaymentMethod ? .defaultFirst : .none
+                removeSavedPaymentMethodMessage: configuration.removeSavedPaymentMethodMessage
             ),
             appearance: configuration.appearance,
             delegate: self

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -88,6 +88,7 @@ class PaymentSheetViewController: UIViewController {
                 customerID: configuration.customer?.id,
                 showApplePay: showApplePay,
                 showLink: showLink,
+                removeSavedDialogBody: configuration.removeSavedDialogBody,
                 autoSelectDefaultBehavior: autoSelectsDefaultPaymentMethod ? .defaultFirst : .none
             ),
             appearance: configuration.appearance,


### PR DESCRIPTION
## Summary
I've added a new configuration `removeSavedPaymentMethodMessage` to PaymentSheet.Configuration and CustomerSheet.Configuration which allows for customization of the `message` of the UIAlertController when removing a saved Payment Method.

Default:
<img width="346" alt="CleanShot 2023-07-06 at 09 51 34@2x" src="https://github.com/stripe/stripe-ios/assets/95632492/7605df1b-12c8-4cda-8608-c3f03584633d">

Customized:
<img width="341" alt="CleanShot 2023-07-06 at 09 52 30@2x" src="https://github.com/stripe/stripe-ios/assets/95632492/cd063953-3668-4ccc-a815-394d2f993009">

## Motivation
With the Payment Element's release of saved payment methods, functionality was added to allow customization of the removal message, so I was porting some of that functionality to iOS.

## Testing
Executed on local machine

