### PR TITLE
Add expiration and name in `ScannedCard` behind experimental header

### DIFF
--- a/StripeCardScan/StripeCardScan/Source/CardScan/UI/CardScanSheet.swift
+++ b/StripeCardScan/StripeCardScan/Source/CardScan/UI/CardScanSheet.swift
@@ -79,7 +79,8 @@ extension CardScanSheet: SimpleScanDelegate {
         _ scanViewController: SimpleScanViewController,
         creditCard: CreditCard
     ) {
-        let scannedCard = ScannedCard(pan: creditCard.number)
+        let scannedCard = ScannedCard(scannedCard: creditCard)
+
         completion?(.completed(card: scannedCard))
     }
 }

--- a/StripeCardScan/StripeCardScan/Source/CardVerify/Card Image Verification/ScannedCard.swift
+++ b/StripeCardScan/StripeCardScan/Source/CardVerify/Card Image Verification/ScannedCard.swift
@@ -11,4 +11,30 @@ import Foundation
 /// the card image verification flow
 public struct ScannedCard: Equatable {
     public let pan: String
+    @_spi(STP) public let expiryMonth: String?
+    @_spi(STP) public let expiryYear: String?
+    @_spi(STP) public let name: String?
+
+    init(
+        pan: String,
+        expiryMonth: String? = nil,
+        expiryYear: String? = nil,
+        name: String? = nil
+    ) {
+        self.pan = pan
+        self.expiryMonth = expiryMonth
+        self.expiryYear = expiryYear
+        self.name = expiryYear
+    }
+}
+
+extension ScannedCard {
+    init(scannedCard: CreditCard) {
+        self.init(
+            pan: scannedCard.number,
+            expiryMonth: scannedCard.expiryMonth,
+            expiryYear: scannedCard.expiryYear,
+            name: scannedCard.name
+        )
+    }
 }

--- a/StripeCardScan/StripeCardScan/Source/CardVerify/VerifyCardAddViewController.swift
+++ b/StripeCardScan/StripeCardScan/Source/CardVerify/VerifyCardAddViewController.swift
@@ -170,7 +170,7 @@ class VerifyCardAddViewController: SimpleScanViewController {
             self.verifyDelegate?.verifyViewControllerDidFinish(
                 self,
                 verificationFramesData: verificationFramesData,
-                scannedCard: ScannedCard(pan: number)
+                scannedCard: ScannedCard(scannedCard: card)
             )
         }
     }

--- a/StripeCardScan/StripeCardScan/Source/CardVerify/VerifyCardViewController.swift
+++ b/StripeCardScan/StripeCardScan/Source/CardVerify/VerifyCardViewController.swift
@@ -217,7 +217,7 @@ class VerifyCardViewController: SimpleScanViewController {
             self.verifyDelegate?.verifyViewControllerDidFinish(
                 self,
                 verificationFramesData: verificationFramesData,
-                scannedCard: ScannedCard(pan: number)
+                scannedCard: ScannedCard(scannedCard: card)
             )
         }
     }


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
* Added `expiryMonth`, `expiryYear`, `name` in `ScannedCard` result behind `@_spi(STP)`. 
* Usage
 ``` 
@_spi(STP) import StripeCardScan  // <-- add @_spi(STP) to import to access expiration and name
import UIKit

class ViewController: UIViewController {
    @IBAction func openCardScanSheet() {
        let cardScanSheet = CardScanSheet()

        cardScanSheet.present(from: self) { [weak self] result in
            switch result {
            case .completed(let card):
                // scanned scan result 
                // card.name 
                // card.expiryMonth
                // card.expiryYear
                // card.name
            case .canceled:
                ...
            case .failed(let error):
                ...
            }
        }
    }
}

```
## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://github.com/stripe/stripe-ios/pull/2450
## Testing
<!-- How was the code tested? Be as specific as possible. -->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
