### PR TITLE
Add UI analytics to basic integration

### DIFF
--- a/Stripe/Stripe.xcodeproj/xcshareddata/xcschemes/StripeiOS.xcscheme
+++ b/Stripe/Stripe.xcodeproj/xcshareddata/xcschemes/StripeiOS.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1010"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -30,12 +30,10 @@
       disableMainThreadChecker = "YES">
       <TestPlans>
          <TestPlanReference
-            default = "YES"
-            reference = "container:StripeiOSTests.xctestplan">
+            reference = "container:StripeiOSTests.xctestplan"
+            default = "YES">
          </TestPlanReference>
       </TestPlans>
-      <Testables>
-      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/Stripe/StripeiOS/Source/STPAddCardViewController.swift
+++ b/Stripe/StripeiOS/Source/STPAddCardViewController.swift
@@ -246,7 +246,6 @@ public class STPAddCardViewController: STPCoreTableViewController, STPAddressVie
     private var lookupSucceeded = false
     private var scannerCompleteAnimationTimer: Timer?
     var didSendFormInteractedAnalytic = false
-    var didSendCardNumberCompletedAnalytic = false
 
     @objc(commonInitWithConfiguration:) func commonInit(with configuration: STPPaymentConfiguration)
     {
@@ -586,11 +585,8 @@ public class STPAddCardViewController: STPCoreTableViewController, STPAddressVie
 
     /// Only send form interacted analytic once per time this screen is shown
     func sendCardNumberCompletedAnalyticIfNecessary(cardNumber: String?) {
-        if !didSendCardNumberCompletedAnalytic, let cardNumber {
-            if STPCardValidator.validationState(forNumber: cardNumber, validatingCardBrand: true) == .valid {
-                didSendCardNumberCompletedAnalytic = true
-                analyticsLogger.logCardNumberCompleted()
-            }
+        if let cardNumber, STPCardValidator.validationState(forNumber: cardNumber, validatingCardBrand: true) == .valid {
+            analyticsLogger.logCardNumberCompleted()
         }
     }
 

--- a/Stripe/StripeiOS/Source/STPAddCardViewController.swift
+++ b/Stripe/StripeiOS/Source/STPAddCardViewController.swift
@@ -51,7 +51,8 @@ public class STPAddCardViewController: STPCoreTableViewController, STPAddressVie
             }
         }
     }
-
+    // Should be overwritten if this class is used by STPPaymentContext or STPPaymentOptionsViewController
+    internal var analyticsLogger: STPPaymentContext.AnalyticsLogger = .init(product: STPAddCardViewController.self)
     private var _customFooterView: UIView?
     /// Provide this view controller with a footer view.
     /// When the footer view needs to be resized, it will be sent a
@@ -195,6 +196,7 @@ public class STPAddCardViewController: STPCoreTableViewController, STPAddressVie
     }
     private var addressHeaderView: STPSectionHeaderView?
     var paymentCell: STPPaymentCardTextFieldCell?
+    var viewDidAppearStartTime: Date?
 
     private var _loading = false
     @objc var loading: Bool {
@@ -243,6 +245,8 @@ public class STPAddCardViewController: STPCoreTableViewController, STPAddressVie
     private var inputAccessoryToolbar: UIToolbar?
     private var lookupSucceeded = false
     private var scannerCompleteAnimationTimer: Timer?
+    var didSendFormInteractedAnalytic = false
+    var didSendCardNumberCompletedAnalytic = false
 
     @objc(commonInitWithConfiguration:) func commonInit(with configuration: STPPaymentConfiguration)
     {
@@ -425,6 +429,7 @@ public class STPAddCardViewController: STPCoreTableViewController, STPAddressVie
         view.endEditing(true)
         isScanning = true
         cardScanner?.start()
+        sendFormInteractedAnalyticIfNecessary()
     }
 
     @objc func endEditing() {
@@ -458,6 +463,9 @@ public class STPAddCardViewController: STPCoreTableViewController, STPAddressVie
     @objc
     public override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        viewDidAppearStartTime = Date()
+        analyticsLogger.logFormShown(paymentMethodType: .card)
+
         stp_beginObservingKeyboardAndInsettingScrollView(
             tableView,
             onChange: nil
@@ -486,6 +494,7 @@ public class STPAddCardViewController: STPCoreTableViewController, STPAddressVie
     }
 
     @objc func nextPressed(_ sender: Any?) {
+        analyticsLogger.logDoneButtonTapped(paymentMethodType: .card, shownStartDate: viewDidAppearStartTime)
         loading = true
         guard let cardParams = paymentCell?.paymentField?.paymentMethodParams.card else {
             return
@@ -567,9 +576,29 @@ public class STPAddCardViewController: STPCoreTableViewController, STPAddressVie
         paymentCell?.inputAccessoryView = hasAddressCells ? inputAccessoryToolbar : nil
     }
 
+    /// Only send form interacted analytic once per time this screen is shown
+    func sendFormInteractedAnalyticIfNecessary() {
+        if !didSendFormInteractedAnalytic {
+            didSendFormInteractedAnalytic = true
+            analyticsLogger.logFormInteracted(paymentMethodType: .card)
+        }
+    }
+
+    /// Only send form interacted analytic once per time this screen is shown
+    func sendCardNumberCompletedAnalyticIfNecessary(cardNumber: String?) {
+        if !didSendCardNumberCompletedAnalytic, let cardNumber {
+            if STPCardValidator.validationState(forNumber: cardNumber, validatingCardBrand: true) == .valid {
+                didSendCardNumberCompletedAnalytic = true
+                analyticsLogger.logCardNumberCompleted()
+            }
+        }
+    }
+
     // MARK: - STPPaymentCardTextField
     @objc
     public func paymentCardTextFieldDidChange(_ textField: STPPaymentCardTextField) {
+        sendFormInteractedAnalyticIfNecessary()
+        sendCardNumberCompletedAnalyticIfNecessary(cardNumber: textField.cardNumber)
         inputAccessoryToolbar?.stp_setEnabled(textField.isValid)
         updateDoneButton()
     }

--- a/Stripe/StripeiOS/Source/STPAnalyticsClient+BasicUI.swift
+++ b/Stripe/StripeiOS/Source/STPAnalyticsClient+BasicUI.swift
@@ -132,7 +132,7 @@ extension STPPaymentContext {
             if let shownStartDate {
                 let duration = Date().timeIntervalSince(shownStartDate)
                 params["duration"] = duration
-            } else {
+            } else if NSClassFromString("XCTest") == nil {
                 assertionFailure("Shown start date should never be nil!")
             }
 

--- a/Stripe/StripeiOS/Source/STPPaymentContext.swift
+++ b/Stripe/StripeiOS/Source/STPPaymentContext.swift
@@ -383,7 +383,7 @@ public class STPPaymentContext: NSObject, STPAuthenticationContext,
             analyticsLogger.apiClient = apiClient
         }
     }
-    private let analyticsLogger: AnalyticsLogger = .init()
+    internal let analyticsLogger: AnalyticsLogger = .init(product: STPPaymentContext.self)
 
     /// If `paymentContext:didFailToLoadWithError:` is called on your delegate, you
     /// can in turn call this method to try loading again (if that hasn't been called,
@@ -403,14 +403,14 @@ public class STPPaymentContext: NSObject, STPAuthenticationContext,
             guard let strongSelf = weakSelf else {
                 return
             }
-            strongSelf.analyticsLogger.logLoadFinished(isSuccess: true, loadStartDate: loadingStartDate)
+            strongSelf.analyticsLogger.logLoadSucceeded(loadStartDate: loadingStartDate, defaultPaymentOption: tuple.selectedPaymentOption)
             strongSelf.paymentOptions = tuple.paymentOptions
             strongSelf.selectedPaymentOption = tuple.selectedPaymentOption
         }).onFailure({ error in
             guard let strongSelf = weakSelf else {
                 return
             }
-            strongSelf.analyticsLogger.logLoadFinished(isSuccess: false, loadStartDate: loadingStartDate)
+            strongSelf.analyticsLogger.logLoadFailed(loadStartDate: loadingStartDate, error: error)
             if strongSelf.hostViewController != nil {
                 if strongSelf.paymentOptionsViewController != nil
                     && strongSelf.paymentOptionsViewController?.viewIfLoaded?.window != nil

--- a/Stripe/StripeiOS/Source/STPPaymentOptionsInternalViewController.swift
+++ b/Stripe/StripeiOS/Source/STPPaymentOptionsInternalViewController.swift
@@ -26,6 +26,7 @@ class STPPaymentOptionsInternalViewController: STPCoreTableViewController, UITab
     init(
         configuration: STPPaymentConfiguration,
         customerContext: STPCustomerContext?,
+        analyticsLogger: STPPaymentContext.AnalyticsLogger,
         apiClient: STPAPIClient,
         theme: STPTheme,
         prefilledInformation: STPUserInformation?,
@@ -33,6 +34,7 @@ class STPPaymentOptionsInternalViewController: STPCoreTableViewController, UITab
         paymentOptionTuple tuple: STPPaymentOptionTuple,
         delegate: STPPaymentOptionsInternalViewControllerDelegate?
     ) {
+        self.analyticsLogger = analyticsLogger
         super.init(theme: theme)
         self.configuration = configuration
         // This parameter may be a custom API adapter, and not a CustomerContext.
@@ -63,6 +65,7 @@ class STPPaymentOptionsInternalViewController: STPCoreTableViewController, UITab
     }
 
     private var _customFooterView: UIView?
+    internal let analyticsLogger: STPPaymentContext.AnalyticsLogger
     var customFooterView: UIView? {
         get {
             _customFooterView
@@ -139,6 +142,11 @@ class STPPaymentOptionsInternalViewController: STPCoreTableViewController, UITab
             "PaymentOptionsViewControllerCancelButtonIdentifier"
         // re-set the custom footer view if it was added before we loaded
         _didSetCustomFooterView()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        analyticsLogger.logPaymentOptionsScreenAppeared()
     }
 
     override func viewDidLayoutSubviews() {
@@ -440,6 +448,7 @@ class STPPaymentOptionsInternalViewController: STPCoreTableViewController, UITab
                     theme: theme
                 )
             }
+            paymentCardViewController?.analyticsLogger = analyticsLogger
             paymentCardViewController?.apiClient = apiClient
             paymentCardViewController?.delegate = self
             paymentCardViewController?.prefilledInformation = prefilledInformation
@@ -561,7 +570,7 @@ class STPPaymentOptionsInternalViewController: STPCoreTableViewController, UITab
     required init?(
         coder aDecoder: NSCoder
     ) {
-        super.init(coder: aDecoder)
+        fatalError("init(coder:) has not been implemented")
     }
 
     required init(

--- a/Stripe/StripeiOS/Source/STPPaymentOptionsViewController.swift
+++ b/Stripe/StripeiOS/Source/STPPaymentOptionsViewController.swift
@@ -42,6 +42,7 @@ public class STPPaymentOptionsViewController: STPCoreViewController,
             configuration: paymentContext.configuration,
             apiAdapter: paymentContext.apiAdapter,
             apiClient: paymentContext.apiClient,
+            analyticsLogger: paymentContext.analyticsLogger,
             loadingPromise: paymentContext.currentValuePromise,
             theme: paymentContext.theme,
             shippingAddress: paymentContext.shippingAddress,
@@ -53,12 +54,14 @@ public class STPPaymentOptionsViewController: STPCoreViewController,
         configuration: STPPaymentConfiguration?,
         apiAdapter: STPBackendAPIAdapter,
         apiClient: STPAPIClient?,
+        analyticsLogger: STPPaymentContext.AnalyticsLogger,
         loadingPromise: STPPromise<STPPaymentOptionTuple>?,
         theme: STPTheme?,
         shippingAddress: STPAddress?,
         delegate: STPPaymentOptionsViewControllerDelegate
     ) {
         self.apiAdapter = apiAdapter
+        self.analyticsLogger = analyticsLogger
         super.init(theme: theme)
         commonInit(
             configuration: configuration,
@@ -108,6 +111,7 @@ public class STPPaymentOptionsViewController: STPCoreViewController,
                     payMethodsInternal = STPPaymentOptionsInternalViewController(
                         configuration: configuration1,
                         customerContext: customerContext,
+                        analyticsLogger: strongSelf.analyticsLogger,
                         apiClient: strongSelf.apiClient,
                         theme: strongSelf.theme,
                         prefilledInformation: strongSelf.prefilledInformation,
@@ -133,6 +137,7 @@ public class STPPaymentOptionsViewController: STPCoreViewController,
                         theme: strongSelf.theme
                     )
                 }
+                addCardViewController?.analyticsLogger = strongSelf.analyticsLogger
                 addCardViewController?.apiClient = strongSelf.apiClient
                 addCardViewController?.delegate = strongSelf
                 addCardViewController?.prefilledInformation = strongSelf.prefilledInformation
@@ -354,6 +359,8 @@ public class STPPaymentOptionsViewController: STPCoreViewController,
     var loadingPromise: STPPromise<STPPaymentOptionTuple>?
     private var activityIndicator: STPPaymentActivityIndicatorView?
     internal var internalViewController: UIViewController?
+    // Should be overwritten if this class is used by STPPaymentContext
+    internal var analyticsLogger: STPPaymentContext.AnalyticsLogger = .init(product: STPPaymentOptionsViewController.self)
 
     func retrievePaymentMethods(
         with configuration: STPPaymentConfiguration,

--- a/Stripe/StripeiOSTests/STPAnalyticsClientPaymentsTest.swift
+++ b/Stripe/StripeiOSTests/STPAnalyticsClientPaymentsTest.swift
@@ -152,11 +152,16 @@ class STPAnalyticsClientPaymentsTest: XCTestCase {
         XCTAssertTrue(
             STPAnalyticsClient.sharedClient.productUsage.contains("STPAddCardViewController")
         )
-        XCTAssertEqual(addCardVC.analyticsLogger.product, "STPPaymentContext")
+        XCTAssertEqual(addCardVC.analyticsLogger.product, "STPAddCardViewController")
     }
 
     func testPaymentOptionsVCAddsUsage() {
-        let paymentOptionsVC = STPPaymentOptionsViewController()
+        let customerContext = Testing_StaticCustomerContext.init(
+            customer: STPFixtures.customerWithCardTokenAndSourceSources(),
+            paymentMethods: []
+        )
+        let delegate = MockSTPPaymentOptionsViewControllerDelegate()
+        let paymentOptionsVC = STPPaymentOptionsViewController(configuration: .shared, theme: .defaultTheme, customerContext: customerContext, delegate: delegate)
         XCTAssertTrue(
             STPAnalyticsClient.sharedClient.productUsage.contains("STPPaymentOptionsViewController")
         )

--- a/Stripe/StripeiOSTests/STPAnalyticsClientPaymentsTest.swift
+++ b/Stripe/StripeiOSTests/STPAnalyticsClientPaymentsTest.swift
@@ -126,8 +126,9 @@ class STPAnalyticsClientPaymentsTest: XCTestCase {
         )
         let apiClient = STPAPIClient()
         let customerContext = STPCustomerContext.init(keyManager: keyManager, apiClient: apiClient)
-        _ = STPPaymentContext(customerContext: customerContext)
+        let paymentContext = STPPaymentContext(customerContext: customerContext)
         XCTAssertTrue(STPAnalyticsClient.sharedClient.productUsage.contains("STPCustomerContext"))
+        XCTAssertEqual(paymentContext.analyticsLogger.product, "STPPaymentContext")
     }
 
     func testApplePayContextAddsUsage() {
@@ -147,10 +148,19 @@ class STPAnalyticsClientPaymentsTest: XCTestCase {
     }
 
     func testAddCardVCAddsUsage() {
-        _ = STPAddCardViewController()
+        let addCardVC = STPAddCardViewController()
         XCTAssertTrue(
             STPAnalyticsClient.sharedClient.productUsage.contains("STPAddCardViewController")
         )
+        XCTAssertEqual(addCardVC.analyticsLogger.product, "STPPaymentContext")
+    }
+
+    func testPaymentOptionsVCAddsUsage() {
+        let paymentOptionsVC = STPPaymentOptionsViewController()
+        XCTAssertTrue(
+            STPAnalyticsClient.sharedClient.productUsage.contains("STPPaymentOptionsViewController")
+        )
+        XCTAssertEqual(paymentOptionsVC.analyticsLogger.product, "STPPaymentOptionsViewController")
     }
 
     func testBankSelectionVCAddsUsage() {

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
@@ -183,6 +183,8 @@ import Foundation
     // MARK: - PaymentSheet checkout
     case paymentSheetCarouselPaymentMethodTapped = "mc_carousel_payment_method_tapped"
     case paymentSheetConfirmButtonTapped = "mc_confirm_button_tapped"
+    case paymentSheetFormShown = "mc_form_shown"
+    case paymentSheetFormInteracted = "mc_form_interacted"
 
     // MARK: - v1/elements/session
     case paymentSheetElementsSessionLoadFailed = "mc_elements_session_load_failed"
@@ -207,14 +209,23 @@ import Foundation
     case customerSheetClosesEditScreen = "cs_cancel_edit_screen"
 
     // MARK: - Basic Integration
+    // Loading
     case biLoadStarted = "bi_load_started"
     case biLoadSucceeded = "bi_load_succeeded"
     case biLoadFailed = "bi_load_failed"
 
+    // Confirmation
     case biPaymentCompleteNewPMSuccess = "bi_complete_payment_newpm_success"
     case biPaymentCompleteSavedPMSuccess = "bi_complete_payment_savedpm_success"
     case biPaymentCompleteApplePaySuccess = "bi_complete_payment_applepay_success"
     case biPaymentCompleteNewPMFailure = "bi_complete_payment_newpm_failure"
     case biPaymentCompleteSavedPMFailure = "bi_complete_payment_savedpm_failure"
     case biPaymentCompleteApplePayFailure = "bi_complete_payment_applepay_failure"
+
+    // UI events
+    case biOptionsShown = "bi_options_shown"
+    case biFormShown = "bi_form_shown"
+    case biFormInteracted = "bi_form_interacted"
+    case biCardNumberCompleted = "bi_card_number_completed"
+    case biDoneButtonTapped = "bi_done_button_tapped"
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
@@ -227,6 +227,7 @@ class AddPaymentMethodViewController: UIViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        STPAnalyticsClient.sharedClient.logPaymentSheetFormShown(paymentMethodTypeIdentifier: selectedPaymentMethodType.identifier, apiClient: configuration.apiClient)
         sendEventToSubviews(.viewDidAppear, from: view)
         delegate?.didUpdate(self)
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
@@ -102,6 +102,10 @@ extension STPAnalyticsClient {
         )
     }
 
+    func logPaymentSheetFormShown(paymentMethodTypeIdentifier: String, apiClient: STPAPIClient) {
+        logPaymentSheetEvent(event: .paymentSheetFormShown, paymentMethodTypeAnalyticsValue: paymentMethodTypeIdentifier)
+    }
+
     enum DeferredIntentConfirmationType: String {
         case server = "server"
         case client = "client"


### PR DESCRIPTION
## Summary
* Sends `bi_options_show`, `bi_form_show`, `bi_form_interacted`, `bi_card_number_completed`, and `bi_done_button_tapped` analytics to Basic Integration. See [doc](https://docs.google.com/document/d/1nv8z6k_fIKPOAbOuj4EgiYu9to92e-Sln-f5xN9z0Dg/edit#heading=h.oe7bk2p3cyhz) for description of each event, when it should be sent, and what parameters are sent with the event.
* Sends `error_message` in `bi_load_failed` events, I missed that in a previous PR.
* Sends `default_payment_method` in `bi_load_succeeded`

Another PR will add similar events to PaymentSheet

## Testing
- Manually tested the new analytics are sent with duration, session, product.
- Tested card scan sends `bi_card_number_completed` analytic.
- Tested STPAddCardViewController and STPPaymentOptionsViewController send the right `product`.
- Tested `bi_load_succeedeed` sends `apple_pay`, `card`, and `none` as `default_payment_method`.
- Tested `bi_load_failed` sends `error_message`.

## Changelog
Not user facing.