### PR TITLE
Don't show account info in button

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/PayWithLinkButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/PayWithLinkButton.swift
@@ -228,7 +228,7 @@ final class PayWithLinkButton: UIControl {
     //        // Stop listening for account changes
     //        LinkAccountContext.shared.removeObserver(self)
     //    }
-        
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/PayWithLinkButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/PayWithLinkButton.swift
@@ -30,7 +30,7 @@ final class PayWithLinkButton: UIControl {
     }
 
     /// Link account of the current user.
-    var linkAccount: PaymentSheetLinkAccountInfoProtocol? = LinkAccountStub(email: "none@stripe.com", redactedPhoneNumber: nil, lastPM: nil, isRegistered: false, isLoggedIn: false) {
+    var linkAccount: PaymentSheetLinkAccountInfoProtocol? = LinkAccountStub(email: "", redactedPhoneNumber: nil, lastPM: nil, isRegistered: false, isLoggedIn: false) {
         didSet {
             updateUI()
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/PayWithLinkButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/PayWithLinkButton.swift
@@ -30,7 +30,7 @@ final class PayWithLinkButton: UIControl {
     }
 
     /// Link account of the current user.
-    var linkAccount: PaymentSheetLinkAccountInfoProtocol? = LinkAccountContext.shared.account {
+    var linkAccount: PaymentSheetLinkAccountInfoProtocol? = LinkAccountStub(email: "none@stripe.com", redactedPhoneNumber: nil, lastPM: nil, isRegistered: false, isLoggedIn: false) {
         didSet {
             updateUI()
         }
@@ -212,18 +212,25 @@ final class PayWithLinkButton: UIControl {
         setupUI()
         applyStyle()
         updateUI()
-
-        // Listen for account changes
-        LinkAccountContext.shared.addObserver(self, selector: #selector(onAccountChange(_:)))
+        // TODO: Re-enable this once we work out the Link button last4/email details
+        // For now, don't show any information in the button.
+        //        // Listen for account changes
+        //        LinkAccountContext.shared.addObserver(self, selector: #selector(onAccountChange(_:)))
     }
-
+    // TODO: Re-enable this once we work out the Link button last4/email details
+    //    @objc
+    //    func onAccountChange(_ notification: Notification) {
+    //        DispatchQueue.main.async { [weak self] in
+    //            self?.linkAccount = notification.object as? PaymentSheetLinkAccount
+    //        }
+    //    }
+    //    deinit {
+    //        // Stop listening for account changes
+    //        LinkAccountContext.shared.removeObserver(self)
+    //    }
+        
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-    deinit {
-        // Stop listening for account changes
-        LinkAccountContext.shared.removeObserver(self)
     }
 
     override func layoutSubviews() {
@@ -233,13 +240,6 @@ final class PayWithLinkButton: UIControl {
 
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
         bounds.contains(point) ? self : nil
-    }
-
-    @objc
-    func onAccountChange(_ notification: Notification) {
-        DispatchQueue.main.async { [weak self] in
-            self?.linkAccount = notification.object as? PaymentSheetLinkAccount
-        }
     }
 
 }


### PR DESCRIPTION
## Summary
As a last-minute change, we won't show the account info in the Link button. We plan to fast follow with this soon, so we've commented it out for now.

## Motivation
For private beta.

## Testing
In PaymentSheet Example.