### PR TITLE
Fix potential memory leak in DownloadManager

### DIFF
--- a/StripeCore/StripeCore/Source/DownloadManager/DownloadManager.swift
+++ b/StripeCore/StripeCore/Source/DownloadManager/DownloadManager.swift
@@ -116,15 +116,16 @@ extension DownloadManager {
             return image
         }
         let urlRequest = URLRequest(url: url, cachePolicy: .useProtocolCachePolicy)
-        let task = self.session.downloadTask(with: url) { tempURL, response, _ in
-            guard let tempURL = tempURL,
+        let task = self.session.downloadTask(with: url) { [weak self] tempURL, response, _ in
+            guard let self = self,
+                  let tempURL = tempURL,
                 let response = response,
                 let data = self.getDataFromURL(tempURL),
                 let image = self.persistToMemory(data, forImageName: imageName)
             else {
-                self.pendingRequestsSemaphore.wait()
-                self.pendingRequests.removeValue(forKey: imageName)
-                self.pendingRequestsSemaphore.signal()
+                self?.pendingRequestsSemaphore.wait()
+                self?.pendingRequests.removeValue(forKey: imageName)
+                self?.pendingRequestsSemaphore.signal()
                 return
             }
             self.urlCache?.storeCachedResponse(


### PR DESCRIPTION
## Summary
- Fixed a circular reference in DownloadManager that was causing a memory leak between the downloadManager instance and the URLSessionTask created in downloadImageAsync.

## Motivation
https://github.com/stripe/stripe-ios/issues/3212

## Testing
Verified in instruments
![CleanShot 2024-01-29 at 10 36 37](https://github.com/stripe/stripe-ios/assets/88012362/47c92cb1-ca5e-4dd3-af11-b43e563655f8)

## Changelog
N/A
