### PR TITLE
Financial Connections: for v3, added data access notice sheet presentation from account pickers

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostController.swift
@@ -83,13 +83,6 @@ extension HostController: HostViewControllerDelegate {
     ) {
         delegate?.hostController(self, didReceiveEvent: FinancialConnectionsEvent(name: .open))
 
-        guard
-            let consentPaneModel = synchronizePayload.text?.consentPane
-        else {
-            continueWithWebFlow(synchronizePayload.manifest)
-            return
-        }
-
         let flowRouter = FlowRouter(
             synchronizePayload: synchronizePayload,
             analyticsClient: analyticsClient
@@ -111,7 +104,7 @@ extension HostController: HostViewControllerDelegate {
             manifest: synchronizePayload.manifest,
             visualUpdate: synchronizePayload.visual,
             returnURL: returnURL,
-            consentPaneModel: consentPaneModel,
+            consentPaneModel: synchronizePayload.text?.consentPane,
             apiClient: api,
             clientSecret: clientSecret,
             analyticsClient: analyticsClient

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerDataSource.swift
@@ -24,6 +24,7 @@ protocol AccountPickerDataSource: AnyObject {
     var selectedAccounts: [FinancialConnectionsPartnerAccount] { get }
     var analyticsClient: FinancialConnectionsAnalyticsClient { get }
     var reduceManualEntryProminenceInErrors: Bool { get }
+    var dataAccessNotice: FinancialConnectionsDataAccessNotice? { get }
 
     func pollAuthSessionAccounts() -> Future<FinancialConnectionsAuthSessionAccounts>
     func updateSelectedAccounts(_ selectedAccounts: [FinancialConnectionsPartnerAccount])
@@ -39,6 +40,7 @@ final class AccountPickerDataSourceImplementation: AccountPickerDataSource {
     let institution: FinancialConnectionsInstitution
     let analyticsClient: FinancialConnectionsAnalyticsClient
     let reduceManualEntryProminenceInErrors: Bool
+    let dataAccessNotice: FinancialConnectionsDataAccessNotice?
 
     private(set) var selectedAccounts: [FinancialConnectionsPartnerAccount] = [] {
         didSet {
@@ -54,7 +56,8 @@ final class AccountPickerDataSourceImplementation: AccountPickerDataSource {
         manifest: FinancialConnectionsSessionManifest,
         institution: FinancialConnectionsInstitution,
         analyticsClient: FinancialConnectionsAnalyticsClient,
-        reduceManualEntryProminenceInErrors: Bool
+        reduceManualEntryProminenceInErrors: Bool,
+        dataAccessNotice: FinancialConnectionsDataAccessNotice?
     ) {
         self.apiClient = apiClient
         self.clientSecret = clientSecret
@@ -63,6 +66,7 @@ final class AccountPickerDataSourceImplementation: AccountPickerDataSource {
         self.institution = institution
         self.analyticsClient = analyticsClient
         self.reduceManualEntryProminenceInErrors = reduceManualEntryProminenceInErrors
+        self.dataAccessNotice = dataAccessNotice
     }
 
     func pollAuthSessionAccounts() -> Future<FinancialConnectionsAuthSessionAccounts> {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerViewController.swift
@@ -92,20 +92,27 @@ final class AccountPickerViewController: UIViewController {
             },
             didSelectMerchantDataAccessLearnMore: { [weak self] url in
                 guard let self = self else { return }
-                SFSafariViewController.present(url: url)
-
-                // TODO(kgaidis): fix/return `dataAccessNotice`
-//                let dataAccessNoticeViewController = DataAccessNoticeViewController(
-//                    dataAccessNotice: dataSource.consent.dataAccessNotice,
-//                    didSelectUrl: { [weak self] url in
-//                        self?.didSelectURLInTextFromBackend(url)
-//                    }
-//                )
-//                dataAccessNoticeViewController.present(on: self)
-
                 self.dataSource
                     .analyticsClient
                     .logMerchantDataAccessLearnMore(pane: .accountPicker)
+
+                if let dataAccessNotice = self.dataSource.dataAccessNotice {
+                    let dataAccessNoticeViewController = DataAccessNoticeViewController(
+                        dataAccessNotice: dataAccessNotice,
+                        didSelectUrl: { [weak self] url in
+                            guard let self = self else { return }
+                            AuthFlowHelpers.handleURLInTextFromBackend(
+                                url: url,
+                                pane: .accountPicker,
+                                analyticsClient: self.dataSource.analyticsClient,
+                                handleStripeScheme: { _ in }
+                            )
+                        }
+                    )
+                    dataAccessNoticeViewController.present(on: self)
+                } else {
+                    SFSafariViewController.present(url: url)
+                }
             }
         )
     }()

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerDataSource.swift
@@ -22,6 +22,7 @@ protocol LinkAccountPickerDataSource: AnyObject {
     var selectedAccountTuple: FinancialConnectionsAccountTuple? { get }
     var nextPaneOnAddAccount: FinancialConnectionsSessionManifest.NextPane? { get set }
     var analyticsClient: FinancialConnectionsAnalyticsClient { get }
+    var dataAccessNotice: FinancialConnectionsDataAccessNotice? { get }
 
     func fetchNetworkedAccounts() -> Future<FinancialConnectionsNetworkedAccountsResponse>
     func selectNetworkedAccount(_ selectedAccount: FinancialConnectionsPartnerAccount) -> Future<FinancialConnectionsInstitutionList>
@@ -36,6 +37,7 @@ final class LinkAccountPickerDataSourceImplementation: LinkAccountPickerDataSour
     private let apiClient: FinancialConnectionsAPIClient
     private let clientSecret: String
     private let consumerSession: ConsumerSessionData
+    let dataAccessNotice: FinancialConnectionsDataAccessNotice?
 
     private(set) var selectedAccountTuple: FinancialConnectionsAccountTuple? {
         didSet {
@@ -49,13 +51,15 @@ final class LinkAccountPickerDataSourceImplementation: LinkAccountPickerDataSour
         apiClient: FinancialConnectionsAPIClient,
         analyticsClient: FinancialConnectionsAnalyticsClient,
         clientSecret: String,
-        consumerSession: ConsumerSessionData
+        consumerSession: ConsumerSessionData,
+        dataAccessNotice: FinancialConnectionsDataAccessNotice?
     ) {
         self.manifest = manifest
         self.apiClient = apiClient
         self.analyticsClient = analyticsClient
         self.clientSecret = clientSecret
         self.consumerSession = consumerSession
+        self.dataAccessNotice = dataAccessNotice
     }
 
     func fetchNetworkedAccounts() -> Future<FinancialConnectionsNetworkedAccountsResponse> {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
@@ -139,6 +139,22 @@ final class LinkAccountPickerViewController: UIViewController {
                 self.dataSource
                     .analyticsClient
                     .logMerchantDataAccessLearnMore(pane: .linkAccountPicker)
+
+                if let dataAccessNotice = self.dataSource.dataAccessNotice {
+                    let dataAccessNoticeViewController = DataAccessNoticeViewController(
+                        dataAccessNotice: dataAccessNotice,
+                        didSelectUrl: { [weak self] url in
+                            guard let self = self else { return }
+                            AuthFlowHelpers.handleURLInTextFromBackend(
+                                url: url,
+                                pane: .linkAccountPicker,
+                                analyticsClient: self.dataSource.analyticsClient,
+                                handleStripeScheme: { _ in }
+                            )
+                        }
+                    )
+                    dataAccessNoticeViewController.present(on: self)
+                }
             }
         )
         self.footerView = footerView

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -897,7 +897,8 @@ private func CreatePaneViewController(
                 manifest: dataManager.manifest,
                 institution: institution,
                 analyticsClient: dataManager.analyticsClient,
-                reduceManualEntryProminenceInErrors: dataManager.reduceManualEntryProminenceInErrors
+                reduceManualEntryProminenceInErrors: dataManager.reduceManualEntryProminenceInErrors,
+                dataAccessNotice: dataManager.consentPaneModel?.dataAccessNotice
             )
             let accountPickerViewController = AccountPickerViewController(dataSource: accountPickerDataSource)
             accountPickerViewController.delegate = nativeFlowController

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -968,7 +968,8 @@ private func CreatePaneViewController(
                 apiClient: dataManager.apiClient,
                 analyticsClient: dataManager.analyticsClient,
                 clientSecret: dataManager.clientSecret,
-                consumerSession: consumerSession
+                consumerSession: consumerSession,
+                dataAccessNotice: dataManager.consentPaneModel?.dataAccessNotice
             )
             let linkAccountPickerViewController = LinkAccountPickerViewController(
                 dataSource: linkAccountPickerDataSource

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowDataManager.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowDataManager.swift
@@ -13,7 +13,7 @@ protocol NativeFlowDataManager: AnyObject {
     var reducedBranding: Bool { get }
     var merchantLogo: [String]? { get }
     var returnURL: String? { get }
-    var consentPaneModel: FinancialConnectionsConsent { get }
+    var consentPaneModel: FinancialConnectionsConsent? { get }
     var apiClient: FinancialConnectionsAPIClient { get }
     var clientSecret: String { get }
     var analyticsClient: FinancialConnectionsAnalyticsClient { get }
@@ -77,7 +77,7 @@ class NativeFlowAPIDataManager: NativeFlowDataManager {
         return visualUpdate.reduceManualEntryProminenceInErrors
     }
     let returnURL: String?
-    let consentPaneModel: FinancialConnectionsConsent
+    let consentPaneModel: FinancialConnectionsConsent?
     let apiClient: FinancialConnectionsAPIClient
     let clientSecret: String
     let analyticsClient: FinancialConnectionsAnalyticsClient
@@ -97,7 +97,7 @@ class NativeFlowAPIDataManager: NativeFlowDataManager {
         manifest: FinancialConnectionsSessionManifest,
         visualUpdate: FinancialConnectionsSynchronize.VisualUpdate,
         returnURL: String?,
-        consentPaneModel: FinancialConnectionsConsent,
+        consentPaneModel: FinancialConnectionsConsent?,
         apiClient: FinancialConnectionsAPIClient,
         clientSecret: String,
         analyticsClient: FinancialConnectionsAnalyticsClient


### PR DESCRIPTION
## Summary

This PR:
1) Changed some early logic that wasn't necessary
2) Added "data access notice" to account picker
3) Added "data access notice" to link account picker

This is the "data access notice:"

![Screenshot 2024-01-29 at 1 29 10 PM](https://github.com/stripe/stripe-ios/assets/105514761/cfce37a6-9ab4-424b-a205-e330c4de9dbd)

Details to understand before reviewing PR:
- This is one PR, out of expected ~50+, to change the design of Financial Connections from a "V2" design to a "V3" design. [Here is a link to the designs](https://www.figma.com/file/wXQ8NJApqSJiLmxxANDRTs/%E2%9C%A8-Connections-3.0?type=design&node-id=2524-217093&mode=design&t=kXaBiAlgVsC7YcH1-0).
- The code here is not the finished version. It's just an iteration towards the final version. This code will be re-visited later. The goal is to go screen-by-screen and make easy changes to learn about all the difficulties in each screen. Later, all the learnings will be combined to do a "final" polish of all screens.
- The above also applies to design. The design here is not the finished version.
- This PR is merged into a feature branch `fc-v3`. It is not merged into `master`.
- There might be TODO's scattered throughout the code. That's expected and they will be fixed later. 

## Testing

### Account Picker "Learn More" button now presents the sheet

https://github.com/stripe/stripe-ios/assets/105514761/bf4c1377-4586-4b30-b6d9-d7b5c5b12942

### Link Account Picker "Learn More" button now presents the sheet

https://github.com/stripe/stripe-ios/assets/105514761/63fddd96-5adb-4037-a12c-9e16e2a92a0e
