### PR TITLE
Refactor deferred intent payment-user-agent hack, add autopm if using…

### DIFF
--- a/Stripe/StripeiOSTests/STPAPIClientStubbedTest.swift
+++ b/Stripe/StripeiOSTests/STPAPIClientStubbedTest.swift
@@ -17,6 +17,26 @@ import XCTest
 @testable@_spi(STP) import StripePaymentSheet
 
 class STPAPIClientStubbedTest: APIStubbedTestCase {
+    func testCreatePaymentMethodWithAdditionalPaymentUserAgentValues() {
+        let sut = stubbedAPIClient()
+        stub { urlRequest in
+            guard let queryItems = urlRequest.queryItems else {
+                return false
+            }
+            XCTAssertTrue(queryItems.contains(where: { item in
+                // The additional payment user agent values "foo" and "bar" should be in the payment_user_agent field
+                item.name == "payment_user_agent" && item.value!.hasSuffix("%3B%20foo%3B%20bar")
+            }))
+            return true
+        } response: { _ in
+            return .init()
+        }
+        let e = expectation(description: "")
+        sut.createPaymentMethod(with: ._testValidCardValue(), additionalPaymentUserAgentValues: ["foo", "bar"]) { _, _ in
+            e.fulfill()
+        }
+        waitForExpectations(timeout: 10)
+    }
 
     func testSetupIntent_LinkAccountSessionForUSBankAccount() {
         let sut = stubbedAPIClient()

--- a/Stripe/StripeiOSTests/STPAPIClientTest.swift
+++ b/Stripe/StripeiOSTests/STPAPIClientTest.swift
@@ -11,6 +11,7 @@ import XCTest
 @testable@_spi(STP) import Stripe
 @testable@_spi(STP) import StripeApplePay
 @testable@_spi(STP) import StripeCore
+@testable@_spi(STP) import StripePayments
 @testable@_spi(STP) import StripePaymentSheet
 @testable@_spi(STP) import StripePaymentsUI
 
@@ -116,8 +117,10 @@ class STPAPIClientTest: XCTestCase {
         STPAnalyticsClient.sharedClient.addClass(toProductUsageIfNecessary: MockUAUsageClass.self)
         var params: [String: Any] = [:]
         params = STPAPIClient.paramsAddingPaymentUserAgent(params)
-        XCTAssert((params["payment_user_agent"] as! String).contains("MockUAUsageClass"))
-        XCTAssert((params["payment_user_agent"] as! String).starts(with: "stripe-ios/"))
+        XCTAssertEqual(params["payment_user_agent"] as! String, "stripe-ios/\(StripeAPIConfiguration.STPSDKVersion); variant.legacy; MockUAUsageClass")
+
+        params = STPAPIClient.paramsAddingPaymentUserAgent(params, additionalValues: ["foo"])
+        XCTAssertEqual(params["payment_user_agent"] as! String, "stripe-ios/\(StripeAPIConfiguration.STPSDKVersion); variant.legacy; MockUAUsageClass; foo")
     }
 
     func testSetAppInfo() {

--- a/Stripe/StripeiOSTests/STPAPIClientTest.swift
+++ b/Stripe/StripeiOSTests/STPAPIClientTest.swift
@@ -114,6 +114,7 @@ class STPAPIClientTest: XCTestCase {
     }
 
     func testPaymentUserAgent() {
+        STPAnalyticsClient.sharedClient.productUsage = .init()
         STPAnalyticsClient.sharedClient.addClass(toProductUsageIfNecessary: MockUAUsageClass.self)
         var params: [String: Any] = [:]
         params = STPAPIClient.paramsAddingPaymentUserAgent(params)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APITest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APITest.swift
@@ -12,8 +12,8 @@ import XCTest
 @testable@_spi(STP) import StripeCore
 @testable@_spi(STP) import StripeCoreTestUtils
 @testable@_spi(STP) import StripePayments
-@testable@_spi(STP) import StripePaymentsTestUtils
 @testable@_spi(STP) import StripePaymentSheet
+@testable@_spi(STP) import StripePaymentsTestUtils
 @testable@_spi(STP) import StripeUICore
 
 class PaymentSheetAPITest: XCTestCase {
@@ -1040,6 +1040,24 @@ class PaymentSheetAPITest: XCTestCase {
             // ...should have mandate data
             XCTAssertNotNil(params_for_si_with_sfu.mandateData)
         }
+    }
+
+    func testMakeDeferredPaymentUserAgent() {
+        let intentConfig_with_nil_payment_method_types = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1099, currency: "USD"), confirmHandler: { _, _, _  in })
+        XCTAssertEqual(
+            PaymentSheet.makeDeferredPaymentUserAgentValue(intentConfiguration: intentConfig_with_nil_payment_method_types),
+            ["deferred-intent", "autopm"]
+        )
+        let intentConfig_with_empty_payment_method_types = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1099, currency: "USD"), paymentMethodTypes: [], confirmHandler: { _, _, _  in })
+        XCTAssertEqual(
+            PaymentSheet.makeDeferredPaymentUserAgentValue(intentConfiguration: intentConfig_with_nil_payment_method_types),
+            ["deferred-intent", "autopm"]
+        )
+        let intentConfig_with_payment_method_types = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1099, currency: "USD"), paymentMethodTypes: ["card"], confirmHandler: { _, _, _  in })
+        XCTAssertEqual(
+            PaymentSheet.makeDeferredPaymentUserAgentValue(intentConfiguration: intentConfig_with_payment_method_types),
+            ["deferred-intent"]
+        )
     }
 }
 

--- a/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+Payments.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+Payments.swift
@@ -729,7 +729,7 @@ extension STPAPIClient {
         createPaymentMethod(with: paymentMethodParams, additionalPaymentUserAgentValues: [], completion: completion)
     }
 
-    /// - Parameter additionalPaymentUserAgentValues: A list of values to append to `payment_user_agent` e.g. `["deferred-intent", "autopm"]`
+    /// - Parameter additionalPaymentUserAgentValues: A list of values to append to the `payment_user_agent` parameter sent in the request. e.g. `["deferred-intent", "autopm"]` will append "; deferred-intent; autopm" to the `payment_user_agent`.
     func createPaymentMethod(
         with paymentMethodParams: STPPaymentMethodParams,
         additionalPaymentUserAgentValues: [String] = [],
@@ -755,6 +755,7 @@ extension STPAPIClient {
     /// - seealso: https://stripe.com/docs/api/payment_methods/create
     /// - Parameters:
     ///   - paymentMethodParams:  The `STPPaymentMethodParams` to pass to `/v1/payment_methods`.  Cannot be nil.
+    ///   - additionalPaymentUserAgentValues:  A list of values to append to the `payment_user_agent` parameter sent in the request. e.g. `["deferred-intent", "autopm"]` will append "; deferred-intent; autopm" to the `payment_user_agent`.
     /// - Returns: the returned PaymentMethod object.
     public func createPaymentMethod(with paymentMethodParams: STPPaymentMethodParams, additionalPaymentUserAgentValues: [String]) async throws -> STPPaymentMethod {
         return try await withCheckedThrowingContinuation({ continuation in

--- a/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+Payments.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+Payments.swift
@@ -726,7 +726,7 @@ extension STPAPIClient {
         with paymentMethodParams: STPPaymentMethodParams,
         completion: @escaping STPPaymentMethodCompletionBlock
     ) {
-        createPaymentMethod(with: paymentMethodParams, completion: completion)
+        createPaymentMethod(with: paymentMethodParams, additionalPaymentUserAgentValues: [], completion: completion)
     }
 
     /// - Parameter additionalPaymentUserAgentValues: A list of values to append to `payment_user_agent` e.g. `["deferred-intent", "autopm"]`

--- a/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+Payments.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+Payments.swift
@@ -726,12 +726,21 @@ extension STPAPIClient {
         with paymentMethodParams: STPPaymentMethodParams,
         completion: @escaping STPPaymentMethodCompletionBlock
     ) {
+        createPaymentMethod(with: paymentMethodParams, completion: completion)
+    }
+
+    /// - Parameter additionalPaymentUserAgentValues: A list of values to append to `payment_user_agent` e.g. `["deferred-intent", "autopm"]`
+    func createPaymentMethod(
+        with paymentMethodParams: STPPaymentMethodParams,
+        additionalPaymentUserAgentValues: [String] = [],
+        completion: @escaping STPPaymentMethodCompletionBlock
+    ) {
         STPAnalyticsClient.sharedClient.logPaymentMethodCreationAttempt(
             with: _stored_configuration,
             paymentMethodType: paymentMethodParams.rawTypeString
         )
         var parameters = STPFormEncoder.dictionary(forObject: paymentMethodParams)
-        parameters = Self.paramsAddingPaymentUserAgent(parameters)
+        parameters = Self.paramsAddingPaymentUserAgent(parameters, additionalValues: additionalPaymentUserAgentValues)
         APIRequest<STPPaymentMethod>.post(
             with: self,
             endpoint: APIEndpointPaymentMethods,
@@ -747,9 +756,9 @@ extension STPAPIClient {
     /// - Parameters:
     ///   - paymentMethodParams:  The `STPPaymentMethodParams` to pass to `/v1/payment_methods`.  Cannot be nil.
     /// - Returns: the returned PaymentMethod object.
-    public func createPaymentMethod(with paymentMethodParams: STPPaymentMethodParams) async throws -> STPPaymentMethod {
+    public func createPaymentMethod(with paymentMethodParams: STPPaymentMethodParams, additionalPaymentUserAgentValues: [String]) async throws -> STPPaymentMethod {
         return try await withCheckedThrowingContinuation({ continuation in
-            createPaymentMethod(with: paymentMethodParams) { paymentMethod, error in
+            createPaymentMethod(with: paymentMethodParams, additionalPaymentUserAgentValues: additionalPaymentUserAgentValues) { paymentMethod, error in
                 if let paymentMethod = paymentMethod {
                     continuation.resume(with: .success(paymentMethod))
                 } else {

--- a/StripePayments/StripePayments/Source/Internal/Categories/STPAPIClient+PaymentsCore.swift
+++ b/StripePayments/StripePayments/Source/Internal/Categories/STPAPIClient+PaymentsCore.swift
@@ -10,6 +10,8 @@ import Foundation
 @_spi(STP) import StripeCore
 
 extension STPAPIClient {
+
+    /// - Parameter additionalValues: A list of values to append to the `payment_user_agent`. e.g. `["deferred-intent", "autopm"]` will append "; deferred-intent; autopm" to the `payment_user_agent`.
     @_spi(STP) public class func paramsAddingPaymentUserAgent(
         _ params: [String: Any],
         additionalValues: [String] = []

--- a/StripePayments/StripePayments/Source/Internal/Categories/STPAPIClient+PaymentsCore.swift
+++ b/StripePayments/StripePayments/Source/Internal/Categories/STPAPIClient+PaymentsCore.swift
@@ -11,10 +11,11 @@ import Foundation
 
 extension STPAPIClient {
     @_spi(STP) public class func paramsAddingPaymentUserAgent(
-        _ params: [String: Any]
+        _ params: [String: Any],
+        additionalValues: [String] = []
     ) -> [String: Any] {
         var newParams = params
-        newParams["payment_user_agent"] = PaymentsSDKVariant.paymentUserAgent
+        newParams["payment_user_agent"] = ([PaymentsSDKVariant.paymentUserAgent] + additionalValues).joined(separator: "; ")
         return newParams
     }
 }


### PR DESCRIPTION
… automatic_payment_methods

## Summary
- Explicitly pass additional payment_user_agent values to `createPaymentMethod` instead of hackily using `STPAnalyticsClient.sharedClient.productUsage` singleton. The big problem with the latter is that once we add `deferred-intent` to `productUsage`, all future calls will send `deferred-intent` regardless of whether it's actually deferred or not.
- Add "autopm" to payment_user_agent for deferred flow if merchant is using auto pms.

## Motivation
https://github.com/stripe/stripe-android/pull/7185

## Testing
- Example request: https://admin.corp.stripe.com/request-log/req_sCrlRBkOFFdxan
- See unit tests

## Changelog
Not user facing