### PR TITLE
Move v1/elements/sessions response fields from STPPaymentIntent to STPElementsSession

### DIFF
--- a/Stripe/StripeiOSTests/STPAnalyticsClientPaymentSheetTest.swift
+++ b/Stripe/StripeiOSTests/STPAnalyticsClientPaymentSheetTest.swift
@@ -13,6 +13,7 @@ import XCTest
 @testable@_spi(STP) import StripeCore
 @testable@_spi(STP) import StripePayments
 @testable@_spi(STP) import StripePaymentSheet
+@_spi(STP)@testable import StripePaymentsTestUtils
 
 class STPAnalyticsClientPaymentSheetTest: XCTestCase {
     private var client: STPAnalyticsClient!
@@ -95,7 +96,7 @@ class STPAnalyticsClientPaymentSheetTest: XCTestCase {
         XCTAssertTrue(client.productUsage.contains("PaymentSheet"))
 
         _ = PaymentSheet.FlowController(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: .paymentIntent(elementsSession: .makeBackupElementsSession(with: STPFixtures.paymentIntent()), paymentIntent: STPFixtures.paymentIntent()),
             savedPaymentMethods: [],
             isLinkEnabled: false,
             configuration: PaymentSheet.Configuration()

--- a/Stripe/StripeiOSTests/STPElementsSessionTest.swift
+++ b/Stripe/StripeiOSTests/STPElementsSessionTest.swift
@@ -11,20 +11,11 @@ import Foundation
 
 class STPElementsSessionTest: XCTestCase {
 
-    // MARK: - Description Tests
-    func testDescription() {
-        let elementsSessionJson = STPTestUtils.jsonNamed("ElementsSession")!
-        let elementsSession = STPElementsSession.decodedObject(fromAPIResponse: elementsSessionJson)!
-
-        XCTAssertNotNil(elementsSession)
-        let desc = elementsSession.description
-        XCTAssertTrue(desc.contains(NSStringFromClass(type(of: elementsSession).self)))
-        XCTAssertGreaterThan((desc.count), 500, "Custom description should be long")
-    }
-
     // MARK: - STPAPIResponseDecodable Tests
     func testDecodedObjectFromAPIResponseMapping() {
-        let elementsSessionJson = STPTestUtils.jsonNamed("ElementsSession")!
+        var elementsSessionJson = STPTestUtils.jsonNamed("ElementsSession")!
+        elementsSessionJson["unactivated_payment_method_types"] = ["cashapp"]
+        elementsSessionJson["card_brand_choice"] = ["eligible": true]
         let elementsSession = STPElementsSession.decodedObject(fromAPIResponse: elementsSessionJson)!
 
         XCTAssertEqual(
@@ -50,6 +41,7 @@ class STPElementsSessionTest: XCTestCase {
         XCTAssertEqual(elementsSession.countryCode, "US")
         XCTAssertEqual(elementsSession.merchantCountryCode, "US")
         XCTAssertNotNil(elementsSession.paymentMethodSpecs)
+        XCTAssertEqual(elementsSession.cardBrandChoice?.eligible, true)
+        XCTAssertEqual(elementsSession.allResponseFields as NSDictionary, elementsSessionJson as NSDictionary)
     }
-
 }

--- a/Stripe/StripeiOSTests/STPIntentWithPreferencesTest.swift
+++ b/Stripe/StripeiOSTests/STPIntentWithPreferencesTest.swift
@@ -21,40 +21,6 @@ class STPIntentWithPreferencesTest: XCTestCase {
     private let setupIntentClientSecret =
         "seti_1GGCuIFY0qyl6XeWVfbQK6b3_secret_GnoX2tzX2JpvxsrcykRSVna2lrYLKew"
 
-    func testPaymentIntentWithPreferences() async {
-        let client = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
-
-        do {
-            let paymentIntentWithPreferences = try await client.retrievePaymentIntentWithPreferences(withClientSecret: paymentIntentClientSecret)
-            // Check for required PI fields
-            XCTAssertEqual(paymentIntentWithPreferences.stripeId, "pi_1H5J4RFY0qyl6XeWFTpgue7g")
-            XCTAssertEqual(
-                paymentIntentWithPreferences.clientSecret,
-                self.paymentIntentClientSecret
-            )
-            XCTAssertEqual(paymentIntentWithPreferences.amount, 2000)
-            XCTAssertEqual(paymentIntentWithPreferences.currency, "usd")
-            XCTAssertEqual(
-                paymentIntentWithPreferences.status,
-                STPPaymentIntentStatus.succeeded
-            )
-            XCTAssertEqual(paymentIntentWithPreferences.livemode, false)
-            XCTAssertEqual(
-                paymentIntentWithPreferences.paymentMethodTypes,
-                STPPaymentMethod.types(from: ["card"])
-            )
-            // Check for ordered payment method types
-            XCTAssertNotNil(paymentIntentWithPreferences.orderedPaymentMethodTypes)
-            XCTAssertEqual(
-                paymentIntentWithPreferences.orderedPaymentMethodTypes,
-                [STPPaymentMethodType.card]
-            )
-        } catch {
-            XCTFail()
-            print(error)
-        }
-    }
-
     func testSetupIntentWithPreferences() async {
         let client = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
 
@@ -76,56 +42,6 @@ class STPIntentWithPreferencesTest: XCTestCase {
             XCTAssertEqual(
                 setupIntentWithPreferences.orderedPaymentMethodTypes,
                 [STPPaymentMethodType.card]
-            )
-        } catch {
-            print(error)
-            XCTFail()
-        }
-    }
-
-    func testRetrieveElementSession_deferredPayment() async {
-        let expectation = XCTestExpectation(description: "Retrieve ElementsSession")
-        let client = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
-
-        let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 2000,
-                                                                           currency: "USD",
-                                                                           setupFutureUsage: .onSession),
-                                                            paymentMethodTypes: ["card", "cashapp"],
-                                                            confirmHandler: { _, _, _ in })
-
-        do {
-            let elementsSession = try await client.retrieveElementsSession(withIntentConfig: intentConfig)
-            XCTAssertNotNil(elementsSession)
-            XCTAssertEqual(elementsSession.countryCode, "US")
-            XCTAssertNotNil(elementsSession.linkSettings)
-            XCTAssertNotNil(elementsSession.paymentMethodSpecs)
-            XCTAssertEqual(
-                elementsSession.orderedPaymentMethodTypes,
-                [STPPaymentMethodType.card, STPPaymentMethodType.cashApp]
-            )
-        } catch {
-            print(error)
-            XCTFail()
-        }
-    }
-
-    func testRetrieveElementSession_deferredSetup() async {
-        let client = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
-
-        let intentConfig = PaymentSheet.IntentConfiguration(mode: .setup(currency: "USD",
-                                                                           setupFutureUsage: .offSession),
-                                                            paymentMethodTypes: ["card", "cashapp"],
-                                                            confirmHandler: { _, _, _ in })
-
-        do {
-            let elementsSession = try await client.retrieveElementsSession(withIntentConfig: intentConfig)
-            XCTAssertNotNil(elementsSession)
-            XCTAssertEqual(elementsSession.countryCode, "US")
-            XCTAssertNotNil(elementsSession.linkSettings)
-            XCTAssertNotNil(elementsSession.paymentMethodSpecs)
-            XCTAssertEqual(
-                elementsSession.orderedPaymentMethodTypes,
-                [STPPaymentMethodType.card, STPPaymentMethodType.cashApp]
             )
         } catch {
             print(error)

--- a/Stripe/StripeiOSTests/STPPaymentIntentTest.swift
+++ b/Stripe/StripeiOSTests/STPPaymentIntentTest.swift
@@ -63,22 +63,7 @@ class STPPaymentIntentTest: XCTestCase {
 
     func testDecodedObjectFromAPIResponseMapping() {
         let paymentIntentJson = STPTestUtils.jsonNamed("PaymentIntent")!
-        let orderedPaymentJson = ["card", "ideal", "sepa_debit"]
-        let paymentIntentResponse =
-            [
-                "payment_intent": paymentIntentJson,
-                "ordered_payment_method_types": orderedPaymentJson,
-            ] as [String: Any]
-        let unactivatedPaymentMethodTypes = ["sepa_debit"]
-        let cardBrandChoice = ["eligible": true]
-        let response =
-            [
-                "payment_method_preference": paymentIntentResponse,
-                "unactivated_payment_method_types": unactivatedPaymentMethodTypes,
-                "card_brand_choice": cardBrandChoice,
-            ] as [String: Any]
-
-        let paymentIntent = STPPaymentIntent.decodedObject(fromAPIResponse: response)!
+        let paymentIntent = STPPaymentIntent.decodedObject(fromAPIResponse: paymentIntentJson)!
 
         XCTAssertEqual(paymentIntent.stripeId, "pi_1Cl15wIl4IdHmuTbCWrpJXN6")
         XCTAssertEqual(
@@ -169,28 +154,9 @@ class STPPaymentIntentTest: XCTestCase {
         XCTAssertEqual(paymentIntent.shipping!.address!.postalCode, "94107")
         XCTAssertEqual(paymentIntent.shipping!.address!.state, "CA")
 
-        // Ordered Payment Method Types
-        XCTAssertEqual(
-            paymentIntent.orderedPaymentMethodTypes.map({ $0.displayName }),
-            ["Card", "iDEAL", "SEPA Debit"]
-        )
-
-        // Unactivated Payment Method Types
-        XCTAssertEqual(
-            paymentIntent.unactivatedPaymentMethodTypes.map({ $0.displayName }),
-            ["SEPA Debit"]
-        )
-
-        // Card brand choice
-        XCTAssertEqual(paymentIntent.cardBrandChoice?.eligible, true)
-
-        var allResponseFields = paymentIntentJson
-        allResponseFields["ordered_payment_method_types"] = orderedPaymentJson
-        allResponseFields["unactivated_payment_method_types"] = unactivatedPaymentMethodTypes
-        allResponseFields["card_brand_choice"] = cardBrandChoice
         XCTAssertEqual(
             paymentIntent.allResponseFields as NSDictionary,
-            allResponseFields as NSDictionary
+            paymentIntentJson as NSDictionary
         )
     }
 }

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
@@ -177,4 +177,7 @@ import Foundation
     // MARK: - PaymentSheet checkout
     case paymentSheetCarouselPaymentMethodTapped = "mc_carousel_payment_method_tapped"
     case paymentSheetConfirmButtonTapped = "mc_confirm_button_tapped"
+
+    // MARK: - v1/elements/session
+    case paymentSheetElementsSessionLoadFailed = "mc_elements_session_load_failed"
 }

--- a/StripeCore/StripeCoreTestUtils/Categories/STPAnalyticsClient+StripeCoreTestingUtils.swift
+++ b/StripeCore/StripeCoreTestUtils/Categories/STPAnalyticsClient+StripeCoreTestingUtils.swift
@@ -1,0 +1,17 @@
+//
+//  STPAnalyticsClient+StripeCoreTestingUtils.swift
+//  StripeCoreTestUtils
+//
+//  Created by Yuki Tokuhiro on 11/4/23.
+//
+
+import Foundation
+@_spi(STP) @testable import StripeCore
+
+@_spi(STP) public class STPTestingAnalyticsClient: STPAnalyticsClient {
+    public var events = [Analytic]()
+
+    public override func log(analytic: Analytic, apiClient: STPAPIClient = .shared) {
+        events.append(analytic)
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPElementsSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPElementsSession.swift
@@ -31,24 +31,10 @@ final class STPElementsSession: NSObject {
     /// A map describing payment method types form specs.
     let paymentMethodSpecs: [[AnyHashable: Any]]?
 
+    /// Card brand choice settings for the merchant.
+    let cardBrandChoice: STPCardBrandChoice?
+
     let allResponseFields: [AnyHashable: Any]
-
-    /// :nodoc:
-    @objc public override var description: String {
-        let props: [String] = [
-            // Object
-            String(format: "%@: %p", NSStringFromClass(STPElementsSession.self), self),
-            "sessionID = \(sessionID)",
-            "orderedPaymentMethodTypes = \(String(describing: orderedPaymentMethodTypes))",
-            "unactivatedPaymentMethodTypes = \(String(describing: unactivatedPaymentMethodTypes))",
-            "linkSettings = \(String(describing: linkSettings))",
-            "countryCode = \(String(describing: countryCode))",
-            "merchantCountryCode = \(String(describing: merchantCountryCode))",
-            "paymentMethodSpecs = \(String(describing: paymentMethodSpecs))",
-        ]
-
-        return "<\(props.joined(separator: "; "))>"
-    }
 
     private init(
         allResponseFields: [AnyHashable: Any],
@@ -58,7 +44,8 @@ final class STPElementsSession: NSObject {
         countryCode: String?,
         merchantCountryCode: String?,
         linkSettings: LinkSettings?,
-        paymentMethodSpecs: [[AnyHashable: Any]]?
+        paymentMethodSpecs: [[AnyHashable: Any]]?,
+        cardBrandChoice: STPCardBrandChoice?
     ) {
         self.allResponseFields = allResponseFields
         self.sessionID = sessionID
@@ -68,13 +55,30 @@ final class STPElementsSession: NSObject {
         self.merchantCountryCode = merchantCountryCode
         self.linkSettings = linkSettings
         self.paymentMethodSpecs = paymentMethodSpecs
+        self.cardBrandChoice = cardBrandChoice
         super.init()
+    }
+
+    /// Returns a "best effort" STPElementsSessions object to be used as a last resort fallback if the endpoint failed to return a response or we failed to parse it.
+    static func makeBackupElementsSession(with paymentIntent: STPPaymentIntent) -> STPElementsSession {
+        return STPElementsSession(
+            allResponseFields: paymentIntent.allResponseFields,
+            sessionID: UUID().uuidString,
+            orderedPaymentMethodTypes: paymentIntent.paymentMethodTypes.map { STPPaymentMethodType.init(rawValue: $0.intValue) ?? .unknown },
+            unactivatedPaymentMethodTypes: [],
+            countryCode: nil,
+            merchantCountryCode: nil,
+            linkSettings: nil,
+            paymentMethodSpecs: nil,
+            cardBrandChoice: STPCardBrandChoice.decodedObject(fromAPIResponse: [:])
+        )
     }
 }
 
 // MARK: - STPAPIResponseDecodable
 extension STPElementsSession: STPAPIResponseDecodable {
     public static func decodedObject(fromAPIResponse response: [AnyHashable: Any]?) -> Self? {
+        // Required fields:
         guard let dict = response,
               let paymentMethodPrefDict = dict["payment_method_preference"] as? [AnyHashable: Any],
               let paymentMethodTypeStrings = paymentMethodPrefDict["ordered_payment_method_types"] as? [String],
@@ -82,9 +86,11 @@ extension STPElementsSession: STPAPIResponseDecodable {
         else {
             return nil
         }
+        // Optional fields:
         let unactivatedPaymentMethodTypeStrings = dict["unactivated_payment_method_types"] as? [String] ?? []
+        let cardBrandChoice = STPCardBrandChoice.decodedObject(fromAPIResponse: dict["card_brand_choice"] as? [AnyHashable: Any])
 
-        return STPElementsSession(
+        return self.init(
             allResponseFields: dict,
             sessionID: sessionID,
             orderedPaymentMethodTypes: paymentMethodTypeStrings.map({ STPPaymentMethod.type(from: $0) }),
@@ -94,7 +100,8 @@ extension STPElementsSession: STPAPIResponseDecodable {
             linkSettings: LinkSettings.decodedObject(
                 fromAPIResponse: dict["link_settings"] as? [AnyHashable: Any]
             ),
-            paymentMethodSpecs: dict["payment_method_specs"] as? [[AnyHashable: Any]]
-        ) as? Self
+            paymentMethodSpecs: dict["payment_method_specs"] as? [[AnyHashable: Any]],
+            cardBrandChoice: cardBrandChoice
+        )
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/Intent+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/Intent+Link.swift
@@ -23,7 +23,7 @@ extension Intent {
 
     var callToAction: ConfirmButton.CallToActionType {
         switch self {
-        case .paymentIntent(let paymentIntent):
+        case .paymentIntent(_, let paymentIntent):
             return .pay(amount: paymentIntent.amount, currency: paymentIntent.currency)
         case .setupIntent:
             return .setup
@@ -39,8 +39,8 @@ extension Intent {
 
     var linkFundingSources: Set<LinkSettings.FundingSource>? {
         switch self {
-        case .paymentIntent(let paymentIntent):
-            return paymentIntent.linkSettings?.fundingSources
+        case .paymentIntent(let elementsSession, _):
+            return elementsSession.linkSettings?.fundingSources
         case .setupIntent(let setupIntent):
             return setupIntent.linkSettings?.fundingSources
         case .deferredIntent(let elementsSession, _):
@@ -51,8 +51,8 @@ extension Intent {
     var linkPopupWebviewOption: LinkSettings.PopupWebviewOption {
         return {
             switch self {
-            case .paymentIntent(let paymentIntent):
-                return paymentIntent.linkSettings?.popupWebviewOption
+            case .paymentIntent(let elementsSession, _):
+                return elementsSession.linkSettings?.popupWebviewOption
             case .setupIntent(let setupIntent):
                 return setupIntent.linkSettings?.popupWebviewOption
             case .deferredIntent(let elementsSession, _):
@@ -63,8 +63,8 @@ extension Intent {
 
     var countryCode: String? {
         switch self {
-        case .paymentIntent(let paymentIntent):
-            return paymentIntent.countryCode
+        case .paymentIntent(let elementsSession, _):
+            return elementsSession.countryCode
         case .setupIntent(let setupIntent):
             return setupIntent.countryCode
         case .deferredIntent(let elementsSession, _):
@@ -74,8 +74,8 @@ extension Intent {
 
     var merchantCountryCode: String? {
         switch self {
-        case .paymentIntent(let paymentIntent):
-            return paymentIntent.merchantCountryCode
+        case .paymentIntent(let elementsSession, _):
+            return elementsSession.merchantCountryCode
         case .setupIntent(let setupIntent):
             return setupIntent.merchantCountryCode
         case .deferredIntent(let elementsSession, _):

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Intent.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Intent.swift
@@ -19,14 +19,14 @@ import UIKit
 
 /// An internal type representing either a PaymentIntent, SetupIntent, or a "deferred Intent"
 enum Intent {
-    case paymentIntent(STPPaymentIntent)
+    case paymentIntent(elementsSession: STPElementsSession, paymentIntent: STPPaymentIntent)
     case setupIntent(STPSetupIntent)
     case deferredIntent(elementsSession: STPElementsSession, intentConfig: PaymentSheet.IntentConfiguration)
 
     var unactivatedPaymentMethodTypes: [STPPaymentMethodType] {
         switch self {
-        case .paymentIntent(let pi):
-            return pi.unactivatedPaymentMethodTypes
+        case .paymentIntent(let elementsSession, _):
+            return elementsSession.unactivatedPaymentMethodTypes
         case .setupIntent(let si):
             return si.unactivatedPaymentMethodTypes
         case .deferredIntent(let elementsSession, _):
@@ -37,8 +37,8 @@ enum Intent {
     /// A sorted list of payment method types supported by the Intent and PaymentSheet, ordered from most recommended to least recommended.
     var recommendedPaymentMethodTypes: [STPPaymentMethodType] {
         switch self {
-        case .paymentIntent(let pi):
-            return pi.orderedPaymentMethodTypes
+        case .paymentIntent(let elementsSession, _):
+            return elementsSession.orderedPaymentMethodTypes
         case .setupIntent(let si):
             return si.orderedPaymentMethodTypes
         case .deferredIntent(let elementsSession, _):
@@ -73,7 +73,7 @@ enum Intent {
 
     var currency: String? {
         switch self {
-        case .paymentIntent(let pi):
+        case .paymentIntent(_, let pi):
             return pi.currency
         case .setupIntent:
             return nil
@@ -89,7 +89,7 @@ enum Intent {
 
     var amount: Int? {
         switch self {
-        case .paymentIntent(let pi):
+        case .paymentIntent(_, let pi):
             return pi.amount
         case .setupIntent:
             return nil
@@ -106,7 +106,7 @@ enum Intent {
     /// True if this ia PaymentIntent with sfu not equal to none or a SetupIntent
     var isSettingUp: Bool {
         switch self {
-        case .paymentIntent(let paymentIntent):
+        case .paymentIntent(_, let paymentIntent):
             return paymentIntent.setupFutureUsage != .none
         case .setupIntent:
             return true
@@ -122,8 +122,8 @@ enum Intent {
 
     var cardBrandChoiceEligible: Bool {
         switch self {
-        case .paymentIntent(let paymentIntent):
-            return (paymentIntent.cardBrandChoice?.eligible ?? false)
+        case .paymentIntent(let elementsSession, _):
+            return (elementsSession.cardBrandChoice?.eligible ?? false)
         case .setupIntent, .deferredIntent: // TODO(porter) We will support SI and DI's later.
             return false
         }
@@ -134,7 +134,7 @@ enum Intent {
         switch self {
         case .deferredIntent(elementsSession: let session, intentConfig: _):
             allResponseFields = session.allResponseFields
-        case .paymentIntent(let intent):
+        case .paymentIntent(_, let intent):
             allResponseFields = intent.allResponseFields
         case .setupIntent(let intent):
             allResponseFields = intent.allResponseFields

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
@@ -354,7 +354,7 @@ class AddPaymentMethodViewController: UIViewController {
             }
         }
         switch intent {
-        case .paymentIntent(let paymentIntent):
+        case .paymentIntent(_, let paymentIntent):
             client.collectBankAccountForPayment(
                 clientSecret: paymentIntent.clientSecret,
                 returnURL: configuration.returnURL,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -106,7 +106,7 @@ extension PaymentSheet {
         case let .new(confirmParams):
             switch intent {
             // MARK: ↪ PaymentIntent
-            case .paymentIntent(let paymentIntent):
+            case .paymentIntent(_, let paymentIntent):
                 let params = makePaymentIntentParams(
                     confirmPaymentMethodType: .new(
                         params: confirmParams.paymentMethodParams,
@@ -162,7 +162,7 @@ extension PaymentSheet {
         case let .saved(paymentMethod):
             switch intent {
             // MARK: ↪ PaymentIntent
-            case .paymentIntent(let paymentIntent):
+            case .paymentIntent(_, let paymentIntent):
                 let paymentIntentParams = makePaymentIntentParams(confirmPaymentMethodType: .saved(paymentMethod), paymentIntent: paymentIntent, configuration: configuration)
 
                 paymentHandler.confirmPayment(
@@ -202,7 +202,7 @@ extension PaymentSheet {
         case .link(let confirmOption):
             let confirmWithPaymentMethodParams: (STPPaymentMethodParams) -> Void = { paymentMethodParams in
                 switch intent {
-                case .paymentIntent(let paymentIntent):
+                case .paymentIntent(_, let paymentIntent):
                     let paymentIntentParams = STPPaymentIntentParams(clientSecret: paymentIntent.clientSecret)
                     paymentIntentParams.paymentMethodParams = paymentMethodParams
                     paymentIntentParams.returnURL = configuration.returnURL
@@ -250,7 +250,7 @@ extension PaymentSheet {
                 mandateCustomerAcceptanceParams.type = .online
                 let mandateData = STPMandateDataParams(customerAcceptance: mandateCustomerAcceptanceParams)
                 switch intent {
-                case .paymentIntent(let paymentIntent):
+                case .paymentIntent(_, let paymentIntent):
                     let paymentIntentParams = STPPaymentIntentParams(clientSecret: paymentIntent.clientSecret)
                     paymentIntentParams.paymentMethodId = paymentMethod.stripeId
                     paymentIntentParams.returnURL = configuration.returnURL

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
@@ -68,7 +68,7 @@ extension PaymentSheet.Configuration: PaymentMethodRequirementProvider {
 extension Intent: PaymentMethodRequirementProvider {
     var fulfilledRequirements: [PaymentMethodTypeRequirement] {
         switch self {
-        case let .paymentIntent(paymentIntent):
+        case let .paymentIntent(_, paymentIntent):
             var reqs = [PaymentMethodTypeRequirement]()
             // Shipping address
             if let shippingInfo = paymentIntent.shipping {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -77,7 +77,7 @@ class PaymentSheetFormFactory {
         }
         var saveMode: SaveMode
         switch intent {
-        case let .paymentIntent(paymentIntent):
+        case let .paymentIntent(_, paymentIntent):
             saveMode = saveModeFor(merchantRequiresSave: paymentIntent.setupFutureUsage != .none)
         case .setupIntent:
             saveMode = .merchantRequired

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -25,15 +25,16 @@ final class PaymentSheetLoader {
     static func load(
         mode: PaymentSheet.InitializationMode,
         configuration: PaymentSheet.Configuration,
+        analyticsClient: STPAnalyticsClient = .sharedClient,
         completion: @escaping (LoadingResult) -> Void
     ) {
         let loadingStartDate = Date()
-        STPAnalyticsClient.sharedClient.logPaymentSheetEvent(event: .paymentSheetLoadStarted)
+        analyticsClient.logPaymentSheetEvent(event: .paymentSheetLoadStarted)
 
         Task { @MainActor in
             do {
                 // Fetch PaymentIntent, SetupIntent, or ElementsSession
-                async let _intent = fetchIntent(mode: mode, configuration: configuration)
+                async let _intent = fetchIntent(mode: mode, configuration: configuration, analyticsClient: analyticsClient)
 
                 // List the Customer's saved PaymentMethods
                 // TODO: Use v1/elements/sessions to fetch saved PMS https://jira.corp.stripe.com/browse/MOBILESDK-964
@@ -45,8 +46,8 @@ final class PaymentSheetLoader {
                 let intent = try await _intent
                 // Overwrite the form specs that were already loaded from disk
                 switch intent {
-                case .paymentIntent(let paymentIntent):
-                    _ = FormSpecProvider.shared.loadFrom(paymentIntent.allResponseFields["payment_method_specs"] ?? [String: Any]())
+                case .paymentIntent(let elementsSession, _):
+                    _ = FormSpecProvider.shared.loadFrom(elementsSession.paymentMethodSpecs as Any)
                 case .setupIntent:
                     break // Not supported
                 case .deferredIntent(elementsSession: let elementsSession, intentConfig: _):
@@ -67,7 +68,7 @@ final class PaymentSheetLoader {
                         )
                     }
 
-                STPAnalyticsClient.sharedClient.logPaymentSheetEvent(event: .paymentSheetLoadSucceeded,
+                analyticsClient.logPaymentSheetEvent(event: .paymentSheetLoadSucceeded,
                                                                      duration: Date().timeIntervalSince(loadingStartDate))
                 completion(
                     .success(
@@ -77,7 +78,7 @@ final class PaymentSheetLoader {
                     )
                 )
             } catch {
-                STPAnalyticsClient.sharedClient.logPaymentSheetEvent(event: .paymentSheetLoadFailed,
+                analyticsClient.logPaymentSheetEvent(event: .paymentSheetLoadFailed,
                                                                      duration: Date().timeIntervalSince(loadingStartDate),
                                                                      error: error)
                 completion(.failure(error))
@@ -138,22 +139,25 @@ final class PaymentSheetLoader {
         }
     }
 
-    static func fetchIntent(mode: PaymentSheet.InitializationMode, configuration: PaymentSheet.Configuration) async throws -> Intent {
+    static func fetchIntent(mode: PaymentSheet.InitializationMode, configuration: PaymentSheet.Configuration, analyticsClient: STPAnalyticsClient) async throws -> Intent {
         let intent: Intent
         switch mode {
         case .paymentIntentClientSecret(let clientSecret):
             let paymentIntent: STPPaymentIntent
+            let elementsSession: STPElementsSession
             do {
-                paymentIntent = try await configuration.apiClient.retrievePaymentIntentWithPreferences(withClientSecret: clientSecret)
-            } catch {
+                (paymentIntent, elementsSession) = try await configuration.apiClient.retrieveElementsSession(paymentIntentClientSecret: clientSecret)
+            } catch let error {
+                analyticsClient.logPaymentSheetEvent(event: .paymentSheetElementsSessionLoadFailed, error: error)
                 // Fallback to regular retrieve PI when retrieve PI with preferences fails
                 paymentIntent = try await configuration.apiClient.retrievePaymentIntent(clientSecret: clientSecret)
+                elementsSession = .makeBackupElementsSession(with: paymentIntent)
             }
             guard ![.succeeded, .canceled, .requiresCapture].contains(paymentIntent.status) else {
                 // Error if the PaymentIntent is in a terminal state
                 throw PaymentSheetError.paymentIntentInTerminalState(status: paymentIntent.status)
             }
-            intent = .paymentIntent(paymentIntent)
+            intent = .paymentIntent(elementsSession: elementsSession, paymentIntent: paymentIntent)
         case .setupIntentClientSecret(let clientSecret):
             let setupIntent: STPSetupIntent
             do {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
@@ -44,7 +44,7 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
         completion: @escaping STPIntentClientSecretCompletionBlock
     ) {
         switch intent {
-        case .paymentIntent(let paymentIntent):
+        case .paymentIntent(_, let paymentIntent):
             completion(paymentIntent.clientSecret, nil)
         case .setupIntent(let setupIntent):
             completion(setupIntent.clientSecret, nil)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -140,7 +140,7 @@ class PaymentSheetViewController: UIViewController {
             }
 
             switch intent {
-            case .paymentIntent(let paymentIntent):
+            case .paymentIntent(_, let paymentIntent):
                 return .pay(amount: paymentIntent.amount, currency: paymentIntent.currency)
             case .setupIntent:
                 return .setup

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/AddPaymentMethodViewControllerSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/AddPaymentMethodViewControllerSnapshotTests.swift
@@ -32,7 +32,7 @@ final class AddPaymentMethodViewControllerSnapshotTests: STPSnapshotTestCase {
         )
         previousCustomerInput.saveForFutureUseCheckboxState = .selected
         // ...and the card doesn't show up *first* in the list (so we can exercise the code that switches to the previously entered pm form)...
-        let intent = Intent.paymentIntent(STPFixtures.paymentIntent(paymentMethodTypes: ["paypal", "card", "cashapp"]))
+        let intent = Intent._testPaymentIntent(paymentMethodTypes: [.payPal, .card, .cashApp])
         var config = PaymentSheet.Configuration._testValue_MostPermissive()
         // ...and a "Save this card" checkbox...
         config.customer = .init(id: "id", ephemeralKeySecret: "ek")

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactorySnapshotTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactorySnapshotTest.swift
@@ -415,9 +415,8 @@ extension PaymentSheetFormFactorySnapshotTest {
         for paymentMethodType: STPPaymentMethodType,
         configuration: PaymentSheet.Configuration
     ) -> PaymentSheetFormFactory {
-        let paymentIntent = STPFixtures.makePaymentIntent(paymentMethodTypes: [paymentMethodType])
         return PaymentSheetFormFactory(
-            intent: .paymentIntent(paymentIntent),
+            intent: ._testPaymentIntent(paymentMethodTypes: [paymentMethodType]),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(paymentMethodType),
             addressSpecProvider: usAddressSpecProvider()

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactoryTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactoryTest.swift
@@ -38,7 +38,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         configuration.defaultBillingDetails.name = "Name"
         configuration.defaultBillingDetails.email = "email@stripe.com"
         let factory = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: ._testValue(),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.SEPADebit)
         )
@@ -59,7 +59,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         var configuration = PaymentSheet.Configuration()
         configuration.defaultBillingDetails.name = "someName"
         let factory = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: ._testValue(),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.iDEAL) // We use iDEAL because it has a LUXE form spec
         )
@@ -78,7 +78,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
 
         // Using the params as previous customer input...
         let name_with_previous_customer_input = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: ._testValue(),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.iDEAL),
             previousCustomerInput: updatedParams
@@ -92,7 +92,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         var configuration = PaymentSheet.Configuration()
         configuration.defaultBillingDetails.name = "someName"
         let factory = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: ._testValue(),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.card)
         )
@@ -109,7 +109,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
 
         // Using the params as previous customer input...
         let name_with_previous_customer_input = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: ._testValue(),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.card),
             previousCustomerInput: updatedParams
@@ -123,7 +123,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         var configuration = PaymentSheet.Configuration()
         configuration.defaultBillingDetails.name = "someName"
         let factory = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: ._testValue(),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.grabPay)
         )
@@ -156,7 +156,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         var configuration = PaymentSheet.Configuration()
         configuration.defaultBillingDetails.name = "someName"
         let factory = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: ._testValue(),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.grabPay)
         )
@@ -184,7 +184,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         var configuration = PaymentSheet.Configuration()
         configuration.defaultBillingDetails.email = "email@stripe.com"
         let factory = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: ._testValue(),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.grabPay)
         )
@@ -203,7 +203,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
 
         // Using the params as previous customer input...
         let email_with_previous_customer_input = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: ._testValue(),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.grabPay),
             previousCustomerInput: updatedParams
@@ -217,7 +217,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         var configuration = PaymentSheet.Configuration()
         configuration.defaultBillingDetails.email = "email@stripe.com"
         let factory = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: ._testValue(),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.grabPay)
         )
@@ -234,7 +234,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
 
         // Using the params as previous customer input...
         let email_with_previous_customer_input = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: ._testValue(),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.grabPay),
             previousCustomerInput: updatedParams
@@ -248,7 +248,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         var configuration = PaymentSheet.Configuration()
         configuration.defaultBillingDetails.email = "email@stripe.com"
         let factory = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: ._testValue(),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.grabPay)
         )
@@ -277,7 +277,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         var configuration = PaymentSheet.Configuration()
         configuration.defaultBillingDetails.phone = "+15555555555"
         let factory = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: ._testValue(),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.grabPay)
         )
@@ -293,7 +293,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
 
         // Using the params as previous customer input...
         let phone_with_previous_customer_input = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: ._testValue(),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.grabPay),
             previousCustomerInput: updatedParams
@@ -307,7 +307,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         var configuration = PaymentSheet.Configuration()
         configuration.defaultBillingDetails.email = "email@stripe.com"
         let factory = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: ._testValue(),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.grabPay)
         )
@@ -334,7 +334,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
     func testMakeFormElement_dropdown() {
         let configuration = PaymentSheet.Configuration()
         let factory = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: ._testValue(),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.SEPADebit)
         )
@@ -367,7 +367,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
 
         // Given a dropdown...
         let dropdown = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: ._testValue(),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.SEPADebit)
         ).makeDropdown(for: selectorSpec)
@@ -376,7 +376,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         // ...using the params as previous customer input to create a new dropdown...
         let previousCustomerInput = dropdown.updateParams(params: IntentConfirmParams(type: .stripe(.SEPADebit)))
         let dropdown_with_previous_customer_input = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: ._testValue(),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.SEPADebit),
             previousCustomerInput: previousCustomerInput
@@ -390,7 +390,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
     func testMakeFormElement_KlarnaCountry_UndefinedAPIPath() {
         let configuration = PaymentSheet.Configuration()
         let factory = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: ._testValue(),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.klarna)
         )
@@ -419,7 +419,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
     func testMakeFormElement_KlarnaCountry_DefinedAPIPath() {
         let configuration = PaymentSheet.Configuration()
         let factory = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: ._testValue(),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.klarna)
         )
@@ -449,7 +449,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
     func testMakeFormElement_BSBNumber() {
         let configuration = PaymentSheet.Configuration()
         let factory = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: ._testValue(),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.AUBECSDebit)
         )
@@ -467,7 +467,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         XCTAssertEqual(updatedParams?.paymentMethodParams.type, .AUBECSDebit)
         // Using the params as previous customer input...
         let bsb_with_previous_input = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: ._testValue(),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.AUBECSDebit),
             previousCustomerInput: updatedParams
@@ -481,7 +481,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
     func testMakeFormElement_BSBNumber_withAPIPath() {
         let configuration = PaymentSheet.Configuration()
         let factory = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: ._testValue(),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.AUBECSDebit)
         )
@@ -501,7 +501,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         XCTAssertEqual(updatedParams?.paymentMethodParams.type, .AUBECSDebit)
         // Using the params as previous customer input...
         let bsb_with_previous_input = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: ._testValue(),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.AUBECSDebit),
             previousCustomerInput: updatedParams
@@ -519,7 +519,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
     func testMakeFormElement_BSBNumber_UndefinedAPIPath() {
         let configuration = PaymentSheet.Configuration()
         let factory = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: ._testValue(),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.AUBECSDebit)
         )
@@ -549,7 +549,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
 
         // Using the params as previous customer input...
         let bsb_with_previous_input = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: ._testValue(),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.AUBECSDebit),
             previousCustomerInput: updatedParams
@@ -563,7 +563,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
     func testMakeFormElement_BSBNumber_DefinedAPIPath() {
         let configuration = PaymentSheet.Configuration()
         let factory = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: ._testValue(),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.AUBECSDebit)
         )
@@ -597,7 +597,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
     func testMakeFormElement_AUBECSAccountNumber_UndefinedAPIPath() {
         let configuration = PaymentSheet.Configuration()
         let factory = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: ._testValue(),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.AUBECSDebit)
         )
@@ -629,7 +629,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
 
         // Using the params as previous customer input...
         let form_with_previous_input = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: ._testValue(),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.AUBECSDebit),
             previousCustomerInput: updatedParams
@@ -643,7 +643,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
     func testMakeFormElement_AUBECSAccountNumber_DefinedAPIPath() {
         let configuration = PaymentSheet.Configuration()
         let factory = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: ._testValue(),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.AUBECSDebit)
         )
@@ -678,7 +678,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
 
         // Using the params as previous customer input...
         let form_with_previous_input = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: ._testValue(),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.AUBECSDebit),
             previousCustomerInput: updatedParams
@@ -697,7 +697,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
     func testMakeFormElement_AUBECSAccountNumber() {
         let configuration = PaymentSheet.Configuration()
         let factory = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: ._testValue(),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.AUBECSDebit)
         )
@@ -720,7 +720,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
     func testMakeFormElement_AUBECSAccountNumber_withAPIPath() {
         let configuration = PaymentSheet.Configuration()
         let factory = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: ._testValue(),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.AUBECSDebit)
         )
@@ -744,7 +744,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
     func testMakeFormElement_BillingAddress_UndefinedAPIPath() {
         let configuration = PaymentSheet.Configuration()
         let factory = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: ._testValue(),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.sofort)
         )
@@ -769,7 +769,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
     func testMakeFormElement_Country_DefinedAPIPath_forSofort() {
         let configuration = PaymentSheet.Configuration()
         let factory = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: ._testValue(),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.sofort)
         )
@@ -802,7 +802,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
     func testMakeFormElement_Country() {
         let configuration = PaymentSheet.Configuration()
         let factory = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: ._testValue(),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.sofort)
         )
@@ -819,7 +819,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
 
         // Using the params as previous customer input...
         let country_with_previous_input = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: ._testValue(),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.sofort),
             previousCustomerInput: updatedParams
@@ -834,7 +834,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         let configuration = PaymentSheet.Configuration()
         func makeCountry(previousCustomerInput: IntentConfirmParams?) -> PaymentMethodElement {
             let factory = PaymentSheetFormFactory(
-                intent: .paymentIntent(STPFixtures.paymentIntent()),
+                intent: ._testValue(),
                 configuration: .paymentSheet(configuration),
                 paymentMethod: .stripe(.sofort),
                 previousCustomerInput: previousCustomerInput
@@ -872,7 +872,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         let configuration = PaymentSheet.Configuration()
         func makeForm(previousCustomerInput: IntentConfirmParams?) -> PaymentMethodElementWrapper<FormElement> {
             let factory = PaymentSheetFormFactory(
-                intent: .paymentIntent(STPFixtures.paymentIntent()),
+                intent: ._testValue(),
                 configuration: .paymentSheet(configuration),
                 paymentMethod: .stripe(.SEPADebit),
                 previousCustomerInput: previousCustomerInput
@@ -911,7 +911,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         let configuration = PaymentSheet.Configuration()
         func makeForm(previousCustomerInput: IntentConfirmParams?) -> PaymentMethodElementWrapper<FormElement> {
             let factory = PaymentSheetFormFactory(
-                intent: .paymentIntent(STPFixtures.paymentIntent()),
+                intent: ._testValue(),
                 configuration: .paymentSheet(configuration),
                 paymentMethod: .stripe(.SEPADebit),
                 previousCustomerInput: previousCustomerInput
@@ -958,7 +958,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
     func testMakeFormElement_Iban() {
         let configuration = PaymentSheet.Configuration()
         let factory = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: ._testValue(),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.SEPADebit)
         )
@@ -976,7 +976,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
     func testMakeFormElement_Iban_withAPIPath() {
         let configuration = PaymentSheet.Configuration()
         let factory = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: ._testValue(),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.SEPADebit)
         )
@@ -998,7 +998,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
     func testMakeFormElement_email_with_unknownField() {
         let configuration = PaymentSheet.Configuration()
         let factory = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: ._testValue(),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.grabPay)
         )
@@ -1041,7 +1041,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         ]
         let configuration = PaymentSheet.Configuration()
         let factory = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: ._testValue(),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.AUBECSDebit),
             addressSpecProvider: addressSpecProvider
@@ -1082,7 +1082,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         let addressSpecProvider = addressSpecProvider(countries: ["US", "FR"])
         let configuration = PaymentSheet.Configuration()
         let factory = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: ._testValue(),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.grabPay),
             addressSpecProvider: addressSpecProvider
@@ -1112,7 +1112,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         let addressSpecProvider = addressSpecProvider(countries: ["US", "FR"])
         let configuration = PaymentSheet.Configuration()
         let factory = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent()),
+            intent: ._testValue(),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.grabPay),
             addressSpecProvider: addressSpecProvider
@@ -1139,7 +1139,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
 
     func testNonCardsAndUSBankAccountsDontHaveSaveForFutureUseCheckbox() {
         let configuration = PaymentSheet.Configuration()
-        let intent = Intent.paymentIntent(STPFixtures.paymentIntent())
+        let intent = Intent._testValue()
         let specProvider = AddressSpecProvider()
         specProvider.addressSpecs = [
             "US": AddressSpec(
@@ -1187,9 +1187,8 @@ class PaymentSheetFormFactoryTest: XCTestCase {
     func testShowsCardCheckbox() {
         var configuration = PaymentSheet.Configuration()
         configuration.customer = .init(id: "id", ephemeralKeySecret: "sec")
-        let paymentIntent = STPFixtures.makePaymentIntent(paymentMethodTypes: [.card])
         let factory = PaymentSheetFormFactory(
-            intent: .paymentIntent(paymentIntent),
+            intent: ._testPaymentIntent(paymentMethodTypes: [.card]),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.card)
         )
@@ -1201,7 +1200,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         configuration.customer = .init(id: "id", ephemeralKeySecret: "sec")
         let paymentIntent = STPFixtures.makePaymentIntent(paymentMethodTypes: [.card, .EPS])
         let factory = PaymentSheetFormFactory(
-            intent: .paymentIntent(paymentIntent),
+            intent: ._testPaymentIntent(paymentMethodTypes: [.card, .EPS]),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.card)
         )
@@ -1220,7 +1219,6 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         var configuration = PaymentSheet.Configuration()
         configuration.customer = .init(id: "id", ephemeralKeySecret: "sec")
         configuration.defaultBillingDetails.address = defaultAddress
-        let paymentIntent = STPFixtures.makePaymentIntent(paymentMethodTypes: [.card])
         // An address section with defaults...
         let specProvider = AddressSpecProvider()
         specProvider.addressSpecs = [
@@ -1234,7 +1232,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
             ),
         ]
         let factory = PaymentSheetFormFactory(
-            intent: .paymentIntent(paymentIntent),
+            intent: ._testPaymentIntent(paymentMethodTypes: [.card]),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.card),
             addressSpecProvider: specProvider
@@ -1266,7 +1264,6 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         configuration.shippingDetails = {
             return .init(address: .init(country: "US", line1: "Shipping line 1"), name: "Name")
         }
-        let paymentIntent = STPFixtures.makePaymentIntent(paymentMethodTypes: [.card])
         // An address section with both default billing and default shipping...
         let specProvider = AddressSpecProvider()
         specProvider.addressSpecs = [
@@ -1280,7 +1277,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
             ),
         ]
         let factory = PaymentSheetFormFactory(
-            intent: .paymentIntent(paymentIntent),
+            intent: ._testPaymentIntent(paymentMethodTypes: [.card]),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.card),
             addressSpecProvider: specProvider
@@ -1400,7 +1397,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
 
         // ...the card form...
         let factory = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent(paymentMethodTypes: ["card"])),
+            intent: ._testPaymentIntent(paymentMethodTypes: [.card]),
             configuration: .paymentSheet(configuration),
             paymentMethod: .stripe(.card),
             previousCustomerInput: previousCustomerInput
@@ -1442,7 +1439,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
             var configuration = PaymentSheet.Configuration._testValue_MostPermissive()
             configuration.customer = .init(id: "id", ephemeralKeySecret: "ek")
             return PaymentSheetFormFactory(
-                intent: isSettingUp ? .setupIntent(STPFixtures.setupIntent()) : .paymentIntent(STPFixtures.paymentIntent()),
+                intent: isSettingUp ? .setupIntent(STPFixtures.setupIntent()) : ._testValue(),
                 configuration: .paymentSheet(configuration),
                 paymentMethod: .stripe(.card),
                 previousCustomerInput: previousCustomerInput
@@ -1510,7 +1507,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
 
         // ...the Afterpay form should be valid
         let afterpayFactory = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent(paymentMethodTypes: ["afterpay_clearpay"])),
+            intent: ._testPaymentIntent(paymentMethodTypes: [.afterpayClearpay]),
             configuration: .paymentSheet(PaymentSheet.Configuration._testValue_MostPermissive()),
             paymentMethod: .stripe(.afterpayClearpay),
             previousCustomerInput: previousAfterpayCustomerInput
@@ -1528,7 +1525,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         )
         // ...the Afterpay form should be blank and invalid, even though the previous input had full billing details
         let afterpayFormWithPreviousCardInput = PaymentSheetFormFactory(
-            intent: .paymentIntent(STPFixtures.paymentIntent(paymentMethodTypes: ["afterpay_clearpay"])),
+            intent: ._testPaymentIntent(paymentMethodTypes: [.afterpayClearpay]),
             configuration: .paymentSheet(PaymentSheet.Configuration._testValue_MostPermissive()),
             paymentMethod: .stripe(.afterpayClearpay),
             previousCustomerInput: previousCardCustomerInput
@@ -1549,7 +1546,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
     func testAppliesPreviousCustomerInput_klarna_country() {
         func makeKlarnaCountry(apiPath: String?, previousCustomerInput: IntentConfirmParams?) -> PaymentMethodElementWrapper<DropdownFieldElement> {
             let factory = PaymentSheetFormFactory(
-                intent: .paymentIntent(STPFixtures.paymentIntent(paymentMethodTypes: ["klarna"], currency: "eur")),
+                intent: ._testPaymentIntent(paymentMethodTypes: [.klarna], currency: "eur"),
                 configuration: .paymentSheet(PaymentSheet.Configuration._testValue_MostPermissive()),
                 paymentMethod: .stripe(.klarna),
                 previousCustomerInput: previousCustomerInput
@@ -1583,7 +1580,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         // Use PayPal as an example PM, since it is an empty form w/ a mandate iff PI+SFU or SI
         func makePaypalForm(isSettingUp: Bool, previousCustomerInput: IntentConfirmParams?) -> PaymentMethodElement {
             return PaymentSheetFormFactory(
-                intent: .paymentIntent(STPFixtures.paymentIntent(paymentMethodTypes: ["paypal"], setupFutureUsage: isSettingUp ? .offSession : .none)),
+                intent: ._testPaymentIntent(paymentMethodTypes: [.payPal], setupFutureUsage: isSettingUp ? .offSession : .none),
                 configuration: .paymentSheet(PaymentSheet.Configuration._testValue_MostPermissive()),
                 paymentMethod: .stripe(.payPal),
                 previousCustomerInput: previousCustomerInput

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLPMConfirmFlowTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLPMConfirmFlowTests.swift
@@ -488,7 +488,7 @@ extension PaymentSheet_LPM_ConfirmFlowTests {
             }
 
             intents = [
-                ("PaymentIntent", .paymentIntent(paymentIntent)),
+                ("PaymentIntent", .paymentIntent(elementsSession: ._testCardValue(), paymentIntent: paymentIntent)),
                 ("Deferred PaymentIntent - client side confirmation", makeDeferredIntent(deferredCSC)),
             ]
             guard paymentMethod != .stripe(.blik) else {
@@ -546,7 +546,7 @@ extension PaymentSheet_LPM_ConfirmFlowTests {
                 )
             }
             return [
-                ("PaymentIntent w/ setup_future_usage", .paymentIntent(paymentIntent)),
+                ("PaymentIntent w/ setup_future_usage", .paymentIntent(elementsSession: ._testCardValue(), paymentIntent: paymentIntent)),
                 ("Deferred PaymentIntent w/ setup_future_usage - client side confirmation", makeDeferredIntent(deferredCSC)),
                 ("Deferred PaymentIntent w/ setup_future_usage - server side confirmation", makeDeferredIntent(deferredSSC)),
             ]

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderStubbedTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderStubbedTest.swift
@@ -7,7 +7,8 @@
 
 import OHHTTPStubs
 import OHHTTPStubsSwift
-import StripeCoreTestUtils
+@_spi(STP) @testable import StripeCore
+@_spi(STP) import StripeCoreTestUtils
 import XCTest
 
 class PaymentSheetLoaderStubbedTest: APIStubbedTestCase {
@@ -34,15 +35,15 @@ class PaymentSheetLoaderStubbedTest: APIStubbedTestCase {
         ) { result in
             switch result {
             case .success(let intent, let paymentMethods, _):
-                guard case .paymentIntent(let paymentIntent) = intent else {
+                guard case .paymentIntent(_, let paymentIntent) = intent else {
                     XCTFail("Expecting payment intent")
                     return
                 }
                 XCTAssertEqual(paymentIntent.stripeId, "pi_3Kth")
                 XCTAssertEqual(paymentMethods.count, 0)
                 loaded.fulfill()
-            case .failure:
-                XCTFail("Failed")
+            case .failure(let error):
+                XCTFail(error.nonGenericDescription)
             }
         }
         wait(for: [loaded], timeout: 2)
@@ -61,7 +62,7 @@ class PaymentSheetLoaderStubbedTest: APIStubbedTestCase {
         ) { result in
             switch result {
             case .success(let intent, let paymentMethods, _):
-                guard case .paymentIntent(let paymentIntent) = intent else {
+                guard case .paymentIntent(_, let paymentIntent) = intent else {
                     XCTFail("Expecting payment intent")
                     return
                 }
@@ -69,8 +70,8 @@ class PaymentSheetLoaderStubbedTest: APIStubbedTestCase {
                 XCTAssertEqual(paymentMethods.count, 1)
                 XCTAssertEqual(paymentMethods[0].type, .card)
                 loaded.fulfill()
-            case .failure:
-                XCTFail("Failed")
+            case .failure(let error):
+                XCTFail(error.nonGenericDescription)
             }
         }
         wait(for: [loaded], timeout: 2)
@@ -89,7 +90,7 @@ class PaymentSheetLoaderStubbedTest: APIStubbedTestCase {
         ) { result in
             switch result {
             case .success(let intent, let paymentMethods, _):
-                guard case .paymentIntent(let paymentIntent) = intent else {
+                guard case .paymentIntent(_, let paymentIntent) = intent else {
                     XCTFail("Expecting payment intent")
                     return
                 }
@@ -97,8 +98,9 @@ class PaymentSheetLoaderStubbedTest: APIStubbedTestCase {
                 XCTAssertEqual(paymentMethods.count, 1)
                 XCTAssertEqual(paymentMethods[0].type, .card)
                 loaded.fulfill()
-            case .failure:
-                XCTFail("Failed")
+            case .failure(let error):
+                XCTFail(error.nonGenericDescription)
+
             }
         }
         wait(for: [loaded], timeout: 2)
@@ -117,7 +119,7 @@ class PaymentSheetLoaderStubbedTest: APIStubbedTestCase {
         ) { result in
             switch result {
             case .success(let intent, let paymentMethods, _):
-                guard case .paymentIntent(let paymentIntent) = intent else {
+                guard case .paymentIntent(_, let paymentIntent) = intent else {
                     XCTFail("Expecting payment intent")
                     return
                 }
@@ -127,10 +129,67 @@ class PaymentSheetLoaderStubbedTest: APIStubbedTestCase {
                 XCTAssertEqual(paymentMethods[1].type, .USBankAccount)
 
                 loaded.fulfill()
-            case .failure:
-                XCTFail("Failed")
+            case .failure(let error):
+                XCTFail(error.nonGenericDescription)
             }
         }
         wait(for: [loaded], timeout: 2)
+    }
+
+    func testPaymentSheetLoadPaymentIntentFallback() {
+        // If v1/elements/session fails to load...
+        stub { urlRequest in
+            return urlRequest.url?.absoluteString.contains("/v1/elements/sessions") ?? false
+        } response: { _ in
+            return HTTPStubsResponse(data: Data(), statusCode: 500, headers: nil)
+        }
+        // ...and /v1/payment_intents succeeds...
+        stub { urlRequest in
+            return urlRequest.url?.absoluteString.contains("/v1/payment_intents") ?? false
+        } response: { _ in
+            return HTTPStubsResponse(data: try! FileMock.payment_intents_200.data(), statusCode: 200, headers: nil)
+        }
+        // ....and the customer has payment methods...
+        StubbedBackend.stubPaymentMethods(fileMock: .saved_payment_methods_withCard_200, pmType: "card")
+        StubbedBackend.stubPaymentMethods(fileMock: .saved_payment_methods_200, pmType: "us_bank_account")
+        StubbedBackend.stubPaymentMethods(fileMock: .saved_payment_methods_200, pmType: "sepa_debit")
+
+        // ...loading PaymentSheet with a customer...
+        let loaded = expectation(description: "Loaded")
+        let analyticsClient = STPTestingAnalyticsClient()
+        PaymentSheetLoader.load(
+            mode: .paymentIntentClientSecret("pi_1234_secret_1234"),
+            configuration: self.configuration(apiClient: stubbedAPIClient()),
+            analyticsClient: analyticsClient
+        ) { result in
+            loaded.fulfill()
+            switch result {
+            case let .success(intent, paymentMethods, isLinkEnabled):
+                // ...should still succeed...
+                guard case let .paymentIntent(elementsSession, paymentIntent) = intent else {
+                    XCTFail()
+                    return
+                }
+
+                // ...with an ElementsSession whose payment method types is equal to the PaymentIntent...
+                XCTAssertEqual(
+                    paymentIntent.paymentMethodTypes.map { STPPaymentMethodType(rawValue: $0.intValue) },
+                    elementsSession.orderedPaymentMethodTypes
+                )
+
+                // ...and with the customer's payment methods
+                XCTAssertEqual(paymentMethods.count, 1)
+
+                // ...and with link disabled
+                XCTAssertFalse(isLinkEnabled)
+
+                // ...and should report analytics indicating the v1/elements/session load failed
+                let analyticEvents = analyticsClient.events.map { $0.event }
+                XCTAssertEqual(analyticEvents, [.paymentSheetLoadStarted, .paymentSheetElementsSessionLoadFailed, .paymentSheetLoadSucceeded])
+            case .failure(let error):
+                XCTFail(error.nonGenericDescription)
+            }
+        }
+        wait(for: [loaded], timeout: 10)
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetPaymentMethodTypeTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetPaymentMethodTypeTest.swift
@@ -89,7 +89,7 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
             PaymentSheet.PaymentMethodType.supportsAdding(
                 paymentMethod: .card,
                 configuration: PaymentSheet.Configuration(),
-                intent: .paymentIntent(STPFixtures.paymentIntent()),
+                intent: ._testValue(),
                 supportedPaymentMethods: []
             )
             , .notSupported
@@ -102,9 +102,7 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
             PaymentSheet.PaymentMethodType.supportsAdding(
                 paymentMethod: .card,
                 configuration: PaymentSheet.Configuration(),
-                intent: .paymentIntent(
-                    STPFixtures.makePaymentIntent(setupFutureUsage: .offSession)
-                ),
+                intent: ._testPaymentIntent(paymentMethodTypes: [.card], setupFutureUsage: .offSession),
                 supportedPaymentMethods: [.card]
             ),
             .supported
@@ -117,7 +115,7 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
             PaymentSheet.PaymentMethodType.supportsAdding(
                 paymentMethod: .card,
                 configuration: makeConfiguration(hasReturnURL: true),
-                intent: .paymentIntent(STPFixtures.makePaymentIntent()),
+                intent: ._testValue(),
                 supportedPaymentMethods: [.card]
             ),
             .supported
@@ -132,7 +130,7 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
             PaymentSheet.PaymentMethodType.supportsAdding(
                 paymentMethod: .iDEAL,
                 configuration: makeConfiguration(hasReturnURL: true),
-                intent: .paymentIntent(STPFixtures.makePaymentIntent()),
+                intent: ._testValue(),
                 supportedPaymentMethods: [.iDEAL]
             ),
             .supported
@@ -145,7 +143,7 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
             PaymentSheet.PaymentMethodType.supportsAdding(
                 paymentMethod: .iDEAL,
                 configuration: makeConfiguration(),
-                intent: .paymentIntent(STPFixtures.makePaymentIntent()),
+                intent: ._testValue(),
                 supportedPaymentMethods: [.iDEAL]
             ),
             .missingRequirements([.returnURL])
@@ -160,7 +158,7 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
             PaymentSheet.PaymentMethodType.supportsAdding(
                 paymentMethod: .afterpayClearpay,
                 configuration: makeConfiguration(hasReturnURL: true),
-                intent: .paymentIntent(STPFixtures.makePaymentIntent(shippingProvided: false)),
+                intent: .paymentIntent(elementsSession: .emptyElementsSession, paymentIntent: STPFixtures.makePaymentIntent(shippingProvided: false)),
                 supportedPaymentMethods: [.afterpayClearpay]
             ),
             .missingRequirements([.shippingAddress])
@@ -173,7 +171,7 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
             PaymentSheet.PaymentMethodType.supportsAdding(
                 paymentMethod: .afterpayClearpay,
                 configuration: makeConfiguration(hasReturnURL: false),
-                intent: .paymentIntent(STPFixtures.makePaymentIntent(shippingProvided: false)),
+                intent: .paymentIntent(elementsSession: .emptyElementsSession, paymentIntent: STPFixtures.makePaymentIntent(shippingProvided: false)),
                 supportedPaymentMethods: [.afterpayClearpay]
             ),
             .missingRequirements([.shippingAddress, .returnURL])
@@ -187,7 +185,7 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
             PaymentSheet.PaymentMethodType.supportsAdding(
                 paymentMethod: .afterpayClearpay,
                 configuration: makeConfiguration(hasReturnURL: true),
-                intent: .paymentIntent(STPFixtures.makePaymentIntent(shippingProvided: true)),
+                intent: .paymentIntent(elementsSession: .emptyElementsSession, paymentIntent: STPFixtures.makePaymentIntent(shippingProvided: true)),
                 supportedPaymentMethods: [.afterpayClearpay]
             ),
             .supported
@@ -199,7 +197,7 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
             PaymentSheet.PaymentMethodType.supportsAdding(
                 paymentMethod: .afterpayClearpay,
                 configuration: config,
-                intent: .paymentIntent(STPFixtures.makePaymentIntent(shippingProvided: false)),
+                intent: .paymentIntent(elementsSession: .emptyElementsSession, paymentIntent: STPFixtures.makePaymentIntent(shippingProvided: false)),
                 supportedPaymentMethods: [.afterpayClearpay]
             ),
             .supported
@@ -218,7 +216,7 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
                 PaymentSheet.PaymentMethodType.supportsAdding(
                     paymentMethod: pm,
                     configuration: makeConfiguration(hasReturnURL: true),
-                    intent: .paymentIntent(STPFixtures.makePaymentIntent()),
+                    intent: ._testValue(),
                     supportedPaymentMethods: sepaFamily.map { $0 }
                 ),
                 .supported
@@ -233,7 +231,7 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
                 PaymentSheet.PaymentMethodType.supportsAdding(
                     paymentMethod: pm,
                     configuration: config,
-                    intent: .paymentIntent(STPFixtures.makePaymentIntent()),
+                    intent: ._testValue(),
                     supportedPaymentMethods: sepaFamily.map { $0 }
                 ),
                 .missingRequirements([.userSupportsDelayedPaymentMethods])
@@ -243,7 +241,7 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
                 PaymentSheet.PaymentMethodType.supportsAdding(
                     paymentMethod: pm,
                     configuration: config,
-                    intent: .paymentIntent(STPFixtures.makePaymentIntent()),
+                    intent: ._testValue(),
                     supportedPaymentMethods: sepaFamily.map { $0 }
                 ),
                 .supported
@@ -277,7 +275,7 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
                     PaymentSheet.PaymentMethodType.supportsAdding(
                         paymentMethod: .USBankAccount,
                         configuration: configuration,
-                        intent: .paymentIntent(pi),
+                        intent: .paymentIntent(elementsSession: .makeBackupElementsSession(with: pi), paymentIntent: pi),
                         supportedPaymentMethods: [.USBankAccount]
                     ),
                     .supported
@@ -288,7 +286,7 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
                     PaymentSheet.PaymentMethodType.supportsAdding(
                         paymentMethod: .USBankAccount,
                         configuration: configuration,
-                        intent: .paymentIntent(pi),
+                        intent: .paymentIntent(elementsSession: .makeBackupElementsSession(with: pi), paymentIntent: pi),
                         supportedPaymentMethods: [.USBankAccount]
                     ),
                     .missingRequirements([.validUSBankVerificationMethod])
@@ -302,24 +300,14 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
     }
 
     func testPaymentIntentRecommendedPaymentMethodTypes() {
-        let paymentIntent = constructPI(
-            paymentMethodTypes: ["card", "us_bank_account", "klarna", "futurePaymentMethod"],
-            orderedPaymentMethodTypes: ["card", "klarna", "us_bank_account", "futurePaymentMethod"]
-        )!
-        let intent = Intent.paymentIntent(paymentIntent)
-        let types = intent.recommendedPaymentMethodTypes
-
-        XCTAssertEqual(types[0], .card)
-        XCTAssertEqual(types[1], .klarna)
-        XCTAssertEqual(types[2], .USBankAccount)
-        XCTAssertEqual(types[3], .unknown)
+        let paymentIntent = STPFixtures.makePaymentIntent(paymentMethodTypes: [.card, .USBankAccount, .klarna, .unknown])
+        // Note PaymentIntent and ElementsSession pm types have different ordering
+        let intent = Intent.paymentIntent(elementsSession: ._testValue(paymentMethodTypes: ["card", "klarna", "us_bank_account", "futurePaymentMethod"]), paymentIntent: paymentIntent)
+        XCTAssertEqual(intent.recommendedPaymentMethodTypes, [.card, .klarna, .USBankAccount, .unknown])
     }
 
     func testPaymentIntentRecommendedPaymentMethodTypes_withoutOrderedPaymentMethodTypes() {
-        let paymentIntent = constructPI(paymentMethodTypes: [
-            "card", "us_bank_account", "klarna", "futurePaymentMethod",
-        ])!
-        let intent = Intent.paymentIntent(paymentIntent)
+        let intent = Intent._testPaymentIntent(paymentMethodTypes: [.card, .USBankAccount, .klarna, .unknown])
         let types = intent.recommendedPaymentMethodTypes
 
         XCTAssertEqual(types[0], .card)
@@ -356,11 +344,7 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
     }
 
     func testPaymentIntentFilteredPaymentMethodTypes() {
-        let paymentIntent = constructPI(
-            paymentMethodTypes: ["card", "klarna", "p24"],
-            orderedPaymentMethodTypes: ["card", "klarna", "p24"]
-        )!
-        let intent = Intent.paymentIntent(paymentIntent)
+        let intent = Intent._testPaymentIntent(paymentMethodTypes: [.card, .klarna, .przelewy24])
         var configuration = PaymentSheet.Configuration()
         configuration.returnURL = "http://return-to-url"
         configuration.allowsDelayedPaymentMethods = true
@@ -373,11 +357,7 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
     }
 
     func testPaymentIntentFilteredPaymentMethodTypes_withUnfulfilledRequirements() {
-        let paymentIntent = constructPI(
-            paymentMethodTypes: ["card", "klarna", "p24"],
-            orderedPaymentMethodTypes: ["card", "klarna", "p24"]
-        )!
-        let intent = Intent.paymentIntent(paymentIntent)
+        let intent = Intent._testPaymentIntent(paymentMethodTypes: [.card, .klarna, .przelewy24])
         let configuration = PaymentSheet.Configuration()
         let types = PaymentSheet.PaymentMethodType.filteredPaymentMethodTypes(
             from: intent,
@@ -388,12 +368,7 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
     }
 
     func testPaymentIntentFilteredPaymentMethodTypes_withSetupFutureUsage() {
-        let paymentIntent = constructPI(
-            paymentMethodTypes: ["card", "cashapp"],
-            orderedPaymentMethodTypes: ["card", "cashapp", "mobilepay"],
-            setupFutureUsage: .onSession
-        )!
-        let intent = Intent.paymentIntent(paymentIntent)
+        let intent = Intent._testPaymentIntent(paymentMethodTypes: [.card, .cashApp, .mobilePay], setupFutureUsage: .onSession)
         var configuration = PaymentSheet.Configuration()
         configuration.returnURL = "http://return-to-url"
         configuration.allowsDelayedPaymentMethods = true
@@ -431,7 +406,6 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
     }
 
     func testUnknownPMTypeIsUnsupported() {
-        let paymentIntent = constructPI(paymentMethodTypes: ["luxe_bucks"])!
         let setupIntent = constructSI(paymentMethodTypes: ["luxe_bucks"])!
         let paymentMethod = STPPaymentMethod.type(from: "luxe_bucks")
         var configuration = PaymentSheet.Configuration()
@@ -450,15 +424,14 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
             PaymentSheet.PaymentMethodType.supportsAdding(
                 paymentMethod: paymentMethod,
                 configuration: configuration,
-                intent: Intent.paymentIntent(paymentIntent)
+                intent: ._testPaymentIntent(paymentMethodTypes: [.unknown])
             ),
             .notSupported
         )
     }
 
     func testSupport() {
-        let paymentIntent = constructPI(paymentMethodTypes: ["luxe_bucks"])!
-        let intent = Intent.paymentIntent(paymentIntent)
+        let intent = Intent._testPaymentIntent(paymentMethodTypes: [.unknown])
         var configuration = PaymentSheet.Configuration()
         configuration.returnURL = "http://return-to-url"
 
@@ -564,35 +537,6 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
         )
     }
 
-    private func constructPI(
-        paymentMethodTypes: [String],
-        orderedPaymentMethodTypes: [String]? = nil,
-        setupFutureUsage: STPPaymentIntentSetupFutureUsage = .none
-    ) -> STPPaymentIntent? {
-        var apiResponse: [AnyHashable: Any?] = [
-            "id": "123",
-            "client_secret": "sec",
-            "amount": 10,
-            "currency": "usd",
-            "status": "requires_payment_method",
-            "livemode": false,
-            "created": 1652736692.0,
-            "payment_method_types": paymentMethodTypes,
-            "setup_future_usage": setupFutureUsage.stringValue,
-        ]
-        if let orderedPaymentMethodTypes = orderedPaymentMethodTypes {
-            apiResponse["ordered_payment_method_types"] = orderedPaymentMethodTypes
-        }
-        guard
-            let stpPaymentIntent = STPPaymentIntent.decodeSTPPaymentIntentObject(
-                fromAPIResponse: apiResponse as [AnyHashable: Any]
-            )
-        else {
-            XCTFail("Failed to decode")
-            return nil
-        }
-        return stpPaymentIntent
-    }
     private func constructSI(
         paymentMethodTypes: [String],
         orderedPaymentMethodTypes: [String]? = nil
@@ -642,7 +586,7 @@ extension STPFixtures {
         json["confirmation_method"] = confirmationMethod
         if let paymentMethodTypes = paymentMethodTypes {
             json["payment_method_types"] = paymentMethodTypes.map {
-                STPPaymentMethod.string(from: $0)
+                STPPaymentMethod.string(from: $0) ?? "unknown"
             }
         }
         if !shippingProvided {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPApplePayContext+PaymentSheetTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPApplePayContext+PaymentSheetTest.swift
@@ -20,7 +20,7 @@ final class STPApplePayContext_PaymentSheetTest: XCTestCase {
     }()
 
     func testCreatePaymentRequest_PaymentIntent() {
-        let intent = Intent.paymentIntent(STPFixtures.paymentIntent())
+        let intent = Intent._testValue()
         let deferredIntent = Intent.deferredIntent(elementsSession: ._testCardValue(), intentConfig: .init(mode: .payment(amount: 2345, currency: "USD"), confirmHandler: dummyDeferredConfirmHandler))
         for intent in [intent, deferredIntent] {
             let sut = STPApplePayContext.createPaymentRequest(intent: intent, configuration: configuration, applePay: applePayConfiguration)
@@ -38,11 +38,11 @@ final class STPApplePayContext_PaymentSheetTest: XCTestCase {
     }
 
     func testCreatePaymentRequest_PaymentIntentWithSetupFutureUsage() {
-        let intent = Intent.paymentIntent(STPFixtures.paymentIntent(paymentMethodTypes: ["card"], setupFutureUsage: .offSession))
-        let deferredIntent = Intent.deferredIntent(elementsSession: ._testCardValue(), intentConfig: .init(mode: .payment(amount: 10, currency: "USD", setupFutureUsage: .offSession), confirmHandler: dummyDeferredConfirmHandler))
+        let intent = Intent._testPaymentIntent(paymentMethodTypes: [.card], setupFutureUsage: .offSession)
+        let deferredIntent = Intent.deferredIntent(elementsSession: ._testCardValue(), intentConfig: .init(mode: .payment(amount: 2345, currency: "USD", setupFutureUsage: .offSession), confirmHandler: dummyDeferredConfirmHandler))
         for intent in [intent, deferredIntent] {
             let sut = STPApplePayContext.createPaymentRequest(intent: intent, configuration: configuration, applePay: applePayConfiguration)
-            XCTAssertEqual(sut.paymentSummaryItems[0].amount, 0.1)
+            XCTAssertEqual(sut.paymentSummaryItems[0].amount, 23.45)
             XCTAssertEqual(sut.paymentSummaryItems[0].type, .final)
             XCTAssertEqual(sut.currencyCode, "USD")
             XCTAssertEqual(sut.merchantIdentifier, "merchant_id")

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPFixtures+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPFixtures+PaymentSheet.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 @_spi(STP) @testable import StripeCore
-import StripePayments
+@_spi(STP) import StripePayments
 @_spi(STP) @testable import StripePaymentSheet
 import StripePaymentsTestUtils
 
@@ -43,8 +43,19 @@ extension STPElementsSession {
 }
 
 extension Intent {
+    static func _testPaymentIntent(
+        paymentMethodTypes: [STPPaymentMethodType],
+        setupFutureUsage: STPPaymentIntentSetupFutureUsage = .none,
+        currency: String = "usd"
+    ) -> Intent {
+        let paymentMethodTypes = paymentMethodTypes.map { STPPaymentMethod.string(from: $0) ?? "unknown" }
+        let paymentIntent = STPFixtures.paymentIntent(paymentMethodTypes: paymentMethodTypes, setupFutureUsage: setupFutureUsage, currency: currency)
+        let elementsSession = STPElementsSession._testValue(paymentMethodTypes: paymentMethodTypes)
+        return .paymentIntent(elementsSession: elementsSession, paymentIntent: paymentIntent)
+    }
+
     static func _testValue() -> Intent {
-        return .paymentIntent(STPFixtures.paymentIntent())
+        return _testPaymentIntent(paymentMethodTypes: [.card])
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Stubbed/StubbedBackend.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Stubbed/StubbedBackend.swift
@@ -75,4 +75,5 @@ public class ClassForBundle {}
     case elementsSessionsPaymentMethod_link_200 = "MockFiles/elements_sessions_paymentMethod_link_200"
 
     case customers_200 = "MockFiles/customers_200"
+    case payment_intents_200 = "MockFiles/payment_intents_200"
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/Resources/MockFiles/payment_intents_200.json
+++ b/StripePaymentSheet/StripePaymentSheetTests/Resources/MockFiles/payment_intents_200.json
@@ -1,0 +1,53 @@
+{
+  "id": "pi_3LN3c2L123456789",
+  "object": "payment_intent",
+  "amount": 5099,
+  "amount_details": {
+    "tip": {}
+  },
+  "automatic_payment_methods": null,
+  "canceled_at": null,
+  "cancellation_reason": null,
+  "capture_method": "automatic",
+  "client_secret": "pi_123456_secret_654321",
+  "confirmation_method": "automatic",
+  "created": 1658187870,
+  "currency": "usd",
+  "description": null,
+  "last_payment_error": null,
+  "livemode": false,
+  "next_action": null,
+  "payment_method": null,
+  "payment_method_options": {
+    "us_bank_account": {
+      "verification_method": "automatic"
+    }
+  },
+  "payment_method_types": [
+    "card",
+    "afterpay_clearpay",
+    "klarna",
+    "us_bank_account",
+    "affirm",
+    "blik"
+  ],
+  "processing": null,
+  "receipt_email": null,
+  "setup_future_usage": null,
+  "shipping": {
+    "address": {
+      "city": "San Francisco",
+      "country": "US",
+      "line1": "510 Townsend St",
+      "line2": null,
+      "postal_code": "94102",
+      "state": "California"
+    },
+    "carrier": null,
+    "name": "John Doe",
+    "phone": null,
+    "tracking_number": null
+  },
+  "source": null,
+  "status": "requires_payment_method"
+}

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentIntents/STPPaymentIntent.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentIntents/STPPaymentIntent.swift
@@ -129,26 +129,8 @@ public class STPPaymentIntent: NSObject {
     /// The optionally expanded PaymentMethod used in this PaymentIntent.
     @objc public let paymentMethod: STPPaymentMethod?
 
-    /// The ordered payment method preference for this PaymentIntent
-    @_spi(STP) public let orderedPaymentMethodTypes: [STPPaymentMethodType]
-
-    /// A list of payment method types that are not activated in live mode, but activated in test mode
-    @_spi(STP) public let unactivatedPaymentMethodTypes: [STPPaymentMethodType]
-
     /// Payment-method-specific configuration for this PaymentIntent.
     @_spi(STP) public let paymentMethodOptions: STPPaymentMethodOptions?
-
-    /// Link-specific settings for this PaymentIntent.
-    @_spi(STP) public let linkSettings: LinkSettings?
-
-    /// Country code of the user.
-    @_spi(STP) public let countryCode: String?
-
-    /// Country code of the merchant.
-    @_spi(STP) public let merchantCountryCode: String?
-
-    /// Card brand choice settings for the merchant.
-    @_spi(STP) public let cardBrandChoice: STPCardBrandChoice?
 
     /// :nodoc:
     @objc public override var description: String {
@@ -163,15 +145,12 @@ public class STPPaymentIntent: NSObject {
             "captureMethod = \(String(describing: allResponseFields["capture_method"] as? String))",
             "clientSecret = <redacted>",
             "confirmationMethod = \(String(describing: allResponseFields["confirmation_method"] as? String))",
-            "countryCode = \(String(describing: countryCode))",
             "created = \(created)",
             "currency = \(currency)",
             "description = \(String(describing: stripeDescription))",
             "lastPaymentError = \(String(describing: lastPaymentError))",
-            "linkSettings = \(String(describing: linkSettings))",
             "livemode = \(livemode)",
             "nextAction = \(String(describing: nextAction))",
-            "merchantCountryCode = \(String(describing: merchantCountryCode))",
             "paymentMethodId = \(String(describing: paymentMethodId))",
             "paymentMethod = \(String(describing: paymentMethod))",
             "paymentMethodOptions = \(String(describing: paymentMethodOptions))",
@@ -181,8 +160,6 @@ public class STPPaymentIntent: NSObject {
             "shipping = \(String(describing: shipping))",
             "sourceId = \(String(describing: sourceId))",
             "status = \(String(describing: allResponseFields["status"] as? String))",
-            "unactivatedPaymentMethodTypes = \(allResponseFields.stp_array(forKey: "unactivated_payment_method_types") ?? [])",
-            "cardBrandChoice = \(String(describing: cardBrandChoice))",
         ]
 
         return "<\(props.joined(separator: "; "))>"
@@ -195,15 +172,11 @@ public class STPPaymentIntent: NSObject {
         captureMethod: STPPaymentIntentCaptureMethod,
         clientSecret: String,
         confirmationMethod: STPPaymentIntentConfirmationMethod,
-        countryCode: String?,
         created: Date,
         currency: String,
         lastPaymentError: STPPaymentIntentLastPaymentError?,
-        linkSettings: LinkSettings?,
         livemode: Bool,
         nextAction: STPIntentAction?,
-        merchantCountryCode: String?,
-        orderedPaymentMethodTypes: [STPPaymentMethodType],
         paymentMethod: STPPaymentMethod?,
         paymentMethodId: String?,
         paymentMethodOptions: STPPaymentMethodOptions?,
@@ -214,9 +187,7 @@ public class STPPaymentIntent: NSObject {
         sourceId: String?,
         status: STPPaymentIntentStatus,
         stripeDescription: String?,
-        stripeId: String,
-        unactivatedPaymentMethodTypes: [STPPaymentMethodType],
-        cardBrandChoice: STPCardBrandChoice?
+        stripeId: String
     ) {
         self.allResponseFields = allResponseFields
         self.amount = amount
@@ -224,15 +195,11 @@ public class STPPaymentIntent: NSObject {
         self.captureMethod = captureMethod
         self.clientSecret = clientSecret
         self.confirmationMethod = confirmationMethod
-        self.countryCode = countryCode
         self.created = created
         self.currency = currency
         self.lastPaymentError = lastPaymentError
-        self.linkSettings = linkSettings
         self.livemode = livemode
         self.nextAction = nextAction
-        self.merchantCountryCode = merchantCountryCode
-        self.orderedPaymentMethodTypes = orderedPaymentMethodTypes
         self.paymentMethod = paymentMethod
         self.paymentMethodId = paymentMethodId
         self.paymentMethodOptions = paymentMethodOptions
@@ -244,8 +211,6 @@ public class STPPaymentIntent: NSObject {
         self.status = status
         self.stripeDescription = stripeDescription
         self.stripeId = stripeId
-        self.unactivatedPaymentMethodTypes = unactivatedPaymentMethodTypes
-        self.cardBrandChoice = cardBrandChoice
         super.init()
     }
 }
@@ -255,32 +220,6 @@ extension STPPaymentIntent: STPAPIResponseDecodable {
 
     @objc
     public class func decodedObject(fromAPIResponse response: [AnyHashable: Any]?) -> Self? {
-        guard let response = response else {
-            return nil
-        }
-
-        if let paymentMethodPrefDict = response["payment_method_preference"] as? [AnyHashable: Any],
-            let paymentIntentDict = paymentMethodPrefDict["payment_intent"] as? [AnyHashable: Any],
-            let orderedPaymentMethodTypes = paymentMethodPrefDict["ordered_payment_method_types"]
-                as? [String]
-        {
-            // Consolidates expanded payment_intent and ordered_payment_method_types into singular dict for decoding
-            var dict = paymentIntentDict
-            dict["country_code"] = paymentMethodPrefDict["country_code"]
-            dict["merchant_country"] = response["merchant_country"]
-            dict["ordered_payment_method_types"] = orderedPaymentMethodTypes
-            dict["unactivated_payment_method_types"] = response["unactivated_payment_method_types"]
-            dict["link_settings"] = response["link_settings"]
-            dict["payment_method_specs"] = response["payment_method_specs"]
-            dict["card_brand_choice"] = response["card_brand_choice"]
-            return decodeSTPPaymentIntentObject(fromAPIResponse: dict)
-        } else {
-            return decodeSTPPaymentIntentObject(fromAPIResponse: response)
-        }
-    }
-
-    class func decodeSTPPaymentIntentObject(fromAPIResponse response: [AnyHashable: Any]?) -> Self?
-    {
         guard let dict = response,
             let stripeId = dict["id"] as? String,
             let clientSecret = dict["client_secret"] as? String,
@@ -299,9 +238,6 @@ extension STPPaymentIntent: STPAPIResponseDecodable {
         )
         let setupFutureUsageString = dict["setup_future_usage"] as? String
         let canceledAtUnixTime = dict["canceled_at"] as? TimeInterval
-        let unactivatedPaymentTypes = STPPaymentMethod.paymentMethodTypes(
-            from: dict["unactivated_payment_method_types"] as? [String] ?? []
-        )
         return STPPaymentIntent(
             allResponseFields: dict,
             amount: amount,
@@ -314,22 +250,14 @@ extension STPPaymentIntent: STPAPIResponseDecodable {
             confirmationMethod: STPPaymentIntentConfirmationMethod.confirmationMethod(
                 from: dict["confirmation_method"] as? String ?? ""
             ),
-            countryCode: dict["country_code"] as? String,
             created: Date(timeIntervalSince1970: createdUnixTime),
             currency: currency,
             lastPaymentError: STPPaymentIntentLastPaymentError.decodedObject(
                 fromAPIResponse: dict["last_payment_error"] as? [AnyHashable: Any]
             ),
-            linkSettings: LinkSettings.decodedObject(
-                fromAPIResponse: dict["link_settings"] as? [AnyHashable: Any]
-            ),
             livemode: livemode,
             nextAction: STPIntentAction.decodedObject(
                 fromAPIResponse: dict["next_action"] as? [AnyHashable: Any]
-            ),
-            merchantCountryCode: dict["merchant_country"] as? String,
-            orderedPaymentMethodTypes: STPPaymentMethod.paymentMethodTypes(
-                from: dict["ordered_payment_method_types"] as? [String] ?? paymentMethodTypeStrings
             ),
             paymentMethod: paymentMethod,
             paymentMethodId: paymentMethod?.stripeId ?? dict["payment_method"] as? String,
@@ -346,9 +274,7 @@ extension STPPaymentIntent: STPAPIResponseDecodable {
             sourceId: dict["source"] as? String,
             status: STPPaymentIntentStatus.status(from: rawStatus),
             stripeDescription: dict["description"] as? String,
-            stripeId: stripeId,
-            unactivatedPaymentMethodTypes: unactivatedPaymentTypes,
-            cardBrandChoice: STPCardBrandChoice.decodedObject(fromAPIResponse: dict["card_brand_choice"] as? [AnyHashable: Any])
+            stripeId: stripeId
         ) as? Self
     }
 }

--- a/StripePayments/StripePaymentsObjcTestUtils/Resources/Mock Files/ElementsSession.json
+++ b/StripePayments/StripePaymentsObjcTestUtils/Resources/Mock Files/ElementsSession.json
@@ -195,5 +195,5 @@
   "shipping_address_settings": {
     "autocomplete_allowed": true
   },
-  "unactivated_payment_method_types": ["cashapp"]
+  "unactivated_payment_method_types": []
 }

--- a/StripePayments/StripePaymentsTestUtils/STPFixtures+Swift.swift
+++ b/StripePayments/StripePaymentsTestUtils/STPFixtures+Swift.swift
@@ -27,28 +27,24 @@ public extension STPFixtures {
 
     static func paymentIntent(
         paymentMethodTypes: [String],
-        orderedPaymentMethodTypes: [String]? = nil,
         setupFutureUsage: STPPaymentIntentSetupFutureUsage = .none,
         currency: String = "usd",
         status: STPPaymentIntentStatus = .requiresPaymentMethod
     ) -> STPPaymentIntent {
-        var apiResponse: [AnyHashable: Any?] = [
+        var apiResponse: [AnyHashable: Any] = [
             "id": "123",
             "client_secret": "sec",
-            "amount": 10,
+            "amount": 2345,
             "currency": currency,
             "status": STPPaymentIntentStatus.string(from: status),
             "livemode": false,
             "created": 1652736692.0,
             "payment_method_types": paymentMethodTypes,
-            "setup_future_usage": setupFutureUsage.stringValue,
         ]
-        if let orderedPaymentMethodTypes = orderedPaymentMethodTypes {
-            apiResponse["ordered_payment_method_types"] = orderedPaymentMethodTypes
+        if let setupFutureUsage = setupFutureUsage.stringValue {
+            apiResponse["setup_future_usage"] = setupFutureUsage
         }
-        return STPPaymentIntent.decodeSTPPaymentIntentObject(
-            fromAPIResponse: apiResponse as [AnyHashable: Any]
-        )!
+        return STPPaymentIntent.decodedObject(fromAPIResponse: apiResponse)!
     }
 }
 

--- a/StripePayments/StripePaymentsTestUtils/STPNetworkStubbingTestCase.swift
+++ b/StripePayments/StripePaymentsTestUtils/STPNetworkStubbingTestCase.swift
@@ -7,16 +7,16 @@
 //
 
 import OHHTTPStubs
-import XCTest
 @testable@_spi(STP) import StripeCore
+import XCTest
 
 /// Test cases that subclass `STPNetworkStubbingTestCase` will automatically capture all network traffic when run with `recordingMode = YES` and save it to disk. When run with `recordingMode = NO`, they will use the persisted request/response pairs, and raise an exception if an unexpected HTTP request is made.
 /// ⚠️ Warning: `STPAPIClient`s created before `setUp` is called are not recorded!
-@objc(STPNetworkStubbingTestCase) public class STPNetworkStubbingTestCase: XCTestCase {
+@objc(STPNetworkStubbingTestCase) open class STPNetworkStubbingTestCase: XCTestCase {
     /// Set this to YES to record all traffic during this test. The test will then fail, to remind you to set this back to NO before pushing.
-    var recordingMode = false
+    open var recordingMode = false
 
-    public override func setUp() {
+    open override func setUp() {
         super.setUp()
 
         // Set the STPTestingAPIClient to use the sharedURLSessionConfig so that we can intercept requests from it too
@@ -131,7 +131,7 @@ import XCTest
         }
     }
 
-    public override func tearDown() {
+    open override func tearDown() {
         super.tearDown()
         // Additional calls to `setFileNamingBlock` will be ignored if you don't do this
         SWHttpTrafficRecorder.shared().stopRecording()


### PR DESCRIPTION
## Summary
When PaymentSheet loads with an IntentConfiguration, we call `retrieveElementsSession` and use `STPElementsSession` to represent the response. Pretty reasonable.

In contrast, when PaymentSheet loads with a PI or SI client secret, the old code loaded `v1/elements/sessions` by calling `retrievePaymentIntentWithPreferences`, a method that returns an API bindings STPPaymentIntent object. This is weird! The endpoint response contains a bunch of other fields in addition to the PaymentIntent object. To access them, we either:
1. Added the field as a `_spi public` property on the STPPaymentIntent object, even though it's not a PaymentIntent field. 
2. Accessed the field via `STPPaymentIntent.additionalAPIParameters`, an untyped dictionary.

This PR refactors the code to use `STPElementsSession` to represent the `v1/elements/session` response.

| Before | After |
| --- | --- |
| `Intent.paymentIntent(STPPaymentIntent)` | `Intent.paymentIntent(STPPaymentIntent, STPElementsSession)` |
| `func retrievePaymentIntentWithPreferences(..) -> STPPaymentIntent` | `func retrieveElementsSession(..) -> (STPaymentIntent, STPElementsSession)` |
| `paymentIntent.cardBrandChoice` | `elementsSession.cardBrandChoice` |

The next PR will do the same work but for STPSetupIntent.

## Other stuff
- I added a "mc_elements_session_load_failed" analytic that's fired when `v1/elements/sessions` fails and we fall back.

## Motivation
Tech debt clean up ahead of adding more things to the `v1/elements/session` request and response.

## Testing
Existing unit tests + some a new one that explicitly tests fallback behavior `testPaymentSheetLoadPaymentIntentFallback`.

## Changelog
Not user facing.
