### PR TITLE
[Identity] Remove documentType from DocumentCaptureViewController and DocumentFileUploadViewController

### DIFF
--- a/StripeIdentity/StripeIdentity/Resources/Localizations/en.lproj/Localizable.strings
+++ b/StripeIdentity/StripeIdentity/Resources/Localizations/en.lproj/Localizable.strings
@@ -7,15 +7,8 @@
 /* Opens the app's settings in the Settings app */
 "App Settings" = "App Settings";
 
-/* Accessibility label when back driver's license photo has successfully uploaded */
-"Back driver's license photo successfully uploaded" = "Back driver's license photo successfully uploaded";
-
 /* Accessibility label when back identity card photo has successfully uploaded */
 "Back identity card photo successfully uploaded" = "Back identity card photo successfully uploaded";
-
-/* Description of back of driver's license image
-   Title of ID document scanning screen when scanning the back of a driver's license */
-"Back of driver's license" = "Back of driver's license";
 
 /* Description of back of identity card image
    Title of ID document scanning screen when scanning the back of an identity card */
@@ -46,21 +39,11 @@
 /* Message for invalid Date of birth field */
 "Date of birth does not look valid" = "Date of birth does not look valid";
 
-/* Instructional text for scanning back of a driver's license */
-"Flip your driver's license over to the other side" = "Flip your driver's license over to the other side";
-
 /* Instructional text for scanning back of a identity card */
 "Flip your identity card over to the other side" = "Flip your identity card over to the other side";
 
-/* Accessibility label when front driver's license photo has successfully uploaded */
-"Front driver's license photo successfully uploaded" = "Front driver's license photo successfully uploaded";
-
 /* Accessibility label when front identity card photo has successfully uploaded */
 "Front identity card photo successfully uploaded" = "Front identity card photo successfully uploaded";
-
-/* Description of front of driver's license image
-   Title of ID document scanning screen when scanning the front of a driver's license */
-"Front of driver's license" = "Front of driver's license";
 
 /* Description of front of identity card image
    Title of ID document scanning screen when scanning the front of an identity card */
@@ -81,9 +64,6 @@
 /* Back button title to go back to screen to select form of identification (driver's license, passport, etc) to verify someone's identity */
 "ID Type" = "ID Type";
 
-/* Description of passport image */
-"Image of passport" = "Image of passport";
-
 /* Label for the ID field to collect individual CPF for Brazilian ID */
 "Individual CPF" = "Individual CPF";
 
@@ -95,12 +75,6 @@
 
 /* Label for the ID field to collect NRIC or FIN for Singaporean ID */
 "NRIC or FIN" = "NRIC or FIN";
-
-/* Title of ID document scanning screen when scanning a passport */
-"Passport" = "Passport";
-
-/* Accessibility label when passport photo has successfully uploaded */
-"Passport photo successfully uploaded" = "Passport photo successfully uploaded";
 
 /* Label for the personal id number field in the hosted verification details collection form for countries without an exception */
 "Personal ID number" = "Personal ID number";
@@ -117,26 +91,14 @@
 /* When selected in an action sheet, opens the device's photo library */
 "Photo Library" = "Photo Library";
 
-/* Instructions for uploading images of passport */
-"Please upload an image of your passport" = "Please upload an image of your passport";
-
-/* Instructions for uploading images of drivers license */
-"Please upload images of the front and back of your driver's license" = "Please upload images of the front and back of your driver's license";
-
 /* Instructions for uploading images of identity card */
 "Please upload images of the front and back of your identity card" = "Please upload images of the front and back of your identity card";
-
-/* Instructional text for scanning front of a driver's license */
-"Position your driver's license in the center of the frame" = "Position your driver's license in the center of the frame";
 
 /* Instructional text for scanning selfies */
 "Position your face in the center of the frame." = "Position your face in the center of the frame.";
 
 /* Instructional text for scanning front of a identity card */
 "Position your identity card in the center of the frame" = "Position your identity card in the center of the frame";
-
-/* Instructional text for scanning a passport */
-"Position your passport in the center of the frame" = "Position your passport in the center of the frame";
 
 /* Button text displayed to the user to retake photo */
 "Retake Photos" = "Retake Photos";
@@ -156,20 +118,11 @@
 /* Help text for action sheet that presents ways to upload the front of an identity document image */
 "Select a location to upload the front of your identity document from" = "Select a location to upload the front of your identity document from";
 
-/* Accessibility label to select a photo of back of driver's license */
-"Select back driver's license photo" = "Select back driver's license photo";
-
 /* Accessibility label to select a photo of back of identity card */
 "Select back identity card photo" = "Select back identity card photo";
 
-/* Accessibility label to select a photo of front of driver's license */
-"Select front driver's license photo" = "Select front driver's license photo";
-
 /* Accessibility label to select a photo of front of identity card */
 "Select front identity card photo" = "Select front identity card photo";
-
-/* Accessibility label to select a photo of passport */
-"Select passport photo" = "Select passport photo";
 
 /* Accessibility label of captured selfie images
    Back button title for returning to the selfie screen */
@@ -209,20 +162,11 @@
 /* Title of document upload screen */
 "Upload your photo ID" = "Upload your photo ID";
 
-/* Accessibility label while photo of back of driver's license is uploading */
-"Uploading back driver's license photo" = "Uploading back driver's license photo";
-
 /* Accessibility label while photo of back of identity card is uploading */
 "Uploading back identity card photo" = "Uploading back identity card photo";
 
-/* Accessibility label while photo of front of driver's license is uploading */
-"Uploading front driver's license photo" = "Uploading front driver's license photo";
-
 /* Accessibility label while photo of front of identity card is uploading */
 "Uploading front identity card photo" = "Uploading front identity card photo";
-
-/* Accessibility label while photo of passport is uploading */
-"Uploading passport photo" = "Uploading passport photo";
 
 /* Displays in the navigation bar title of the Identity Verification Sheet */
 "Verify your identity" = "Verify your identity";

--- a/StripeIdentity/StripeIdentity/Source/Analytics/IdentityAnalyticsClient.swift
+++ b/StripeIdentity/StripeIdentity/Source/Analytics/IdentityAnalyticsClient.swift
@@ -194,9 +194,6 @@ final class IdentityAnalyticsClient {
     ) -> [String: Any] {
         var metadata: [String: Any] = [:]
 
-        if let idDocumentType = sheetController.collectedData.idDocumentType {
-            metadata["scan_type"] = idDocumentType.rawValue
-        }
         if let verificationPage = try? sheetController.verificationPageResponse?.get() {
             metadata["require_selfie"] = verificationPage.requirements.missing.contains(.face)
             metadata["from_fallback_url"] = verificationPage.unsupportedClient
@@ -290,12 +287,10 @@ final class IdentityAnalyticsClient {
         screenName: ScreenName,
         sheetController: VerificationSheetControllerProtocol
     ) {
-        var metadata: [String: Any] = [
+        let metadata: [String: Any] = [
             "screen_name": screenName.rawValue
         ]
-        if let idDocumentType = sheetController.collectedData.idDocumentType {
-            metadata["scan_type"] = idDocumentType.rawValue
-        }
+
         logAnalytic(.screenAppeared, metadata: metadata)
     }
 
@@ -307,9 +302,6 @@ final class IdentityAnalyticsClient {
         line: UInt = #line
     ) {
         var metadata: [String: Any] = [:]
-        if let idDocumentType = sheetController.collectedData.idDocumentType {
-            metadata["scan_type"] = idDocumentType.rawValue
-        }
         metadata["error"] = AnalyticsClientV2.serialize(
             error: error,
             filePath: filePath,
@@ -323,26 +315,19 @@ final class IdentityAnalyticsClient {
         sheetController: VerificationSheetControllerProtocol,
         isGranted: Bool?
     ) {
-        var metadata: [String: Any] = [:]
-        if let idDocumentType = sheetController.collectedData.idDocumentType {
-            metadata["scan_type"] = idDocumentType.rawValue
-        }
-
         let eventName: EventName =
             (isGranted == true) ? .cameraPermissionGranted : .cameraPermissionDenied
 
-        logAnalytic(eventName, metadata: metadata)
+        logAnalytic(eventName, metadata: [:])
     }
 
     /// Logs an event when document capture times out
     func logDocumentCaptureTimeout(
-        idDocumentType: DocumentType,
         documentSide: DocumentSide
     ) {
         logAnalytic(
             .documentCaptureTimeout,
             metadata: [
-                "scan_type": idDocumentType.rawValue,
                 "side": documentSide.rawValue,
             ]
         )
@@ -409,7 +394,6 @@ final class IdentityAnalyticsClient {
 
     /// Logs the time it takes to upload an image along with its file size and compression quality
     func logImageUpload(
-        idDocumentType: DocumentType?,
         timeToUpload: TimeInterval,
         compressionQuality: CGFloat,
         fileId: String,
@@ -417,16 +401,13 @@ final class IdentityAnalyticsClient {
         fileSizeBytes: Int
     ) {
         // NOTE: File size is logged in kB
-        var metadata: [String: Any] = [
+        let metadata: [String: Any] = [
             "value": timeToUpload.milliseconds,
             "id": fileId,
             "compression_quality": compressionQuality,
             "file_name": fileName,
             "file_size": fileSizeBytes / 1024,
         ]
-        if let idDocumentType = idDocumentType {
-            metadata["scan_type"] = idDocumentType.rawValue
-        }
 
         logAnalytic(.imageUpload, metadata: metadata)
     }

--- a/StripeIdentity/StripeIdentity/Source/Helpers/String+Localized.swift
+++ b/StripeIdentity/StripeIdentity/Source/Helpers/String+Localized.swift
@@ -178,4 +178,12 @@ extension String.Localized {
         )
     }
 
+    // MARK: - DocumentFileUpload
+    static var fileUploadInstructionText: String {
+        STPLocalizedString(
+            "Please upload images of the front and back of your identity card",
+            "Instructions for uploading images of identity card"
+        )
+    }
+
 }

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/ImageScanner/DocumentScanner/DocumentScanner.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/ImageScanner/DocumentScanner/DocumentScanner.swift
@@ -141,20 +141,16 @@ extension IDDetectorOutput.Classification {
     /// scanner's desired classification.
     ///
     /// - Parameters:
-    ///   - type: The desired document type
     ///   - side: The desired document side
     ///
     /// - Returns: True if this classification matches the desired classification.
     func matchesDocument(
-        type: DocumentType,
         side: DocumentSide
     ) -> Bool {
-        switch (type, side, self) {
-        case (.drivingLicense, .front, .idCardFront),
-            (.idCard, .front, .idCardFront),
-            (.drivingLicense, .back, .idCardBack),
-            (.idCard, .back, .idCardBack),
-            (.passport, _, .passport):
+        switch (side, self) {
+        case (.front, .idCardFront),
+            (.front, .passport),
+            (.back, .idCardBack):
             return true
         default:
             return false

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/ImageScanner/DocumentScanner/DocumentScannerOutput.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/ImageScanner/DocumentScanner/DocumentScannerOutput.swift
@@ -22,16 +22,14 @@ struct DocumentScannerOutput: Equatable {
     /// Determines if the document is high quality and matches the desired
     /// document type and side.
     /// - Parameters:
-    ///   - type: Type of the desired document
     ///   - side: Side of the desired document.
     func isHighQuality(
-        matchingDocumentType type: DocumentType,
         side: DocumentSide
     ) -> Bool {
         // Don't check barcode result as it would end up returning fast and collecting a blury image
         // that fails to decode on backend
         // TODO(ccen|IDPROD-4697): Implement better heuristic to decode the back of ID.
-        return idDetectorOutput.classification.matchesDocument(type: type, side: side)
+        return idDetectorOutput.classification.matchesDocument(side: side)
             && cameraProperties?.isAdjustingFocus != true
             && !motionBlur.hasMotionBlur
             && blurResult.isBlurry != true

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/ImageUploaders/IdentityImageUploader.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/ImageUploaders/IdentityImageUploader.swift
@@ -34,7 +34,6 @@ final class IdentityImageUploader {
 
     let apiClient: IdentityAPIClient
     let analyticsClient: IdentityAnalyticsClient
-    let idDocumentType: DocumentType?
 
     /// Worker queue to encode the image to jpeg
     let imageEncodingQueue = DispatchQueue(label: "com.stripe.identity.image-encoding")
@@ -42,13 +41,11 @@ final class IdentityImageUploader {
     init(
         configuration: Configuration,
         apiClient: IdentityAPIClient,
-        analyticsClient: IdentityAnalyticsClient,
-        idDocumentType: DocumentType?
+        analyticsClient: IdentityAnalyticsClient
     ) {
         self.configuration = configuration
         self.apiClient = apiClient
         self.analyticsClient = analyticsClient
-        self.idDocumentType = idDocumentType
     }
 
     func uploadLowAndHighResImages(
@@ -162,7 +159,6 @@ final class IdentityImageUploader {
                     case .success((let file, let metrics)) = result
                 {
                     self.analyticsClient.logImageUpload(
-                        idDocumentType: self.idDocumentType,
                         timeToUpload: metrics.timeToUpload,
                         compressionQuality: jpegCompressionQuality,
                         fileId: file.id,

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/VerificationSheetFlowController.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/VerificationSheetFlowController.swift
@@ -589,23 +589,12 @@ extension VerificationSheetFlowController: VerificationSheetFlowControllerProtoc
         staticContent: StripeAPI.VerificationPage,
         sheetController: VerificationSheetControllerProtocol
     ) -> UIViewController {
-        // Show error if we haven't collected document type
-        guard let documentType = sheetController.collectedData.idDocumentType else {
-            return ErrorViewController(
-                sheetController: sheetController,
-                error: .error(
-                    VerificationSheetFlowControllerError.missingRequiredInput([.idDocumentType])
-                )
-            )
-        }
-
         // reinitalize documentUploader with new idDocumentType each time
         let documentUploader = DocumentUploader(
             imageUploader: IdentityImageUploader(
                 configuration: .init(from: staticContent.documentCapture),
                 apiClient: sheetController.apiClient,
-                analyticsClient: sheetController.analyticsClient,
-                idDocumentType: documentType
+                analyticsClient: sheetController.analyticsClient
             )
         )
         self.documentUploader = documentUploader
@@ -616,7 +605,6 @@ extension VerificationSheetFlowController: VerificationSheetFlowControllerProtoc
 
             // Return document upload screen if we can't load models for auto-capture
             return DocumentFileUploadViewController(
-                documentType: documentType,
                 requireLiveCapture: staticContent.documentCapture.requireLiveCapture,
                 sheetController: sheetController,
                 documentUploader: documentUploader
@@ -625,7 +613,6 @@ extension VerificationSheetFlowController: VerificationSheetFlowControllerProtoc
         case .success(let anyDocumentScanner):
             return DocumentCaptureViewController(
                 apiConfig: staticContent.documentCapture,
-                documentType: documentType,
                 sheetController: sheetController,
                 cameraSession: makeDocumentCaptureCameraSession(),
                 documentUploader: documentUploader,
@@ -659,8 +646,7 @@ extension VerificationSheetFlowController: VerificationSheetFlowControllerProtoc
                     imageUploader: IdentityImageUploader(
                         configuration: .init(from: selfiePageConfig),
                         apiClient: sheetController.apiClient,
-                        analyticsClient: sheetController.analyticsClient,
-                        idDocumentType: nil
+                        analyticsClient: sheetController.analyticsClient
                     )
                 ),
                 anyFaceScanner: anyFaceScanner

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/DocumentCaptureViewController+Strings.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/DocumentCaptureViewController+Strings.swift
@@ -12,31 +12,15 @@ import Foundation
 extension DocumentCaptureViewController {
 
     func titleText(for side: DocumentSide) -> String {
-        switch (documentType, side) {
-        case (.drivingLicense, .front):
-            return STPLocalizedString(
-                "Front of driver's license",
-                "Title of ID document scanning screen when scanning the front of a driver's license"
-            )
-        case (.drivingLicense, .back):
-            return STPLocalizedString(
-                "Back of driver's license",
-                "Title of ID document scanning screen when scanning the back of a driver's license"
-            )
-        case (.idCard, .front):
+        if side == .front {
             return STPLocalizedString(
                 "Front of identity card",
                 "Title of ID document scanning screen when scanning the front of an identity card"
             )
-        case (.idCard, .back):
+        } else {
             return STPLocalizedString(
                 "Back of identity card",
                 "Title of ID document scanning screen when scanning the back of an identity card"
-            )
-        case (.passport, _):
-            return STPLocalizedString(
-                "Passport",
-                "Title of ID document scanning screen when scanning a passport"
             )
         }
     }
@@ -46,35 +30,19 @@ extension DocumentCaptureViewController {
         foundClassification: IDDetectorOutput.Classification?
     ) -> String {
         let matchesClassification =
-            foundClassification?.matchesDocument(type: documentType, side: side) ?? false
-
-        switch (documentType, side, matchesClassification) {
-        case (.drivingLicense, .front, false):
-            return STPLocalizedString(
-                "Position your driver's license in the center of the frame",
-                "Instructional text for scanning front of a driver's license"
-            )
-        case (.drivingLicense, .back, false):
-            return STPLocalizedString(
-                "Flip your driver's license over to the other side",
-                "Instructional text for scanning back of a driver's license"
-            )
-        case (.idCard, .front, false):
+        foundClassification?.matchesDocument(side: side) ?? false
+        switch (side, matchesClassification) {
+        case (.front, false):
             return STPLocalizedString(
                 "Position your identity card in the center of the frame",
                 "Instructional text for scanning front of a identity card"
             )
-        case (.idCard, .back, false):
+        case (.back, false):
             return STPLocalizedString(
                 "Flip your identity card over to the other side",
                 "Instructional text for scanning back of a identity card"
             )
-        case (.passport, _, false):
-            return STPLocalizedString(
-                "Position your passport in the center of the frame",
-                "Instructional text for scanning a passport"
-            )
-        case (_, _, true):
+        case (_, true):
             return STPLocalizedString(
                 "Hold still, scanning",
                 "Instructional text when camera is focusing on a document while scanning it"

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/DocumentFileUploadViewController+Strings.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/DocumentFileUploadViewController+Strings.swift
@@ -9,49 +9,14 @@
 import Foundation
 
 extension DocumentFileUploadViewController {
-    var instructionText: String {
-        switch documentType {
-        case .passport:
-            return STPLocalizedString(
-                "Please upload an image of your passport",
-                "Instructions for uploading images of passport"
-            )
-        case .drivingLicense:
-            return STPLocalizedString(
-                "Please upload images of the front and back of your driver's license",
-                "Instructions for uploading images of drivers license"
-            )
-        case .idCard:
-            return STPLocalizedString(
-                "Please upload images of the front and back of your identity card",
-                "Instructions for uploading images of identity card"
-            )
-        }
-    }
-
     func listItemText(for side: DocumentSide) -> String {
-        switch (documentType, side) {
-        case (.passport, _):
-            return STPLocalizedString(
-                "Image of passport",
-                "Description of passport image"
-            )
-        case (.drivingLicense, .front):
-            return STPLocalizedString(
-                "Front of driver's license",
-                "Description of front of driver's license image"
-            )
-        case (.drivingLicense, .back):
-            return STPLocalizedString(
-                "Back of driver's license",
-                "Description of back of driver's license image"
-            )
-        case (.idCard, .front):
+        switch side {
+        case .front:
             return STPLocalizedString(
                 "Front of identity card",
                 "Description of front of identity card image"
             )
-        case (.idCard, .back):
+        case .back:
             return STPLocalizedString(
                 "Back of identity card",
                 "Description of back of identity card image"
@@ -75,28 +40,13 @@ extension DocumentFileUploadViewController {
     }
 
     func selectAccessibilityLabel(for side: DocumentSide) -> String {
-        switch (documentType, side) {
-        case (.passport, _):
-            return STPLocalizedString(
-                "Select passport photo",
-                "Accessibility label to select a photo of passport"
-            )
-        case (.drivingLicense, .front):
-            return STPLocalizedString(
-                "Select front driver's license photo",
-                "Accessibility label to select a photo of front of driver's license"
-            )
-        case (.drivingLicense, .back):
-            return STPLocalizedString(
-                "Select back driver's license photo",
-                "Accessibility label to select a photo of back of driver's license"
-            )
-        case (.idCard, .front):
+        switch side {
+        case .front:
             return STPLocalizedString(
                 "Select front identity card photo",
                 "Accessibility label to select a photo of front of identity card"
             )
-        case (.idCard, .back):
+        case .back:
             return STPLocalizedString(
                 "Select back identity card photo",
                 "Accessibility label to select a photo of back of identity card"
@@ -105,28 +55,13 @@ extension DocumentFileUploadViewController {
     }
 
     func uploadingAccessibilityLabel(for side: DocumentSide) -> String {
-        switch (documentType, side) {
-        case (.passport, _):
-            return STPLocalizedString(
-                "Uploading passport photo",
-                "Accessibility label while photo of passport is uploading"
-            )
-        case (.drivingLicense, .front):
-            return STPLocalizedString(
-                "Uploading front driver's license photo",
-                "Accessibility label while photo of front of driver's license is uploading"
-            )
-        case (.drivingLicense, .back):
-            return STPLocalizedString(
-                "Uploading back driver's license photo",
-                "Accessibility label while photo of back of driver's license is uploading"
-            )
-        case (.idCard, .front):
+        switch side {
+        case .front:
             return STPLocalizedString(
                 "Uploading front identity card photo",
                 "Accessibility label while photo of front of identity card is uploading"
             )
-        case (.idCard, .back):
+        case .back:
             return STPLocalizedString(
                 "Uploading back identity card photo",
                 "Accessibility label while photo of back of identity card is uploading"
@@ -135,28 +70,13 @@ extension DocumentFileUploadViewController {
     }
 
     func uploadCompleteAccessibilityLabel(for side: DocumentSide) -> String {
-        switch (documentType, side) {
-        case (.passport, _):
-            return STPLocalizedString(
-                "Passport photo successfully uploaded",
-                "Accessibility label when passport photo has successfully uploaded"
-            )
-        case (.drivingLicense, .front):
-            return STPLocalizedString(
-                "Front driver's license photo successfully uploaded",
-                "Accessibility label when front driver's license photo has successfully uploaded"
-            )
-        case (.drivingLicense, .back):
-            return STPLocalizedString(
-                "Back driver's license photo successfully uploaded",
-                "Accessibility label when back driver's license photo has successfully uploaded"
-            )
-        case (.idCard, .front):
+        switch side {
+        case .front:
             return STPLocalizedString(
                 "Front identity card photo successfully uploaded",
                 "Accessibility label when front identity card photo has successfully uploaded"
             )
-        case (.idCard, .back):
+        case .back:
             return STPLocalizedString(
                 "Back identity card photo successfully uploaded",
                 "Accessibility label when back identity card photo has successfully uploaded"

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/DocumentFileUploadViewController.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/DocumentFileUploadViewController.swift
@@ -40,9 +40,6 @@ final class DocumentFileUploadViewController: IdentityFlowViewController {
 
     let instructionListView = InstructionListView()
 
-    /// The document type selected by the user
-    let documentType: DocumentType
-
     /// If the image must come from a live camera feed
     let requireLiveCapture: Bool
 
@@ -96,8 +93,7 @@ final class DocumentFileUploadViewController: IdentityFlowViewController {
                 onTap: nil
             ),
         ]
-
-        if documentType.hasBack && sheetController?.collectedData.idDocumentFront != nil {
+        if sheetController?.collectedData.idDocumentFront != nil {
             items.append(
                 .init(
                     text: listItemText(for: .back),
@@ -115,7 +111,7 @@ final class DocumentFileUploadViewController: IdentityFlowViewController {
             )
         }
 
-        return .init(instructionText: instructionText, listViewModel: .init(items: items))
+        return .init(instructionText: String.Localized.fileUploadInstructionText, listViewModel: .init(items: items))
     }
 
     var buttonState: IdentityFlowView.ViewModel.Button.State {
@@ -132,7 +128,6 @@ final class DocumentFileUploadViewController: IdentityFlowViewController {
     // MARK: - Init
 
     init(
-        documentType: DocumentType,
         requireLiveCapture: Bool,
         sheetController: VerificationSheetControllerProtocol,
         documentUploader: DocumentUploaderProtocol,
@@ -140,7 +135,6 @@ final class DocumentFileUploadViewController: IdentityFlowViewController {
             .shared,
         appSettingsHelper: AppSettingsHelperProtocol = AppSettingsHelper.shared
     ) {
-        self.documentType = documentType
         self.requireLiveCapture = requireLiveCapture
         self.documentUploader = documentUploader
         self.cameraPermissionsManager = cameraPermissionsManager

--- a/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/Coordinators/DocumentUploaderTest.swift
+++ b/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/Coordinators/DocumentUploaderTest.swift
@@ -99,8 +99,7 @@ final class DocumentUploaderTest: XCTestCase {
             imageUploader: IdentityImageUploader(
                 configuration: mockConfig,
                 apiClient: mockAPIClient,
-                analyticsClient: .init(verificationSessionId: ""),
-                idDocumentType: .passport
+                analyticsClient: .init(verificationSessionId: "")
             )
         )
         mockDelegate = MockDocumentUploaderDelegate()

--- a/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/Coordinators/IdentityImageUploaderTest.swift
+++ b/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/Coordinators/IdentityImageUploaderTest.swift
@@ -44,8 +44,7 @@ final class IdentityImageUploaderTest: XCTestCase {
             analyticsClient: IdentityAnalyticsClient(
                 verificationSessionId: "",
                 analyticsClient: mockAnalyticsClient
-            ),
-            idDocumentType: .passport
+            )
         )
     }
 
@@ -157,7 +156,6 @@ final class IdentityImageUploaderTest: XCTestCase {
             hasMetadata: "compression_quality",
             withValue: CGFloat(0.9)
         )
-        XCTAssert(analytic: uploadAnalytic, hasMetadata: "scan_type", withValue: "passport")
         XCTAssert(analytic: uploadAnalytic, hasMetadata: "id", withValue: "file_id")
         XCTAssert(analytic: uploadAnalytic, hasMetadata: "file_name", withValue: "mock_file_name")
         XCTAssert(analytic: uploadAnalytic, hasMetadata: "file_size", withValue: 2)

--- a/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/ViewControllers/DocumentCaptureViewControllerTest.swift
+++ b/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/ViewControllers/DocumentCaptureViewControllerTest.swift
@@ -72,7 +72,7 @@ final class DocumentCaptureViewControllerTest: XCTestCase {
     }
 
     func testTransitionFromInitialCardFront() {
-        let vc = makeViewController(state: .initial, documentType: .idCard)
+        let vc = makeViewController(state: .initial)
         // Mock that view appeared
         vc.viewWillAppear(false)
         // Verify camera access requested
@@ -91,8 +91,7 @@ final class DocumentCaptureViewControllerTest: XCTestCase {
 
     func testTransitionFromScanningCardFront() {
         let vc = makeViewController(
-            state: .scanning(.front, nil),
-            documentType: .idCard
+            state: .scanning(.front, nil)
         )
         let mockDocumentScannerOutput = makeDocumentScannerOutput(with: .idCardFront)
         // Mock timer so we can verify it was invalidated
@@ -121,8 +120,7 @@ final class DocumentCaptureViewControllerTest: XCTestCase {
 
     func testTransitionFromScannedCardFront() {
         let vc = makeViewController(
-            state: .scanned(.front, UIImage()),
-            documentType: .idCard
+            state: .scanned(.front, UIImage())
         )
         vc.buttonViewModels.first!.didTap()
         // Verify state is scanning
@@ -136,7 +134,7 @@ final class DocumentCaptureViewControllerTest: XCTestCase {
     }
 
     func testTransitionFromTimeoutCardFront() {
-        let vc = makeViewController(state: .timeout(.front), documentType: .idCard)
+        let vc = makeViewController(state: .timeout(.front))
         vc.buttonViewModels.last!.didTap()
         // Verify camera session started
         waitForCameraSessionToStart()
@@ -149,8 +147,7 @@ final class DocumentCaptureViewControllerTest: XCTestCase {
 
     func testTransitionFromScanningCardBack() {
         let vc = makeViewController(
-            state: .scanning(.back, nil),
-            documentType: .idCard
+            state: .scanning(.back, nil)
         )
         let mockDocumentScannerOutput = makeDocumentScannerOutput(with: .idCardBack)
         // Mock timer so we can verify it was invalidated
@@ -179,8 +176,7 @@ final class DocumentCaptureViewControllerTest: XCTestCase {
 
     func testTransitionFromScannedCardBack() {
         let vc = makeViewController(
-            state: .scanned(.back, UIImage()),
-            documentType: .idCard
+            state: .scanned(.back, UIImage())
         )
         vc.buttonViewModels.first!.didTap()
         verify(
@@ -193,7 +189,7 @@ final class DocumentCaptureViewControllerTest: XCTestCase {
     }
 
     func testTransitionFromTimeoutCardBack() {
-        let vc = makeViewController(state: .timeout(.back), documentType: .idCard)
+        let vc = makeViewController(state: .timeout(.back))
         vc.buttonViewModels.last!.didTap()
         waitForCameraSessionToStart()
         verify(
@@ -204,7 +200,7 @@ final class DocumentCaptureViewControllerTest: XCTestCase {
     }
 
     func testTransitionFromInitialPassport() {
-        let vc = makeViewController(state: .initial, documentType: .passport)
+        let vc = makeViewController(state: .initial)
         vc.buttonViewModels.first!.didTap()
         // Mock that view appeared
         vc.viewWillAppear(false)
@@ -224,8 +220,7 @@ final class DocumentCaptureViewControllerTest: XCTestCase {
 
     func testTransitionFromScanningPassport() {
         let vc = makeViewController(
-            state: .scanning(.front, nil),
-            documentType: .passport
+            state: .scanning(.front, nil)
         )
         let mockDocumentScannerOutput = makeDocumentScannerOutput(with: .passport)
         // Mock timer so we can verify it was invalidated
@@ -254,8 +249,7 @@ final class DocumentCaptureViewControllerTest: XCTestCase {
 
     func testTransitionFromScannedPassport() {
         let vc = makeViewController(
-            state: .scanned(.front, UIImage()),
-            documentType: .passport
+            state: .scanned(.front, UIImage())
         )
         vc.buttonViewModels.first!.didTap()
         verify(
@@ -268,7 +262,7 @@ final class DocumentCaptureViewControllerTest: XCTestCase {
     }
 
     func testTransitionFromTimeoutPassport() {
-        let vc = makeViewController(state: .timeout(.front), documentType: .passport)
+        let vc = makeViewController(state: .timeout(.front))
         vc.buttonViewModels.last!.didTap()
         waitForCameraSessionToStart()
         verify(
@@ -281,8 +275,7 @@ final class DocumentCaptureViewControllerTest: XCTestCase {
     func testResetTimeoutDuringScanning() {
         // Mock that existing sacnningState already found a desired classification
         let vc = makeViewController(
-            state: .scanning(.front, .passport),
-            documentType: .passport
+            state: .scanning(.front, .passport)
         )
 
         // Mock that scanner found non-desired classification
@@ -347,7 +340,7 @@ final class DocumentCaptureViewControllerTest: XCTestCase {
         // Mock collected data for analytics
         mockSheetController.collectedData = VerificationPageDataUpdateMock.default.collectedData!
 
-        let vc = makeViewController(state: .initial, documentType: .idCard)
+        let vc = makeViewController(state: .initial)
         // Mock that view appeared
         vc.viewWillAppear(false)
         // Deny access
@@ -358,11 +351,6 @@ final class DocumentCaptureViewControllerTest: XCTestCase {
             expectedState: .noCameraAccess,
             expectedButtonState: .enabled
         )
-        // Verify analytics
-        let analytic = mockAnalyticsClient.loggedAnalyticPayloads(
-            withEventName: "camera_permission_denied"
-        ).first
-        XCTAssert(analytic: analytic, hasMetadata: "scan_type", withValue: "driving_license")
         XCTAssertEqual(
             mockAnalyticsClient.loggedAnalyticPayloads(withEventName: "camera_permission_granted")
                 .count,
@@ -374,7 +362,7 @@ final class DocumentCaptureViewControllerTest: XCTestCase {
         // Mock collected data for analytics
         mockSheetController.collectedData = VerificationPageDataUpdateMock.default.collectedData!
 
-        let vc = makeViewController(state: .initial, documentType: .drivingLicense)
+        let vc = makeViewController(state: .initial)
         // Mock that view appeared
         vc.viewWillAppear(false)
 
@@ -392,7 +380,6 @@ final class DocumentCaptureViewControllerTest: XCTestCase {
         // Verify analytics
         let analytic = mockAnalyticsClient.loggedAnalyticPayloads(withEventName: "camera_error")
             .first
-        XCTAssert(analytic: analytic, hasMetadata: "scan_type", withValue: "driving_license")
         XCTAssert(
             analytic: analytic,
             hasMetadataError: "error",
@@ -406,17 +393,13 @@ final class DocumentCaptureViewControllerTest: XCTestCase {
         // Mock collected data for analytics
         mockSheetController.collectedData = VerificationPageDataUpdateMock.default.collectedData!
 
-        let vc = makeViewController(state: .initial, documentType: .idCard)
+        let vc = makeViewController(state: .initial)
         // Mock that view appeared
         vc.viewWillAppear(false)
         // Grant access
         grantCameraAccess(granted: true)
 
         // Verify analytics
-        let analytic = mockAnalyticsClient.loggedAnalyticPayloads(
-            withEventName: "camera_permission_granted"
-        ).first
-        XCTAssert(analytic: analytic, hasMetadata: "scan_type", withValue: "driving_license")
         XCTAssertEqual(
             mockAnalyticsClient.loggedAnalyticPayloads(withEventName: "camera_permission_denied")
                 .count,
@@ -425,7 +408,7 @@ final class DocumentCaptureViewControllerTest: XCTestCase {
     }
 
     func testSettingsButton() {
-        let vc = makeViewController(state: .noCameraAccess, documentType: .idCard)
+        let vc = makeViewController(state: .noCameraAccess)
         vc.buttonViewModels.last!.didTap()
         // Should open settings
         XCTAssertTrue(mockAppSettingsHelper.didOpenAppSettings)
@@ -438,7 +421,7 @@ final class DocumentCaptureViewControllerTest: XCTestCase {
     }
 
     func testFileUploadButtonCameraAccess() {
-        let vc = makeViewController(state: .noCameraAccess, documentType: .idCard)
+        let vc = makeViewController(state: .noCameraAccess)
         vc.buttonViewModels.first!.didTap()
         // Should open File Upload screen
         XCTAssertIs(
@@ -448,7 +431,7 @@ final class DocumentCaptureViewControllerTest: XCTestCase {
     }
 
     func testFileUploadButtonTimeout() {
-        let vc = makeViewController(state: .timeout(.front), documentType: .idCard)
+        let vc = makeViewController(state: .timeout(.front))
         vc.buttonViewModels.first!.didTap()
         // Should open File Upload screen
         XCTAssertIs(
@@ -463,7 +446,6 @@ final class DocumentCaptureViewControllerTest: XCTestCase {
         let mockResponse = try VerificationPageMock.requireLiveCapture.make()
         let vc = makeViewController(
             state: .noCameraAccess,
-            documentType: .idCard,
             apiConfig: mockResponse.documentCapture
         )
         XCTAssertEqual(vc.buttonViewModels.count, 1)
@@ -475,7 +457,6 @@ final class DocumentCaptureViewControllerTest: XCTestCase {
         let mockResponse = try VerificationPageMock.response200.make()
         let vc = makeViewController(
             state: .noCameraAccess,
-            documentType: .idCard,
             apiConfig: mockResponse.documentCapture
         )
         XCTAssertEqual(vc.buttonViewModels.count, 2)
@@ -486,8 +467,7 @@ final class DocumentCaptureViewControllerTest: XCTestCase {
         mockSheetController.collectedData = VerificationPageDataUpdateMock.default.collectedData!
 
         let vc = makeViewController(
-            state: .scanning(.front, nil),
-            documentType: .drivingLicense
+            state: .scanning(.front, nil)
         )
         let startedScanningDate = Date()
         // Mock that scanner is scanning
@@ -522,14 +502,12 @@ final class DocumentCaptureViewControllerTest: XCTestCase {
         // Verify analytic logged
         let analytic = mockAnalyticsClient.loggedAnalyticPayloads(withEventName: "document_timeout")
             .first
-        XCTAssert(analytic: analytic, hasMetadata: "scan_type", withValue: "driving_license")
         XCTAssert(analytic: analytic, hasMetadata: "side", withValue: "front")
     }
 
     func testScanAttemptsFront() {
         let vc = makeViewController(
-            state: .scanning(.front, nil),
-            documentType: .drivingLicense
+            state: .scanning(.front, nil)
         )
         // Mock that scanner is scanning
         vc.imageScanningSession.startScanning(expectedClassification: .front)
@@ -554,8 +532,7 @@ final class DocumentCaptureViewControllerTest: XCTestCase {
 
     func testScanningUpdatesState() {
         let vc = makeViewController(
-            state: .scanning(.front, nil),
-            documentType: .idCard
+            state: .scanning(.front, nil)
         )
         // Mock that scanner is scanning
         vc.imageScanningSession.startScanning(expectedClassification: .front)
@@ -569,9 +546,6 @@ final class DocumentCaptureViewControllerTest: XCTestCase {
 
         mockConcurrencyManager.respondToScan(output: makeDocumentScannerOutput(with: .idCardBack))
         XCTAssertStateEqual(vc.imageScanningSession.state, .scanning(.front, .idCardBack))
-
-        mockConcurrencyManager.respondToScan(output: makeDocumentScannerOutput(with: .passport))
-        XCTAssertStateEqual(vc.imageScanningSession.state, .scanning(.front, .passport))
 
         mockConcurrencyManager.respondToScan(output: nil)
         XCTAssertStateEqual(vc.imageScanningSession.state, .scanning(.front, nil))
@@ -590,8 +564,7 @@ final class DocumentCaptureViewControllerTest: XCTestCase {
     func testAppBackgrounded() {
         // Mock that vc is scanning
         let vc = makeViewController(
-            state: .scanning(.front, nil),
-            documentType: .idCard
+            state: .scanning(.front, nil)
         )
         vc.imageScanningSession.startScanning(expectedClassification: .front)
         waitForCameraSessionToStart()
@@ -608,8 +581,7 @@ final class DocumentCaptureViewControllerTest: XCTestCase {
     func testAppForegrounded() {
         // Mock that vc is in background
         let vc = makeViewController(
-            state: .scanning(.front, nil),
-            documentType: .idCard
+            state: .scanning(.front, nil)
         )
         vc.imageScanningSession.appDidEnterBackground()
 
@@ -623,8 +595,7 @@ final class DocumentCaptureViewControllerTest: XCTestCase {
     func testResetFromScanned() {
         // Mock that vc is done scanning
         let vc = makeViewController(
-            state: .scanned(.back, UIImage()),
-            documentType: .drivingLicense
+            state: .scanned(.back, UIImage())
         )
 
         // Reset
@@ -638,8 +609,7 @@ final class DocumentCaptureViewControllerTest: XCTestCase {
     func testResetFromScanning() {
         // Mock that vc is scanning
         let vc = makeViewController(
-            state: .scanning(.front, nil),
-            documentType: .idCard
+            state: .scanning(.front, nil)
         )
         vc.imageScanningSession.startScanning(expectedClassification: .front)
         waitForCameraSessionToStart()
@@ -669,8 +639,7 @@ final class DocumentCaptureViewControllerTest: XCTestCase {
 
         // Mock that vc is scanning
         let vc = makeViewController(
-            state: .scanning(.front, nil),
-            documentType: .idCard
+            state: .scanning(.front, nil)
         )
         vc.imageScanningSession.startScanning(expectedClassification: .front)
         waitForCameraSessionToStart()
@@ -763,7 +732,6 @@ extension DocumentCaptureViewControllerTest {
     ) -> DocumentCaptureViewController {
         return .init(
             apiConfig: DocumentCaptureViewControllerTest.mockVerificationPage.documentCapture,
-            documentType: documentType,
             sheetController: mockSheetController,
             cameraSession: mockCameraSession,
             cameraPermissionsManager: mockCameraPermissionsManager,
@@ -776,13 +744,11 @@ extension DocumentCaptureViewControllerTest {
 
     fileprivate func makeViewController(
         state: DocumentCaptureViewController.State,
-        documentType: DocumentType,
         apiConfig: StripeAPI.VerificationPageStaticContentDocumentCapturePage =
             DocumentCaptureViewControllerTest.mockVerificationPage.documentCapture
     ) -> DocumentCaptureViewController {
         return .init(
             apiConfig: apiConfig,
-            documentType: documentType,
             initialState: state,
             sheetController: mockSheetController,
             cameraSession: mockCameraSession,

--- a/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/ViewControllers/DocumentFileUploadViewControllerTest.swift
+++ b/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/ViewControllers/DocumentFileUploadViewControllerTest.swift
@@ -34,35 +34,8 @@ final class DocumentFileUploadViewControllerTest: XCTestCase {
         mockSheetController = .init()
     }
 
-    func testDrivingLicenseFront() {
-        let vc = makeViewController(documentType: .drivingLicense)
-        // Allows front
-        XCTAssertEqual(vc.viewModel.listViewModel?.items.count, 1)
-        XCTAssertEqual(vc.viewModel.listViewModel?.items[0].text, "Front of driver's license")
-    }
-
-    func testDrivingLicenseBack() {
-        // Mock front collected
-        mockSheetController.collectedData.merge(
-            VerificationPageDataUpdateMock.frontOnly.collectedData!
-        )
-
-        let vc = makeViewController(documentType: .drivingLicense)
-        // Allows front and back
-        XCTAssertEqual(vc.viewModel.listViewModel?.items.count, 2)
-        XCTAssertEqual(vc.viewModel.listViewModel?.items[0].text, "Front of driver's license")
-        XCTAssertEqual(vc.viewModel.listViewModel?.items[1].text, "Back of driver's license")
-
-        // Verify button is only enabled after both front and back images are uploaded
-        XCTAssertEqual(vc.buttonState, .disabled)
-        mockDocumentUploader.backUploadStatus = .complete
-        XCTAssertEqual(vc.buttonState, .disabled)
-        mockDocumentUploader.frontUploadStatus = .complete
-        XCTAssertEqual(vc.buttonState, .disabled)
-    }
-
     func testIdCardFront() {
-        let vc = makeViewController(documentType: .idCard)
+        let vc = makeViewController()
         // Allows front
         XCTAssertEqual(vc.viewModel.listViewModel?.items.count, 1)
         XCTAssertEqual(vc.viewModel.listViewModel?.items[0].text, "Front of identity card")
@@ -74,7 +47,7 @@ final class DocumentFileUploadViewControllerTest: XCTestCase {
             VerificationPageDataUpdateMock.frontOnly.collectedData!
         )
 
-        let vc = makeViewController(documentType: .idCard)
+        let vc = makeViewController()
         // Allows front and back
         XCTAssertEqual(vc.viewModel.listViewModel?.items.count, 2)
         XCTAssertEqual(vc.viewModel.listViewModel?.items[0].text, "Front of identity card")
@@ -88,19 +61,8 @@ final class DocumentFileUploadViewControllerTest: XCTestCase {
         XCTAssertEqual(vc.buttonState, .disabled)
     }
 
-    func testPassport() {
-        let vc = makeViewController(documentType: .passport)
-        // Allows only front upload
-        XCTAssertEqual(vc.viewModel.listViewModel?.items[0].text, "Image of passport")
-
-        // Verify button is enabled after front image is uploaded
-        XCTAssertEqual(vc.buttonState, .disabled)
-        mockDocumentUploader.frontUploadStatus = .complete
-        XCTAssertEqual(vc.buttonState, .disabled)
-    }
-
     func testAlertNoRequireLiveCapture() {
-        let vc = makeViewController(documentType: .passport, requireLiveCapture: false)
+        let vc = makeViewController(requireLiveCapture: false)
         vc.didTapSelect(for: .front)
         guard let alert = vc.test_presentedViewController as? UIAlertController else {
             return XCTFail("Expected UIAlertController")
@@ -111,7 +73,7 @@ final class DocumentFileUploadViewControllerTest: XCTestCase {
     }
 
     func testSelectPhotoFromLibrary() {
-        let vc = makeViewController(documentType: .drivingLicense)
+        let vc = makeViewController()
         // Mock that user selected to upload front of document
         vc.didTapSelect(for: .front)
         // Mock that user chooses to Photo Library
@@ -137,7 +99,7 @@ final class DocumentFileUploadViewControllerTest: XCTestCase {
         // for camera use. So this will only test that camera access is
         // requested.
 
-        let vc = makeViewController(documentType: .idCard)
+        let vc = makeViewController()
         // Mock that user selected to upload front of document
         vc.didTapSelect(for: .back)
         // Mock that user chooses to Take Photo
@@ -156,7 +118,7 @@ final class DocumentFileUploadViewControllerTest: XCTestCase {
     }
 
     func testSelectFileFromSystem() {
-        let vc = makeViewController(documentType: .passport)
+        let vc = makeViewController()
         // Mock that user selected to upload front of document
         vc.didTapSelect(for: .front)
         // Mock that user chooses to Select File
@@ -175,7 +137,7 @@ final class DocumentFileUploadViewControllerTest: XCTestCase {
     }
 
     func testContinueButton() {
-        let vc = makeViewController(documentType: .drivingLicense)
+        let vc = makeViewController()
 
         let frontFileData = (VerificationPageDataUpdateMock.default.collectedData?.idDocumentFront)!
         let backFileData = (VerificationPageDataUpdateMock.default.collectedData?.idDocumentBack)!
@@ -202,11 +164,9 @@ final class DocumentFileUploadViewControllerTest: XCTestCase {
 
 extension DocumentFileUploadViewControllerTest {
     fileprivate func makeViewController(
-        documentType: DocumentType,
         requireLiveCapture: Bool = false
     ) -> DocumentFileUploadViewController {
         return .init(
-            documentType: documentType,
             requireLiveCapture: requireLiveCapture,
             sheetController: mockSheetController,
             documentUploader: mockDocumentUploader,


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
`documentType`(possible value `id_number`, `driver_license` and `passport) was used in `DocumentCaptureViewController` and `DocumentFileUploadViewController` to drive the UX and instructions, this change removes `documentType` from the two controllers and always use the same UX for all types. 

This change is also a prerequisite for Butter M1 to remove the [document type selector](https://docs.google.com/document/d/1m74HPjVrhHnuRdl8sda1wjRpj33ULyFoupk4xPibx7s/edit#bookmark=id.ue2ldjf8xkrc).


## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
See more details in this internal doc: [Butter M1](https://docs.google.com/document/d/1m74HPjVrhHnuRdl8sda1wjRpj33ULyFoupk4xPibx7s)

## Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] unit test
- [x] manually verified


## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
