### PR TITLE
Test analytics in PaymentSheet UI tests

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -65,6 +65,9 @@ struct PaymentSheetTestPlayground: View {
                 VStack {
                     Group {
                         HStack {
+                            if ProcessInfo.processInfo.environment["UITesting"] != nil {
+                                AnalyticsLogForTesting(analyticsLog: $playgroundController.analyticsLog)
+                            }
                             Text("Backend")
                                 .font(.headline)
                             Spacer()
@@ -309,6 +312,20 @@ struct PaymentSheetButtons: View {
                 }
             }
         }
+    }
+}
+
+/// A zero-sized view whose only purpose is to let XCUITests access the analytics sent by the SDK.
+struct AnalyticsLogForTesting: View {
+    @Binding var analyticsLog: [[String: Any]]
+    var analyticsLogString: String {
+        return try! JSONSerialization.data(withJSONObject: analyticsLog).base64EncodedString()
+    }
+    var body: some View {
+        Text(analyticsLogString)
+            .frame(width: 0, height: 0)
+            .accessibility(identifier: "_testAnalyticsLog")
+            .accessibility(label: Text(analyticsLogString))
     }
 }
 

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -639,7 +639,9 @@ extension PaymentSheet.IntentConfiguration.Mode {
 
 extension PlaygroundController: STPAnalyticsClientDelegate {
     func analyticsClientDidLog(analyticsClient: StripeCore.STPAnalyticsClient, payload: [String: Any]) {
-        analyticsLog.append(payload)
+        DispatchQueue.main.async {
+            self.analyticsLog.append(payload)
+        }
     }
 }
 

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -12,10 +12,11 @@
 import Combine
 import Contacts
 import PassKit
+@_spi(STP) import StripeCore
 import StripePayments
-@_spi(STP) import StripePaymentSheet
-@_spi(STP) @_spi(PaymentSheetSkipConfirmation) import StripePaymentSheet
 @_spi(EarlyAccessCVCRecollectionFeature) import StripePaymentSheet
+@_spi(STP) @_spi(PaymentSheetSkipConfirmation) import StripePaymentSheet
+@_spi(STP) import StripePaymentSheet
 import SwiftUI
 import UIKit
 
@@ -260,6 +261,8 @@ class PlaygroundController: ObservableObject {
     var addressViewController: AddressViewController?
     var appearance = PaymentSheet.Appearance.default
     var currentDataTask: URLSessionDataTask?
+    /// All analytic events sent by the SDK since the playground was loaded.
+    @Published var analyticsLog: [[String: Any]] = []
 
     func makeAlertController() -> UIAlertController {
         let alertController = UIAlertController(
@@ -297,6 +300,9 @@ class PlaygroundController: ObservableObject {
                 self.load()
             }
         }.store(in: &subscribers)
+
+        // Listen for analytics
+        STPAnalyticsClient.sharedClient.delegate = self
     }
 
     func buildPaymentSheet() {
@@ -449,6 +455,7 @@ extension PlaygroundController {
             }
 
             DispatchQueue.main.async {
+                self.analyticsLog.removeAll()
                 self.lastPaymentResult = nil
                 self.clientSecret = json["intentClientSecret"]
                 self.ephemeralKey = json["customerEphemeralKeySecret"]
@@ -625,6 +632,14 @@ extension PaymentSheet.IntentConfiguration.Mode {
         @unknown default:
             fatalError()
         }
+    }
+}
+
+// MARK: - STPAnalyticsClientDelegate
+
+extension PlaygroundController: STPAnalyticsClientDelegate {
+    func analyticsClientDidLog(analyticsClient: StripeCore.STPAnalyticsClient, payload: [String: Any]) {
+        analyticsLog.append(payload)
     }
 }
 

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2021 stripe-ios. All rights reserved.
 //
 
-import StripePayments
 import XCTest
 
 class PaymentSheetUITestCase: XCTestCase {
@@ -1421,6 +1420,7 @@ class PaymentSheetDeferredUITests: PaymentSheetUITestCase {
         )
 
         app.buttons["Present PaymentSheet"].tap()
+        app.buttons["Pay $50.99"].waitForExistence(timeout: 10)
 
         XCTAssertEqual(
             // Ignore luxe_* analytics since there are a lot and I'm not sure if they're the same every time

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -12,6 +12,21 @@ import XCTest
 class PaymentSheetUITestCase: XCTestCase {
     var app: XCUIApplication!
 
+    /// This element's `label` contains all the analytic events sent by the SDK since the the playground was loaded, as a base-64 encoded string.
+    /// - Note: Only exists in test playground.
+    lazy var analyticsLogElement: XCUIElement = { app.staticTexts["_testAnalyticsLog"] }()
+    /// Convenience var to grab all the events sent since the playground was loaded.
+    var analyticsLog: [[String: Any]] {
+        let logRawString = analyticsLogElement.label
+        guard
+            let data = Data(base64Encoded: logRawString),
+            let json = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]]
+        else {
+            return []
+        }
+        return json
+    }
+
     override func setUpWithError() throws {
         try super.setUpWithError()
         // Put setup code here. This method is called before the invocation of each test method in the class.
@@ -180,7 +195,17 @@ class PaymentSheetStandardUITests: PaymentSheetUITestCase {
         )
 
         app.buttons["Apple Pay, apple_pay"].waitForExistenceAndTap(timeout: 30) // Should default to Apple Pay
+        XCTAssertEqual(
+            analyticsLog.map({ $0[string: "event"] }),
+            ["mc_load_started", "link.account_lookup.complete", "mc_load_succeeded", "mc_custom_init_customer_applepay", "mc_custom_sheet_savedpm_show"]
+        )
+        // `mc_load_succeeded` event `selected_lpm` should be "apple_pay", the default payment method.
+        XCTAssertEqual(analyticsLog[2][string: "selected_lpm"], "apple_pay")
         app.buttons["+ Add"].waitForExistenceAndTap()
+
+        // Should fire the `mc_form_shown` event w/ `selected_lpm` = card
+        XCTAssertEqual(analyticsLog.last?[string: "event"], "mc_form_shown")
+        XCTAssertEqual(analyticsLog.last?[string: "selected_lpm"], "card")
 
         try! fillCardData(app)
 
@@ -204,13 +229,38 @@ class PaymentSheetStandardUITests: PaymentSheetUITestCase {
 
         // Complete payment
         app.buttons["Continue"].tap()
+
+        // Check analytics
+        XCTAssertEqual(
+            analyticsLog.suffix(3).map({ $0[string: "event"] }),
+            ["mc_form_interacted", "mc_card_number_completed", "mc_confirm_button_tapped"]
+        )
+
         app.buttons["Confirm"].tap()
         var successText = app.staticTexts["Success!"]
         XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
+        XCTAssertEqual(analyticsLog.last?[string: "event"], "mc_custom_payment_newpm_success")
+        XCTAssertEqual(analyticsLog.last?[string: "selected_lpm"], "card")
+        // Make sure they all have the same session id
+        let sessionID = analyticsLog.first![string: "session_id"]
+        XCTAssertTrue(!sessionID!.isEmpty)
+        for analytic in analyticsLog {
+            if analytic[string: "event"] == "stripeios.payment_intent_confirmation" {
+                continue
+            }
+            XCTAssertEqual(analytic[string: "session_id"], sessionID)
+        }
+        // Make sure the appropriate events have "selected_lpm" = "card"
+        for analytic in analyticsLog {
+            if ["mc_form_shown", "mc_form_interacted", "mc_confirm_button_tapped", "mc_custom_payment_newpm_success"].contains(analytic[string: "event"]) {
+               XCTAssertEqual(analytic[string: "selected_lpm"], "card")
+            }
+        }
 
         // Reload w/ same customer
         reload(app, settings: settings)
         app.buttons["Apple Pay, apple_pay"].waitForExistenceAndTap(timeout: 30) // Should default to Apple Pay
+        XCTAssertNotEqual(analyticsLog.first?[string: "session_id"], sessionID) // Sanity check this has a different session ID than before
         XCTAssertEqual(app.cells.count, 3) // Should be "Add" and "Apple Pay" and "Link"
         app.buttons["+ Add"].waitForExistenceAndTap()
 
@@ -1371,12 +1421,36 @@ class PaymentSheetDeferredUITests: PaymentSheetUITestCase {
         )
 
         app.buttons["Present PaymentSheet"].tap()
+
+        XCTAssertEqual(
+            // Ignore luxe_* analytics since there are a lot and I'm not sure if they're the same every time
+            analyticsLog.map({ $0[string: "event"] }).filter({ $0 != "luxe_image_selector_icon_from_bundle" && $0 != "luxe_image_selector_icon_downloaded" }),
+            ["mc_complete_init_applepay", "mc_load_started", "mc_load_succeeded", "mc_complete_sheet_newpm_show", "mc_form_shown"]
+        )
+        XCTAssertEqual(analyticsLog.last?[string: "selected_lpm"], "card")
+
         try? fillCardData(app, container: nil)
 
         app.buttons["Pay $50.99"].tap()
 
         let successText = app.staticTexts["Success!"]
         XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
+
+        XCTAssertEqual(
+            analyticsLog.suffix(6).map({ $0[string: "event"] }),
+            ["mc_form_interacted", "mc_card_number_completed", "mc_confirm_button_tapped", "stripeios.payment_method_creation", "stripeios.payment_intent_confirmation", "mc_complete_payment_newpm_success"]
+        )
+
+        // Make sure they all have the same session id
+        let sessionID = analyticsLog.first![string: "session_id"]
+        XCTAssertTrue(!sessionID!.isEmpty)
+        for analytic in analyticsLog {
+            if (analytic["event"] as! String).starts(with: "stripeios") {
+                continue
+            }
+            XCTAssertEqual(analytic[string: "session_id"], sessionID)
+        }
+
     }
 
     func testDeferredPaymentIntent_ClientSideConfirmation_LostCardDecline() {
@@ -2928,5 +3002,11 @@ extension XCUIApplication {
         let offset = CGVector(dx: point.x, dy: point.y)
         let coordinate = normalized.withOffset(offset)
         coordinate.tap()
+    }
+}
+
+extension Dictionary {
+    subscript(string key: Key) -> String? {
+        return self[key] as? String
     }
 }

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticsClient.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticsClient.swift
@@ -18,11 +18,17 @@ import UIKit
     func log(analytic: Analytic, apiClient: STPAPIClient)
 }
 
+/// This exists so our example/test apps can hook into when STPAnalyticsClient.sharedClient sends events.
+@_spi(STP) public protocol STPAnalyticsClientDelegate: AnyObject {
+    func analyticsClientDidLog(analyticsClient: STPAnalyticsClient, payload: [String: Any])
+}
+
 @_spi(STP) public class STPAnalyticsClient: NSObject, STPAnalyticsClientProtocol {
     @objc public static let sharedClient = STPAnalyticsClient()
     /// When this class logs a payload in an XCTestCase, it's added to `_testLogHistory` instead of being sent over the network.
     /// This is a hack - ideally, we inject a different analytics client in our tests. This is an escape hatch until we can make that (significant) refactor
     public var _testLogHistory: [[String: Any]] = []
+    public weak var delegate: STPAnalyticsClientDelegate?
 
     @objc public var productUsage: Set<String> = Set()
     private var additionalInfoSet: Set<String> = Set()
@@ -112,6 +118,7 @@ import UIKit
 
         #if DEBUG
         NSLog("LOG ANALYTICS: \(analytic.event.rawValue) - \(analytic.params.sorted { $0.0 > $1.0 })")
+        delegate?.analyticsClientDidLog(analyticsClient: self, payload: payload)
         #endif
 
         guard type(of: self).shouldCollectAnalytics(),

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/PaymentMethodTypeCollectionView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/PaymentMethodTypeCollectionView.swift
@@ -116,13 +116,12 @@ extension PaymentMethodTypeCollectionView: UICollectionViewDataSource, UICollect
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         collectionView.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: true)
-        selected = paymentMethodTypes[indexPath.item]
-
         // Only log this event when this collection view is being used by PaymentSheet
         if isPaymentSheet {
             STPAnalyticsClient.sharedClient.logPaymentSheetEvent(event: .paymentSheetCarouselPaymentMethodTapped,
                                                                  paymentMethodTypeAnalyticsValue: paymentMethodTypes[indexPath.row].identifier)
         }
+        selected = paymentMethodTypes[indexPath.item]
     }
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {


### PR DESCRIPTION
## Summary
- Make STPAnalyticsClient report to a new delegate when it sends an analytic. 
- Make the test playground a STPAnalyticsClientDelegate
- Add a hidden view to the playground whose accessibility label contains all analytics sent as a base64 encoded string
- Add asserts in our XCUITest against analytics.

## Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-1575

## Testing
Yes

## Changelog
Not user facing