### PR TITLE
Make FormSpecProvider skip unparsable specs

### DIFF
--- a/Stripe/StripeiOSTests/FormSpecProviderTest.swift
+++ b/Stripe/StripeiOSTests/FormSpecProviderTest.swift
@@ -635,6 +635,23 @@ class FormSpecProviderTest: XCTestCase {
         // loadFrom should return false because not all specs were parsed successfully.
         XCTAssertFalse(sut.loadFrom(formSpec))
 
+        // Verify that eps spec was not overridden.
+        let epsSpec = sut.formSpec(for: "eps")
+        XCTAssertEqual(epsSpec?.fields.count, 5)
+        guard
+            case .name = epsSpec?.fields[0],
+            case .placeholder(let emailPlaceholder) = epsSpec?.fields[1],
+            emailPlaceholder.field == .email,
+            case .placeholder(let phonePlaceholder) = epsSpec?.fields[2],
+            phonePlaceholder.field == .phone,
+            case .selector = epsSpec?.fields[3],
+            case .placeholder(let addressPlaceholder) = epsSpec?.fields[4],
+            addressPlaceholder.field == .billingAddress
+        else {
+            XCTFail("Incorrect eps spec: \(epsSpec!)")
+            return
+        }
+
         // Verify that the affirm spec was not overridden.
         let affirmSpec = sut.formSpec(for: "affirm")
         XCTAssertEqual(affirmSpec?.fields.count, 1)

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
@@ -124,6 +124,8 @@ import Foundation
 
     // MARK: - LUXE
     case luxeSerializeFailure = "luxe_serialize_failure"
+    case luxeUnknownActionsFailure = "luxe_unknown_actions_failure"
+    case luxeSpecSerializeFailure = "luxe_spec_serialize_failure"
 
     case luxeImageSelectorIconDownloaded = "luxe_image_selector_icon_downloaded"
     case luxeImageSelectorIconFromBundle = "luxe_image_selector_icon_from_bundle"

--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/STPAnalyticsClient+LUXE.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/STPAnalyticsClient+LUXE.swift
@@ -11,6 +11,15 @@ extension STPAnalyticsClient {
     func logLUXESerializeFailure() {
         self.logPaymentSheetEvent(event: .luxeSerializeFailure)
     }
+
+    func logLUXEUnknownActionsFailure() {
+        self.logPaymentSheetEvent(event: .luxeUnknownActionsFailure)
+    }
+
+    func logLUXESpecSerilizeFailure(error: Error?) {
+        self.logPaymentSheetEvent(event: .luxeSpecSerializeFailure, error: error)
+    }
+
     func logImageSelectorIconDownloadedIfNeeded(paymentMethod: PaymentSheet.PaymentMethodType) {
         guard case .dynamic(let name) = paymentMethod else {
             return


### PR DESCRIPTION
## Summary
Currently, if a spec fails to parse, the FormSpecProvider will skip all remaining specs and report an error, this is undesirable as the rest of the specs should still be loaded.
This PR changes the behavior to skip failing specs and report a different error for more accurate observability.

## Motivation
ir-powering-solitary

## Testing
Added a test
