### PR TITLE
Longer timeout in LPMConfirmFlowTest testSavedSEPA, better debugging …

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example.xctestplan
+++ b/Example/PaymentSheet Example/PaymentSheet Example.xctestplan
@@ -24,7 +24,6 @@
   },
   "testTargets" : [
     {
-      "parallelizable" : true,
       "target" : {
         "containerPath" : "container:PaymentSheet Example.xcodeproj",
         "identifier" : "AAF1424C7F0424C3506712E6",

--- a/Example/PaymentSheet Example/PaymentSheet Example.xctestplan
+++ b/Example/PaymentSheet Example/PaymentSheet Example.xctestplan
@@ -24,6 +24,7 @@
   },
   "testTargets" : [
     {
+      "parallelizable" : true,
       "target" : {
         "containerPath" : "container:PaymentSheet Example.xcodeproj",
         "identifier" : "AAF1424C7F0424C3506712E6",

--- a/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
@@ -484,7 +484,7 @@ class CustomerSheetUITest: XCTestCase {
         try! fillCardData(app, cardNumber: "5555555555554444", postalEnabled: true)
         app.buttons["Save"].tap()
 
-        app.staticTexts["Apple Pay"].tap()
+        app.staticTexts["Apple Pay"].waitForExistenceAndTap()
         let confirmButton = app.buttons["Confirm"]
         XCTAssertTrue(confirmButton.waitForExistence(timeout: 60.0))
         // Don't tap!

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLPMConfirmFlowTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLPMConfirmFlowTests.swift
@@ -326,14 +326,14 @@ final class PaymentSheet_LPM_ConfirmFlowTests: XCTestCase {
                     e.fulfill()
                     switch result {
                     case .failed(error: let error):
-                        XCTFail("❌ \(description): PaymentSheet.confirm failed - \(error)")
+                        XCTFail("❌ \(description): PaymentSheet.confirm failed - \(error.nonGenericDescription)")
                     case .canceled:
                         XCTFail()
                     case .completed:
                         print("✅ \(description): PaymentSheet.confirm completed")
                     }
                 }
-                await fulfillment(of: [e], timeout: 5)
+                await fulfillment(of: [e], timeout: 10)
             }
         }
     }
@@ -425,7 +425,7 @@ extension PaymentSheet_LPM_ConfirmFlowTests {
             ) { result, _  in
                 switch result {
                 case .failed(error: let error):
-                    XCTFail("❌ \(description): PaymentSheet.confirm failed - \(error)")
+                    XCTFail("❌ \(description): PaymentSheet.confirm failed - \(error.nonGenericDescription)")
                 case .canceled:
                     XCTAssertTrue(redirectShimCalled, "❌ \(description): PaymentSheet.confirm canceled")
                 case .completed:
@@ -543,7 +543,7 @@ extension PaymentSheet_LPM_ConfirmFlowTests {
                 )
             }
             return [
-                ("PaymentIntent", .paymentIntent(paymentIntent)),
+                ("PaymentIntent w/ setup_future_usage", .paymentIntent(paymentIntent)),
                 ("Deferred PaymentIntent w/ setup_future_usage - client side confirmation", makeDeferredIntent(deferredCSC)),
                 ("Deferred PaymentIntent w/ setup_future_usage - server side confirmation", makeDeferredIntent(deferredSSC)),
             ]


### PR DESCRIPTION
…logs


## Motivation
This test is timing out sometimes. Other tests here have a 10 second timeout. I also noticed the print logs could be better.

This isn't the best long-term solution, might need to use recorded network traffic for this.

## Testing
automated tests

