### PR TITLE
Dismiss sheet after adding account w/ microdeposits

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
@@ -583,6 +583,48 @@ class CustomerSheetUITest: XCTestCase {
 
         dismissAlertView(alertBody: "Success: ••••6789, selected", alertTitle: "Complete", buttonToTap: "OK")
     }
+    func testCustomerSheetStandard_applePayOff_addUSBankAccount_MicroDeposit() throws {
+        var settings = CustomerSheetTestPlaygroundSettings.defaultValues()
+        settings.customerMode = .new
+        settings.applePay = .off
+
+        loadPlayground(
+            app,
+            settings
+        )
+
+        let selectButton = app.staticTexts["None"]
+        XCTAssertTrue(selectButton.waitForExistence(timeout: 60.0))
+        selectButton.tap()
+
+        let usBankAccountPMSelectorButton = app.staticTexts["US Bank Account"]
+        XCTAssertTrue(usBankAccountPMSelectorButton.waitForExistence(timeout: 60.0))
+        usBankAccountPMSelectorButton.tap()
+
+        try! fillUSBankData(app)
+
+        let continueButton = app.buttons["Continue"]
+        XCTAssertTrue(continueButton.waitForExistence(timeout: 60.0))
+        continueButton.tap()
+
+        // Go through connections flow
+        app.links["Manually verify instead"].tap()
+        try! fillUSBankData_microdeposits(app)
+
+        let continueManualEntry = app.buttons["manual_entry_continue_button"]
+        XCTAssertTrue(continueManualEntry.waitForExistence(timeout: 60.0))
+        continueManualEntry.tap()
+
+        let doneManualEntry = app.buttons["manual_entry_success_done_button"]
+        XCTAssertTrue(doneManualEntry.waitForExistence(timeout: 60.0))
+        doneManualEntry.tap()
+
+        let saveButton = app.buttons["Save"]
+        XCTAssertTrue(saveButton.waitForExistence(timeout: 60.0))
+        saveButton.tap()
+
+        dismissAlertView(alertBody: "Success: payment method not set, canceled", alertTitle: "Complete", buttonToTap: "OK")
+    }
     func presentCSAndAddCardFrom(buttonLabel: String, tapAdd: Bool = true) {
         let selectButton = app.staticTexts[buttonLabel]
         XCTAssertTrue(selectButton.waitForExistence(timeout: 60.0))

--- a/Example/PaymentSheet Example/PaymentSheetUITest/XCUITest+Utilities.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/XCUITest+Utilities.swift
@@ -117,6 +117,30 @@ extension XCTestCase {
         emailField.forceTapWhenHittableInTestCase(self)
         app.typeText("test@example.com")
     }
+    func fillUSBankData_microdeposits(_ app: XCUIApplication,
+                                      container: XCUIElement? = nil) throws {
+        let context = container ?? app
+        let routingField = context.textFields["manual_entry_routing_number_text_field"]
+        routingField.forceTapWhenHittableInTestCase(self)
+        app.typeText("110000000")
+
+        let acctField = context.textFields["manual_entry_account_number_text_field"]
+        acctField.forceTapWhenHittableInTestCase(self)
+        app.typeText("000123456789")
+
+        // Dismiss keyboard, otherwise we can not see the next field
+        // This is only an artifact in the (test) native version of the flow
+        let hackDismissKeyboardText = context.textViews["Your bank information will be verified with micro-deposits to your account"].firstMatch
+        hackDismissKeyboardText.tap()
+
+        let acctConfirmField = context.textFields["manual_entry_account_number_confirmation_text_field"]
+        acctConfirmField.forceTapWhenHittableInTestCase(self)
+        app.typeText("000123456789")
+
+        // Dismiss keyboard again otherwise we can not see the continue button
+        // This is only an artifact in the (test) native version of the flow
+        hackDismissKeyboardText.tap()
+    }
 
     func waitToDisappear(_ target: Any?) {
         let exists = NSPredicate(format: "exists == 0")

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/en.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/en.lproj/Localizable.strings
@@ -188,8 +188,8 @@ is not supported by the merchant */
 /* Error message when an error case happens when linking your account */
 "Something went wrong when linking your account.\nPlease try again later." = "Something went wrong when linking your account.\nPlease try again later.";
 
-/* Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name */
-"Stripe will deposit $0.01 to your account in 1-2 business days. Then you’ll get an email with instructions to complete before confirming your bank account with %@." = "Stripe will deposit $0.01 to your account in 1-2 business days. Then you’ll get an email with instructions to complete before confirming your bank account with %@.";
+/* Prompt for microdeposit verification before completing saving payment method with merchant. %@ will be replaced by merchant business name */
+"Stripe will deposit $0.01 to your account in 1-2 business days. Then you’ll get an email with instructions before saving your bank account with %@." = "Stripe will deposit $0.01 to your account in 1-2 business days. Then you’ll get an email with instructions before saving your bank account with %@.";
 
 /* Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name */
 "Stripe will deposit $0.01 to your account in 1-2 business days. Then you’ll get an email with instructions to complete payment to %@." = "Stripe will deposit $0.01 to your account in 1-2 business days. Then you’ll get an email with instructions to complete payment to %@.";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/en.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/en.lproj/Localizable.strings
@@ -189,7 +189,7 @@ is not supported by the merchant */
 "Something went wrong when linking your account.\nPlease try again later." = "Something went wrong when linking your account.\nPlease try again later.";
 
 /* Prompt for microdeposit verification before completing saving payment method with merchant. %@ will be replaced by merchant business name */
-"Stripe will deposit $0.01 to your account in 1-2 business days. Then you’ll get an email with instructions before saving your bank account with %@." = "Stripe will deposit $0.01 to your account in 1-2 business days. Then you’ll get an email with instructions before saving your bank account with %@.";
+"Stripe will deposit $0.01 to your account in 1-2 business days. Then you'll get an email with instructions to finish saving your bank account with %@." = "Stripe will deposit $0.01 to your account in 1-2 business days. Then you'll get an email with instructions to finish saving your bank account with %@.";
 
 /* Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name */
 "Stripe will deposit $0.01 to your account in 1-2 business days. Then you’ll get an email with instructions to complete payment to %@." = "Stripe will deposit $0.01 to your account in 1-2 business days. Then you’ll get an email with instructions to complete payment to %@.";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/en.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/en.lproj/Localizable.strings
@@ -189,6 +189,9 @@ is not supported by the merchant */
 "Something went wrong when linking your account.\nPlease try again later." = "Something went wrong when linking your account.\nPlease try again later.";
 
 /* Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name */
+"Stripe will deposit $0.01 to your account in 1-2 business days. Then you’ll get an email with instructions to complete before confirming your bank account with %@." = "Stripe will deposit $0.01 to your account in 1-2 business days. Then you’ll get an email with instructions to complete before confirming your bank account with %@.";
+
+/* Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name */
 "Stripe will deposit $0.01 to your account in 1-2 business days. Then you’ll get an email with instructions to complete payment to %@." = "Stripe will deposit $0.01 to your account in 1-2 business days. Then you’ll get an email with instructions to complete payment to %@.";
 
 /* An error message. */

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsViewController.swift
@@ -443,17 +443,26 @@ class CustomerSavedPaymentMethodsViewController: UIViewController {
             }
             let setupIntent = Intent.setupIntent(fetchedSetupIntent)
 
-            guard let paymentMethod = await self.confirm(intent: setupIntent, paymentOption: paymentOption) else {
+            guard let setupIntent = await self.confirm(intent: setupIntent, paymentOption: paymentOption),
+                  let paymentMethod = setupIntent.paymentMethod else {
                 self.processingInFlight = false
                 self.updateUI()
                 return
             }
             self.processingInFlight = false
-            self.savedPaymentOptionsViewController.didAddSavedPaymentMethod(paymentMethod: paymentMethod)
-            self.mode = .selectingSaved
-            self.updateUI(animated: true)
-            self.reinitAddPaymentMethodViewController()
+            if shouldDismissSheetOnConfirm(paymentMethod: paymentMethod, setupIntent: setupIntent) {
+                self.handleDismissSheet()
+            } else {
+                self.savedPaymentOptionsViewController.didAddSavedPaymentMethod(paymentMethod: paymentMethod)
+                self.mode = .selectingSaved
+                self.updateUI(animated: true)
+                self.reinitAddPaymentMethodViewController()
+            }
         }
+    }
+
+    private func shouldDismissSheetOnConfirm(paymentMethod: STPPaymentMethod, setupIntent: STPSetupIntent) -> Bool{
+        return paymentMethod.type == .USBankAccount && setupIntent.nextAction?.type == .verifyWithMicrodeposits
     }
 
     private func fetchClientSecret() async -> String? {
@@ -483,10 +492,10 @@ class CustomerSavedPaymentMethodsViewController: UIViewController {
         return setupIntent
     }
 
-    func confirm(intent: Intent?, paymentOption: PaymentOption) async -> STPPaymentMethod? {
-        var paymentMethod: STPPaymentMethod?
+    func confirm(intent: Intent?, paymentOption: PaymentOption) async -> STPSetupIntent? {
+        var setupIntent: STPSetupIntent?
         do {
-            paymentMethod = try await withCheckedThrowingContinuation { continuation in
+            setupIntent = try await withCheckedThrowingContinuation { continuation in
                 self.delegate?.savedPaymentMethodsViewControllerShouldConfirm(intent, with: paymentOption, completion: { result in
                     switch result {
                     case .canceled:
@@ -496,8 +505,7 @@ class CustomerSavedPaymentMethodsViewController: UIViewController {
                         STPAnalyticsClient.sharedClient.logCSAddPaymentMethodViaSetupIntentFailure()
                         continuation.resume(throwing: error)
                     case .completed(let intent):
-                        guard let intent = intent as? STPSetupIntent,
-                              let paymentMethod = intent.paymentMethod else {
+                        guard let intent = intent as? STPSetupIntent else {
                             STPAnalyticsClient.sharedClient.logCSAddPaymentMethodViaSetupIntentFailure()
                             // Not ideal (but also very rare): If this fails, customers will need to know there is an error
                             // so that they can back out and try again
@@ -506,14 +514,14 @@ class CustomerSavedPaymentMethodsViewController: UIViewController {
                             continuation.resume(throwing: CustomerSheetError.unknown(debugDescription: "Unexpected error occured"))
                             return
                         }
-                        continuation.resume(with: .success(paymentMethod))
+                        continuation.resume(with: .success(intent))
                     }
                 })
             }
         } catch {
             self.error = error
         }
-        return paymentMethod
+        return setupIntent
     }
 
     private func addPaymentOptionToCustomer(paymentOption: PaymentOption) {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/USBankAccountPaymentMethodElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/USBankAccountPaymentMethodElement.swift
@@ -50,7 +50,7 @@ final class USBankAccountPaymentMethodElement: Element {
     static let ContinueMandateText: String = STPLocalizedString("By continuing, you agree to authorize payments pursuant to <terms>these terms</terms>.", "Text providing link to terms for ACH payments")
     static let SaveAccountMandateText: String = STPLocalizedString("By saving your bank account for %@ you agree to authorize payments pursuant to <terms>these terms</terms>.", "Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@).")
     static let MicrodepositCopy: String = STPLocalizedString("Stripe will deposit $0.01 to your account in 1-2 business days. Then you’ll get an email with instructions to complete payment to %@.", "Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name")
-    static let MicrodepositCopy_CustomerSheet: String = STPLocalizedString("Stripe will deposit $0.01 to your account in 1-2 business days. Then you’ll get an email with instructions to complete before confirming your bank account with %@.", "Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name")
+    static let MicrodepositCopy_CustomerSheet: String = STPLocalizedString("Stripe will deposit $0.01 to your account in 1-2 business days. Then you’ll get an email with instructions before saving your bank account with %@.", "Prompt for microdeposit verification before completing saving payment method with merchant. %@ will be replaced by merchant business name")
 
     var canLinkAccount: Bool {
         let params = self.formElement.updateParams(params: IntentConfirmParams(type: .USBankAccount))

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/USBankAccountPaymentMethodElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/USBankAccountPaymentMethodElement.swift
@@ -50,7 +50,7 @@ final class USBankAccountPaymentMethodElement: Element {
     static let ContinueMandateText: String = STPLocalizedString("By continuing, you agree to authorize payments pursuant to <terms>these terms</terms>.", "Text providing link to terms for ACH payments")
     static let SaveAccountMandateText: String = STPLocalizedString("By saving your bank account for %@ you agree to authorize payments pursuant to <terms>these terms</terms>.", "Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@).")
     static let MicrodepositCopy: String = STPLocalizedString("Stripe will deposit $0.01 to your account in 1-2 business days. Then you’ll get an email with instructions to complete payment to %@.", "Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name")
-    static let MicrodepositCopy_CustomerSheet: String = STPLocalizedString("Stripe will deposit $0.01 to your account in 1-2 business days. Then you’ll get an email with instructions before saving your bank account with %@.", "Prompt for microdeposit verification before completing saving payment method with merchant. %@ will be replaced by merchant business name")
+    static let MicrodepositCopy_CustomerSheet: String = STPLocalizedString("Stripe will deposit $0.01 to your account in 1-2 business days. Then you'll get an email with instructions to finish saving your bank account with %@.", "Prompt for microdeposit verification before completing saving payment method with merchant. %@ will be replaced by merchant business name")
 
     var canLinkAccount: Bool {
         let params = self.formElement.updateParams(params: IntentConfirmParams(type: .USBankAccount))


### PR DESCRIPTION
## Summary
After adding a bank account manually, we need to dismiss the sheet, rather than allowing it to be a selectable payment method option.

## Motivation
Bank account isn't confirmed yet, so it can not be selected.

## Testing
- added ui test
- Manually tested w/ and without microdeposits

