### PR TITLE
Financial Connections: Fix failing UI test

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
@@ -77,7 +77,7 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         emailTextField.tap()
         emailTextField.typeText(emailAddress)
 
-        let phoneTextField = app.textFields["Phone"]
+        let phoneTextField = app.textFields["Phone number"]
         XCTAssertTrue(phoneTextField.waitForExistence(timeout: 120.0))  // wait for lookup to complete
         phoneTextField.tap()
         phoneTextField.typeText("4015006000")


### PR DESCRIPTION
## Summary

This PR changed the label:
- https://github.com/stripe/stripe-ios/pull/3261

Tests started failing: https://app.bitrise.io/build/63911f9d-d646-4f8a-83a0-1e81657c1ecb?tab=log

Note that this should really use an accessibility label, and the code will ~soon be changing with FC V3 anyway, but just making this quick fix.

## Testing

Re-ran the failing test

<img width="418" alt="Screenshot 2024-02-07 at 7 44 08 PM" src="https://github.com/stripe/stripe-ios/assets/105514761/f59c1989-2172-496e-af44-8ff1ffeafa61">
