### PR TITLE
Add CBC eventing

### DIFF
--- a/Stripe/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe/Stripe.xcodeproj/project.pbxproj
@@ -146,6 +146,7 @@
 		609C2C8F10AFAA2711639CD0 /* NSArray+StripeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C17799DC7FA54E758EED31A6 /* NSArray+StripeTest.swift */; };
 		609E4D384B75F6A111DC0E27 /* STPPaymentActivityIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FFBAA4B44967B157A4F4E91 /* STPPaymentActivityIndicatorView.swift */; };
 		610791E82B1952F000D9A098 /* STPPaymentMethodDisplayBrandTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 610791E72B1952F000D9A098 /* STPPaymentMethodDisplayBrandTest.swift */; };
+		610DF5DC2B33597500DA6AAA /* HostedSurfaceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 610DF5DB2B33597500DA6AAA /* HostedSurfaceTest.swift */; };
 		62B91808A088C4F9FDB62C53 /* STPEphemeralKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 890660C21E3666CE7B82695B /* STPEphemeralKey.swift */; };
 		64801CF2D2CAC9008C17D154 /* LinkSecureCookieStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10BAD33BEC6C2894F9266902 /* LinkSecureCookieStoreTests.swift */; };
 		66065B1D65D7D5502D4E2F2B /* STPCard+BasicUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E5FB20B2BEFC00D54FDD87D /* STPCard+BasicUI.swift */; };
@@ -600,6 +601,7 @@
 		5F7AB40A5A10C2D267323ABE /* STPApplePayContextTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPApplePayContextTest.swift; sourceTree = "<group>"; };
 		5FDD4956E0A04D33F0856F31 /* STPThreeDSLabelCustomizationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPThreeDSLabelCustomizationTest.swift; sourceTree = "<group>"; };
 		610791E72B1952F000D9A098 /* STPPaymentMethodDisplayBrandTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPPaymentMethodDisplayBrandTest.swift; sourceTree = "<group>"; };
+		610DF5DB2B33597500DA6AAA /* HostedSurfaceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostedSurfaceTest.swift; sourceTree = "<group>"; };
 		618DE183886175AF23C4E668 /* sl-SI */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "sl-SI"; path = "sl-SI.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		61AF6E95FE0DD913204CAB32 /* AnalyticsHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHelperTests.swift; sourceTree = "<group>"; };
 		61F8308B7250B642D19827D8 /* STPCameraView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPCameraView.swift; sourceTree = "<group>"; };
@@ -1127,6 +1129,7 @@
 				0E10C4D64477638398251FFB /* Info.plist */,
 				436074876478126262BD05C0 /* IntentConfirmParamsTest.swift */,
 				8D866DCC403994A0D3CFB1D7 /* KlarnaHelperTest.swift */,
+				610DF5DB2B33597500DA6AAA /* HostedSurfaceTest.swift */,
 				BC7B7ED388B6C6AE57D3D627 /* LinkAccountServiceTests.swift */,
 				CEB30E3846E24FD57A44764A /* LinkInMemoryCookieStoreTests.swift */,
 				835CB781FBC19773ACC20676 /* LinkLegalTermsViewSnapshotTests.swift */,
@@ -1782,6 +1785,7 @@
 				492F7C4DABB4CE8EBE34EEF2 /* STPConnectAccountAddressTest.swift in Sources */,
 				C8490E55B1F2EB836144F91C /* STPConnectAccountFunctionalTest.swift in Sources */,
 				14656D177E67594B8C75A9FE /* STPConnectAccountParamsTest.swift in Sources */,
+				610DF5DC2B33597500DA6AAA /* HostedSurfaceTest.swift in Sources */,
 				9D464A252FBD0D4E2A0A7398 /* STPCountryPickerInputFieldSnapshotTests.swift in Sources */,
 				4C3B161481D11385352B06D4 /* STPCustomerContextTest.swift in Sources */,
 				6EDFC83541EED9E361B71C02 /* STPCustomerTest.swift in Sources */,

--- a/Stripe/StripeiOSTests/HostedSurfaceTest.swift
+++ b/Stripe/StripeiOSTests/HostedSurfaceTest.swift
@@ -1,0 +1,83 @@
+//
+//  HostedSurfaceTest.swift
+//  StripeiOSTests
+//
+//  Created by Nick Porter on 12/20/23.
+//
+
+import Foundation
+@testable@_spi(STP) import Stripe
+@testable@_spi(STP) import StripeCore
+@testable@_spi(STP) import StripePayments
+@testable@_spi(STP) import StripePaymentSheet
+@testable@_spi(STP) import StripePaymentsUI
+
+class HostedSurfaceTest: XCTestCase {
+
+    // Test the initializer
+    func testHostedSurfaceInitializer() {
+        let paymentSheetConfig = PaymentSheetFormFactoryConfig.paymentSheet(.init())
+        
+        let hostedSurfaceForPaymentSheet = HostedSurface(config: paymentSheetConfig)
+        XCTAssertEqual(hostedSurfaceForPaymentSheet, .paymentSheet)
+        
+        let customerSheetConfig = PaymentSheetFormFactoryConfig.customerSheet(.init())
+        
+        let hostedSurfaceForCustomerSheet = HostedSurface(config: customerSheetConfig)
+        XCTAssertEqual(hostedSurfaceForCustomerSheet, .customerSheet)
+    }
+
+    // Test analyticEvent function for every event in CardBrandChoiceEvents
+    func testPaymentSheetAnalyticEvents() {
+        let hostedSurface = HostedSurface.paymentSheet
+        testAnalyticEvents(for: hostedSurface)
+    }
+    
+    func testCustomerSheetAnalyticEvents() {
+        let hostedSurface = HostedSurface.customerSheet
+        testAnalyticEvents(for: hostedSurface)
+    }
+    
+    private func testAnalyticEvents(for hostedSurface: HostedSurface) {
+        let events: [HostedSurface.CardBrandChoiceEvents] = [
+            .displayCardBrandDropdownIndicator,
+            .openCardBrandDropdown,
+            .closeCardBrandDropDown,
+            .openCardBrandEditScreen,
+            .updateCardBrand,
+            .updateCardBrandFailed,
+            .closeEditScreen,
+        ]
+        
+        let expectedEventsPaymentSheet: [HostedSurface.CardBrandChoiceEvents: STPAnalyticEvent] = [
+            .displayCardBrandDropdownIndicator: .paymentSheetDisplayCardBrandDropdownIndicator,
+            .openCardBrandDropdown: .paymentSheetOpenCardBrandDropdown,
+            .closeCardBrandDropDown: .paymentSheetCloseCardBrandDropDown,
+            .openCardBrandEditScreen: .paymentSheetOpenCardBrandEditScreen,
+            .updateCardBrand: .paymentSheetUpdateCardBrand,
+            .updateCardBrandFailed: .paymentSheetUpdateCardBrandFailed,
+            .closeEditScreen: .paymentSheetClosesEditScreen,
+        ]
+        
+        let expectedEventsCustomerSheet: [HostedSurface.CardBrandChoiceEvents: STPAnalyticEvent] = [
+            .displayCardBrandDropdownIndicator: .customerSheetDisplayCardBrandDropdownIndicator,
+            .openCardBrandDropdown: .customerSheetOpenCardBrandDropdown,
+            .closeCardBrandDropDown: .customerSheetCloseCardBrandDropDown,
+            .openCardBrandEditScreen: .customerSheetOpenCardBrandEditScreen,
+            .updateCardBrand: .customerSheetUpdateCardBrand,
+            .updateCardBrandFailed: .customerSheetUpdateCardBrandFailed,
+            .closeEditScreen: .customerSheetClosesEditScreen,
+        ]
+        
+        for event in events {
+            let analyticEvent = hostedSurface.analyticEvent(for: event)
+            // assert that the event is the expected one
+            switch hostedSurface {
+            case .paymentSheet:
+                XCTAssertEqual(analyticEvent, expectedEventsPaymentSheet[event])
+            case .customerSheet:
+                XCTAssertEqual(analyticEvent, expectedEventsCustomerSheet[event])
+            }
+        }
+    }
+}

--- a/Stripe/StripeiOSTests/HostedSurfaceTest.swift
+++ b/Stripe/StripeiOSTests/HostedSurfaceTest.swift
@@ -17,12 +17,12 @@ class HostedSurfaceTest: XCTestCase {
     // Test the initializer
     func testHostedSurfaceInitializer() {
         let paymentSheetConfig = PaymentSheetFormFactoryConfig.paymentSheet(.init())
-        
+
         let hostedSurfaceForPaymentSheet = HostedSurface(config: paymentSheetConfig)
         XCTAssertEqual(hostedSurfaceForPaymentSheet, .paymentSheet)
-        
+
         let customerSheetConfig = PaymentSheetFormFactoryConfig.customerSheet(.init())
-        
+
         let hostedSurfaceForCustomerSheet = HostedSurface(config: customerSheetConfig)
         XCTAssertEqual(hostedSurfaceForCustomerSheet, .customerSheet)
     }
@@ -32,12 +32,12 @@ class HostedSurfaceTest: XCTestCase {
         let hostedSurface = HostedSurface.paymentSheet
         testAnalyticEvents(for: hostedSurface)
     }
-    
+
     func testCustomerSheetAnalyticEvents() {
         let hostedSurface = HostedSurface.customerSheet
         testAnalyticEvents(for: hostedSurface)
     }
-    
+
     private func testAnalyticEvents(for hostedSurface: HostedSurface) {
         let events: [HostedSurface.CardBrandChoiceEvents] = [
             .displayCardBrandDropdownIndicator,
@@ -48,7 +48,7 @@ class HostedSurfaceTest: XCTestCase {
             .updateCardBrandFailed,
             .closeEditScreen,
         ]
-        
+
         let expectedEventsPaymentSheet: [HostedSurface.CardBrandChoiceEvents: STPAnalyticEvent] = [
             .displayCardBrandDropdownIndicator: .paymentSheetDisplayCardBrandDropdownIndicator,
             .openCardBrandDropdown: .paymentSheetOpenCardBrandDropdown,
@@ -58,7 +58,7 @@ class HostedSurfaceTest: XCTestCase {
             .updateCardBrandFailed: .paymentSheetUpdateCardBrandFailed,
             .closeEditScreen: .paymentSheetClosesEditScreen,
         ]
-        
+
         let expectedEventsCustomerSheet: [HostedSurface.CardBrandChoiceEvents: STPAnalyticEvent] = [
             .displayCardBrandDropdownIndicator: .customerSheetDisplayCardBrandDropdownIndicator,
             .openCardBrandDropdown: .customerSheetOpenCardBrandDropdown,
@@ -68,7 +68,7 @@ class HostedSurfaceTest: XCTestCase {
             .updateCardBrandFailed: .customerSheetUpdateCardBrandFailed,
             .closeEditScreen: .customerSheetClosesEditScreen,
         ]
-        
+
         for event in events {
             let analyticEvent = hostedSurface.analyticEvent(for: event)
             // assert that the event is the expected one

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
@@ -182,4 +182,23 @@ import Foundation
     // MARK: - v1/elements/session
     case paymentSheetElementsSessionLoadFailed = "mc_elements_session_load_failed"
     case paymentSheetElementsSessionEPMLoadFailed = "mc_elements_session_epms_load_failed"
+
+    // MARK: - PaymentSheet card brand choice
+    case paymentSheetDisplayCardBrandDropdownIndicator = "mc_display_cbc_dropdown"
+    case paymentSheetOpenCardBrandDropdown = "mc_open_cbc_dropdown"
+    case paymentSheetCloseCardBrandDropDown = "mc_close_cbc_dropdown"
+    case paymentSheetOpenCardBrandEditScreen = "mc_open_edit_screen"
+    case paymentSheetUpdateCardBrand = "mc_update_card"
+    case paymentSheetUpdateCardBrandFailed = "mc_update_card_failed"
+    case paymentSheetClosesEditScreen = "mc_cancel_edit_screen"
+
+    // MARK: - CustomerSheet card brand choice
+    case customerSheetDisplayCardBrandDropdownIndicator = "cs_display_cbc_dropdown"
+    case customerSheetOpenCardBrandDropdown = "cs_open_cbc_dropdown"
+    case customerSheetCloseCardBrandDropDown = "cs_close_cbc_dropdown"
+    case customerSheetOpenCardBrandEditScreen = "cs_open_edit_screen"
+    case customerSheetUpdateCardBrand = "cs_update_card"
+    case customerSheetUpdateCardBrandFailed = "cs_update_card_failed"
+    case customerSheetClosesEditScreen = "cs_cancel_edit_screen"
+
 }

--- a/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
+++ b/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
@@ -105,6 +105,7 @@
 		5C047CFEA91C1A04EAEC0CFF /* StripeUICore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 35BFC60D1945087E74B6BD89 /* StripeUICore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5C0D1B932954D0EF3F3A679F /* ManualEntryButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95BDADF560DB0B1ED175EF50 /* ManualEntryButton.swift */; };
 		5E00512CDFBC1C93781E20AB /* PaymentSheetLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88DBDEE23A856CE8D3B49861 /* PaymentSheetLoader.swift */; };
+		610DF5DA2B334DBF00DA6AAA /* HostedSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 610DF5D92B334DBF00DA6AAA /* HostedSurface.swift */; };
 		6151DDC02B14FDCF00ED4F7E /* UpdateCardViewControllerSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6151DDBF2B14FDCF00ED4F7E /* UpdateCardViewControllerSnapshotTests.swift */; };
 		61C0D3B8C63EB4558AB74A7E /* StripePayments.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A1C7CFA5C9C1A8A73CFA1C0 /* StripePayments.framework */; };
 		623C2D9F87929D6DA9C09E23 /* STPCameraView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D39B31D0B890A4F8E4819B15 /* STPCameraView.swift */; };
@@ -414,6 +415,7 @@
 		5EFCD0B8D104E175C9EFF7A0 /* zh-HK */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-HK"; path = "zh-HK.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		5F884F7A5FF4FC6D0E24E6FC /* PaymentSheetErrorTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSheetErrorTest.swift; sourceTree = "<group>"; };
 		5FD715F32B61017198E9F952 /* BottomSheetTransitioningDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetTransitioningDelegate.swift; sourceTree = "<group>"; };
+		610DF5D92B334DBF00DA6AAA /* HostedSurface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = HostedSurface.swift; path = ../Elements/CardSectionWithScanner/HostedSurface.swift; sourceTree = "<group>"; };
 		6139AA50F07A1E2AC7E9827F /* AUBECSMandate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AUBECSMandate.swift; sourceTree = "<group>"; };
 		6151DDBF2B14FDCF00ED4F7E /* UpdateCardViewControllerSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateCardViewControllerSnapshotTests.swift; sourceTree = "<group>"; };
 		617C44F9338DE2E93E318291 /* PayWithLinkWebController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayWithLinkWebController.swift; sourceTree = "<group>"; };
@@ -969,6 +971,7 @@
 		9A5ACB8060F5CFC60687631B /* BottomSheet */ = {
 			isa = PBXGroup;
 			children = (
+				610DF5D92B334DBF00DA6AAA /* HostedSurface.swift */,
 				A8F7582743930881FEB8C206 /* BottomSheetPresentable.swift */,
 				E8F09CF961C943E36D76860F /* BottomSheetPresentationAnimator.swift */,
 				06CA605ED1C2F5469889E9AC /* BottomSheetPresentationController.swift */,
@@ -1582,6 +1585,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				610DF5DA2B334DBF00DA6AAA /* HostedSurface.swift in Sources */,
 				3BAF910D2D3E23FF2A29B013 /* AnalyticsHelper.swift in Sources */,
 				4E5A3324BBD882A780925E2B /* STPAnalyticsClient+Address.swift in Sources */,
 				0FB52E5B87B1854B28362BF3 /* STPAnalyticsClient+CustomerSheet.swift in Sources */,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewController.swift
@@ -423,6 +423,7 @@ extension CustomerSavedPaymentMethodsCollectionViewController: PaymentOptionCell
                                               paymentMethod: paymentMethod,
                                               removeSavedPaymentMethodMessage: savedPaymentMethodsConfiguration.removeSavedPaymentMethodMessage,
                                               appearance: appearance,
+                                              hostedSurface: .customerSheet,
                                               isTestMode: configuration.isTestMode)
         editVc.delegate = self
         self.bottomSheetController?.pushContentViewController(editVc)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSectionWithScanner/CardSectionWithScannerElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSectionWithScanner/CardSectionWithScannerElement.swift
@@ -57,14 +57,17 @@ final class CardSection: ContainerElement {
     let expiryElement: TextFieldElement
     let theme: ElementsUITheme
     let preferredNetworks: [STPCardBrand]?
+    let hostedSurface: HostedSurface
 
     init(
         collectName: Bool = false,
         defaultValues: DefaultValues = .init(),
         preferredNetworks: [STPCardBrand]? = nil,
         cardBrandChoiceEligible: Bool = false,
+        hostedSurface: HostedSurface,
         theme: ElementsUITheme = .default
     ) {
+        self.hostedSurface = hostedSurface
         self.theme = theme
         let nameElement = collectName
             ? PaymentMethodElementWrapper(
@@ -135,6 +138,22 @@ final class CardSection: ContainerElement {
         self.expiryElement = expiryElement.element
         self.preferredNetworks = preferredNetworks
         cardSection.delegate = self
+
+        // Hook up CBC analytics after self is initialized
+        self.cardBrandDropDown?.didPresent = { [weak self] in
+            guard let self = self, let cardBrandDropDown = self.cardBrandDropDown else { return }
+            let selectedCardBrand = cardBrandDropDown.selectedItem.rawData.toCardBrand ?? .unknown
+            let params = ["selected_card_brand": selectedCardBrand, "cbc_event_source": "add"]
+            STPAnalyticsClient.sharedClient.logPaymentSheetEvent(event: self.hostedSurface.analyticEvent(for: .openCardBrandDropdown),
+                                                                 params: params)
+        }
+
+        self.cardBrandDropDown?.didTapClose = { [weak self] in
+            guard let self = self, let cardBrandDropDown = self.cardBrandDropDown else { return }
+            let selectedCardBrand = cardBrandDropDown.selectedItem.rawData.toCardBrand ?? .unknown
+            STPAnalyticsClient.sharedClient.logPaymentSheetEvent(event: self.hostedSurface.analyticEvent(for: .closeCardBrandDropDown),
+                                                                 params: ["selected_card_brand": STPCardBrandUtilities.apiValue(from: selectedCardBrand)])
+        }
     }
 
     // MARK: - ElementDelegate
@@ -177,6 +196,7 @@ final class CardSection: ContainerElement {
         var fetchedCardBrands = Set<STPCardBrand>()
         let hadBrands = !cardBrands.isEmpty
         STPCardValidator.possibleBrands(forNumber: panElement.text) { [weak self] result in
+            guard let self = self else { return }
             switch result {
             case .success(let brands):
                 fetchedCardBrands = brands
@@ -185,20 +205,25 @@ final class CardSection: ContainerElement {
                 fetchedCardBrands = Set<STPCardBrand>()
             }
 
-            if self?.cardBrands != fetchedCardBrands {
-                self?.cardBrands = fetchedCardBrands
-                cardBrandDropDown.update(items: DropdownFieldElement.items(from: fetchedCardBrands, theme: self?.theme ?? .default))
+            // If we had no brands but now have brands the CBC indicator will appear, log the analytic
+            if !hadBrands, !fetchedCardBrands.isEmpty {
+                STPAnalyticsClient.sharedClient.logPaymentSheetEvent(event: hostedSurface.analyticEvent(for: .displayCardBrandDropdownIndicator))
+            }
+
+            if self.cardBrands != fetchedCardBrands {
+                self.cardBrands = fetchedCardBrands
+                cardBrandDropDown.update(items: DropdownFieldElement.items(from: fetchedCardBrands, theme: self.theme))
 
                 // If we didn't previously have brands but now have them select based on merchant preference
                 // Select the first brand in the fetched brands that appears earliest in the merchants preferred networks
                 if !hadBrands,
-                   let preferredNetworks = self?.preferredNetworks,
+                   let preferredNetworks = self.preferredNetworks,
                    let brandToSelect = preferredNetworks.first(where: { fetchedCardBrands.contains($0) }),
                    let indexToSelect = cardBrandDropDown.items.firstIndex(where: { $0.rawData == STPCardBrandUtilities.apiValue(from: brandToSelect) }) {
                     cardBrandDropDown.select(index: indexToSelect, shouldAutoAdvance: false)
                 }
 
-                self?.panElement.setText(self?.panElement.text ?? "") // Hack to get the accessory view to update
+                self.panElement.setText(self.panElement.text) // Hack to get the accessory view to update
             }
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSectionWithScanner/CardSectionWithScannerElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSectionWithScanner/CardSectionWithScannerElement.swift
@@ -143,7 +143,7 @@ final class CardSection: ContainerElement {
         self.cardBrandDropDown?.didPresent = { [weak self] in
             guard let self = self, let cardBrandDropDown = self.cardBrandDropDown else { return }
             let selectedCardBrand = cardBrandDropDown.selectedItem.rawData.toCardBrand ?? .unknown
-            let params = ["selected_card_brand": selectedCardBrand, "cbc_event_source": "add"]
+            let params = ["selected_card_brand": STPCardBrandUtilities.apiValue(from: selectedCardBrand), "cbc_event_source": "add"]
             STPAnalyticsClient.sharedClient.logPaymentSheetEvent(event: self.hostedSurface.analyticEvent(for: .openCardBrandDropdown),
                                                                  params: params)
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSectionWithScanner/CardSectionWithScannerElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSectionWithScanner/CardSectionWithScannerElement.swift
@@ -17,6 +17,7 @@ import UIKit
 /// If card scanning is available, it uses a custom view that adds card scanning. Otherwise, it uses the default SectionElement view.
 /// It coordinates between the PAN and CVC fields.
 final class CardSection: ContainerElement {
+
     var elements: [Element] {
         return [cardSection]
     }
@@ -207,7 +208,7 @@ final class CardSection: ContainerElement {
 
             // If we had no brands but now have brands the CBC indicator will appear, log the analytic
             if !hadBrands, !fetchedCardBrands.isEmpty {
-                STPAnalyticsClient.sharedClient.logPaymentSheetEvent(event: hostedSurface.analyticEvent(for: .displayCardBrandDropdownIndicator))
+                STPAnalyticsClient.sharedClient.logPaymentSheetEvent(event: self.hostedSurface.analyticEvent(for: .displayCardBrandDropdownIndicator))
             }
 
             if self.cardBrands != fetchedCardBrands {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSectionWithScanner/HostedSurface.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSectionWithScanner/HostedSurface.swift
@@ -12,7 +12,7 @@ import Foundation
 enum HostedSurface {
     case paymentSheet
     case customerSheet
-    
+
     init(config: PaymentSheetFormFactoryConfig) {
         switch config {
         case .paymentSheet:
@@ -21,7 +21,7 @@ enum HostedSurface {
             self = .customerSheet
         }
     }
-    
+
     func analyticEvent(for event: CardBrandChoiceEvents) -> STPAnalyticEvent {
         switch (event, self) {
         case (.displayCardBrandDropdownIndicator, .paymentSheet):
@@ -54,7 +54,7 @@ enum HostedSurface {
             return .customerSheetClosesEditScreen
         }
     }
-    
+
     // Helper for mapping between PaymentSheet and CustomerSheet CBC events
     enum CardBrandChoiceEvents {
         case displayCardBrandDropdownIndicator

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSectionWithScanner/HostedSurface.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSectionWithScanner/HostedSurface.swift
@@ -1,0 +1,68 @@
+//
+//  HostedSurface.swift
+//  StripePaymentSheet
+//
+//  Created by Nick Porter on 12/20/23.
+//
+
+import Foundation
+@_spi(STP) import StripeCore
+
+// Used to indicate if this card section is being used by either PaymentSheet or CustomerSheet
+enum HostedSurface {
+    case paymentSheet
+    case customerSheet
+    
+    init(config: PaymentSheetFormFactoryConfig) {
+        switch config {
+        case .paymentSheet:
+            self = .paymentSheet
+        case .customerSheet:
+            self = .customerSheet
+        }
+    }
+    
+    func analyticEvent(for event: CardBrandChoiceEvents) -> STPAnalyticEvent {
+        switch (event, self) {
+        case (.displayCardBrandDropdownIndicator, .paymentSheet):
+            return .paymentSheetDisplayCardBrandDropdownIndicator
+        case (.openCardBrandDropdown, .paymentSheet):
+            return .paymentSheetOpenCardBrandDropdown
+        case (.closeCardBrandDropDown, .paymentSheet):
+            return .paymentSheetCloseCardBrandDropDown
+        case (.openCardBrandEditScreen, .paymentSheet):
+            return .paymentSheetOpenCardBrandEditScreen
+        case (.updateCardBrand, .paymentSheet):
+            return .paymentSheetUpdateCardBrand
+        case (.updateCardBrandFailed, .paymentSheet):
+            return .paymentSheetUpdateCardBrandFailed
+        case (.closeEditScreen, .paymentSheet):
+            return .paymentSheetClosesEditScreen
+        case (.displayCardBrandDropdownIndicator, .customerSheet):
+            return .customerSheetDisplayCardBrandDropdownIndicator
+        case (.openCardBrandDropdown, .customerSheet):
+            return .customerSheetOpenCardBrandDropdown
+        case (.closeCardBrandDropDown, .customerSheet):
+            return .customerSheetCloseCardBrandDropDown
+        case (.openCardBrandEditScreen, .customerSheet):
+            return .customerSheetOpenCardBrandEditScreen
+        case (.updateCardBrand, .customerSheet):
+            return .customerSheetUpdateCardBrand
+        case (.updateCardBrandFailed, .customerSheet):
+            return .customerSheetUpdateCardBrandFailed
+        case (.closeEditScreen, .customerSheet):
+            return .customerSheetClosesEditScreen
+        }
+    }
+    
+    // Helper for mapping between PaymentSheet and CustomerSheet CBC events
+    enum CardBrandChoiceEvents {
+        case displayCardBrandDropdownIndicator
+        case openCardBrandDropdown
+        case closeCardBrandDropDown
+        case openCardBrandEditScreen
+        case updateCardBrand
+        case updateCardBrandFailed
+        case closeEditScreen
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
@@ -58,6 +58,7 @@ extension PaymentSheetFormFactory {
             defaultValues: cardDefaultValues,
             preferredNetworks: configuration.preferredNetworks,
             cardBrandChoiceEligible: cardBrandChoiceEligible,
+            hostedSurface: .init(config: configuration),
             theme: theme
         )
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
@@ -366,6 +366,7 @@ extension PaymentSheet.Configuration {
         payload["save_payment_method_opt_in_behavior"] = savePaymentMethodOptInBehavior.description
         payload["appearance"] = appearance.analyticPayload
         payload["billing_details_collection_configuration"] = billingDetailsCollectionConfiguration.analyticPayload
+        payload["preferred_networks"] = preferredNetworks?.map({ STPCardBrandUtilities.apiValue(from: $0) }).joined(separator: ", ")
         return payload
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
@@ -382,6 +382,7 @@ extension SavedPaymentOptionsViewController: PaymentOptionCellDelegate {
                                               paymentMethod: paymentMethod,
                                               removeSavedPaymentMethodMessage: configuration.removeSavedPaymentMethodMessage,
                                               appearance: appearance,
+                                              hostedSurface: .paymentSheet,
                                               isTestMode: configuration.isTestMode)
         editVc.delegate = self
         self.bottomSheetController?.pushContentViewController(editVc)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/UpdateCardViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/UpdateCardViewController.swift
@@ -103,7 +103,7 @@ final class UpdateCardViewController: UIViewController {
                                                                            includePlaceholder: false) { [weak self] in
                                                                                 guard let self = self else { return }
                                                                                 let selectedCardBrand = self.cardBrandDropDown.selectedItem.rawData.toCardBrand ?? .unknown
-                                                                                let params = ["selected_card_brand": selectedCardBrand, "cbc_event_source": "edit"]
+                                                                                let params = ["selected_card_brand": STPCardBrandUtilities.apiValue(from: selectedCardBrand), "cbc_event_source": "edit"]
                                                                                 STPAnalyticsClient.sharedClient.logPaymentSheetEvent(event: self.hostedSurface.analyticEvent(for: .openCardBrandDropdown),
                                                                                                                                                                              params: params)
                                                                             } didTapClose: { [weak self] in

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/UpdateCardViewControllerSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/UpdateCardViewControllerSnapshotTests.swift
@@ -29,6 +29,7 @@ final class UpdateCardViewControllerSnapshotTests: STPSnapshotTestCase {
                                            paymentMethod: STPFixtures.paymentMethod(),
                                            removeSavedPaymentMethodMessage: "Test removal string",
                                            appearance: appearance,
+                                           hostedSurface: .paymentSheet,
                                            isTestMode: false)
         let testWindow = UIWindow(frame: CGRect(x: 0, y: 0, width: 428, height: 500))
         testWindow.isHidden = false

--- a/StripePaymentsUI/StripePaymentsUI/Source/Internal/UI/Elements/DropDownFieldElement+CardBrand.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/Internal/UI/Elements/DropDownFieldElement+CardBrand.swift
@@ -17,14 +17,18 @@ extension DropdownFieldElement {
                                                         theme: ElementsUITheme = .default,
                                                         includePlaceholder: Bool = true,
                                                         maxWidth: CGFloat? = nil,
-                                                        hasPadding: Bool = true) -> DropdownFieldElement {
+                                                        hasPadding: Bool = true,
+                                                        didPresent: DropdownFieldElement.DidPresent? = nil,
+                                                        didTapClose: DropdownFieldElement.DidTapClose? = nil) -> DropdownFieldElement {
         return DropdownFieldElement(
             items: items(from: cardBrands, theme: theme, includePlaceholder: includePlaceholder, maxWidth: maxWidth),
             defaultIndex: 0,
             label: nil,
             theme: theme,
             hasPadding: hasPadding,
-            isOptional: true
+            isOptional: true,
+            didPresent: didPresent,
+            didTapClose: didTapClose
         )
     }
 

--- a/StripeUICore/StripeUICore/Source/Elements/DropdownFieldElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/DropdownFieldElement.swift
@@ -17,7 +17,9 @@ import UIKit
  */
 @objc(STP_Internal_DropdownFieldElement)
 @_spi(STP) public class DropdownFieldElement: NSObject {
+    public typealias DidPresent = () -> Void
     public typealias DidUpdateSelectedIndex = (Int) -> Void
+    public typealias DidTapClose = () -> Void
 
     public struct DropdownItem {
         public init(pickerDisplayName: NSAttributedString, labelDisplayName: NSAttributedString, accessibilityValue: String, rawData: String, isPlaceholder: Bool = false) {
@@ -68,7 +70,9 @@ import UIKit
             updatePickerField()
         }
     }
+    public var didPresent: DidPresent?
     public var didUpdate: DidUpdateSelectedIndex?
+    public var didTapClose: DidTapClose?
     public let theme: ElementsUITheme
     public let hasPadding: Bool
 
@@ -145,7 +149,9 @@ import UIKit
         hasPadding: Bool = true,
         disableDropdownWithSingleElement: Bool = false,
         isOptional: Bool = false,
-        didUpdate: DidUpdateSelectedIndex? = nil
+        didPresent: DidPresent? = nil,
+        didUpdate: DidUpdateSelectedIndex? = nil,
+        didTapClose: DidTapClose? = nil
     ) {
         assert(!items.isEmpty, "`items` must contain at least one item")
 
@@ -154,7 +160,9 @@ import UIKit
         self.items = items
         self.disableDropdownWithSingleElement = disableDropdownWithSingleElement
         self.isOptional = isOptional
+        self.didPresent = didPresent
         self.didUpdate = didUpdate
+        self.didTapClose = didTapClose
         self.hasPadding = hasPadding
 
         // Default to defaultIndex, if in bounds
@@ -254,7 +262,7 @@ extension DropdownFieldElement: UIPickerViewDataSource {
 
 extension DropdownFieldElement: PickerFieldViewDelegate {
     func didBeginEditing(_ pickerFieldView: PickerFieldView) {
-        // No-op
+        didPresent?()
     }
 
     func didFinish(_ pickerFieldView: PickerFieldView, shouldAutoAdvance: Bool) {
@@ -275,5 +283,6 @@ extension DropdownFieldElement: PickerFieldViewDelegate {
     func didCancel(_ pickerFieldView: PickerFieldView) {
         // Reset to previously selected index when canceling
         selectedIndex = previouslySelectedIndex
+        didTapClose?()
     }
 }


### PR DESCRIPTION
## Summary
- Adds eventing for card brand choice

## Motivation
https://docs.google.com/document/d/1OPsfb60KmHhVBRa8TW1BiMhTqYpL7uxR30gBgTQ8x4A/edit

## Testing
- Manual in both PaymentSheet and CustomerSheet
- Added unit tests

## Changelog
N/A
