### PR TITLE
Financial Connections: for v3, made networking warm up pane handle being presented as a sheet from consent

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -218,7 +218,7 @@ extension NativeFlowController {
             pane: pane,
             nativeFlowController: self,
             dataManager: dataManager,
-            presentAsSheet: true
+            panePresentationStyle: .sheet
         )
         guard let paneViewController = paneViewController as? SheetViewController else {
             assertionFailure("expected the pane to always be a sheet if `presentAsSheet` is used")
@@ -934,7 +934,7 @@ private func CreatePaneViewController(
     pane: FinancialConnectionsSessionManifest.NextPane,
     nativeFlowController: NativeFlowController,
     dataManager: NativeFlowDataManager,
-    presentAsSheet: Bool = false
+    panePresentationStyle: PanePresentationStyle = .fullscreen
 ) -> UIViewController? {
     let viewController: UIViewController?
     switch pane {
@@ -1189,7 +1189,7 @@ private func CreatePaneViewController(
         )
         let networkingLinkWarmupViewController = NetworkingLinkLoginWarmupViewController(
             dataSource: networkingLinkWarmupDataSource,
-            presentAsSheet: presentAsSheet
+            panePresentationStyle: panePresentationStyle
         )
         networkingLinkWarmupViewController.delegate = nativeFlowController
         viewController = networkingLinkWarmupViewController

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -138,21 +138,27 @@ class NativeFlowController {
 
 extension NativeFlowController {
 
-    private func setNavigationControllerViewControllers(_ viewControllers: [UIViewController], animated: Bool = true) {
-        viewControllers.forEach { viewController in
-            FinancialConnectionsNavigationController.configureNavigationItemForNative(
-                viewController.navigationItem,
-                closeItem: navigationBarCloseBarButtonItem,
-                shouldHideStripeLogo: ShouldHideStripeLogoInNavigationBar(
-                    forViewController: viewController,
-                    reducedBranding: dataManager.reducedBranding,
-                    merchantLogo: dataManager.merchantLogo
-                ),
-                shouldLeftAlignStripeLogo: viewControllers.first == viewController
-                    && viewController is ConsentViewController
-            )
+    private func setNavigationControllerViewControllers(
+        _ viewControllers: [UIViewController],
+        animated: Bool = true
+    ) {
+        dismissVisibleSheetsIfNeeded { [weak self] in
+            guard let self else { return }
+            viewControllers.forEach { viewController in
+                FinancialConnectionsNavigationController.configureNavigationItemForNative(
+                    viewController.navigationItem,
+                    closeItem: self.navigationBarCloseBarButtonItem,
+                    shouldHideStripeLogo: ShouldHideStripeLogoInNavigationBar(
+                        forViewController: viewController,
+                        reducedBranding: self.dataManager.reducedBranding,
+                        merchantLogo: self.dataManager.merchantLogo
+                    ),
+                    shouldLeftAlignStripeLogo: viewControllers.first == viewController
+                        && viewController is ConsentViewController
+                )
+            }
+            navigationController.setViewControllers(viewControllers, animated: animated)
         }
-        navigationController.setViewControllers(viewControllers, animated: animated)
     }
 
     private func pushPane(
@@ -183,22 +189,60 @@ extension NativeFlowController {
     }
 
     private func pushViewController(_ viewController: UIViewController?, animated: Bool) {
-        if let viewController = viewController {
-            FinancialConnectionsNavigationController.configureNavigationItemForNative(
-                viewController.navigationItem,
-                closeItem: navigationBarCloseBarButtonItem,
-                shouldHideStripeLogo: ShouldHideStripeLogoInNavigationBar(
-                    forViewController: viewController,
-                    reducedBranding: dataManager.reducedBranding,
-                    merchantLogo: dataManager.merchantLogo
-                ),
-                shouldLeftAlignStripeLogo: false  // if we `push`, this is not the first VC
+        dismissVisibleSheetsIfNeeded { [weak self] in
+            guard let self else { return }
+            if let viewController = viewController {
+                FinancialConnectionsNavigationController.configureNavigationItemForNative(
+                    viewController.navigationItem,
+                    closeItem: navigationBarCloseBarButtonItem,
+                    shouldHideStripeLogo: ShouldHideStripeLogoInNavigationBar(
+                        forViewController: viewController,
+                        reducedBranding: dataManager.reducedBranding,
+                        merchantLogo: dataManager.merchantLogo
+                    ),
+                    shouldLeftAlignStripeLogo: false  // if we `push`, this is not the first VC
+                )
+                navigationController.pushViewController(viewController, animated: animated)
+            } else {
+                // when we can't find a view controller to present,
+                // show a terminal error
+                showTerminalError()
+            }
+        }
+    }
+
+    private func presentPaneAsSheet(
+        _ pane: FinancialConnectionsSessionManifest.NextPane
+    ) {
+        let paneViewController = CreatePaneViewController(
+            pane: pane,
+            nativeFlowController: self,
+            dataManager: dataManager,
+            presentAsSheet: true
+        )
+        guard let paneViewController = paneViewController as? SheetViewController else {
+            assertionFailure("expected the pane to always be a sheet if `presentAsSheet` is used")
+            pushPane(pane, animated: true)
+            return
+        }
+        paneViewController.present(on: navigationController)
+    }
+
+    private func dismissVisibleSheetsIfNeeded(completionHandler: @escaping () -> Void) {
+        if let viewController = navigationController.presentedViewController {
+            viewController.dismiss(
+                animated: true,
+                completion: { [weak self] in
+                    // recursively dismiss any presented VC until
+                    // there are none
+                    //
+                    // this is likely not needed, but it's there as
+                    // an extra safe-guard
+                    self?.dismissVisibleSheetsIfNeeded(completionHandler: completionHandler)
+                }
             )
-            navigationController.pushViewController(viewController, animated: animated)
         } else {
-            // when we can't find a view controller to present,
-            // show a terminal error
-            showTerminalError()
+            completionHandler()
         }
     }
 }
@@ -428,7 +472,12 @@ extension NativeFlowController: ConsentViewControllerDelegate {
 
         dataManager.manifest = manifest
 
-        pushPane(manifest.nextPane, animated: true)
+        let nextPane = manifest.nextPane
+        if nextPane == .networkingLinkLoginWarmup {
+            presentPaneAsSheet(nextPane)
+        } else {
+            pushPane(nextPane, animated: true)
+        }
     }
 
     func consentViewControllerDidSelectManuallyVerify(_ viewController: ConsentViewController) {
@@ -884,7 +933,8 @@ extension NativeFlowController: NetworkingLinkStepUpVerificationViewControllerDe
 private func CreatePaneViewController(
     pane: FinancialConnectionsSessionManifest.NextPane,
     nativeFlowController: NativeFlowController,
-    dataManager: NativeFlowDataManager
+    dataManager: NativeFlowDataManager,
+    presentAsSheet: Bool = false
 ) -> UIViewController? {
     let viewController: UIViewController?
     switch pane {
@@ -1138,7 +1188,8 @@ private func CreatePaneViewController(
             analyticsClient: dataManager.analyticsClient
         )
         let networkingLinkWarmupViewController = NetworkingLinkLoginWarmupViewController(
-            dataSource: networkingLinkWarmupDataSource
+            dataSource: networkingLinkWarmupDataSource,
+            presentAsSheet: presentAsSheet
         )
         networkingLinkWarmupViewController.delegate = nativeFlowController
         viewController = networkingLinkWarmupViewController

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupViewController.swift
@@ -27,10 +27,10 @@ final class NetworkingLinkLoginWarmupViewController: SheetViewController {
 
     init(
         dataSource: NetworkingLinkLoginWarmupDataSource,
-        presentAsSheet: Bool
+        panePresentationStyle: PanePresentationStyle
     ) {
         self.dataSource = dataSource
-        super.init(presentAsSheet: presentAsSheet)
+        super.init(panePresentationStyle: panePresentationStyle)
     }
 
     required init?(coder: NSCoder) {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupViewController.swift
@@ -20,14 +20,17 @@ protocol NetworkingLinkLoginWarmupViewControllerDelegate: AnyObject {
     func networkingLinkLoginWarmupViewController(_ viewController: NetworkingLinkLoginWarmupViewController, didReceiveTerminalError error: Error)
 }
 
-final class NetworkingLinkLoginWarmupViewController: UIViewController {
+final class NetworkingLinkLoginWarmupViewController: SheetViewController {
 
     private let dataSource: NetworkingLinkLoginWarmupDataSource
     weak var delegate: NetworkingLinkLoginWarmupViewControllerDelegate?
 
-    init(dataSource: NetworkingLinkLoginWarmupDataSource) {
+    init(
+        dataSource: NetworkingLinkLoginWarmupDataSource,
+        presentAsSheet: Bool
+    ) {
         self.dataSource = dataSource
-        super.init(nibName: nil, bundle: nil)
+        super.init(presentAsSheet: presentAsSheet)
     }
 
     required init?(coder: NSCoder) {
@@ -36,10 +39,8 @@ final class NetworkingLinkLoginWarmupViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .customBackgroundColor
-
-        let paneLayoutView = PaneLayoutView(
-            contentView: PaneLayoutView.createContentView(
+        setup(
+            withContentView: PaneLayoutView.createContentView(
                 iconView: RoundedIconView(
                     image: .image(.person),
                     style: .circle
@@ -80,7 +81,6 @@ final class NetworkingLinkLoginWarmupViewController: UIViewController {
                 )
             ).footerView
         )
-        paneLayoutView.addTo(view: view)
     }
 
     private func didSelectContinue() {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/SheetViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/SheetViewController.swift
@@ -9,17 +9,21 @@ import Foundation
 @_spi(STP) import StripeUICore
 import UIKit
 
+enum PanePresentationStyle {
+    case fullscreen
+    case sheet
+}
+
 class SheetViewController: UIViewController {
 
     private static let cornerRadius: CGFloat = 20
 
-    // Indicates whether to enable sheet-specific logic.
+    // Used to toggle between sheet-specific logic and fullscreen.
     //
     // Due to `SheetViewController` being a subclass, and auth flow
     // design constraints of dynamically presenting panes either
-    // as sheets or full-screen, we need this boolean to handle
-    // both states (sheet or full-screen).
-    private let presentAsSheet: Bool
+    // as sheets or fullscreen, we need this to handle both states.
+    private let panePresentationStyle: PanePresentationStyle
 
     // The `contentView` represents the area of the sheet
     // where content is displayed. It's about 80% of the
@@ -34,7 +38,7 @@ class SheetViewController: UIViewController {
         contentStackView.spacing = 0
         contentStackView.layer.cornerRadius = Self.cornerRadius
         contentStackView.clipsToBounds = true
-        if presentAsSheet {
+        if panePresentationStyle == .sheet {
             contentStackView.addArrangedSubview(handleView)
         }
         return contentStackView
@@ -63,8 +67,8 @@ class SheetViewController: UIViewController {
         return tapGestureRecognizer
     }()
 
-    init(presentAsSheet: Bool = true) {
-        self.presentAsSheet = presentAsSheet
+    init(panePresentationStyle: PanePresentationStyle = .sheet) {
+        self.panePresentationStyle = panePresentationStyle
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -74,9 +78,9 @@ class SheetViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = presentAsSheet ? .clear : .customBackgroundColor
+        view.backgroundColor = panePresentationStyle == .sheet ? .clear : .customBackgroundColor
 
-        if presentAsSheet {
+        if panePresentationStyle == .sheet {
             view.addSubview(contentView)
 
             contentStackView.translatesAutoresizingMaskIntoConstraints = false
@@ -112,7 +116,7 @@ class SheetViewController: UIViewController {
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 
-        if presentAsSheet {
+        if panePresentationStyle == .sheet {
             var contentViewMinY = view.window?.safeAreaInsets.top ?? 0
             // estimated iOS value of how far default sheet
             // stretches beyond safeAreaInset.top
@@ -172,7 +176,7 @@ class SheetViewController: UIViewController {
     }
 
     override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
-        if presentAsSheet {
+        if panePresentationStyle == .sheet {
             // animate dismiss animation
             UIView.animate(
                 withDuration: sheetAnimationDuration,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/SheetViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/SheetViewController.swift
@@ -13,6 +13,14 @@ class SheetViewController: UIViewController {
 
     private static let cornerRadius: CGFloat = 20
 
+    // Indicates whether to enable sheet-specific logic.
+    //
+    // Due to `SheetViewController` being a subclass, and auth flow
+    // design constraints of dynamically presenting panes either
+    // as sheets or full-screen, we need this boolean to handle
+    // both states (sheet or full-screen).
+    private let presentAsSheet: Bool
+
     // The `contentView` represents the area of the sheet
     // where content is displayed. It's about 80% of the
     // screen and does NOT contain the dark overlay at the top.
@@ -26,7 +34,9 @@ class SheetViewController: UIViewController {
         contentStackView.spacing = 0
         contentStackView.layer.cornerRadius = Self.cornerRadius
         contentStackView.clipsToBounds = true
-        contentStackView.addArrangedSubview(handleView)
+        if presentAsSheet {
+            contentStackView.addArrangedSubview(handleView)
+        }
         return contentStackView
     }()
 
@@ -53,7 +63,8 @@ class SheetViewController: UIViewController {
         return tapGestureRecognizer
     }()
 
-    init() {
+    init(presentAsSheet: Bool = true) {
+        self.presentAsSheet = presentAsSheet
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -63,73 +74,85 @@ class SheetViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .clear
-        view.addSubview(contentView)
+        view.backgroundColor = presentAsSheet ? .clear : .customBackgroundColor
 
-        contentStackView.translatesAutoresizingMaskIntoConstraints = false
-        contentView.addSubview(contentStackView)
-        NSLayoutConstraint.activate([
-            contentStackView.topAnchor.constraint(
-                // keep the `contentStackView` flexible to resize
-                greaterThanOrEqualTo: contentView.topAnchor,
-                constant: 0
-            ),
-            contentStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-            contentStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            contentStackView.bottomAnchor.constraint(equalTo: contentView.safeAreaLayoutGuide.bottomAnchor),
-        ])
+        if presentAsSheet {
+            view.addSubview(contentView)
 
-        Self.addBottomExtensionView(toView: contentView)
+            contentStackView.translatesAutoresizingMaskIntoConstraints = false
+            contentView.addSubview(contentStackView)
+            NSLayoutConstraint.activate([
+                contentStackView.topAnchor.constraint(
+                    // keep the `contentStackView` flexible to resize
+                    greaterThanOrEqualTo: contentView.topAnchor,
+                    constant: 0
+                ),
+                contentStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+                contentStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+                contentStackView.bottomAnchor.constraint(equalTo: contentView.safeAreaLayoutGuide.bottomAnchor),
+            ])
 
-        let panGestureRecognizer = UIPanGestureRecognizer(
-            target: self,
-            action: #selector(handlePanGesture(_:))
-        )
-        view.addGestureRecognizer(panGestureRecognizer)
+            Self.addBottomExtensionView(toView: contentView)
 
-        view.addGestureRecognizer(darkAreaTapGestureRecognizer)
+            let panGestureRecognizer = UIPanGestureRecognizer(
+                target: self,
+                action: #selector(handlePanGesture(_:))
+            )
+            view.addGestureRecognizer(panGestureRecognizer)
+
+            view.addGestureRecognizer(darkAreaTapGestureRecognizer)
+        }
+        // non-sheet logic
+        else {
+            view.addAndPinSubview(contentView)
+            contentView.addAndPinSubview(contentStackView)
+        }
     }
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 
-        var contentViewMinY = view.window?.safeAreaInsets.top ?? 0
-        // estimated iOS value of how far default sheet
-        // stretches beyond safeAreaInset.top
-        contentViewMinY += 10
-        contentViewMinY += UINavigationController().navigationBar.bounds.height
-        contentViewMinY += 24 // typical Financial Connecitons padding
-        let didChangeContentViewMinY = (self.contentViewMinY != contentViewMinY)
-        self.contentViewMinY = contentViewMinY
+        if presentAsSheet {
+            var contentViewMinY = view.window?.safeAreaInsets.top ?? 0
+            // estimated iOS value of how far default sheet
+            // stretches beyond safeAreaInset.top
+            contentViewMinY += 10
+            contentViewMinY += UINavigationController().navigationBar.bounds.height
+            contentViewMinY += 24 // typical Financial Connecitons padding
+            let didChangeContentViewMinY = (self.contentViewMinY != contentViewMinY)
+            self.contentViewMinY = contentViewMinY
 
-        // we only want `contentView.frame` to be adjusted
-        // if view changes (ex. first presentation or rotation)
-        // otherwise, there could be layout/animation glitches
-        if didChangeContentViewMinY {
-            var contentViewFrame = view.bounds
-            contentViewFrame.size.height -= contentViewMinY
-            contentViewFrame.origin.y = view.bounds.height - contentViewFrame.height
-            contentView.frame = contentViewFrame
+            // we only want `contentView.frame` to be adjusted
+            // if view changes (ex. first presentation or rotation)
+            // otherwise, there could be layout/animation glitches
+            if didChangeContentViewMinY {
+                var contentViewFrame = view.bounds
+                contentViewFrame.size.height -= contentViewMinY
+                contentViewFrame.origin.y = view.bounds.height - contentViewFrame.height
+                contentView.frame = contentViewFrame
 
-            // animate the sheet from top to bottom
-            if !performedSheetPresentationAnimation {
-                performedSheetPresentationAnimation = true
+                // animate the sheet from top to bottom
+                if !performedSheetPresentationAnimation {
+                    performedSheetPresentationAnimation = true
 
-                var initialFrame = contentViewFrame
-                initialFrame.origin.y += contentViewFrame.height
-                let finalFrame = contentViewFrame
+                    var initialFrame = contentViewFrame
+                    initialFrame.origin.y += contentViewFrame.height
+                    let finalFrame = contentViewFrame
 
-                contentView.frame = initialFrame
-                UIView.animate(
-                    withDuration: sheetAnimationDuration,
-                    delay: 0,
-                    options: .curveEaseOut,
-                    animations: {
-                        self.contentView.frame = finalFrame
-                    },
-                    completion: { _ in }
-                )
+                    contentView.frame = initialFrame
+                    UIView.animate(
+                        withDuration: sheetAnimationDuration,
+                        delay: 0,
+                        options: .curveEaseOut,
+                        animations: {
+                            self.contentView.frame = finalFrame
+                        },
+                        completion: { _ in }
+                    )
+                }
             }
+        } else {
+            // non-sheet layout is handled by auto-layout
         }
     }
 
@@ -149,21 +172,23 @@ class SheetViewController: UIViewController {
     }
 
     override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
-        // animate dismiss animation
-        UIView.animate(
-            withDuration: sheetAnimationDuration,
-            delay: 0,
-            usingSpringWithDamping: 1.0,
-            initialSpringVelocity: abs(dismissAnimationInitialSpringVelocityY)/view.bounds.height,
-            options: [.curveEaseOut]
-        ) {
-            self.contentView.frame = CGRect(
-                x: 0,
-                y: self.view.bounds.height,
-                width: self.contentView.bounds.width,
-                height: self.contentView.bounds.height
-            )
-            self.removeContentViewSnapshot()
+        if presentAsSheet {
+            // animate dismiss animation
+            UIView.animate(
+                withDuration: sheetAnimationDuration,
+                delay: 0,
+                usingSpringWithDamping: 1.0,
+                initialSpringVelocity: abs(dismissAnimationInitialSpringVelocityY)/view.bounds.height,
+                options: [.curveEaseOut]
+            ) {
+                self.contentView.frame = CGRect(
+                    x: 0,
+                    y: self.view.bounds.height,
+                    width: self.contentView.bounds.width,
+                    height: self.contentView.bounds.height
+                )
+                self.removeContentViewSnapshot()
+            }
         }
 
         super.dismiss(animated: flag, completion: completion)


### PR DESCRIPTION
## Summary

This PR:
1) Introduces some new logic that allows VC's(/panes) to be presented as sheets OR full-screen views
2) It uses this new logic to present `networkingLinkLoginWarmup` as a sheet (previously, it was presented as a full-screen view)

NOTE: This PR is merged into a new feature branch (`kg-v3nav`) as there will be more navigation-related changes similar to this. But will be merged into the `fc-v3` feature branch after `kg-v3nav` is ready.

Details to understand before reviewing PR:
- This is one PR, out of expected ~50+, to change the design of Financial Connections from a "V2" design to a "V3" design. [Here is a link to the designs](https://www.figma.com/file/wXQ8NJApqSJiLmxxANDRTs/%E2%9C%A8-Connections-3.0?type=design&node-id=2524-217093&mode=design&t=kXaBiAlgVsC7YcH1-0).
- The code here is not the finished version. It's just an iteration towards the final version. This code will be re-visited later. The goal is to go screen-by-screen and make easy changes to learn about all the difficulties in each screen. Later, all the learnings will be combined to do a "final" polish of all screens.
- The above also applies to design. The design here is not the finished version.
- This PR is merged into a feature branch `fc-v3`. It is not merged into `master`.
- There might be TODO's scattered throughout the code. That's expected and they will be fixed later. 

## Testing

| Before | After |
| --- | --- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-02-05 at 16 09 30](https://github.com/stripe/stripe-ios/assets/105514761/495cbd3a-1fc0-4351-a540-d6b001344c82) | ![Simulator Screenshot - iPhone 15 Pro - 2024-02-05 at 16 11 50](https://github.com/stripe/stripe-ios/assets/105514761/6a797d15-1421-4640-968f-de20701b943d) |

### Before (shows up as full screen)

https://github.com/stripe/stripe-ios/assets/105514761/d16145f7-11b3-4987-aefa-5c339eb686cb

### After (has the ability to show up as a sheet)

#### Sheet (the default)

https://github.com/stripe/stripe-ios/assets/105514761/4215f220-1129-44a0-a24f-7f68b298ef78

#### Non-sheet (I hacked this code just to test that full-screen still works)

https://github.com/stripe/stripe-ios/assets/105514761/e036d9f6-c882-4a51-be87-baf4f9ea0de9
