### PR TITLE
Reinit addPaymentMethodViewController on pm creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### CustomerSheet
 * [Fixed] Ability to removing payment method immediately after adding it.
+* [Fixed] Re-init addPaymentMethodViewController after adding payment method to allow for adding another payment method
 
 ## 23.11.1 2023-07-18
 ### PaymentSheet

--- a/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
@@ -135,6 +135,90 @@ class CustomerSheetUITest: XCTestCase {
         XCTAssertTrue(selectButtonFinal.waitForExistence(timeout: 60.0))
     }
 
+    func testAddPaymentMethod_setupIntent_reInitAdddViewController() throws {
+        var settings = CustomerSheetTestPlaygroundSettings.defaultValues()
+        settings.customerMode = .new
+        settings.applePay = .on
+        settings.paymentMethodMode = .setupIntent
+        loadPlayground(
+            app,
+            settings
+        )
+        let selectButton = app.staticTexts["None"]
+        XCTAssertTrue(selectButton.waitForExistence(timeout: 60.0))
+        selectButton.tap()
+
+        app.staticTexts["+ Add"].tap()
+
+        try! fillCardData(app, postalEnabled: true)
+        app.buttons["Save"].tap()
+
+        let cardPresence = app.staticTexts["••••4242"]
+        XCTAssertTrue(cardPresence.waitForExistence(timeout: 60.0))
+
+        app.staticTexts["+ Add"].tap()
+
+        if let cardInformation = app.textFields["Card number"].value as? String {
+            XCTAssert(cardInformation.isEmpty)
+        } else {
+            XCTFail("unable to get card number field")
+        }
+
+        let backButton = app.buttons["Back"]
+        XCTAssertTrue(backButton.waitForExistence(timeout: 60.0))
+        backButton.tap()
+
+        let closeButton = app.buttons["Close"]
+        XCTAssertTrue(closeButton.waitForExistence(timeout: 60.0))
+        closeButton.tap()
+
+        dismissAlertView(alertBody: "Success: payment method not set, canceled", alertTitle: "Complete", buttonToTap: "OK")
+
+        let selectButtonFinal = app.staticTexts["None"]
+        XCTAssertTrue(selectButtonFinal.waitForExistence(timeout: 60.0))
+    }
+    func testAddPaymentMethod_createAndAttach_reInitAdddViewController() throws {
+        var settings = CustomerSheetTestPlaygroundSettings.defaultValues()
+        settings.customerMode = .new
+        settings.applePay = .on
+        settings.paymentMethodMode = .createAndAttach
+        loadPlayground(
+            app,
+            settings
+        )
+        let selectButton = app.staticTexts["None"]
+        XCTAssertTrue(selectButton.waitForExistence(timeout: 60.0))
+        selectButton.tap()
+
+        app.staticTexts["+ Add"].tap()
+
+        try! fillCardData(app, postalEnabled: true)
+        app.buttons["Save"].tap()
+
+        let cardPresence = app.staticTexts["••••4242"]
+        XCTAssertTrue(cardPresence.waitForExistence(timeout: 60.0))
+
+        app.staticTexts["+ Add"].tap()
+
+        if let cardInformation = app.textFields["Card number"].value as? String {
+            XCTAssert(cardInformation.isEmpty)
+        } else {
+            XCTFail("unable to get card number field")
+        }
+
+        let backButton = app.buttons["Back"]
+        XCTAssertTrue(backButton.waitForExistence(timeout: 60.0))
+        backButton.tap()
+
+        let closeButton = app.buttons["Close"]
+        XCTAssertTrue(closeButton.waitForExistence(timeout: 60.0))
+        closeButton.tap()
+
+        dismissAlertView(alertBody: "Success: payment method not set, canceled", alertTitle: "Complete", buttonToTap: "OK")
+
+        let selectButtonFinal = app.staticTexts["None"]
+        XCTAssertTrue(selectButtonFinal.waitForExistence(timeout: 60.0))
+    }
     func testAddTwoPaymentMethods_RemoveTwoPaymentMethods() throws {
         var settings = CustomerSheetTestPlaygroundSettings.defaultValues()
         settings.customerMode = .new

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsViewController.swift
@@ -437,6 +437,7 @@ class CustomerSavedPaymentMethodsViewController: UIViewController {
                 self.savedPaymentOptionsViewController.didAddSavedPaymentMethod(paymentMethod: paymentMethod)
                 self.mode = .selectingSaved
                 self.updateUI(animated: true)
+                self.reinitAddPaymentMethodViewController()
             }
         })
     }
@@ -480,9 +481,18 @@ class CustomerSavedPaymentMethodsViewController: UIViewController {
                     self.savedPaymentOptionsViewController.didAddSavedPaymentMethod(paymentMethod: paymentMethod)
                     self.mode = .selectingSaved
                     self.updateUI(animated: true)
+                    self.reinitAddPaymentMethodViewController()
                 }
             }
         }
+    }
+
+    // Called after adding a new payment method to clear out any text
+    // that was entered as part of adding a new payment method.
+    private func reinitAddPaymentMethodViewController() {
+        self.addPaymentMethodViewController = CustomerAddPaymentMethodViewController(
+            configuration: configuration,
+            delegate: self)
     }
 
     private func set(error: Error?) {


### PR DESCRIPTION
## Summary
Re-initialize view controller to clear out data

## Motivation
After adding a payment method, text fields should be cleared

## Testing
Added ui tests

