### PR TITLE
Add card funnel analytics to paymentsheet

### DIFF
--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
@@ -185,6 +185,7 @@ import Foundation
     case paymentSheetConfirmButtonTapped = "mc_confirm_button_tapped"
     case paymentSheetFormShown = "mc_form_shown"
     case paymentSheetFormInteracted = "mc_form_interacted"
+    case paymentSheetCardNumberCompleted = "mc_card_number_completed"
 
     // MARK: - v1/elements/session
     case paymentSheetElementsSessionLoadFailed = "mc_elements_session_load_failed"

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticsClient.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticsClient.swift
@@ -111,7 +111,7 @@ import UIKit
         let payload = payload(from: analytic, apiClient: apiClient)
 
         #if DEBUG
-            NSLog("LOG ANALYTICS: \(payload)")
+        NSLog("LOG ANALYTICS: \(analytic.event.rawValue) - \(analytic.params.sorted { $0.0 > $1.0 })")
         #endif
 
         guard type(of: self).shouldCollectAnalytics(),

--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/AnalyticsHelper.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/AnalyticsHelper.swift
@@ -22,6 +22,9 @@ final class AnalyticsHelper {
     private let timeProvider: () -> Date
 
     private var startTimes: [TimeMeasurement: Date] = [:]
+    
+    /// Used to ensure we only send one `mc_form_interacted` event per `mc_form_shown` to avoid spamming.
+    var didSendPaymentSheetFormInteractedEventAfterFormShown: Bool = false
 
     init(timeProvider: @escaping () -> Date = Date.init) {
         self.timeProvider = timeProvider

--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/AnalyticsHelper.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/AnalyticsHelper.swift
@@ -23,7 +23,7 @@ final class AnalyticsHelper {
     private let timeProvider: () -> Date
 
     private var startTimes: [TimeMeasurement: Date] = [:]
-    
+
     /// Used to ensure we only send one `mc_form_interacted` event per `mc_form_shown` to avoid spamming.
     var didSendPaymentSheetFormInteractedEventAfterFormShown: Bool = false
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/AnalyticsHelper.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/AnalyticsHelper.swift
@@ -13,6 +13,7 @@ final class AnalyticsHelper {
         case checkout
         case linkSignup
         case linkPopup
+        case formShown
     }
 
     static let shared = AnalyticsHelper()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSectionWithScanner/CardSectionWithScannerElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSectionWithScanner/CardSectionWithScannerElement.swift
@@ -138,6 +138,7 @@ final class CardSection: ContainerElement {
         self.cvcElement = cvcElement.element
         self.expiryElement = expiryElement.element
         self.preferredNetworks = preferredNetworks
+        self.lastPanElementValidationState = panElement.validationState
         cardSection.delegate = self
 
         // Hook up CBC analytics after self is initialized
@@ -168,6 +169,8 @@ final class CardSection: ContainerElement {
         return .init(rawValue: cardBrandCaseIndex) ?? .unknown
     }
 
+    /// Tracks the last known validation state of the PAN element, so that we can know when it changes from invalid to valid
+    var lastPanElementValidationState: ElementValidationState
     func didUpdate(element: Element) {
         // Update the CVC field if the card brand changes
         let cardBrand = selectedBrand ?? STPCardValidator.brand(forNumber: panElement.text)
@@ -177,6 +180,14 @@ final class CardSection: ContainerElement {
         }
 
         fetchAndUpdateCardBrands()
+        
+        /// Send an analytic whenever the card number field is completed
+        if lastPanElementValidationState.isValid != panElement.validationState.isValid {
+            lastPanElementValidationState = panElement.validationState
+            if case .valid = panElement.validationState {
+                STPAnalyticsClient.sharedClient.logPaymentSheetEvent(event: .paymentSheetCardNumberCompleted)
+            }
+        }
         delegate?.didUpdate(element: self)
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSectionWithScanner/CardSectionWithScannerElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSectionWithScanner/CardSectionWithScannerElement.swift
@@ -180,7 +180,7 @@ final class CardSection: ContainerElement {
         }
 
         fetchAndUpdateCardBrands()
-        
+
         /// Send an analytic whenever the card number field is completed
         if lastPanElementValidationState.isValid != panElement.validationState.isValid {
             lastPanElementValidationState = panElement.validationState

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSectionWithScanner/CardSectionWithScannerView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSectionWithScanner/CardSectionWithScannerView.swift
@@ -60,6 +60,7 @@ final class CardSectionWithScannerView: UIView {
     }
 
     @objc func didTapCardScanButton() {
+        STPAnalyticsClient.sharedClient.logPaymentSheetFormInteracted(paymentMethodTypeIdentifier: "card")
         setCardScanVisible(true)
         cardScanningView.start()
         becomeFirstResponder()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
@@ -420,6 +420,7 @@ extension AddPaymentMethodViewController: ElementDelegate {
     }
 
     func didUpdate(element: Element) {
+        STPAnalyticsClient.sharedClient.logPaymentSheetFormInteracted(paymentMethodTypeIdentifier: selectedPaymentMethodType.identifier)
         delegate?.didUpdate(self)
         animateHeightChange()
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
@@ -252,6 +252,7 @@ class AddPaymentMethodViewController: UIViewController {
     private func updateUI() {
         // Swap out the input view if necessary
         if paymentMethodFormElement.view !== paymentMethodDetailsView {
+            STPAnalyticsClient.sharedClient.logPaymentSheetFormShown(paymentMethodTypeIdentifier: selectedPaymentMethodType.identifier, apiClient: configuration.apiClient)
             let oldView = paymentMethodDetailsView
             let newView = paymentMethodFormElement.view
             self.paymentMethodDetailsView = newView

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -25,7 +25,7 @@ extension PaymentSheet {
         case link(option: LinkConfirmOption)
         case external(paymentMethod: ExternalPaymentMethod, billingDetails: STPPaymentMethodBillingDetails)
 
-        var paymentMethodTypeAnalyticsValue: String? {
+        var paymentMethodTypeAnalyticsValue: String {
             switch self {
             case .applePay:
                 return "apple_pay"

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
@@ -130,14 +130,14 @@ extension STPAnalyticsClient {
         AnalyticsHelper.shared.startTimeMeasurement(.formShown)
         logPaymentSheetEvent(event: .paymentSheetFormShown, paymentMethodTypeAnalyticsValue: paymentMethodTypeIdentifier, apiClient: apiClient)
     }
-    
+
     func logPaymentSheetFormInteracted(paymentMethodTypeIdentifier: String) {
         if !AnalyticsHelper.shared.didSendPaymentSheetFormInteractedEventAfterFormShown {
             AnalyticsHelper.shared.didSendPaymentSheetFormInteractedEventAfterFormShown = true
             logPaymentSheetEvent(event: .paymentSheetFormInteracted, paymentMethodTypeAnalyticsValue: paymentMethodTypeIdentifier)
         }
     }
-    
+
     func logPaymentSheetConfirmButtonTapped(paymentMethodTypeIdentifier: String) {
         let duration = AnalyticsHelper.shared.getDuration(for: .formShown)
         logPaymentSheetEvent(event: .paymentSheetConfirmButtonTapped, duration: duration, paymentMethodTypeAnalyticsValue: paymentMethodTypeIdentifier)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
@@ -126,7 +126,15 @@ extension STPAnalyticsClient {
     }
 
     func logPaymentSheetFormShown(paymentMethodTypeIdentifier: String, apiClient: STPAPIClient) {
-        logPaymentSheetEvent(event: .paymentSheetFormShown, paymentMethodTypeAnalyticsValue: paymentMethodTypeIdentifier)
+        AnalyticsHelper.shared.didSendPaymentSheetFormInteractedEventAfterFormShown = false
+        logPaymentSheetEvent(event: .paymentSheetFormShown, paymentMethodTypeAnalyticsValue: paymentMethodTypeIdentifier, apiClient: apiClient)
+    }
+    
+    func logPaymentSheetFormInteracted(paymentMethodTypeIdentifier: String) {
+        if !AnalyticsHelper.shared.didSendPaymentSheetFormInteractedEventAfterFormShown {
+            AnalyticsHelper.shared.didSendPaymentSheetFormInteractedEventAfterFormShown = true
+            logPaymentSheetEvent(event: .paymentSheetFormInteracted, paymentMethodTypeAnalyticsValue: paymentMethodTypeIdentifier)
+        }
     }
 
     enum DeferredIntentConfirmationType: String {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
@@ -127,6 +127,7 @@ extension STPAnalyticsClient {
 
     func logPaymentSheetFormShown(paymentMethodTypeIdentifier: String, apiClient: STPAPIClient) {
         AnalyticsHelper.shared.didSendPaymentSheetFormInteractedEventAfterFormShown = false
+        AnalyticsHelper.shared.startTimeMeasurement(.formShown)
         logPaymentSheetEvent(event: .paymentSheetFormShown, paymentMethodTypeAnalyticsValue: paymentMethodTypeIdentifier, apiClient: apiClient)
     }
     
@@ -135,6 +136,11 @@ extension STPAnalyticsClient {
             AnalyticsHelper.shared.didSendPaymentSheetFormInteractedEventAfterFormShown = true
             logPaymentSheetEvent(event: .paymentSheetFormInteracted, paymentMethodTypeAnalyticsValue: paymentMethodTypeIdentifier)
         }
+    }
+    
+    func logPaymentSheetConfirmButtonTapped(paymentMethodTypeIdentifier: String) {
+        let duration = AnalyticsHelper.shared.getDuration(for: .formShown)
+        logPaymentSheetEvent(event: .paymentSheetConfirmButtonTapped, duration: duration, paymentMethodTypeAnalyticsValue: paymentMethodTypeIdentifier)
     }
 
     enum DeferredIntentConfirmationType: String {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -445,7 +445,7 @@ class PaymentSheetFlowControllerViewController: UIViewController {
 
     @objc
     private func didTapAddButton() {
-        STPAnalyticsClient.sharedClient.logPaymentSheetEvent(event: .paymentSheetConfirmButtonTapped)
+        STPAnalyticsClient.sharedClient.logPaymentSheetConfirmButtonTapped(paymentMethodTypeIdentifier: selectedPaymentMethodType.identifier)
         switch mode {
         case .selectingSaved:
             self.delegate?.paymentSheetFlowControllerViewControllerShouldClose(self, didCancel: false)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -421,17 +421,18 @@ class PaymentSheetViewController: UIViewController {
 
     @objc
     private func didTapBuyButton() {
-        STPAnalyticsClient.sharedClient.logPaymentSheetEvent(event: .paymentSheetConfirmButtonTapped)
+        let paymentOption: PaymentOption
         switch mode {
         case .addingNew:
             if let buyButtonOverrideBehavior = addPaymentMethodViewController.overrideBuyButtonBehavior {
                 addPaymentMethodViewController.didTapCallToActionButton(behavior: buyButtonOverrideBehavior, from: self)
+                return
             } else {
                 guard let newPaymentOption = addPaymentMethodViewController.paymentOption else {
                     assertionFailure()
                     return
                 }
-                pay(with: newPaymentOption)
+                paymentOption = newPaymentOption
             }
         case .selectingSaved:
             guard
@@ -440,8 +441,10 @@ class PaymentSheetViewController: UIViewController {
                 assertionFailure()
                 return
             }
-            pay(with: selectedPaymentOption)
+            paymentOption = selectedPaymentOption
         }
+        STPAnalyticsClient.sharedClient.logPaymentSheetConfirmButtonTapped(paymentMethodTypeIdentifier: paymentOption.paymentMethodTypeAnalyticsValue)
+        pay(with: paymentOption)
     }
 
     func pay(with paymentOption: PaymentOption) {


### PR DESCRIPTION
## Summary
- Sends `mc_form_shown` w/ `selected_lpm`
- Sends `mc_form_interacted` w/ `selected_lpm` when customer taps a field or the 'scan card' button. Fired once per `mc_form_shown`.
- Sends `mc_card_number_completed` when customer types or scans valid PAN.
- Adds `duration` and `selected_lpm` to `mc_confirm_button_tapped`

Seealso: https://docs.google.com/document/d/1nv8z6k_fIKPOAbOuj4EgiYu9to92e-Sln-f5xN9z0Dg/edit#heading=h.bhci16fyr5sm

## Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-1562

## Testing
Manual testing. Will do a bug bash with Android to make sure we're sending events the same.

## Changelog
Not user facing.
