### PR TITLE
Remove unused `productUsage` from various `Analytic` shaped protocols…

### DIFF
--- a/Stripe/StripeiOS/Source/STPAnalyticsClient+Payments.swift
+++ b/Stripe/StripeiOS/Source/STPAnalyticsClient+Payments.swift
@@ -12,7 +12,6 @@ import Foundation
 /// An analytic specific to payments that serializes payment-specific
 /// information into its params.
 @_spi(STP) public protocol PaymentAnalytic: Analytic {
-    var productUsage: Set<String> { get }
     var additionalParams: [String: Any] { get }
 }
 

--- a/Stripe/StripeiOSTests/PaymentAnalyticTest.swift
+++ b/Stripe/StripeiOSTests/PaymentAnalyticTest.swift
@@ -21,9 +21,6 @@ final class PaymentAnalyticTest: XCTestCase {
         let analytic = GenericPaymentAnalytic(
             event: .cardScanCancelled,
             paymentConfiguration: STPPaymentConfiguration(),
-            productUsage: [
-                STPPaymentContext.stp_analyticsIdentifier
-            ],
             additionalParams: [:]
         )
 

--- a/Stripe/StripeiOSTests/STPAnalyticsClientPaymentSheetTest.swift
+++ b/Stripe/StripeiOSTests/STPAnalyticsClientPaymentSheetTest.swift
@@ -174,7 +174,6 @@ class STPAnalyticsClientPaymentSheetTest: XCTestCase {
         // setup
         let analytic = PaymentSheetAnalytic(
             event: STPAnalyticEvent.mcInitCompleteApplePay,
-            productUsage: Set<String>([STPPaymentContext.stp_analyticsIdentifier]),
             additionalParams: ["testKey": "testVal"]
         )
 

--- a/StripeApplePay/StripeApplePay/Source/PaymentsCore/Analytics/STPAnalyticsClient+Payments.swift
+++ b/StripeApplePay/StripeApplePay/Source/PaymentsCore/Analytics/STPAnalyticsClient+Payments.swift
@@ -12,7 +12,6 @@ import Foundation
 /// An analytic specific to payments that serializes payment-specific
 /// information into its params.
 @_spi(STP) public protocol PaymentAnalytic: Analytic {
-    var productUsage: Set<String> { get }
     var additionalParams: [String: Any] { get }
 }
 

--- a/StripeApplePay/StripeApplePay/Source/PaymentsCore/Analytics/STPAnalyticsClient+PaymentsAPI.swift
+++ b/StripeApplePay/StripeApplePay/Source/PaymentsCore/Analytics/STPAnalyticsClient+PaymentsAPI.swift
@@ -16,9 +16,8 @@ extension STPAnalyticsClient {
         log(
             analytic: PaymentAPIAnalytic(
                 event: .paymentMethodCreation,
-                productUsage: productUsage,
                 additionalParams: [
-                    "source_type": paymentMethodType ?? "unknown"
+                    "source_type": paymentMethodType ?? "unknown",
                 ]
             )
         )
@@ -28,9 +27,8 @@ extension STPAnalyticsClient {
         log(
             analytic: PaymentAPIAnalytic(
                 event: .tokenCreation,
-                productUsage: productUsage,
                 additionalParams: [
-                    "token_type": tokenType ?? "unknown"
+                    "token_type": tokenType ?? "unknown",
                 ]
             )
         )
@@ -42,9 +40,8 @@ extension STPAnalyticsClient {
         log(
             analytic: PaymentAPIAnalytic(
                 event: .paymentMethodIntentCreation,
-                productUsage: productUsage,
                 additionalParams: [
-                    "source_type": paymentMethodType ?? "unknown"
+                    "source_type": paymentMethodType ?? "unknown",
                 ]
             )
         )
@@ -56,9 +53,8 @@ extension STPAnalyticsClient {
         log(
             analytic: PaymentAPIAnalytic(
                 event: .setupIntentConfirmationAttempt,
-                productUsage: productUsage,
                 additionalParams: [
-                    "source_type": paymentMethodType ?? "unknown"
+                    "source_type": paymentMethodType ?? "unknown",
                 ]
             )
         )
@@ -67,6 +63,5 @@ extension STPAnalyticsClient {
 
 struct PaymentAPIAnalytic: PaymentAnalytic {
     let event: STPAnalyticEvent
-    let productUsage: Set<String>
     let additionalParams: [String: Any]
 }

--- a/StripeApplePay/StripeApplePayTests/STPAnalyticsClient+ApplePayTest.swift
+++ b/StripeApplePay/StripeApplePayTests/STPAnalyticsClient+ApplePayTest.swift
@@ -20,7 +20,6 @@ class STPAnalyticsClientApplePayTest: XCTestCase {
         // setup
         let analytic = PaymentAPIAnalytic(
             event: .paymentMethodCreation,
-            productUsage: [],
             additionalParams: [:]
         )
         let client = STPAnalyticsClient()

--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/STPAnalyticsClient+Address.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/STPAnalyticsClient+Address.swift
@@ -24,7 +24,6 @@ extension STPAnalyticsClient {
         additionalParams["address_data_blob"] = addressAnalyticData?.analyticsPayload
 
         let analytic = AddressAnalytic(event: event,
-                                       productUsage: productUsage,
                                        params: additionalParams)
 
         log(analytic: analytic, apiClient: apiClient)
@@ -88,6 +87,5 @@ extension PaymentSheet.Address {
 
 struct AddressAnalytic: Analytic {
     let event: STPAnalyticEvent
-    let productUsage: Set<String>
     let params: [String: Any]
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
@@ -284,7 +284,6 @@ extension STPAnalyticsClient {
             additionalParams[param] = param_value
         }
         let analytic = PaymentSheetAnalytic(event: event,
-                                            productUsage: productUsage,
                                             additionalParams: additionalParams)
         log(analytic: analytic, apiClient: apiClient)
     }
@@ -354,7 +353,6 @@ extension PaymentSheet.PaymentOption {
 
 struct PaymentSheetAnalytic: StripePayments.PaymentAnalytic {
     let event: STPAnalyticEvent
-    let productUsage: Set<String>
     let additionalParams: [String: Any]
 }
 

--- a/StripePaymentSheet/StripePaymentSheetTests/STPAnalyticsClient+PaymentSheetTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/STPAnalyticsClient+PaymentSheetTests.swift
@@ -15,7 +15,6 @@ class STPAnalyticsClientPaymentSheetTest: XCTestCase {
         // setup
         let analytic = PaymentSheetAnalytic(
             event: .paymentMethodCreation,
-            productUsage: [],
             additionalParams: [:]
         )
         let client = STPAnalyticsClient()

--- a/StripePayments/StripePayments/Source/Internal/Analytics/Analytic+Payments.swift
+++ b/StripePayments/StripePayments/Source/Internal/Analytics/Analytic+Payments.swift
@@ -15,7 +15,6 @@ import Foundation
 struct GenericPaymentAnalytic: PaymentAnalytic {
     let event: STPAnalyticEvent
     let paymentConfiguration: NSObject?
-    let productUsage: Set<String>
     let additionalParams: [String: Any]
 }
 
@@ -23,7 +22,6 @@ struct GenericPaymentAnalytic: PaymentAnalytic {
 struct GenericPaymentErrorAnalytic: PaymentAnalytic, ErrorAnalytic {
     let event: STPAnalyticEvent
     let paymentConfiguration: NSObject?
-    let productUsage: Set<String>
     let additionalParams: [String: Any]
     let error: Error
 }

--- a/StripePayments/StripePayments/Source/Internal/Analytics/STPAnalyticsClient+Payments.swift
+++ b/StripePayments/StripePayments/Source/Internal/Analytics/STPAnalyticsClient+Payments.swift
@@ -19,7 +19,6 @@ extension STPAnalyticsClient {
             analytic: GenericPaymentAnalytic(
                 event: .tokenCreation,
                 paymentConfiguration: configuration,
-                productUsage: productUsage,
                 additionalParams: [
                     "token_type": tokenType ?? "unknown",
                 ]
@@ -35,7 +34,6 @@ extension STPAnalyticsClient {
             analytic: GenericPaymentAnalytic(
                 event: .sourceCreation,
                 paymentConfiguration: configuration,
-                productUsage: productUsage,
                 additionalParams: [
                     "source_type": sourceType ?? "unknown",
                 ]
@@ -52,7 +50,6 @@ extension STPAnalyticsClient {
             analytic: GenericPaymentAnalytic(
                 event: .paymentMethodCreation,
                 paymentConfiguration: configuration,
-                productUsage: productUsage,
                 additionalParams: [
                     "source_type": paymentMethodType ?? "unknown",
                 ]
@@ -68,7 +65,6 @@ extension STPAnalyticsClient {
             analytic: GenericPaymentAnalytic(
                 event: .paymentMethodUpdate,
                 paymentConfiguration: configuration,
-                productUsage: productUsage,
                 additionalParams: [:]
             )
         )
@@ -86,7 +82,6 @@ extension STPAnalyticsClient {
             analytic: GenericPaymentAnalytic(
                 event: .paymentMethodIntentCreation,
                 paymentConfiguration: configuration,
-                productUsage: productUsage,
                 additionalParams: [
                     "source_type": paymentMethodType ?? "unknown",
                 ]
@@ -104,7 +99,6 @@ extension STPAnalyticsClient {
             analytic: GenericPaymentAnalytic(
                 event: .setupIntentConfirmationAttempt,
                 paymentConfiguration: configuration,
-                productUsage: productUsage,
                 additionalParams: [
                     "source_type": paymentMethodType ?? "unknown",
                 ]
@@ -125,7 +119,6 @@ extension STPAnalyticsClient {
             analytic: GenericPaymentErrorAnalytic(
                 event: ._3DS2AuthenticationRequestParamsFailed,
                 paymentConfiguration: configuration,
-                productUsage: productUsage,
                 additionalParams: [
                     "intent_id": intentID,
                 ],
@@ -142,7 +135,6 @@ extension STPAnalyticsClient {
             analytic: GenericPaymentAnalytic(
                 event: ._3DS2AuthenticationAttempt,
                 paymentConfiguration: configuration,
-                productUsage: productUsage,
                 additionalParams: [
                     "intent_id": intentID,
                 ]
@@ -158,7 +150,6 @@ extension STPAnalyticsClient {
             analytic: GenericPaymentAnalytic(
                 event: ._3DS2FrictionlessFlow,
                 paymentConfiguration: configuration,
-                productUsage: productUsage,
                 additionalParams: [
                     "intent_id": intentID,
                 ]
@@ -174,7 +165,6 @@ extension STPAnalyticsClient {
             analytic: GenericPaymentAnalytic(
                 event: .urlRedirectNextAction,
                 paymentConfiguration: configuration,
-                productUsage: productUsage,
                 additionalParams: [
                     "intent_id": intentID,
                 ]
@@ -191,7 +181,6 @@ extension STPAnalyticsClient {
             analytic: GenericPaymentAnalytic(
                 event: ._3DS2ChallengeFlowPresented,
                 paymentConfiguration: configuration,
-                productUsage: productUsage,
                 additionalParams: [
                     "intent_id": intentID,
                     "3ds2_ui_type": uiType,
@@ -209,7 +198,6 @@ extension STPAnalyticsClient {
             analytic: GenericPaymentAnalytic(
                 event: ._3DS2ChallengeFlowTimedOut,
                 paymentConfiguration: configuration,
-                productUsage: productUsage,
                 additionalParams: [
                     "intent_id": intentID,
                     "3ds2_ui_type": uiType,
@@ -227,7 +215,6 @@ extension STPAnalyticsClient {
             analytic: GenericPaymentAnalytic(
                 event: ._3DS2ChallengeFlowUserCanceled,
                 paymentConfiguration: configuration,
-                productUsage: productUsage,
                 additionalParams: [
                     "intent_id": intentID,
                     "3ds2_ui_type": uiType,
@@ -244,7 +231,6 @@ extension STPAnalyticsClient {
             analytic: GenericPaymentAnalytic(
                 event: ._3DS2RedirectUserCanceled,
                 paymentConfiguration: configuration,
-                productUsage: productUsage,
                 additionalParams: [
                     "intent_id": intentID,
                 ]
@@ -261,7 +247,6 @@ extension STPAnalyticsClient {
             analytic: GenericPaymentAnalytic(
                 event: ._3DS2ChallengeFlowCompleted,
                 paymentConfiguration: configuration,
-                productUsage: productUsage,
                 additionalParams: [
                     "intent_id": intentID,
                     "3ds2_ui_type": uiType,
@@ -279,7 +264,6 @@ extension STPAnalyticsClient {
             analytic: GenericPaymentErrorAnalytic(
                 event: ._3DS2ChallengeFlowErrored,
                 paymentConfiguration: configuration,
-                productUsage: productUsage,
                 additionalParams: [
                     "intent_id": intentID,
                 ],
@@ -296,7 +280,6 @@ extension STPAnalyticsClient {
             analytic: GenericPaymentAnalytic(
                 event: .cardMetadataLoadedTooSlow,
                 paymentConfiguration: nil,
-                productUsage: productUsage,
                 additionalParams: [:]
             )
         )
@@ -307,7 +290,6 @@ extension STPAnalyticsClient {
             analytic: GenericPaymentAnalytic(
                 event: .cardMetadataResponseFailure,
                 paymentConfiguration: nil,
-                productUsage: productUsage,
                 additionalParams: [:]
             )
         )
@@ -318,7 +300,6 @@ extension STPAnalyticsClient {
             analytic: GenericPaymentAnalytic(
                 event: .cardMetadataMissingRange,
                 paymentConfiguration: nil,
-                productUsage: productUsage,
                 additionalParams: [:]
             )
         )
@@ -357,7 +338,6 @@ extension STPAnalyticsClient {
             analytic: GenericPaymentAnalytic(
                 event: .cardElementConfigLoadFailure,
                 paymentConfiguration: nil,
-                productUsage: productUsage,
                 additionalParams: [:]
             )
         )
@@ -367,7 +347,6 @@ extension STPAnalyticsClient {
 /// An analytic specific to payments that serializes payment-specific
 /// information into its params.
 @_spi(STP) public protocol PaymentAnalytic: Analytic {
-    var productUsage: Set<String> { get }
     var additionalParams: [String: Any] { get }
 }
 

--- a/StripePayments/StripePaymentsTests/STPAnalyticsClient+StripePayments.swift
+++ b/StripePayments/StripePaymentsTests/STPAnalyticsClient+StripePayments.swift
@@ -20,7 +20,6 @@ class STPAnalyticsClientPaymentsUITest: XCTestCase {
         let analytic = GenericPaymentAnalytic(
             event: .paymentMethodCreation,
             paymentConfiguration: nil,
-            productUsage: [],
             additionalParams: [:]
         )
         let client = STPAnalyticsClient()

--- a/StripePaymentsUI/StripePaymentsUITests/STPAnalyticsClient+PaymentsUITests.swift
+++ b/StripePaymentsUI/StripePaymentsUITests/STPAnalyticsClient+PaymentsUITests.swift
@@ -23,7 +23,6 @@ class STPAnalyticsClientPaymentsUITest: XCTestCase {
         let analytic = GenericPaymentAnalytic(
             event: .paymentMethodCreation,
             paymentConfiguration: nil,
-            productUsage: [],
             additionalParams: [:]
         )
         let client = STPAnalyticsClient()


### PR DESCRIPTION
… and conformers.

Nothing reads this property. `STPAnalyticsClient` uses its own `productUsage` property, not this.