### PR TITLE
[Identity] Add zoom level and barcode scanner

### DIFF
--- a/StripeIdentity/StripeIdentity/Resources/Localizations/en.lproj/Localizable.strings
+++ b/StripeIdentity/StripeIdentity/Resources/Localizations/en.lproj/Localizable.strings
@@ -88,6 +88,12 @@
 /* Body for selfie warmup page */
 "Make sure you're in a well lit space." = "Make sure you're in a well lit space.";
 
+/* Instructional text when camera is too far from a document */
+"Move closer" = "Move closer";
+
+/* Instructional text when camera is too close to a document */
+"Move farther" = "Move farther";
+
 /* Label for the ID field to collect NRIC or FIN for Singaporean ID */
 "NRIC or FIN" = "NRIC or FIN";
 

--- a/StripeIdentity/StripeIdentity/Source/Helpers/String+Localized.swift
+++ b/StripeIdentity/StripeIdentity/Source/Helpers/String+Localized.swift
@@ -67,6 +67,43 @@ extension String.Localized {
         )
     }
 
+    // MARK: - Document Capture
+
+    static var position_in_center: String {
+        return STPLocalizedString(
+            "Position your identity card in the center of the frame",
+            "Instructional text for scanning front of a identity card"
+        )
+    }
+
+    static var flip_to_other_side: String {
+        return STPLocalizedString(
+            "Flip your identity card over to the other side",
+            "Instructional text for scanning back of a identity card"
+        )
+    }
+
+    static var scanning: String {
+        return STPLocalizedString(
+            "Hold still, scanning",
+            "Instructional text when camera is focusing on a document while scanning it"
+        )
+    }
+
+    static var move_closer: String {
+        return STPLocalizedString(
+            "Move closer",
+            "Instructional text when camera is too far from a document"
+        )
+    }
+
+    static var move_farther: String {
+        return STPLocalizedString(
+            "Move farther",
+            "Instructional text when camera is too close to a document"
+        )
+    }
+
     // MARK: - Document Upload
 
     static var app_settings: String {

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/ImageScanningSession/ImageScanningSession.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/ImageScanningSession/ImageScanningSession.swift
@@ -267,7 +267,7 @@ final class ImageScanningSession<
 
             // Configure camera session
             // Tell the camera to automatically adjust focus to the center of
-            // the image
+            // the image and restrict autofocus range to .near.
             self.cameraSession.configureSession(
                 configuration: .init(
                     initialCameraPosition: self.initialCameraPosition,
@@ -278,7 +278,8 @@ final class ImageScanningSession<
                         (kCVPixelBufferPixelFormatTypeKey as String): Int(
                             IDDetectorConstants.requiredPixelFormat
                         ),
-                    ]
+                    ],
+                    autoFocusRangeRestriction: .near
                 ),
                 delegate: self,
                 completeOn: .main

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/DocumentCaptureViewController+Strings.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/DocumentCaptureViewController+Strings.swift
@@ -27,26 +27,32 @@ extension DocumentCaptureViewController {
 
     func scanningInstructionText(
         for side: DocumentSide,
-        foundClassification: IDDetectorOutput.Classification?
+        idDetectorOutput: IDDetectorOutput?
     ) -> String {
+        let foundClassification = idDetectorOutput?.classification
         let matchesClassification =
         foundClassification?.matchesDocument(side: side) ?? false
-        switch (side, matchesClassification) {
-        case (.front, false):
-            return STPLocalizedString(
-                "Position your identity card in the center of the frame",
-                "Instructional text for scanning front of a identity card"
-            )
-        case (.back, false):
-            return STPLocalizedString(
-                "Flip your identity card over to the other side",
-                "Instructional text for scanning back of a identity card"
-            )
-        case (_, true):
-            return STPLocalizedString(
-                "Hold still, scanning",
-                "Instructional text when camera is focusing on a document while scanning it"
-            )
+        let zoomLevel = idDetectorOutput?.computeZoomLevel()
+
+        guard let zoomLevel = zoomLevel else {
+            if side == .front {
+                return String.Localized.position_in_center
+            } else {
+                return String.Localized.flip_to_other_side
+            }
+        }
+
+        switch (side, matchesClassification, zoomLevel) {
+        case (.front, false, _):
+            return String.Localized.position_in_center
+        case (.back, false, _):
+            return String.Localized.flip_to_other_side
+        case (_, true, .ok):
+            return String.Localized.scanning
+        case (_, true, .tooClose):
+            return String.Localized.move_farther
+        case (_, true, .tooFar):
+            return String.Localized.move_closer
         }
     }
 

--- a/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/ViewControllers/DocumentCaptureViewControllerTest.swift
+++ b/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/ViewControllers/DocumentCaptureViewControllerTest.swift
@@ -542,8 +542,7 @@ final class DocumentCaptureViewControllerTest: XCTestCase {
         // Mock that scanner found a classification that was not desired and
         // verify the state is updated accordingly
         mockConcurrencyManager.respondToScan(output: makeDocumentScannerOutput(with: .invalid))
-        
-        
+
         XCTAssertStateEqual(vc.imageScanningSession.state, .scanning(.front, .init(classification: .invalid, documentBounds: CGRect(), allClassificationScores: [.invalid: 0])))
 
         mockConcurrencyManager.respondToScan(output: makeDocumentScannerOutput(with: .idCardBack))
@@ -562,7 +561,7 @@ final class DocumentCaptureViewControllerTest: XCTestCase {
         mockConcurrencyManager.respondToScan(output: makeDocumentScannerOutput(with: .idCardFront))
         XCTAssertStateEqual(vc.imageScanningSession.state, .scanned(.front, UIImage()))
     }
-    
+
     func testScanningWithBarcode() {
         let vc = makeViewController(
             state: .scanning(.front, nil)
@@ -575,8 +574,7 @@ final class DocumentCaptureViewControllerTest: XCTestCase {
         // Mock that scanner found a classification that was not desired and
         // verify the state is updated accordingly
         mockConcurrencyManager.respondToScan(output: makeDocumentScannerOutput(with: .invalid))
-        
-        
+
         XCTAssertStateEqual(vc.imageScanningSession.state, .scanning(.front, .init(classification: .invalid, documentBounds: CGRect(), allClassificationScores: [.invalid: 0])))
 
         mockConcurrencyManager.respondToScan(output: makeDocumentScannerOutput(with: .idCardBack))


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Add `ZoomLevel` to detect whether the camera is too far or too close, and show corresponding instructions.
Also return fast when barcode is detected.
Also set `autoFocusRangeRestriction` in `CameraSession`, override it to `.near` for Identity


## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Better capture UX

## Testing
<!-- How was the code tested? Be as specific as possible. -->
* Manually verified
* Added Unitest
* Modified Unitest

## Recording:
![zoomLvl](https://github.com/stripe/stripe-ios/assets/79880926/ce492e8a-4682-4808-9269-869a8d2f4015)




## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
