### PR TITLE
Inject card brand choice flag into CustomerSheet

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlayground.swift
@@ -78,7 +78,7 @@ struct CustomerSheetTestPlayground: View {
                 .environmentObject(playgroundController)
         }
     }
-    
+
     var merchantCountryBinding: Binding<CustomerSheetTestPlaygroundSettings.MerchantCountry> {
         Binding<CustomerSheetTestPlaygroundSettings.MerchantCountry> {
             return playgroundController.settings.merchantCountryCode

--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlayground.swift
@@ -50,6 +50,7 @@ struct CustomerSheetTestPlayground: View {
                                 Text("Appearance").font(.callout.smallCaps())
                             }.buttonStyle(.bordered)
                         }
+                        SettingPickerView(setting: merchantCountryBinding)
                         SettingView(setting: $playgroundController.settings.paymentMethodMode)
                         SettingView(setting: $playgroundController.settings.applePay)
                         SettingView(setting: $playgroundController.settings.defaultBillingAddress)
@@ -75,6 +76,19 @@ struct CustomerSheetTestPlayground: View {
             Divider()
             CustomerSheetButtons()
                 .environmentObject(playgroundController)
+        }
+    }
+    
+    var merchantCountryBinding: Binding<CustomerSheetTestPlaygroundSettings.MerchantCountry> {
+        Binding<CustomerSheetTestPlaygroundSettings.MerchantCountry> {
+            return playgroundController.settings.merchantCountryCode
+        } set: { newCountry in
+            // Reset customer id if country changes
+            if playgroundController.settings.merchantCountryCode.rawValue != newCountry.rawValue {
+                playgroundController.settings.customerId = nil
+                playgroundController.settings.customerMode = .new
+            }
+            playgroundController.settings.merchantCountryCode = newCountry
         }
     }
 

--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlayground.swift
@@ -85,7 +85,6 @@ struct CustomerSheetTestPlayground: View {
         } set: { newCountry in
             // Reset customer id if country changes
             if playgroundController.settings.merchantCountryCode.rawValue != newCountry.rawValue {
-                playgroundController.settings.customerId = nil
                 playgroundController.settings.customerMode = .new
             }
             playgroundController.settings.merchantCountryCode = newCountry

--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundController.swift
@@ -136,7 +136,7 @@ class CustomerSheetTestPlaygroundController: ObservableObject {
                 // This should be a block that fetches this from your server
                 .init(customerId: customerId, ephemeralKeySecret: ephemeralKey)
             }, setupIntentClientSecretProvider: {
-                return try await self.backend.createSetupIntent(customerId: customerId)
+                return try await self.backend.createSetupIntent(customerId: customerId, merchantCountryCode: self.settings.merchantCountryCode.rawValue)
             })
         case .createAndAttach:
             customerAdapter = StripeCustomerAdapter(customerEphemeralKeyProvider: {
@@ -296,8 +296,9 @@ class CustomerSheetBackend {
         task.resume()
     }
 
-    func createSetupIntent(customerId: String) async throws -> String {
+    func createSetupIntent(customerId: String, merchantCountryCode: String) async throws -> String {
         let body = [ "customer_id": customerId,
+                     "merchant_country_code": merchantCountryCode
         ] as [String: Any]
         let url = URL(string: "\(endpoint)/create_setup_intent")!
         let session = URLSession.shared

--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundController.swift
@@ -298,7 +298,7 @@ class CustomerSheetBackend {
 
     func createSetupIntent(customerId: String, merchantCountryCode: String) async throws -> String {
         let body = [ "customer_id": customerId,
-                     "merchant_country_code": merchantCountryCode
+                     "merchant_country_code": merchantCountryCode,
         ] as [String: Any]
         let url = URL(string: "\(endpoint)/create_setup_intent")!
         let session = URLSession.shared

--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundSettings.swift
@@ -71,6 +71,12 @@ public struct CustomerSheetTestPlaygroundSettings: Codable, Equatable {
         case never
         case full
     }
+    enum MerchantCountry: String, PickerEnum {
+        static var enumName: String { "MerchantCountry" }
+
+        case US
+        case FR
+    }
 
     var customerMode: CustomerMode
     var customerId: String?
@@ -85,6 +91,7 @@ public struct CustomerSheetTestPlaygroundSettings: Codable, Equatable {
     var collectEmail: BillingDetailsEmail
     var collectPhone: BillingDetailsPhone
     var collectAddress: BillingDetailsAddress
+    var merchantCountryCode: MerchantCountry
 
     static func defaultValues() -> CustomerSheetTestPlaygroundSettings {
         return CustomerSheetTestPlaygroundSettings(customerMode: .new,
@@ -98,7 +105,8 @@ public struct CustomerSheetTestPlaygroundSettings: Codable, Equatable {
                                                    collectName: .automatic,
                                                    collectEmail: .automatic,
                                                    collectPhone: .automatic,
-                                                   collectAddress: .automatic)
+                                                   collectAddress: .automatic,
+                                                   merchantCountryCode: .US)
     }
 
     var base64Data: String {

--- a/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
@@ -660,21 +660,21 @@ class CustomerSheetUITest: XCTestCase {
         let last4Selectedlabel = app.staticTexts["(Selected)"]
         XCTAssertTrue(last4Selectedlabel.waitForExistence(timeout: 10.0))
     }
-    
+
     // MARK: - Card Brand Choice tests
-    
+
     func testCardBrandChoice() throws {
         app.launch()
         app.staticTexts["CustomerSheet (test playground)"].tap()
-        
+
         // Change to French merchant
         let predicate = NSPredicate(format: "label BEGINSWITH[cd] 'MerchantCountry'")
         app.buttons.element(matching: predicate).waitForExistenceAndTap(timeout: 5)
         app.buttons["FR"].waitForExistenceAndTap(timeout: 5)
-        
+
         // Use a new customer each time
         app.buttons["new"].tap()
-        
+
         let button = app.buttons["Payment method"]
         XCTAssertTrue(button.waitForExistence(timeout: 5))
         button.forceTapElement()
@@ -745,21 +745,21 @@ class CustomerSheetUITest: XCTestCase {
         // Currently only our French merchant is eligible for card brand choice
         app.launch()
         app.staticTexts["CustomerSheet (test playground)"].tap()
-        
+
         // Use a new customer each time
         app.buttons["new"].tap()
-        
+
         // Change to French merchant
         let predicate = NSPredicate(format: "label BEGINSWITH[cd] 'MerchantCountry'")
         app.buttons.element(matching: predicate).waitForExistenceAndTap(timeout: 5)
         app.buttons["FR"].waitForExistenceAndTap(timeout: 5)
-        
+
         let button = app.buttons["Payment method"]
         XCTAssertTrue(button.waitForExistence(timeout: 5))
         button.forceTapElement()
 
         app.staticTexts["+ Add"].tap()
-        
+
         let numberField = app.textFields["Card number"]
         let cardBrandChoiceDropdown = app.pickerWheels.firstMatch
 

--- a/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
@@ -663,96 +663,14 @@ class CustomerSheetUITest: XCTestCase {
 
     // MARK: - Card Brand Choice tests
 
-    func testCardBrandChoice() throws {
-        app.launch()
-        app.staticTexts["CustomerSheet (test playground)"].tap()
-
-        // Change to French merchant
-        let predicate = NSPredicate(format: "label BEGINSWITH[cd] 'MerchantCountry'")
-        app.buttons.element(matching: predicate).waitForExistenceAndTap(timeout: 5)
-        app.buttons["FR"].waitForExistenceAndTap(timeout: 5)
-
-        // Use a new customer each time
-        app.buttons["new"].tap()
-
-        let button = app.buttons["Payment method"]
-        XCTAssertTrue(button.waitForExistence(timeout: 5))
-        button.forceTapElement()
-
-        app.staticTexts["+ Add"].tap()
-
-        let cardBrandTextField = app.textFields["Select card brand (optional)"]
-        let cardBrandChoiceDropdown = app.pickerWheels.firstMatch
-        // Card brand choice textfield/dropdown should not be visible
-        XCTAssertFalse(cardBrandTextField.waitForExistence(timeout: 2))
-
-        let numberField = app.textFields["Card number"]
-        numberField.tap()
-        // Enter 8 digits to start fetching card brand
-        numberField.typeText("49730197")
-
-        // Card brand choice drop down should be enabled
-        cardBrandTextField.tap()
-        XCTAssertTrue(cardBrandChoiceDropdown.waitForExistence(timeout: 5))
-        cardBrandChoiceDropdown.swipeUp()
-        app.toolbars.buttons["Cancel"].tap()
-
-        // We should still have no selected card brand
-        XCTAssertTrue(app.textFields["Select card brand (optional)"].waitForExistence(timeout: 5))
-
-        // Select Visa from the CBC dropdown
-        cardBrandTextField.tap()
-        XCTAssertTrue(cardBrandChoiceDropdown.waitForExistence(timeout: 5))
-        cardBrandChoiceDropdown.swipeUp()
-        app.toolbars.buttons["Done"].tap()
-
-        // We should have selected Visa
-        XCTAssertTrue(app.textFields["Visa"].waitForExistence(timeout: 5))
-
-        // Clear card text field, should reset selected card brand
-        numberField.tap()
-        numberField.clearText()
-
-        // We should reset to showing unknown in the textfield for card brand
-        XCTAssertFalse(app.textFields["Select card brand (optional)"].waitForExistence(timeout: 5))
-
-        // Type full card number to start fetching card brands again
-        numberField.forceTapWhenHittableInTestCase(self)
-        app.typeText("4000002500001001")
-        app.textFields["expiration date"].waitForExistenceAndTap(timeout: 5)
-        app.typeText("1228") // Expiry
-        app.typeText("123") // CVC
-        app.toolbars.buttons["Done"].tap() // Country picker toolbar's "Done" button
-        app.typeText("12345") // Postal
-
-        // Card brand choice drop down should be enabled
-        XCTAssertTrue(app.textFields["Select card brand (optional)"].waitForExistenceAndTap(timeout: 5))
-        XCTAssertTrue(cardBrandChoiceDropdown.waitForExistence(timeout: 5))
-        cardBrandChoiceDropdown.swipeUp() // Swipe to select Visa
-        app.toolbars.buttons["Done"].tap()
-
-        // We should have selected Visa
-        XCTAssertTrue(app.textFields["Visa"].waitForExistence(timeout: 5))
-
-        // Finish saving card
-        app.buttons["Save"].tap()
-        app.buttons["Confirm"].waitForExistenceAndTap(timeout: 5)
-        let completeText = app.staticTexts["Complete"]
-        XCTAssertTrue(completeText.waitForExistence(timeout: 5))
-    }
-
     func testCardBrandChoiceSavedCard() {
-        // Currently only our French merchant is eligible for card brand choice
-        app.launch()
-        app.staticTexts["CustomerSheet (test playground)"].tap()
-
-        // Use a new customer each time
-        app.buttons["new"].tap()
-
-        // Change to French merchant
-        let predicate = NSPredicate(format: "label BEGINSWITH[cd] 'MerchantCountry'")
-        app.buttons.element(matching: predicate).waitForExistenceAndTap(timeout: 5)
-        app.buttons["FR"].waitForExistenceAndTap(timeout: 5)
+        var settings = CustomerSheetTestPlaygroundSettings.defaultValues()
+        settings.customerMode = .new
+        settings.merchantCountryCode = .FR
+        loadPlayground(
+            app,
+            settings
+        )
 
         let button = app.buttons["Payment method"]
         XCTAssertTrue(button.waitForExistence(timeout: 5))
@@ -802,6 +720,8 @@ class CustomerSheetUITest: XCTestCase {
         XCTAssertTrue(app.buttons["CircularButton.Edit"].waitForExistenceAndTap(timeout: 5))
         // TODO(porter) Verify card is removed once it is implemented
     }
+
+    // MARK: - Helpers
 
     func presentCSAndAddCardFrom(buttonLabel: String, tapAdd: Bool = true) {
         let selectButton = app.staticTexts[buttonLabel]

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerAddPaymentMethodViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerAddPaymentMethodViewController.swift
@@ -214,7 +214,7 @@ class CustomerAddPaymentMethodViewController: UIViewController {
             addressSpecProvider: .shared,
             offerSaveToLinkWhenSupported: false,
             linkAccount: nil,
-            cardBrandChoiceEligible: configuration.cbcEnabled,
+            cardBrandChoiceEligible: cbcEligible,
             supportsLinkCard: false,
             isPaymentIntent: false,
             currency: nil,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerAddPaymentMethodViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerAddPaymentMethodViewController.swift
@@ -18,6 +18,7 @@ protocol CustomerAddPaymentMethodViewControllerDelegate: AnyObject {
 class CustomerAddPaymentMethodViewController: UIViewController {
 
     let paymentMethodTypes: [PaymentSheet.PaymentMethodType]
+    let cbcEligible: Bool
 
     // MARK: - Read-only Properties
     weak var delegate: CustomerAddPaymentMethodViewControllerDelegate?
@@ -115,11 +116,13 @@ class CustomerAddPaymentMethodViewController: UIViewController {
     required init(
         configuration: CustomerSheet.Configuration,
         paymentMethodTypes: [PaymentSheet.PaymentMethodType],
+        cbcEligible: Bool,
         delegate: CustomerAddPaymentMethodViewControllerDelegate
     ) {
         self.configuration = configuration
         self.delegate = delegate
         self.paymentMethodTypes = paymentMethodTypes
+        self.cbcEligible = cbcEligible
         super.init(nibName: nil, bundle: nil)
         self.view.backgroundColor = configuration.appearance.colors.background
     }
@@ -211,6 +214,7 @@ class CustomerAddPaymentMethodViewController: UIViewController {
             addressSpecProvider: .shared,
             offerSaveToLinkWhenSupported: false,
             linkAccount: nil,
+            cardBrandChoiceEligible: configuration.cbcEnabled,
             supportsLinkCard: false,
             isPaymentIntent: false,
             currency: nil,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewController.swift
@@ -114,7 +114,7 @@ class CustomerSavedPaymentMethodsCollectionViewController: UIViewController {
     let savedPaymentMethodsConfiguration: CustomerSheet.Configuration
     let customerAdapter: CustomerAdapter
     let cbcEligible: Bool
-    
+
     var selectedPaymentOption: PaymentOption? {
         guard let index = selectedViewModelIndex else {
             return nil

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewController.swift
@@ -343,7 +343,7 @@ extension CustomerSavedPaymentMethodsCollectionViewController: UICollectionViewD
         }
 
         cell.setViewModel(viewModel.toSavedPaymentOptionsViewControllerSelection(),
-                          cbcEligible: savedPaymentMethodsConfiguration.cbcEnabled && cbcEligible)
+                          cbcEligible: cbcEligible)
         cell.delegate = self
         cell.isRemovingPaymentMethods = self.collectionView.isRemovingPaymentMethods
         cell.appearance = appearance

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewController.swift
@@ -113,7 +113,8 @@ class CustomerSavedPaymentMethodsCollectionViewController: UIViewController {
     let configuration: Configuration
     let savedPaymentMethodsConfiguration: CustomerSheet.Configuration
     let customerAdapter: CustomerAdapter
-
+    let cbcEligible: Bool
+    
     var selectedPaymentOption: PaymentOption? {
         guard let index = selectedViewModelIndex else {
             return nil
@@ -196,6 +197,7 @@ class CustomerSavedPaymentMethodsCollectionViewController: UIViewController {
         customerAdapter: CustomerAdapter,
         configuration: Configuration,
         appearance: PaymentSheet.Appearance,
+        cbcEligible: Bool,
         delegate: CustomerSavedPaymentMethodsCollectionViewControllerDelegate? = nil
     ) {
         self.savedPaymentMethods = savedPaymentMethods
@@ -204,6 +206,7 @@ class CustomerSavedPaymentMethodsCollectionViewController: UIViewController {
         self.configuration = configuration
         self.customerAdapter = customerAdapter
         self.appearance = appearance
+        self.cbcEligible = cbcEligible
         self.delegate = delegate
         self.unsyncedSavedPaymentMethods = []
         super.init(nibName: nil, bundle: nil)
@@ -339,8 +342,8 @@ extension CustomerSavedPaymentMethodsCollectionViewController: UICollectionViewD
             return UICollectionViewCell()
         }
 
-        // TODO(porter) CBC check in CustomerSheet
-        cell.setViewModel(viewModel.toSavedPaymentOptionsViewControllerSelection(), cbcEligible: false)
+        cell.setViewModel(viewModel.toSavedPaymentOptionsViewControllerSelection(),
+                          cbcEligible: savedPaymentMethodsConfiguration.cbcEnabled && cbcEligible)
         cell.delegate = self
         cell.isRemovingPaymentMethods = self.collectionView.isRemovingPaymentMethods
         cell.appearance = appearance

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsViewController.swift
@@ -26,6 +26,7 @@ class CustomerSavedPaymentMethodsViewController: UIViewController {
     let isApplePayEnabled: Bool
     let configuration: CustomerSheet.Configuration
     let customerAdapter: CustomerAdapter
+    let cbcEligible: Bool
 
     // MARK: - Writable Properties
     weak var delegate: CustomerSavedPaymentMethodsViewControllerDelegate?
@@ -45,6 +46,7 @@ class CustomerSavedPaymentMethodsViewController: UIViewController {
         return CustomerAddPaymentMethodViewController(
             configuration: configuration,
             paymentMethodTypes: paymentMethodTypes,
+            cbcEligible: cbcEligible,
             delegate: self)
     }()
     private var cachedClientSecret: String?
@@ -86,6 +88,7 @@ class CustomerSavedPaymentMethodsViewController: UIViewController {
                 showApplePay: showApplePay
             ),
             appearance: configuration.appearance,
+            cbcEligible: cbcEligible,
             delegate: self
         )
     }()
@@ -123,6 +126,7 @@ class CustomerSavedPaymentMethodsViewController: UIViewController {
         configuration: CustomerSheet.Configuration,
         customerAdapter: CustomerAdapter,
         isApplePayEnabled: Bool,
+        cbcEligible: Bool,
         csCompletion: CustomerSheet.CustomerSheetCompletion?,
         delegate: CustomerSavedPaymentMethodsViewControllerDelegate
     ) {
@@ -132,6 +136,7 @@ class CustomerSavedPaymentMethodsViewController: UIViewController {
         self.configuration = configuration
         self.customerAdapter = customerAdapter
         self.isApplePayEnabled = isApplePayEnabled
+        self.cbcEligible = cbcEligible
         self.csCompletion = csCompletion
         self.delegate = delegate
         if Self.shouldShowPaymentMethodCarousel(savedPaymentMethods: savedPaymentMethods, isApplePayEnabled: isApplePayEnabled) {
@@ -574,6 +579,7 @@ class CustomerSavedPaymentMethodsViewController: UIViewController {
         self.addPaymentMethodViewController = CustomerAddPaymentMethodViewController(
             configuration: configuration,
             paymentMethodTypes: paymentMethodTypes,
+            cbcEligible: cbcEligible,
             delegate: self)
         cachedClientSecret = nil
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetConfiguration.swift
@@ -58,6 +58,9 @@ extension CustomerSheet {
 
         /// Optional configuration to display a custom message when a saved payment method is removed.
         public var removeSavedPaymentMethodMessage: String?
+        
+        // TODO(porter) Remove for CBC GA
+        @_spi(STP) public var cbcEnabled: Bool = false
 
         public init () {
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetConfiguration.swift
@@ -58,7 +58,7 @@ extension CustomerSheet {
 
         /// Optional configuration to display a custom message when a saved payment method is removed.
         public var removeSavedPaymentMethodMessage: String?
-        
+
         // TODO(porter) Remove for CBC GA
         @_spi(STP) public var cbcEnabled: Bool = false
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/CustomerSheet/CustomerSheetTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/CustomerSheet/CustomerSheetTests.swift
@@ -87,14 +87,14 @@ class CustomerSheetTests: APIStubbedTestCase {
         let loadPaymentMethodInfo = expectation(description: "loadPaymentMethodInfo completed")
         let customerSheet = CustomerSheet(configuration: configuration, customer: customerAdapter)
         customerSheet.loadPaymentMethodInfo { result in
-            guard case .success((let paymentMethods, let selectedPaymentMethod, let merchantSupportedPaymentMethodTypes)) = result else {
+            guard case .success((let paymentMethods, let selectedPaymentMethod, let elementsSession)) = result else {
                 XCTFail()
                 return
             }
             XCTAssertEqual(paymentMethods.count, 1)
             XCTAssertEqual(paymentMethods[0].type, .USBankAccount)
             XCTAssert(selectedPaymentMethod == nil)
-            XCTAssertEqual(merchantSupportedPaymentMethodTypes, [.USBankAccount])
+            XCTAssertEqual(elementsSession.orderedPaymentMethodTypes, [.USBankAccount])
             loadPaymentMethodInfo.fulfill()
         }
         wait(for: [loadPaymentMethodInfo], timeout: 5.0)

--- a/StripeUICore/StripeUICore/Source/Elements/PickerField/PickerFieldView.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/PickerField/PickerFieldView.swift
@@ -194,7 +194,7 @@ final class PickerFieldView: UIView {
     }
 
     override func becomeFirstResponder() -> Bool {
-        guard _canBecomeFirstResponder else {
+        guard _canBecomeFirstResponder, isUserInteractionEnabled else {
             return false
         }
 

--- a/StripeUICore/StripeUICore/Source/Elements/PickerField/PickerFieldView.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/PickerField/PickerFieldView.swift
@@ -194,6 +194,9 @@ final class PickerFieldView: UIView {
     }
 
     override func becomeFirstResponder() -> Bool {
+        // Prevents unwanted invocation of the picker's `becomeFirstResponder` method.
+        // Sometimes, when the picker is added as a subview or when its `isUserInteractionEnabled` is toggled,
+        // the operating system mistakenly calls `becomeFirstResponder`, causing the drop-down to display unintentionally.
         guard _canBecomeFirstResponder, isUserInteractionEnabled else {
             return false
         }


### PR DESCRIPTION
## Summary
- Adds a CBC enabled flag to the CustomerSheet configuration. This flag will be removed for GA, but exists as a way for us to disable CBC while it is still in development.
- Reads off the elements/session response if the merchant is eligible for card brand choice, and injects that into child components that already have support for CBC.
- Updates CustomerSheet playground to send merchant country code
- Adds some UI tests

## Motivation
CBC

## Testing
- Manual
- New UI tests

## Changelog
N/A
