### PR TITLE
Allow saving PM to customer with deferred flows examples

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleCheckoutDeferredViewController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleCheckoutDeferredViewController.swift
@@ -253,6 +253,7 @@ class ExampleDeferredCheckoutViewController: UIViewController {
             "is_subscribing": subscribeSwitch.isOn,
             "should_save_payment_method": shouldSavePaymentMethod,
             "return_url": "payments-example://stripe-redirect",
+            "customer_id": paymentSheetConfiguration.customer?.id,
         ]
 
         request.httpBody = try! JSONSerialization.data(withJSONObject: body, options: [])

--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleCustomDeferredCheckoutViewController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleCustomDeferredCheckoutViewController.swift
@@ -311,7 +311,7 @@ class ExampleCustomDeferredCheckoutViewController: UIViewController {
             "is_subscribing": subscribeSwitch.isOn,
             "should_save_payment_method": shouldSavePaymentMethod,
             "return_url": "payments-example://stripe-redirect",
-            "customer_id": paymentSheetFlowController.configuration.customer?.id
+            "customer_id": paymentSheetFlowController.configuration.customer?.id,
         ]
 
         request.httpBody = try! JSONSerialization.data(withJSONObject: body, options: [])

--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleCustomDeferredCheckoutViewController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleCustomDeferredCheckoutViewController.swift
@@ -311,6 +311,7 @@ class ExampleCustomDeferredCheckoutViewController: UIViewController {
             "is_subscribing": subscribeSwitch.isOn,
             "should_save_payment_method": shouldSavePaymentMethod,
             "return_url": "payments-example://stripe-redirect",
+            "customer_id": paymentSheetFlowController.configuration.customer?.id
         ]
 
         request.httpBody = try! JSONSerialization.data(withJSONObject: body, options: [])


### PR DESCRIPTION
## Summary
Updates examples to pass the customerId through to simulated merchant backends

## Motivation
Payment method was not being saved to the customerObject

## Testing
Manually tested w/ merchant backend
