### PR TITLE
Financial Connections: for v3, changed OTP to better match designs

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
@@ -46,7 +46,16 @@ final class NetworkingOTPView: UIView {
     // TODO(kgaidis): make changes to `OneTimeCodeTextField` to
     // make the font larger
     private(set) lazy var otpTextField: OneTimeCodeTextField = {
-        let otpTextField = OneTimeCodeTextField(theme: theme)
+        let otpTextField = OneTimeCodeTextField(
+            configuration: OneTimeCodeTextField.Configuration(
+                itemSpacing: 8,
+                enableDigitGrouping: false,
+                font: UIFont.systemFont(ofSize: 28, weight: .regular),
+                itemCornerRadius: 12,
+                itemHeight: 56
+            ),
+            theme: theme
+        )
         otpTextField.tintColor = .textBrand
         otpTextField.addTarget(self, action: #selector(otpTextFieldDidChange), for: .valueChanged)
         otpTextField.tintColor = .textActionPrimaryFocused

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
@@ -43,8 +43,6 @@ final class NetworkingOTPView: UIView {
         otpVerticalStackView.spacing = 16
         return otpVerticalStackView
     }()
-    // TODO(kgaidis): make changes to `OneTimeCodeTextField` to
-    // make the font larger
     private(set) lazy var otpTextField: OneTimeCodeTextField = {
         let otpTextField = OneTimeCodeTextField(
             configuration: OneTimeCodeTextField.Configuration(


### PR DESCRIPTION
## Summary

This PR:
- Changed the design of OTP text field to better match design.

Details to understand before reviewing PR:
- This is one PR, out of expected ~50+, to change the design of Financial Connections from a "V2" design to a "V3" design. [Here is a link to the designs](https://www.figma.com/file/wXQ8NJApqSJiLmxxANDRTs/%E2%9C%A8-Connections-3.0?type=design&node-id=2524-217093&mode=design&t=kXaBiAlgVsC7YcH1-0).
- The code here is not the finished version. It's just an iteration towards the final version. This code will be re-visited later. The goal is to go screen-by-screen and make easy changes to learn about all the difficulties in each screen. Later, all the learnings will be combined to do a "final" polish of all screens.
- The above also applies to design. The design here is not the finished version.
- This PR is merged into a feature branch `fc-v3`. It is not merged into `master`.
- There might be TODO's scattered throughout the code. That's expected and they will be fixed later. 

## Testing

| Before | After |
| --- | --- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-01-23 at 15 42 48](https://github.com/stripe/stripe-ios/assets/105514761/3df68763-7f8f-4339-8d6c-eafc574ccdf8) | ![after](https://github.com/stripe/stripe-ios/assets/105514761/5df19c8f-e5b9-4e7d-b3f3-c21413577f14) |


