### PR TITLE
Update legacy-tests-14 to use Xcode 14.3 instead of Xcode 14.1 to be …

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -413,6 +413,11 @@ workflows:
         title: fastlane legacy_tests_14
     envs:
     - DEFAULT_TEST_DEVICE: platform=iOS Simulator,name=iPhone 8,OS=14.5
+    meta:
+      bitrise.io:
+        stack: osx-xcode-14.3.x-ventura
+        machine_type_id: g2-m1.8core
+
     before_run:
     - prep_all
     after_run:


### PR DESCRIPTION
…able to use async test methods


## Motivation
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-2499

## Testing
https://app.bitrise.io/build/22ef5fb5-d67d-4884-a09d-8c25e5ac3cc3

