### PR TITLE
Fix STPPinManagementService deprecation annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 ### PaymentSheet
 * [Fixed] Fixed a bug where deleting the last saved payment method in PaymentSheet wouldn't automatically transition to the "Add a payment method" screen.
 
+* [Changed] Make STPPinManagementService still usable from Swift.
+
 ## 23.21.2 2024-02-05
 ### Payments
 * [Changed] We now auto append `mandate_data` when using Klarna with a SetupIntent. If you are interested in using Klarna with SetupIntents you sign up for the beta [here](https://stripe.com/docs/payments/klarna/accept-a-payment). 

--- a/Stripe/StripeiOS/Source/STPPinManagementService.swift
+++ b/Stripe/StripeiOS/Source/STPPinManagementService.swift
@@ -13,7 +13,7 @@ import Foundation
 import UIKit
 
 /// STPAPIClient extensions to manage PIN on Stripe Issuing cards
-@available(*, deprecated, message: "Please use Issuing Elements instead: https://stripe.com/docs/issuing/elements")
+@available(iOS, deprecated: 100000.0, message: "Please use Issuing Elements instead: https://stripe.com/docs/issuing/elements")
 public class STPPinManagementService: NSObject {
     /// The API Client to use to make requests.
     /// Defaults to STPAPIClient.shared


### PR DESCRIPTION
## Summary
We don't actually want to prevent users from using it at all in Swift (yet), only to let folks know it's going away, though we're not sure when yet.

## Motivation
https://github.com/stripe/stripe-ios/issues/3257
https://jira.corp.stripe.com/browse/RUN_ISSUING_TED-2233
