### PR TITLE
[MOBILESDK-1399] Update Link only behavior in flow controller

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -2142,7 +2142,7 @@ class PaymentSheetDeferredServerSideUITests: PaymentSheetUITestCase {
 
         XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
     }
-    
+
     func testLinkOnlyFlowController() throws {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
         settings.uiStyle = .flowController
@@ -2151,27 +2151,29 @@ class PaymentSheetDeferredServerSideUITests: PaymentSheetUITestCase {
         settings.linkEnabled = .on
 
         loadPlayground(app, settings)
-
         app.buttons["Payment method"].waitForExistenceAndTap()
         app.buttons["pay_with_link_button"].waitForExistenceAndTap()
-        
-        
-        let expectation = XCTestExpectation(description: "Link sign in dialog")
-//        XCTAssertTrue(app.alerts.staticTexts["\"PaymentSheetExample\" Wants to Use \"link.com\" to Sign In"].waitForExistence(timeout: 5.0))
-        addUIInterruptionMonitor(withDescription: "Link sign in system dialog") { alert in
 
-            if alert.staticTexts["\"PaymentSheetExample\" Wants to Use \"link.com\" to Sign In"].exists {
-                expectation.fulfill()
-                return true
-            }
+        let expectation = XCTestExpectation(description: "Link sign in dialog")
+        // Listen for the system login dialog
+        addUIInterruptionMonitor(withDescription: "Link sign in system dialog") { alert in
+            // Cancel the payment
+            alert.buttons["Cancel"].waitForExistenceAndTap()
             expectation.fulfill()
-            return false
+            return true
         }
-        
+
         app.buttons["Confirm"].waitForExistenceAndTap()
+        app.tap() // required to trigger the UI interruption monitor
         wait(for: [expectation], timeout: 5.0)
+
+        XCTAssertTrue(app.staticTexts["Payment canceled."].waitForExistence(timeout: 5))
+
+        // Re-tapping the payment method button should present the saved payment view
+        app.buttons["Payment method"].waitForExistenceAndTap()
+        XCTAssertTrue(app.staticTexts["Select your payment method"].waitForExistence(timeout: 5))
     }
-    
+
     /* Disable Link test
      func testDeferredIntentLinkSignIn_SeverSideConfirmation() throws {
      loadPlayground(

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -2142,6 +2142,36 @@ class PaymentSheetDeferredServerSideUITests: PaymentSheetUITestCase {
 
         XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
     }
+    
+    func testLinkOnlyFlowController() throws {
+        var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
+        settings.uiStyle = .flowController
+        settings.customerMode = .new
+        settings.applePayEnabled = .off
+        settings.linkEnabled = .on
+
+        loadPlayground(app, settings)
+
+        app.buttons["Payment method"].waitForExistenceAndTap()
+        app.buttons["pay_with_link_button"].waitForExistenceAndTap()
+        
+        
+        let expectation = XCTestExpectation(description: "Link sign in dialog")
+//        XCTAssertTrue(app.alerts.staticTexts["\"PaymentSheetExample\" Wants to Use \"link.com\" to Sign In"].waitForExistence(timeout: 5.0))
+        addUIInterruptionMonitor(withDescription: "Link sign in system dialog") { alert in
+
+            if alert.staticTexts["\"PaymentSheetExample\" Wants to Use \"link.com\" to Sign In"].exists {
+                expectation.fulfill()
+                return true
+            }
+            expectation.fulfill()
+            return false
+        }
+        
+        app.buttons["Confirm"].waitForExistenceAndTap()
+        wait(for: [expectation], timeout: 5.0)
+    }
+    
     /* Disable Link test
      func testDeferredIntentLinkSignIn_SeverSideConfirmation() throws {
      loadPlayground(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/WalletHeaderView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/WalletHeaderView.swift
@@ -63,6 +63,7 @@ extension PaymentSheetViewController {
         private lazy var payWithLinkButton: PayWithLinkButton = {
             let button = PayWithLinkButton()
             button.cornerRadius = appearance.cornerRadius
+            button.accessibilityIdentifier = "pay_with_link_button"
             button.addTarget(self, action: #selector(handleTapPayWithLink), for: .touchUpInside)
             return button
         }()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
@@ -145,6 +145,18 @@ class SavedPaymentOptionsViewController: UIViewController {
             return true
         }
     }
+    /// Whether or not there are any payment options we can show
+    /// i.e. Are there any cells besides the Add and Link cell?
+    var hasOptionsExcludingLink: Bool {
+        return viewModels.contains {
+            switch $0 {
+            case .add, .link:
+                return false
+            default:
+                return true
+            }
+        }
+    }
     weak var delegate: SavedPaymentOptionsViewControllerDelegate?
     var appearance = PaymentSheet.Appearance.default
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -123,7 +123,7 @@ class PaymentSheetFlowControllerViewController: UIViewController {
     private lazy var bottomNoticeTextField: UITextView = {
         return ElementsUI.makeNoticeTextField(theme: configuration.appearance.asElementsTheme)
     }()
-    
+
     private typealias WalletHeaderView = PaymentSheetViewController.WalletHeaderView
     private lazy var walletHeader: WalletHeaderView = {
         var walletOptions: WalletHeaderView.WalletOptions = []
@@ -259,7 +259,7 @@ class PaymentSheetFlowControllerViewController: UIViewController {
         if linkOnlyMode {
             mode = .addingNew
         }
-        
+
         updateUI()
     }
 
@@ -316,12 +316,12 @@ class PaymentSheetFlowControllerViewController: UIViewController {
         isDismissable = !isSavingInProgress && !isVerificationInProgress
 
         configureNavBar()
-        
+
         // Content header
         walletHeader.isHidden = !shouldShowWalletHeader
         walletHeader.showsCardPaymentMessage = (addPaymentMethodViewController.paymentMethodTypes == [.stripe(.card)])
         headerLabel.isHidden = shouldShowWalletHeader
-        
+
         switch mode {
         case .selectingSaved:
             headerLabel.text = STPLocalizedString(
@@ -632,7 +632,7 @@ extension PaymentSheetFlowControllerViewController: WalletHeaderViewDelegate {
     func walletHeaderViewApplePayButtonTapped(_ header: PaymentSheetViewController.WalletHeaderView) {
         // no-op
     }
-    
+
     func walletHeaderViewPayWithLinkTapped(_ header: PaymentSheetViewController.WalletHeaderView) {
         // Link should be the selected payment option as the Link header button is only available in `linkOnlyMode`
         mode = .selectingSaved

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -70,6 +70,19 @@ class PaymentSheetFlowControllerViewController: UIViewController {
         navBar.delegate = self
         return navBar
     }()
+    /// Returns true if Apple Pay is not enabled and Link is enabled and there are no saved payment methods
+    private var linkOnlyMode: Bool {
+        return !isApplePayEnabled && isLinkEnabled && !savedPaymentOptionsViewController.hasOptionsExcludingLink
+    }
+    // Only show the wallet header when Link is the only available PM
+    private var shouldShowWalletHeader: Bool {
+        switch mode {
+        case .addingNew:
+            return linkOnlyMode
+        case .selectingSaved:
+            return false
+        }
+    }
     private(set) var error: Error?
     private(set) var isDismissable: Bool = true
 
@@ -109,6 +122,23 @@ class PaymentSheetFlowControllerViewController: UIViewController {
 
     private lazy var bottomNoticeTextField: UITextView = {
         return ElementsUI.makeNoticeTextField(theme: configuration.appearance.asElementsTheme)
+    }()
+    
+    private typealias WalletHeaderView = PaymentSheetViewController.WalletHeaderView
+    private lazy var walletHeader: WalletHeaderView = {
+        var walletOptions: WalletHeaderView.WalletOptions = []
+
+        if linkOnlyMode {
+            walletOptions.insert(.link)
+        }
+
+        let header = WalletHeaderView(
+            options: walletOptions,
+            appearance: configuration.appearance,
+            applePayButtonType: configuration.applePay?.buttonType ?? .plain,
+            delegate: self
+        )
+        return header
     }()
 
     // MARK: - Init
@@ -194,6 +224,7 @@ class PaymentSheetFlowControllerViewController: UIViewController {
         // One stack view contains all our subviews
         let stackView = UIStackView(arrangedSubviews: [
             headerLabel,
+            walletHeader,
             paymentContainerView,
             errorLabel,
             confirmButton,
@@ -224,6 +255,11 @@ class PaymentSheetFlowControllerViewController: UIViewController {
                 equalTo: view.bottomAnchor, constant: -PaymentSheetUI.defaultSheetMargins.bottom),
         ])
 
+        // Automatically switch into the adding new mode when Link is the only available payment method
+        if linkOnlyMode {
+            mode = .addingNew
+        }
+        
         updateUI()
     }
 
@@ -280,7 +316,12 @@ class PaymentSheetFlowControllerViewController: UIViewController {
         isDismissable = !isSavingInProgress && !isVerificationInProgress
 
         configureNavBar()
-
+        
+        // Content header
+        walletHeader.isHidden = !shouldShowWalletHeader
+        walletHeader.showsCardPaymentMessage = (addPaymentMethodViewController.paymentMethodTypes == [.stripe(.card)])
+        headerLabel.isHidden = shouldShowWalletHeader
+        
         switch mode {
         case .selectingSaved:
             headerLabel.text = STPLocalizedString(
@@ -549,7 +590,7 @@ extension PaymentSheetFlowControllerViewController: AddPaymentMethodViewControll
     }
 
     func shouldOfferLinkSignup(_ viewController: AddPaymentMethodViewController) -> Bool {
-        guard isLinkEnabled else {
+        guard isLinkEnabled, !linkOnlyMode else {
             return false
         }
 
@@ -584,5 +625,18 @@ extension PaymentSheetFlowControllerViewController: SheetNavigationBarDelegate {
 extension PaymentSheet.PaymentMethodType {
     var requiresMandateDisplayForSavedSelection: Bool {
         return self == .stripe(.USBankAccount) || self == .stripe(.SEPADebit)
+    }
+}
+
+extension PaymentSheetFlowControllerViewController: WalletHeaderViewDelegate {
+    func walletHeaderViewApplePayButtonTapped(_ header: PaymentSheetViewController.WalletHeaderView) {
+        // no-op
+    }
+    
+    func walletHeaderViewPayWithLinkTapped(_ header: PaymentSheetViewController.WalletHeaderView) {
+        // Link should be the selected payment option as the Link header button is only available in `linkOnlyMode`
+        mode = .selectingSaved
+        didDismiss(didCancel: false)
+        updateUI()
     }
 }


### PR DESCRIPTION
## Summary
- When FlowController is presented for the first time when Apple Pay is disabled and no saved payment methods are available it goes straight to the add payment view, where the Link button is in the header wallet view.
- Tapping the Link button dismisses the sheet

Demo:
https://github.com/stripe/stripe-ios/assets/88012362/e17863c7-4148-4ce0-9cb8-1332c5e75936

## Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-1399

## Testing
- Manual
- New UI test

## Changelog
N/A
