### PR TITLE
Fix test issue on iOS 16 and lower, enable iOS 15/16 tests

### DIFF
--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+DashboardConfirmParamsTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+DashboardConfirmParamsTest.swift
@@ -301,7 +301,7 @@ private extension PaymentSheet_ConfirmParamsTest {
 
     func bodyParams(from request: URLRequest, line: UInt) -> [String: String] {
         guard let httpBody = request.httpBodyOrBodyStream,
-              let query = String(data: httpBody, encoding: .utf8),
+              let query = String(data: httpBody, encoding: .utf8)?.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed),
               let components = URLComponents(string: "http://someurl.com?\(query)") else {
             XCTFail("Request body empty", line: line)
             return [:]

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -62,6 +62,8 @@ stages:
     - ui-tests-1: {}
     - ui-tests-2: {}
     - legacy-tests-14: {}
+    - legacy-tests-15: {}
+    - legacy-tests-16: {}
     - carthage-install-test: {}
     - pod-lint-tests: {}
     - integration-all: {}
@@ -70,6 +72,8 @@ stages:
     - basic-integration-tests: {}
     - check-docs: {}
     - legacy-tests-14: {}
+    - legacy-tests-15: {}
+    - legacy-tests-16: {}
     - carthage-install-test: {}
     - data-theorem-sast: {}
     - deploy-dry-run: {}
@@ -449,12 +453,41 @@ workflows:
       bitrise.io:
         stack: osx-xcode-14.3.x-ventura
         machine_type_id: g2-m1.8core
-
     before_run:
     - prep_all
     after_run:
     - upload_logs
     - notify_ci
+  legacy-tests-15:
+    steps:
+    - fastlane@3:
+        inputs:
+        - lane: legacy_tests_15
+        title: fastlane legacy_tests_15
+    envs:
+    - DEFAULT_TEST_DEVICE: platform=iOS Simulator,name=iPhone 12 mini,OS=15.4
+    meta:
+      bitrise.io:
+        stack: osx-xcode-14.3.x-ventura
+        machine_type_id: g2-m1.8core
+    before_run:
+    - prep_all
+    after_run:
+    - upload_logs
+    - notify_ci
+  legacy-tests-16:
+    steps:
+    - fastlane@3:
+        inputs:
+        - lane: legacy_tests_16
+        title: fastlane legacy_tests_16
+    envs:
+    - DEFAULT_TEST_DEVICE: platform=iOS Simulator,name=iPhone 12 mini,OS=16.1
+    before_run:
+    - prep_all
+    after_run:
+    - upload_logs
+    - notify_ci        
   lint-tests:
     steps:
     - script@1:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -482,12 +482,16 @@ workflows:
         - lane: legacy_tests_16
         title: fastlane legacy_tests_16
     envs:
-    - DEFAULT_TEST_DEVICE: platform=iOS Simulator,name=iPhone 12 mini,OS=16.1
+    - DEFAULT_TEST_DEVICE: platform=iOS Simulator,name=iPhone 12 mini,OS=16.4
     before_run:
     - prep_all
     after_run:
     - upload_logs
-    - notify_ci        
+    - notify_ci   
+    meta:
+      bitrise.io:
+        stack: osx-xcode-14.3.x-ventura
+        machine_type_id: g2-m1.8core     
   lint-tests:
     steps:
     - script@1:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -105,7 +105,7 @@ workflows:
     after_run:
     - notify_ci
     envs:
-    - DEFAULT_TEST_DEVICE: platform=iOS Simulator,name=iPhone 12 mini,OS=16.4
+    - DEFAULT_TEST_DEVICE: platform=iOS Simulator,name=iPhone 12 mini,OS=16.1
   check-docs:
     steps:
     - script@1:
@@ -482,7 +482,7 @@ workflows:
         - lane: legacy_tests_16
         title: fastlane legacy_tests_16
     envs:
-    - DEFAULT_TEST_DEVICE: platform=iOS Simulator,name=iPhone 12 mini,OS=16.1
+    - DEFAULT_TEST_DEVICE: platform=iOS Simulator,name=iPhone 12 mini,OS=16.4
     before_run:
     - prep_all
     after_run:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -482,7 +482,7 @@ workflows:
         - lane: legacy_tests_16
         title: fastlane legacy_tests_16
     envs:
-    - DEFAULT_TEST_DEVICE: platform=iOS Simulator,name=iPhone 12 mini,OS=16.4
+    - DEFAULT_TEST_DEVICE: platform=iOS Simulator,name=iPhone 12 mini,OS=16.1
     before_run:
     - prep_all
     after_run:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -105,7 +105,7 @@ workflows:
     after_run:
     - notify_ci
     envs:
-    - DEFAULT_TEST_DEVICE: platform=iOS Simulator,name=iPhone 12 mini,OS=16.1
+    - DEFAULT_TEST_DEVICE: platform=iOS Simulator,name=iPhone 12 mini,OS=16.4
   check-docs:
     steps:
     - script@1:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -90,6 +90,14 @@ platform :ios do
     legacy_tests(device: 'iPhone 11', version: '14.5')
   end
 
+  lane :legacy_tests_15 do
+    legacy_tests(device: 'iPhone 12 mini', version: '15.4')
+  end
+
+  lane :legacy_tests_16 do
+    legacy_tests(device: 'iPhone 12 mini', version: '16.1')
+  end
+
   lane :e2e_only do
     Dir.chdir('..') do
       sh("./ci_scripts/test.rb --scheme 'StripeiOS' --device '#{DEFAULT_TEST_DEVICE}' --version #{DEFAULT_TEST_VERSION} --only-test 'StripeiOS Tests/STPE2ETest' --retry-on-failure")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -95,7 +95,7 @@ platform :ios do
   end
 
   lane :legacy_tests_16 do
-    legacy_tests(device: 'iPhone 12 mini', version: '16.1')
+    legacy_tests(device: 'iPhone 12 mini', version: '16.4')
   end
 
   lane :e2e_only do

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -95,7 +95,7 @@ platform :ios do
   end
 
   lane :legacy_tests_16 do
-    legacy_tests(device: 'iPhone 12 mini', version: '16.4')
+    legacy_tests(device: 'iPhone 12 mini', version: '16.1')
   end
 
   lane :e2e_only do


### PR DESCRIPTION
## Summary
* Fix an issue in a test with un-escaped URLComponents on iOS versions below iOS 17.
* Re-enable nightly tests for iOS 15 and 16.

## Motivation
Better test coverage, fix nightly tests.

## Testing
Kicked off manual run of nightly build in CI