### PR TITLE
Add mandate_data to Klarna automatically for SetupIntents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## x.x.x x-x-x
+### Payments
+* [Changed] We now auto append `mandate_data` when using Klarna with a SetupIntent. If you are interested in using Klarna with SetupIntents you sign up for the beta [here](https://stripe.com/docs/payments/klarna/accept-a-payment). 
+
 ## 23.21.1 2024-01-22
 ### Payments
 * [Changed] Increased the maximum number of status update retries when waiting for an intent to update to a terminal state. This impacts Cash App Pay and 3DS2.

--- a/Stripe/StripeiOSTests/STPSetupIntentConfirmParamsTest.swift
+++ b/Stripe/StripeiOSTests/STPSetupIntentConfirmParamsTest.swift
@@ -46,7 +46,7 @@ class STPSetupIntentConfirmParamsTest: XCTestCase {
         // card type should have no default mandateData
         XCTAssertNil(params.mandateData)
 
-        for type in ["sepa_debit", "au_becs_debit", "bacs_debit"] {
+        for type in ["sepa_debit", "au_becs_debit", "bacs_debit", "bancontact", "ideal", "eps", "sofort", "link", "us_bank_account", "cashapp", "paypal", "revolut_pay", "klarna"] {
             params.mandateData = nil
             params.paymentMethodParams?.rawTypeString = type
             // Mandate-required type should have mandateData

--- a/StripePayments/StripePayments/Source/API Bindings/Models/SetupIntents/STPSetupIntentConfirmParams.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/SetupIntents/STPSetupIntentConfirmParams.swift
@@ -69,7 +69,7 @@ public class STPSetupIntentConfirmParams: NSObject, NSCopying, STPFormEncodable 
             }
             switch paymentMethodType {
             case .AUBECSDebit, .bacsDebit, .bancontact, .iDEAL, .SEPADebit, .EPS, .sofort, .link, .USBankAccount,
-                    .cashApp, .payPal, .revolutPay:
+                    .cashApp, .payPal, .revolutPay, .klarna:
                 return .makeWithInferredValues()
             default: break
             }


### PR DESCRIPTION
## Summary
- Klarna + SetupIntents are now in beta, before this change you would get an error that the request was missing a required parameter: `mandate_data`.

## Motivation
- https://jira.corp.stripe.com/browse/RUN_MOBILESDK-2904
- https://stripe.slack.com/archives/C02HQBW38JX/p1706808728503869

## Testing
- Manual in test mode
- Updated test

## Changelog
See diff