### PR TITLE
Fix PaymentSheet performance on Catalyst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## X.X.X
 ### Payments
 * [Fixed] Fixed an issue where amounts in Serbian Dinar were displayed incorrectly.
-
+* [Fixed] Fixed an issue where the SDK could hang in macOS Catalyst.
 
 ## 23.16.0 2023-09-18
 ### Payments

--- a/Stripe/StripeiOSTests/STPPaymentConfigurationTest.m
+++ b/Stripe/StripeiOSTests/STPPaymentConfigurationTest.m
@@ -71,6 +71,8 @@
 }
 
 - (void)testApplePayEnabledMisisngDeviceSupport {
+    // Change the supported networks list to reset the applePayEnabled cache
+    StripeAPI.additionalEnabledApplePayNetworks = @[PKPaymentNetworkJCB];
     id paymentAuthControllerMock = OCMClassMock([PKPaymentAuthorizationController class]);
     OCMStub([paymentAuthControllerMock canMakePaymentsUsingNetworks:[OCMArg any]]).andReturn(NO);
     
@@ -79,6 +81,8 @@
 
     XCTAssertFalse([paymentConfiguration applePayEnabled]);
     [paymentAuthControllerMock stopMocking];
+    // Re-reset cache:
+    StripeAPI.additionalEnabledApplePayNetworks = @[];
 }
 
 #pragma mark - Description

--- a/StripeCore/StripeCore/Source/API Bindings/StripeAPI.swift
+++ b/StripeCore/StripeCore/Source/API Bindings/StripeAPI.swift
@@ -72,7 +72,12 @@ import PassKit
     ///
     /// Set this property to enable other card networks in addition to these.
     /// For example, `additionalEnabledApplePayNetworks = [.JCB]` enables JCB (note this requires onboarding from JCB and Stripe).
-    @objc public static var additionalEnabledApplePayNetworks: [PKPaymentNetwork] = []
+    @objc public static var additionalEnabledApplePayNetworks: [PKPaymentNetwork] = [] {
+        didSet {
+            // Reset deviceSupportsApplePay for the updated network list:
+            _deviceSupportsApplePay = nil
+        }
+    }
 
     /// Whether or not this device is capable of using Apple Pay.
     ///
@@ -95,14 +100,13 @@ import PassKit
     }
 
     class func supportedPKPaymentNetworks() -> [PKPaymentNetwork] {
-        var additionalOSSupportedNetworks: [PKPaymentNetwork] = []
-        additionalOSSupportedNetworks.append(.maestro)
         return [
             .amex,
             .masterCard,
+            .maestro,
             .visa,
             .discover,
-        ] + additionalEnabledApplePayNetworks + additionalOSSupportedNetworks
+        ] + additionalEnabledApplePayNetworks
     }
 
     /// Whether or not this can make Apple Pay payments via a card network supported
@@ -116,10 +120,16 @@ import PassKit
     /// of the supported networks. NO if the user does not have a saved card of a
     /// supported type, or other restrictions prevent payment (such as parental controls).
     @objc public class func deviceSupportsApplePay() -> Bool {
-        return PKPaymentAuthorizationController.canMakePayments(
+        if let deviceSupportsApplePay = _deviceSupportsApplePay {
+            return deviceSupportsApplePay
+        }
+        let deviceSupportsApplePay = PKPaymentAuthorizationController.canMakePayments(
             usingNetworks: self.supportedPKPaymentNetworks()
         )
+        _deviceSupportsApplePay = deviceSupportsApplePay
+        return deviceSupportsApplePay
     }
+    private static var _deviceSupportsApplePay: Bool?
 
     /// A convenience method to build a `PKPaymentRequest` with sane default values.
     ///

--- a/StripeCore/StripeCore/Source/API Bindings/StripeAPI.swift
+++ b/StripeCore/StripeCore/Source/API Bindings/StripeAPI.swift
@@ -129,7 +129,7 @@ import PassKit
         _deviceSupportsApplePay = deviceSupportsApplePay
         return deviceSupportsApplePay
     }
-    
+
     /// Cached value of deviceSupportsApplePay
     /// `PKPaymentAuthorizationController.canMakePayments` is very slow on macOS Catalyst, so we only request once per process
     /// or when the additional networks list changes.

--- a/StripeCore/StripeCore/Source/API Bindings/StripeAPI.swift
+++ b/StripeCore/StripeCore/Source/API Bindings/StripeAPI.swift
@@ -129,6 +129,12 @@ import PassKit
         _deviceSupportsApplePay = deviceSupportsApplePay
         return deviceSupportsApplePay
     }
+    
+    /// Cached value of deviceSupportsApplePay
+    /// `PKPaymentAuthorizationController.canMakePayments` is very slow on macOS Catalyst, so we only request once per process
+    /// or when the additional networks list changes.
+    /// This should only return `false` based on the current hardware or parental controls. We don't expect these to change
+    /// during the life of the process.
     private static var _deviceSupportsApplePay: Bool?
 
     /// A convenience method to build a `PKPaymentRequest` with sane default values.

--- a/ci_scripts/deploy_release.rb
+++ b/ci_scripts/deploy_release.rb
@@ -100,11 +100,13 @@ def reply_email
 end
 
 def cleanup_project_files
-  rputs 'Cleanup generated project files from repo'
-  run_command("git checkout -b #{@cleanup_branchname}")
-  run_command("git pull -r origin master")
-  run_command('ci_scripts/delete_project_files.rb')
-  run_command("git add -u && git commit -m \"Remove generated project files for v#{@version}\"")
+  unless @is_dry_run
+    rputs 'Cleanup generated project files from repo'
+    run_command("git checkout -b #{@cleanup_branchname}")
+    run_command("git pull -r origin master")
+    run_command('ci_scripts/delete_project_files.rb')
+    run_command("git add -u && git commit -m \"Remove generated project files for v#{@version}\"")
+  end
 end
 
 def create_cleanup_pr


### PR DESCRIPTION
## Summary
Cache the value of `PKPaymentAuthorizationController.canMakePayments()`.

## Motivation
On Catalyst, `PKPaymentAuthorizationController.canMakePayments()` makes a surprisingly slow blocking XPC call. We call this every time we fire an analytics event, which was making PaymentSheet take over 7 seconds(!) to open.

## Testing
In PaymentSheet Example

## Changelog
Added fix entry