### PR TITLE
Financial Connections: modified partner auth to have new loading states

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerAccountLoadErrorView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerAccountLoadErrorView.swift
@@ -80,7 +80,7 @@ final class AccountPickerAccountLoadErrorView: UIView {
             footerView: PaneLayoutView.createFooterView(
                 primaryButtonConfiguration: primaryButtonConfiguration,
                 secondaryButtonConfiguration: secondaryButtonConfiguration
-            )
+            ).footerView
         )
         paneLayoutView.addTo(view: self)
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerNoAccountEligibleErrorView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerNoAccountEligibleErrorView.swift
@@ -142,7 +142,7 @@ final class AccountPickerNoAccountEligibleErrorView: UIView {
                     }(),
                     action: didSelectAnotherBank
                 )
-            )
+            ).footerView
         )
         paneLayoutView.addTo(view: self)
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AttachLinkedPaymentAccount/AccountNumberRetrievalErrorView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AttachLinkedPaymentAccount/AccountNumberRetrievalErrorView.swift
@@ -61,7 +61,7 @@ final class AccountNumberRetrievalErrorView: UIView {
                         return nil
                     }
                 }()
-            )
+            ).footerView
         )
         paneLayoutView.addTo(view: self)
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupViewController.swift
@@ -78,7 +78,7 @@ final class NetworkingLinkLoginWarmupViewController: UIViewController {
                         self?.didSelectSkip()
                     }
                 )
-            )
+            ).footerView
         )
         paneLayoutView.addTo(view: view)
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationViewController.swift
@@ -82,7 +82,7 @@ final class NetworkingSaveToLinkVerificationViewController: UIViewController {
                         )
                     }
                 )
-            )
+            ).footerView
         )
         paneLayoutView.addTo(view: view)
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PrepaneView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PrepaneView.swift
@@ -15,6 +15,18 @@ final class PrepaneView: UIView {
     private let didSelectContinue: () -> Void
     private let didSelectCancel: () -> Void
 
+    private let contentStackView: UIStackView = {
+        let contentStackView = UIStackView()
+        contentStackView.axis = .vertical
+        contentStackView.spacing = 0
+        return contentStackView
+    }()
+    private let headerView: UIView
+    private let bodyView: UIView
+    private var loadingView: UIView?
+    private var primaryButton: StripeUICore.Button?
+    private var secondaryButton: StripeUICore.Button?
+
     init(
         prepaneModel: FinancialConnectionsOAuthPrepane,
         isRepairSession: Bool,
@@ -24,53 +36,81 @@ final class PrepaneView: UIView {
     ) {
         self.didSelectContinue = didSelectContinue
         self.didSelectCancel = didSelectCancel
+        self.headerView = PaneLayoutView.createHeaderView(
+            iconView: {
+                if let institutionIconUrl = prepaneModel.institutionIcon?.default {
+                    let institutionIconView = InstitutionIconView()
+                    institutionIconView.setImageUrl(institutionIconUrl)
+                    return institutionIconView
+                } else {
+                    return nil
+                }
+            }(),
+            title: prepaneModel.title
+        )
+        self.bodyView = PaneLayoutView.createBodyView(
+            text: prepaneModel.subtitle,
+            contentView: CreateContentView(
+                prepaneBodyModel: prepaneModel.body,
+                didSelectURL: didSelectURL
+            )
+        )
         super.init(frame: .zero)
         backgroundColor = .customBackgroundColor
 
-        let paneLayoutView = PaneLayoutView(
-            contentView: PaneLayoutView.createContentView(
-                iconView: {
-                    if let institutionIconUrl = prepaneModel.institutionIcon?.default {
-                        let institutionIconView = InstitutionIconView()
-                        institutionIconView.setImageUrl(institutionIconUrl)
-                        return institutionIconView
-                    } else {
-                        return nil
-                    }
-                }(),
-                title: prepaneModel.title,
-                subtitle: prepaneModel.subtitle,
-                contentView: CreateContentView(
-                    prepaneBodyModel: prepaneModel.body,
-                    didSelectURL: didSelectURL
-                )
+        contentStackView.addArrangedSubview(headerView)
+
+        let footerViewTuple = PaneLayoutView.createFooterView(
+            primaryButtonConfiguration: PaneLayoutView.ButtonConfiguration(
+                title: prepaneModel.cta.text,
+                accessibilityIdentifier: "prepane_continue_button",
+                action: didSelectContinue
             ),
-            footerView: PaneLayoutView.createFooterView(
-                primaryButtonConfiguration: PaneLayoutView.ButtonConfiguration(
-                    title: prepaneModel.cta.text,
-                    accessibilityIdentifier: "prepane_continue_button",
-                    action: didSelectContinue
-                ),
-                secondaryButtonConfiguration: {
-                    if isRepairSession {
-                        return nil
-                    } else {
-                        return PaneLayoutView.ButtonConfiguration(
-                            title: STPLocalizedString(
-                                "Choose a different bank",
-                                "Title of a button. It acts as a back button to go back to choosing a different bank instead of the currently selected one."
-                            ),
-                            action: didSelectCancel
-                        )
-                    }
-                }()
-            )
+            secondaryButtonConfiguration: {
+                if isRepairSession {
+                    return nil
+                } else {
+                    return PaneLayoutView.ButtonConfiguration(
+                        title: STPLocalizedString(
+                            "Choose a different bank",
+                            "Title of a button. It acts as a back button to go back to choosing a different bank instead of the currently selected one."
+                        ),
+                        action: didSelectCancel
+                    )
+                }
+            }()
+        )
+        self.primaryButton = footerViewTuple.primaryButton
+        self.secondaryButton = footerViewTuple.secondaryButton
+
+        let paneLayoutView = PaneLayoutView(
+            contentView: contentStackView,
+            footerView: footerViewTuple.footerView
         )
         paneLayoutView.addTo(view: self)
+
+        // setup the `contentContainerView`
+        showLoadingView(false)
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    func showLoadingView(_ show: Bool) {
+        bodyView.removeFromSuperview()
+        loadingView?.removeFromSuperview()
+        loadingView = nil
+
+        if show {
+            let loadingView = PrepaneLoadingView()
+            self.loadingView = loadingView
+            contentStackView.addArrangedSubview(loadingView)
+        } else {
+            contentStackView.addArrangedSubview(bodyView)
+        }
+        primaryButton?.isLoading = show
+        secondaryButton?.isEnabled = !show
     }
 
     @objc fileprivate func didSelectContinueButton() {
@@ -110,11 +150,54 @@ private func CreateContentView(
     return verticalStackView
 }
 
+private class PrepaneLoadingView: ShimmeringView {
+
+    init() {
+        super.init(frame: .zero)
+        let verticalStackView = UIStackView(
+            arrangedSubviews: [
+                CreateLoadingLabelView(width: 400),
+                CreateLoadingLabelView(width: 163),
+            ]
+        )
+        verticalStackView.axis = .vertical
+        verticalStackView.alignment = .leading
+        verticalStackView.spacing = 8
+        verticalStackView.isLayoutMarginsRelativeArrangement = true
+        verticalStackView.directionalLayoutMargins = NSDirectionalEdgeInsets(
+            top: 0,
+            leading: 24,
+            bottom: 0,
+            trailing: 24
+        )
+        addAndPinSubview(verticalStackView)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+private func CreateLoadingLabelView(width: CGFloat) -> UIView {
+    let labelView = UIView()
+    labelView.backgroundColor = .backgroundOffset
+    labelView.layer.cornerRadius = 8
+    labelView.translatesAutoresizingMaskIntoConstraints = false
+    NSLayoutConstraint.activate([
+        labelView.heightAnchor.constraint(equalToConstant: 16),
+        labelView.widthAnchor.constraint(equalToConstant: width),
+    ])
+    // make the width fit the screen if-needed
+    labelView.setContentCompressionResistancePriority(.fittingSizeLevel, for: .horizontal)
+    return labelView
+}
+
 #if DEBUG
 
 import SwiftUI
 
 private struct PrepaneViewUIViewRepresentable: UIViewRepresentable {
+
+    let isLoading: Bool
 
     func makeUIView(context: Context) -> PrepaneView {
         PrepaneView(
@@ -167,7 +250,9 @@ private struct PrepaneViewUIViewRepresentable: UIViewRepresentable {
         )
     }
 
-    func updateUIView(_ uiView: PrepaneView, context: Context) {}
+    func updateUIView(_ prepaneView: PrepaneView, context: Context) {
+        prepaneView.showLoadingView(isLoading)
+    }
 }
 
 @available(iOS 14.0, *)
@@ -175,14 +260,23 @@ struct PrepaneView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
             VStack {
-                PrepaneViewUIViewRepresentable()
+                PrepaneViewUIViewRepresentable(isLoading: false)
             }
             .frame(maxWidth: .infinity)
             .background(Color.purple.opacity(0.1))
-            .navigationTitle("Stripe")
+            .navigationTitle("stripe")
             .navigationBarTitleDisplayMode(.inline)
         }
 
+        NavigationView {
+            VStack {
+                PrepaneViewUIViewRepresentable(isLoading: true)
+            }
+            .frame(maxWidth: .infinity)
+            .background(Color.purple.opacity(0.1))
+            .navigationTitle("stripe")
+            .navigationBarTitleDisplayMode(.inline)
+        }
     }
 }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/CloseConfirmationViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/CloseConfirmationViewController.swift
@@ -70,7 +70,7 @@ final class CloseConfirmationViewController: SheetViewController {
                         self?.dismiss(animated: true)
                     }
                 )
-            )
+            ).footerView
         )
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/DataAccessNoticeViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/DataAccessNoticeViewController.swift
@@ -54,7 +54,7 @@ final class DataAccessNoticeViewController: SheetViewController {
                 secondaryButtonConfiguration: nil,
                 topText: dataAccessNotice.disclaimer,
                 didSelectURL: didSelectUrl
-            )
+            ).footerView
         )
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/LegalDetailsNoticeViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/LegalDetailsNoticeViewController.swift
@@ -54,7 +54,7 @@ final class LegalDetailsNoticeViewController: SheetViewController {
                 secondaryButtonConfiguration: nil,
                 topText: legalDetailsNotice.disclaimer,
                 didSelectURL: didSelectUrl
-            )
+            ).footerView
         )
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/PaneLayoutView/PaneLayoutView+Extensions.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/PaneLayoutView/PaneLayoutView+Extensions.swift
@@ -85,7 +85,7 @@ extension PaneLayoutView {
     }
 
     @available(iOSApplicationExtension, unavailable)
-    private static func createBodyView(
+    static func createBodyView(
         text: String?,
         contentView: UIView?
     ) -> UIView {
@@ -146,11 +146,11 @@ extension PaneLayoutView {
         secondaryButtonConfiguration: PaneLayoutView.ButtonConfiguration? = nil,
         topText: String? = nil,
         didSelectURL: ((URL) -> Void)? = nil
-    ) -> UIView? {
+    ) -> (footerView: UIView?, primaryButton: StripeUICore.Button?, secondaryButton: StripeUICore.Button?) {
         guard
             primaryButtonConfiguration != nil || secondaryButtonConfiguration != nil
         else {
-            return nil  // display no footer
+            return (nil, nil, nil)  // display no footer
         }
         let footerStackView = FooterStackView(
             didSelectPrimaryButton: primaryButtonConfiguration?.action,
@@ -175,8 +175,10 @@ extension PaneLayoutView {
             footerStackView.setCustomSpacing(16, after: topTextLabel)
         }
 
+        var primaryButtonReference: StripeUICore.Button?
         if let primaryButtonConfiguration = primaryButtonConfiguration {
             let primaryButton = Button(configuration: FinancialConnectionsPrimaryButtonConfiguration())
+            primaryButtonReference = primaryButton
             primaryButton.title = primaryButtonConfiguration.title
             primaryButton.accessibilityIdentifier = primaryButtonConfiguration.accessibilityIdentifier
             primaryButton.addTarget(
@@ -191,8 +193,10 @@ extension PaneLayoutView {
             footerStackView.addArrangedSubview(primaryButton)
         }
 
+        var secondaryButtonReference: StripeUICore.Button?
         if let secondaryButtonConfiguration = secondaryButtonConfiguration {
             let secondaryButton = Button(configuration: FinancialConnectionsSecondaryButtonConfiguration())
+            secondaryButtonReference = secondaryButton
             secondaryButton.title = secondaryButtonConfiguration.title
             secondaryButton.accessibilityIdentifier = secondaryButtonConfiguration.accessibilityIdentifier
             secondaryButton.addTarget(
@@ -219,7 +223,7 @@ extension PaneLayoutView {
             bottom: 16,
             trailing: 24
         )
-        return paddingStackView
+        return (paddingStackView, primaryButtonReference, secondaryButtonReference)
     }
 }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/TerminalError/TerminalErrorViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/TerminalError/TerminalErrorViewController.swift
@@ -81,7 +81,7 @@ final class TerminalErrorViewController: UIViewController {
                         )
                     }
                 }()
-            )
+            ).footerView
         )
         paneLayoutView.addTo(view: view)
     }


### PR DESCRIPTION
## Summary

This PR:
- Modifies the "Partner Auth" step (users enter a screen to connect to a specific bank) to have a new loading state.

Details to understand before reviewing PR:
- This is one PR, out of expected ~50+, to change the design of Financial Connections from a "V2" design to a "V3" design. [Here is a link to the designs](https://www.figma.com/file/wXQ8NJApqSJiLmxxANDRTs/%E2%9C%A8-Connections-3.0?type=design&node-id=2524-217093&mode=design&t=kXaBiAlgVsC7YcH1-0).
- The code here is not the finished version. It's just an iteration towards the final version. This code will be re-visited later. The goal is to go screen-by-screen and make easy changes to learn about all the difficulties in each screen. Later, all the learnings will be combined to do a "final" polish of all screens.
- The above also applies to design. The design here is not the finished version.
- This PR is merged into a feature branch `fc-v3`. It is not merged into `master`.
- There might be TODO's scattered throughout the code. That's expected and they will be fixed later. 

## Testing

### Loading Before

https://github.com/stripe/stripe-ios/assets/105514761/b9ce3b50-f43e-424d-bf8a-1fc1047a3d5d

### Loading After

https://github.com/stripe/stripe-ios/assets/105514761/a7a8808c-40f2-4ba1-b9fe-6428ba7828f0
