### PR TITLE
Financial Connections: for v3, modified prepane design

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsOAuthPrepane.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsOAuthPrepane.swift
@@ -12,6 +12,7 @@ struct FinancialConnectionsOAuthPrepane: Decodable {
 
     let institutionIcon: FinancialConnectionsImage?
     let title: String
+    let subtitle: String?
     let body: OauthPrepaneBody
     let partnerNotice: OauthPrepanePartnerNotice?
     let cta: OauthPrepaneCTA

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthViewController.swift
@@ -111,6 +111,7 @@ final class PartnerAuthViewController: UIViewController {
         if authSession.isOauthNonOptional, let prepaneModel = authSession.display?.text?.oauthPrepane {
             let prepaneView = PrepaneView(
                 prepaneModel: prepaneModel,
+                isRepairSession: false, // TODO(kgaidis): change this for repair sessions
                 didSelectURL: { [weak self] url in
                     self?.didSelectURLInTextFromBackend(url)
                 },
@@ -129,6 +130,10 @@ final class PartnerAuthViewController: UIViewController {
                     } else {
                         self.openInstitutionAuthenticationWebView(authSession: authSession)
                     }
+                },
+                didSelectCancel: { [weak self] in
+                    guard let self = self else { return }
+                    self.delegate?.partnerAuthViewControllerDidRequestToGoBack(self)
                 }
             )
             view.addAndPinSubview(prepaneView)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/PaneLayoutView/PaneLayoutView+Extensions.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/PaneLayoutView/PaneLayoutView+Extensions.swift
@@ -14,7 +14,7 @@ extension PaneLayoutView {
 
     @available(iOSApplicationExtension, unavailable)
     static func createContentView(
-        iconView: RoundedIconView?,
+        iconView: UIView?,
         title: String?,
         subtitle: String?,
         contentView: UIView?,
@@ -43,7 +43,7 @@ extension PaneLayoutView {
 
     @available(iOSApplicationExtension, unavailable)
     static func createHeaderView(
-        iconView: RoundedIconView?,
+        iconView: UIView?,
         title: String?,
         isSheet: Bool = false
     ) -> UIView {
@@ -117,13 +117,24 @@ extension PaneLayoutView {
 
     struct ButtonConfiguration {
         let title: String
+        let accessibilityIdentifier: String?
         let action: () -> Void
+
+        init(
+            title: String,
+            accessibilityIdentifier: String? = nil,
+            action: @escaping () -> Void
+        ) {
+            self.title = title
+            self.accessibilityIdentifier = accessibilityIdentifier
+            self.action = action
+        }
     }
 
     @available(iOSApplicationExtension, unavailable)
     static func createFooterView(
         primaryButtonConfiguration: PaneLayoutView.ButtonConfiguration?,
-        secondaryButtonConfiguration: PaneLayoutView.ButtonConfiguration?,
+        secondaryButtonConfiguration: PaneLayoutView.ButtonConfiguration? = nil,
         topText: String? = nil,
         didSelectURL: ((URL) -> Void)? = nil
     ) -> UIView? {
@@ -158,6 +169,7 @@ extension PaneLayoutView {
         if let primaryButtonConfiguration = primaryButtonConfiguration {
             let primaryButton = Button(configuration: FinancialConnectionsPrimaryButtonConfiguration())
             primaryButton.title = primaryButtonConfiguration.title
+            primaryButton.accessibilityIdentifier = primaryButtonConfiguration.accessibilityIdentifier
             primaryButton.addTarget(
                 footerStackView,
                 action: #selector(FooterStackView.didSelectPrimaryButton),
@@ -173,6 +185,7 @@ extension PaneLayoutView {
         if let secondaryButtonConfiguration = secondaryButtonConfiguration {
             let secondaryButton = Button(configuration: FinancialConnectionsSecondaryButtonConfiguration())
             secondaryButton.title = secondaryButtonConfiguration.title
+            secondaryButton.accessibilityIdentifier = secondaryButtonConfiguration.accessibilityIdentifier
             secondaryButton.addTarget(
                 footerStackView,
                 action: #selector(FooterStackView.didSelectSecondaryButton),


### PR DESCRIPTION
## Summary

This PR:
- This PR modifies the prepane to a different/new design

Details to understand before reviewing PR:
- This is one PR, out of expected ~50+, to change the design of Financial Connections from a "V2" design to a "V3" design. [Here is a link to the designs](https://www.figma.com/file/wXQ8NJApqSJiLmxxANDRTs/%E2%9C%A8-Connections-3.0?type=design&node-id=2524-217093&mode=design&t=kXaBiAlgVsC7YcH1-0).
- The code here is not the finished version. It's just an iteration towards the final version. This code will be re-visited later. The goal is to go screen-by-screen and make easy changes to learn about all the difficulties in each screen. Later, all the learnings will be combined to do a "final" polish of all screens.
- The above also applies to design. The design here is not the finished version.
- This PR is merged into a feature branch `fc-v3`. It is not merged into `master`.
- There might be TODO's scattered throughout the code. That's expected and they will be fixed later. 

## Testing

![Simulator Screenshot - iPhone 15 Pro - 2024-01-05 at 11 26 11](https://github.com/stripe/stripe-ios/assets/105514761/6c067e1a-b614-4d38-b89c-0f7a030b17af)
