### PR TITLE
Fix STPApplePayContext initializer not fully validating the payment r…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## X.Y.Z 2023-xx-yy
+### Apple Pay
+* [Fixed] STPApplePayContext initializer returns nil in more cases where the request is invalid. 
+
 ## 23.18.3 2023-11-28
 ### PaymentSheet
 * [Fixed] Visual bug where re-presenting PaymentSheet wouldn't show a spinner while it reloads.

--- a/Stripe/StripeiOSTests/STPApplePayContextTest.swift
+++ b/Stripe/StripeiOSTests/STPApplePayContextTest.swift
@@ -47,8 +47,20 @@ class STPApplePayTestDelegateiOS11: NSObject, STPApplePayContextDelegate {
     }
 }
 
-// MARK: - STPApplePayTestDelegateiOS11
 class STPApplePayContextTest: XCTestCase {
+    func testInvalidPaymentRequest() {
+        // An invalid request (missing payment summary items)...
+        let request = StripeAPI.paymentRequest(
+            withMerchantIdentifier: "foo",
+            country: "US",
+            currency: "USD"
+        )
+        // ...should cause ApplePayContext to be nil
+        let applePayContext = STPApplePayContext(paymentRequest: request, delegate: STPApplePayTestDelegateiOS11())
+        XCTAssertNil(applePayContext)
+    }
+
+    // MARK: - STPApplePayTestDelegateiOS11
     func testiOS11ApplePayDelegateMethodsForwarded() {
         // With a user that only implements iOS 11 delegate methods...
         let delegate = STPApplePayTestDelegateiOS11()
@@ -58,7 +70,7 @@ class STPApplePayContextTest: XCTestCase {
             currency: "USD"
         )
         request.paymentSummaryItems = [
-            PKPaymentSummaryItem(label: "bar", amount: NSDecimalNumber(string: "1.00"))
+            PKPaymentSummaryItem(label: "bar", amount: NSDecimalNumber(string: "1.00")),
         ]
         let context = STPApplePayContext(paymentRequest: request, delegate: delegate)!
 
@@ -120,7 +132,7 @@ class STPApplePayContextTest: XCTestCase {
             currency: "USD"
         )
         request.paymentSummaryItems = [
-            PKPaymentSummaryItem(label: "bar", amount: NSDecimalNumber(string: "1.00"))
+            PKPaymentSummaryItem(label: "bar", amount: NSDecimalNumber(string: "1.00")),
         ]
         let context = STPApplePayContext(paymentRequest: request, delegate: delegate)
 


### PR DESCRIPTION
…equest

## Summary
STPApplePayContext's init says it returns nil if the request is invalid. 

It does this, in part, by checking if `PKPaymentAuthorizationController` is nil.

PKPaymentAuthorizationController's docs state:
"If the user can’t make payments on any of the payment request’s supported networks, initialization fails and this method returns nil."

In actuality, this initializer is non-nullable. To make sure STPApplePayContext returns nil when the request is invalid, we'll use PKPaymentAuthorizationViewController's initializer, which *is* nullable.


## Motivation
https://github.com/stripe/stripe-ios/issues/2937

## Testing
See unit test - failed before, passes after.

## Changelog
### Apple Pay
* [Fixed] STPApplePayContext initializer returns nil in more cases where the request is invalid.
