### PR TITLE
Refactor confirm in customersheet to async/await

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsViewController.swift
@@ -427,6 +427,7 @@ class CustomerSavedPaymentMethodsViewController: UIViewController {
             self.savedPaymentOptionsViewController.didAddSavedPaymentMethod(paymentMethod: paymentMethod)
             self.mode = .selectingSaved
             self.updateUI(animated: true)
+            self.reinitAddPaymentMethodViewController()
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsViewController.swift
@@ -423,21 +423,10 @@ class CustomerSavedPaymentMethodsViewController: UIViewController {
                 self.updateUI()
                 return
             }
-            let paymentOptionSelection = CustomerSheet.PaymentOptionSelection.paymentMethod(paymentMethod)
-            self.setSelectablePaymentMethod(paymentOptionSelection: paymentOptionSelection) { error in
-                STPAnalyticsClient.sharedClient.logCSAddPaymentMethodViaSetupIntentFailure()
-                self.processingInFlight = false
-                self.error = error
-                self.updateUI()
-            } onSuccess: {
-                STPAnalyticsClient.sharedClient.logCSAddPaymentMethodViaSetupIntentSuccess()
-                self.processingInFlight = false
-                self.actionButton.update(state: .disabled, animated: true) {
-                    self.delegate?.savedPaymentMethodsViewControllerDidFinish(self) {
-                        self.csCompletion?(.selected(paymentOptionSelection))
-                    }
-                }
-            }
+            self.processingInFlight = false
+            self.savedPaymentOptionsViewController.didAddSavedPaymentMethod(paymentMethod: paymentMethod)
+            self.mode = .selectingSaved
+            self.updateUI(animated: true)
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsViewController.swift
@@ -423,7 +423,7 @@ class CustomerSavedPaymentMethodsViewController: UIViewController {
                 self.updateUI()
                 return
             }
-            let paymentOptionSelection = CustomerSheet.PaymentOptionSelection.newPaymentMethod(paymentMethod)
+            let paymentOptionSelection = CustomerSheet.PaymentOptionSelection.paymentMethod(paymentMethod)
             self.setSelectablePaymentMethod(paymentOptionSelection: paymentOptionSelection) { error in
                 STPAnalyticsClient.sharedClient.logCSAddPaymentMethodViaSetupIntentFailure()
                 self.processingInFlight = false


### PR DESCRIPTION
## Summary
Refactor addPaymentOption/confirm in CustomerSavedPaymentMethodsViewController to use async/await

In attempts to break up the PR, this is a follow on PR to: https://github.com/stripe/stripe-ios/pull/2726

## Motivation
Attempting to split up PR into multiple pieces to make it easier to read

## Testing
Will be included in the over-arching PR
