### PR TITLE
Make properties in STPConnectAccountParams var instead of let

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## X.Y.Z 2023-XX-YY
+### Payments
+* [Added] Properties of STPConnectAccountParams are now mutable.
+
 ## 23.15.0 2023-08-28
 ### PaymentSheet
 * [Added] Support for AmazonPay (private beta), BLIK, and FPX with PaymentIntents.

--- a/StripePayments/StripePayments/Source/API Bindings/Models/STPConnectAccountParams.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/STPConnectAccountParams.swift
@@ -25,16 +25,16 @@ public class STPConnectAccountParams: NSObject {
 
     /// Boolean indicating that the Terms Of Service were shown to the user &
     /// the user accepted them.
-    @objc public let tosShownAndAccepted: NSNumber?
+    @objc public var tosShownAndAccepted: NSNumber?
 
     /// The business type.
-    @objc public let businessType: STPConnectAccountBusinessType
+    @objc public var businessType: STPConnectAccountBusinessType
 
     /// Information about the individual represented by the account.
-    @objc public let individual: STPConnectAccountIndividualParams?
+    @objc public var individual: STPConnectAccountIndividualParams?
 
     /// Information about the company or business.
-    @objc public let company: STPConnectAccountCompanyParams?
+    @objc public var company: STPConnectAccountCompanyParams?
 
     @objc public var additionalAPIParameters: [AnyHashable: Any] = [:]
 


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

## Motivation
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-2526

We did intentionally make these properties readonly in 3f2bc395c77e9b55953d2d5106525cec94e9d0ef but I don't see why. The property values are modifiable via `additionalAPIParameters`. Making these properties `var` follows other "parameter" objects.

## Testing
Existing unit tests

## Changelog
[Added] Properties of STPConnectAccountParams are now mutable.