### PR TITLE
Financial Connections: removed featured institution limit

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
@@ -194,7 +194,6 @@ extension STPAPIClient: FinancialConnectionsAPIClient {
     func fetchFeaturedInstitutions(clientSecret: String) -> Promise<FinancialConnectionsInstitutionList> {
         let parameters = [
             "client_secret": clientSecret,
-            "limit": "10",
         ]
         return self.get(
             resource: APIEndpointFeaturedInstitutions,


### PR DESCRIPTION
## Summary

This PR removes a featured institution limitation. We now can display any amount of featured institutions - as controlled by backend.

## Testing

I tested all sorts of different device sizes to ensure we support scrollable featured institutions:


https://github.com/stripe/stripe-ios/assets/105514761/4b9751c3-6fec-4497-adfe-2aac7a9be6fd


https://github.com/stripe/stripe-ios/assets/105514761/cd5085d1-c783-4a89-9e98-20b0a8c88ac9


https://github.com/stripe/stripe-ios/assets/105514761/840afd95-bf5c-4bdc-893e-b56b08004558


https://github.com/stripe/stripe-ios/assets/105514761/14ecd35c-4132-47cf-8716-f765acd75180
