### PR TITLE
Financial Connections: fixed bitrise.yml env to stop builds from failing

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -243,6 +243,8 @@ workflows:
         - webhook_url: $SLACK_KGAIDIS_TESTING_WEBHOOK_URL
         - webhook_url_on_error: $SLACK_KGAIDIS_TESTING_WEBHOOK_URL
     - deploy-to-bitrise-io@2: {}
+    envs:
+    - DEFAULT_TEST_DEVICE: platform=iOS Simulator,name=iPhone 12 mini,OS=16.1
   financial-connections-stability-tests-for-edge:
     before_run:
     - prep_all
@@ -254,6 +256,8 @@ workflows:
         - maximum_test_repetitions: "5"
         - scheme: FinancialConnections Example
     - deploy-to-bitrise-io@2: {}
+    envs:
+    - DEFAULT_TEST_DEVICE: platform=iOS Simulator,name=iPhone 12 mini,OS=16.1
   framework-tests:
     steps:
     - fastlane@3:


### PR DESCRIPTION
## Summary

This PR changed env of various build steps:
	- https://github.com/stripe/stripe-ios/pull/2966

This caused some test/build failures:

```
Process config: simulator UDID lookup failed: runtime OS (16.4) on platform (iOS) is unavailable
Process config: simulator UDID lookup failed: runtime OS (16.4) on platform (iOS) is unavailable
````

We fixed some of them here for a release:
	- https://github.com/stripe/stripe-ios/pull/2978


And this PR fixes this error for Financial Connections tests.

## Testing

Previously running `bitrise run financial-connections-stability-tests` would show errors mentioned above. Now it does not:

```
FinancialConnectionsNetworkingUITests
    ✓ testNativeNetworkingTestMode (92.340 seconds)
FinancialConnectionsUITests
    ✓ testDataLiveModeOAuthNativeAuthFlow (31.963 seconds)
    ✓ testDataLiveModeOAuthWebAuthFlow (28.101 seconds)
    ✓ testDataTestModeOAuthNativeAuthFlow (22.363 seconds)
    ✓ testPaymentTestModeLegacyNativeAuthFlow (24.777 seconds)
    ✓ testPaymentTestModeManualEntryNativeAuthFlow (28.043 seconds)
    ✓ testSearchInLiveModeNativeAuthFlow (26.157 seconds)


	 Executed 7 tests, with 0 failures (0 unexpected) in 253.745 (253.754) seconds
```