### PR TITLE
Updating CustomerSheet behavior to allow for cancel on adding a new payment method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 * [Added] Support for Alipay with PaymentIntents.
 * [Added] Support for OXXO with PaymentIntents.
 
+### CustomerSheet
+* [Changed] When adding a payment method, and tapping the close button, the newly added payment method was implicitly selected resulting with `.selected(PaymentOptionSelection?)`.  Now, the result will be `.canceled(PaymentOptionSelection?)`.
+
 ## 23.15.0 2023-08-28
 ### PaymentSheet
 * [Added] Support for AmazonPay (private beta), BLIK, and FPX with PaymentIntents.

--- a/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
@@ -401,7 +401,7 @@ class CustomerSheetUITest: XCTestCase {
         XCTAssertTrue(closeButton.waitForExistence(timeout: 60.0))
         closeButton.tap()
 
-        dismissAlertView(alertBody: "Success: ••••4242, selected", alertTitle: "Complete", buttonToTap: "OK")
+        dismissAlertView(alertBody: "Success: payment method not set, canceled", alertTitle: "Complete", buttonToTap: "OK")
     }
 
     func testNoPrevPM_AddPM_ApplePay_closeInsteadOfConfirming() throws {
@@ -432,7 +432,7 @@ class CustomerSheetUITest: XCTestCase {
         XCTAssertTrue(closeButton.waitForExistence(timeout: 60.0))
         closeButton.tap()
 
-        dismissAlertView(alertBody: "Success: ••••4242, selected", alertTitle: "Complete", buttonToTap: "OK")
+        dismissAlertView(alertBody: "Success: payment method not set, canceled", alertTitle: "Complete", buttonToTap: "OK")
     }
 
     func testPrevPM_AddPM_selectedWithoutTapping_noApplePay() throws {
@@ -462,7 +462,7 @@ class CustomerSheetUITest: XCTestCase {
         XCTAssertTrue(closeButton.waitForExistence(timeout: 60.0))
         closeButton.tap()
 
-        dismissAlertView(alertBody: "Success: ••••4444, selected", alertTitle: "Complete", buttonToTap: "OK")
+        dismissAlertView(alertBody: "Success: ••••4242, canceled", alertTitle: "Complete", buttonToTap: "OK")
     }
 
     func testPrevPM_AddPM_canceled_ApplePay() throws {


### PR DESCRIPTION
## Summary
* Prevents the dismissal of the saved payment methods sheet by tapping outside of the boundaries of customer sheet if you just added a payment method.
* Allows for dismissing the sheet if you tap the close button

## Motivation
We initially decided to implicitly select the Confirm button after a user adds a payment method, because we felt that if users take the time to enter their payment method information, they would most likely want to select that payment method.  Users could  easily (accidentally) tap out of the sheet thereby loosing their state.

This has lead to some confusion as expressed in issue #2900. To remedy this, this PR proposes to prevent dismissing the sheet if a user taps outside the boundary of CustomerSheet, and does not implicitly select the payment method if a user taps the close button.

## Testing
Updated UI tests.
