### PR TITLE
Financial Connections: disable checking Chase for end to end tests

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
@@ -155,12 +155,12 @@ final class FinancialConnectionsUITests: XCTestCase {
         // they don't get featured
         let institutionButton: XCUIElement?
         let institutionName: String?
-        let chaseBankName = "Chase"
-        let chaseInstitutionButton = app.cells[chaseBankName]
-        if chaseInstitutionButton.waitForExistence(timeout: 10) {
-            institutionButton = chaseInstitutionButton
-            institutionName = chaseBankName
-        } else {
+//        let chaseBankName = "Chase"
+//        let chaseInstitutionButton = app.cells[chaseBankName]
+//        if chaseInstitutionButton.waitForExistence(timeout: 10) {
+//            institutionButton = chaseInstitutionButton
+//            institutionName = chaseBankName
+//        } else {
             let bankOfAmericaBankName = "Bank of America"
             let bankOfAmericaInstitutionButton = app.cells[bankOfAmericaBankName]
             if bankOfAmericaInstitutionButton.waitForExistence(timeout: 10) {
@@ -177,7 +177,7 @@ final class FinancialConnectionsUITests: XCTestCase {
                     institutionName = nil
                 }
             }
-        }
+//        }
         guard let institutionButton = institutionButton, let institutionName = institutionName else {
             XCTFail("Couldn't find a Live Mode institution.")
             return
@@ -257,12 +257,12 @@ final class FinancialConnectionsUITests: XCTestCase {
         // they don't get featured
         let institutionButton: XCUIElement?
         let institutionName: String?
-        let chaseBankName = "Chase"
-        let chaseInstitutionButton = app.webViews.buttons[chaseBankName]
-        if chaseInstitutionButton.waitForExistence(timeout: 10) {
-            institutionButton = chaseInstitutionButton
-            institutionName = chaseBankName
-        } else {
+//        let chaseBankName = "Chase"
+//        let chaseInstitutionButton = app.webViews.buttons[chaseBankName]
+//        if chaseInstitutionButton.waitForExistence(timeout: 10) {
+//            institutionButton = chaseInstitutionButton
+//            institutionName = chaseBankName
+//        } else {
             let bankOfAmericaBankName = "Bank of America"
             let bankOfAmericaInstitutionButton = app.webViews.buttons[bankOfAmericaBankName]
             if bankOfAmericaInstitutionButton.waitForExistence(timeout: 10) {
@@ -279,7 +279,7 @@ final class FinancialConnectionsUITests: XCTestCase {
                     institutionName = nil
                 }
             }
-        }
+//        }
         guard let institutionButton = institutionButton, let institutionName = institutionName else {
             XCTFail("Couldn't find a Live Mode institution.")
             return


### PR DESCRIPTION
## Summary

This is just end to end tests. There's an ongoing issue that we can't resolve on our end, so temporarily disabling checking a specific bank.

Currently the tests are failing all the time.

## Testing

`bitrise run financial-connections-stability-tests`

```
Test Suite FinancialConnectionsUITests.xctest started
FinancialConnectionsNetworkingUITests
    ✓ testNativeNetworkingTestMode (79.473 seconds)
FinancialConnectionsUITests
    ✓ testDataLiveModeOAuthNativeAuthFlow (42.573 seconds)
    ✓ testDataLiveModeOAuthWebAuthFlow (62.401 seconds)
    ✓ testDataTestModeOAuthNativeAuthFlow (22.998 seconds)
    ✓ testPaymentTestModeLegacyNativeAuthFlow (23.906 seconds)
    ✓ testPaymentTestModeManualEntryNativeAuthFlow (27.769 seconds)
    ✓ testSearchInLiveModeNativeAuthFlow (25.874 seconds)

```