### PR TITLE
Assert that a return URL is configured

### DIFF
--- a/Stripe/StripeiOSTests/STPAnalyticsClientPaymentSheetTest.swift
+++ b/Stripe/StripeiOSTests/STPAnalyticsClientPaymentSheetTest.swift
@@ -90,7 +90,7 @@ class STPAnalyticsClientPaymentSheetTest: XCTestCase {
     func testPaymentSheetAddsUsage() {
         let client = STPAnalyticsClient.sharedClient
         var configuration = PaymentSheet.Configuration()
-        configuration.returnURL = "dummy-return-url"
+        configuration.returnURL = "foo://bar"
         _ = PaymentSheet(
             paymentIntentClientSecret: "",
             configuration: configuration

--- a/Stripe/StripeiOSTests/STPAnalyticsClientPaymentSheetTest.swift
+++ b/Stripe/StripeiOSTests/STPAnalyticsClientPaymentSheetTest.swift
@@ -94,13 +94,14 @@ class STPAnalyticsClientPaymentSheetTest: XCTestCase {
             configuration: PaymentSheet.Configuration()
         )
         XCTAssertTrue(client.productUsage.contains("PaymentSheet"))
-
+        var configuration = PaymentSheet.Configuration()
+        configuration.returnURL = "dummy-return-url"
         _ = PaymentSheet.FlowController(
             intent: .paymentIntent(elementsSession: .makeBackupElementsSession(with: STPFixtures.paymentIntent()), paymentIntent: STPFixtures.paymentIntent()),
             savedPaymentMethods: [],
             isLinkEnabled: false,
             isApplePayEnabled: false,
-            configuration: PaymentSheet.Configuration()
+            configuration: configuration
         )
         XCTAssertTrue(client.productUsage.contains("PaymentSheet.FlowController"))
     }

--- a/Stripe/StripeiOSTests/STPAnalyticsClientPaymentSheetTest.swift
+++ b/Stripe/StripeiOSTests/STPAnalyticsClientPaymentSheetTest.swift
@@ -89,13 +89,14 @@ class STPAnalyticsClientPaymentSheetTest: XCTestCase {
 
     func testPaymentSheetAddsUsage() {
         let client = STPAnalyticsClient.sharedClient
-        _ = PaymentSheet(
-            paymentIntentClientSecret: "",
-            configuration: PaymentSheet.Configuration()
-        )
-        XCTAssertTrue(client.productUsage.contains("PaymentSheet"))
         var configuration = PaymentSheet.Configuration()
         configuration.returnURL = "dummy-return-url"
+        _ = PaymentSheet(
+            paymentIntentClientSecret: "",
+            configuration: configuration
+        )
+        XCTAssertTrue(client.productUsage.contains("PaymentSheet"))
+
         _ = PaymentSheet.FlowController(
             intent: .paymentIntent(elementsSession: .makeBackupElementsSession(with: STPFixtures.paymentIntent()), paymentIntent: STPFixtures.paymentIntent()),
             savedPaymentMethods: [],

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
@@ -104,6 +104,9 @@ public class PaymentSheet {
     }
 
     required init(mode: InitializationMode, configuration: Configuration) {
+        assert(configuration.returnURL != nil,
+               "Configuring a return URL is required to initialize PaymentSheet. See the documentation for more details: https://stripe.com/docs/payments/accept-a-payment?platform=ios&ui=payment-sheet#ios-set-up-return-url")
+
         AnalyticsHelper.shared.generateSessionID()
         STPAnalyticsClient.sharedClient.addClass(toProductUsageIfNecessary: PaymentSheet.self)
         self.mode = mode

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -151,6 +151,9 @@ extension PaymentSheet {
             isApplePayEnabled: Bool,
             configuration: Configuration
         ) {
+            assert(configuration.returnURL != nil,
+                   "Configuring a return URL is required to initialize PaymentSheet. See the documentation for more details: https://stripe.com/docs/payments/accept-a-payment?platform=ios&ui=payment-sheet#ios-set-up-return-url")
+
             STPAnalyticsClient.sharedClient.addClass(toProductUsageIfNecessary: PaymentSheet.FlowController.self)
             STPAnalyticsClient.sharedClient.logPaymentSheetInitialized(isCustom: true,
                                                                        configuration: configuration,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -30,8 +30,6 @@ final class PaymentSheetLoader {
         isFlowController: Bool,
         completion: @escaping (LoadingResult) -> Void
     ) {
-        assert(configuration.returnURL != nil,
-               "Configuring a return URL is required to use PaymentSheet. See the documentation for more details: https://stripe.com/docs/payments/accept-a-payment?platform=ios&ui=payment-sheet#ios-set-up-return-url")
         let loadingStartDate = Date()
         analyticsClient.logPaymentSheetEvent(event: .paymentSheetLoadStarted)
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -30,10 +30,8 @@ final class PaymentSheetLoader {
         isFlowController: Bool,
         completion: @escaping (LoadingResult) -> Void
     ) {
-        guard configuration.returnURL != nil else {
-            assertionFailure("Setting a return URL is required to use PaymentSheet. See the documentation for more details: https://stripe.com/docs/payments/accept-a-payment?platform=ios&ui=payment-sheet#ios-set-up-return-url")
-            return
-        }
+        assert(configuration.returnURL != nil,
+               "Configuring a return URL is required to use PaymentSheet. See the documentation for more details: https://stripe.com/docs/payments/accept-a-payment?platform=ios&ui=payment-sheet#ios-set-up-return-url")
         let loadingStartDate = Date()
         analyticsClient.logPaymentSheetEvent(event: .paymentSheetLoadStarted)
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -30,6 +30,10 @@ final class PaymentSheetLoader {
         isFlowController: Bool,
         completion: @escaping (LoadingResult) -> Void
     ) {
+        guard configuration.returnURL != nil else {
+            assertionFailure("Setting a return URL is required to use PaymentSheet. See the documentation for more details: https://stripe.com/docs/payments/accept-a-payment?platform=ios&ui=payment-sheet#ios-set-up-return-url")
+            return
+        }
         let loadingStartDate = Date()
         analyticsClient.logPaymentSheetEvent(event: .paymentSheetLoadStarted)
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APITest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APITest.swift
@@ -29,6 +29,7 @@ class PaymentSheetAPITest: XCTestCase {
         var config = PaymentSheet.Configuration()
         config.apiClient = apiClient
         config.allowsDelayedPaymentMethods = true
+        config.returnURL = "dummy-return-url"
         config.shippingDetails = {
             return .init(
                 address: .init(

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APITest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APITest.swift
@@ -29,7 +29,7 @@ class PaymentSheetAPITest: XCTestCase {
         var config = PaymentSheet.Configuration()
         config.apiClient = apiClient
         config.allowsDelayedPaymentMethods = true
-        config.returnURL = "dummy-return-url"
+        config.returnURL = "foo://bar"
         config.shippingDetails = {
             return .init(
                 address: .init(

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLPMConfirmFlowTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLPMConfirmFlowTests.swift
@@ -375,12 +375,9 @@ extension PaymentSheet_LPM_ConfirmFlowTests {
                       paymentMethodType: PaymentSheet.PaymentMethodType,
                       merchantCountry: MerchantCountry = .US,
                       formCompleter: (PaymentMethodElement) -> Void) async throws {
-        // Initialize PaymentSheet at least once to set the correct payment_user_agent for this process:
-        let ic = PaymentSheet.IntentConfiguration(mode: .setup(), confirmHandler: { _, _, _ in })
-        _ = PaymentSheet(mode: .deferredIntent(ic), configuration: PaymentSheet.Configuration())
-
         // Update the API client based on the merchant country
         let apiClient = STPAPIClient(publishableKey: merchantCountry.publishableKey)
+        
         let configuration: PaymentSheet.Configuration = {
             var config = PaymentSheet.Configuration()
             config.apiClient = apiClient
@@ -389,6 +386,10 @@ extension PaymentSheet_LPM_ConfirmFlowTests {
             config.allowsPaymentMethodsRequiringShippingAddress = true
             return config
         }()
+        
+        // Initialize PaymentSheet at least once to set the correct payment_user_agent for this process:
+        let ic = PaymentSheet.IntentConfiguration(mode: .setup(), confirmHandler: { _, _, _ in })
+        _ = PaymentSheet(mode: .deferredIntent(ic), configuration: configuration)
 
         let intents = try await makeTestIntents(intentKind: intentKind, currency: currency, paymentMethod: paymentMethodType, merchantCountry: merchantCountry, apiClient: apiClient)
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLPMConfirmFlowTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLPMConfirmFlowTests.swift
@@ -377,7 +377,7 @@ extension PaymentSheet_LPM_ConfirmFlowTests {
                       formCompleter: (PaymentMethodElement) -> Void) async throws {
         // Update the API client based on the merchant country
         let apiClient = STPAPIClient(publishableKey: merchantCountry.publishableKey)
-        
+
         let configuration: PaymentSheet.Configuration = {
             var config = PaymentSheet.Configuration()
             config.apiClient = apiClient
@@ -386,7 +386,7 @@ extension PaymentSheet_LPM_ConfirmFlowTests {
             config.allowsPaymentMethodsRequiringShippingAddress = true
             return config
         }()
-        
+
         // Initialize PaymentSheet at least once to set the correct payment_user_agent for this process:
         let ic = PaymentSheet.IntentConfiguration(mode: .setup(), confirmHandler: { _, _, _ in })
         _ = PaymentSheet(mode: .deferredIntent(ic), configuration: configuration)

--- a/Tests/installation_tests/cocoapods/with_frameworks_swift/CocoapodsTest/ViewController.swift
+++ b/Tests/installation_tests/cocoapods/with_frameworks_swift/CocoapodsTest/ViewController.swift
@@ -38,9 +38,11 @@ class ViewController: UIViewController {
             )
         }
 
+        var configuration = PaymentSheet.Configuration()
+        configuration.returnURL = "dummy-return-url"
         let _ = PaymentSheet(
             paymentIntentClientSecret: "",
-            configuration: PaymentSheet.Configuration()
+            configuration: configuration
         )
         // Do any additional setup after loading the view, typically from a nib.
     }

--- a/Tests/installation_tests/cocoapods/with_frameworks_swift/CocoapodsTest/ViewController.swift
+++ b/Tests/installation_tests/cocoapods/with_frameworks_swift/CocoapodsTest/ViewController.swift
@@ -39,7 +39,7 @@ class ViewController: UIViewController {
         }
 
         var configuration = PaymentSheet.Configuration()
-        configuration.returnURL = "dummy-return-url"
+        configuration.returnURL = "foo://bar"
         let _ = PaymentSheet(
             paymentIntentClientSecret: "",
             configuration: configuration

--- a/Tests/installation_tests/swift_package_manager/with_swift/SPMTest/ViewController.swift
+++ b/Tests/installation_tests/swift_package_manager/with_swift/SPMTest/ViewController.swift
@@ -40,9 +40,11 @@ class ViewController: UIViewController {
             cardImageVerificationIntentSecret: "foo"
         )
 
+        var configuration = PaymentSheet.Configuration()
+        configuration.returnURL = "dummy-return-url"
         let _ = PaymentSheet(
             setupIntentClientSecret: "",
-            configuration: PaymentSheet.Configuration()
+            configuration: configuration
         )
         // Do any additional setup after loading the view.
 

--- a/Tests/installation_tests/swift_package_manager/with_swift/SPMTest/ViewController.swift
+++ b/Tests/installation_tests/swift_package_manager/with_swift/SPMTest/ViewController.swift
@@ -41,7 +41,7 @@ class ViewController: UIViewController {
         )
 
         var configuration = PaymentSheet.Configuration()
-        configuration.returnURL = "dummy-return-url"
+        configuration.returnURL = "foo://bar"
         let _ = PaymentSheet(
             setupIntentClientSecret: "",
             configuration: configuration


### PR DESCRIPTION
## Summary
- Some merchants skip this step even though it is required. This leads to some LPMs or 3DS not working properly. We should not allow initialization of PaymentSheet without a return URL. Otherwise failures may happen silently when a return url is required.
- This change could lead to some merchants having crashes during development they didn't previously have, but it would only catch bad integrations.

## Motivation
- https://stripe.slack.com/archives/C067GRGBP3R/p1704486362992749
- https://stripe.slack.com/archives/C0523SWAA78/p1706892365064939?thread_ts=1706038686.959179&cid=C0523SWAA78

## Testing
Commented out the return url in an example view controller to see the failure

## Changelog
N/A
