### PR TITLE
Fix bug on removing payment method immediately after adding it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## x.x.x
+### PaymentSheet
 * [Fixed] Update stp_icon_add@3x.png to 8bit color depth (Thanks @jszumski)
+
+### CustomerSheet
+* [Fixed] Ability to removing payment method immediately after adding it.
 
 ## 23.11.1 2023-07-18
 ### PaymentSheet

--- a/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
@@ -92,6 +92,48 @@ class CustomerSheetUITest: XCTestCase {
         let paymentMethodButton = app.staticTexts["Success: Apple Pay, selected"]  // The card should be saved now
         XCTAssertTrue(paymentMethodButton.waitForExistence(timeout: 60.0))
     }
+    func testAddPaymentMethod_RemoveBeforeConfirming() throws {
+        var settings = CustomerSheetTestPlaygroundSettings.defaultValues()
+        settings.customerMode = .new
+        settings.applePay = .on
+        loadPlayground(
+            app,
+            settings
+        )
+        let selectButton = app.staticTexts["None"]
+        XCTAssertTrue(selectButton.waitForExistence(timeout: 60.0))
+        selectButton.tap()
+
+        app.staticTexts["+ Add"].tap()
+
+        try! fillCardData(app, postalEnabled: true)
+        app.buttons["Save"].tap()
+
+        let cardPresence_beforeRemoval = app.staticTexts["••••4242"]
+        XCTAssertTrue(cardPresence_beforeRemoval.waitForExistence(timeout: 60.0))
+
+        let editButton = app.staticTexts["Edit"]
+        XCTAssertTrue(editButton.waitForExistence(timeout: 60.0))
+        editButton.tap()
+
+        removeFirstPaymentMethodInList()
+
+        let doneButton = app.staticTexts["Done"]
+        XCTAssertTrue(doneButton.waitForExistence(timeout: 60.0))
+        doneButton.tap()
+
+        let cardPresence_afterRemoval = app.staticTexts["••••4242"]
+        XCTAssertFalse(cardPresence_afterRemoval.exists)
+
+        let closeButton = app.buttons["Close"]
+        XCTAssertTrue(closeButton.waitForExistence(timeout: 60.0))
+        closeButton.tap()
+
+        dismissAlertView(alertBody: "Success: payment method not set, canceled", alertTitle: "Complete", buttonToTap: "OK")
+
+        let selectButtonFinal = app.staticTexts["None"]
+        XCTAssertTrue(selectButtonFinal.waitForExistence(timeout: 60.0))
+    }
 
     func testAddTwoPaymentMethods_RemoveTwoPaymentMethods() throws {
         var settings = CustomerSheetTestPlaygroundSettings.defaultValues()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewController.swift
@@ -67,7 +67,7 @@ class CustomerSavedPaymentMethodsCollectionViewController: UIViewController {
 
     var hasRemovablePaymentMethods: Bool {
         return (
-            !savedPaymentMethods.isEmpty
+            !savedPaymentMethods.isEmpty || !unsyncedSavedPaymentMethods.isEmpty
         )
     }
 
@@ -388,6 +388,9 @@ extension CustomerSavedPaymentMethodsCollectionViewController: PaymentOptionCell
                 self.collectionView.deleteItems(at: [indexPath])
             } completion: { _ in
                 self.savedPaymentMethods.removeAll(where: {
+                    $0.stripeId == paymentMethod.stripeId
+                })
+                self.unsyncedSavedPaymentMethods.removeAll(where: {
                     $0.stripeId == paymentMethod.stripeId
                 })
 


### PR DESCRIPTION
## Summary
Fix bug on removing payment method immediately after adding it

## Motivation
It's a bug -- we should allow customers to remove a payment method directly after adding it.  They could technically re-present the sheet to remove as a workaround.

## Testing
manual testing and added UI test

## Changelog
Updated