### PR TITLE
Don't store last email address

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
@@ -136,12 +136,11 @@ class PaymentSheetLinkAccount: PaymentSheetLinkAccountInfoProtocol {
             consentAction: consentAction.rawValue,
             with: apiClient,
             cookieStore: cookieStore
-        ) { [weak self, email] result in
+        ) { [weak self] result in
             switch result {
             case .success(let signupResponse):
                 self?.currentSession = signupResponse.consumerSession
                 self?.publishableKey = signupResponse.publishableKey
-                self?.cookieStore.write(key: .lastSignupEmail, value: email)
                 completion(.success(()))
             case .failure(let error):
                 completion(.failure(error))

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/CookieStore/LinkCookieStore.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/CookieStore/LinkCookieStore.swift
@@ -73,6 +73,5 @@ extension LinkCookieStore {
     func clear() {
         delete(key: .session)
         delete(key: .lastLogoutEmail)
-        delete(key: .lastSignupEmail)
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Services/LinkAccountService.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Services/LinkAccountService.swift
@@ -109,10 +109,6 @@ final class LinkAccountService: LinkAccountServiceProtocol {
         return cookieStore.read(key: .lastLogoutEmail) == hashedEmail
     }
 
-    func getLastSignUpEmail() -> String? {
-        return cookieStore.read(key: .lastSignupEmail)
-    }
-
     func getLastPMDetails() -> LinkPMDisplayDetails? {
         if let lastBrandString = cookieStore.read(key: .lastPMBrand),
            let last4 = cookieStore.read(key: .lastPMLast4) {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Verification/LinkCookieKey.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Verification/LinkCookieKey.swift
@@ -9,7 +9,6 @@
 enum LinkCookieKey: String {
     case session = "com.stripe.pay_sid"
     case lastLogoutEmail = "com.stripe.link_account"
-    case lastSignupEmail = "com.stripe.link.last_signup_email"
     case lastPMLast4 = "com.stripe.link.last_pm_last4"
     case lastPMBrand = "com.stripe.link.last_pm_brand"
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -118,9 +118,7 @@ final class PaymentSheetLoader {
             }
         }
 
-        if let email = linkAccountService.getLastSignUpEmail() {
-            return try await lookUpConsumerSession(email: email)
-        } else if let email = configuration.defaultBillingDetails.email {
+        if let email = configuration.defaultBillingDetails.email {
             return try await lookUpConsumerSession(email: email)
         } else if let customerID = configuration.customer?.id,
             let ephemeralKey = configuration.customer?.ephemeralKeySecret


### PR DESCRIPTION
## Summary
We will use the last4/brand instead (though this isn't hooked up on the backend yet), so we won't store the last email address.

## Motivation
We shouldn't store extra data we're not using and don't need.

## Testing
CI, Link test app.