### PR TITLE
Add remove msg to PaymentSheet and CustomerSheet

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewController.swift
@@ -421,7 +421,7 @@ extension CustomerSavedPaymentMethodsCollectionViewController: PaymentOptionCell
 
         let alertController = UIAlertController(
             title: paymentMethod.removalMessage.title,
-            message: paymentMethod.removalMessage.message,
+            message: self.savedPaymentMethodsConfiguration.removeSavedPaymentMethodMessage != nil ? self.savedPaymentMethodsConfiguration.removeSavedPaymentMethodMessage : paymentMethod.removalMessage.message,
             preferredStyle: .alert
         )
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewController.swift
@@ -421,7 +421,7 @@ extension CustomerSavedPaymentMethodsCollectionViewController: PaymentOptionCell
 
         let alertController = UIAlertController(
             title: paymentMethod.removalMessage.title,
-            message: self.savedPaymentMethodsConfiguration.removeSavedPaymentMethodMessage != nil ? self.savedPaymentMethodsConfiguration.removeSavedPaymentMethodMessage : paymentMethod.removalMessage.message,
+            message: self.savedPaymentMethodsConfiguration.removeSavedPaymentMethodMessage ?? paymentMethod.removalMessage.message,
             preferredStyle: .alert
         )
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetConfiguration.swift
@@ -56,6 +56,9 @@ extension CustomerSheet {
         /// you **must** provide an appropriate value as part of `defaultBillingDetails`.
         public var billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration()
 
+        /// Optional configuration to display a custom message when a saved payment method is removed.
+        public var removeSavedPaymentMethodMessage: String?
+
         public init () {
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
@@ -163,6 +163,9 @@ extension PaymentSheet {
         /// If `never` is used for a required field for the Payment Method used during checkout,
         /// you **must** provide an appropriate value as part of `defaultBillingDetails`.
         public var billingDetailsCollectionConfiguration = BillingDetailsCollectionConfiguration()
+
+        /// Optional configuration to display a custom message when a saved payment method is removed.
+        public var removeSavedPaymentMethodMessage: String?
     }
 
     /// Configuration related to the Stripe Customer

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
@@ -372,7 +372,7 @@ extension SavedPaymentOptionsViewController: PaymentOptionCellDelegate {
 
         let alertController = UIAlertController(
             title: paymentMethod.removalMessage.title,
-            message: configuration.removeSavedPaymentMethodMessage != nil ? configuration.removeSavedPaymentMethodMessage : paymentMethod.removalMessage.message,
+            message: configuration.removeSavedPaymentMethodMessage ?? paymentMethod.removalMessage.message,
             preferredStyle: .alert
         )
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
@@ -54,6 +54,7 @@ class SavedPaymentOptionsViewController: UIViewController {
         let customerID: String?
         let showApplePay: Bool
         let showLink: Bool
+        let removeSavedPaymentMethodMessage: String?
     }
 
     var hasRemovablePaymentMethods: Bool {
@@ -371,7 +372,7 @@ extension SavedPaymentOptionsViewController: PaymentOptionCellDelegate {
 
         let alertController = UIAlertController(
             title: paymentMethod.removalMessage.title,
-            message: paymentMethod.removalMessage.message,
+            message: configuration.removeSavedPaymentMethodMessage != nil ? configuration.removeSavedPaymentMethodMessage : paymentMethod.removalMessage.message,
             preferredStyle: .alert
         )
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -156,7 +156,8 @@ class PaymentSheetFlowControllerViewController: UIViewController {
             configuration: .init(
                 customerID: configuration.customer?.id,
                 showApplePay: isApplePayEnabled,
-                showLink: isLinkEnabled
+                showLink: isLinkEnabled,
+                removeSavedPaymentMethodMessage: configuration.removeSavedPaymentMethodMessage
             ),
             appearance: configuration.appearance
         )

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -85,7 +85,8 @@ class PaymentSheetViewController: UIViewController {
             configuration: .init(
                 customerID: configuration.customer?.id,
                 showApplePay: showApplePay,
-                showLink: showLink
+                showLink: showLink,
+                removeSavedPaymentMethodMessage: configuration.removeSavedPaymentMethodMessage
             ),
             appearance: configuration.appearance,
             delegate: self


### PR DESCRIPTION
## Summary
I've added a new configuration `removeSavedPaymentMethodMessage` to PaymentSheet.Configuration and CustomerSheet.Configuration which allows for customization of the `message` of the UIAlertController when removing a saved Payment Method.

Default:
<img width="346" alt="CleanShot 2023-07-06 at 09 51 34@2x" src="https://github.com/stripe/stripe-ios/assets/95632492/7605df1b-12c8-4cda-8608-c3f03584633d">

Customized:
<img width="341" alt="CleanShot 2023-07-06 at 09 52 30@2x" src="https://github.com/stripe/stripe-ios/assets/95632492/cd063953-3668-4ccc-a815-394d2f993009">

## Motivation
With the Payment Element's release of saved payment methods, functionality was added to allow customization of the removal message, so I was porting some of that functionality to iOS.

API Review: https://jira.corp.stripe.com/browse/MOBILE_APIREVIEW-48

## Testing
Executed on local machine