### PR TITLE
Financial Connections: introduced a new ErrorViewController for unexpected_error pane and added it to PartnerAuth related errors

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
+++ b/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
@@ -98,6 +98,9 @@
 		6A78141A2B45D53700168992 /* DataAccessNoticeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7814192B45D53700168992 /* DataAccessNoticeViewController.swift */; };
 		6A78141C2B462D5D00168992 /* LegalDetailsNoticeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A78141B2B462D5D00168992 /* LegalDetailsNoticeViewController.swift */; };
 		6ABFE5522B72BE630037437C /* PrepaneViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ABFE5512B72BE630037437C /* PrepaneViews.swift */; };
+		6ABFE5552B74479A0037437C /* ErrorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ABFE5542B74479A0037437C /* ErrorViewController.swift */; };
+		6ABFE5572B7449390037437C /* ErrorDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ABFE5562B7449390037437C /* ErrorDataSource.swift */; };
+		6ABFE5592B7451710037437C /* TerminalErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ABFE5582B7451710037437C /* TerminalErrorView.swift */; };
 		6BC6DB482984F9288944FE25 /* NetworkingSaveToLinkVerificationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66D3CAB53EC9D33831C5A48B /* NetworkingSaveToLinkVerificationViewController.swift */; };
 		6D018BB3C1253ED4C1674E0B /* ManualEntryFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73C03F4DDC67B50C5E1993F6 /* ManualEntryFormView.swift */; };
 		6D29E55F6A3864ED52799169 /* InstitutionPickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3BF292FD82A198752A82EB /* InstitutionPickerViewController.swift */; };
@@ -378,6 +381,9 @@
 		6A7814192B45D53700168992 /* DataAccessNoticeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataAccessNoticeViewController.swift; sourceTree = "<group>"; };
 		6A78141B2B462D5D00168992 /* LegalDetailsNoticeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegalDetailsNoticeViewController.swift; sourceTree = "<group>"; };
 		6ABFE5512B72BE630037437C /* PrepaneViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrepaneViews.swift; sourceTree = "<group>"; };
+		6ABFE5542B74479A0037437C /* ErrorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorViewController.swift; sourceTree = "<group>"; };
+		6ABFE5562B7449390037437C /* ErrorDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorDataSource.swift; sourceTree = "<group>"; };
+		6ABFE5582B7451710037437C /* TerminalErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalErrorView.swift; sourceTree = "<group>"; };
 		6B70A0C4DBFE46805549CF8B /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
 		6C81D547F6BAD96C62E1E4D3 /* hr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hr; path = hr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		6CDEF702710EEA29BA3DC653 /* NetworkingLinkSignupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkingLinkSignupViewController.swift; sourceTree = "<group>"; };
@@ -787,6 +793,15 @@
 			path = PaneLayoutView;
 			sourceTree = "<group>";
 		};
+		6ABFE5532B7446C70037437C /* Error */ = {
+			isa = PBXGroup;
+			children = (
+				6ABFE5542B74479A0037437C /* ErrorViewController.swift */,
+				6ABFE5562B7449390037437C /* ErrorDataSource.swift */,
+			);
+			path = Error;
+			sourceTree = "<group>";
+		};
 		7879CBA341D7E807714A831B = {
 			isa = PBXGroup;
 			children = (
@@ -934,6 +949,7 @@
 			isa = PBXGroup;
 			children = (
 				B83A2749140B4E129CEF39C4 /* TerminalErrorViewController.swift */,
+				6ABFE5582B7451710037437C /* TerminalErrorView.swift */,
 			);
 			path = TerminalError;
 			sourceTree = "<group>";
@@ -941,6 +957,7 @@
 		BF0B937496C645C3ED6E265E /* Native */ = {
 			isa = PBXGroup;
 			children = (
+				6ABFE5532B7446C70037437C /* Error */,
 				5A844A24E4E9F4B7E3802DA9 /* AccountPicker */,
 				7BFDCD3B61A38A4BA3466780 /* AttachLinkedPaymentAccount */,
 				EB6632ED2E696DA6381326C0 /* Consent */,
@@ -1313,6 +1330,7 @@
 				3FE4DEFAD6FF77B8D9EE68D3 /* String+Localized.swift in Sources */,
 				3ECA346F75060BD954376EBF /* StripeFinancialConnectionsBundleLocator.swift in Sources */,
 				E760C94B619A8934D1D5E1D0 /* UIColor+Extensions.swift in Sources */,
+				6ABFE5572B7449390037437C /* ErrorDataSource.swift in Sources */,
 				4A537AE0C50CAFF3889EFE28 /* UIViewController+Extensions.swift in Sources */,
 				C38BEDD99477C83C91B105DD /* AccountPickerAccountLoadErrorView.swift in Sources */,
 				C1A079E8E76A02EBCB2588DA /* AccountPickerDataSource.swift in Sources */,
@@ -1347,6 +1365,7 @@
 				4A0D015C978BD79BBFE6CE57 /* ManualEntryDataSource.swift in Sources */,
 				6A78141A2B45D53700168992 /* DataAccessNoticeViewController.swift in Sources */,
 				2343C58289259920DD81620D /* ManualEntryErrorView.swift in Sources */,
+				6ABFE5552B74479A0037437C /* ErrorViewController.swift in Sources */,
 				A1AEE72611F62550267C326C /* ManualEntryFooterView.swift in Sources */,
 				6A732C9C2B61C56A00828CB1 /* InstitutionTableLoadingView.swift in Sources */,
 				6D018BB3C1253ED4C1674E0B /* ManualEntryFormView.swift in Sources */,
@@ -1386,6 +1405,7 @@
 				6A732CA42B69871F00828CB1 /* EmailTextField.swift in Sources */,
 				22426A37E01AE759BF93C422 /* AttributedLabel.swift in Sources */,
 				2FADCA33DEC08E6551D94811 /* AttributedTextView.swift in Sources */,
+				6ABFE5592B7451710037437C /* TerminalErrorView.swift in Sources */,
 				368DFF9D68F1F8D6A4353961 /* AuthFlowHelpers.swift in Sources */,
 				9AF6EC34D666BEB3C1397092 /* BulletPointLabelView.swift in Sources */,
 				313F5F7F2B0BE5D100BD98A9 /* Docs.docc in Sources */,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsAnalyticsClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsAnalyticsClient.swift
@@ -211,6 +211,8 @@ extension FinancialConnectionsAnalyticsClient {
             return .networkingSaveToLinkVerification
         case is LinkAccountPickerViewController:
             return .linkAccountPicker
+        case is ErrorViewController:
+            return .unexpectedError
         default:
             return .unparsable
         }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Error/ErrorDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Error/ErrorDataSource.swift
@@ -1,0 +1,35 @@
+//
+//  ErrorDataSource.swift
+//  StripeFinancialConnections
+//
+//  Created by Krisjanis Gaidis on 2/7/24.
+//
+
+import Foundation
+@_spi(STP) import StripeCore
+
+final class ErrorDataSource {
+    
+    let error: Error
+    let referrerPane: FinancialConnectionsSessionManifest.NextPane
+    let manifest: FinancialConnectionsSessionManifest
+    let reduceManualEntryProminenceInErrors: Bool
+    let analyticsClient: FinancialConnectionsAnalyticsClient
+    let institution: FinancialConnectionsInstitution?
+    
+    init(
+        error: Error,
+        referrerPane: FinancialConnectionsSessionManifest.NextPane,
+        manifest: FinancialConnectionsSessionManifest,
+        reduceManualEntryProminenceInErrors: Bool,
+        analyticsClient: FinancialConnectionsAnalyticsClient,
+        institution: FinancialConnectionsInstitution?
+    ) {
+        self.error = error
+        self.referrerPane = referrerPane
+        self.manifest = manifest
+        self.reduceManualEntryProminenceInErrors = reduceManualEntryProminenceInErrors
+        self.analyticsClient = analyticsClient
+        self.institution = institution
+    }
+}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Error/ErrorDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Error/ErrorDataSource.swift
@@ -9,14 +9,14 @@ import Foundation
 @_spi(STP) import StripeCore
 
 final class ErrorDataSource {
-    
+
     let error: Error
     let referrerPane: FinancialConnectionsSessionManifest.NextPane
     let manifest: FinancialConnectionsSessionManifest
     let reduceManualEntryProminenceInErrors: Bool
     let analyticsClient: FinancialConnectionsAnalyticsClient
     let institution: FinancialConnectionsInstitution?
-    
+
     init(
         error: Error,
         referrerPane: FinancialConnectionsSessionManifest.NextPane,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Error/ErrorViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Error/ErrorViewController.swift
@@ -1,0 +1,215 @@
+//
+//  ErrorViewController.swift
+//  StripeFinancialConnections
+//
+//  Created by Krisjanis Gaidis on 2/7/24.
+//
+
+import Foundation
+import UIKit
+@_spi(STP) import StripeCore
+@_spi(STP) import StripeUICore
+
+protocol ErrorViewControllerDelegate: AnyObject {
+    func errorViewControllerDidSelectAnotherBank(_ viewController: ErrorViewController)
+    func errorViewControllerDidSelectManualEntry(_ viewController: ErrorViewController)
+    func errorViewController(
+        _ viewController: ErrorViewController,
+        didSelectCloseWithError error: Error
+    )
+}
+
+/// Represents the VC for `unexpected_error` pane. It's used for
+/// all types of errors and the naming of "unexpected_error" is just a
+/// convention from old backend naming.
+final class ErrorViewController: UIViewController {
+    
+    private let dataSource: ErrorDataSource
+    
+    weak var delegate: ErrorViewControllerDelegate?
+    
+    init(dataSource: ErrorDataSource) {
+        self.dataSource = dataSource
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .customBackgroundColor
+        navigationItem.hidesBackButton = true
+
+        let error = dataSource.error
+        let allowManualEntryInNonTerminalErrors = (dataSource.manifest.allowManualEntry && !dataSource.reduceManualEntryProminenceInErrors)
+        let errorView: UIView
+        if let error = dataSource.error as? StripeError,
+            case .apiError(let apiError) = error,
+            let extraFields = apiError.allResponseFields["extra_fields"] as? [String: Any],
+            let institutionUnavailable = extraFields["institution_unavailable"] as? Bool,
+            institutionUnavailable
+        {
+            assert(
+                dataSource.institution != nil,
+                "expected institution to be set before handling institution errors"
+            )
+            
+            let institutionIconView = InstitutionIconView()
+            institutionIconView.setImageUrl(dataSource.institution?.icon?.default)
+            let primaryButtonConfiguration = PaneLayoutView.ButtonConfiguration(
+                title: String.Localized.select_another_bank,
+                action: { [weak self] in
+                    guard let self else { return }
+                    delegate?.errorViewControllerDidSelectAnotherBank(self)
+                }
+            )
+            if let expectedToBeAvailableAt = extraFields["expected_to_be_available_at"] as? TimeInterval {
+                let expectedToBeAvailableDate = Date(timeIntervalSince1970: expectedToBeAvailableAt)
+                let dateFormatter = DateFormatter()
+                dateFormatter.timeStyle = .short
+                let expectedToBeAvailableTimeString = dateFormatter.string(from: expectedToBeAvailableDate)
+                errorView = PaneLayoutView(
+                    contentView: PaneLayoutView.createContentView(
+                        iconView: institutionIconView,
+                        title: String(
+                            format: STPLocalizedString(
+                                "%@ is undergoing maintenance",
+                                "Title of a screen that shows an error. The error indicates that the bank user selected is currently under maintenance."
+                            ),
+                            dataSource.institution?.name ?? "Bank"
+                        ),
+                        subtitle: {
+                            let beginningOfSubtitle: String = {
+                                if isToday(expectedToBeAvailableDate) {
+                                    return String(
+                                        format: STPLocalizedString(
+                                            "Maintenance is scheduled to end at %@.",
+                                            "The first part of a subtitle/description of a screen that shows an error. The error indicates that the bank user selected is currently under maintenance."
+                                        ),
+                                        expectedToBeAvailableTimeString
+                                    )
+                                } else {
+                                    let dateFormatter = DateFormatter()
+                                    dateFormatter.dateStyle = .short
+                                    let expectedToBeAvailableDateString = dateFormatter.string(
+                                        from: expectedToBeAvailableDate
+                                    )
+                                    return String(
+                                        format: STPLocalizedString(
+                                            "Maintenance is scheduled to end on %@ at %@.",
+                                            "The first part of a subtitle/description of a screen that shows an error. The error indicates that the bank user selected is currently under maintenance."
+                                        ),
+                                        expectedToBeAvailableDateString,
+                                        expectedToBeAvailableTimeString
+                                    )
+                                }
+                            }()
+                            let endOfSubtitle: String = {
+                                if allowManualEntryInNonTerminalErrors {
+                                    return STPLocalizedString(
+                                        "Please enter your bank details manually or select another bank.",
+                                        "The second part of a subtitle/description of a screen that shows an error. The error indicates that the bank user selected is currently under maintenance."
+                                    )
+                                } else {
+                                    return STPLocalizedString(
+                                        "Please select another bank or try again later.",
+                                        "The second part of a subtitle/description of a screen that shows an error. The error indicates that the bank user selected is currently under maintenance."
+                                    )
+                                }
+                            }()
+                            return beginningOfSubtitle + " " + endOfSubtitle
+                        }(),
+                        contentView: nil
+                    ),
+                    footerView: PaneLayoutView.createFooterView(
+                        primaryButtonConfiguration: primaryButtonConfiguration,
+                        secondaryButtonConfiguration: allowManualEntryInNonTerminalErrors
+                        ? PaneLayoutView.ButtonConfiguration(
+                            title: String.Localized.enter_bank_details_manually,
+                            action: { [weak self] in
+                                guard let self = self else { return }
+                                delegate?.errorViewControllerDidSelectManualEntry(self)
+                            }
+                        ) : nil
+                    ).footerView
+                ).createView()
+                dataSource.analyticsClient.logExpectedError(
+                    error,
+                    errorName: "InstitutionPlannedDowntimeError",
+                    pane: dataSource.referrerPane
+                )
+            } else {
+                errorView = PaneLayoutView(
+                    contentView: PaneLayoutView.createContentView(
+                        iconView: institutionIconView,
+                        title: String(
+                            format: STPLocalizedString(
+                                "%@ is currently unavailable",
+                                "Title of a screen that shows an error. The error indicates that the bank user selected is currently under maintenance."
+                            ),
+                            dataSource.institution?.name ?? "Bank"
+                        ),
+                        subtitle: {
+                            if allowManualEntryInNonTerminalErrors {
+                                return STPLocalizedString(
+                                    "Please enter your bank details manually or select another bank.",
+                                    "The subtitle/description of a screen that shows an error. The error indicates that the bank user selected is currently under maintenance."
+                                )
+                            } else {
+                                return STPLocalizedString(
+                                    "Please select another bank or try again later.",
+                                    "The subtitle/description of a screen that shows an error. The error indicates that the bank user selected is currently under maintenance."
+                                )
+                            }
+                        }(),
+                        contentView: nil
+                    ),
+                    footerView: PaneLayoutView.createFooterView(
+                        primaryButtonConfiguration: primaryButtonConfiguration,
+                        secondaryButtonConfiguration: allowManualEntryInNonTerminalErrors
+                        ? PaneLayoutView.ButtonConfiguration(
+                            title: String.Localized.enter_bank_details_manually,
+                            action: { [weak self] in
+                                guard let self else { return }
+                                delegate?.errorViewControllerDidSelectManualEntry(self)
+                            }
+                        ) : nil
+                    ).footerView
+                ).createView()
+                dataSource.analyticsClient.logExpectedError(
+                    error,
+                    errorName: "InstitutionUnplannedDowntimeError",
+                    pane: dataSource.referrerPane
+                )
+            }
+        } else {
+            dataSource.analyticsClient.logUnexpectedError(
+                error,
+                errorName: "UnexpectedErrorPaneError",
+                pane: dataSource.referrerPane
+            )
+
+            // if we didn't get specific errors back, we don't know
+            // what's wrong, so show a generic error
+            errorView = TerminalErrorView(
+                allowManualEntry: dataSource.manifest.allowManualEntry,
+                didSelectManualEntry: { [weak self] in
+                    guard let self else { return }
+                    delegate?.errorViewControllerDidSelectManualEntry(self)
+                },
+                didSelectClose: { [weak self] in
+                    guard let self else { return }
+                    delegate?.errorViewController(self, didSelectCloseWithError: error)
+                }
+            )
+        }
+
+        view.addAndPinSubview(errorView)
+    }
+}
+
+private func isToday(_ comparisonDate: Date) -> Bool {
+    return Calendar.current.startOfDay(for: comparisonDate) == Calendar.current.startOfDay(for: Date())
+}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Error/ErrorViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Error/ErrorViewController.swift
@@ -6,9 +6,9 @@
 //
 
 import Foundation
-import UIKit
 @_spi(STP) import StripeCore
 @_spi(STP) import StripeUICore
+import UIKit
 
 protocol ErrorViewControllerDelegate: AnyObject {
     func errorViewControllerDidSelectAnotherBank(_ viewController: ErrorViewController)
@@ -23,20 +23,20 @@ protocol ErrorViewControllerDelegate: AnyObject {
 /// all types of errors and the naming of "unexpected_error" is just a
 /// convention from old backend naming.
 final class ErrorViewController: UIViewController {
-    
+
     private let dataSource: ErrorDataSource
-    
+
     weak var delegate: ErrorViewControllerDelegate?
-    
+
     init(dataSource: ErrorDataSource) {
         self.dataSource = dataSource
         super.init(nibName: nil, bundle: nil)
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .customBackgroundColor
@@ -55,7 +55,7 @@ final class ErrorViewController: UIViewController {
                 dataSource.institution != nil,
                 "expected institution to be set before handling institution errors"
             )
-            
+
             let institutionIconView = InstitutionIconView()
             institutionIconView.setImageUrl(dataSource.institution?.icon?.default)
             let primaryButtonConfiguration = PaneLayoutView.ButtonConfiguration(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionPickerViewController.swift
@@ -13,7 +13,11 @@ import UIKit
 protocol InstitutionPickerViewControllerDelegate: AnyObject {
     func institutionPickerViewController(
         _ viewController: InstitutionPickerViewController,
-        didSelect institution: FinancialConnectionsInstitution,
+        didSelect institution: FinancialConnectionsInstitution
+    )
+    func institutionPickerViewController(
+        _ viewController: InstitutionPickerViewController,
+        didFinishSelecting institution: FinancialConnectionsInstitution,
         authSession: FinancialConnectionsAuthSession
     )
     func institutionPickerViewControllerDidSelectManuallyAddYourAccount(
@@ -21,6 +25,10 @@ protocol InstitutionPickerViewControllerDelegate: AnyObject {
     )
     func institutionPickerViewControllerDidSearch(
         _ viewController: InstitutionPickerViewController
+    )
+    func institutionPickerViewController(
+        _ viewController: InstitutionPickerViewController,
+        didReceiveError error: Error
     )
 }
 
@@ -113,6 +121,8 @@ class InstitutionPickerViewController: UIViewController {
     }
 
     private func didSelectInstitution(_ institution: FinancialConnectionsInstitution) {
+        delegate?.institutionPickerViewController(self, didSelect: institution)
+
         searchBar.resignFirstResponder()
 
         let showLoadingView: (Bool) -> Void = { [weak self] show in
@@ -134,7 +144,7 @@ class InstitutionPickerViewController: UIViewController {
                 case .success(let authSession):
                     self.delegate?.institutionPickerViewController(
                         self,
-                        didSelect: institution,
+                        didFinishSelecting: institution,
                         authSession: authSession
                     )
 
@@ -146,8 +156,10 @@ class InstitutionPickerViewController: UIViewController {
                         hideOverlayView()
                     }
                 case .failure(let error):
-                    // TODO(kgaidis): handle errors...
-                    print(error)
+                    delegate?.institutionPickerViewController(
+                        self,
+                        didReceiveError: error
+                    )
                 }
                 showLoadingView(false)
             }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowDataManager.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowDataManager.swift
@@ -23,6 +23,8 @@ protocol NativeFlowDataManager: AnyObject {
     var authSession: FinancialConnectionsAuthSession? { get set }
     var linkedAccounts: [FinancialConnectionsPartnerAccount]? { get set }
     var terminalError: Error? { get set }
+    var errorPaneError: Error? { get set }
+    var errorPaneReferrerPane: FinancialConnectionsSessionManifest.NextPane? { get set }
     var paymentAccountResource: FinancialConnectionsPaymentAccountResource? { get set }
     var accountNumberLast4: String? { get set }
     var consumerSession: ConsumerSessionData? { get set }
@@ -86,6 +88,8 @@ class NativeFlowAPIDataManager: NativeFlowDataManager {
     var authSession: FinancialConnectionsAuthSession?
     var linkedAccounts: [FinancialConnectionsPartnerAccount]?
     var terminalError: Error?
+    var errorPaneError: Error?
+    var errorPaneReferrerPane: FinancialConnectionsSessionManifest.NextPane?
     var paymentAccountResource: FinancialConnectionsPaymentAccountResource?
     var accountNumberLast4: String?
     var consumerSession: ConsumerSessionData?

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthDataSource.swift
@@ -14,7 +14,6 @@ protocol PartnerAuthDataSource: AnyObject {
     var returnURL: String? { get }
     var analyticsClient: FinancialConnectionsAnalyticsClient { get }
     var pendingAuthSession: FinancialConnectionsAuthSession? { get }
-    var reduceManualEntryProminenceInErrors: Bool { get }
     var disableAuthSessionRetrieval: Bool { get }
 
     func createAuthSession() -> Future<FinancialConnectionsAuthSession>
@@ -33,7 +32,6 @@ final class PartnerAuthDataSourceImplementation: PartnerAuthDataSource {
     private let apiClient: FinancialConnectionsAPIClient
     private let clientSecret: String
     let analyticsClient: FinancialConnectionsAnalyticsClient
-    let reduceManualEntryProminenceInErrors: Bool
     var disableAuthSessionRetrieval: Bool {
         return manifest.features?["bank_connections_disable_defensive_auth_session_retrieval_on_complete"] == true
     }
@@ -52,8 +50,7 @@ final class PartnerAuthDataSourceImplementation: PartnerAuthDataSource {
         returnURL: String?,
         apiClient: FinancialConnectionsAPIClient,
         clientSecret: String,
-        analyticsClient: FinancialConnectionsAnalyticsClient,
-        reduceManualEntryProminenceInErrors: Bool
+        analyticsClient: FinancialConnectionsAnalyticsClient
     ) {
         self.pendingAuthSession = authSession
         self.institution = institution
@@ -62,7 +59,6 @@ final class PartnerAuthDataSourceImplementation: PartnerAuthDataSource {
         self.apiClient = apiClient
         self.clientSecret = clientSecret
         self.analyticsClient = analyticsClient
-        self.reduceManualEntryProminenceInErrors = reduceManualEntryProminenceInErrors
     }
 
     func createAuthSession() -> Future<FinancialConnectionsAuthSession> {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthViewController.swift
@@ -49,9 +49,6 @@ final class PartnerAuthViewController: SheetViewController {
     private var prepaneViews: PrepaneViews?
     private var loadingView: UIView?
     private var legacyLoadingView: UIView?
-    private var isLoadingViewVisible: Bool {
-        return loadingView != nil
-    }
     private var showLegacyBrowserOnViewDidAppear = false
 
     init(
@@ -784,8 +781,4 @@ extension PartnerAuthViewController: ASWebAuthenticationPresentationContextProvi
     func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
         return self.view.window ?? ASPresentationAnchor()
     }
-}
-
-private func isToday(_ comparisonDate: Date) -> Bool {
-    return Calendar.current.startOfDay(for: comparisonDate) == Calendar.current.startOfDay(for: Date())
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/TerminalError/TerminalErrorView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/TerminalError/TerminalErrorView.swift
@@ -6,8 +6,8 @@
 //
 
 import Foundation
-import UIKit
 @_spi(STP) import StripeCore
+import UIKit
 
 func TerminalErrorView(
     allowManualEntry: Bool,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/TerminalError/TerminalErrorView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/TerminalError/TerminalErrorView.swift
@@ -1,0 +1,62 @@
+//
+//  TerminalErrorView.swift
+//  StripeFinancialConnections
+//
+//  Created by Krisjanis Gaidis on 2/7/24.
+//
+
+import Foundation
+import UIKit
+@_spi(STP) import StripeCore
+
+func TerminalErrorView(
+    allowManualEntry: Bool,
+    didSelectManualEntry: @escaping () -> Void,
+    didSelectClose: @escaping () -> Void
+) -> UIView {
+    return PaneLayoutView(
+        contentView: PaneLayoutView.createContentView(
+            iconView: RoundedIconView(
+                image: .image(.warning_triangle),
+                style: .circle
+            ),
+            title: STPLocalizedString(
+                "Something went wrong",
+                "Title of a screen that shows an error. The error screen appears after user has selected a bank. The error is a generic one: something wrong happened and we are not sure what."
+            ),
+            subtitle: {
+                if allowManualEntry {
+                    return STPLocalizedString(
+                        "Your account can’t be connected at this time. Please enter your bank details manually or try again later.",
+                        "The subtitle/description of a screen that shows an error. The error is generic: something wrong happened and we are not sure what."
+                    )
+                } else {
+                    return STPLocalizedString(
+                        "Your account can’t be connected at this time. Please try again later.",
+                        "The subtitle/description of a screen that shows an error. The error is generic: something wrong happened and we are not sure what."
+                    )
+                }
+            }(),
+            contentView: nil
+        ),
+        footerView: PaneLayoutView.createFooterView(
+            primaryButtonConfiguration: {
+                if allowManualEntry {
+                    return PaneLayoutView.ButtonConfiguration(
+                        title: String.Localized.enter_bank_details_manually,
+                        action: {
+                            didSelectManualEntry()
+                        }
+                    )
+                } else {
+                    return PaneLayoutView.ButtonConfiguration(
+                        title: "Close",  // TODO: once we localize use String.Localized.close
+                        action: {
+                            didSelectClose()
+                        }
+                    )
+                }
+            }()
+        ).footerView
+    ).createView()
+}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/TerminalError/TerminalErrorViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/TerminalError/TerminalErrorViewController.swift
@@ -36,53 +36,17 @@ final class TerminalErrorViewController: UIViewController {
         view.backgroundColor = .customBackgroundColor
         navigationItem.hidesBackButton = true
 
-        let paneLayoutView = PaneLayoutView(
-            contentView: PaneLayoutView.createContentView(
-                iconView: RoundedIconView(
-                    image: .image(.warning_triangle),
-                    style: .circle
-                ),
-                title: STPLocalizedString(
-                    "Something went wrong",
-                    "Title of a screen that shows an error. The error screen appears after user has selected a bank. The error is a generic one: something wrong happened and we are not sure what."
-                ),
-                subtitle: {
-                    if allowManualEntry {
-                        return STPLocalizedString(
-                            "Your account can’t be connected at this time. Please enter your bank details manually or try again later.",
-                            "The subtitle/description of a screen that shows an error. The error is generic: something wrong happened and we are not sure what."
-                        )
-                    } else {
-                        return STPLocalizedString(
-                            "Your account can’t be connected at this time. Please try again later.",
-                            "The subtitle/description of a screen that shows an error. The error is generic: something wrong happened and we are not sure what."
-                        )
-                    }
-                }(),
-                contentView: nil
-            ),
-            footerView: PaneLayoutView.createFooterView(
-                primaryButtonConfiguration: {
-                    if allowManualEntry {
-                        return PaneLayoutView.ButtonConfiguration(
-                            title: String.Localized.enter_bank_details_manually,
-                            action: { [weak self] in
-                                guard let self = self else { return }
-                                self.delegate?.terminalErrorViewControllerDidSelectManualEntry(self)
-                            }
-                        )
-                    } else {
-                        return PaneLayoutView.ButtonConfiguration(
-                            title: "Close",  // TODO: once we localize use String.Localized.close
-                            action: { [weak self] in
-                                guard let self = self else { return }
-                                self.delegate?.terminalErrorViewController(self, didCloseWithError: self.error)
-                            }
-                        )
-                    }
-                }()
-            ).footerView
+        let terminalErrorView = TerminalErrorView(
+            allowManualEntry: true,
+            didSelectManualEntry: { [weak self] in
+                guard let self = self else { return }
+                self.delegate?.terminalErrorViewControllerDidSelectManualEntry(self)
+            },
+            didSelectClose: { [weak self] in
+                guard let self = self else { return }
+                self.delegate?.terminalErrorViewController(self, didCloseWithError: self.error)
+            }
         )
-        paneLayoutView.addTo(view: view)
+        view.addAndPinSubview(terminalErrorView)
     }
 }


### PR DESCRIPTION
## Summary

This PR:
- Creates a new "pane" (/screen) called `ErrorViewController` driven by the pane `unexpected_error`
- It then uses this new "pane" to display errors that used to come from `PartnerAuthViewController` (the reason for this code change is because we moved logic from `PartnerAuthViewController` to `InstitutionPickerViewController` (for sheets)

---

NOTE: This PR is merged into a new feature branch (`kg-v3nav`) as there will be more navigation-related changes similar to this. But will be merged into the `fc-v3` feature branch after `kg-v3nav` is ready.

Details to understand before reviewing PR:
- This is one PR, out of expected ~50+, to change the design of Financial Connections from a "V2" design to a "V3" design. [Here is a link to the designs](https://www.figma.com/file/wXQ8NJApqSJiLmxxANDRTs/%E2%9C%A8-Connections-3.0?type=design&node-id=2524-217093&mode=design&t=kXaBiAlgVsC7YcH1-0).
- The code here is not the finished version. It's just an iteration towards the final version. This code will be re-visited later. The goal is to go screen-by-screen and make easy changes to learn about all the difficulties in each screen. Later, all the learnings will be combined to do a "final" polish of all screens.
- The above also applies to design. The design here is not the finished version.
- This PR is merged into a feature branch `fc-v3`. It is not merged into `master`.
- There might be TODO's scattered throughout the code. That's expected and they will be fixed later. 

## Testing

This video shows errors now appearing from the `createAuthSession` call of `InstitutionPickerViewController` (which is also reused in `PartnerAuthViewController`)

https://github.com/stripe/stripe-ios/assets/105514761/d40bc30a-cec1-4d44-97d6-246719e2146d
