### PR TITLE
Disable card scanning on visionOS

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/STPCardScanner.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/STPCardScanner.swift
@@ -43,6 +43,10 @@ class STPCardScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, ST
         if NSClassFromString("XCTest") != nil {
             return true
         }
+        #if os(visionOS)
+        // visionOS does not currently support a live camera feed, so we can't scan cards.
+        return false
+        #endif
         return cardScanningAvailableCameraHasUsageDescription
     }
 


### PR DESCRIPTION
## Summary
visionOS exposes a null camera in the back and a spatial persona in the front. I don't think we'll get a valid PAN out of either.

## Motivation
Removing a button that won't work on visionOS.

## Testing
In simulator