### PR TITLE
Fix card element not updating value when deleting on empty field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## X.X.X
+### PaymentsUI
+* [Fixed] An issue with `STPPaymentCardTextField`, where the card params were not updated after deleting an empty sub field.
+
 ## 23.17.1 2023-10-09
 ### PaymentSheet
 * [Fixed] Fixed an issue when advancing from the country dropdown that prevented user's' from typing in their postal code. ([#2936](https://github.com/stripe/stripe-ios/issues/2936))

--- a/Stripe/StripeiOSTests/STPPaymentCardTextFieldTest.swift
+++ b/Stripe/StripeiOSTests/STPPaymentCardTextFieldTest.swift
@@ -1214,7 +1214,7 @@ class STPPaymentCardTextFieldUITests: XCTestCase {
         XCTAssertTrue(didEnd, "delegate method has been invoked")
     }
 
-    func testDidChangeCalledOnDeleteEmptyField() {
+    func testValueUpdatesWhenDeletingOnEmptyField() {
         let card = STPPaymentMethodCardParams()
         let number = "4242424242424242"
         card.number = number
@@ -1223,6 +1223,7 @@ class STPPaymentCardTextFieldUITests: XCTestCase {
         let delegate = PaymentCardTextFieldBlockDelegate()
         delegate.didChange = { textField in
             XCTAssertEqual(textField.numberField.text, "424242424242424")
+            XCTAssertEqual(textField.cardNumber, "424242424242424")
             XCTAssertFalse(hasChanged, "didChange delegate method should not have been called yet")
             hasChanged = true
         }
@@ -1230,6 +1231,8 @@ class STPPaymentCardTextFieldUITests: XCTestCase {
         sut.delegate = delegate
         sut.becomeFirstResponder()
         sut.deleteBackward()
+        XCTAssertEqual(sut.numberField.text, "424242424242424")
+        XCTAssertEqual(sut.cardNumber, "424242424242424")
         XCTAssertTrue(hasChanged, "delegate method has been invoked")
     }
 }

--- a/StripePaymentsUI/StripePaymentsUI/Source/Internal/UI/Views/STPFormTextField.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/Internal/UI/Views/STPFormTextField.swift
@@ -197,17 +197,7 @@ import UIKit
     /// :nodoc:
     @objc
     public override func deleteBackward() {
-        // `UITextField.deleteBackwards` doesn't update the `text` property directly, and we depend on the `didSet`
-        // call on it to update our backing store.
-        // To get around this we manually remove the last character if the text is not empty, instead of forwarding
-        // the `deleteBackwards` call.
-        if var text = text, text.count > 0 {
-            text.removeLast()
-            self.text = text
-        } else {
-            super.deleteBackward()
-        }
-
+        super.deleteBackward()
         if (text?.count ?? 0) == 0 {
             if formDelegate?.responds(
                 to: #selector(STPPaymentCardTextField.formTextFieldDidBackspace(onEmpty:))

--- a/StripePaymentsUI/StripePaymentsUI/Source/Internal/UI/Views/STPFormTextField.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/Internal/UI/Views/STPFormTextField.swift
@@ -197,7 +197,17 @@ import UIKit
     /// :nodoc:
     @objc
     public override func deleteBackward() {
-        super.deleteBackward()
+        // `UITextField.deleteBackwards` doesn't update the `text` property directly, and we depend on the `didSet`
+        // call on it to update our backing store.
+        // To get around this we manually remove the last character if the text is not empty, instead of forwarding
+        // the `deleteBackwards` call.
+        if var text = text, text.count > 0 {
+            text.removeLast()
+            self.text = text
+        } else {
+            super.deleteBackward()
+        }
+
         if (text?.count ?? 0) == 0 {
             if formDelegate?.responds(
                 to: #selector(STPPaymentCardTextField.formTextFieldDidBackspace(onEmpty:))

--- a/StripePaymentsUI/StripePaymentsUI/Source/UI Components/STPPaymentCardTextField.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/UI Components/STPPaymentCardTextField.swift
@@ -1604,9 +1604,8 @@ open class STPPaymentCardTextField: UIControl, UIKeyInput, STPFormTextFieldDeleg
         let previous = previousField()
         previous?.becomeFirstResponder()
         UIAccessibility.post(notification: .screenChanged, argument: nil)
-        if previous?.hasText ?? false {
-            previous?.deleteBackward()
-            onChange()
+        if let previous = previous, previous.hasText {
+            previous.deleteBackward()
         }
     }
 

--- a/StripePaymentsUI/StripePaymentsUI/Source/UI Components/STPPaymentCardTextField.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/UI Components/STPPaymentCardTextField.swift
@@ -1605,7 +1605,13 @@ open class STPPaymentCardTextField: UIControl, UIKeyInput, STPFormTextFieldDeleg
         previous?.becomeFirstResponder()
         UIAccessibility.post(notification: .screenChanged, argument: nil)
         if let previous = previous, previous.hasText {
-            previous.deleteBackward()
+            // `UITextField.deleteBackwards` doesn't update the `text` property directly, and we depend on the `didSet`
+            // call on it to update our backing store.
+            // To get around this we manually remove the last character instead of calling `deleteBackwards` in the
+            // previous field.
+            var previousText = previous.text
+            previousText?.removeLast()
+            previous.text = previousText
         }
     }
 

--- a/StripePaymentsUI/StripePaymentsUI/Source/UI Components/STPPaymentCardTextField.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/UI Components/STPPaymentCardTextField.swift
@@ -1604,14 +1604,12 @@ open class STPPaymentCardTextField: UIControl, UIKeyInput, STPFormTextFieldDeleg
         let previous = previousField()
         previous?.becomeFirstResponder()
         UIAccessibility.post(notification: .screenChanged, argument: nil)
-        if let previous = previous, previous.hasText {
+        if let previous = previous, previous.hasText, let previousText = previous.text {
             // `UITextField.deleteBackwards` doesn't update the `text` property directly, and we depend on the `didSet`
             // call on it to update our backing store.
             // To get around this we manually remove the last character instead of calling `deleteBackwards` in the
             // previous field.
-            var previousText = previous.text
-            previousText?.removeLast()
-            previous.text = previousText
+            previous.text = String(previousText.dropLast())
         }
     }
 


### PR DESCRIPTION
## Summary
This is a followup to https://github.com/stripe/stripe-ios/pull/2971, it turns out that on top of not calling the delegate, we were not updating the backing view model, this was due to the implementation of `UITextField.deleteBackwards()`, which doesn't update the `text` property directly, causing `didSet` to not be called, which we depend on to update the backing view model. To get around this, I'm manually removing the last character in the text if it isn't empty.

## Motivation
https://github.com/stripe/stripe-ios/issues/2483

## Testing
- Verified visually
- Added test

## Changelog
* [Fixed] An issue with `STPPaymentCardTextField`, where the card params were not updated after deleting an empty sub field.