### PR TITLE
Fix FC mc_custom_payment_*_success analytic duration value...

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -90,6 +90,9 @@ final class PaymentSheetLoader {
                     showLink: isFlowController ? isLinkEnabled : false
                 )
                 analyticsClient.logPaymentSheetLoadSucceeded(loadingStartDate: loadingStartDate, defaultPaymentMethod: paymentOptionsViewModels.stp_boundSafeObject(at: defaultSelectedIndex))
+                if isFlowController {
+                    AnalyticsHelper.shared.startTimeMeasurement(.checkout)
+                }
 
                 // Call completion
                 completion(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
@@ -77,7 +77,9 @@ extension STPAnalyticsClient {
         intentConfig: PaymentSheet.IntentConfiguration? = nil,
         apiClient: STPAPIClient
     ) {
-        AnalyticsHelper.shared.startTimeMeasurement(.checkout)
+        if !isCustom {
+            AnalyticsHelper.shared.startTimeMeasurement(.checkout)
+        }
         logPaymentSheetEvent(
             event: paymentSheetShowEventValue(isCustom: isCustom, paymentMethod: paymentMethod),
             linkEnabled: linkEnabled,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/PaymentSheetUIKitAdditions.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/PaymentSheetUIKitAdditions.swift
@@ -29,7 +29,7 @@ enum PaymentSheetUI {
     static let minimumTapSize: CGSize = CGSize(width: 44, height: 44)
     static let defaultAnimationDuration: TimeInterval = 0.2
     static let quickAnimationDuration: TimeInterval = 0.1
-    /// The minimnum amount of time to spend processing before transitioning to success/failure
+    /// The minimum amount of time to spend processing before transitioning to success/failure
     static let minimumFlightTime: TimeInterval = 1
     static let delayBetweenSuccessAndDismissal: TimeInterval = 1.5
     static let minimumHitArea = CGSize(width: 44, height: 44)


### PR DESCRIPTION
...to be seconds elapsed since load succeeded

## Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-1573

## Testing
Manually tested scenario where you pay with the default (e.g. Apple Pay) and never open the sheet. Before - duration is not sent. After - duration is sent. 

Scenario where you open the sheet, then leave playground, come back, and pay with default (never opening the sheet). Before - duration is sent as the time since the first sheet opened.   After - duration is sent as time since load.

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
