### PR TITLE
[WIP] PI Confirm Params Test

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
+++ b/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
@@ -219,6 +219,7 @@
 		E5571A970EB9DFC4B690636F /* STPAnalyticsClient+PaymentSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 966339C092711FED8EFE98FB /* STPAnalyticsClient+PaymentSheet.swift */; };
 		E5C7667A08EA85C0FF12523D /* AddPaymentMethodViewControllerSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F70E5F0FE6218715432D55A /* AddPaymentMethodViewControllerSnapshotTests.swift */; };
 		E672F7F306C9D2BC941AE8C9 /* PaymentSheetConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C46CB5AB992F8EEFE4E5460A /* PaymentSheetConfiguration.swift */; };
+		E6D4B2042B2B8C350047DE11 /* PaymentSheet+ConfirmParamsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D4B2032B2B8C350047DE11 /* PaymentSheet+ConfirmParamsTest.swift */; };
 		E6D9F6C7D768F76B7A84BC91 /* StripeCoreTestUtils.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 169C7CCB7A003FEDEA598095 /* StripeCoreTestUtils.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E792B9597C67C5E6EA70E81A /* StripePaymentsTestUtils.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 15854DCE06F859BB426E9C9A /* StripePaymentsTestUtils.framework */; };
 		EA712D67C03385B9AD80288C /* Appearance+FontScaling.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0150C1C20FD33EA024096A /* Appearance+FontScaling.swift */; };
@@ -561,6 +562,7 @@
 		E41AA4E90E5BB28D588FDE51 /* StripeCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripeCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E5189D848E2F33291680E5E2 /* PaymentSheetFormFactory+BLIK.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PaymentSheetFormFactory+BLIK.swift"; sourceTree = "<group>"; };
 		E5240ECFD40B8605939C4E09 /* LinkMoreInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkMoreInfoView.swift; sourceTree = "<group>"; };
+		E6D4B2032B2B8C350047DE11 /* PaymentSheet+ConfirmParamsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PaymentSheet+ConfirmParamsTest.swift"; sourceTree = "<group>"; };
 		E6DDBBAAC2892467CED23402 /* PaymentSheetError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSheetError.swift; sourceTree = "<group>"; };
 		E77A5A5E70770575F1D02837 /* LinkEnabledPaymentMethodElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkEnabledPaymentMethodElement.swift; sourceTree = "<group>"; };
 		E80287504EEBBEE85081BFB5 /* id */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = id; path = id.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -1283,6 +1285,7 @@
 				C830FEC205E7162FF4D414BE /* PaymentMethodMessagingViewFunctionalTest.swift */,
 				5BA7BFC43DB3EFD38A460EB9 /* PaymentMethodMessagingViewSnapshotTests.swift */,
 				8A0B7F6E25D93C0C0ACE3B3D /* PaymentSheet+APITest.swift */,
+				E6D4B2032B2B8C350047DE11 /* PaymentSheet+ConfirmParamsTest.swift */,
 				AA8F7F2824DFC78268ED6459 /* PaymentSheet+DeferredAPITest.swift */,
 				135B7354260E0E7CADCF3426 /* PaymentSheetAddressTests.swift */,
 				357B9EB0751819566843117E /* PaymentSheetDeferredValidatorTests.swift */,
@@ -1555,6 +1558,7 @@
 				FBAC012322FE99046A484E65 /* PaymentSheetFormFactoryTest.swift in Sources */,
 				44D0F92C4AA2DF0C9DC4C9B4 /* PaymentSheetLPMConfirmFlowTests.swift in Sources */,
 				ABE13E65678673EC4DE14EF4 /* PaymentSheetLinkAccountTests.swift in Sources */,
+				E6D4B2042B2B8C350047DE11 /* PaymentSheet+ConfirmParamsTest.swift in Sources */,
 				142C03879DC4CD43BB743022 /* PaymentSheetLoaderStubbedTest.swift in Sources */,
 				1C70F42915587CBF883E01DD /* PaymentSheetLoaderTest.swift in Sources */,
 				96B31ABDA593F9C7FC3DBF79 /* PaymentSheetPaymentMethodTypeTest.swift in Sources */,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+ConfirmParamsTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+ConfirmParamsTest.swift
@@ -1,0 +1,351 @@
+//
+//  PaymentSheet+ConfirmParamsTest.swift
+//  StripePaymentSheetTests
+//
+//  Created by Mel Ludowise on 12/14/23.
+//
+
+import Foundation
+
+@testable@_spi(STP) import StripeCore
+@testable@_spi(STP) import StripeCoreTestUtils
+@testable@_spi(STP) import StripePayments
+@testable@_spi(STP) import StripePaymentSheet
+@testable@_spi(STP) import StripePaymentsTestUtils
+@testable@_spi(STP) import StripeUICore
+
+import OHHTTPStubs
+import OHHTTPStubsSwift
+
+final class PaymentSheet_ConfirmParamsTest: APIStubbedTestCase {
+    enum MockJson {
+        static let cardPaymentMethod = STPTestUtils.jsonNamed("CardPaymentMethod")!
+        static let paymentIntent = STPTestUtils.jsonNamed("PaymentIntent")!
+        static let setupIntent = STPTestUtils.jsonNamed("SetupIntent")!
+    }
+
+    enum MockParams {
+        static let dashboardClientSecret = "pi_xxx"
+        static let dashboardPublicKey = "uk_xxx"
+
+        static func configuration(pk: String) -> PaymentSheet.Configuration {
+            var config = PaymentSheet.Configuration()
+            config.apiClient = STPAPIClient(publishableKey: pk)
+            config.allowsDelayedPaymentMethods = true
+            config.shippingDetails = {
+                return .init(
+                    address: .init(
+                        country: "US",
+                        line1: "Line 1"
+                    ),
+                    name: "Jane Doe",
+                    phone: "5551234567"
+                )
+            }
+            config.savePaymentMethodOptInBehavior = .requiresOptOut
+            return config
+        }
+
+        static func configurationWithCustomer(pk: String) -> PaymentSheet.Configuration {
+            var configuration = self.configuration(pk: pk)
+            configuration.customer = .init(id: "id", ephemeralKeySecret: "ek")
+            return configuration
+        }
+
+        static let paymentMethodCardParams: STPPaymentMethodCardParams = {
+            let cardParams = STPPaymentMethodCardParams()
+            cardParams.number = "4242424242424242"
+            cardParams.cvc = "123"
+            cardParams.expYear = 32
+            cardParams.expMonth = 12
+            return cardParams
+        }()
+
+        static var intentConfirmParams: IntentConfirmParams {
+            .init(
+                params: .init(
+                    card: paymentMethodCardParams,
+                    billingDetails: .init(),
+                    metadata: nil
+                ),
+                type: .stripe(.card)
+            )
+        }
+
+        static let cardPaymentMethod = STPPaymentMethod.decodedObject(fromAPIResponse: MockJson.cardPaymentMethod)!
+
+        static let paymentIntent = STPPaymentIntent.decodedObject(fromAPIResponse: MockJson.paymentIntent)!
+
+        static let setupIntent = STPSetupIntent.decodedObject(fromAPIResponse: MockJson.setupIntent)!
+
+        static func deferredPaymentIntentConfiguration(clientSecret: String) -> PaymentSheet.IntentConfiguration {
+            .init(mode: .payment(amount: 123, currency: "USD"), paymentMethodTypes: ["card"]) { _, _, c in c(.success(clientSecret)) }
+        }
+
+        static func deferredSetupIntentConfiguration(clientSecret: String) -> PaymentSheet.IntentConfiguration {
+            .init(mode: .setup(currency: "USD", setupFutureUsage: .offSession), confirmHandler: { _, _, c in c(.success(clientSecret)) })
+        }
+    }
+
+    override func setUp() {
+        super.setUp()
+
+        // Stub all API calls that can be made
+
+        stub { urlRequest in
+            urlRequest.url?.absoluteString.contains("payment_methods") ?? false
+        } response: { _ in
+            return HTTPStubsResponse(jsonObject: MockJson.cardPaymentMethod, statusCode: 200, headers: nil)
+        }
+
+        stub { urlRequest in
+            guard let pathComponents = urlRequest.url?.pathComponents else { return false }
+            return pathComponents[2] == "payment_intents" && pathComponents.last != "confirm"
+        } response: { request in
+            var json = MockJson.paymentIntent
+
+            // Mock that the PI requires confirmation if it's being fetched for a deferred PI
+            if request.httpMethod == "GET" {
+                json["status"] = "requires_confirmation"
+                json["capture_method"] = "automatic"
+            }
+
+            return HTTPStubsResponse(jsonObject: json, statusCode: 200, headers: nil)
+        }
+
+        stub { urlRequest in
+            guard let pathComponents = urlRequest.url?.pathComponents else { return false }
+            return pathComponents[2] == "setup_intents" && pathComponents.last != "confirm"
+        } response: { _ in
+            return HTTPStubsResponse(jsonObject: MockJson.setupIntent, statusCode: 200, headers: nil)
+        }
+    }
+
+    // MARK: - Dashboard PaymentIntent
+
+    func testDashboard_PaymentIntent_saved() {
+        stubConfirmPaymentExpecting(
+            paymentMethodId: MockParams.cardPaymentMethod.stripeId,
+            shippingAddressLine1: "Line 1",
+            shippingAddressCountry: "US",
+            shippingName: "Jane Doe",
+            shippingPhone: "5551234567",
+            cardMoto: true
+        )
+
+        let configuration = MockParams.configurationWithCustomer(pk: MockParams.dashboardPublicKey)
+
+        PaymentSheet.confirm(
+            configuration: configuration,
+            authenticationContext: self,
+            intent: .paymentIntent(elementsSession: .emptyElementsSession, paymentIntent: MockParams.paymentIntent),
+            paymentOption: .saved(paymentMethod: MockParams.cardPaymentMethod),
+            paymentHandler: STPPaymentHandler(apiClient: configuration.apiClient),
+            completion: { _, _ in }
+        )
+
+        waitForExpectations(timeout: 10)
+    }
+
+    func testDashboard_PaymentIntent_new_saveUnchecked() {
+        stubConfirmPaymentExpecting(
+            paymentMethodData: MockParams.paymentMethodCardParams,
+            shippingAddressLine1: "Line 1",
+            shippingAddressCountry: "US",
+            shippingName: "Jane Doe",
+            shippingPhone: "5551234567",
+            cardMoto: true
+        )
+
+        let configuration = MockParams.configuration(pk: MockParams.dashboardPublicKey)
+
+        PaymentSheet.confirm(
+            configuration: configuration,
+            authenticationContext: self,
+            intent: .paymentIntent(elementsSession: .emptyElementsSession, paymentIntent: MockParams.paymentIntent),
+            paymentOption: .new(confirmParams: MockParams.intentConfirmParams),
+            paymentHandler: STPPaymentHandler(apiClient: configuration.apiClient),
+            completion: { _, _ in }
+        )
+
+        waitForExpectations(timeout: 10)
+    }
+
+    func testDashboard_PaymentIntent_new_saveChecked() {
+        let intentConfirmParams = MockParams.intentConfirmParams
+        intentConfirmParams.saveForFutureUseCheckboxState = .selected
+
+        stubConfirmPaymentExpecting(
+            paymentMethodData: MockParams.paymentMethodCardParams,
+            setupFutureUsage: "off_session",
+            shippingAddressLine1: "Line 1",
+            shippingAddressCountry: "US",
+            shippingName: "Jane Doe",
+            shippingPhone: "5551234567",
+            cardMoto: true
+        )
+
+        let configuration = MockParams.configurationWithCustomer(pk: MockParams.dashboardPublicKey)
+
+        PaymentSheet.confirm(
+            configuration: configuration,
+            authenticationContext: self,
+            intent: .paymentIntent(elementsSession: .emptyElementsSession, paymentIntent: MockParams.paymentIntent),
+            paymentOption: .new(confirmParams: intentConfirmParams),
+            paymentHandler: STPPaymentHandler(apiClient: configuration.apiClient),
+            completion: { _, _ in }
+        )
+
+        waitForExpectations(timeout: 10)
+    }
+
+    // MARK: - Dashboard Deferred PaymentIntent
+
+    func testDashboard_DeferredPaymentIntent_saved() {
+        stubConfirmPaymentExpecting(
+            paymentMethodId: MockParams.cardPaymentMethod.stripeId,
+            shippingAddressLine1: "Line 1",
+            shippingAddressCountry: "US",
+            shippingName: "Jane Doe",
+            shippingPhone: "5551234567",
+            cardMoto: true
+        )
+
+        let configuration = MockParams.configurationWithCustomer(pk: MockParams.dashboardPublicKey)
+
+        PaymentSheet.confirm(
+            configuration: configuration,
+            authenticationContext: self,
+            intent: .deferredIntent(elementsSession: .emptyElementsSession, intentConfig: MockParams.deferredPaymentIntentConfiguration(clientSecret: MockParams.dashboardClientSecret)),
+            paymentOption: .saved(paymentMethod: MockParams.cardPaymentMethod),
+            paymentHandler: STPPaymentHandler(apiClient: configuration.apiClient),
+            completion: { _, _ in }
+        )
+
+        waitForExpectations(timeout: 10)
+    }
+
+    func testDashboard_DeferredPaymentIntent_new_saveUnchecked() {
+        stubConfirmPaymentExpecting(
+            paymentMethodId: MockParams.cardPaymentMethod.stripeId,
+            shippingAddressLine1: "Line 1",
+            shippingAddressCountry: "US",
+            shippingName: "Jane Doe",
+            shippingPhone: "5551234567",
+            cardMoto: true
+        )
+
+        let configuration = MockParams.configuration(pk: MockParams.dashboardPublicKey)
+
+        PaymentSheet.confirm(
+            configuration: configuration,
+            authenticationContext: self,
+            intent: .deferredIntent(elementsSession: .emptyElementsSession, intentConfig: MockParams.deferredPaymentIntentConfiguration(clientSecret: MockParams.dashboardClientSecret)),
+            paymentOption: .new(confirmParams: MockParams.intentConfirmParams),
+            paymentHandler: STPPaymentHandler(apiClient: configuration.apiClient),
+            completion: { _, _ in }
+        )
+
+        waitForExpectations(timeout: 10)
+    }
+
+    func testDashboard_DeferredPaymentIntent_new_saveChecked() {
+        let intentConfirmParams = MockParams.intentConfirmParams
+        intentConfirmParams.saveForFutureUseCheckboxState = .selected
+
+        stubConfirmPaymentExpecting(
+            paymentMethodId: MockParams.cardPaymentMethod.stripeId,
+            setupFutureUsage: "off_session",
+            shippingAddressLine1: "Line 1",
+            shippingAddressCountry: "US",
+            shippingName: "Jane Doe",
+            shippingPhone: "5551234567",
+            cardMoto: true
+        )
+
+        let configuration = MockParams.configurationWithCustomer(pk: MockParams.dashboardPublicKey)
+
+        PaymentSheet.confirm(
+            configuration: configuration,
+            authenticationContext: self,
+            intent: .deferredIntent(elementsSession: .emptyElementsSession, intentConfig: MockParams.deferredPaymentIntentConfiguration(clientSecret: MockParams.dashboardClientSecret)),
+            paymentOption: .new(confirmParams: intentConfirmParams),
+            paymentHandler: STPPaymentHandler(apiClient: configuration.apiClient),
+            completion: { _, _ in }
+        )
+
+        waitForExpectations(timeout: 10)
+    }
+}
+
+extension PaymentSheet_ConfirmParamsTest: STPAuthenticationContext {
+    func authenticationPresentingViewController() -> UIViewController {
+        return UIViewController()
+    }
+}
+
+// MARK: - Helpers
+
+private extension PaymentSheet_ConfirmParamsTest {
+    func stubConfirmPaymentExpecting(
+        paymentMethodId: String? = nil,
+        paymentMethodData: STPPaymentMethodCardParams? = nil,
+        setupFutureUsage: String? = nil,
+        shippingAddressLine1: String? = nil,
+        shippingAddressCountry: String? = nil,
+        shippingName: String? = nil,
+        shippingPhone: String? = nil,
+        cardMoto: Bool? = nil,
+        line: UInt = #line
+    ) {
+        let exp = expectation(description: "confirm payment requested")
+
+        stub { urlRequest in
+            guard let pathComponents = urlRequest.url?.pathComponents else { return false }
+            return pathComponents[2] == "payment_intents" && pathComponents.last == "confirm"
+        } response: { [self] request in
+            let params = bodyParams(from: request, line: line)
+
+            assertParam(params, named: "payment_method", is: paymentMethodId, line: line)
+
+            // Payment Method Card
+            assertParam(params, named: "payment_method_data[type]", is: paymentMethodData.map { _ in "card" }, line: line)
+            assertParam(params, named: "payment_method_data[card][number]", is: paymentMethodData?.number, line: line)
+            assertParam(params, named: "payment_method_data[card][cvc]", is: paymentMethodData?.cvc, line: line)
+            assertParam(params, named: "payment_method_data[card][exp_year]", is: paymentMethodData?.expYear.map { "\($0)" }, line: line)
+            assertParam(params, named: "payment_method_data[card][exp_month]", is: paymentMethodData?.expMonth.map { "\($0)" }, line: line)
+
+            // Payment Method Options
+            assertParam(params, named: "payment_method_options[card][setup_future_usage]", is: setupFutureUsage, line: line)
+            assertParam(params, named: "payment_method_options[card][moto]", is: cardMoto.map { "\($0)" }, line: line)
+
+            // Shipping
+            assertParam(params, named: "shipping[name]", is: shippingName, line: line)
+            assertParam(params, named: "shipping[phone]", is: shippingPhone, line: line)
+            assertParam(params, named: "shipping[address][line1]", is: shippingAddressLine1, line: line)
+            assertParam(params, named: "shipping[address][country]", is: shippingAddressCountry, line: line)
+
+            defer { exp.fulfill() }
+
+            return HTTPStubsResponse(jsonObject: MockJson.paymentIntent, statusCode: 200, headers: nil)
+        }
+    }
+
+    func assertParam(_ params: [String: String], named name: String, is value: String?, line: UInt) {
+        XCTAssertEqual(params[name], value, name, line: line)
+    }
+
+    func bodyParams(from request: URLRequest, line: UInt) -> [String: String] {
+        guard let httpBody = request.httpBodyOrBodyStream,
+              let query = String(data: httpBody, encoding: .utf8),
+              let components = URLComponents(string: "http://someurl.com?\(query)") else {
+            XCTFail("Request body empty", line: line)
+            return [:]
+        }
+
+        return components.queryItems?.reduce(into: [:], { partialResult, item in
+            guard item.value != "" else { return }
+            partialResult[item.name] = item.value?.removingPercentEncoding
+        }) ?? [:]
+    }
+}


### PR DESCRIPTION
Handoff notes:
- The Deferred PIs confirm params correctly have `moto` set to true, but the non-deferred PIs do not.
- I can run each test function individually, but cannot run the entire test case. It looks like `STPPaymentHandler.inProgress` isn't getting cleaned up between tests, so only the first test runs and the other ones time out. I thin the root cause is that a completion block isn't getting called somewhere in the stack, but haven't been able to debug it.
- This test only tests cases the Dashboard app uses, but should probably be included to test others (e.g. Link, ApplePay, and SetupIntents using pk_ keys)

## Summary
<!-- Simple summary of what was changed. -->

Adds tests to verify the `moto` flag is true for Payment Intent confirm params originating from Dashboard uk_ keys. The test uses HTTPStubs to stub the API requests and tests that the `/v1/payment_intents/*/confirm` POST has the correct params.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
