### PR TITLE
Fix build on visionOS 1.1

### DIFF
--- a/StripeCore/StripeCore/Source/Analytics/NetworkDetector.swift
+++ b/StripeCore/StripeCore/Source/Analytics/NetworkDetector.swift
@@ -15,6 +15,7 @@ import SystemConfiguration
 class NetworkDetector {
 
     static func getConnectionType() -> String? {
+#if canImport(CoreTelephony)
         guard let reachability = SCNetworkReachabilityCreateWithName(kCFAllocatorDefault, "www.stripe.com") else {
             return nil
         }
@@ -32,7 +33,7 @@ class NetworkDetector {
         guard isWWAN else {
             return "Wi-Fi"
         }
-#if canImport(CoreTelephony)
+
         let networkInfo = CTTelephonyNetworkInfo()
         let carrierType = networkInfo.serviceCurrentRadioAccessTechnology
 
@@ -51,7 +52,7 @@ class NetworkDetector {
             return "5G"
         }
 #else
-        return "unknown"
+        return "Wi-Fi"
 #endif
     }
 


### PR DESCRIPTION
## Summary
Fix the build on visionOS 1.1. Also change the output to "Wi-Fi", as we can assume a device without CoreTelephony is on wifi.

## Motivation
SCNetworkReachabilityCreateWithName is no longer available on visionOS 1.1.

## Testing
Manually in Xcode 15.3 beta 3. Will add Xcode 15.3 to CI soon.

## Changelog
None