### PR TITLE
Server-driven External Payment Methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### PaymentSheet
 * [Fixed] PaymentSheet sets newly saved payment methods as the default so that they're pre-selected the next time the customer pays.
+* [Added] PaymentSheet now supports external payment methods. See https://stripe.com/docs/payments/external-payment-methods?platform=ios
 
 ### CustomerSheet
 * [Added] Saved SEPA payment methods are now displayed to the customer for reuse, similar to saved cards.

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -230,9 +230,6 @@ class PlaygroundController: ObservableObject {
             completion(.failed(error: exampleError))
         })
         if self.settings.uiStyle == .paymentSheet {
-            self.rootViewController.presentedViewController?.dismiss(animated: true) {
-                self.rootViewController.presentedViewController?.present(alert, animated: true)
-            }
             self.rootViewController.presentedViewController?.present(alert, animated: true)
         } else {
             self.rootViewController.present(alert, animated: true)

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -2038,7 +2038,7 @@ class PaymentSheetDeferredServerSideUITests: PaymentSheetUITestCase {
 
         payButton.tap()
         app.buttons["Fail"].tap()
-        XCTAssertTrue(app.staticTexts["An unknown error occurred."].waitForExistence(timeout: 5.0))
+        XCTAssertTrue(app.staticTexts["Something went wrong!"].waitForExistence(timeout: 5.0))
 
         payButton.tap()
         app.buttons["Confirm"].tap()
@@ -2067,7 +2067,7 @@ class PaymentSheetDeferredServerSideUITests: PaymentSheetUITestCase {
         let payButton = app.buttons["Confirm"]
         payButton.tap()
         app.buttons["Fail"].tap()
-        XCTAssertTrue(app.staticTexts["Payment failed: PaymentSheetExample.PlaygroundController.ConfirmHandlerError.unknown"].waitForExistence(timeout: 5.0))
+        XCTAssertTrue(app.staticTexts["Payment failed: Error Domain= Code=0 \"Something went wrong!\" UserInfo={NSLocalizedDescription=Something went wrong!}"].waitForExistence(timeout: 5.0))
 
         payButton.tap()
         app.alerts.buttons["Confirm"].tap()

--- a/Stripe/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe/Stripe.xcodeproj/project.pbxproj
@@ -36,7 +36,6 @@
 		1CCFC43F7FCD273E2100D321 /* STPPaymentMethodBancontactTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E5416F6AE8BED88980D6F8 /* STPPaymentMethodBancontactTests.swift */; };
 		1CD3AB315580606AF87A7B1F /* STPPaymentCardTextFieldKVOTest.m in Sources */ = {isa = PBXBuildFile; fileRef = BB08D2AC882B21C8ADD76B92 /* STPPaymentCardTextFieldKVOTest.m */; };
 		1E8D8E2494062262A332879C /* STPCardValidatorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1644AA33E81233EF33022BA /* STPCardValidatorTest.swift */; };
-		1F417D0874CC86F4C9AB2790 /* STPIntentWithPreferencesTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C8FE751333F580004BD72BA /* STPIntentWithPreferencesTest.swift */; };
 		1F432D0B37949217E4299A20 /* STPPaymentOptionsInternalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5C4A4CC7D2E9B5AB3EC3B79 /* STPPaymentOptionsInternalViewController.swift */; };
 		225140E0BD9C0630116DDE4A /* STPPaymentMethodUSBankAccountTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B112FFF3FCA82094281493F /* STPPaymentMethodUSBankAccountTest.swift */; };
 		229E25F8DFCC55CA9EDD15AB /* LinkInMemoryCookieStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB30E3846E24FD57A44764A /* LinkInMemoryCookieStoreTests.swift */; };
@@ -619,7 +618,6 @@
 		6A9E7B637A8747431B38FD1D /* STPCardValidationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPCardValidationState.swift; sourceTree = "<group>"; };
 		6B7A947152A728EB2CBC4DB2 /* STPSourceReceiverTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPSourceReceiverTest.swift; sourceTree = "<group>"; };
 		6C7B8DACB0A7294BC235E3BC /* STPPaymentIntentLastPaymentErrorTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPPaymentIntentLastPaymentErrorTest.swift; sourceTree = "<group>"; };
-		6C8FE751333F580004BD72BA /* STPIntentWithPreferencesTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPIntentWithPreferencesTest.swift; sourceTree = "<group>"; };
 		6CC0B1FC92A573AAEA4F4E94 /* STPSetupIntentConfirmParamsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPSetupIntentConfirmParamsTest.swift; sourceTree = "<group>"; };
 		6E1F6514E7530C2A3478B2F5 /* STPCardCVCInputTextFieldFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPCardCVCInputTextFieldFormatterTests.swift; sourceTree = "<group>"; };
 		6F01150CD0255164FE2CF3A4 /* STPPaymentIntentParams+BasicUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "STPPaymentIntentParams+BasicUI.swift"; sourceTree = "<group>"; };
@@ -1226,7 +1224,6 @@
 				33B9D01D037909D1C9C0B617 /* STPIntentActionTest.swift */,
 				D2F205F920E971DEA59E3C31 /* STPIntentActionTypeTest.swift */,
 				4CA5D11C977A95B8E936E907 /* STPIntentActionWeChatPayRedirectToAppTest.swift */,
-				6C8FE751333F580004BD72BA /* STPIntentWithPreferencesTest.swift */,
 				78D1EEABBAE5BD5615486B0F /* STPLabeledFormTextFieldViewSnapshotTests.swift */,
 				7F68637E75142DCD46710796 /* STPLabeledMultiFormTextFieldViewSnapshotTests.swift */,
 				C713F58BC61A962C720AE0AE /* STPMandateCustomerAcceptanceParamsTest.swift */,
@@ -1811,7 +1808,6 @@
 				ACC1B91FC687AFD0DFD27CD4 /* STPIntentActionTest.swift in Sources */,
 				4935C8B3ECFBAD947E694934 /* STPIntentActionTypeTest.swift in Sources */,
 				8F0326E98C74EB62E34B9FEA /* STPIntentActionWeChatPayRedirectToAppTest.swift in Sources */,
-				1F417D0874CC86F4C9AB2790 /* STPIntentWithPreferencesTest.swift in Sources */,
 				9FB20E559379F468070C7B50 /* STPLabeledFormTextFieldViewSnapshotTests.swift in Sources */,
 				A22D548084E7DE1FE5ABE8E7 /* STPLabeledMultiFormTextFieldViewSnapshotTests.swift in Sources */,
 				331924F0801287BAD413FDCB /* STPMandateCustomerAcceptanceParamsTest.swift in Sources */,

--- a/Stripe/StripeiOSTests/STPAPIClient+PaymentSheetTest.swift
+++ b/Stripe/StripeiOSTests/STPAPIClient+PaymentSheetTest.swift
@@ -12,13 +12,11 @@ import XCTest
 @testable@_spi(STP) import Stripe
 @testable@_spi(STP) import StripeCore
 @testable@_spi(STP) import StripePayments
-@testable@_spi(STP) import StripePaymentSheet
+@testable@_spi(STP) @_spi(ExternalPaymentMethodsPrivateBeta) import StripePaymentSheet
 @testable@_spi(STP) import StripePaymentsUI
 
-class STPIntentWithPreferencesTest: XCTestCase {
-    // MARK: PaymentSheet.IntentConfiguration+elementsSessionPayload tests
-
-    func testElementsSessionPayload_Payment() throws {
+class STPAPIClient_PaymentSheetTest: XCTestCase {
+    func testElementsSessionParameters_DeferredPayment() throws {
         let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 2000,
                                                                            currency: "USD",
                                                                            setupFutureUsage: .onSession,
@@ -26,10 +24,13 @@ class STPIntentWithPreferencesTest: XCTestCase {
                                                             paymentMethodTypes: ["card", "cashapp"],
                                                             onBehalfOf: "acct_connect",
                                                             confirmHandler: { _, _, _ in })
+        var config = PaymentSheet.Configuration()
+        config.externalPaymentMethodConfiguration = .init(externalPaymentMethods: ["external_foo", "external_bar"], externalPaymentMethodConfirmHandler: { _, _, _ in })
 
-        let payload = intentConfig.elementsSessionParameters(publishableKey: "pk_test")
+        let payload = STPAPIClient(publishableKey: "pk_test").makeElementsSessionsParams(mode: .deferredIntent(intentConfig), configuration: config)
         XCTAssertEqual(payload["key"] as? String, "pk_test")
         XCTAssertEqual(payload["locale"] as? String, Locale.current.toLanguageTag())
+        XCTAssertEqual(payload["external_payment_methods"] as? [String], ["external_foo", "external_bar"])
 
         let deferredIntent = try XCTUnwrap(payload["deferred_intent"] as?  [String: Any])
         XCTAssertEqual(deferredIntent["payment_method_types"] as? [String], ["card", "cashapp"])
@@ -41,16 +42,17 @@ class STPIntentWithPreferencesTest: XCTestCase {
         XCTAssertEqual(deferredIntent["capture_method"] as? String, "automatic_async")
     }
 
-    func testElementsSessionPayload_Setup() throws {
+    func testElementsSessionParameters_DeferredSetup() throws {
         let intentConfig = PaymentSheet.IntentConfiguration(mode: .setup(currency: "USD",
                                                                            setupFutureUsage: .offSession),
                                                             paymentMethodTypes: ["card", "cashapp"],
                                                             onBehalfOf: "acct_connect",
                                                             confirmHandler: { _, _, _ in })
 
-        let payload = intentConfig.elementsSessionParameters(publishableKey: "pk_test")
+        let payload = STPAPIClient(publishableKey: "pk_test").makeElementsSessionsParams(mode: .deferredIntent(intentConfig), configuration: .init())
         XCTAssertEqual(payload["key"] as? String, "pk_test")
         XCTAssertEqual(payload["locale"] as? String, Locale.current.toLanguageTag())
+        XCTAssertEqual(payload["external_payment_methods"] as? [String], [])
 
         let deferredIntent = try XCTUnwrap(payload["deferred_intent"] as?  [String: Any])
         XCTAssertEqual(deferredIntent["payment_method_types"] as? [String], ["card", "cashapp"])

--- a/Stripe/StripeiOSTests/STPAPIClient+PaymentSheetTest.swift
+++ b/Stripe/StripeiOSTests/STPAPIClient+PaymentSheetTest.swift
@@ -1,5 +1,5 @@
 //
-//  STPIntentWithPreferencesTest.swift
+//  STPAPIClient+PaymentSheetTest.swift
 //  StripeiOS Tests
 //
 //  Created by Jaime Park on 6/23/21.
@@ -12,7 +12,7 @@ import XCTest
 @testable@_spi(STP) import Stripe
 @testable@_spi(STP) import StripeCore
 @testable@_spi(STP) import StripePayments
-@testable@_spi(STP) @_spi(ExternalPaymentMethodsPrivateBeta) import StripePaymentSheet
+@testable@_spi(STP) import StripePaymentSheet
 @testable@_spi(STP) import StripePaymentsUI
 
 class STPAPIClient_PaymentSheetTest: XCTestCase {
@@ -27,12 +27,12 @@ class STPAPIClient_PaymentSheetTest: XCTestCase {
         var config = PaymentSheet.Configuration()
         config.externalPaymentMethodConfiguration = .init(externalPaymentMethods: ["external_foo", "external_bar"], externalPaymentMethodConfirmHandler: { _, _, _ in })
 
-        let payload = STPAPIClient(publishableKey: "pk_test").makeElementsSessionsParams(mode: .deferredIntent(intentConfig), configuration: config)
-        XCTAssertEqual(payload["key"] as? String, "pk_test")
-        XCTAssertEqual(payload["locale"] as? String, Locale.current.toLanguageTag())
-        XCTAssertEqual(payload["external_payment_methods"] as? [String], ["external_foo", "external_bar"])
+        let parameters = STPAPIClient(publishableKey: "pk_test").makeElementsSessionsParams(mode: .deferredIntent(intentConfig), configuration: config)
+        XCTAssertEqual(parameters["key"] as? String, "pk_test")
+        XCTAssertEqual(parameters["locale"] as? String, Locale.current.toLanguageTag())
+        XCTAssertEqual(parameters["external_payment_methods"] as? [String], ["external_foo", "external_bar"])
 
-        let deferredIntent = try XCTUnwrap(payload["deferred_intent"] as?  [String: Any])
+        let deferredIntent = try XCTUnwrap(parameters["deferred_intent"] as?  [String: Any])
         XCTAssertEqual(deferredIntent["payment_method_types"] as? [String], ["card", "cashapp"])
         XCTAssertEqual(deferredIntent["on_behalf_of"] as? String, "acct_connect")
         XCTAssertEqual(deferredIntent["mode"] as? String, "payment")
@@ -49,12 +49,12 @@ class STPAPIClient_PaymentSheetTest: XCTestCase {
                                                             onBehalfOf: "acct_connect",
                                                             confirmHandler: { _, _, _ in })
 
-        let payload = STPAPIClient(publishableKey: "pk_test").makeElementsSessionsParams(mode: .deferredIntent(intentConfig), configuration: .init())
-        XCTAssertEqual(payload["key"] as? String, "pk_test")
-        XCTAssertEqual(payload["locale"] as? String, Locale.current.toLanguageTag())
-        XCTAssertEqual(payload["external_payment_methods"] as? [String], [])
+        let parameters = STPAPIClient(publishableKey: "pk_test").makeElementsSessionsParams(mode: .deferredIntent(intentConfig), configuration: .init())
+        XCTAssertEqual(parameters["key"] as? String, "pk_test")
+        XCTAssertEqual(parameters["locale"] as? String, Locale.current.toLanguageTag())
+        XCTAssertEqual(parameters["external_payment_methods"] as? [String], [])
 
-        let deferredIntent = try XCTUnwrap(payload["deferred_intent"] as?  [String: Any])
+        let deferredIntent = try XCTUnwrap(parameters["deferred_intent"] as?  [String: Any])
         XCTAssertEqual(deferredIntent["payment_method_types"] as? [String], ["card", "cashapp"])
         XCTAssertEqual(deferredIntent["on_behalf_of"] as? String, "acct_connect")
         XCTAssertEqual(deferredIntent["mode"] as? String, "setup")

--- a/Stripe/StripeiOSTests/STPAPIClient+PaymentSheetTest.swift
+++ b/Stripe/StripeiOSTests/STPAPIClient+PaymentSheetTest.swift
@@ -27,7 +27,7 @@ class STPAPIClient_PaymentSheetTest: XCTestCase {
         var config = PaymentSheet.Configuration()
         config.externalPaymentMethodConfiguration = .init(externalPaymentMethods: ["external_foo", "external_bar"], externalPaymentMethodConfirmHandler: { _, _, _ in })
 
-        let parameters = STPAPIClient(publishableKey: "pk_test").makeElementsSessionsParams(mode: .deferredIntent(intentConfig), configuration: config)
+        let parameters = STPAPIClient(publishableKey: "pk_test").makeElementsSessionsParams(mode: .deferredIntent(intentConfig), epmConfiguration: config.externalPaymentMethodConfiguration)
         XCTAssertEqual(parameters["key"] as? String, "pk_test")
         XCTAssertEqual(parameters["locale"] as? String, Locale.current.toLanguageTag())
         XCTAssertEqual(parameters["external_payment_methods"] as? [String], ["external_foo", "external_bar"])
@@ -49,7 +49,7 @@ class STPAPIClient_PaymentSheetTest: XCTestCase {
                                                             onBehalfOf: "acct_connect",
                                                             confirmHandler: { _, _, _ in })
 
-        let parameters = STPAPIClient(publishableKey: "pk_test").makeElementsSessionsParams(mode: .deferredIntent(intentConfig), configuration: .init())
+        let parameters = STPAPIClient(publishableKey: "pk_test").makeElementsSessionsParams(mode: .deferredIntent(intentConfig), epmConfiguration: nil)
         XCTAssertEqual(parameters["key"] as? String, "pk_test")
         XCTAssertEqual(parameters["locale"] as? String, Locale.current.toLanguageTag())
         XCTAssertEqual(parameters["external_payment_methods"] as? [String], [])

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
@@ -181,4 +181,5 @@ import Foundation
 
     // MARK: - v1/elements/session
     case paymentSheetElementsSessionLoadFailed = "mc_elements_session_load_failed"
+    case paymentSheetElementsSessionEPMLoadFailed = "mc_elements_session_epms_load_failed"
 }

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticsClient.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticsClient.swift
@@ -21,8 +21,8 @@ import UIKit
 @_spi(STP) public class STPAnalyticsClient: NSObject, STPAnalyticsClientProtocol {
     @objc public static let sharedClient = STPAnalyticsClient()
     /// When this class logs a payload in an XCTestCase, it's added to `_testLogHistory` instead of being sent over the network.
-    /// This is a hack - ideally, we inject a different analytics client in our tests, but until we can make that significant refactor, this is an escape hatch.
-    public private(set) var _testLogHistory: [[String: Any]] = []
+    /// This is a hack - ideally, we inject a different analytics client in our tests. This is an escape hatch until we can make that (significant) refactor
+    public var _testLogHistory: [[String: Any]] = []
 
     @objc public var productUsage: Set<String> = Set()
     private var additionalInfoSet: Set<String> = Set()

--- a/StripeCore/StripeCore/Source/Coder/StripeJSONDecoder.swift
+++ b/StripeCore/StripeCore/Source/Coder/StripeJSONDecoder.swift
@@ -10,6 +10,8 @@
 import Foundation
 
 @_spi(STP) public class StripeJSONDecoder {
+    @_spi(STP) public init() {}
+
     @_spi(STP) public var userInfo: [CodingUserInfoKey: Any] = [:]
 
     @_spi(STP) public var inputFormatting: JSONSerialization.ReadingOptions = []

--- a/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
+++ b/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
@@ -187,6 +187,7 @@
 		B306EA3F66D07CCABF17CB9C /* LinkInlineSignupViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7910B57E6FD99F2AFCA4DAC2 /* LinkInlineSignupViewModel.swift */; };
 		B4679C9095BCD53CCC2C7D25 /* StripeCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E41AA4E90E5BB28D588FDE51 /* StripeCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		B55EFA2557B5BE39CC12E357 /* STPPaymentMethod+PaymentSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 813E88EE408666654EF835E2 /* STPPaymentMethod+PaymentSheet.swift */; };
+		B68CB9632B0D2169006ACDB1 /* STPAPIClient+PaymentSheetTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B68CB9622B0D2169006ACDB1 /* STPAPIClient+PaymentSheetTest.swift */; };
 		B6B3481CBA798CF22EE8411A /* TextFieldElement+IBAN.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570931B897DCCAC0F55FB6E3 /* TextFieldElement+IBAN.swift */; };
 		B8A217F26AAEC592B9B0D2E1 /* CardScanButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24AB1D50F770A8A035EF31DF /* CardScanButton.swift */; };
 		B8A7575878C5124CF5482097 /* VerificationSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 441C3414745D483C9A47ED0B /* VerificationSession.swift */; };
@@ -510,6 +511,7 @@
 		B54274B9DEB3F1B0906127D1 /* et-EE */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "et-EE"; path = "et-EE.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		B61FFE76D0960C7F1E34B405 /* PaymentSheetAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSheetAppearance.swift; sourceTree = "<group>"; };
 		B667E074D30964FABC64B552 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/Localizable.strings; sourceTree = "<group>"; };
+		B68CB9622B0D2169006ACDB1 /* STPAPIClient+PaymentSheetTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "STPAPIClient+PaymentSheetTest.swift"; path = "../../../Stripe/StripeiOSTests/STPAPIClient+PaymentSheetTest.swift"; sourceTree = "<group>"; };
 		B70D161E50723A8953665C4B /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		B829BC7EEE9576F724F7A9B3 /* StripePaymentSheetTestHostApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = StripePaymentSheetTestHostApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B8A49995CE949176F7A8C71F /* SimpleMandateTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleMandateTextView.swift; sourceTree = "<group>"; };
@@ -1269,16 +1271,15 @@
 		F8A74FF9A80AC3BCD5856058 /* PaymentSheet */ = {
 			isa = PBXGroup;
 			children = (
-				25AB69CF78A2B13839EB32EC /* AddressViewController */,
-				0C53358C028E528F0FC626A2 /* CustomerSheet */,
-				FCA28FF8CD5BA829A44CDCE7 /* Link */,
-				AC0DBA7D63BAD0182695E436 /* Stubbed */,
 				3F70E5F0FE6218715432D55A /* AddPaymentMethodViewControllerSnapshotTests.swift */,
+				25AB69CF78A2B13839EB32EC /* AddressViewController */,
 				BE92D55DA4B4D449734B2917 /* BacsDDMandateViewSnapshotTests.swift */,
+				0C53358C028E528F0FC626A2 /* CustomerSheet */,
 				989C2E3E03E42DA64A2FAE0D /* CustomerSheetSnapshotTests.swift */,
 				73FB30705EC36BD0868904A2 /* Elements+TestHelpers.swift */,
 				64C8F350CDB5A29F62E86592 /* FlowControllerStateTests.swift */,
 				990304EF35A0EE37DCE20D5B /* IntentStatusPollerTest.swift */,
+				FCA28FF8CD5BA829A44CDCE7 /* Link */,
 				33B8F21A22FA091BC9D2924B /* LinkStubs.swift */,
 				C830FEC205E7162FF4D414BE /* PaymentMethodMessagingViewFunctionalTest.swift */,
 				5BA7BFC43DB3EFD38A460EB9 /* PaymentMethodMessagingViewSnapshotTests.swift */,
@@ -1302,10 +1303,12 @@
 				C1AED4473AD4C07D461E9E48 /* SavedPaymentOptionsViewControllerSnapshotTests.swift */,
 				BA3902DA8D647E934686CB5C /* SepaMandateViewControllerSnapshotTest.swift */,
 				6151DDBF2B14FDCF00ED4F7E /* UpdateCardViewControllerSnapshotTests.swift */,
+				B68CB9622B0D2169006ACDB1 /* STPAPIClient+PaymentSheetTest.swift */,
 				D16926577504D37992F8917E /* STPApplePayContext+PaymentSheetTest.swift */,
 				E09C073021CE89593466548C /* STPCardBrandChoiceTest.swift */,
 				E198795E4D8677B6ECFCEEDC /* STPElementsSessionTest.swift */,
 				A39F7EBA2E9E3CE55E7AADC9 /* STPFixtures+PaymentSheet.swift */,
+				AC0DBA7D63BAD0182695E436 /* Stubbed */,
 				D00C7F5905759525C9BF8BD4 /* TextFieldElement+CardTest.swift */,
 			);
 			path = PaymentSheet;
@@ -1567,6 +1570,7 @@
 				29C98FB712F3FB987CBE18B0 /* STPFixtures+PaymentSheet.swift in Sources */,
 				45D9849E9B36C56E15EAAE0A /* SavedPaymentOptionsViewControllerSnapshotTests.swift in Sources */,
 				9787A622B527C1AD96A73827 /* SepaMandateViewControllerSnapshotTest.swift in Sources */,
+				B68CB9632B0D2169006ACDB1 /* STPAPIClient+PaymentSheetTest.swift in Sources */,
 				4A1A0A542B824C830A200BE0 /* StubbedBackend.swift in Sources */,
 				6151DDC02B14FDCF00ED4F7E /* UpdateCardViewControllerSnapshotTests.swift in Sources */,
 				34CF08CBC636F596B8BA4C12 /* TextFieldElement+CardTest.swift in Sources */,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPAPIClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPAPIClient+PaymentSheet.swift
@@ -12,11 +12,11 @@ import Foundation
 
 extension STPAPIClient {
     typealias STPIntentCompletionBlock = ((Result<Intent, Error>) -> Void)
-    
+
     func makeElementsSessionsParams(mode: PaymentSheet.InitializationMode, configuration: PaymentSheet.Configuration) -> [String: Any] {
         var parameters: [String: Any] = [
             "locale": Locale.current.toLanguageTag(),
-            "external_payment_methods": configuration.externalPaymentMethodConfiguration?.externalPaymentMethods.compactMap { $0.lowercased() } ?? []
+            "external_payment_methods": configuration.externalPaymentMethodConfiguration?.externalPaymentMethods.compactMap { $0.lowercased() } ?? [],
         ]
         switch mode {
         case .deferredIntent(let intentConfig):

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPAPIClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPAPIClient+PaymentSheet.swift
@@ -13,10 +13,10 @@ import Foundation
 extension STPAPIClient {
     typealias STPIntentCompletionBlock = ((Result<Intent, Error>) -> Void)
 
-    func makeElementsSessionsParams(mode: PaymentSheet.InitializationMode, configuration: PaymentSheet.Configuration) -> [String: Any] {
+    func makeElementsSessionsParams(mode: PaymentSheet.InitializationMode, epmConfiguration: PaymentSheet.ExternalPaymentMethodConfiguration?) -> [String: Any] {
         var parameters: [String: Any] = [
             "locale": Locale.current.toLanguageTag(),
-            "external_payment_methods": configuration.externalPaymentMethodConfiguration?.externalPaymentMethods.compactMap { $0.lowercased() } ?? [],
+            "external_payment_methods": epmConfiguration?.externalPaymentMethods.compactMap { $0.lowercased() } ?? [],
         ]
         switch mode {
         case .deferredIntent(let intentConfig):
@@ -59,7 +59,7 @@ extension STPAPIClient {
         let elementsSession = try await APIRequest<STPElementsSession>.getWith(
             self,
             endpoint: APIEndpointElementsSessions,
-            parameters: makeElementsSessionsParams(mode: .paymentIntentClientSecret(paymentIntentClientSecret), configuration: configuration)
+            parameters: makeElementsSessionsParams(mode: .paymentIntentClientSecret(paymentIntentClientSecret), epmConfiguration: configuration.externalPaymentMethodConfiguration)
         )
         // The v1/elements/sessions response contains a PaymentIntent hash that we parse out into a PaymentIntent
         guard
@@ -78,7 +78,7 @@ extension STPAPIClient {
         let elementsSession = try await APIRequest<STPElementsSession>.getWith(
             self,
             endpoint: APIEndpointElementsSessions,
-            parameters: makeElementsSessionsParams(mode: .setupIntentClientSecret(setupIntentClientSecret), configuration: configuration)
+            parameters: makeElementsSessionsParams(mode: .setupIntentClientSecret(setupIntentClientSecret), epmConfiguration: configuration.externalPaymentMethodConfiguration)
         )
         // The v1/elements/sessions response contains a SetupIntent hash that we parse out into a SetupIntent
         guard
@@ -94,7 +94,7 @@ extension STPAPIClient {
         withIntentConfig intentConfig: PaymentSheet.IntentConfiguration,
         configuration: PaymentSheet.Configuration
     ) async throws -> STPElementsSession {
-        let parameters = makeElementsSessionsParams(mode: .deferredIntent(intentConfig), configuration: configuration)
+        let parameters = makeElementsSessionsParams(mode: .deferredIntent(intentConfig), epmConfiguration: configuration.externalPaymentMethodConfiguration)
         return try await APIRequest<STPElementsSession>.getWith(
             self,
             endpoint: APIEndpointElementsSessions,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/ExternalPaymentMethod.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/ExternalPaymentMethod.swift
@@ -17,9 +17,9 @@ struct ExternalPaymentMethod: Decodable, Equatable, Hashable {
     let type: String
     /// A localized label for the payment method e.g. "FooPay"
     let label: String
-    /// URL of a 48x pixel tall PNG representing the payment method suitable for display against a light background color.
+    /// URL of a 48x pixel tall, variable width PNG representing the payment method suitable for display against a light background color.
     let lightImageUrl: URL
-    /// URL of a 48x pixel tall PNG representing the payment method suitable for display against a dark background color. If `nil`, use `lightImageUrl` instead.
+    /// URL of a 48x pixel, variable width tall PNG representing the payment method suitable for display against a dark background color. If `nil`, use `lightImageUrl` instead.
     let darkImageUrl: URL?
 
     /// Helper method to decode the `v1/elements/sessions` response's `external_payment_methods_data` hash.

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/ExternalPaymentMethod.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/ExternalPaymentMethod.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+@_spi(STP) import StripeCore
 @_spi(STP) import StripePayments
 
 /// ViewModel-like information for displaying external payment methods (EPMs), delivered in the `v1/elements/sessions` response.
@@ -15,34 +16,22 @@ struct ExternalPaymentMethod: Decodable, Equatable, Hashable {
     /// These match the strings specified by the merchant in `ExternalPaymentMethodConfiguration`.
     let type: String
     /// A localized label for the payment method e.g. "FooPay"
-    let localizedLabel: String
+    let label: String
     /// URL of a 48x pixel tall PNG representing the payment method suitable for display against a light background color.
-    let lightImageURL: URL
-    /// URL of a 48x pixel tall PNG representing the payment method suitable for display against a dark background color.
-    let darkImageURL: URL
+    let lightImageUrl: URL
+    /// URL of a 48x pixel tall PNG representing the payment method suitable for display against a dark background color. If `nil`, use `lightImageUrl` instead.
+    let darkImageUrl: URL?
 
-    // TODO: Temporary shim while we only support hardcoded "external_paypal"
-    static func makeExternalPaypal() -> ExternalPaymentMethod {
-        return .init(
-            type: "external_paypal",
-            localizedLabel: STPPaymentMethodType.payPal.displayName,
-            lightImageURL: URL(string: "https://todo.com")!,
-            darkImageURL: URL(string: "https://todo.com")!
-        )
-    }
-
-    /// Helper method to decode the `v1/elements/sessions` response.
+    /// Helper method to decode the `v1/elements/sessions` response's `external_payment_methods_data` hash.
     /// - Parameter response: The value of the `external_payment_methods_data` key in the `v1/elements/sessions` response.
     public static func decoded(fromAPIResponse response: [[AnyHashable: Any]]?) -> [ExternalPaymentMethod]? {
         guard let response else {
             return nil
         }
-        let jsonDecoder = JSONDecoder()
-        jsonDecoder.keyDecodingStrategy = .convertFromSnakeCase
         do {
             return try response.map { dict in
                 let data = try JSONSerialization.data(withJSONObject: dict)
-                return try jsonDecoder.decode(ExternalPaymentMethod.self, from: data)
+                return try StripeJSONDecoder().decode(ExternalPaymentMethod.self, from: data)
             }
         } catch {
             return nil

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/ExternalPaymentMethod.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/ExternalPaymentMethod.swift
@@ -8,19 +8,44 @@
 import Foundation
 @_spi(STP) import StripePayments
 
-/// ViewModel-like information for displaying external payment methods (EPMs)
+/// ViewModel-like information for displaying external payment methods (EPMs), delivered in the `v1/elements/sessions` response.
+/// - Seealso: https://git.corp.stripe.com/stripe-internal/pay-server/blob/master/lib/elements/api/private/struct/external_payment_method_data.rb
 struct ExternalPaymentMethod: Decodable, Equatable, Hashable {
     /// The type of the external payment method. e.g. `"external_foopay"`
     /// These match the strings specified by the merchant in `ExternalPaymentMethodConfiguration`.
     let type: String
     /// A localized label for the payment method e.g. "FooPay"
     let localizedLabel: String
+    /// URL of a 48x pixel tall PNG representing the payment method suitable for display against a light background color.
+    let lightImageURL: URL
+    /// URL of a 48x pixel tall PNG representing the payment method suitable for display against a dark background color.
+    let darkImageURL: URL
 
     // TODO: Temporary shim while we only support hardcoded "external_paypal"
     static func makeExternalPaypal() -> ExternalPaymentMethod {
         return .init(
             type: "external_paypal",
-            localizedLabel: STPPaymentMethodType.payPal.displayName
+            localizedLabel: STPPaymentMethodType.payPal.displayName,
+            lightImageURL: URL(string: "https://todo.com")!,
+            darkImageURL: URL(string: "https://todo.com")!
         )
+    }
+
+    /// Helper method to decode the `v1/elements/sessions` response.
+    /// - Parameter response: The value of the `external_payment_methods_data` key in the `v1/elements/sessions` response.
+    public static func decoded(fromAPIResponse response: [[AnyHashable: Any]]?) -> [ExternalPaymentMethod]? {
+        guard let response else {
+            return nil
+        }
+        let jsonDecoder = JSONDecoder()
+        jsonDecoder.keyDecodingStrategy = .convertFromSnakeCase
+        do {
+            return try response.map { dict in
+                let data = try JSONSerialization.data(withJSONObject: dict)
+                return try jsonDecoder.decode(ExternalPaymentMethod.self, from: data)
+            }
+        } catch {
+            return nil
+        }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
@@ -121,14 +121,15 @@ extension STPElementsSession: STPAPIResponseDecodable {
         let isApplePayEnabled = applePayPreference != "disabled"
         let externalPaymentMethods: [ExternalPaymentMethod] = {
             guard
-                let epmsDataJSON = response["external_payment_methods_data"] as? [[AnyHashable: Any]],
-                let epmsData = ExternalPaymentMethod.decoded(fromAPIResponse: epmsDataJSON) else {
+                let epmsJSON = response["external_payment_method_data"] as? [[AnyHashable: Any]],
+                let epms = ExternalPaymentMethod.decoded(fromAPIResponse: epmsJSON)
+            else {
                 // We don't want to fail the entire v1/elements/sessions request if we fail to parse external_payment_methods_data
                 // Instead, fall back to an empty array and log an error.
                 STPAnalyticsClient.sharedClient.logPaymentSheetEvent(event: .paymentSheetElementsSessionEPMLoadFailed)
                 return []
             }
-            return epmsData
+            return epms
         }()
 
         return self.init(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsViewController.swift
@@ -489,7 +489,8 @@ class CustomerSavedPaymentMethodsViewController: UIViewController {
 
     private func fetchSetupIntent(clientSecret: String) async -> (STPSetupIntent, STPElementsSession)? {
         do {
-            return try await configuration.apiClient.retrieveElementsSession(setupIntentClientSecret: clientSecret)
+            // Why do we retrieve an elements session here? Does anything use it?
+            return try await configuration.apiClient.retrieveElementsSession(setupIntentClientSecret: clientSecret, configuration: .init())
         } catch {
             STPAnalyticsClient.sharedClient.logCSAddPaymentMethodViaSetupIntentFailure()
             self.error = error

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsViewController.swift
@@ -489,7 +489,6 @@ class CustomerSavedPaymentMethodsViewController: UIViewController {
 
     private func fetchSetupIntent(clientSecret: String) async -> (STPSetupIntent, STPElementsSession)? {
         do {
-            // Why do we retrieve an elements session here? Does anything use it?
             return try await configuration.apiClient.retrieveElementsSession(setupIntentClientSecret: clientSecret, configuration: .init())
         } catch {
             STPAnalyticsClient.sharedClient.logCSAddPaymentMethodViaSetupIntentFailure()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Intent.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Intent.swift
@@ -126,14 +126,6 @@ enum Intent {
         }
     }
 
-    var shouldDisableExternalPayPal: Bool {
-        // Only disable external_paypal iff this flag is present and false
-        guard let flag = elementsSession.allResponseFields[jsonDict: "flags"]?["elements_enable_external_payment_method_paypal"] as? Bool else {
-            return false
-        }
-        return flag == false
-    }
-
     var isApplePayEnabled: Bool {
         switch self {
         case .paymentIntent(let elementSession, _):

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -24,7 +24,7 @@ extension PaymentSheet {
             case .stripe(let paymentMethodType):
                 return paymentMethodType.displayName
             case .external(let externalPaymentMethod):
-                return externalPaymentMethod.localizedLabel
+                return externalPaymentMethod.label
             }
         }
 
@@ -53,53 +53,49 @@ extension PaymentSheet {
         /// to download the image.
         func makeImage(forDarkBackground: Bool = false, updateHandler: DownloadManager.UpdateImageHandler?) -> UIImage {
             // TODO: Refactor this out of PaymentMethodType. Users shouldn't have to convert STPPaymentMethodType to PaymentMethodType in order to get its image.
-            // Get the client-side asset first
-            let localImage = {
-                switch self {
-                case .external(let paymentMethod):
-                    // TODO(yuki|EPMs): Use URLs from the ExternalPaymentMethod instead
-                    if paymentMethod.type == "external_paypal" {
-                        return STPPaymentMethodType.payPal.makeImage(forDarkBackground: forDarkBackground)
-                    } else {
-                        assertionFailure("Tried to make an icon for an unsupported external payment method type")
-                        return UIImage()
-                    }
-
-                case .stripe(let paymentMethodType):
-                    return paymentMethodType.makeImage(forDarkBackground: forDarkBackground)
-                }
-            }()
-            // Next, try to download the image from the spec if possible
-            if
-                FormSpecProvider.shared.isLoaded,
-                let spec = FormSpecProvider.shared.formSpec(for: identifier),
-                let selectorIcon = spec.selectorIcon,
-                var imageUrl = URL(string: selectorIcon.lightThemePng)
-            {
-                if forDarkBackground,
-                    let darkImageString = selectorIcon.darkThemePng,
-                    let darkImageUrl = URL(string: darkImageString)
+            switch self {
+            case .external(let paymentMethod):
+                let url = forDarkBackground ? paymentMethod.darkImageUrl : paymentMethod.lightImageUrl
+                return DownloadManager.sharedManager.downloadImage(
+                    url: url ?? paymentMethod.lightImageUrl,
+                    placeholder: nil,
+                    updateHandler: updateHandler
+                )
+            case .stripe(let paymentMethodType):
+                // Get the client-side asset first
+                let localImage = paymentMethodType.makeImage(forDarkBackground: forDarkBackground)
+                // Next, try to download the image from the spec if possible
+                if
+                    FormSpecProvider.shared.isLoaded,
+                    let spec = FormSpecProvider.shared.formSpec(for: identifier),
+                    let selectorIcon = spec.selectorIcon,
+                    var imageUrl = URL(string: selectorIcon.lightThemePng)
                 {
-                    imageUrl = darkImageUrl
+                    if forDarkBackground,
+                       let darkImageString = selectorIcon.darkThemePng,
+                       let darkImageUrl = URL(string: darkImageString)
+                    {
+                        imageUrl = darkImageUrl
+                    }
+                    if PaymentSheet.PaymentMethodType.shouldLogAnalytic(paymentMethod: self) {
+                        STPAnalyticsClient.sharedClient.logImageSelectorIconDownloadedIfNeeded(paymentMethod: self)
+                    }
+                    // If there's a form spec, download the spec's image, using the local image as a placeholder until it loads
+                    return DownloadManager.sharedManager.downloadImage(url: imageUrl, placeholder: localImage, updateHandler: updateHandler)
+                } else if let localImage {
+                    if PaymentSheet.PaymentMethodType.shouldLogAnalytic(paymentMethod: self) {
+                        STPAnalyticsClient.sharedClient.logImageSelectorIconFromBundleIfNeeded(paymentMethod: self)
+                    }
+                    // If there's no form spec, return the local image if it exists
+                    return localImage
+                } else {
+                    // If the local image doesn't exist and there's no form spec, fire an analytic and return an empty image
+                    assertionFailure()
+                    if PaymentSheet.PaymentMethodType.shouldLogAnalytic(paymentMethod: self) {
+                        STPAnalyticsClient.sharedClient.logImageSelectorIconNotFoundIfNeeded(paymentMethod: self)
+                    }
+                    return DownloadManager.sharedManager.imagePlaceHolder()
                 }
-                if PaymentSheet.PaymentMethodType.shouldLogAnalytic(paymentMethod: self) {
-                    STPAnalyticsClient.sharedClient.logImageSelectorIconDownloadedIfNeeded(paymentMethod: self)
-                }
-                // If there's a form spec, download the spec's image, using the local image as a placeholder until it loads
-                return DownloadManager.sharedManager.downloadImage(url: imageUrl, placeholder: localImage, updateHandler: updateHandler)
-            } else if let localImage {
-                if PaymentSheet.PaymentMethodType.shouldLogAnalytic(paymentMethod: self) {
-                    STPAnalyticsClient.sharedClient.logImageSelectorIconFromBundleIfNeeded(paymentMethod: self)
-                }
-                // If there's no form spec, return the local image if it exists
-                return localImage
-            } else {
-                // If the local image doesn't exist and there's no form spec, fire an analytic and return an empty image
-                assertionFailure()
-                if PaymentSheet.PaymentMethodType.shouldLogAnalytic(paymentMethod: self) {
-                    STPAnalyticsClient.sharedClient.logImageSelectorIconNotFoundIfNeeded(paymentMethod: self)
-                }
-                return DownloadManager.sharedManager.imagePlaceHolder()
             }
         }
 
@@ -148,22 +144,19 @@ extension PaymentSheet {
                 return availabilityStatus == .supported
             }
 
-            // Now that we have all our Stripe PaymentMethod types, we'll add external payment method types.
-            var recommendedPaymentMethodTypes = recommendedStripePaymentMethodTypes.map { PaymentMethodType.stripe($0) }
-
-            // TODO(yuki|EPMs): Rewrite this to access intent.elementsSession.externalPaymentMethods when we support more EPMs
-            // Add external_paypal if...
-            if
-                // ...the merchant configured external_paypal...
-                let epms = configuration.externalPaymentMethodConfiguration?.externalPaymentMethods,
-                epms.contains("external_paypal"),
-                // ...the intent doesn't already have "paypal"...
-                !recommendedStripePaymentMethodTypes.contains(.payPal),
-                // ...and external_paypal isn't disabled.
-                !intent.shouldDisableExternalPayPal
-            {
-                recommendedPaymentMethodTypes.append(.external(.makeExternalPaypal()))
+            // Log a warning if elements session doesn't contain all the merchant's desired external payment methods
+            let missingExternalPaymentMethods = Set(configuration.externalPaymentMethodConfiguration?.externalPaymentMethods.map { $0.lowercased() } ?? [])
+                .subtracting(Set(intent.elementsSession.externalPaymentMethods.map { $0.type }))
+            if !missingExternalPaymentMethods.isEmpty {
+                print("[Stripe SDK]: PaymentSheet could not offer these external payment methods: \(missingExternalPaymentMethods). See https://stripe.com/docs/payments/external-payment-methods#available-external-payment-methods")
             }
+
+            // The full ordered list of recommended payment method types:
+            var recommendedPaymentMethodTypes: [PaymentMethodType] =
+                // Stripe PaymentMethod types
+                recommendedStripePaymentMethodTypes.map { PaymentMethodType.stripe($0) }
+                // External Payment Methods
+                + intent.elementsSession.externalPaymentMethods.map { PaymentMethodType.external($0) }
 
             if let merchantPaymentMethodOrder = configuration.paymentMethodOrder?.map({ $0.lowercased() }) {
                 // Order the payment methods according to the merchant's `paymentMethodOrder` configuration:

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -147,7 +147,7 @@ extension PaymentSheet {
             // Log a warning if elements session doesn't contain all the merchant's desired external payment methods
             let missingExternalPaymentMethods = Set(configuration.externalPaymentMethodConfiguration?.externalPaymentMethods.map { $0.lowercased() } ?? [])
                 .subtracting(Set(intent.elementsSession.externalPaymentMethods.map { $0.type }))
-            if !missingExternalPaymentMethods.isEmpty {
+            if logAvailability && !missingExternalPaymentMethods.isEmpty {
                 print("[Stripe SDK]: PaymentSheet could not offer these external payment methods: \(missingExternalPaymentMethods). See https://stripe.com/docs/payments/external-payment-methods#available-external-payment-methods")
             }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
@@ -180,7 +180,6 @@ extension PaymentSheet {
         public var removeSavedPaymentMethodMessage: String?
 
         /// Configuration for external payment methods.
-        @_spi(ExternalPaymentMethodsPrivateBeta)
         public var externalPaymentMethodConfiguration: ExternalPaymentMethodConfiguration?
 
         /// By default, PaymentSheet will use a dynamic ordering that optimizes payment method display for the customer.
@@ -188,7 +187,6 @@ extension PaymentSheet {
         /// See https://stripe.com/docs/api/payment_methods/object#payment_method_object-type for the list of valid types.  You may also pass external payment methods.
         /// - Example: ["card", "external_paypal", "klarna"]
         /// - Note: If you omit payment methods from this list, they’ll be automatically ordered by Stripe after the ones you provide. Invalid payment methods are ignored.
-        @_spi(ExternalPaymentMethodsPrivateBeta)
         public var paymentMethodOrder: [String]?
     }
 
@@ -405,8 +403,14 @@ extension PaymentSheet {
         public var attachDefaultsToPaymentMethod = false
     }
 
-    @_spi(ExternalPaymentMethodsPrivateBeta)
+    /// Configuration for external payment methods
+    /// - Seealso: See the [integration guide](https://stripe.com/docs/payments/external-payment-methods?platform=ios).
     public struct ExternalPaymentMethodConfiguration {
+
+        /// Initializes an `ExternalPaymentMethodConfiguration`
+        /// - Parameter externalPaymentMethods: A list of external payment methods to display in PaymentSheet e.g., ["external_paypal"].
+        /// - Parameter externalPaymentMethodConfirmHandler: A handler called when the customer confirms the payment using an external payment method.
+        /// - Seealso: See the [integration guide](https://stripe.com/docs/payments/external-payment-methods?platform=ios).
         public init(externalPaymentMethods: [String], externalPaymentMethodConfirmHandler: @escaping PaymentSheet.ExternalPaymentMethodConfiguration.ExternalPaymentMethodConfirmHandler) {
             self.externalPaymentMethods = externalPaymentMethods
             self.externalPaymentMethodConfirmHandler = externalPaymentMethodConfirmHandler
@@ -416,7 +420,7 @@ extension PaymentSheet {
         /// e.g. ["external_paypal"].
         public var externalPaymentMethods: [String] = []
 
-        /// - Parameter externalPaymentMethodType: The external payment method to confirm payment with.  e.g. "external_paypal"
+        /// - Parameter externalPaymentMethodType: The external payment method to confirm payment with e.g., "external_paypal"
         /// - Parameter billingDetails: An object containing any billing details you've configured PaymentSheet to collect.
         /// - Parameter completion: Call this after payment has completed, passing the result of the payment.
         /// - Returns: The result of the attempt to confirm payment using the given external payment method.
@@ -427,7 +431,7 @@ extension PaymentSheet {
         ) -> Void
 
         /// This handler is called when the customer confirms the payment using an external payment method.
-        /// Your implementation should complete the payment and call the `completion` paramter with the result.
+        /// Your implementation should complete the payment and call the `completion` parameter with the result.
         /// - Note: This is always called on the main thread.
         public var externalPaymentMethodConfirmHandler: ExternalPaymentMethodConfirmHandler
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -62,8 +62,8 @@ extension PaymentSheet {
                     label = confirmParams.paymentSheetLabel
                 case .link(let option):
                     label = option.paymentSheetLabel
-                case .external(let PaymentMethod, _):
-                    label = PaymentMethod.localizedLabel
+                case .external(let paymentMethod, _):
+                    label = paymentMethod.label
                 }
             }
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -141,7 +141,7 @@ class PaymentSheetFormFactory {
 
     func make() -> PaymentMethodElement {
         guard case .stripe(let paymentMethod) = paymentMethod else {
-            return makeExternalPayPal()
+            return makeExternalPaymentMethodForm()
         }
         var additionalElements = [Element]()
 
@@ -594,7 +594,8 @@ extension PaymentSheetFormFactory {
         return FormElement(autoSectioningElements: elements, theme: theme)
     }
 
-    func makeExternalPayPal() -> PaymentMethodElement {
+    /// All external payment methods use the same form that collects no user input except for any details the merchant configured PaymentSheet to collect (name, email, phone, billing address).
+    func makeExternalPaymentMethodForm() -> PaymentMethodElement {
         let contactInfoSection = makeContactInformationSection(nameRequiredByPaymentMethod: false, emailRequiredByPaymentMethod: false, phoneRequiredByPaymentMethod: false)
         let billingDetails = makeBillingAddressSectionIfNecessary(requiredByPaymentMethod: false)
         return FormElement(elements: [contactInfoSection, billingDetails], theme: theme)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -146,7 +146,7 @@ final class PaymentSheetLoader {
             let paymentIntent: STPPaymentIntent
             let elementsSession: STPElementsSession
             do {
-                (paymentIntent, elementsSession) = try await configuration.apiClient.retrieveElementsSession(paymentIntentClientSecret: clientSecret)
+                (paymentIntent, elementsSession) = try await configuration.apiClient.retrieveElementsSession(paymentIntentClientSecret: clientSecret, configuration: configuration)
             } catch let error {
                 analyticsClient.logPaymentSheetEvent(event: .paymentSheetElementsSessionLoadFailed, error: error)
                 // Fallback to regular retrieve PI when retrieve PI with preferences fails
@@ -162,7 +162,7 @@ final class PaymentSheetLoader {
             let setupIntent: STPSetupIntent
             let elementsSession: STPElementsSession
             do {
-                (setupIntent, elementsSession) = try await configuration.apiClient.retrieveElementsSession(setupIntentClientSecret: clientSecret)
+                (setupIntent, elementsSession) = try await configuration.apiClient.retrieveElementsSession(setupIntentClientSecret: clientSecret, configuration: configuration)
             } catch let error {
                 analyticsClient.logPaymentSheetEvent(event: .paymentSheetElementsSessionLoadFailed, error: error)
                 // Fallback to regular retrieve SI when retrieve SI with preferences fails
@@ -176,7 +176,7 @@ final class PaymentSheetLoader {
             intent = .setupIntent(elementsSession: elementsSession, setupIntent: setupIntent)
         case .deferredIntent(let intentConfig):
             do {
-                let elementsSession = try await configuration.apiClient.retrieveElementsSession(withIntentConfig: intentConfig)
+                let elementsSession = try await configuration.apiClient.retrieveElementsSession(withIntentConfig: intentConfig, configuration: configuration)
                 intent = .deferredIntent(elementsSession: elementsSession, intentConfig: intentConfig)
             } catch let error as NSError where error == NSError.stp_genericFailedToParseResponseError() {
                 // Most errors are useful and should be reported back to the merchant to help them debug their integration (e.g. bad connection, unknown parameter, invalid api key).

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
@@ -336,7 +336,6 @@ extension PaymentSheet.PaymentOption {
         case .applePay:
             return .applePay
         case .new, .external:
-            // TODO(yuki|EPMs): Add analytics for EPMs - probably new AnalyticsPaymentMethodType .external(String) case
             return .newPM
         case .saved:
             return .savedPM
@@ -367,7 +366,8 @@ extension PaymentSheet.Configuration {
         payload["save_payment_method_opt_in_behavior"] = savePaymentMethodOptInBehavior.description
         payload["appearance"] = appearance.analyticPayload
         payload["billing_details_collection_configuration"] = billingDetailsCollectionConfiguration.analyticPayload
-
+        // Only grab the first 10 as a safeguard, since `externalPaymentMethods` is configured by the merchant and theoretically ~unbounded
+        payload["external_payment_methods"] = externalPaymentMethodConfiguration?.externalPaymentMethods.prefix(10)
         return payload
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
@@ -366,8 +366,6 @@ extension PaymentSheet.Configuration {
         payload["save_payment_method_opt_in_behavior"] = savePaymentMethodOptInBehavior.description
         payload["appearance"] = appearance.analyticPayload
         payload["billing_details_collection_configuration"] = billingDetailsCollectionConfiguration.analyticPayload
-        // Only grab the first 10 as a safeguard, since `externalPaymentMethods` is configured by the merchant and theoretically ~unbounded
-        payload["external_payment_methods"] = externalPaymentMethodConfiguration?.externalPaymentMethods.prefix(10)
         return payload
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLPMConfirmFlowTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLPMConfirmFlowTests.swift
@@ -11,7 +11,7 @@ import XCTest
 import SafariServices
 @testable@_spi(STP) import StripeCore
 @testable@_spi(STP) import StripePayments
-@testable@_spi(ExternalPaymentMethodsPrivateBeta) import StripePaymentSheet
+@testable import StripePaymentSheet
 @testable@_spi(STP) import StripePaymentSheet
 @testable@_spi(STP) import StripePaymentsTestUtils
 @testable@_spi(STP) import StripeUICore

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPElementsSessionTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPElementsSessionTest.swift
@@ -47,8 +47,6 @@ class STPElementsSessionTest: XCTestCase {
         XCTAssertEqual(elementsSession.cardBrandChoice?.eligible, true)
         XCTAssertTrue(elementsSession.isApplePayEnabled)
         XCTAssertEqual(elementsSession.allResponseFields as NSDictionary, elementsSessionJson as NSDictionary)
-
-        // TODO: Test epms
     }
 
     func testDecodedObjectFromAPIResponseMapping_applePayPreferenceDisabled() {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPFixtures+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPFixtures+PaymentSheet.swift
@@ -32,11 +32,18 @@ extension STPElementsSession {
 
     static func _testValue(
         paymentMethodTypes: [String],
-        flags: [String: Bool] = [:]
+        externalPaymentMethodTypes: [String] = []
     ) -> STPElementsSession {
         var json = STPTestUtils.jsonNamed("ElementsSession")!
         json[jsonDict: "payment_method_preference"]?["ordered_payment_method_types"] = paymentMethodTypes
-        json["flags"] = flags
+        json["external_payment_method_data"] = externalPaymentMethodTypes.map {
+            [
+                "type": $0,
+                "label": $0,
+                "light_image_url": "https://test.com",
+                "dark_image_url": "https://test.com",
+            ]
+        }
         let elementsSession = STPElementsSession.decodedObject(fromAPIResponse: json)!
         return elementsSession
     }


### PR DESCRIPTION
[Don't merge yet]
## Summary
This PR replaces hardcoded paypal EPM support with a server-driven solution that can handle arbitrary EPMs.

- Sends merchant-supplied `external_payment_methods` to `v1/elements/sessions`.
- Adds `externalPaymentMethods` to `STPElementsSession`.  Sends a new `mc_elements_session_epms_load_failed` analytic if parsing ^ fails, and falls back to an empty array.
- Replaces `externalPayPal` hardcoded form and image code with generic EPM form/image based on `STPElementsSession.externalPaymentMethods`
- Removes `

## Motivation
https://docs.google.com/document/d/1TYrUZmd-gz1Cu4blWmRQ7NUZwgIi5n16nc7vLvHtSXk/edit?pli=1

## Testing
Added tests for:
- Loading external payment methods in `v1/elements/sessions`
- Parsing EPMs in the response. Failing to parse falls back and reports an analytic.

Existing tests cover the rest of the behavior, which is unchanged from the private beta.

## Changelog
* [Added] PaymentSheet now supports external payment methods. See https://stripe.com/docs/payments/external-payment-methods?platform=ios