### PR TITLE
Fix macOS Catalyst build

### DIFF
--- a/Stripe/StripeiOS/Source/STPAddCardViewController.swift
+++ b/Stripe/StripeiOS/Source/STPAddCardViewController.swift
@@ -401,11 +401,11 @@ public class STPAddCardViewController: STPCoreTableViewController, STPAddressVie
             }
             let scannerCell = STPCardScannerTableViewCell()
             self.scannerCell = scannerCell
-            
+
             let cardScanner = STPCardScanner(delegate: self)
             cardScanner.cameraView = scannerCell.cameraView
             self.cardScanner = cardScanner
-            
+
             cardHeaderView?.buttonHidden = false
             cardHeaderView?.button?.setTitle(
                 String.Localized.scan_card_title_capitalization,
@@ -420,12 +420,11 @@ public class STPAddCardViewController: STPCoreTableViewController, STPAddressVie
         }
     }
 
+    @available(macCatalyst 14.0, *)
     @objc func scanCard() {
-        if #available(macCatalyst 14.0, *) {
-            view.endEditing(true)
-            isScanning = true
-            cardScanner?.start()
-        }
+        view.endEditing(true)
+        isScanning = true
+        cardScanner?.start()
     }
 
     @objc func endEditing() {
@@ -816,6 +815,7 @@ public class STPAddCardViewController: STPCoreTableViewController, STPAddressVie
 
     // MARK: - STPCardScanner
     /// :nodoc:
+    @available(macCatalyst 14.0, *)
     @objc
     public override func viewWillTransition(
         to size: CGSize,
@@ -824,9 +824,7 @@ public class STPAddCardViewController: STPCoreTableViewController, STPAddressVie
         super.viewWillTransition(to: size, with: coordinator)
         let orientation = UIDevice.current.orientation
         if orientation.isPortrait || orientation.isLandscape {
-            if #available(macCatalyst 14.0, *) {
-                cardScanner?.deviceOrientation = orientation
-            }
+            cardScanner?.deviceOrientation = orientation
         }
         if isScanning {
             let indexPath = IndexPath(

--- a/Stripe/StripeiOS/Source/STPCameraView.swift
+++ b/Stripe/StripeiOS/Source/STPCameraView.swift
@@ -9,6 +9,7 @@
 import AVFoundation
 import UIKit
 
+@available(macCatalyst 14.0, *)
 class STPCameraView: UIView {
     private var flashLayer: CALayer?
 

--- a/Stripe/StripeiOS/Source/STPCardScanner.swift
+++ b/Stripe/StripeiOS/Source/STPCardScanner.swift
@@ -19,6 +19,7 @@ enum STPCardScannerError: Int {
     case cameraNotAvailable
 }
 
+@available(macCatalyst 14.0, *)
 @objc protocol STPCardScannerDelegate: NSObjectProtocol {
     @objc(cardScanner:didFinishWithCardParams:error:) func cardScanner(
         _ scanner: STPCardScanner,
@@ -27,6 +28,7 @@ enum STPCardScannerError: Int {
     )
 }
 
+@available(macCatalyst 14.0, *)
 @objc(STPCardScanner_legacy)
 class STPCardScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate,
     STPCardScanningProtocol
@@ -510,6 +512,7 @@ private let kSTPCardScanningTimeout: TimeInterval = 1.0
 let STPCardScannerErrorDomain = "STPCardScannerErrorDomain"
 
 /// :nodoc:
+@available(macCatalyst 14.0, *)
 extension STPCardScanner: STPAnalyticsProtocol {
     static var stp_analyticsIdentifier = "STPCardScanner"
 }

--- a/Stripe/StripeiOS/Source/STPCardScannerTableViewCell.swift
+++ b/Stripe/StripeiOS/Source/STPCardScannerTableViewCell.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+@available(macCatalyst 14.0, *)
 class STPCardScannerTableViewCell: UITableViewCell {
     private(set) weak var cameraView: STPCameraView?
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/STPCameraView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/STPCameraView.swift
@@ -9,6 +9,7 @@
 import AVFoundation
 import UIKit
 
+@available(macCatalyst 14.0, *)
 class STPCameraView: UIView {
     private var flashLayer: CALayer?
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/STPCardScanner.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/STPCardScanner.swift
@@ -19,6 +19,7 @@ enum STPCardScannerError: Int {
     case cameraNotAvailable
 }
 
+@available(macCatalyst 14.0, *)
 @objc protocol STPCardScannerDelegate: NSObjectProtocol {
     @objc(cardScanner:didFinishWithCardParams:error:) func cardScanner(
         _ scanner: STPCardScanner,
@@ -27,6 +28,7 @@ enum STPCardScannerError: Int {
         error: Error?)
 }
 
+@available(macCatalyst 14.0, *)
 @objc(STPCardScanner)
 class STPCardScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, STPCardScanningProtocol {
     // iOS will kill the app if it tries to request the camera without an NSCameraUsageDescription
@@ -479,6 +481,7 @@ private let kSTPCardScanningTimeout: TimeInterval = 1.0
 let STPCardScannerErrorDomain = "STPCardScannerErrorDomain"
 
 /// :nodoc:
+@available(macCatalyst 14.0, *)
 extension STPCardScanner: STPAnalyticsProtocol {
     static var stp_analyticsIdentifier = "STPCardScanner"
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSectionWithScanner/CardSectionWithScannerView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSectionWithScanner/CardSectionWithScannerView.swift
@@ -17,6 +17,7 @@ import UIKit
  A view that wraps a normal section and adds a "Scan card" button. Tapping the button displays a card scan view below the section.
  */
 /// For internal SDK use only
+@available(macCatalyst 14.0, *)
 @objc(STP_Internal_CardSectionWithScannerView)
 final class CardSectionWithScannerView: UIView {
     let cardSectionView: UIView
@@ -81,6 +82,7 @@ final class CardSectionWithScannerView: UIView {
     }
 }
 
+@available(macCatalyst 14.0, *)
 extension CardSectionWithScannerView: STP_Internal_CardScanningViewDelegate {
     func cardScanningView(_ cardScanningView: CardScanningView, didFinishWith cardParams: STPPaymentMethodCardParams?) {
         setCardScanVisible(false)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/CardScanningView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/CardScanningView.swift
@@ -23,6 +23,7 @@ private class CardScanningEasilyTappableButton: UIButton {
 }
 
 /// For internal SDK use only
+@available(macCatalyst 14.0, *)
 @objc protocol STP_Internal_CardScanningViewDelegate: NSObjectProtocol {
     func cardScanningView(
         _ cardScanningView: CardScanningView, didFinishWith cardParams: STPPaymentMethodCardParams?)
@@ -30,6 +31,7 @@ private class CardScanningEasilyTappableButton: UIButton {
 
 /// For internal SDK use only
 @objc(STP_Internal_CardScanningView)
+@available(macCatalyst 14.0, *)
 class CardScanningView: UIView, STPCardScannerDelegate {
     private(set) weak var cameraView: STPCameraView?
 


### PR DESCRIPTION
## Summary
Went a little too far with the `@available` removal: Camera support was added for macOS Catalyst in the iOS 14 SDK, so we need to hide it for Catalyst in the iOS 13 SDK. Add some availability checks.

## Motivation
Fixing the release

## Testing
Locally, will also run in Xcode Cloud
