### PR TITLE
Financial Connections: for v3, added support for tapping privacy terms from networking sign up pane

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsNetworkingLinkSignup.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsNetworkingLinkSignup.swift
@@ -13,6 +13,7 @@ struct FinancialConnectionsNetworkingLinkSignup: Decodable {
     let aboveCta: String
     let cta: String
     let skipCta: String
+    let legalDetailsNotice: FinancialConnectionsLegalDetailsNotice?
 
     struct Body: Decodable {
         let bullets: [FinancialConnectionsBulletPoint]

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
@@ -128,7 +128,10 @@ final class NetworkingLinkSignupViewController: UIViewController {
                 )
             },
             didSelectURL: { [weak self] url in
-                self?.didSelectURLInTextFromBackend(url)
+                self?.didSelectURLInTextFromBackend(
+                    url,
+                    legalDetailsNotice: networkingLinkSignup.legalDetailsNotice
+                )
             }
         )
         self.footerView = footerView
@@ -141,7 +144,10 @@ final class NetworkingLinkSignupViewController: UIViewController {
                     bulletPoints: networkingLinkSignup.body.bullets,
                     formView: formView,
                     didSelectURL: { [weak self] url in
-                        self?.didSelectURLInTextFromBackend(url)
+                        self?.didSelectURLInTextFromBackend(
+                            url,
+                            legalDetailsNotice: networkingLinkSignup.legalDetailsNotice
+                        )
                     }
                 )
             ),
@@ -216,13 +222,27 @@ final class NetworkingLinkSignupViewController: UIViewController {
         }
     }
 
-    private func didSelectURLInTextFromBackend(_ url: URL) {
+    private func didSelectURLInTextFromBackend(
+        _ url: URL,
+        legalDetailsNotice: FinancialConnectionsLegalDetailsNotice?
+    ) {
         AuthFlowHelpers.handleURLInTextFromBackend(
             url: url,
             pane: .networkingLinkSignupPane,
             analyticsClient: dataSource.analyticsClient,
-            handleStripeScheme: { _ in
-                // no custom stripe scheme is handled
+            handleStripeScheme: { urlHost in
+                if urlHost == "legal-details-notice", let legalDetailsNotice {
+                    let legalDetailsNoticeViewController = LegalDetailsNoticeViewController(
+                        legalDetailsNotice: legalDetailsNotice,
+                        didSelectUrl: { [weak self] url in
+                            self?.didSelectURLInTextFromBackend(
+                                url,
+                                legalDetailsNotice: legalDetailsNotice
+                            )
+                        }
+                    )
+                    legalDetailsNoticeViewController.present(on: self)
+                }
             }
         )
     }


### PR DESCRIPTION
## Summary

^ the tap on the "Terms and Privacy Policy" was broken before this

## Testing

https://github.com/stripe/stripe-ios/assets/105514761/8ba7eef8-5f21-4732-a3cc-71b786a2be66
