### PR TITLE
Fix PaymentSheet remove card not updating the rest of UI properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 ### Payments
 * [Changed] We now auto append `mandate_data` when using Klarna with a SetupIntent. If you are interested in using Klarna with SetupIntents you sign up for the beta [here](https://stripe.com/docs/payments/klarna/accept-a-payment). 
 
+### PaymentSheet
+* [Fixed] Fixed a bug where deleting the last saved payment method in PaymentSheet wouldn't automatically transition to the "Add a payment method" screen.
+
 ## 23.21.1 2024-01-22
 ### Payments
 * [Changed] Increased the maximum number of status update retries when waiting for an intent to update to a terminal state. This impacts Cash App Pay and 3DS2.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,12 @@
 ### Payments
 * [Added] Support for CVC recollection PaymentSheet and PaymentSheet.FlowController (client-side confirmation)
 
+### PaymentSheet
+* [Fixed] Fixed a bug where deleting the last saved payment method in PaymentSheet wouldn't automatically transition to the "Add a payment method" screen.
+
 ## 23.21.2 2024-02-05
 ### Payments
 * [Changed] We now auto append `mandate_data` when using Klarna with a SetupIntent. If you are interested in using Klarna with SetupIntents you sign up for the beta [here](https://stripe.com/docs/payments/klarna/accept-a-payment). 
-
-### PaymentSheet
-* [Fixed] Fixed a bug where deleting the last saved payment method in PaymentSheet wouldn't automatically transition to the "Add a payment method" screen.
 
 ## 23.21.1 2024-01-22
 ### Payments


### PR DESCRIPTION
## Summary
Fixed a bug where deleting payment methods in PaymentSheet wouldn't update the Buy button or transition to the "Add" screen if there are no more payment methods.

Follow-up to https://github.com/stripe/stripe-ios/pull/3251

### After

Remove card (w/ can't remove all pms flag)

![CleanShot 2024-02-06 at 09 02 09](https://github.com/stripe/stripe-ios/assets/47796191/099b52b0-faae-4bac-99c0-966b907809a0)

Remove card

https://github.com/stripe/stripe-ios/assets/47796191/aaaa06ae-cbc5-48a5-b5c2-861ed8dd87a2

Remove CBC

https://github.com/stripe/stripe-ios/assets/47796191/875eeb40-2a5c-42b1-aadd-f410397fd48e

## Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-376
https://jira.corp.stripe.com/browse/MOBILESDK-1609

## Testing
See videos

## Changelog
Fixed a bug where deleting the last saved payment method in PaymentSheet wouldn't automatically transition to the "Add a payment method" screen.
