### PR TITLE
Financial Connections: added support for reduceManualEntryProminenceInErrors

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsSynchronize.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsSynchronize.swift
@@ -20,5 +20,6 @@ struct FinancialConnectionsSynchronize: Decodable {
     struct VisualUpdate: Decodable {
         let reducedBranding: Bool
         let merchantLogo: [String]
+        let reduceManualEntryProminenceInErrors: Bool
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerDataSource.swift
@@ -23,6 +23,7 @@ protocol AccountPickerDataSource: AnyObject {
     var institution: FinancialConnectionsInstitution { get }
     var selectedAccounts: [FinancialConnectionsPartnerAccount] { get }
     var analyticsClient: FinancialConnectionsAnalyticsClient { get }
+    var reduceManualEntryProminenceInErrors: Bool { get }
 
     func pollAuthSessionAccounts() -> Future<FinancialConnectionsAuthSessionAccounts>
     func updateSelectedAccounts(_ selectedAccounts: [FinancialConnectionsPartnerAccount])
@@ -37,6 +38,7 @@ final class AccountPickerDataSourceImplementation: AccountPickerDataSource {
     let manifest: FinancialConnectionsSessionManifest
     let institution: FinancialConnectionsInstitution
     let analyticsClient: FinancialConnectionsAnalyticsClient
+    let reduceManualEntryProminenceInErrors: Bool
 
     private(set) var selectedAccounts: [FinancialConnectionsPartnerAccount] = [] {
         didSet {
@@ -51,7 +53,8 @@ final class AccountPickerDataSourceImplementation: AccountPickerDataSource {
         authSession: FinancialConnectionsAuthSession,
         manifest: FinancialConnectionsSessionManifest,
         institution: FinancialConnectionsInstitution,
-        analyticsClient: FinancialConnectionsAnalyticsClient
+        analyticsClient: FinancialConnectionsAnalyticsClient,
+        reduceManualEntryProminenceInErrors: Bool
     ) {
         self.apiClient = apiClient
         self.clientSecret = clientSecret
@@ -59,6 +62,7 @@ final class AccountPickerDataSourceImplementation: AccountPickerDataSource {
         self.manifest = manifest
         self.institution = institution
         self.analyticsClient = analyticsClient
+        self.reduceManualEntryProminenceInErrors = reduceManualEntryProminenceInErrors
     }
 
     func pollAuthSessionAccounts() -> Future<FinancialConnectionsAuthSessionAccounts> {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerViewController.swift
@@ -61,7 +61,7 @@ final class AccountPickerViewController: UIViewController {
             } : nil
     }
     private var didSelectManualEntry: (() -> Void)? {
-        return dataSource.manifest.allowManualEntry
+        return (dataSource.manifest.allowManualEntry && !dataSource.reduceManualEntryProminenceInErrors)
             ? { [weak self] in
                 guard let self = self else { return }
                 self.delegate?.accountPickerViewControllerDidSelectManualEntry(self)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AttachLinkedPaymentAccount/AttachLinkedPaymentAccountDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AttachLinkedPaymentAccount/AttachLinkedPaymentAccountDataSource.swift
@@ -14,6 +14,7 @@ protocol AttachLinkedPaymentAccountDataSource: AnyObject {
     var institution: FinancialConnectionsInstitution { get }
     var analyticsClient: FinancialConnectionsAnalyticsClient { get }
     var authSessionId: String? { get }
+    var reduceManualEntryProminenceInErrors: Bool { get }
 
     func attachLinkedAccountIdToLinkAccountSession() -> Future<FinancialConnectionsPaymentAccountResource>
 }
@@ -28,6 +29,7 @@ final class AttachLinkedPaymentAccountDataSourceImplementation: AttachLinkedPaym
     let analyticsClient: FinancialConnectionsAnalyticsClient
     let authSessionId: String?
     private let consumerSessionClientSecret: String?
+    let reduceManualEntryProminenceInErrors: Bool
 
     init(
         apiClient: FinancialConnectionsAPIClient,
@@ -37,7 +39,8 @@ final class AttachLinkedPaymentAccountDataSourceImplementation: AttachLinkedPaym
         linkedAccountId: String,
         analyticsClient: FinancialConnectionsAnalyticsClient,
         authSessionId: String?,
-        consumerSessionClientSecret: String?
+        consumerSessionClientSecret: String?,
+        reduceManualEntryProminenceInErrors: Bool
     ) {
         self.apiClient = apiClient
         self.clientSecret = clientSecret
@@ -47,6 +50,7 @@ final class AttachLinkedPaymentAccountDataSourceImplementation: AttachLinkedPaym
         self.analyticsClient = analyticsClient
         self.authSessionId = authSessionId
         self.consumerSessionClientSecret = consumerSessionClientSecret
+        self.reduceManualEntryProminenceInErrors = reduceManualEntryProminenceInErrors
     }
 
     func attachLinkedAccountIdToLinkAccountSession() -> Future<FinancialConnectionsPaymentAccountResource> {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AttachLinkedPaymentAccount/AttachLinkedPaymentAccountViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AttachLinkedPaymentAccount/AttachLinkedPaymentAccountViewController.swift
@@ -49,7 +49,7 @@ final class AttachLinkedPaymentAccountViewController: UIViewController {
             } : nil
     }
     private var didSelectManualEntry: (() -> Void)? {
-        return dataSource.manifest.allowManualEntry
+        return (dataSource.manifest.allowManualEntry && !dataSource.reduceManualEntryProminenceInErrors)
             ? { [weak self] in
                 guard let self = self else { return }
                 self.delegate?.attachLinkedPaymentAccountViewControllerDidSelectManualEntry(self)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -789,7 +789,8 @@ private func CreatePaneViewController(
                 authSession: authSession,
                 manifest: dataManager.manifest,
                 institution: institution,
-                analyticsClient: dataManager.analyticsClient
+                analyticsClient: dataManager.analyticsClient,
+                reduceManualEntryProminenceInErrors: dataManager.reduceManualEntryProminenceInErrors
             )
             let accountPickerViewController = AccountPickerViewController(dataSource: accountPickerDataSource)
             accountPickerViewController.delegate = nativeFlowController
@@ -810,7 +811,8 @@ private func CreatePaneViewController(
                 linkedAccountId: linkedAccountId,
                 analyticsClient: dataManager.analyticsClient,
                 authSessionId: dataManager.authSession?.id,
-                consumerSessionClientSecret: dataManager.consumerSession?.clientSecret
+                consumerSessionClientSecret: dataManager.consumerSession?.clientSecret,
+                reduceManualEntryProminenceInErrors: dataManager.reduceManualEntryProminenceInErrors
             )
             let attachedLinkedPaymentAccountViewController = AttachLinkedPaymentAccountViewController(
                 dataSource: dataSource
@@ -978,7 +980,8 @@ private func CreatePaneViewController(
                 returnURL: dataManager.returnURL,
                 apiClient: dataManager.apiClient,
                 clientSecret: dataManager.clientSecret,
-                analyticsClient: dataManager.analyticsClient
+                analyticsClient: dataManager.analyticsClient,
+                reduceManualEntryProminenceInErrors: dataManager.reduceManualEntryProminenceInErrors
             )
             let partnerAuthViewController = PartnerAuthViewController(dataSource: partnerAuthDataSource)
             partnerAuthViewController.delegate = nativeFlowController

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowDataManager.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowDataManager.swift
@@ -17,6 +17,7 @@ protocol NativeFlowDataManager: AnyObject {
     var apiClient: FinancialConnectionsAPIClient { get }
     var clientSecret: String { get }
     var analyticsClient: FinancialConnectionsAnalyticsClient { get }
+    var reduceManualEntryProminenceInErrors: Bool { get }
 
     var institution: FinancialConnectionsInstitution? { get set }
     var authSession: FinancialConnectionsAuthSession? { get set }
@@ -70,6 +71,9 @@ class NativeFlowAPIDataManager: NativeFlowDataManager {
             // show the "control" experience of showing logo in the nav bar
             return nil
         }
+    }
+    var reduceManualEntryProminenceInErrors: Bool {
+        return visualUpdate.reduceManualEntryProminenceInErrors
     }
     let returnURL: String?
     let consentPaneModel: FinancialConnectionsConsent

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthDataSource.swift
@@ -14,6 +14,7 @@ protocol PartnerAuthDataSource: AnyObject {
     var returnURL: String? { get }
     var analyticsClient: FinancialConnectionsAnalyticsClient { get }
     var pendingAuthSession: FinancialConnectionsAuthSession? { get }
+    var reduceManualEntryProminenceInErrors: Bool { get }
 
     func createAuthSession() -> Future<FinancialConnectionsAuthSession>
     func authorizeAuthSession(_ authSession: FinancialConnectionsAuthSession) -> Future<FinancialConnectionsAuthSession>
@@ -30,6 +31,7 @@ final class PartnerAuthDataSourceImplementation: PartnerAuthDataSource {
     private let apiClient: FinancialConnectionsAPIClient
     private let clientSecret: String
     let analyticsClient: FinancialConnectionsAnalyticsClient
+    let reduceManualEntryProminenceInErrors: Bool
 
     // a "pending" auth session is a session which has started
     // BUT the session is still yet-to-be authorized
@@ -44,7 +46,8 @@ final class PartnerAuthDataSourceImplementation: PartnerAuthDataSource {
         returnURL: String?,
         apiClient: FinancialConnectionsAPIClient,
         clientSecret: String,
-        analyticsClient: FinancialConnectionsAnalyticsClient
+        analyticsClient: FinancialConnectionsAnalyticsClient,
+        reduceManualEntryProminenceInErrors: Bool
     ) {
         self.institution = institution
         self.manifest = manifest
@@ -52,6 +55,7 @@ final class PartnerAuthDataSourceImplementation: PartnerAuthDataSource {
         self.apiClient = apiClient
         self.clientSecret = clientSecret
         self.analyticsClient = analyticsClient
+        self.reduceManualEntryProminenceInErrors = reduceManualEntryProminenceInErrors
     }
 
     func createAuthSession() -> Future<FinancialConnectionsAuthSession> {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthViewController.swift
@@ -146,6 +146,7 @@ final class PartnerAuthViewController: UIViewController {
         // PartnerAuth to try again
         navigationItem.hidesBackButton = true
 
+        let allowManualEntryInErrors = (dataSource.manifest.allowManualEntry && !dataSource.reduceManualEntryProminenceInErrors)
         let errorView: UIView?
         if let error = error as? StripeError,
             case .apiError(let apiError) = error,
@@ -203,7 +204,7 @@ final class PartnerAuthViewController: UIViewController {
                             }
                         }()
                         let endOfSubtitle: String = {
-                            if dataSource.manifest.allowManualEntry {
+                            if allowManualEntryInErrors {
                                 return STPLocalizedString(
                                     "Please enter your bank details manually or select another bank.",
                                     "The second part of a subtitle/description of a screen that shows an error. The error indicates that the bank user selected is currently under maintenance."
@@ -218,7 +219,7 @@ final class PartnerAuthViewController: UIViewController {
                         return beginningOfSubtitle + " " + endOfSubtitle
                     }(),
                     primaryButtonConfiguration: primaryButtonConfiguration,
-                    secondaryButtonConfiguration: dataSource.manifest.allowManualEntry
+                    secondaryButtonConfiguration: allowManualEntryInErrors
                         ? ReusableInformationView.ButtonConfiguration(
                             title: String.Localized.enter_bank_details_manually,
                             action: { [weak self] in
@@ -243,7 +244,7 @@ final class PartnerAuthViewController: UIViewController {
                         institution.name
                     ),
                     subtitle: {
-                        if dataSource.manifest.allowManualEntry {
+                        if allowManualEntryInErrors {
                             return STPLocalizedString(
                                 "Please enter your bank details manually or select another bank.",
                                 "The subtitle/description of a screen that shows an error. The error indicates that the bank user selected is currently under maintenance."
@@ -256,7 +257,7 @@ final class PartnerAuthViewController: UIViewController {
                         }
                     }(),
                     primaryButtonConfiguration: primaryButtonConfiguration,
-                    secondaryButtonConfiguration: dataSource.manifest.allowManualEntry
+                    secondaryButtonConfiguration: allowManualEntryInErrors
                         ? ReusableInformationView.ButtonConfiguration(
                             title: String.Localized.enter_bank_details_manually,
                             action: { [weak self] in


### PR DESCRIPTION
## Summary

Old PR: https://github.com/stripe/stripe-ios/pull/2784
[Backend PR](https://git.corp.stripe.com/stripe-internal/pay-server/pull/660957)
[Doc](https://docs.google.com/document/d/1IouZwTiCDJW4SVz-Vl09nc0A-hUE6wfdbDIHSVRancE/edit)

## Testing

### reduceManualEntryProminenceInErrors = false (default)

Tested using the default scenario with test mode ON

https://github.com/stripe/stripe-ios/assets/105514761/81a9b587-e03f-4c7a-bcc1-ff1939078076

### reduceManualEntryProminenceInErrors = true

Tested using the special "CA" merchant on test mode keys

https://github.com/stripe/stripe-ios/assets/105514761/fbbf68dd-3646-4468-b49a-ccead1f683d2
