### PR TITLE
[Identity] Fix test mode return value

### DIFF
--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/VerificationSheetController.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/VerificationSheetController.swift
@@ -71,11 +71,13 @@ protocol VerificationSheetControllerProtocol: AnyObject {
     )
 
     func verifyAndTransition(
-        simulateDelay: Bool
+        simulateDelay: Bool,
+        completion: @escaping () -> Void
     )
 
     func unverifyAndTransition(
-        simulateDelay: Bool
+        simulateDelay: Bool,
+        completion: @escaping () -> Void
     )
 
     /// Request a new phoneOtp, transition to error view controller if request failed, callback on successCallback otherwise.
@@ -357,22 +359,28 @@ final class VerificationSheetController: VerificationSheetControllerProtocol {
     }
 
     func verifyAndTransition(
-        simulateDelay: Bool
+        simulateDelay: Bool,
+        completion: @escaping () -> Void
     ) {
         apiClient.verifyTestVerificationSession(
             simulateDelay: simulateDelay
         ).observe(on: .main) { [weak self] result in
+            self?.overrideTestModeReturnValue(result: .flowCompleted)
             self?.transitionWithVerificaionPageDataResult(result)
+            completion()
         }
     }
 
     func unverifyAndTransition(
-        simulateDelay: Bool
+        simulateDelay: Bool,
+        completion: @escaping () -> Void
     ) {
         apiClient.unverifyTestVerificationSession(
             simulateDelay: simulateDelay
         ).observe(on: .main) { [weak self] result in
+            self?.overrideTestModeReturnValue(result: .flowCompleted)
             self?.transitionWithVerificaionPageDataResult(result)
+            completion()
         }
     }
 

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/DebugViewController.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/DebugViewController.swift
@@ -44,13 +44,13 @@ final class DebugViewController: IdentityFlowViewController {
         case .submit(let completeOption):
             switch completeOption {
             case .success:
-                self.sheetController?.verifyAndTransition(simulateDelay: false)
+                self.sheetController?.verifyAndTransition(simulateDelay: false, completion: {})
             case .failure:
-                self.sheetController?.unverifyAndTransition(simulateDelay: false)
+                self.sheetController?.unverifyAndTransition(simulateDelay: false, completion: {})
             case .successAsync:
-                self.sheetController?.verifyAndTransition(simulateDelay: true)
+                self.sheetController?.verifyAndTransition(simulateDelay: true, completion: {})
             case .failureAsync:
-                self.sheetController?.unverifyAndTransition(simulateDelay: true)
+                self.sheetController?.unverifyAndTransition(simulateDelay: true, completion: {})
             }
         case .cancelled:
             finishWithResult(result: .flowCanceled)

--- a/StripeIdentity/StripeIdentityTests/Helpers/VerificationSheetControllerMock.swift
+++ b/StripeIdentity/StripeIdentityTests/Helpers/VerificationSheetControllerMock.swift
@@ -152,11 +152,13 @@ final class VerificationSheetControllerMock: VerificationSheetControllerProtocol
 
     }
 
-    func verifyAndTransition(simulateDelay: Bool) {
+    func verifyAndTransition(simulateDelay: Bool, completion: @escaping () -> Void) {
+        testModeReturnResult = .flowCompleted
         completeOption = simulateDelay ? .successAsync : .success
     }
 
-    func unverifyAndTransition(simulateDelay: Bool) {
+    func unverifyAndTransition(simulateDelay: Bool, completion: @escaping () -> Void) {
+        testModeReturnResult = .flowCompleted
         completeOption = simulateDelay ? .failureAsync : .failure
     }
 

--- a/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/Coordinators/VerificationSheetControllerTest.swift
+++ b/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/Coordinators/VerificationSheetControllerTest.swift
@@ -631,7 +631,10 @@ final class VerificationSheetControllerTest: XCTestCase {
         // Mock initial VerificationPage request successful
         controller.verificationPageResponse = .success(try VerificationPageMock.response200.make())
 
-        controller.verifyAndTransition(simulateDelay: false)
+        exp = XCTestExpectation(description: "transition finished")
+        controller.verifyAndTransition(simulateDelay: false) {
+            self.exp.fulfill()
+        }
 
         XCTAssertEqual(mockAPIClient.verifyUnverifyRequest.requestHistory.count, 1)
 
@@ -639,13 +642,22 @@ final class VerificationSheetControllerTest: XCTestCase {
             mockAPIClient.verifyUnverifyRequest.requestHistory.first,
             ["simulateDelay": false]
         )
+
+        mockAPIClient.verifyUnverifyRequest.respondToRequests(with: .success(try VerificationPageDataMock.response200.make()))
+
+        wait(for: [exp], timeout: 1)
+
+        XCTAssertEqual(controller.testModeReturnValue, IdentityVerificationSheet.VerificationFlowResult.flowCompleted)
     }
 
     func testVerifyAndTransitionWithDelay() throws {
         // Mock initial VerificationPage request successful
         controller.verificationPageResponse = .success(try VerificationPageMock.response200.make())
 
-        controller.verifyAndTransition(simulateDelay: true)
+        exp = XCTestExpectation(description: "transition finished")
+        controller.verifyAndTransition(simulateDelay: true) {
+            self.exp.fulfill()
+        }
 
         XCTAssertEqual(mockAPIClient.verifyUnverifyRequest.requestHistory.count, 1)
 
@@ -653,13 +665,22 @@ final class VerificationSheetControllerTest: XCTestCase {
             mockAPIClient.verifyUnverifyRequest.requestHistory.first,
             ["simulateDelay": true]
         )
+
+        mockAPIClient.verifyUnverifyRequest.respondToRequests(with: .success(try VerificationPageDataMock.response200.make()))
+
+        wait(for: [exp], timeout: 1)
+
+        XCTAssertEqual(controller.testModeReturnValue, IdentityVerificationSheet.VerificationFlowResult.flowCompleted)
     }
 
     func testUnverifyAndTransitionWithoutDelay() throws {
         // Mock initial VerificationPage request successful
         controller.verificationPageResponse = .success(try VerificationPageMock.response200.make())
 
-        controller.unverifyAndTransition(simulateDelay: false)
+        exp = XCTestExpectation(description: "transition finished")
+        controller.unverifyAndTransition(simulateDelay: false) {
+            self.exp.fulfill()
+        }
 
         XCTAssertEqual(mockAPIClient.verifyUnverifyRequest.requestHistory.count, 1)
 
@@ -667,6 +688,12 @@ final class VerificationSheetControllerTest: XCTestCase {
             mockAPIClient.verifyUnverifyRequest.requestHistory.first,
             ["simulateDelay": false]
         )
+
+        mockAPIClient.verifyUnverifyRequest.respondToRequests(with: .success(try VerificationPageDataMock.response200.make()))
+
+        wait(for: [exp], timeout: 1)
+
+        XCTAssertEqual(controller.testModeReturnValue, IdentityVerificationSheet.VerificationFlowResult.flowCompleted)
     }
 
     func testUnverifyAndTransitionWithDelay() throws {
@@ -674,7 +701,10 @@ final class VerificationSheetControllerTest: XCTestCase {
         controller.verificationPageResponse = .success(try VerificationPageMock.response200.make())
 
         // Verify
-        controller.unverifyAndTransition(simulateDelay: true)
+        exp = XCTestExpectation(description: "transition finished")
+        controller.unverifyAndTransition(simulateDelay: true) {
+            self.exp.fulfill()
+        }
 
         XCTAssertEqual(mockAPIClient.verifyUnverifyRequest.requestHistory.count, 1)
 
@@ -682,6 +712,12 @@ final class VerificationSheetControllerTest: XCTestCase {
             mockAPIClient.verifyUnverifyRequest.requestHistory.first,
             ["simulateDelay": true]
         )
+
+        mockAPIClient.verifyUnverifyRequest.respondToRequests(with: .success(try VerificationPageDataMock.response200.make()))
+
+        wait(for: [exp], timeout: 1)
+
+        XCTAssertEqual(controller.testModeReturnValue, IdentityVerificationSheet.VerificationFlowResult.flowCompleted)
     }
 
     func testGeneratePhoneOtp() throws {

--- a/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/ViewControllers/DebugViewControllerTest.swift
+++ b/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/ViewControllers/DebugViewControllerTest.swift
@@ -45,21 +45,29 @@ final class DebugViewControllerTest: XCTestCase {
 
     func testClickSubmitWithSuccess() {
         vc.didTapButton(.submit(completeOption: .success))
+
+        XCTAssertEqual(mockSheetController.testModeReturnResult, .flowCompleted)
         XCTAssertEqual(mockSheetController.completeOption, .success)
     }
 
     func testClickSubmitWithSuccessAsync() {
         vc.didTapButton(.submit(completeOption: .successAsync))
+
+        XCTAssertEqual(mockSheetController.testModeReturnResult, .flowCompleted)
         XCTAssertEqual(mockSheetController.completeOption, .successAsync)
     }
 
     func testClickSubmitWithFailure() {
         vc.didTapButton(.submit(completeOption: .failure))
+
+        XCTAssertEqual(mockSheetController.testModeReturnResult, .flowCompleted)
         XCTAssertEqual(mockSheetController.completeOption, .failure)
     }
 
     func testClickSubmitWithFailureAsync() {
         vc.didTapButton(.submit(completeOption: .failureAsync))
+
+        XCTAssertEqual(mockSheetController.testModeReturnResult, .flowCompleted)
         XCTAssertEqual(mockSheetController.completeOption, .failureAsync)
     }
 }


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Return `flowCompleted` instead of `flowCancelled` when clicking submit on test mode

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fix test mode return result

## Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Unit
- [x] Manual

## Recordings
| Before  | After |
| ------------- | ------------- |
| ![testReturnBefore](https://github.com/stripe/stripe-ios/assets/79880926/220f2ace-b9fe-42f2-96de-a76a49067b1a)  | ![testReturnAfter](https://github.com/stripe/stripe-ios/assets/79880926/fa735ea1-e907-40e5-8ce3-4f2e3cfca57c) |









## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
