### PR TITLE
Add preferredNetworks to CustomerSheet and co-branded removal support

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlayground.swift
@@ -54,6 +54,7 @@ struct CustomerSheetTestPlayground: View {
                         SettingView(setting: $playgroundController.settings.paymentMethodMode)
                         SettingView(setting: $playgroundController.settings.applePay)
                         SettingView(setting: $playgroundController.settings.defaultBillingAddress)
+                        SettingView(setting: $playgroundController.settings.preferredNetworksEnabled)
                         SettingView(setting: $playgroundController.settings.autoreload)
                         TextField("headerTextForSelectionScreen", text: headerTextForSelectionScreenBinding)
                     }

--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundController.swift
@@ -124,6 +124,7 @@ class CustomerSheetTestPlaygroundController: ObservableObject {
         configuration.billingDetailsCollectionConfiguration.email = .init(rawValue: settings.collectEmail.rawValue)!
         configuration.billingDetailsCollectionConfiguration.address = .init(rawValue: settings.collectAddress.rawValue)!
         configuration.billingDetailsCollectionConfiguration.attachDefaultsToPaymentMethod = settings.attachDefaults == .on
+        configuration.preferredNetworks = settings.preferredNetworksEnabled == .on ? [.visa, .cartesBancaires] : nil
         configuration.cbcEnabled = true // TODO(porter) Remove this for CBC GA
         return configuration
     }

--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundSettings.swift
@@ -77,6 +77,21 @@ public struct CustomerSheetTestPlaygroundSettings: Codable, Equatable {
         case US
         case FR
     }
+    enum PreferredNetworksEnabled: String, PickerEnum {
+        static let enumName: String = "Preferred Networks (CBC)"
+
+        case on
+        case off
+
+        var displayName: String {
+            switch self {
+            case .on:
+                return "[visa, cartesBancaires]"
+            case .off:
+                return "off"
+            }
+        }
+    }
 
     var customerMode: CustomerMode
     var customerId: String?
@@ -92,6 +107,7 @@ public struct CustomerSheetTestPlaygroundSettings: Codable, Equatable {
     var collectPhone: BillingDetailsPhone
     var collectAddress: BillingDetailsAddress
     var merchantCountryCode: MerchantCountry
+    var preferredNetworksEnabled: PreferredNetworksEnabled
 
     static func defaultValues() -> CustomerSheetTestPlaygroundSettings {
         return CustomerSheetTestPlaygroundSettings(customerMode: .new,
@@ -106,7 +122,8 @@ public struct CustomerSheetTestPlaygroundSettings: Codable, Equatable {
                                                    collectEmail: .automatic,
                                                    collectPhone: .automatic,
                                                    collectAddress: .automatic,
-                                                   merchantCountryCode: .US)
+                                                   merchantCountryCode: .US,
+                                                   preferredNetworksEnabled: .off)
     }
 
     var base64Data: String {

--- a/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
@@ -718,7 +718,20 @@ class CustomerSheetUITest: XCTestCase {
 
         // Saved card should show the edit icon since it is co-branded
         XCTAssertTrue(app.buttons["CircularButton.Edit"].waitForExistenceAndTap(timeout: 5))
-        // TODO(porter) Verify card is removed once it is implemented
+
+        // Remove this card
+        XCTAssertTrue(app.buttons["Remove card"].waitForExistenceAndTap(timeout: 5))
+        let confirmRemoval = app.alerts.buttons["Remove"]
+        XCTAssertTrue(confirmRemoval.waitForExistence(timeout: 5))
+        confirmRemoval.tap()
+
+        // Verify card is removed
+        app.buttons["Done"].waitForExistenceAndTap(timeout: 5)
+        app.buttons["Close"].waitForExistenceAndTap(timeout: 5)
+        app.buttons["Reload"].waitForExistenceAndTap(timeout: 5)
+        app.buttons["Payment method"].waitForExistenceAndTap(timeout: 5)
+        // Card is no longer saved
+        XCTAssertFalse(app.staticTexts["••••1001"].waitForExistence(timeout: 5))
     }
 
     func testCardBrandChoiceWithPreferredNetworks() throws {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetConfiguration.swift
@@ -59,6 +59,17 @@ extension CustomerSheet {
         /// Optional configuration to display a custom message when a saved payment method is removed.
         public var removeSavedPaymentMethodMessage: String?
 
+        /// The list of preferred networks that should be used to process payments made with a co-branded card.
+        /// This value will only be used if your user hasn't selected a network themselves.
+        @_spi(STP)
+        public var preferredNetworks: [STPCardBrand]? {
+            didSet {
+                guard let preferredNetworks = preferredNetworks else { return }
+                assert(Set<STPCardBrand>(preferredNetworks).count == preferredNetworks.count,
+                       "preferredNetworks must not contain any duplicate card brands")
+            }
+        }
+
         // TODO(porter) Remove for CBC GA
         @_spi(STP) public var cbcEnabled: Bool = false
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetConfiguration.swift
@@ -61,7 +61,7 @@ extension CustomerSheet {
 
         /// The list of preferred networks that should be used to process payments made with a co-branded card.
         /// This value will only be used if your user hasn't selected a network themselves.
-        @_spi(STP)
+        @_spi(STP) // TODO(porter) Remove STP before CBC GA
         public var preferredNetworks: [STPCardBrand]? {
             didSet {
                 guard let preferredNetworks = preferredNetworks else { return }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
@@ -152,7 +152,7 @@ extension PaymentSheet {
 
         /// The list of preferred networks that should be used to process payments made with a co-branded card.
         /// This value will only be used if your user hasn't selected a network themselves.
-        @_spi(STP)
+        @_spi(STP) // TODO(porter) Remove STP before CBC GA
         public var preferredNetworks: [STPCardBrand]? {
             didSet {
                 guard let preferredNetworks = preferredNetworks else { return }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactoryConfig.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactoryConfig.swift
@@ -80,9 +80,8 @@ enum PaymentSheetFormFactoryConfig {
         switch self {
         case .paymentSheet(let config):
             return config.preferredNetworks
-        case .customerSheet:
-            // TODO(porter) Support CBC in CustomerSheet
-            return nil
+        case .customerSheet(let config):
+            return config.preferredNetworks
         }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
@@ -446,7 +446,7 @@ extension STPPaymentMethod {
     var removalMessage: (title: String, message: String) {
         switch type {
         case .card:
-            let brandString = STPCardBrandUtilities.stringFrom(card?.brand ?? .unknown) ?? ""
+            let brandString = STPCardBrandUtilities.stringFrom(card?.networks?.preferred?.toCardBrand ?? card?.brand ?? .unknown) ?? ""
             let last4 = card?.last4 ?? ""
             let formattedMessage = STPLocalizedString(
                 "Remove %1$@ ending in %2$@",

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
@@ -375,7 +375,7 @@ extension SavedPaymentOptionsViewController: PaymentOptionCellDelegate {
 
         let editVc = UpdateCardViewController(paymentOptionCell: paymentOptionCell,
                                               paymentMethod: paymentMethod,
-                                              configuration: configuration,
+                                              removeSavedPaymentMethodMessage: configuration.removeSavedPaymentMethodMessage,
                                               appearance: appearance)
         editVc.delegate = self
         self.bottomSheetController?.pushContentViewController(editVc)
@@ -391,7 +391,8 @@ extension SavedPaymentOptionsViewController: PaymentOptionCellDelegate {
             return
         }
 
-        let alertController = UIAlertController.makeRemoveAlertController(paymentMethod: paymentMethod, configuration: configuration) { [weak self] in
+        let alertController = UIAlertController.makeRemoveAlertController(paymentMethod: paymentMethod,
+                                                                          removeSavedPaymentMethodMessage: configuration.removeSavedPaymentMethodMessage) { [weak self] in
             guard let self = self else { return }
             self.removePaymentMethod(paymentOptionCell: paymentOptionCell)
         }
@@ -483,7 +484,7 @@ extension STPPaymentMethod {
 
 extension UIAlertController {
     static func makeRemoveAlertController(paymentMethod: STPPaymentMethod,
-                                          configuration: SavedPaymentOptionsViewController.Configuration,
+                                          removeSavedPaymentMethodMessage: String?,
                                           completion: @escaping () -> Void) -> UIAlertController {
         let alert = UIAlertAction(
             title: String.Localized.remove, style: .destructive
@@ -497,7 +498,7 @@ extension UIAlertController {
 
         let alertController = UIAlertController(
             title: paymentMethod.removalMessage.title,
-            message: configuration.removeSavedPaymentMethodMessage ?? paymentMethod.removalMessage.message,
+            message: removeSavedPaymentMethodMessage ?? paymentMethod.removalMessage.message,
             preferredStyle: .alert
         )
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/UpdateCardViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/UpdateCardViewController.swift
@@ -21,7 +21,7 @@ final class UpdateCardViewController: UIViewController {
     private let appearance: PaymentSheet.Appearance
     private let paymentMethod: STPPaymentMethod
     private let paymentOptionCell: SavedPaymentMethodCollectionView.PaymentOptionCell
-    private let configuration: SavedPaymentOptionsViewController.Configuration
+    private let removeSavedPaymentMethodMessage: String?
 
     weak var delegate: UpdateCardViewControllerDelegate?
 
@@ -102,11 +102,11 @@ final class UpdateCardViewController: UIViewController {
     // MARK: Overrides
     init(paymentOptionCell: SavedPaymentMethodCollectionView.PaymentOptionCell,
          paymentMethod: STPPaymentMethod,
-         configuration: SavedPaymentOptionsViewController.Configuration,
+         removeSavedPaymentMethodMessage: String?,
          appearance: PaymentSheet.Appearance) {
         self.paymentOptionCell = paymentOptionCell
         self.paymentMethod = paymentMethod
-        self.configuration = configuration
+        self.removeSavedPaymentMethodMessage = removeSavedPaymentMethodMessage
         self.appearance = appearance
 
         super.init(nibName: nil, bundle: nil)
@@ -145,7 +145,8 @@ final class UpdateCardViewController: UIViewController {
     }
 
     private func removeCard() {
-        let alertController = UIAlertController.makeRemoveAlertController(paymentMethod: paymentMethod, configuration: configuration) { [weak self] in
+        let alertController = UIAlertController.makeRemoveAlertController(paymentMethod: paymentMethod,
+                                                                          removeSavedPaymentMethodMessage: removeSavedPaymentMethodMessage) { [weak self] in
             guard let self = self else { return }
             self.delegate?.didRemove(paymentOptionCell: self.paymentOptionCell)
             self.dismiss()


### PR DESCRIPTION
## Summary
- Adds `preferredNetworks` to the CustomerSheet configuration. See [API review](https://docs.google.com/document/d/1AS-KAjxiIe49y87pZjxxTzhS0Do-BVe-UjYBwwDDx5M/edit#heading=h.570u4leviueu).
- Updates the CustomerSheet playground to allow for enabling preferred networks
- Updates the FormFactory config to read the preferred networks from the CustomerSheet configuration.
- Now when the edit button is tapped on a saved co-branded card we present the UpdateCardViewController
- We also handle the delegate (UpdateCardViewControllerDelegate) method for removing a co-branded card 

Demo of removing a co-branded card in CustomerSheet


https://github.com/stripe/stripe-ios/assets/88012362/46036df6-a1fa-4bfc-9ad6-2e90fb2f71c7



## Motivation
CBC

## Testing
- Manual
- Update exiting UI test
- New UI test

## Changelog
N/A
