### PR TITLE
Financial Connections: for v3, fixed a bug where sheet rotations would sometimes not relayout properly

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/SheetViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/SheetViewController.swift
@@ -61,6 +61,7 @@ class SheetViewController: UIViewController {
 
     private var paneViewContainerView: UIView?
     private var paneView: PaneLayoutView?
+    private var sheetTopConstraint: NSLayoutConstraint?
 
     private lazy var darkAreaTapGestureRecognizer: UITapGestureRecognizer = {
         let tapGestureRecognizer = UITapGestureRecognizer(
@@ -89,12 +90,15 @@ class SheetViewController: UIViewController {
 
             contentStackView.translatesAutoresizingMaskIntoConstraints = false
             contentView.addSubview(contentStackView)
+
+            let sheetTopConstraint = contentStackView.topAnchor.constraint(
+                // keep the `contentStackView` flexible to resize
+                greaterThanOrEqualTo: contentView.topAnchor,
+                constant: 0
+            )
+            self.sheetTopConstraint = sheetTopConstraint
             NSLayoutConstraint.activate([
-                contentStackView.topAnchor.constraint(
-                    // keep the `contentStackView` flexible to resize
-                    greaterThanOrEqualTo: contentView.topAnchor,
-                    constant: 0
-                ),
+                sheetTopConstraint,
                 contentStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
                 contentStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
                 contentStackView.bottomAnchor.constraint(equalTo: contentView.safeAreaLayoutGuide.bottomAnchor),
@@ -145,6 +149,11 @@ class SheetViewController: UIViewController {
                 contentViewFrame.size.height -= contentViewMinY
                 contentViewFrame.origin.y = view.bounds.height - contentViewFrame.height
                 contentView.frame = contentViewFrame
+
+                // fixes a bug where rotations wouldn't properly
+                // resize the sheet
+                sheetTopConstraint?.isActive = false
+                sheetTopConstraint?.isActive = true
 
                 // animate the sheet from top to bottom
                 if !performedSheetPresentationAnimation {


### PR DESCRIPTION
## Summary

This PR fixes a bug with sheet rotations where the sheet expands after rotation (when it should not). See "Before" video.

## Testing

### Before

https://github.com/stripe/stripe-ios/assets/105514761/682cb565-915a-4f9c-9ad2-200fb9876492

### After

https://github.com/stripe/stripe-ios/assets/105514761/efc19ebf-a3e0-4fba-888b-d45d7568acc1
