### PR TITLE
Fix paymentCardTextFieldDidChange not called when deleting empty field

### DIFF
--- a/Stripe/StripeiOSTests/STPPaymentCardTextFieldTest.swift
+++ b/Stripe/StripeiOSTests/STPPaymentCardTextFieldTest.swift
@@ -1213,4 +1213,23 @@ class STPPaymentCardTextFieldUITests: XCTestCase {
         XCTAssertTrue(hasReturned, "delegate method has been invoked")
         XCTAssertTrue(didEnd, "delegate method has been invoked")
     }
+
+    func testDidChangeCalledOnDeleteEmptyField() {
+        let card = STPPaymentMethodCardParams()
+        let number = "4242424242424242"
+        card.number = number
+        sut.paymentMethodParams = STPPaymentMethodParams(card: card, billingDetails: nil, metadata: nil)
+        var hasChanged = false
+        let delegate = PaymentCardTextFieldBlockDelegate()
+        delegate.didChange = { textField in
+            XCTAssertEqual(textField.numberField.text, "424242424242424")
+            XCTAssertFalse(hasChanged, "didChange delegate method should not have been called yet")
+            hasChanged = true
+        }
+
+        sut.delegate = delegate
+        sut.becomeFirstResponder()
+        sut.deleteBackward()
+        XCTAssertTrue(hasChanged, "delegate method has been invoked")
+    }
 }

--- a/StripePaymentsUI/StripePaymentsUI/Source/UI Components/STPPaymentCardTextField.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/UI Components/STPPaymentCardTextField.swift
@@ -1606,6 +1606,7 @@ open class STPPaymentCardTextField: UIControl, UIKeyInput, STPFormTextFieldDeleg
         UIAccessibility.post(notification: .screenChanged, argument: nil)
         if previous?.hasText ?? false {
             previous?.deleteBackward()
+            onChange()
         }
     }
 


### PR DESCRIPTION
## Summary
When a sub field is empty and we hit backspace we focus the previous field and delete the last character, however, this change is not reported in the delegate method, this fixes this issue.
More context in https://github.com/stripe/stripe-ios/issues/2483

## Motivation
https://github.com/stripe/stripe-ios/issues/2483

## Testing
- Verified visually
- Added unit test

## Changelog

### PaymentsUI
* [Fixed] An issue with `STPPaymentCardTextField`, where the `paymentCardTextFieldDidChange` delegate method wasn't being called after deleting an empty sub field.
