### PR TITLE
Stop sending empty error_message in PaymentSheet error analytics

### DIFF
--- a/StripePaymentSheet/StripePaymentSheetTests/STPAnalyticsClient+PaymentSheetTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/STPAnalyticsClient+PaymentSheetTests.swift
@@ -27,10 +27,10 @@ class STPAnalyticsClientPaymentSheetTest: XCTestCase {
         var debugDescription: String {
             return "Some debug description that accidentally contains PII"
         }
-        
+
         case foo
     }
-    
+
     func testMakeSafeLoggingString() {
         let testCases: [(Error, String)] = [
             // List of inputs and expected outputs
@@ -42,10 +42,8 @@ class STPAnalyticsClientPaymentSheetTest: XCTestCase {
              "cardError"),
             (NSError(domain: STPError.stripeDomain, code: STPErrorCode.invalidRequestError.rawValue),
              "invalidRequestError"),
-            (NSError(domain: STPError.stripeDomain, code: STPErrorCode.invalidRequestError.rawValue, userInfo: [STPError.errorMessageKey: "rate_limit_exceeded"]),
-             "rate_limit_exceeded"),
             (MyError.foo,
-             "StripePaymentSheetTests.STPAnalyticsClientPaymentSheetTest.MyError"),
+             "StripePaymentSheetTests.STPAnalyticsClientPaymentSheetTest.MyError, 0"),
 
         ]
         for testCase in testCases {

--- a/StripePaymentSheet/StripePaymentSheetTests/STPAnalyticsClient+PaymentSheetTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/STPAnalyticsClient+PaymentSheetTests.swift
@@ -22,4 +22,34 @@ class STPAnalyticsClientPaymentSheetTest: XCTestCase {
         let payload = client.payload(from: analytic)
         XCTAssertEqual("paymentsheet", payload["pay_var"] as? String)
     }
+
+    enum MyError: Error, CustomDebugStringConvertible {
+        var debugDescription: String {
+            return "Some debug description that accidentally contains PII"
+        }
+        
+        case foo
+    }
+    
+    func testMakeSafeLoggingString() {
+        let testCases: [(Error, String)] = [
+            // List of inputs and expected outputs
+            (NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut),
+             "NSURLErrorDomain, -1001"),
+            (PaymentSheetError.errorHandlingNextAction,
+             "errorHandlingNextAction"),
+            (NSError(domain: STPError.stripeDomain, code: STPErrorCode.cardError.rawValue),
+             "cardError"),
+            (NSError(domain: STPError.stripeDomain, code: STPErrorCode.invalidRequestError.rawValue),
+             "invalidRequestError"),
+            (NSError(domain: STPError.stripeDomain, code: STPErrorCode.invalidRequestError.rawValue, userInfo: [STPError.errorMessageKey: "rate_limit_exceeded"]),
+             "rate_limit_exceeded"),
+            (MyError.foo,
+             "StripePaymentSheetTests.STPAnalyticsClientPaymentSheetTest.MyError"),
+
+        ]
+        for testCase in testCases {
+            XCTAssertEqual(STPAnalyticsClient().makeSafeLoggingString(from: testCase.0), testCase.1)
+        }
+    }
 }


### PR DESCRIPTION


## Summary
The SDK sends an analytic when PaymentSheet confirmation or load fails. This analytic contains an `error_message` field.

This PR provides `error_message` values for all errors, not just PaymentSheetError and STPError.

## Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-1509

## Testing
- See unit tests

## Changelog
Not user facing
