### PR TITLE
Fix LUXE PMs for FlowController

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -118,11 +118,6 @@ extension PaymentSheet {
             return ""
         }
 
-        var paymentSheetLabel: String {
-            assertionFailure()
-            return "Unknown"
-        }
-
         static func shouldLogAnalytic(paymentMethod: PaymentSheet.PaymentMethodType) -> Bool {
             analyticLogForIconSemaphore.wait()
             defer { analyticLogForIconSemaphore.signal() }
@@ -524,7 +519,7 @@ extension STPPaymentMethodParams {
         default:
             if self.type == .unknown, let rawTypeString = rawTypeString {
                 let paymentMethodType = PaymentSheet.PaymentMethodType(from: rawTypeString)
-                return paymentMethodType.paymentSheetLabel
+                return paymentMethodType.displayName
             } else {
                 return label
             }


### PR DESCRIPTION
## Summary
- Before we would assert or return "Unknown" for display names of LUXE pms in flow controller
- Now we just return the display name e.g. "Amazon Pay".

## Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-1232

## Testing
No longer crashing/return unknown
https://github.com/stripe/stripe-ios/assets/88012362/7fef8545-1431-47f8-9852-cdc0860bfbe0

## Changelog
N/A (could warrant an update?)
