### PR TITLE
Enable testmode for Stripe Dashboard app

### DIFF
--- a/StripeCore/StripeCore/Source/API Bindings/STPAPIClient.swift
+++ b/StripeCore/StripeCore/Source/API Bindings/STPAPIClient.swift
@@ -87,6 +87,10 @@ import UIKit
         return publishableKey?.hasPrefix("uk_") ?? false
     }
 
+    /// Determines the `Stripe-Livemode` header value when the publishable key is a user key
+    /// :nodoc:
+    @_spi(StripeAppsOnly) public var userKeyLiveMode = true
+
     // MARK: Initializers
     override public init() {
         sourcePollers = [:]
@@ -214,8 +218,7 @@ import UIKit
         var headers = ["Authorization": "Bearer " + authorizationBearer]
 
         if publishableKeyIsUserKey {
-            let liveMode = ProcessInfo.processInfo.environment["Stripe-Livemode"] != "false"
-            headers["Stripe-Livemode"] = liveMode ? "true" : "false"
+            headers["Stripe-Livemode"] = userKeyLiveMode ? "true" : "false"
         }
         return headers
     }
@@ -224,7 +227,7 @@ import UIKit
         guard let publishableKey = publishableKey, !publishableKey.isEmpty else {
             return false
         }
-        return publishableKey.lowercased().hasPrefix("pk_test")
+        return publishableKey.lowercased().hasPrefix("pk_test") || (publishableKeyIsUserKey && !userKeyLiveMode)
     }
 }
 

--- a/StripeCore/StripeCore/Source/API Bindings/STPAPIClient.swift
+++ b/StripeCore/StripeCore/Source/API Bindings/STPAPIClient.swift
@@ -88,8 +88,7 @@ import UIKit
     }
 
     /// Determines the `Stripe-Livemode` header value when the publishable key is a user key
-    /// :nodoc:
-    @_spi(StripeAppsOnly) public var userKeyLiveMode = true
+    @_spi(DashboardOnly) public var userKeyLiveMode = true
 
     // MARK: Initializers
     override public init() {


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

Allows the Stripe Dashboard app to internally test the payment sheet in test mode.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

The Stripe Dashboard app has an internal debug menu that allows us to toggle live mode vs. test mode during development, however the SDK was setting the `Stripe-Livemode` header needed for Dashboard keys based on a run scheme environment variable instead of the debug menu. The env var could get out of sync if the debug menu was changed and would only work when running the app attached to Xcode.

This fix enables the Dashboard app to directly toggle livemode in the SDK when importing the module with `@_spi(DashboardOnly)`.

## Testing
<!-- How was the code tested? Be as specific as possible. -->

See corresponding Dashboard app change.

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
n/a