### PR TITLE
Send network_type as metadata on analytics requests

### DIFF
--- a/Stripe/StripeiOSTests/STPAnalyticsClientPaymentSheetTest.swift
+++ b/Stripe/StripeiOSTests/STPAnalyticsClientPaymentSheetTest.swift
@@ -180,8 +180,9 @@ class STPAnalyticsClientPaymentSheetTest: XCTestCase {
         let payload = client.payload(from: analytic, apiClient: apiClient)
 
         // verify
-        XCTAssertEqual(15, payload.count)
+        XCTAssertEqual(16, payload.count)
         XCTAssertNotNil(payload["device_type"] as? String)
+        XCTAssertEqual("Wi-Fi", payload["network_type"] as? String)
         // In xctest, this is the version of Xcode
         XCTAssertNotNil(payload["app_version"] as? String)
         XCTAssertEqual("none", payload["ocr_type"] as? String)

--- a/Stripe/StripeiOSTests/STPAnalyticsClientPaymentsTest.swift
+++ b/Stripe/StripeiOSTests/STPAnalyticsClientPaymentsTest.swift
@@ -44,7 +44,7 @@ class STPAnalyticsClientPaymentsTest: XCTestCase {
         let mockAnalytic = MockAnalytic()
         let payload = client.payload(from: mockAnalytic)
 
-        XCTAssertEqual(payload.count, 13)
+        XCTAssertEqual(payload.count, 14)
 
         // Verify event name is included
         XCTAssertEqual(payload["event"] as? String, mockAnalytic.event.rawValue)

--- a/StripeCore/StripeCore/Source/Analytics/NetworkDetector.swift
+++ b/StripeCore/StripeCore/Source/Analytics/NetworkDetector.swift
@@ -5,13 +5,13 @@
 //  Created by Nick Porter on 7/5/23.
 //
 
+import CoreTelephony
 import Foundation
 import SystemConfiguration
-import CoreTelephony
 
 /// A class which can detect the current network type of the device
 class NetworkDetector {
-    
+
     static func getConnectionType() -> String? {
         guard let reachability = SCNetworkReachabilityCreateWithName(kCFAllocatorDefault, "www.stripe.com") else {
             return nil
@@ -26,11 +26,11 @@ class NetworkDetector {
         guard isReachable else {
             return nil
         }
-        
+
         guard isWWAN else {
             return "Wi-Fi"
         }
-        
+
         let networkInfo = CTTelephonyNetworkInfo()
         let carrierType = networkInfo.serviceCurrentRadioAccessTechnology
 
@@ -48,7 +48,7 @@ class NetworkDetector {
         default:
             return "5G"
         }
-        
+
     }
-    
+
 }

--- a/StripeCore/StripeCore/Source/Analytics/NetworkDetector.swift
+++ b/StripeCore/StripeCore/Source/Analytics/NetworkDetector.swift
@@ -1,0 +1,54 @@
+//
+//  NetworkDetector.swift
+//  StripeCore
+//
+//  Created by Nick Porter on 7/5/23.
+//
+
+import Foundation
+import SystemConfiguration
+import CoreTelephony
+
+/// A class which can detect the current network type of the device
+class NetworkDetector {
+    
+    static func getConnectionType() -> String? {
+        guard let reachability = SCNetworkReachabilityCreateWithName(kCFAllocatorDefault, "www.stripe.com") else {
+            return nil
+        }
+
+        var flags = SCNetworkReachabilityFlags()
+        SCNetworkReachabilityGetFlags(reachability, &flags)
+
+        let isReachable = flags.contains(.reachable)
+        let isWWAN = flags.contains(.isWWAN)
+
+        guard isReachable else {
+            return nil
+        }
+        
+        guard isWWAN else {
+            return "Wi-Fi"
+        }
+        
+        let networkInfo = CTTelephonyNetworkInfo()
+        let carrierType = networkInfo.serviceCurrentRadioAccessTechnology
+
+        guard let carrierTypeName = carrierType?.first?.value else {
+            return "unknown"
+        }
+
+        switch carrierTypeName {
+        case CTRadioAccessTechnologyGPRS, CTRadioAccessTechnologyEdge, CTRadioAccessTechnologyCDMA1x:
+            return "2G"
+        case CTRadioAccessTechnologyWCDMA, CTRadioAccessTechnologyHSDPA, CTRadioAccessTechnologyHSUPA, CTRadioAccessTechnologyCDMAEVDORev0, CTRadioAccessTechnologyCDMAEVDORevA, CTRadioAccessTechnologyCDMAEVDORevB, CTRadioAccessTechnologyeHRPD:
+            return "3G"
+        case CTRadioAccessTechnologyLTE:
+            return "4G"
+        default:
+            return "5G"
+        }
+        
+    }
+    
+}

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticsClient.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticsClient.swift
@@ -144,6 +144,7 @@ extension STPAnalyticsClient {
         payload["app_name"] = Bundle.stp_applicationName() ?? ""
         payload["app_version"] = Bundle.stp_applicationVersion() ?? ""
         payload["plugin_type"] = PluginDetector.shared.pluginType?.rawValue
+        payload["network_type"] = NetworkDetector.getConnectionType()
         payload["install"] = InstallMethod.current.rawValue
         payload["publishable_key"] = apiClient.sanitizedPublishableKey ?? "unknown"
 


### PR DESCRIPTION
## Summary
- Adds `network_type` as metadata to our analytics requests.

## Motivation
https://docs.google.com/document/d/1yr8IILZuOr860nFgLoeT53IlTqAKThmbKgo37Z0iUvY/edit
## Testing
Manually tested Wi-Fi, 4G, and 5G on my physical device.

## Changelog
N/A
