### PR TITLE
visionOS design tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## X.X.X
+### PaymentSheet
+* [Fixed] Fixed a few design issues on visionOS.
+
 ## 23.20.0 2023-12-18
 ### PaymentSheet
 * [Added] Support for [card brand choice](https://stripe.com/docs/card-brand-choice). To set default preferred networks, use the new configuration option `PaymentSheet.Configuration.preferredNetworks`.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetAppearance.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetAppearance.swift
@@ -74,10 +74,18 @@ public extension PaymentSheet {
             public init() {}
 
             /// The primary color used throughout PaymentSheet
+            #if canImport(CompositorServices)
+            public var primary: UIColor = .label
+            #else
             public var primary: UIColor = .systemBlue
+            #endif
 
             /// The color used for the background of PaymentSheet
+            #if canImport(CompositorServices)
+            public var background: UIColor = .clear
+            #else
             public var background: UIColor = .systemBackground
+            #endif
 
             /// The color used for the background of inputs, tabs, and other components
             public var componentBackground: UIColor = UIColor.dynamic(light: .systemBackground,
@@ -161,7 +169,11 @@ public extension PaymentSheet {
 
             /// The background color of the primary button
             /// - Note: If `nil`, `appearance.colors.primary` will be used as the primary button background color
+            #if canImport(CompositorServices)
+            public var backgroundColor: UIColor? = .systemBlue
+            #else
             public var backgroundColor: UIColor?
+            #endif
 
             /// The text color of the primary button
             /// - Note: If `nil`, defaults to either white or black depending on the color of the button

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/PaymentSheetUIKitAdditions.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/PaymentSheetUIKitAdditions.swift
@@ -15,6 +15,13 @@ import UIKit
 enum PaymentSheetUI {
     /// The padding between views in the sheet e.g., between the bottom of the form and the Pay button
     static let defaultPadding: CGFloat = 20
+
+#if canImport(CompositorServices)
+    static let navBarPadding: CGFloat = 30
+#else
+    static let navBarPadding = defaultPadding
+#endif
+    
     static let defaultMargins: NSDirectionalEdgeInsets = .insets(
         leading: defaultPadding, trailing: defaultPadding)
     static let defaultSheetMargins: NSDirectionalEdgeInsets = .insets(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/PaymentSheetUIKitAdditions.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/PaymentSheetUIKitAdditions.swift
@@ -21,7 +21,7 @@ enum PaymentSheetUI {
 #else
     static let navBarPadding = defaultPadding
 #endif
-    
+
     static let defaultMargins: NSDirectionalEdgeInsets = .insets(
         leading: defaultPadding, trailing: defaultPadding)
     static let defaultSheetMargins: NSDirectionalEdgeInsets = .insets(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/SheetNavigationBar.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/SheetNavigationBar.swift
@@ -79,7 +79,9 @@ class SheetNavigationBar: UIView {
         testModeView.isHidden = !isTestMode
         self.appearance = appearance
         super.init(frame: .zero)
+        #if !canImport(CompositorServices)
         backgroundColor = appearance.colors.background.withAlphaComponent(0.9)
+        #endif
         [leftItemsStackView, closeButtonRight, additionalButton].forEach {
             $0.translatesAutoresizingMaskIntoConstraints = false
             addSubview($0)
@@ -87,17 +89,17 @@ class SheetNavigationBar: UIView {
 
         NSLayoutConstraint.activate([
             leftItemsStackView.leadingAnchor.constraint(
-                equalTo: leadingAnchor, constant: PaymentSheetUI.defaultPadding),
+                equalTo: leadingAnchor, constant: PaymentSheetUI.navBarPadding),
             leftItemsStackView.centerYAnchor.constraint(equalTo: centerYAnchor),
             leftItemsStackView.trailingAnchor.constraint(lessThanOrEqualTo: closeButtonRight.leadingAnchor),
             leftItemsStackView.trailingAnchor.constraint(lessThanOrEqualTo: additionalButton.leadingAnchor),
 
             additionalButton.trailingAnchor.constraint(
-                equalTo: trailingAnchor, constant: -PaymentSheetUI.defaultPadding),
+                equalTo: trailingAnchor, constant: -PaymentSheetUI.navBarPadding),
             additionalButton.centerYAnchor.constraint(equalTo: centerYAnchor),
 
             closeButtonRight.trailingAnchor.constraint(
-                equalTo: trailingAnchor, constant: -PaymentSheetUI.defaultPadding),
+                equalTo: trailingAnchor, constant: -PaymentSheetUI.navBarPadding),
             closeButtonRight.centerYAnchor.constraint(equalTo: centerYAnchor),
         ])
 

--- a/StripeUICore/StripeUICore/Source/Elements/DropdownFieldElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/DropdownFieldElement.swift
@@ -78,7 +78,7 @@ import UIKit
 
     /// A label displayed in the dropdown field UI e.g. "Country or region" for a country dropdown
     public let label: String?
-#if targetEnvironment(macCatalyst)
+#if targetEnvironment(macCatalyst) || canImport(CompositorServices)
     private(set) lazy var pickerView: UIButton = {
         let button = UIButton()
         let action = { (action: UIAction) -> Void in
@@ -197,7 +197,7 @@ import UIKit
 private extension DropdownFieldElement {
 
     func updatePickerField() {
-        #if targetEnvironment(macCatalyst)
+        #if targetEnvironment(macCatalyst) || canImport(CompositorServices)
         if #available(macCatalyst 14.0, *) {
             // Mark the enabled menu item as selected
             pickerView.menu?.children.forEach { ($0 as? UIAction)?.state = .off }

--- a/StripeUICore/StripeUICore/Source/Elements/Factories/DropdownFieldElement+AddressFactory.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Factories/DropdownFieldElement+AddressFactory.swift
@@ -27,7 +27,7 @@ import Foundation
             let dropdownItems: [DropdownItem] = countryCodes.map {
                 let flagEmoji = String.countryFlagEmoji(for: $0) ?? ""              // 🇺🇸
                 let countryName = locale.localizedString(forRegionCode: $0) ?? $0   // United States
-                #if targetEnvironment(macCatalyst)
+                #if targetEnvironment(macCatalyst) || canImport(CompositorServices)
                 // When using UIMenu with a keyboard, type-ahead search is based on the string name.
                 // This doesn't work if we prepend an emoji, so leave that out on macOS.
                 let pickerDisplayName = countryName

--- a/StripeUICore/StripeUICore/Source/Elements/PickerField/PickerFieldView.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/PickerField/PickerFieldView.swift
@@ -28,8 +28,8 @@ final class PickerFieldView: UIView {
     private lazy var toolbar = DoneButtonToolbar(delegate: self, showCancelButton: true, theme: theme)
     private lazy var textField: PickerTextField = {
         let textField = PickerTextField()
-        // Input views are not supported on Catalyst
-#if !targetEnvironment(macCatalyst)
+        // Input views are not supported on Catalyst (and are non-optimal on visionOS)
+#if !targetEnvironment(macCatalyst) && !canImport(CompositorServices)
         textField.inputView = pickerView
 #endif
         textField.adjustsFontForContentSizeCategory = true
@@ -138,8 +138,8 @@ final class PickerFieldView: UIView {
         self.isOptional = isOptional
         super.init(frame: .zero)
         addAndPinSubview(hStackView, directionalLayoutMargins: hasPadding ? ElementsUI.contentViewInsets : .zero)
-//      On Catalyst, add the picker view as a subview instead of an input view.
-        #if targetEnvironment(macCatalyst)
+//      On Catalyst/visionOS, add the picker view as a subview instead of an input view.
+        #if targetEnvironment(macCatalyst) || canImport(CompositorServices)
         addAndPinSubview(pickerView, directionalLayoutMargins: ElementsUI.contentViewInsets)
         #endif
         layer.borderColor = theme.colors.border.cgColor
@@ -179,7 +179,7 @@ final class PickerFieldView: UIView {
         guard isUserInteractionEnabled, !isHidden, self.point(inside: point, with: event) else {
             return nil
         }
-        #if targetEnvironment(macCatalyst)
+        #if targetEnvironment(macCatalyst) || canImport(CompositorServices)
         // Forward all events within our bounds to the button
         return pickerView
         #else


### PR DESCRIPTION
## Summary
* Tweak default theme colors to work better against the visionOS glass material.
* Remove the background at the top of PaymentSheet, tweak the metrics of the top bar a bit.
* Use UIMenus on visionOS (as we do on Catalyst), as input views don't work well on visionOS.

Before:
![CleanShot 2024-01-08 at 13 43 30@2x](https://github.com/stripe/stripe-ios/assets/52758633/644fa22f-fbc2-4157-924b-066829cfe9ff)
![CleanShot 2024-01-08 at 13 44 24@2x](https://github.com/stripe/stripe-ios/assets/52758633/3152399c-839c-4f70-bc9a-a330ce89d1a9)

After:
![CleanShot 2024-01-08 at 13 39 42@2x](https://github.com/stripe/stripe-ios/assets/52758633/f3cc36cc-4751-4d0a-8707-af1f530e0012)
![CleanShot 2024-01-08 at 13 45 49@2x](https://github.com/stripe/stripe-ios/assets/52758633/c2269a47-50cb-4fc9-9c63-608401d9e168)

## Motivation
Preparing for visionOS launch.

## Testing
visionOS simulator

## Changelog
Adding