### PR TITLE
Experimental allowsRemovalOfLastSavedPaymentMethod in CustomerSheet

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlayground.swift
@@ -57,6 +57,7 @@ struct CustomerSheetTestPlayground: View {
                         SettingView(setting: $playgroundController.settings.preferredNetworksEnabled)
                         SettingView(setting: $playgroundController.settings.autoreload)
                         TextField("headerTextForSelectionScreen", text: headerTextForSelectionScreenBinding)
+                        SettingView(setting: $playgroundController.settings.allowsRemovalOfLastSavedPaymentMethod)
                     }
                     Divider()
                     Group {

--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundController.swift
@@ -105,6 +105,7 @@ class CustomerSheetTestPlaygroundController: ObservableObject {
         configuration.appearance = appearance
         configuration.returnURL = "payments-example://stripe-redirect"
         configuration.headerTextForSelectionScreen = settings.headerTextForSelectionScreen
+        configuration.allowsRemovalOfLastSavedPaymentMethod = settings.allowsRemovalOfLastSavedPaymentMethod == .on
 
         if settings.defaultBillingAddress == .on {
             configuration.defaultBillingDetails.name = "Jane Doe"

--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundSettings.swift
@@ -92,6 +92,12 @@ public struct CustomerSheetTestPlaygroundSettings: Codable, Equatable {
             }
         }
     }
+    enum AllowsRemovalOfLastSavedPaymentMethod: String, PickerEnum {
+        static let enumName: String = "AllowsRemovalOfLastSavedPaymentMethod"
+
+        case on
+        case off
+    }
 
     var customerMode: CustomerMode
     var customerId: String?
@@ -108,6 +114,7 @@ public struct CustomerSheetTestPlaygroundSettings: Codable, Equatable {
     var collectAddress: BillingDetailsAddress
     var merchantCountryCode: MerchantCountry
     var preferredNetworksEnabled: PreferredNetworksEnabled
+    var allowsRemovalOfLastSavedPaymentMethod: AllowsRemovalOfLastSavedPaymentMethod
 
     static func defaultValues() -> CustomerSheetTestPlaygroundSettings {
         return CustomerSheetTestPlaygroundSettings(customerMode: .new,
@@ -123,7 +130,8 @@ public struct CustomerSheetTestPlaygroundSettings: Codable, Equatable {
                                                    collectPhone: .automatic,
                                                    collectAddress: .automatic,
                                                    merchantCountryCode: .US,
-                                                   preferredNetworksEnabled: .off)
+                                                   preferredNetworksEnabled: .off,
+                                                   allowsRemovalOfLastSavedPaymentMethod: .on)
     }
 
     var base64Data: String {

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -35,6 +35,7 @@ struct PaymentSheetTestPlayground: View {
             SettingView(setting: $playgroundController.settings.userOverrideCountry)
             SettingView(setting: $playgroundController.settings.externalPayPalEnabled)
             SettingView(setting: $playgroundController.settings.preferredNetworksEnabled)
+            SettingView(setting: $playgroundController.settings.allowsRemovalOfLastSavedPaymentMethod)
         }
         Group {
             SettingView(setting: $playgroundController.settings.requireCVCRecollection)

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -244,6 +244,12 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
         case off
     }
 
+    enum AllowsRemovalOfLastSavedPaymentMethodEnabled: String, PickerEnum {
+        static let enumName: String = "allowsRemovalOfLastSavedPaymentMethod"
+        case on
+        case off
+    }
+
     var uiStyle: UIStyle
     var mode: Mode
     var customerId: String?
@@ -267,6 +273,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
     var externalPayPalEnabled: ExternalPayPalEnabled
     var preferredNetworksEnabled: PreferredNetworksEnabled
     var requireCVCRecollection: RequireCVCRecollectionEnabled
+    var allowsRemovalOfLastSavedPaymentMethod: AllowsRemovalOfLastSavedPaymentMethodEnabled
 
     var attachDefaults: BillingDetailsAttachDefaults
     var collectName: BillingDetailsName
@@ -298,6 +305,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
             externalPayPalEnabled: .off,
             preferredNetworksEnabled: .off,
             requireCVCRecollection: .off,
+            allowsRemovalOfLastSavedPaymentMethod: .on,
             attachDefaults: .off,
             collectName: .automatic,
             collectEmail: .automatic,

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -16,7 +16,7 @@ import PassKit
 import StripePayments
 @_spi(EarlyAccessCVCRecollectionFeature) import StripePaymentSheet
 @_spi(STP) @_spi(PaymentSheetSkipConfirmation) import StripePaymentSheet
-@_spi(STP) import StripePaymentSheet
+@_spi(ExperimentalAllowsRemovalOfLastSavedPaymentMethodAPI) import StripePaymentSheet
 import SwiftUI
 import UIKit
 
@@ -150,6 +150,7 @@ class PlaygroundController: ObservableObject {
         configuration.billingDetailsCollectionConfiguration.address = .init(rawValue: settings.collectAddress.rawValue)!
         configuration.billingDetailsCollectionConfiguration.attachDefaultsToPaymentMethod = settings.attachDefaults == .on
         configuration.preferredNetworks = settings.preferredNetworksEnabled == .on ? [.visa, .cartesBancaires] : nil
+        configuration.allowsRemovalOfLastSavedPaymentMethod = settings.allowsRemovalOfLastSavedPaymentMethod == .on
         return configuration
     }
 

--- a/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
@@ -849,6 +849,69 @@ class CustomerSheetUITest: XCTestCase {
         XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
     }
 
+    // MARK: - allowsRemovalOfLastSavedPaymentMethod
+
+    func testRemoveLastSavedPaymentMethod() throws {
+        var settings = CustomerSheetTestPlaygroundSettings.defaultValues()
+        settings.merchantCountryCode = .FR
+        settings.customerMode = .new
+        settings.applePay = .on
+        settings.allowsRemovalOfLastSavedPaymentMethod = .off
+        loadPlayground(
+            app,
+            settings
+        )
+
+        // Save a card
+        app.staticTexts["None"].waitForExistenceAndTap()
+        app.buttons["+ Add"].waitForExistenceAndTap()
+        try! fillCardData(app, postalEnabled: true)
+        app.buttons["Save"].tap()
+        XCTAssertTrue(app.buttons["Confirm"].waitForExistence(timeout: 10))
+
+        // Shouldn't be able to edit only one saved PM when allowsRemovalOfLastSavedPaymentMethod = .off
+        XCTAssertFalse(app.staticTexts["Edit"].waitForExistence(timeout: 1))
+
+        // Add another PM
+        app.buttons["+ Add"].waitForExistenceAndTap()
+        try! fillCardData(app, postalEnabled: true)
+        app.buttons["Save"].tap()
+        XCTAssertTrue(app.buttons["Confirm"].waitForExistence(timeout: 10))
+
+        // Should be able to edit two saved PMs
+        XCTAssertTrue(app.staticTexts["Edit"].waitForExistenceAndTap())
+        XCTAssertTrue(app.staticTexts["Done"].waitForExistence(timeout: 1)) // Sanity check "Done" button is there
+
+        // Remove one saved PM
+        XCTAssertNotNil(scroll(collectionView: app.collectionViews.firstMatch, toFindButtonWithId: "CircularButton.Remove")?.tap())
+        XCTAssertTrue(app.alerts.buttons["Remove"].waitForExistenceAndTap())
+
+        // Should be kicked out of edit mode now that we have one saved PM
+        XCTAssertFalse(app.staticTexts["Done"].waitForExistence(timeout: 1)) // "Done" button is gone - we are not in edit mode
+        XCTAssertFalse(app.staticTexts["Edit"].waitForExistence(timeout: 1)) // "Edit" button is gone - we can't edit
+
+        // Add a CBC enabled PM
+        app.buttons["+ Add"].waitForExistenceAndTap()
+        try! fillCardData(app, cardNumber: "4000002500001001", postalEnabled: true)
+        app.buttons["Save"].tap()
+        XCTAssertTrue(app.buttons["Confirm"].waitForExistence(timeout: 10))
+
+        // Should be able to edit two saved PMs
+        XCTAssertTrue(app.staticTexts["Edit"].waitForExistenceAndTap())
+        XCTAssertTrue(app.staticTexts["Done"].waitForExistence(timeout: 1)) // Sanity check "Done" button is there
+
+        // Remove the 4242 saved PM
+        XCTAssertNotNil(scroll(collectionView: app.collectionViews.firstMatch, toFindButtonWithId: "CircularButton.Remove")?.tap())
+        XCTAssertTrue(app.alerts.buttons["Remove"].waitForExistenceAndTap())
+
+        // Should be able to edit CBC enabled PM even though it's the only one
+        XCTAssertTrue(app.buttons["CircularButton.Edit"].waitForExistenceAndTap(timeout: 5))
+        XCTAssertTrue(app.buttons["Update card"].waitForExistence(timeout: 5))
+
+        // ...but should not be able to remove it.
+        XCTAssertFalse(app.buttons["Remove card"].exists)
+    }
+
     // MARK: - Helpers
 
     func presentCSAndAddCardFrom(buttonLabel: String, tapAdd: Bool = true) {

--- a/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
@@ -120,10 +120,6 @@ class CustomerSheetUITest: XCTestCase {
 
         removeFirstPaymentMethodInList()
 
-        let doneButton = app.staticTexts["Done"]
-        XCTAssertTrue(doneButton.waitForExistence(timeout: 60.0))
-        doneButton.tap()
-
         let cardPresence_afterRemoval = app.staticTexts["••••4242"]
         XCTAssertFalse(cardPresence_afterRemoval.exists)
 
@@ -326,10 +322,6 @@ class CustomerSheetUITest: XCTestCase {
         removeFirstPaymentMethodInList()
         removeFirstPaymentMethodInList()
 
-        let doneButton = app.staticTexts["Done"]
-        XCTAssertTrue(doneButton.waitForExistence(timeout: 60.0))
-        doneButton.tap()
-
         let closeButton = app.buttons["Close"]
         XCTAssertTrue(closeButton.waitForExistence(timeout: 60.0))
         closeButton.tap()
@@ -362,10 +354,6 @@ class CustomerSheetUITest: XCTestCase {
 
         removeFirstPaymentMethodInList()
         removeFirstPaymentMethodInList()
-
-        let doneButton = app.staticTexts["Done"]
-        XCTAssertTrue(doneButton.waitForExistence(timeout: 60.0))
-        doneButton.tap()
 
         let closeButton = app.buttons["Close"]
         XCTAssertTrue(closeButton.waitForExistence(timeout: 60.0))

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -288,8 +288,13 @@ class PaymentSheetStandardUITests: PaymentSheetUITestCase {
         XCTAssertTrue(editButton.waitForExistence(timeout: 60.0))
         editButton.tap()
 
-        XCTAssertTrue(app.buttons["Remove"].waitForExistenceAndTap())
-        XCTAssertTrue(app.alerts.buttons["Remove"].waitForExistenceAndTap())
+        let removeButton = app.buttons["Remove"]
+        XCTAssertTrue(removeButton.waitForExistence(timeout: 60.0))
+        removeButton.tap()
+
+        let confirmRemoval = app.alerts.buttons["Remove"]
+        XCTAssertTrue(confirmRemoval.waitForExistence(timeout: 60.0))
+        confirmRemoval.tap()
 
         XCTAssertEqual(app.cells.count, 3) // Should be "Add", "Apple Pay", "Link"
     }

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -2210,6 +2210,7 @@ class PaymentSheetDeferredServerSideUITests: PaymentSheetUITestCase {
         // Should be kicked out of edit mode now that we have one saved PM
         XCTAssertFalse(app.staticTexts["Done"].waitForExistence(timeout: 1)) // "Done" button is gone - we are not in edit mode
         XCTAssertFalse(app.staticTexts["Edit"].waitForExistence(timeout: 1)) // "Edit" button is gone - we can't edit
+        XCTAssertTrue(app.buttons["Close"].waitForExistence(timeout: 1))
     }
 
     func testRemoveLastSavedPaymentMethodFlowController() throws {
@@ -2264,6 +2265,7 @@ class PaymentSheetDeferredServerSideUITests: PaymentSheetUITestCase {
         // Should be kicked out of edit mode now that we have one saved PM
         XCTAssertFalse(app.staticTexts["Done"].waitForExistence(timeout: 1)) // "Done" button is gone - we are not in edit mode
         XCTAssertFalse(app.staticTexts["Edit"].waitForExistence(timeout: 1)) // "Edit" button is gone - we can't edit
+        XCTAssertTrue(app.buttons["Close"].waitForExistence(timeout: 1))
     }
 
     func testPreservesSelectionAfterDismissPaymentSheetFlowController() throws {

--- a/Example/PaymentSheet Example/PaymentSheetUITest/XCUITest+Utilities.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/XCUITest+Utilities.swift
@@ -64,6 +64,26 @@ extension XCUIApplication {
 
 // https://gist.github.com/jlnquere/d2cd529874ca73624eeb7159e3633d0f
 func scroll(collectionView: XCUIElement, toFindCellWithId identifier: String) -> XCUIElement? {
+    return scroll(collectionView: collectionView) { collectionView in
+        let cell = collectionView.cells[identifier]
+        if cell.exists {
+            return cell
+        }
+        return nil
+    }
+}
+
+func scroll(collectionView: XCUIElement, toFindButtonWithId identifier: String) -> XCUIElement? {
+    return scroll(collectionView: collectionView) { collectionView in
+        let button = collectionView.buttons[identifier].firstMatch
+        if button.exists {
+            return button
+        }
+        return nil
+    }
+}
+
+func scroll(collectionView: XCUIElement, toFindElementInCollectionView getElementInCollectionView: (XCUIElement) -> XCUIElement?) -> XCUIElement? {
     guard collectionView.elementType == .collectionView else {
         fatalError("XCUIElement is not a collectionView.")
     }
@@ -72,11 +92,9 @@ func scroll(collectionView: XCUIElement, toFindCellWithId identifier: String) ->
     var allVisibleElements = [String]()
 
     while !reachedTheEnd {
-        let cell = collectionView.cells[identifier]
-
-        // Did we find our cell ?
-        if cell.exists {
-            return cell
+        // Did we find our element ?
+        if let element = getElementInCollectionView(collectionView) {
+           return element
         }
 
         // If not: we store the list of all the elements we've got in the CollectionView

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetConfiguration.swift
@@ -69,6 +69,11 @@ extension CustomerSheet {
             }
         }
 
+        /// This is an experimental feature that may be removed at any time.
+        /// If true (the default), the customer can delete all saved payment methods.
+        /// If false, the customer can't delete if they only have one saved payment method remaining.
+        @_spi(STP) public var allowsRemovalOfLastSavedPaymentMethod = true
+
         public init () {
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentMethodCollectionView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentMethodCollectionView.swift
@@ -138,6 +138,7 @@ extension SavedPaymentMethodCollectionView {
             label.isAccessibilityElement = false
             accessibilityElements = [shadowRoundedRectangle, accessoryButton]
             shadowRoundedRectangle.isAccessibilityElement = true
+            shadowRoundedRectangle.accessibilityTraits = [.button]
 
             paymentMethodLogo.contentMode = .scaleAspectFit
             accessoryButton.addTarget(self, action: #selector(didSelectAccessory), for: .touchUpInside)
@@ -294,17 +295,20 @@ extension SavedPaymentMethodCollectionView {
                     } else {
                         label.text = paymentMethod.paymentSheetLabel
                     }
+                    accessibilityIdentifier = label.text
                     shadowRoundedRectangle.accessibilityIdentifier = label.text
                     shadowRoundedRectangle.accessibilityLabel = paymentMethod.paymentSheetAccessibilityLabel
                     paymentMethodLogo.image = paymentMethod.makeSavedPaymentMethodCellImage()
                 case .applePay:
                     // TODO (cleanup) - get this from PaymentOptionDisplayData?
                     label.text = String.Localized.apple_pay
+                    accessibilityIdentifier = label.text
                     shadowRoundedRectangle.accessibilityIdentifier = label.text
                     shadowRoundedRectangle.accessibilityLabel = label.text
                     paymentMethodLogo.image = PaymentOption.applePay.makeSavedPaymentMethodCellImage(for: self)
                 case .link:
                     label.text = STPPaymentMethodType.link.displayName
+                    accessibilityIdentifier = label.text
                     shadowRoundedRectangle.accessibilityIdentifier = label.text
                     shadowRoundedRectangle.accessibilityLabel = label.text
                     paymentMethodLogo.image = PaymentOption.link(option: .wallet).makeSavedPaymentMethodCellImage(for: self)


### PR DESCRIPTION
## Summary
See [API Review](https://docs.google.com/document/d/12pqFEANgkDvvwFNWtXOAB_a4vYE0gikWCICj78Su8kQ/edit#heading=h.1kuxwrt88dsj)

Seealso: https://github.com/stripe/stripe-ios/pull/3251

## Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-1606

## Testing
See UI test

https://github.com/stripe/stripe-ios/assets/47796191/a7f3da94-b1e6-4f42-9a47-c7e21c142a96


https://github.com/stripe/stripe-ios/assets/47796191/1cc8bf9c-acb2-4f2e-95a0-b573779804f3


https://github.com/stripe/stripe-ios/assets/47796191/0e9e96f4-c2ac-4b5b-a35d-90cc18cd1446


## Changelog
Not public.