### PR TITLE
Hide Apple/Google Pay saved cards in PaymentSheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## x.x.x
 ### PaymentSheet
 * [Fixed] Added a public initializer for `PaymentSheet.BillingDetails`.
+* [Fixed] Fixed some payment method icons not updating to use the latest assets.
+* [Fixed] PaymentSheet no longer displays saved cards that originated from Apple Pay or Google Pay.
 
 ### PaymentsUI
 * [Fixed] And issue with `STPPaymentCardTextField` where the `paymentCardTextFieldDidEndEditing` delegate method was not called.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -199,10 +199,15 @@ final class PaymentSheetLoader {
                 using: ephemeralKey,
                 types: savedPaymentMethodTypes
             ) { paymentMethods, error in
-                guard let paymentMethods = paymentMethods, error == nil else {
+                guard var paymentMethods, error == nil else {
                     let error = error ?? PaymentSheetError.fetchPaymentMethodsFailure
                     continuation.resume(throwing: error)
                     return
+                }
+                // Remove cards that originated from Apple or Google Pay
+                paymentMethods = paymentMethods.filter { paymentMethod in
+                    let isAppleOrGooglePay = paymentMethod.type == .card && [.applePay, .googlePay].contains(paymentMethod.card?.wallet?.type)
+                    return !isAppleOrGooglePay
                 }
                 continuation.resume(returning: paymentMethods)
             }


### PR DESCRIPTION
## Summary
Hide Apple/Google Pay saved cards in PaymentSheet.
Also adds CHANGELOG entry I forgot to add in https://github.com/stripe/stripe-ios/pull/3021, 

## Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-1089

## Testing
See unit test. Manually tested in simulator too.

## Changelog
* [Fixed] PaymentSheet no longer displays saved cards that originated from Apple Pay or Google Pay.
