### PR TITLE
Update tests to move off of dead 3DS1 3063 test card 

### DIFF
--- a/Stripe/StripeiOSTests.xctestplan
+++ b/Stripe/StripeiOSTests.xctestplan
@@ -27,8 +27,6 @@
       "skippedTests" : [
         "PaymentMethodMessagingViewSnapshotTests",
         "STPCardBINMetadataTests",
-        "STPPaymentIntentFunctionalTest\/testConfirmPaymentIntentWith3DSCardPaymentMethodSucceeds()",
-        "STPPaymentIntentFunctionalTest\/testConfirmPaymentIntentWith3DSCardSucceeds()",
         "TextFieldElementCardTest\/testBINRangeThatRequiresNetworkCallToValidate()"
       ],
       "target" : {

--- a/Stripe/StripeiOSTests/STPPaymentIntentFunctionalTest.swift
+++ b/Stripe/StripeiOSTests/STPPaymentIntentFunctionalTest.swift
@@ -206,7 +206,7 @@ class STPPaymentIntentFunctionalTest: XCTestCase {
 
         let params = STPPaymentIntentParams(clientSecret: clientSecret!)
         let cardParams = STPPaymentMethodCardParams()
-        cardParams.number = "4000000000003063"
+        cardParams.number = "4000000000003220"
         cardParams.expMonth = NSNumber(value: 7)
         cardParams.expYear = NSNumber(value: Calendar.current.component(.year, from: Date()) + 5)
 
@@ -1264,7 +1264,7 @@ class STPPaymentIntentFunctionalTest: XCTestCase {
 
     func cardSourceParams() -> STPSourceParams {
         let card = STPCardParams()
-        card.number = "4000 0000 0000 3063" // Test 3DS required card
+        card.number = "4000 0000 0000 3220" // Test 3DS required card
         card.expMonth = 7
         card.expYear = UInt(Calendar.current.component(.year, from: Date()) + 5)
         card.currency = "usd"

--- a/Testers/IntegrationTester/IntegrationTester.xctestplan
+++ b/Testers/IntegrationTester/IntegrationTester.xctestplan
@@ -20,7 +20,6 @@
     {
       "parallelizable" : true,
       "skippedTests" : [
-        "IntegrationTesterUICardTests\/testStandardCustomCard3DS1()"
       ],
       "target" : {
         "containerPath" : "container:IntegrationTester.xcodeproj",

--- a/Testers/IntegrationTester/IntegrationTesterUITests/IntegrationTesterUITests.swift
+++ b/Testers/IntegrationTester/IntegrationTesterUITests/IntegrationTesterUITests.swift
@@ -54,10 +54,6 @@ class IntegrationTesterUICardEntryTests: IntegrationTesterUITests {
 }
 
 class IntegrationTesterUICardTests: IntegrationTesterUITests {
-    func testStandardCustomCard3DS1() throws {
-        testAuthentication(cardNumber: "4000000000003063", confirmationBehavior: .threeDS1)
-    }
-
     func testStandardCustomCard3DS2() throws {
         testAuthentication(cardNumber: "4000000000003220", confirmationBehavior: .threeDS2)
     }


### PR DESCRIPTION


## Summary
3DS1 is deprecated (see comments in https://jira.corp.stripe.com/browse/RUN_AUTHN-6351) and the 3063 test card doesn't work anymore, so move tests that used it to use the 3220 test card (triggering 3DS2) instead.


## Motivation
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-2765

## Testing
Using automated tests
