### PR TITLE
Fix issue where delete button is tappable when hidden

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewController.swift
@@ -77,7 +77,12 @@ class CustomerSavedPaymentMethodsCollectionViewController: UIViewController {
         }
         set {
             collectionView.isRemovingPaymentMethods = newValue
-            collectionView.reloadSections([0])
+            UIView.transition(with: collectionView,
+                              duration: 0.3,
+                              options: .transitionCrossDissolve,
+                              animations: {
+                self.collectionView.reloadData()
+            })
             if !collectionView.isRemovingPaymentMethods {
                 // re-select
                 collectionView.selectItem(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentMethodCollectionView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentMethodCollectionView.swift
@@ -203,7 +203,7 @@ extension SavedPaymentMethodCollectionView {
             let translatedPoint = deleteButton.convert(point, from: self)
 
             // Ensures taps on the delete button are handled properly as it lives outside its cells' bounds
-            if deleteButton.bounds.contains(translatedPoint) && !deleteButton.isHidden {
+            if deleteButton.bounds.contains(translatedPoint) && !deleteButton.isUserInteractionEnabled {
                 return deleteButton.hitTest(translatedPoint, with: event)
             }
 
@@ -319,13 +319,17 @@ extension SavedPaymentMethodCollectionView {
 
             if isRemovingPaymentMethods {
                 if case .saved = viewModel {
-                    deleteButton.isHidden = false
+                    deleteButton.alpha = 1.0
+                    deleteButton.isUserInteractionEnabled = true
+
+                    deleteButton.isEnabled = true
                     deleteButton.backgroundColor = appearance.colors.danger
                     deleteButton.iconColor = appearance.colors.danger.contrastingColor
                     contentView.bringSubviewToFront(deleteButton)
                     applyDefaultStyle()
                 } else {
-                    deleteButton.isHidden = true
+                    deleteButton.alpha = 0.0
+                    deleteButton.isUserInteractionEnabled = false
 
                     // apply disabled style
                     shadowRoundedRectangle.isEnabled = false
@@ -337,7 +341,8 @@ extension SavedPaymentMethodCollectionView {
                 }
 
             } else if isSelected {
-                deleteButton.isHidden = true
+                deleteButton.alpha = 0.0
+                deleteButton.isUserInteractionEnabled = false
                 shadowRoundedRectangle.isEnabled = true
                 label.textColor = appearance.colors.text
                 paymentMethodLogo.alpha = 1
@@ -350,7 +355,8 @@ extension SavedPaymentMethodCollectionView {
                 shadowRoundedRectangle.layer.borderColor = appearance.colors.primary.cgColor
                 shadowRoundedRectangle.layer.cornerRadius = appearance.cornerRadius
             } else {
-                deleteButton.isHidden = true
+                deleteButton.alpha = 0.0
+                deleteButton.isUserInteractionEnabled = false
                 shadowRoundedRectangle.isEnabled = true
                 applyDefaultStyle()
             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentMethodCollectionView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentMethodCollectionView.swift
@@ -203,7 +203,7 @@ extension SavedPaymentMethodCollectionView {
             let translatedPoint = deleteButton.convert(point, from: self)
 
             // Ensures taps on the delete button are handled properly as it lives outside its cells' bounds
-            if deleteButton.bounds.contains(translatedPoint) && !deleteButton.isUserInteractionEnabled {
+            if deleteButton.bounds.contains(translatedPoint) && !deleteButton.isHidden {
                 return deleteButton.hitTest(translatedPoint, with: event)
             }
 
@@ -319,17 +319,13 @@ extension SavedPaymentMethodCollectionView {
 
             if isRemovingPaymentMethods {
                 if case .saved = viewModel {
-                    deleteButton.alpha = 1.0
-                    deleteButton.isUserInteractionEnabled = true
-
-                    deleteButton.isEnabled = true
+                    deleteButton.isHidden = false
                     deleteButton.backgroundColor = appearance.colors.danger
                     deleteButton.iconColor = appearance.colors.danger.contrastingColor
                     contentView.bringSubviewToFront(deleteButton)
                     applyDefaultStyle()
                 } else {
-                    deleteButton.alpha = 0.0
-                    deleteButton.isUserInteractionEnabled = false
+                    deleteButton.isHidden = true
 
                     // apply disabled style
                     shadowRoundedRectangle.isEnabled = false
@@ -341,8 +337,7 @@ extension SavedPaymentMethodCollectionView {
                 }
 
             } else if isSelected {
-                deleteButton.alpha = 0.0
-                deleteButton.isUserInteractionEnabled = false
+                deleteButton.isHidden = true
                 shadowRoundedRectangle.isEnabled = true
                 label.textColor = appearance.colors.text
                 paymentMethodLogo.alpha = 1
@@ -355,8 +350,7 @@ extension SavedPaymentMethodCollectionView {
                 shadowRoundedRectangle.layer.borderColor = appearance.colors.primary.cgColor
                 shadowRoundedRectangle.layer.cornerRadius = appearance.cornerRadius
             } else {
-                deleteButton.alpha = 0.0
-                deleteButton.isUserInteractionEnabled = false
+                deleteButton.isHidden = true
                 shadowRoundedRectangle.isEnabled = true
                 applyDefaultStyle()
             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
@@ -69,7 +69,12 @@ class SavedPaymentOptionsViewController: UIViewController {
         }
         set {
             collectionView.isRemovingPaymentMethods = newValue
-            collectionView.reloadSections([0])
+            UIView.transition(with: collectionView,
+                              duration: 0.3,
+                              options: .transitionCrossDissolve,
+                              animations: {
+                self.collectionView.reloadData()
+            })
             if !collectionView.isRemovingPaymentMethods {
                 // re-select
                 collectionView.selectItem(


### PR DESCRIPTION
## Summary
Fix issue where delete button is tappable when hidden

## Theory behind the fix
My first approach didn't really work, the touch targeting outside the boundaries of the card doesn't register.

The underlying issue seems to be that when calling `reloadSections`, there cells that weren't properly being cleaned up . 
 These "ghost" cells that would receive taps that had pointers to cells that no longer existed and were attempting to be removed from (and hence the assertion fault).

To remedy this, it seems that `reloadData()` seems to properly dispose (ghost) cells.


To prove the existence of ghost cells:
1. Put a printout inside of `SavedPaymentMethodCollectionView::hitTest`.  This will help you see the ghost frames, and whether deleteButton is or isn't hidden.
```
            print("deleteButton.isHidden=\(deleteButton.isHidden), self=\(self)")
```
2. Removing the call to check if hittest for the button should/shouldn’t register.  Based on this, you can see more than expected number of calls happening in here (should be one call for each cell you have)
```
-            let translatedPoint = deleteButton.convert(point, from: self)

-            // Ensures taps on the delete button are handled properly as it lives outside its cells' bounds
-            if deleteButton.bounds.contains(translatedPoint) && !deleteButton.isHidden {
-                return deleteButton.hitTest(translatedPoint, with: event)
-            }
```

3.  Follow the repro steps below
4.  Observe that hittest is begin executed from ghost cells


## Motivation
1. Have one saved payment method in CustomerSheet or Payment Sheet
2. Tap “edit” to reveal the red x’s
3. Tap done to hide the red x’s
4. Despite the red x not being visible, it’s still tappable, so attempt to tap it

Observed behavior:
assertionFailure()

## Testing
Manual testing

