### PR TITLE
Fix rotating brand view animation

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/RotatingCardBrandsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/RotatingCardBrandsView.swift
@@ -180,7 +180,6 @@ class RotatingCardBrandsView: UIView {
                 imageView.contentMode = .scaleAspectFit
                 imageView.setContentHuggingPriority(.required, for: .horizontal)
                 imageView.image = STPImageLibrary.cardBrandImage(for: brand)
-//                imageView.translatesAutoresizingMaskIntoConstraints = false
                 return imageView
             }) + [rotatingCardBrandView]
             rotatingCardBrands = Array(cardBrands.suffix(from: min(cardBrands.count, Self.MaxStaticBrands)))


### PR DESCRIPTION
## Summary
I don't think `UIView.transition` was intended to be used within a UIViewPropertyAnimator. We'll recreate this transition on our own by cross-fading between two UIImageViews.

## Motivation
Inexplicably, this animation was breaking the background transition animation from Apple Pay to PaymentSheet when presenting as a `.formSheet` on iPad.

## Testing
Manually in iPad simulator, existing CI snapshot tests.