### PR TITLE
Enable SEPA Debit + SetupIntents / PaymentIntents+SFU in PaymentSheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## x.x.x
 ### PaymentSheet
 * [Fixed] Update stp_icon_add@3x.png to 8bit color depth (Thanks @jszumski)
+* [Added] Enable SEPA Debit for SetupIntents and PaymentIntents with setup_future_usage. Note: PaymentSheet doesn't display saved SEPA Debit payment methods yet.
 
 ### CustomerSheet
 * [Fixed] Ability to removing payment method immediately after adding it.

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -691,6 +691,8 @@ class PaymentSheetStandardLPMUITests: PaymentSheetUITestCase {
         XCTAssertFalse(payButton.isEnabled)
     }
 
+    // This only tests the PaymentSheet + PaymentIntent flow.
+    // Other confirmation flows are tested in PaymentSheet+LPMTests.swift
     func testSEPADebitPaymentMethod_PaymentSheet() {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
 //        settings.mode = .payment

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -695,10 +695,6 @@ class PaymentSheetStandardLPMUITests: PaymentSheetUITestCase {
     // Other confirmation flows are tested in PaymentSheet+LPMTests.swift
     func testSEPADebitPaymentMethod_PaymentSheet() {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
-//        settings.mode = .payment
-//        settings.applePayEnabled = .off
-//        settings.uiStyle = .paymentSheet
-//        settings.integrationType = .normal
         settings.currency = .eur
         settings.allowsDelayedPMs = .on
         loadPlayground(

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -690,6 +690,38 @@ class PaymentSheetStandardLPMUITests: PaymentSheetUITestCase {
 
         XCTAssertFalse(payButton.isEnabled)
     }
+    
+    func testSEPADebitPaymentMethod_PaymentSheet() {
+        var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
+//        settings.mode = .payment
+//        settings.applePayEnabled = .off
+//        settings.uiStyle = .paymentSheet
+//        settings.integrationType = .normal
+        settings.currency = .eur
+        settings.allowsDelayedPMs = .on
+        loadPlayground(
+            app,
+            settings
+        )
+        app.buttons["Present PaymentSheet"].tap()
+
+        guard let sepa = scroll(collectionView: app.collectionViews.firstMatch, toFindCellWithId: "SEPA Debit") else { XCTFail("Couldn't find SEPA"); return; }
+        sepa.tap()
+
+        app.textFields["Full name"].tap()
+        app.typeText("John Doe" + XCUIKeyboardKey.return.rawValue)
+        app.typeText("test@example.com" + XCUIKeyboardKey.return.rawValue)
+        app.typeText("AT611904300234573201" + XCUIKeyboardKey.return.rawValue)
+        app.textFields["Address line 1"].tap()
+        app.typeText("510 Townsend St" + XCUIKeyboardKey.return.rawValue)
+        app.typeText("Floor 3" + XCUIKeyboardKey.return.rawValue)
+        app.typeText("San Francisco" + XCUIKeyboardKey.return.rawValue)
+        app.textFields["ZIP"].tap()
+        app.typeText("94102" + XCUIKeyboardKey.return.rawValue)
+        app.buttons["Pay €50.99"].tap()
+        let successText = app.staticTexts["Success!"]
+        XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
+    }
 }
 
 class PaymentSheetDeferredUITests: PaymentSheetUITestCase {
@@ -1859,87 +1891,8 @@ class PaymentSheetDeferredServerSideUITests: PaymentSheetUITestCase {
  }
  */
 
-// MARK: - SEPA tests
-class PaymentSheet_SEPA_UI_Tests: PaymentSheetUITestCase {
-    func testSEPADebit_PaymentSheet_SetupIntent_ClientSideConfirmation() {
-        _testSEPA(ui: .paymentSheet, mode: .setup, integrationType: .normal)
-    }
-    
-    func testSEPADebit_PaymentSheet_SetupIntent_ServerSideConfirmation() {
-        _testSEPA(ui: .paymentSheet, mode: .setup, integrationType: .deferred_ssc)
-    }
-    
-    func testSEPADebit_PaymentSheet_PaymentIntent_ClientSideConfirmation() {
-        _testSEPA(ui: .paymentSheet, mode: .payment, integrationType: .normal)
-    }
-    
-    func testSEPADebit_PaymentSheet_PaymentIntent_ServerSideConfirmation() {
-        _testSEPA(ui: .paymentSheet, mode: .payment, integrationType: .deferred_ssc)
-    }
-    
-    func testSEPADebit_PaymentSheet_PaymentIntentWithSetupFutureUsage_ClientSideConfirmation() {
-        _testSEPA(ui: .paymentSheet, mode: .paymentWithSetup, integrationType: .normal)
-    }
-    
-    func testSEPADebit_PaymentSheet_PaymentIntentWithSetupFutureUsage_ServerSideConfirmation() {
-        _testSEPA(ui: .paymentSheet, mode: .paymentWithSetup, integrationType: .deferred_ssc)
-    }
-    
-    // Only test one scenario w/ FlowController - the confirm code is shared between it and PaymentSheet
-    func testSEPADebit_PaymentSheetFlowController_PaymentIntent_ClientSideConfirmation() {
-        _testSEPA(ui: .flowController, mode: .payment, integrationType: .normal)
-    }
-}
-
 // MARK: Helpers
 extension PaymentSheetUITestCase {
-    func _testSEPA(ui: PaymentSheetTestPlaygroundSettings.UIStyle, mode: PaymentSheetTestPlaygroundSettings.Mode, integrationType: PaymentSheetTestPlaygroundSettings.IntegrationType) {
-        var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
-        settings.mode = mode
-        settings.applePayEnabled = .off
-        settings.uiStyle = ui
-        settings.integrationType = integrationType
-        settings.currency = .eur
-        settings.allowsDelayedPMs = .on
-        loadPlayground(
-            app,
-            settings
-        )
-        switch ui {
-        case .paymentSheet:
-            app.buttons["Present PaymentSheet"].tap()
-        case .flowController:
-            app.buttons["Payment method"].tap()
-        }
-
-        guard let sepa = scroll(collectionView: app.collectionViews.firstMatch, toFindCellWithId: "SEPA Debit") else { XCTFail("Couldn't find SEPA"); return; }
-        sepa.tap()
-
-        app.textFields["Full name"].tap()
-        app.typeText("John Doe" + XCUIKeyboardKey.return.rawValue)
-        app.typeText("test@example.com" + XCUIKeyboardKey.return.rawValue)
-        app.typeText("AT611904300234573201" + XCUIKeyboardKey.return.rawValue)
-        app.textFields["Address line 1"].tap()
-        app.typeText("510 Townsend St" + XCUIKeyboardKey.return.rawValue)
-        app.typeText("Floor 3" + XCUIKeyboardKey.return.rawValue)
-        app.typeText("San Francisco" + XCUIKeyboardKey.return.rawValue)
-        app.textFields["ZIP"].tap()
-        app.typeText("94102" + XCUIKeyboardKey.return.rawValue)
-        switch ui {
-        case .paymentSheet:
-            if mode == .setup {
-                app.buttons["Set up"].tap()
-            } else {
-                app.buttons["Pay €50.99"].tap()
-            }
-        case .flowController:
-            app.buttons["Continue"].tap()
-            app.buttons["Confirm"].tap()
-        }
-        let successText = app.staticTexts["Success!"]
-        XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
-    }
-    
     func _testUSBankAccount(mode: PaymentSheetTestPlaygroundSettings.Mode, integrationType: PaymentSheetTestPlaygroundSettings.IntegrationType) {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
         settings.customerMode = .new

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -690,7 +690,7 @@ class PaymentSheetStandardLPMUITests: PaymentSheetUITestCase {
 
         XCTAssertFalse(payButton.isEnabled)
     }
-    
+
     func testSEPADebitPaymentMethod_PaymentSheet() {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
 //        settings.mode = .payment

--- a/Stripe/StripeiOSTests/PaymentSheet+APITest.swift
+++ b/Stripe/StripeiOSTests/PaymentSheet+APITest.swift
@@ -13,6 +13,7 @@ import XCTest
 @testable@_spi(STP) import StripeCore
 @testable@_spi(STP) import StripePayments
 @testable@_spi(STP) import StripePaymentSheet
+@testable@_spi(STP) import StripeUICore
 
 class PaymentSheetAPITest: XCTestCase {
 

--- a/Stripe/StripeiOSTests/PaymentSheet+LPMTests.swift
+++ b/Stripe/StripeiOSTests/PaymentSheet+LPMTests.swift
@@ -63,8 +63,11 @@ extension PaymentSheet_LPMTests {
         }
     }
 
-    /// A helper method that tests confirmation flows ("normal" client-side confirmation, deferred client-side confirmation, deferred server-side confirmation) for a payment method.
-    /// - Parameter intentKind: Which kind of Intent you want to test
+    /// A helper method that tests three confirmation flows successfully complete:
+    /// 1. normal" client-side confirmation
+    /// 2. deferred client-side confirmation
+    /// 3. deferred server-side
+    /// - Parameter intentKind: Which kind of Intent you want to test.
     /// - Parameter currency: A valid currency for the payment method you're testing
     /// - Parameter paymentMethodType: The payment method type you're testing
     /// - Parameter formCompleter: A closure that takes the form for your payment method. Your implementaiton should fill in the form's textfields etc. You can also perform additional checks e.g. to ensure certain fields are shown/hidden.

--- a/Stripe/StripeiOSTests/PaymentSheet+LPMTests.swift
+++ b/Stripe/StripeiOSTests/PaymentSheet+LPMTests.swift
@@ -1,0 +1,195 @@
+//
+//  PaymentSheet+LPMTests.swift
+//  StripeiOSTests
+//
+//  Created by Yuki Tokuhiro on 7/18/23.
+//
+
+import StripeCoreTestUtils
+import XCTest
+
+@testable@_spi(STP) import Stripe
+@testable@_spi(STP) import StripeCore
+@testable@_spi(STP) import StripePayments
+@testable@_spi(STP) import StripePaymentSheet
+@testable@_spi(STP) import StripeUICore
+
+final class PaymentSheet_LPMTests: XCTestCase {
+    let apiClient = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
+    lazy var paymentHandler: STPPaymentHandler = {
+        return STPPaymentHandler(
+            apiClient: apiClient,
+            formSpecPaymentHandler: PaymentSheetFormSpecPaymentHandler()
+        )
+    }()
+    lazy var configuration: PaymentSheet.Configuration = {
+        var config = PaymentSheet.Configuration()
+        config.apiClient = apiClient
+        config.allowsDelayedPaymentMethods = true
+        config.returnURL = "https://foo.com"
+        config.allowsPaymentMethodsRequiringShippingAddress = true
+        return config
+    }()
+    
+    override func setUp() async throws {
+        await PaymentSheetLoader.loadMiscellaneousSingletons()
+    }
+    
+    @MainActor
+    func testSEPADebitConfirmFlows() async throws {
+        await _testConfirm(intentKinds: [.paymentIntent, .paymentIntentWithSetupFutureUsage, .setupIntent], currency: "EUR", paymentMethodType: .dynamic("sepa_debit")) { form in
+            form.getTextFieldElement("Full name")?.setText("Foo")
+            form.getTextFieldElement("Email")?.setText("f@z.c")
+            form.getTextFieldElement("IBAN")?.setText("DE89370400440532013000")
+            form.getTextFieldElement("Address line 1")?.setText("asdf")
+            form.getTextFieldElement("City")?.setText("asdf")
+            form.getTextFieldElement("ZIP")?.setText("12345")
+            XCTAssertNotNil(form.getMandateElement())
+        }
+    }
+}
+
+// MARK: - Helper methods
+extension PaymentSheet_LPMTests {
+    enum IntentKind: CaseIterable {
+        case paymentIntent
+        case paymentIntentWithSetupFutureUsage
+        case setupIntent
+    }
+    
+    func _testConfirm(intentKinds: [IntentKind], currency: String, paymentMethodType: PaymentSheet.PaymentMethodType, formCompleter: (PaymentMethodElement) -> Void) async {
+        for intentKind in intentKinds {
+            await _testConfirm(intentKind: intentKind, currency: currency, paymentMethodType: paymentMethodType, formCompleter: formCompleter)
+        }
+    }
+    
+    @MainActor
+    /// A helper method that tests confirmation flows ("normal" client-side confirmation, deferred client-side confirmation, deferred server-side confirmation) for a payment method.
+    /// - Parameter intentKind: Which kind of Intent you want to test
+    /// - Parameter currency: A valid currency for the payment method you're testing
+    /// - Parameter paymentMethodType: The payment method type you're testing
+    /// - Parameter formCompleter: A closure that takes the form for your payment method. Your implementaiton should fill in the form's textfields etc. You can also perform additional checks e.g. to ensure certain fields are shown/hidden.
+    func _testConfirm(intentKind: IntentKind, currency: String, paymentMethodType: PaymentSheet.PaymentMethodType, formCompleter: (PaymentMethodElement) -> Void) async {
+        func makeDeferredIntent(_ intentConfig: PaymentSheet.IntentConfiguration) -> Intent {
+            return .deferredIntent(elementsSession: ._testCardValue(), intentConfig: intentConfig)
+        }
+        let paymentMethodString = PaymentSheet.PaymentMethodType.string(from: paymentMethodType)!
+        let intents: [(String, Intent)]
+        switch intentKind {
+        case .paymentIntent:
+            let deferredCSC = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1099, currency: currency)) { paymentMethod, shouldSavePaymentMethod in
+                return try await STPTestingAPIClient.shared.fetchPaymentIntent(types: [paymentMethodString])
+            }
+            let deferredSSC = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1099, currency: currency)) { paymentMethod, shouldSavePaymentMethod in
+                return try await STPTestingAPIClient.shared.fetchPaymentIntent(types: [paymentMethodString], paymentMethodID: paymentMethod.stripeId, confirm: true, otherParams: [
+                    "mandate_data": [
+                        "customer_acceptance": [
+                            "type": "online",
+                            "online": [
+                                "user_agent": "123",
+                                "ip_address": "172.18.117.125",
+                            ],
+                        ] as [String : Any],
+                    ],
+                ])
+            }
+            intents = [
+                ("Deferred PaymentIntent - client side confirmation", makeDeferredIntent(deferredCSC)),
+                ("Deferred PaymentIntent - server side confirmation", makeDeferredIntent(deferredSSC)),
+            ]
+        case .paymentIntentWithSetupFutureUsage:
+            let deferredCSC = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1099, currency: currency, setupFutureUsage: .offSession)) { paymentMethod, shouldSavePaymentMethod in
+                return try await STPTestingAPIClient.shared.fetchPaymentIntent(types: [paymentMethodString], otherParams: ["setup_future_usage": "off_session"])
+            }
+            let deferredSSC = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1099, currency: currency, setupFutureUsage: .offSession)) { paymentMethod, shouldSavePaymentMethod in
+                return try await STPTestingAPIClient.shared.fetchPaymentIntent(types: [paymentMethodString], paymentMethodID: paymentMethod.stripeId, confirm: true, otherParams: [
+                    "setup_future_usage": "off_session",
+                    "mandate_data": [
+                        "customer_acceptance": [
+                            "type": "online",
+                            "online": [
+                                "user_agent": "123",
+                                "ip_address": "172.18.117.125",
+                            ],
+                        ] as [String : Any],
+                    ],
+                ])
+            }
+            intents = [
+                ("Deferred PaymentIntent w/ setup_future_usage - client side confirmation", makeDeferredIntent(deferredCSC)),
+                ("Deferred PaymentIntent w/ setup_future_usage - server side confirmation", makeDeferredIntent(deferredSSC)),
+            ]
+            break
+        case .setupIntent:
+            let deferredCSC = PaymentSheet.IntentConfiguration(mode: .setup(setupFutureUsage: .offSession)) { paymentMethod, shouldSavePaymentMethod in
+                return try await STPTestingAPIClient.shared.fetchSetupIntent(types: [paymentMethodString])
+            }
+            let deferredSSC = PaymentSheet.IntentConfiguration(mode: .setup(setupFutureUsage: .offSession)) { paymentMethod, shouldSavePaymentMethod in
+                return try await STPTestingAPIClient.shared.fetchSetupIntent(types: [paymentMethodString], paymentMethodID: paymentMethod.stripeId, confirm: true, otherParams: [
+                    "mandate_data": [
+                        "customer_acceptance": [
+                            "type": "online",
+                            "online": [
+                                "user_agent": "123",
+                                "ip_address": "172.18.117.125",
+                            ],
+                        ] as [String : Any],
+                    ],
+                ])
+            }
+            intents = [
+                ("Deferred PaymentIntent w/ setup_future_usage - client side confirmation", makeDeferredIntent(deferredCSC)),
+                ("Deferred PaymentIntent w/ setup_future_usage - server side confirmation", makeDeferredIntent(deferredSSC)),
+            ]
+            break
+        }
+        for (description, intent) in intents {
+            // Make the form
+            let formFactory = PaymentSheetFormFactory(intent: intent, configuration: .paymentSheet(configuration), paymentMethod: paymentMethodType)
+            let paymentMethodForm = formFactory.make()
+            let view = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 1000))
+            view.addAndPinSubview(paymentMethodForm.view)
+            
+            // Fill out the form
+            sendEventToSubviews(.viewDidAppear, from: paymentMethodForm.view) // Simulate view appearance. This makes SimpleMandateElement mark its mandate as having been displayed.
+            formCompleter(paymentMethodForm)
+            
+            // Generate params from the form
+            guard let intentConfirmParams = paymentMethodForm.updateParams(params: IntentConfirmParams(type: paymentMethodType)) else {
+                XCTFail("Form failed to create params. Validation state: \(paymentMethodForm.validationState)")
+                return
+            }
+            let e = expectation(description: "Confirm")
+            paymentHandler._redirectShim = { _, _, _ in
+                // This gets called instead of the PaymentSheet.confirm callback if the Intent is successfully confirmed and requires next actions.
+                print("✅ \(description): Successfully confirmed the intent. It's status is now requires_action.")
+                e.fulfill()
+            }
+            // Confirm the intent with the form details
+            PaymentSheet.confirm(
+                configuration: configuration,
+                authenticationContext: self,
+                intent: intent,
+                paymentOption: .new(confirmParams: intentConfirmParams),
+                paymentHandler: paymentHandler
+            ) { result in
+                e.fulfill()
+                switch result {
+                case .failed(error: let error):
+                    XCTFail("❌ \(description): PaymentSheet.confirm failed - \(error)")
+                case .canceled:
+                    XCTFail("❌ \(description): PaymentSheet.confirm canceled!")
+                case .completed:
+                    print("✅ \(description): PaymentSheet.confirm completed")
+                }
+            }
+            await fulfillment(of: [e], timeout: 5)
+        }
+    }
+}
+
+extension PaymentSheet_LPMTests: STPAuthenticationContext {
+    func authenticationPresentingViewController() -> UIViewController {
+        return UIViewController()
+    }
+}

--- a/Stripe/StripeiOSTests/PaymentSheetFormFactoryTest.swift
+++ b/Stripe/StripeiOSTests/PaymentSheetFormFactoryTest.swift
@@ -1886,6 +1886,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
 }
 
 extension Element {
+    
     /// A convenience method that overwrites the one defined in Element.swift that unwraps any Elements wrapped in `PaymentMethodElementWrapper`
     /// and returns all Elements underneath this Element, including this Element.
     public func getAllUnwrappedSubElements() -> [Element] {
@@ -1903,5 +1904,29 @@ extension Element {
         default:
             return [self]
         }
+    }
+    
+    func getTextFieldElement(_ label: String) -> TextFieldElement? {
+        return getAllUnwrappedSubElements()
+            .compactMap { $0 as? TextFieldElement }
+            .first { $0.configuration.label == label }
+    }
+    
+    func getDropdownFieldElement(_ label: String) -> DropdownFieldElement? {
+        return getAllUnwrappedSubElements()
+            .compactMap { $0 as? DropdownFieldElement }
+            .first { $0.label == label }
+    }
+    
+    func getMandateElement() -> SimpleMandateElement? {
+        return getAllUnwrappedSubElements()
+            .compactMap { $0 as? SimpleMandateElement }
+            .first
+    }
+}
+
+extension TextFieldElement: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        return "TextFieldElement (\"\(configuration.label)\") (\(validationState))"
     }
 }

--- a/Stripe/StripeiOSTests/PaymentSheetFormFactoryTest.swift
+++ b/Stripe/StripeiOSTests/PaymentSheetFormFactoryTest.swift
@@ -1886,7 +1886,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
 }
 
 extension Element {
-    
+
     /// A convenience method that overwrites the one defined in Element.swift that unwraps any Elements wrapped in `PaymentMethodElementWrapper`
     /// and returns all Elements underneath this Element, including this Element.
     public func getAllUnwrappedSubElements() -> [Element] {
@@ -1905,19 +1905,19 @@ extension Element {
             return [self]
         }
     }
-    
+
     func getTextFieldElement(_ label: String) -> TextFieldElement? {
         return getAllUnwrappedSubElements()
             .compactMap { $0 as? TextFieldElement }
             .first { $0.configuration.label == label }
     }
-    
+
     func getDropdownFieldElement(_ label: String) -> DropdownFieldElement? {
         return getAllUnwrappedSubElements()
             .compactMap { $0 as? DropdownFieldElement }
             .first { $0.label == label }
     }
-    
+
     func getMandateElement() -> SimpleMandateElement? {
         return getAllUnwrappedSubElements()
             .compactMap { $0 as? SimpleMandateElement }

--- a/Stripe/StripeiOSTests/PaymentSheetPaymentMethodTypeTest.swift
+++ b/Stripe/StripeiOSTests/PaymentSheetPaymentMethodTypeTest.swift
@@ -154,7 +154,6 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
         PaymentSheet.PaymentMethodType.dynamic("ideal"),
         PaymentSheet.PaymentMethodType.dynamic("bancontact"),
         PaymentSheet.PaymentMethodType.dynamic("sofort"),
-        PaymentSheet.PaymentMethodType.dynamic("sepa_debit"),
     ]
     func testCantSetupSEPAFamily() {
         // All SEPA family pms...

--- a/Stripe/StripeiOSTests/PaymentSheetPaymentMethodTypeTest.swift
+++ b/Stripe/StripeiOSTests/PaymentSheetPaymentMethodTypeTest.swift
@@ -151,13 +151,14 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
     // MARK: - SEPA family
 
     let sepaFamily = [
+        PaymentSheet.PaymentMethodType.dynamic("sepa_debit"),
         PaymentSheet.PaymentMethodType.dynamic("ideal"),
         PaymentSheet.PaymentMethodType.dynamic("bancontact"),
         PaymentSheet.PaymentMethodType.dynamic("sofort"),
     ]
     func testCantSetupSEPAFamily() {
-        // All SEPA family pms...
-        for pm in sepaFamily {
+        // All SEPA family pms excluding SEPA itself...
+        for pm in sepaFamily.dropFirst() {
             // ...can't be used for PIs...
             XCTAssertEqual(
                 PaymentSheet.PaymentMethodType.supportsAdding(

--- a/Stripe/StripeiOSTests/STPTestingAPIClient+Swift.swift
+++ b/Stripe/StripeiOSTests/STPTestingAPIClient+Swift.swift
@@ -16,6 +16,7 @@ extension STPTestingAPIClient {
         currency: String = "eur",
         paymentMethodID: String? = nil,
         confirm: Bool = false,
+        otherParams: [String: Any] = [:],
         completion: @escaping (Result<(String), Error>) -> Void
     ) {
         var params = [String: Any]()
@@ -26,6 +27,7 @@ extension STPTestingAPIClient {
         if let paymentMethodID = paymentMethodID {
             params["payment_method"] = paymentMethodID
         }
+        params.merge(otherParams) { a, b in b }
 
         createPaymentIntent(
             withParams: params
@@ -45,34 +47,45 @@ extension STPTestingAPIClient {
         types: [String],
         currency: String = "eur",
         paymentMethodID: String? = nil,
-        confirm: Bool = false
+        confirm: Bool = false,
+        otherParams: [String: Any] = [:]
     ) async throws -> String {
         try await withCheckedThrowingContinuation { continuation in
             fetchPaymentIntent(
                 types: types,
                 currency: currency,
                 paymentMethodID: paymentMethodID,
-                confirm: confirm
+                confirm: confirm,
+                otherParams: otherParams
             ) { result in
                 continuation.resume(with: result)
             }
         }
     }
-
-    func fetchSetupIntent(types: [String], completion: @escaping (Result<(String), Error>) -> Void) {
-        createSetupIntent(
-            withParams: [
-                "payment_method_types": types,
-            ]
-        ) { clientSecret, error in
-            guard let clientSecret = clientSecret,
-                  error == nil
-            else {
-                completion(.failure(error!))
-                return
+    
+    func fetchSetupIntent(
+        types: [String],
+        paymentMethodID: String? = nil,
+        confirm: Bool = false,
+        otherParams: [String: Any] = [:]
+    ) async throws -> String {
+        var params = [String: Any]()
+        params["payment_method_types"] = types
+        params["confirm"] = confirm
+        if let paymentMethodID = paymentMethodID {
+            params["payment_method"] = paymentMethodID
+        }
+        params.merge(otherParams) { a, b in b }
+        return try await withCheckedThrowingContinuation { continuation in
+            createSetupIntent(withParams: params) { clientSecret, error in
+                guard let clientSecret = clientSecret,
+                      error == nil
+                else {
+                    continuation.resume(throwing: error!)
+                    return
+                }
+                continuation.resume(returning: clientSecret)
             }
-
-            completion(.success(clientSecret))
         }
     }
 }

--- a/Stripe/StripeiOSTests/STPTestingAPIClient+Swift.swift
+++ b/Stripe/StripeiOSTests/STPTestingAPIClient+Swift.swift
@@ -27,7 +27,7 @@ extension STPTestingAPIClient {
         if let paymentMethodID = paymentMethodID {
             params["payment_method"] = paymentMethodID
         }
-        params.merge(otherParams) { a, b in b }
+        params.merge(otherParams) { _, b in b }
 
         createPaymentIntent(
             withParams: params
@@ -62,7 +62,7 @@ extension STPTestingAPIClient {
             }
         }
     }
-    
+
     func fetchSetupIntent(
         types: [String],
         paymentMethodID: String? = nil,
@@ -75,7 +75,7 @@ extension STPTestingAPIClient {
         if let paymentMethodID = paymentMethodID {
             params["payment_method"] = paymentMethodID
         }
-        params.merge(otherParams) { a, b in b }
+        params.merge(otherParams) { _, b in b }
         return try await withCheckedThrowingContinuation { continuation in
             createSetupIntent(withParams: params) { clientSecret, error in
                 guard let clientSecret = clientSecret,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -283,8 +283,7 @@ extension PaymentSheet {
                         // n.b. While iDEAL and bancontact are themselves not delayed, they turn into SEPA upon save, which IS delayed.
                         return [.returnURL, .userSupportsDelayedPaymentMethods, .unsupportedForSetup]
                     case .SEPADebit:
-                        // SEPA-family PMs are disallowed until we can reuse them for PI+sfu and SI.
-                        return [.userSupportsDelayedPaymentMethods, .unsupportedForSetup]
+                        return [.userSupportsDelayedPaymentMethods]
                     case .bacsDebit:
                         return [.returnURL, .userSupportsDelayedPaymentMethods]
                     case .AUBECSDebit, .cardPresent, .blik, .weChatPay, .grabPay, .FPX, .giropay, .przelewy24, .EPS,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetIntentConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetIntentConfiguration.swift
@@ -114,13 +114,13 @@ public extension PaymentSheet {
                 setupFutureUsage: SetupFutureUsage = .offSession
             )
         }
-        
+
         /// An async version of `ConfirmHandler`.
         typealias AsyncConfirmHandler = (
             _ paymentMethod: STPPaymentMethod,
             _ shouldSavePaymentMethod: Bool
         ) async throws -> String
-        
+
         /// An async version of the initializer. See the other initializer for documentation.
         init(
             mode: Mode,

--- a/StripeUICore/StripeUICore/Source/Elements/DropdownFieldElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/DropdownFieldElement.swift
@@ -54,6 +54,8 @@ import UIKit
         }
     }
     public var didUpdate: DidUpdateSelectedIndex?
+    /// A label displayed in the dropdown field UI e.g. "Country or region" for a country dropdown
+    public let label: String?
 
     private(set) lazy var pickerView: UIPickerView = {
         let picker = UIPickerView()
@@ -76,7 +78,6 @@ import UIKit
     }()
 
     // MARK: - Private properties
-    private let label: String?
     private let theme: ElementsUITheme
     private var previouslySelectedIndex: Int
     private let disableDropdownWithSingleElement: Bool


### PR DESCRIPTION
## Summary
Enable SEPA Debit + SetupIntents / PaymentIntents+SFU in PaymentSheet

## Motivation
We can enable this now that we have a [path forward](https://jira.corp.stripe.com/browse/RUN_EMEADEBITS-6729) for saved SEPA payment methods. 

## Testing
I added PaymentSheet+LPMTests.swift. This has a helper method that tests the three confirmation flows
- "normal" client-side confirmation
- deferred client-side confirmation
- deferred server-side confirmation)

for any of the three kinds of Intents:
- PaymentIntent
- PaymentIntent+setup_future_usage
- SetupIntent

Manually tested confirming a [SetupIntent](https://admin.corp.stripe.com/setup_intent/seti_1NViRDLu5o3P18Zp9p8xXd9g) and that its [PM](https://admin.corp.stripe.com/object/pm_1NViStLu5o3P18Zp6qKuvozK) is attached to the [Customer](https://admin.corp.stripe.com/object/cus_IWu2703QtpbQ34).


## Changelog
### PaymentSheet
* [Added] Enable SEPA Debit for SetupIntents and PaymentIntents with setup_future_usage. Note: PaymentSheet doesn't display saved SEPA Debit payment methods yet.