### PR TITLE
Add country_inferring_method to Link signup API call

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
@@ -79,6 +79,7 @@ extension STPAPIClient {
             "email_address": email.lowercased(),
             "phone_number": phoneNumber,
             "locale": locale.toLanguageTag(),
+            "country_inferring_method": "PHONE_NUMBER"
         ]
 
         if let legalName = legalName {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
@@ -79,7 +79,7 @@ extension STPAPIClient {
             "email_address": email.lowercased(),
             "phone_number": phoneNumber,
             "locale": locale.toLanguageTag(),
-            "country_inferring_method": "PHONE_NUMBER"
+            "country_inferring_method": "PHONE_NUMBER",
         ]
 
         if let legalName = legalName {


### PR DESCRIPTION
## Summary
- Now sends `country_inferring_method` in the Link signup API call

## Motivation
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-2807

## Testing
Manual

## Changelog
N/A
