### PR TITLE
 Fix sending EPM load failed analytic when `external_payment_method_data` is missing in the v1/elements/sessions response

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
@@ -123,10 +123,10 @@ extension STPElementsSession: STPAPIResponseDecodable {
         let applePayPreference = response["apple_pay_preference"] as? String
         let isApplePayEnabled = applePayPreference != "disabled"
         let externalPaymentMethods: [ExternalPaymentMethod] = {
-            guard
-                let epmsJSON = response["external_payment_method_data"] as? [[AnyHashable: Any]],
-                let epms = ExternalPaymentMethod.decoded(fromAPIResponse: epmsJSON)
-            else {
+            guard let epmsJSON = response["external_payment_method_data"] as? [[AnyHashable: Any]] else {
+                return []
+            }
+            guard let epms = ExternalPaymentMethod.decoded(fromAPIResponse: epmsJSON) else {
                 // We don't want to fail the entire v1/elements/sessions request if we fail to parse external_payment_methods_data
                 // Instead, fall back to an empty array and log an error.
                 STPAnalyticsClient.sharedClient.logPaymentSheetEvent(event: .paymentSheetElementsSessionEPMLoadFailed)

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
@@ -123,10 +123,14 @@ extension STPElementsSession: STPAPIResponseDecodable {
         let applePayPreference = response["apple_pay_preference"] as? String
         let isApplePayEnabled = applePayPreference != "disabled"
         let externalPaymentMethods: [ExternalPaymentMethod] = {
-            guard let epmsJSON = response["external_payment_method_data"] as? [[AnyHashable: Any]] else {
+            let externalPaymentMethodDataKey = "external_payment_method_data"
+            guard response.keys.contains(externalPaymentMethodDataKey) else {
                 return []
             }
-            guard let epms = ExternalPaymentMethod.decoded(fromAPIResponse: epmsJSON) else {
+            guard
+                let epmsJSON = response[externalPaymentMethodDataKey] as? [[AnyHashable: Any]],
+                let epms = ExternalPaymentMethod.decoded(fromAPIResponse: epmsJSON)
+            else {
                 // We don't want to fail the entire v1/elements/sessions request if we fail to parse external_payment_methods_data
                 // Instead, fall back to an empty array and log an error.
                 STPAnalyticsClient.sharedClient.logPaymentSheetEvent(event: .paymentSheetElementsSessionEPMLoadFailed)


### PR DESCRIPTION
I thought the server would always send `external_payment_method_data=[]` - instead, it sometimes just omits `external_payment_method_data` entirely.  In any case, if it omits it, we shouldn't send a failed-to-load analytic.

## Testing
Manually tested before and after