### PR TITLE
Fix bug w/ showing mandate on edit in CS

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewController.swift
@@ -103,6 +103,7 @@ class CustomerSavedPaymentMethodsCollectionViewController: UIViewController {
                     selectedViewModelIndex = originalSelectedViewModelIndex
                 }
             }
+            updateMandateView()
         }
     }
     var bottomNoticeAttributedString: NSAttributedString? {


### PR DESCRIPTION
## Summary
Fix issue with showing mandate after tapping edit

## Motivation
Open sheet with returning customer
Select SEPA, but don’t confirm
Press edit, then press Done
See the mandate still there


## Testing
Manually tested

Before:
![before_fix_3114](https://github.com/stripe/stripe-ios/assets/99628984/b41efd7a-5b22-435e-b65b-305adb670708)

After:
![Fixed_3114](https://github.com/stripe/stripe-ios/assets/99628984/c09da851-d9cd-470f-a058-711a8cc53cd7)


