### PR TITLE
Financial Connections: changed "institution picker" to open "partner auth" as a sheet for OAuth

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionCellView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionCellView.swift
@@ -50,6 +50,27 @@ final class InstitutionCellView: UIView {
         return subtitleLabel
     }()
     private var iconView: UIView?
+    private lazy var loadingView: ActivityIndicator = {
+        let activityIndicator = ActivityIndicator(size: .medium)
+        activityIndicator.color = .iconActionPrimary
+        activityIndicator.startAnimating()
+
+        // re-size `ActivityIndicator` to a size we desire
+        // because its hard-coded
+        let mediumIconDiameter: CGFloat = 20
+        let desiredIconDiameter: CGFloat = 24
+        let transform = CGAffineTransform(
+            scaleX: desiredIconDiameter / mediumIconDiameter,
+            y: desiredIconDiameter / mediumIconDiameter
+        )
+        activityIndicator.transform = transform
+        activityIndicator.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            activityIndicator.widthAnchor.constraint(equalToConstant: desiredIconDiameter),
+            activityIndicator.heightAnchor.constraint(equalToConstant: desiredIconDiameter),
+        ])
+        return activityIndicator
+    }()
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -81,5 +102,16 @@ final class InstitutionCellView: UIView {
             self.iconView = iconView
         }
         horizontalStackView.addArrangedSubview(labelStackView)
+    }
+
+    func showLoadingView(_ show: Bool) {
+        loadingView.removeFromSuperview()
+
+        if show {
+            horizontalStackView.addArrangedSubview(loadingView)
+            loadingView.startAnimating()
+        } else {
+            loadingView.stopAnimating()
+        }
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionDataSource.swift
@@ -16,6 +16,7 @@ protocol InstitutionDataSource: AnyObject {
 
     func fetchInstitutions(searchQuery: String) -> Future<FinancialConnectionsInstitutionSearchResultResource>
     func fetchFeaturedInstitutions() -> Future<[FinancialConnectionsInstitution]>
+    func createAuthSession(institutionId: String) -> Future<FinancialConnectionsAuthSession>
 }
 
 class InstitutionAPIDataSource: InstitutionDataSource {
@@ -58,5 +59,12 @@ class InstitutionAPIDataSource: InstitutionDataSource {
                 self?.featuredInstitutions = featuredInstitutions
                 return Promise(value: featuredInstitutions)
             }
+    }
+
+    func createAuthSession(institutionId: String) -> Future<FinancialConnectionsAuthSession> {
+        return apiClient.createAuthSession(
+            clientSecret: clientSecret,
+            institutionId: institutionId
+        )
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionPickerViewController.swift
@@ -130,8 +130,6 @@ class InstitutionPickerViewController: UIViewController {
         dataSource.createAuthSession(institutionId: institution.id)
             .observe { [weak self] result in
                 guard let self else { return }
-                showLoadingView(false)
-
                 switch result {
                 case .success(let authSession):
                     self.delegate?.institutionPickerViewController(
@@ -141,12 +139,11 @@ class InstitutionPickerViewController: UIViewController {
                     )
 
                     if authSession.isOauthNonOptional {
-                        // only oauth presents a sheet where we
-                        // do not clear the overlay until the
-                        // sheet is dismissed
-                        observePartnerAuthSheetDismissToClearOverlay()
+                        // oauth presents a sheet where we do not hide
+                        // the overlay until the sheet is dismissed
+                        observePartnerAuthDismissToHideOverlay()
                     } else {
-                        clearOverlayView()
+                        hideOverlayView()
                     }
                 case .failure(let error):
                     // TODO(kgaidis): handle errors...
@@ -161,7 +158,7 @@ class InstitutionPickerViewController: UIViewController {
     }
 
     private var partnerAuthDismissObserver: Any?
-    private func observePartnerAuthSheetDismissToClearOverlay() {
+    private func observePartnerAuthDismissToHideOverlay() {
         partnerAuthDismissObserver = NotificationCenter.default.addObserver(
             forName: .sheetViewControllerWillDismiss,
             object: nil,
@@ -171,12 +168,12 @@ class InstitutionPickerViewController: UIViewController {
             guard notification.object is PartnerAuthViewController else {
                 return
             }
-            clearOverlayView()
+            hideOverlayView()
             partnerAuthDismissObserver = nil
         }
     }
 
-    private func clearOverlayView() {
+    private func hideOverlayView() {
         institutionTableView.showOverlayView(false)
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionTableView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionTableView.swift
@@ -88,7 +88,7 @@ final class InstitutionTableView: UIView {
     private lazy var loadingView: UIView = {
         return InstitutionTableLoadingView()
     }()
-    
+
     init(frame: CGRect, allowManualEntry: Bool) {
         self.allowManualEntry = allowManualEntry
         let cellIdentifier = "\(InstitutionTableViewCell.self)"
@@ -163,7 +163,7 @@ final class InstitutionTableView: UIView {
                 tableView.tableFooterView = tableFooterView
             }
         }
-        
+
         // resize loading view to always be below header view
         let headerViewHeight = tableView.tableHeaderView?.frame.height ?? 0
         loadingView.frame = CGRect(
@@ -190,7 +190,7 @@ final class InstitutionTableView: UIView {
 
         // clear state (some of this is defensive programming)
         showError(false, isUserSearching: isUserSearching)
-        
+
         if isUserSearching {
             if institutions.isEmpty {
                 showTableFooterView(
@@ -220,7 +220,7 @@ final class InstitutionTableView: UIView {
     func showLoadingView(_ show: Bool) {
         loadingView.isHidden = !show
         bringSubviewToFront(loadingView)  // defensive programming to avoid loadingView being hiddden
-        
+
         // ensure the loading view is resized to account for header view
         setNeedsLayout()
         layoutIfNeeded()
@@ -241,7 +241,7 @@ final class InstitutionTableView: UIView {
             }
         }
     }
-    
+
     func setTableHeaderView(_ tableHeaderView: UIView?) {
         if let tableHeaderView {
             tableView.setTableHeaderViewWithCompressedFrameSize(tableHeaderView)
@@ -249,7 +249,7 @@ final class InstitutionTableView: UIView {
             tableView.tableHeaderView = nil
         }
     }
-    
+
     // the footer is always shown, except for when there is an error searching
     private func showTableFooterView(_ show: Bool, view: UIView?) {
         if show, let view = view {
@@ -257,6 +257,52 @@ final class InstitutionTableView: UIView {
         } else {
             tableView.tableFooterView = nil
         }
+    }
+
+    func showLoadingView(
+        _ show: Bool,
+        forInstitution institution: FinancialConnectionsInstitution
+    ) {
+        guard
+            let index = institutions.firstIndex(where: { $0.id == institution.id }),
+            let loadingCell = tableView.cellForRow(
+                at: IndexPath(row: index, section: 0)
+            ) as? InstitutionTableViewCell
+        else {
+            return
+        }
+        loadingCell.showLoadingView(show)
+    }
+
+    func showOverlayView(
+        _ show: Bool,
+        exceptForInstitution institution: FinancialConnectionsInstitution? = nil
+    ) {
+        let exceptInstitutionCell: UITableViewCell? = {
+            if
+                let institution,
+                let index = institutions.firstIndex(where: { $0.id == institution.id }),
+                let cell = tableView.cellForRow(
+                    at: IndexPath(row: index, section: 0)
+                )
+            {
+                return cell
+            } else {
+                return nil
+            }
+        }()
+
+        tableView
+            .visibleCells
+            .forEach { visibleCell in
+                guard
+                    let visibleCell = visibleCell as? InstitutionTableViewCell,
+                    visibleCell !== exceptInstitutionCell
+                else {
+                    return
+                }
+                visibleCell.showOverlayView(show)
+            }
     }
 }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionTableView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionTableView.swift
@@ -274,6 +274,7 @@ final class InstitutionTableView: UIView {
         loadingCell.showLoadingView(show)
     }
 
+    /// Grays out all visible rows except the one with `institution`.
     func showOverlayView(
         _ show: Bool,
         exceptForInstitution institution: FinancialConnectionsInstitution? = nil

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionTableViewCell.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionTableViewCell.swift
@@ -17,6 +17,12 @@ final class InstitutionTableViewCell: UITableViewCell {
     private lazy var institutionCellView: InstitutionCellView = {
         return InstitutionCellView()
     }()
+    private lazy var overlayView: UIView = {
+        let overlayView = UIView()
+        overlayView.backgroundColor = .customBackgroundColor.withAlphaComponent(0.8)
+        overlayView.alpha = 0
+        return overlayView
+    }()
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -35,6 +41,25 @@ final class InstitutionTableViewCell: UITableViewCell {
 
     private func adjustBackgroundColor(isHighlighted: Bool) {
         contentView.backgroundColor = isHighlighted ? .backgroundContainer : .customBackgroundColor
+    }
+
+    func showLoadingView(_ show: Bool) {
+        institutionCellView.showLoadingView(show)
+    }
+
+    func showOverlayView(_ show: Bool) {
+        if overlayView.superview == nil {
+            contentView.addAndPinSubview(overlayView)
+        }
+        UIView.animate(
+            withDuration: 0.3,
+            delay: 0,
+            usingSpringWithDamping: 1,
+            initialSpringVelocity: 0.3,
+            animations: {
+                self.overlayView.alpha = show ? 1.0 : 0
+            }
+        )
     }
 }
 
@@ -60,6 +85,9 @@ import SwiftUI
 @available(iOS 14.0, *)
 private struct InstitutionTableViewCellUIViewRepresentable: UIViewRepresentable {
 
+    let showLoadingView: Bool
+    let showOverlayView: Bool
+
     func makeUIView(context: Context) -> InstitutionTableViewCell {
         InstitutionTableViewCell(style: .default, reuseIdentifier: "test")
     }
@@ -75,6 +103,8 @@ private struct InstitutionTableViewCellUIViewRepresentable: UIViewRepresentable 
                 logo: nil
             )
         )
+        uiView.showLoadingView(showLoadingView)
+        uiView.showOverlayView(showOverlayView)
     }
 }
 
@@ -82,8 +112,20 @@ private struct InstitutionTableViewCellUIViewRepresentable: UIViewRepresentable 
 struct InstitutionTableViewCell_Previews: PreviewProvider {
     static var previews: some View {
         VStack(spacing: 20) {
-            InstitutionTableViewCellUIViewRepresentable()
-                .frame(width: 343, height: 72)
+            InstitutionTableViewCellUIViewRepresentable(
+                showLoadingView: false,
+                showOverlayView: false
+            ).frame(width: 343, height: 72)
+
+            InstitutionTableViewCellUIViewRepresentable(
+                showLoadingView: true,
+                showOverlayView: false
+            ).frame(width: 343, height: 72)
+
+            InstitutionTableViewCellUIViewRepresentable(
+                showLoadingView: false,
+                showOverlayView: true
+            ).frame(width: 343, height: 72)
             Spacer()
         }
         .background(Color.gray.opacity(0.5).ignoresSafeArea())

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthDataSource.swift
@@ -46,6 +46,7 @@ final class PartnerAuthDataSourceImplementation: PartnerAuthDataSource {
     private(set) var pendingAuthSession: FinancialConnectionsAuthSession?
 
     init(
+        authSession: FinancialConnectionsAuthSession?,
         institution: FinancialConnectionsInstitution,
         manifest: FinancialConnectionsSessionManifest,
         returnURL: String?,
@@ -54,6 +55,7 @@ final class PartnerAuthDataSourceImplementation: PartnerAuthDataSource {
         analyticsClient: FinancialConnectionsAnalyticsClient,
         reduceManualEntryProminenceInErrors: Bool
     ) {
+        self.pendingAuthSession = authSession
         self.institution = institution
         self.manifest = manifest
         self.returnURL = returnURL

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthViewController.swift
@@ -51,7 +51,7 @@ final class PartnerAuthViewController: SheetViewController {
     private var isLoadingViewVisible: Bool {
         return loadingView != nil
     }
-    private var viewDidAppear = false
+    private var showLegacyBrowserOnViewDidAppear = false
 
     init(
         dataSource: PartnerAuthDataSource,
@@ -78,6 +78,7 @@ final class PartnerAuthViewController: SheetViewController {
                 // for legacy (non-oauth), start showing the loading indicator,
                 // and wait until `viewDidAppear` gets called
                 insertLegacyLoadingView()
+                showLegacyBrowserOnViewDidAppear = true
             }
         } else {
             assert(
@@ -90,8 +91,8 @@ final class PartnerAuthViewController: SheetViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        if !viewDidAppear {
-            viewDidAppear = true
+        if showLegacyBrowserOnViewDidAppear {
+            showLegacyBrowserOnViewDidAppear = false
             // wait until `viewDidAppear` gets called for legacy (non-oauth) because
             // calling `createdAuthSession` WHILE the VC is animating causes an
             // animation glitch due to ASWebAuthenticationSession browser animation

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PrepaneViews.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PrepaneViews.swift
@@ -60,7 +60,7 @@ final class PrepaneViews {
                 didSelectURL: didSelectURL
             )
         )
-        
+
         contentStackView.addArrangedSubview(headerView)
 
         let footerViewTuple = PaneLayoutView.createFooterView(
@@ -98,10 +98,10 @@ final class PrepaneViews {
         self.secondaryButton = footerViewTuple.secondaryButton
 
         contentStackView.addArrangedSubview(bodyView)
-        
+
         showLoadingView(false)
     }
-    
+
     deinit {
         contentStackView.removeFromSuperview()
         footerView?.removeFromSuperview()
@@ -154,7 +154,7 @@ private func CreateContentView(
 import SwiftUI
 
 private class PrepanePreviewView: UIView {
-    
+
     let prepaneViews = PrepaneViews(
         prepaneModel: FinancialConnectionsOAuthPrepane(
             institutionIcon: nil,
@@ -204,7 +204,7 @@ private class PrepanePreviewView: UIView {
         didSelectContinue: {},
         didSelectCancel: {}
     )
-    
+
     init() {
         super.init(frame: .zero)
         let paneLayoutView = PaneLayoutView(
@@ -214,7 +214,7 @@ private class PrepanePreviewView: UIView {
         paneLayoutView.addTo(view: self)
         backgroundColor = .customBackgroundColor
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/SheetViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/SheetViewController.swift
@@ -14,6 +14,10 @@ enum PanePresentationStyle {
     case sheet
 }
 
+extension Notification.Name {
+    static let sheetViewControllerWillDismiss = Notification.Name("FinancialConnectionsSheetViewControllerWillDismiss")
+}
+
 class SheetViewController: UIViewController {
 
     private static let cornerRadius: CGFloat = 20
@@ -110,6 +114,13 @@ class SheetViewController: UIViewController {
         else {
             view.addAndPinSubview(contentView)
             contentView.addAndPinSubview(contentStackView)
+        }
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        if isBeingDismissed {
+            NotificationCenter.default.post(name: .sheetViewControllerWillDismiss, object: self)
         }
     }
 


### PR DESCRIPTION
## Summary

This PR starts modifying the "institution picker pane" to support a sheet presentation for "partner auth pane."
- We add a loading animation when a user clicks on a "institution" row
- We make an API call while the loading animation is happening
- The result, if the "institution" uses OAuth, is that we present a sheet (non-OAuth/legacy remains the same)

This is "partner auth" with a "prepane:"

![Simulator Screenshot - iPhone 15 Pro - 2024-02-06 at 13 49 03](https://github.com/stripe/stripe-ios/assets/105514761/70ca1fa7-3654-4119-91ed-5dc9cc74a028)

---

NOTE: This PR is merged into a new feature branch (`kg-v3nav`) as there will be more navigation-related changes similar to this. But will be merged into the `fc-v3` feature branch after `kg-v3nav` is ready.

Details to understand before reviewing PR:
- This is one PR, out of expected ~50+, to change the design of Financial Connections from a "V2" design to a "V3" design. [Here is a link to the designs](https://www.figma.com/file/wXQ8NJApqSJiLmxxANDRTs/%E2%9C%A8-Connections-3.0?type=design&node-id=2524-217093&mode=design&t=kXaBiAlgVsC7YcH1-0).
- The code here is not the finished version. It's just an iteration towards the final version. This code will be re-visited later. The goal is to go screen-by-screen and make easy changes to learn about all the difficulties in each screen. Later, all the learnings will be combined to do a "final" polish of all screens.
- The above also applies to design. The design here is not the finished version.
- This PR is merged into a feature branch `fc-v3`. It is not merged into `master`.
- There might be TODO's scattered throughout the code. That's expected and they will be fixed later. 

## Testing

| Loading State | Sheet | 
| --- | --- | 
| ![Simulator Screenshot - iPhone 15 Pro - 2024-02-07 at 11 07 09](https://github.com/stripe/stripe-ios/assets/105514761/717d4d35-d75f-4cb6-b321-b6da34e8ad0b) | ![Simulator Screenshot - iPhone 15 Pro - 2024-02-07 at 11 07 11](https://github.com/stripe/stripe-ios/assets/105514761/4fc8eccc-b798-4d00-ab48-52f8661d48c9) |

### Test Various Scenarios In Live Mode

https://github.com/stripe/stripe-ios/assets/105514761/4dae7d6a-d45a-4b5b-924e-8c74f138a333

### Test OAuth Completing in Test Mode

https://github.com/stripe/stripe-ios/assets/105514761/900574ae-c0ad-4c22-910a-99a5a3785d7f

### Test Legacy (non-OAuth institution) Completing in Test Mode

https://github.com/stripe/stripe-ios/assets/105514761/a6c644c9-c56a-4ad9-84f1-271c045680d6

### All/New Cell States

Regular / Loading / Overlay

![Screenshot 2024-02-07 at 11 04 51 AM](https://github.com/stripe/stripe-ios/assets/105514761/062d64f0-ef53-4013-953c-a85214abade8)

