### PR TITLE
Make shared STPAnalyticsClient singleton testable and fix bug where `…

### DIFF
--- a/Stripe/StripeiOSTests/STPAnalyticsClientPaymentSheetTest.swift
+++ b/Stripe/StripeiOSTests/STPAnalyticsClientPaymentSheetTest.swift
@@ -266,7 +266,8 @@ private class STPTestingAnalyticsClient: STPAnalyticsClient {
         expectedEvents[expectation.description] = expectation
     }
 
-    override func logPayload(_ payload: [String: Any]) {
+    override func log(analytic: Analytic, apiClient: STPAPIClient = .shared) {
+        let payload = payload(from: analytic, apiClient: apiClient)
         if let event = payload["event"] as? String,
             let expectedEvent = expectedEvents[event]
         {

--- a/StripeCore/StripeCoreTests/Analytics/STPAnalyticsClientTest.swift
+++ b/StripeCore/StripeCoreTests/Analytics/STPAnalyticsClientTest.swift
@@ -41,4 +41,14 @@ class STPAnalyticsClientTest: XCTestCase {
         XCTAssertEqual("pk_foo", payload["publishable_key"] as? String)
     }
 
+    func testLogShouldRespectAPIClient() {
+        STPAPIClient.shared.publishableKey = "pk_shared"
+        let apiClient = STPAPIClient(publishableKey: "pk_not_shared")
+        let analyticsClient = STPAnalyticsClient()
+        // ...logging an arbitrary analytic and passing apiClient...
+        analyticsClient.log(analytic: GenericAnalytic.init(event: .addressShow, params: [:]), apiClient: apiClient)
+        // ...should use the passed in apiClient publishable key and not the shared apiClient
+        let payload = analyticsClient._testLogHistory.first!
+        XCTAssertEqual("pk_not_shared", payload["publishable_key"] as? String)
+    }
 }


### PR DESCRIPTION
…log(analytic:apiClient:)` wasn't using the apiClient



## Motivation
As noted in the code: this is a hack - ideally, we inject a different analytics client in our tests, but until we can make that significant refactor, this is an escape hatch.

## Testing
Added a unit test for the bugfix - saw it fail before the fix and pass after.

## Changelog
No user-facing behavior change. 