### PR TITLE
Financial Connections: for v3, improved partner auth app to app state transitions

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PrepaneViews.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PrepaneViews.swift
@@ -26,7 +26,6 @@ final class PrepaneViews {
     }()
     private let headerView: UIView
     private let bodyView: UIView
-    private var loadingView: UIView?
     private var primaryButton: StripeUICore.Button?
     private var secondaryButton: StripeUICore.Button?
     let footerView: UIView?

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Web/ContinueStateView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Web/ContinueStateView.swift
@@ -11,10 +11,17 @@ import UIKit
 
 final class ContinueStateViews {
 
-    private init() {}
+    let contentView: UIView
+    private var primaryButton: StripeUICore.Button?
+    private var secondaryButton: StripeUICore.Button?
+    let footerView: UIView?
 
-    static func createContentView(institutionImageUrl: String?) -> UIView {
-        return PaneLayoutView.createContentView(
+    init(
+        institutionImageUrl: String?,
+        didSelectContinue: @escaping () -> Void,
+        didSelectCancel: (() -> Void)? = nil
+    ) {
+        self.contentView = PaneLayoutView.createContentView(
             iconView: {
                 if let institutionImageUrl {
                     let institutionIconView = InstitutionIconView()
@@ -34,13 +41,7 @@ final class ContinueStateViews {
             ),
             contentView: nil
         )
-    }
-
-    static func createFooterView(
-        didSelectContinue: @escaping () -> Void,
-        didSelectCancel: (() -> Void)? = nil
-    ) -> UIView? {
-        return PaneLayoutView.createFooterView(
+        let footerViewTuple = PaneLayoutView.createFooterView(
             primaryButtonConfiguration: PaneLayoutView.ButtonConfiguration(
                 title: "Continue", // TODO: when Financial Connections starts supporting localization, change this to `String.Localized.continue`,
                 action: didSelectContinue
@@ -55,6 +56,14 @@ final class ContinueStateViews {
                     return nil
                 }
             }()
-        ).footerView
+        )
+        self.footerView = footerViewTuple.footerView
+        self.primaryButton = footerViewTuple.primaryButton
+        self.secondaryButton = footerViewTuple.secondaryButton
+    }
+
+    func showLoadingView(_ show: Bool) {
+        primaryButton?.isLoading = show
+        secondaryButton?.isEnabled = !show
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsWebFlowViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsWebFlowViewController.swift
@@ -35,20 +35,21 @@ final class FinancialConnectionsWebFlowViewController: UIViewController {
     // MARK: - Waiting state view
 
     private lazy var continueStateView: UIView = {
-        return PaneLayoutView(
-            contentView: ContinueStateViews.createContentView(
-                institutionImageUrl: nil
-            ),
-            footerView: ContinueStateViews.createFooterView(
-                didSelectContinue: { [weak self] in
-                    guard let self else { return }
-                    if let url = self.lastOpenedNativeURL {
-                        self.redirect(to: url)
-                    } else {
-                        self.startAuthenticationSession(manifest: manifest)
-                    }
+        let continueStateViews = ContinueStateViews(
+            institutionImageUrl: nil,
+            didSelectContinue: { [weak self] in
+                guard let self else { return }
+                if let url = self.lastOpenedNativeURL {
+                    self.redirect(to: url)
+                } else {
+                    self.startAuthenticationSession(manifest: manifest)
                 }
-            )
+            },
+            didSelectCancel: nil
+        )
+        return PaneLayoutView(
+            contentView: continueStateViews.contentView,
+            footerView: continueStateViews.footerView
         ).createView()
     }()
 


### PR DESCRIPTION
## Summary

This smoothens/improves various UI loading states around app to app flow. In very simple terms, it improves loading states to appear in more places. 

## Testing

I tested web too, but the videos show Native as that's where core logic changes happened.

Below you can see some videos of success state and cancel state.

https://github.com/stripe/stripe-ios/assets/105514761/f9453580-db9c-4698-ab77-8f74a4854327

https://github.com/stripe/stripe-ios/assets/105514761/af052a23-ca18-4713-b7ca-6d55eb1df1a7
