### PR TITLE
Remove checks that prevents ApplePay to onboard new users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## X.Y.Z 2023-XX-YY
+### Apple Pay
+* [Fixed] ApplePay sheet prompts the user to add a card if none is registered.
 ### Payments
 * [Fixed] A bug where `mandate_data` was not being properly attached to PayPal SetupIntent's.
 ### PaymentSheet

--- a/StripeApplePay/StripeApplePay/Source/ApplePayContext/STPApplePayContext.swift
+++ b/StripeApplePay/StripeApplePay/Source/ApplePayContext/STPApplePayContext.swift
@@ -107,7 +107,11 @@ public class STPApplePayContext: NSObject, PKPaymentAuthorizationControllerDeleg
         delegate: _stpinternal_STPApplePayContextDelegateBase?
     ) {
         STPAnalyticsClient.sharedClient.addClass(toProductUsageIfNecessary: STPApplePayContext.self)
-        if !StripeAPI.canSubmitPaymentRequest(paymentRequest) {
+        if paymentRequest.merchantIdentifier.isEmpty {
+            return nil
+        }
+        // "In versions of iOS prior to version 12.0 and watchOS prior to version 5.0, the amount of the grand total must be greater than zero."
+        if !(paymentRequest.paymentSummaryItems.last?.amount.floatValue ?? 0.0 >= 0) {
             return nil
         }
 


### PR DESCRIPTION
## Summary
Changed a simple check in the conditional initialiser of STPApplePayContext.

## Motivation
Whenever the user does not have a card registered for ApplePay, the conditional initialiser fails, causing no ApplePay sheet to be presented. ApplePay sheet does support a built-in onboarding flow to invite the user to add a new card. 

## Testing
I have removed all the cards saved in my phone and made a payment. The sheet appears as expected, prompting the user to add a new card, once the card has been added, the user can confirm the payment without ever leaving the sheet. Once the payment has been confirmed, the flow resumes as normal.

## Changelog
    - [Fixed] ApplePay sheet prompts the user to add a card if none is registered.
