### PR TITLE
Financial Connections: for v3, networking sign up, modified the screen to new designs

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupBodyFormView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupBodyFormView.swift
@@ -62,19 +62,22 @@ final class NetworkingLinkSignupBodyFormView: UIView {
     private lazy var theme: ElementsUITheme = {
         var theme: ElementsUITheme = .default
         theme.borderWidth = 1
-        theme.cornerRadius = 8
+        theme.cornerRadius = 12
         theme.shadow = nil
         theme.fonts = {
             var fonts = ElementsUITheme.Font()
+            // text field font
             fonts.subheadline = FinancialConnectionsFont.label(.large).uiFont
+            // error message font
+            fonts.footnote = FinancialConnectionsFont.label(.small).uiFont
             return fonts
         }()
         theme.colors = {
             var colors = ElementsUITheme.Color()
             colors.border = .borderNeutral
-            colors.danger = .textCritical
-            colors.placeholderText = .textSecondary
-            colors.textFieldText = .textPrimary
+            colors.danger = .textFeedbackCritical
+            colors.placeholderText = .textSubdued
+            colors.textFieldText = .textDefault
             colors.parentBackground = .customBackgroundColor
             colors.background = .customBackgroundColor
             return colors

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupBodyView.swift
@@ -43,7 +43,7 @@ private func CreateMultipleBulletPointView(
 ) -> UIView {
     let verticalStackView = HitTestStackView()
     verticalStackView.axis = .vertical
-    verticalStackView.spacing = 12
+    verticalStackView.spacing = 16
     bulletPoints.forEach { bulletPoint in
         let bulletPointView = CreateBulletPointView(
             title: bulletPoint.title,
@@ -64,9 +64,10 @@ private func CreateBulletPointView(
 ) -> UIView {
     let imageView = UIImageView()
     imageView.contentMode = .scaleAspectFit
+    imageView.tintColor = .iconDefault
     imageView.setImage(with: iconUrl)
     imageView.translatesAutoresizingMaskIntoConstraints = false
-    let imageDiameter: CGFloat = 16
+    let imageDiameter: CGFloat = 20
     NSLayoutConstraint.activate([
         imageView.widthAnchor.constraint(equalToConstant: imageDiameter),
         imageView.heightAnchor.constraint(equalToConstant: imageDiameter),
@@ -98,7 +99,7 @@ private func CreateBulletPointView(
         ]
     )
     horizontalStackView.axis = .horizontal
-    horizontalStackView.spacing = 10
+    horizontalStackView.spacing = 16
     horizontalStackView.alignment = .top
     return horizontalStackView
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupFooterView.swift
@@ -22,7 +22,14 @@ class NetworkingLinkSignupFooterView: HitTestView {
     private lazy var footerVerticalStackView: UIStackView = {
         let verticalStackView = UIStackView()
         verticalStackView.axis = .vertical
-        verticalStackView.spacing = 24
+        verticalStackView.spacing = 16
+        verticalStackView.isLayoutMarginsRelativeArrangement = true
+        verticalStackView.directionalLayoutMargins = NSDirectionalEdgeInsets(
+            top: 16,
+            leading: 24,
+            bottom: 16,
+            trailing: 24
+        )
         verticalStackView.addArrangedSubview(aboveCtaLabel)
         verticalStackView.addArrangedSubview(buttonVerticalStack)
         return verticalStackView
@@ -30,10 +37,10 @@ class NetworkingLinkSignupFooterView: HitTestView {
 
     private lazy var aboveCtaLabel: AttributedTextView = {
         let termsAndPrivacyPolicyLabel = AttributedTextView(
-            font: .body(.small),
-            boldFont: .body(.smallEmphasized),
-            linkFont: .body(.smallEmphasized),
-            textColor: .textSecondary,
+            font: .label(.small),
+            boldFont: .label(.smallEmphasized),
+            linkFont: .label(.small),
+            textColor: .textDefault,
             alignCenter: true
         )
         termsAndPrivacyPolicyLabel.setText(
@@ -46,7 +53,8 @@ class NetworkingLinkSignupFooterView: HitTestView {
     private lazy var buttonVerticalStack: UIStackView = {
         let verticalStackView = UIStackView()
         verticalStackView.axis = .vertical
-        verticalStackView.spacing = 12
+        verticalStackView.spacing = 8
+        verticalStackView.addArrangedSubview(saveToLinkButton)
         verticalStackView.addArrangedSubview(notNowButton)
         return verticalStackView
     }()
@@ -94,15 +102,6 @@ class NetworkingLinkSignupFooterView: HitTestView {
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-    func showSaveToLinkButtonIfNeeded() {
-        guard saveToLinkButton.superview == nil else {
-            return  // already added
-        }
-        notNowButton.removeFromSuperview()
-        buttonVerticalStack.addArrangedSubview(saveToLinkButton)
-        buttonVerticalStack.addArrangedSubview(notNowButton)
     }
 
     func enableSaveToLinkButton(_ enable: Bool) {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
@@ -132,22 +132,26 @@ final class NetworkingLinkSignupViewController: UIViewController {
             }
         )
         self.footerView = footerView
-        let pane = PaneWithHeaderLayoutView(
-            title: networkingLinkSignup.title,
-            contentView: NetworkingLinkSignupBodyView(
-                bulletPoints: networkingLinkSignup.body.bullets,
-                formView: formView,
-                didSelectURL: { [weak self] url in
-                    self?.didSelectURLInTextFromBackend(url)
-                }
+        let paneLayoutView = PaneLayoutView(
+            contentView: PaneLayoutView.createContentView(
+                iconView: nil,
+                title: networkingLinkSignup.title,
+                subtitle: nil,
+                contentView: NetworkingLinkSignupBodyView(
+                    bulletPoints: networkingLinkSignup.body.bullets,
+                    formView: formView,
+                    didSelectURL: { [weak self] url in
+                        self?.didSelectURLInTextFromBackend(url)
+                    }
+                )
             ),
             footerView: footerView
         )
-        pane.addTo(view: view)
+        paneLayoutView.addTo(view: view)
 
         #if !canImport(CompositorServices)
         // if user drags, dismiss keyboard so the CTA buttons can be shown
-        pane.scrollView.keyboardDismissMode = .onDrag
+        paneLayoutView.scrollView.keyboardDismissMode = .onDrag
         #endif
 
         let emailAddress = dataSource.manifest.accountholderCustomerEmailAddress
@@ -156,6 +160,9 @@ final class NetworkingLinkSignupViewController: UIViewController {
         }
 
         assert(self.footerView != nil, "footer view should be initialized as part of displaying content")
+
+        // disable CTA if needed
+        adjustSaveToLinkButtonDisabledState()
     }
 
     private func showLoadingView(_ show: Bool) {
@@ -302,7 +309,6 @@ extension NetworkingLinkSignupViewController: NetworkingLinkSignupBodyFormViewDe
                                 self.formView.endEditingEmailAddressField()
                             }
                         }
-                        self.footerView?.showSaveToLinkButtonIfNeeded()
                     }
                 case .failure(let error):
                     self.dataSource.analyticsClient.logUnexpectedError(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/PaneLayoutView/PaneLayoutView+Extensions.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/PaneLayoutView/PaneLayoutView+Extensions.swift
@@ -75,6 +75,8 @@ extension PaneLayoutView {
         paddingStackView.directionalLayoutMargins = NSDirectionalEdgeInsets(
             top: isSheet ? 0 : 16, // the sheet handle adds some padding
             leading: 24,
+            // if there is a subtitle in the "body/content view,"
+            // we will add extra "8" padding
             bottom: 16,
             trailing: 24
         )
@@ -82,16 +84,22 @@ extension PaneLayoutView {
     }
 
     @available(iOSApplicationExtension, unavailable)
-    static func createBodyView(
+    private static func createBodyView(
         text: String?,
         contentView: UIView?
     ) -> UIView {
+        let willShowDescriptionText = (text != nil)
+
         let paddingStackView = HitTestStackView()
         paddingStackView.axis = .vertical
-        paddingStackView.spacing = 16
+        // add 24 spacing between the text and `contentView`
+        paddingStackView.spacing = willShowDescriptionText ? 24 : 0
         paddingStackView.isLayoutMarginsRelativeArrangement = true
         paddingStackView.directionalLayoutMargins = NSDirectionalEdgeInsets(
-            top: 0,
+            // when we don't show text, add extra 8 spacing
+            // to create 24 spacing between "content" and "header"
+            // where 16 spacing is already added in `createHeaderView`
+            top: willShowDescriptionText ? 0 : 8,
             leading: 24,
             bottom: 8,
             trailing: 24


### PR DESCRIPTION
## Summary

This PR:
- Modifies "Networking Sign Up Pane" pane from V2 design to V3 design

Details to understand before reviewing PR:
- This is one PR, out of expected ~50+, to change the design of Financial Connections from a "V2" design to a "V3" design. [Here is a link to the designs](https://www.figma.com/file/wXQ8NJApqSJiLmxxANDRTs/%E2%9C%A8-Connections-3.0?type=design&node-id=2524-217093&mode=design&t=kXaBiAlgVsC7YcH1-0).
- The code here is not the finished version. It's just an iteration towards the final version. This code will be re-visited later. The goal is to go screen-by-screen and make easy changes to learn about all the difficulties in each screen. Later, all the learnings will be combined to do a "final" polish of all screens.
- The above also applies to design. The design here is not the finished version.
- This PR is merged into a feature branch `fc-v3`. It is not merged into `master`.
- There might be TODO's scattered throughout the code. That's expected and they will be fixed later. 

## Testing

| Before | After |
| --- | --- |
| ![before](https://github.com/stripe/stripe-ios/assets/105514761/d96cefe2-7693-46d2-bba2-5a035ba3f38e) | ![after](https://github.com/stripe/stripe-ios/assets/105514761/b4a3ff1e-01ad-4627-abae-319a7e923d21) |
