### PR TITLE
Add default initializer for PaymentSheet.BillingDetails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## x.x.x
-### PaymentsUI
+### PaymentSheet
+* [Fixed] Added a public initializer for `PaymentSheet.BillingDetails`.
 
+### PaymentsUI
 * [Fixed] And issue with `STPPaymentCardTextField` where the `paymentCardTextFieldDidEndEditing` delegate method was not called.
 
 ## 23.18.0 2023-10-23

--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkPaymentCheckoutViewController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkPaymentCheckoutViewController.swift
@@ -18,6 +18,13 @@ class ExampleLinkPaymentCheckoutViewController: UIViewController {
     let backendCheckoutUrl = "https://abundant-elderly-universe.glitch.me/checkout"  // An example backend endpoint
     let confirmEndpoint = "https://abundant-elderly-universe.glitch.me/confirm_intent"
     private var token = 0
+    
+    let billingDetails: PaymentSheet.BillingDetails = {
+        var billingDetails = PaymentSheet.BillingDetails()
+        billingDetails.email = "testsekfljaed@example.com"
+        billingDetails.phone = "+15551232414567"
+        return billingDetails
+    }()
 
     private func loadBackend() {
         token += 1
@@ -47,9 +54,9 @@ class ExampleLinkPaymentCheckoutViewController: UIViewController {
                                 self?.handleDeferredIntent(intentCreationCallback: intentCreationCallback)
                             }
 
-                    self.linkPaymentController = LinkPaymentController(intentConfiguration: intentConfiguration, returnURL: returnURL)
+                    self.linkPaymentController = LinkPaymentController(intentConfiguration: intentConfiguration, returnURL: returnURL, billingDetails: self.billingDetails)
                 } else {
-                    self.linkPaymentController = LinkPaymentController(paymentIntentClientSecret: paymentIntentClientSecret, returnURL: returnURL)
+                    self.linkPaymentController = LinkPaymentController(paymentIntentClientSecret: paymentIntentClientSecret, returnURL: returnURL, billingDetails: self.billingDetails)
                 }
 
                 self.updateButtons()

--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkPaymentCheckoutViewController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkPaymentCheckoutViewController.swift
@@ -21,7 +21,7 @@ class ExampleLinkPaymentCheckoutViewController: UIViewController {
 
     let billingDetails: PaymentSheet.BillingDetails = {
         var billingDetails = PaymentSheet.BillingDetails()
-        billingDetails.email = "testsekfljaed@example.com"
+        billingDetails.email = "test@example.com"
         billingDetails.phone = "+15551232414567"
         return billingDetails
     }()

--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkPaymentCheckoutViewController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkPaymentCheckoutViewController.swift
@@ -18,7 +18,7 @@ class ExampleLinkPaymentCheckoutViewController: UIViewController {
     let backendCheckoutUrl = "https://abundant-elderly-universe.glitch.me/checkout"  // An example backend endpoint
     let confirmEndpoint = "https://abundant-elderly-universe.glitch.me/confirm_intent"
     private var token = 0
-    
+
     let billingDetails: PaymentSheet.BillingDetails = {
         var billingDetails = PaymentSheet.BillingDetails()
         billingDetails.email = "testsekfljaed@example.com"

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
@@ -349,7 +349,12 @@ extension PaymentSheet {
         public var phone: String?
 
         /// Initializes billing details
-        public init() { }
+        public init(address: PaymentSheet.Address = Address(), email: String? = nil, name: String? = nil, phone: String? = nil) {
+            self.address = address
+            self.email = email
+            self.name = name
+            self.phone = phone
+        }
     }
 
     /// Configuration for how billing details are collected during checkout.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
@@ -347,11 +347,9 @@ extension PaymentSheet {
 
         /// The customer's phone number without formatting (e.g. 5551234567)
         public var phone: String?
-        
+
         /// Initializes billing details
-        public init() {
-            
-        }
+        public init() { }
     }
 
     /// Configuration for how billing details are collected during checkout.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
@@ -347,6 +347,11 @@ extension PaymentSheet {
 
         /// The customer's phone number without formatting (e.g. 5551234567)
         public var phone: String?
+        
+        /// Initializes billing details
+        public init() {
+            
+        }
     }
 
     /// Configuration for how billing details are collected during checkout.


### PR DESCRIPTION
## Summary
Add a default initializer for `PaymentSheet.BillingDetails`.

## Motivation
LinkPaymentController accepts an optional billing details, but it wasn't possible to construct one.

## Testing
Use Billing Details in PaymentSheet Example

## Changelog
Added fixed entry