### PR TITLE
Add product usage flags for CustomerSheet and StripeCustomerAdapter

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerAdapter/CustomerAdapter.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerAdapter/CustomerAdapter.swift
@@ -8,6 +8,7 @@
 import Foundation
 import UIKit
 
+@_spi(STP) import StripeCore
 @_spi(STP) import StripePayments
 @_spi(STP) import StripePaymentsUI
 
@@ -104,6 +105,7 @@ import UIKit
     public init(customerEphemeralKeyProvider: @escaping () async throws -> CustomerEphemeralKey,
                 setupIntentClientSecretProvider: (() async throws -> String)? = nil,
                 apiClient: STPAPIClient = .shared) {
+        STPAnalyticsClient.sharedClient.addClass(toProductUsageIfNecessary: StripeCustomerAdapter.self)
         self.customerEphemeralKeyProvider = customerEphemeralKeyProvider
         self.setupIntentClientSecretProvider = setupIntentClientSecretProvider
         self.apiClient = apiClient
@@ -195,6 +197,10 @@ import UIKit
         }
         return try await setupIntentClientSecretProvider()
     }
+}
+
+@_spi(PrivateBetaCustomerSheet) extension StripeCustomerAdapter: STPAnalyticsProtocol {
+    @_spi(PrivateBetaCustomerSheet) public static var stp_analyticsIdentifier = "StripeCustomerAdapter"
 }
 
 /// Stores the key we use in NSUserDefaults to save a dictionary of Customer id to their last selected payment method ID

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheet.swift
@@ -60,6 +60,7 @@ internal enum InternalCustomerSheetResult {
     /// Use a StripeCustomerAdapter, or build your own.
     public init(configuration: CustomerSheet.Configuration,
                 customer: CustomerAdapter) {
+        STPAnalyticsClient.sharedClient.addClass(toProductUsageIfNecessary: CustomerSheet.self)
         self.configuration = configuration
         self.customerAdapter = customer
     }
@@ -213,6 +214,10 @@ extension CustomerSheet: LoadingViewControllerDelegate {
             self.completion?()
         }
     }
+}
+
+@_spi(PrivateBetaCustomerSheet) extension CustomerSheet: STPAnalyticsProtocol {
+    @_spi(PrivateBetaCustomerSheet) public static var stp_analyticsIdentifier = "CustomerSheet"
 }
 
 @_spi(PrivateBetaCustomerSheet) extension StripeCustomerAdapter {


### PR DESCRIPTION
## Summary
Add product usage flags for CustomerSheet and StripeCustomerAdapter

## Motivation
analytics

## Testing
manual testing -- looking at logs

