### PR TITLE
Avoid clashing, allow new returning customer in PaymentSheetTestPlayground

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -66,6 +66,7 @@ struct PaymentSheetTestPlayground: View {
                         SettingPickerView(setting: $playgroundController.settings.integrationType)
                         SettingView(setting: customerModeBinding)
                         TextField("CustomerId", text: customerIdBinding)
+                            .disabled(true)
                         SettingPickerView(setting: $playgroundController.settings.currency)
                         SettingPickerView(setting: $playgroundController.settings.merchantCountryCode)
                         SettingView(setting: $playgroundController.settings.apmsEnabled)

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -64,7 +64,7 @@ struct PaymentSheetTestPlayground: View {
                         }
                         SettingView(setting: $playgroundController.settings.mode)
                         SettingPickerView(setting: $playgroundController.settings.integrationType)
-                        SettingView(setting: $playgroundController.settings.customerMode)
+                        SettingView(setting: customerModeBinding)
                         TextField("CustomerId", text: customerIdBinding)
                         SettingPickerView(setting: $playgroundController.settings.currency)
                         SettingPickerView(setting: $playgroundController.settings.merchantCountryCode)
@@ -115,9 +115,24 @@ struct PaymentSheetTestPlayground: View {
             playgroundController.settings.customCtaLabel = (newString != "") ? newString : nil
         }
     }
+    var customerModeBinding: Binding<PaymentSheetTestPlaygroundSettings.CustomerMode> {
+        Binding<PaymentSheetTestPlaygroundSettings.CustomerMode> {
+            return playgroundController.settings.customerMode
+        } set: { newMode in
+            playgroundController.settings.customerId = nil
+            playgroundController.settings.customerMode = newMode
+        }
+    }
     var customerIdBinding: Binding<String> {
         Binding<String> {
-            return playgroundController.settings.customerId ?? ""
+            switch playgroundController.settings.customerMode {
+            case .guest:
+                return ""
+            case .new:
+                return playgroundController.settings.customerId ?? ""
+            case .returning:
+                return playgroundController.settings.customerId ?? ""
+            }
         } set: { newString in
             playgroundController.settings.customerId = (newString != "") ? newString : nil
         }

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -65,6 +65,7 @@ struct PaymentSheetTestPlayground: View {
                         SettingView(setting: $playgroundController.settings.mode)
                         SettingPickerView(setting: $playgroundController.settings.integrationType)
                         SettingView(setting: $playgroundController.settings.customerMode)
+                        TextField("CustomerId", text: customerIdBinding)
                         SettingPickerView(setting: $playgroundController.settings.currency)
                         SettingPickerView(setting: $playgroundController.settings.merchantCountryCode)
                         SettingView(setting: $playgroundController.settings.apmsEnabled)
@@ -113,7 +114,13 @@ struct PaymentSheetTestPlayground: View {
         } set: { newString in
             playgroundController.settings.customCtaLabel = (newString != "") ? newString : nil
         }
-
+    }
+    var customerIdBinding: Binding<String> {
+        Binding<String> {
+            return playgroundController.settings.customerId ?? ""
+        } set: { newString in
+            playgroundController.settings.customerId = (newString != "") ? newString : nil
+        }
     }
 }
 

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -70,6 +70,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
         case guest
         case new
         case returning
+        case id
     }
 
     enum Currency: String, PickerEnum {
@@ -225,6 +226,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
 
     var uiStyle: UIStyle
     var mode: Mode
+    var customerId: String?
     var integrationType: IntegrationType
     var customerMode: CustomerMode
     var currency: Currency
@@ -253,6 +255,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
         return PaymentSheetTestPlaygroundSettings(
             uiStyle: .paymentSheet,
             mode: .payment,
+            customerId: nil,
             integrationType: .normal,
             customerMode: .guest,
             currency: .usd,

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -70,7 +70,6 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
         case guest
         case new
         case returning
-        case id
     }
 
     enum Currency: String, PickerEnum {

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -187,16 +187,14 @@ class PlaygroundController: ObservableObject {
         }
     }
 
-    var customer: String {
+    var customerIdOrType: String {
         switch settings.customerMode {
         case .guest:
             return "guest"
         case .new:
-            return "new"
+            return settings.customerId ?? "new"
         case .returning:
             return "returning"
-        case .id:
-            return self.settings.customerId ?? ""
         }
     }
 
@@ -374,7 +372,7 @@ extension PlaygroundController {
         let settingsToLoad = self.settings
 
         let body = [
-            "customer": customer,
+            "customer": customerIdOrType,
             "currency": settings.currency.rawValue,
             "merchant_country_code": settings.merchantCountryCode.rawValue,
             "mode": settings.mode.rawValue,
@@ -417,7 +415,6 @@ extension PlaygroundController {
                 self.clientSecret = json["intentClientSecret"]
                 self.ephemeralKey = json["customerEphemeralKeySecret"]
                 self.settings.customerId = json["customerId"]
-                self.settings.customerMode = .id
                 self.paymentMethodTypes = json["paymentMethodTypes"]?.components(separatedBy: ",")
                 self.amount = Int(json["amount"] ?? "")
                 STPAPIClient.shared.publishableKey = json["publishableKey"]


### PR DESCRIPTION
## Summary
To avoid us all using the same returning customer, I propose
A new customer results in creating a new customer and save/

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
