### PR TITLE
Expose billing details & PMT for FlowController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## X.X.X
+## x.x.x x-x-x
 ### PaymentSheet
 * [Fixed] Fixed a few design issues on visionOS.
+* [Added] Exposed BillingDetails and type on selected PaymentOption when dismissing FlowController's payment option selector
 
 ## 23.20.0 2023-12-18
 ### PaymentSheet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## x.x.x x-x-x
 ### PaymentSheet
 * [Fixed] Fixed a few design issues on visionOS.
-* [Added] Exposed BillingDetails and type on selected PaymentOption when dismissing FlowController's payment option selector
+* [Added] Added billing details and type properties to [`PaymentSheet.FlowController.PaymentOptionDisplayData`](https://stripe.dev/stripe-ios/stripepaymentsheet/documentation/stripepaymentsheet/paymentsheet/flowcontroller/paymentoptiondisplaydata). 
 
 ## 23.20.0 2023-12-18
 ### PaymentSheet

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -325,21 +325,96 @@ struct PaymentOptionView: View {
     let paymentOptionDisplayData: PaymentSheet.FlowController.PaymentOptionDisplayData?
 
     var body: some View {
-        HStack {
-            Image(uiImage: paymentOptionDisplayData?.image ?? UIImage(systemName: "creditcard")!)
-                .resizable()
-                .scaledToFit()
-                .frame(maxWidth: 30, maxHeight: 30, alignment: .leading)
-                .foregroundColor(.black)
-            Text(paymentOptionDisplayData?.label ?? "None")
+        VStack {
+            HStack {
+                Image(uiImage: paymentOptionDisplayData?.image ?? UIImage(systemName: "creditcard")!)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(maxWidth: 30, maxHeight: 30, alignment: .leading)
+                    .foregroundColor(.black)
+                Text(paymentOptionDisplayData?.label ?? "None")
                 // Surprisingly, setting the accessibility identifier on the HStack causes the identifier to be
                 // "Payment method-Payment method". We'll set it on a single View instead.
-                .accessibility(identifier: "Payment method")
-                .foregroundColor(.primary)
+                    .accessibility(identifier: "Payment method")
+                    .foregroundColor(.primary)
+            }
+            .padding()
+            .foregroundColor(.black)
+            .cornerRadius(6)
+            if let paymentMethodType = paymentOptionDisplayData?.paymentMethodType {
+                Text(paymentMethodType)
+                    .accessibility(identifier: "Payment Method Type")
+                    .font(.caption)
+                    .foregroundColor(.primary)
+
+            }
+            if let billingDetails = paymentOptionDisplayData?.billingDetails {
+                BillingDetailsView(billingDetails: billingDetails)
+            }
         }
-        .padding()
-        .foregroundColor(.black)
-        .cornerRadius(6)
+    }
+}
+
+struct BillingDetailsView: View {
+    let billingDetails: PaymentSheet.BillingDetails
+
+    var body: some View {
+        VStack {
+            if let name = billingDetails.name {
+                Text(name)
+                    .accessibility(identifier: "Name")
+                    .font(.caption)
+                    .foregroundColor(.primary)
+            }
+            if let email = billingDetails.email {
+                Text(email)
+                    .accessibility(identifier: "Email")
+                    .font(.caption)
+                    .foregroundColor(.primary)
+            }
+            if let phone = billingDetails.phone {
+                Text(phone)
+                    .accessibility(identifier: "Phone")
+                    .font(.caption)
+                    .foregroundColor(.primary)
+            }
+            if let line1 = billingDetails.address.line1 {
+                Text(line1)
+                    .accessibility(identifier: "Line1")
+                    .font(.caption)
+                    .foregroundColor(.primary)
+            }
+            if let line2 = billingDetails.address.line2 {
+                Text(line2)
+                    .accessibility(identifier: "Line2")
+                    .font(.caption)
+                    .foregroundColor(.primary)
+            }
+            if let city = billingDetails.address.city {
+                Text(city)
+                    .accessibility(identifier: "City")
+                    .font(.caption)
+                    .foregroundColor(.primary)
+            }
+            if let state = billingDetails.address.state {
+                Text(state)
+                    .accessibility(identifier: "State")
+                    .font(.caption)
+                    .foregroundColor(.primary)
+            }
+            if let postalCode = billingDetails.address.postalCode {
+                Text(postalCode)
+                    .accessibility(identifier: "postalCode")
+                    .font(.caption)
+                    .foregroundColor(.primary)
+            }
+            if let country = billingDetails.address.country {
+                Text(country)
+                    .accessibility(identifier: "country")
+                    .font(.caption)
+                    .foregroundColor(.primary)
+            }
+        }
     }
 }
 

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -271,13 +271,21 @@ struct PaymentSheetButtons: View {
                     }.padding(.horizontal)
                     HStack {
                         if let psfc = playgroundController.paymentSheetFlowController {
-                            Button {
-                                psFCOptionsIsPresented = true
-                            } label: {
-                                PaymentOptionView(paymentOptionDisplayData: playgroundController.paymentSheetFlowController?.paymentOption)
+                            VStack {
+                                Button {
+                                    psFCOptionsIsPresented = true
+                                } label: {
+                                    PaymentOptionView(paymentOptionDisplayData: playgroundController.paymentSheetFlowController?.paymentOption)
+                                }
+                                .disabled(playgroundController.paymentSheetFlowController == nil)
+                                Button {
+                                    psFCOptionsIsPresented = true
+                                } label: {
+                                    PaymentOptionInfoView(paymentOptionDisplayData: playgroundController.paymentSheetFlowController?.paymentOption)
+                                }
+                                .disabled(playgroundController.paymentSheetFlowController == nil)
+                                .padding()
                             }
-                            .disabled(playgroundController.paymentSheetFlowController == nil)
-                            .padding()
                             Button {
                                 playgroundController.didTapShippingAddressButton()
                             } label: {
@@ -320,27 +328,29 @@ struct StaleView: View {
             .cornerRadius(8.0)
     }
 }
-
 struct PaymentOptionView: View {
+    let paymentOptionDisplayData: PaymentSheet.FlowController.PaymentOptionDisplayData?
+    var body: some View {
+        HStack {
+            Image(uiImage: paymentOptionDisplayData?.image ?? UIImage(systemName: "creditcard")!)
+                .resizable()
+                .scaledToFit()
+                .frame(maxWidth: 30, maxHeight: 30, alignment: .leading)
+                .foregroundColor(.black)
+            Text(paymentOptionDisplayData?.label ?? "None")
+            // Surprisingly, setting the accessibility identifier on the HStack causes the identifier to be
+            // "Payment method-Payment method". We'll set it on a single View instead.
+                .accessibility(identifier: "Payment method")
+                .foregroundColor(.primary)
+            }
+        }
+}
+
+struct PaymentOptionInfoView: View {
     let paymentOptionDisplayData: PaymentSheet.FlowController.PaymentOptionDisplayData?
 
     var body: some View {
         VStack {
-            HStack {
-                Image(uiImage: paymentOptionDisplayData?.image ?? UIImage(systemName: "creditcard")!)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(maxWidth: 30, maxHeight: 30, alignment: .leading)
-                    .foregroundColor(.black)
-                Text(paymentOptionDisplayData?.label ?? "None")
-                // Surprisingly, setting the accessibility identifier on the HStack causes the identifier to be
-                // "Payment method-Payment method". We'll set it on a single View instead.
-                    .accessibility(identifier: "Payment method")
-                    .foregroundColor(.primary)
-            }
-            .padding()
-            .foregroundColor(.black)
-            .cornerRadius(6)
             if let paymentMethodType = paymentOptionDisplayData?.paymentMethodType {
                 Text(paymentMethodType)
                     .font(.caption)

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -364,7 +364,7 @@ struct BillingDetailsView: View {
             if let email = billingDetails.email {
                 Text(email)
             }
-            if let phone = billingDetails.phone {
+            if let phone = billingDetails.phoneNumberForDisplay {
                 Text(phone)
             }
             if let line1 = billingDetails.address.line1 {

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -330,6 +330,7 @@ struct StaleView: View {
 }
 struct PaymentOptionView: View {
     let paymentOptionDisplayData: PaymentSheet.FlowController.PaymentOptionDisplayData?
+
     var body: some View {
         HStack {
             Image(uiImage: paymentOptionDisplayData?.image ?? UIImage(systemName: "creditcard")!)
@@ -338,8 +339,8 @@ struct PaymentOptionView: View {
                 .frame(maxWidth: 30, maxHeight: 30, alignment: .leading)
                 .foregroundColor(.black)
             Text(paymentOptionDisplayData?.label ?? "None")
-            // Surprisingly, setting the accessibility identifier on the HStack causes the identifier to be
-            // "Payment method-Payment method". We'll set it on a single View instead.
+                // Surprisingly, setting the accessibility identifier on the HStack causes the identifier to be
+                // "Payment method-Payment method". We'll set it on a single View instead.
                 .accessibility(identifier: "Payment method")
                 .foregroundColor(.primary)
             }
@@ -355,10 +356,12 @@ struct PaymentOptionInfoView: View {
                 Text(paymentMethodType)
                     .font(.caption)
                     .foregroundColor(.primary)
-
             }
             if let billingDetails = paymentOptionDisplayData?.billingDetails {
                 BillingDetailsView(billingDetails: billingDetails)
+                    .font(.caption)
+                    .foregroundColor(.primary)
+
             }
         }
     }
@@ -372,56 +375,38 @@ struct BillingDetailsView: View {
             if let name = billingDetails.name {
                 Text(name)
                     .accessibility(identifier: "Name")
-                    .font(.caption)
-                    .foregroundColor(.primary)
             }
             if let email = billingDetails.email {
                 Text(email)
                     .accessibility(identifier: "Email")
-                    .font(.caption)
-                    .foregroundColor(.primary)
             }
             if let phone = billingDetails.phone {
                 Text(phone)
                     .accessibility(identifier: "Phone")
-                    .font(.caption)
-                    .foregroundColor(.primary)
             }
             if let line1 = billingDetails.address.line1 {
                 Text(line1)
                     .accessibility(identifier: "Line1")
-                    .font(.caption)
-                    .foregroundColor(.primary)
             }
             if let line2 = billingDetails.address.line2 {
                 Text(line2)
                     .accessibility(identifier: "Line2")
-                    .font(.caption)
-                    .foregroundColor(.primary)
             }
             if let city = billingDetails.address.city {
                 Text(city)
                     .accessibility(identifier: "City")
-                    .font(.caption)
-                    .foregroundColor(.primary)
             }
             if let state = billingDetails.address.state {
                 Text(state)
                     .accessibility(identifier: "State")
-                    .font(.caption)
-                    .foregroundColor(.primary)
             }
             if let postalCode = billingDetails.address.postalCode {
                 Text(postalCode)
-                    .accessibility(identifier: "postalCode")
-                    .font(.caption)
-                    .foregroundColor(.primary)
+                    .accessibility(identifier: "PostalCode")
             }
             if let country = billingDetails.address.country {
                 Text(country)
-                    .accessibility(identifier: "country")
-                    .font(.caption)
-                    .foregroundColor(.primary)
+                    .accessibility(identifier: "Country")
             }
         }
     }

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -271,21 +271,13 @@ struct PaymentSheetButtons: View {
                     }.padding(.horizontal)
                     HStack {
                         if let psfc = playgroundController.paymentSheetFlowController {
-                            VStack {
-                                Button {
-                                    psFCOptionsIsPresented = true
-                                } label: {
-                                    PaymentOptionView(paymentOptionDisplayData: playgroundController.paymentSheetFlowController?.paymentOption)
-                                }
-                                .disabled(playgroundController.paymentSheetFlowController == nil)
-                                Button {
-                                    psFCOptionsIsPresented = true
-                                } label: {
-                                    PaymentOptionInfoView(paymentOptionDisplayData: playgroundController.paymentSheetFlowController?.paymentOption)
-                                }
-                                .disabled(playgroundController.paymentSheetFlowController == nil)
-                                .padding()
+                            Button {
+                                psFCOptionsIsPresented = true
+                            } label: {
+                                PaymentOptionView(paymentOptionDisplayData: playgroundController.paymentSheetFlowController?.paymentOption)
                             }
+                            .disabled(playgroundController.paymentSheetFlowController == nil)
+                            .padding()
                             Button {
                                 playgroundController.didTapShippingAddressButton()
                             } label: {
@@ -333,26 +325,19 @@ struct PaymentOptionView: View {
     let paymentOptionDisplayData: PaymentSheet.FlowController.PaymentOptionDisplayData?
 
     var body: some View {
-        HStack {
-            Image(uiImage: paymentOptionDisplayData?.image ?? UIImage(systemName: "creditcard")!)
-                .resizable()
-                .scaledToFit()
-                .frame(maxWidth: 30, maxHeight: 30, alignment: .leading)
-                .foregroundColor(.black)
-            Text(paymentOptionDisplayData?.label ?? "None")
+        VStack {
+            HStack {
+                Image(uiImage: paymentOptionDisplayData?.image ?? UIImage(systemName: "creditcard")!)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(maxWidth: 30, maxHeight: 30, alignment: .leading)
+                    .foregroundColor(.black)
+                Text(paymentOptionDisplayData?.label ?? "None")
                 // Surprisingly, setting the accessibility identifier on the HStack causes the identifier to be
                 // "Payment method-Payment method". We'll set it on a single View instead.
-                .accessibility(identifier: "Payment method")
-                .foregroundColor(.primary)
+                    .accessibility(identifier: "Payment method")
+                    .foregroundColor(.primary)
             }
-        }
-}
-
-struct PaymentOptionInfoView: View {
-    let paymentOptionDisplayData: PaymentSheet.FlowController.PaymentOptionDisplayData?
-
-    var body: some View {
-        VStack {
             if let paymentMethodType = paymentOptionDisplayData?.paymentMethodType {
                 Text(paymentMethodType)
                     .font(.caption)
@@ -375,39 +360,30 @@ struct BillingDetailsView: View {
         VStack {
             if let name = billingDetails.name {
                 Text(name)
-                    .accessibility(identifier: "Name")
             }
             if let email = billingDetails.email {
                 Text(email)
-                    .accessibility(identifier: "Email")
             }
             if let phone = billingDetails.phone {
                 Text(phone)
-                    .accessibility(identifier: "Phone")
             }
             if let line1 = billingDetails.address.line1 {
                 Text(line1)
-                    .accessibility(identifier: "Line1")
             }
             if let line2 = billingDetails.address.line2 {
                 Text(line2)
-                    .accessibility(identifier: "Line2")
             }
             if let city = billingDetails.address.city {
                 Text(city)
-                    .accessibility(identifier: "City")
             }
             if let state = billingDetails.address.state {
                 Text(state)
-                    .accessibility(identifier: "State")
             }
             if let postalCode = billingDetails.address.postalCode {
                 Text(postalCode)
-                    .accessibility(identifier: "PostalCode")
             }
             if let country = billingDetails.address.country {
                 Text(country)
-                    .accessibility(identifier: "Country")
             }
         }
     }

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -328,6 +328,7 @@ struct StaleView: View {
             .cornerRadius(8.0)
     }
 }
+
 struct PaymentOptionView: View {
     let paymentOptionDisplayData: PaymentSheet.FlowController.PaymentOptionDisplayData?
 

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -343,7 +343,6 @@ struct PaymentOptionView: View {
             .cornerRadius(6)
             if let paymentMethodType = paymentOptionDisplayData?.paymentMethodType {
                 Text(paymentMethodType)
-                    .accessibility(identifier: "Payment Method Type")
                     .font(.caption)
                     .foregroundColor(.primary)
 

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetBillingCollectionUITests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetBillingCollectionUITests.swift
@@ -35,6 +35,12 @@ class PaymentSheetBillingCollectionUITestCase: XCTestCase {
     var checkoutButton: XCUIElement { app.buttons["Present PaymentSheet"] }
     var payButton: XCUIElement { app.buttons["Pay $50.99"] }
     var successText: XCUIElement { app.staticTexts["Success!"] }
+
+    // FlowController specific buttons
+    var paymentMethodSelectorNoneButton: XCUIElement { app.buttons["None"] }
+    var confirmButton: XCUIElement { app.buttons["Confirm"] }
+    var continueButton: XCUIElement { app.buttons["Continue"] }
+
 }
 
 class PaymentSheetBillingCollectionUICardTests: PaymentSheetBillingCollectionUITestCase {
@@ -113,6 +119,68 @@ class PaymentSheetBillingCollectionUICardTests: PaymentSheetBillingCollectionUIT
 
         // Complete payment
         payButton.tap()
+        XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
+    }
+
+    func testCard_AllFields_flowController_WithDefaults() throws {
+
+        var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
+        settings.customerMode = .guest
+        settings.uiStyle = .flowController
+        settings.currency = .usd
+        settings.merchantCountryCode = .US
+        settings.applePayEnabled = .off
+        settings.apmsEnabled = .off
+        settings.linkEnabled = .off
+        settings.defaultBillingAddress = .on
+        settings.attachDefaults = .on
+        settings.collectName = .always
+        settings.collectEmail = .always
+        settings.collectPhone = .always
+        settings.collectAddress = .full
+        loadPlayground(
+            app,
+            settings
+        )
+        paymentMethodSelectorNoneButton.tap()
+
+        let card = try XCTUnwrap(scroll(collectionView: app.collectionViews.firstMatch, toFindCellWithId: "card"))
+        card.tap()
+
+        XCTAssertTrue(cardInfoField.waitForExistence(timeout: 10.0))
+        XCTAssertTrue(contactInfoField.exists)
+        XCTAssertEqual(emailField.value as? String, "foo@bar.com")
+        XCTAssertEqual(phoneField.value as? String, "(310) 555-1234")
+        XCTAssertEqual(nameOnCardField.value as? String, "Jane Doe")
+        XCTAssertTrue(billingAddressField.exists)
+        XCTAssertEqual(countryField.value as? String, "United States")
+        XCTAssertEqual(line1Field.value as? String, "510 Townsend St.")
+        XCTAssertEqual(line2Field.value as? String, "")
+        XCTAssertEqual(cityField.value as? String, "San Francisco")
+        XCTAssertEqual(stateField.value as? String, "California")
+        XCTAssertEqual(zipField.value as? String, "94102")
+
+        let numberField = app.textFields["Card number"]
+        numberField.forceTapWhenHittableInTestCase(self)
+        app.typeText("4242424242424242")
+        app.typeText("1228") // Expiry
+        app.typeText("123") // CVC
+        app.toolbars.buttons["Done"].tap() // Dismiss keyboard.
+
+        // Dismiss FlowController payment method selector
+        continueButton.tap()
+
+        XCTAssertTrue(app.staticTexts["card"].waitForExistence(timeout: 10.0))
+        XCTAssertTrue(app.staticTexts["Jane Doe"].waitForExistence(timeout: 10.0))
+        XCTAssertTrue(app.staticTexts["foo@bar.com"].waitForExistence(timeout: 10.0))
+        XCTAssertTrue(app.staticTexts["+13105551234"].waitForExistence(timeout: 10.0))
+        XCTAssertTrue(app.staticTexts["510 Townsend St."].waitForExistence(timeout: 10.0))
+        XCTAssertTrue(app.staticTexts["San Francisco"].waitForExistence(timeout: 10.0))
+        XCTAssertTrue(app.staticTexts["CA"].waitForExistence(timeout: 10.0))
+        XCTAssertTrue(app.staticTexts["94102"].waitForExistence(timeout: 10.0))
+        XCTAssertTrue(app.staticTexts["US"].waitForExistence(timeout: 10.0))
+
+        confirmButton.tap()
         XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
     }
 

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetBillingCollectionUITests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetBillingCollectionUITests.swift
@@ -173,7 +173,7 @@ class PaymentSheetBillingCollectionUICardTests: PaymentSheetBillingCollectionUIT
         XCTAssertTrue(app.staticTexts["card"].waitForExistence(timeout: 10.0))
         XCTAssertTrue(app.staticTexts["Jane Doe"].waitForExistence(timeout: 10.0))
         XCTAssertTrue(app.staticTexts["foo@bar.com"].waitForExistence(timeout: 10.0))
-        XCTAssertTrue(app.staticTexts["+13105551234"].waitForExistence(timeout: 10.0))
+        XCTAssertTrue(app.staticTexts["+1 (310) 555-1234"].waitForExistence(timeout: 10.0))
         XCTAssertTrue(app.staticTexts["510 Townsend St."].waitForExistence(timeout: 10.0))
         XCTAssertTrue(app.staticTexts["San Francisco"].waitForExistence(timeout: 10.0))
         XCTAssertTrue(app.staticTexts["CA"].waitForExistence(timeout: 10.0))

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -179,7 +179,7 @@ class PaymentSheetStandardUITests: PaymentSheetUITestCase {
             settings
         )
 
-        app.buttons["Apple Pay"].waitForExistenceAndTap(timeout: 30) // Should default to Apple Pay
+        app.buttons["Apple Pay, apple_pay"].waitForExistenceAndTap(timeout: 30) // Should default to Apple Pay
         app.buttons["+ Add"].waitForExistenceAndTap()
 
         try! fillCardData(app)
@@ -210,7 +210,7 @@ class PaymentSheetStandardUITests: PaymentSheetUITestCase {
 
         // Reload w/ same customer
         reload(app, settings: settings)
-        app.buttons["Apple Pay"].waitForExistenceAndTap(timeout: 30) // Should default to Apple Pay
+        app.buttons["Apple Pay, apple_pay"].waitForExistenceAndTap(timeout: 30) // Should default to Apple Pay
         XCTAssertEqual(app.cells.count, 3) // Should be "Add" and "Apple Pay" and "Link"
         app.buttons["+ Add"].waitForExistenceAndTap()
 
@@ -1331,7 +1331,8 @@ class PaymentSheetStandardLPMUITests: PaymentSheetUITestCase {
         // Reload w/ same customer
         reload(app, settings: settings)
         // This time, expect SEPA to be pre-selected as the default
-        XCTAssertEqual(paymentMethodButton.label, "••••3201")
+        XCTAssert(paymentMethodButton.label.hasPrefix("••••3201, sepa_debit"))
+
         // Tapping confirm without presenting flowcontroller should show the mandate
         app.buttons["Confirm"].tap()
         XCTAssertTrue(app.otherElements.matching(identifier: "mandatetextview").element.waitForExistence(timeout: 1))
@@ -1346,7 +1347,9 @@ class PaymentSheetStandardLPMUITests: PaymentSheetUITestCase {
         // Reload w/ same customer
         reload(app, settings: settings)
         // If you present the flowcontroller and see the mandate...
-        app.buttons["••••3201"].waitForExistenceAndTap()
+        XCTAssert(paymentMethodButton.label.hasPrefix("••••3201, sepa_debit"))
+        paymentMethodButton.waitForExistenceAndTap()
+
         XCTAssertTrue(app.otherElements.matching(identifier: "mandatetextview").element.exists)
         // ...you shouldn't see the mandate again when you confirm
         app.buttons["Continue"].tap()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PaymentSheet-LinkConfirmOption.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PaymentSheet-LinkConfirmOption.swift
@@ -76,4 +76,19 @@ extension PaymentSheet.LinkConfirmOption {
         }
     }
 
+    var billingDetails: STPPaymentMethodBillingDetails? {
+        switch self {
+        case .wallet:
+            return nil
+        case .signUp(_, _, _, let paymentMethodParams):
+            return paymentMethodParams.billingDetails
+        case .withPaymentDetails:
+            return nil
+        case .withPaymentMethodParams(_, let paymentMethodParams):
+            return paymentMethodParams.billingDetails
+        case .withPaymentMethod(let paymentMethod):
+            return paymentMethod.billingDetails
+        }
+    }
+
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
@@ -344,7 +344,7 @@ extension PaymentSheet {
         public var name: String?
 
         /// The customer's phone number in e164 formatting (e.g. +15551234567)
-        /// - Note: Not passing in a '+' will assume a US based phone number
+        /// - Note: When used with defaultBillingDetails, omitting '+' will assume a US based phone number.
         public var phone: String?
 
         /// The customer's phone number used for displaying in your UI (e.g. +1 (555) 555-5555)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
@@ -347,7 +347,7 @@ extension PaymentSheet {
         /// - Note: When used with defaultBillingDetails, omitting '+' will assume a US based phone number.
         public var phone: String?
 
-        /// The customer's phone number used for displaying in your UI (e.g. +1 (555) 555-5555)
+        /// The customer's phone number formatted for display in your UI (e.g. "+1 (555) 555-5555")
         public var phoneNumberForDisplay: String? {
             guard let phone = self.phone else {
                 return nil

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
@@ -9,6 +9,7 @@
 import Foundation
 import PassKit
 @_spi(STP) import StripeCore
+@_spi(STP) import StripeUICore
 @_spi(STP) import StripePaymentsUI
 import UIKit
 
@@ -342,8 +343,17 @@ extension PaymentSheet {
         /// - Note: When used with defaultBillingDetails, the value set is displayed in the payment sheet as-is. Depending on the payment method, the customer may be required to edit this value.
         public var name: String?
 
-        /// The customer's phone number without formatting (e.g. +15551234567)
+        /// The customer's phone number in e164 formatting (e.g. +15551234567)
+        /// - Note: Not passing in a '+' will assume a US based phone number
         public var phone: String?
+
+        /// The customer's phone number used for displaying in your UI (e.g. +1 (555) 555-5555)
+        public var phoneNumberForDisplay: String? {
+            guard let phone = self.phone else {
+                return nil
+            }
+            return PhoneNumber.fromE164(phone)?.string(as: .international)
+        }
 
         /// Initializes billing details
         public init(address: PaymentSheet.Address = Address(), email: String? = nil, name: String? = nil, phone: String? = nil) {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
@@ -342,7 +342,7 @@ extension PaymentSheet {
         /// - Note: When used with defaultBillingDetails, the value set is displayed in the payment sheet as-is. Depending on the payment method, the customer may be required to edit this value.
         public var name: String?
 
-        /// The customer's phone number without formatting (e.g. 5551234567)
+        /// The customer's phone number without formatting (e.g. +15551234567)
         public var phone: String?
 
         /// Initializes billing details

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
@@ -9,8 +9,8 @@
 import Foundation
 import PassKit
 @_spi(STP) import StripeCore
-@_spi(STP) import StripeUICore
 @_spi(STP) import StripePaymentsUI
+@_spi(STP) import StripeUICore
 import UIKit
 
 // MARK: - Configuration

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
@@ -335,11 +335,11 @@ extension PaymentSheet {
         public var address: Address = Address()
 
         /// The customer's email
-        /// - Note: The value set is displayed in the payment sheet as-is. Depending on the payment method, the customer may be required to edit this value.
+        /// - Note: When used with defaultBillingDetails, the value set is displayed in the payment sheet as-is. Depending on the payment method, the customer may be required to edit this value.
         public var email: String?
 
         /// The customer's full name
-        /// - Note: The value set is displayed in the payment sheet as-is. Depending on the payment method, the customer may be required to edit this value.
+        /// - Note: When used with defaultBillingDetails, the value set is displayed in the payment sheet as-is. Depending on the payment method, the customer may be required to edit this value.
         public var name: String?
 
         /// The customer's phone number without formatting (e.g. 5551234567)
@@ -442,5 +442,20 @@ extension PaymentSheet.Configuration {
         || billingDetailsCollectionConfiguration.phone == .always
         || billingDetailsCollectionConfiguration.email == .always
         || billingDetailsCollectionConfiguration.address == .full
+    }
+}
+
+extension STPPaymentMethodBillingDetails {
+    func toPaymentSheetBillingDetails() -> PaymentSheet.BillingDetails {
+        let address = PaymentSheet.Address(city: self.address?.city,
+                                           country: self.address?.country,
+                                           line1: self.address?.line1,
+                                           line2: self.address?.line2,
+                                           postalCode: self.address?.postalCode,
+                                           state: self.address?.state)
+        return PaymentSheet.BillingDetails(address: address,
+                                           email: self.email,
+                                           name: self.name,
+                                           phone: self.phone)
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -51,19 +51,38 @@ extension PaymentSheet {
             /// A user facing string representing the payment method; e.g. "Apple Pay" or "····4242" for a card
             public let label: String
 
+            /// The billing details associated with the customer's desired payment option
+            public let billingDetails: PaymentSheet.BillingDetails?
+
+            /// A string representation of the customer's desired payment option
+            /// - If this is a Stripe payment method, see https://stripe.com/docs/api/payment_methods/object#payment_method_object-type for possible values.
+            /// - If this is an external payment method, see https://stripe.com/docs/payments/external-payment-methods?platform=ios#available-external-payment-methods for possible values.
+            /// - If this is Apple Pay, the value is "apple_pay"
+            public let paymentMethodType: String
+
             init(paymentOption: PaymentOption) {
                 image = paymentOption.makeIcon(updateImageHandler: nil)
                 switch paymentOption {
                 case .applePay:
                     label = String.Localized.apple_pay
+                    paymentMethodType = "apple_pay"
+                    billingDetails = nil
                 case .saved(let paymentMethod):
                     label = paymentMethod.paymentSheetLabel
+                    paymentMethodType = paymentMethod.type.identifier
+                    billingDetails = paymentMethod.billingDetails?.toPaymentSheetBillingDetails()
                 case .new(let confirmParams):
                     label = confirmParams.paymentSheetLabel
+                    paymentMethodType = confirmParams.paymentMethodType.identifier
+                    billingDetails = confirmParams.paymentMethodParams.billingDetails?.toPaymentSheetBillingDetails()
                 case .link(let option):
                     label = option.paymentSheetLabel
-                case .external(let paymentMethod, _):
+                    paymentMethodType = STPPaymentMethodType.link.identifier
+                    billingDetails = option.billingDetails?.toPaymentSheetBillingDetails()
+                case .external(let paymentMethod, let stpBillingDetails):
                     label = paymentMethod.label
+                    paymentMethodType = paymentMethod.type
+                    billingDetails = stpBillingDetails.toPaymentSheetBillingDetails()
                 }
             }
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -54,7 +54,7 @@ extension PaymentSheet {
             /// The billing details associated with the customer's desired payment method
             public let billingDetails: PaymentSheet.BillingDetails?
 
-            /// A string representation of the customer's desired payment option
+            /// A string representation of the customer's desired payment method
             /// - If this is a Stripe payment method, see https://stripe.com/docs/api/payment_methods/object#payment_method_object-type for possible values.
             /// - If this is an external payment method, see https://stripe.com/docs/payments/external-payment-methods?platform=ios#available-external-payment-methods for possible values.
             /// - If this is Apple Pay, the value is "apple_pay"

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -51,7 +51,7 @@ extension PaymentSheet {
             /// A user facing string representing the payment method; e.g. "Apple Pay" or "····4242" for a card
             public let label: String
 
-            /// The billing details associated with the customer's desired payment option
+            /// The billing details associated with the customer's desired payment method
             public let billingDetails: PaymentSheet.BillingDetails?
 
             /// A string representation of the customer's desired payment option

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetConfigurationTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetConfigurationTests.swift
@@ -60,4 +60,28 @@ class PaymentSheetConfigurationTests: XCTestCase {
         configuration.billingDetailsCollectionConfiguration.phone = .always
         XCTAssert(configuration.isUsingBillingAddressCollection())
     }
+
+    func testSTPPaymentMethodBillingDetailsToPaymentSheetBililngDetails() {
+        var billingDetails = STPPaymentMethodBillingDetails()
+        billingDetails.name = "Jane Doe"
+        billingDetails.email = "janedoe@test.com"
+        billingDetails.phone = "+18885551234"
+        billingDetails.address = STPPaymentMethodAddress()
+        billingDetails.address?.line1 = "123 Main Street"
+        billingDetails.address?.line2 = ""
+        billingDetails.address?.city = "San Francisco"
+        billingDetails.address?.state = "California"
+        billingDetails.address?.country = "US"
+
+        let psBillingDetails = billingDetails.toPaymentSheetBillingDetails()
+
+        XCTAssertEqual(psBillingDetails.name, "Jane Doe")
+        XCTAssertEqual(psBillingDetails.email, "janedoe@test.com")
+        XCTAssertEqual(psBillingDetails.phone, "+18885551234")
+        XCTAssertEqual(psBillingDetails.address.line1, "123 Main Street")
+        XCTAssertEqual(psBillingDetails.address.line2, "")
+        XCTAssertEqual(psBillingDetails.address.city, "San Francisco")
+        XCTAssertEqual(psBillingDetails.address.state, "California")
+        XCTAssertEqual(psBillingDetails.address.country, "US")
+    }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetConfigurationTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetConfigurationTests.swift
@@ -78,6 +78,7 @@ class PaymentSheetConfigurationTests: XCTestCase {
         XCTAssertEqual(psBillingDetails.name, "Jane Doe")
         XCTAssertEqual(psBillingDetails.email, "janedoe@test.com")
         XCTAssertEqual(psBillingDetails.phone, "+18885551234")
+        XCTAssertEqual(psBillingDetails.phoneNumberForDisplay, "+1 (888) 555-1234")
         XCTAssertEqual(psBillingDetails.address.line1, "123 Main Street")
         XCTAssertEqual(psBillingDetails.address.line2, "")
         XCTAssertEqual(psBillingDetails.address.city, "San Francisco")

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetConfigurationTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetConfigurationTests.swift
@@ -61,7 +61,7 @@ class PaymentSheetConfigurationTests: XCTestCase {
         XCTAssert(configuration.isUsingBillingAddressCollection())
     }
 
-    func testSTPPaymentMethodBillingDetailsToPaymentSheetBililngDetails() {
+    func testSTPPaymentMethodBillingDetailsToPaymentSheetBillingDetails() {
         var billingDetails = STPPaymentMethodBillingDetails()
         billingDetails.name = "Jane Doe"
         billingDetails.email = "janedoe@test.com"

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetConfigurationTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetConfigurationTests.swift
@@ -73,7 +73,7 @@ class PaymentSheetConfigurationTests: XCTestCase {
         billingDetails.address?.state = "California"
         billingDetails.address?.country = "US"
 
-        let psBillingDetails = billingDetails.toPaymentSheetBillingDetails()
+        let psBillingDetails: PaymentSheet.BillingDetails = billingDetails.toPaymentSheetBillingDetails()
 
         XCTAssertEqual(psBillingDetails.name, "Jane Doe")
         XCTAssertEqual(psBillingDetails.email, "janedoe@test.com")


### PR DESCRIPTION
## Summary
Expose billing details & PMT for FlowController

## Motivation
BillingDetails typed in by customers, and payment method type, should be available immediately when flowcontroller payment method selector sheet is dismissed

## Testing
Added ui test
Updated playground and did manual tests

## Changelog
* [Added] Exposed BillingDetails and type on selected PaymentOption when dismissing FlowController's payment option selector