### PR TITLE
PaymentSheet Example: Add URL sharing support

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundController.swift
@@ -204,7 +204,7 @@ extension CustomerSheetTestPlaygroundController {
                 return
             }
 
-            StripeAPI.defaultPublishableKey = publishableKey
+            STPAPIClient.shared.publishableKey = publishableKey
 
             Task {
                 // Create Customer Sheet

--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleSwiftUICustomerSheet.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleSwiftUICustomerSheet.swift
@@ -132,7 +132,7 @@ class MyBackendCustomerSheetModel: ObservableObject {
               let publishableKey = json["publishableKey"] else {
             return
         }
-        StripeAPI.defaultPublishableKey = publishableKey
+        STPAPIClient.shared.publishableKey = publishableKey
 
         // Create Customer Sheet
         var configuration = CustomerSheet.Configuration()

--- a/Example/PaymentSheet Example/PaymentSheet Example/Info.plist
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Info.plist
@@ -38,6 +38,16 @@
 				<string>stripe-paymentsheet-example</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>com.example.paymentsheet-playground</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>stp-paymentsheet-playground</string>
+			</array>
+		</dict>
 	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -10,8 +10,9 @@ import SwiftUI
 
 @available(iOS 15.0, *)
 struct PaymentSheetTestPlayground: View {
-    @StateObject var playgroundController: PlaygroundController
-
+    @StateObject var playgroundController: PlaygroundController    
+    @State var showingQRSheet = false
+    
     init(settings: PaymentSheetTestPlaygroundSettings) {
         _playgroundController = StateObject(wrappedValue: PlaygroundController(settings: settings))
     }
@@ -39,17 +40,31 @@ struct PaymentSheetTestPlayground: View {
                                 .font(.headline)
                             Spacer()
                             Button {
+                                playgroundController.didTapResetConfig()
+                            } label: {
+                                Text("Reset")
+                                    .font(.callout.smallCaps())
+                            }.buttonStyle(.bordered)
+                            Button {
                                 playgroundController.didTapEndpointConfiguration()
                             } label: {
                                 Text("Endpoints")
                                     .font(.callout.smallCaps())
                             }.buttonStyle(.bordered)
                             Button {
-                                playgroundController.didTapResetConfig()
+                                showingQRSheet.toggle()
                             } label: {
-                                Text("Reset")
+                                Text("QR")
                                     .font(.callout.smallCaps())
                             }.buttonStyle(.bordered)
+                                .sheet(isPresented: $showingQRSheet, content: {
+                                    QRView(url: playgroundController.settings.base64URL)
+                                })
+                            if #available(iOS 16.0, *) {
+                                ShareLink(item: playgroundController.settings.base64URL) {
+                                    Image(systemName: "square.and.arrow.up")
+                                }
+                            }
                         }
                         SettingView(setting: $playgroundController.settings.mode)
                         SettingPickerView(setting: $playgroundController.settings.integrationType)

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -10,9 +10,9 @@ import SwiftUI
 
 @available(iOS 15.0, *)
 struct PaymentSheetTestPlayground: View {
-    @StateObject var playgroundController: PlaygroundController    
+    @StateObject var playgroundController: PlaygroundController
     @State var showingQRSheet = false
-    
+
     init(settings: PaymentSheetTestPlaygroundSettings) {
         _playgroundController = StateObject(wrappedValue: PlaygroundController(settings: settings))
     }
@@ -60,11 +60,6 @@ struct PaymentSheetTestPlayground: View {
                                 .sheet(isPresented: $showingQRSheet, content: {
                                     QRView(url: playgroundController.settings.base64URL)
                                 })
-                            if #available(iOS 16.0, *) {
-                                ShareLink(item: playgroundController.settings.base64URL) {
-                                    Image(systemName: "square.and.arrow.up")
-                                }
-                            }
                         }
                         SettingView(setting: $playgroundController.settings.mode)
                         SettingPickerView(setting: $playgroundController.settings.integrationType)

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -272,9 +272,9 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
         let jsonData = try! JSONEncoder().encode(self)
         return jsonData.base64EncodedString()
     }
-    
+
     var base64URL: URL {
-        URL(string: "stp-paymentsheet-playground:/?\(base64Data)")!
+        URL(string: "stp-paymentsheet-playground://?\(base64Data)")!
     }
 
     static func fromBase64<T: Decodable>(base64: String, className: T.Type) -> T? {

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -272,6 +272,10 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
         let jsonData = try! JSONEncoder().encode(self)
         return jsonData.base64EncodedString()
     }
+    
+    var base64URL: URL {
+        URL(string: "stp-paymentsheet-playground:/?\(base64Data)")!
+    }
 
     static func fromBase64<T: Decodable>(base64: String, className: T.Type) -> T? {
         if let base64Data = base64.data(using: .utf8),

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -418,7 +418,7 @@ extension PlaygroundController {
             self.customerID = json["customerId"]
             self.paymentMethodTypes = json["paymentMethodTypes"]?.components(separatedBy: ",")
             self.amount = Int(json["amount"] ?? "")
-            StripeAPI.defaultPublishableKey = json["publishableKey"]
+            STPAPIClient.shared.publishableKey = json["publishableKey"]
 
             DispatchQueue.main.async {
                 if self.settings.customerMode == .new && self.newCustomerID == nil {

--- a/Example/PaymentSheet Example/PaymentSheet Example/QRView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/QRView.swift
@@ -5,16 +5,16 @@
 //  Created by David Estes on 9/14/23.
 //
 
+import CoreImage.CIFilterBuiltins
 import Foundation
 import SwiftUI
 import UIKit
-import CoreImage.CIFilterBuiltins
 
 struct QRView: View {
     let url: URL
     let context = CIContext()
     let filter = CIFilter.qrCodeGenerator()
-    
+
     private func generateQRCode() -> UIImage {
         filter.message = Data(url.absoluteString.utf8)
 
@@ -26,13 +26,18 @@ struct QRView: View {
 
         return UIImage(systemName: "xmark.circle") ?? UIImage()
     }
-    
+
     var body: some View {
-        Image(uiImage: generateQRCode())
-            .interpolation(.none)
-            .resizable()
-            .scaledToFit()
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .padding()
+        VStack {
+            Image(uiImage: generateQRCode())
+                .interpolation(.none)
+                .resizable()
+                .scaledToFit()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .padding()
+            if #available(iOS 16.0, *) {
+                ShareLink(item: url)
+            }
+        }
     }
 }

--- a/Example/PaymentSheet Example/PaymentSheet Example/QRView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/QRView.swift
@@ -1,0 +1,38 @@
+//
+//  QRView.swift
+//  PaymentSheet Example
+//
+//  Created by David Estes on 9/14/23.
+//
+
+import Foundation
+import SwiftUI
+import UIKit
+import CoreImage.CIFilterBuiltins
+
+struct QRView: View {
+    let url: URL
+    let context = CIContext()
+    let filter = CIFilter.qrCodeGenerator()
+    
+    private func generateQRCode() -> UIImage {
+        filter.message = Data(url.absoluteString.utf8)
+
+        if let outputImage = filter.outputImage {
+            if let cgimg = context.createCGImage(outputImage, from: outputImage.extent) {
+                return UIImage(cgImage: cgimg)
+            }
+        }
+
+        return UIImage(systemName: "xmark.circle") ?? UIImage()
+    }
+    
+    var body: some View {
+        Image(uiImage: generateQRCode())
+            .interpolation(.none)
+            .resizable()
+            .scaledToFit()
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding()
+    }
+}

--- a/Example/PaymentSheet Example/PaymentSheet Example/SceneDelegate.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/SceneDelegate.swift
@@ -29,7 +29,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
                 if #available(iOS 15.0, *) {
                     // In this case, we'll pass it to the playground for test configuration.
-                    if url.host == "playground" {
+                    if url.scheme == "stp-paymentsheet-playground" {
                         launchWith(base64String: url.query!)
                     }
                 }


### PR DESCRIPTION
## Summary
* Adds support for opening PaymentSheet Example URLs via a scheme
* Buttons to share URLs via QR codes or the share sheet
* Fixes an issue where we would sometimes fail to update the publishable key, as we were accidentally mixing updating defaultPublishableKey with the STPAPIClient's publishableKey. The former will not change the key if it was already set on the singleton STPAPIClient.

## Motivation
Easier sharing of scenarios and on-device testing

## Testing
Tested locally

## Changelog
Not user-facing