### PR TITLE
Log returnURL on linkPopupError with redacted arg

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkWebController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkWebController.swift
@@ -165,7 +165,7 @@ final class PayWithLinkWebController: NSObject, ASWebAuthenticationPresentationC
             self.webAuthSession = webAuthSession
             webAuthSession.start()
         } catch {
-            self.canceledWithError(error: error)
+            self.canceledWithError(error: error, returnURL: nil)
         }
     }
 
@@ -177,8 +177,8 @@ final class PayWithLinkWebController: NSObject, ASWebAuthenticationPresentationC
         self.payWithLinkDelegate?.payWithLinkWebControllerDidCancel(self)
     }
 
-    private func canceledWithError(error: Error?) {
-        STPAnalyticsClient.sharedClient.logLinkPopupError(error: error, sessionType: self.context.intent.linkPopupWebviewOption)
+    private func canceledWithError(error: Error?, returnURL: URL?) {
+        STPAnalyticsClient.sharedClient.logLinkPopupError(error: error, returnURL: returnURL, sessionType: self.context.intent.linkPopupWebviewOption)
         self.payWithLinkDelegate?.payWithLinkWebControllerDidCancel(self)
     }
 
@@ -190,7 +190,7 @@ final class PayWithLinkWebController: NSObject, ASWebAuthenticationPresentationC
                 self.canceledWithoutError()
             } else {
                 // Canceled for another reason - raise an error.
-                self.canceledWithError(error: error)
+                self.canceledWithError(error: error, returnURL: returnURL)
             }
             return
         }
@@ -209,7 +209,7 @@ final class PayWithLinkWebController: NSObject, ASWebAuthenticationPresentationC
                 self.payWithLinkDelegate?.payWithLinkWebControllerDidCancel(self)
             }
         } catch {
-            self.canceledWithError(error: error)
+            self.canceledWithError(error: error, returnURL: returnURL)
         }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/STPAnalyticsClient+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/STPAnalyticsClient+Link.swift
@@ -69,9 +69,16 @@ extension STPAnalyticsClient {
         logPaymentSheetEvent(event: .linkPopupSkipped)
     }
 
-    func logLinkPopupError(error: Error?, sessionType: LinkSettings.PopupWebviewOption) {
+    func logLinkPopupError(error: Error?, returnURL: URL?, sessionType: LinkSettings.PopupWebviewOption) {
         let duration = AnalyticsHelper.shared.getDuration(for: .linkPopup)
-        self.logLinkPopupEvent(event: .linkPopupError, duration: duration, sessionType: sessionType, error: error)
+        var params: [String: Any] = [:]
+        if let redactedURL = LinkPopupURLParser.redactedURLForLogging(url: returnURL) {
+            params["returnURL"] = redactedURL
+        }
+        if let error = error {
+            params["error"] = error.localizedDescription
+        }
+        logPaymentSheetEvent(event: .linkPopupError, duration: duration, linkSessionType: sessionType, params: params)
     }
 
     func logLinkPopupLogout(sessionType: LinkSettings.PopupWebviewOption) {
@@ -93,5 +100,4 @@ extension STPAnalyticsClient {
                                  linkSessionType: sessionType,
                                  params: params)
         }
-
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Utils/LinkPopupURLParser.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Utils/LinkPopupURLParser.swift
@@ -26,6 +26,26 @@ class LinkPopupURLParser {
         let pm = try STPPaymentMethod.decodedObject(base64: pmItem)
         return LinkResult(link_status: status, pm: pm)
     }
+
+    static func redactedURLForLogging(url: URL?) -> URL? {
+        guard let url = url,
+              var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return nil
+        }
+        let originalQueryItems = components.queryItems
+
+        var updatedQueryItems: [URLQueryItem] = []
+        originalQueryItems?.forEach { item in
+            if item.name == "pm" {
+                let updatedItem = URLQueryItem(name: item.name, value: "<redacted>")
+                updatedQueryItems.append(updatedItem)
+            } else {
+                updatedQueryItems.append(item)
+            }
+        }
+        components.queryItems = updatedQueryItems
+        return components.url
+    }
 }
 
 extension STPPaymentMethod {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkPopupURLParserTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkPopupURLParserTests.swift
@@ -34,4 +34,23 @@ class LinkPopupURLParserTests: XCTestCase {
             XCTAssertEqual(error as! LinkPopupURLParserError, LinkPopupURLParserError.invalidURLParams)
         }
     }
+
+    func testRedactQueryStringWithKey() {
+        let result = LinkPopupURLParser.redactedURLForLogging(url: testURL)
+        XCTAssertEqual(result?.absoluteString, "link-popup://complete?link_status=complete&pm=%3Credacted%3E")
+    }
+    func testRedactQueryStringWithKey_noPm() {
+        let testURLNoPM = URL(string: "link-popup://complete?link_status=complete")!
+        let result = LinkPopupURLParser.redactedURLForLogging(url: testURLNoPM)
+        XCTAssertEqual(result?.absoluteString, "link-popup://complete?link_status=complete")
+    }
+    func testRedactQueryStringWithKey_multiPm() {
+        let testURLNoPM = URL(string: "link-popup://complete?link_status=complete&pm=pm1&pm=pm2")!
+        let result = LinkPopupURLParser.redactedURLForLogging(url: testURLNoPM)
+        XCTAssertEqual(result?.absoluteString, "link-popup://complete?link_status=complete&pm=%3Credacted%3E&pm=%3Credacted%3E")
+    }
+    func testRedactQueryStringWithKey_nil() {
+        let result = LinkPopupURLParser.redactedURLForLogging(url: nil)
+        XCTAssertNil(result)
+    }
 }


### PR DESCRIPTION
## Summary
Log the returnURL of the link popup error w/ redacted pmId

## Motivation
Saw an error. Would like more info on it.

## Testing
Added unit tests

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
