### PR TITLE
[Identity] Add an different initializer for IconLabelHTMLView.ViewModel

### DIFF
--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Views/IdentityHTMLView/IconLabelHTMLView.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Views/IdentityHTMLView/IconLabelHTMLView.swift
@@ -18,17 +18,34 @@ final class IconLabelHTMLView: UIView {
     struct ViewModel {
         let image: UIImage
         let text: String
-        let isTextHTML: Bool
+        let style: HTMLTextView.ViewModel.Style
         let didOpenURL: (URL) -> Void
 
-        var htmlTextViewModel: HTMLTextView.ViewModel {
-            let style: HTMLTextView.ViewModel.Style
-            if isTextHTML {
-                style = .html(makeStyle: Styling.iconLabelHTMLStyle)
-            } else {
-                style = .plainText(font: Styling.iconLabelFont, textColor: IdentityUI.textColor)
-            }
+        init(
+            image: UIImage,
+            text: String,
+            style: HTMLTextView.ViewModel.Style,
+            didOpenURL: @escaping (URL) -> Void
+        ) {
+            self.image = image
+            self.text = text
+            self.style = style
+            self.didOpenURL = didOpenURL
+        }
 
+        init(
+            image: UIImage,
+            text: String,
+            isTextHTML: Bool,
+            didOpenURL: @escaping (URL) -> Void
+        ) {
+            self.image = image
+            self.text = text
+            self.didOpenURL = didOpenURL
+            self.style = isTextHTML ? .html(makeStyle: Styling.iconLabelHTMLStyle) : .plainText(font: Styling.iconLabelFont, textColor: IdentityUI.textColor)
+        }
+
+        var htmlTextViewModel: HTMLTextView.ViewModel {
             return .init(
                 text: text,
                 style: style,


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Add an initializer to pass `style` directly to `IconLabelHTMLView.ViewModel`

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
this change allows `IconLabelHTMLView` to display different font sizes

## Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] manually tested

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
