### PR TITLE
Send CVC for transaction after Link signup

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
@@ -227,7 +227,7 @@ class PaymentSheetLinkAccount: PaymentSheetLinkAccountInfoProtocol {
         }
     }
 
-    func sharePaymentDetails(id: String, completion: @escaping (Result<PaymentDetailsShareResponse, Error>) -> Void) {
+    func sharePaymentDetails(id: String, cvc: String?, completion: @escaping (Result<PaymentDetailsShareResponse, Error>) -> Void) {
         guard let session = currentSession else {
             assertionFailure()
             return completion(
@@ -241,6 +241,7 @@ class PaymentSheetLinkAccount: PaymentSheetLinkAccountInfoProtocol {
             session.sharePaymentDetails(
                 with: apiClient,
                 id: id,
+                cvc: cvc,
                 consumerAccountPublishableKey: publishableKey,
                 completion: completionWrapper
             )
@@ -418,7 +419,7 @@ extension PaymentSheetLinkAccount {
     ///
     /// - Parameter paymentDetails: Payment details
     /// - Returns: Payment method params for paying with Link.
-    func makePaymentMethodParams(from paymentDetails: ConsumerPaymentDetails) -> STPPaymentMethodParams? {
+    func makePaymentMethodParams(from paymentDetails: ConsumerPaymentDetails, cvc: String?) -> STPPaymentMethodParams? {
         guard let currentSession = currentSession else {
             assertionFailure("Cannot make payment method params without an active session.")
             return nil
@@ -428,7 +429,7 @@ extension PaymentSheetLinkAccount {
         params.link?.paymentDetailsID = paymentDetails.stripeID
         params.link?.credentials = ["consumer_session_client_secret": currentSession.clientSecret]
 
-        if let cvc = paymentDetails.cvc {
+        if let cvc = cvc {
             params.link?.additionalAPIParameters["card"] = [
                 "cvc": cvc,
             ]

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/ConsumerSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/ConsumerSession.swift
@@ -171,6 +171,7 @@ extension ConsumerSession {
     func sharePaymentDetails(
         with apiClient: STPAPIClient = STPAPIClient.shared,
         id: String,
+        cvc: String?,
         consumerAccountPublishableKey: String?,
         completion: @escaping (Result<PaymentDetailsShareResponse, Error>) -> Void
     ) {
@@ -178,6 +179,7 @@ extension ConsumerSession {
             for: clientSecret,
             id: id,
             consumerAccountPublishableKey: consumerAccountPublishableKey,
+            cvc: cvc,
             completion: completion)
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/PaymentDetails.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/PaymentDetails.swift
@@ -208,7 +208,7 @@ extension ConsumerPaymentDetails {
             return ""
         }
     }
-    
+
     var accessibilityDescription: String {
         switch details {
         case .card(let card):

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/PaymentDetails.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/PaymentDetails.swift
@@ -134,10 +134,6 @@ extension ConsumerPaymentDetails.Details {
             case checks
         }
 
-        /// A frontend convenience property, i.e. not part of the API Object
-        /// As such this is deliberately omitted from CodingKeys
-        var cvc: String?
-
         init(expiryYear: Int,
              expiryMonth: Int,
              brand: String,
@@ -212,18 +208,7 @@ extension ConsumerPaymentDetails {
             return ""
         }
     }
-
-    var cvc: String? {
-        switch details {
-        case .card(let card):
-            return card.cvc
-        case .bankAccount:
-            return nil
-        case .unparsable:
-            return nil
-        }
-    }
-
+    
     var accessibilityDescription: String {
         switch details {
         case .card(let card):

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
@@ -291,9 +291,9 @@ extension STPAPIClient {
             "request_surface": "ios_payment_element",
             "id": id,
         ]
-        
+
         if let cvc = cvc {
-            parameters["payment_method_options"] = ["card": ["cvc" : cvc ]]
+            parameters["payment_method_options"] = ["card": ["cvc": cvc ]]
         }
 
         post(

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
@@ -281,15 +281,20 @@ extension STPAPIClient {
         for consumerSessionClientSecret: String,
         id: String,
         consumerAccountPublishableKey: String?,
+        cvc: String?,
         completion: @escaping (Result<PaymentDetailsShareResponse, Error>) -> Void
     ) {
         let endpoint: String = "consumers/payment_details/share"
 
-        let parameters: [String: Any] = [
+        var parameters: [String: Any] = [
             "credentials": ["consumer_session_client_secret": consumerSessionClientSecret],
             "request_surface": "ios_payment_element",
             "id": id,
         ]
+        
+        if let cvc = cvc {
+            parameters["payment_method_options"] = ["card": ["cvc" : cvc ]]
+        }
 
         post(
             resource: endpoint,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
@@ -293,7 +293,7 @@ extension STPAPIClient {
         ]
 
         if let cvc = cvc {
-            parameters["payment_method_options"] = ["card": ["cvc": cvc ]]
+            parameters["payment_method_options"] = ["card": ["cvc": cvc]]
         }
 
         post(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -340,9 +340,10 @@ extension PaymentSheet {
             let confirmWithPaymentDetails:
                 (
                     PaymentSheetLinkAccount,
-                    ConsumerPaymentDetails
-                ) -> Void = { linkAccount, paymentDetails in
-                    guard let paymentMethodParams = linkAccount.makePaymentMethodParams(from: paymentDetails) else {
+                    ConsumerPaymentDetails,
+                    String?
+                ) -> Void = { linkAccount, paymentDetails, cvc in
+                    guard let paymentMethodParams = linkAccount.makePaymentMethodParams(from: paymentDetails, cvc: cvc) else {
                         let error = PaymentSheetError.payingWithoutValidLinkSession
                         completion(.failed(error: error), nil)
                         return
@@ -371,7 +372,7 @@ extension PaymentSheet {
                         case .success(let paymentDetails):
                             if intent.linkPassthroughModeEnabled {
                                 // If passthrough mode, share payment details
-                                linkAccount.sharePaymentDetails(id: paymentDetails.stripeID) { result in
+                                linkAccount.sharePaymentDetails(id: paymentDetails.stripeID, cvc: paymentMethodParams.card?.cvc) { result in
                                     switch result {
                                     case .success(let shareResponse):
                                         confirmWithPaymentMethod(STPPaymentMethod(stripeId: shareResponse.paymentMethod))
@@ -383,7 +384,7 @@ extension PaymentSheet {
                                 }
                             } else {
                                 // If not passthrough mode, confirm details directly
-                                confirmWithPaymentDetails(linkAccount, paymentDetails)
+                                confirmWithPaymentDetails(linkAccount, paymentDetails, paymentMethodParams.card?.cvc)
                             }
                         case .failure:
                             assertionFailure("Failed to create payment details")
@@ -428,7 +429,7 @@ extension PaymentSheet {
                     }
                 }
             case .withPaymentDetails(let linkAccount, let paymentDetails):
-                confirmWithPaymentDetails(linkAccount, paymentDetails)
+                confirmWithPaymentDetails(linkAccount, paymentDetails, nil)
             case .withPaymentMethodParams(let linkAccount, let paymentMethodParams):
                 createPaymentDetailsAndConfirm(linkAccount, paymentMethodParams)
             case .withPaymentMethod(let paymentMethod):

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLinkAccountTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLinkAccountTests.swift
@@ -42,7 +42,7 @@ final class PaymentSheetLinkAccountTests: XCTestCase {
         XCTAssertEqual(
             result?.link?.additionalAPIParameters["card"] as? [String: String],
             [
-                "cvc": "12345"
+                "cvc": "1234"
             ]
         )
     }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLinkAccountTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLinkAccountTests.swift
@@ -36,8 +36,8 @@ final class PaymentSheetLinkAccountTests: XCTestCase {
     func testMakePaymentMethodParams_withCVC() {
         let sut = makeSUT()
 
-        let paymentDetails = makePaymentDetailsStub(withCVC: "12345")
-        let result = sut.makePaymentMethodParams(from: paymentDetails, cvc: paymentDetails.cvc)
+        let paymentDetails = makePaymentDetailsStub()
+        let result = sut.makePaymentMethodParams(from: paymentDetails, cvc: "1234")
 
         XCTAssertEqual(
             result?.link?.additionalAPIParameters["card"] as? [String: String],
@@ -51,7 +51,7 @@ final class PaymentSheetLinkAccountTests: XCTestCase {
 
 extension PaymentSheetLinkAccountTests {
 
-    func makePaymentDetailsStub(withCVC cvc: String? = nil) -> ConsumerPaymentDetails {
+    func makePaymentDetailsStub() -> ConsumerPaymentDetails {
         let card = ConsumerPaymentDetails.Details.Card(
             expiryYear: 2030,
             expiryMonth: 1,
@@ -59,8 +59,6 @@ extension PaymentSheetLinkAccountTests {
             last4: "4242",
             checks: nil
         )
-
-        card.cvc = cvc
 
         return ConsumerPaymentDetails(
             stripeID: "1",

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLinkAccountTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLinkAccountTests.swift
@@ -11,9 +11,8 @@ import XCTest
 @testable@_spi(STP) import StripeCore
 @testable@_spi(STP) import StripePayments
 @testable@_spi(STP) import StripePaymentSheet
-@testable@_spi(STP) import StripePaymentsUI
 @testable@_spi(STP) import StripePaymentsTestUtils
-
+@testable@_spi(STP) import StripePaymentsUI
 
 final class PaymentSheetLinkAccountTests: XCTestCase {
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLinkAccountTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLinkAccountTests.swift
@@ -21,7 +21,7 @@ final class PaymentSheetLinkAccountTests: XCTestCase {
         let sut = makeSUT()
 
         let paymentDetails = makePaymentDetailsStub()
-        let result = sut.makePaymentMethodParams(from: paymentDetails)
+        let result = sut.makePaymentMethodParams(from: paymentDetails, cvc: nil)
 
         XCTAssertEqual(result?.type, .link)
         XCTAssertEqual(result?.link?.paymentDetailsID, "1")
@@ -38,7 +38,7 @@ final class PaymentSheetLinkAccountTests: XCTestCase {
         let sut = makeSUT()
 
         let paymentDetails = makePaymentDetailsStub(withCVC: "12345")
-        let result = sut.makePaymentMethodParams(from: paymentDetails)
+        let result = sut.makePaymentMethodParams(from: paymentDetails, cvc: paymentDetails.cvc)
 
         XCTAssertEqual(
             result?.link?.additionalAPIParameters["card"] as? [String: String],

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/Types/STPPaymentMethodLinkParams.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/Types/STPPaymentMethodLinkParams.swift
@@ -18,7 +18,7 @@ public class STPPaymentMethodLinkParams: NSObject, STPFormEncodable {
 
     /// :nodoc:
     @objc @_spi(STP) public var card: [AnyHashable: Any]?
-    
+
     /// :nodoc:
     @objc public var additionalAPIParameters: [AnyHashable: Any] = [:]
 

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/Types/STPPaymentMethodLinkParams.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/Types/STPPaymentMethodLinkParams.swift
@@ -17,9 +17,6 @@ public class STPPaymentMethodLinkParams: NSObject, STPFormEncodable {
     @objc @_spi(STP) public var credentials: [AnyHashable: Any]?
 
     /// :nodoc:
-    @objc @_spi(STP) public var card: [AnyHashable: Any]?
-
-    /// :nodoc:
     @objc public var additionalAPIParameters: [AnyHashable: Any] = [:]
 
     // MARK: - STPFormEncodable
@@ -33,7 +30,6 @@ public class STPPaymentMethodLinkParams: NSObject, STPFormEncodable {
         return [
             NSStringFromSelector(#selector(getter: credentials)): "credentials",
             NSStringFromSelector(#selector(getter: paymentDetailsID)): "payment_details_id",
-            NSStringFromSelector(#selector(getter: card)): "card",
         ]
     }
 }

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/Types/STPPaymentMethodLinkParams.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/Types/STPPaymentMethodLinkParams.swift
@@ -17,6 +17,9 @@ public class STPPaymentMethodLinkParams: NSObject, STPFormEncodable {
     @objc @_spi(STP) public var credentials: [AnyHashable: Any]?
 
     /// :nodoc:
+    @objc @_spi(STP) public var card: [AnyHashable: Any]?
+    
+    /// :nodoc:
     @objc public var additionalAPIParameters: [AnyHashable: Any] = [:]
 
     // MARK: - STPFormEncodable
@@ -30,6 +33,7 @@ public class STPPaymentMethodLinkParams: NSObject, STPFormEncodable {
         return [
             NSStringFromSelector(#selector(getter: credentials)): "credentials",
             NSStringFromSelector(#selector(getter: paymentDetailsID)): "payment_details_id",
+            NSStringFromSelector(#selector(getter: card)): "card",
         ]
     }
 }


### PR DESCRIPTION
## Summary
Send CVC to the correct signup endpoints for both PM and passthrough mode.

## Motivation
We weren't passing along the CVC during Link signup transactions in PM or passthrough mode.

## Testing
CI, manually in PaymentSheet example.
