### PR TITLE
Prevent dismissal if you have a linked bank account, and auto confirm if recently added PM

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
@@ -451,7 +451,7 @@ class CustomerSheetUITest: XCTestCase {
 
         app.staticTexts["+ Add"].tap()
 
-        try! fillCardData(app, cardNumber: "5555555555554444",  postalEnabled: true)
+        try! fillCardData(app, cardNumber: "5555555555554444", postalEnabled: true)
         app.buttons["Save"].tap()
 
         let confirmButton = app.buttons["Confirm"]
@@ -481,7 +481,7 @@ class CustomerSheetUITest: XCTestCase {
 
         app.staticTexts["+ Add"].tap()
 
-        try! fillCardData(app, cardNumber: "5555555555554444",  postalEnabled: true)
+        try! fillCardData(app, cardNumber: "5555555555554444", postalEnabled: true)
         app.buttons["Save"].tap()
 
         app.staticTexts["Apple Pay"].tap()

--- a/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
@@ -137,7 +137,7 @@ class CustomerSheetUITest: XCTestCase {
         XCTAssertTrue(selectButtonFinal.waitForExistence(timeout: 60.0))
     }
 
-    func testAddPaymentMethod_setupIntent_reInitAdddViewController() throws {
+    func testAddPaymentMethod_setupIntent_reInitAddViewController() throws {
         var settings = CustomerSheetTestPlaygroundSettings.defaultValues()
         settings.customerMode = .new
         settings.applePay = .on
@@ -170,13 +170,13 @@ class CustomerSheetUITest: XCTestCase {
         XCTAssertTrue(backButton.waitForExistence(timeout: 60.0))
         backButton.tap()
 
-        let closeButton = app.buttons["Close"]
+        let closeButton = app.buttons["Confirm"]
         XCTAssertTrue(closeButton.waitForExistence(timeout: 60.0))
         closeButton.tap()
 
-        dismissAlertView(alertBody: "Success: payment method not set, canceled", alertTitle: "Complete", buttonToTap: "OK")
+        dismissAlertView(alertBody: "Success: ••••4242, selected", alertTitle: "Complete", buttonToTap: "OK")
 
-        let selectButtonFinal = app.staticTexts["None"]
+        let selectButtonFinal = app.staticTexts["••••4242"]
         XCTAssertTrue(selectButtonFinal.waitForExistence(timeout: 60.0))
     }
     func testAddTwoPaymentMethod_setupIntent() throws {
@@ -211,13 +211,13 @@ class CustomerSheetUITest: XCTestCase {
         let cardPresence4242 = app.staticTexts["••••4242"]
         XCTAssertTrue(cardPresence4242.waitForExistence(timeout: 60.0))
 
-        let closeButton = app.buttons["Close"]
+        let closeButton = app.buttons["Confirm"]
         XCTAssertTrue(closeButton.waitForExistence(timeout: 60.0))
         closeButton.tap()
 
-        dismissAlertView(alertBody: "Success: payment method not set, canceled", alertTitle: "Complete", buttonToTap: "OK")
+        dismissAlertView(alertBody: "Success: ••••4444, selected", alertTitle: "Complete", buttonToTap: "OK")
 
-        let selectButtonFinal = app.staticTexts["None"]
+        let selectButtonFinal = app.staticTexts["••••4444"]
         XCTAssertTrue(selectButtonFinal.waitForExistence(timeout: 60.0))
     }
     func testAddPaymentMethod_createAndAttach_reInitAdddViewController() throws {
@@ -253,13 +253,13 @@ class CustomerSheetUITest: XCTestCase {
         XCTAssertTrue(backButton.waitForExistence(timeout: 60.0))
         backButton.tap()
 
-        let closeButton = app.buttons["Close"]
+        let closeButton = app.buttons["Confirm"]
         XCTAssertTrue(closeButton.waitForExistence(timeout: 60.0))
         closeButton.tap()
 
-        dismissAlertView(alertBody: "Success: payment method not set, canceled", alertTitle: "Complete", buttonToTap: "OK")
+        dismissAlertView(alertBody: "Success: ••••4242, selected", alertTitle: "Complete", buttonToTap: "OK")
 
-        let selectButtonFinal = app.staticTexts["None"]
+        let selectButtonFinal = app.staticTexts["••••4242"]
         XCTAssertTrue(selectButtonFinal.waitForExistence(timeout: 60.0))
     }
     func testAddTwoPaymentMethod_createAndAttach() throws {
@@ -294,13 +294,13 @@ class CustomerSheetUITest: XCTestCase {
         let cardPresence4242 = app.staticTexts["••••4242"]
         XCTAssertTrue(cardPresence4242.waitForExistence(timeout: 60.0))
 
-        let closeButton = app.buttons["Close"]
+        let closeButton = app.buttons["Confirm"]
         XCTAssertTrue(closeButton.waitForExistence(timeout: 60.0))
         closeButton.tap()
 
-        dismissAlertView(alertBody: "Success: payment method not set, canceled", alertTitle: "Complete", buttonToTap: "OK")
+        dismissAlertView(alertBody: "Success: ••••4444, selected", alertTitle: "Complete", buttonToTap: "OK")
 
-        let selectButtonFinal = app.staticTexts["None"]
+        let selectButtonFinal = app.staticTexts["••••4444"]
         XCTAssertTrue(selectButtonFinal.waitForExistence(timeout: 60.0))
     }
     func testAddTwoPaymentMethods_RemoveTwoPaymentMethods() throws {
@@ -377,7 +377,7 @@ class CustomerSheetUITest: XCTestCase {
         XCTAssertTrue(selectButtonFinal.waitForExistence(timeout: 60.0))
     }
 
-    func testNoPrevPM_AddPM_canceled_noApplePay() throws {
+    func testNoPrevPM_AddPM_noApplePay_closeInsteadOfConfirming() throws {
         var settings = CustomerSheetTestPlaygroundSettings.defaultValues()
         settings.customerMode = .new
         settings.applePay = .off
@@ -401,10 +401,10 @@ class CustomerSheetUITest: XCTestCase {
         XCTAssertTrue(closeButton.waitForExistence(timeout: 60.0))
         closeButton.tap()
 
-        dismissAlertView(alertBody: "Success: payment method not set, canceled", alertTitle: "Complete", buttonToTap: "OK")
+        dismissAlertView(alertBody: "Success: ••••4242, selected", alertTitle: "Complete", buttonToTap: "OK")
     }
 
-    func testNoPrevPM_AddPM_canceled_ApplePay() throws {
+    func testNoPrevPM_AddPM_ApplePay_closeInsteadOfConfirming() throws {
         var settings = CustomerSheetTestPlaygroundSettings.defaultValues()
         settings.customerMode = .new
         settings.applePay = .on
@@ -432,10 +432,10 @@ class CustomerSheetUITest: XCTestCase {
         XCTAssertTrue(closeButton.waitForExistence(timeout: 60.0))
         closeButton.tap()
 
-        dismissAlertView(alertBody: "Success: payment method not set, canceled", alertTitle: "Complete", buttonToTap: "OK")
+        dismissAlertView(alertBody: "Success: ••••4242, selected", alertTitle: "Complete", buttonToTap: "OK")
     }
 
-    func testPrevPM_AddPM_canceled_noApplePay() throws {
+    func testPrevPM_AddPM_selectedWithoutTapping_noApplePay() throws {
         var settings = CustomerSheetTestPlaygroundSettings.defaultValues()
         settings.customerMode = .new
         settings.applePay = .off
@@ -451,7 +451,7 @@ class CustomerSheetUITest: XCTestCase {
 
         app.staticTexts["+ Add"].tap()
 
-        try! fillCardData(app, postalEnabled: true)
+        try! fillCardData(app, cardNumber: "5555555555554444",  postalEnabled: true)
         app.buttons["Save"].tap()
 
         let confirmButton = app.buttons["Confirm"]
@@ -462,7 +462,7 @@ class CustomerSheetUITest: XCTestCase {
         XCTAssertTrue(closeButton.waitForExistence(timeout: 60.0))
         closeButton.tap()
 
-        dismissAlertView(alertBody: "Success: ••••4242, canceled", alertTitle: "Complete", buttonToTap: "OK")
+        dismissAlertView(alertBody: "Success: ••••4444, selected", alertTitle: "Complete", buttonToTap: "OK")
     }
 
     func testPrevPM_AddPM_canceled_ApplePay() throws {
@@ -478,6 +478,11 @@ class CustomerSheetUITest: XCTestCase {
         let selectButton = app.staticTexts["••••4242"]
         XCTAssertTrue(selectButton.waitForExistence(timeout: 60.0))
         selectButton.tap()
+
+        app.staticTexts["+ Add"].tap()
+
+        try! fillCardData(app, cardNumber: "5555555555554444",  postalEnabled: true)
+        app.buttons["Save"].tap()
 
         app.staticTexts["Apple Pay"].tap()
         let confirmButton = app.buttons["Confirm"]

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerAddPaymentMethodViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerAddPaymentMethodViewController.swift
@@ -156,6 +156,14 @@ class CustomerAddPaymentMethodViewController: UIViewController {
         updateUI()
     }
 
+    func shouldPreventDismissal() -> Bool {
+        guard let usBankAccountPaymentMethodElement = self.paymentMethodFormElement as? USBankAccountPaymentMethodElement else {
+            return false
+        }
+        let customerHasLinkedBankAccount = usBankAccountPaymentMethodElement.getLinkedBank() != nil
+        return customerHasLinkedBankAccount
+    }
+
     private func updateUI() {
         // Swap out the input view if necessary
         if paymentMethodFormElement.view !== paymentMethodDetailsView {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/USBankAccountPaymentMethodElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/USBankAccountPaymentMethodElement.swift
@@ -150,6 +150,9 @@ final class USBankAccountPaymentMethodElement: Element {
         }
         self.delegate?.didUpdate(element: self)
     }
+    func getLinkedBank() -> LinkedBank? {
+        return linkedBank
+    }
 
     class func attributedMandateText(for linkedBank: LinkedBank?,
                                      merchantName: String,

--- a/StripeUICore/StripeUICore/Resources/Localizations/en.lproj/Localizable.strings
+++ b/StripeUICore/StripeUICore/Resources/Localizations/en.lproj/Localizable.strings
@@ -60,6 +60,9 @@ Label of an address field */
 /* Label of an address field */
 "Do Si" = "Do Si";
 
+/* Used as the title for prompting the user if they want to close the sheet */
+"Do you want to close this form?" = "Do you want to close this form?";
+
 /* Done button title */
 "Done" = "Done";
 
@@ -176,6 +179,9 @@ Label of an address field */
 
 /* Error message when email is invalid */
 "Your email is invalid." = "Your email is invalid.";
+
+/* Used as the title for prompting the user if they want to close the sheet */
+"Your payment information will not be saved." = "Your payment information will not be saved.";
 
 /* Error message for when postal code in form is incomplete */
 "Your postal code is incomplete." = "Your postal code is incomplete.";

--- a/StripeUICore/StripeUICore/Source/Helpers/String+Localized.swift
+++ b/StripeUICore/StripeUICore/Source/Helpers/String+Localized.swift
@@ -261,6 +261,16 @@ import Foundation
         STPLocalizedString("Cancel", "Button title to cancel action in an alert")
     }
 
+    static var closeFormTitle: String {
+        STPLocalizedString("Do you want to close this form?",
+                           "Used as the title for prompting the user if they want to close the sheet")
+    }
+
+    static var paymentInfoWontBeSaved: String {
+        STPLocalizedString("Your payment information will not be saved.",
+                           "Used as the title for prompting the user if they want to close the sheet")
+    }
+
     static var ok: String {
         STPLocalizedString("OK", "ok button")
     }


### PR DESCRIPTION
## Summary
In Customer sheet we added two changes to the UX:
 * If you linked a bank account but didn't confirm the setup intent, it's possible for you to tap outside the boundaries of the sheet thereby dismissing it.  In this case, we throw up an alert view to check if you really meant to dismiss the sheet.
 * After saving a payment method, if you tap close or outside the boundaries of the sheet, the sheet could be dismissed and leaving you in a "canceled" state without actually confirming.  In this case, because a user added a new payment method, we assume they wanted to confirm the payment method.

## Motivation
Improvements to UX

## Testing
Walked through each of the UI tests, and updated as needed.
