### PR TITLE
Financial Connections: for v3, fix a bug where the background color of institution cell was wrong when rotated

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionTableViewCell.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionTableViewCell.swift
@@ -41,6 +41,12 @@ final class InstitutionTableViewCell: UITableViewCell {
 
     private func adjustBackgroundColor(isHighlighted: Bool) {
         contentView.backgroundColor = isHighlighted ? .backgroundContainer : .customBackgroundColor
+        
+        // fix a bug where the background color of a
+        // rotated, selected cell was wrong
+        let selectedBackgroundView = UIView()
+        selectedBackgroundView.backgroundColor = contentView.backgroundColor
+        self.selectedBackgroundView = selectedBackgroundView
     }
 
     func showLoadingView(_ show: Bool) {


### PR DESCRIPTION
## Summary

^ see title

## Testing

| Before | After |
| --- | --- | 
| ![Simulator Screenshot - iPhone 15 Pro - 2024-02-12 at 16 50 59](https://github.com/stripe/stripe-ios/assets/105514761/fa6c09ad-5012-4356-b4b5-6a859b469b6c) | ![Simulator Screenshot - iPhone 15 Pro - 2024-02-13 at 14 05 52](https://github.com/stripe/stripe-ios/assets/105514761/0c2f0c2e-6ce2-4c55-bc5e-47b20943a3ee) |

