### PR TITLE
Fix max CVC length for unknown cards in Card Brand Choice

### DIFF
--- a/Stripe/StripeiOSTests/STPCardFormViewTests.swift
+++ b/Stripe/StripeiOSTests/STPCardFormViewTests.swift
@@ -161,6 +161,25 @@ class STPCardFormViewTests: XCTestCase {
         waitForExpectations(timeout: 3.0)
     }
 
+    func testCBCFourDigitCVCIsInvalid() {
+        STPAPIClient.shared.publishableKey = STPTestingDefaultPublishableKey
+        let cardFormView = STPCardFormView(billingAddressCollection: .automatic, cbcEnabledOverride: true)
+        let cardParams = STPPaymentMethodCardParams()
+        cardParams.number = "5555552500001001"
+        cardParams.expYear = 2080
+        cardParams.expMonth = 12
+        cardParams.cvc = "1234"
+        let billingDetails = STPPaymentMethodBillingDetails(postalCode: "12345", countryCode: "US")
+        let paymentMethodParams = STPPaymentMethodParams(card: cardParams, billingDetails: billingDetails, metadata: nil)
+        cardFormView.cardParams = paymentMethodParams
+        let exp = expectation(description: "Wait for validation")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            XCTAssertFalse(cardFormView.cvcField.isValid)
+            exp.fulfill()
+        }
+        waitForExpectations(timeout: 0.5)
+    }
+
     // MARK: Functional Tests
     // If these fail it's _possibly_ because the returned error formats have changed
 

--- a/Stripe/StripeiOSTests/STPPaymentCardTextFieldTest.swift
+++ b/Stripe/StripeiOSTests/STPPaymentCardTextFieldTest.swift
@@ -938,6 +938,21 @@ class STPPaymentCardTextFieldTest: XCTestCase {
         }
         waitForExpectations(timeout: 3.0)
     }
+
+    func testFourDigitCVCNotAllowedUnknownCBCCard() {
+        STPAPIClient.shared.publishableKey = STPTestingDefaultPublishableKey
+        let sut = STPPaymentCardTextField()
+        sut.cbcEnabledOverride = true
+        sut.preferredNetworks = [.visa]
+        let card = STPPaymentMethodCardParams()
+        card.number = "4973019750239993"
+        card.expMonth = 12
+        card.expYear = 43
+        card.cvc = "1234"
+        let params = STPPaymentMethodParams(card: card, billingDetails: nil, metadata: nil)
+        sut.paymentMethodParams = params
+        XCTAssertFalse(sut.isValid)
+    }
 }
 
 // N.B. It is eexpected for setting the card params to generate API response errors

--- a/StripePaymentsUI/StripePaymentsUI/Source/Helpers/STPCBCController.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/Helpers/STPCBCController.swift
@@ -134,6 +134,13 @@ class STPCBCController {
             return .brand(STPCardValidator.brand(forNumber: cardNumber ?? ""))
         }
     }
+    
+    // Instead of validating against the selected brand (for CBC purposes),
+    // validate CVCs against the default brand of the PAN.
+    // We can assume that the CVC length will not change based on the choice of card brand.
+    var brandForCVC: STPCardBrand {
+        return STPCardValidator.brand(forNumber: cardNumber ?? "")
+    }
 
     var contextMenuConfiguration: UIContextMenuConfiguration {
         return UIContextMenuConfiguration(actionProvider: { _ in

--- a/StripePaymentsUI/StripePaymentsUI/Source/Helpers/STPCBCController.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/Helpers/STPCBCController.swift
@@ -134,7 +134,7 @@ class STPCBCController {
             return .brand(STPCardValidator.brand(forNumber: cardNumber ?? ""))
         }
     }
-    
+
     // Instead of validating against the selected brand (for CBC purposes),
     // validate CVCs against the default brand of the PAN.
     // We can assume that the CVC length will not change based on the choice of card brand.

--- a/StripePaymentsUI/StripePaymentsUI/Source/Internal/UI/Views/Inputs/Card/STPCardNumberInputTextField.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/Internal/UI/Views/Inputs/Card/STPCardNumberInputTextField.swift
@@ -28,6 +28,10 @@ import UIKit
     var cardBrandState: STPCBCController.BrandState {
         return (validator as! STPCardNumberInputTextFieldValidator).cardBrandState
     }
+    
+    var brandForCVC: STPCardBrand {
+        return (validator as! STPCardNumberInputTextFieldValidator).cbcController.brandForCVC
+    }
 
     var preferredNetworks: [STPCardBrand]? {
         get {

--- a/StripePaymentsUI/StripePaymentsUI/Source/Internal/UI/Views/Inputs/Card/STPCardNumberInputTextField.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/Internal/UI/Views/Inputs/Card/STPCardNumberInputTextField.swift
@@ -28,7 +28,7 @@ import UIKit
     var cardBrandState: STPCBCController.BrandState {
         return (validator as! STPCardNumberInputTextFieldValidator).cardBrandState
     }
-    
+
     var brandForCVC: STPCardBrand {
         return (validator as! STPCardNumberInputTextFieldValidator).cbcController.brandForCVC
     }

--- a/StripePaymentsUI/StripePaymentsUI/Source/Internal/UI/Views/Inputs/Card/STPCardNumberInputTextFieldValidator.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/Internal/UI/Views/Inputs/Card/STPCardNumberInputTextFieldValidator.swift
@@ -38,6 +38,7 @@ class STPCardNumberInputTextFieldValidator: STPInputTextFieldValidator {
 
     override public var inputValue: String? {
         didSet {
+            cbcController.cardNumber = inputValue
             guard let inputValue = inputValue else {
                 validationState = .incomplete(description: nil)
                 return
@@ -77,7 +78,6 @@ class STPCardNumberInputTextFieldValidator: STPInputTextFieldValidator {
                     validationState = .processing
                 }
             }
-            cbcController.cardNumber = inputValue
         }
     }
 

--- a/StripePaymentsUI/StripePaymentsUI/Source/Internal/UI/Views/STPPaymentCardTextFieldViewModel.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/Internal/UI/Views/STPPaymentCardTextFieldViewModel.swift
@@ -190,7 +190,7 @@ class STPPaymentCardTextFieldViewModel: NSObject {
     }
 
     func validationStateForCVC() -> STPCardValidationState {
-        return STPCardValidator.validationState(forCVC: cvc ?? "", cardBrand: brand)
+        return STPCardValidator.validationState(forCVC: cvc ?? "", cardBrand: cbcController.brandForCVC)
     }
 
     func validationStateForPostalCode() -> STPCardValidationState {

--- a/StripePaymentsUI/StripePaymentsUI/Source/UI Components/STPCardFormView.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/UI Components/STPCardFormView.swift
@@ -467,7 +467,7 @@ public class STPCardFormView: STPFormView {
         }
 
         if textField == numberField {
-            cvcField.cardBrand = numberField.cardBrandState.brand
+            cvcField.cardBrand = numberField.brandForCVC
         } else if textField == countryField {
             let countryChanged = textField.inputValue != countryCode
 

--- a/StripePaymentsUI/StripePaymentsUI/Source/UI Components/STPPaymentCardTextField.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/UI Components/STPPaymentCardTextField.swift
@@ -1177,7 +1177,7 @@ open class STPPaymentCardTextField: UIControl, UIKeyInput, STPFormTextFieldDeleg
         } else {
             // Otherwise size to fit our placeholder or what is likely to be the
             // largest possible string enterable (whichever is larger)
-            let maxCvcLength = Int(STPCardValidator.maxCVCLength(for: viewModel.brand))
+            let maxCvcLength = Int(STPCardValidator.maxCVCLength(for: viewModel.cbcController.brandForCVC))
             var longestCvc = "888"
             if maxCvcLength == 4 {
                 longestCvc = "8888"
@@ -1827,7 +1827,7 @@ open class STPPaymentCardTextField: UIControl, UIKeyInput, STPFormTextFieldDeleg
                 let sanitizedCvc = STPCardValidator.sanitizedNumericString(
                     for: formTextField.text ?? ""
                 )
-                if sanitizedCvc.count >= STPCardValidator.maxCVCLength(for: viewModel.brand) {
+                if sanitizedCvc.count >= STPCardValidator.maxCVCLength(for: viewModel.cbcController.brandForCVC) {
                     // auto-advance
                     nextFirstResponderField().becomeFirstResponder()
                     UIAccessibility.post(notification: .screenChanged, argument: nil)


### PR DESCRIPTION
## Summary
During Card Brand Choice, when the selected brand is unknown, we should validate the CVC based on the default brand for the PAN.

## Motivation
Fixes an issue where the CVC field would not auto-advance after 3 digits when CBC is enabled and a card brand is not selected.

## Testing
Manually in UI Examples, added new tests