### PR TITLE
Log out of Link after transaction completes

### DIFF
--- a/Stripe/StripeiOSTests/ConsumerSessionTests.swift
+++ b/Stripe/StripeiOSTests/ConsumerSessionTests.swift
@@ -10,10 +10,10 @@ import XCTest
 
 @testable@_spi(STP) import Stripe
 @testable@_spi(STP) import StripeCore
+import StripeCoreTestUtils
 @testable@_spi(STP) import StripePayments
 @testable@_spi(STP) import StripePaymentSheet
 @testable@_spi(STP) import StripePaymentsUI
-import StripeCoreTestUtils
 
 class ConsumerSessionTests: XCTestCase {
 
@@ -21,7 +21,6 @@ class ConsumerSessionTests: XCTestCase {
         let apiClient = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
         return apiClient
     }()
-
 
     func testLookupSession_noParams() {
         let expectation = self.expectation(description: "Lookup ConsumerSession")
@@ -157,7 +156,6 @@ class ConsumerSessionTests: XCTestCase {
             address.postalCode = "55555"
             address.country = "US"
             billingParams.address = address
-            
 
             let paymentMethodParams = STPPaymentMethodParams.paramsWith(
                 card: cardParams,
@@ -185,7 +183,7 @@ class ConsumerSessionTests: XCTestCase {
                                 case .success(let success):
                                     XCTFail("Logout failed to invalidate token")
                                 case .failure(let error):
-                                    
+
                                     guard let stripeError = error as? StripeError,
                                         case let .apiError(stripeAPIError) = stripeError else {
                                         XCTFail("Received unexpected error response")

--- a/Stripe/StripeiOSTests/ConsumerSessionTests.swift
+++ b/Stripe/StripeiOSTests/ConsumerSessionTests.swift
@@ -80,7 +80,7 @@ class ConsumerSessionTests: XCTestCase {
         let expectation = self.expectation(description: "Lookup ConsumerSession")
 
         ConsumerSession.lookupSession(
-            for: "mobile-payments-sdk-ci+not-a-consumer@stripe.com",
+            for: "mobile-payments-sdk-ci+not-a-consumer+\(UUID())@stripe.com",
             with: apiClient
         ) { result in
             switch result {
@@ -116,7 +116,7 @@ class ConsumerSessionTests: XCTestCase {
             phoneNumber: "+13105551234",
             legalName: nil,
             countryCode: "US",
-            consentAction: "clicked_checkbox_nospm_mobile_v0",
+            consentAction: PaymentSheetLinkAccount.ConsentAction.checkbox_v0.rawValue,
             with: apiClient
         ) { result in
             switch result {

--- a/Stripe/StripeiOSTests/ConsumerSessionTests.swift
+++ b/Stripe/StripeiOSTests/ConsumerSessionTests.swift
@@ -13,22 +13,20 @@ import XCTest
 @testable@_spi(STP) import StripePayments
 @testable@_spi(STP) import StripePaymentSheet
 @testable@_spi(STP) import StripePaymentsUI
+import StripeCoreTestUtils
 
 class ConsumerSessionTests: XCTestCase {
 
-// Disable Consumer Session integration tests
-/*
     let apiClient: STPAPIClient = {
         let apiClient = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
         return apiClient
     }()
 
-    let cookieStore = LinkInMemoryCookieStore()
 
     func testLookupSession_noParams() {
         let expectation = self.expectation(description: "Lookup ConsumerSession")
 
-        ConsumerSession.lookupSession(for: nil, with: apiClient, cookieStore: cookieStore) {
+        ConsumerSession.lookupSession(for: nil, with: apiClient) {
             result in
             switch result {
             case .success(let lookupResponse):
@@ -51,67 +49,12 @@ class ConsumerSessionTests: XCTestCase {
         wait(for: [expectation], timeout: STPTestingNetworkRequestTimeout)
     }
 
-    func testLookupSession_shouldDeleteInvalidSessionCookies() {
-        let expectation = self.expectation(description: "Lookup ConsumerSession")
-
-        cookieStore.write(key: .session, value: "bad_session_cookie", allowSync: false)
-
-        ConsumerSession.lookupSession(for: nil, with: apiClient, cookieStore: cookieStore) {
-            result in
-            switch result {
-            case .success(let lookupResponse):
-                switch lookupResponse.responseType {
-                case .notFound:
-                    // Expected response type.
-                    break
-
-                case .noAvailableLookupParams, .found:
-                    XCTFail("Unexpected response type: \(lookupResponse.responseType)")
-                }
-            case .failure(let error):
-                XCTFail("Received error: \(error.nonGenericDescription)")
-            }
-
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: STPTestingNetworkRequestTimeout)
-        XCTAssertNil(cookieStore.read(key: .session), "Invalid cookie not deleted")
-    }
-
-    func testLookupSession_cookieOnly() {
-        _ = createVerifiedConsumerSession()
-        let expectation = self.expectation(description: "Lookup ConsumerSession")
-        ConsumerSession.lookupSession(for: nil, with: apiClient, cookieStore: cookieStore) {
-            result in
-            switch result {
-            case .success(let lookupResponse):
-                switch lookupResponse.responseType {
-                case .found:
-                    break  // Pass
-
-                case .notFound(let errorMessage):
-                    XCTFail("Got not found response with \(errorMessage)")
-
-                case .noAvailableLookupParams:
-                    XCTFail("Got no avilable lookup params")
-                }
-            case .failure(let error):
-                XCTFail("Received error: \(error.nonGenericDescription)")
-            }
-
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: STPTestingNetworkRequestTimeout)
-    }
-
     func testLookupSession_existingConsumer() {
         let expectation = self.expectation(description: "Lookup ConsumerSession")
 
         ConsumerSession.lookupSession(
             for: "mobile-payments-sdk-ci+a-consumer@stripe.com",
-            with: apiClient,
-            cookieStore: cookieStore
+            with: apiClient
         ) { result in
             switch result {
             case .success(let lookupResponse):
@@ -139,8 +82,7 @@ class ConsumerSessionTests: XCTestCase {
 
         ConsumerSession.lookupSession(
             for: "mobile-payments-sdk-ci+not-a-consumer@stripe.com",
-            with: apiClient,
-            cookieStore: cookieStore
+            with: apiClient
         ) { result in
             switch result {
             case .success(let lookupResponse):
@@ -164,7 +106,7 @@ class ConsumerSessionTests: XCTestCase {
     }
 
     // tests signup, createPaymentDetails
-    func testSignUpAndCreateDetails() {
+    func testSignUpAndCreateDetailsAndLogout() {
         let expectation = self.expectation(description: "consumer sign up")
         let newAccountEmail = "mobile-payments-sdk-ci+\(UUID())@stripe.com"
 
@@ -175,9 +117,8 @@ class ConsumerSessionTests: XCTestCase {
             phoneNumber: "+13105551234",
             legalName: nil,
             countryCode: "US",
-            consentAction: nil,
-            with: apiClient,
-            cookieStore: cookieStore
+            consentAction: "clicked_checkbox_nospm_mobile_v0",
+            with: apiClient
         ) { result in
             switch result {
             case .success(let signupResponse):
@@ -214,7 +155,9 @@ class ConsumerSessionTests: XCTestCase {
             billingParams.name = "Payments SDK CI"
             let address = STPPaymentMethodAddress()
             address.postalCode = "55555"
+            address.country = "US"
             billingParams.address = address
+            
 
             let paymentMethodParams = STPPaymentMethodParams.paramsWith(
                 card: cardParams,
@@ -223,6 +166,8 @@ class ConsumerSessionTests: XCTestCase {
             )
 
             let createExpectation = self.expectation(description: "create payment details")
+            let logoutExpectation = self.expectation(description: "logout")
+            let useDetailsAfterLogoutExpectation = self.expectation(description: "try using payment details after logout")
             consumerSession.createPaymentDetails(
                 paymentMethodParams: paymentMethodParams,
                 with: apiClient,
@@ -230,11 +175,30 @@ class ConsumerSessionTests: XCTestCase {
             ) { result in
                 switch result {
                 case .success(let createdPaymentDetails):
-                    if case .card(let cardDetails) = createdPaymentDetails.details {
-                        XCTAssertEqual(cardDetails.expiryMonth, cardParams.expMonth?.intValue)
-                        XCTAssertEqual(cardDetails.expiryYear, cardParams.expYear?.intValue)
-                    } else {
-                        XCTAssert(false)
+                    // If this succeeds, log out...
+                    consumerSession.logout(with: self.apiClient, consumerAccountPublishableKey: sessionWithKey?.publishableKey) { logoutResult in
+                        switch logoutResult {
+                        case .success:
+                            // Try to use the session again, it shouldn't work
+                            consumerSession.createPaymentDetails(paymentMethodParams: paymentMethodParams, with: self.apiClient, consumerAccountPublishableKey: sessionWithKey?.publishableKey) { loggedOutAuthenticatedActionResult in
+                                switch loggedOutAuthenticatedActionResult {
+                                case .success(let success):
+                                    XCTFail("Logout failed to invalidate token")
+                                case .failure(let error):
+                                    
+                                    guard let stripeError = error as? StripeError,
+                                        case let .apiError(stripeAPIError) = stripeError else {
+                                        XCTFail("Received unexpected error response")
+                                        return
+                                    }
+                                    XCTAssertEqual(stripeAPIError.code, "consumer_session_credentials_invalid")
+                                }
+                                useDetailsAfterLogoutExpectation.fulfill()
+                            }
+                        case .failure(let error):
+                            XCTFail("Logout failed: \(error.nonGenericDescription)")
+                        }
+                        logoutExpectation.fulfill()
                     }
                 case .failure(let error):
                     XCTFail("Received error: \(error.nonGenericDescription)")
@@ -243,248 +207,8 @@ class ConsumerSessionTests: XCTestCase {
                 createExpectation.fulfill()
             }
 
-            wait(for: [createExpectation], timeout: STPTestingNetworkRequestTimeout)
+            waitForExpectations(timeout: STPTestingNetworkRequestTimeout)
         }
     }
 
-    func testListPaymentDetails() {
-        let (consumerSession, publishableKey) = createVerifiedConsumerSession()
-
-        let listExpectation = self.expectation(description: "list payment details")
-
-        consumerSession.listPaymentDetails(
-            with: apiClient,
-            consumerAccountPublishableKey: publishableKey
-        ) { result in
-            switch result {
-            case .success(let paymentDetails):
-                XCTAssertFalse(paymentDetails.isEmpty)
-            case .failure(let error):
-                XCTFail("Received error: \(error.nonGenericDescription)")
-            }
-
-            listExpectation.fulfill()
-        }
-
-        wait(for: [listExpectation], timeout: STPTestingNetworkRequestTimeout)
-    }
-
-    func testCreateLinkAccountSession() {
-        let createLinkAccountSessionExpectation = self.expectation(
-            description: "Create LinkAccountSession"
-        )
-
-        let (consumerSession, publishableKey) = createVerifiedConsumerSession()
-        consumerSession.createLinkAccountSession(
-            with: apiClient,
-            consumerAccountPublishableKey: publishableKey
-        ) { result in
-            switch result {
-            case .success:
-                // Pass
-                break
-            case .failure(let error):
-                XCTFail("Received error: \(error.nonGenericDescription)")
-            }
-
-            createLinkAccountSessionExpectation.fulfill()
-        }
-
-        wait(for: [createLinkAccountSessionExpectation], timeout: STPTestingNetworkRequestTimeout)
-    }
-
-    func testUpdatePaymentDetails() {
-        let (consumerSession, publishableKey) = createVerifiedConsumerSession()
-
-        let listExpectation = self.expectation(description: "list payment details")
-        var storedPaymentDetails = [ConsumerPaymentDetails]()
-
-        consumerSession.listPaymentDetails(
-            with: apiClient,
-            consumerAccountPublishableKey: publishableKey
-        ) { result in
-            switch result {
-            case .success(let paymentDetails):
-                storedPaymentDetails = paymentDetails
-            case .failure(let error):
-                XCTFail("Received error: \(error.nonGenericDescription)")
-            }
-
-            listExpectation.fulfill()
-        }
-
-        wait(for: [listExpectation], timeout: STPTestingNetworkRequestTimeout)
-
-        let billingParams = STPPaymentMethodBillingDetails()
-        billingParams.name = "Payments SDK CI"
-        let address = STPPaymentMethodAddress()
-        address.postalCode = "55555"
-        billingParams.address = address
-
-        let updateExpectation = self.expectation(description: "update payment details")
-        let paymentMethodToUpdate = try! XCTUnwrap(storedPaymentDetails.first)
-
-        guard case .card(let card) = paymentMethodToUpdate.details else {
-            XCTFail("Payment method must be `card` type")
-            return
-        }
-
-        let calendar = Calendar(identifier: .gregorian)
-        let yearOne = calendar.component(.year, from: Date()) + 1
-        let yearTwo = calendar.component(.year, from: Date()) + 2
-
-        // toggle between expiry years/months
-        let newExpiryDate = CardExpiryDate(
-            month: card.expiryDate.month == 1 ? 2 : 1,
-            year: card.expiryDate.year == yearOne ? yearTwo : yearOne
-        )
-
-        let updateParams = UpdatePaymentDetailsParams(
-            isDefault: !paymentMethodToUpdate.isDefault,
-            details: .card(
-                expiryDate: newExpiryDate,
-                billingDetails: billingParams
-            )
-        )
-
-        consumerSession.updatePaymentDetails(
-            with: apiClient,
-            id: paymentMethodToUpdate.stripeID,
-            updateParams: updateParams,
-            consumerAccountPublishableKey: publishableKey
-        ) { result in
-            switch result {
-            case .success(let paymentDetails):
-                XCTAssertNotEqual(paymentDetails.isDefault, paymentMethodToUpdate.isDefault)
-                switch paymentDetails.details {
-                case .card(let card):
-                    XCTAssertEqual(newExpiryDate, card.expiryDate)
-                case .bankAccount, .unparsable:
-                    XCTFail("Unexpected payment details type")
-                }
-            case .failure(let error):
-                XCTFail("Received error: \(error.nonGenericDescription)")
-            }
-
-            updateExpectation.fulfill()
-        }
-
-        wait(for: [updateExpectation], timeout: STPTestingNetworkRequestTimeout)
-    }
-
-    func testLogout() {
-        let (consumerSession, publishableKey) = createVerifiedConsumerSession()
-
-        XCTAssertNotNil(cookieStore.formattedSessionCookies())
-
-        let logoutExpectation = self.expectation(description: "Logout")
-
-        consumerSession.logout(
-            with: apiClient,
-            cookieStore: cookieStore,
-            consumerAccountPublishableKey: publishableKey
-        ) { result in
-            switch result {
-            case .success:
-                XCTAssertNil(self.cookieStore.formattedSessionCookies())
-            case .failure(let error):
-                XCTFail("Received error: \(error.nonGenericDescription)")
-            }
-
-            logoutExpectation.fulfill()
-        }
-
-        wait(for: [logoutExpectation], timeout: STPTestingNetworkRequestTimeout)
-    }
-*/
-}
-
-extension ConsumerSessionTests {
-/*
-    fileprivate func lookupExistingConsumer() -> ConsumerSession.SessionWithPublishableKey {
-        var sessionWithKey: ConsumerSession.SessionWithPublishableKey!
-
-        let lookupExpectation = self.expectation(description: "Lookup ConsumerSession")
-
-        let email = "mobile-payments-sdk-ci+a-consumer@stripe.com"
-
-        ConsumerSession.lookupSession(
-            for: email,
-            with: apiClient,
-            cookieStore: cookieStore
-        ) { result in
-            switch result {
-            case .success(let lookupResponse):
-                switch lookupResponse.responseType {
-                case .found(let session):
-                    sessionWithKey = session
-                case .notFound(let errorMessage):
-                    XCTFail("Got not found response with \(errorMessage)")
-                case .noAvailableLookupParams:
-                    XCTFail("Got no avilable lookup params")
-                }
-            case .failure(let error):
-                XCTFail("Received error: \(error.nonGenericDescription)")
-            }
-
-            lookupExpectation.fulfill()
-        }
-
-        wait(for: [lookupExpectation], timeout: STPTestingNetworkRequestTimeout)
-
-        return sessionWithKey
-    }
-
-    fileprivate func createVerifiedConsumerSession() -> (ConsumerSession, String) {
-        let sessionWithKey = lookupExistingConsumer()
-        var consumerSession = sessionWithKey.consumerSession
-        let publishableKey = sessionWithKey.publishableKey
-
-        // Start verification
-
-        let startVerificationExpectation = self.expectation(description: "Start verification")
-
-        consumerSession.startVerification(
-            with: apiClient,
-            cookieStore: cookieStore,
-            consumerAccountPublishableKey: publishableKey
-        ) { result in
-            switch result {
-            case .success:
-                // Pass
-                break
-            case .failure(let error):
-                XCTFail("Received error: \(error.nonGenericDescription)")
-            }
-
-            startVerificationExpectation.fulfill()
-        }
-
-        wait(for: [startVerificationExpectation], timeout: STPTestingNetworkRequestTimeout)
-
-        // Verify via SMS
-
-        let confirmVerificationExpectation = self.expectation(description: "Confirm verification")
-
-        consumerSession.confirmSMSVerification(
-            with: "000000",
-            with: apiClient,
-            cookieStore: cookieStore,
-            consumerAccountPublishableKey: publishableKey
-        ) { result in
-            switch result {
-            case .success(let verifiedSession):
-                consumerSession = verifiedSession
-            case .failure(let error):
-                XCTFail("Received error: \(error.nonGenericDescription)")
-            }
-
-            confirmVerificationExpectation.fulfill()
-        }
-
-        wait(for: [confirmVerificationExpectation], timeout: STPTestingNetworkRequestTimeout)
-
-        return (consumerSession, publishableKey)
-    }
-*/
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
@@ -186,6 +186,15 @@ class PaymentSheetLinkAccount: PaymentSheetLinkAccountInfoProtocol {
             )
         }
     }
+
+    func logout() {
+        guard let session = currentSession else {
+            return
+        }
+        session.logout(with: apiClient, consumerAccountPublishableKey: publishableKey) { _ in
+            // Nothing to do if logout fails.
+        }
+    }
 }
 
 // MARK: - Equatable

--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
@@ -192,7 +192,7 @@ class PaymentSheetLinkAccount: PaymentSheetLinkAccountInfoProtocol {
             return
         }
         session.logout(with: apiClient, consumerAccountPublishableKey: publishableKey) { _ in
-            // Nothing to do if logout fails.
+            // We don't need to do anything if this fails, the key will expire automatically.
         }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/ConsumerSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/ConsumerSession.swift
@@ -134,4 +134,16 @@ extension ConsumerSession {
             completion: completion)
     }
 
+    func logout(
+        with apiClient: STPAPIClient = STPAPIClient.shared,
+        consumerAccountPublishableKey: String?,
+        completion: @escaping (Result<ConsumerSession, Error>) -> Void
+    ) {
+        // Logout from server.
+        apiClient.logout(
+            consumerSessionClientSecret: clientSecret,
+            consumerAccountPublishableKey: consumerAccountPublishableKey,
+            completion: completion)
+    }
+
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/ConsumerSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/ConsumerSession.swift
@@ -139,7 +139,6 @@ extension ConsumerSession {
         consumerAccountPublishableKey: String?,
         completion: @escaping (Result<ConsumerSession, Error>) -> Void
     ) {
-        // Logout from server.
         apiClient.logout(
             consumerSessionClientSecret: clientSecret,
             consumerAccountPublishableKey: consumerAccountPublishableKey,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
@@ -222,6 +222,28 @@ extension STPAPIClient {
             completion: completion
         )
     }
+
+    func logout(
+        consumerSessionClientSecret: String,
+        consumerAccountPublishableKey: String?,
+        completion: @escaping (Result<ConsumerSession, Error>) -> Void
+    ) {
+        let endpoint: String = "consumers/sessions/log_out"
+
+        let parameters: [String: Any] = [
+            "credentials": [
+                "consumer_session_client_secret": consumerSessionClientSecret
+            ],
+            "request_surface": "ios_payment_element",
+        ]
+
+        makeConsumerSessionRequest(
+            endpoint: endpoint,
+            parameters: parameters,
+            consumerAccountPublishableKey: consumerAccountPublishableKey,
+            completion: completion
+        )
+    }
 }
 
 // TODO(ramont): Remove this after switching to modern bindings.

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
@@ -222,7 +222,7 @@ extension STPAPIClient {
             completion: completion
         )
     }
-    
+
     func logout(
         consumerSessionClientSecret: String,
         consumerAccountPublishableKey: String?,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
@@ -222,7 +222,7 @@ extension STPAPIClient {
             completion: completion
         )
     }
-
+    
     func logout(
         consumerSessionClientSecret: String,
         consumerAccountPublishableKey: String?,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkWebController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkWebController.swift
@@ -25,15 +25,6 @@ protocol PayWithLinkWebControllerDelegate: AnyObject {
 
 }
 
-protocol PayWithLinkCoordinating: AnyObject {
-    func confirm(
-        with linkAccount: PaymentSheetLinkAccount,
-        paymentDetails: ConsumerPaymentDetails
-    )
-    func cancel()
-    func accountUpdated(_ linkAccount: PaymentSheetLinkAccount)
-}
-
 /// A view controller for paying with Link using ASWebAuthenticationSession.
 ///
 /// Instantiate and present this controller when the user chooses to pay with Link.

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkWebController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkWebController.swift
@@ -202,31 +202,3 @@ final class PayWithLinkWebController: NSObject, ASWebAuthenticationPresentationC
         }
     }
 }
-
-// MARK: - Coordinating
-
-extension PayWithLinkWebController: PayWithLinkCoordinating {
-
-    func confirm(
-        with linkAccount: PaymentSheetLinkAccount,
-        paymentDetails: ConsumerPaymentDetails
-    ) {
-        payWithLinkDelegate?.payWithLinkWebControllerDidComplete(
-            self,
-            intent: context.intent,
-            with: PaymentOption.link(
-                option: .withPaymentDetails(account: linkAccount, paymentDetails: paymentDetails)
-            )
-        )
-    }
-
-    func cancel() {
-        webAuthSession?.cancel()
-        payWithLinkDelegate?.payWithLinkWebControllerDidCancel(self)
-    }
-
-    func accountUpdated(_ linkAccount: PaymentSheetLinkAccount) {
-        self.linkAccount = linkAccount
-    }
-
-}

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/ViewModels/LinkInlineSignupViewModel.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/ViewModels/LinkInlineSignupViewModel.swift
@@ -17,7 +17,6 @@ protocol LinkInlineSignupViewModelDelegate: AnyObject {
 
 final class LinkInlineSignupViewModel {
     enum Action: Equatable {
-        case pay(account: PaymentSheetLinkAccount)
         case signupAndPay(account: PaymentSheetLinkAccount, phoneNumber: PhoneNumber, legalName: String?)
         case continueWithoutLink
     }
@@ -233,7 +232,9 @@ final class LinkInlineSignupViewModel {
                 legalName: requiresNameCollection ? legalName : nil
             )
         case .verified, .requiresVerification:
-            return .pay(account: linkAccount)
+            // This should never happen: The session should only be verified as part of the signup request,
+            // as inline verification is not enabled. Continue without Link.
+            return .continueWithoutLink
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/LinkEnabledPaymentMethodElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/LinkEnabledPaymentMethodElement.swift
@@ -68,13 +68,6 @@ final class LinkEnabledPaymentMethodElement: ContainerElement {
         }
 
         switch inlineSignupElement.action {
-        case .pay(let account):
-            return .link(
-                option: .withPaymentMethodParams(
-                    account: account,
-                    paymentMethodParams: params.paymentMethodParams
-                )
-            )
         case .signupAndPay(let account, let phoneNumber, let legalName):
             return .link(
                 option: .signUp(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PaymentSheet-LinkConfirmOption.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PaymentSheet-LinkConfirmOption.swift
@@ -24,7 +24,7 @@ extension PaymentSheet {
             legalName: String?,
             paymentMethodParams: STPPaymentMethodParams
         )
-        
+
         /// Confirm with Payment Method.
         case withPaymentMethod(
             paymentMethod: STPPaymentMethod

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PaymentSheet-LinkConfirmOption.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PaymentSheet-LinkConfirmOption.swift
@@ -24,19 +24,7 @@ extension PaymentSheet {
             legalName: String?,
             paymentMethodParams: STPPaymentMethodParams
         )
-
-        /// Confirm intent with paymentDetails.
-        case withPaymentDetails(
-            account: PaymentSheetLinkAccount,
-            paymentDetails: ConsumerPaymentDetails
-        )
-
-        /// Confirm with Payment Method Params.
-        case withPaymentMethodParams(
-            account: PaymentSheetLinkAccount,
-            paymentMethodParams: STPPaymentMethodParams
-        )
-
+        
         /// Confirm with Payment Method.
         case withPaymentMethod(
             paymentMethod: STPPaymentMethod
@@ -55,10 +43,6 @@ extension PaymentSheet.LinkConfirmOption {
             return nil
         case .signUp(let account, _, _, _, _):
             return account
-        case .withPaymentDetails(let account, _):
-            return account
-        case .withPaymentMethodParams(let account, _):
-            return account
         case .withPaymentMethod:
             return nil
         }
@@ -66,11 +50,9 @@ extension PaymentSheet.LinkConfirmOption {
 
     var paymentSheetLabel: String {
         switch self {
-        case .wallet, .withPaymentDetails:
+        case .wallet:
             return STPPaymentMethodType.link.displayName
         case .signUp(_, _, _, _, let paymentMethodParams):
-            return paymentMethodParams.paymentSheetLabel
-        case .withPaymentMethodParams(_, let paymentMethodParams):
             return paymentMethodParams.paymentSheetLabel
         case .withPaymentMethod(let paymentMethod):
             return paymentMethod.paymentSheetLabel
@@ -82,10 +64,6 @@ extension PaymentSheet.LinkConfirmOption {
         case .wallet:
             return nil
         case .signUp(_, _, _, _, let paymentMethodParams):
-            return paymentMethodParams.billingDetails
-        case .withPaymentDetails:
-            return nil
-        case .withPaymentMethodParams(_, let paymentMethodParams):
             return paymentMethodParams.billingDetails
         case .withPaymentMethod(let paymentMethod):
             return paymentMethod.billingDetails

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -423,10 +423,6 @@ extension PaymentSheet {
                         confirmWithPaymentMethodParams(paymentMethodParams)
                     }
                 }
-            case .withPaymentDetails(let linkAccount, let paymentDetails):
-                confirmWithPaymentDetails(linkAccount, paymentDetails, nil)
-            case .withPaymentMethodParams(let linkAccount, let paymentMethodParams):
-                createPaymentDetailsAndConfirm(linkAccount, paymentMethodParams)
             case .withPaymentMethod(let paymentMethod):
                 confirmWithPaymentMethod(paymentMethod)
             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -260,7 +260,10 @@ extension PaymentSheet {
         // MARK: - Link
         case .link(let confirmOption):
             // This is called when the customer pays in the sheet (as opposed to the Link webview) and agreed to sign up for Link
-            let confirmWithPaymentMethodParams: (STPPaymentMethodParams) -> Void = { paymentMethodParams in
+            // Parameters:
+            // - paymentMethodParams: The params to use for the payment.
+            // - linkAccount: The Link account used for payment. Will be logged out if present after payment completes, whether it was successful or not.
+            let confirmWithPaymentMethodParams: (STPPaymentMethodParams, PaymentSheetLinkAccount?) -> Void = { paymentMethodParams, linkAccount in
                 switch intent {
                 case .paymentIntent(_, let paymentIntent):
                     let paymentIntentParams = STPPaymentIntentParams(clientSecret: paymentIntent.clientSecret)
@@ -272,6 +275,7 @@ extension PaymentSheet {
                         with: authenticationContext,
                         completion: { actionStatus, _, error in
                             paymentHandlerCompletion(actionStatus, error)
+                            linkAccount?.logout()
                         }
                     )
                 case .setupIntent(_, let setupIntent):
@@ -283,6 +287,7 @@ extension PaymentSheet {
                         with: authenticationContext,
                         completion: { actionStatus, _, error in
                             paymentHandlerCompletion(actionStatus, error)
+                            linkAccount?.logout()
                         }
                     )
                 case .deferredIntent(_, let intentConfig):
@@ -297,11 +302,14 @@ extension PaymentSheet {
                         authenticationContext: authenticationContext,
                         paymentHandler: paymentHandler,
                         isFlowController: isFlowController,
-                        completion: completion
+                        completion: { psResult, confirmationType in
+                            linkAccount?.logout()
+                            completion(psResult, confirmationType)
+                        }
                     )
                 }
             }
-            let confirmWithPaymentMethod: (STPPaymentMethod) -> Void = { paymentMethod in
+            let confirmWithPaymentMethod: (STPPaymentMethod, PaymentSheetLinkAccount?) -> Void = { paymentMethod, linkAccount in
                 let mandateCustomerAcceptanceParams = STPMandateCustomerAcceptanceParams()
                 let onlineParams = STPMandateOnlineParams(ipAddress: "", userAgent: "")
                 // Tell Stripe to infer mandate info from client
@@ -320,6 +328,7 @@ extension PaymentSheet {
                         paymentIntentParams,
                         with: authenticationContext,
                         completion: { actionStatus, _, error in
+                            linkAccount?.logout()
                             paymentHandlerCompletion(actionStatus, error)
                         }
                     )
@@ -332,6 +341,7 @@ extension PaymentSheet {
                         setupIntentParams,
                         with: authenticationContext,
                         completion: { actionStatus, _, error in
+                            linkAccount?.logout()
                             paymentHandlerCompletion(actionStatus, error)
                         }
                     )
@@ -343,7 +353,10 @@ extension PaymentSheet {
                         authenticationContext: authenticationContext,
                         paymentHandler: paymentHandler,
                         isFlowController: isFlowController,
-                        completion: completion
+                        completion: { psResult, confirmationType in
+                            linkAccount?.logout()
+                            completion(psResult, confirmationType)
+                        }
                     )
                 }
             }
@@ -360,7 +373,7 @@ extension PaymentSheet {
                         return
                     }
 
-                    confirmWithPaymentMethodParams(paymentMethodParams)
+                    confirmWithPaymentMethodParams(paymentMethodParams, linkAccount)
                 }
 
             let createPaymentDetailsAndConfirm:
@@ -374,7 +387,7 @@ extension PaymentSheet {
                         STPAnalyticsClient.sharedClient.logLinkPopupSkipped()
 
                         // Attempt to confirm directly with params
-                        confirmWithPaymentMethodParams(paymentMethodParams)
+                        confirmWithPaymentMethodParams(paymentMethodParams, linkAccount)
                         return
                     }
 
@@ -386,11 +399,11 @@ extension PaymentSheet {
                                 linkAccount.sharePaymentDetails(id: paymentDetails.stripeID, cvc: paymentMethodParams.card?.cvc) { result in
                                     switch result {
                                     case .success(let shareResponse):
-                                        confirmWithPaymentMethod(STPPaymentMethod(stripeId: shareResponse.paymentMethod))
+                                        confirmWithPaymentMethod(STPPaymentMethod(stripeId: shareResponse.paymentMethod), linkAccount)
                                     case .failure(let error):
                                         STPAnalyticsClient.sharedClient.logLinkSharePaymentDetailsFailure(error: error)
                                         // If this fails, confirm directly
-                                        confirmWithPaymentMethodParams(paymentMethodParams)
+                                        confirmWithPaymentMethodParams(paymentMethodParams, linkAccount)
                                     }
                                 }
                             } else {
@@ -400,7 +413,7 @@ extension PaymentSheet {
                         case .failure(let error):
                             STPAnalyticsClient.sharedClient.logLinkCreatePaymentDetailsFailure(error: error)
                             // Attempt to confirm directly with params
-                            confirmWithPaymentMethodParams(paymentMethodParams)
+                            confirmWithPaymentMethodParams(paymentMethodParams, linkAccount)
                         }
                     }
                 }
@@ -420,11 +433,11 @@ extension PaymentSheet {
                     case .failure(let error as NSError):
                         STPAnalyticsClient.sharedClient.logLinkSignupFailure(error: error)
                         // Attempt to confirm directly with params as a fallback.
-                        confirmWithPaymentMethodParams(paymentMethodParams)
+                        confirmWithPaymentMethodParams(paymentMethodParams, linkAccount)
                     }
                 }
             case .withPaymentMethod(let paymentMethod):
-                confirmWithPaymentMethod(paymentMethod)
+                confirmWithPaymentMethod(paymentMethod, nil)
             }
         case let .external(paymentMethod, billingDetails):
             guard let confirmHandler = configuration.externalPaymentMethodConfiguration?.externalPaymentMethodConfirmHandler else {


### PR DESCRIPTION
## Summary
Invalidate the client secret by calling `log_out` immediately after the transaction completes.

Remove a bit of related unused code from Link v1.

## Testing
* CI end-to-end tests, manual testing of Link inline signup.
* Bring the ConsumerSessionsTests to test this scenario, ensure the token no longer works after logout.