### PR TITLE
Update copy for achv2 in customer sheet

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/en.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/en.lproj/Localizable.strings
@@ -169,6 +169,9 @@ to be saved and used in future checkout sessions. */
 /* The label of a switch indicating whether to save the user's card for future payment */
 "Save this card for future %@ payments" = "Save this card for future %@ payments";
 
+/* US Bank Account copy title for Mobile payment element form */
+"Save your bank account in just a few steps." = "Save your bank account in just a few steps.";
+
 /* Title shown above a carousel containing the customer's payment methods */
 "Select your payment method" = "Select your payment method";
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -513,7 +513,7 @@ extension PaymentSheetFormFactory {
     }
 
     private func makeUSBankAccountCopyLabel() -> StaticElement {
-        switch(configuration) {
+        switch configuration {
         case .customerSheet:
             return makeSectionTitleLabelWith(
                 text: STPLocalizedString(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -513,12 +513,22 @@ extension PaymentSheetFormFactory {
     }
 
     private func makeUSBankAccountCopyLabel() -> StaticElement {
-        return makeSectionTitleLabelWith(
-            text: STPLocalizedString(
-                "Pay with your bank account in just a few steps.",
-                "US Bank Account copy title for Mobile payment element form"
+        switch(configuration) {
+        case .customerSheet:
+            return makeSectionTitleLabelWith(
+                text: STPLocalizedString(
+                    "Save your bank account in just a few steps.",
+                    "US Bank Account copy title for Mobile payment element form"
+                )
             )
-        )
+        case .paymentSheet:
+            return makeSectionTitleLabelWith(
+                text: STPLocalizedString(
+                    "Pay with your bank account in just a few steps.",
+                    "US Bank Account copy title for Mobile payment element form"
+                )
+            )
+        }
     }
 
     func makeSectionTitleLabelWith(text: String) -> StaticElement {


### PR DESCRIPTION
## Summary
Update copy for achv2 in customer sheet

## Motivation
Saying "Pay" in customer sheet isn't accurate

## Testing
Manual testing, achv2 is not yet enabled, so this will not be shown until we enable it (and back it up with snapshot tests)

![Screenshot 2023-07-26 at 4 26 02 PM](https://github.com/stripe/stripe-ios/assets/99628984/c1c5140a-ae12-43ad-b6d4-0ebd0712d5fe)
