### PR TITLE
Support visionOS across Xcode 14 and 15

### DIFF
--- a/BuildConfigurations/StripeiOS Tests-Shared.xcconfig
+++ b/BuildConfigurations/StripeiOS Tests-Shared.xcconfig
@@ -88,6 +88,3 @@ ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES
 LIBRARY_SEARCH_PATHS = $(inherited)
 
 DEFINES_MODULE = YES
-
-// A way to check for visionOS that will work across Xcode 14 and 15
-SWIFT_ACTIVE_COMPILATION_CONDITIONS[sdk=xr*] = $(inherited) STP_BUILD_FOR_VISION

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## X.Y.Z 2023-xx-yy
 ### PaymentSheet
 * [Added] Support for [card brand choice](https://stripe.com/docs/card-brand-choice). To set default preferred networks, use the new configuration option `PaymentSheet.Configuration.preferredNetworks`.
+* [Fixed] Fixed visionOS support in Swift Package Manager and Cocoapods.
 
 ### CustomerSheet
 * [Added] Support for [card brand choice](https://stripe.com/docs/card-brand-choice). To set default preferred networks, use the new configuration option `PaymentSheet.Configuration.preferredNetworks`.

--- a/StripeApplePay/StripeApplePay/Source/ApplePayContext/STPApplePayContext.swift
+++ b/StripeApplePay/StripeApplePay/Source/ApplePayContext/STPApplePayContext.swift
@@ -145,7 +145,17 @@ public class STPApplePayContext: NSObject, PKPaymentAuthorizationControllerDeleg
     @available(macCatalystApplicationExtension, unavailable)
     @objc(presentApplePayWithCompletion:)
     public func presentApplePay(completion: STPVoidBlock? = nil) {
-        #if STP_BUILD_FOR_VISION
+        // A note on `canImport(CompositorServices)`, found here and elsewhere
+        // in the codebase: This is a terrible, terrible hack.
+        // We should use #if os(visionOS), but that will fail to compile
+        // on Xcode 14. Because we need to continue supporting both Xcode 14
+        // *and* building on visionOS, we instead check `canImport(CompositerServices)`, as CompositerServices currently
+        // only exists on visionOS. I'm sure it will exist on iOS someday,
+        // but we only need this in place until we drop Xcode 14.
+        //
+        // Future engineers in May 2024: Please delete this! Find every mention
+        // of canImport(CompositorServices) and replace it with os(visionOS).
+        #if canImport(CompositorServices)
         // This isn't great: We should encourage the use of presentApplePay(from window:) instead.
         let windows = UIApplication.shared.connectedScenes
             .compactMap { ($0 as? UIWindowScene)?.windows }

--- a/StripeCore/StripeCore/Source/API Bindings/StripeAPI.swift
+++ b/StripeCore/StripeCore/Source/API Bindings/StripeAPI.swift
@@ -160,7 +160,7 @@ import PassKit
         let paymentRequest = PKPaymentRequest()
         paymentRequest.merchantIdentifier = merchantIdentifier
         paymentRequest.supportedNetworks = self.supportedPKPaymentNetworks()
-        #if STP_BUILD_FOR_VISION
+        #if canImport(CompositorServices)
         paymentRequest.merchantCapabilities = .threeDSecure
         #else
         paymentRequest.merchantCapabilities = .capability3DS

--- a/StripeCore/StripeCore/Source/Categories/Locale+StripeCore.swift
+++ b/StripeCore/StripeCore/Source/Categories/Locale+StripeCore.swift
@@ -11,7 +11,7 @@ import Foundation
     /// Returns the regionCode, for visionOS compatibility
     /// We can remove this once we drop iOS 16
     var stp_regionCode: String? {
-#if STP_BUILD_FOR_VISION
+#if canImport(CompositorServices)
         return self.region?.identifier
         #else
         return self.regionCode
@@ -19,7 +19,7 @@ import Foundation
     }
 
     var stp_currencyCode: String? {
-        #if STP_BUILD_FOR_VISION
+        #if canImport(CompositorServices)
         return self.currency?.identifier
         #else
         return self.currencyCode
@@ -27,7 +27,7 @@ import Foundation
     }
 
     var stp_languageCode: String? {
-#if STP_BUILD_FOR_VISION
+#if canImport(CompositorServices)
         return self.language.languageCode?.identifier
         #else
         return self.languageCode
@@ -35,7 +35,7 @@ import Foundation
     }
 
     static var stp_isoRegionCodes: [String] {
-#if STP_BUILD_FOR_VISION
+#if canImport(CompositorServices)
         return self.Region.isoRegions.map { $0.identifier }
 #else
         return self.isoRegionCodes

--- a/StripeCore/StripeCore/Source/DownloadManager/DownloadManager.swift
+++ b/StripeCore/StripeCore/Source/DownloadManager/DownloadManager.swift
@@ -198,7 +198,7 @@ extension DownloadManager {
     }
 
     func persistToMemory(_ imageData: Data, forImageName imageName: String) -> UIImage? {
-        #if STP_BUILD_FOR_VISION
+        #if canImport(CompositorServices)
         let scale = 1.0
         #else
         let scale = UIScreen.main.scale

--- a/StripeCore/StripeCore/Source/Telemetry/STPTelemetryClient.swift
+++ b/StripeCore/StripeCore/Source/Telemetry/STPTelemetryClient.swift
@@ -113,7 +113,7 @@ private let TelemetryURL = URL(string: "https://m.stripe.com/6")!
     private var osVersion = UIDevice.current.systemVersion
 
     private var screenSize: String {
-        #if STP_BUILD_FOR_VISION
+        #if canImport(CompositorServices)
         return "visionOS"
         #else
         let screen = UIScreen.main

--- a/StripeCore/StripeCoreTestUtils/STPSnapshotTestCase.swift
+++ b/StripeCore/StripeCoreTestUtils/STPSnapshotTestCase.swift
@@ -5,7 +5,7 @@
 //  Created by David Estes on 4/13/22.
 //
 
-#if !STP_BUILD_FOR_VISION
+#if !canImport(CompositorServices)
 import Foundation
 import iOSSnapshotTestCase
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/ScreenNativeScale.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/ScreenNativeScale.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 var stp_screenNativeScale: CGFloat {
-    #if STP_BUILD_FOR_VISION
+    #if canImport(CompositorServices)
     return 1.0
     #else
     return UIScreen.main.nativeScale

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/FeaturedInstitutionGridView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/FeaturedInstitutionGridView.swift
@@ -40,7 +40,7 @@ class FeaturedInstitutionGridView: UIView {
             bottom: 16,
             right: horizontalPadding
         )
-        #if !STP_BUILD_FOR_VISION
+        #if !canImport(CompositorServices)
         collectionView.keyboardDismissMode = .onDrag
         #endif
         let cellIdentifier = "\(FeaturedInstitutionGridCell.self)"

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionSearchTableView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionSearchTableView.swift
@@ -122,7 +122,7 @@ final class InstitutionSearchTableView: UIView {
         tableView.rowHeight = UITableView.automaticDimension
         tableView.estimatedRowHeight = 54
 
-        #if !STP_BUILD_FOR_VISION
+        #if !canImport(CompositorServices)
         tableView.contentInset = UIEdgeInsets(
             // add extra inset at the top/bottom to show the cell-selected-state separators
             top: 1.0 / UIScreen.main.nativeScale,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/ManualEntry/ManualEntryViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/ManualEntry/ManualEntryViewController.swift
@@ -65,7 +65,7 @@ final class ManualEntryViewController: UIViewController {
             footerView: footerView
         )
         paneWithHeaderLayoutView.addTo(view: view)
-        #if !STP_BUILD_FOR_VISION
+        #if !canImport(CompositorServices)
         paneWithHeaderLayoutView.scrollView.keyboardDismissMode = .onDrag
         #endif
         stp_beginObservingKeyboardAndInsettingScrollView(paneWithHeaderLayoutView.scrollView, onChange: nil)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
@@ -148,7 +148,7 @@ final class NetworkingLinkSignupViewController: UIViewController {
         )
         pane.addTo(view: view)
 
-        #if !STP_BUILD_FOR_VISION
+        #if !canImport(CompositorServices)
         // if user drags, dismiss keyboard so the CTA buttons can be shown
         pane.scrollView.keyboardDismissMode = .onDrag
         #endif

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/AttributedTextView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/AttributedTextView.swift
@@ -149,7 +149,7 @@ final class AttributedTextView: HitTestView {
 
 extension AttributedTextView: UITextViewDelegate {
 
-    #if !STP_BUILD_FOR_VISION
+    #if !canImport(CompositorServices)
     func textView(
         _ textView: UITextView,
         shouldInteractWith URL: URL,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Categories/UIApplication+StripePaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Categories/UIApplication+StripePaymentSheet.swift
@@ -11,7 +11,7 @@ import UIKit
 extension UIApplication {
     func stp_hackilyFumbleAroundUntilYouFindAKeyWindow() -> UIWindow? {
         // We really shouldn't do this: Try to find a way to get the user to pass us a window instead.
-        #if STP_BUILD_FOR_VISION
+        #if canImport(CompositorServices)
         let windows = connectedScenes
             .compactMap { ($0 as? UIWindowScene)?.windows }
             .flatMap { $0 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/STPCameraView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/STPCameraView.swift
@@ -5,7 +5,7 @@
 //  Created by David Estes on 8/17/20.
 //  Copyright © 2020 Stripe, Inc. All rights reserved.
 //
-#if !STP_BUILD_FOR_VISION
+#if !canImport(CompositorServices)
 
 import AVFoundation
 import UIKit

--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/STPCardScanner.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/STPCardScanner.swift
@@ -5,7 +5,7 @@
 //  Created by David Estes on 8/17/20.
 //  Copyright © 2020 Stripe, Inc. All rights reserved.
 //
-#if !STP_BUILD_FOR_VISION
+#if !canImport(CompositorServices)
 
 import AVFoundation
 import Foundation

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/InlineSignup/LinkInlineSignupView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/InlineSignup/LinkInlineSignupView.swift
@@ -149,7 +149,7 @@ final class LinkInlineSignupView: UIView {
         }
     }
 
-    #if !STP_BUILD_FOR_VISION
+    #if !canImport(CompositorServices)
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         updateAppearance()
@@ -217,7 +217,7 @@ extension LinkInlineSignupView: LinkLegalTermsViewDelegate {
     func legalTermsView(_ legalTermsView: LinkLegalTermsView, didTapOnLinkWithURL url: URL) -> Bool {
         let safariVC = SFSafariViewController(url: url)
 
-        #if !STP_BUILD_FOR_VISION
+        #if !canImport(CompositorServices)
         safariVC.dismissButtonStyle = .close
         #endif
         safariVC.modalPresentationStyle = .overFullScreen

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/UIColor+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/UIColor+Link.swift
@@ -159,7 +159,7 @@ extension UIColor {
         forBackgroundColor backgroundColor: UIColor,
         traitCollection: UITraitCollection = .current
     ) -> UIColor {
-        #if STP_BUILD_FOR_VISION
+        #if canImport(CompositorServices)
         let resolvedLightModeColor = resolvedColor(with: traitCollection.modifyingTraits({ mutableTraits in
             mutableTraits.userInterfaceStyle = .light
         }))

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Views/LinkLegalTermsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Views/LinkLegalTermsView.swift
@@ -120,7 +120,7 @@ final class LinkLegalTermsView: UIView {
 
 extension LinkLegalTermsView: UITextViewDelegate {
 
-#if !STP_BUILD_FOR_VISION
+#if !canImport(CompositorServices)
     func textView(
         _ textView: UITextView,
         shouldInteractWith URL: URL,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/BottomSheet/BottomSheetPresentationController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/BottomSheet/BottomSheetPresentationController.swift
@@ -78,7 +78,7 @@ class BottomSheetPresentationController: UIPresentationController {
 
         coordinator.animate(alongsideTransition: { [weak self] _ in
             self?.backgroundView.alpha = 1
-            #if !STP_BUILD_FOR_VISION
+            #if !canImport(CompositorServices)
             self?.presentedViewController.setNeedsStatusBarAppearanceUpdate()
             #endif
         })
@@ -98,7 +98,7 @@ class BottomSheetPresentationController: UIPresentationController {
 
         coordinator.animate(alongsideTransition: { [weak self] _ in
             self?.backgroundView.alpha = 0
-            #if !STP_BUILD_FOR_VISION
+            #if !canImport(CompositorServices)
             self?.presentingViewController.setNeedsStatusBarAppearanceUpdate()
             #endif
         })

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/BottomSheet/UIViewController+BottomSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/BottomSheet/UIViewController+BottomSheet.swift
@@ -15,7 +15,7 @@ extension UIViewController {
         completion: (() -> Void)? = nil
     ) {
         var presentAsFormSheet: Bool {
-            #if STP_BUILD_FOR_VISION
+            #if canImport(CompositorServices)
             return true
             #else
             // Present as form sheet in larger devices (iPad/Mac).

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerAddPaymentMethodViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerAddPaymentMethodViewController.swift
@@ -179,7 +179,7 @@ class CustomerAddPaymentMethodViewController: UIViewController {
             paymentMethodDetailsContainerView.layoutIfNeeded()
             newView.alpha = 0
 
-            #if !STP_BUILD_FOR_VISION
+            #if !canImport(CompositorServices)
             UISelectionFeedbackGenerator().selectionChanged()
             #endif
             // Fade the new one in and the old one out

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSectionWithScanner/CardSectionWithScannerElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSectionWithScanner/CardSectionWithScannerElement.swift
@@ -23,7 +23,7 @@ final class CardSection: ContainerElement {
 
     weak var delegate: ElementDelegate?
     lazy var view: UIView = {
-        #if !STP_BUILD_FOR_VISION
+        #if !canImport(CompositorServices)
         if #available(iOS 13.0, macCatalyst 14, *), STPCardScanner.cardScanningAvailable {
             return CardSectionWithScannerView(cardSectionView: cardSection.view, delegate: self, theme: theme)
         } else {
@@ -215,7 +215,7 @@ private func cardParams(for intentParams: IntentConfirmParams) -> STPPaymentMeth
     return cardParams
 }
 
-#if !STP_BUILD_FOR_VISION
+#if !canImport(CompositorServices)
 // MARK: - CardSectionWithScannerViewDelegate
 
 extension CardSection: CardSectionWithScannerViewDelegate {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSectionWithScanner/CardSectionWithScannerView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSectionWithScanner/CardSectionWithScannerView.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2022 Stripe, Inc. All rights reserved.
 //
 
-#if !STP_BUILD_FOR_VISION
+#if !canImport(CompositorServices)
 import Foundation
 @_spi(STP) import StripeCore
 @_spi(STP) import StripePayments

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
@@ -259,7 +259,7 @@ class AddPaymentMethodViewController: UIViewController {
             paymentMethodDetailsContainerView.addPinnedSubview(newView)
             paymentMethodDetailsContainerView.layoutIfNeeded()
             newView.alpha = 0
-            #if !STP_BUILD_FOR_VISION
+            #if !canImport(CompositorServices)
             UISelectionFeedbackGenerator().selectionChanged()
             #endif
             // Fade the new one in and the old one out

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/PaymentMethodTypeCollectionView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/PaymentMethodTypeCollectionView.swift
@@ -127,7 +127,7 @@ extension PaymentMethodTypeCollectionView: UICollectionViewDataSource, UICollect
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         var useFixedSizeCells: Bool {
-            #if STP_BUILD_FOR_VISION
+            #if canImport(CompositorServices)
             return true
             #else
             // Prefer fixed size cells for iPads and Mac.
@@ -259,7 +259,7 @@ extension PaymentMethodTypeCollectionView {
             fatalError("init(coder:) has not been implemented")
         }
 
-        #if !STP_BUILD_FOR_VISION
+        #if !canImport(CompositorServices)
         override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
             super.traitCollectionDidChange(previousTraitCollection)
             update()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentMethodCollectionView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentMethodCollectionView.swift
@@ -199,7 +199,7 @@ extension SavedPaymentMethodCollectionView {
             fatalError("init(coder:) has not been implemented")
         }
 
-        #if !STP_BUILD_FOR_VISION
+        #if !canImport(CompositorServices)
         override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
             super.traitCollectionDidChange(previousTraitCollection)
             update()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/AutoComplete/AutoCompleteViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/AutoComplete/AutoCompleteViewController.swift
@@ -68,7 +68,7 @@ class AutoCompleteViewController: UIViewController {
         let tableView = UITableView()
         tableView.delegate = self
         tableView.dataSource = self
-        #if !STP_BUILD_FOR_VISION
+        #if !canImport(CompositorServices)
         tableView.keyboardDismissMode = .onDrag
         #endif
         tableView.backgroundColor = configuration.appearance.colors.background

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/BottomSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/BottomSheetViewController.swift
@@ -195,7 +195,7 @@ class BottomSheetViewController: UIViewController, BottomSheetPresentable {
 
     @objc
     private func keyboardDidShow(notification: Notification) {
-        #if STP_BUILD_FOR_VISION
+        #if canImport(CompositorServices)
         let landscape = true
         #else
         // Hack to get orientation without using `UIApplication`

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -475,7 +475,7 @@ class PaymentSheetViewController: UIViewController {
                     // Do nothing, keep customer on payment sheet
                     self.updateUI()
                 case .failed(let error):
-                    #if !STP_BUILD_FOR_VISION
+                    #if !canImport(CompositorServices)
                     UINotificationFeedbackGenerator().notificationOccurred(.error)
                     #endif
                     // Update state
@@ -492,7 +492,7 @@ class PaymentSheetViewController: UIViewController {
                         self.presentedViewController?.isBeingDismissed == true ? 1 : 0
                     // Hack: PaymentHandler calls the completion block while SafariVC is still being dismissed - "wait" until it's finished before updating UI
                     DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
-                        #if !STP_BUILD_FOR_VISION
+                        #if !canImport(CompositorServices)
                         UINotificationFeedbackGenerator().notificationOccurred(.success)
                         #endif
                         self.buyButton.update(state: .succeeded, animated: true) {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PollingViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PollingViewController.swift
@@ -180,7 +180,7 @@ class PollingViewController: UIViewController {
         // disable swipe to dismiss
         isModalInPresentation = true
 
-        #if STP_BUILD_FOR_VISION
+        #if canImport(CompositorServices)
         let height = parent?.view.frame.size.height ?? 600 // An arbitrary value for visionOS
         #else
         // Height of the polling view controller is either the height of the parent, or the height of the screen (flow controller use case)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/AUBECSMandate.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/AUBECSMandate.swift
@@ -49,7 +49,7 @@ final class AUBECSLegalTermsView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-#if !STP_BUILD_FOR_VISION
+#if !canImport(CompositorServices)
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         textView.font = .preferredFont(forTextStyle: .caption1)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/AffirmCopyLabel.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/AffirmCopyLabel.swift
@@ -30,7 +30,7 @@ class AffirmCopyLabel: UIView {
         addAndPinSubview(affirmLabel)
     }
 
-#if !STP_BUILD_FOR_VISION
+#if !canImport(CompositorServices)
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         logo.image = PaymentSheetImageLibrary.affirmLogo()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/AfterpayPriceBreakdownView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/AfterpayPriceBreakdownView.swift
@@ -164,7 +164,7 @@ class AfterpayPriceBreakdownView: UIView {
         }
     }
 
-#if !STP_BUILD_FOR_VISION
+#if !canImport(CompositorServices)
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         afterpayMarkImageView.tintColor = theme.colors.parentBackground.contrastingColor

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/CVCPaymentMethodInformationView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/CVCPaymentMethodInformationView.swift
@@ -84,7 +84,7 @@ class CVCPaymentMethodInformationView: UIView {
         ])
     }
 
-    #if !STP_BUILD_FOR_VISION
+    #if !canImport(CompositorServices)
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         self.transparentMaskView.backgroundColor = transparentMaskViewBackgroundColor()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/CVCRecollectionView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/CVCRecollectionView.swift
@@ -64,7 +64,7 @@ class CVCRecollectionView: UIView {
         addAndPinSubview(stackView)
 
     }
-    #if !STP_BUILD_FOR_VISION
+    #if !canImport(CompositorServices)
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         self.stackView.layer.borderColor = appearance.colors.componentBorder.cgColor

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/CardScanningView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/CardScanningView.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Stripe, Inc. All rights reserved.
 //
 
-#if !STP_BUILD_FOR_VISION
+#if !canImport(CompositorServices)
 
 import Foundation
 @_spi(STP) import StripeCore

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/CircularButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/CircularButton.swift
@@ -132,7 +132,7 @@ class CircularButton: UIControl {
         imageView.tintColor = isEnabled ? iconColor : .tertiaryLabel
     }
 
-#if !STP_BUILD_FOR_VISION
+#if !canImport(CompositorServices)
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         updateShadow()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/ConfirmButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/ConfirmButton.swift
@@ -124,7 +124,7 @@ class ConfirmButton: UIView {
         super.layoutSubviews()
     }
 
-#if !STP_BUILD_FOR_VISION
+#if !canImport(CompositorServices)
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         self.buyButton.update(status: state, callToAction: callToAction, animated: false)
@@ -354,7 +354,7 @@ class ConfirmButton: UIView {
             overriddenForegroundColor = appearance.primaryButton.textColor
         }
 
-#if !STP_BUILD_FOR_VISION
+#if !canImport(CompositorServices)
         override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
             super.traitCollectionDidChange(previousTraitCollection)
             layer.borderColor = appearance.primaryButton.borderColor.cgColor

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/ShadowedRoundedRectangleView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/ShadowedRoundedRectangleView.swift
@@ -78,7 +78,7 @@ class ShadowedRoundedRectangle: UIView {
         layer.applyShadow(shadow: appearance.asElementsTheme.shadow)
     }
 
-    #if !STP_BUILD_FOR_VISION
+    #if !canImport(CompositorServices)
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         setNeedsLayout()

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/AddPaymentMethodViewControllerSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/AddPaymentMethodViewControllerSnapshotTests.swift
@@ -5,7 +5,7 @@
 //  Created by Yuki Tokuhiro on 3/22/23.
 //
 
-#if !STP_BUILD_FOR_VISION
+#if !canImport(CompositorServices)
 import iOSSnapshotTestCase
 import StripeCoreTestUtils
 @_spi(STP) @testable import StripePaymentSheet

--- a/StripePayments/StripePayments/Source/API Bindings/STPRedirectContext.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/STPRedirectContext.swift
@@ -274,7 +274,7 @@ public class STPRedirectContext: NSObject,
             lastKnownSafariVCURL = redirectURL
             let safariVC = SFSafariViewController(url: lastKnownSafariVCURL!)
             safariVC.transitioningDelegate = self
-            #if !STP_BUILD_FOR_VISION
+            #if !canImport(CompositorServices)
             safariVC.delegate = self
             #endif
             safariVC.modalPresentationStyle = .custom
@@ -561,7 +561,7 @@ extension UIApplication: UIApplicationProtocol {
     }
 }
 
-#if !STP_BUILD_FOR_VISION
+#if !canImport(CompositorServices)
 extension STPRedirectContext: SFSafariViewControllerDelegate {
     // MARK: - SFSafariViewControllerDelegate -
     /// :nodoc:

--- a/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
@@ -1701,7 +1701,7 @@ public class STPPaymentHandler: NSObject {
                 {
                     let safariViewController = SFSafariViewController(url: fallbackURL)
                     safariViewController.modalPresentationStyle = .overFullScreen
-#if !STP_BUILD_FOR_VISION
+#if !canImport(CompositorServices)
                     safariViewController.dismissButtonStyle = .close
                     safariViewController.delegate = self
 #endif
@@ -2095,7 +2095,7 @@ public class STPPaymentHandler: NSObject {
     }
 }
 
-#if !STP_BUILD_FOR_VISION
+#if !canImport(CompositorServices)
 extension STPPaymentHandler: SFSafariViewControllerDelegate {
     // MARK: - SFSafariViewControllerDelegate
     /// :nodoc:

--- a/StripePaymentsUI/StripePaymentsUI/Source/Internal/Categories/UIButton+Stripe.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/Internal/Categories/UIButton+Stripe.swift
@@ -20,7 +20,7 @@ extension UIButton {
         withEdgeInsets edgeInsets: NSDirectionalEdgeInsets
     ) {
 // TODO: Rewrite this for visionOS & iOS 17.
-        #if STP_BUILD_FOR_VISION
+        #if canImport(CompositorServices)
         #else
         // UIButton doesn't have support for directional edge insets. We should
         // apply insets depending on the layout direction.

--- a/StripePaymentsUI/StripePaymentsUI/Source/Internal/UI/Views/CardBrandView.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/Internal/UI/Views/CardBrandView.swift
@@ -101,7 +101,7 @@ import UIKit
             targetSize.height
             / (Self.legacyIconSize.height - Self.iconPadding.top - Self.iconPadding.bottom)
         // We could adapt this for multiple screens, but probably not worth it (better solution is to remove padding from images)
-        #if STP_BUILD_FOR_VISION
+        #if canImport(CompositorServices)
         let screenScale = 1.0
         #else
         let screenScale = UIScreen.main.scale
@@ -242,7 +242,7 @@ import UIKit
     }
 
     // MARK: - Callbacks
-#if !STP_BUILD_FOR_VISION
+#if !canImport(CompositorServices)
     @_spi(STP) public override func traitCollectionDidChange(
         _ previousTraitCollection: UITraitCollection?
     ) {

--- a/StripePaymentsUI/StripePaymentsUI/Source/Internal/UI/Views/Inputs/STPGenericInputPickerField.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/Internal/UI/Views/Inputs/STPGenericInputPickerField.swift
@@ -103,7 +103,7 @@ import UIKit
         pickerView.dataSource = wrappedDataSource
         inputView = pickerView
 
-#if !STP_BUILD_FOR_VISION
+#if !canImport(CompositorServices)
         inputAccessoryView = DoneButtonToolbar(delegate: self)
 #endif
 

--- a/StripePaymentsUI/StripePaymentsUI/Source/Internal/UI/Views/STPViewWithSeparator.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/Internal/UI/Views/STPViewWithSeparator.swift
@@ -75,7 +75,7 @@ class STPViewWithSeparator: UIView {
     }
 
     func _currentPixelHeight() -> CGFloat {
-        #if STP_BUILD_FOR_VISION
+        #if canImport(CompositorServices)
         return 1.0
         #else
         let screen = window?.screen ?? UIScreen.main

--- a/StripePaymentsUI/StripePaymentsUI/Source/UI Components/PaymentMethodMessagingView.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/UI Components/PaymentMethodMessagingView.swift
@@ -104,7 +104,7 @@ import WebKit
 
     // MARK: Overrides
 
-#if !STP_BUILD_FOR_VISION
+#if !canImport(CompositorServices)
     // Overriden so we can respond to changing dark mode by updating the image color
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)

--- a/StripePaymentsUI/StripePaymentsUI/Source/UI Components/STPAUBECSDebitFormView.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/UI Components/STPAUBECSDebitFormView.swift
@@ -516,7 +516,7 @@ public class STPAUBECSDebitFormView: STPMultiFormTextField, STPMultiFormFieldDel
 
     // MARK: - UITextViewDelegate
     /// :nodoc:
-#if !STP_BUILD_FOR_VISION
+#if !canImport(CompositorServices)
     @objc
     public func textView(
         _ textView: UITextView,

--- a/StripePaymentsUI/StripePaymentsUI/Source/UI Components/STPPaymentCardTextField.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/UI Components/STPPaymentCardTextField.swift
@@ -228,7 +228,7 @@ open class STPPaymentCardTextField: UIControl, UIKeyInput, STPFormTextFieldDeleg
         }
     }
 
-#if !STP_BUILD_FOR_VISION
+#if !canImport(CompositorServices)
     private var _inputAccessoryView: UIView?
     /// This behaves identically to setting the inputAccessoryView for each child text field.
     @objc open override var inputAccessoryView: UIView? {
@@ -967,7 +967,7 @@ open class STPPaymentCardTextField: UIControl, UIKeyInput, STPFormTextFieldDeleg
 
     static let placeholderGrayColor: UIColor = .systemGray2
 
-#if !STP_BUILD_FOR_VISION
+#if !canImport(CompositorServices)
     open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         if previousTraitCollection?.preferredContentSizeCategory

--- a/StripeUICore/StripeUICore/Source/Controls/ActivityIndicator.swift
+++ b/StripeUICore/StripeUICore/Source/Controls/ActivityIndicator.swift
@@ -140,7 +140,7 @@ import UIKit
         updateColor()
     }
 
-#if !STP_BUILD_FOR_VISION
+#if !canImport(CompositorServices)
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         updateColor()
@@ -166,7 +166,7 @@ import UIKit
 
         if let window = newWindow {
             contentLayer.shouldRasterize = true
-#if !STP_BUILD_FOR_VISION
+#if !canImport(CompositorServices)
             contentLayer.rasterizationScale = window.screen.scale
 #endif
         }

--- a/StripeUICore/StripeUICore/Source/Controls/Button.swift
+++ b/StripeUICore/StripeUICore/Source/Controls/Button.swift
@@ -295,7 +295,7 @@ import UIKit
         updateColors()
     }
 
-#if !STP_BUILD_FOR_VISION
+#if !canImport(CompositorServices)
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         invalidateIntrinsicContentSize()

--- a/StripeUICore/StripeUICore/Source/Controls/OneTimeCodeTextField.swift
+++ b/StripeUICore/StripeUICore/Source/Controls/OneTimeCodeTextField.swift
@@ -54,7 +54,7 @@ import UIKit
         return DigitView(theme: theme)
     }
 
-#if !STP_BUILD_FOR_VISION
+#if !canImport(CompositorServices)
     private let feedbackGenerator = UINotificationFeedbackGenerator()
 #endif
 
@@ -139,7 +139,7 @@ import UIKit
         let result = super.resignFirstResponder()
 
         if result {
-            #if !STP_BUILD_FOR_VISION
+            #if !canImport(CompositorServices)
             hideMenu()
             #endif
             update()
@@ -157,7 +157,7 @@ import UIKit
         }
 
         if isFirstResponder {
-            #if !STP_BUILD_FOR_VISION
+            #if !canImport(CompositorServices)
             toggleMenu()
             #endif
         } else {
@@ -227,7 +227,7 @@ private extension OneTimeCodeTextField {
             : STPLocalizedString("Double tap to edit", "Accessibility hint for a text field")
     }
 
-    #if !STP_BUILD_FOR_VISION // Don't mess with the UIMenuController on visionOS
+    #if !canImport(CompositorServices) // Don't mess with the UIMenuController on visionOS
     func toggleMenu() {
         if UIMenuController.shared.isMenuVisible {
             hideMenu()
@@ -315,7 +315,7 @@ public extension OneTimeCodeTextField {
             digitView.borderLayer.add(borderColorAnimation, forKey: "borderColor")
         }
 
-#if !STP_BUILD_FOR_VISION
+#if !canImport(CompositorServices)
         feedbackGenerator.notificationOccurred(.error)
 #endif
 
@@ -354,7 +354,7 @@ extension OneTimeCodeTextField: UIKeyInput {
         inputDelegate?.textDidChange(self)
 
         sendActions(for: [.editingChanged, .valueChanged])
-        #if !STP_BUILD_FOR_VISION
+        #if !canImport(CompositorServices)
         hideMenu()
         #endif
         update()
@@ -370,7 +370,7 @@ extension OneTimeCodeTextField: UIKeyInput {
         inputDelegate?.textDidChange(self)
 
         sendActions(for: [.editingChanged, .valueChanged])
-        #if !STP_BUILD_FOR_VISION
+        #if !canImport(CompositorServices)
         hideMenu()
         #endif
         update()
@@ -790,7 +790,7 @@ private extension OneTimeCodeTextField {
             updateColors()
         }
 
-#if !STP_BUILD_FOR_VISION
+#if !canImport(CompositorServices)
         override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
             super.traitCollectionDidChange(previousTraitCollection)
             updateColors()

--- a/StripeUICore/StripeUICore/Source/Elements/Checkbox/CheckboxButton.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Checkbox/CheckboxButton.swift
@@ -152,7 +152,7 @@ import UIKit
         textView.invalidateIntrinsicContentSize()
     }
 
-#if !STP_BUILD_FOR_VISION
+#if !canImport(CompositorServices)
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         updateLabels()
@@ -242,7 +242,7 @@ import UIKit
 
 // MARK: - UITextViewDelegate
 extension CheckboxButton: UITextViewDelegate {
-    #if !STP_BUILD_FOR_VISION
+    #if !canImport(CompositorServices)
     // This is only used by StripeIdentity, which does not support visionOS.
     public func textView(_ textView: UITextView, shouldInteractWith url: URL, in characterRange: NSRange) -> Bool {
         return delegate?.checkboxButton(self, shouldOpen: url) ?? true

--- a/StripeUICore/StripeUICore/Source/Elements/PickerField/PickerFieldView.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/PickerField/PickerFieldView.swift
@@ -34,7 +34,7 @@ final class PickerFieldView: UIView {
 #endif
         textField.adjustsFontForContentSizeCategory = true
         textField.font = theme.fonts.subheadline
-#if !STP_BUILD_FOR_VISION
+#if !canImport(CompositorServices)
         textField.inputAccessoryView = toolbar
 #endif
         textField.delegate = self
@@ -166,7 +166,7 @@ final class PickerFieldView: UIView {
         }
     }
 
-#if !STP_BUILD_FOR_VISION
+#if !canImport(CompositorServices)
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         layer.borderColor = theme.colors.border.cgColor

--- a/StripeUICore/StripeUICore/Source/Elements/Section/SectionContainerView.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Section/SectionContainerView.swift
@@ -106,7 +106,7 @@ class SectionContainerView: UIView {
         )
     }
 
-#if !STP_BUILD_FOR_VISION
+#if !canImport(CompositorServices)
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         updateUI()

--- a/StripeUICore/StripeUICore/Source/Elements/TextField/TextFieldElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/TextField/TextFieldElement.swift
@@ -41,7 +41,7 @@ import UIKit
 
     private let theme: ElementsUITheme
 
-#if !STP_BUILD_FOR_VISION
+#if !canImport(CompositorServices)
     public var inputAccessoryView: UIView? {
         get {
             return textFieldView.textField.inputAccessoryView

--- a/StripeUICore/StripeUICore/Source/Elements/TextField/TextFieldView.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/TextField/TextFieldView.swift
@@ -196,7 +196,7 @@ class TextFieldView: UIView {
         textField.textContentType = viewModel.keyboardProperties.textContentType
         if viewModel.keyboardProperties.type != textField.keyboardType {
             textField.keyboardType = viewModel.keyboardProperties.type
-#if !STP_BUILD_FOR_VISION
+#if !canImport(CompositorServices)
             textField.inputAccessoryView = textField.keyboardType.hasReturnKey ? nil : toolbar
 #endif
             textField.reloadInputViews()
@@ -228,7 +228,7 @@ class TextFieldView: UIView {
         layoutIfNeeded()
     }
 
-#if !STP_BUILD_FOR_VISION
+#if !canImport(CompositorServices)
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         updateUI(with: viewModel)

--- a/StripeUICore/StripeUICore/Source/Helpers/StackViewWithSeparator.swift
+++ b/StripeUICore/StripeUICore/Source/Helpers/StackViewWithSeparator.swift
@@ -203,7 +203,7 @@ import UIKit
             UIBezierPath(roundedRect: bounds, cornerRadius: borderCornerRadius).cgPath
     }
 
-#if !STP_BUILD_FOR_VISION
+#if !canImport(CompositorServices)
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         // CGColor's must be manually updated when the trait collection changes

--- a/StripeUICore/StripeUICore/Source/Views/DynamicImageView.swift
+++ b/StripeUICore/StripeUICore/Source/Views/DynamicImageView.swift
@@ -43,7 +43,7 @@ import UIKit
         fatalError("init(coder:) has not been implemented")
     }
 
-    #if !STP_BUILD_FOR_VISION
+    #if !canImport(CompositorServices)
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         image = Self.makeImage(for: traitCollection, dynamicImage: dynamicImage, pairedColor: pairedColor)


### PR DESCRIPTION
## Summary
We need to support visionOS across Xcode 14 and 15 and all package managers. To do this, we need a solution that doesn't involve compile-time flags, as SPM won't let us provide them.

See https://github.com/stripe/stripe-ios/pull/3127/files#diff-ae2869cf29a9ac2a97e2b2f976d80f6ec5b7e59a004b6bf6bee0aa2e3f281ba5R148 for a full explanation of the hack.

## Motivation
Fix visionOS support in various package managers.

## Testing
CI and manually in Xcode 15.3. Re-adding automated visionOS tests in https://github.com/stripe/stripe-ios/pull/3126.

## Changelog
Added.