### PR TITLE
Fix improper setup `STPPaymentOptionsViewController` in `PaymentContext`.

### DIFF
--- a/Stripe/StripeiOS/Source/STPPaymentContext.swift
+++ b/Stripe/StripeiOS/Source/STPPaymentContext.swift
@@ -530,8 +530,10 @@ public class STPPaymentContext: NSObject, STPAuthenticationContext,
         if state == STPPaymentContextState.none {
             state = .showingRequestedViewController
 
+            let setupPromise = STPPromise<Bool>.init()
             let paymentOptionsViewController = STPPaymentOptionsViewController(paymentContext: self)
             self.paymentOptionsViewController = paymentOptionsViewController
+
             paymentOptionsViewController.prefilledInformation = prefilledInformation
             paymentOptionsViewController.defaultPaymentMethod = defaultPaymentMethod
             paymentOptionsViewController.paymentOptionsViewControllerFooterView =
@@ -540,6 +542,8 @@ public class STPPaymentContext: NSObject, STPAuthenticationContext,
                 addCardViewControllerFooterView
             paymentOptionsViewController.navigationItem.largeTitleDisplayMode =
                 largeTitleDisplayMode
+
+            setupPromise.succeed(true)
 
             navigationController?.pushViewController(
                 paymentOptionsViewController,
@@ -807,8 +811,11 @@ public class STPPaymentContext: NSObject, STPAuthenticationContext,
         )
         if self.state == STPPaymentContextState.none {
             self.state = state
-            let paymentOptionsViewController = STPPaymentOptionsViewController(paymentContext: self)
+
+            let setupPromise = STPPromise<Bool>.init()
+            let paymentOptionsViewController = STPPaymentOptionsViewController(paymentContext: self, setupPromise: setupPromise)
             self.paymentOptionsViewController = paymentOptionsViewController
+
             paymentOptionsViewController.prefilledInformation = prefilledInformation
             paymentOptionsViewController.defaultPaymentMethod = defaultPaymentMethod
             paymentOptionsViewController.paymentOptionsViewControllerFooterView =
@@ -817,6 +824,8 @@ public class STPPaymentContext: NSObject, STPAuthenticationContext,
                 addCardViewControllerFooterView
             paymentOptionsViewController.navigationItem.largeTitleDisplayMode =
                 largeTitleDisplayMode
+
+            setupPromise.succeed(true)
 
             let navigationController = UINavigationController(
                 rootViewController: paymentOptionsViewController


### PR DESCRIPTION
## Summary
Fix improper setup `STPPaymentOptionsViewController` in `PaymentContext`.

If a user chooses to wait for the `PaymentContext` to completely load, loading the payment options can cause its overall setup to not be taken into account because the `loadingPromise` it waits for will already be complete, causing `onSuccess` to be called synchronously before any additional setup is called. See the issue and this [thread](https://stripe.slack.com/archives/C01CY476ESJ/p1707359504378399) for more information.

## Motivation
Resolves [RUN_MOBILESDK-2929](https://jira.corp.stripe.com/browse/RUN_MOBILESDK-2929)

## Testing
To be added. I want to validate my approach first with the team.
