### PR TITLE
Ability to remove co-branded saved cards

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -1030,8 +1030,12 @@ class PaymentSheetStandardLPMUITests: PaymentSheetUITestCase {
 
         // Remove this card
         XCTAssertTrue(app.buttons["Remove card"].waitForExistenceAndTap(timeout: 5))
+        let confirmRemoval = app.alerts.buttons["Remove"]
+        XCTAssertTrue(confirmRemoval.waitForExistence(timeout: 5))
+        confirmRemoval.tap()
 
-        // TODO(porter) Verify card is removed once it is implemented
+        // Card should be removed
+        XCTAssertFalse(app.staticTexts["••••1001"].waitForExistence(timeout: 5.0))
     }
 
     // This only tests the PaymentSheet + PaymentIntent flow.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
@@ -386,7 +386,7 @@ extension SavedPaymentOptionsViewController: PaymentOptionCellDelegate {
     ) {
         removePaymentMethod(paymentOptionCell: paymentOptionCell)
     }
-    
+
     private func removePaymentMethod(paymentOptionCell: SavedPaymentMethodCollectionView.PaymentOptionCell) {
             guard let indexPath = collectionView.indexPath(for: paymentOptionCell),
                   case .saved(let paymentMethod) = viewModels[indexPath.row]

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
@@ -375,6 +375,7 @@ extension SavedPaymentOptionsViewController: PaymentOptionCellDelegate {
 
         let editVc = UpdateCardViewController(paymentOptionCell: paymentOptionCell,
                                               paymentMethod: paymentMethod,
+                                              configuration: configuration,
                                               appearance: appearance)
         editVc.delegate = self
         self.bottomSheetController?.pushContentViewController(editVc)
@@ -383,16 +384,17 @@ extension SavedPaymentOptionsViewController: PaymentOptionCellDelegate {
     func paymentOptionCellDidSelectRemove(
         _ paymentOptionCell: SavedPaymentMethodCollectionView.PaymentOptionCell
     ) {
-        guard let indexPath = collectionView.indexPath(for: paymentOptionCell),
-              case .saved(let paymentMethod) = viewModels[indexPath.row]
-        else {
-            assertionFailure()
-            return
-        }
-        let viewModel = viewModels[indexPath.row]
-        let alert = UIAlertAction(
-            title: String.Localized.remove, style: .destructive
-        ) { (_) in
+        removePaymentMethod(paymentOptionCell: paymentOptionCell)
+    }
+    
+    private func removePaymentMethod(paymentOptionCell: SavedPaymentMethodCollectionView.PaymentOptionCell) {
+            guard let indexPath = collectionView.indexPath(for: paymentOptionCell),
+                  case .saved(let paymentMethod) = viewModels[indexPath.row]
+            else {
+                assertionFailure()
+                return
+            }
+            let viewModel = viewModels[indexPath.row]
             self.viewModels.remove(at: indexPath.row)
             // the deletion needs to be in a performBatchUpdates so we make sure it is completed
             // before potentially leaving edit mode (which triggers a reload that may collide with
@@ -418,27 +420,12 @@ extension SavedPaymentOptionsViewController: PaymentOptionCellDelegate {
                 )
             }
         }
-        let cancel = UIAlertAction(
-            title: String.Localized.cancel,
-            style: .cancel, handler: nil
-        )
-
-        let alertController = UIAlertController(
-            title: paymentMethod.removalMessage.title,
-            message: configuration.removeSavedPaymentMethodMessage ?? paymentMethod.removalMessage.message,
-            preferredStyle: .alert
-        )
-
-        alertController.addAction(cancel)
-        alertController.addAction(alert)
-        present(alertController, animated: true, completion: nil)
-    }
 }
 
 // MARK: - UpdateCardViewControllerDelegate
 extension SavedPaymentOptionsViewController: UpdateCardViewControllerDelegate {
     func didRemove(paymentOptionCell: SavedPaymentMethodCollectionView.PaymentOptionCell) {
-        // TODO(porter) Implement removal
+        removePaymentMethod(paymentOptionCell: paymentOptionCell)
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/UpdateCardViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/UpdateCardViewController.swift
@@ -143,7 +143,7 @@ final class UpdateCardViewController: UIViewController {
         guard let bottomVc = parent as? BottomSheetViewController else { return }
         _ = bottomVc.popContentViewController()
     }
-    
+
     private func removeCard() {
         let alert = UIAlertAction(
             title: String.Localized.remove, style: .destructive


### PR DESCRIPTION
## Summary
- Adds the ability to remove co-branded saved cards from the UpdateCardViewController

## Motivation
https://docs.google.com/document/d/1T12LgVTkEv-LaDtQO3lGgNDt3nV_mwrUOJWgfUmTa9U/edit#heading=h.jc7kakrp60yy

## Testing
- Manual
- Updated UI test

## Changelog
N/A