### PR TITLE
Financial Connections: for v3, fixed an issue that where consent pane dots were not animating

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentLogoView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentLogoView.swift
@@ -58,6 +58,10 @@ final class ConsentLogoView: UIView {
         guard let multipleDotView = multipleDotView else {
             return
         }
+        
+        // remove any previous animations if-needed
+        multipleDotView.layer.removeAllAnimations()
+        
         multipleDotView.frame = CGRect(
             x: -multipleDotView.bounds.width + ellipsisViewWidth,
             y: 0,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentLogoView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentLogoView.swift
@@ -10,8 +10,11 @@ import Foundation
 import UIKit
 
 private let blurRadius = 3
+private let ellipsisViewWidth: CGFloat = 32.0
 
 final class ConsentLogoView: UIView {
+
+    private var multipleDotView: UIView?
 
     init(merchantLogo: [String]) {
         super.init(frame: .zero)
@@ -30,13 +33,16 @@ final class ConsentLogoView: UIView {
 
                 let isLastLogo = (i == merchantLogo.count - 1)
                 if !isLastLogo {
-                    horizontalStackView.addArrangedSubview(
-                        CreateEllipsisView(
-                            leftLogoUrl:
-                                merchantLogo[i],
-                            rightLogoUrl: merchantLogo[i+1]
-                        )
+                    let ellipsisViewTuple = CreateEllipsisView(
+                        leftLogoUrl:
+                            merchantLogo[i],
+                        rightLogoUrl: merchantLogo[i+1]
                     )
+                    self.multipleDotView = ellipsisViewTuple.multipleDotView
+                    horizontalStackView.addArrangedSubview(
+                        ellipsisViewTuple.ellipsisView
+                    )
+                    animateDots()
                 }
             }
         }
@@ -46,6 +52,31 @@ final class ConsentLogoView: UIView {
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    func animateDots() {
+        guard let multipleDotView = multipleDotView else {
+            return
+        }
+        multipleDotView.frame = CGRect(
+            x: -multipleDotView.bounds.width + ellipsisViewWidth,
+            y: 0,
+            width: multipleDotView.bounds.width,
+            height: multipleDotView.bounds.height
+        )
+        UIView.animate(
+            withDuration: 1.0,
+            delay: 0,
+            options: [.repeat, .curveLinear],
+            animations: {
+                multipleDotView.frame = CGRect(
+                    x: multipleDotView.frame.minX + MultipleDotView.dotRadius + MultipleDotView.dotSpacing,
+                    y: 0,
+                    width: multipleDotView.bounds.width,
+                    height: multipleDotView.bounds.height
+                )
+            }
+        )
     }
 }
 
@@ -67,9 +98,7 @@ private func CreateRoundedLogoView(urlString: String) -> UIView {
 private func CreateEllipsisView(
     leftLogoUrl: String?,
     rightLogoUrl: String?
-) -> UIView {
-    let ellipsisViewWidth: CGFloat = 32.0
-
+) -> (ellipsisView: UIView, multipleDotView: UIView) {
     let backgroundView = MergedLogoView(
         leftImageUrl: leftLogoUrl,
         rightImageUrl: rightLogoUrl
@@ -82,31 +111,9 @@ private func CreateEllipsisView(
     ])
 
     let multipleDotView = MultipleDotView()
-    multipleDotView.frame = CGRect(
-        x: -multipleDotView.bounds.width + ellipsisViewWidth,
-        y: 0,
-        width: multipleDotView.bounds.width,
-        height: multipleDotView.bounds.height
-    )
-
     backgroundView.mask = multipleDotView
 
-    // TODO(kgaidis): add code to repeat animation even when UIViewController is presented
-    UIView.animate(
-        withDuration: 1.0,
-        delay: 0,
-        options: [.repeat, .curveLinear],
-        animations: {
-            multipleDotView.frame = CGRect(
-                x: multipleDotView.frame.minX + MultipleDotView.dotRadius + MultipleDotView.dotSpacing,
-                y: 0,
-                width: multipleDotView.bounds.width,
-                height: multipleDotView.bounds.height
-            )
-        }
-    )
-
-    return backgroundView
+    return (backgroundView, multipleDotView)
 }
 
 /// A view that blurs two logos together.

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentViewController.swift
@@ -56,6 +56,7 @@ class ConsentViewController: UIViewController {
             }
         )
     }()
+    private var consentLogoView: ConsentLogoView?
 
     init(dataSource: ConsentDataSource) {
         self.dataSource = dataSource
@@ -73,9 +74,11 @@ class ConsentViewController: UIViewController {
         let paneLayoutView = PaneWithCustomHeaderLayoutView(
             headerView: {
                 if let merchantLogo = dataSource.merchantLogo {
+                    let consentLogoView = ConsentLogoView(merchantLogo: merchantLogo)
+                    self.consentLogoView = consentLogoView
                     let stackView = UIStackView(
                         arrangedSubviews: [
-                            ConsentLogoView(merchantLogo: merchantLogo),
+                            consentLogoView,
                             titleLabel,
                         ]
                     )
@@ -99,6 +102,13 @@ class ConsentViewController: UIViewController {
         paneLayoutView.addTo(view: view)
 
         dataSource.analyticsClient.logPaneLoaded(pane: .consent)
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        // this fixes an issue where presenting a UIViewController
+        // on top of ConsentViewController would stop the dot animation
+        consentLogoView?.animateDots()
     }
 
     private func didSelectAgree() {


### PR DESCRIPTION
## Summary

This PR:
- Previously, the "dot" animation at the top stopped working if a UIViewController was presented on top. This PR fixes this issue by restarting the animation every time we present the UIViewController. 

![Screenshot 2024-01-23 at 3 24 20 PM](https://github.com/stripe/stripe-ios/assets/105514761/16c6ae87-5586-45dc-9235-1bb353d29864)

Details to understand before reviewing PR:
- This is one PR, out of expected ~50+, to change the design of Financial Connections from a "V2" design to a "V3" design. [Here is a link to the designs](https://www.figma.com/file/wXQ8NJApqSJiLmxxANDRTs/%E2%9C%A8-Connections-3.0?type=design&node-id=2524-217093&mode=design&t=kXaBiAlgVsC7YcH1-0).
- The code here is not the finished version. It's just an iteration towards the final version. This code will be re-visited later. The goal is to go screen-by-screen and make easy changes to learn about all the difficulties in each screen. Later, all the learnings will be combined to do a "final" polish of all screens.
- The above also applies to design. The design here is not the finished version.
- This PR is merged into a feature branch `fc-v3`. It is not merged into `master`.
- There might be TODO's scattered throughout the code. That's expected and they will be fixed later. 

## Testing

This video shows the "dot animation" working regardless of whether a VC is presented on top:

https://github.com/stripe/stripe-ios/assets/105514761/9fa47862-2506-4367-9837-15eb1931eca8

