### PR TITLE
Fixed Serbian Dinar display issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## X.X.X
+### Payments
+* [Fixed] Fixed an issue where amounts in Serbian Dinar were displayed incorrectly.
+
+
 ## 23.16.0 2023-09-18
 ### Payments
 * [Added] Properties of STPConnectAccountParams are now mutable.

--- a/Stripe/StripeiOSTests/NSDecimalNumber+StripeTest.swift
+++ b/Stripe/StripeiOSTests/NSDecimalNumber+StripeTest.swift
@@ -27,6 +27,7 @@ class NSDecimalNumberStripeTest: XCTestCase {
         "cop",
         "pkr",
         "lak",
+        "rsd",
     ]
 
     private let noDecimalPointCurrencies = [

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/Types/STPPaymentMethodCardParams.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/Types/STPPaymentMethodCardParams.swift
@@ -40,7 +40,6 @@ public class STPPaymentMethodCardParams: NSObject, STPFormEncodable {
     /// Card security code. It is highly recommended to always include this value.
     @objc public var cvc: String?
     /// The last 4 digits of the card.
-
     @objc public var last4: String? {
         if number != nil && (number?.count ?? 0) >= 4 {
             return (number as NSString?)?.substring(from: (number?.count ?? 0) - 4) ?? ""
@@ -48,6 +47,7 @@ public class STPPaymentMethodCardParams: NSObject, STPFormEncodable {
             return ""
         }
     }
+    
 
     // MARK: - Description
     /// :nodoc:

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/Types/STPPaymentMethodCardParams.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/Types/STPPaymentMethodCardParams.swift
@@ -40,6 +40,7 @@ public class STPPaymentMethodCardParams: NSObject, STPFormEncodable {
     /// Card security code. It is highly recommended to always include this value.
     @objc public var cvc: String?
     /// The last 4 digits of the card.
+
     @objc public var last4: String? {
         if number != nil && (number?.count ?? 0) >= 4 {
             return (number as NSString?)?.substring(from: (number?.count ?? 0) - 4) ?? ""
@@ -47,7 +48,6 @@ public class STPPaymentMethodCardParams: NSObject, STPFormEncodable {
             return ""
         }
     }
-    
 
     // MARK: - Description
     /// :nodoc:

--- a/StripePayments/StripePayments/Source/Internal/Categories/NSDecimalNumber+Stripe_Currency.swift
+++ b/StripePayments/StripePayments/Source/Internal/Categories/NSDecimalNumber+Stripe_Currency.swift
@@ -15,6 +15,7 @@ extension NSDecimalNumber {
         "COP": 2,
         "PKR": 2,
         "LAK": 2,
+        "RSD": 2,
     ]
 
     @objc @_spi(STP) public class func stp_decimalNumber(


### PR DESCRIPTION
## Summary
Fixed an issue where amounts in Serbian Dinar were displayed with 0 decimal places, when we use 2 decimal places to represent it internally.

## Testing
CI, existing tests

## Changelog
Added