### PR TITLE
Financial Connections: end-to-end test polish to handle bank maintenance periods

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundMainView.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundMainView.swift
@@ -56,16 +56,13 @@ struct PlaygroundMainView: View {
                                     .italic()
                             }
 
-                            if viewModel.customPublicKey.isEmpty || viewModel.customSecretKey.isEmpty
-                            {
-                                Toggle("Enable Test Mode", isOn: $viewModel.enableTestMode)
-                                // test mode color
-                                    .toggleStyle(
-                                        SwitchToggleStyle(
-                                            tint: Color(red: 231 / 255.0, green: 151 / 255.0, blue: 104 / 255.0)
-                                        )
+                            Toggle("Enable Test Mode", isOn: $viewModel.enableTestMode)
+                            // test mode color
+                                .toggleStyle(
+                                    SwitchToggleStyle(
+                                        tint: Color(red: 231 / 255.0, green: 151 / 255.0, blue: 104 / 255.0)
                                     )
-                            }
+                                )
 
                             if viewModel.flow == .networking {
                                 TextField("Email (existing Link consumer)", text: $viewModel.email)

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
@@ -44,9 +44,7 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         app.fc_playgroundNativeButton.tap()
 
         let enableTestModeSwitch = app.fc_playgroundEnableTestModeSwitch
-        if (enableTestModeSwitch.value as? String) == "0" {
-            enableTestModeSwitch.tap()
-        }
+        enableTestModeSwitch.turnSwitch(on: true)
 
         app.swipeUp() // scroll to see email field
 
@@ -58,9 +56,7 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
 
         let playgroundTransactionsPermissionsSwitch = app.switches["playground-transactions-permission"]
         XCTAssertTrue(playgroundTransactionsPermissionsSwitch.waitForExistence(timeout: 60.0))
-        if (playgroundTransactionsPermissionsSwitch.value as? String) == "0" {
-            playgroundTransactionsPermissionsSwitch.tap() // turn ON transactions
-        }
+        playgroundTransactionsPermissionsSwitch.turnSwitch(on: true)
 
         app.fc_playgroundShowAuthFlowButton.tap()
         app.fc_nativeConsentAgreeButton.tap()
@@ -122,9 +118,7 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         app.fc_playgroundNativeButton.tap()
 
         let enableTestModeSwitch = app.fc_playgroundEnableTestModeSwitch
-        if (enableTestModeSwitch.value as? String) == "0" {
-            enableTestModeSwitch.tap()
-        }
+        enableTestModeSwitch.turnSwitch(on: true)
 
         app.swipeUp() // scroll to see email field
 
@@ -137,9 +131,7 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
 
         let playgroundTransactionsPermissionsSwitch = app.switches["playground-transactions-permission"]
         XCTAssertTrue(playgroundTransactionsPermissionsSwitch.waitForExistence(timeout: 60.0))
-        if (playgroundTransactionsPermissionsSwitch.value as? String) == "0" {
-            playgroundTransactionsPermissionsSwitch.tap() // turn ON transactions
-        }
+        playgroundTransactionsPermissionsSwitch.turnSwitch(on: true)
 
         app.fc_playgroundShowAuthFlowButton.tap()
         app.fc_nativeConsentAgreeButton.tap()

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
@@ -34,9 +34,7 @@ final class FinancialConnectionsUITests: XCTestCase {
         app.fc_playgroundNativeButton.tap()
 
         let enableTestModeSwitch = app.fc_playgroundEnableTestModeSwitch
-        if (enableTestModeSwitch.value as? String) == "0" {
-            enableTestModeSwitch.tap()
-        }
+        enableTestModeSwitch.turnSwitch(on: true)
 
         app.fc_playgroundShowAuthFlowButton.tap()
         app.fc_nativeConsentAgreeButton.tap()
@@ -65,9 +63,7 @@ final class FinancialConnectionsUITests: XCTestCase {
         app.fc_playgroundNativeButton.tap()
 
         let enableTestModeSwitch = app.fc_playgroundEnableTestModeSwitch
-        if (enableTestModeSwitch.value as? String) == "0" {
-            enableTestModeSwitch.tap()
-        }
+        enableTestModeSwitch.turnSwitch(on: true)
 
         app.fc_playgroundShowAuthFlowButton.tap()
         app.fc_nativeConsentAgreeButton.tap()
@@ -99,9 +95,7 @@ final class FinancialConnectionsUITests: XCTestCase {
         app.fc_playgroundNativeButton.tap()
 
         let enableTestModeSwitch = app.fc_playgroundEnableTestModeSwitch
-        if (enableTestModeSwitch.value as? String) == "0" {
-            enableTestModeSwitch.tap()
-        }
+        enableTestModeSwitch.turnSwitch(on: true)
 
         app.fc_playgroundShowAuthFlowButton.tap()
 
@@ -152,9 +146,7 @@ final class FinancialConnectionsUITests: XCTestCase {
         app.fc_playgroundNativeButton.tap()
 
         let enableTestModeSwitch = app.fc_playgroundEnableTestModeSwitch
-        if (enableTestModeSwitch.value as? String) == "1" {
-            enableTestModeSwitch.tap()
-        }
+        enableTestModeSwitch.turnSwitch(on: false)
 
         app.fc_playgroundShowAuthFlowButton.tap()
         app.fc_nativeConsentAgreeButton.tap()
@@ -190,6 +182,8 @@ final class FinancialConnectionsUITests: XCTestCase {
         institutionButton.tap()
 
         app.fc_nativePrepaneContinueButton.tap()
+
+        // At this point, the bank could be down for maintenance, and that's OK.
 
         // check that the WebView loaded
         let institutionWebViewText = app.webViews
@@ -231,9 +225,7 @@ final class FinancialConnectionsUITests: XCTestCase {
         webSegmentPickerButton.tap()
 
         let enableTestModeSwitch = app.fc_playgroundEnableTestModeSwitch
-        if (enableTestModeSwitch.value as? String) == "1" {
-            enableTestModeSwitch.tap()
-        }
+        enableTestModeSwitch.turnSwitch(on: false)
 
         app.fc_playgroundShowAuthFlowButton.tap()
 
@@ -305,9 +297,7 @@ final class FinancialConnectionsUITests: XCTestCase {
         app.fc_playgroundNativeButton.tap()
 
         let enableTestModeSwitch = app.fc_playgroundEnableTestModeSwitch
-        if (enableTestModeSwitch.value as? String) == "1" {
-            enableTestModeSwitch.tap()
-        }
+        enableTestModeSwitch.turnSwitch(on: false)
 
         app.fc_playgroundShowAuthFlowButton.tap()
         app.fc_nativeConsentAgreeButton.tap()
@@ -343,22 +333,5 @@ final class FinancialConnectionsUITests: XCTestCase {
 extension XCTestCase {
     func wait(timeout: TimeInterval) {
         _ = XCTWaiter.wait(for: [XCTestExpectation(description: "")], timeout: timeout)
-    }
-}
-
-extension XCUIElement {
-
-    fileprivate func wait(
-        until expression: @escaping (XCUIElement) -> Bool,
-        timeout: TimeInterval
-    ) -> Bool {
-        let expectation = XCTNSPredicateExpectation(
-            predicate: NSPredicate { _, _ in
-                expression(self)
-            },
-            object: nil
-        )
-        let result = XCTWaiter().wait(for: [expectation], timeout: timeout)
-        return (result == .completed)
     }
 }

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
@@ -154,47 +154,61 @@ final class FinancialConnectionsUITests: XCTestCase {
         // find + tap an institution; we add extra institutions in case
         // they don't get featured
         let institutionButton: XCUIElement?
-        let institutionTextInWebView: String?
+        let institutionName: String?
         let chaseInstitutionButton = app.cells["Chase"]
         if chaseInstitutionButton.waitForExistence(timeout: 10) {
             institutionButton = chaseInstitutionButton
-            institutionTextInWebView = "Chase"
+            institutionName = "Chase"
         } else {
             let bankOfAmericaInstitutionButton = app.cells["Bank of America"]
             if bankOfAmericaInstitutionButton.waitForExistence(timeout: 10) {
                 institutionButton = bankOfAmericaInstitutionButton
-                institutionTextInWebView = "Bank of America"
+                institutionName = "Bank of America"
             } else {
                 let wellsFargoInstitutionButton = app.cells["Wells Fargo"]
                 if wellsFargoInstitutionButton.waitForExistence(timeout: 10) {
                     institutionButton = wellsFargoInstitutionButton
-                    institutionTextInWebView = "Wells Fargo"
+                    institutionName = "Wells Fargo"
                 } else {
                     institutionButton = nil
-                    institutionTextInWebView = nil
+                    institutionName = nil
                 }
             }
         }
-        guard let institutionButton = institutionButton, let institutionTextInWebView = institutionTextInWebView else {
+        guard let institutionButton = institutionButton, let institutionName = institutionName else {
             XCTFail("Couldn't find a Live Mode institution.")
             return
         }
         institutionButton.tap()
 
-        app.fc_nativePrepaneContinueButton.tap()
+        // ...at this point the bank is either:
+        // 1. active, which means prepane is visible
+        // 2. under maintenance, which means an 'error' screen is visible
 
-        // At this point, the bank could be down for maintenance, and that's OK.
+        // (1) bank is NOT under maintenance
+        if app.fc_nativePrepaneContinueButton_noWait.waitForExistence(timeout: 60) {
+            app.fc_nativePrepaneContinueButton.tap()
 
-        // check that the WebView loaded
-        let institutionWebViewText = app.webViews
-            .staticTexts
-            .containing(NSPredicate(format: "label CONTAINS '\(institutionTextInWebView)'"))
-            .firstMatch
-        XCTAssertTrue(institutionWebViewText.waitForExistence(timeout: 120.0))
+            // check that the WebView loaded
+            let institutionWebViewText = app.webViews
+                .staticTexts
+                .containing(NSPredicate(format: "label CONTAINS '\(institutionName)'"))
+                .firstMatch
+            XCTAssertTrue(institutionWebViewText.waitForExistence(timeout: 120.0))
 
-        let secureWebViewCancelButton = app.buttons["Cancel"]
-        XCTAssertTrue(secureWebViewCancelButton.waitForExistence(timeout: 60.0))
-        secureWebViewCancelButton.tap()
+            let secureWebViewCancelButton = app.buttons["Cancel"]
+            XCTAssertTrue(secureWebViewCancelButton.waitForExistence(timeout: 60.0))
+            secureWebViewCancelButton.tap()
+        }
+        // (2) bank IS under maintenance
+        else {
+            // check that we see a maintenance error
+            let errorViewText = app
+                .textViews
+                .containing(NSPredicate(format: "label CONTAINS 'unavailable' OR label CONTAINS 'maintenance' OR label CONTAINS 'scheduled'"))
+                .firstMatch
+            XCTAssertTrue(errorViewText.waitForExistence(timeout: 10))
+        }
 
         let navigationBarCloseButton = app.navigationBars.buttons["close"]
         XCTAssertTrue(navigationBarCloseButton.waitForExistence(timeout: 60.0))
@@ -239,46 +253,62 @@ final class FinancialConnectionsUITests: XCTestCase {
         // find + tap an institution; we add extra institutions in case
         // they don't get featured
         let institutionButton: XCUIElement?
-        let institutionTextInWebView: String?
+        let institutionName: String?
         let chaseInstitutionButton = app.webViews.buttons["Chase"]
         if chaseInstitutionButton.waitForExistence(timeout: 10) {
             institutionButton = chaseInstitutionButton
-            institutionTextInWebView = "Chase"
+            institutionName = "Chase"
         } else {
             let bankOfAmericaInstitutionButton = app.webViews.buttons["Bank of America"]
             if bankOfAmericaInstitutionButton.waitForExistence(timeout: 10) {
                 institutionButton = bankOfAmericaInstitutionButton
-                institutionTextInWebView = "Bank of America"
+                institutionName = "Bank of America"
             } else {
                 let wellsFargoInstitutionButton = app.webViews.buttons["Wells Fargo"]
                 if wellsFargoInstitutionButton.waitForExistence(timeout: 10) {
                     institutionButton = wellsFargoInstitutionButton
-                    institutionTextInWebView = "Wells Fargo"
+                    institutionName = "Wells Fargo"
                 } else {
                     institutionButton = nil
-                    institutionTextInWebView = nil
+                    institutionName = nil
                 }
             }
         }
-        guard let institutionButton = institutionButton, let institutionTextInWebView = institutionTextInWebView else {
+        guard let institutionButton = institutionButton, let institutionName = institutionName else {
             XCTFail("Couldn't find a Live Mode institution.")
             return
         }
         institutionButton.tap()
 
+        // ...at this point the bank is either:
+        // 1. active, which means prepane is visible
+        // 2. under maintenance, which means an 'error' screen is visible
+
         let prepaneContinueButton = app.webViews
             .buttons
             .containing(NSPredicate(format: "label CONTAINS 'Continue'"))
             .firstMatch
-        XCTAssertTrue(prepaneContinueButton.waitForExistence(timeout: 60.0))
-        prepaneContinueButton.tap()
 
-        // check that the WebView loaded
-        let institutionWebViewText = app.webViews
-            .staticTexts
-            .containing(NSPredicate(format: "label CONTAINS '\(institutionTextInWebView)'"))
-            .firstMatch
-        XCTAssertTrue(institutionWebViewText.waitForExistence(timeout: 120.0))
+        // (1) bank is NOT under maintenance
+        if prepaneContinueButton.waitForExistence(timeout: 60.0) {
+            prepaneContinueButton.tap()
+
+            // check that the WebView loaded
+            let institutionWebViewText = app.webViews
+                .staticTexts
+                .containing(NSPredicate(format: "label CONTAINS '\(institutionName)'"))
+                .firstMatch
+            XCTAssertTrue(institutionWebViewText.waitForExistence(timeout: 120.0))
+        }
+        // (2) bank IS under maintenance
+        else {
+            // check that we see a maintenance error
+            let errorViewText = app.webViews
+                .staticTexts
+                .containing(NSPredicate(format: "label CONTAINS 'unavailable' OR label CONTAINS 'maintenance' OR label CONTAINS 'scheduled'"))
+                .firstMatch
+            XCTAssertTrue(errorViewText.waitForExistence(timeout: 10))
+        }
 
         let secureWebViewCancelButton = app.buttons["Cancel"]
         XCTAssertTrue(secureWebViewCancelButton.waitForExistence(timeout: 60.0))

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
@@ -155,20 +155,23 @@ final class FinancialConnectionsUITests: XCTestCase {
         // they don't get featured
         let institutionButton: XCUIElement?
         let institutionName: String?
-        let chaseInstitutionButton = app.cells["Chase"]
+        let chaseBankName = "Chase"
+        let chaseInstitutionButton = app.cells[chaseBankName]
         if chaseInstitutionButton.waitForExistence(timeout: 10) {
             institutionButton = chaseInstitutionButton
-            institutionName = "Chase"
+            institutionName = chaseBankName
         } else {
-            let bankOfAmericaInstitutionButton = app.cells["Bank of America"]
+            let bankOfAmericaBankName = "Bank of America"
+            let bankOfAmericaInstitutionButton = app.cells[bankOfAmericaBankName]
             if bankOfAmericaInstitutionButton.waitForExistence(timeout: 10) {
                 institutionButton = bankOfAmericaInstitutionButton
-                institutionName = "Bank of America"
+                institutionName = bankOfAmericaBankName
             } else {
-                let wellsFargoInstitutionButton = app.cells["Wells Fargo"]
+                let wellsFargoBankName = "Wells Fargo"
+                let wellsFargoInstitutionButton = app.cells[wellsFargoBankName]
                 if wellsFargoInstitutionButton.waitForExistence(timeout: 10) {
                     institutionButton = wellsFargoInstitutionButton
-                    institutionName = "Wells Fargo"
+                    institutionName = wellsFargoBankName
                 } else {
                     institutionButton = nil
                     institutionName = nil
@@ -254,20 +257,23 @@ final class FinancialConnectionsUITests: XCTestCase {
         // they don't get featured
         let institutionButton: XCUIElement?
         let institutionName: String?
-        let chaseInstitutionButton = app.webViews.buttons["Chase"]
+        let chaseBankName = "Chase"
+        let chaseInstitutionButton = app.webViews.buttons[chaseBankName]
         if chaseInstitutionButton.waitForExistence(timeout: 10) {
             institutionButton = chaseInstitutionButton
-            institutionName = "Chase"
+            institutionName = chaseBankName
         } else {
-            let bankOfAmericaInstitutionButton = app.webViews.buttons["Bank of America"]
+            let bankOfAmericaBankName = "Bank of America"
+            let bankOfAmericaInstitutionButton = app.webViews.buttons[bankOfAmericaBankName]
             if bankOfAmericaInstitutionButton.waitForExistence(timeout: 10) {
                 institutionButton = bankOfAmericaInstitutionButton
-                institutionName = "Bank of America"
+                institutionName = bankOfAmericaBankName
             } else {
-                let wellsFargoInstitutionButton = app.webViews.buttons["Wells Fargo"]
+                let wellsFargoBankName = "Wells Fargo"
+                let wellsFargoInstitutionButton = app.webViews.buttons[wellsFargoBankName]
                 if wellsFargoInstitutionButton.waitForExistence(timeout: 10) {
                     institutionButton = wellsFargoInstitutionButton
-                    institutionName = "Wells Fargo"
+                    institutionName = wellsFargoBankName
                 } else {
                     institutionButton = nil
                     institutionName = nil

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIApplication+Extensions.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIApplication+Extensions.swift
@@ -62,8 +62,13 @@ extension XCUIApplication {
         return consentAgreeButton
     }
 
-    var fc_nativePrepaneContinueButton: XCUIElement {
+    var fc_nativePrepaneContinueButton_noWait: XCUIElement {
         let prepaneContinueButton = buttons["prepane_continue_button"]
+        return prepaneContinueButton
+    }
+
+    var fc_nativePrepaneContinueButton: XCUIElement {
+        let prepaneContinueButton = fc_nativePrepaneContinueButton_noWait
         XCTAssertTrue(prepaneContinueButton.waitForExistence(timeout: 60.0), "\(#function) waiting failed")
         return prepaneContinueButton
     }

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIApplication+Extensions.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIApplication+Extensions.swift
@@ -14,43 +14,43 @@ extension XCUIApplication {
 
     var fc_playgroundCell: XCUIElement {
         let playgroundCell = tables.staticTexts["Playground"]
-        XCTAssertTrue(playgroundCell.waitForExistence(timeout: 10.0))
+        XCTAssertTrue(playgroundCell.waitForExistence(timeout: 10.0), "\(#function) waiting failed")
         return playgroundCell
     }
 
     var fc_playgroundDataFlowButton: XCUIElement {
         let playgroundDataFlowButton = segmentedControls.buttons["Data"]
-        XCTAssertTrue(playgroundDataFlowButton.waitForExistence(timeout: 60.0))
+        XCTAssertTrue(playgroundDataFlowButton.waitForExistence(timeout: 60.0), "\(#function) waiting failed")
         return playgroundDataFlowButton
     }
 
     var fc_playgroundPaymentFlowButton: XCUIElement {
         let playgroundPaymentFlowButton = segmentedControls.buttons["Payments"]
-        XCTAssertTrue(playgroundPaymentFlowButton.waitForExistence(timeout: 60.0))
+        XCTAssertTrue(playgroundPaymentFlowButton.waitForExistence(timeout: 60.0), "\(#function) waiting failed")
         return playgroundPaymentFlowButton
     }
 
     var fc_playgroundNativeButton: XCUIElement {
         let playgroundNativeButton = segmentedControls.buttons["Native"]
-        XCTAssertTrue(playgroundNativeButton.waitForExistence(timeout: 60.0))
+        XCTAssertTrue(playgroundNativeButton.waitForExistence(timeout: 60.0), "\(#function) waiting failed")
         return playgroundNativeButton
     }
 
     var fc_playgroundEnableTestModeSwitch: XCUIElement {
         let enableTestModeSwitch = switches["Enable Test Mode"].firstMatch
-        XCTAssertTrue(enableTestModeSwitch.waitForExistence(timeout: 60.0))
+        XCTAssertTrue(enableTestModeSwitch.waitForExistence(timeout: 60.0), "\(#function) waiting failed")
         return enableTestModeSwitch
     }
 
     var fc_playgroundShowAuthFlowButton: XCUIElement {
         let showAuthFlowButton = buttons["Show Auth Flow"]
-        XCTAssertTrue(showAuthFlowButton.waitForExistence(timeout: 60.0))
+        XCTAssertTrue(showAuthFlowButton.waitForExistence(timeout: 60.0), "\(#function) waiting failed")
         return showAuthFlowButton
     }
 
     var fc_playgroundSuccessAlertView: XCUIElement {
         let playgroundSuccessAlertView = alerts["Success"]
-        XCTAssertTrue(playgroundSuccessAlertView.waitForExistence(timeout: 60.0))
+        XCTAssertTrue(playgroundSuccessAlertView.waitForExistence(timeout: 60.0), "\(#function) waiting failed")
         return playgroundSuccessAlertView
     }
 
@@ -58,25 +58,25 @@ extension XCUIApplication {
 
     var fc_nativeConsentAgreeButton: XCUIElement {
         let consentAgreeButton = buttons["consent_agree_button"]
-        XCTAssertTrue(consentAgreeButton.waitForExistence(timeout: 120.0))  // glitch app can take time to lload
+        XCTAssertTrue(consentAgreeButton.waitForExistence(timeout: 120.0), "\(#function) waiting failed")  // glitch app can take time to lload
         return consentAgreeButton
     }
 
     var fc_nativePrepaneContinueButton: XCUIElement {
         let prepaneContinueButton = buttons["prepane_continue_button"]
-        XCTAssertTrue(prepaneContinueButton.waitForExistence(timeout: 60.0))
+        XCTAssertTrue(prepaneContinueButton.waitForExistence(timeout: 60.0), "\(#function) waiting failed")
         return prepaneContinueButton
     }
 
     var fc_nativeAccountPickerLinkAccountsButton: XCUIElement {
         let accountPickerLinkAccountsButton = buttons["account_picker_link_accounts_button"]
-        XCTAssertTrue(accountPickerLinkAccountsButton.waitForExistence(timeout: 120.0))  // wait for accounts to fetch
+        XCTAssertTrue(accountPickerLinkAccountsButton.waitForExistence(timeout: 120.0), "\(#function) waiting failed")  // wait for accounts to fetch
         return accountPickerLinkAccountsButton
     }
 
     var fc_nativeSuccessDoneButton: XCUIElement {
         let successDoneButton = buttons["success_done_button"]
-        XCTAssertTrue(successDoneButton.waitForExistence(timeout: 120.0))  // wait for accounts to link
+        XCTAssertTrue(successDoneButton.waitForExistence(timeout: 120.0), "\(#function) waiting failed")  // wait for accounts to link
         return successDoneButton
     }
 

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIElement+Extensions.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIElement+Extensions.swift
@@ -1,0 +1,48 @@
+//
+//  XCUIElement+Extensions.swift
+//  FinancialConnectionsUITests
+//
+//  Created by Krisjanis Gaidis on 8/14/23.
+//
+
+import Foundation
+import XCTest
+
+extension XCUIElement {
+
+    fileprivate func wait(
+        until expression: @escaping (XCUIElement) -> Bool,
+        timeout: TimeInterval
+    ) -> Bool {
+        let expectation = XCTNSPredicateExpectation(
+            predicate: NSPredicate { _, _ in
+                expression(self)
+            },
+            object: nil
+        )
+        let result = XCTWaiter().wait(for: [expectation], timeout: timeout)
+        return (result == .completed)
+    }
+
+    func turnSwitch(on: Bool) {
+        if (value as? String) == (on ? "0" : "1") {
+            tap()
+            // starting iOS 16.4 (where 16.1 previously worked), calling
+            // `tap()` on a switch didn't do anything, so below we
+            // try a different method...
+            if (value as? String) == (on ? "0" : "1") {
+                let coordinate = coordinate(
+                    withNormalizedOffset: CGVector(
+                        dx: 0.9,
+                        dy: 0.5
+                    )
+                )
+                coordinate.tap()
+            }
+        }
+        XCTAssert(wait(
+            until: { ($0.value as? String == (on ? "1" : "0")) },
+            timeout: 5
+        ), "switch failed to change")
+    }
+}


### PR DESCRIPTION
## Summary

Two things:
1. Did some small polishes of end to end tests. For example, starting iOS 16.4, the switch/toggles were not turning on/off.
2. I added support for banks that are down due to maintenance periods. Before this support/fix, we could get end-to-end test failures.

| Down Example 1 | Down Example 2 |
| --- | --- |
| <img width="178" alt="Screenshot 2023-08-15 at 1 37 17 PM" src="https://github.com/stripe/stripe-ios/assets/105514761/04a366c2-47ea-414c-a406-d543a2530a97"> | <img width="117" alt="Screenshot 2023-08-15 at 1 38 23 PM" src="https://github.com/stripe/stripe-ios/assets/105514761/e557f93c-c2f7-4d66-849b-a3a0767233ef"> |

## Testing

**Note that all this code is just testing code. No core code is modified, so its safe.**

I did all sorts of manual testing to handle down bank screen. 

Below I ran `bitrise run financial-connections-stability-tests` to verify that all tests pass:

```
Test Suite FinancialConnectionsUITests.xctest started
FinancialConnectionsNetworkingUITests
    ✓ testNativeNetworkingTestMode (95.465 seconds)
FinancialConnectionsUITests
    ✓ testDataLiveModeOAuthNativeAuthFlow (35.275 seconds)
    ✓ testDataLiveModeOAuthWebAuthFlow (29.325 seconds)
    ✓ testDataTestModeOAuthNativeAuthFlow (24.777 seconds)
    ✓ testPaymentTestModeLegacyNativeAuthFlow (26.048 seconds)
    ✓ testPaymentTestModeManualEntryNativeAuthFlow (29.168 seconds)
    ✓ testSearchInLiveModeNativeAuthFlow (27.401 seconds)
```