### PR TITLE
Financial Connections: added close confirmation in more places like institution picker

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -82,14 +82,9 @@ class NativeFlowController {
         )
 
         let showConfirmationAlert =
-            (navigationController.topViewController is AccountPickerViewController
-                || navigationController.topViewController is PartnerAuthViewController
-                || navigationController.topViewController is AttachLinkedPaymentAccountViewController
-                || navigationController.topViewController is NetworkingLinkSignupViewController
-                || navigationController.topViewController is NetworkingLinkStepUpVerificationViewController
-                || navigationController.topViewController is NetworkingLinkVerificationViewController
-                || navigationController.topViewController is NetworkingSaveToLinkVerificationViewController
-                || navigationController.topViewController is LinkAccountPickerViewController)
+            !(navigationController.topViewController is ConsentViewController
+                || navigationController.topViewController is SuccessViewController
+                || navigationController.topViewController is ManualEntrySuccessViewController)
 
         let finishClosingAuthFlow = { [weak self] in
             self?.closeAuthFlow()


### PR DESCRIPTION
## Summary

We are now going to display a close confirmation in more places, and also simplify the logic with these changes. The close confirmation appears when a user presses "X" button on top-right corner.

## Testing

Testing all the various places where one can close:

https://github.com/stripe/stripe-ios/assets/105514761/61c3f286-d313-48c8-85ed-a007e5b7d300

