### PR TITLE
Preserve selection when tapping to dismiss in flow controller

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -2074,6 +2074,33 @@ class PaymentSheetDeferredServerSideUITests: PaymentSheetUITestCase {
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 5.0))
     }
 
+    func testPreservesSelectionAfterDismissPaymentSheetFlowController() throws {
+        var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
+        settings.uiStyle = .flowController
+        settings.customerMode = .new
+
+        loadPlayground(app, settings)
+
+        app.buttons["Payment method"].waitForExistenceAndTap()
+        app.buttons["+ Add"].waitForExistenceAndTap()
+        try fillCardData(app)
+
+        app.buttons["Continue"].tap()
+        app.buttons["Confirm"].tap()
+        XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 5.0))
+        reload(app, settings: settings)
+
+        app.buttons["Payment method"].waitForExistenceAndTap()
+        app.buttons["+ Add"].waitForExistenceAndTap()
+
+        // Tap to dismiss PaymentSheet
+        app.tapCoordinate(at: CGPoint(x: 100, y: 100))
+        // Give time for the dismiss animation and the payment option to update
+        sleep(2)
+
+        XCTAssertTrue(app.staticTexts["••••4242"].waitForExistenceAndTap(timeout: 10))
+    }
+
     func testCVCRecollectionFlowController() throws {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
         settings.uiStyle = .flowController
@@ -2817,5 +2844,14 @@ extension XCUIElement {
         let startCoord = self.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
         let endCoord = startCoord.withOffset(CGVector(dx: 0.0, dy: 30.0)) // 30pts = height of picker item
         endCoord.tap()
+    }
+}
+
+extension XCUIApplication {
+    func tapCoordinate(at point: CGPoint) {
+        let normalized = coordinate(withNormalizedOffset: .zero)
+        let offset = CGVector(dx: point.x, dy: point.y)
+        let coordinate = normalized.withOffset(offset)
+        coordinate.tap()
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
@@ -115,7 +115,7 @@ class SavedPaymentOptionsViewController: UIViewController {
     let configuration: Configuration
 
     var selectedPaymentOption: PaymentOption? {
-        guard let index = selectedViewModelIndex else {
+        guard let index = selectedViewModelIndex, viewModels.count > index else {
             return nil
         }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
@@ -115,7 +115,7 @@ class SavedPaymentOptionsViewController: UIViewController {
     let configuration: Configuration
 
     var selectedPaymentOption: PaymentOption? {
-        guard let index = selectedViewModelIndex, viewModels.count > index else {
+        guard let index = selectedViewModelIndex, viewModels.indices.contains(index) else {
             return nil
         }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -34,6 +34,9 @@ class PaymentSheetFlowControllerViewController: UIViewController {
         case .addingNew:
             if let paymentOption = addPaymentMethodViewController.paymentOption {
                 return paymentOption
+            } else if let paymentOption = savedPaymentOptionsViewController.selectedPaymentOption {
+                // If no valid payment option from adding, fallback on any saved payment method
+                return paymentOption
             } else if isApplePayEnabled {
                 return .applePay
             }


### PR DESCRIPTION
## Summary
- See ticket for description of bug.
- Now when computing a payment option we fallback on the saved payment view controller if anything was selected, otherwise fallback on Apple Pay.

## Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-1149

## Testing
- Manual
- New UI test

## Changelog
N/A