### PR TITLE
Fix PaymentSheet scan card broken UI

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSectionWithScanner/CardSectionWithScannerView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSectionWithScanner/CardSectionWithScannerView.swift
@@ -69,7 +69,7 @@ final class CardSectionWithScannerView: UIView {
     private func setCardScanVisible(_ isCardScanVisible: Bool) {
         UIView.animate(withDuration: PaymentSheetUI.defaultAnimationDuration) {
             self.cardScanButton.alpha = isCardScanVisible ? 0 : 1
-            self.cardScanningView.isHidden = !isCardScanVisible
+            self.cardScanningView.setHiddenIfNecessary(!isCardScanVisible)
             self.cardScanningView.alpha = isCardScanVisible ? 1 : 0
         }
     }


### PR DESCRIPTION
## Summary
Fixing issue where camera showing/hiding the camera is broken if you:

1. Use returning customer (with SPM)
2. Open PS or PS.FC
3. Tap "+ Add"
4. Tap "Scan card"
5. Close (important - does not repro if you don't close it)
6. Go back
7. Repeat steps 3 and 4.

## Motivation
Broken UI

## Testing
Manual testing on emulator and real phone.

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
