### PR TITLE
Fix PaymentSheet.FlowController not generating session ID until after…

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -151,7 +151,6 @@ extension PaymentSheet {
             isApplePayEnabled: Bool,
             configuration: Configuration
         ) {
-            AnalyticsHelper.shared.generateSessionID()
             STPAnalyticsClient.sharedClient.addClass(toProductUsageIfNecessary: PaymentSheet.FlowController.self)
             STPAnalyticsClient.sharedClient.logPaymentSheetInitialized(isCustom: true,
                                                                        configuration: configuration,
@@ -226,6 +225,7 @@ extension PaymentSheet {
             configuration: PaymentSheet.Configuration,
             completion: @escaping (Result<PaymentSheet.FlowController, Error>) -> Void
         ) {
+            AnalyticsHelper.shared.generateSessionID()
             PaymentSheetLoader.load(
                 mode: mode,
                 configuration: configuration,


### PR DESCRIPTION
… it's loaded.

## Summary
This means the first time it loads, the session ID is nil. It also means subsequent loads use the previous session's ID!

## Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-1599

## Testing
See test
