### PR TITLE
Update font size for errors in playground

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleSwiftUIViews.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleSwiftUIViews.swift
@@ -45,7 +45,7 @@ struct ExamplePaymentStatusView: View {
             case .failed(let error):
                 Image(systemName: "xmark.octagon.fill").foregroundColor(.red)
                 Text("Payment failed: \((error as NSError).debugDescription)")
-                    .font(.system(size: 8.0))
+                    .font(.system(size: 12.0))
             case .canceled:
                 Image(systemName: "xmark.octagon.fill").foregroundColor(.orange)
                 Text("Payment canceled.")


### PR DESCRIPTION
## Summary
Increase font size

## Motivation
Run ticket

## Testing
manually tested.

Repro steps:
Present payment sheet
confirm PI
then immediately attempt to confirm the same PI again by hitting present again.

Observe:
Error shown in our UI

Before:
<img width="462" alt="Screenshot 2023-07-17 at 4 31 49 PM" src="https://github.com/stripe/stripe-ios/assets/99628984/d188f57c-6898-4015-bd25-7f95be52250e">



After:

![Screenshot 2023-07-17 at 4 31 23 PM](https://github.com/stripe/stripe-ios/assets/99628984/a80e4728-5c8b-4583-a75c-99fb8fd560e4)

