### PR TITLE
Fix PaymentMethodType image loading

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetSnapshotTests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetSnapshotTests.swift
@@ -63,6 +63,7 @@ class CustomerSheetSnapshotTests: FBSnapshotTestCase {
     override func setUp() {
         super.setUp()
 
+        FormSpecProvider.shared.load()
         LinkAccountService.defaultCookieStore = LinkInMemoryCookieStore()  // use in-memory cookie store
 //        self.recordMode = true
     }

--- a/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetSnapshotTests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetSnapshotTests.swift
@@ -63,7 +63,6 @@ class CustomerSheetSnapshotTests: FBSnapshotTestCase {
     override func setUp() {
         super.setUp()
 
-        FormSpecProvider.shared.load()
         LinkAccountService.defaultCookieStore = LinkInMemoryCookieStore()  // use in-memory cookie store
 //        self.recordMode = true
     }

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetSnapshotTests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetSnapshotTests.swift
@@ -53,6 +53,7 @@ class PaymentSheetSnapshotTests: FBSnapshotTestCase {
         if !self.runAgainstLiveService {
             APIStubbedTestCase.stubAllOutgoingRequests()
         }
+        stubAllImageRequests()
     }
 
     public override func tearDown() {
@@ -1116,6 +1117,15 @@ class PaymentSheetSnapshotTests: FBSnapshotTestCase {
             file: file,
             line: line
         )
+    }
+
+    private func stubAllImageRequests() {
+        // Just fail all image requests so that these snapshot tests only use hardcoded image assets
+        stub { urlRequest in
+            return urlRequest.url?.absoluteString.contains("/v3/fingerprinted/img/payment-methods") ?? false
+        } response: { _ in
+            return HTTPStubsResponse(data: Data(), statusCode: 404, headers: nil)
+        }
     }
 
     private func stubNewCustomerResponse() {

--- a/StripeCore/StripeCore/Source/DownloadManager/DownloadManager.swift
+++ b/StripeCore/StripeCore/Source/DownloadManager/DownloadManager.swift
@@ -66,15 +66,16 @@ import UIKit
 
 // MARK: - Download management
 extension DownloadManager {
-    public func downloadImage(url: URL, updateHandler: UpdateImageHandler?) -> UIImage {
+    public func downloadImage(url: URL, placeholder: UIImage?, updateHandler: UpdateImageHandler?) -> UIImage {
         if updateHandler == nil {
-            return downloadImageBlocking(url: url)
+            return downloadImageBlocking(placeholder: placeholder, url: url)
         } else {
-            return downloadImageAsync(url: url, updateHandler: updateHandler)
+            return downloadImageAsync(url: url, placeholder: placeholder, updateHandler: updateHandler)
         }
     }
 
-    func downloadImageBlocking(url: URL) -> UIImage {
+    func downloadImageBlocking(placeholder: UIImage?, url: URL) -> UIImage {
+        let placeholder = placeholder ?? imagePlaceHolder()
         let imageName = imageNameFromURL(url: url)
         if let image = cachedImageNamed(imageName) {
             return image
@@ -105,10 +106,11 @@ extension DownloadManager {
         }
         task.resume()
         blockingDownloadSemaphore.wait()
-        return blockingDownloadedImage ?? imagePlaceHolder()
+        return blockingDownloadedImage ?? placeholder
     }
 
-    func downloadImageAsync(url: URL, updateHandler: UpdateImageHandler?) -> UIImage {
+    func downloadImageAsync(url: URL, placeholder: UIImage?, updateHandler: UpdateImageHandler?) -> UIImage {
+        let placeholder = placeholder ?? imagePlaceHolder()
         let imageName = imageNameFromURL(url: url)
         if let image = cachedImageNamed(imageName) {
             return image
@@ -145,14 +147,14 @@ extension DownloadManager {
         guard self.pendingRequests[imageName] == nil else {
             addUpdateHandlerWithoutLocking(updateHandler, forImageName: imageName)
             self.pendingRequestsSemaphore.signal()
-            return imagePlaceHolder()
+            return placeholder
         }
         self.pendingRequests[imageName] = task
         addUpdateHandlerWithoutLocking(updateHandler, forImageName: imageName)
         self.pendingRequestsSemaphore.signal()
         task.resume()
 
-        return imagePlaceHolder()
+        return placeholder
     }
 
     func imageNameFromURL(url: URL) -> String {

--- a/StripeCore/StripeCoreTests/DownloadManager/DownloadManagerTest.swift
+++ b/StripeCore/StripeCoreTests/DownloadManager/DownloadManagerTest.swift
@@ -37,7 +37,7 @@ class DownloadManagerTest: APIStubbedTestCase {
             return HTTPStubsResponse(data: self.validImageData(), statusCode: 200, headers: nil)
         }
 
-        let image = rm.downloadImage(url: validURL, updateHandler: nil)
+        let image = rm.downloadImage(url: validURL, placeholder: nil, updateHandler: nil)
         XCTAssertEqual(image.size, validImageSize)
     }
 
@@ -51,12 +51,12 @@ class DownloadManagerTest: APIStubbedTestCase {
             return HTTPStubsResponse(data: self.validImageData(), statusCode: 200, headers: nil)
         }
 
-        let image = rm.downloadImage(url: validURL, updateHandler: nil)
+        let image = rm.downloadImage(url: validURL, placeholder: nil, updateHandler: nil)
         XCTAssertEqual(image.size, validImageSize)
 
         wait(for: [expectedRequest], timeout: 1.0)
 
-        let cachedImageWithoutNetworkCall = rm.downloadImage(url: validURL, updateHandler: nil)
+        let cachedImageWithoutNetworkCall = rm.downloadImage(url: validURL, placeholder: nil, updateHandler: nil)
         XCTAssertEqual(cachedImageWithoutNetworkCall.size, validImageSize)
     }
 
@@ -78,14 +78,14 @@ class DownloadManagerTest: APIStubbedTestCase {
             return HTTPStubsResponse(data: self.validImageData(), statusCode: 200, headers: nil)
         }
 
-        let image = rm.downloadImage(url: validURL, updateHandler: nil)
+        let image = rm.downloadImage(url: validURL, placeholder: nil, updateHandler: nil)
         XCTAssertEqual(image.size, validImageSize)
         wait(for: [expectedRequest1], timeout: 1.0)
 
         rm.resetDiskCache()
         rm.resetMemoryCache()
 
-        let cachedImageWithoutNetworkCall = rm.downloadImage(url: validURL, updateHandler: nil)
+        let cachedImageWithoutNetworkCall = rm.downloadImage(url: validURL, placeholder: nil, updateHandler: nil)
         XCTAssertEqual(cachedImageWithoutNetworkCall.size, validImageSize)
         wait(for: [expectedRequest2], timeout: 1.0)
     }
@@ -97,7 +97,7 @@ class DownloadManagerTest: APIStubbedTestCase {
             return HTTPStubsResponse(error: NotFoundError())
         }
 
-        let image = rm.downloadImage(url: invalidURL, updateHandler: nil)
+        let image = rm.downloadImage(url: invalidURL, placeholder: nil, updateHandler: nil)
 
         XCTAssertEqual(image.size, placeholderImageSize)
     }
@@ -112,7 +112,7 @@ class DownloadManagerTest: APIStubbedTestCase {
         }
 
         let image = rm.downloadImage(
-            url: validURL,
+            url: validURL, placeholder: nil,
             updateHandler: { image in
                 XCTAssertEqual(image.size, self.validImageSize)
                 expected_imageUpdaterCalled.fulfill()
@@ -139,7 +139,7 @@ class DownloadManagerTest: APIStubbedTestCase {
         }
 
         let image = rm.downloadImage(
-            url: validURL,
+            url: validURL, placeholder: nil,
             updateHandler: { image in
                 XCTAssertEqual(image.size, self.validImageSize)
                 expected1.fulfill()
@@ -154,7 +154,7 @@ class DownloadManagerTest: APIStubbedTestCase {
         )
         expected2.isInverted = true
         let imageCached = rm.downloadImage(
-            url: validURL,
+            url: validURL, placeholder: nil,
             updateHandler: { _ in
                 expected2.fulfill()
             }
@@ -178,7 +178,7 @@ class DownloadManagerTest: APIStubbedTestCase {
         }
 
         let image = rm.downloadImage(
-            url: validURL,
+            url: validURL, placeholder: nil,
             updateHandler: { image in
                 XCTAssertEqual(image.size, self.validImageSize)
                 expected1.fulfill()
@@ -193,7 +193,7 @@ class DownloadManagerTest: APIStubbedTestCase {
 
         let expected2 = expectation(description: "updateHandler us called a second time")
         let image2 = rm.downloadImage(
-            url: validURL,
+            url: validURL, placeholder: nil,
             updateHandler: { image in
                 XCTAssertEqual(image.size, self.validImageSize)
                 expected2.fulfill()
@@ -214,7 +214,7 @@ class DownloadManagerTest: APIStubbedTestCase {
         }
 
         let image = rm.downloadImage(
-            url: invalidURL,
+            url: invalidURL, placeholder: nil,
             updateHandler: { image in
                 XCTAssertEqual(image.size, self.validImageSize)
                 expected.fulfill()
@@ -242,12 +242,12 @@ class DownloadManagerTest: APIStubbedTestCase {
         }
 
         let image = rm.downloadImage(
-            url: validURL,
+            url: validURL, placeholder: nil,
             updateHandler: { cb_image1 in
                 XCTAssertEqual(cb_image1.size, self.validImageSize)
                 expected_imageUpdater1.fulfill()
                 let image2 = self.rm.downloadImage(
-                    url: self.validURL2,
+                    url: self.validURL2, placeholder: nil,
                     updateHandler: { cb_image2 in
                         XCTAssertEqual(cb_image2.size, self.validImageSize2)
                         expected_imageUpdater2.fulfill()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -125,8 +125,20 @@ extension PaymentSheet {
         /// If the image is not immediately available, the updateHandler will be called if we are able
         /// to download the image.
         func makeImage(forDarkBackground: Bool = false, updateHandler: DownloadManager.UpdateImageHandler?) -> UIImage {
-            if case .dynamic(let name) = self,
-                let spec = FormSpecProvider.shared.formSpec(for: name),
+            // TODO: Refactor this out of PaymentMethodType. Users shouldn't have to convert STPPaymentMethodType to PaymentMethodType in order to get its image.
+            // Get the client-side asset first
+            let localImage = {
+                switch self {
+                case .externalPayPal:
+                    return STPPaymentMethodType.payPal.makeImage(forDarkBackground: forDarkBackground)
+                default:
+                    return stpPaymentMethodType?.makeImage(forDarkBackground: forDarkBackground)
+                }
+            }()
+            // Next, try to download the image from the spec if possible
+            if
+                FormSpecProvider.shared.isLoaded,
+                let spec = FormSpecProvider.shared.formSpec(for: identifier),
                 let selectorIcon = spec.selectorIcon,
                 var imageUrl = URL(string: selectorIcon.lightThemePng)
             {
@@ -139,21 +151,22 @@ extension PaymentSheet {
                 if PaymentSheet.PaymentMethodType.shouldLogAnalytic(paymentMethod: self) {
                     STPAnalyticsClient.sharedClient.logImageSelectorIconDownloadedIfNeeded(paymentMethod: self)
                 }
-                return DownloadManager.sharedManager.downloadImage(url: imageUrl, updateHandler: updateHandler)
-            }
-            if let stpPaymentMethodType = stpPaymentMethodType {
+                // If there's a form spec, download the spec's image, using the local image as a placeholder until it loads
+                return DownloadManager.sharedManager.downloadImage(url: imageUrl, placeholder: localImage, updateHandler: updateHandler)
+            } else if let localImage {
                 if PaymentSheet.PaymentMethodType.shouldLogAnalytic(paymentMethod: self) {
                     STPAnalyticsClient.sharedClient.logImageSelectorIconFromBundleIfNeeded(paymentMethod: self)
                 }
-                return stpPaymentMethodType.makeImage(forDarkBackground: forDarkBackground)
+                // If there's no form spec, return the local image if it exists
+                return localImage
+            } else {
+                // If the local image doesn't exist and there's no form spec, fire an analytic and return an empty image
+                assertionFailure()
+                if PaymentSheet.PaymentMethodType.shouldLogAnalytic(paymentMethod: self) {
+                    STPAnalyticsClient.sharedClient.logImageSelectorIconNotFoundIfNeeded(paymentMethod: self)
+                }
+                return DownloadManager.sharedManager.imagePlaceHolder()
             }
-            if case .externalPayPal = self {
-                return STPPaymentMethodType.payPal.makeImage(forDarkBackground: forDarkBackground)
-            }
-            if PaymentSheet.PaymentMethodType.shouldLogAnalytic(paymentMethod: self) {
-                STPAnalyticsClient.sharedClient.logImageSelectorIconNotFoundIfNeeded(paymentMethod: self)
-            }
-            return DownloadManager.sharedManager.imagePlaceHolder()
         }
 
         var iconRequiresTinting: Bool {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentOption+Images.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentOption+Images.swift
@@ -60,15 +60,18 @@ extension STPPaymentMethod {
             }
 
             return STPImageLibrary.cardBrandImage(for: card.networks?.preferred?.toCardBrand ?? card.brand)
-        case .iDEAL:
-            return Image.pm_type_ideal.makeImage()
         case .USBankAccount:
             return PaymentSheetImageLibrary.bankIcon(
                 for: PaymentSheetImageLibrary.bankIconCode(for: usBankAccount?.bankName)
             )
         default:
             // If there's no image specific to this PaymentMethod (eg card network logo, bank logo), default to the PaymentMethod type's icon
-            return type.makeImage()
+            // TODO: This only looks at client-side assets! 
+            let image = type.makeImage()
+            if image == nil {
+                assertionFailure()
+            }
+            return image ?? UIImage()
         }
     }
 
@@ -135,66 +138,60 @@ extension STPPaymentMethodType {
         }
     }
 
-    func makeImage(forDarkBackground: Bool = false) -> UIImage {
-        guard
-            let image: Image = {
-                switch self {
-                case .card:
-                    return .pm_type_card
-                case .iDEAL:
-                    return .pm_type_ideal
-                case .bancontact:
-                    return .pm_type_bancontact
-                case .SEPADebit:
-                    return .pm_type_sepa
-                case .EPS:
-                    return .pm_type_eps
-                case .giropay:
-                    return .pm_type_giropay
-                case .przelewy24:
-                    return .pm_type_p24
-                case .afterpayClearpay:
-                    return .pm_type_afterpay
-                case .sofort, .klarna:
-                    return .pm_type_klarna
-                case .affirm:
-                    return .pm_type_affirm
-                case .payPal:
-                    return .pm_type_paypal
-                case .AUBECSDebit:
-                    return .pm_type_aubecsdebit
-                case .USBankAccount, .linkInstantDebit:
-                    return .pm_type_us_bank
-                case .UPI:
-                    return .pm_type_upi
-                case .cashApp:
-                    return .pm_type_cashapp
-                case .revolutPay:
-                    return .pm_type_revolutpay
-                case .blik:
-                    return .pm_type_blik
-                case .bacsDebit:
-                    return .pm_type_us_bank
-                case .alipay:
-                    return .pm_type_alipay
-                case .OXXO:
-                    return .pm_type_oxxo
-                case .konbini:
-                    return .pm_type_konbini
-                case .boleto:
-                    return .pm_type_boleto
-                case .swish:
-                    return .pm_type_swish
-                default:
-                    return nil
-                }
-            }()
-        else {
-            assertionFailure()
-            return UIImage()
-        }
-
-        return image.makeImage(overrideUserInterfaceStyle: forDarkBackground ? .dark : .light)
+    func makeImage(forDarkBackground: Bool = false) -> UIImage? {
+        let image: Image? = {
+            switch self {
+            case .card:
+                return .pm_type_card
+            case .iDEAL:
+                return .pm_type_ideal
+            case .bancontact:
+                return .pm_type_bancontact
+            case .SEPADebit:
+                return .pm_type_sepa
+            case .EPS:
+                return .pm_type_eps
+            case .giropay:
+                return .pm_type_giropay
+            case .przelewy24:
+                return .pm_type_p24
+            case .afterpayClearpay:
+                return .pm_type_afterpay
+            case .sofort, .klarna:
+                return .pm_type_klarna
+            case .affirm:
+                return .pm_type_affirm
+            case .payPal:
+                return .pm_type_paypal
+            case .AUBECSDebit:
+                return .pm_type_aubecsdebit
+            case .USBankAccount, .linkInstantDebit:
+                return .pm_type_us_bank
+            case .UPI:
+                return .pm_type_upi
+            case .cashApp:
+                return .pm_type_cashapp
+            case .revolutPay:
+                return .pm_type_revolutpay
+            case .blik:
+                return .pm_type_blik
+            case .bacsDebit:
+                return .pm_type_us_bank
+            case .alipay:
+                return .pm_type_alipay
+            case .OXXO:
+                return .pm_type_oxxo
+            case .konbini:
+                return .pm_type_konbini
+            case .boleto:
+                return .pm_type_boleto
+            case .swish:
+                return .pm_type_swish
+            default:
+                return nil
+            }
+        }()
+        return image?.makeImage(overrideUserInterfaceStyle: forDarkBackground ? .dark : .light)
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/FormSpec/FormSpecProvider.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/FormSpec/FormSpecProvider.swift
@@ -24,6 +24,10 @@ class FormSpecProvider {
         DispatchQueue(label: "com.stripe.Form.FormSpecProvider", qos: .userInitiated)
     }()
 
+    var isLoaded: Bool {
+        return !formSpecs.isEmpty
+    }
+
     /// Loads the JSON form spec from disk into memory
     func load(completion: ((Bool) -> Void)? = nil) {
         formSpecsUpdateQueue.async { [weak self] in


### PR DESCRIPTION
There are two ways we can get image icons for payment methods today:
1. local client-side asset
2. downloaded using the URL in the LUXE form spec

There were two problems:
1. Payment methods with a case in PaymentMethodType (e.g. `PaymentMethodType.bacsDebit`) only attempt to use client-side assets and never the form spec image URL. Whether a payment method has a case or not is arbitrary.
2. Payment methods that use `PaymentMethodType.dynamic` would never use the client-side asset, even if one exists. They always use a blank image that is replaced by the form spec image URL if it loads successfully. If it fails to load, an image never appears - even if we have a local image.

This is now changed: All payment methods attempt to use the form spec image URL. If there's no form spec URL or if the URL fails to load, it falls back to the client-side asset.

## Motivation
Preparation for removing arbitrary payment method and dynamic cases from PaymentMethodType (https://github.com/stripe/stripe-ios/pull/3006).

## Testing
See unit tests

## Changelog
* [Fixed] Fixed some payment method icons not updating to use the latest assets.

