### PR TITLE
Don't show Link cards in SPM mode

### DIFF
--- a/Stripe/StripeiOSTests/STPPaymentMethodCardWalletTest.swift
+++ b/Stripe/StripeiOSTests/STPPaymentMethodCardWalletTest.swift
@@ -25,6 +25,8 @@ class STPPaymentMethodCardWalletTest: XCTestCase {
         XCTAssertEqual(STPPaymentMethodCardWallet.type(from: "SAMSUNG_PAY"), .samsungPay)
         XCTAssertEqual(STPPaymentMethodCardWallet.type(from: "visa_checkout"), .visaCheckout)
         XCTAssertEqual(STPPaymentMethodCardWallet.type(from: "VISA_CHECKOUT"), .visaCheckout)
+        XCTAssertEqual(STPPaymentMethodCardWallet.type(from: "link"), .link)
+        XCTAssertEqual(STPPaymentMethodCardWallet.type(from: "LINK"), .link)
     }
 
     // MARK: - STPAPIResponseDecodable Tests

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -253,10 +253,10 @@ final class PaymentSheetLoader {
                     continuation.resume(throwing: error)
                     return
                 }
-                // Remove cards that originated from Apple or Google Pay
+                // Remove cards that originated from Apple Pay, Google Pay, or Link
                 paymentMethods = paymentMethods.filter { paymentMethod in
-                    let isAppleOrGooglePay = paymentMethod.type == .card && [.applePay, .googlePay].contains(paymentMethod.card?.wallet?.type)
-                    return !isAppleOrGooglePay
+                    let isWalletCard = paymentMethod.type == .card && [.applePay, .googlePay, .link].contains(paymentMethod.card?.wallet?.type)
+                    return !isWalletCard
                 }
                 continuation.resume(returning: paymentMethods)
             }

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/Types/STPPaymentMethodCardWallet.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/Types/STPPaymentMethodCardWallet.swift
@@ -23,6 +23,8 @@ public enum STPPaymentMethodCardWalletType: Int {
     case samsungPay
     /// Visa Checkout
     case visaCheckout
+    /// Link
+    case link
     /// An unknown Card Wallet type.
     case unknown
 }
@@ -61,6 +63,7 @@ public class STPPaymentMethodCardWallet: NSObject, STPAPIResponseDecodable {
             "masterpass": NSNumber(value: STPPaymentMethodCardWalletType.masterpass.rawValue),
             "samsung_pay": NSNumber(value: STPPaymentMethodCardWalletType.samsungPay.rawValue),
             "visa_checkout": NSNumber(value: STPPaymentMethodCardWalletType.visaCheckout.rawValue),
+            "link": NSNumber(value: STPPaymentMethodCardWalletType.link.rawValue),
         ]
     }
 

--- a/StripePayments/StripePayments/Source/Categories/Enums+CustomStringConvertible.swift
+++ b/StripePayments/StripePayments/Source/Categories/Enums+CustomStringConvertible.swift
@@ -445,6 +445,8 @@ extension STPPaymentMethodCardWalletType: CustomStringConvertible {
             return "masterpass"
         case .samsungPay:
             return "samsungPay"
+        case .link:
+            return "link"
         case .unknown:
             return "unknown"
         case .visaCheckout:


### PR DESCRIPTION
## Summary
Every time a user uses Link, it adds another card to the Customer object. Just like Apple Pay and Google Pay, we should filter these out.

## Testing
Updated unit tests, tested manually on a test account
