### PR TITLE
Increase retry count for Cash App Pay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## x.x.x x-x-x
+### Payments
+* [Changed] Increased the maximum number of retries from 2 to 4 when waiting for an intent to update to a terminal state, this impacts Cash App Pay and 3DS2.
+
 ## 23.20.0 2023-12-18
 ### PaymentSheet
 * [Added] Support for [card brand choice](https://stripe.com/docs/card-brand-choice). To set default preferred networks, use the new configuration option `PaymentSheet.Configuration.preferredNetworks`.

--- a/Stripe/StripeiOSTests/STPPaymentHandlerTests.swift
+++ b/Stripe/StripeiOSTests/STPPaymentHandlerTests.swift
@@ -242,7 +242,7 @@ class STPPaymentHandlerTests: APIStubbedTestCase {
             checkedStillInProgress.fulfill()
         }
 
-        wait(for: [paymentHandlerExpectation, checkedStillInProgress], timeout: 30)
+        wait(for: [paymentHandlerExpectation, checkedStillInProgress], timeout: 60)
         STPPaymentHandler.sharedHandler.apiClient = STPAPIClient.shared
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLPMConfirmFlowTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLPMConfirmFlowTests.swift
@@ -436,7 +436,7 @@ extension PaymentSheet_LPM_ConfirmFlowTests {
                 }
                 e.fulfill()
             }
-            await fulfillment(of: [e], timeout: 10)
+            await fulfillment(of: [e], timeout: 45)
         }
     }
 

--- a/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
@@ -1938,7 +1938,7 @@ public class STPPaymentHandler: NSObject {
         }
     }
 
-    static let maxChallengeRetries = 2
+    static let maxChallengeRetries = 4
     func _markChallengeCompleted(
         withCompletion completion: @escaping STPBooleanSuccessBlock,
         retryCount: Int = maxChallengeRetries


### PR DESCRIPTION
## Summary
- Bumps the max retry count from 2 to 4
- In some cases a merchant was noticing longer than expected duration for the intent to update. This is a short term remediation to improve the reliability. 
- Impacts 3DS2 as well since we use the same max retry between the two. I don't foresee any issues with increasing the max for 3DS2.

## Motivation
https://stripe.slack.com/archives/C061CRHSYE6/p1703173693846139
https://stripe.slack.com/archives/C061CRHSYE6/p1703173997870339

## Testing
- Manual

## Changelog
See diff