### PR TITLE
Financial Connections: for v3, more various polish/fixes

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionSearchBar.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionSearchBar.swift
@@ -66,6 +66,10 @@ final class InstitutionSearchBar: UIView {
             for: .editingChanged
         )
         textField.accessibilityIdentifier = "search_bar_text_field"
+        textField.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            textField.heightAnchor.constraint(greaterThanOrEqualToConstant: 24)
+        ])
         return textField
     }()
     private lazy var textFieldClearButton: UIButton = {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionTableViewCell.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionTableViewCell.swift
@@ -41,6 +41,7 @@ final class InstitutionTableViewCell: UITableViewCell {
 
     private func adjustBackgroundColor(isHighlighted: Bool) {
         contentView.backgroundColor = isHighlighted ? .backgroundContainer : .customBackgroundColor
+        backgroundColor = contentView.backgroundColor
 
         // fix a bug where the background color of a
         // rotated, selected cell was wrong

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PrepaneViews.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PrepaneViews.swift
@@ -118,12 +118,21 @@ final class PrepaneViews {
 private func CreateContentView(
     prepaneBodyModel: FinancialConnectionsOAuthPrepane.OauthPrepaneBody,
     didSelectURL: @escaping (URL) -> Void
-) -> UIView {
+) -> UIView? {
+    guard
+        let entries = prepaneBodyModel.entries,
+        !entries.isEmpty
+    else {
+        // returning an empty `UIStackView` added unnecessary
+        // padding, so returning `nil` removes the extra padding
+        return nil
+    }
+
     let verticalStackView = UIStackView()
     verticalStackView.spacing = 22
     verticalStackView.axis = .vertical
 
-    prepaneBodyModel.entries?.forEach { entry in
+    entries.forEach { entry in
         switch entry.content {
         case .text(let text):
             let label = AttributedTextView(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/SheetViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/SheetViewController.swift
@@ -132,13 +132,15 @@ class SheetViewController: UIViewController {
         super.viewDidLayoutSubviews()
 
         if panePresentationStyle == .sheet {
-            let isLandscape = UIDevice.current.orientation.isLandscape
+            // Note that using `UIDevice.current.orientation.isLandscape`
+            // performed worse (/ was buggy) when testing on device
+            let isLandscapePhone = UIDevice.current.userInterfaceIdiom == .phone && (UIScreen.main.bounds.size.width > UIScreen.main.bounds.size.height)
             var contentViewMinY = view.window?.safeAreaInsets.top ?? 0
             // estimated iOS value of how far default sheet
             // stretches beyond safeAreaInset.top
-            contentViewMinY += isLandscape ? 0 : 10
+            contentViewMinY += isLandscapePhone ? 0 : 10
             contentViewMinY += UINavigationController().navigationBar.bounds.height
-            contentViewMinY += isLandscape ? 0 : 24
+            contentViewMinY += isLandscapePhone ? 0 : 24
             let didChangeContentViewMinY = (self.contentViewMinY != contentViewMinY)
             self.contentViewMinY = contentViewMinY
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/SheetViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/SheetViewController.swift
@@ -409,8 +409,8 @@ private func CreateCustomSheetHandleView() -> UIView {
     ])
 
     let handleView = UIView()
-    handleView.backgroundColor = UIColor.textDisabled
-    handleView.layer.cornerRadius = 4
+    handleView.backgroundColor = UIColor.neutral200
+    handleView.layer.cornerRadius = 2
     containerView.addSubview(handleView)
     handleView.translatesAutoresizingMaskIntoConstraints = false
     NSLayoutConstraint.activate([


### PR DESCRIPTION
## Summary

- fixed an issue where device sheet orientation layout was buggy.
- fixed institution cell background color.
- increased search bar text field height.
- changed the sheet handle/knob color and radius.
- removed unnecessary prepane padding.

## Testing

### Prepane Padding

| Before | After |
| --- | --- |
| ![prepane-padding-before](https://github.com/stripe/stripe-ios/assets/105514761/12550b6a-4664-4a05-bb03-565cdf4f148f) | ![prepane-padding-after](https://github.com/stripe/stripe-ios/assets/105514761/f36e4e01-ce98-4e93-98bb-e55d3a0eceac) |

### Kob color / radius

| Before | After |
| --- | --- |
| ![sheet-knob-before](https://github.com/stripe/stripe-ios/assets/105514761/08adc080-a4c2-4be2-8f9e-9614d12e1f56) | ![sheet-knob-after](https://github.com/stripe/stripe-ios/assets/105514761/f5282986-3f3e-43fb-a0f9-29882781bff8) |

### Search Bar Height

| Before | After |
| --- | --- |
| ![before-search-bar-height](https://github.com/stripe/stripe-ios/assets/105514761/e622bc29-b8ff-403b-8553-0e8f48293da7) | ![after-search-bar-height](https://github.com/stripe/stripe-ios/assets/105514761/88a325ed-a6ff-49e9-9dd5-ff101970748a) |

### Landscape Background Colors

| Before | After |
| --- | --- |
| ![before-background-color](https://github.com/stripe/stripe-ios/assets/105514761/323006c7-4ef5-4eb5-bbf0-df471ef251fb) | ![after-background-color](https://github.com/stripe/stripe-ios/assets/105514761/e1649850-dd7c-4f62-8de5-527732820616) |


