### PR TITLE
Replace makeDefaultsApplierWrapper with simpler implementation to app…

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerAddPaymentMethodViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerAddPaymentMethodViewController.swift
@@ -26,8 +26,8 @@ class CustomerAddPaymentMethodViewController: UIViewController {
         return paymentMethodTypesView.selected
     }
     var paymentOption: PaymentOption? {
-        var params = IntentConfirmParams(type: selectedPaymentMethodType)
-        params = paymentMethodFormElement.applyDefaults(params: params)
+        let params = IntentConfirmParams(type: selectedPaymentMethodType)
+        params.setDefaultBillingDetailsIfNecessary(for: configuration)
         if let params = paymentMethodFormElement.updateParams(params: params) {
             return .new(confirmParams: params)
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/PaymentMethodElement/PaymentMethodElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/PaymentMethodElement/PaymentMethodElement.swift
@@ -16,12 +16,6 @@
  Other elements can rely on the default implementation provided in this file.
  */
 protocol PaymentMethodElement: Element {
-    /// Modify the params with default values.
-    ///
-    /// This method is called before `updateParams(params:)` and should be used to populate `params` with any necessary
-    /// default values, these can include values for fields not included in the element hierarchy.
-    func applyDefaults(params: IntentConfirmParams) -> IntentConfirmParams
-
     /// Modify the params according to your input, or return nil if invalid.
     /// - Note: This is called on the Element hierarchy in depth-first search order.
     func updateParams(params: IntentConfirmParams) -> IntentConfirmParams?
@@ -29,24 +23,6 @@ protocol PaymentMethodElement: Element {
 
 // MARK: - Default implementations
 extension ContainerElement {
-    func applyDefaults(params: IntentConfirmParams) -> IntentConfirmParams {
-        applyDefaultsRecursively(params: params)
-    }
-
-    func applyDefaultsRecursively(params: IntentConfirmParams) -> IntentConfirmParams {
-        return elements.filter({ $0.view.isHidden == false })
-            .reduce(params) { (params: IntentConfirmParams, element: Element) in
-                switch element {
-                case let element as PaymentMethodElement:
-                    return element.applyDefaults(params: params)
-                case let element as ContainerElement:
-                    return element.applyDefaults(params: params)
-                default:
-                    return params
-                }
-            }
-    }
-
     func updateParams(params: IntentConfirmParams) -> IntentConfirmParams? {
         return elements.filter({ $0.view.isHidden == false })
             .reduce(params) { (params: IntentConfirmParams?, element: Element) in
@@ -65,24 +41,12 @@ extension ContainerElement {
     }
 }
 
-extension FormElement: PaymentMethodElement {
-    func applyDefaults(params: IntentConfirmParams) -> IntentConfirmParams {
-        applyDefaultsRecursively(params: params)
-    }
-}
+extension FormElement: PaymentMethodElement {}
 
-extension SectionElement: PaymentMethodElement {
-    func applyDefaults(params: IntentConfirmParams) -> IntentConfirmParams {
-        applyDefaultsRecursively(params: params)
-    }
-}
+extension SectionElement: PaymentMethodElement {}
 
 extension StaticElement: PaymentMethodElement {
     func updateParams(params: IntentConfirmParams) -> IntentConfirmParams? {
         return params
     }
-}
-
-extension PaymentMethodElement {
-    func applyDefaults(params: IntentConfirmParams) -> IntentConfirmParams { params }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/PaymentMethodElement/PaymentMethodElementWrapper.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/PaymentMethodElement/PaymentMethodElementWrapper.swift
@@ -71,11 +71,6 @@ class PaymentMethodElementWrapper<WrappedElementType: Element> {
 
 // MARK: - PaymentMethodElement
 extension PaymentMethodElementWrapper: PaymentMethodElement {
-    func applyDefaults(params: IntentConfirmParams) -> IntentConfirmParams {
-        guard let defaultsApplier = defaultsApplier else { return params }
-        return defaultsApplier(element, params)
-    }
-
     func updateParams(params: IntentConfirmParams) -> IntentConfirmParams? {
         guard !element.view.isHidden else {
             return params

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfirmParams.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfirmParams.swift
@@ -93,6 +93,36 @@ class IntentConfirmParams {
 
         return params
     }
+
+    /// Applies the values of `Configuration.defaultBillingDetails` to this IntentConfirmParams if `attachDefaultsToPaymentMethod` is true.
+    /// - Note: This overwrites `paymentMethodParams.billingDetails`.
+    func setDefaultBillingDetailsIfNecessary(for configuration: PaymentSheet.Configuration) {
+        _setDefaultBillingDetailsIfNecessary(defaultBillingDetails: configuration.defaultBillingDetails, billingDetailsCollectionConfiguration: configuration.billingDetailsCollectionConfiguration)
+    }
+
+    /// Applies the values of `Configuration.defaultBillingDetails` to this IntentConfirmParams if `attachDefaultsToPaymentMethod` is true.
+    /// - Note: This overwrites `paymentMethodParams.billingDetails`.
+    func setDefaultBillingDetailsIfNecessary(for configuration: CustomerSheet.Configuration) {
+        _setDefaultBillingDetailsIfNecessary(defaultBillingDetails: configuration.defaultBillingDetails, billingDetailsCollectionConfiguration: configuration.billingDetailsCollectionConfiguration)
+    }
+
+    private func _setDefaultBillingDetailsIfNecessary(defaultBillingDetails: PaymentSheet.BillingDetails, billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration) {
+        guard billingDetailsCollectionConfiguration.attachDefaultsToPaymentMethod else {
+           return
+        }
+        if let name = defaultBillingDetails.name {
+            paymentMethodParams.nonnil_billingDetails.name = name
+        }
+        if let phone = defaultBillingDetails.phone {
+            paymentMethodParams.nonnil_billingDetails.phone = phone
+        }
+        if let email = defaultBillingDetails.email {
+            paymentMethodParams.nonnil_billingDetails.email = email
+        }
+        if defaultBillingDetails.address != .init() {
+            paymentMethodParams.nonnil_billingDetails.address = STPPaymentMethodAddress(address: defaultBillingDetails.address)
+        }
+    }
 }
 
 extension STPConfirmPaymentMethodOptions {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfirmParams.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfirmParams.swift
@@ -97,16 +97,16 @@ class IntentConfirmParams {
     /// Applies the values of `Configuration.defaultBillingDetails` to this IntentConfirmParams if `attachDefaultsToPaymentMethod` is true.
     /// - Note: This overwrites `paymentMethodParams.billingDetails`.
     func setDefaultBillingDetailsIfNecessary(for configuration: PaymentSheet.Configuration) {
-        _setDefaultBillingDetailsIfNecessary(defaultBillingDetails: configuration.defaultBillingDetails, billingDetailsCollectionConfiguration: configuration.billingDetailsCollectionConfiguration)
+        setDefaultBillingDetailsIfNecessary(defaultBillingDetails: configuration.defaultBillingDetails, billingDetailsCollectionConfiguration: configuration.billingDetailsCollectionConfiguration)
     }
 
     /// Applies the values of `Configuration.defaultBillingDetails` to this IntentConfirmParams if `attachDefaultsToPaymentMethod` is true.
     /// - Note: This overwrites `paymentMethodParams.billingDetails`.
     func setDefaultBillingDetailsIfNecessary(for configuration: CustomerSheet.Configuration) {
-        _setDefaultBillingDetailsIfNecessary(defaultBillingDetails: configuration.defaultBillingDetails, billingDetailsCollectionConfiguration: configuration.billingDetailsCollectionConfiguration)
+        setDefaultBillingDetailsIfNecessary(defaultBillingDetails: configuration.defaultBillingDetails, billingDetailsCollectionConfiguration: configuration.billingDetailsCollectionConfiguration)
     }
 
-    private func _setDefaultBillingDetailsIfNecessary(defaultBillingDetails: PaymentSheet.BillingDetails, billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration) {
+    private func setDefaultBillingDetailsIfNecessary(defaultBillingDetails: PaymentSheet.BillingDetails, billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration) {
         guard billingDetailsCollectionConfiguration.attachDefaultsToPaymentMethod else {
            return
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
@@ -46,8 +46,8 @@ class AddPaymentMethodViewController: UIViewController {
             return linkEnabledElement.makePaymentOption()
         }
 
-        var params = IntentConfirmParams(type: selectedPaymentMethodType)
-        params = paymentMethodFormElement.applyDefaults(params: params)
+        let params = IntentConfirmParams(type: selectedPaymentMethodType)
+        params.setDefaultBillingDetailsIfNecessary(for: configuration)
         if let params = paymentMethodFormElement.updateParams(params: params) {
             // TODO(yuki): Hack to support external_paypal
             if selectedPaymentMethodType == .externalPayPal {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
@@ -87,18 +87,17 @@ extension PaymentSheetFormFactory {
                 shouldDisplaySaveCheckbox ? saveCheckbox : nil,
             ],
             theme: theme)
-        let cardFormElementWrapper = makeDefaultsApplierWrapper(for: cardFormElement)
 
         if case .paymentSheet(let configuration) = configuration, isLinkEnabled {
             return LinkEnabledPaymentMethodElement(
                 type: .card,
-                paymentMethodElement: cardFormElementWrapper,
+                paymentMethodElement: cardFormElement,
                 configuration: configuration,
                 linkAccount: linkAccount,
                 country: countryCode
             )
         } else {
-            return cardFormElementWrapper
+            return cardFormElement
         }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -146,7 +146,7 @@ class PaymentSheetFormFactory {
         } else if paymentMethod == .USBankAccount {
             return makeUSBankAccount(merchantName: configuration.merchantDisplayName)
         } else if paymentMethod == .UPI {
-            return makeDefaultsApplierWrapper(for: makeUPI())
+            return makeUPI()
         } else if paymentMethod == .cashApp && saveMode == .merchantRequired {
             // special case, display mandate for Cash App when setting up or pi+sfu
             additionalElements = [makeCashAppMandate()]
@@ -156,11 +156,11 @@ class PaymentSheetFormFactory {
         } else if paymentMethod.stpPaymentMethodType == .bancontact {
             return makeBancontact()
         } else if paymentMethod.stpPaymentMethodType == .blik {
-            return makeDefaultsApplierWrapper(for: makeBLIK())
+            return makeBLIK()
         } else if paymentMethod == .externalPayPal {
             return makeExternalPayPal()
         } else if paymentMethod.stpPaymentMethodType == .OXXO {
-            return makeDefaultsApplierWrapper(for: makeOXXO())
+            return  makeOXXO()
         }
 
         guard let spec = specFromJSONProvider() else {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/USBankAccountPaymentMethodElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/USBankAccountPaymentMethodElement.swift
@@ -241,26 +241,6 @@ extension USBankAccountPaymentMethodElement: BankAccountInfoViewDelegate {
 }
 
 extension USBankAccountPaymentMethodElement: PaymentMethodElement {
-    func applyDefaults(params: IntentConfirmParams) -> IntentConfirmParams {
-        guard configuration.billingDetailsCollectionConfiguration.attachDefaultsToPaymentMethod else {
-            return params
-        }
-        if let name = configuration.defaultBillingDetails.name {
-            params.paymentMethodParams.nonnil_billingDetails.name = name
-        }
-        if let email = configuration.defaultBillingDetails.email {
-            params.paymentMethodParams.nonnil_billingDetails.email = email
-        }
-        if let phone = configuration.defaultBillingDetails.phone {
-            params.paymentMethodParams.nonnil_billingDetails.phone = phone
-        }
-        if configuration.defaultBillingDetails.address != .init() {
-            params.paymentMethodParams.nonnil_billingDetails.address =
-                STPPaymentMethodAddress(address: configuration.defaultBillingDetails.address)
-        }
-        return params
-    }
-
     func updateParams(params: IntentConfirmParams) -> IntentConfirmParams? {
         if let updatedParams = self.formElement.updateParams(params: params),
            let linkedBank = linkedBank {


### PR DESCRIPTION
…ly defaults when attachDefaultsToPaymentMethod is true.


## Motivation
Simplifies the implementation and makes it apply universally to all PMs instead of having each PM need to call `makeDefaultsApplierWrapper`.

## Testing
Relying on existing tests.

## Changelog
Not user facing.
