### PR TITLE
Add request id to PaymentSheet error analytics

### DIFF
--- a/Stripe/StripeiOSTests/StripeErrorTest.swift
+++ b/Stripe/StripeiOSTests/StripeErrorTest.swift
@@ -251,4 +251,23 @@ class StripeErrorTest: XCTestCase {
             "insufficient_funds"
         )
     }
+
+    func testErrorAddsRequestIdToUserInfo() {
+        let response = [
+            "error": [
+                "type": "card_error",
+                "code": "card_declined",
+                "decline_code": "insufficient_funds",
+            ],
+        ]
+        let httpURLResponse = HTTPURLResponse(url: URL(string: "https://api.stripe.com/v1/some_endpoint")!, statusCode: 400, httpVersion: nil, headerFields: ["request-id": "req_123"])
+        guard let error = NSError.stp_error(fromStripeResponse: response, httpResponse: httpURLResponse) else {
+            XCTFail()
+            return
+        }
+        XCTAssertEqual(
+            error.userInfo[STPError.stripeRequestIDKey] as? String,
+            "req_123"
+        )
+    }
 }

--- a/StripeCore/StripeCore/Source/Helpers/STPError.swift
+++ b/StripeCore/StripeCore/Source/Helpers/STPError.swift
@@ -69,6 +69,9 @@ import Foundation
     ///
     /// - seealso: https://stripe.com/docs/declines/codes
     @objc public static let stripeDeclineCodeKey = "com.stripe.lib:DeclineCodeKey"
+
+    /// The Stripe API request ID, if available. Looks like `req_123`.
+    @_spi(STP) public static let stripeRequestIDKey = "com.stripe.lib:StripeRequestIDKey"
 }
 
 extension NSError {
@@ -205,6 +208,11 @@ extension NSError {
                     }
                 }
             }
+        }
+
+        // Add the Stripe request id if it exists
+        if let requestId = httpResponse?.value(forHTTPHeaderField: "request-id") {
+            userInfo[STPError.stripeRequestIDKey] = requestId
         }
 
         return NSError(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
@@ -278,6 +278,7 @@ extension STPAnalyticsClient {
 
         if let error {
             additionalParams["error_message"] = makeSafeLoggingString(from: error)
+            additionalParams["request_id"] = (error as NSError).userInfo[STPError.stripeRequestIDKey]
         }
 
         for (param, param_value) in params {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderTest.swift
@@ -175,6 +175,7 @@ final class PaymentSheetLoaderTest: XCTestCase {
                 // Should send a load failure analytic
                 let analyticEvent = analyticsClient._testLogHistory.last
                 XCTAssertEqual(analyticEvent?["error_message"] as? String, "invalidRequestError")
+                XCTAssertTrue((analyticEvent?["request_id"] as? String)?.starts(with: "req_") ?? false)
             }
         }
         wait(for: [loadExpectation], timeout: STPTestingNetworkRequestTimeout)


### PR DESCRIPTION
## Summary
- Adds request id to the `userInfo` dictionary of errors that come from the Stripe API
- Send a new `request_id` field in PaymentSheet error analytics that is populated using ^

## Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-1510

## Testing
See unit tests. Manually tested by using a test card that gets declined in playground.

## Changelog
Not user facing.