### PR TITLE
Fixed localizedDescription for PaymentSheetError.

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetError.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetError.swift
@@ -14,7 +14,7 @@ import StripePayments
 ///
 /// Most errors do not originate from PaymentSheet itself; instead, they come from the Stripe API
 /// or other SDK components like STPPaymentHandler, PassKit (Apple Pay), etc.
-public enum PaymentSheetError: Error {
+public enum PaymentSheetError: Error, LocalizedError {
 
     /// An unknown error.
     case unknown(debugDescription: String)
@@ -53,8 +53,7 @@ public enum PaymentSheetError: Error {
     case failedToCreateLinkSession
     case linkNotAuthorized
 
-    /// Localized description of the error
-    public var localizedDescription: String {
+    public var errorDescription: String? {
         return NSError.stp_unexpectedErrorMessage()
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetErrorTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetErrorTest.swift
@@ -1,0 +1,18 @@
+//
+//  PaymentSheetErrorTest.swift
+//  StripePaymentSheetTests
+//
+//  Created by Chris Mays on 11/2/23.
+//
+
+@testable@_spi(STP) import StripeCore
+@testable import StripePaymentSheet
+import XCTest
+
+final class PaymentSheetErrorTest: XCTestCase {
+    func testLocalizedDescription() throws {
+        // Upcasting to Error to ensure localizedDescription is implemented properly.
+        // Context: https://github.com/stripe/stripe-ios/pull/3038
+        XCTAssertEqual((PaymentSheetError.accountLinkFailure as Error).localizedDescription, NSError.stp_unexpectedErrorMessage())
+    }
+}


### PR DESCRIPTION
## Summary
PaymentSheetError was overriding localizedDescription directly which doesn't work when the PaymentSheetError is upcasted to Error. This PR implements the LocalizedError protocol which will make localizedDescription accurate and implements a test to ensure that.

## Test Plan
### Before
<img width="297" alt="Screenshot 2023-11-02 at 10 40 03 AM" src="https://github.com/stripe/stripe-ios/assets/108435196/ea83746d-f986-4c4b-9db5-e555644044dd">

### After
![Simulator Screenshot - iPhone 15 Pro - 2023-11-02 at 10 38 50](https://github.com/stripe/stripe-ios/assets/108435196/acbd5685-47a3-4ddf-8907-119d811a813c)
