### PR TITLE
Don't show "Pay using" header if we already have the "Pay using" text below.

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/en.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/en.lproj/Localizable.strings
@@ -120,9 +120,6 @@ e.g, 'Pay faster at Example, Inc. and thousands of merchants.' */
 /* Pay over time with Affirm copy */
 "Pay over time with %@" = "Pay over time with %@";
 
-/* Title shown above a section containing various payment options */
-"Pay using" = "Pay using";
-
 /* Pay with {payment method} */
 "Pay with %@" = "Pay with %@";
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -322,7 +322,7 @@ class PaymentSheetViewController: UIViewController {
                 "Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc."
             )
         case .selectingSaved:
-            headerLabel.isHidden = false
+            headerLabel.isHidden = shouldShowWalletHeader
             headerLabel.text =
                 shouldShowWalletHeader && intent.isPaymentIntent
                 ? STPLocalizedString(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -323,16 +323,10 @@ class PaymentSheetViewController: UIViewController {
             )
         case .selectingSaved:
             headerLabel.isHidden = shouldShowWalletHeader
-            headerLabel.text =
-                shouldShowWalletHeader && intent.isPaymentIntent
-                ? STPLocalizedString(
-                    "Pay using",
-                    "Title shown above a section containing various payment options"
-                )
-                : STPLocalizedString(
-                    "Select your payment method",
-                    "Title shown above a carousel containing the customer's payment methods"
-                )
+            headerLabel.text = STPLocalizedString(
+                "Select your payment method",
+                "Title shown above a carousel containing the customer's payment methods"
+            )
         }
 
         // Content


### PR DESCRIPTION
## Summary
Don't show "Pay using" twice.


## Motivation
Design feedback.

## Testing
PaymentSheet Example app