### PR TITLE
Add PromptPay to PaymentSheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@
 * [Changed] Fixed STPConnectAccountCompanyParams.address being force unwrapped. It's now optional.
 
 ### PaymentSheet
+* [Added] Support for Alipay, OXXO, PayNow, and PromptPay with PaymentIntents.
 * [Added] Support for Cash App Pay with SetupIntents and PaymentIntents with `setup_future_usage`.
 * [Added] Support for AU BECS Debit with SetupIntents.
 * [Added] Support for OXXO with PaymentIntents.
 * [Added] Support for Konbini with PaymentIntents.
 * [Added] Support for PayNow with PaymentIntents.
+* [Added] Support for PromptPay with PaymentIntents.
 * [Added] Support for Boleto with PaymentIntents.
 * [Added] Support for External Payment Method as an invite-only private beta.
 * [Added] Support for Alma (Private Beta) with PaymentIntents.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 * [Changed] Fixed STPConnectAccountCompanyParams.address being force unwrapped. It's now optional.
 
 ### PaymentSheet
-* [Added] Support for Alipay, OXXO, PayNow, and PromptPay with PaymentIntents.
 * [Added] Support for Cash App Pay with SetupIntents and PaymentIntents with `setup_future_usage`.
 * [Added] Support for AU BECS Debit with SetupIntents.
 * [Added] Support for OXXO with PaymentIntents.

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -86,6 +86,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
         case mxn
         case jpy
         case brl
+        case thb
     }
 
     enum MerchantCountry: String, PickerEnum {
@@ -101,6 +102,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
         case MX
         case JP
         case BR
+        case TH
     }
 
     enum APMSEnabled: String, PickerEnum {

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -1024,6 +1024,42 @@ class PaymentSheetStandardLPMUITests: PaymentSheetUITestCase {
         XCTAssertTrue(webviewCloseButton.waitForExistence(timeout: 10.0))
         webviewCloseButton.tap()
     }
+
+    func testPromptPayPaymentMethod() throws {
+        var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
+        settings.customerMode = .new // new customer
+        settings.apmsEnabled = .on
+        settings.currency = .thb
+        settings.merchantCountryCode = .TH
+        loadPlayground(
+            app,
+            settings
+        )
+
+        app.buttons["Present PaymentSheet"].tap()
+
+        // Select PromptPay
+        guard let promptPay = scroll(collectionView: app.collectionViews.firstMatch, toFindCellWithId: "PromptPay")
+        else {
+            XCTFail()
+            return
+        }
+        promptPay.tap()
+
+        // Fill in email
+        let email = app.textFields["Email"]
+        email.tap()
+        email.typeText("foo@bar.com")
+        email.typeText(XCUIKeyboardKey.return.rawValue)
+
+        // Attempt payment
+        XCTAssertTrue(app.buttons["Pay THB 50.99"].waitForExistenceAndTap(timeout: 5.0))
+
+        // Close the webview, no need to see the successful pay
+        let webviewCloseButton = app.otherElements["TopBrowserBar"].buttons["Close"]
+        XCTAssertTrue(webviewCloseButton.waitForExistence(timeout: 10.0))
+        webviewCloseButton.tap()
+    }
 }
 
 class PaymentSheetDeferredUITests: PaymentSheetUITestCase {

--- a/Stripe/StripeiOS/Source/STPPaymentMethod+BasicUI.swift
+++ b/Stripe/StripeiOS/Source/STPPaymentMethod+BasicUI.swift
@@ -69,7 +69,7 @@ extension STPPaymentMethod: STPPaymentOption {
             .bacsDebit, .SEPADebit, .iDEAL, .FPX, .cardPresent, .giropay, .EPS, .payPal,
             .przelewy24, .bancontact,
             .OXXO, .sofort, .grabPay, .netBanking, .UPI, .afterpayClearpay, .blik,
-            .weChatPay, .boleto, .klarna, .linkInstantDebit, .affirm, .cashApp, .paynow, .zip, .revolutPay, .amazonPay, .alma, .mobilePay, .konbini,
+            .weChatPay, .boleto, .klarna, .linkInstantDebit, .affirm, .cashApp, .paynow, .zip, .revolutPay, .amazonPay, .alma, .mobilePay, .konbini, .promptPay,
             .unknown:
             return false
 

--- a/Stripe/StripeiOS/Source/STPPaymentMethodParams+BasicUI.swift
+++ b/Stripe/StripeiOS/Source/STPPaymentMethodParams+BasicUI.swift
@@ -38,7 +38,7 @@ extension STPPaymentMethodParams: STPPaymentOption {
             return true
         case .alipay, .AUBECSDebit, .bacsDebit, .SEPADebit, .iDEAL, .FPX, .cardPresent, .giropay,
             .grabPay, .EPS, .przelewy24, .bancontact, .netBanking, .OXXO, .payPal, .sofort, .UPI,
-            .afterpayClearpay, .blik, .weChatPay, .boleto, .klarna, .linkInstantDebit, .affirm, .cashApp, .paynow, .zip, .revolutPay, .amazonPay, .alma, .mobilePay, .konbini,
+            .afterpayClearpay, .blik, .weChatPay, .boleto, .klarna, .linkInstantDebit, .affirm, .cashApp, .paynow, .zip, .revolutPay, .amazonPay, .alma, .mobilePay, .konbini, .promptPay,
             .unknown:
             return false
         @unknown default:

--- a/Stripe/StripeiOSTests/STPIntentActionPromptPayDisplayQrCodeTest.swift
+++ b/Stripe/StripeiOSTests/STPIntentActionPromptPayDisplayQrCodeTest.swift
@@ -1,0 +1,38 @@
+//
+//  STPIntentActionPromptPayDisplayQrCodeTest.swift
+//  StripeiOSTests
+//
+//  Created by Nick Porter on 9/12/23.
+//
+
+import Foundation
+@testable@_spi(STP) import Stripe
+
+class STPIntentActionPromptPayDisplayQrCodeTest: XCTestCase {
+    func testActionHostedUrl() throws {
+        let testJSONString = """
+            {
+              "promptpay_display_qr_code": {
+                "hosted_instructions_url": "stripe.com/test/promptpay/qr",
+              },
+              "type": "promptpay_display_qr_code"
+            }
+            """
+        guard
+            let testJSONData = testJSONString.data(using: .utf8),
+            let json = try? JSONSerialization.jsonObject(
+                with: testJSONData,
+                options: .allowFragments
+            ) as? [AnyHashable: Any],
+            let nextAction = STPIntentAction.decodedObject(fromAPIResponse: json),
+            let promptPayDisplayQrCode = nextAction.promptPayDisplayQrCode
+        else {
+            XCTFail()
+            return
+        }
+        XCTAssertEqual(
+            promptPayDisplayQrCode.hostedInstructionsURL,
+            URL(string: "stripe.com/test/promptpay/qr")
+        )
+    }
+}

--- a/Stripe/StripeiOSTests/STPPaymentHandlerTests.swift
+++ b/Stripe/StripeiOSTests/STPPaymentHandlerTests.swift
@@ -198,6 +198,7 @@ class STPPaymentHandlerTests: APIStubbedTestCase {
             cashAppRedirectToApp: nil,
             payNowDisplayQrCode: nil,
             konbiniDisplayDetails: nil,
+            promptPayDisplayQrCode: nil,
             allResponseFields: [:]
         )
         let setupIntent = STPSetupIntent(

--- a/StripePaymentSheet/StripePaymentSheet/Resources/JSON/form_specs.json
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/JSON/form_specs.json
@@ -995,5 +995,35 @@
         "dark_theme_svg": "https://js.stripe.com/v3/fingerprinted/img/payment-methods/icon-pm-paynow_dark-d700c844535c608fd5fd4048f6a21146.svg"
       },
       "fields": []
+    },
+    {
+      "type": "promptpay",
+      "async": false,
+      "selector_icon": {
+        "light_theme_png": "https://js.stripe.com/v3/fingerprinted/img/payment-methods/promptpay.png",
+        "light_theme_svg": "https://js.stripe.com/v3/fingerprinted/img/payment-methods/icon-pm-promptpay-8bc83c76f38f2a4d3a5f64b6229450dd.svg",
+        "dark_theme_svg": "https://js.stripe.com/v3/fingerprinted/img/payment-methods/icon-pm-promptpay_dark-dfd2904083152023d89a8300f04a666f.svg"
+      },
+      "fields": [
+        {
+          "type": "placeholder",
+          "for": "name"
+        },
+        {
+          "type": "email",
+          "api_path": {
+            "v1": "billing_details[email]"
+          }
+        },
+        {
+          "type": "placeholder",
+          "for": "phone"
+        },
+        {
+          "type": "placeholder",
+          "for": "billing_address"
+        }
+      ]
     }
+
 ]

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -333,7 +333,7 @@ extension PaymentSheet {
                         return [.returnURL, .userSupportsDelayedPaymentMethods]
                     case .cardPresent, .blik, .weChatPay, .grabPay, .FPX, .giropay, .przelewy24, .EPS,
                         .netBanking, .OXXO, .afterpayClearpay, .UPI, .boleto, .klarna, .link, .linkInstantDebit,
-                        .affirm, .paynow, .zip, .revolutPay, .amazonPay, .alma, .mobilePay, .unknown, .alipay, .konbini:
+                        .affirm, .paynow, .zip, .revolutPay, .amazonPay, .alma, .mobilePay, .unknown, .alipay, .konbini, .promptPay:
                         return [.unsupportedForSetup]
                     @unknown default:
                         return [.unsupportedForSetup]
@@ -342,7 +342,7 @@ extension PaymentSheet {
             } else {
                 requirements = {
                     switch stpPaymentMethodType {
-                    case .blik, .card, .cardPresent, .UPI, .weChatPay, .paynow:
+                    case .blik, .card, .cardPresent, .UPI, .weChatPay, .paynow, .promptPay:
                         return []
                     case .alipay, .EPS, .FPX, .giropay, .grabPay, .netBanking, .payPal, .przelewy24, .klarna,
                             .linkInstantDebit, .bancontact, .iDEAL, .cashApp, .affirm, .zip, .revolutPay, .amazonPay, .alma, .mobilePay:

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
@@ -30,7 +30,7 @@ extension PaymentSheet {
         .grabPay,
         .FPX,
         .alipay,
-        .OXXO, .zip, .revolutPay, .amazonPay, .alma, .mobilePay, .konbini, .paynow,
+        .OXXO, .zip, .revolutPay, .amazonPay, .alma, .mobilePay, .konbini, .paynow, .promptPay,
         .boleto,
     ]
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PollingViewModel.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PollingViewModel.swift
@@ -15,14 +15,14 @@ import UIKit
 class PollingViewModel {
 
     let paymentMethodType: STPPaymentMethodType
-    let supportedPaymentMethods: [STPPaymentMethodType] = [.UPI, .blik, .paynow]
+    let supportedPaymentMethods: [STPPaymentMethodType] = [.UPI, .blik, .paynow, .promptPay]
     lazy var CTA: String = {
         switch paymentMethodType {
         case .UPI:
             return .Localized.open_upi_app
         case .blik:
             return .Localized.blik_confirm_payment
-        case .paynow:
+        case .paynow, .promptPay:
             return .Localized.paynow_confirm_payment
         default:
             fatalError("Polling CTA has not been implemented for \(paymentMethodType)")
@@ -34,7 +34,7 @@ class PollingViewModel {
             return Date().addingTimeInterval(60 * 5) // 5 minutes
         case .blik:
             return Date().addingTimeInterval(60) // 60 seconds
-        case .paynow:
+        case .paynow, .promptPay:
             return Date().addingTimeInterval(60 * 60) // 1 hour
         default:
             fatalError("Polling deadline has not been implemented for \(paymentMethodType)")
@@ -42,7 +42,7 @@ class PollingViewModel {
     }()
     var retryInterval: TimeInterval {
         switch paymentMethodType {
-        case .blik, .paynow:
+        case .blik, .paynow, .promptPay:
             return 1
         case .UPI:
             return 10

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLPMConfirmFlowTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLPMConfirmFlowTests.swift
@@ -34,6 +34,7 @@ final class PaymentSheet_LPM_ConfirmFlowTests: XCTestCase {
         case JP = "jp"
         case BR = "br"
         case FR = "fr"
+        case TH = "th"
 
         var publishableKey: String {
             switch self {
@@ -55,6 +56,8 @@ final class PaymentSheet_LPM_ConfirmFlowTests: XCTestCase {
                 return STPTestingBRPublishableKey
             case .FR:
                 return STPTestingFRPublishableKey
+            case .TH:
+                return STPTestingTHPublishableKey
             }
         }
     }
@@ -237,6 +240,15 @@ final class PaymentSheet_LPM_ConfirmFlowTests: XCTestCase {
             form.getTextFieldElement("City")?.setText("City")
             form.getTextFieldElement("State")?.setText("AC")  // Valid Brazilian state code
             form.getTextFieldElement("Postal code")?.setText("11111111")
+        }
+    }
+    
+    func testPromptPayConfirmFlows() async throws {
+        try await _testConfirm(intentKinds: [.paymentIntent],
+                               currency: "THB",
+                               paymentMethodType: .dynamic("promptpay"),
+                               merchantCountry: .TH) { form in
+            form.getTextFieldElement("Email")?.setText("foo@bar.com")
         }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLPMConfirmFlowTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLPMConfirmFlowTests.swift
@@ -242,7 +242,7 @@ final class PaymentSheet_LPM_ConfirmFlowTests: XCTestCase {
             form.getTextFieldElement("Postal code")?.setText("11111111")
         }
     }
-    
+
     func testPromptPayConfirmFlows() async throws {
         try await _testConfirm(intentKinds: [.paymentIntent],
                                currency: "THB",

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodEnums.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodEnums.swift
@@ -81,6 +81,8 @@ import Foundation
     case mobilePay
     /// A Konbini payment method
     case konbini
+    /// A PromptPay payment method
+    case promptPay
     /// An unknown type.
     case unknown
 
@@ -159,6 +161,8 @@ import Foundation
             return "MobilePay"
         case .konbini:
             return STPLocalizedString("Konbini", "Payment Method type brand name")
+        case .promptPay:
+            return "PromptPay"
         case .bacsDebit,
             .cardPresent,
             .unknown:
@@ -243,6 +247,8 @@ import Foundation
             return "mobilepay"
         case .konbini:
             return "konbini"
+        case .promptPay:
+            return "promptpay"
         }
     }
 }

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodParams.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodParams.swift
@@ -592,7 +592,7 @@ public class STPPaymentMethodParams: NSObject, STPFormEncodable {
             self.klarna = STPPaymentMethodKlarnaParams()
         case .affirm:
             self.affirm = STPPaymentMethodAffirmParams()
-        case .paynow, .zip, .amazonPay, .alma, .mobilePay, .konbini:
+        case .paynow, .zip, .amazonPay, .alma, .mobilePay, .konbini, .promptPay:
             // No parameters
             break
         // All reusable PaymentMethods go below:
@@ -1102,7 +1102,7 @@ extension STPPaymentMethodParams {
             usBankAccount = STPPaymentMethodUSBankAccountParams()
         case .cashApp:
             cashApp = STPPaymentMethodCashAppParams()
-        case .cardPresent, .linkInstantDebit, .paynow, .zip, .revolutPay, .amazonPay, .alma, .mobilePay, .konbini:
+        case .cardPresent, .linkInstantDebit, .paynow, .zip, .revolutPay, .amazonPay, .alma, .mobilePay, .konbini, .promptPay:
             // These payment methods don't have any params
             break
         case .unknown:
@@ -1180,7 +1180,7 @@ extension STPPaymentMethodParams {
             return "Cash App Pay"
         case .cardPresent, .unknown:
             return STPLocalizedString("Unknown", "Default missing source type label")
-        case .paynow, .zip, .revolutPay, .amazonPay, .alma, .mobilePay, .konbini:
+        case .paynow, .zip, .revolutPay, .amazonPay, .alma, .mobilePay, .konbini, .promptPay:
             // Use the label already defined in STPPaymentMethodType; the params object for these types don't contain additional information that affect the display label (like cards do)
             return type.displayName
         @unknown default:

--- a/StripePayments/StripePayments/Source/API Bindings/Models/Shared/STPIntentAction.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/Shared/STPIntentAction.swift
@@ -63,7 +63,7 @@ import Foundation
 
     /// Contains instructions for completing Konbini payments.
     case konbiniDisplayDetails
-    
+
     /// Contains details for displaying the QR code required for PromptPay.
     case promptpayDisplayQrCode
 
@@ -182,7 +182,7 @@ public class STPIntentAction: NSObject {
 
     /// Contains instructions for authenticating a Konbini payment.
     @objc public let konbiniDisplayDetails: STPIntentActionKonbiniDisplayDetails?
-    
+
     /// Contains details for displaying the QR code required for PromptPay.
     @objc public let promptPayDisplayQrCode: STPIntentActionPromptPayDisplayQrCode?
 

--- a/StripePayments/StripePayments/Source/API Bindings/Models/Shared/STPIntentAction.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/Shared/STPIntentAction.swift
@@ -63,6 +63,9 @@ import Foundation
 
     /// Contains instructions for completing Konbini payments.
     case konbiniDisplayDetails
+    
+    /// Contains details for displaying the QR code required for PromptPay.
+    case promptpayDisplayQrCode
 
     /// Parse the string and return the correct `STPIntentActionType`,
     /// or `STPIntentActionTypeUnknown` if it's unrecognized by this version of the SDK.
@@ -95,6 +98,8 @@ import Foundation
             self = .payNowDisplayQrCode
         case "konbini_display_details":
             self = .konbiniDisplayDetails
+        case "promptpay_display_qr_code":
+            self = .promptpayDisplayQrCode
         default:
             self = .unknown
         }
@@ -131,6 +136,8 @@ import Foundation
             break
         case .payNowDisplayQrCode:
             return "paynow_display_qr_code"
+        case .promptpayDisplayQrCode:
+            return "promptpay_display_qr_code"
         }
 
         // catch any unknown values here
@@ -175,6 +182,9 @@ public class STPIntentAction: NSObject {
 
     /// Contains instructions for authenticating a Konbini payment.
     @objc public let konbiniDisplayDetails: STPIntentActionKonbiniDisplayDetails?
+    
+    /// Contains details for displaying the QR code required for PromptPay.
+    @objc public let promptPayDisplayQrCode: STPIntentActionPromptPayDisplayQrCode?
 
     internal let useStripeSDK: STPIntentActionUseStripeSDK?
 
@@ -236,6 +246,10 @@ public class STPIntentAction: NSObject {
             if let konbiniDisplayDetails {
                 props.append("konbini_display_details = \(konbiniDisplayDetails)")
             }
+        case .promptpayDisplayQrCode:
+            if let promptPayDisplayQrCode = promptPayDisplayQrCode {
+                props.append("promptpayDisplayQrCode = \(promptPayDisplayQrCode)")
+            }
         case .unknown:
             // unrecognized type, just show the original dictionary for debugging help
             props.append("allResponseFields = \(allResponseFields)")
@@ -256,6 +270,7 @@ public class STPIntentAction: NSObject {
         cashAppRedirectToApp: STPIntentActionCashAppRedirectToApp?,
         payNowDisplayQrCode: STPIntentActionPayNowDisplayQrCode?,
         konbiniDisplayDetails: STPIntentActionKonbiniDisplayDetails?,
+        promptPayDisplayQrCode: STPIntentActionPromptPayDisplayQrCode?,
         allResponseFields: [AnyHashable: Any]
     ) {
         self.type = type
@@ -269,6 +284,7 @@ public class STPIntentAction: NSObject {
         self.cashAppRedirectToApp = cashAppRedirectToApp
         self.payNowDisplayQrCode = payNowDisplayQrCode
         self.konbiniDisplayDetails = konbiniDisplayDetails
+        self.promptPayDisplayQrCode = promptPayDisplayQrCode
         self.allResponseFields = allResponseFields
         super.init()
     }
@@ -299,6 +315,7 @@ extension STPIntentAction: STPAPIResponseDecodable {
         var cashAppRedirectToApp: STPIntentActionCashAppRedirectToApp?
         var payNowDisplayQrCode: STPIntentActionPayNowDisplayQrCode?
         var konbiniDisplayDetails: STPIntentActionKonbiniDisplayDetails?
+        var promptPayDisplayQrCode: STPIntentActionPromptPayDisplayQrCode?
 
         switch type {
         case .unknown:
@@ -377,6 +394,13 @@ extension STPIntentAction: STPAPIResponseDecodable {
             if konbiniDisplayDetails == nil {
                 type = .unknown
             }
+        case .promptpayDisplayQrCode:
+            promptPayDisplayQrCode = STPIntentActionPromptPayDisplayQrCode.decodedObject(
+                fromAPIResponse: dict["promptpay_display_qr_code"] as? [AnyHashable: Any]
+            )
+            if promptPayDisplayQrCode == nil {
+                type = .unknown
+            }
         }
 
         return STPIntentAction(
@@ -391,6 +415,7 @@ extension STPIntentAction: STPAPIResponseDecodable {
             cashAppRedirectToApp: cashAppRedirectToApp,
             payNowDisplayQrCode: payNowDisplayQrCode,
             konbiniDisplayDetails: konbiniDisplayDetails,
+            promptPayDisplayQrCode: promptPayDisplayQrCode,
             allResponseFields: dict
         ) as? Self
     }

--- a/StripePayments/StripePayments/Source/API Bindings/Models/Shared/STPIntentActionPromptPayDisplayQrCode.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/Shared/STPIntentActionPromptPayDisplayQrCode.swift
@@ -1,0 +1,63 @@
+//
+//  STPIntentActionPromptPayDisplayQrCode.swift
+//  StripePayments
+//
+//  Created by Nick Porter on 9/12/23.
+//
+
+import Foundation
+
+/// Contains instructions for presenting the QR code required to complete a PromptPay payment.
+/// You cannot directly instantiate an `STPIntentActionPromptPayDisplayQrCode`.
+public class STPIntentActionPromptPayDisplayQrCode: NSObject {
+
+    /// The URL to open which contains instructions on how to complete the payment.
+    @objc public let hostedInstructionsURL: URL?
+
+    /// :nodoc:
+    @objc public let allResponseFields: [AnyHashable: Any]
+
+    /// :nodoc:
+    @objc public override var description: String {
+        let props: [String] = [
+            // Object
+            String(
+                format: "%@: %p",
+                NSStringFromClass(STPIntentActionPromptPayDisplayQrCode.self),
+                self
+            ),
+            "hostedInstructionsURL = \(String(describing: hostedInstructionsURL))",
+        ]
+
+        return "<\(props.joined(separator: "; "))>"
+    }
+
+    internal init(
+        hostedInstructionsURL: URL,
+        allResponseFields: [AnyHashable: Any]
+    ) {
+        self.hostedInstructionsURL = hostedInstructionsURL
+        self.allResponseFields = allResponseFields
+        super.init()
+    }
+}
+
+// MARK: - STPAPIResponseDecodable
+extension STPIntentActionPromptPayDisplayQrCode: STPAPIResponseDecodable {
+
+    @objc
+    public class func decodedObject(fromAPIResponse response: [AnyHashable: Any]?) -> Self? {
+        guard let dict = response,
+            let hostedInstructionsURLString = dict["hosted_instructions_url"] as? String,
+            let hostedInstructionsURL = URL(string: hostedInstructionsURLString)
+        else {
+            return nil
+        }
+
+        return STPIntentActionPromptPayDisplayQrCode(
+            hostedInstructionsURL: hostedInstructionsURL,
+            allResponseFields: dict
+        ) as? Self
+    }
+
+}

--- a/StripePayments/StripePayments/Source/Categories/Enums+CustomStringConvertible.swift
+++ b/StripePayments/StripePayments/Source/Categories/Enums+CustomStringConvertible.swift
@@ -515,7 +515,7 @@ extension STPPaymentMethodType: CustomStringConvertible {
             return "weChatPay"
         case .cashApp:
             return "cashApp"
-        case .paynow, .zip, .revolutPay, .mobilePay, .amazonPay, .alma, .konbini:
+        case .paynow, .zip, .revolutPay, .mobilePay, .amazonPay, .alma, .konbini, .promptPay:
             // `description` is the value used when this type is converted to a string for debugging purposes, just use the display name.
             return displayName
         }

--- a/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
@@ -643,7 +643,7 @@ public class STPPaymentHandler: NSObject {
             .mobilePay,
             .amazonPay,
             .alma,
-            .konbini:
+            .konbini,
             .promptPay:
             return false
 

--- a/StripePayments/StripePaymentsObjcTestUtils/STPTestingAPIClient.h
+++ b/StripePayments/StripePaymentsObjcTestUtils/STPTestingAPIClient.h
@@ -40,6 +40,9 @@ static NSString * const STPTestingJPPublishableKey =
 // Test account in France
 static NSString * const STPTestingFRPublishableKey =
     @"pk_test_51JtgfQKG6vc7r7YCU0qQNOkDaaHrEgeHgGKrJMNfuWwaKgXMLzPUA1f8ZlCNPonIROLOnzpUnJK1C1xFH3M3Mz8X00Q6O4GfUt";
+// Test account in Thailand
+static NSString * const STPTestingTHPublishableKey =
+    @"pk_test_51NpEAWBgCYKNuUnnoBpaJZQYWOO6UpLtcioKggla08zpvDDy0cjfGKZdl5BsU8Gm5ilJNCqT7laCsqvyc0LndskG00pnPnJSpD";
 
 @interface STPTestingAPIClient : NSObject
 


### PR DESCRIPTION
## Summary
- Supports PromptPay for PaymentIntents in PaymentSheet.

## Demos

### Test mode 
#### Success
https://github.com/stripe/stripe-ios/assets/88012362/8a4cc04c-7317-4b47-8b56-adfcc16526fc
#### Expired
https://github.com/stripe/stripe-ios/assets/88012362/dc645456-367b-44d8-8bd9-edf9df694d7c
#### Cancel and pay another way
https://github.com/stripe/stripe-ios/assets/88012362/969c34d5-eb39-4073-a835-aa4f2a7d253c

### Leaving web view open
#### Success
https://github.com/stripe/stripe-ios/assets/88012362/717e5738-ca44-4fd0-ba95-174d86f85d23
#### Expired
https://github.com/stripe/stripe-ios/assets/88012362/ed949383-d196-4bd7-91db-00ed8ae0f5d0

### Dismissing web view
#### Success
https://github.com/stripe/stripe-ios/assets/88012362/473d8044-b22c-42b0-9068-88dbe996ab65


#### Expired
https://github.com/stripe/stripe-ios/assets/88012362/c18ca706-9eb1-4fa2-b0a1-de2eaf0a625b

## Motivation
LPM sprint

## Testing
- New unit and UI tests
- Manually

## Changelog
See diff