### PR TITLE
Enable Cash App Pay for setup intents

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -286,7 +286,7 @@ extension PaymentSheet {
                     switch stpPaymentMethodType {
                     case .card:
                         return []
-                    case .alipay, .payPal:
+                    case .alipay, .payPal, .cashApp:
                         return [.returnURL]
                     case .USBankAccount:
                         return [.userSupportsDelayedPaymentMethods]
@@ -300,7 +300,7 @@ extension PaymentSheet {
                         return [.returnURL, .userSupportsDelayedPaymentMethods]
                     case .AUBECSDebit, .cardPresent, .blik, .weChatPay, .grabPay, .FPX, .giropay, .przelewy24, .EPS,
                         .netBanking, .OXXO, .afterpayClearpay, .UPI, .boleto, .klarna, .link, .linkInstantDebit,
-                        .affirm, .cashApp, .unknown:
+                        .affirm, .unknown:
                         return [.unsupportedForSetup]
                     @unknown default:
                         return [.unsupportedForSetup]


### PR DESCRIPTION
## Summary
- Enables Cash App Pay for Setup Intents in PaymentSheet
![Simulator Screenshot - iPhone 14 - 2023-09-05 at 13 29 47](https://github.com/stripe/stripe-ios/assets/88012362/941d8a83-2907-4558-9e9a-5f02e340e4eb)

## Motivation
LPM sprint

## Testing
Manually in playground

## Changelog
Batch all changes at end of sprint?