### PR TITLE
Add load and payment analytics to basic integration

### DIFF
--- a/Stripe/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe/Stripe.xcodeproj/project.pbxproj
@@ -245,6 +245,7 @@
 		B4719234E4BBDAD260E31373 /* STPPaymentCardTextFieldViewModelTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6DEE912364C9F4B51B374D0 /* STPPaymentCardTextFieldViewModelTest.swift */; };
 		B6656829DEC006DBEED2AA0E /* STPEphemeralKeyTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5BEAA15B53AC5662A33D0E1 /* STPEphemeralKeyTest.swift */; };
 		B6784B7F4B9B04617C0EE510 /* PKAddPaymentPassRequest+Stripe_Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 273EE407039913F0B644172B /* PKAddPaymentPassRequest+Stripe_Error.swift */; };
+		B6EC2F572B618A3D00FF72A2 /* STPBasicUIAnalyticsSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6EC2F562B618A3D00FF72A2 /* STPBasicUIAnalyticsSerializer.swift */; };
 		B71F04D02538FA1723558C48 /* STPPaymentMethodiDEALTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B83930B631CF8EADFB606D6 /* STPPaymentMethodiDEALTest.swift */; };
 		B795A5EB8FDECA1060A9655C /* iOSSnapshotTestCase in Frameworks */ = {isa = PBXBuildFile; productRef = C55551F29B99CF6D6DD9EE2F /* iOSSnapshotTestCase */; };
 		B82859A4444B9F735720F232 /* STPMandateOnlineParamsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB58AC5E2E0A68221260FD44 /* STPMandateOnlineParamsTest.swift */; };
@@ -727,6 +728,7 @@
 		B4D31B0D7BD9F97AF3BB61E6 /* StripeBundleLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StripeBundleLocator.swift; sourceTree = "<group>"; };
 		B5B86F3355E44DF4A980B82C /* STPPaymentContextSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPPaymentContextSnapshotTests.swift; sourceTree = "<group>"; };
 		B669C53A601CD3CB0203A4B9 /* STPAPISettingsObjCBridgeTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPAPISettingsObjCBridgeTest.m; sourceTree = "<group>"; };
+		B6EC2F562B618A3D00FF72A2 /* STPBasicUIAnalyticsSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPBasicUIAnalyticsSerializer.swift; sourceTree = "<group>"; };
 		B6F3B966470A530E0DC53F8C /* STPThreeDSButtonCustomizationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPThreeDSButtonCustomizationTest.swift; sourceTree = "<group>"; };
 		B70DF0B659009041F485EE0F /* Stripe+Exports.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Stripe+Exports.swift"; sourceTree = "<group>"; };
 		B78C72B0DB434EC7F700FDE0 /* STPCoreTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPCoreTableViewController.swift; sourceTree = "<group>"; };
@@ -930,6 +932,7 @@
 				72903593DC432D01720DC9D9 /* STPAddressFieldTableViewCell.swift */,
 				28A50AFA4603E488FF3D82D0 /* STPAddressViewModel.swift */,
 				12DBB3F72AEFB52DE27C27ED /* STPAnalyticsClient+BasicUI.swift */,
+				B6EC2F562B618A3D00FF72A2 /* STPBasicUIAnalyticsSerializer.swift */,
 				BD89580A3E41D7167C30B287 /* STPAnalyticsClient+Payments.swift */,
 				1E8AFAE24610EC983727F860 /* STPAPIClient+BasicUI.swift */,
 				807FF966F1DE05F3496B817B /* STPAPIClient+PushProvisioning.swift */,
@@ -1622,6 +1625,7 @@
 				4FB67F10A0B7106A8142B842 /* STPEphemeralKeyManager.swift in Sources */,
 				B8385576DC25BDEEB92D812F /* STPEphemeralKeyProvider.swift in Sources */,
 				AF23CB4EF17E87007CFC3E96 /* STPFPXBankStatusResponse.swift in Sources */,
+				B6EC2F572B618A3D00FF72A2 /* STPBasicUIAnalyticsSerializer.swift in Sources */,
 				0B9C0E9A7A750607413C9E53 /* STPFakeAddPaymentPassViewController.swift in Sources */,
 				5D6B52EB4D7258129F134D07 /* STPImageLibrary.swift in Sources */,
 				D2869246B446B8B31F1CD368 /* STPIntentActionLinkAuthenticateAccount.swift in Sources */,

--- a/Stripe/StripeiOS/Source/STPAnalyticsClient+BasicUI.swift
+++ b/Stripe/StripeiOS/Source/STPAnalyticsClient+BasicUI.swift
@@ -14,15 +14,19 @@ extension STPPaymentContext {
         let analyticsClient = STPAnalyticsClient.sharedClient
         let sessionID: String = UUID().uuidString.lowercased()
         var apiClient: STPAPIClient = .shared
+        lazy var commonParameters: [String: Any] = {
+            ["session_id": sessionID]
+        }()
 
         func logLoadStarted() {
-            analyticsClient.log(analytic: GenericAnalytic(event: .biLoadStarted, params: [:]), apiClient: apiClient)
+            analyticsClient.log(analytic: GenericAnalytic(event: .biLoadStarted, params: commonParameters), apiClient: apiClient)
         }
 
         func logLoadFinished(isSuccess: Bool, loadStartDate: Date) {
             let event: STPAnalyticEvent = isSuccess ? .biLoadSucceeded : .biLoadFailed
             let duration = Date().timeIntervalSince(loadStartDate)
-            let params = ["duration": duration]
+            var params = commonParameters
+            params["duration"] = duration
             let analytic = GenericAnalytic(event: event, params: params)
             analyticsClient.log(analytic: analytic, apiClient: apiClient)
         }
@@ -58,10 +62,8 @@ extension STPPaymentContext {
                 return
             }
 
-            var params: [String: Any] = [
-                "selected_lpm": paymentMethodType,
-                "session_id": sessionID,
-            ]
+            var params = commonParameters
+            params["selected_lpm"] = paymentMethodType
             if STPAnalyticsClient.isSimulatorOrTest {
                 params["is_development"] = true
             }

--- a/Stripe/StripeiOS/Source/STPBasicUIAnalyticsSerializer.swift
+++ b/Stripe/StripeiOS/Source/STPBasicUIAnalyticsSerializer.swift
@@ -1,0 +1,84 @@
+//
+//  STPAnalyticsClient+BasicUI.swift
+//  StripeiOS
+//
+//  Created by David Estes on 6/30/22.
+//  Copyright © 2022 Stripe, Inc. All rights reserved.
+//
+
+import Foundation
+@_spi(STP) import StripeCore
+@_spi(STP) import StripePayments
+
+@objc(STPBasicUIAnalyticsSerializer)
+class STPBasicUIAnalyticsSerializer: NSObject, STPAnalyticsSerializer {
+    static func serializeConfiguration(
+        _ configuration: NSObject
+    ) -> [String:
+        String]
+    {
+        var dictionary: [String: String] = [:]
+        dictionary["publishable_key"] = STPAPIClient.shared.publishableKey ?? "unknown"
+
+        guard let configuration = configuration as? STPPaymentConfiguration else {
+            return dictionary
+        }
+
+        if configuration.applePayEnabled && !configuration.fpxEnabled {
+            dictionary["additional_payment_methods"] = "default"
+        } else if !configuration.applePayEnabled && !configuration.fpxEnabled {
+            dictionary["additional_payment_methods"] = "none"
+        } else if !configuration.applePayEnabled && configuration.fpxEnabled {
+            dictionary["additional_payment_methods"] = "fpx"
+        } else if configuration.applePayEnabled && configuration.fpxEnabled {
+            dictionary["additional_payment_methods"] = "applepay,fpx"
+        }
+
+        switch configuration.requiredBillingAddressFields {
+        case .none:
+            dictionary["required_billing_address_fields"] = "none"
+        case .postalCode:
+            dictionary["required_billing_address_fields"] = "zip"
+        case .full:
+            dictionary["required_billing_address_fields"] = "full"
+        case .name:
+            dictionary["required_billing_address_fields"] = "name"
+        default:
+            fatalError()
+        }
+
+        var shippingFields: [String] = []
+        if let shippingAddressFields = configuration.requiredShippingAddressFields {
+            if shippingAddressFields.contains(.name) {
+                shippingFields.append("name")
+            }
+            if shippingAddressFields.contains(.emailAddress) {
+                shippingFields.append("email")
+            }
+            if shippingAddressFields.contains(.postalAddress) {
+                shippingFields.append("address")
+            }
+            if shippingAddressFields.contains(.phoneNumber) {
+                shippingFields.append("phone")
+            }
+        }
+
+        if shippingFields.isEmpty {
+            shippingFields.append("none")
+        }
+        dictionary["required_shipping_address_fields"] = shippingFields.joined(separator: "_")
+
+        switch configuration.shippingType {
+        case .shipping:
+            dictionary["shipping_type"] = "shipping"
+        case .delivery:
+            dictionary["shipping_type"] = "delivery"
+        @unknown default:
+            break
+        }
+
+        dictionary["company_name"] = configuration.companyName
+        dictionary["apple_merchant_identifier"] = configuration.appleMerchantIdentifier ?? "unknown"
+        return dictionary
+    }
+}

--- a/StripeCore/StripeCore/Source/Analytics/AnalyticLoggableError.swift
+++ b/StripeCore/StripeCore/Source/Analytics/AnalyticLoggableError.swift
@@ -49,4 +49,20 @@ where Self: RawRepresentable, Self.RawValue == String {
 
         return payload
     }
+
+    /// This is like `serializeForLogging` but returns a single String instead of a dict. 
+    /// TODO(MOBILESDK-1547) I don't think pattern is very good but it's here to share between PaymentSheet and STPPaymentContext. Please rethink before spreading its usage.
+    public func makeSafeLoggingString() -> String {
+        let error = self as NSError
+        if error.domain == STPError.stripeDomain, let code = STPErrorCode(rawValue: error.code) {
+            // An error from our networking layer
+            return code.description
+        } else {
+            // Default behavior for other errors.
+            // Note: For Swift Error enums, `domain` is the type name and `code` is the case index
+            // e.g. `LinkURLGeneratorError.noPublishableKey` -> "StripePaymentSheet.LinkURLGeneratorError, 1"
+            return "\(error.domain), \(error.code)"
+        }
+    }
+
 }

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
@@ -203,4 +203,15 @@ import Foundation
     case customerSheetUpdateCardBrandFailed = "cs_update_card_failed"
     case customerSheetClosesEditScreen = "cs_cancel_edit_screen"
 
+    // MARK: - Basic Integration
+    case biLoadStarted = "bi_load_started"
+    case biLoadSucceeded = "bi_load_succeeded"
+    case biLoadFailed = "bi_load_failed"
+
+    case biPaymentCompleteNewPMSuccess = "bi_complete_payment_newpm_success"
+    case biPaymentCompleteSavedPMSuccess = "bi_complete_payment_savedpm_success"
+    case biPaymentCompleteApplePaySuccess = "bi_complete_payment_applepay_success"
+    case biPaymentCompleteNewPMFailure = "bi_complete_payment_newpm_failure"
+    case biPaymentCompleteSavedPMFailure = "bi_complete_payment_savedpm_failure"
+    case biPaymentCompleteApplePayFailure = "bi_complete_payment_applepay_failure"
 }

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticsClient.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticsClient.swift
@@ -59,14 +59,18 @@ import UIKit
         additionalInfoSet.removeAll()
     }
 
+    public static var isSimulatorOrTest: Bool {
+        #if targetEnvironment(simulator)
+            return true
+        #else
+            return NSClassFromString("XCTest") != nil
+        #endif
+    }
+
     // MARK: - Card Scanning
 
-    @objc class func shouldCollectAnalytics() -> Bool {
-        #if targetEnvironment(simulator)
-            return false
-        #else
-            return NSClassFromString("XCTest") == nil
-        #endif
+    @objc public class func shouldCollectAnalytics() -> Bool {
+        return !isSimulatorOrTest
     }
 
     public func additionalInfo() -> [String] {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/STPAnalyticsClient+Address.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/STPAnalyticsClient+Address.swift
@@ -17,7 +17,7 @@ extension STPAnalyticsClient {
         apiClient: STPAPIClient
     ) {
         var additionalParams = [:] as [String: Any]
-        if isSimulatorOrTest {
+        if Self.isSimulatorOrTest {
             additionalParams["is_development"] = true
         }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
@@ -258,7 +258,7 @@ extension STPAnalyticsClient {
         apiClient: STPAPIClient = .shared
     ) {
         var additionalParams = [:] as [String: Any]
-        if isSimulatorOrTest {
+        if Self.isSimulatorOrTest {
             additionalParams["is_development"] = true
         }
 
@@ -294,25 +294,10 @@ extension STPAnalyticsClient {
         let error = error as NSError
         if let error = error as? PaymentSheetError {
             return error.safeLoggingString
-        } else if error.domain == STPError.stripeDomain, let code = STPErrorCode(rawValue: error.code) {
-            // An error from our networking layer
-            return code.description
         } else {
-            // Default behavior for other errors.
-            // Note: For Swift Error enums, `domain` is the type name and `code` is the case index
-            // e.g. `LinkURLGeneratorError.noPublishableKey` -> "StripePaymentSheet.LinkURLGeneratorError, 1"
-            return "\(error.domain), \(error.code)"
+            return error.makeSafeLoggingString()
         }
     }
-
-    var isSimulatorOrTest: Bool {
-        #if targetEnvironment(simulator)
-            return true
-        #else
-            return NSClassFromString("XCTest") != nil
-        #endif
-    }
-
 }
 
 extension PaymentSheetViewController.Mode {


### PR DESCRIPTION
## Summary
Adds equivalents to Basic Integration for the following PaymentSheet analytic events

- `mc_load_started` -> `bi_load_started`
- `mc_load_{failed / succeeded}` -> `bi_load{failed / succeeded}`
- `mc_{complete / custom}_payment_{newpm / savedpm, applepay}_{success / failure}` -> `bi_complete_payment_{newpm / savedpm / applepay}_{success / failure}`

See more details [here](https://docs.google.com/document/d/1nv8z6k_fIKPOAbOuj4EgiYu9to92e-Sln-f5xN9z0Dg/edit#heading=h.11nxp230h37h)

Another PR will add UI events.

## Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-1544

## Testing
Manually tested
- load succeeding & failing
- confirming a card successfully
- confirming a card unsuccessfully
- confirming apple pay successfully
- canceling payment doesn't send analytic

## Changelog
Not user facing.