### PR TITLE
Financial Connections: added a auth_session.url_received event.

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsAnalyticsClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsAnalyticsClient.swift
@@ -53,7 +53,6 @@ final class FinancialConnectionsAnalyticsClient {
             !parameters.contains(where: { type(of: $0.value) == FinancialConnectionsSessionManifest.NextPane.self }),
             "Do not pass NextPane enum. Use the raw value."
         )
-
         assert((parameters["pane"] as? String) != nil, "We expect pane to be set as a String for all analytics events.")
         analyticsClient.log(eventName: eventName, parameters: parameters)
     }


### PR DESCRIPTION
## Summary

Added a new event that logs the "return_url" we received when we return back from the secure browser.

## Testing

Splunk for success:
- https://splunk.corp.stripe.com/en-US/app/search/search?sid=1690922179.259219_16A88E4A-C308-4A39-B80F-1C1910B5BF26

```
     p_auth_session_id: bcsess_1NaPIfL6p1bboFUQ1JUne1lG
     p_event_name: linked_accounts.auth_session.url_received
     p_pane: partner_auth
     p_status: success
     p_url: stripe://ios?status=success
```

Splunk for cancels:

https://splunk.corp.stripe.com/en-US/app/search/search?sid=1690922570.259310_16A88E4A-C308-4A39-B80F-1C1910B5BF26