### PR TITLE
Fix ScannedCard name incorrectly being set to expiryYear

### DIFF
--- a/StripeCardScan/StripeCardScan/Source/CardVerify/Card Image Verification/ScannedCard.swift
+++ b/StripeCardScan/StripeCardScan/Source/CardVerify/Card Image Verification/ScannedCard.swift
@@ -24,7 +24,7 @@ public struct ScannedCard: Equatable {
         self.pan = pan
         self.expiryMonth = expiryMonth
         self.expiryYear = expiryYear
-        self.name = expiryYear
+        self.name = name
     }
 }
 


### PR DESCRIPTION
## Summary
`ScannedCard`'s name was incorrectly being set to `expiryYear` instead of `name` in its `init`.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
