### PR TITLE
Update Localizable.strings

### DIFF
--- a/StripePaymentsUI/StripePaymentsUI/Resources/Localizations/et-EE.lproj/Localizable.strings
+++ b/StripePaymentsUI/StripePaymentsUI/Resources/Localizations/et-EE.lproj/Localizable.strings
@@ -60,6 +60,6 @@
 
 "card number" = "kaardinumber";
 
-"example@example.com" = "näide@näide.com";
+"example@example.com" = "näide@example.com";
 
 "expiration date" = "aegumiskuupäev";


### PR DESCRIPTION
**näide.com** is not the same as **example.com**

Read more - https://secret.näide.com/

## Summary
Localization was fixed, to use example.com domain not a private domain not owned by Stripe

## Motivation
Security related. Not an urgent(probably seen as a no-issue by many) security issue, but could/should trigger the thought process of the same "example.com" email in other languages

## Testing
Compare the output of
[https://example.com/](https://youtu.be/dQw4w9WgXcQ?Seriously+Watch+Where+You+Are+Clicking)
https://näide.com/
https://secret.example.com/
https://secret.näide.com/
To verify that they are not the same
