### PR TITLE
Show SEPA mandate sheet in FlowController unless the customer sees th…

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -121,7 +121,7 @@ extension PaymentSheet {
         }
 
         private var isPresented = false
-        private(set) var didPresent: Bool = false
+        private(set) var didPresentAndContinue: Bool = false
 
         // MARK: - Initializer (Internal)
 
@@ -269,7 +269,6 @@ extension PaymentSheet {
 
                 presentingViewController.presentAsBottomSheet(bottomSheetVC, appearance: self.configuration.appearance)
                 self.isPresented = true
-                self.didPresent = true
             }
 
             showPaymentOptions()
@@ -308,7 +307,7 @@ extension PaymentSheet {
 
             let authenticationContext = AuthenticationContext(presentingViewController: presentingViewController, appearance: configuration.appearance)
 
-            guard didPresent || viewController.selectedPaymentMethodType != .dynamic("sepa_debit") else {
+            guard didPresentAndContinue || viewController.selectedPaymentMethodType != .dynamic("sepa_debit") else {
                 // We're legally required to show the customer the SEPA mandate before every payment/setup
                 // In the edge case where the customer never opened the sheet, and thus never saw the mandate, we present the mandate directly
                 presentSEPAMandate()
@@ -459,8 +458,12 @@ extension PaymentSheet {
 // MARK: - PaymentSheetFlowControllerViewControllerDelegate
 extension PaymentSheet.FlowController: PaymentSheetFlowControllerViewControllerDelegate {
     func paymentSheetFlowControllerViewControllerShouldClose(
-        _ PaymentSheetFlowControllerViewController: PaymentSheetFlowControllerViewController
+        _ PaymentSheetFlowControllerViewController: PaymentSheetFlowControllerViewController,
+        didCancel: Bool
     ) {
+        if !didCancel {
+            self.didPresentAndContinue = true
+        }
         PaymentSheetFlowControllerViewController.dismiss(animated: true) {
             self.presentPaymentOptionsCompletion?()
             self.isPresented = false

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -15,7 +15,7 @@ import UIKit
 
 protocol PaymentSheetFlowControllerViewControllerDelegate: AnyObject {
     func paymentSheetFlowControllerViewControllerShouldClose(
-        _ PaymentSheetFlowControllerViewController: PaymentSheetFlowControllerViewController)
+        _ PaymentSheetFlowControllerViewController: PaymentSheetFlowControllerViewController, didCancel: Bool)
     func paymentSheetFlowControllerViewControllerDidUpdateSelection(
         _ PaymentSheetFlowControllerViewController: PaymentSheetFlowControllerViewController)
 }
@@ -400,20 +400,20 @@ class PaymentSheetFlowControllerViewController: UIViewController {
         STPAnalyticsClient.sharedClient.logPaymentSheetEvent(event: .paymentSheetConfirmButtonTapped)
         switch mode {
         case .selectingSaved:
-            self.delegate?.paymentSheetFlowControllerViewControllerShouldClose(self)
+            self.delegate?.paymentSheetFlowControllerViewControllerShouldClose(self, didCancel: false)
         case .addingNew:
             if let buyButtonOverrideBehavior = addPaymentMethodViewController.overrideBuyButtonBehavior {
                 addPaymentMethodViewController.didTapCallToActionButton(behavior: buyButtonOverrideBehavior, from: self)
             } else {
-                self.delegate?.paymentSheetFlowControllerViewControllerShouldClose(self)
+                self.delegate?.paymentSheetFlowControllerViewControllerShouldClose(self, didCancel: false)
             }
         }
 
     }
 
-    func didDismiss() {
+    func didDismiss(didCancel: Bool) {
         // If the customer was adding a new payment method and it's incomplete/invalid, return to the saved PM screen
-        delegate?.paymentSheetFlowControllerViewControllerShouldClose(self)
+        delegate?.paymentSheetFlowControllerViewControllerShouldClose(self, didCancel: didCancel)
         if savedPaymentOptionsViewController.isRemovingPaymentMethods {
             savedPaymentOptionsViewController.isRemovingPaymentMethods = false
             configureEditSavedPaymentMethodsButton()
@@ -431,7 +431,7 @@ extension PaymentSheetFlowControllerViewController: BottomSheetContentViewContro
 
     func didTapOrSwipeToDismiss() {
         if isDismissable {
-            didDismiss()
+            didDismiss(didCancel: true)
         }
     }
 
@@ -463,7 +463,7 @@ extension PaymentSheetFlowControllerViewController: SavedPaymentOptionsViewContr
             delegate?.paymentSheetFlowControllerViewControllerDidUpdateSelection(self)
             updateUI()
             if isDismissable, !selectedPaymentMethodType.requiresMandateDisplayForSavedSelection {
-                delegate?.paymentSheetFlowControllerViewControllerShouldClose(self)
+                delegate?.paymentSheetFlowControllerViewControllerShouldClose(self, didCancel: false)
             }
         }
     }
@@ -540,7 +540,7 @@ extension PaymentSheetFlowControllerViewController: AddPaymentMethodViewControll
 /// :nodoc:
 extension PaymentSheetFlowControllerViewController: SheetNavigationBarDelegate {
     func sheetNavigationBarDidClose(_ sheetNavigationBar: SheetNavigationBar) {
-        didDismiss()
+        didDismiss(didCancel: true)
     }
 
     func sheetNavigationBarDidBack(_ sheetNavigationBar: SheetNavigationBar) {


### PR DESCRIPTION
…e saved PM sheet *and* hits continue

## Summary
Require the customer to hit "continue" in FlowController, instead of just seeing it, in order for them to 'agree' to the SEPA mandate.

## Motivation
Consistency with Android and seems more self-consistent in that canceling out of the special SEPA mandate sheet also does not "count" as "agreeing to the mandate" i.e. we won't confirm the payment until you hit "Continue" in the SEPA mandate sheet.

## Testing
Manually tested, existing automated tests 
