### PR TITLE
Updating release instructions to use squash and merge

### DIFF
--- a/ci_scripts/deploy_release.rb
+++ b/ci_scripts/deploy_release.rb
@@ -17,7 +17,7 @@ end
 
 def approve_pr
   rputs 'Open the PR, approve it, and merge it.'
-  rputs '(Use "Create merge commit" and not "Squash and merge")'
+  rputs '(Use "Squash and merge")'
   rputs 'Don\'t continue until the PR has been merged into `master`!'
   notify_user
 end


### PR DESCRIPTION
## Summary
Update instructions to use squash and merge instead of merge commit.

## Motivation
We no longer support merge commits in this repository

## Testing
none.
