### PR TITLE
Switch dynamic PMs to STPPaymentMethodType 

### DIFF
--- a/Stripe/StripeiOS/Source/STPPaymentMethod+BasicUI.swift
+++ b/Stripe/StripeiOS/Source/STPPaymentMethod+BasicUI.swift
@@ -69,7 +69,7 @@ extension STPPaymentMethod: STPPaymentOption {
             .bacsDebit, .SEPADebit, .iDEAL, .FPX, .cardPresent, .giropay, .EPS, .payPal,
             .przelewy24, .bancontact,
             .OXXO, .sofort, .grabPay, .netBanking, .UPI, .afterpayClearpay, .blik,
-            .weChatPay, .boleto, .klarna, .linkInstantDebit, .affirm, .cashApp, .paynow, .zip, // fall through
+            .weChatPay, .boleto, .klarna, .linkInstantDebit, .affirm, .cashApp, .paynow, .zip, .revolutPay, .amazonPay, .mobilePay,
             .unknown:
             return false
         @unknown default:

--- a/Stripe/StripeiOS/Source/STPPaymentMethod+BasicUI.swift
+++ b/Stripe/StripeiOS/Source/STPPaymentMethod+BasicUI.swift
@@ -69,7 +69,7 @@ extension STPPaymentMethod: STPPaymentOption {
             .bacsDebit, .SEPADebit, .iDEAL, .FPX, .cardPresent, .giropay, .EPS, .payPal,
             .przelewy24, .bancontact,
             .OXXO, .sofort, .grabPay, .netBanking, .UPI, .afterpayClearpay, .blik,
-            .weChatPay, .boleto, .klarna, .linkInstantDebit, .affirm, .cashApp, .paynow, // fall through
+            .weChatPay, .boleto, .klarna, .linkInstantDebit, .affirm, .cashApp, .paynow, .zip, // fall through
             .unknown:
             return false
         @unknown default:

--- a/Stripe/StripeiOS/Source/STPPaymentMethodParams+BasicUI.swift
+++ b/Stripe/StripeiOS/Source/STPPaymentMethodParams+BasicUI.swift
@@ -38,7 +38,7 @@ extension STPPaymentMethodParams: STPPaymentOption {
             return true
         case .alipay, .AUBECSDebit, .bacsDebit, .SEPADebit, .iDEAL, .FPX, .cardPresent, .giropay,
             .grabPay, .EPS, .przelewy24, .bancontact, .netBanking, .OXXO, .payPal, .sofort, .UPI,
-            .afterpayClearpay, .blik, .weChatPay, .boleto, .klarna, .linkInstantDebit, .affirm, .cashApp, .paynow, .zip,
+            .afterpayClearpay, .blik, .weChatPay, .boleto, .klarna, .linkInstantDebit, .affirm, .cashApp, .paynow, .zip, .revolutPay, .amazonPay, .mobilePay,
             .unknown:
             return false
         @unknown default:

--- a/Stripe/StripeiOS/Source/STPPaymentMethodParams+BasicUI.swift
+++ b/Stripe/StripeiOS/Source/STPPaymentMethodParams+BasicUI.swift
@@ -38,7 +38,7 @@ extension STPPaymentMethodParams: STPPaymentOption {
             return true
         case .alipay, .AUBECSDebit, .bacsDebit, .SEPADebit, .iDEAL, .FPX, .cardPresent, .giropay,
             .grabPay, .EPS, .przelewy24, .bancontact, .netBanking, .OXXO, .payPal, .sofort, .UPI,
-            .afterpayClearpay, .blik, .weChatPay, .boleto, .klarna, .linkInstantDebit, .affirm, .cashApp, .paynow,
+            .afterpayClearpay, .blik, .weChatPay, .boleto, .klarna, .linkInstantDebit, .affirm, .cashApp, .paynow, .zip,
             .unknown:
             return false
         @unknown default:

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -23,8 +23,6 @@ extension PaymentSheet {
                 return [.returnURL]
             case .dynamic("mobilepay"):
                 return [.returnURL]
-            case .dynamic("zip"):
-                return [.returnURL]
             default:
                 return [.unsupported]
             }
@@ -95,8 +93,6 @@ extension PaymentSheet {
                 return "Revolut Pay"
             } else if case .dynamic("mobilepay") = self {
                 return "MobilePay"
-            } else if case .dynamic("zip") = self {
-                return "Zip"
             } else if case .dynamic("amazon_pay") = self {
                 return "Amazon Pay"
             } else if case .dynamic(let name) = self {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -349,7 +349,7 @@ extension PaymentSheet {
                         return [.returnURL, .userSupportsDelayedPaymentMethods]
                     case .AUBECSDebit, .cardPresent, .blik, .weChatPay, .grabPay, .FPX, .giropay, .przelewy24, .EPS,
                         .netBanking, .OXXO, .afterpayClearpay, .UPI, .boleto, .klarna, .link, .linkInstantDebit,
-                        .affirm, .unknown, .paynow:
+                        .affirm, .paynow, .zip, .unknown:
                         return [.unsupportedForSetup]
                     @unknown default:
                         return [.unsupportedForSetup]
@@ -361,7 +361,7 @@ extension PaymentSheet {
                     case .blik, .card, .cardPresent, .UPI, .weChatPay, .paynow:
                         return []
                     case .alipay, .EPS, .FPX, .giropay, .grabPay, .netBanking, .payPal, .przelewy24, .klarna,
-                            .linkInstantDebit, .bancontact, .iDEAL, .cashApp, .affirm:
+                            .linkInstantDebit, .bancontact, .iDEAL, .cashApp, .affirm, .zip:
                         return [.returnURL]
                     case .USBankAccount:
                         return [

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -17,12 +17,6 @@ extension PaymentSheet {
 
         func supportsAddingRequirements() -> [PaymentMethodTypeRequirement] {
             switch self {
-            case .dynamic("revolut_pay"):
-                return [.returnURL]
-            case .dynamic("amazon_pay"):
-                return [.returnURL]
-            case .dynamic("mobilepay"):
-                return [.returnURL]
             default:
                 return [.unsupported]
             }
@@ -89,12 +83,6 @@ extension PaymentSheet {
         var displayName: String {
             if let stpPaymentMethodType = stpPaymentMethodType {
                 return stpPaymentMethodType.displayName
-            } else if case .dynamic("revolut_pay") = self {
-                return "Revolut Pay"
-            } else if case .dynamic("mobilepay") = self {
-                return "MobilePay"
-            } else if case .dynamic("amazon_pay") = self {
-                return "Amazon Pay"
             } else if case .dynamic(let name) = self {
                 // TODO: We should introduce a display name in our model rather than presenting the payment method type
                 return name
@@ -345,7 +333,7 @@ extension PaymentSheet {
                         return [.returnURL, .userSupportsDelayedPaymentMethods]
                     case .AUBECSDebit, .cardPresent, .blik, .weChatPay, .grabPay, .FPX, .giropay, .przelewy24, .EPS,
                         .netBanking, .OXXO, .afterpayClearpay, .UPI, .boleto, .klarna, .link, .linkInstantDebit,
-                        .affirm, .paynow, .zip, .unknown:
+                        .affirm, .paynow, .zip, .revolutPay, .amazonPay, .mobilePay, .unknown:
                         return [.unsupportedForSetup]
                     @unknown default:
                         return [.unsupportedForSetup]
@@ -357,7 +345,7 @@ extension PaymentSheet {
                     case .blik, .card, .cardPresent, .UPI, .weChatPay, .paynow:
                         return []
                     case .alipay, .EPS, .FPX, .giropay, .grabPay, .netBanking, .payPal, .przelewy24, .klarna,
-                            .linkInstantDebit, .bancontact, .iDEAL, .cashApp, .affirm, .zip:
+                            .linkInstantDebit, .bancontact, .iDEAL, .cashApp, .affirm, .zip, .revolutPay, .amazonPay, .mobilePay:
                         return [.returnURL]
                     case .USBankAccount:
                         return [

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
@@ -30,7 +30,7 @@ extension PaymentSheet {
         .grabPay,
         .FPX,
         .alipay,
-        .OXXO,
+        .OXXO, .zip, .revolutPay, .amazonPay, .mobilePay,
     ]
 
     /// An unordered list of paymentMethodtypes that can be used with Link in PaymentSheet

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethod.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethod.swift
@@ -141,55 +141,16 @@ public class STPPaymentMethod: NSObject, STPAPIResponseDecodable {
     }
 
     // MARK: - STPPaymentMethodType
-    class func stringToTypeMapping() -> [String: NSNumber] {
-        return [
-            "card": NSNumber(value: STPPaymentMethodType.card.rawValue),
-            "ideal": NSNumber(value: STPPaymentMethodType.iDEAL.rawValue),
-            "fpx": NSNumber(value: STPPaymentMethodType.FPX.rawValue),
-            "card_present": NSNumber(value: STPPaymentMethodType.cardPresent.rawValue),
-            "sepa_debit": NSNumber(value: STPPaymentMethodType.SEPADebit.rawValue),
-            "bacs_debit": NSNumber(value: STPPaymentMethodType.bacsDebit.rawValue),
-            "au_becs_debit": NSNumber(value: STPPaymentMethodType.AUBECSDebit.rawValue),
-            "grabpay": NSNumber(value: STPPaymentMethodType.grabPay.rawValue),
-            "giropay": NSNumber(value: STPPaymentMethodType.giropay.rawValue),
-            "p24": NSNumber(value: STPPaymentMethodType.przelewy24.rawValue),
-            "eps": NSNumber(value: STPPaymentMethodType.EPS.rawValue),
-            "bancontact": NSNumber(value: STPPaymentMethodType.bancontact.rawValue),
-            "netbanking": NSNumber(value: STPPaymentMethodType.netBanking.rawValue),
-            "oxxo": NSNumber(value: STPPaymentMethodType.OXXO.rawValue),
-            "sofort": NSNumber(value: STPPaymentMethodType.sofort.rawValue),
-            "upi": NSNumber(value: STPPaymentMethodType.UPI.rawValue),
-            "alipay": NSNumber(value: STPPaymentMethodType.alipay.rawValue),
-            "paypal": NSNumber(value: STPPaymentMethodType.payPal.rawValue),
-            "afterpay_clearpay": NSNumber(value: STPPaymentMethodType.afterpayClearpay.rawValue),
-            "blik": NSNumber(value: STPPaymentMethodType.blik.rawValue),
-            "link": NSNumber(value: STPPaymentMethodType.link.rawValue),
-            "wechat_pay": NSNumber(value: STPPaymentMethodType.weChatPay.rawValue),
-            "boleto": NSNumber(value: STPPaymentMethodType.boleto.rawValue),
-            "klarna": NSNumber(value: STPPaymentMethodType.klarna.rawValue),
-            "affirm": NSNumber(value: STPPaymentMethodType.affirm.rawValue),
-            "us_bank_account": NSNumber(value: STPPaymentMethodType.USBankAccount.rawValue),
-            "cashapp": NSNumber(value: STPPaymentMethodType.cashApp.rawValue),
-        ]
-    }
 
     @_spi(STP) public class func string(from type: STPPaymentMethodType) -> String? {
-        return
-            (self.stringToTypeMapping() as NSDictionary).allKeys(
-                for: NSNumber(value: type.rawValue)
-            )
-            .first as? String
+        return type.identifier
     }
 
     @_spi(STP) public class func type(from string: String) -> STPPaymentMethodType {
         let key = string.lowercased()
-        let typeNumber = self.stringToTypeMapping()[key]
-
-        if let typeNumber = typeNumber {
-            return STPPaymentMethodType(rawValue: Int(truncating: typeNumber)) ?? .unknown
-        }
-
-        return .unknown
+        return STPPaymentMethodType.allCases.first(where: { type in
+            type.identifier == key
+        }) ?? .unknown
     }
 
     class func types(from strings: [String]) -> [NSNumber] {

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethod.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethod.swift
@@ -143,6 +143,9 @@ public class STPPaymentMethod: NSObject, STPAPIResponseDecodable {
     // MARK: - STPPaymentMethodType
 
     @_spi(STP) public class func string(from type: STPPaymentMethodType) -> String? {
+        guard type != .unknown else {
+            return nil
+        }
         return type.identifier
     }
 

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodEnums.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodEnums.swift
@@ -71,6 +71,12 @@ import Foundation
     case paynow
     /// A Zip payment method
     case zip
+    /// A RevolutPay payment method
+    case revolutPay
+    /// An AmazonPay payment method
+    case amazonPay
+    /// A MobilePay payment method
+    case mobilePay
     /// An unknown type.
     case unknown
 
@@ -135,14 +141,20 @@ import Foundation
             )
         case .cashApp:
             return STPLocalizedString("Cash App Pay", "Payment Method type brand name")
-        case .bacsDebit,
-            .cardPresent,
-            .unknown:
-            return STPLocalizedString("Unknown", "Default missing source type label")
         case .paynow:
             return "PayNow"
         case .zip:
             return "Zip"
+        case .revolutPay:
+            return "Revolut Pay"
+        case .amazonPay:
+            return "Amazon Pay"
+        case .mobilePay:
+            return "MobilePay"
+        case .bacsDebit,
+            .cardPresent,
+            .unknown:
+            return STPLocalizedString("Unknown", "Default missing source type label")
         @unknown default:
             return STPLocalizedString("Unknown", "Default missing source type label")
         }
@@ -213,6 +225,12 @@ import Foundation
             return "unknown"
         case .paynow:
             return "paynow"
+        case .revolutPay:
+            return "revolut_pay"
+        case .amazonPay:
+            return "amazon_pay"
+        case .mobilePay:
+            return "mobilepay"
         }
     }
 }

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodEnums.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodEnums.swift
@@ -69,6 +69,8 @@ import Foundation
     case cashApp
     /// A PayNow payment method
     case paynow
+    /// A Zip payment method
+    case zip
     /// An unknown type.
     case unknown
 
@@ -139,6 +141,8 @@ import Foundation
             return STPLocalizedString("Unknown", "Default missing source type label")
         case .paynow:
             return "PayNow"
+        case .zip:
+            return "Zip"
         @unknown default:
             return STPLocalizedString("Unknown", "Default missing source type label")
         }
@@ -203,6 +207,8 @@ import Foundation
             return "us_bank_account"
         case .cashApp:
             return "cashapp"
+        case .zip:
+            return "zip"
         case .unknown:
             return "unknown"
         case .paynow:

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodEnums.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodEnums.swift
@@ -234,3 +234,5 @@ import Foundation
         }
     }
 }
+
+extension STPPaymentMethodType: CaseIterable { }

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodParams.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodParams.swift
@@ -541,92 +541,61 @@ public class STPPaymentMethodParams: NSObject, STPFormEncodable {
         singleUsePaymentMethod paymentMethod: STPPaymentMethod
     ) {
         self.init()
+        self.type = paymentMethod.type
+        self.billingDetails = paymentMethod.billingDetails
         switch paymentMethod.type {
         case .EPS:
-            self.type = .EPS
-            let eps = STPPaymentMethodEPSParams()
-            self.eps = eps
-            self.billingDetails = paymentMethod.billingDetails
+            self.eps = STPPaymentMethodEPSParams()
         case .FPX:
-            self.type = .FPX
             let fpx = STPPaymentMethodFPXParams()
             fpx.rawBankString = paymentMethod.fpx?.bankIdentifierCode
             self.fpx = fpx
-            self.billingDetails = paymentMethod.billingDetails
         case .iDEAL:
-            self.type = .iDEAL
             let iDEAL = STPPaymentMethodiDEALParams()
             self.iDEAL = iDEAL
             self.iDEAL?.bankName = paymentMethod.iDEAL?.bankName
-            self.billingDetails = paymentMethod.billingDetails
         case .giropay:
-            self.type = .giropay
             let giropay = STPPaymentMethodGiropayParams()
             self.giropay = giropay
-            self.billingDetails = paymentMethod.billingDetails
         case .przelewy24:
-            self.type = .przelewy24
             let przelewy24 = STPPaymentMethodPrzelewy24Params()
             self.przelewy24 = przelewy24
-            self.billingDetails = paymentMethod.billingDetails
         case .bancontact:
-            self.type = .bancontact
             let bancontact = STPPaymentMethodBancontactParams()
             self.bancontact = bancontact
-            self.billingDetails = paymentMethod.billingDetails
         case .netBanking:
-            self.type = .netBanking
             let netBanking = STPPaymentMethodNetBankingParams()
             self.netBanking = netBanking
-            self.billingDetails = paymentMethod.billingDetails
         case .OXXO:
-            self.type = .OXXO
             let oxxo = STPPaymentMethodOXXOParams()
             self.oxxo = oxxo
-            self.billingDetails = paymentMethod.billingDetails
         case .alipay:
+            self.alipay = STPPaymentMethodAlipayParams()
             // Careful! In the future, when we add recurring Alipay, we'll need to look at this!
-            self.type = .alipay
-            self.billingDetails = paymentMethod.billingDetails
+            break
         case .sofort:
-            self.type = .sofort
             let sofort = STPPaymentMethodSofortParams()
             self.sofort = sofort
-            self.billingDetails = paymentMethod.billingDetails
         case .UPI:
-            self.type = .UPI
             let upi = STPPaymentMethodUPIParams()
             self.upi = upi
             self.billingDetails = paymentMethod.billingDetails
         case .grabPay:
-            self.type = .grabPay
             let grabpay = STPPaymentMethodGrabPayParams()
             self.grabPay = grabpay
             self.billingDetails = paymentMethod.billingDetails
         case .afterpayClearpay:
-            self.type = .afterpayClearpay
             self.afterpayClearpay = STPPaymentMethodAfterpayClearpayParams()
-            self.billingDetails = paymentMethod.billingDetails
         case .boleto:
-            self.type = .boleto
             let boleto = STPPaymentMethodBoletoParams()
             self.boleto = boleto
-            self.billingDetails = paymentMethod.billingDetails
         case .klarna:
-            self.type = .klarna
             self.klarna = STPPaymentMethodKlarnaParams()
-            self.billingDetails = paymentMethod.billingDetails
         case .affirm:
-            self.type = .affirm
             self.affirm = STPPaymentMethodAffirmParams()
-            self.billingDetails = paymentMethod.billingDetails
-        case .paynow:
-            self.type = .paynow
-            self.billingDetails = paymentMethod.billingDetails
-        case .zip:
-            self.type = .zip
-            self.billingDetails = paymentMethod.billingDetails
-            return nil
+        case .paynow, .zip:
+            // No parameters
+            break
         // All reusable PaymentMethods go below:
         case .SEPADebit,
             .bacsDebit,

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodParams.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodParams.swift
@@ -623,6 +623,10 @@ public class STPPaymentMethodParams: NSObject, STPFormEncodable {
         case .paynow:
             self.type = .paynow
             self.billingDetails = paymentMethod.billingDetails
+        case .zip:
+            self.type = .zip
+            self.billingDetails = paymentMethod.billingDetails
+            return nil
         // All reusable PaymentMethods go below:
         case .SEPADebit,
             .bacsDebit,
@@ -1129,7 +1133,7 @@ extension STPPaymentMethodParams {
             usBankAccount = STPPaymentMethodUSBankAccountParams()
         case .cashApp:
             cashApp = STPPaymentMethodCashAppParams()
-        case .cardPresent, .linkInstantDebit, .paynow:
+        case .cardPresent, .linkInstantDebit, .paynow, .zip:
             // These payment methods don't have any params
             break
         case .unknown:
@@ -1209,6 +1213,8 @@ extension STPPaymentMethodParams {
             return STPLocalizedString("Unknown", "Default missing source type label")
         case .paynow:
             return "PayNow"
+        case .zip:
+            return "Zip"
         @unknown default:
             return STPLocalizedString("Unknown", "Default missing source type label")
         }

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodParams.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodParams.swift
@@ -572,7 +572,6 @@ public class STPPaymentMethodParams: NSObject, STPFormEncodable {
         case .alipay:
             self.alipay = STPPaymentMethodAlipayParams()
             // Careful! In the future, when we add recurring Alipay, we'll need to look at this!
-            break
         case .sofort:
             let sofort = STPPaymentMethodSofortParams()
             self.sofort = sofort
@@ -593,7 +592,7 @@ public class STPPaymentMethodParams: NSObject, STPFormEncodable {
             self.klarna = STPPaymentMethodKlarnaParams()
         case .affirm:
             self.affirm = STPPaymentMethodAffirmParams()
-        case .paynow, .zip:
+        case .paynow, .zip, .amazonPay, .mobilePay:
             // No parameters
             break
         // All reusable PaymentMethods go below:
@@ -609,6 +608,7 @@ public class STPPaymentMethodParams: NSObject, STPFormEncodable {
             .linkInstantDebit,
             .USBankAccount,
             .cashApp,
+            .revolutPay,
             .unknown:
             return nil
         }
@@ -1102,7 +1102,7 @@ extension STPPaymentMethodParams {
             usBankAccount = STPPaymentMethodUSBankAccountParams()
         case .cashApp:
             cashApp = STPPaymentMethodCashAppParams()
-        case .cardPresent, .linkInstantDebit, .paynow, .zip:
+        case .cardPresent, .linkInstantDebit, .paynow, .zip, .revolutPay, .amazonPay, .mobilePay:
             // These payment methods don't have any params
             break
         case .unknown:
@@ -1180,10 +1180,9 @@ extension STPPaymentMethodParams {
             return "Cash App Pay"
         case .cardPresent, .unknown:
             return STPLocalizedString("Unknown", "Default missing source type label")
-        case .paynow:
-            return "PayNow"
-        case .zip:
-            return "Zip"
+        case .paynow, .zip, .revolutPay, .amazonPay, .mobilePay:
+            // Use the label already defined in STPPaymentMethodType; the params object for these types don't contain additional information that affect the display label (like cards do)
+            return type.displayName
         @unknown default:
             return STPLocalizedString("Unknown", "Default missing source type label")
         }

--- a/StripePayments/StripePayments/Source/Categories/Enums+CustomStringConvertible.swift
+++ b/StripePayments/StripePayments/Source/Categories/Enums+CustomStringConvertible.swift
@@ -538,10 +538,9 @@ extension STPPaymentMethodType: CustomStringConvertible {
             return "weChatPay"
         case .cashApp:
             return "cashApp"
-        case .paynow:
-            return "PayNow"
-        case .zip:
-            return "zip"
+        case .paynow, .zip, .revolutPay, .mobilePay, .amazonPay:
+            // `description` is the value used when this type is converted to a string for debugging purposes, just use the display name.
+            return displayName
         }
     }
 }

--- a/StripePayments/StripePayments/Source/Categories/Enums+CustomStringConvertible.swift
+++ b/StripePayments/StripePayments/Source/Categories/Enums+CustomStringConvertible.swift
@@ -540,6 +540,8 @@ extension STPPaymentMethodType: CustomStringConvertible {
             return "cashApp"
         case .paynow:
             return "PayNow"
+        case .zip:
+            return "zip"
         }
     }
 }

--- a/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
@@ -637,7 +637,8 @@ public class STPPaymentHandler: NSObject {
             .affirm,
             .linkInstantDebit,
             .cashApp,
-            .paynow:
+            .paynow,
+            .zip:
             return false
 
         case .unknown:

--- a/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
@@ -638,7 +638,10 @@ public class STPPaymentHandler: NSObject {
             .linkInstantDebit,
             .cashApp,
             .paynow,
-            .zip:
+            .zip,
+            .revolutPay,
+            .mobilePay,
+            .amazonPay:
             return false
 
         case .unknown:


### PR DESCRIPTION
## Summary
Adds zip, revolutPay, amazonPay, mobilePay to STPPaymentMethodType.

## Motivation
Following on from https://github.com/stripe/stripe-ios/pull/2910 and https://stripe.slack.com/archives/C05QUGYHR7G/p1694210412610729 - this gets us closer to being able to delete `PaymentMethodType.dynamic`.

## Testing
Relying on existing tests.
Manually tested zip.
