### PR TITLE
Fix validation errors in `localized_address_data.json`

### DIFF
--- a/StripeUICore/StripeUICore/Resources/JSON/localized_address_data.json
+++ b/StripeUICore/StripeUICore/Resources/JSON/localized_address_data.json
@@ -166,7 +166,7 @@
         "PE",
         "QC",
         "SK",
-        "YT",
+        "YT"
       ],
       "sub_labels": [
         "Alberta",
@@ -181,8 +181,8 @@
         "Prince Edward Island",
         "Quebec",
         "Saskatchewan",
-        "Yukon",
-      ],
+        "Yukon"
+      ]
    },
    "CD":{
       "fmt":"%C"
@@ -1060,7 +1060,7 @@
         "WA",
         "WV",
         "WI",
-        "WY",
+        "WY"
       ],
       "sub_labels": [
         "Alabama",
@@ -1124,7 +1124,7 @@
         "Washington",
         "West Virginia",
         "Wisconsin",
-        "Wyoming",
+        "Wyoming"
       ]
    },
    "UY":{


### PR DESCRIPTION
## Summary
Removes trailing commas in `localized_address_data.json` so the file is valid JSON

## Motivation
My project recently integrated a JSON linter that flagged this file.  Note that Foundation's JSON parser will accept trailing commas even when they technically violate the spec.

## Testing
`jq empty StripeUICore/StripeUICore/StripeUICore/Resources/JSON/localized_address_data.json`

## Changelog
n/a