### PR TITLE
Financial Connections: for v3, more polish in institution picker pane

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionPickerViewController.swift
@@ -43,9 +43,11 @@ class InstitutionPickerViewController: UIViewController {
         let verticalStackView = UIStackView(
             arrangedSubviews: [
                 CreateHeaderTitleLabel(),
-                searchBar,
             ]
         )
+        if !dataSource.manifest.institutionSearchDisabled {
+            verticalStackView.addArrangedSubview(searchBar)
+        }
         verticalStackView.axis = .vertical
         verticalStackView.spacing = 24
         verticalStackView.isLayoutMarginsRelativeArrangement = true

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionSearchBar.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionSearchBar.swift
@@ -34,6 +34,7 @@ final class InstitutionSearchBar: UIView {
     private lazy var textField: UITextField = {
         let textField = IncreasedHitTestTextField()
         textField.textColor = .textDefault
+        textField.tintColor = textField.textColor // caret color
         textField.font = FinancialConnectionsFont.label(.large).uiFont
         // this removes the `searchTextField` background color.
         // for an unknown reason, setting the `backgroundColor` to

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionSearchBar.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionSearchBar.swift
@@ -71,7 +71,7 @@ final class InstitutionSearchBar: UIView {
         let imageView = UIImageView()
         let textFieldClearButton = TextFieldClearButton()
         let cancelImage = Image.cancel_circle.makeImage()
-            .withTintColor(.neutral200)
+            .withTintColor(.textSubdued)
         textFieldClearButton.setImage(cancelImage, for: .normal)
         textFieldClearButton.addTarget(
             self,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionSearchBar.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionSearchBar.swift
@@ -153,15 +153,25 @@ final class InstitutionSearchBar: UIView {
     private func highlightBorder(_ shouldHighlightBorder: Bool) {
         let searchBarBorderColor: UIColor
         let searchBarBorderWidth: CGFloat
+        let shadowOpacity: Float
         if shouldHighlightBorder {
             searchBarBorderColor = .textActionPrimaryFocused
             searchBarBorderWidth = 2
+            shadowOpacity = 0.1
         } else {
             searchBarBorderColor = .borderDefault
             searchBarBorderWidth = 1
+            shadowOpacity = 0
         }
         layer.borderColor = searchBarBorderColor.cgColor
         layer.borderWidth = searchBarBorderWidth
+        layer.shadowOpacity = shadowOpacity
+        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowRadius = 2 / UIScreen.main.nativeScale
+        layer.shadowOffset = CGSize(
+            width: 0,
+            height: 1 / UIScreen.main.nativeScale
+        )
     }
 
     func updateSearchingIndicator(_ isSearching: Bool) {


### PR DESCRIPTION
## Summary

various polish changes:
- modified institution search clear buton color
- changed institution search caret color.
- added shadows to search bar in highlight state in institution picker
- added support of hiding the search bar

## Testing

### Search Button color

| Before | After |
| --- | --- | 
| <img width="363" alt="search_before" src="https://github.com/stripe/stripe-ios/assets/105514761/74137a06-563f-4f6c-bd52-787c1bd4bf7e"> | <img width="357" alt="search_after" src="https://github.com/stripe/stripe-ios/assets/105514761/bdb0a46f-d7e3-4e1d-8d71-67210694fafd"> | 

### No search bar test

![no_search_bar](https://github.com/stripe/stripe-ios/assets/105514761/e1a451f6-6203-4f6a-ae4d-ca2a22c6c6a1)

### Highlight state has shadows

<img width="371" alt="border_after" src="https://github.com/stripe/stripe-ios/assets/105514761/13afc029-1076-4f38-91db-6041b9441a88">

### New Caret Color

<img width="98" alt="Screenshot 2024-02-16 at 3 06 57 PM" src="https://github.com/stripe/stripe-ios/assets/105514761/6827d2f7-22be-4795-b056-30cbb68f4c7e">