### PR TITLE
Add fallback if v1/elements/sessions fails in deferred flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## X.Y.Z 2023-y-z
 ### PaymentSheet
 * [Fixed] Visual bug where re-presenting PaymentSheet wouldn't show a spinner while it reloads.
+* [Added] If PaymentSheet fails to load a deferred intent configuration, we fall back to displaying cards (or the intent configuration payment method types) instead of failing.
 
 ## 23.18.2 2023-11-06
 ### CustomerSheet


### PR DESCRIPTION
## Summary
If /v1/elements/sessions fails in the deferred flow, we now fall back to a basic ElementsSession object that only has [cards] or the merchant intent configuration's payment method types.

## Motivation
Match web PE fallback behavior.

## Testing
See unit test

## Changelog
* [Added] If PaymentSheet fails to load a deferred intent configuration, we fall back to displaying cards (or the intent configuration payment method types) instead of failing.