### PR TITLE
Financial Connections: added institution maintenance support to search end to end test.

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundMainViewModel.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundMainViewModel.swift
@@ -313,9 +313,11 @@ private func PresentFinancialConnectionsSheet(
 
     STPAPIClient.shared.publishableKey = publishableKey
 
+    let isUITest = (ProcessInfo.processInfo.environment["UITesting"] != nil)
     let financialConnectionsSheet = FinancialConnectionsSheet(
         financialConnectionsSessionClientSecret: clientSecret,
-        returnURL: "financial-connections-example://redirect"
+        // disable app-to-app for UI tests
+        returnURL: isUITest ? nil : "financial-connections-example://redirect"
     )
     financialConnectionsSheet.onEvent = onEvent
     financialConnectionsSheet.present(

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
@@ -32,8 +32,7 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
     }
 
     private func executeNativeNetworkingTestModeSignUpFlowTest(emailAddress: String) {
-        let app = XCUIApplication()
-        app.launch()
+        let app = XCUIApplication.fc_launch()
 
         app.fc_playgroundCell.tap()
 
@@ -106,8 +105,7 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
     }
 
     private func executeNativeNetworkingTestModeSignInFlowTest(emailAddress: String) {
-        let app = XCUIApplication()
-        app.launch()
+        let app = XCUIApplication.fc_launch()
 
         app.fc_playgroundCell.tap()
 

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
@@ -26,8 +26,7 @@ final class FinancialConnectionsUITests: XCTestCase {
     }
 
     func testDataTestModeOAuthNativeAuthFlow() throws {
-        let app = XCUIApplication()
-        app.launch()
+        let app = XCUIApplication.fc_launch()
 
         app.fc_playgroundCell.tap()
         app.fc_playgroundDataFlowButton.tap()
@@ -55,8 +54,7 @@ final class FinancialConnectionsUITests: XCTestCase {
     }
 
     func testPaymentTestModeLegacyNativeAuthFlow() throws {
-        let app = XCUIApplication()
-        app.launch()
+        let app = XCUIApplication.fc_launch()
 
         app.fc_playgroundCell.tap()
         app.fc_playgroundPaymentFlowButton.tap()
@@ -87,8 +85,7 @@ final class FinancialConnectionsUITests: XCTestCase {
     }
 
     func testPaymentTestModeManualEntryNativeAuthFlow() throws {
-        let app = XCUIApplication()
-        app.launch()
+        let app = XCUIApplication.fc_launch()
 
         app.fc_playgroundCell.tap()
         app.fc_playgroundPaymentFlowButton.tap()
@@ -138,8 +135,7 @@ final class FinancialConnectionsUITests: XCTestCase {
     // note that this does NOT complete the Auth Flow, but its a decent check on
     // whether live mode is ~working
     func testDataLiveModeOAuthNativeAuthFlow() throws {
-        let app = XCUIApplication()
-        app.launch()
+        let app = XCUIApplication.fc_launch()
 
         app.fc_playgroundCell.tap()
         app.fc_playgroundDataFlowButton.tap()
@@ -236,8 +232,7 @@ final class FinancialConnectionsUITests: XCTestCase {
     // note that this does NOT complete the Auth Flow, but its a decent check on
     // whether live mode is ~working
     func testDataLiveModeOAuthWebAuthFlow() throws {
-        let app = XCUIApplication()
-        app.launch()
+        let app = XCUIApplication.fc_launch()
 
         app.fc_playgroundCell.tap()
         app.fc_playgroundDataFlowButton.tap()
@@ -335,8 +330,7 @@ final class FinancialConnectionsUITests: XCTestCase {
     }
 
     func testSearchInLiveModeNativeAuthFlow() throws {
-        let app = XCUIApplication()
-        app.launch()
+        let app = XCUIApplication.fc_launch()
 
         app.fc_playgroundCell.tap()
         app.fc_playgroundPaymentFlowButton.tap()

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
@@ -357,7 +357,23 @@ final class FinancialConnectionsUITests: XCTestCase {
         XCTAssertTrue(bankOfAmericaSearchRow.waitForExistence(timeout: 120.0))
         bankOfAmericaSearchRow.tap()
 
-        XCTAssert(app.fc_nativePrepaneContinueButton.exists) // check that prepane was opened
+        // ...at this point the bank is either:
+        // 1. active, which means prepane is visible
+        // 2. under maintenance, which means an 'error' screen is visible
+
+        // (1) bank is NOT under maintenance
+        if app.fc_nativePrepaneContinueButton_noWait.waitForExistence(timeout: 60) {
+            // do nothing...prepane is there
+        }
+        // (2) bank IS under maintenance
+        else {
+            // check that we see a maintenance error
+            let errorViewText = app
+                .textViews
+                .containing(NSPredicate(format: "label CONTAINS 'unavailable' OR label CONTAINS 'maintenance' OR label CONTAINS 'scheduled'"))
+                .firstMatch
+            XCTAssertTrue(errorViewText.waitForExistence(timeout: 10))
+        }
 
         let backButton = app.navigationBars["fc_navigation_bar"].buttons["Back"]
         XCTAssertTrue(backButton.waitForExistence(timeout: 60.0))

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIApplication+Extensions.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIApplication+Extensions.swift
@@ -10,6 +10,13 @@ import XCTest
 
 extension XCUIApplication {
 
+    static func fc_launch() -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchEnvironment = ["UITesting": "true"]
+        app.launch()
+        return app
+    }
+
     // MARK: - Example App Helpers
 
     var fc_playgroundCell: XCUIElement {
@@ -44,13 +51,13 @@ extension XCUIApplication {
 
     var fc_playgroundShowAuthFlowButton: XCUIElement {
         let showAuthFlowButton = buttons["Show Auth Flow"]
-        XCTAssertTrue(showAuthFlowButton.waitForExistence(timeout: 60.0), "\(#function) waiting failed")
+        XCTAssertTrue(showAuthFlowButton.waitForExistence(timeout: 60.0), "Failed to press Playground App show auth flow button - \(#function) waiting failed")
         return showAuthFlowButton
     }
 
     var fc_playgroundSuccessAlertView: XCUIElement {
         let playgroundSuccessAlertView = alerts["Success"]
-        XCTAssertTrue(playgroundSuccessAlertView.waitForExistence(timeout: 60.0), "\(#function) waiting failed")
+        XCTAssertTrue(playgroundSuccessAlertView.waitForExistence(timeout: 60.0), "Failed to show Playground App success alert - \(#function) waiting failed")
         return playgroundSuccessAlertView
     }
 
@@ -58,7 +65,7 @@ extension XCUIApplication {
 
     var fc_nativeConsentAgreeButton: XCUIElement {
         let consentAgreeButton = buttons["consent_agree_button"]
-        XCTAssertTrue(consentAgreeButton.waitForExistence(timeout: 120.0), "\(#function) waiting failed")  // glitch app can take time to lload
+        XCTAssertTrue(consentAgreeButton.waitForExistence(timeout: 120.0), "Failed to open Consent pane - \(#function) waiting failed")  // glitch app can take time to lload
         return consentAgreeButton
     }
 
@@ -69,19 +76,19 @@ extension XCUIApplication {
 
     var fc_nativePrepaneContinueButton: XCUIElement {
         let prepaneContinueButton = fc_nativePrepaneContinueButton_noWait
-        XCTAssertTrue(prepaneContinueButton.waitForExistence(timeout: 60.0), "\(#function) waiting failed")
+        XCTAssertTrue(prepaneContinueButton.waitForExistence(timeout: 60.0), "Failed to open Partner Auth Prepane - \(#function) waiting failed")
         return prepaneContinueButton
     }
 
     var fc_nativeAccountPickerLinkAccountsButton: XCUIElement {
         let accountPickerLinkAccountsButton = buttons["account_picker_link_accounts_button"]
-        XCTAssertTrue(accountPickerLinkAccountsButton.waitForExistence(timeout: 120.0), "\(#function) waiting failed")  // wait for accounts to fetch
+        XCTAssertTrue(accountPickerLinkAccountsButton.waitForExistence(timeout: 120.0), "Failed to open Account Picker pane - \(#function) waiting failed")  // wait for accounts to fetch
         return accountPickerLinkAccountsButton
     }
 
     var fc_nativeSuccessDoneButton: XCUIElement {
         let successDoneButton = buttons["success_done_button"]
-        XCTAssertTrue(successDoneButton.waitForExistence(timeout: 120.0), "\(#function) waiting failed")  // wait for accounts to link
+        XCTAssertTrue(successDoneButton.waitForExistence(timeout: 120.0), "Failed to open Success pane - \(#function) waiting failed")  // wait for accounts to link
         return successDoneButton
     }
 


### PR DESCRIPTION
## Summary

This PR modifies Financial Connections end to end tests to:
- account for an institution being in maintenance
- disable app to app for UI tests
- improve some XCAssert messaging for better debugging

## Testing

Run `bitrise run financial-connections-stability-tests`

Result:

```
FinancialConnectionsNetworkingUITests
    ✓ testNativeNetworkingTestMode (76.915 seconds)
FinancialConnectionsUITests
    ✓ testDataLiveModeOAuthNativeAuthFlow (31.186 seconds)
    ✓ testDataLiveModeOAuthWebAuthFlow (25.858 seconds)
    ✓ testDataTestModeOAuthNativeAuthFlow (22.535 seconds)
    ✓ testPaymentTestModeLegacyNativeAuthFlow (24.577 seconds)
    ✓ testPaymentTestModeManualEntryNativeAuthFlow (28.091 seconds)
    ✓ testSearchInLiveModeNativeAuthFlow (26.179 seconds)
```