### PR TITLE
Financial Connections: fixed an issue with SheetViewController where it could freeze

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/SheetViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/SheetViewController.swift
@@ -339,7 +339,7 @@ class SheetViewController: UIViewController {
         guard dampingFactor > 0, value >= 0 else {
             return value
         }
-        return (1 - exp(-dampingFactor * value)) / dampingFactor
+        return round((1 - exp(-dampingFactor * value)) / dampingFactor)
     }
 
     @objc private func didTapDarkArea() {


### PR DESCRIPTION
## Summary

There was a problem where "playing too much" with the sheet would cause the app to kind-of freeze. I say, kind of, because unlike 'clear' infinite-loops / freezes, there was no clear indication of what was freezing and it was rare for iOS to kill the app quickly.

This took quite a bit of time to figure out, but after eliminating a lot of variables (pausing debugger showed nothing [no infinite loops etc.], log statements showed nothing, crash traces from iOS killing app showed nothing), this was the only one that fixed it; why? something about too many layout operations (there is quite a bit of auto layout / stack view magic to hold this together) and, seemingly, introducing many decimal points "overloads" it? 🤷 

https://github.com/stripe/stripe-ios/assets/105514761/12f3806d-dfc4-492a-8ff5-3766e97823f9

## Testing

I tried to repro the issue as in the video above and it no longer freezes 🤷 (I still keep testing it in disbelief, but so far no freezes where a repro before was very easy)