### PR TITLE
Fix `ConsentAction` event names

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
@@ -31,13 +31,13 @@ class PaymentSheetLinkAccount: PaymentSheetLinkAccountInfoProtocol {
     // More information: go/link-signup-consent-action-log
     enum ConsentAction: String {
         // Checkbox, no fields prefilled
-        case checkbox_v0 = "clicked_checkbox_no_spm_mobile_v0"
+        case checkbox_v0 = "clicked_checkbox_nospm_mobile_v0"
 
         // Checkbox, w/ email prefilled
-        case checkbox_v0_0 = "clicked_checkbox_no_spm_mobile_v0_0"
+        case checkbox_v0_0 = "clicked_checkbox_nospm_mobile_v0_0"
 
         // Checkbox, w/ email & phone prefilled
-        case checkbox_v0_1 = "clicked_checkbox_no_spm_mobile_v0_1"
+        case checkbox_v0_1 = "clicked_checkbox_nospm_mobile_v0_1"
 
         // Inline, no fields prefilled
         case implied_v0 = "implied_consent_withspm_mobile_v0"


### PR DESCRIPTION
## Summary
Fix `ConsentAction` event names

## Motivation
The `ConsentAction` event names are just slightly wrong (see [pay-server](https://git.corp.stripe.com/stripe-internal/pay-server/blob/35330ad5dbcc109c1905c6210ea939e81ee48884/lib/consumer/api/consent_action_types.rb#L28)). They do end up resulting in a payment error unfortunately when passed in incorrectly. This PR fixes the naming.
