### PR TITLE
Remove duplicate merchant country switcher

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlayground.swift
@@ -38,13 +38,6 @@ struct CustomerSheetTestPlayground: View {
                             }.buttonStyle(.bordered)
                         }
                         SettingView(setting: $playgroundController.settings.customerMode)
-                        SettingPickerView(setting: Binding(
-                            get: { playgroundController.settings.merchantCountryCode },
-                            set: { newValue in
-                                // If we change to a new country, default to a new customer
-                                playgroundController.settings.customerMode = .new
-                                playgroundController.settings.merchantCountryCode = newValue
-                            }))
                         TextField("CustomerId", text: customerIdBinding)
                     }
                     Group {


### PR DESCRIPTION
## Summary
Oops, there are two merchant country switchers

## Motivation
We don't need two

## Testing
Manual testing

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
