### PR TITLE
Remove error_domain from analytics

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
@@ -259,7 +259,6 @@ extension STPAnalyticsClient {
         additionalParams["locale"] = Locale.autoupdatingCurrent.identifier
         additionalParams["currency"] = currency
         additionalParams["is_decoupled"] = intentConfig != nil
-        additionalParams["error_domain"] = (error as? NSError)?.domain
         additionalParams["deferred_intent_confirmation_type"] = deferredIntentConfirmationType?.rawValue
         if let error = error as? PaymentSheetError {
             additionalParams["error_message"] = error.safeLoggingString


### PR DESCRIPTION
## Summary
- Populating error_message (which is already being sent) in favor of error_domain as error domain isn't very useful. Going to drop this column from the table. It just sends `StripePaymentSheet.PaymentSheetError`

## Motivation
- Only send useful info.

## Testing
Manual

## Changelog
N/A
