### PR TITLE
[Camera-core] Try search for `builtInTripleCamera`

### DIFF
--- a/StripeCameraCore/StripeCameraCore/Source/Coordinators/CameraSession.swift
+++ b/StripeCameraCore/StripeCameraCore/Source/Coordinators/CameraSession.swift
@@ -441,6 +441,7 @@ extension CameraSession {
         guard let captureDevice = captureDevices.devices.first else {
             throw CameraSessionError.captureDeviceNotFound
         }
+        print("BGLM - captureDevice: \(captureDevice)")
 
         return try AVCaptureDeviceInput(device: captureDevice)
     }
@@ -482,7 +483,7 @@ extension CameraSession.CameraPosition {
 
         case .back:
             if #available(iOS 13.0, *) {
-                return [.builtInDualCamera, .builtInDualWideCamera, .builtInWideAngleCamera]
+                return [.builtInTripleCamera, .builtInDualCamera, .builtInDualWideCamera, .builtInWideAngleCamera]
             } else {
                 return [.builtInDualCamera, .builtInWideAngleCamera]
             }

--- a/StripeCameraCore/StripeCameraCore/Source/Coordinators/CameraSession.swift
+++ b/StripeCameraCore/StripeCameraCore/Source/Coordinators/CameraSession.swift
@@ -441,7 +441,6 @@ extension CameraSession {
         guard let captureDevice = captureDevices.devices.first else {
             throw CameraSessionError.captureDeviceNotFound
         }
-        print("BGLM - captureDevice: \(captureDevice)")
 
         return try AVCaptureDeviceInput(device: captureDevice)
     }


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
We're currently not searching for `builtInTripleCamera` when trying to take video from back camera, this results in iPhone 14 pro/max choosing `builtInDualCamera`, which fails to focus when getting too close to object.


## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fix iPhone 14 pro camera focus issue


## Testing
<!-- How was the code tested? Be as specific as possible. -->
Manually verified, see recording


## Recording(on iPhone 14 pro)
| Before  | After |
| ------------- | ------------- |
| ![before](https://github.com/stripe/stripe-ios/assets/79880926/1efaed34-a6c2-42b6-a14e-1d5c95b91181)  | ![after](https://github.com/stripe/stripe-ios/assets/79880926/fde3eef9-adaf-4c9c-bc9d-dae4cc45a0a2) |



## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
