### PR TITLE
Remove PaymentSheetError.unknown usage

### DIFF
--- a/Stripe/StripeiOSTests/Error+PaymentSheetTests.swift
+++ b/Stripe/StripeiOSTests/Error+PaymentSheetTests.swift
@@ -30,7 +30,7 @@ class Error_PaymentSheetTests: XCTestCase {
     func testPaymentSheetError_UsesDebubDescription() {
         let error = PaymentSheetError.unknown(debugDescription: "Test debugDescription")
 
-        XCTAssertEqual("An error occured in PaymentSheet. Test debugDescription", error.nonGenericDescription)
+        XCTAssertEqual("An unknown error occurred in PaymentSheet. Test debugDescription", error.nonGenericDescription)
     }
 
     func testError_HasGenericLocalizedDescription_NoSeverError() {

--- a/Stripe/StripeiOSTests/PaymentSheet+APITest.swift
+++ b/Stripe/StripeiOSTests/PaymentSheet+APITest.swift
@@ -657,7 +657,7 @@ class PaymentSheetAPITest: XCTestCase {
                 XCTFail()
                 return
             }
-            XCTAssertEqual((error as CustomDebugStringConvertible).debugDescription, "An unknown error occurred in PaymentSheet. Your PaymentIntent currency (GBP) does not match the PaymentSheet.IntentConfiguration currency (USD).")
+            XCTAssertEqual((error as CustomDebugStringConvertible).debugDescription, "An error occurred in PaymentSheet. Your PaymentIntent currency (GBP) does not match the PaymentSheet.IntentConfiguration currency (USD).")
         }
         waitForExpectations(timeout: 10)
     }
@@ -713,7 +713,7 @@ class PaymentSheetAPITest: XCTestCase {
                 XCTFail()
                 return
             }
-            XCTAssertEqual((error as CustomDebugStringConvertible).debugDescription, "An unknown error occurred in PaymentSheet. Your SetupIntent usage (onSession) does not match the PaymentSheet.IntentConfiguration setupFutureUsage (offSession).")
+            XCTAssertEqual((error as CustomDebugStringConvertible).debugDescription, "An error occurred in PaymentSheet. Your SetupIntent usage (onSession) does not match the PaymentSheet.IntentConfiguration setupFutureUsage (offSession).")
         }
         waitForExpectations(timeout: 10)
     }

--- a/Stripe/StripeiOSTests/PaymentSheet+APITest.swift
+++ b/Stripe/StripeiOSTests/PaymentSheet+APITest.swift
@@ -657,7 +657,7 @@ class PaymentSheetAPITest: XCTestCase {
                 XCTFail()
                 return
             }
-            XCTAssertEqual((error as CustomDebugStringConvertible).debugDescription, "An error occured in PaymentSheet. Your PaymentIntent currency (GBP) does not match the PaymentSheet.IntentConfiguration currency (USD).")
+            XCTAssertEqual((error as CustomDebugStringConvertible).debugDescription, "An unknown error occurred in PaymentSheet. Your PaymentIntent currency (GBP) does not match the PaymentSheet.IntentConfiguration currency (USD).")
         }
         waitForExpectations(timeout: 10)
     }
@@ -713,7 +713,7 @@ class PaymentSheetAPITest: XCTestCase {
                 XCTFail()
                 return
             }
-            XCTAssertEqual((error as CustomDebugStringConvertible).debugDescription, "An error occured in PaymentSheet. Your SetupIntent usage (onSession) does not match the PaymentSheet.IntentConfiguration setupFutureUsage (offSession).")
+            XCTAssertEqual((error as CustomDebugStringConvertible).debugDescription, "An unknown error occurred in PaymentSheet. Your SetupIntent usage (onSession) does not match the PaymentSheet.IntentConfiguration setupFutureUsage (offSession).")
         }
         waitForExpectations(timeout: 10)
     }

--- a/Stripe/StripeiOSTests/PaymentSheetDeferredValidatorTests.swift
+++ b/Stripe/StripeiOSTests/PaymentSheetDeferredValidatorTests.swift
@@ -17,12 +17,12 @@ final class PaymentSheetDeferredValidatorTests: XCTestCase {
         XCTAssertThrowsError(try PaymentSheetDeferredValidator.validate(paymentIntent: pi,
                                                                         intentConfiguration: intentConfig_si,
                                                                         isFlowController: false)) { error in
-            XCTAssertEqual("\(error)", "An error occured in PaymentSheet. You returned a PaymentIntent client secret but used a PaymentSheet.IntentConfiguration in setup mode.")
+            XCTAssertEqual("\(error)", "An error occurred in PaymentSheet. You returned a PaymentIntent client secret but used a PaymentSheet.IntentConfiguration in setup mode.")
         }
         let si = STPFixtures.makeSetupIntent()
         let intentConfig_pi = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1080, currency: "USD"), confirmHandler: confirmHandler)
         XCTAssertThrowsError(try PaymentSheetDeferredValidator.validate(setupIntent: si, intentConfiguration: intentConfig_pi)) { error in
-            XCTAssertEqual("\(error)", "An error occured in PaymentSheet. You returned a SetupIntent client secret but used a PaymentSheet.IntentConfiguration in payment mode.")
+            XCTAssertEqual("\(error)", "An error occurred in PaymentSheet. You returned a SetupIntent client secret but used a PaymentSheet.IntentConfiguration in payment mode.")
         }
     }
 
@@ -32,7 +32,7 @@ final class PaymentSheetDeferredValidatorTests: XCTestCase {
         XCTAssertThrowsError(try PaymentSheetDeferredValidator.validate(paymentIntent: pi,
                                                                         intentConfiguration: intentConfig,
                                                                         isFlowController: false)) { error in
-            XCTAssertEqual("\(error)", "An error occured in PaymentSheet. Your PaymentIntent currency (GBP) does not match the PaymentSheet.IntentConfiguration currency (USD).")
+            XCTAssertEqual("\(error)", "An error occurred in PaymentSheet. Your PaymentIntent currency (GBP) does not match the PaymentSheet.IntentConfiguration currency (USD).")
         }
     }
 
@@ -42,7 +42,7 @@ final class PaymentSheetDeferredValidatorTests: XCTestCase {
         XCTAssertThrowsError(try PaymentSheetDeferredValidator.validate(paymentIntent: pi,
                                                                         intentConfiguration: intentConfig,
                                                                         isFlowController: false)) { error in
-            XCTAssertEqual("\(error)", "An error occured in PaymentSheet. Your PaymentIntent setupFutureUsage (offSession) does not match the PaymentSheet.IntentConfiguration setupFutureUsage (nil).")
+            XCTAssertEqual("\(error)", "An error occurred in PaymentSheet. Your PaymentIntent setupFutureUsage (offSession) does not match the PaymentSheet.IntentConfiguration setupFutureUsage (nil).")
         }
     }
 
@@ -52,7 +52,7 @@ final class PaymentSheetDeferredValidatorTests: XCTestCase {
         XCTAssertThrowsError(try PaymentSheetDeferredValidator.validate(paymentIntent: pi,
                                                                         intentConfiguration: intentConfig,
                                                                         isFlowController: false)) { error in
-            XCTAssertEqual("\(error)", "An error occured in PaymentSheet. Your PaymentIntent captureMethod (manual) does not match the PaymentSheet.IntentConfiguration amount (automatic).")
+            XCTAssertEqual("\(error)", "An error occurred in PaymentSheet. Your PaymentIntent captureMethod (manual) does not match the PaymentSheet.IntentConfiguration amount (automatic).")
         }
     }
 
@@ -62,7 +62,7 @@ final class PaymentSheetDeferredValidatorTests: XCTestCase {
         XCTAssertThrowsError(try PaymentSheetDeferredValidator.validate(paymentIntent: pi,
                                                                         intentConfiguration: intentConfig,
                                                                         isFlowController: false)) { error in
-             XCTAssertEqual("\(error)", "An error occured in PaymentSheet. Your PaymentIntent confirmationMethod (manual) can only be used with PaymentSheet.FlowController.")
+             XCTAssertEqual("\(error)", "An error occurred in PaymentSheet. Your PaymentIntent confirmationMethod (manual) can only be used with PaymentSheet.FlowController.")
          }
      }
 
@@ -70,7 +70,7 @@ final class PaymentSheetDeferredValidatorTests: XCTestCase {
         let si = STPFixtures.makeSetupIntent(usage: "on_session")
         let intentConfig = PaymentSheet.IntentConfiguration(mode: .setup(currency: "USD", setupFutureUsage: .offSession), confirmHandler: confirmHandler)
         XCTAssertThrowsError(try PaymentSheetDeferredValidator.validate(setupIntent: si, intentConfiguration: intentConfig)) { error in
-            XCTAssertEqual("\(error)", "An error occured in PaymentSheet. Your SetupIntent usage (onSession) does not match the PaymentSheet.IntentConfiguration setupFutureUsage (offSession).")
+            XCTAssertEqual("\(error)", "An error occurred in PaymentSheet. Your SetupIntent usage (onSession) does not match the PaymentSheet.IntentConfiguration setupFutureUsage (offSession).")
         }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
@@ -121,7 +121,7 @@ class PaymentSheetLinkAccount: PaymentSheetLinkAccountInfoProtocol {
             DispatchQueue.main.async {
                 completion(
                     .failure(
-                        PaymentSheetError.unknown(debugDescription: "Don't call sign up if not needed")
+                        PaymentSheetError.linkSignUpNotRequired
                     )
                 )
             }
@@ -162,7 +162,7 @@ class PaymentSheetLinkAccount: PaymentSheetLinkAccountInfoProtocol {
             DispatchQueue.main.async {
                 completion(
                     .failure(
-                        PaymentSheetError.unknown(debugDescription: "Don't call verify if not needed")
+                        PaymentSheetError.linkCallVerifyNotRequired
                     )
                 )
             }
@@ -193,7 +193,7 @@ class PaymentSheetLinkAccount: PaymentSheetLinkAccountInfoProtocol {
             DispatchQueue.main.async {
                 completion(
                     .failure(
-                        PaymentSheetError.unknown(debugDescription: "Don't call verify if not needed")
+                        PaymentSheetError.linkCallVerifyNotRequired
                     )
                 )
             }
@@ -223,9 +223,7 @@ class PaymentSheetLinkAccount: PaymentSheetLinkAccountInfoProtocol {
             assertionFailure()
             completion(
                 .failure(
-                    PaymentSheetError.unknown(
-                        debugDescription: "Linking account session without valid consumer session"
-                    )
+                    PaymentSheetError.linkingWithoutValidSession
                 )
             )
             return
@@ -246,7 +244,7 @@ class PaymentSheetLinkAccount: PaymentSheetLinkAccountInfoProtocol {
         guard let session = currentSession else {
             assertionFailure()
             completion(
-                .failure(PaymentSheetError.unknown(debugDescription: "Saving to Link without valid session"))
+                .failure(PaymentSheetError.savingWithoutValidLinkSession)
             )
             return
         }
@@ -267,7 +265,7 @@ class PaymentSheetLinkAccount: PaymentSheetLinkAccountInfoProtocol {
     ) {
         guard let session = currentSession else {
             assertionFailure()
-            completion(.failure(PaymentSheetError.unknown(debugDescription: "Saving to Link without valid session")))
+            completion(.failure(PaymentSheetError.savingWithoutValidLinkSession))
             return
         }
         retryingOnAuthError(completion: completion) { [publishableKey] completionWrapper in
@@ -284,7 +282,7 @@ class PaymentSheetLinkAccount: PaymentSheetLinkAccountInfoProtocol {
     ) {
         guard let session = currentSession else {
             assertionFailure()
-            completion(.failure(PaymentSheetError.unknown(debugDescription: "Paying with Link without valid session")))
+            completion(.failure(PaymentSheetError.payingWithoutValidLinkSession))
             return
         }
 
@@ -302,9 +300,7 @@ class PaymentSheetLinkAccount: PaymentSheetLinkAccountInfoProtocol {
             assertionFailure()
             return completion(
                 .failure(
-                    PaymentSheetError.unknown(
-                        debugDescription: "Deleting Link payment details without valid session"
-                    )
+                    PaymentSheetError.deletingWithoutValidLinkSession
                 )
             )
         }
@@ -328,9 +324,7 @@ class PaymentSheetLinkAccount: PaymentSheetLinkAccountInfoProtocol {
             assertionFailure()
             return completion(
                 .failure(
-                    PaymentSheetError.unknown(
-                        debugDescription: "Updating Link payment details without valid session"
-                    )
+                    PaymentSheetError.updatingWithoutValidLinkSession
                 )
             )
         }
@@ -444,13 +438,13 @@ private extension PaymentSheetLinkAccount {
                     self?.currentSession = session.consumerSession
                     self?.publishableKey = session.publishableKey
                     completion(.success(()))
-                case .notFound(let errorMessage):
+                case .notFound:
                     completion(
-                        .failure(PaymentSheetError.unknown(debugDescription: errorMessage))
+                        .failure(PaymentSheetError.linkLookupNotFound)
                     )
                 case .noAvailableLookupParams:
                     completion(
-                        .failure(PaymentSheetError.unknown(debugDescription: "The client secret is missing"))
+                        .failure(PaymentSheetError.missingClientSecret)
                     )
                 }
             case .failure(let error):

--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
@@ -438,9 +438,9 @@ private extension PaymentSheetLinkAccount {
                     self?.currentSession = session.consumerSession
                     self?.publishableKey = session.publishableKey
                     completion(.success(()))
-                case .notFound:
+                case .notFound(let message):
                     completion(
-                        .failure(PaymentSheetError.linkLookupNotFound)
+                        .failure(PaymentSheetError.linkLookupNotFound(serverErrorMessage: message))
                     )
                 case .noAvailableLookupParams:
                     completion(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerAdapter/CustomerAdapter.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerAdapter/CustomerAdapter.swift
@@ -191,10 +191,7 @@ import UIKit
 
     open func setupIntentClientSecretForCustomerAttach() async throws -> String {
         guard let setupIntentClientSecretProvider = setupIntentClientSecretProvider else {
-//            TODO
-            throw PaymentSheetError.missingClientSecret
-
-//            throw PaymentSheetError.unknown(debugDescription: "setupIntentClientSecretForCustomerAttach, but setupIntentClientSecretProvider is nil") // TODO: This is a programming error, setupIntentClientSecretForCustomerAttach should not be called if canCreateSetupIntents is false
+            throw PaymentSheetError.setupIntentClientSecretProviderNil // TODO: This is a programming error, setupIntentClientSecretForCustomerAttach should not be called if canCreateSetupIntents is false
         }
         return try await setupIntentClientSecretProvider()
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerAdapter/CustomerAdapter.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerAdapter/CustomerAdapter.swift
@@ -142,7 +142,7 @@ import UIKit
                 types: savedPaymentMethodTypes
             ) { paymentMethods, error in
                 guard let paymentMethods = paymentMethods, error == nil else {
-                    let error = error ?? PaymentSheetError.unknown(debugDescription: "Unexpected response from Stripe API.") // TODO: make a better default error
+                    let error = error ?? PaymentSheetError.unexpectedResponseFromStripeAPI // TODO: make a better default error
                     continuation.resume(throwing: error)
                     return
                 }
@@ -191,7 +191,10 @@ import UIKit
 
     open func setupIntentClientSecretForCustomerAttach() async throws -> String {
         guard let setupIntentClientSecretProvider = setupIntentClientSecretProvider else {
-            throw PaymentSheetError.unknown(debugDescription: "setupIntentClientSecretForCustomerAttach, but setupIntentClientSecretProvider is nil") // TODO: This is a programming error, setupIntentClientSecretForCustomerAttach should not be called if canCreateSetupIntents is false
+//            TODO
+            throw PaymentSheetError.missingClientSecret
+
+//            throw PaymentSheetError.unknown(debugDescription: "setupIntentClientSecretForCustomerAttach, but setupIntentClientSecretProvider is nil") // TODO: This is a programming error, setupIntentClientSecretForCustomerAttach should not be called if canCreateSetupIntents is false
         }
         return try await setupIntentClientSecretProvider()
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkPaymentController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkPaymentController.swift
@@ -142,7 +142,7 @@ import UIKit
             switch mode {
             case .paymentIntentClientSecret(let clientSecret):
                 guard let paymentIntentId = STPPaymentIntent.id(fromClientSecret: clientSecret) else {
-                    continuation.resume(throwing: PaymentSheetError.unknown(debugDescription: "Invalid client secret"))
+                    continuation.resume(throwing: PaymentSheetError.invalidClientSecret)
                     return
                 }
                 apiClient.createLinkAccountSession(paymentIntentID: paymentIntentId,
@@ -155,7 +155,7 @@ import UIKit
                 }
             case .setupIntentClientSecret(let clientSecret):
                 guard let setupIntentId = STPSetupIntent.id(fromClientSecret: clientSecret) else {
-                    continuation.resume(throwing: PaymentSheetError.unknown(debugDescription: "Invalid client secret"))
+                    continuation.resume(throwing: PaymentSheetError.invalidClientSecret)
                     return
                 }
                 apiClient.createLinkAccountSession(setupIntentID: setupIntentId,
@@ -225,7 +225,7 @@ import UIKit
         }
 
         guard let linkAccountSession = linkAccountSession else {
-            continuation.resume(throwing: PaymentSheetError.unknown(debugDescription: "Failed to create link account session"))
+            continuation.resume(throwing: PaymentSheetError.failedToCreateLinkSession)
             return
         }
 
@@ -270,7 +270,7 @@ import UIKit
     @_spi(LinkOnly) public func confirm(from presentingViewController: UIViewController) async throws {
         guard let paymentMethodId = paymentMethodId else {
             assertionFailure("`confirm` should not be called without the customer authorizing Link. Make sure to call `present` first if your customer hasn't previously selected Link as a payment method.")
-            throw PaymentSheetError.unknown(debugDescription: "confirm called without authorizing Link")
+            throw PaymentSheetError.linkNotAuthorized
         }
         let authenticationContext = AuthenticationContext(presentingViewController: presentingViewController, appearance: .default)
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Swift.Error>) in

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
@@ -324,11 +324,7 @@ class AddPaymentMethodViewController: UIViewController {
             email: email
         )
         let client = STPBankAccountCollector()
-        let errorText = STPLocalizedString(
-            "Something went wrong when linking your account.\nPlease try again later.",
-            "Error message when an error case happens when linking your account"
-        )
-        let genericError = PaymentSheetError.unknown(debugDescription: errorText)
+        let genericError = PaymentSheetError.accountLinkFailure
 
         let financialConnectionsCompletion: (FinancialConnectionsSDKResult?, LinkAccountSession?, NSError?) -> Void = {
             result,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -43,8 +43,8 @@ extension PaymentSheet {
                     completion: completion
                 )
             else {
-                assertionFailure(PaymentSheetError.applePayNotSupported.debugDescription)
-                completion(.failed(error: PaymentSheetError.applePayNotSupported))
+                assertionFailure(PaymentSheetError.applePayNotSupportedOrMisconfigured.debugDescription)
+                completion(.failed(error: PaymentSheetError.applePayNotSupportedOrMisconfigured))
                 return
             }
             applePayContext.presentApplePay()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -43,10 +43,8 @@ extension PaymentSheet {
                     completion: completion
                 )
             else {
-                let message =
-                    "Attempted Apple Pay but it's not supported by the device, not configured, or missing a presenter"
-                assertionFailure(message)
-                completion(.failed(error: PaymentSheetError.unknown(debugDescription: message)))
+                assertionFailure(PaymentSheetError.applePayNotSupported.debugDescription)
+                completion(.failed(error: PaymentSheetError.applePayNotSupported))
                 return
             }
             applePayContext.presentApplePay()
@@ -254,9 +252,7 @@ extension PaymentSheet {
                     ConsumerPaymentDetails
                 ) -> Void = { linkAccount, paymentDetails in
                     guard let paymentMethodParams = linkAccount.makePaymentMethodParams(from: paymentDetails) else {
-                        let error = PaymentSheetError.unknown(
-                            debugDescription: "Paying with Link without valid session"
-                        )
+                        let error = PaymentSheetError.payingWithoutValidLinkSession
                         completion(.failed(error: error))
                         return
                     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+DeferredAPI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+DeferredAPI.swift
@@ -123,10 +123,10 @@ extension PaymentSheet {
         case .canceled:
             return .canceled
         case .failed:
-            let error = error ?? PaymentSheetError.unknown(debugDescription: "Unknown error occured while handling intent next action")
+            let error = error ?? PaymentSheetError.errorHandlingNextAction
             return .failed(error: error)
         @unknown default:
-            return .failed(error: PaymentSheetError.unknown(debugDescription: "Unrecognized STPPaymentHandlerActionStatus status"))
+            return .failed(error: PaymentSheetError.unrecognizedHandlerStatus)
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
@@ -122,10 +122,8 @@ public class PaymentSheet {
 
         // Guard against basic user error
         guard presentingViewController.presentedViewController == nil else {
-            assertionFailure("presentingViewController is already presenting a view controller")
-            let error = PaymentSheetError.unknown(
-                debugDescription: "presentingViewController is already presenting a view controller"
-            )
+            assertionFailure(PaymentSheetError.alreadyPresented.debugDescription)
+            let error = PaymentSheetError.alreadyPresented
             completion(.failed(error: error))
             return
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetDeferredValidator.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetDeferredValidator.swift
@@ -14,16 +14,16 @@ struct PaymentSheetDeferredValidator {
                          intentConfiguration: PaymentSheet.IntentConfiguration,
                          isFlowController: Bool) throws {
         guard case let .payment(_, currency, setupFutureUsage, captureMethod) = intentConfiguration.mode else {
-            throw PaymentSheetError.unknown(debugDescription: "You returned a PaymentIntent client secret but used a PaymentSheet.IntentConfiguration in setup mode.")
+            throw PaymentSheetError.deferredIntentValidationFailed(message: "You returned a PaymentIntent client secret but used a PaymentSheet.IntentConfiguration in setup mode.")
         }
         guard paymentIntent.currency.uppercased() == currency.uppercased() else {
-            throw PaymentSheetError.unknown(debugDescription: "Your PaymentIntent currency (\(paymentIntent.currency.uppercased())) does not match the PaymentSheet.IntentConfiguration currency (\(currency.uppercased())).")
+            throw PaymentSheetError.deferredIntentValidationFailed(message: "Your PaymentIntent currency (\(paymentIntent.currency.uppercased())) does not match the PaymentSheet.IntentConfiguration currency (\(currency.uppercased())).")
         }
         guard paymentIntent.setupFutureUsage == setupFutureUsage else {
-            throw PaymentSheetError.unknown(debugDescription: "Your PaymentIntent setupFutureUsage (\(paymentIntent.setupFutureUsage)) does not match the PaymentSheet.IntentConfiguration setupFutureUsage (\(String(describing: setupFutureUsage))).")
+            throw PaymentSheetError.deferredIntentValidationFailed(message: "Your PaymentIntent setupFutureUsage (\(paymentIntent.setupFutureUsage)) does not match the PaymentSheet.IntentConfiguration setupFutureUsage (\(String(describing: setupFutureUsage))).")
         }
         guard paymentIntent.captureMethod == captureMethod else {
-            throw PaymentSheetError.unknown(debugDescription: "Your PaymentIntent captureMethod (\(paymentIntent.captureMethod)) does not match the PaymentSheet.IntentConfiguration amount (\(captureMethod)).")
+            throw PaymentSheetError.deferredIntentValidationFailed(message: "Your PaymentIntent captureMethod (\(paymentIntent.captureMethod)) does not match the PaymentSheet.IntentConfiguration amount (\(captureMethod)).")
         }
 
         /*
@@ -31,17 +31,17 @@ struct PaymentSheetDeferredValidator {
          Showing a successful payment in the complete flow may be misleading when merchants still need to do a final confirmation which could fail e.g., bad network
          */
         if !isFlowController && paymentIntent.confirmationMethod == .manual {
-            throw PaymentSheetError.unknown(debugDescription: "Your PaymentIntent confirmationMethod (\(paymentIntent.confirmationMethod)) can only be used with PaymentSheet.FlowController.")
+            throw PaymentSheetError.deferredIntentValidationFailed(message: "Your PaymentIntent confirmationMethod (\(paymentIntent.confirmationMethod)) can only be used with PaymentSheet.FlowController.")
         }
     }
 
     static func validate(setupIntent: STPSetupIntent,
                          intentConfiguration: PaymentSheet.IntentConfiguration) throws {
         guard case let .setup(_, setupFutureUsage) = intentConfiguration.mode else {
-            throw PaymentSheetError.unknown(debugDescription: "You returned a SetupIntent client secret but used a PaymentSheet.IntentConfiguration in payment mode.")
+            throw PaymentSheetError.deferredIntentValidationFailed(message: "You returned a SetupIntent client secret but used a PaymentSheet.IntentConfiguration in payment mode.")
         }
         guard setupIntent.usage == setupFutureUsage else {
-            throw PaymentSheetError.unknown(debugDescription: "Your SetupIntent usage (\(setupIntent.usage)) does not match the PaymentSheet.IntentConfiguration setupFutureUsage (\(String(describing: setupFutureUsage))).")
+            throw PaymentSheetError.deferredIntentValidationFailed(message: "Your SetupIntent usage (\(setupIntent.usage)) does not match the PaymentSheet.IntentConfiguration setupFutureUsage (\(String(describing: setupFutureUsage))).")
         }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetError.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetError.swift
@@ -23,7 +23,7 @@ public enum PaymentSheetError: Error {
     case missingClientSecret
     case invalidClientSecret
     case unexpectedResponseFromStripeAPI
-    case applePayNotSupported
+    case applePayNotSupportedOrMisconfigured
     case alreadyPresented
     case flowControllerConfirmFailed(message: String)
     case errorHandlingNextAction
@@ -49,7 +49,7 @@ public enum PaymentSheetError: Error {
     case payingWithoutValidLinkSession
     case deletingWithoutValidLinkSession
     case updatingWithoutValidLinkSession
-    case linkLookupNotFound
+    case linkLookupNotFound(serverErrorMessage: String)
     case failedToCreateLinkSession
     case linkNotAuthorized
 
@@ -73,7 +73,7 @@ extension PaymentSheetError: CustomDebugStringConvertible {
             return "The client secret is missing"
         case .unexpectedResponseFromStripeAPI:
             return "Unexpected response from Stripe API."
-        case .applePayNotSupported:
+        case .applePayNotSupportedOrMisconfigured:
             return "Attempted Apple Pay but it's not supported by the device, not configured, or missing a presenter"
         case .deferredIntentValidationFailed(message: let message):
             return message
@@ -130,10 +130,12 @@ extension PaymentSheetError: CustomDebugStringConvertible {
     /// A description logged to a developer for debugging
     public var debugDescription: String {
         switch self {
-        case .unknown(debugDescription: let debugDescription):
-            return "An error occured in PaymentSheet. " + debugDescription
+        case .unknown(debugDescription: let message):
+            return "An unknown error occurred in PaymentSheet. " + message
+        case .linkLookupNotFound(serverErrorMessage: let message):
+            return "An error occurred in PaymentSheet. " + message
         default:
-            return "An error occured in PaymentSheet. " + safeLoggingString
+            return "An error occurred in PaymentSheet. " + safeLoggingString
         }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetError.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetError.swift
@@ -82,8 +82,6 @@ extension PaymentSheetError: CustomDebugStringConvertible {
             return "Unrecognized STPPaymentHandlerActionStatus status"
         case .invalidClientSecret:
             return "Invalid client secret"
-        case .failedToCreateLinkSession:
-            return "Failed to create Link account session"
         case .accountLinkFailure:
             return STPLocalizedString(
                 "Something went wrong when linking your account.\nPlease try again later.",
@@ -113,6 +111,8 @@ extension PaymentSheetError: CustomDebugStringConvertible {
             return "Updating Link payment details without valid session"
         case .linkLookupNotFound:
             return "Link account not found"
+        case .failedToCreateLinkSession:
+            return "Failed to create Link account session"
         case .linkNotAuthorized:
             return "confirm called without authorizing Link"
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetError.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetError.swift
@@ -15,7 +15,7 @@ import StripePayments
 /// Most errors do not originate from PaymentSheet itself; instead, they come from the Stripe API
 /// or other SDK components like STPPaymentHandler, PassKit (Apple Pay), etc.
 public enum PaymentSheetError: Error {
-    
+
     /// An unknown error.
     case unknown(debugDescription: String)
 
@@ -64,7 +64,7 @@ extension PaymentSheetError: CustomDebugStringConvertible {
         // TODO: Expired ephemeral key
         return false
     }
-    
+
     /// A string that can safley be logged to our analytics service that does not contain any PII
     public var safeLoggingString: String {
         switch self {
@@ -123,14 +123,14 @@ extension PaymentSheetError: CustomDebugStringConvertible {
             return "unknown"
         }
     }
-    
+
     /// A description logged to a developer for debugging
     public var debugDescription: String {
         switch self {
         case .unknown(debugDescription: let debugDescription):
-            return debugDescription
+            return "An error occured in PaymentSheet. " + debugDescription
         default:
-            return safeLoggingString
+            return "An error occured in PaymentSheet. " + safeLoggingString
         }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetError.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetError.swift
@@ -29,6 +29,7 @@ public enum PaymentSheetError: Error {
     case errorHandlingNextAction
     case unrecognizedHandlerStatus
     case accountLinkFailure
+    case setupIntentClientSecretProviderNil
     /// No payment method types available error.
     case noPaymentMethodTypesAvailable(intentPaymentMethods: [STPPaymentMethodType])
 
@@ -119,6 +120,8 @@ extension PaymentSheetError: CustomDebugStringConvertible {
             return "Failed to create Link account session"
         case .linkNotAuthorized:
             return "confirm called without authorizing Link"
+        case .setupIntentClientSecretProviderNil:
+            return "setupIntentClientSecretForCustomerAttach, but setupIntentClientSecretProvider is nil"
         case .unknown:
             return "unknown"
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetError.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetError.swift
@@ -17,7 +17,6 @@ import StripePayments
 public enum PaymentSheetError: Error {
     
     /// An unknown error.
-    @available(*, deprecated, message: "Depcreated in favor of specfic errors defined in PaymentSheetError.")
     case unknown(debugDescription: String)
 
     // MARK: Generic errors
@@ -65,8 +64,9 @@ extension PaymentSheetError: CustomDebugStringConvertible {
         // TODO: Expired ephemeral key
         return false
     }
-
-    public var debugDescription: String {
+    
+    /// A string that can safley be logged to our analytics service that does not contain any PII
+    public var safeLoggingString: String {
         switch self {
         case .missingClientSecret:
             return "The client secret is missing"
@@ -119,8 +119,18 @@ extension PaymentSheetError: CustomDebugStringConvertible {
             return "Failed to create Link account session"
         case .linkNotAuthorized:
             return "confirm called without authorizing Link"
+        case .unknown:
+            return "unknown"
+        }
+    }
+    
+    /// A description logged to a developer for debugging
+    public var debugDescription: String {
+        switch self {
         case .unknown(debugDescription: let debugDescription):
             return debugDescription
+        default:
+            return safeLoggingString
         }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetError.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetError.swift
@@ -15,11 +15,39 @@ import StripePayments
 /// Most errors do not originate from PaymentSheet itself; instead, they come from the Stripe API
 /// or other SDK components like STPPaymentHandler, PassKit (Apple Pay), etc.
 public enum PaymentSheetError: Error {
-    /// An unknown error.
-    case unknown(debugDescription: String)
 
+    // MARK: Generic errors
+    case missingClientSecret
+    case invalidClientSecret
+    case unexpectedResponseFromStripeAPI
+    case applePayNotSupported
+    case alreadyPresented
+    case flowControllerConfirmFailed(message: String)
+    case errorHandlingNextAction
+    case unrecognizedHandlerStatus
+    case accountLinkFailure
     /// No payment method types available error.
     case noPaymentMethodTypesAvailable(intentPaymentMethods: [STPPaymentMethodType])
+
+    // MARK: Loading errors
+    case paymentIntentInTerminalState(status: STPPaymentIntentStatus)
+    case setupIntentInTerminalState(status: STPSetupIntentStatus)
+    case fetchPaymentMethodsFailure
+
+    // MARK: Deferred intent errors
+    case deferredIntentValidationFailed(message: String)
+
+    // MARK: - Link errors
+    case linkSignUpNotRequired
+    case linkCallVerifyNotRequired
+    case linkingWithoutValidSession
+    case savingWithoutValidLinkSession
+    case payingWithoutValidLinkSession
+    case deletingWithoutValidLinkSession
+    case updatingWithoutValidLinkSession
+    case linkLookupNotFound
+    case failedToCreateLinkSession
+    case linkNotAuthorized
 
     /// Localized description of the error
     public var localizedDescription: String {
@@ -35,13 +63,58 @@ extension PaymentSheetError: CustomDebugStringConvertible {
     }
 
     public var debugDescription: String {
-        return "An error occured in PaymentSheet. " + {
-            switch self {
-            case .noPaymentMethodTypesAvailable(let intentPaymentMethods):
-                return "None of the payment methods on the PaymentIntent/SetupIntent can be used in PaymentSheet: \(intentPaymentMethods). You may need to set `allowsDelayedPaymentMethods` or `allowsPaymentMethodsRequiringShippingAddress` in your PaymentSheet.Configuration object."
-            case .unknown(let debugDescription):
-                return debugDescription
-            }
-        }()
+        switch self {
+        case .missingClientSecret:
+            return "The client secret is missing"
+        case .unexpectedResponseFromStripeAPI:
+            return "Unexpected response from Stripe API."
+        case .applePayNotSupported:
+            return "Attempted Apple Pay but it's not supported by the device, not configured, or missing a presenter"
+        case .deferredIntentValidationFailed(message: let message):
+            return message
+        case .alreadyPresented:
+            return "presentingViewController is already presenting a view controller"
+        case .flowControllerConfirmFailed(message: let message):
+            return message
+        case .errorHandlingNextAction:
+            return "Unknown error occured while handling intent next action"
+        case .unrecognizedHandlerStatus:
+            return "Unrecognized STPPaymentHandlerActionStatus status"
+        case .invalidClientSecret:
+            return "Invalid client secret"
+        case .failedToCreateLinkSession:
+            return "Failed to create Link account session"
+        case .accountLinkFailure:
+            return STPLocalizedString(
+                "Something went wrong when linking your account.\nPlease try again later.",
+                "Error message when an error case happens when linking your account"
+            )
+        case .paymentIntentInTerminalState(status: let status):
+            return "PaymentSheet received a PaymentIntent in a terminal state: \(status)"
+        case .setupIntentInTerminalState(status: let status):
+            return "PaymentSheet received a SetupIntent in a terminal state: \(status)"
+        case .fetchPaymentMethodsFailure:
+            return "Failed to retrieve PaymentMethods for the customer"
+        case .linkSignUpNotRequired:
+            return "Don't call sign up if not needed"
+        case .noPaymentMethodTypesAvailable(intentPaymentMethods: let intentPaymentMethods):
+            return "None of the payment methods on the PaymentIntent/SetupIntent can be used in PaymentSheet: \(intentPaymentMethods). You may need to set `allowsDelayedPaymentMethods` or `allowsPaymentMethodsRequiringShippingAddress` in your PaymentSheet.Configuration object."
+        case .linkCallVerifyNotRequired:
+            return "Don't call verify if not needed"
+        case .linkingWithoutValidSession:
+            return "Linking account session without valid consumer session"
+        case .savingWithoutValidLinkSession:
+            return "Saving to Link without valid session"
+        case .payingWithoutValidLinkSession:
+            return "Paying with Link without valid session"
+        case .deletingWithoutValidLinkSession:
+            return "Deleting Link payment details without valid session"
+        case .updatingWithoutValidLinkSession:
+            return "Updating Link payment details without valid session"
+        case .linkLookupNotFound:
+            return "Link account not found"
+        case .linkNotAuthorized:
+            return "confirm called without authorizing Link"
+        }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetError.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetError.swift
@@ -15,6 +15,10 @@ import StripePayments
 /// Most errors do not originate from PaymentSheet itself; instead, they come from the Stripe API
 /// or other SDK components like STPPaymentHandler, PassKit (Apple Pay), etc.
 public enum PaymentSheetError: Error {
+    
+    /// An unknown error.
+    @available(*, deprecated, message: "Depcreated in favor of specfic errors defined in PaymentSheetError.")
+    case unknown(debugDescription: String)
 
     // MARK: Generic errors
     case missingClientSecret
@@ -115,6 +119,8 @@ extension PaymentSheetError: CustomDebugStringConvertible {
             return "Failed to create Link account session"
         case .linkNotAuthorized:
             return "confirm called without authorizing Link"
+        case .unknown(debugDescription: let debugDescription):
+            return debugDescription
         }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -268,12 +268,12 @@ extension PaymentSheet {
             switch latestUpdateContext?.status {
             case .inProgress:
                 assertionFailure("`confirmPayment` should only be called when the last update has completed.")
-                let error = PaymentSheetError.unknown(debugDescription: "confirmPayment was called with an update API call in progress.")
+                let error = PaymentSheetError.flowControllerConfirmFailed(message: "confirmPayment was called with an update API call in progress.")
                 completion(.failed(error: error))
                 return
             case .failed:
                 assertionFailure("`confirmPayment` should only be called when the last update has completed without error.")
-                let error = PaymentSheetError.unknown(debugDescription: "confirmPayment was called when the last update API call failed.")
+                let error = PaymentSheetError.flowControllerConfirmFailed(message: "confirmPayment was called when the last update API call failed.")
                 completion(.failed(error: error))
                 return
             default:
@@ -282,7 +282,7 @@ extension PaymentSheet {
 
             guard let paymentOption = _paymentOption else {
                 assertionFailure("`confirmPayment` should only be called when `paymentOption` is not nil")
-                let error = PaymentSheetError.unknown(debugDescription: "confirmPayment was called with a nil paymentOption")
+                let error = PaymentSheetError.flowControllerConfirmFailed(message: "confirmPayment was called with a nil paymentOption")
                 completion(.failed(error: error))
                 return
             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -146,8 +146,7 @@ final class PaymentSheetLoader {
             }
             guard ![.succeeded, .canceled, .requiresCapture].contains(paymentIntent.status) else {
                 // Error if the PaymentIntent is in a terminal state
-                let message = "PaymentSheet received a PaymentIntent in a terminal state: \(paymentIntent.status)"
-                throw PaymentSheetError.unknown(debugDescription: message)
+                throw PaymentSheetError.paymentIntentInTerminalState(status: paymentIntent.status)
             }
             intent = .paymentIntent(paymentIntent)
         case .setupIntentClientSecret(let clientSecret):
@@ -160,8 +159,7 @@ final class PaymentSheetLoader {
             }
             guard ![.succeeded, .canceled].contains(setupIntent.status) else {
                 // Error if the SetupIntent is in a terminal state
-                let message = "PaymentSheet received a SetupIntent in a terminal state: \(setupIntent.status)"
-                throw PaymentSheetError.unknown(debugDescription: message)
+                throw PaymentSheetError.setupIntentInTerminalState(status: setupIntent.status)
             }
             intent = .setupIntent(setupIntent)
 
@@ -197,7 +195,7 @@ final class PaymentSheetLoader {
                 types: savedPaymentMethodTypes
             ) { paymentMethods, error in
                 guard let paymentMethods = paymentMethods, error == nil else {
-                    let error = error ?? PaymentSheetError.unknown(debugDescription: "Failed to retrieve PaymentMethods for the customer")
+                    let error = error ?? PaymentSheetError.fetchPaymentMethodsFailure
                     continuation.resume(throwing: error)
                     return
                 }


### PR DESCRIPTION
## Summary
- Removes usage of `PaymentSheetError.unknown` in favor of specific errors
- `PaymentSheetError.unknown` was abused as a catch all error, now users will be encouraged to define more specific errors 

## Motivation
- Make errors more easily loggable into our analytics table
- Currently we are unable to identity errors by their domain or code since they all share the same given by `.unknown`.
- https://stripe.slack.com/archives/CFA2HJ99A/p1689180194110519

## Testing
Project compiles

## Changelog
N/A
