### PR TITLE
Financial Connections: fixed an issue with end to end tests failing

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
@@ -193,9 +193,14 @@ final class FinancialConnectionsUITests: XCTestCase {
             app.fc_nativePrepaneContinueButton.tap()
 
             // check that the WebView loaded
+            var predicateString = "label CONTAINS '\(institutionName)'"
+            if institutionName == "Chase" {
+                // Chase does not contain the word "Chase" on their log-in page
+                predicateString = "label CONTAINS 'username' OR label CONTAINS 'password'"
+            }
             let institutionWebViewText = app.webViews
                 .staticTexts
-                .containing(NSPredicate(format: "label CONTAINS '\(institutionName)'"))
+                .containing(NSPredicate(format: predicateString))
                 .firstMatch
             XCTAssertTrue(institutionWebViewText.waitForExistence(timeout: 120.0))
 
@@ -300,9 +305,14 @@ final class FinancialConnectionsUITests: XCTestCase {
             prepaneContinueButton.tap()
 
             // check that the WebView loaded
+            var predicateString = "label CONTAINS '\(institutionName)'"
+            if institutionName == "Chase" {
+                // Chase does not contain the word "Chase" on their log-in page
+                predicateString = "label CONTAINS 'username' OR label CONTAINS 'password'"
+            }
             let institutionWebViewText = app.webViews
                 .staticTexts
-                .containing(NSPredicate(format: "label CONTAINS '\(institutionName)'"))
+                .containing(NSPredicate(format: predicateString))
                 .firstMatch
             XCTAssertTrue(institutionWebViewText.waitForExistence(timeout: 120.0))
         }


### PR DESCRIPTION
## Summary

^ currently end to end tests are failing because a bank changed their webpage to no longer contain the bank name

## Testing

Run `bitrise run financial-connections-stability-tests`:

```
Executed 7 tests, with 0 failures

FinancialConnectionsNetworkingUITests
    ✓ testNativeNetworkingTestMode (79.476 seconds)
FinancialConnectionsUITests
    ✓ testDataLiveModeOAuthNativeAuthFlow (33.022 seconds)
    ✓ testDataLiveModeOAuthWebAuthFlow (24.932 seconds)
    ✓ testDataTestModeOAuthNativeAuthFlow (22.821 seconds)
    ✓ testPaymentTestModeLegacyNativeAuthFlow (23.726 seconds)
    ✓ testPaymentTestModeManualEntryNativeAuthFlow (27.936 seconds)
    ✓ testSearchInLiveModeNativeAuthFlow (25.773 seconds) 
```