### PR TITLE
Fix sending EPM load failed analytic when `external_payment_method_da…

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
@@ -124,7 +124,7 @@ extension STPElementsSession: STPAPIResponseDecodable {
         let isApplePayEnabled = applePayPreference != "disabled"
         let externalPaymentMethods: [ExternalPaymentMethod] = {
             let externalPaymentMethodDataKey = "external_payment_method_data"
-            guard response.keys.contains(externalPaymentMethodDataKey) else {
+            guard response[externalPaymentMethodDataKey] != nil, !(response[externalPaymentMethodDataKey] is NSNull) else {
                 return []
             }
             guard

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderTest.swift
@@ -20,8 +20,9 @@ final class PaymentSheetLoaderTest: XCTestCase {
         return config
     }()
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override func tearDown() {
+        STPAnalyticsClient.sharedClient._testLogHistory = []
+        super.tearDown()
     }
 
     func testPaymentSheetLoadWithPaymentIntent() async throws {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPElementsSessionTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPElementsSessionTest.swift
@@ -67,7 +67,7 @@ class STPElementsSessionTest: XCTestCase {
         var elementsSessionJson = STPTestUtils.jsonNamed("ElementsSession")!
         // ...that doesn't contain "external_payment_method_data"
         elementsSessionJson["external_payment_method_data"] = nil
-        let elementsSession = STPElementsSession.decodedObject(fromAPIResponse: elementsSessionJson)!
+        var elementsSession = STPElementsSession.decodedObject(fromAPIResponse: elementsSessionJson)!
         // ...it should successfully decode...
         XCTAssertNotNil(elementsSession)
         // ...with an empty `externalPaymentMethods` property
@@ -75,6 +75,18 @@ class STPElementsSessionTest: XCTestCase {
         // ...and not send a failure analytic
         let analyticEvents = STPAnalyticsClient.sharedClient._testLogHistory
         XCTAssertFalse(analyticEvents.contains(where: { dict in
+            (dict["event"] as? String) == STPAnalyticEvent.paymentSheetElementsSessionEPMLoadFailed.rawValue
+        }))
+
+        // Same test as above, but when "external_payment_method_data" is NSNull...
+        elementsSessionJson["external_payment_method_data"] = NSNull()
+        elementsSession = STPElementsSession.decodedObject(fromAPIResponse: elementsSessionJson)!
+        // ...it should successfully decode...
+        XCTAssertNotNil(elementsSession)
+        // ...with an empty `externalPaymentMethods` property
+        XCTAssertTrue(elementsSession.externalPaymentMethods.isEmpty)
+        // ...and not send a failure analytic
+        XCTAssertFalse(STPAnalyticsClient.sharedClient._testLogHistory.contains(where: { dict in
             (dict["event"] as? String) == STPAnalyticEvent.paymentSheetElementsSessionEPMLoadFailed.rawValue
         }))
     }


### PR DESCRIPTION
…ta` is NSNull in the v1/elements/sessions response.

Follow-up to #3232


## Motivation
Turns out the server can also send `NSNull` as a value, so don't send an error in that case either!

## Testing
Add a unit test

## Changelog
Not user facing
