### PR TITLE
Financial Connections: for v3, step up, redesigned screen for v3

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/UIColor+Extensions.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/UIColor+Extensions.swift
@@ -23,6 +23,10 @@ extension UIColor {
         return neutral600
     }
 
+    static var textActionPrimary: UIColor {
+        return brand600
+    }
+
     static var textActionPrimaryFocused: UIColor {
         return brand600
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationBodyView.swift
@@ -12,131 +12,83 @@ import UIKit
 
 final class NetworkingLinkStepUpVerificationBodyView: UIView {
 
-    private let email: String
     private let didSelectResendCode: () -> Void
 
-    private lazy var footnoteHorizontalStackView: UIStackView = {
-        let footnoteHorizontalStackView = UIStackView()
-        footnoteHorizontalStackView.axis = .horizontal
-        footnoteHorizontalStackView.spacing = 8
-        footnoteHorizontalStackView.alignment = .center
-        return footnoteHorizontalStackView
+    // `UIStackView` is used only for padding
+    private lazy var footnoteStackView: UIStackView = {
+        let footnoteStackView = UIStackView()
+        footnoteStackView.axis = .vertical
+        footnoteStackView.alignment = .center
+        footnoteStackView.isLayoutMarginsRelativeArrangement = true
+        footnoteStackView.directionalLayoutMargins = NSDirectionalEdgeInsets(
+            top: 8,
+            leading: 0,
+            bottom: 8,
+            trailing: 0
+        )
+        return footnoteStackView
     }()
 
     init(
-        email: String,
         otpView: UIView,
         didSelectResendCode: @escaping () -> Void
     ) {
-        self.email = email
         self.didSelectResendCode = didSelectResendCode
         super.init(frame: .zero)
         let verticalStackView = UIStackView(
             arrangedSubviews: [
                 otpView,
-                footnoteHorizontalStackView,
+                footnoteStackView,
             ]
         )
         verticalStackView.axis = .vertical
-        verticalStackView.spacing = 20
+        verticalStackView.spacing = 16
         addAndPinSubview(verticalStackView)
 
-        setupFootnoteView(isResendingCode: false)
+        showResendCodeLabel(true)
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func isResendingCode(_ isResendingCode: Bool) {
-        setupFootnoteView(isResendingCode: isResendingCode)
-    }
-
-    private func setupFootnoteView(isResendingCode: Bool) {
+    func showResendCodeLabel(_ show: Bool) {
         // clear all previous state
-        footnoteHorizontalStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        footnoteStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
 
-        footnoteHorizontalStackView.addArrangedSubview(
-            CreateEmailLabel(email: email)
-        )
-        footnoteHorizontalStackView.addArrangedSubview(
-            CreateCreateDotLabel()
-        )
-        footnoteHorizontalStackView.addArrangedSubview(
-            CreateResendCodeLabel(
-                isEnabled: !isResendingCode,
-                didSelect: didSelectResendCode
+        if show {
+            footnoteStackView.addArrangedSubview(
+                CreateResendCodeLabel(
+                    didSelect: didSelectResendCode
+                )
             )
-        )
-        if isResendingCode {
-            footnoteHorizontalStackView.addArrangedSubview(
-                CreateResendCodeLoadingView()
-            )
-            let spacerView = UIView()
-            footnoteHorizontalStackView.addArrangedSubview(spacerView)
         }
     }
 }
 
-private func CreateEmailLabel(email: String) -> UIView {
-    let emailLabel = AttributedLabel(
-        font: .label(.medium),
-        textColor: .textSecondary
-    )
-    emailLabel.text = "\(email)"
-    return emailLabel
-}
-
-private func CreateCreateDotLabel() -> UIView {
-    let dotLabel = AttributedLabel(
-        font: .label(.medium),
-        textColor: .textDisabled
-    )
-    dotLabel.text = "•"
-    return dotLabel
-}
-
-private func CreateResendCodeLabel(isEnabled: Bool, didSelect: @escaping () -> Void) -> UIView {
+private func CreateResendCodeLabel(
+    didSelect: @escaping () -> Void
+) -> UIView {
     let resendCodeLabel = AttributedTextView(
         font: .label(.medium),
         boldFont: .label(.mediumEmphasized),
         linkFont: .label(.mediumEmphasized),
-        textColor: .textDisabled,
+        textColor: .textActionPrimary,
+        showLinkUnderline: false,
         alignCenter: false
     )
     let text = STPLocalizedString(
         "Resend code",
         "The title of a button that allows a user to request a one-time-password (OTP) again in case they did not receive it."
     )
-    if isEnabled {
-        resendCodeLabel.setText(
-            "[\(text)](https://www.just-fire-action.com)",
-            action: { _ in
-                didSelect()
-            }
-        )
-    } else {
-        resendCodeLabel.setText(text)
-    }
+    resendCodeLabel.setText(
+        // we add a fake link to fire the `action` closure
+        "[\(text)](https://www.just-fire-action.com)",
+        action: { _ in
+            didSelect()
+        }
+    )
     return resendCodeLabel
-}
-
-private func CreateResendCodeLoadingView() -> UIView {
-    let activityIndicator = ActivityIndicator(size: .medium)
-    activityIndicator.color = .textDisabled
-    activityIndicator.startAnimating()
-
-    // `ActivityIndicator` is hard-coded to have specific sizes, so here we scale it to our needs
-    let mediumIconDiameter: CGFloat = 20
-    let desiredIconDiameter: CGFloat = 12
-    let transform = CGAffineTransform(scaleX: desiredIconDiameter / mediumIconDiameter, y: desiredIconDiameter / mediumIconDiameter)
-    activityIndicator.transform = transform
-    activityIndicator.translatesAutoresizingMaskIntoConstraints = false
-    NSLayoutConstraint.activate([
-        activityIndicator.widthAnchor.constraint(equalToConstant: desiredIconDiameter),
-        activityIndicator.heightAnchor.constraint(equalToConstant: desiredIconDiameter),
-    ])
-    return activityIndicator
 }
 
 #if DEBUG
@@ -147,7 +99,6 @@ private struct NetworkingLinkStepUpVerificationBodyViewUIViewRepresentable: UIVi
 
     func makeUIView(context: Context) -> NetworkingLinkStepUpVerificationBodyView {
         NetworkingLinkStepUpVerificationBodyView(
-            email: "test@stripe.com",
             otpView: UIView(),
             didSelectResendCode: {}
         )

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationViewController.swift
@@ -29,15 +29,11 @@ final class NetworkingLinkStepUpVerificationViewController: UIViewController {
     private let dataSource: NetworkingLinkStepUpVerificationDataSource
     weak var delegate: NetworkingLinkStepUpVerificationViewControllerDelegate?
 
-    private lazy var loadingView: ActivityIndicator = {
-        let activityIndicator = ActivityIndicator(size: .large)
-        activityIndicator.color = .textDisabled
-        activityIndicator.backgroundColor = .customBackgroundColor
-        return activityIndicator
+    private lazy var fullScreenLoadingView: UIView = {
+        return SpinnerView()
     }()
     private lazy var bodyView: NetworkingLinkStepUpVerificationBodyView = {
         let bodyView = NetworkingLinkStepUpVerificationBodyView(
-            email: dataSource.consumerSession.emailAddress,
             otpView: otpView,
             didSelectResendCode: { [weak self] in
                 self?.didSelectResendCode()
@@ -91,36 +87,39 @@ final class NetworkingLinkStepUpVerificationViewController: UIViewController {
     private func showContent() {
         didShowContent = true
 
-        let pane = PaneWithHeaderLayoutView(
-            title: STPLocalizedString(
-                "Check your email to confirm your identity",
-                "The title of a screen where users are asked to enter a one-time-password (OTP) that they received in their email."
+        let paneLayoutView = PaneLayoutView(
+            contentView: PaneLayoutView.createContentView(
+                iconView: nil,
+                title: STPLocalizedString(
+                    "Verify your email",
+                    "The title of a screen where users are asked to enter a one-time-password (OTP) that they received in their email."
+                ),
+                subtitle: String(
+                    format: STPLocalizedString(
+                        "Enter the code sent to %@. We periodically request this extra step to keep your account safe.",
+                        "The subtitle/description of a screen where users are asked to enter a one-time-password (OTP) that they received in their email. '%@' is replaced with an email, for example, 'test@test.com'."
+                    ), dataSource.consumerSession.emailAddress
+                ),
+                contentView: bodyView
             ),
-            subtitle: String(
-                format: STPLocalizedString(
-                    "To keep your Link account safe, we periodically need to confirm you're you. Enter the code sent to your email %@.",
-                    "The subtitle/description of a screen where users are asked to enter a one-time-password (OTP) that they received in their email. '%@' is replaced with an email, for example, 'test@test.com'."
-                ), "**\(dataSource.consumerSession.emailAddress)**" // asterisks make the e-mail bold
-            ),
-            contentView: bodyView,
             footerView: nil
         )
-        pane.addTo(view: view)
+        paneLayoutView.addTo(view: view)
     }
 
-    private func showLoadingView(_ show: Bool) {
-        if show && loadingView.superview == nil {
+    private func showFullScreenLoadingView(_ show: Bool) {
+        if show && fullScreenLoadingView.superview == nil {
             // first-time we are showing this, so add the view to hierarchy
-            view.addAndPinSubview(loadingView)
+            view.addAndPinSubview(fullScreenLoadingView)
         }
 
-        loadingView.isHidden = !show
-        if show {
-            loadingView.startAnimating()
-        } else {
-            loadingView.stopAnimating()
-        }
-        view.bringSubviewToFront(loadingView)  // defensive programming to avoid loadingView being hiddden
+        fullScreenLoadingView.isHidden = !show
+        view.bringSubviewToFront(fullScreenLoadingView)  // defensive programming to avoid loadingView being hiddden
+    }
+
+    private func showSmallLoadingView(_ showLoadingView: Bool) {
+        bodyView.showResendCodeLabel(!showLoadingView)
+        otpView.showLoadingView(showLoadingView)
     }
 
     private func didSelectResendCode() {
@@ -134,17 +133,17 @@ extension NetworkingLinkStepUpVerificationViewController: NetworkingOTPViewDeleg
 
     func networkingOTPViewWillStartConsumerLookup(_ view: NetworkingOTPView) {
         if !didShowContent {
-            showLoadingView(true)
+            showFullScreenLoadingView(true)
         } else {
-            bodyView.isResendingCode(true)
+            showSmallLoadingView(true)
         }
     }
 
     func networkingOTPViewConsumerNotFound(_ view: NetworkingOTPView) {
-        // side-note: it is redundant to call `showLoadingView` & `isResendingCode` because
+        // side-note: it is redundant to call `showLoadingView` & `showSmallLoadingView` because
         // usually only one needs to be hidden, but this keeps the code simple
-        showLoadingView(false)
-        bodyView.isResendingCode(false)
+        showFullScreenLoadingView(false)
+        showSmallLoadingView(false)
 
         dataSource.analyticsClient.log(
             eventName: "networking.verification.step_up.error",
@@ -159,8 +158,8 @@ extension NetworkingLinkStepUpVerificationViewController: NetworkingOTPViewDeleg
     func networkingOTPView(_ view: NetworkingOTPView, didFailConsumerLookup error: Error) {
         // side-note: it is redundant to call both (`showLoadingView` & `isResendingCode`) because
         // only one needs to be hidden (depends on the state), but this keeps the code simple
-        showLoadingView(false)
-        bodyView.isResendingCode(false)
+        showFullScreenLoadingView(false)
+        showSmallLoadingView(false)
 
         handleFailure(error: error, errorName: "LookupConsumerSessionError")
     }
@@ -172,24 +171,33 @@ extension NetworkingLinkStepUpVerificationViewController: NetworkingOTPViewDeleg
     func networkingOTPView(_ view: NetworkingOTPView, didStartVerification consumerSession: ConsumerSessionData) {
         // it's important to call this BEFORE we call `showContent` because of `didShowContent`
         if !didShowContent {
-            showLoadingView(false)
+            showFullScreenLoadingView(false)
         } else {
-            bodyView.isResendingCode(false)
+            showSmallLoadingView(false)
         }
 
         showContent()
     }
 
     func networkingOTPView(_ view: NetworkingOTPView, didFailToStartVerification error: Error) {
-        // side-note: it is redundant to call `showLoadingView` & `isResendingCode` because
+        // side-note: it is redundant to call `showLoadingView` & `showSmallLoadingView` because
         // usually only one needs to be hidden, but this keeps the code simple
-        showLoadingView(false)
-        bodyView.isResendingCode(false)
+        showFullScreenLoadingView(false)
+        showSmallLoadingView(false)
 
         handleFailure(error: error, errorName: "StartVerificationSessionError")
     }
 
+    func networkingOTPViewWillConfirmVerification(_ view: NetworkingOTPView) {
+        showSmallLoadingView(true)
+    }
+
     func networkingOTPViewDidConfirmVerification(_ view: NetworkingOTPView) {
+        // we could call `showSmallLoadingView(false)` here but we do
+        // not because next step will be to transition to a different
+        // screen and its better to keep showing the loading to
+        // avoid the animation lag
+
         dataSource.markLinkStepUpAuthenticationVerified()
             .observe { [weak self] result in
                 guard let self = self else { return }
@@ -253,7 +261,18 @@ extension NetworkingLinkStepUpVerificationViewController: NetworkingOTPViewDeleg
             }
     }
 
-    func networkingOTPView(_ view: NetworkingOTPView, didTerminallyFailToConfirmVerification error: Error) {
-        delegate?.networkingLinkStepUpVerificationViewController(self, didReceiveTerminalError: error)
+    func networkingOTPView(
+        _ view: NetworkingOTPView,
+        didFailToConfirmVerification error: Error,
+        isTerminal: Bool
+    ) {
+        showSmallLoadingView(false)
+
+        if isTerminal {
+            delegate?.networkingLinkStepUpVerificationViewController(
+                self,
+                didReceiveTerminalError: error
+            )
+        }
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationViewController.swift
@@ -155,6 +155,10 @@ extension NetworkingLinkVerificationViewController: NetworkingOTPViewDelegate {
         delegate?.networkingLinkVerificationViewController(self, didReceiveTerminalError: error)
     }
 
+    func networkingOTPViewWillConfirmVerification(_ view: NetworkingOTPView) {
+        // no-op
+    }
+
     func networkingOTPViewDidConfirmVerification(_ view: NetworkingOTPView) {
         dataSource.markLinkVerified()
             .observe { [weak self] result in
@@ -213,7 +217,16 @@ extension NetworkingLinkVerificationViewController: NetworkingOTPViewDelegate {
             }
     }
 
-    func networkingOTPView(_ view: NetworkingOTPView, didTerminallyFailToConfirmVerification error: Error) {
-        delegate?.networkingLinkVerificationViewController(self, didReceiveTerminalError: error)
+    func networkingOTPView(
+        _ view: NetworkingOTPView,
+        didFailToConfirmVerification error: Error,
+        isTerminal: Bool
+    ) {
+        if isTerminal {
+            delegate?.networkingLinkVerificationViewController(
+                self,
+                didReceiveTerminalError: error
+            )
+        }
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationViewController.swift
@@ -128,6 +128,10 @@ extension NetworkingSaveToLinkVerificationViewController: NetworkingOTPViewDeleg
         delegate?.networkingSaveToLinkVerificationViewController(self, didReceiveTerminalError: error)
     }
 
+    func networkingOTPViewWillConfirmVerification(_ view: NetworkingOTPView) {
+        // no-op
+    }
+
     func networkingOTPViewDidConfirmVerification(_ view: NetworkingOTPView) {
         dataSource.saveToLink()
             .observe { [weak self] result in
@@ -172,8 +176,17 @@ extension NetworkingSaveToLinkVerificationViewController: NetworkingOTPViewDeleg
             }
     }
 
-    func networkingOTPView(_ view: NetworkingOTPView, didTerminallyFailToConfirmVerification error: Error) {
-        delegate?.networkingSaveToLinkVerificationViewController(self, didReceiveTerminalError: error)
+    func networkingOTPView(
+        _ view: NetworkingOTPView,
+        didFailToConfirmVerification error: Error,
+        isTerminal: Bool
+    ) {
+        if isTerminal {
+            delegate?.networkingSaveToLinkVerificationViewController(
+                self,
+                didReceiveTerminalError: error
+            )
+        }
     }
 
     func networkingOTPViewWillStartConsumerLookup(_ view: NetworkingOTPView) {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/SpinnerView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/SpinnerView.swift
@@ -16,8 +16,25 @@ final class SpinnerView: UIView {
         let activityIndicator = ActivityIndicator(size: .large)
         activityIndicator.color = .iconActionPrimary
         activityIndicator.backgroundColor = .customBackgroundColor
-        addAndPinSubviewToSafeArea(activityIndicator)
         activityIndicator.startAnimating()
+        addSubview(activityIndicator)
+
+        // `ActivityIndicator` is hard-coded to have specific sizes, so here we scale it to our needs
+        let largeIconDiameter: CGFloat = 37
+        let desiredIconDiameter: CGFloat = 44
+        let transform = CGAffineTransform(
+            scaleX: desiredIconDiameter / largeIconDiameter,
+            y: desiredIconDiameter / largeIconDiameter
+        )
+        activityIndicator.transform = transform
+        activityIndicator.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            activityIndicator.widthAnchor.constraint(equalToConstant: desiredIconDiameter),
+            activityIndicator.heightAnchor.constraint(equalToConstant: desiredIconDiameter),
+            activityIndicator.centerXAnchor.constraint(equalTo: centerXAnchor),
+            activityIndicator.centerYAnchor.constraint(equalTo: centerYAnchor),
+        ])
+
     }
 
     required init?(coder: NSCoder) {


### PR DESCRIPTION
## Summary

This PR:
- Modifies "Networking Step Up Pane"  to new V3 designs

Details to understand before reviewing PR:
- This is one PR, out of expected ~50+, to change the design of Financial Connections from a "V2" design to a "V3" design. [Here is a link to the designs](https://www.figma.com/file/wXQ8NJApqSJiLmxxANDRTs/%E2%9C%A8-Connections-3.0?type=design&node-id=2524-217093&mode=design&t=kXaBiAlgVsC7YcH1-0).
- The code here is not the finished version. It's just an iteration towards the final version. This code will be re-visited later. The goal is to go screen-by-screen and make easy changes to learn about all the difficulties in each screen. Later, all the learnings will be combined to do a "final" polish of all screens.
- The above also applies to design. The design here is not the finished version.
- This PR is merged into a feature branch `fc-v3`. It is not merged into `master`.
- There might be TODO's scattered throughout the code. That's expected and they will be fixed later. 

## Testing

| Before | After | 
| --- | --- |
| ![before_stepup_2](https://github.com/stripe/stripe-ios/assets/105514761/5b0819f9-e0a8-4f13-8033-a7adfbb6850f) | ![after_stepup](https://github.com/stripe/stripe-ios/assets/105514761/2295e58f-dad1-4b2e-ab3e-b58af0084c40) |
