### PR TITLE
Disable link on usage of billingDetailsCollectionConfig

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
+++ b/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
@@ -117,6 +117,8 @@
 		694A3B36AC19FC1F87EF0CB1 /* CustomerSheetPaymentMethodAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F42DA5892E8E4C28D434AEA7 /* CustomerSheetPaymentMethodAvailabilityTests.swift */; };
 		6A529F76ECB33C9154314C1F /* STPAnalyticsClient+LUXE.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B5AAA4347A6918EC267210 /* STPAnalyticsClient+LUXE.swift */; };
 		6B7E675071649AE3047D388C /* PaymentSheetFormFactoryConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A21CC86104388EFE07CB37D /* PaymentSheetFormFactoryConfig.swift */; };
+		6B87704F2B4776940025DCE5 /* PaymentSheetConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B87704E2B4776940025DCE5 /* PaymentSheetConfigurationTests.swift */; };
+		6B8770512B4779E00025DCE5 /* CustomerSheetConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8770502B4779E00025DCE5 /* CustomerSheetConfigurationTests.swift */; };
 		6BA8D3342B0C1F79008C51FF /* CVCRecollectionElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA8D3332B0C1F79008C51FF /* CVCRecollectionElement.swift */; };
 		6BA8D3362B0C1F9B008C51FF /* CVCReconfirmationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA8D3352B0C1F9B008C51FF /* CVCReconfirmationViewController.swift */; };
 		6BA8D3382B0C1FA9008C51FF /* PreConfirmationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA8D3372B0C1FA9008C51FF /* PreConfirmationViewController.swift */; };
@@ -428,6 +430,8 @@
 		68C3318ED094D63626740234 /* InstantDebitsOnlyFinancialConnectionsAuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstantDebitsOnlyFinancialConnectionsAuthManager.swift; sourceTree = "<group>"; };
 		6A065CEE8A7BCE60FC9D50BF /* el-GR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "el-GR"; path = "el-GR.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		6B680A2FF197F612D065F16C /* PaymentSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSheet.swift; sourceTree = "<group>"; };
+		6B87704E2B4776940025DCE5 /* PaymentSheetConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSheetConfigurationTests.swift; sourceTree = "<group>"; };
+		6B8770502B4779E00025DCE5 /* CustomerSheetConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerSheetConfigurationTests.swift; sourceTree = "<group>"; };
 		6B9A346A7A4290BAA7BCA1A2 /* PaymentMethodTypeCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodTypeCollectionView.swift; sourceTree = "<group>"; };
 		6BA8D3332B0C1F79008C51FF /* CVCRecollectionElement.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CVCRecollectionElement.swift; sourceTree = "<group>"; };
 		6BA8D3352B0C1F9B008C51FF /* CVCReconfirmationViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CVCReconfirmationViewController.swift; sourceTree = "<group>"; };
@@ -648,6 +652,7 @@
 			children = (
 				F42DA5892E8E4C28D434AEA7 /* CustomerSheetPaymentMethodAvailabilityTests.swift */,
 				ED7ABCE56539213DCE501C54 /* CustomerSheetTests.swift */,
+				6B8770502B4779E00025DCE5 /* CustomerSheetConfigurationTests.swift */,
 			);
 			path = CustomerSheet;
 			sourceTree = "<group>";
@@ -1289,6 +1294,7 @@
 				8A0B7F6E25D93C0C0ACE3B3D /* PaymentSheet+APITest.swift */,
 				AA8F7F2824DFC78268ED6459 /* PaymentSheet+DeferredAPITest.swift */,
 				135B7354260E0E7CADCF3426 /* PaymentSheetAddressTests.swift */,
+				6B87704E2B4776940025DCE5 /* PaymentSheetConfigurationTests.swift */,
 				357B9EB0751819566843117E /* PaymentSheetDeferredValidatorTests.swift */,
 				5F884F7A5FF4FC6D0E24E6FC /* PaymentSheetErrorTest.swift */,
 				35853BC78F9E64F5729EAE1E /* PaymentSheetExternalPaymentMethodTests.swift */,
@@ -1564,6 +1570,7 @@
 				142C03879DC4CD43BB743022 /* PaymentSheetLoaderStubbedTest.swift in Sources */,
 				1C70F42915587CBF883E01DD /* PaymentSheetLoaderTest.swift in Sources */,
 				96B31ABDA593F9C7FC3DBF79 /* PaymentSheetPaymentMethodTypeTest.swift in Sources */,
+				6B87704F2B4776940025DCE5 /* PaymentSheetConfigurationTests.swift in Sources */,
 				041E3F2DFDFD8FA7D3353CDB /* PaymentSheetSnapshotTests.swift in Sources */,
 				1330B53140DE10F641A82099 /* PaymentSheetViewControllerSnapshotTests.swift in Sources */,
 				47AD56A9889DF5EFBBA9CEFB /* PollingViewTests.swift in Sources */,
@@ -1571,6 +1578,7 @@
 				714FBCA75296C291FDB3B345 /* STPCardBrandChoiceTest.swift in Sources */,
 				E0E47773D3C0B432E26AA457 /* STPElementsSessionTest.swift in Sources */,
 				29C98FB712F3FB987CBE18B0 /* STPFixtures+PaymentSheet.swift in Sources */,
+				6B8770512B4779E00025DCE5 /* CustomerSheetConfigurationTests.swift in Sources */,
 				45D9849E9B36C56E15EAAE0A /* SavedPaymentOptionsViewControllerSnapshotTests.swift in Sources */,
 				9787A622B527C1AD96A73827 /* SepaMandateViewControllerSnapshotTest.swift in Sources */,
 				B68CB9632B0D2169006ACDB1 /* STPAPIClient+PaymentSheetTest.swift in Sources */,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetConfiguration.swift
@@ -122,3 +122,12 @@ extension CustomerSheet {
         }
     }
 }
+
+extension CustomerSheet.Configuration {
+    func isUsingBillingAddressCollection() -> Bool {
+        return billingDetailsCollectionConfiguration.name == .always
+        || billingDetailsCollectionConfiguration.phone == .always
+        || billingDetailsCollectionConfiguration.email == .always
+        || billingDetailsCollectionConfiguration.address == .full
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
@@ -432,3 +432,12 @@ extension PaymentSheet {
         public var externalPaymentMethodConfirmHandler: ExternalPaymentMethodConfirmHandler
     }
 }
+
+extension PaymentSheet.Configuration {
+    func isUsingBillingAddressCollection() -> Bool {
+        return billingDetailsCollectionConfiguration.name == .always
+        || billingDetailsCollectionConfiguration.phone == .always
+        || billingDetailsCollectionConfiguration.email == .always
+        || billingDetailsCollectionConfiguration.address == .full
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -44,7 +44,10 @@ class PaymentSheetFormFactory {
     var canSaveToLink: Bool {
         // For Link private beta, only save cards in ".userSelectable" mode.
         // We don't want to override the merchant's own "Save this card" checkbox.
-        return (supportsLinkCard && paymentMethod == .stripe(.card) && saveMode != .userSelectable)
+        return (supportsLinkCard &&
+                paymentMethod == .stripe(.card) &&
+                saveMode != .userSelectable &&
+                !configuration.isUsingBillingAddressCollection)
     }
 
     var theme: ElementsUITheme {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactoryConfig.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactoryConfig.swift
@@ -84,4 +84,13 @@ enum PaymentSheetFormFactoryConfig {
             return config.preferredNetworks
         }
     }
+
+    var isUsingBillingAddressCollection: Bool {
+        switch self {
+        case .paymentSheet(let config):
+            return config.isUsingBillingAddressCollection()
+        case .customerSheet(let config):
+            return config.isUsingBillingAddressCollection()
+        }
+    }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -67,14 +67,14 @@ final class PaymentSheetLoader {
                             intent: intent
                         )
                     }
-
+                let isLinkEnabled = isLinkEnabled(intent: intent, configuration: configuration)
                 analyticsClient.logPaymentSheetEvent(event: .paymentSheetLoadSucceeded,
                                                                      duration: Date().timeIntervalSince(loadingStartDate))
                 completion(
                     .success(
                         intent: intent,
                         savedPaymentMethods: filteredSavedPaymentMethods,
-                        isLinkEnabled: intent.supportsLink
+                        isLinkEnabled: isLinkEnabled
                     )
                 )
             } catch {
@@ -137,6 +137,16 @@ final class PaymentSheetLoader {
         } else {
             return nil
         }
+    }
+
+    static func isLinkEnabled(intent: Intent, configuration: PaymentSheet.Configuration) -> Bool {
+        guard intent.supportsLink else {
+            return false
+        }
+        return configuration.billingDetailsCollectionConfiguration.name == .automatic
+        && configuration.billingDetailsCollectionConfiguration.phone == .automatic
+        && configuration.billingDetailsCollectionConfiguration.email == .automatic
+        && configuration.billingDetailsCollectionConfiguration.address == .automatic
     }
 
     static func fetchIntent(mode: PaymentSheet.InitializationMode, configuration: PaymentSheet.Configuration, analyticsClient: STPAnalyticsClient) async throws -> Intent {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -143,10 +143,7 @@ final class PaymentSheetLoader {
         guard intent.supportsLink else {
             return false
         }
-        return configuration.billingDetailsCollectionConfiguration.name == .automatic
-        && configuration.billingDetailsCollectionConfiguration.phone == .automatic
-        && configuration.billingDetailsCollectionConfiguration.email == .automatic
-        && configuration.billingDetailsCollectionConfiguration.address == .automatic
+        return !configuration.isUsingBillingAddressCollection()
     }
 
     static func fetchIntent(mode: PaymentSheet.InitializationMode, configuration: PaymentSheet.Configuration, analyticsClient: STPAnalyticsClient) async throws -> Intent {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/CustomerSheet/CustomerSheetConfigurationTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/CustomerSheet/CustomerSheetConfigurationTests.swift
@@ -1,0 +1,64 @@
+//
+//  CustomerSheetConfigurationTests.swift
+//  StripePaymentSheetTests
+//
+
+import XCTest
+
+@testable@_spi(STP) import StripePaymentSheet
+
+class CustomerSheetConfigurationTests: XCTestCase {
+    func testIsUsingBillingAddressCollection_Default() {
+        let configuration = CustomerSheet.Configuration()
+        XCTAssertFalse(configuration.isUsingBillingAddressCollection())
+    }
+
+    func testIsUsingBillingAddressCollection_address_never() {
+        var configuration = CustomerSheet.Configuration()
+        configuration.billingDetailsCollectionConfiguration.address = .never
+        XCTAssertFalse(configuration.isUsingBillingAddressCollection())
+    }
+
+    func testIsUsingBillingAddressCollection_address_full() {
+        var configuration = CustomerSheet.Configuration()
+        configuration.billingDetailsCollectionConfiguration.address = .full
+        XCTAssert(configuration.isUsingBillingAddressCollection())
+    }
+
+    func testIsUsingBillingAddressCollection_email_never() {
+        var configuration = CustomerSheet.Configuration()
+        configuration.billingDetailsCollectionConfiguration.email = .never
+        XCTAssertFalse(configuration.isUsingBillingAddressCollection())
+    }
+
+    func testIsUsingBillingAddressCollection_email_full() {
+        var configuration = CustomerSheet.Configuration()
+        configuration.billingDetailsCollectionConfiguration.email = .always
+        XCTAssert(configuration.isUsingBillingAddressCollection())
+    }
+
+    func testIsUsingBillingAddressCollection_name_never() {
+        var configuration = CustomerSheet.Configuration()
+        configuration.billingDetailsCollectionConfiguration.name = .never
+        XCTAssertFalse(configuration.isUsingBillingAddressCollection())
+    }
+
+    func testIsUsingBillingAddressCollection_name_full() {
+        var configuration = CustomerSheet.Configuration()
+        configuration.billingDetailsCollectionConfiguration.name = .always
+        XCTAssert(configuration.isUsingBillingAddressCollection())
+    }
+
+    func testIsUsingBillingAddressCollection_phone_never() {
+        var configuration = CustomerSheet.Configuration()
+        configuration.billingDetailsCollectionConfiguration.phone = .never
+        XCTAssertFalse(configuration.isUsingBillingAddressCollection())
+    }
+
+    func testIsUsingBillingAddressCollection_phone_full() {
+        var configuration = CustomerSheet.Configuration()
+        configuration.billingDetailsCollectionConfiguration.phone = .always
+        XCTAssert(configuration.isUsingBillingAddressCollection())
+    }
+}
+

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/CustomerSheet/CustomerSheetConfigurationTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/CustomerSheet/CustomerSheetConfigurationTests.swift
@@ -61,4 +61,3 @@ class CustomerSheetConfigurationTests: XCTestCase {
         XCTAssert(configuration.isUsingBillingAddressCollection())
     }
 }
-

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetConfigurationTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetConfigurationTests.swift
@@ -1,0 +1,64 @@
+//
+//  PaymentSheetConfigurationTests.swift
+//  StripePaymentSheetTests
+//
+
+import XCTest
+
+@testable@_spi(STP) import StripePaymentSheet
+
+class PaymentSheetConfigurationTests: XCTestCase {
+    func testIsUsingBillingAddressCollection_Default() {
+        let configuration = PaymentSheet.Configuration()
+        XCTAssertFalse(configuration.isUsingBillingAddressCollection())
+    }
+
+    func testIsUsingBillingAddressCollection_address_never() {
+        var configuration = PaymentSheet.Configuration()
+        configuration.billingDetailsCollectionConfiguration.address = .never
+        XCTAssertFalse(configuration.isUsingBillingAddressCollection())
+    }
+
+    func testIsUsingBillingAddressCollection_address_full() {
+        var configuration = PaymentSheet.Configuration()
+        configuration.billingDetailsCollectionConfiguration.address = .full
+        XCTAssert(configuration.isUsingBillingAddressCollection())
+    }
+
+    func testIsUsingBillingAddressCollection_email_never() {
+        var configuration = PaymentSheet.Configuration()
+        configuration.billingDetailsCollectionConfiguration.email = .never
+        XCTAssertFalse(configuration.isUsingBillingAddressCollection())
+    }
+
+    func testIsUsingBillingAddressCollection_email_full() {
+        var configuration = PaymentSheet.Configuration()
+        configuration.billingDetailsCollectionConfiguration.email = .always
+        XCTAssert(configuration.isUsingBillingAddressCollection())
+    }
+
+    func testIsUsingBillingAddressCollection_name_never() {
+        var configuration = PaymentSheet.Configuration()
+        configuration.billingDetailsCollectionConfiguration.name = .never
+        XCTAssertFalse(configuration.isUsingBillingAddressCollection())
+    }
+
+    func testIsUsingBillingAddressCollection_name_full() {
+        var configuration = PaymentSheet.Configuration()
+        configuration.billingDetailsCollectionConfiguration.name = .always
+        XCTAssert(configuration.isUsingBillingAddressCollection())
+    }
+
+    func testIsUsingBillingAddressCollection_phone_never() {
+        var configuration = PaymentSheet.Configuration()
+        configuration.billingDetailsCollectionConfiguration.phone = .never
+        XCTAssertFalse(configuration.isUsingBillingAddressCollection())
+    }
+
+    func testIsUsingBillingAddressCollection_phone_full() {
+        var configuration = PaymentSheet.Configuration()
+        configuration.billingDetailsCollectionConfiguration.phone = .always
+        XCTAssert(configuration.isUsingBillingAddressCollection())
+    }
+}
+

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetConfigurationTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetConfigurationTests.swift
@@ -61,4 +61,3 @@ class PaymentSheetConfigurationTests: XCTestCase {
         XCTAssert(configuration.isUsingBillingAddressCollection())
     }
 }
-


### PR DESCRIPTION
## Summary
Disable link if user attempts to use BDCC

## Motivation
Configuring BDCC will not work in link popup.  Address info can not be passed via url navigate, etc.  Therefore, disable link in this case for now

## Testing
Manually testing, relying on unit tests
