### PR TITLE
Pass Link flags from elements/session to Link Popup URL

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/Intent+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/Intent+Link.swift
@@ -21,7 +21,7 @@ extension Intent {
     var onlySupportsLinkBank: Bool {
         return supportsLink(allowV2Features: false) && (linkFundingSources == [.bankAccount])
     }
-    
+
     var linkFlags: [String: Bool] {
         switch self {
         case .paymentIntent(let paymentIntent, _):

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/Intent+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/Intent+Link.swift
@@ -21,6 +21,17 @@ extension Intent {
     var onlySupportsLinkBank: Bool {
         return supportsLink(allowV2Features: false) && (linkFundingSources == [.bankAccount])
     }
+    
+    var linkFlags: [String: Bool] {
+        switch self {
+        case .paymentIntent(let paymentIntent, _):
+            return paymentIntent.linkSettings?.linkFlags ?? [:]
+        case .setupIntent(let setupIntent, _):
+            return setupIntent.linkSettings?.linkFlags ?? [:]
+        case .deferredIntent(let elementsSession, _):
+            return elementsSession.linkSettings?.linkFlags ?? [:]
+        }
+    }
 
     var callToAction: ConfirmButton.CallToActionType {
         switch self {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Utils/LinkURLGenerator.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Utils/LinkURLGenerator.swift
@@ -76,7 +76,9 @@ class LinkURLGenerator {
                              merchantInfo: merchantInfo,
                              customerInfo: customerInfo,
                              paymentInfo: paymentInfo,
-                             experiments: [:], flags: [:], loggerMetadata: [:],
+                             experiments: [:],
+                             flags: intent.linkFlags,
+                             loggerMetadata: [:],
                              locale: Locale.current.toLanguageTag())
     }
 

--- a/StripePayments/StripePayments/Source/API Bindings/Models/Shared/LinkSettings.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/Shared/LinkSettings.swift
@@ -24,6 +24,7 @@ import Foundation
     @_spi(STP) public let fundingSources: Set<FundingSource>
     @_spi(STP) public let popupWebviewOption: PopupWebviewOption?
     @_spi(STP) public let passthroughModeEnabled: Bool?
+    @_spi(STP) public let linkFlags: [String: Bool]?
 
     @_spi(STP) public let allResponseFields: [AnyHashable: Any]
 
@@ -31,11 +32,13 @@ import Foundation
         fundingSources: Set<FundingSource>,
         popupWebviewOption: PopupWebviewOption?,
         passthroughModeEnabled: Bool?,
+        linkFlags: [String: Bool]?,
         allResponseFields: [AnyHashable: Any]
     ) {
         self.fundingSources = fundingSources
         self.popupWebviewOption = popupWebviewOption
         self.passthroughModeEnabled = passthroughModeEnabled
+        self.linkFlags = linkFlags
         self.allResponseFields = allResponseFields
     }
 
@@ -55,10 +58,18 @@ import Foundation
         let webviewOption = PopupWebviewOption(rawValue: response["link_popup_webview_option"] as? String ?? "")
         let passthroughModeEnabled = response["link_passthrough_mode_enabled"] as? Bool ?? false
 
+        // Collect the flags for the URL generator
+        let linkFlags = response.reduce(into: [String: Bool]()) { partialResult, element in
+            if let key = element.key as? String, let value = element.value as? Bool {
+                partialResult[key] = value
+            }
+        }
+        
         return LinkSettings(
             fundingSources: validFundingSources,
             popupWebviewOption: webviewOption,
             passthroughModeEnabled: passthroughModeEnabled,
+            linkFlags: linkFlags,
             allResponseFields: response
         ) as? Self
     }

--- a/StripePayments/StripePayments/Source/API Bindings/Models/Shared/LinkSettings.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/Shared/LinkSettings.swift
@@ -64,7 +64,7 @@ import Foundation
                 partialResult[key] = value
             }
         }
-        
+
         return LinkSettings(
             fundingSources: validFundingSources,
             popupWebviewOption: webviewOption,


### PR DESCRIPTION
## Summary
Pass the flags from elements/session to the Link popup URL.

## Motivation
Some features are missing when flags are not passed.

## Testing
In PaymentSheet Example, existing CI tests
