### PR TITLE
Send "selected_lpm" on success and failure to confirm analytics events

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/PaymentMethodTypeCollectionView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/PaymentMethodTypeCollectionView.swift
@@ -121,7 +121,7 @@ extension PaymentMethodTypeCollectionView: UICollectionViewDataSource, UICollect
         // Only log this event when this collection view is being used by PaymentSheet
         if isPaymentSheet {
             STPAnalyticsClient.sharedClient.logPaymentSheetEvent(event: .paymentSheetCarouselPaymentMethodTapped,
-                                                                 params: ["selected_lpm": paymentMethodTypes[indexPath.row].identifier])
+                                                                 paymentMethodTypeAnalyticsValue: paymentMethodTypes[indexPath.row].identifier)
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -22,6 +22,19 @@ extension PaymentSheet {
         case saved(paymentMethod: STPPaymentMethod)
         case new(confirmParams: IntentConfirmParams)
         case link(option: LinkConfirmOption)
+        
+        var paymentMethodTypeAnalyticsValue: String? {
+            switch self {
+            case .applePay:
+                return PaymentSheet.PaymentMethodType.dynamic("apple_pay").identifier
+            case .saved(paymentMethod: let paymentMethod):
+                return paymentMethod.type.identifier
+            case .new(confirmParams: let confirmParams):
+                return confirmParams.paymentMethodType.identifier
+            case .link:
+                return PaymentSheet.PaymentMethodType.link.identifier
+            }
+        }
     }
 
     /// A class that presents the individual steps of a payment flow
@@ -306,7 +319,8 @@ extension PaymentSheet {
                     linkSessionType: intent.linkPopupWebviewOption,
                     currency: intent.currency,
                     intentConfig: intent.intentConfig,
-                    deferredIntentConfirmationType: deferredIntentConfirmationType
+                    deferredIntentConfirmationType: deferredIntentConfirmationType,
+                    paymentMethodTypeAnalyticsValue: paymentOption.paymentMethodTypeAnalyticsValue
                 )
 
                 if case .completed = result, case .link = paymentOption {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -26,7 +26,7 @@ extension PaymentSheet {
         var paymentMethodTypeAnalyticsValue: String? {
             switch self {
             case .applePay:
-                return PaymentSheet.PaymentMethodType.dynamic("apple_pay").identifier
+                return "apple_pay"
             case .saved(paymentMethod: let paymentMethod):
                 return paymentMethod.type.identifier
             case .new(confirmParams: let confirmParams):

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -22,7 +22,7 @@ extension PaymentSheet {
         case saved(paymentMethod: STPPaymentMethod)
         case new(confirmParams: IntentConfirmParams)
         case link(option: LinkConfirmOption)
-        
+
         var paymentMethodTypeAnalyticsValue: String? {
             switch self {
             case .applePay:

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
@@ -32,7 +32,8 @@ extension STPAnalyticsClient {
         linkSessionType: LinkSettings.PopupWebviewOption?,
         currency: String?,
         intentConfig: PaymentSheet.IntentConfiguration? = nil,
-        deferredIntentConfirmationType: DeferredIntentConfirmationType?
+        deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+        paymentMethodTypeAnalyticsValue: String? = nil
     ) {
         var success = false
         switch result {
@@ -57,7 +58,8 @@ extension STPAnalyticsClient {
             linkSessionType: linkSessionType,
             currency: currency,
             intentConfig: intentConfig,
-            deferredIntentConfirmationType: deferredIntentConfirmationType
+            deferredIntentConfirmationType: deferredIntentConfirmationType,
+            paymentMethodTypeAnalyticsValue: paymentMethodTypeAnalyticsValue
         )
     }
 
@@ -241,6 +243,7 @@ extension STPAnalyticsClient {
         intentConfig: PaymentSheet.IntentConfiguration? = nil,
         error: Error? = nil,
         deferredIntentConfirmationType: DeferredIntentConfirmationType? = nil,
+        paymentMethodTypeAnalyticsValue: String? = nil,
         params: [String: Any] = [:]
     ) {
         var additionalParams = [:] as [String: Any]
@@ -260,6 +263,7 @@ extension STPAnalyticsClient {
         additionalParams["currency"] = currency
         additionalParams["is_decoupled"] = intentConfig != nil
         additionalParams["deferred_intent_confirmation_type"] = deferredIntentConfirmationType?.rawValue
+        additionalParams["selected_lpm"] = paymentMethodTypeAnalyticsValue
         if let error = error as? PaymentSheetError {
             additionalParams["error_message"] = error.safeLoggingString
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -461,7 +461,8 @@ class PaymentSheetViewController: UIViewController {
                     linkSessionType: self.intent.linkPopupWebviewOption,
                     currency: self.intent.currency,
                     intentConfig: self.intent.intentConfig,
-                    deferredIntentConfirmationType: deferredIntentConfirmationType
+                    deferredIntentConfirmationType: deferredIntentConfirmationType,
+                    paymentMethodTypeAnalyticsValue: paymentOption.paymentMethodTypeAnalyticsValue
                 )
 
                 self.isPaymentInFlight = false


### PR DESCRIPTION
## Summary
- Sends `selected_lpm` payload on success and failure events
- This will allow us to see success rate and checkout times for given LPMs

## Motivation
https://docs.google.com/document/d/1yr8IILZuOr860nFgLoeT53IlTqAKThmbKgo37Z0iUvY/edit

## Testing
Manual

## Changelog
N/A
