### PR TITLE
Add PayNow to STPPaymentMethodType enum

### DIFF
--- a/Stripe/StripeiOS/Source/STPPaymentMethod+BasicUI.swift
+++ b/Stripe/StripeiOS/Source/STPPaymentMethod+BasicUI.swift
@@ -69,7 +69,7 @@ extension STPPaymentMethod: STPPaymentOption {
             .bacsDebit, .SEPADebit, .iDEAL, .FPX, .cardPresent, .giropay, .EPS, .payPal,
             .przelewy24, .bancontact,
             .OXXO, .sofort, .grabPay, .netBanking, .UPI, .afterpayClearpay, .blik,
-            .weChatPay, .boleto, .klarna, .linkInstantDebit, .affirm, .cashApp,  // fall through
+            .weChatPay, .boleto, .klarna, .linkInstantDebit, .affirm, .cashApp, .paynow, // fall through
             .unknown:
             return false
         @unknown default:

--- a/Stripe/StripeiOS/Source/STPPaymentMethodParams+BasicUI.swift
+++ b/Stripe/StripeiOS/Source/STPPaymentMethodParams+BasicUI.swift
@@ -38,7 +38,7 @@ extension STPPaymentMethodParams: STPPaymentOption {
             return true
         case .alipay, .AUBECSDebit, .bacsDebit, .SEPADebit, .iDEAL, .FPX, .cardPresent, .giropay,
             .grabPay, .EPS, .przelewy24, .bancontact, .netBanking, .OXXO, .payPal, .sofort, .UPI,
-            .afterpayClearpay, .blik, .weChatPay, .boleto, .klarna, .linkInstantDebit, .affirm, .cashApp,
+            .afterpayClearpay, .blik, .weChatPay, .boleto, .klarna, .linkInstantDebit, .affirm, .cashApp, .paynow,
             .unknown:
             return false
         @unknown default:

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -341,16 +341,15 @@ extension PaymentSheet {
                     case .USBankAccount:
                         return [.userSupportsDelayedPaymentMethods]
                     case .sofort, .iDEAL, .bancontact:
-                        // n.b. While sofort, iDEAL and bancontact are themselves not delayed, they turn into SEPA upon save, which IS delayed.
+                        // n.b. While sofort, iDEAL, and bancontact are themselves not delayed, they turn into SEPA upon save, which IS delayed.
                         return [.returnURL, .userSupportsDelayedPaymentMethods]
-                        // n.b. While iDEAL and bancontact are themselves not delayed, they turn into SEPA upon save, which IS delayed.
                     case .SEPADebit:
                         return [.userSupportsDelayedPaymentMethods]
                     case .bacsDebit:
                         return [.returnURL, .userSupportsDelayedPaymentMethods]
                     case .AUBECSDebit, .cardPresent, .blik, .weChatPay, .grabPay, .FPX, .giropay, .przelewy24, .EPS,
                         .netBanking, .OXXO, .afterpayClearpay, .UPI, .boleto, .klarna, .link, .linkInstantDebit,
-                        .affirm, .unknown:
+                        .affirm, .unknown, .paynow:
                         return [.unsupportedForSetup]
                     @unknown default:
                         return [.unsupportedForSetup]
@@ -359,7 +358,7 @@ extension PaymentSheet {
             } else {
                 requirements = {
                     switch stpPaymentMethodType {
-                    case .blik, .card, .cardPresent, .UPI, .weChatPay:
+                    case .blik, .card, .cardPresent, .UPI, .weChatPay, .paynow:
                         return []
                     case .alipay, .EPS, .FPX, .giropay, .grabPay, .netBanking, .payPal, .przelewy24, .klarna,
                             .linkInstantDebit, .bancontact, .iDEAL, .cashApp, .affirm:

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodEnums.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodEnums.swift
@@ -67,6 +67,8 @@ import Foundation
     case USBankAccount
     /// A CashApp payment method
     case cashApp
+    /// A PayNow payment method
+    case paynow
     /// An unknown type.
     case unknown
 
@@ -135,6 +137,8 @@ import Foundation
             .cardPresent,
             .unknown:
             return STPLocalizedString("Unknown", "Default missing source type label")
+        case .paynow:
+            return "PayNow"
         @unknown default:
             return STPLocalizedString("Unknown", "Default missing source type label")
         }
@@ -201,6 +205,8 @@ import Foundation
             return "cashapp"
         case .unknown:
             return "unknown"
+        case .paynow:
+            return "paynow"
         }
     }
 }

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodParams.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodParams.swift
@@ -620,6 +620,9 @@ public class STPPaymentMethodParams: NSObject, STPFormEncodable {
             self.type = .affirm
             self.affirm = STPPaymentMethodAffirmParams()
             self.billingDetails = paymentMethod.billingDetails
+        case .paynow:
+            self.type = .paynow
+            self.billingDetails = paymentMethod.billingDetails
         // All reusable PaymentMethods go below:
         case .SEPADebit,
             .bacsDebit,
@@ -1084,8 +1087,6 @@ extension STPPaymentMethodParams {
             iDEAL = STPPaymentMethodiDEALParams()
         case .FPX:
             fpx = STPPaymentMethodFPXParams()
-        case .cardPresent:
-            break
         case .SEPADebit:
             sepaDebit = STPPaymentMethodSEPADebitParams()
         case .AUBECSDebit:
@@ -1124,12 +1125,13 @@ extension STPPaymentMethodParams {
             klarna = STPPaymentMethodKlarnaParams()
         case .affirm:
             affirm = STPPaymentMethodAffirmParams()
-        case .linkInstantDebit:
-            break
         case .USBankAccount:
             usBankAccount = STPPaymentMethodUSBankAccountParams()
         case .cashApp:
             cashApp = STPPaymentMethodCashAppParams()
+        case .cardPresent, .linkInstantDebit, .paynow:
+            // These payment methods don't have any params
+            break
         case .unknown:
             break
         }
@@ -1205,6 +1207,8 @@ extension STPPaymentMethodParams {
             return "Cash App Pay"
         case .cardPresent, .unknown:
             return STPLocalizedString("Unknown", "Default missing source type label")
+        case .paynow:
+            return "PayNow"
         @unknown default:
             return STPLocalizedString("Unknown", "Default missing source type label")
         }

--- a/StripePayments/StripePayments/Source/Categories/Enums+CustomStringConvertible.swift
+++ b/StripePayments/StripePayments/Source/Categories/Enums+CustomStringConvertible.swift
@@ -538,6 +538,8 @@ extension STPPaymentMethodType: CustomStringConvertible {
             return "weChatPay"
         case .cashApp:
             return "cashApp"
+        case .paynow:
+            return "PayNow"
         }
     }
 }

--- a/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
@@ -636,7 +636,8 @@ public class STPPaymentHandler: NSObject {
             .klarna,
             .affirm,
             .linkInstantDebit,
-            .cashApp:
+            .cashApp,
+            .paynow:
             return false
 
         case .unknown:


### PR DESCRIPTION
## Motivation
In preparation for adding support for PayNow.

I'd like to do this for *all* PMs, both going forward and retroactively, instead of using `PaymentMethodType.dynamic("paynow")`, because:
1. it un-breaks the decoupled flow, where we pass an `STPPaymentMethod` object with type = unknown today for PMs that use `PaymentMethodType.dynamic`.  
2. It gets us to a future where we can delete `PaymentMethodType.dynamic("a string")` entirely

## Testing
Relying on existing tests.