### PR TITLE
Fix CPF/CNPJ field formatting

### DIFF
--- a/StripeUICore/StripeUICore/Source/Elements/Factories/IDNumberTextFieldConfiguration.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Factories/IDNumberTextFieldConfiguration.swift
@@ -71,7 +71,7 @@ import Foundation
             .BR_CPF_CNPJ where text.count <= 11:
             return "###.###.###-##"
         case .BR_CPF_CNPJ:
-            return "###.###.###/###-##"
+            return "##.###.###/####-##"
         case .US_SSN_LAST4:
             return "••• - •• - ####"
         case .none:

--- a/StripeUICore/StripeUICoreTests/Unit/Elements/IDNumberTextFieldConfigurationTest.swift
+++ b/StripeUICore/StripeUICoreTests/Unit/Elements/IDNumberTextFieldConfigurationTest.swift
@@ -57,9 +57,9 @@ final class IDNumberTextFieldConfigurationTest: XCTestCase {
         XCTAssertEqual(config.makeDisplayText(for: "12345678901").string, "123.456.789-01")
 
         // Format as CNPJ if > 11 characters
-        XCTAssertEqual(config.makeDisplayText(for: "123456789012").string, "123.456.789/012")
-        XCTAssertEqual(config.makeDisplayText(for: "12345678901234").string, "123.456.789/012-34")
-        XCTAssertEqual(config.makeDisplayText(for: "12345678901234567").string, "123.456.789/012-34")
+        XCTAssertEqual(config.makeDisplayText(for: "123456789012").string, "12.345.678/9012")
+        XCTAssertEqual(config.makeDisplayText(for: "12345678901234").string, "12.345.678/9012-34")
+        XCTAssertEqual(config.makeDisplayText(for: "12345678901234567").string, "12.345.678/9012-34")
     }
 }
 


### PR DESCRIPTION
## Summary
We found out that this field was formatting CNPJ incorrectly, it was using `###.###.###/###-##` as the mask, instead of `##.###.###/####-##`.

## Motivation
Fix formatting for field

## Testing
Updated tests
