### PR TITLE
Add default payment method to PaymentSheet loading analytic

### DIFF
--- a/Stripe/StripeiOS/Source/STPAnalyticsClient+BasicUI.swift
+++ b/Stripe/StripeiOS/Source/STPAnalyticsClient+BasicUI.swift
@@ -51,7 +51,7 @@ extension STPPaymentContext {
             }()
             let params: [String: Any] = [
                 "duration": duration,
-                "default_payment_method": defaultPaymentMethod,
+                "selected_lpm": defaultPaymentMethod,
             ]
             log(event: event, params: params)
         }

--- a/Stripe/StripeiOSTests/STPAnalyticsClientPaymentSheetTest.swift
+++ b/Stripe/StripeiOSTests/STPAnalyticsClientPaymentSheetTest.swift
@@ -98,7 +98,8 @@ class STPAnalyticsClientPaymentSheetTest: XCTestCase {
         _ = PaymentSheet.FlowController(
             intent: .paymentIntent(elementsSession: .makeBackupElementsSession(with: STPFixtures.paymentIntent()), paymentIntent: STPFixtures.paymentIntent()),
             savedPaymentMethods: [],
-            isLinkEnabled: false,
+            isLinkEnabled: false, 
+            isApplePayEnabled: false,
             configuration: PaymentSheet.Configuration()
         )
         XCTAssertTrue(client.productUsage.contains("PaymentSheet.FlowController"))

--- a/Stripe/StripeiOSTests/STPAnalyticsClientPaymentSheetTest.swift
+++ b/Stripe/StripeiOSTests/STPAnalyticsClientPaymentSheetTest.swift
@@ -98,7 +98,7 @@ class STPAnalyticsClientPaymentSheetTest: XCTestCase {
         _ = PaymentSheet.FlowController(
             intent: .paymentIntent(elementsSession: .makeBackupElementsSession(with: STPFixtures.paymentIntent()), paymentIntent: STPFixtures.paymentIntent()),
             savedPaymentMethods: [],
-            isLinkEnabled: false, 
+            isLinkEnabled: false,
             isApplePayEnabled: false,
             configuration: PaymentSheet.Configuration()
         )

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
@@ -147,15 +147,12 @@ public class PaymentSheet {
         // Configure the Payment Sheet VC after loading the PI/SI, Customer, etc.
         PaymentSheetLoader.load(
             mode: mode,
-            configuration: configuration
+            configuration: configuration,
+            isFlowController: false
         ) { result in
             switch result {
-            case .success(let intent, let savedPaymentMethods, let isLinkEnabled):
+            case .success(let intent, let savedPaymentMethods, let isLinkEnabled, let isApplePayEnabled):
                 // Set the PaymentSheetViewController as the content of our bottom sheet
-                let isApplePayEnabled = StripeAPI.deviceSupportsApplePay()
-                    && self.configuration.applePay != nil
-                    && intent.isApplePayEnabled
-
                 let presentPaymentSheetVC = { (justVerifiedLinkOTP: Bool) in
                     let paymentSheetVC = PaymentSheetViewController(
                         intent: intent,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -118,35 +118,6 @@ final class PaymentSheetLoader {
         return !configuration.isUsingBillingAddressCollection()
     }
 
-    /// Returns a list of viewmodels to display in SavedPaymentOptionsViewController aka the "saved PMs" screen.
-    static func makePaymentOptionsListViewModels(
-        savedPaymentMethods: [STPPaymentMethod],
-        configuration: PaymentSheet.Configuration,
-        showApplePay: Bool,
-        showLink: Bool
-    ) -> [SavedPaymentOptionsViewController.Selection] {
-        var savedPaymentMethods = savedPaymentMethods
-        let defaultPaymentMethod = CustomerPaymentOption.defaultPaymentMethod(for: configuration.customer?.id)
-
-        // Move default to front
-        if let defaultPMIndex = savedPaymentMethods.firstIndex(where: {
-            $0.stripeId == defaultPaymentMethod?.value
-        }) {
-            let defaultPM = savedPaymentMethods.remove(at: defaultPMIndex)
-            savedPaymentMethods.insert(defaultPM, at: 0)
-        }
-
-        // Transform saved PaymentMethods into view models
-        let savedPMViewModels = savedPaymentMethods.compactMap { paymentMethod in
-            return SavedPaymentOptionsViewController.Selection.saved(paymentMethod: paymentMethod)
-        }
-
-        return [.add]
-            + (showApplePay ? [.applePay] : [])
-            + (showLink ? [.link] : [])
-            + savedPMViewModels
-    }
-
     // MARK: - Helper methods that load things
 
     /// Loads miscellaneous singletons

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -86,7 +86,7 @@ final class PaymentSheetLoader {
                 let (defaultSelectedIndex, paymentOptionsViewModels) = SavedPaymentOptionsViewController.makeViewModels(
                     savedPaymentMethods: filteredSavedPaymentMethods,
                     customerID: configuration.customer?.id,
-                    showApplePay: isFlowController ? isApplePayEnabled : PaymentSheetViewController.shouldShowApplePayAsSavedPaymentOption(isLinkEnabled: isLinkEnabled, isApplePayEnabled: isApplePayEnabled),
+                    showApplePay: isFlowController ? isApplePayEnabled : PaymentSheetViewController.shouldShowApplePayAsSavedPaymentOption(hasSavedPaymentMethods: !filteredSavedPaymentMethods.isEmpty, isLinkEnabled: isLinkEnabled, isApplePayEnabled: isApplePayEnabled),
                     showLink: isFlowController ? isLinkEnabled : false
                 )
                 analyticsClient.logPaymentSheetLoadSucceeded(loadingStartDate: loadingStartDate, defaultPaymentMethod: paymentOptionsViewModels.stp_boundSafeObject(at: defaultSelectedIndex))

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
@@ -102,6 +102,29 @@ extension STPAnalyticsClient {
         )
     }
 
+    func logPaymentSheetLoadSucceeded(loadingStartDate: Date, defaultPaymentMethod: SavedPaymentOptionsViewController.Selection?) {
+        let defaultPaymentMethodAnalyticsValue: String = {
+            switch defaultPaymentMethod {
+            case .applePay:
+                return "apple_pay"
+            case .link:
+                return "link"
+            case .saved(paymentMethod: let paymentMethod):
+                return paymentMethod.type.identifier
+            case nil:
+                return "none"
+            case .add:
+                assertionFailure("Caller should ensure that default payment method is `nil` in this case.")
+                return "none"
+            }
+        }()
+        logPaymentSheetEvent(
+            event: .paymentSheetLoadSucceeded,
+            duration: Date().timeIntervalSince(loadingStartDate),
+            params: ["default_payment_method": defaultPaymentMethodAnalyticsValue]
+        )
+    }
+
     func logPaymentSheetFormShown(paymentMethodTypeIdentifier: String, apiClient: STPAPIClient) {
         logPaymentSheetEvent(event: .paymentSheetFormShown, paymentMethodTypeAnalyticsValue: paymentMethodTypeIdentifier)
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
@@ -121,7 +121,7 @@ extension STPAnalyticsClient {
         logPaymentSheetEvent(
             event: .paymentSheetLoadSucceeded,
             duration: Date().timeIntervalSince(loadingStartDate),
-            params: ["default_payment_method": defaultPaymentMethodAnalyticsValue]
+            params: ["selected_lpm": defaultPaymentMethodAnalyticsValue]
         )
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -211,10 +211,6 @@ class PaymentSheetFlowControllerViewController: UIViewController {
         self.addPaymentMethodViewController.delegate = self
     }
 
-    func selectLink() {
-        savedPaymentOptionsViewController.selectLink()
-    }
-
     // MARK: - UIViewController Methods
 
     override func viewDidLoad() {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -55,6 +55,11 @@ class PaymentSheetViewController: UIViewController {
         }
     }
 
+    /// This is a hack to encapsulate this logic so that it can be reused by PaymentSheetLoader to determine whether Apple Pay will be shown as a payment option or not.
+    static func shouldShowApplePayAsSavedPaymentOption(isLinkEnabled: Bool, isApplePayEnabled: Bool) -> Bool {
+        return !isLinkEnabled && isApplePayEnabled
+    }
+
     // MARK: - Writable Properties
     weak var delegate: PaymentSheetViewControllerDelegate?
     private(set) var intent: Intent
@@ -77,15 +82,12 @@ class PaymentSheetViewController: UIViewController {
         )
     }()
     private lazy var savedPaymentOptionsViewController: SavedPaymentOptionsViewController = {
-        let showApplePay = !shouldShowWalletHeader && isApplePayEnabled
-        let showLink = !shouldShowWalletHeader && isLinkEnabled
-
         return SavedPaymentOptionsViewController(
             savedPaymentMethods: savedPaymentMethods,
             configuration: .init(
                 customerID: configuration.customer?.id,
-                showApplePay: showApplePay,
-                showLink: showLink,
+                showApplePay: Self.shouldShowApplePayAsSavedPaymentOption(isLinkEnabled: isLinkEnabled, isApplePayEnabled: isApplePayEnabled),
+                showLink: false,
                 removeSavedPaymentMethodMessage: configuration.removeSavedPaymentMethodMessage,
                 merchantDisplayName: configuration.merchantDisplayName,
                 isTestMode: configuration.apiClient.isTestmode

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -56,8 +56,8 @@ class PaymentSheetViewController: UIViewController {
     }
 
     /// This is a hack to encapsulate this logic so that it can be reused by PaymentSheetLoader to determine whether Apple Pay will be shown as a payment option or not.
-    static func shouldShowApplePayAsSavedPaymentOption(isLinkEnabled: Bool, isApplePayEnabled: Bool) -> Bool {
-        return !isLinkEnabled && isApplePayEnabled
+    static func shouldShowApplePayAsSavedPaymentOption(hasSavedPaymentMethods: Bool, isLinkEnabled: Bool, isApplePayEnabled: Bool) -> Bool {
+        return hasSavedPaymentMethods && !isLinkEnabled && isApplePayEnabled
     }
 
     // MARK: - Writable Properties
@@ -86,7 +86,7 @@ class PaymentSheetViewController: UIViewController {
             savedPaymentMethods: savedPaymentMethods,
             configuration: .init(
                 customerID: configuration.customer?.id,
-                showApplePay: Self.shouldShowApplePayAsSavedPaymentOption(isLinkEnabled: isLinkEnabled, isApplePayEnabled: isApplePayEnabled),
+                showApplePay: Self.shouldShowApplePayAsSavedPaymentOption(hasSavedPaymentMethods: !savedPaymentMethods.isEmpty, isLinkEnabled: isLinkEnabled, isApplePayEnabled: isApplePayEnabled),
                 showLink: false,
                 removeSavedPaymentMethodMessage: configuration.removeSavedPaymentMethodMessage,
                 merchantDisplayName: configuration.merchantDisplayName,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APITest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APITest.swift
@@ -81,10 +81,11 @@ class PaymentSheetAPITest: XCTestCase {
                 // 1. Load the PI
                 PaymentSheetLoader.load(
                     mode: .paymentIntentClientSecret(clientSecret),
-                    configuration: self.configuration
+                    configuration: self.configuration,
+                    isFlowController: false
                 ) { result in
                     switch result {
-                    case .success(let paymentIntent, let paymentMethods, _):
+                    case .success(let paymentIntent, let paymentMethods, _, _):
                         XCTAssertEqual(
                             Set(paymentIntent.recommendedPaymentMethodTypes),
                             Set(expected)
@@ -162,10 +163,11 @@ class PaymentSheetAPITest: XCTestCase {
                                                             confirmHandler: confirmHandler)
         PaymentSheetLoader.load(
             mode: .deferredIntent(intentConfig),
-            configuration: self.configuration
+            configuration: self.configuration,
+            isFlowController: false
         ) { result in
             switch result {
-            case .success(let intent, let paymentMethods, _):
+            case .success(let intent, let paymentMethods, _, _):
                 XCTAssertEqual(
                     Set(intent.recommendedPaymentMethodTypes),
                     Set(expected)
@@ -227,10 +229,11 @@ class PaymentSheetAPITest: XCTestCase {
                                                             confirmHandler: serverSideConfirmHandler)
         PaymentSheetLoader.load(
             mode: .deferredIntent(intentConfig),
-            configuration: self.configuration
+            configuration: self.configuration,
+            isFlowController: false
         ) { result in
             switch result {
-            case .success(let intent, let paymentMethods, _):
+            case .success(let intent, let paymentMethods, _, _):
                 XCTAssertEqual(
                     Set(intent.recommendedPaymentMethodTypes),
                     Set(expected)
@@ -283,9 +286,10 @@ class PaymentSheetAPITest: XCTestCase {
             // 1. Load the PI
             PaymentSheetLoader.load(
                 mode: .paymentIntentClientSecret(clientSecret),
-                configuration: self.configuration
+                configuration: self.configuration,
+                isFlowController: false
             ) { result in
-                guard case .success(let paymentIntent, _, _) = result else {
+                guard case .success(let paymentIntent, _, _, _) = result else {
                     XCTFail()
                     return
                 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderStubbedTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderStubbedTest.swift
@@ -45,10 +45,10 @@ class PaymentSheetLoaderStubbedTest: APIStubbedTestCase {
                 XCTAssertFalse(applePayEnabled)
                 XCTAssertEqual(setupIntent.stripeId, "pi_3Kth")
                 XCTAssertEqual(paymentMethods.count, 0)
-                // The last analytic should be a load succeeded event w/ default_payment_method set
+                // The last analytic should be a load succeeded event w/ selected_lpm set
                 let lastAnalytic = analyticsClient.events.last
                 XCTAssertEqual(lastAnalytic?.event, .paymentSheetLoadSucceeded)
-                XCTAssertEqual(lastAnalytic?.params["default_payment_method"] as? String, "none")
+                XCTAssertEqual(lastAnalytic?.params["selected_lpm"] as? String, "none")
                 loaded.fulfill()
             case .failure(let error):
                 XCTFail(error.nonGenericDescription)
@@ -80,10 +80,10 @@ class PaymentSheetLoaderStubbedTest: APIStubbedTestCase {
                 XCTAssertEqual(setupIntent.stripeId, "pi_3Kth")
                 XCTAssertEqual(paymentMethods.count, 1)
                 XCTAssertEqual(paymentMethods[0].type, .card)
-                // The last analytic should be a load succeeded event w/ default_payment_method set
+                // The last analytic should be a load succeeded event w/ selected_lpm set
                 let lastAnalytic = analyticsClient.events.last
                 XCTAssertEqual(lastAnalytic?.event, .paymentSheetLoadSucceeded)
-                XCTAssertEqual(lastAnalytic?.params["default_payment_method"] as? String, "card")
+                XCTAssertEqual(lastAnalytic?.params["selected_lpm"] as? String, "card")
                 loaded.fulfill()
             case .failure(let error):
                 XCTFail(error.nonGenericDescription)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderStubbedTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderStubbedTest.swift
@@ -19,6 +19,7 @@ class PaymentSheetLoaderStubbedTest: APIStubbedTestCase {
         let customer = PaymentSheet.CustomerConfiguration(id: "123", ephemeralKeySecret: "ek_456")
         config.customer = customer
         config.allowsDelayedPaymentMethods = true
+        config.applePay = .init(merchantId: "foo", merchantCountryCode: "US")
         return config
     }
 
@@ -30,9 +31,12 @@ class PaymentSheetLoaderStubbedTest: APIStubbedTestCase {
 
         let loaded = expectation(description: "Loaded")
         let analyticsClient = STPTestingAnalyticsClient()
+        var configuration = self.configuration(apiClient: stubbedAPIClient())
+        configuration.applePay = nil
+
         PaymentSheetLoader.load(
             mode: .paymentIntentClientSecret("pi_12345_secret_54321"),
-            configuration: self.configuration(apiClient: stubbedAPIClient()),
+            configuration: configuration,
             analyticsClient: analyticsClient,
             isFlowController: true
         ) { result in
@@ -65,9 +69,11 @@ class PaymentSheetLoaderStubbedTest: APIStubbedTestCase {
 
         let loaded = expectation(description: "Loaded")
         let analyticsClient = STPTestingAnalyticsClient()
+        var configuration = self.configuration(apiClient: stubbedAPIClient())
+        configuration.applePay = nil
         PaymentSheetLoader.load(
             mode: .paymentIntentClientSecret("pi_12345_secret_54321"),
-            configuration: self.configuration(apiClient: stubbedAPIClient()),
+            configuration: configuration,
             analyticsClient: analyticsClient,
             isFlowController: true
         ) { result in

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderTest.swift
@@ -29,10 +29,10 @@ final class PaymentSheetLoaderTest: XCTestCase {
         let types = ["ideal", "card", "bancontact", "sofort"]
         let clientSecret = try await STPTestingAPIClient.shared.fetchPaymentIntent(types: types)
         // Given a PaymentIntent client secret...
-        PaymentSheetLoader.load(mode: .paymentIntentClientSecret(clientSecret), configuration: self.configuration) { result in
+        PaymentSheetLoader.load(mode: .paymentIntentClientSecret(clientSecret), configuration: self.configuration, isFlowController: false) { result in
             expectation.fulfill()
             switch result {
-            case .success(let intent, let paymentMethods, _):
+            case .success(let intent, let paymentMethods, _, let isApplePayEnabled):
                 // ...PaymentSheet should successfully load
                 guard case let .paymentIntent(elementsSession, paymentIntent) = intent else {
                     XCTFail()
@@ -46,7 +46,7 @@ final class PaymentSheetLoaderTest: XCTestCase {
                 // Sanity check the PI matches the one we fetched
                 XCTAssertEqual(paymentIntent.clientSecret, clientSecret)
                 XCTAssertEqual(paymentMethods, [])
-                XCTAssertTrue(intent.isApplePayEnabled)
+                XCTAssertTrue(isApplePayEnabled)
             case .failure(let error):
                 XCTFail(error.nonGenericDescription)
             }
@@ -61,16 +61,17 @@ final class PaymentSheetLoaderTest: XCTestCase {
         let clientSecret = try await STPTestingAPIClient.shared.fetchSetupIntent(types: types)
         PaymentSheetLoader.load(
             mode: .setupIntentClientSecret(clientSecret),
-            configuration: self.configuration
+            configuration: self.configuration,
+            isFlowController: false
         ) { result in
             switch result {
-            case .success(let setupIntent, let paymentMethods, _):
+            case .success(let setupIntent, let paymentMethods, _, let isApplePayEnabled):
                 XCTAssertEqual(
                     Set(setupIntent.recommendedPaymentMethodTypes),
                     Set(expected)
                 )
                 XCTAssertEqual(paymentMethods, [])
-                XCTAssertTrue(setupIntent.isApplePayEnabled)
+                XCTAssertTrue(isApplePayEnabled)
                 expectation.fulfill()
             case .failure(let error):
                 XCTFail()
@@ -95,7 +96,8 @@ final class PaymentSheetLoaderTest: XCTestCase {
 
             PaymentSheetLoader.load(
                 mode: .setupIntentClientSecret(clientSecret),
-                configuration: self.configuration
+                configuration: self.configuration,
+                isFlowController: false
             ) { result in
                 defer { expectation.fulfill() }
                 guard case .success = result else {
@@ -127,15 +129,15 @@ final class PaymentSheetLoaderTest: XCTestCase {
         ]
         loadExpectation.expectedFulfillmentCount = intentConfigTestcases.count
         for (index, intentConfig) in intentConfigTestcases.enumerated() {
-            PaymentSheetLoader.load(mode: .deferredIntent(intentConfig), configuration: self.configuration) { result in
+            PaymentSheetLoader.load(mode: .deferredIntent(intentConfig), configuration: self.configuration, isFlowController: true) { result in
                 loadExpectation.fulfill()
                 switch result {
-                case .success(let intent, _, _):
+                case .success(let intent, _, _, let isApplePayEnabled):
                     guard case .deferredIntent = intent else {
                         XCTFail()
                         return
                     }
-                    XCTAssertTrue(intent.isApplePayEnabled)
+                    XCTAssertTrue(isApplePayEnabled)
                 case .failure(let error):
                     XCTFail("Test case at index \(index) failed: \(error)")
                     print(error)
@@ -164,7 +166,7 @@ final class PaymentSheetLoaderTest: XCTestCase {
         ]
         loadExpectation.expectedFulfillmentCount = intentConfigTestcases.count
         for (index, intentConfig) in intentConfigTestcases.enumerated() {
-            PaymentSheetLoader.load(mode: .deferredIntent(intentConfig), configuration: self.configuration, analyticsClient: analyticsClient) { result in
+            PaymentSheetLoader.load(mode: .deferredIntent(intentConfig), configuration: self.configuration, analyticsClient: analyticsClient, isFlowController: false) { result in
                 loadExpectation.fulfill()
                 switch result {
                 case .success:
@@ -212,10 +214,10 @@ final class PaymentSheetLoaderTest: XCTestCase {
             XCTFail("Confirm handler shouldn't be called.")
         }
         let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1000, currency: "JPY"), confirmHandler: confirmHandler)
-        PaymentSheetLoader.load(mode: .deferredIntent(intentConfig), configuration: configuration) { result in
+        PaymentSheetLoader.load(mode: .deferredIntent(intentConfig), configuration: configuration, isFlowController: true) { result in
             loadExpectation.fulfill()
             switch result {
-            case .success(_, let savedPaymentMethods, _):
+            case .success(_, let savedPaymentMethods, _, _):
                 // ...check that it only loads the one normal saved card
                 XCTAssertEqual(savedPaymentMethods.count, 1)
                 XCTAssertEqual(savedPaymentMethods.first?.stripeId, savedNonApplePayCard)
@@ -237,10 +239,10 @@ final class PaymentSheetLoaderTest: XCTestCase {
             externalPaymentMethods: ["external_paypal"],
             externalPaymentMethodConfirmHandler: { _, _, _ in /* no-op */ }
         )
-        PaymentSheetLoader.load(mode: .paymentIntentClientSecret(clientSecret), configuration: configuration) { result in
+        PaymentSheetLoader.load(mode: .paymentIntentClientSecret(clientSecret), configuration: configuration, isFlowController: false) { result in
             expectation.fulfill()
             switch result {
-            case .success(let intent, let paymentMethods, _):
+            case .success(let intent, let paymentMethods, _, let isApplePayEnabled):
                 // ...PaymentSheet should successfully load
                 guard case let .paymentIntent(elementsSession, paymentIntent) = intent else {
                     XCTFail()
@@ -258,7 +260,7 @@ final class PaymentSheetLoaderTest: XCTestCase {
                 // Sanity check the PI matches the one we fetched
                 XCTAssertEqual(paymentIntent.clientSecret, clientSecret)
                 XCTAssertEqual(paymentMethods, [])
-                XCTAssertTrue(intent.isApplePayEnabled)
+                XCTAssertTrue(isApplePayEnabled)
             case .failure(let error):
                 XCTFail(error.nonGenericDescription)
             }
@@ -278,10 +280,10 @@ final class PaymentSheetLoaderTest: XCTestCase {
             externalPaymentMethods: ["external_invalid_value"],
             externalPaymentMethodConfirmHandler: { _, _, _ in /* no-op */ }
         )
-        PaymentSheetLoader.load(mode: .paymentIntentClientSecret(clientSecret), configuration: configuration) { result in
+        PaymentSheetLoader.load(mode: .paymentIntentClientSecret(clientSecret), configuration: configuration, isFlowController: true) { result in
             expectation.fulfill()
             switch result {
-            case .success(let intent, let paymentMethods, _):
+            case .success(let intent, let paymentMethods, _, let isApplePayEnabled):
                 // ...PaymentSheet should *still* successfully load
                 guard case let .paymentIntent(elementsSession, paymentIntent) = intent else {
                     XCTFail()
@@ -290,7 +292,7 @@ final class PaymentSheetLoaderTest: XCTestCase {
                 // Sanity check the PI matches the one we fetched
                 XCTAssertEqual(paymentIntent.clientSecret, clientSecret)
                 XCTAssertEqual(paymentMethods, [])
-                XCTAssertTrue(intent.isApplePayEnabled)
+                XCTAssertTrue(isApplePayEnabled)
 
                 // ...with an empty `externalPaymentMethods` property
                 XCTAssertTrue(elementsSession.externalPaymentMethods.isEmpty)
@@ -319,7 +321,7 @@ final class PaymentSheetLoaderTest: XCTestCase {
         // Set it to another number to manually run if you're making changes to load and want to measure its performance.
         measure(options: options) {
             let e = expectation(description: "")
-            PaymentSheetLoader.load(mode: .deferredIntent(intentConfig), configuration: configuration) { result in
+            PaymentSheetLoader.load(mode: .deferredIntent(intentConfig), configuration: configuration, isFlowController: true) { result in
                 switch result {
                 case .failure(let error):
                     XCTFail(error.localizedDescription)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderTest.swift
@@ -17,6 +17,7 @@ final class PaymentSheetLoaderTest: XCTestCase {
     lazy var configuration: PaymentSheet.Configuration = {
         var config = PaymentSheet.Configuration()
         config.apiClient = apiClient
+        config.applePay = .init(merchantId: "foo", merchantCountryCode: "US")
         return config
     }()
 


### PR DESCRIPTION
## Summary
Sends `selected_lpm` in the `mc_load_succeeded` analytic. This was pretty difficult, since the code that determines the default is inside the SavedPaymentOptionsVC which isn't necessarily loaded until after `mc_load_succeeded` is sent.

To make this work I extracted out the code to determine the SavedPaymentOptionsVC view models and default selection, and call it in load to know the value ahead of time. 

The long term fix might be to continue to create view models in the load path and then *flow that through* to the SavedPaymentOptionsVC - and more generally, generate view models for *all* the UI at load and then flow that through to the views.  

Also renames BI's equivalent analytic's param from `default_payment_method` to `selected_lpm`.

## Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-1562

## Testing
Unit tests + manual testing for "apple_pay", "link", "card", "us_bank_account", "none"

## Changelog
Not user facing