### PR TITLE
Align card brand icon in textfield

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Categories/STPCardBrand+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Categories/STPCardBrand+PaymentSheet.swift
@@ -18,6 +18,8 @@ extension STPCardBrand: Comparable {
     func brandIconAttributedString(theme: ElementsUITheme = .default) -> NSAttributedString {
         let brandImageAttachment = NSTextAttachment()
         brandImageAttachment.image = self == .unknown ? DynamicImageView.makeUnknownCardImageView(theme: theme).image : STPImageLibrary.cardBrandImage(for: self)
+        // Hard code image size to fit nicely in the card textfield
+        brandImageAttachment.bounds = CGRect(x: 0, y: -3, width: 27.5, height: 17)
 
         return NSAttributedString(attachment: brandImageAttachment)
     }


### PR DESCRIPTION
## Summary
- Move the card brand icon down a little and scale it down to make it fit better in the card text field

Before
![Simulator Screenshot - iPhone 14 Pro - 2023-09-26 at 14 39 00](https://github.com/stripe/stripe-ios/assets/88012362/5cc1c828-d5c8-4776-9776-8cdeafc0c522)

After
![Simulator Screenshot - iPhone 14 Pro - 2023-09-26 at 14 39 48](https://github.com/stripe/stripe-ios/assets/88012362/79eb8dd2-7c9c-4d5b-8ac2-333033b7a977)

## Motivation
Polish

## Testing
See screenshtos

## Changelog
N/A
