### PR TITLE
Don't add image if Link string doesn't exist

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/PayWithLinkButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/PayWithLinkButton.swift
@@ -122,11 +122,13 @@ final class PayWithLinkButton: UIControl {
 
         // Add a spacer before the Link logo and after the Link logo
         let range = payWithLinkString.mutableString.range(of: "Link")
-        payWithLinkString.insert(Self.makeSpacerString(width: 1), at: range.location + range.length)
-        payWithLinkString.insert(Self.makeSpacerString(width: 1), at: range.location)
+        if range.location != NSNotFound {
+            payWithLinkString.insert(Self.makeSpacerString(width: 1), at: range.location + range.length)
+            payWithLinkString.insert(Self.makeSpacerString(width: 1), at: range.location)
 
-        // Add the Link attachment
-        payWithLinkString.replaceOccurrences(of: "Link", with: linkAttachment)
+            // Add the Link attachment
+            payWithLinkString.replaceOccurrences(of: "Link", with: linkAttachment)
+        }
 
         linkView.attributedText = payWithLinkString
         return linkView


### PR DESCRIPTION
## Summary
🤦 , check for the existence of the Link string before applying the range

## Motivation
Don't crash if the translators mess up

## Testing
Changed string to "Lonk", button still rendered