### PR TITLE
Financial Connections: for v3, disabled institution search auto correct

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionSearchBar.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionSearchBar.swift
@@ -51,6 +51,13 @@ final class InstitutionSearchBar: UIView {
             ]
         )
         textField.returnKeyType = .search
+        // fixes a 'bug' where if a user types a keyword, and autocorrect
+        // wants to correct it, pressing "search" button will choose
+        // the autocorrected word even though the intent was to use the
+        // typed-in word
+        //
+        // also, bank names are not always friendly to autocorrect suggestions
+        textField.autocorrectionType = .no
         textField.delegate = self
         textField.addTarget(
             self,


### PR DESCRIPTION
## Summary

^ wa discussion we had within the team to change this

## Testing

Tested and saw that autocorrect is not activated