### PR TITLE
ApplePayContext allows Apple Pay when customer doesn’t have saved cards but can set them up in the Apple Pay sheet.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## X.Y.Z 2023-xx-yy
 ### Apple Pay
-* [Fixed] STPApplePayContext initializer returns nil in more cases where the request is invalid. 
+* [Fixed] STPApplePayContext initializer returns nil in more cases where the request is invalid.
+* [Fixed] STPApplePayContext now allows Apple Pay when the customer doesn’t have saved cards but can set them up in the Apple Pay sheet (iOS 15+).
 
 ## 23.18.3 2023-11-28
 ### PaymentSheet

--- a/StripeCore/StripeCore/Source/API Bindings/StripeAPI.swift
+++ b/StripeCore/StripeCore/Source/API Bindings/StripeAPI.swift
@@ -99,7 +99,7 @@ import PassKit
         return paymentRequest.paymentSummaryItems.last?.amount.floatValue ?? 0.0 >= 0
     }
 
-    class func supportedPKPaymentNetworks() -> [PKPaymentNetwork] {
+    @_spi(STP) public class func supportedPKPaymentNetworks() -> [PKPaymentNetwork] {
         return [
             .amex,
             .masterCard,


### PR DESCRIPTION
## Summary
- Reworked ApplePayContext init to allow Apple Pay when customer doesn’t have saved cards but can set them up in the Apple Pay sheet.

## Motivation
- User surprised that in iOS they can't render the ApplePay PaySheet even if there are no cards in the wallet. 
- https://github.com/stripe/stripe-ios/pull/2721
- https://jira.corp.stripe.com/browse/RUN_MOBILESDK-2771

## Testing
ApplePayContext used to use `canSubmitPaymentRequest`, which checks 3 things. I made sure they're preserved:
- `PKPaymentAuthorizationController.canMakePayments(usingNetworks:)` (already used on <iOS 15)
- `paymentRequest.merchantIdentifier.isEmpty` (added an assertionfailure too, since this is an integration error)
- `paymentRequest.paymentSummaryItems.last?.amount.floatValue ?? 0.0 >= 0` (unnecessary, already considered by other checks)


## Changelog
* [Fixed] On iOS 15+, STPApplePayContext initializer no longer returns if the customer has no available saved cards but their phone supports Apple Pay. In this case, the customer can still add cards in the Apple Pay sheet.
