### PR TITLE
Refactor and add tests for dashboard params

### DIFF
--- a/Stripe/StripeiOSTests/IntentConfirmParamsTest.swift
+++ b/Stripe/StripeiOSTests/IntentConfirmParamsTest.swift
@@ -1,0 +1,32 @@
+//
+//  IntentConfirmParamsTest.swift
+//  StripeiOSTests
+//
+//  Created by Nick Porter on 10/11/23.
+//
+
+import XCTest
+
+@testable@_spi(STP) import Stripe
+@testable@_spi(STP) import StripeCore
+@testable@_spi(STP) import StripePayments
+@testable@_spi(STP) import StripePaymentSheet
+@testable@_spi(STP) import StripePaymentsUI
+
+final class IntentConfirmParamsTest: XCTestCase {
+
+    func testMakeDashboardParams() {
+        let params = IntentConfirmParams.makeDashboardParams(paymentIntentClientSecret: "test_client_secret",
+                                                             paymentMethodID: "test_payment_method_id",
+                                                             shouldSave: true,
+                                                             paymentMethodType: .card,
+                                                             customer: .init(id: "test_id",
+                                                                             ephemeralKeySecret: "test_key"))
+        
+        XCTAssertEqual(params.clientSecret, "test_client_secret")
+        XCTAssertEqual(params.paymentMethodId, "test_payment_method_id")
+        XCTAssertEqual(params.paymentMethodOptions?.cardOptions?.additionalAPIParameters["setup_future_usage"] as? String, "off_session")
+        XCTAssertTrue(params.paymentMethodOptions?.cardOptions?.additionalAPIParameters["moto"] as? Bool ?? false)
+    }
+
+}

--- a/Stripe/StripeiOSTests/IntentConfirmParamsTest.swift
+++ b/Stripe/StripeiOSTests/IntentConfirmParamsTest.swift
@@ -22,7 +22,7 @@ final class IntentConfirmParamsTest: XCTestCase {
                                                              paymentMethodType: .card,
                                                              customer: .init(id: "test_id",
                                                                              ephemeralKeySecret: "test_key"))
-        
+
         XCTAssertEqual(params.clientSecret, "test_client_secret")
         XCTAssertEqual(params.paymentMethodId, "test_payment_method_id")
         XCTAssertEqual(params.paymentMethodOptions?.cardOptions?.additionalAPIParameters["setup_future_usage"] as? String, "off_session")

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfirmParams.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfirmParams.swift
@@ -72,10 +72,12 @@ class IntentConfirmParams {
         self.confirmPaymentMethodOptions = STPConfirmPaymentMethodOptions()
     }
 
-    func makeDashboardParams(
+    static func makeDashboardParams(
         paymentIntentClientSecret: String,
         paymentMethodID: String,
-        configuration: PaymentSheet.Configuration
+        shouldSave: Bool,
+        paymentMethodType: STPPaymentMethodType,
+        customer: PaymentSheet.CustomerConfiguration?
     ) -> STPPaymentIntentParams {
         let params = STPPaymentIntentParams(clientSecret: paymentIntentClientSecret)
         params.paymentMethodId = paymentMethodID
@@ -83,9 +85,9 @@ class IntentConfirmParams {
         // Dashboard only supports a specific payment flow today
         let options = STPConfirmPaymentMethodOptions()
         options.setSetupFutureUsageIfNecessary(
-            saveForFutureUseCheckboxState == .selected,
+            shouldSave,
             paymentMethodType: paymentMethodType,
-            customer: configuration.customer
+            customer: customer
         )
         params.paymentMethodOptions = options
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkPaymentController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkPaymentController.swift
@@ -319,6 +319,7 @@ import UIKit
                         authenticationContext: authenticationContext,
                         paymentHandler: STPPaymentHandler.shared(),
                         isFlowController: true,
+                        isDashboardApp: configuration.apiClient.publishableKeyIsUserKey,
                         mandateData: STPMandateDataParams.makeWithInferredValues()) { result, _ in
                     switch result {
                     case .canceled:

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkPaymentController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkPaymentController.swift
@@ -319,7 +319,6 @@ import UIKit
                         authenticationContext: authenticationContext,
                         paymentHandler: STPPaymentHandler.shared(),
                         isFlowController: true,
-                        isDashboardApp: configuration.apiClient.publishableKeyIsUserKey,
                         mandateData: STPMandateDataParams.makeWithInferredValues()) { result, _ in
                     switch result {
                     case .canceled:

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -154,7 +154,6 @@ extension PaymentSheet {
                     authenticationContext: authenticationContext,
                     paymentHandler: paymentHandler,
                     isFlowController: isFlowController,
-                    isDashboardApp: configuration.apiClient.publishableKeyIsUserKey,
                     completion: completion
                 )
             }
@@ -196,7 +195,6 @@ extension PaymentSheet {
                     authenticationContext: authenticationContext,
                     paymentHandler: paymentHandler,
                     isFlowController: isFlowController,
-                    isDashboardApp: configuration.apiClient.publishableKeyIsUserKey,
                     completion: completion
                 )
             }
@@ -239,7 +237,6 @@ extension PaymentSheet {
                         authenticationContext: authenticationContext,
                         paymentHandler: paymentHandler,
                         isFlowController: isFlowController,
-                        isDashboardApp: configuration.apiClient.publishableKeyIsUserKey,
                         completion: completion
                     )
                 }
@@ -286,7 +283,6 @@ extension PaymentSheet {
                         authenticationContext: authenticationContext,
                         paymentHandler: paymentHandler,
                         isFlowController: isFlowController,
-                        isDashboardApp: configuration.apiClient.publishableKeyIsUserKey,
                         completion: completion
                     )
                 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -107,50 +107,22 @@ extension PaymentSheet {
             switch intent {
             // MARK: ↪ PaymentIntent
             case .paymentIntent(let paymentIntent):
-                // The Dashboard app cannot pass `paymentMethodParams` ie payment_method_data
-                if configuration.apiClient.publishableKeyIsUserKey {
-                    configuration.apiClient.createPaymentMethod(with: confirmParams.paymentMethodParams) {
-                        paymentMethod,
-                        error in
-                        if let error = error {
-                            completion(.failed(error: error), nil)
-                            return
-                        }
-                        let paymentIntentParams = confirmParams.makeDashboardParams(
-                            paymentIntentClientSecret: paymentIntent.clientSecret,
-                            paymentMethodID: paymentMethod?.stripeId ?? "",
-                            configuration: configuration
-                        )
-                        paymentIntentParams.shipping = makeShippingParams(
-                            for: paymentIntent,
-                            configuration: configuration
-                        )
-                        paymentHandler.confirmPayment(
-                            paymentIntentParams,
-                            with: authenticationContext,
-                            completion: { actionStatus, _, error in
-                                paymentHandlerCompletion(actionStatus, error)
-                            }
-                        )
+                let params = makePaymentIntentParams(
+                    confirmPaymentMethodType: .new(
+                        params: confirmParams.paymentMethodParams,
+                        paymentOptions: confirmParams.confirmPaymentMethodOptions,
+                        shouldSave: confirmParams.saveForFutureUseCheckboxState == .selected
+                    ),
+                    paymentIntent: paymentIntent,
+                    configuration: configuration
+                )
+                paymentHandler.confirmPayment(
+                    params,
+                    with: authenticationContext,
+                    completion: { actionStatus, _, error in
+                        paymentHandlerCompletion(actionStatus, error)
                     }
-                } else {
-                    let params = makePaymentIntentParams(
-                        confirmPaymentMethodType: .new(
-                            params: confirmParams.paymentMethodParams,
-                            paymentOptions: confirmParams.confirmPaymentMethodOptions,
-                            shouldSave: confirmParams.saveForFutureUseCheckboxState == .selected
-                        ),
-                        paymentIntent: paymentIntent,
-                        configuration: configuration
-                    )
-                    paymentHandler.confirmPayment(
-                        params,
-                        with: authenticationContext,
-                        completion: { actionStatus, _, error in
-                            paymentHandlerCompletion(actionStatus, error)
-                        }
-                    )
-                }
+                )
             // MARK: ↪ SetupIntent
             case .setupIntent(let setupIntent):
                 let setupIntentParams = makeSetupIntentParams(
@@ -182,6 +154,7 @@ extension PaymentSheet {
                     authenticationContext: authenticationContext,
                     paymentHandler: paymentHandler,
                     isFlowController: isFlowController,
+                    isDashboardApp: configuration.apiClient.publishableKeyIsUserKey,
                     completion: completion
                 )
             }
@@ -192,11 +165,6 @@ extension PaymentSheet {
             // MARK: ↪ PaymentIntent
             case .paymentIntent(let paymentIntent):
                 let paymentIntentParams = makePaymentIntentParams(confirmPaymentMethodType: .saved(paymentMethod), paymentIntent: paymentIntent, configuration: configuration)
-
-                // The Dashboard app requires MOTO
-                if configuration.apiClient.publishableKeyIsUserKey {
-                    paymentIntentParams.paymentMethodOptions?.setMoto()
-                }
 
                 paymentHandler.confirmPayment(
                     paymentIntentParams,
@@ -228,6 +196,7 @@ extension PaymentSheet {
                     authenticationContext: authenticationContext,
                     paymentHandler: paymentHandler,
                     isFlowController: isFlowController,
+                    isDashboardApp: configuration.apiClient.publishableKeyIsUserKey,
                     completion: completion
                 )
             }
@@ -270,6 +239,7 @@ extension PaymentSheet {
                         authenticationContext: authenticationContext,
                         paymentHandler: paymentHandler,
                         isFlowController: isFlowController,
+                        isDashboardApp: configuration.apiClient.publishableKeyIsUserKey,
                         completion: completion
                     )
                 }
@@ -316,6 +286,7 @@ extension PaymentSheet {
                         authenticationContext: authenticationContext,
                         paymentHandler: paymentHandler,
                         isFlowController: isFlowController,
+                        isDashboardApp: configuration.apiClient.publishableKeyIsUserKey,
                         completion: completion
                     )
                 }
@@ -491,6 +462,7 @@ extension PaymentSheet {
         params.paymentMethodOptions = paymentOptions
         params.returnURL = configuration.returnURL
         params.shipping = makeShippingParams(for: paymentIntent, configuration: configuration)
+
         return params
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+DeferredAPI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+DeferredAPI.swift
@@ -169,6 +169,7 @@ extension PaymentSheet {
         switch confirmType {
         case .saved:
             // The Dashboard app requires MOTO
+            intentParamsCopy.paymentMethodOptions = intentParamsCopy.paymentMethodOptions == nil ? .init() : intentParamsCopy.paymentMethodOptions
             intentParamsCopy.paymentMethodOptions?.setMoto()
         case .new(_, _, let paymentMethod, let shouldSave):
             // The Dashboard app cannot pass `paymentMethodParams` ie payment_method_data

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+DeferredAPI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+DeferredAPI.swift
@@ -17,6 +17,8 @@ extension PaymentSheet {
         authenticationContext: STPAuthenticationContext,
         paymentHandler: STPPaymentHandler,
         isFlowController: Bool,
+        isDashboardApp: Bool,
+        dashboardParamsUpdater: @escaping DashboardParamsUpdater = setParamsForDashboardApp(confirmType:paymentIntentParams:paymentIntent:configuration:),
         mandateData: STPMandateDataParams? = nil,
         completion: @escaping (PaymentSheetResult, STPAnalyticsClient.DeferredIntentConfirmationType?) -> Void
     ) {
@@ -52,12 +54,21 @@ extension PaymentSheet {
                     if [STPPaymentIntentStatus.requiresPaymentMethod, STPPaymentIntentStatus.requiresConfirmation].contains(paymentIntent.status) {
                         // 4a. Client-side confirmation
                         try PaymentSheetDeferredValidator.validate(paymentIntent: paymentIntent, intentConfiguration: intentConfig, isFlowController: isFlowController)
-                        let paymentIntentParams = makePaymentIntentParams(
+                        var paymentIntentParams = makePaymentIntentParams(
                             confirmPaymentMethodType: confirmType,
                             paymentIntent: paymentIntent,
                             configuration: configuration,
                             mandateData: mandateData
                         )
+
+                        // Dashboard specfic logic
+                        if isDashboardApp {
+                            paymentIntentParams = dashboardParamsUpdater(confirmType,
+                                                                           paymentIntentParams,
+                                                                           paymentIntent,
+                                                                           configuration)
+                        }
+
                         paymentHandler.confirmPayment(
                             paymentIntentParams,
                             with: authenticationContext
@@ -147,5 +158,33 @@ extension PaymentSheet {
             paymentUserAgentValues.append("autopm")
         }
         return paymentUserAgentValues
+    }
+
+    typealias DashboardParamsUpdater = (ConfirmPaymentMethodType, STPPaymentIntentParams, STPPaymentIntent, PaymentSheet.Configuration) -> STPPaymentIntentParams
+    static func setParamsForDashboardApp(confirmType: ConfirmPaymentMethodType,
+                                         paymentIntentParams: STPPaymentIntentParams,
+                                         paymentIntent: STPPaymentIntent,
+                                         configuration: PaymentSheet.Configuration) -> STPPaymentIntentParams {
+        var intentParamsCopy = paymentIntentParams
+        switch confirmType {
+        case .saved:
+            // The Dashboard app requires MOTO
+            intentParamsCopy.paymentMethodOptions?.setMoto()
+        case .new(_, _, let paymentMethod, let shouldSave):
+            // The Dashboard app cannot pass `paymentMethodParams` ie payment_method_data
+            intentParamsCopy = IntentConfirmParams.makeDashboardParams(
+                paymentIntentClientSecret: paymentIntent.clientSecret,
+                paymentMethodID: paymentMethod?.stripeId ?? "",
+                shouldSave: shouldSave,
+                paymentMethodType: paymentMethod?.type ?? .unknown,
+                customer: configuration.customer
+            )
+            intentParamsCopy.shipping = makeShippingParams(
+                for: paymentIntent,
+                configuration: configuration
+            )
+        }
+
+        return intentParamsCopy
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+DeferredAPI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+DeferredAPI.swift
@@ -17,8 +17,6 @@ extension PaymentSheet {
         authenticationContext: STPAuthenticationContext,
         paymentHandler: STPPaymentHandler,
         isFlowController: Bool,
-        isDashboardApp: Bool,
-        dashboardParamsUpdater: @escaping DashboardParamsUpdater = setParamsForDashboardApp(confirmType:paymentIntentParams:paymentIntent:configuration:),
         mandateData: STPMandateDataParams? = nil,
         completion: @escaping (PaymentSheetResult, STPAnalyticsClient.DeferredIntentConfirmationType?) -> Void
     ) {
@@ -62,11 +60,11 @@ extension PaymentSheet {
                         )
 
                         // Dashboard specfic logic
-                        if isDashboardApp {
-                            paymentIntentParams = dashboardParamsUpdater(confirmType,
-                                                                           paymentIntentParams,
-                                                                           paymentIntent,
-                                                                           configuration)
+                        if configuration.apiClient.publishableKeyIsUserKey {
+                            paymentIntentParams = setParamsForDashboardApp(confirmType: confirmType,
+                                                                           paymentIntentParams: paymentIntentParams,
+                                                                           paymentIntent: paymentIntent,
+                                                                           configuration: configuration)
                         }
 
                         paymentHandler.confirmPayment(
@@ -160,7 +158,6 @@ extension PaymentSheet {
         return paymentUserAgentValues
     }
 
-    typealias DashboardParamsUpdater = (ConfirmPaymentMethodType, STPPaymentIntentParams, STPPaymentIntent, PaymentSheet.Configuration) -> STPPaymentIntentParams
     static func setParamsForDashboardApp(confirmType: ConfirmPaymentMethodType,
                                          paymentIntentParams: STPPaymentIntentParams,
                                          paymentIntent: STPPaymentIntent,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+DeferredAPITest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+DeferredAPITest.swift
@@ -1,0 +1,195 @@
+//
+//  PaymentSheet+DeferredAPITest.swift
+//  StripePaymentSheetTests
+//
+//  Created by Nick Porter on 10/11/23.
+//
+
+import XCTest
+@testable@_spi(STP) import StripeCore
+@testable@_spi(STP) import StripeCoreTestUtils
+@testable@_spi(STP) import StripePayments
+@testable@_spi(STP) import StripePaymentSheet
+@testable@_spi(STP) import StripePaymentsTestUtils
+@testable@_spi(STP) import StripeUICore
+
+final class PaymentSheet_DeferredAPITest: XCTestCase {
+    let apiClient = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
+    
+    lazy var configuration: PaymentSheet.Configuration = {
+        var config = PaymentSheet.Configuration()
+        config.apiClient = apiClient
+        config.allowsDelayedPaymentMethods = true
+        config.shippingDetails = {
+            return .init(
+                address: .init(
+                    country: "US",
+                    line1: "Line 1"
+                ),
+                name: "Jane Doe",
+                phone: "5551234567"
+            )
+        }
+        return config
+    }()
+    
+    lazy var paymentHandler: STPPaymentHandler = {
+        return STPPaymentHandler(
+            apiClient: apiClient,
+            formSpecPaymentHandler: PaymentSheetFormSpecPaymentHandler()
+        )
+    }()
+    
+    var confirmHandlerPaymentIntent: PaymentSheet.IntentConfiguration.ConfirmHandler = { paymentMethod, _, intentCreationCallback in
+        let createIntentCompletion: (String?, Error?) -> Void = { clientSecret, error in
+            if let clientSecret {
+                intentCreationCallback(.success(clientSecret))
+            } else {
+                intentCreationCallback(.failure(error ?? ExpectedError()))
+            }
+        }
+        let params: [String: Any] = [
+            "amount": 1050,
+        ]
+        STPTestingAPIClient.shared.createPaymentIntent(withParams: params, completion: createIntentCompletion)
+    }
+    
+    var confirmHandlerSetupIntent: PaymentSheet.IntentConfiguration.ConfirmHandler = { paymentMethod, _, intentCreationCallback in
+        let createIntentCompletion: (String?, Error?) -> Void = { clientSecret, error in
+            if let clientSecret {
+                intentCreationCallback(.success(clientSecret))
+            } else {
+                intentCreationCallback(.failure(error ?? ExpectedError()))
+            }
+        }
+
+        STPTestingAPIClient.shared.createSetupIntent(withParams: [:], completion: createIntentCompletion)
+    }
+    
+    struct ExpectedError: LocalizedError {
+        var errorDescription: String?
+    }
+    
+    // MARK: handleDeferredIntentConfirmation Dashboard tests
+    
+    // When isDashboardApp is true for a PaymentIntent we should call the Dashboard closure
+    func testHandleDeferredIntentConfirmation_shouldCallDashboardClosure_paymentIntent() {
+        let expectation = XCTestExpectation()
+        let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1050, currency: "USD"), confirmHandler: confirmHandlerPaymentIntent)
+        
+        PaymentSheet.handleDeferredIntentConfirmation(confirmType: .saved(createValidSavedPaymentMethod()),
+                                                      configuration: configuration, intentConfig: intentConfig, authenticationContext: self, paymentHandler: paymentHandler, isFlowController: false, isDashboardApp: true) { confirmType, intentParams, intent, config in
+            expectation.fulfill()
+            return STPPaymentIntentParams()
+        } completion: { _, _ in
+            // no-op
+        }
+        
+        wait(for: [expectation], timeout: 5.0)
+    }
+    
+    // When isDashboardApp for a PaymentIntent is false we should not call the Dashboard closure
+    func testHandleDeferredIntentConfirmation_shouldNotCallDashboardClosure_paymentIntent() {
+        let expectation = XCTestExpectation()
+        expectation.isInverted = true
+        let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1050, currency: "USD"), confirmHandler: confirmHandlerPaymentIntent)
+        
+        PaymentSheet.handleDeferredIntentConfirmation(confirmType: .saved(createValidSavedPaymentMethod()),
+                                                      configuration: configuration, intentConfig: intentConfig, authenticationContext: self, paymentHandler: paymentHandler, isFlowController: false, isDashboardApp: false) { confirmType, intentParams, intent, config in
+            expectation.fulfill()
+            return STPPaymentIntentParams()
+        } completion: { _, _ in
+            // no-op
+        }
+        
+        wait(for: [expectation], timeout: 5.0)
+    }
+    
+    // When isDashboardApp is true for a SetupIntent we should not call the Dashboard closure
+    func testHandleDeferredIntentConfirmation_shouldCallDashboardClosure_setupIntent() {
+        let expectation = XCTestExpectation()
+        expectation.isInverted = true
+        let intentConfig = PaymentSheet.IntentConfiguration(mode: .setup(currency: "USD", setupFutureUsage: .offSession), confirmHandler: confirmHandlerSetupIntent)
+        
+        PaymentSheet.handleDeferredIntentConfirmation(confirmType: .saved(createValidSavedPaymentMethod()),
+                                                      configuration: configuration, intentConfig: intentConfig, authenticationContext: self, paymentHandler: paymentHandler, isFlowController: false, isDashboardApp: true) { confirmType, intentParams, intent, config in
+            expectation.fulfill()
+            return STPPaymentIntentParams()
+        } completion: { _, _ in
+            // no-op
+        }
+        
+        wait(for: [expectation], timeout: 5.0)
+    }
+    
+    // When isDashboardApp for a SetupIntent is false we should not call the Dashboard closure
+    func testHandleDeferredIntentConfirmation_shouldNotCallDashboardClosure_setupIntent() {
+        let expectation = XCTestExpectation()
+        expectation.isInverted = true
+        let intentConfig = PaymentSheet.IntentConfiguration(mode: .setup(currency: "USD", setupFutureUsage: .offSession), confirmHandler: confirmHandlerSetupIntent)
+        
+        PaymentSheet.handleDeferredIntentConfirmation(confirmType: .saved(createValidSavedPaymentMethod()),
+                                                      configuration: configuration, intentConfig: intentConfig, authenticationContext: self, paymentHandler: paymentHandler, isFlowController: false, isDashboardApp: false) { confirmType, intentParams, intent, config in
+            expectation.fulfill()
+            return STPPaymentIntentParams()
+        } completion: { _, _ in
+            // no-op
+        }
+        
+        wait(for: [expectation], timeout: 5.0)
+    }
+    
+    // MARK: setParamsForDashboardApp tests
+    func testSetParamsForDashboardApp_saved() {
+        let examplePaymentMethodParams = STPPaymentMethodParams(card: STPFixtures.paymentMethodCardParams(), billingDetails: nil, metadata: nil)
+        let paymentOptions = STPConfirmPaymentMethodOptions()
+        let examplePaymentMethod = STPFixtures.paymentMethod()
+        var configurationWithCustomer = configuration
+        configurationWithCustomer.customer = .init(id: "id", ephemeralKeySecret: "ek")
+        let params = PaymentSheet.setParamsForDashboardApp(confirmType: .new(params: examplePaymentMethodParams,
+                                                                             paymentOptions: paymentOptions,
+                                                                             paymentMethod: examplePaymentMethod,
+                                                                             shouldSave: true),
+                                                           paymentIntentParams: .init(),
+                                                           paymentIntent: STPFixtures.makePaymentIntent(),
+                                                           configuration: configurationWithCustomer)
+        
+        // moto should be set to true and sfu = off_session
+        XCTAssertTrue(params.paymentMethodOptions?.cardOptions?.additionalAPIParameters["moto"] as? Bool ?? false)
+        XCTAssertEqual(params.paymentMethodOptions?.cardOptions?.additionalAPIParameters["setup_future_usage"] as? String, "off_session")
+    }
+    
+    func testSetParamsForDashboardApp_new() {
+        let params = PaymentSheet.setParamsForDashboardApp(confirmType: .saved(createValidSavedPaymentMethod()),
+                                                           paymentIntentParams: .init(),
+                                                           paymentIntent: STPFixtures.makePaymentIntent(),
+                                                           configuration: configuration)
+        
+        // moto should be set to true
+        XCTAssertTrue(params.paymentMethodOptions?.cardOptions?.additionalAPIParameters["moto"] as? Bool ?? false)
+    }
+    
+    // MARK: Helpers
+    func createValidSavedPaymentMethod() -> STPPaymentMethod {
+        var validSavedPM: STPPaymentMethod?
+        let createPMExpectation = expectation(description: "Create PM")
+        apiClient.createPaymentMethod(with: ._testValidCardValue()) { paymentMethod, error in
+            guard let paymentMethod = paymentMethod else {
+                XCTFail(String(describing: error))
+                return
+            }
+            validSavedPM = paymentMethod
+            createPMExpectation.fulfill()
+        }
+        waitForExpectations(timeout: 10)
+        return validSavedPM!
+    }
+}
+
+// MARK: - STPAuthenticationContext
+
+extension PaymentSheet_DeferredAPITest: STPAuthenticationContext {
+    func authenticationPresentingViewController() -> UIViewController {
+        return UIViewController()
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+DeferredAPITest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+DeferredAPITest.swift
@@ -5,17 +5,17 @@
 //  Created by Nick Porter on 10/11/23.
 //
 
-import XCTest
 @testable@_spi(STP) import StripeCore
 @testable@_spi(STP) import StripeCoreTestUtils
 @testable@_spi(STP) import StripePayments
 @testable@_spi(STP) import StripePaymentSheet
 @testable@_spi(STP) import StripePaymentsTestUtils
 @testable@_spi(STP) import StripeUICore
+import XCTest
 
 final class PaymentSheet_DeferredAPITest: XCTestCase {
     let apiClient = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
-    
+
     lazy var configuration: PaymentSheet.Configuration = {
         var config = PaymentSheet.Configuration()
         config.apiClient = apiClient
@@ -32,15 +32,15 @@ final class PaymentSheet_DeferredAPITest: XCTestCase {
         }
         return config
     }()
-    
+
     lazy var paymentHandler: STPPaymentHandler = {
         return STPPaymentHandler(
             apiClient: apiClient,
             formSpecPaymentHandler: PaymentSheetFormSpecPaymentHandler()
         )
     }()
-    
-    var confirmHandlerPaymentIntent: PaymentSheet.IntentConfiguration.ConfirmHandler = { paymentMethod, _, intentCreationCallback in
+
+    var confirmHandlerPaymentIntent: PaymentSheet.IntentConfiguration.ConfirmHandler = { _, _, intentCreationCallback in
         let createIntentCompletion: (String?, Error?) -> Void = { clientSecret, error in
             if let clientSecret {
                 intentCreationCallback(.success(clientSecret))
@@ -53,8 +53,8 @@ final class PaymentSheet_DeferredAPITest: XCTestCase {
         ]
         STPTestingAPIClient.shared.createPaymentIntent(withParams: params, completion: createIntentCompletion)
     }
-    
-    var confirmHandlerSetupIntent: PaymentSheet.IntentConfiguration.ConfirmHandler = { paymentMethod, _, intentCreationCallback in
+
+    var confirmHandlerSetupIntent: PaymentSheet.IntentConfiguration.ConfirmHandler = { _, _, intentCreationCallback in
         let createIntentCompletion: (String?, Error?) -> Void = { clientSecret, error in
             if let clientSecret {
                 intentCreationCallback(.success(clientSecret))
@@ -65,80 +65,80 @@ final class PaymentSheet_DeferredAPITest: XCTestCase {
 
         STPTestingAPIClient.shared.createSetupIntent(withParams: [:], completion: createIntentCompletion)
     }
-    
+
     struct ExpectedError: LocalizedError {
         var errorDescription: String?
     }
-    
+
     // MARK: handleDeferredIntentConfirmation Dashboard tests
-    
+
     // When isDashboardApp is true for a PaymentIntent we should call the Dashboard closure
     func testHandleDeferredIntentConfirmation_shouldCallDashboardClosure_paymentIntent() {
         let expectation = XCTestExpectation()
         let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1050, currency: "USD"), confirmHandler: confirmHandlerPaymentIntent)
-        
+
         PaymentSheet.handleDeferredIntentConfirmation(confirmType: .saved(createValidSavedPaymentMethod()),
-                                                      configuration: configuration, intentConfig: intentConfig, authenticationContext: self, paymentHandler: paymentHandler, isFlowController: false, isDashboardApp: true) { confirmType, intentParams, intent, config in
+                                                      configuration: configuration, intentConfig: intentConfig, authenticationContext: self, paymentHandler: paymentHandler, isFlowController: false, isDashboardApp: true) { _, _, _, _ in
             expectation.fulfill()
             return STPPaymentIntentParams()
         } completion: { _, _ in
             // no-op
         }
-        
+
         wait(for: [expectation], timeout: 5.0)
     }
-    
+
     // When isDashboardApp for a PaymentIntent is false we should not call the Dashboard closure
     func testHandleDeferredIntentConfirmation_shouldNotCallDashboardClosure_paymentIntent() {
         let expectation = XCTestExpectation()
         expectation.isInverted = true
         let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1050, currency: "USD"), confirmHandler: confirmHandlerPaymentIntent)
-        
+
         PaymentSheet.handleDeferredIntentConfirmation(confirmType: .saved(createValidSavedPaymentMethod()),
-                                                      configuration: configuration, intentConfig: intentConfig, authenticationContext: self, paymentHandler: paymentHandler, isFlowController: false, isDashboardApp: false) { confirmType, intentParams, intent, config in
+                                                      configuration: configuration, intentConfig: intentConfig, authenticationContext: self, paymentHandler: paymentHandler, isFlowController: false, isDashboardApp: false) { _, _, _, _ in
             expectation.fulfill()
             return STPPaymentIntentParams()
         } completion: { _, _ in
             // no-op
         }
-        
+
         wait(for: [expectation], timeout: 5.0)
     }
-    
+
     // When isDashboardApp is true for a SetupIntent we should not call the Dashboard closure
     func testHandleDeferredIntentConfirmation_shouldCallDashboardClosure_setupIntent() {
         let expectation = XCTestExpectation()
         expectation.isInverted = true
         let intentConfig = PaymentSheet.IntentConfiguration(mode: .setup(currency: "USD", setupFutureUsage: .offSession), confirmHandler: confirmHandlerSetupIntent)
-        
+
         PaymentSheet.handleDeferredIntentConfirmation(confirmType: .saved(createValidSavedPaymentMethod()),
-                                                      configuration: configuration, intentConfig: intentConfig, authenticationContext: self, paymentHandler: paymentHandler, isFlowController: false, isDashboardApp: true) { confirmType, intentParams, intent, config in
+                                                      configuration: configuration, intentConfig: intentConfig, authenticationContext: self, paymentHandler: paymentHandler, isFlowController: false, isDashboardApp: true) { _, _, _, _ in
             expectation.fulfill()
             return STPPaymentIntentParams()
         } completion: { _, _ in
             // no-op
         }
-        
+
         wait(for: [expectation], timeout: 5.0)
     }
-    
+
     // When isDashboardApp for a SetupIntent is false we should not call the Dashboard closure
     func testHandleDeferredIntentConfirmation_shouldNotCallDashboardClosure_setupIntent() {
         let expectation = XCTestExpectation()
         expectation.isInverted = true
         let intentConfig = PaymentSheet.IntentConfiguration(mode: .setup(currency: "USD", setupFutureUsage: .offSession), confirmHandler: confirmHandlerSetupIntent)
-        
+
         PaymentSheet.handleDeferredIntentConfirmation(confirmType: .saved(createValidSavedPaymentMethod()),
-                                                      configuration: configuration, intentConfig: intentConfig, authenticationContext: self, paymentHandler: paymentHandler, isFlowController: false, isDashboardApp: false) { confirmType, intentParams, intent, config in
+                                                      configuration: configuration, intentConfig: intentConfig, authenticationContext: self, paymentHandler: paymentHandler, isFlowController: false, isDashboardApp: false) { _, _, _, _ in
             expectation.fulfill()
             return STPPaymentIntentParams()
         } completion: { _, _ in
             // no-op
         }
-        
+
         wait(for: [expectation], timeout: 5.0)
     }
-    
+
     // MARK: setParamsForDashboardApp tests
     func testSetParamsForDashboardApp_saved() {
         let examplePaymentMethodParams = STPPaymentMethodParams(card: STPFixtures.paymentMethodCardParams(), billingDetails: nil, metadata: nil)
@@ -153,22 +153,22 @@ final class PaymentSheet_DeferredAPITest: XCTestCase {
                                                            paymentIntentParams: .init(),
                                                            paymentIntent: STPFixtures.makePaymentIntent(),
                                                            configuration: configurationWithCustomer)
-        
+
         // moto should be set to true and sfu = off_session
         XCTAssertTrue(params.paymentMethodOptions?.cardOptions?.additionalAPIParameters["moto"] as? Bool ?? false)
         XCTAssertEqual(params.paymentMethodOptions?.cardOptions?.additionalAPIParameters["setup_future_usage"] as? String, "off_session")
     }
-    
+
     func testSetParamsForDashboardApp_new() {
         let params = PaymentSheet.setParamsForDashboardApp(confirmType: .saved(createValidSavedPaymentMethod()),
                                                            paymentIntentParams: .init(),
                                                            paymentIntent: STPFixtures.makePaymentIntent(),
                                                            configuration: configuration)
-        
+
         // moto should be set to true
         XCTAssertTrue(params.paymentMethodOptions?.cardOptions?.additionalAPIParameters["moto"] as? Bool ?? false)
     }
-    
+
     // MARK: Helpers
     func createValidSavedPaymentMethod() -> STPPaymentMethod {
         var validSavedPM: STPPaymentMethod?


### PR DESCRIPTION
## Summary
- Refactors the Dashboard hack so it is only applied to deferred PaymentIntents
- Adds unit tests

## Motivation
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-2650
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-2653

## Testing
- New unit tests

## Changelog
N/A
