### PR TITLE
Update STPConnectAccountParams to allow nil business type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ### PaymentSheet
 * [Added] Support for GrabPay with PaymentIntent's.
 
+### Payments
+* [Added] You can now create an STPConnectAccountParams without specifying a business type.
+
 ## 23.13.0 2023-08-07
 ### All
 * [Fixed] Fixed compatibility with Xcode 15 beta 3. visionOS is now supported in iPadOS compatibility mode.

--- a/Stripe/StripeiOSTests/STPConnectAccountFunctionalTest.swift
+++ b/Stripe/StripeiOSTests/STPConnectAccountFunctionalTest.swift
@@ -56,6 +56,11 @@ class STPConnectAccountFunctionalTest: XCTestCase {
             shouldSucceed: true)
     }
 
+    func testTokenCreation_empty_init() {
+        createToken(STPConnectAccountParams(), shouldSucceed: true)
+
+    }
+
     // MARK: -
 
     func createToken(_ params: STPConnectAccountParams?, shouldSucceed: Bool) {

--- a/Stripe/StripeiOSTests/STPConnectAccountParamsTest.swift
+++ b/Stripe/StripeiOSTests/STPConnectAccountParamsTest.swift
@@ -30,6 +30,7 @@ class STPConnectAccountParamsTest: XCTestCase {
     func testBusinessTypeString() {
         XCTAssertEqual("individual", STPConnectAccountParams.string(from: .individual))
         XCTAssertEqual("company", STPConnectAccountParams.string(from: .company))
+        XCTAssertEqual(nil, STPConnectAccountParams.string(from: .none))
     }
 
     func testPropertyNamesToFormFieldNamesMapping() {
@@ -39,18 +40,11 @@ class STPConnectAccountParamsTest: XCTestCase {
         let mapping = STPConnectAccountParams.propertyNamesToFormFieldNamesMapping()
 
         for propertyName in mapping.keys {
-            guard let propertyName = propertyName as? String else {
-                continue
-            }
             XCTAssertFalse(propertyName.contains(":"))
             XCTAssert(accountParams.responds(to: NSSelectorFromString(propertyName)))
         }
 
         for formFieldName in mapping.values {
-            guard let formFieldName = formFieldName as? String else {
-                continue
-            }
-            XCTAssert((formFieldName is NSString))
             XCTAssert(formFieldName.count > 0)
         }
 

--- a/StripePayments/StripePayments/Source/API Bindings/Models/STPConnectAccountParams.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/STPConnectAccountParams.swift
@@ -14,6 +14,9 @@ import Foundation
     case individual
     /// This Connect account represents a company.
     case company
+    /// No value was provided.
+    /// - Note: This value is used instead of `nil` for Obj-C compatibility.
+    case none
 }
 
 /// Parameters for creating a Connect Account token.
@@ -110,6 +113,14 @@ public class STPConnectAccountParams: NSObject {
         super.init()
     }
 
+    @objc public override init() {
+        tosShownAndAccepted = false
+        businessType = .none
+        individual = nil
+        company = nil
+        super.init()
+    }
+
     // MARK: - description
     /// :nodoc:
     @objc public override var description: String {
@@ -119,19 +130,20 @@ public class STPConnectAccountParams: NSObject {
             "tosShownAndAccepted = \(String(describing: tosShownAndAccepted))",
             "individual = \(String(describing: individual))",
             "company = \(String(describing: company))",
-            "business_type = \(STPConnectAccountParams.string(from: businessType))",
+            "business_type = \(STPConnectAccountParams.string(from: businessType) ?? "nil")",
         ]
         return "<\(props.joined(separator: "; "))>"
     }
 
     // MARK: - STPConnectAccountBusinessType
-    @objc(stringFromBusinessType:)
-    class func string(from businessType: STPConnectAccountBusinessType) -> String {
+    class func string(from businessType: STPConnectAccountBusinessType) -> String? {
         switch businessType {
         case .individual:
             return "individual"
         case .company:
             return "company"
+        case .none:
+            return nil
         }
     }
 
@@ -140,7 +152,7 @@ public class STPConnectAccountParams: NSObject {
 // MARK: - STPFormEncodable
 extension STPConnectAccountParams: STPFormEncodable {
 
-    @objc internal var businessTypeString: String {
+    @objc var businessTypeString: String? {
         return STPConnectAccountParams.string(from: businessType)
     }
 

--- a/StripePayments/StripePayments/Source/Categories/Enums+CustomStringConvertible.swift
+++ b/StripePayments/StripePayments/Source/Categories/Enums+CustomStringConvertible.swift
@@ -100,6 +100,8 @@ extension STPConnectAccountBusinessType: CustomStringConvertible {
             return "company"
         case .individual:
             return "individual"
+        case .none:
+            return "nil"
         }
     }
 }


### PR DESCRIPTION
## Motivation
This is optional in the API https://stripe.com/docs/api/tokens/create_account#create_account_token-account-business_type

https://jira.corp.stripe.com/browse/RUN_MOBILESDK-2526

## Testing
See tests

## Changelog
See CHANGELOG
