### PR TITLE
[Link] Don't fetch the customer email in LinkURLGenerator

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Utils/LinkURLGenerator.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Utils/LinkURLGenerator.swift
@@ -40,7 +40,7 @@ struct LinkURLParams: Encodable {
 }
 
 class LinkURLGenerator {
-    static func linkParams(configuration: PaymentSheet.Configuration, intent: Intent) async throws -> LinkURLParams {
+    static func linkParams(configuration: PaymentSheet.Configuration, intent: Intent) throws -> LinkURLParams {
         guard let publishableKey = configuration.apiClient.publishableKey ?? STPAPIClient.shared.publishableKey else {
             throw LinkURLGeneratorError.noPublishableKey
         }
@@ -56,14 +56,6 @@ class LinkURLGenerator {
         if customerEmail == nil,
            let defaultBillingEmail = configuration.defaultBillingDetails.email {
             customerEmail = defaultBillingEmail
-        }
-
-        if customerEmail == nil,
-           let customerID = configuration.customer?.id,
-           let ephemeralKey = configuration.customer?.ephemeralKeySecret,
-           let customer = try? await configuration.apiClient.retrieveCustomer(customerID, using: ephemeralKey)
-        {
-            customerEmail = customer.email
         }
 
         let merchantInfo = LinkURLParams.MerchantInfo(businessName: configuration.merchantDisplayName, country: merchantCountryCode)
@@ -96,7 +88,7 @@ class LinkURLGenerator {
     }
 
     static func url(configuration: PaymentSheet.Configuration, intent: Intent) async throws -> URL {
-        let params = try await Self.linkParams(configuration: configuration, intent: intent)
+        let params = try Self.linkParams(configuration: configuration, intent: intent)
         return try url(params: params)
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkURLGeneratorTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkURLGeneratorTests.swift
@@ -56,7 +56,7 @@ class LinkURLGeneratorTests: XCTestCase {
         }
         config.apiClient.publishableKey = "pk_123"
         let intent = Intent.deferredIntent(elementsSession: STPElementsSession.emptyElementsSession, intentConfig: intentConfig)
-        let params = try! await LinkURLGenerator.linkParams(configuration: config, intent: intent)
+        let params = try! LinkURLGenerator.linkParams(configuration: config, intent: intent)
 
         let expectedParams = LinkURLParams(paymentObject: .link_payment_method,
                                            publishableKey: config.apiClient.publishableKey!,


### PR DESCRIPTION
## Summary
It isn't necessary to fetch the customer email here: We already fetch it in `lookUpConsumerSession` and then read it earlier in this function. This was left in by mistake during testing.

## Motivation
Link button should respond immediately instead of waiting for a network request.

## Testing
Manually in PaymentSheet Example app