### PR TITLE
Clean up after test is ran to avoid payment method limit

### DIFF
--- a/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+Payments.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+Payments.swift
@@ -1108,6 +1108,21 @@ extension STPAPIClient {
         }
     }
 
+    @_spi(STP) public func detachPaymentMethod(
+        _ paymentMethodID: String,
+        fromCustomerUsing ephemeralKeySecret: String
+    ) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) -> Void in
+            detachPaymentMethod(paymentMethodID, fromCustomerUsing: ephemeralKeySecret) { error in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume()
+                }
+            }
+        }
+    }
+
     @_spi(STP) public func attachPaymentMethod(
         _ paymentMethodID: String,
         customerID: String,


### PR DESCRIPTION
## Summary
- Originally the test was failing since we hit a 400 payment method limit on the hardcoded customer
- Updated this to detach after the test to avoid this
- Now uses a fresh customer as well

## Motivation
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-2897

## Testing
- Ran test
- Verified in dashboard that no payment method was attached after running the test
![CleanShot 2024-01-31 at 10 44 58](https://github.com/stripe/stripe-ios/assets/88012362/21bfe23c-6e18-4060-b938-f54fbc834fd0)

## Changelog
N/A