### PR TITLE
Call to backend for deferred intent csc w/ playground

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -583,7 +583,7 @@ extension PlaygroundController {
             "should_save_payment_method": shouldSavePaymentMethod,
             "mode": intentConfig.mode.requestBody,
             "return_url": configuration.returnURL ?? "",
-            "customer": customerID ?? ""
+            "customer": customerID ?? "",
         ] as [String: Any]
 
         isLoading = true


### PR DESCRIPTION
## Summary
Disregard the initially created client secret and call checkout in the intentCreationCallback

## Motivation
Upcoming requirements for CVC recollection

## Testing
Manually tested

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
