### PR TITLE
Replace exponential backoff with a simpler approach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## x.x.x x-x-x
+### Payments
+* [Changed] Increased the maximum number of status update retries when waiting for an intent to update to a terminal state. This impacts Cash App Pay and 3DS2.
+
 ## 23.21.0 2024-01-16
 ### PaymentSheet
 * [Fixed] Fixed a few design issues on visionOS.

--- a/Stripe/StripeiOSTests/STPPaymentHandlerTests.swift
+++ b/Stripe/StripeiOSTests/STPPaymentHandlerTests.swift
@@ -242,7 +242,7 @@ class STPPaymentHandlerTests: APIStubbedTestCase {
             checkedStillInProgress.fulfill()
         }
 
-        wait(for: [paymentHandlerExpectation, checkedStillInProgress], timeout: 30)
+        wait(for: [paymentHandlerExpectation, checkedStillInProgress], timeout: 60)
         STPPaymentHandler.sharedHandler.apiClient = STPAPIClient.shared
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLPMConfirmFlowTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLPMConfirmFlowTests.swift
@@ -436,7 +436,7 @@ extension PaymentSheet_LPM_ConfirmFlowTests {
                 }
                 e.fulfill()
             }
-            await fulfillment(of: [e], timeout: 10)
+            await fulfillment(of: [e], timeout: 25)
         }
     }
 

--- a/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
@@ -1412,7 +1412,7 @@ public class STPPaymentHandler: NSObject {
 
     func _retryAfterDelay(retryCount: Int, block: @escaping STPVoidBlock) {
         // Add some backoff time:
-        let delayTime = TimeInterval(5.0)
+        let delayTime = TimeInterval(3)
 
         DispatchQueue.main.asyncAfter(deadline: .now() + delayTime) {
             block()
@@ -1936,7 +1936,7 @@ public class STPPaymentHandler: NSObject {
         }
     }
 
-    static let maxChallengeRetries = 3
+    static let maxChallengeRetries = 5
     func _markChallengeCompleted(
         withCompletion completion: @escaping STPBooleanSuccessBlock,
         retryCount: Int = maxChallengeRetries


### PR DESCRIPTION
## Summary
- Instead of using exponential backoff, we now use a simple approach of retrying every 3 seconds up to 5 times.

## Motivation
https://stripe.slack.com/archives/C06C1SXRGU8/p1705625289866399

## Testing
- Manual in live mode

## Changelog
See diff
