### PR TITLE
Pass along billing address collection config to Apple Pay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## X.X.X
 ### PaymentSheet
 * [Fixed] Fixed an issue with scanning card expiration dates.
+* [Fixed] Fixed an issue where billing address collection configuration was not passed to Apple Pay.
 
 ### Basic Integration
 * [Fixed] Fixed an issue with scanning card expiration dates.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
@@ -163,6 +163,7 @@ extension STPApplePayContext {
             country: applePay.merchantCountryCode,
             currency: intent.currency ?? "USD"
         )
+        paymentRequest.requiredBillingContactFields = makeRequiredBillingDetails(from: configuration)
         if let paymentSummaryItems = applePay.paymentSummaryItems {
             // Use the merchant supplied paymentSummaryItems
             paymentRequest.paymentSummaryItems = paymentSummaryItems
@@ -213,4 +214,24 @@ private func makeShippingDetails(from configuration: PaymentSheet.Configuration)
         name: name,
         phone: shippingDetails.phone
     )
+}
+
+private func makeRequiredBillingDetails(from configuration: PaymentSheet.Configuration) -> Set<PKContactField> {
+    var requiredPKContactFields = Set<PKContactField>()
+    let billingConfig = configuration.billingDetailsCollectionConfiguration
+    // By default, we always want to request the billing address (as it includes the postal code)
+    if billingConfig.address == .automatic || billingConfig.address == .full {
+        requiredPKContactFields.insert(.postalAddress)
+    }
+    // Only request other fields if requested:
+    if billingConfig.email == .always {
+        requiredPKContactFields.insert(.emailAddress)
+    }
+    if billingConfig.phone == .always {
+        requiredPKContactFields.insert(.phoneNumber)
+    }
+    if billingConfig.name == .always {
+        requiredPKContactFields.insert(.name)
+    }
+    return requiredPKContactFields
 }


### PR DESCRIPTION
## Summary
We should observe the `billingDetailsCollectionConfiguration` when creating a PKPaymentRequest

## Motivation
Some users don't want to collect the postal code from Apple Pay.

## Testing
In PaymentSheet Example

## Changelog
Added