### PR TITLE
Add new and plumb ConsentAction to consumer endpoint

### DIFF
--- a/Stripe/StripeiOSTests/LinkSignupViewModelTests.swift
+++ b/Stripe/StripeiOSTests/LinkSignupViewModelTests.swift
@@ -23,7 +23,7 @@ class LinkInlineSignupViewModelTests: XCTestCase {
     let accountLookupTimeout: TimeInterval = 4
 
     func test_defaults() {
-        let sut = makeSUT(country: "US")
+        let sut = makeSUT(country: "US", showCheckbox: true)
 
         XCTAssertFalse(sut.shouldShowEmailField)
         XCTAssertFalse(sut.shouldShowPhoneField)
@@ -32,7 +32,7 @@ class LinkInlineSignupViewModelTests: XCTestCase {
     }
 
     func test_shouldShowEmailFieldWhenCheckboxIsChecked() {
-        let sut = makeSUT(country: "US")
+        let sut = makeSUT(country: "US", showCheckbox: true)
 
         sut.saveCheckboxChecked = true
         XCTAssertTrue(sut.shouldShowEmailField)
@@ -42,7 +42,7 @@ class LinkInlineSignupViewModelTests: XCTestCase {
     }
 
     func test_shouldShowRegistrationFieldsWhenEmailIsProvided() {
-        let sut = makeSUT(country: "US")
+        let sut = makeSUT(country: "US", showCheckbox: true)
 
         sut.saveCheckboxChecked = true
         sut.emailAddress = "user@example.com"
@@ -75,13 +75,13 @@ class LinkInlineSignupViewModelTests: XCTestCase {
     }
 
     func test_shouldShowNameField_nonUSCustomers() {
-        let sut = makeSUT(country: "CA", hasAccount: true)
+        let sut = makeSUT(country: "CA", showCheckbox: true, hasAccount: true)
         sut.saveCheckboxChecked = true
         XCTAssertTrue(sut.shouldShowNameField, "Should show name field for non-US customers")
     }
 
     func test_action_returnsNilUnlessPhoneRequirementIsFulfilled() {
-        let sut = makeSUT(country: "US", hasAccount: true)
+        let sut = makeSUT(country: "US", showCheckbox: true, hasAccount: true)
 
         sut.saveCheckboxChecked = true
         XCTAssertNil(sut.action)
@@ -92,7 +92,7 @@ class LinkInlineSignupViewModelTests: XCTestCase {
 
     func test_action_returnsNilUnlessNameRequirementIsFulfilled() {
         // Non-US customers require providing a name
-        let sut = makeSUT(country: "CA", hasAccount: true)
+        let sut = makeSUT(country: "CA", showCheckbox: true, hasAccount: true)
 
         sut.saveCheckboxChecked = true
         sut.phoneNumber = PhoneNumber(number: "5555555555", countryCode: "CA")
@@ -103,14 +103,14 @@ class LinkInlineSignupViewModelTests: XCTestCase {
     }
 
     func test_action_returnsContinueWithoutLinkIfCheckboxIsNotChecked() {
-        let sut = makeSUT(country: "US")
+        let sut = makeSUT(country: "US", showCheckbox: true)
 
         sut.saveCheckboxChecked = false
         XCTAssertEqual(sut.action, .continueWithoutLink)
     }
 
     func test_action_returnsContinueWithoutLinkIfLookupFails() {
-        let sut = makeSUT(country: "US", shouldFailLookup: true)
+        let sut = makeSUT(country: "US", showCheckbox: true, shouldFailLookup: true)
 
         sut.saveCheckboxChecked = true
         sut.emailAddress = "user@example.com"
@@ -125,13 +125,32 @@ class LinkInlineSignupViewModelTests: XCTestCase {
 
         XCTAssertEqual(sut.action, .continueWithoutLink)
     }
+
     func test_consentAction_checkbox() {
-        let sut = makeSUT(country: "US", hasAccount: false)
-        XCTAssertEqual(sut.consentAction, .checkbox)
+        let sut = makeSUT(country: "US", showCheckbox: true, hasAccount: false)
+        XCTAssertEqual(sut.consentAction, .checkbox_v0)
     }
+
+    func test_consentAction_checkbox_prefillEmail() {
+        let sut = makeSUT(country: "US", showCheckbox: true, hasAccount: true)
+        XCTAssertEqual(sut.consentAction, .checkbox_v0_0)
+    }
+
+    func test_consentAction_checkbox_prefillEmailAndPhone() {
+        let sut = makeSUT(country: "US", showCheckbox: true, hasAccount: true)
+        sut.phoneNumber = PhoneNumber(number: "555555555", countryCode: "1")
+        sut.phoneNumberWasPrefilled = true
+        XCTAssertEqual(sut.consentAction, .checkbox_v0_1)
+    }
+
     func test_consentAction_implied() {
-        let sut = makeSUT(country: "US", mode: .textFieldsOnly, hasAccount: false)
-        XCTAssertEqual(sut.consentAction, .implied)
+        let sut = makeSUT(country: "US", showCheckbox: false, hasAccount: false)
+        XCTAssertEqual(sut.consentAction, .implied_v0)
+    }
+
+    func test_consentAction_implied_prefillEmail() {
+        let sut = makeSUT(country: "US", showCheckbox: false, hasAccount: true)
+        XCTAssertEqual(sut.consentAction, .implied_v0_0)
     }
 }
 
@@ -167,7 +186,7 @@ extension LinkInlineSignupViewModelTests {
 
     func makeSUT(
         country: String,
-        showCheckbox: Bool = true,
+        showCheckbox: Bool,
         hasAccount: Bool = false,
         shouldFailLookup: Bool = false
     ) -> LinkInlineSignupViewModel {
@@ -178,7 +197,7 @@ extension LinkInlineSignupViewModelTests {
 
         return LinkInlineSignupViewModel(
             configuration: .init(),
-            showCheckbox: true,
+            showCheckbox: showCheckbox,
             accountService: MockAccountService(shouldFailLookup: shouldFailLookup),
             linkAccount: linkAccount,
             country: country

--- a/Stripe/StripeiOSTests/LinkSignupViewModelTests.swift
+++ b/Stripe/StripeiOSTests/LinkSignupViewModelTests.swift
@@ -125,7 +125,14 @@ class LinkInlineSignupViewModelTests: XCTestCase {
 
         XCTAssertEqual(sut.action, .continueWithoutLink)
     }
-
+    func test_consentAction_checkbox() {
+        let sut = makeSUT(country: "US", hasAccount: false)
+        XCTAssertEqual(sut.consentAction, .checkbox)
+    }
+    func test_consentAction_implied() {
+        let sut = makeSUT(country: "US", mode: .textFieldsOnly, hasAccount: false)
+        XCTAssertEqual(sut.consentAction, .implied)
+    }
 }
 
 extension LinkInlineSignupViewModelTests {
@@ -160,6 +167,7 @@ extension LinkInlineSignupViewModelTests {
 
     func makeSUT(
         country: String,
+        showCheckbox: Bool = true,
         hasAccount: Bool = false,
         shouldFailLookup: Bool = false
     ) -> LinkInlineSignupViewModel {

--- a/Stripe/StripeiOSTests/LinkSignupViewModelTests.swift
+++ b/Stripe/StripeiOSTests/LinkSignupViewModelTests.swift
@@ -75,13 +75,13 @@ class LinkInlineSignupViewModelTests: XCTestCase {
     }
 
     func test_shouldShowNameField_nonUSCustomers() {
-        let sut = makeSUT(country: "CA", showCheckbox: true, hasAccount: true)
+        let sut = makeSUT(country: "CA", showCheckbox: true, hasAccountObject: true)
         sut.saveCheckboxChecked = true
         XCTAssertTrue(sut.shouldShowNameField, "Should show name field for non-US customers")
     }
 
     func test_action_returnsNilUnlessPhoneRequirementIsFulfilled() {
-        let sut = makeSUT(country: "US", showCheckbox: true, hasAccount: true)
+        let sut = makeSUT(country: "US", showCheckbox: true, hasAccountObject: true)
 
         sut.saveCheckboxChecked = true
         XCTAssertNil(sut.action)
@@ -92,7 +92,7 @@ class LinkInlineSignupViewModelTests: XCTestCase {
 
     func test_action_returnsNilUnlessNameRequirementIsFulfilled() {
         // Non-US customers require providing a name
-        let sut = makeSUT(country: "CA", showCheckbox: true, hasAccount: true)
+        let sut = makeSUT(country: "CA", showCheckbox: true, hasAccountObject: true)
 
         sut.saveCheckboxChecked = true
         sut.phoneNumber = PhoneNumber(number: "5555555555", countryCode: "CA")
@@ -127,29 +127,29 @@ class LinkInlineSignupViewModelTests: XCTestCase {
     }
 
     func test_consentAction_checkbox() {
-        let sut = makeSUT(country: "US", showCheckbox: true, hasAccount: false)
+        let sut = makeSUT(country: "US", showCheckbox: true, hasAccountObject: false)
         XCTAssertEqual(sut.consentAction, .checkbox_v0)
     }
 
     func test_consentAction_checkbox_prefillEmail() {
-        let sut = makeSUT(country: "US", showCheckbox: true, hasAccount: true)
+        let sut = makeSUT(country: "US", showCheckbox: true, hasAccountObject: true)
         XCTAssertEqual(sut.consentAction, .checkbox_v0_0)
     }
 
     func test_consentAction_checkbox_prefillEmailAndPhone() {
-        let sut = makeSUT(country: "US", showCheckbox: true, hasAccount: true)
+        let sut = makeSUT(country: "US", showCheckbox: true, hasAccountObject: true)
         sut.phoneNumber = PhoneNumber(number: "555555555", countryCode: "1")
         sut.phoneNumberWasPrefilled = true
         XCTAssertEqual(sut.consentAction, .checkbox_v0_1)
     }
 
     func test_consentAction_implied() {
-        let sut = makeSUT(country: "US", showCheckbox: false, hasAccount: false)
+        let sut = makeSUT(country: "US", showCheckbox: false, hasAccountObject: false)
         XCTAssertEqual(sut.consentAction, .implied_v0)
     }
 
     func test_consentAction_implied_prefillEmail() {
-        let sut = makeSUT(country: "US", showCheckbox: false, hasAccount: true)
+        let sut = makeSUT(country: "US", showCheckbox: false, hasAccountObject: true)
         XCTAssertEqual(sut.consentAction, .implied_v0_0)
     }
 }
@@ -187,11 +187,10 @@ extension LinkInlineSignupViewModelTests {
     func makeSUT(
         country: String,
         showCheckbox: Bool,
-        hasAccount: Bool = false,
+        hasAccountObject: Bool = false,
         shouldFailLookup: Bool = false
     ) -> LinkInlineSignupViewModel {
-        let linkAccount: PaymentSheetLinkAccount? =
-            hasAccount
+        let linkAccount: PaymentSheetLinkAccount? = hasAccountObject
             ? PaymentSheetLinkAccount(email: "user@example.com", session: nil, publishableKey: nil)
             : nil
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
@@ -29,8 +29,8 @@ class PaymentSheetLinkAccount: PaymentSheetLinkAccountInfoProtocol {
     }
 
     enum ConsentAction: String {
-        case checkbox = "clicked_checkbox_mobile"
-        case button = "clicked_button_mobile"
+        case checkbox = "clicked_checkbox_no_spm_mobile_v0"
+        case implied = "implied_consent_withspm_mobile_v0"
     }
 
     // Dependencies

--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
@@ -28,9 +28,23 @@ class PaymentSheetLinkAccount: PaymentSheetLinkAccountInfoProtocol {
         case verified
     }
 
+    // More information: go/link-signup-consent-action-log
     enum ConsentAction: String {
-        case checkbox = "clicked_checkbox_no_spm_mobile_v0"
-        case implied = "implied_consent_withspm_mobile_v0"
+        // Checkbox, no fields prefilled
+        case checkbox_v0 = "clicked_checkbox_no_spm_mobile_v0"
+
+        // Checkbox, w/ email prefilled
+        case checkbox_v0_0 = "clicked_checkbox_no_spm_mobile_v0_0"
+
+        // Checkbox, w/ email & phone prefilled
+        case checkbox_v0_1 = "clicked_checkbox_no_spm_mobile_v0_1"
+
+        // Inline, no fields prefilled
+        case implied_v0 = "implied_consent_withspm_mobile_v0"
+
+        // Inline, email-prefilled
+        case implied_v0_0 = "implied_consent_withspm_mobile_v0_0"
+
     }
 
     // Dependencies

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/InlineSignup/LinkInlineSignupView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/InlineSignup/LinkInlineSignupView.swift
@@ -153,6 +153,10 @@ final class LinkInlineSignupView: UIView {
 
     func setupDefaults() {
         viewModel.phoneNumber = phoneNumberElement.phoneNumber
+        if let phoneNumber = viewModel.phoneNumber,
+           !phoneNumber.isEmpty {
+            viewModel.phoneNumberWasPrefilled = true
+        }
     }
 
     func setupBindings() {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/ViewModels/LinkInlineSignupViewModel.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/ViewModels/LinkInlineSignupViewModel.swift
@@ -76,6 +76,15 @@ final class LinkInlineSignupViewModel {
         }
     }
 
+    var consentAction: PaymentSheetLinkAccount.ConsentAction {
+        switch mode {
+        case .normal:
+            return .checkbox
+        case .textFieldsOnly:
+            return .implied
+        }
+    }
+
     private(set) var linkAccount: PaymentSheetLinkAccount? {
         didSet {
             if linkAccount !== oldValue {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/ViewModels/LinkInlineSignupViewModel.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/ViewModels/LinkInlineSignupViewModel.swift
@@ -75,13 +75,23 @@ final class LinkInlineSignupViewModel {
             }
         }
     }
+    var phoneNumberWasPrefilled: Bool = false
+    var emailWasPrefilled: Bool = false
 
     var consentAction: PaymentSheetLinkAccount.ConsentAction {
         switch mode {
-        case .normal:
-            return .checkbox
-        case .textFieldsOnly:
-            return .implied
+        case .checkbox:
+            if phoneNumberWasPrefilled && emailWasPrefilled {
+                return .checkbox_v0_1
+            } else if emailWasPrefilled {
+                return .checkbox_v0_0
+            } else {
+                return .checkbox_v0
+            }
+        case .textFieldsOnlyEmailFirst:
+            return .implied_v0
+        case .textFieldsOnlyPhoneFirst:
+            return .implied_v0_0
         }
     }
 
@@ -287,6 +297,10 @@ final class LinkInlineSignupViewModel {
         self.accountService = accountService
         self.linkAccount = linkAccount
         self.emailAddress = linkAccount?.email
+        if let email = self.emailAddress,
+           !email.isEmpty {
+            emailWasPrefilled = true
+        }
         if showCheckbox {
             self.mode = .checkbox
         } else {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/LinkEnabledPaymentMethodElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/LinkEnabledPaymentMethodElement.swift
@@ -80,6 +80,7 @@ final class LinkEnabledPaymentMethodElement: ContainerElement {
                 option: .signUp(
                     account: account,
                     phoneNumber: phoneNumber,
+                    consentAction: inlineSignupElement.viewModel.consentAction,
                     legalName: legalName,
                     paymentMethodParams: params.paymentMethodParams
                 )

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PaymentSheet-LinkConfirmOption.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PaymentSheet-LinkConfirmOption.swift
@@ -20,6 +20,7 @@ extension PaymentSheet {
         case signUp(
             account: PaymentSheetLinkAccount,
             phoneNumber: PhoneNumber,
+            consentAction: PaymentSheetLinkAccount.ConsentAction,
             legalName: String?,
             paymentMethodParams: STPPaymentMethodParams
         )
@@ -52,7 +53,7 @@ extension PaymentSheet.LinkConfirmOption {
         switch self {
         case .wallet:
             return nil
-        case .signUp(let account, _, _, _):
+        case .signUp(let account, _, _, _, _):
             return account
         case .withPaymentDetails(let account, _):
             return account
@@ -67,7 +68,7 @@ extension PaymentSheet.LinkConfirmOption {
         switch self {
         case .wallet, .withPaymentDetails:
             return STPPaymentMethodType.link.displayName
-        case .signUp(_, _, _, let paymentMethodParams):
+        case .signUp(_, _, _, _, let paymentMethodParams):
             return paymentMethodParams.paymentSheetLabel
         case .withPaymentMethodParams(_, let paymentMethodParams):
             return paymentMethodParams.paymentSheetLabel
@@ -80,7 +81,7 @@ extension PaymentSheet.LinkConfirmOption {
         switch self {
         case .wallet:
             return nil
-        case .signUp(_, _, _, let paymentMethodParams):
+        case .signUp(_, _, _, _, let paymentMethodParams):
             return paymentMethodParams.billingDetails
         case .withPaymentDetails:
             return nil

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -398,8 +398,8 @@ extension PaymentSheet {
             case .wallet:
                 let linkController = PayWithLinkController(intent: intent, configuration: configuration)
                 linkController.present(completion: completion)
-            case .signUp(let linkAccount, let phoneNumber, let legalName, let paymentMethodParams):
-                linkAccount.signUp(with: phoneNumber, legalName: legalName, consentAction: .checkbox) { result in
+            case .signUp(let linkAccount, let phoneNumber, let consentAction, let legalName, let paymentMethodParams):
+                linkAccount.signUp(with: phoneNumber, legalName: legalName, consentAction: consentAction) { result in
                     switch result {
                     case .success:
                         STPAnalyticsClient.sharedClient.logLinkSignupComplete()


### PR DESCRIPTION
## Summary
Adds the two new consent actions, and plumbs it through sign up

## Motivation
Need to keep track of what customers are consenting to

## Testing
Added/Updated unit tests