### PR TITLE
Financial Connections: for v3, more polish around icon colors

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/FinancialConnectionsNavigationController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/FinancialConnectionsNavigationController.swift
@@ -140,7 +140,7 @@ extension FinancialConnectionsNavigationController {
         navigationBar.compactAppearance = appearance
 
         // change the back button color
-        navigationBar.tintColor = UIColor.textDisabled
+        navigationBar.tintColor = UIColor.iconDefault
         navigationBar.isTranslucent = false
     }
 
@@ -166,7 +166,7 @@ extension FinancialConnectionsNavigationController {
                         }
                     }()
                 )
-                stripeLogoImageView.tintColor = UIColor.textBrand
+                stripeLogoImageView.tintColor = UIColor.textActionPrimary
                 stripeLogoImageView.contentMode = .scaleAspectFit
                 stripeLogoImageView.sizeToFit()
                 stripeLogoImageView.frame = CGRect(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -35,7 +35,7 @@ class NativeFlowController {
             target: self,
             action: #selector(didSelectNavigationBarCloseButton)
         )
-        item.tintColor = .textDisabled
+        item.tintColor = .iconDefault
         item.imageInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 5)
         return item
     }()

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/DataAccessNoticeViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/DataAccessNoticeViewController.swift
@@ -92,11 +92,11 @@ private func CreateSingleBulletinView(
 ) -> UIView {
     let imageView = UIImageView()
     imageView.contentMode = .scaleAspectFit
+    imageView.tintColor = .iconDefault
     if let iconUrl = iconUrl {
-        imageView.setImage(with: iconUrl)
+        imageView.setImage(with: iconUrl, useAlwaysTemplateRenderingMode: true)
     } else {
         imageView.image = Image.bullet.makeImage().withRenderingMode(.alwaysTemplate)
-        imageView.tintColor = .textDefault
     }
     imageView.translatesAutoresizingMaskIntoConstraints = false
     let imageDiameter: CGFloat = 20

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/RoundedIconView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/RoundedIconView.swift
@@ -42,14 +42,15 @@ final class RoundedIconView: UIView {
         ])
 
         let iconImageView = UIImageView()
+        iconImageView.tintColor = .iconActionPrimary
         switch image {
         case .image(let image):
-            iconImageView.image = image.makeImage()
-                .withTintColor(.iconActionPrimary)
+            iconImageView.image = image.makeImage(template: true)
         case .imageUrl(let imageUrl):
             iconImageView.setImage(
                 with: imageUrl,
-                placeholder: nil
+                placeholder: nil,
+                useAlwaysTemplateRenderingMode: true
             )
         }
         addSubview(iconImageView)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/UIImageView+Extensions.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/UIImageView+Extensions.swift
@@ -13,6 +13,7 @@ extension UIImageView {
     func setImage(
         with urlString: String?,
         placeholder: UIImage? = nil,
+        useAlwaysTemplateRenderingMode: Bool = false,
         completionHandler: ((_ didDownloadImage: Bool) -> Void)? = nil
     ) {
         if let placeholder = placeholder {
@@ -33,7 +34,13 @@ extension UIImageView {
             if let image = image {
                 DispatchQueue.main.async {
                     if self?.tag == urlString.hashValue {
-                        self?.image = image
+                        if useAlwaysTemplateRenderingMode {
+                            // this ensures that if `UIImageView.tintColor` is set,
+                            // the image will be re-colored according to `tintColor`
+                            self?.image = image.withRenderingMode(.alwaysTemplate)
+                        } else {
+                            self?.image = image
+                        }
                         completionHandler?(true)
                     }
                 }


### PR DESCRIPTION
## Summary

^ see title, polish around icon colors

## Testing

### Navigation Color Changes

| Before | After |
| --- | --- | 
| ![before_nav_bar](https://github.com/stripe/stripe-ios/assets/105514761/9a960d75-01a9-4ba5-a303-7149331af2c8) | ![after_nav_bar](https://github.com/stripe/stripe-ios/assets/105514761/1d01e14b-0946-42a9-820e-6da988b6b3f4) |

### Template Image Color Changes (ex. see the 'pancake stack' icon be brighter)

| Before | After |
| --- | --- |
| ![before_template](https://github.com/stripe/stripe-ios/assets/105514761/beb9519f-34c4-43ae-9868-a84aaec30786) | ![after_template](https://github.com/stripe/stripe-ios/assets/105514761/01ac490b-c078-4e4a-9de5-0d159d4438cb) |

