### PR TITLE
Financial Connections: for v3, improved phone verification phone format

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/ConsumerSession/ConsumerSessionModels.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/ConsumerSession/ConsumerSessionModels.swift
@@ -10,7 +10,7 @@ import Foundation
 struct ConsumerSessionData: Decodable {
     let clientSecret: String
     let emailAddress: String
-    let redactedPhoneNumber: String
+    let redactedFormattedPhoneNumber: String
 }
 
 struct LookupConsumerSessionResponse: Decodable {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationViewController.swift
@@ -60,7 +60,7 @@ final class NetworkingLinkVerificationViewController: UIViewController {
             subtitle: String(format: STPLocalizedString(
                 "Enter the code sent to %@.",
                 "The subtitle/description of a screen where users are informed that they have received a One-Type-Password (OTP) to their phone. '%@' gets replaced by a redacted phone number."
-            ), redactedPhoneNumber),
+            ), AuthFlowHelpers.formatRedactedPhoneNumber(redactedPhoneNumber)),
             contentView: otpView,
             footerView: nil
         )
@@ -134,7 +134,7 @@ extension NetworkingLinkVerificationViewController: NetworkingOTPViewDelegate {
 
     func networkingOTPView(_ view: NetworkingOTPView, didStartVerification consumerSession: ConsumerSessionData) {
         showLoadingView(false) // started in networkingOTPViewWillStartConsumerLookup
-        showContent(redactedPhoneNumber: consumerSession.redactedPhoneNumber)
+        showContent(redactedPhoneNumber: consumerSession.redactedFormattedPhoneNumber)
     }
 
     func networkingOTPView(_ view: NetworkingOTPView, didFailToStartVerification error: Error) {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationViewController.swift
@@ -63,7 +63,7 @@ final class NetworkingSaveToLinkVerificationViewController: UIViewController {
                 subtitle: String(format: STPLocalizedString(
                     "Enter the code sent to %@.",
                     "The subtitle/description of a screen where users are informed that they have received a One-Type-Password (OTP) to their phone. '%@' gets replaced by a redacted phone number."
-                ), redactedPhoneNumber),
+                ), AuthFlowHelpers.formatRedactedPhoneNumber(redactedPhoneNumber)),
                 contentView: otpView
             ),
             footerView: PaneLayoutView.createFooterView(
@@ -108,7 +108,7 @@ extension NetworkingSaveToLinkVerificationViewController: NetworkingOTPViewDeleg
 
     func networkingOTPView(_ view: NetworkingOTPView, didStartVerification consumerSession: ConsumerSessionData) {
         showLoadingView(false)
-        showContent(redactedPhoneNumber: consumerSession.redactedPhoneNumber)
+        showContent(redactedPhoneNumber: consumerSession.redactedFormattedPhoneNumber)
     }
 
     func networkingOTPView(_ view: NetworkingOTPView, didFailToStartVerification error: Error) {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/AuthFlowHelpers.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/AuthFlowHelpers.swift
@@ -85,4 +85,8 @@ final class AuthFlowHelpers {
             return nil
         }
     }
+
+    static func formatRedactedPhoneNumber(_ redactedPhoneNumber: String) -> String {
+        return redactedPhoneNumber.replacingOccurrences(of: "*", with: "•")
+    }
 }


### PR DESCRIPTION
## Summary

This PR:
- Improves the phone number formatting in UI.

Details to understand before reviewing PR:
- This is one PR, out of expected ~50+, to change the design of Financial Connections from a "V2" design to a "V3" design. [Here is a link to the designs](https://www.figma.com/file/wXQ8NJApqSJiLmxxANDRTs/%E2%9C%A8-Connections-3.0?type=design&node-id=2524-217093&mode=design&t=kXaBiAlgVsC7YcH1-0).
- The code here is not the finished version. It's just an iteration towards the final version. This code will be re-visited later. The goal is to go screen-by-screen and make easy changes to learn about all the difficulties in each screen. Later, all the learnings will be combined to do a "final" polish of all screens.
- The above also applies to design. The design here is not the finished version.
- This PR is merged into a feature branch `fc-v3`. It is not merged into `master`.
- There might be TODO's scattered throughout the code. That's expected and they will be fixed later. 

## Testing

| Before | After |
| --- | --- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-01-29 at 14 51 50](https://github.com/stripe/stripe-ios/assets/105514761/b8afe486-84d4-4838-8e50-94cde8f80f4c) | ![Simulator Screenshot - iPhone 15 Pro - 2024-01-29 at 14 48 44](https://github.com/stripe/stripe-ios/assets/105514761/920ce399-0eac-431d-bb21-79f3911fbd39) |
| --- |  ![Simulator Screenshot - iPhone 15 Pro - 2024-01-29 at 14 49 21](https://github.com/stripe/stripe-ios/assets/105514761/97f472eb-3d03-4978-8364-6e7637f1a663) |





