### PR TITLE
Update link sign up ui test to run in non-US locale

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -30,6 +30,7 @@ struct PaymentSheetTestPlayground: View {
             SettingView(setting: $playgroundController.settings.defaultBillingAddress)
             SettingView(setting: $playgroundController.settings.linkEnabled)
             SettingView(setting: $playgroundController.settings.linkV2Allowed)
+            SettingView(setting: $playgroundController.settings.linkOverrideCountry)
             SettingView(setting: $playgroundController.settings.externalPayPalEnabled)
             SettingView(setting: $playgroundController.settings.preferredNetworksEnabled)
         }

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -32,7 +32,7 @@ struct PaymentSheetTestPlayground: View {
         Group {
             SettingView(setting: $playgroundController.settings.linkEnabled)
             SettingView(setting: $playgroundController.settings.linkV2Allowed)
-            SettingView(setting: $playgroundController.settings.linkOverrideCountry)
+            SettingView(setting: $playgroundController.settings.userOverrideCountry)
             SettingView(setting: $playgroundController.settings.externalPayPalEnabled)
             SettingView(setting: $playgroundController.settings.preferredNetworksEnabled)
         }

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -28,6 +28,8 @@ struct PaymentSheetTestPlayground: View {
             SettingView(setting: $playgroundController.settings.applePayButtonType)
             SettingView(setting: $playgroundController.settings.allowsDelayedPMs)
             SettingView(setting: $playgroundController.settings.defaultBillingAddress)
+        }
+        Group {
             SettingView(setting: $playgroundController.settings.linkEnabled)
             SettingView(setting: $playgroundController.settings.linkV2Allowed)
             SettingView(setting: $playgroundController.settings.linkOverrideCountry)

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -166,7 +166,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
         case off
     }
 
-    enum LinkOverrideCountry: String, PickerEnum {
+    enum UserOverrideCountry: String, PickerEnum {
         static var enumName: String { "Link override country" }
 
         case off
@@ -258,7 +258,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
     var defaultBillingAddress: DefaultBillingAddress
     var linkEnabled: LinkEnabled
     var linkV2Allowed: LinkV2Allowed
-    var linkOverrideCountry: LinkOverrideCountry
+    var userOverrideCountry: UserOverrideCountry
     var customCtaLabel: String?
     var checkoutEndpoint: String?
     var autoreload: Autoreload
@@ -289,7 +289,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
             defaultBillingAddress: .off,
             linkEnabled: .off,
             linkV2Allowed: .off,
-            linkOverrideCountry: .off,
+            userOverrideCountry: .off,
             customCtaLabel: nil,
             checkoutEndpoint: Self.defaultCheckoutEndpoint,
             autoreload: .on,

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -167,7 +167,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
     }
 
     enum UserOverrideCountry: String, PickerEnum {
-        static var enumName: String { "Link override country" }
+        static var enumName: String { "UserOverrideCountry (debug only)" }
 
         case off
         case GB

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -166,6 +166,13 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
         case off
     }
 
+    enum LinkOverrideCountry: String, PickerEnum {
+        static var enumName: String { "Link override country" }
+
+        case off
+        case GB
+    }
+
     enum BillingDetailsAttachDefaults: String, PickerEnum {
         static var enumName: String { "Attach defaults" }
 
@@ -251,6 +258,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
     var defaultBillingAddress: DefaultBillingAddress
     var linkEnabled: LinkEnabled
     var linkV2Allowed: LinkV2Allowed
+    var linkOverrideCountry: LinkOverrideCountry
     var customCtaLabel: String?
     var checkoutEndpoint: String?
     var autoreload: Autoreload
@@ -281,6 +289,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
             defaultBillingAddress: .off,
             linkEnabled: .off,
             linkV2Allowed: .off,
+            linkOverrideCountry: .off,
             customCtaLabel: nil,
             checkoutEndpoint: Self.defaultCheckoutEndpoint,
             autoreload: .on,

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -104,6 +104,10 @@ class PlaygroundController: ObservableObject {
         configuration.customer = customerConfiguration
         configuration.appearance = appearance
         configuration.allowLinkV2Features = settings.linkV2Allowed == .on
+        if settings.linkOverrideCountry != .off {
+            configuration.linkOverrideCountry = settings.linkOverrideCountry.rawValue
+        }
+
         configuration.returnURL = "payments-example://stripe-redirect"
         if settings.defaultBillingAddress == .on {
             configuration.defaultBillingDetails.name = "Jane Doe"

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -104,8 +104,8 @@ class PlaygroundController: ObservableObject {
         configuration.customer = customerConfiguration
         configuration.appearance = appearance
         configuration.allowLinkV2Features = settings.linkV2Allowed == .on
-        if settings.linkOverrideCountry != .off {
-            configuration.linkOverrideCountry = settings.linkOverrideCountry.rawValue
+        if settings.userOverrideCountry != .off {
+            configuration.userOverrideCountry = settings.userOverrideCountry.rawValue
         }
 
         configuration.returnURL = "payments-example://stripe-redirect"

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -2318,7 +2318,7 @@ class PaymentSheetLinkUITests: PaymentSheetUITestCase {
         settings.apmsEnabled = .on
         settings.linkEnabled = .on
         settings.linkV2Allowed = .on
-        settings.linkOverrideCountry = .GB
+        settings.userOverrideCountry = .GB
 
         loadPlayground(app, settings)
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
@@ -11,6 +11,9 @@ import Foundation
 
 /// The response returned by v1/elements/sessions
 final class STPElementsSession: NSObject {
+    #if DEBUG && targetEnvironment(simulator)
+    public static let countryCodeOverride: String? = nil
+    #endif
     /// Elements Session ID for analytics purposes, looks like "elements_session_1234"
     let sessionID: String
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/Intent+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/Intent+Link.swift
@@ -58,7 +58,7 @@ extension Intent {
     }
 
     func countryCode(overrideCountry: String?) -> String? {
-#if DEBUG && targetEnvironment(simulator)
+#if DEBUG
         if let overrideCountry {
             return overrideCountry
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/Intent+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/Intent+Link.swift
@@ -57,7 +57,12 @@ extension Intent {
         return elementsSession.linkSettings?.popupWebviewOption ?? .shared
     }
 
-    var countryCode: String? {
+    func countryCode(overrideCountry: String?) -> String? {
+#if DEBUG && targetEnvironment(simulator)
+        if let overrideCountry {
+            return overrideCountry
+        }
+#endif
         return elementsSession.countryCode
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Utils/LinkURLGenerator.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Utils/LinkURLGenerator.swift
@@ -46,7 +46,7 @@ class LinkURLGenerator {
         }
 
         // We only expect regionCode to be nil in rare situations with a buggy simulator. Use a default value we can detect server-side.
-        let customerCountryCode = intent.countryCode(overrideCountry: configuration.linkOverrideCountry) ?? configuration.defaultBillingDetails.address.country ?? Locale.current.stp_regionCode ?? "US"
+        let customerCountryCode = intent.countryCode(overrideCountry: configuration.userOverrideCountry) ?? configuration.defaultBillingDetails.address.country ?? Locale.current.stp_regionCode ?? "US"
 
         let merchantCountryCode = intent.merchantCountryCode ?? customerCountryCode
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Utils/LinkURLGenerator.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Utils/LinkURLGenerator.swift
@@ -46,7 +46,7 @@ class LinkURLGenerator {
         }
 
         // We only expect regionCode to be nil in rare situations with a buggy simulator. Use a default value we can detect server-side.
-        let customerCountryCode = intent.countryCode ?? configuration.defaultBillingDetails.address.country ?? Locale.current.stp_regionCode ?? "US"
+        let customerCountryCode = intent.countryCode(overrideCountry: configuration.linkOverrideCountry) ?? configuration.defaultBillingDetails.address.country ?? Locale.current.stp_regionCode ?? "US"
 
         let merchantCountryCode = intent.merchantCountryCode ?? customerCountryCode
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
@@ -171,7 +171,7 @@ extension PaymentSheet {
         @_spi(STP) public var allowLinkV2Features: Bool = false
 
         /// Override country for test purposes
-        @_spi(STP) public var linkOverrideCountry: String?
+        @_spi(STP) public var userOverrideCountry: String?
 
         /// Describes how billing details should be collected.
         /// All values default to `automatic`.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
@@ -170,6 +170,9 @@ extension PaymentSheet {
         /// If enabled, PaymentSheet will offer V2 Link features, such as passthrough mode
         @_spi(STP) public var allowLinkV2Features: Bool = false
 
+        /// Override country for test purposes
+        @_spi(STP) public var linkOverrideCountry: String?
+
         /// Describes how billing details should be collected.
         /// All values default to `automatic`.
         /// If `never` is used for a required field for the Payment Method used during checkout,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -101,7 +101,7 @@ class PaymentSheetFormFactory {
                   isPaymentIntent: intent.isPaymentIntent,
                   currency: intent.currency,
                   amount: intent.amount,
-                  countryCode: intent.countryCode,
+                  countryCode: intent.countryCode(overrideCountry: configuration.overrideCountry),
                   saveMode: saveMode)
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactoryConfig.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactoryConfig.swift
@@ -43,6 +43,14 @@ enum PaymentSheetFormFactoryConfig {
             return false
         }
     }
+    var overrideCountry: String? {
+        switch self {
+        case .paymentSheet(let config):
+            return config.linkOverrideCountry
+        case .customerSheet:
+            return nil
+        }
+    }
     var billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration {
         switch self {
         case .paymentSheet(let config):

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactoryConfig.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactoryConfig.swift
@@ -46,7 +46,7 @@ enum PaymentSheetFormFactoryConfig {
     var overrideCountry: String? {
         switch self {
         case .paymentSheet(let config):
-            return config.linkOverrideCountry
+            return config.userOverrideCountry
         case .customerSheet:
             return nil
         }


### PR DESCRIPTION
## Summary
Added ability to run link signup test in non-us country

## Motivation
Name field is required in non-US countries

## Testing
Added test
