### PR TITLE
Refactor contact information section 

### DIFF
--- a/Stripe/StripeiOSTests/Elements+TestHelpers.swift
+++ b/Stripe/StripeiOSTests/Elements+TestHelpers.swift
@@ -5,8 +5,8 @@
 //  Created by Yuki Tokuhiro on 7/20/23.
 //
 
-@testable@_spi(STP) import StripeUICore
 @testable@_spi(STP) import StripePaymentSheet
+@testable@_spi(STP) import StripeUICore
 
 extension Element {
 

--- a/Stripe/StripeiOSTests/Elements+TestHelpers.swift
+++ b/Stripe/StripeiOSTests/Elements+TestHelpers.swift
@@ -1,0 +1,63 @@
+//
+//  Elements+TestHelpers.swift
+//  StripeiOSTests
+//
+//  Created by Yuki Tokuhiro on 7/20/23.
+//
+
+@testable@_spi(STP) import StripeUICore
+@testable@_spi(STP) import StripePaymentSheet
+
+extension Element {
+
+    /// A convenience method that nwraps any Elements wrapped in `PaymentMethodElementWrapper`
+    /// and returns all Elements underneath this Element, including this Element.
+    public func getAllUnwrappedSubElements() -> [Element] {
+        switch self {
+        case let container as ContainerElement:
+            return [container] + container.elements.flatMap { $0.getAllUnwrappedSubElements() }
+        case let wrappedElement as PaymentMethodElementWrapper<FormElement>:
+            return wrappedElement.element.getAllUnwrappedSubElements()
+        case let wrappedElement as PaymentMethodElementWrapper<CheckboxElement>:
+            return wrappedElement.element.getAllUnwrappedSubElements()
+        case let wrappedElement as PaymentMethodElementWrapper<TextFieldElement>:
+            return wrappedElement.element.getAllUnwrappedSubElements()
+        case let wrappedElement as PaymentMethodElementWrapper<DropdownFieldElement>:
+            return wrappedElement.element.getAllUnwrappedSubElements()
+        case let wrappedElement as PaymentMethodElementWrapper<AddressSectionElement>:
+            return wrappedElement.element.getAllUnwrappedSubElements()
+        default:
+            return [self]
+        }
+    }
+
+    func getTextFieldElement(_ label: String) -> TextFieldElement? {
+        return getAllUnwrappedSubElements()
+            .compactMap { $0 as? TextFieldElement }
+            .first { $0.configuration.label == label }
+    }
+
+    func getDropdownFieldElement(_ label: String) -> DropdownFieldElement? {
+        return getAllUnwrappedSubElements()
+            .compactMap { $0 as? DropdownFieldElement }
+            .first { $0.label == label }
+    }
+
+    func getMandateElement() -> SimpleMandateElement? {
+        return getAllUnwrappedSubElements()
+            .compactMap { $0 as? SimpleMandateElement }
+            .first
+    }
+}
+
+extension TextFieldElement: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        return "<TextFieldElement: \(Unmanaged.passUnretained(self).toOpaque())>  -  \"\(configuration.label)\"  -  \(validationState)"
+    }
+}
+
+extension DropdownFieldElement: CustomDebugStringConvertible {
+    public override var debugDescription: String {
+        return "<DropdownFieldElement: \(Unmanaged.passUnretained(self).toOpaque())>  -  \"\(label ?? "nil")\"  -  \(validationState)"
+    }
+}

--- a/Stripe/StripeiOSTests/PaymentSheetFormFactoryTest.swift
+++ b/Stripe/StripeiOSTests/PaymentSheetFormFactoryTest.swift
@@ -14,7 +14,6 @@ import XCTest
 @testable@_spi(STP) import StripePaymentSheet
 @testable@_spi(STP) import StripePaymentsUI
 @testable@_spi(STP) import StripeUICore
-@testable@_spi(STP) import StripeUICore
 
 class MockElement: Element {
     var paramsUpdater: (IntentConfirmParams) -> IntentConfirmParams?
@@ -1882,51 +1881,5 @@ class PaymentSheetFormFactoryTest: XCTestCase {
             return nil
         }
         return wrapper.element
-    }
-}
-
-extension Element {
-
-    /// A convenience method that overwrites the one defined in Element.swift that unwraps any Elements wrapped in `PaymentMethodElementWrapper`
-    /// and returns all Elements underneath this Element, including this Element.
-    public func getAllUnwrappedSubElements() -> [Element] {
-        switch self {
-        case let container as ContainerElement:
-            return [container] + container.elements.flatMap { $0.getAllUnwrappedSubElements() }
-        case let wrappedElement as PaymentMethodElementWrapper<FormElement>:
-            return wrappedElement.element.getAllUnwrappedSubElements()
-        case let wrappedElement as PaymentMethodElementWrapper<CheckboxElement>:
-            return wrappedElement.element.getAllUnwrappedSubElements()
-        case let wrappedElement as PaymentMethodElementWrapper<TextFieldElement>:
-            return wrappedElement.element.getAllUnwrappedSubElements()
-        case let wrappedElement as PaymentMethodElementWrapper<AddressSectionElement>:
-            return wrappedElement.element.getAllUnwrappedSubElements()
-        default:
-            return [self]
-        }
-    }
-
-    func getTextFieldElement(_ label: String) -> TextFieldElement? {
-        return getAllUnwrappedSubElements()
-            .compactMap { $0 as? TextFieldElement }
-            .first { $0.configuration.label == label }
-    }
-
-    func getDropdownFieldElement(_ label: String) -> DropdownFieldElement? {
-        return getAllUnwrappedSubElements()
-            .compactMap { $0 as? DropdownFieldElement }
-            .first { $0.label == label }
-    }
-
-    func getMandateElement() -> SimpleMandateElement? {
-        return getAllUnwrappedSubElements()
-            .compactMap { $0 as? SimpleMandateElement }
-            .first
-    }
-}
-
-extension TextFieldElement: CustomDebugStringConvertible {
-    public var debugDescription: String {
-        return "TextFieldElement (\"\(configuration.label)\") (\(validationState))"
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Categories/String+Localized.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Categories/String+Localized.swift
@@ -186,4 +186,8 @@ extension String.Localized {
             "Paypal mandate text"
         )
     }
+
+    static var contact_information: String {
+        STPLocalizedString("Contact information", "Title for the contact information section")
+    }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
@@ -22,14 +22,22 @@ extension PaymentSheetFormFactory {
         )
         let shouldDisplaySaveCheckbox: Bool = saveMode == .userSelectable && !canSaveToLink
 
-        // Link can't collect phone.
-        let includePhone = !configuration.linkPaymentMethodsOnly
-            && configuration.billingDetailsCollectionConfiguration.phone == .always
-
-        let contactInformationSection = makeContactInformation(
-            includeName: false, // Name is included in the card details section.
-            includeEmail: configuration.billingDetailsCollectionConfiguration.email == .always,
-            includePhone: includePhone)
+        // Make Contact Information section
+        let contactInformationSection: SectionElement? = {
+            let emailElement: Element? = configuration.billingDetailsCollectionConfiguration.email == .always ? makeEmail() : nil
+            // Link can't collect phone.
+            let includePhone = !configuration.linkPaymentMethodsOnly && configuration.billingDetailsCollectionConfiguration.phone == .always
+            let phoneElement: Element? = includePhone ? makePhone() : nil
+            let contactInformationElements = [emailElement, phoneElement].compactMap { $0 }
+            guard !contactInformationElements.isEmpty else {
+                return nil
+            }
+            return SectionElement(
+                title: .Localized.contact_information,
+                elements: contactInformationElements,
+                theme: theme
+            )
+        }()
 
         let previousCardInput = previousCustomerInput?.paymentMethodParams.card
         let formattedExpiry: String? = {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
@@ -22,12 +22,12 @@ extension PaymentSheetFormFactory {
         )
         let shouldDisplaySaveCheckbox: Bool = saveMode == .userSelectable && !canSaveToLink
 
-        // Make Contact Information section
-        let contactInformationSection: SectionElement? = {
+        // Make section titled "Contact Information" w/ phone and email if merchant requires it.
+        let optionalPhoneAndEmailInformationSection: SectionElement? = {
             let emailElement: Element? = configuration.billingDetailsCollectionConfiguration.email == .always ? makeEmail() : nil
             // Link can't collect phone.
-            let includePhone = !configuration.linkPaymentMethodsOnly && configuration.billingDetailsCollectionConfiguration.phone == .always
-            let phoneElement: Element? = includePhone ? makePhone() : nil
+            let shouldIncludePhone = !configuration.linkPaymentMethodsOnly && configuration.billingDetailsCollectionConfiguration.phone == .always
+            let phoneElement: Element? = shouldIncludePhone ? makePhone() : nil
             let contactInformationElements = [emailElement, phoneElement].compactMap { $0 }
             guard !contactInformationElements.isEmpty else {
                 return nil
@@ -70,7 +70,7 @@ extension PaymentSheetFormFactory {
             }
         }()
 
-        let phoneElement = contactInformationSection?.elements.compactMap {
+        let phoneElement = optionalPhoneAndEmailInformationSection?.elements.compactMap {
             $0 as? PaymentMethodElementWrapper<PhoneNumberElement>
         }.first
 
@@ -81,7 +81,7 @@ extension PaymentSheetFormFactory {
 
         let cardFormElement = FormElement(
             elements: [
-                contactInformationSection,
+                optionalPhoneAndEmailInformationSection,
                 cardSection,
                 billingAddressSection,
                 shouldDisplaySaveCheckbox ? saveCheckbox : nil,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+UPI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+UPI.swift
@@ -15,10 +15,7 @@ import UIKit
 extension PaymentSheetFormFactory {
 
     func makeUPI() -> FormElement {
-        let contactInformationElement = makeContactInformation(
-            includeName: configuration.billingDetailsCollectionConfiguration.name == .always,
-            includeEmail: configuration.billingDetailsCollectionConfiguration.email == .always,
-            includePhone: configuration.billingDetailsCollectionConfiguration.phone == .always)
+        let contactInformationElement = makeContactInformationSection(nameRequiredByPaymentMethod: false, emailRequiredByPaymentMethod: false, phoneRequiredByPaymentMethod: false)
         let billingAddressElement = configuration.billingDetailsCollectionConfiguration.address == .full
             ? makeBillingAddressSection(countries: nil)
             : nil

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -530,7 +530,7 @@ extension PaymentSheetFormFactory {
         return StaticElement(view: label)
     }
 
-    /// This method returns a "Contact information" Section containing a name, email, and phone field depending on the `PaymentSheet.Configuration.billingDetailsCollectionConfiguration`and your payment method's required fields.
+    /// This method returns a "Contact information" Section containing a name, email, and phone field depending on the `PaymentSheet.Configuration.billingDetailsCollectionConfiguration` and your payment method's required fields.
     /// - Parameter nameRequiredByPaymentMethod: Whether your payment method requires the name field.
     /// - Parameter emailRequiredByPaymentMethod: Whether your payment method requires the email field.
     /// - Parameter phoneRequiredByPaymentMethod: Whether your payment method requires the phone field.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -530,18 +530,22 @@ extension PaymentSheetFormFactory {
         return StaticElement(view: label)
     }
 
-    func makeContactInformation(includeName: Bool, includeEmail: Bool, includePhone: Bool) -> SectionElement? {
-        let nameElement = includeName ? makeName() : nil
-        let emailElement = includeEmail ? makeEmail() : nil
-        let phoneElement = includePhone ? makePhone() : nil
-
-        let allElements: [Element?] = [nameElement, emailElement, phoneElement]
-        let elements = allElements.compactMap { $0 }
-
+    /// This method returns a "Contact information" Section containing a name, email, and phone field depending on the `PaymentSheet.Configuration.billingDetailsCollectionConfiguration`and your payment method's required fields.
+    /// - Parameter nameRequiredByPaymentMethod: Whether your payment method requires the name field.
+    /// - Parameter emailRequiredByPaymentMethod: Whether your payment method requires the email field.
+    /// - Parameter phoneRequiredByPaymentMethod: Whether your payment method requires the phone field.
+    func makeContactInformationSection(nameRequiredByPaymentMethod: Bool, emailRequiredByPaymentMethod: Bool, phoneRequiredByPaymentMethod: Bool) -> SectionElement? {
+        let nameElement = configuration.billingDetailsCollectionConfiguration.name == .always
+            || (configuration.billingDetailsCollectionConfiguration.name == .automatic && nameRequiredByPaymentMethod) ? makeName() : nil
+        let emailElement = configuration.billingDetailsCollectionConfiguration.email == .always
+            || (configuration.billingDetailsCollectionConfiguration.email == .automatic && emailRequiredByPaymentMethod) ? makeEmail() : nil
+        let phoneElement = configuration.billingDetailsCollectionConfiguration.phone == .always
+            || (configuration.billingDetailsCollectionConfiguration.phone == .automatic && phoneRequiredByPaymentMethod) ? makePhone() : nil
+        let elements = ([nameElement, emailElement, phoneElement] as [Element?]).compactMap { $0 }
         guard !elements.isEmpty else { return nil }
 
         return SectionElement(
-            title: STPLocalizedString("Contact information", "Title for the contact information section"),
+            title: .Localized.contact_information,
             elements: elements,
             theme: theme)
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -535,12 +535,13 @@ extension PaymentSheetFormFactory {
     /// - Parameter emailRequiredByPaymentMethod: Whether your payment method requires the email field.
     /// - Parameter phoneRequiredByPaymentMethod: Whether your payment method requires the phone field.
     func makeContactInformationSection(nameRequiredByPaymentMethod: Bool, emailRequiredByPaymentMethod: Bool, phoneRequiredByPaymentMethod: Bool) -> SectionElement? {
-        let nameElement = configuration.billingDetailsCollectionConfiguration.name == .always
-            || (configuration.billingDetailsCollectionConfiguration.name == .automatic && nameRequiredByPaymentMethod) ? makeName() : nil
-        let emailElement = configuration.billingDetailsCollectionConfiguration.email == .always
-            || (configuration.billingDetailsCollectionConfiguration.email == .automatic && emailRequiredByPaymentMethod) ? makeEmail() : nil
-        let phoneElement = configuration.billingDetailsCollectionConfiguration.phone == .always
-            || (configuration.billingDetailsCollectionConfiguration.phone == .automatic && phoneRequiredByPaymentMethod) ? makePhone() : nil
+        let config = configuration.billingDetailsCollectionConfiguration
+        let nameElement = config.name == .always
+            || (config.name == .automatic && nameRequiredByPaymentMethod) ? makeName() : nil
+        let emailElement = config.email == .always
+            || (config.email == .automatic && emailRequiredByPaymentMethod) ? makeEmail() : nil
+        let phoneElement = config.phone == .always
+            || (config.phone == .automatic && phoneRequiredByPaymentMethod) ? makePhone() : nil
         let elements = ([nameElement, emailElement, phoneElement] as [Element?]).compactMap { $0 }
         guard !elements.isEmpty else { return nil }
 

--- a/StripeUICore/StripeUICore/Source/Helpers/String+Localized.swift
+++ b/StripeUICore/StripeUICore/Source/Helpers/String+Localized.swift
@@ -75,6 +75,10 @@ import Foundation
         STPLocalizedString("Billing address is same as shipping", "Label for a checkbox that makes customers billing address same as their shipping address")
     }
 
+    static var contact_information: String {
+        STPLocalizedString("Contact information", "Title for the contact information section")
+    }
+
     // MARK: - Phone number
 
     static var phone: String {

--- a/StripeUICore/StripeUICore/Source/Helpers/String+Localized.swift
+++ b/StripeUICore/StripeUICore/Source/Helpers/String+Localized.swift
@@ -75,10 +75,6 @@ import Foundation
         STPLocalizedString("Billing address is same as shipping", "Label for a checkbox that makes customers billing address same as their shipping address")
     }
 
-    static var contact_information: String {
-        STPLocalizedString("Contact information", "Title for the contact information section")
-    }
-
     // MARK: - Phone number
 
     static var phone: String {


### PR DESCRIPTION
## Summary
* [Move Elements helper methods out of test into dedicated file](https://github.com/stripe/stripe-ios/commit/18680e535745e6a59157b37e68119c1c269579c9) `Elements+TestHelpers.swift` 
* [Refactor makeContactInformation in preparation for usage w/ other PMs.](https://github.com/stripe/stripe-ios/commit/b7f125aff05b664655be9a91733848b4e0d28a50) - The idea is that every non-LUXE PM will use this method to handle the collection of name, email, and phone in accordance with the merchant's billing collection configuration and the payment method's requirements.

## Motivation
Adding support for more non-LUXE PMs in future PRs.


