### PR TITLE
Financial Connections: for v3, improved sheet top padding for landscape

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/SheetViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/SheetViewController.swift
@@ -132,12 +132,13 @@ class SheetViewController: UIViewController {
         super.viewDidLayoutSubviews()
 
         if panePresentationStyle == .sheet {
+            let isLandscape = UIDevice.current.orientation.isLandscape
             var contentViewMinY = view.window?.safeAreaInsets.top ?? 0
             // estimated iOS value of how far default sheet
             // stretches beyond safeAreaInset.top
-            contentViewMinY += 10
+            contentViewMinY += isLandscape ? 0 : 10
             contentViewMinY += UINavigationController().navigationBar.bounds.height
-            contentViewMinY += 24 // typical Financial Connecitons padding
+            contentViewMinY += isLandscape ? 0 : 24
             let didChangeContentViewMinY = (self.contentViewMinY != contentViewMinY)
             self.contentViewMinY = contentViewMinY
 


### PR DESCRIPTION
## Summary

^ added less TOP PADDING for sheets in landscape 

## Testing Top Padding

### Landscape (changed)

| Before | After |
| --- | --- | 
| ![before-landscape](https://github.com/stripe/stripe-ios/assets/105514761/42f1777d-d2eb-4f69-a492-87df10c18139) | ![after-landscape](https://github.com/stripe/stripe-ios/assets/105514761/3f4c4b91-c075-4588-88be-df294b5d0cab) |

### Portrait (unchanged)

| Before | After |
| --- | --- | 
| ![before-portrait](https://github.com/stripe/stripe-ios/assets/105514761/a1e90ed2-45b5-4410-95ac-e41b8f656092) | ![after-portrait](https://github.com/stripe/stripe-ios/assets/105514761/50303a25-ba02-4170-bff3-9d59820e899e) |

