### PR TITLE
Pass email to Link URL generator

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
@@ -206,15 +206,20 @@ extension STPAPIClient {
 
     func generatedLinkAccountSessionManifest(
         with clientSecret: String,
+        emailAddress: String?,
         completion: @escaping (Result<Manifest, Error>) -> Void
     ) {
+        var params: [String: AnyHashable] = [
+            "client_secret": clientSecret,
+            "fullscreen": true,
+            "hide_close_button": true,
+        ]
+        if let emailAddress = emailAddress, !emailAddress.isEmpty {
+            params["account_holder_email"] = emailAddress
+        }
         let future: Future<Manifest> = self.post(
             resource: "link_account_sessions/generate_hosted_url",
-            parameters: [
-                "client_secret": clientSecret,
-                "fullscreen": true,
-                "hide_close_button": true,
-            ]
+            parameters: params
         )
         future.observe { result in
             switch result {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkPaymentController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkPaymentController.swift
@@ -149,7 +149,7 @@ import UIKit
                                                    customerName: configuration.defaultBillingDetails.name,
                                                    customerEmailAddress: configuration.defaultBillingDetails.email,
                                                    additionalParameteres: parameters) { [weak self] linkAccountSession, error in
-                    self?.generateManifest(continuation: continuation, error: error, linkAccountSession: linkAccountSession)
+                    self?.generateManifest(continuation: continuation, error: error, emailAddress: self?.configuration.defaultBillingDetails.email, linkAccountSession: linkAccountSession)
                 }
             case .setupIntentClientSecret(let clientSecret):
                 guard let setupIntentId = STPSetupIntent.id(fromClientSecret: clientSecret) else {
@@ -162,7 +162,7 @@ import UIKit
                                                    customerName: configuration.defaultBillingDetails.name,
                                                    customerEmailAddress: configuration.defaultBillingDetails.email,
                                                    additionalParameteres: parameters) { [weak self] linkAccountSession, error in
-                    self?.generateManifest(continuation: continuation, error: error, linkAccountSession: linkAccountSession)
+                    self?.generateManifest(continuation: continuation, error: error, emailAddress: self?.configuration.defaultBillingDetails.email, linkAccountSession: linkAccountSession)
                 }
             case .deferredIntent(let intentConfiguration):
                 let amount: Int?
@@ -183,7 +183,7 @@ import UIKit
                         onBehalfOf: intentConfiguration.onBehalfOf,
                         additionalParameters: ["product": "instant_debits"]
                     ) { [weak self] linkAccountSession, error in
-                        self?.generateManifest(continuation: continuation, error: error, linkAccountSession: linkAccountSession)
+                        self?.generateManifest(continuation: continuation, error: error, emailAddress: self?.configuration.defaultBillingDetails.email, linkAccountSession: linkAccountSession)
                     }
             }
         }
@@ -216,6 +216,7 @@ import UIKit
 
     private func generateManifest(continuation: CheckedContinuation<Manifest, Swift.Error>,
                                   error: Swift.Error?,
+                                  emailAddress: String?,
                                   linkAccountSession: LinkAccountSession?) {
         if let error = error {
             continuation.resume(throwing: error)
@@ -227,7 +228,7 @@ import UIKit
             return
         }
 
-        configuration.apiClient.generatedLinkAccountSessionManifest(with: linkAccountSession.clientSecret) { result in
+        configuration.apiClient.generatedLinkAccountSessionManifest(with: linkAccountSession.clientSecret, emailAddress: emailAddress) { result in
             switch result {
             case .success(let manifest):
                 continuation.resume(returning: manifest)


### PR DESCRIPTION
## Summary
For the LinkPaymentController bank-only flow, we want to pass the billing details in the email address to the Link URL generator.

## Motivation
Autofilling emails in the deferred intent flow.

## Testing
LinkPaymentController doesn't appear to have any tests. Will follow up with the product owners later.

## Changelog
None, this is a private beta feature.