### PR TITLE
Modify deploy script to only push release tag, not all tags

### DIFF
--- a/ci_scripts/deploy_release.rb
+++ b/ci_scripts/deploy_release.rb
@@ -39,9 +39,9 @@ end
 
 def push_tag
   unless @is_dry_run
-    # Create a signed git tag and push to GitHub: git tag -s X.Y.Z -m "Version X.Y.Z" && git push origin --tags
+    # Create a signed git tag and push to GitHub: git tag -s X.Y.Z -m "Version X.Y.Z" && git push origin X.Y.Z
     run_command("git tag -s #{@version} -m \"Version #{@version}\"")
-    run_command('git push origin --tags')
+    run_command("git push origin #{@version}")
   end
 end
 


### PR DESCRIPTION
Pushing all tags is a bit dangerous and unnecessary.


