### PR TITLE
Fix deploy script to not delete Package.resolved

### DIFF
--- a/Stripe.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Stripe.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,32 @@
+{
+  "pins" : [
+    {
+      "identity" : "ios-snapshot-test-case",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/uber/ios-snapshot-test-case",
+      "state" : {
+        "revision" : "7b10770333a961be6e5a41c9ce04b8c6d3990126",
+        "version" : "8.0.0"
+      }
+    },
+    {
+      "identity" : "ocmock",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/erikdoe/ocmock",
+      "state" : {
+        "branch" : "master",
+        "revision" : "05cbc9d934e84ad32530fa53fd7d29c7966d5828"
+      }
+    },
+    {
+      "identity" : "ohhttpstubs",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/eurias-stripe/OHHTTPStubs",
+      "state" : {
+        "branch" : "master",
+        "revision" : "94cf8e1d9e38b0edd580ddc699dda23a7bf66515"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/ci_scripts/delete_project_files.rb
+++ b/ci_scripts/delete_project_files.rb
@@ -3,7 +3,7 @@
 require_relative 'common'
 
 run_command('rm -f .package.resolved', false)
-run_command('rm -rf Stripe.xcworkspace', false)
+run_command('find Stripe.xcworkspace -type f ! -name "Package.resolved" -exec rm {} +', false)
 run_command('find Stripe* -type d -name "*.xcodeproj" -exec rm -r {} +', false)
 run_command('find Example -type d -name "*.xcodeproj" -exec rm -r {} +', false)
 run_command('find Testers -type d -name "*.xcodeproj" -exec rm -r {} +', false)


### PR DESCRIPTION
## Summary
We want to commit Package.resolved to the repo. The deploy script deleted this, it should not.

## Testing
Ran script locally.