### PR TITLE
Fix loading time calculation

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -71,7 +71,7 @@ final class PaymentSheetLoader {
                     }
 
                 STPAnalyticsClient.sharedClient.logPaymentSheetEvent(event: .paymentSheetLoadSucceeded,
-                                                                     duration: loadingStartDate.timeIntervalSinceNow)
+                                                                     duration: Date().timeIntervalSince(loadingStartDate))
                 completion(
                     .success(
                         intent: intent,
@@ -81,7 +81,7 @@ final class PaymentSheetLoader {
                 )
             } catch {
                 STPAnalyticsClient.sharedClient.logPaymentSheetEvent(event: .paymentSheetLoadFailed,
-                                                                     duration: loadingStartDate.timeIntervalSinceNow,
+                                                                     duration: Date().timeIntervalSince(loadingStartDate),
                                                                      error: error)
                 completion(.failure(error))
             }


### PR DESCRIPTION
## Summary
- The existing calculation for loading time was returning a negative value rather than positive (wrong sign), to make our queries easier we can flip it.

## Motivation
Make Hubble queries easier

## Testing
Manual

## Changelog
N/A
