### PR TITLE
Add support for PaymentMethodConfigurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## X.X.X
+### PaymentSheet
+* [Added] Added support for [payment method configurations](https://docs.stripe.com/payments/multiple-payment-method-configs) when using the deferred intent integration path.
+
 ## 23.22.0 2024-02-12
 ### PaymentSheet
 * [Changed] The separator text under the Apple Pay button from "Or pay with a card" to "Or use a card" when using a SetupIntent.

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -103,6 +103,7 @@ struct PaymentSheetTestPlayground: View {
                         }
                         clientSettings
                         TextField("Custom CTA", text: customCTABinding)
+                        TextField("Payment Method Settings ID", text: paymentMethodSettingsBinding)
                     }
                     Divider()
                     Group {
@@ -131,6 +132,13 @@ struct PaymentSheetTestPlayground: View {
             return playgroundController.settings.customCtaLabel ?? ""
         } set: { newString in
             playgroundController.settings.customCtaLabel = (newString != "") ? newString : nil
+        }
+    }
+    var paymentMethodSettingsBinding: Binding<String> {
+        Binding<String> {
+            return playgroundController.settings.paymentMethodSettingsID ?? ""
+        } set: { newString in
+            playgroundController.settings.paymentMethodSettingsID = (newString != "") ? newString : nil
         }
     }
     var customerModeBinding: Binding<PaymentSheetTestPlaygroundSettings.CustomerMode> {

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -136,9 +136,9 @@ struct PaymentSheetTestPlayground: View {
     }
     var paymentMethodSettingsBinding: Binding<String> {
         Binding<String> {
-            return playgroundController.settings.paymentMethodSettingsID ?? ""
+            return playgroundController.settings.paymentMethodConfigurationId ?? ""
         } set: { newString in
-            playgroundController.settings.paymentMethodSettingsID = (newString != "") ? newString : nil
+            playgroundController.settings.paymentMethodConfigurationId = (newString != "") ? newString : nil
         }
     }
     var customerModeBinding: Binding<PaymentSheetTestPlaygroundSettings.CustomerMode> {

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -268,6 +268,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
     var linkV2Allowed: LinkV2Allowed
     var userOverrideCountry: UserOverrideCountry
     var customCtaLabel: String?
+    var paymentMethodSettingsID: String?
     var checkoutEndpoint: String?
     var autoreload: Autoreload
     var externalPayPalEnabled: ExternalPayPalEnabled
@@ -300,6 +301,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
             linkV2Allowed: .off,
             userOverrideCountry: .off,
             customCtaLabel: nil,
+            paymentMethodSettingsID: nil,
             checkoutEndpoint: Self.defaultCheckoutEndpoint,
             autoreload: .on,
             externalPayPalEnabled: .off,

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -268,7 +268,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
     var linkV2Allowed: LinkV2Allowed
     var userOverrideCountry: UserOverrideCountry
     var customCtaLabel: String?
-    var paymentMethodSettingsID: String?
+    var paymentMethodConfigurationId: String?
     var checkoutEndpoint: String?
     var autoreload: Autoreload
     var externalPayPalEnabled: ExternalPayPalEnabled
@@ -301,7 +301,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
             linkV2Allowed: .off,
             userOverrideCountry: .off,
             customCtaLabel: nil,
-            paymentMethodSettingsID: nil,
+            paymentMethodConfigurationId: nil,
             checkoutEndpoint: Self.defaultCheckoutEndpoint,
             autoreload: .on,
             externalPayPalEnabled: .off,

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -191,6 +191,7 @@ class PlaygroundController: ObservableObject {
             return PaymentSheet.IntentConfiguration(
                 mode: .payment(amount: amount!, currency: settings.currency.rawValue, setupFutureUsage: nil),
                 paymentMethodTypes: paymentMethodTypes,
+                paymentMethodConfiguration: settings.paymentMethodSettingsID,
                 confirmHandler: confirmHandler,
                 isCVCRecollectionEnabledCallback: isCVCRecollectionEnabledCallback
             )
@@ -198,6 +199,7 @@ class PlaygroundController: ObservableObject {
             return PaymentSheet.IntentConfiguration(
                 mode: .payment(amount: amount!, currency: settings.currency.rawValue, setupFutureUsage: .offSession),
                 paymentMethodTypes: paymentMethodTypes,
+                paymentMethodConfiguration: settings.paymentMethodSettingsID,
                 confirmHandler: confirmHandler,
                 isCVCRecollectionEnabledCallback: isCVCRecollectionEnabledCallback
             )
@@ -205,6 +207,7 @@ class PlaygroundController: ObservableObject {
             return PaymentSheet.IntentConfiguration(
                 mode: .setup(currency: settings.currency.rawValue, setupFutureUsage: .offSession),
                 paymentMethodTypes: paymentMethodTypes,
+                paymentMethodConfiguration: settings.paymentMethodSettingsID,
                 confirmHandler: confirmHandler
             )
         }

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -191,7 +191,7 @@ class PlaygroundController: ObservableObject {
             return PaymentSheet.IntentConfiguration(
                 mode: .payment(amount: amount!, currency: settings.currency.rawValue, setupFutureUsage: nil),
                 paymentMethodTypes: paymentMethodTypes,
-                paymentMethodConfiguration: settings.paymentMethodSettingsID,
+                paymentMethodConfigurationId: settings.paymentMethodConfigurationId,
                 confirmHandler: confirmHandler,
                 isCVCRecollectionEnabledCallback: isCVCRecollectionEnabledCallback
             )
@@ -199,7 +199,7 @@ class PlaygroundController: ObservableObject {
             return PaymentSheet.IntentConfiguration(
                 mode: .payment(amount: amount!, currency: settings.currency.rawValue, setupFutureUsage: .offSession),
                 paymentMethodTypes: paymentMethodTypes,
-                paymentMethodConfiguration: settings.paymentMethodSettingsID,
+                paymentMethodConfigurationId: settings.paymentMethodConfigurationId,
                 confirmHandler: confirmHandler,
                 isCVCRecollectionEnabledCallback: isCVCRecollectionEnabledCallback
             )
@@ -207,7 +207,7 @@ class PlaygroundController: ObservableObject {
             return PaymentSheet.IntentConfiguration(
                 mode: .setup(currency: settings.currency.rawValue, setupFutureUsage: .offSession),
                 paymentMethodTypes: paymentMethodTypes,
-                paymentMethodConfiguration: settings.paymentMethodSettingsID,
+                paymentMethodConfigurationId: settings.paymentMethodConfigurationId,
                 confirmHandler: confirmHandler
             )
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPAPIClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPAPIClient+PaymentSheet.swift
@@ -13,7 +13,8 @@ import Foundation
 extension STPAPIClient {
     typealias STPIntentCompletionBlock = ((Result<Intent, Error>) -> Void)
 
-    func makeElementsSessionsParams(mode: PaymentSheet.InitializationMode, epmConfiguration: PaymentSheet.ExternalPaymentMethodConfiguration?) -> [String: Any] {
+    func makeElementsSessionsParams(mode: PaymentSheet.InitializationMode,
+                                    epmConfiguration: PaymentSheet.ExternalPaymentMethodConfiguration?) -> [String: Any] {
         var parameters: [String: Any] = [
             "locale": Locale.current.toLanguageTag(),
             "external_payment_methods": epmConfiguration?.externalPaymentMethods.compactMap { $0.lowercased() } ?? [],
@@ -26,6 +27,9 @@ extension STPAPIClient {
                 var deferredIntent = [String: Any]()
                 deferredIntent["payment_method_types"] = intentConfig.paymentMethodTypes
                 deferredIntent["on_behalf_of"] = intentConfig.onBehalfOf
+                if let paymentMethodConfiguration = intentConfig.paymentMethodConfiguration {
+                    deferredIntent["payment_method_configuration"] = ["id": paymentMethodConfiguration]
+                }
                 switch intentConfig.mode {
                 case .payment(let amount, let currency, let setupFutureUsage, let captureMethod):
                     deferredIntent["mode"] = "payment"

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPAPIClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPAPIClient+PaymentSheet.swift
@@ -27,8 +27,8 @@ extension STPAPIClient {
                 var deferredIntent = [String: Any]()
                 deferredIntent["payment_method_types"] = intentConfig.paymentMethodTypes
                 deferredIntent["on_behalf_of"] = intentConfig.onBehalfOf
-                if let paymentMethodConfiguration = intentConfig.paymentMethodConfiguration {
-                    deferredIntent["payment_method_configuration"] = ["id": paymentMethodConfiguration]
+                if let paymentMethodConfigurationId = intentConfig.paymentMethodConfigurationId {
+                    deferredIntent["payment_method_configuration"] = ["id": paymentMethodConfigurationId]
                 }
                 switch intentConfig.mode {
                 case .payment(let amount, let currency, let setupFutureUsage, let captureMethod):

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetIntentConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetIntentConfiguration.swift
@@ -95,7 +95,7 @@ public extension PaymentSheet {
         /// The account (if any) for which the funds of the intent are intended.
         /// - Seealso: https://stripe.com/docs/api/payment_intents/object#payment_intent_object-on_behalf_of
         public var onBehalfOf: String?
-        
+
         /// Optional configuration ID for the selected payment method configuration.
         /// See https://stripe.com/docs/payments/multiple-payment-method-configs for more information.
         public var paymentMethodConfiguration: String?

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetIntentConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetIntentConfiguration.swift
@@ -44,14 +44,17 @@ public extension PaymentSheet {
         ///   - mode: The mode of this intent, either payment or setup
         ///   - paymentMethodTypes: The payment method types for the intent
         ///   - onBehalfOf: The account (if any) for which the funds of the intent are intended
+        ///   - paymentMethodConfiguration: Configuration ID (if any) for the selected payment method configuration
         ///   - confirmHandler: A handler called with payment details when the user taps the primary button (e.g. the "Pay" or "Continue" button).
         public init(mode: Mode,
                     paymentMethodTypes: [String]? = nil,
                     onBehalfOf: String? = nil,
+                    paymentMethodConfiguration: String? = nil,
                     confirmHandler: @escaping ConfirmHandler) {
             self.mode = mode
             self.paymentMethodTypes = paymentMethodTypes
             self.onBehalfOf = onBehalfOf
+            self.paymentMethodConfiguration = paymentMethodConfiguration
             self.confirmHandler = confirmHandler
             self.isCVCRecollectionEnabledCallback = { return false }
         }
@@ -61,17 +64,20 @@ public extension PaymentSheet {
         ///   - mode: The mode of this intent, either payment or setup
         ///   - paymentMethodTypes: The payment method types for the intent
         ///   - onBehalfOf: The account (if any) for which the funds of the intent are intended
+        ///   - paymentMethodConfiguration: Configuration ID (if any) for the selected payment method configuration
         ///   - confirmHandler: A handler called with payment details when the user taps the primary button (e.g. the "Pay" or "Continue" button).
         ///   - isCVCRecollectionEnabledCallback: Callback to determine whether to display the CVC recollection form
         @_spi(EarlyAccessCVCRecollectionFeature)
         public init(mode: Mode,
                     paymentMethodTypes: [String]? = nil,
                     onBehalfOf: String? = nil,
+                    paymentMethodConfiguration: String? = nil,
                     confirmHandler: @escaping ConfirmHandler,
                     isCVCRecollectionEnabledCallback: CVCRecollectionEnabledCallback? = nil) {
             self.mode = mode
             self.paymentMethodTypes = paymentMethodTypes
             self.onBehalfOf = onBehalfOf
+            self.paymentMethodConfiguration = paymentMethodConfiguration
             self.confirmHandler = confirmHandler
             self.isCVCRecollectionEnabledCallback = isCVCRecollectionEnabledCallback ?? { return false }
         }
@@ -89,6 +95,10 @@ public extension PaymentSheet {
         /// The account (if any) for which the funds of the intent are intended.
         /// - Seealso: https://stripe.com/docs/api/payment_intents/object#payment_intent_object-on_behalf_of
         public var onBehalfOf: String?
+        
+        /// Optional configuration ID for the selected payment method configuration.
+        /// See https://stripe.com/docs/payments/multiple-payment-method-configs for more information.
+        public var paymentMethodConfiguration: String?
 
         /// A callback that controls when to recollect the CVC for saved cards
         /// In the case of client-side confirmation, the CVC/CVV value will be

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetIntentConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetIntentConfiguration.swift
@@ -44,17 +44,17 @@ public extension PaymentSheet {
         ///   - mode: The mode of this intent, either payment or setup
         ///   - paymentMethodTypes: The payment method types for the intent
         ///   - onBehalfOf: The account (if any) for which the funds of the intent are intended
-        ///   - paymentMethodConfiguration: Configuration ID (if any) for the selected payment method configuration
+        ///   - paymentMethodConfigurationId: Configuration ID (if any) for the selected payment method configuration
         ///   - confirmHandler: A handler called with payment details when the user taps the primary button (e.g. the "Pay" or "Continue" button).
         public init(mode: Mode,
                     paymentMethodTypes: [String]? = nil,
                     onBehalfOf: String? = nil,
-                    paymentMethodConfiguration: String? = nil,
+                    paymentMethodConfigurationId: String? = nil,
                     confirmHandler: @escaping ConfirmHandler) {
             self.mode = mode
             self.paymentMethodTypes = paymentMethodTypes
             self.onBehalfOf = onBehalfOf
-            self.paymentMethodConfiguration = paymentMethodConfiguration
+            self.paymentMethodConfigurationId = paymentMethodConfigurationId
             self.confirmHandler = confirmHandler
             self.isCVCRecollectionEnabledCallback = { return false }
         }
@@ -64,20 +64,20 @@ public extension PaymentSheet {
         ///   - mode: The mode of this intent, either payment or setup
         ///   - paymentMethodTypes: The payment method types for the intent
         ///   - onBehalfOf: The account (if any) for which the funds of the intent are intended
-        ///   - paymentMethodConfiguration: Configuration ID (if any) for the selected payment method configuration
+        ///   - paymentMethodConfigurationId: Configuration ID (if any) for the selected payment method configuration
         ///   - confirmHandler: A handler called with payment details when the user taps the primary button (e.g. the "Pay" or "Continue" button).
         ///   - isCVCRecollectionEnabledCallback: Callback to determine whether to display the CVC recollection form
         @_spi(EarlyAccessCVCRecollectionFeature)
         public init(mode: Mode,
                     paymentMethodTypes: [String]? = nil,
                     onBehalfOf: String? = nil,
-                    paymentMethodConfiguration: String? = nil,
+                    paymentMethodConfigurationId: String? = nil,
                     confirmHandler: @escaping ConfirmHandler,
                     isCVCRecollectionEnabledCallback: CVCRecollectionEnabledCallback? = nil) {
             self.mode = mode
             self.paymentMethodTypes = paymentMethodTypes
             self.onBehalfOf = onBehalfOf
-            self.paymentMethodConfiguration = paymentMethodConfiguration
+            self.paymentMethodConfigurationId = paymentMethodConfigurationId
             self.confirmHandler = confirmHandler
             self.isCVCRecollectionEnabledCallback = isCVCRecollectionEnabledCallback ?? { return false }
         }
@@ -98,7 +98,7 @@ public extension PaymentSheet {
 
         /// Optional configuration ID for the selected payment method configuration.
         /// See https://stripe.com/docs/payments/multiple-payment-method-configs for more information.
-        public var paymentMethodConfiguration: String?
+        public var paymentMethodConfigurationId: String?
 
         /// A callback that controls when to recollect the CVC for saved cards
         /// In the case of client-side confirmation, the CVC/CVV value will be

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPAPIClient+PaymentSheetTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPAPIClient+PaymentSheetTest.swift
@@ -22,7 +22,7 @@ class STPAPIClient_PaymentSheetTest: XCTestCase {
                                                                            captureMethod: .automaticAsync),
                                                             paymentMethodTypes: ["card", "cashapp"],
                                                             onBehalfOf: "acct_connect",
-                                                            paymentMethodConfiguration: "pmc_234",
+                                                            paymentMethodConfigurationId: "pmc_234",
                                                             confirmHandler: { _, _, _ in })
         var config = PaymentSheet.Configuration()
         config.externalPaymentMethodConfiguration = .init(externalPaymentMethods: ["external_foo", "external_bar"], externalPaymentMethodConfirmHandler: { _, _, _ in })

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPAPIClient+PaymentSheetTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPAPIClient+PaymentSheetTest.swift
@@ -22,15 +22,15 @@ class STPAPIClient_PaymentSheetTest: XCTestCase {
                                                                            captureMethod: .automaticAsync),
                                                             paymentMethodTypes: ["card", "cashapp"],
                                                             onBehalfOf: "acct_connect",
+                                                            paymentMethodConfiguration: "pmc_234",
                                                             confirmHandler: { _, _, _ in })
         var config = PaymentSheet.Configuration()
         config.externalPaymentMethodConfiguration = .init(externalPaymentMethods: ["external_foo", "external_bar"], externalPaymentMethodConfirmHandler: { _, _, _ in })
 
-        let parameters = STPAPIClient(publishableKey: "pk_test").makeElementsSessionsParams(mode: .deferredIntent(intentConfig), epmConfiguration: config.externalPaymentMethodConfiguration, paymentMethodConfiguration: "pmc_234")
+        let parameters = STPAPIClient(publishableKey: "pk_test").makeElementsSessionsParams(mode: .deferredIntent(intentConfig), epmConfiguration: config.externalPaymentMethodConfiguration)
         XCTAssertEqual(parameters["key"] as? String, "pk_test")
         XCTAssertEqual(parameters["locale"] as? String, Locale.current.toLanguageTag())
         XCTAssertEqual(parameters["external_payment_methods"] as? [String], ["external_foo", "external_bar"])
-        XCTAssertEqual(parameters["payment_method_configuration"] as? String, "pmc_234")
 
         let deferredIntent = try XCTUnwrap(parameters["deferred_intent"] as?  [String: Any])
         XCTAssertEqual(deferredIntent["payment_method_types"] as? [String], ["card", "cashapp"])
@@ -40,6 +40,7 @@ class STPAPIClient_PaymentSheetTest: XCTestCase {
         XCTAssertEqual(deferredIntent["currency"] as? String, "USD")
         XCTAssertEqual(deferredIntent["setup_future_usage"] as? String, "on_session")
         XCTAssertEqual(deferredIntent["capture_method"] as? String, "automatic_async")
+        XCTAssertEqual((deferredIntent["payment_method_configuration"] as? [String: Any])?["id"] as? String, "pmc_234")
     }
 
     func testElementsSessionParameters_DeferredSetup() throws {
@@ -49,7 +50,7 @@ class STPAPIClient_PaymentSheetTest: XCTestCase {
                                                             onBehalfOf: "acct_connect",
                                                             confirmHandler: { _, _, _ in })
 
-        let parameters = STPAPIClient(publishableKey: "pk_test").makeElementsSessionsParams(mode: .deferredIntent(intentConfig), epmConfiguration: nil, paymentMethodConfiguration: nil)
+        let parameters = STPAPIClient(publishableKey: "pk_test").makeElementsSessionsParams(mode: .deferredIntent(intentConfig), epmConfiguration: nil)
         XCTAssertEqual(parameters["key"] as? String, "pk_test")
         XCTAssertEqual(parameters["locale"] as? String, Locale.current.toLanguageTag())
         XCTAssertEqual(parameters["external_payment_methods"] as? [String], [])

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPAPIClient+PaymentSheetTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPAPIClient+PaymentSheetTest.swift
@@ -26,10 +26,11 @@ class STPAPIClient_PaymentSheetTest: XCTestCase {
         var config = PaymentSheet.Configuration()
         config.externalPaymentMethodConfiguration = .init(externalPaymentMethods: ["external_foo", "external_bar"], externalPaymentMethodConfirmHandler: { _, _, _ in })
 
-        let parameters = STPAPIClient(publishableKey: "pk_test").makeElementsSessionsParams(mode: .deferredIntent(intentConfig), epmConfiguration: config.externalPaymentMethodConfiguration)
+        let parameters = STPAPIClient(publishableKey: "pk_test").makeElementsSessionsParams(mode: .deferredIntent(intentConfig), epmConfiguration: config.externalPaymentMethodConfiguration, paymentMethodConfiguration: "pmc_234")
         XCTAssertEqual(parameters["key"] as? String, "pk_test")
         XCTAssertEqual(parameters["locale"] as? String, Locale.current.toLanguageTag())
         XCTAssertEqual(parameters["external_payment_methods"] as? [String], ["external_foo", "external_bar"])
+        XCTAssertEqual(parameters["payment_method_configuration"] as? String, "pmc_234")
 
         let deferredIntent = try XCTUnwrap(parameters["deferred_intent"] as?  [String: Any])
         XCTAssertEqual(deferredIntent["payment_method_types"] as? [String], ["card", "cashapp"])
@@ -48,10 +49,11 @@ class STPAPIClient_PaymentSheetTest: XCTestCase {
                                                             onBehalfOf: "acct_connect",
                                                             confirmHandler: { _, _, _ in })
 
-        let parameters = STPAPIClient(publishableKey: "pk_test").makeElementsSessionsParams(mode: .deferredIntent(intentConfig), epmConfiguration: nil)
+        let parameters = STPAPIClient(publishableKey: "pk_test").makeElementsSessionsParams(mode: .deferredIntent(intentConfig), epmConfiguration: nil, paymentMethodConfiguration: nil)
         XCTAssertEqual(parameters["key"] as? String, "pk_test")
         XCTAssertEqual(parameters["locale"] as? String, Locale.current.toLanguageTag())
         XCTAssertEqual(parameters["external_payment_methods"] as? [String], [])
+        XCTAssertNil(parameters["payment_method_configurations"])
 
         let deferredIntent = try XCTUnwrap(parameters["deferred_intent"] as?  [String: Any])
         XCTAssertEqual(deferredIntent["payment_method_types"] as? [String], ["card", "cashapp"])


### PR DESCRIPTION
## Summary
Add support for [Payment Method Configurations](https://stripe.com/docs/payments/multiple-payment-method-configs) in the deferred intent flow.

See also: https://github.com/stripe/stripe-android/pull/7929

## Motivation
RUN_MOBILESDK-2935

## Testing
Added API test, tested manually in PaymentSheet Playground

## Changelog
Added