### PR TITLE
Stop deleting Package.resolved

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,4 +59,5 @@ Example/**/*.xcodeproj
 Testers/**/*.xcodeproj
 
 # But make sure to store the Package.resolved file for Xcode Cloud
+# https://forums.swift.org/t/package-resolved-should-go-in-the-gitignore/14699/29
 !Stripe.xcworkspace/xcshareddata/swiftpm

--- a/Stripe.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Stripe.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,32 @@
+{
+  "pins" : [
+    {
+      "identity" : "ios-snapshot-test-case",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/uber/ios-snapshot-test-case",
+      "state" : {
+        "revision" : "7b10770333a961be6e5a41c9ce04b8c6d3990126",
+        "version" : "8.0.0"
+      }
+    },
+    {
+      "identity" : "ocmock",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/erikdoe/ocmock",
+      "state" : {
+        "branch" : "master",
+        "revision" : "05cbc9d934e84ad32530fa53fd7d29c7966d5828"
+      }
+    },
+    {
+      "identity" : "ohhttpstubs",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/eurias-stripe/OHHTTPStubs",
+      "state" : {
+        "branch" : "master",
+        "revision" : "94cf8e1d9e38b0edd580ddc699dda23a7bf66515"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/ci_scripts/delete_project_files.rb
+++ b/ci_scripts/delete_project_files.rb
@@ -3,7 +3,7 @@
 require_relative 'common'
 
 run_command('rm -f .package.resolved', false)
-run_command('find Stripe.xcworkspace -type f ! -name "Package.resolved" -exec rm {} +', false)
-run_command('find Stripe* -type d -name "*.xcodeproj" -exec rm -r {} +', false)
-run_command('find Example -type d -name "*.xcodeproj" -exec rm -r {} +', false)
-run_command('find Testers -type d -name "*.xcodeproj" -exec rm -r {} +', false)
+run_command('find Stripe.xcworkspace -type f ! -name "Package.resolved"', false)
+run_command('find Stripe* -type d -name "*.xcodeproj"', false)
+run_command('find Example -type d -name "*.xcodeproj"', false)
+run_command('find Testers -type d -name "*.xcodeproj"', false)

--- a/ci_scripts/delete_project_files.rb
+++ b/ci_scripts/delete_project_files.rb
@@ -2,8 +2,10 @@
 
 require_relative 'common'
 
+# If we delete the project while Xcode is running, it will corrupt the Package.resolved
+run_command('killall -9 Xcode', false)
 run_command('rm -f .package.resolved', false)
-run_command('find Stripe.xcworkspace -type f ! -name "Package.resolved"', false)
-run_command('find Stripe* -type d -name "*.xcodeproj"', false)
-run_command('find Example -type d -name "*.xcodeproj"', false)
-run_command('find Testers -type d -name "*.xcodeproj"', false)
+run_command('find Stripe.xcworkspace -type f ! -name "Package.resolved" -exec rm {} +', false)
+run_command('find Stripe* -type d -name "*.xcodeproj" -exec rm -r {} +', false)
+run_command('find Example -type d -name "*.xcodeproj" -exec rm -r {} +', false)
+run_command('find Testers -type d -name "*.xcodeproj" -exec rm -r {} +', false)


### PR DESCRIPTION
## Summary
* If we run the project cleanup script while Xcode has the project open, Xcode will delete the Package.resolved. To prevent this, we'll kill Xcode before cleaning up the project.
* Add a comment to the .gitignore to explain why we commit the Package.resolved.

## Testing
Ran script locally
