### PR TITLE
Fix test playground when switching countries

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -31,7 +31,6 @@ struct PaymentSheetTestPlayground: View {
             SettingView(setting: $playgroundController.settings.linkEnabled)
             SettingView(setting: $playgroundController.settings.externalPayPalEnabled)
             SettingView(setting: $playgroundController.settings.preferredNetworksEnabled)
-            SettingView(setting: $playgroundController.settings.autoreload)
         }
         Group {
             if playgroundController.settings.uiStyle == .flowController {
@@ -39,6 +38,9 @@ struct PaymentSheetTestPlayground: View {
                     SettingView(setting: $playgroundController.settings.requireCVCRecollection)
                 }
             }
+        }
+        Group {
+            SettingView(setting: $playgroundController.settings.autoreload)
         }
     }
 
@@ -90,7 +92,7 @@ struct PaymentSheetTestPlayground: View {
                         TextField("CustomerId", text: customerIdBinding)
                             .disabled(true)
                         SettingPickerView(setting: $playgroundController.settings.currency)
-                        SettingPickerView(setting: $playgroundController.settings.merchantCountryCode)
+                        SettingPickerView(setting: merchantCountryBinding)
                         SettingView(setting: $playgroundController.settings.apmsEnabled)
                     }
                     Divider()
@@ -171,6 +173,18 @@ struct PaymentSheetTestPlayground: View {
             playgroundController.settings.customerId = (newString != "") ? newString : nil
         }
     }
+    var merchantCountryBinding: Binding<PaymentSheetTestPlaygroundSettings.MerchantCountry> {
+        Binding<PaymentSheetTestPlaygroundSettings.MerchantCountry> {
+            return playgroundController.settings.merchantCountryCode
+        } set: { newCountry in
+            // Reset customer id if country changes
+            if playgroundController.settings.merchantCountryCode.rawValue != newCountry.rawValue {
+                playgroundController.settings.customerMode = .guest
+            }
+            playgroundController.settings.merchantCountryCode = newCountry
+        }
+    }
+
 }
 
 @available(iOS 14.0, *)


### PR DESCRIPTION
## Summary
I found that switching countires in test playground results in the backend not sending a response, in which case the client just hangs. 

Proposed changes:
1. Instead of waiting for a response to come back, i suggest that we just cancel the existing job, and kick off a new one.
2. Default to a "guest" when changing countries as to avoid crashing the backend
3. re-order autoload below cvc recollection
4.  nil out the lastPaymentResult if we've successfully loaded

## Motivation
Spinner occurs for a long period of time when switching countries

## Testing
manually tested/emulator
