### PR TITLE
Financial Connections: for v3, worked on supporting app to app state for sheets

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PrepaneViews.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PrepaneViews.swift
@@ -51,7 +51,8 @@ final class PrepaneViews {
                     return nil
                 }
             }(),
-            title: prepaneModel.title
+            title: prepaneModel.title,
+            isSheet: (panePresentationStyle == .sheet)
         )
         self.bodyView = PaneLayoutView.createBodyView(
             text: prepaneModel.subtitle,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PrepaneViews.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PrepaneViews.swift
@@ -78,15 +78,12 @@ final class PrepaneViews {
                         title: {
                             switch panePresentationStyle {
                             case .fullscreen:
-                                STPLocalizedString(
+                                return STPLocalizedString(
                                    "Choose a different bank",
                                    "Title of a button. It acts as a back button to go back to choosing a different bank instead of the currently selected one."
                                )
                             case .sheet:
-                                STPLocalizedString(
-                                   "Cancel",
-                                   "Title of a button. It acts as a back button to go back to choosing a different bank instead of the currently selected one."
-                               )
+                                return "Cancel" // TODO: when Financial Connections starts supporting localization, change this to `String.Localized.cancel`
                             }
                         }(),
                         action: didSelectCancel

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/CloseConfirmationViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/CloseConfirmationViewController.swift
@@ -62,10 +62,7 @@ final class CloseConfirmationViewController: SheetViewController {
                     }
                 ),
                 secondaryButtonConfiguration: PaneLayoutView.ButtonConfiguration(
-                    title: STPLocalizedString(
-                        "Cancel",
-                        "A button title. The user encounters it as part of a confirmation pop-up when trying to exit a screen. Pressing it will close the pop-up, and will ensure that the screen does NOT exit."
-                    ),
+                    title: "Cancel", // TODO: when Financial Connections starts supporting localization, change this to `String.Localized.cancel`
                     action: { [weak self] in
                         self?.dismiss(animated: true)
                     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Web/ContinueStateView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Web/ContinueStateView.swift
@@ -48,10 +48,7 @@ final class ContinueStateViews {
             secondaryButtonConfiguration: {
                 if let didSelectCancel {
                     return PaneLayoutView.ButtonConfiguration(
-                        title: STPLocalizedString(
-                            "Cancel",
-                            "Title of a button. It acts as a back button to go back to choosing a different bank instead of the currently selected one."
-                        ),
+                        title: "Cancel", // TODO: when Financial Connections starts supporting localization, change this to `String.Localized.cancel`
                         action: didSelectCancel
                     )
                 } else {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Web/ContinueStateView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Web/ContinueStateView.swift
@@ -9,30 +9,21 @@
 @_spi(STP) import StripeUICore
 import UIKit
 
-class ContinueStateView: UIView {
+final class ContinueStateViews {
 
-    // MARK: - Properties
+    private init() {}
 
-    private let didSelectContinue: () -> Void
-
-    // MARK: - UIView
-
-    init(
-        institutionImageUrl: String?,
-        didSelectContinue: @escaping () -> Void
-    ) {
-        self.didSelectContinue = didSelectContinue
-        super.init(frame: .zero)
-        backgroundColor = .customBackgroundColor
-
-        let paneLayoutView = PaneWithHeaderLayoutView(
-            icon: .view(
-                {
-                    let institutionIconView = InstitutionIconView(size: .large)
+    static func createContentView(institutionImageUrl: String?) -> UIView {
+        return PaneLayoutView.createContentView(
+            iconView: {
+                if let institutionImageUrl {
+                    let institutionIconView = InstitutionIconView()
                     institutionIconView.setImageUrl(institutionImageUrl)
                     return institutionIconView
-                }()
-            ),
+                } else {
+                    return nil
+                }
+            }(),
             title: STPLocalizedString(
                 "Continue linking your account",
                 "Title for a label of a screen telling users to tap below to continue linking process."
@@ -41,42 +32,32 @@ class ContinueStateView: UIView {
                 "You haven't finished linking your account. Press continue to finish the process.",
                 "Title for a label explaining that the linking process hasn't finished yet."
             ),
-            contentView: {
-                let clearView = UIView()
-                clearView.backgroundColor = .clear
-                return clearView
-            }(),
-            footerView: CreateFooterView(
-                view: self
-            )
+            contentView: nil
         )
-        paneLayoutView.addTo(view: self)
     }
 
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+    static func createFooterView(
+        didSelectContinue: @escaping () -> Void,
+        didSelectCancel: (() -> Void)? = nil
+    ) -> UIView? {
+        return PaneLayoutView.createFooterView(
+            primaryButtonConfiguration: PaneLayoutView.ButtonConfiguration(
+                title: "Continue", // TODO: when Financial Connections starts supporting localization, change this to `String.Localized.continue`,
+                action: didSelectContinue
+            ),
+            secondaryButtonConfiguration: {
+                if let didSelectCancel {
+                    return PaneLayoutView.ButtonConfiguration(
+                        title: STPLocalizedString(
+                            "Cancel",
+                            "Title of a button. It acts as a back button to go back to choosing a different bank instead of the currently selected one."
+                        ),
+                        action: didSelectCancel
+                    )
+                } else {
+                    return nil
+                }
+            }()
+        ).footerView
     }
-
-    @objc fileprivate func didSelectContinueButton() {
-        didSelectContinue()
-    }
-}
-
-private func CreateFooterView(
-    view: ContinueStateView
-) -> UIView {
-    let continueButton = Button(configuration: .financialConnectionsPrimary)
-    continueButton.title = "Continue"  // TODO: when Financial Connections starts supporting localization, change this to `String.Localized.continue`
-    continueButton.addTarget(view, action: #selector(ContinueStateView.didSelectContinueButton), for: .touchUpInside)
-    continueButton.translatesAutoresizingMaskIntoConstraints = false
-    NSLayoutConstraint.activate([
-        continueButton.heightAnchor.constraint(equalToConstant: 56)
-    ])
-
-    let footerStackView = UIStackView()
-    footerStackView.axis = .vertical
-    footerStackView.spacing = 20
-    footerStackView.addArrangedSubview(continueButton)
-
-    return footerStackView
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsWebFlowViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsWebFlowViewController.swift
@@ -35,15 +35,21 @@ final class FinancialConnectionsWebFlowViewController: UIViewController {
     // MARK: - Waiting state view
 
     private lazy var continueStateView: UIView = {
-        let view = ContinueStateView(institutionImageUrl: nil) { [weak self] in
-            guard let self = self else { return }
-            if let url = self.lastOpenedNativeURL {
-                self.redirect(to: url)
-            } else {
-                self.startAuthenticationSession(manifest: self.manifest)
-            }
-        }
-        return view
+        return PaneLayoutView(
+            contentView: ContinueStateViews.createContentView(
+                institutionImageUrl: nil
+            ),
+            footerView: ContinueStateViews.createFooterView(
+                didSelectContinue: { [weak self] in
+                    guard let self else { return }
+                    if let url = self.lastOpenedNativeURL {
+                        self.redirect(to: url)
+                    } else {
+                        self.startAuthenticationSession(manifest: manifest)
+                    }
+                }
+            )
+        ).createView()
     }()
 
     /**


### PR DESCRIPTION
## Summary

This PR:
- Adds "app to app" support for the new sheet V3 design. "App to app" is the ability to connect a bank account directly through the banking app (ex. Chase) rather than an OAuth Website.

---

NOTE: This PR is merged into a new feature branch (`kg-v3nav`) as there will be more navigation-related changes similar to this. But will be merged into the `fc-v3` feature branch after `kg-v3nav` is ready.

Details to understand before reviewing PR:
- This is one PR, out of expected ~50+, to change the design of Financial Connections from a "V2" design to a "V3" design. [Here is a link to the designs](https://www.figma.com/file/wXQ8NJApqSJiLmxxANDRTs/%E2%9C%A8-Connections-3.0?type=design&node-id=2524-217093&mode=design&t=kXaBiAlgVsC7YcH1-0).
- The code here is not the finished version. It's just an iteration towards the final version. This code will be re-visited later. The goal is to go screen-by-screen and make easy changes to learn about all the difficulties in each screen. Later, all the learnings will be combined to do a "final" polish of all screens.
- The above also applies to design. The design here is not the finished version.
- This PR is merged into a feature branch `fc-v3`. It is not merged into `master`.
- There might be TODO's scattered throughout the code. That's expected and they will be fixed later. 
## Testing

### Test Native App To App

This video shows that the "app to app" works for Native (with the UI state changing):

https://github.com/stripe/stripe-ios/assets/105514761/7295a36c-16d0-4a81-ade5-4f664fbede0c

### Test Web App To App

This video shows that the "app to app" works for Web (with the UI state changing):

https://github.com/stripe/stripe-ios/assets/105514761/e6f83003-ec5c-4105-8ccf-7a65b33a4cac
