### PR TITLE
Financial Connections: for v3 added primary button shadows

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerFooterView.swift
@@ -15,7 +15,7 @@ final class AccountPickerFooterView: UIView {
     private let didSelectLinkAccounts: () -> Void
 
     private lazy var linkAccountsButton: Button = {
-        let linkAccountsButton = Button(configuration: .financialConnectionsPrimary)
+        let linkAccountsButton = Button.primary()
         linkAccountsButton.addTarget(self, action: #selector(didSelectLinkAccountsButton), for: .touchUpInside)
         linkAccountsButton.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentFooterView.swift
@@ -16,7 +16,7 @@ class ConsentFooterView: HitTestView {
     private let didSelectAgree: () -> Void
 
     private lazy var agreeButton: StripeUICore.Button = {
-        let agreeButton = Button(configuration: .financialConnectionsPrimary)
+        let agreeButton = Button.primary()
         agreeButton.title = agreeButtonText
         agreeButton.addTarget(self, action: #selector(didSelectAgreeButton), for: .touchUpInside)
         agreeButton.translatesAutoresizingMaskIntoConstraints = false

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerFooterView.swift
@@ -16,7 +16,7 @@ final class LinkAccountPickerFooterView: UIView {
     private let didSelectConnectAccount: () -> Void
 
     private lazy var connectAccountButton: Button = {
-        let connectAccountButton = Button(configuration: .financialConnectionsPrimary)
+        let connectAccountButton = Button.primary()
         connectAccountButton.title = defaultCta
         connectAccountButton.isEnabled = false // disable by default
         connectAccountButton.addTarget(self, action: #selector(didSelectLinkAccountsButton), for: .touchUpInside)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/ManualEntry/ManualEntryFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/ManualEntry/ManualEntryFooterView.swift
@@ -14,7 +14,7 @@ final class ManualEntryFooterView: UIView {
     private let didSelectContinue: () -> Void
 
     private(set) lazy var continueButton: Button = {
-        let continueButton = Button(configuration: .financialConnectionsPrimary)
+        let continueButton = Button.primary()
         continueButton.title = "Submit"  // TODO(kgaidis): localize
         continueButton.addTarget(self, action: #selector(didSelectContinueButton), for: .touchUpInside)
         continueButton.translatesAutoresizingMaskIntoConstraints = false

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupFooterView.swift
@@ -60,7 +60,7 @@ class NetworkingLinkSignupFooterView: HitTestView {
     }()
 
     private lazy var saveToLinkButton: StripeUICore.Button = {
-        let saveToLinkButton = Button(configuration: .financialConnectionsPrimary)
+        let saveToLinkButton = Button.primary()
         saveToLinkButton.title = saveToLinkButtonText
         saveToLinkButton.addTarget(self, action: #selector(didSelectSaveToLinkButton), for: .touchUpInside)
         saveToLinkButton.translatesAutoresizingMaskIntoConstraints = false

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/AccountPickerRowView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/AccountPickerRowView.swift
@@ -26,8 +26,8 @@ final class AccountPickerRowView: UIView {
                     transform: nil
                 )
                 layer.shadowColor = UIColor.black.cgColor
-                layer.shadowRadius = 0.5
-                layer.shadowOpacity = 0.17
+                layer.shadowRadius = 1.5 / UIScreen.main.nativeScale
+                layer.shadowOpacity = 0.23
                 layer.shadowOffset = CGSize(
                     width: 0,
                     height: 1 / UIScreen.main.nativeScale

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/Button+Extensions.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/Button+Extensions.swift
@@ -7,12 +7,7 @@
 
 import Foundation
 @_spi(STP) import StripeUICore
-
-// Fixes a SwiftUI preview bug where previews will crash
-// if `.financialConnectionsPrimary` is directly referenced
-func FinancialConnectionsPrimaryButtonConfiguration() -> Button.Configuration {
-    return .financialConnectionsPrimary
-}
+import UIKit
 
 // Fixes a SwiftUI preview bug where previews will crash
 // if `.financialConnectionsPrimary` is directly referenced
@@ -20,8 +15,23 @@ func FinancialConnectionsSecondaryButtonConfiguration() -> Button.Configuration 
     return .financialConnectionsSecondary
 }
 
+extension Button {
+    static func primary() -> StripeUICore.Button {
+        let button = Button(configuration: .financialConnectionsPrimary)
+        button.layer.shadowColor = UIColor.black.cgColor
+        button.layer.shadowRadius = 1.5 / UIScreen.main.nativeScale
+        button.layer.shadowOpacity = 0.23
+        button.layer.shadowOffset = CGSize(
+            width: 0,
+            height: 1 / UIScreen.main.nativeScale
+        )
+        return button
+    }
+}
+
 extension Button.Configuration {
-    static var financialConnectionsPrimary: Button.Configuration {
+
+    fileprivate static var financialConnectionsPrimary: Button.Configuration {
         var primaryButtonConfiguration = Button.Configuration.primary()
         primaryButtonConfiguration.font = FinancialConnectionsFont.label(.largeEmphasized).uiFont
         primaryButtonConfiguration.cornerRadius = 12.0

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/PaneLayoutView/PaneLayoutView+Extensions.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/PaneLayoutView/PaneLayoutView+Extensions.swift
@@ -177,7 +177,7 @@ extension PaneLayoutView {
 
         var primaryButtonReference: StripeUICore.Button?
         if let primaryButtonConfiguration = primaryButtonConfiguration {
-            let primaryButton = Button(configuration: FinancialConnectionsPrimaryButtonConfiguration())
+            let primaryButton = Button.primary()
             primaryButtonReference = primaryButton
             primaryButton.title = primaryButtonConfiguration.title
             primaryButton.accessibilityIdentifier = primaryButtonConfiguration.accessibilityIdentifier

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Success/SuccessFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Success/SuccessFooterView.swift
@@ -15,7 +15,7 @@ final class SuccessFooterView: UIView {
     private let didSelectDone: (SuccessFooterView) -> Void
 
     private lazy var doneButton: Button = {
-        let doneButton = Button(configuration: .financialConnectionsPrimary)
+        let doneButton = Button.primary()
         doneButton.title = "Done"  // TODO: replace with UIButton.doneButtonTitle once the SDK is localized
         doneButton.addTarget(self, action: #selector(didSelectDoneButton), for: .touchUpInside)
         doneButton.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
## Summary

^ added shadow to primary button

## Testing

subtle, but its there 😅 

| Before | After |
| --- | --- |
| ![before-cell-shadow](https://github.com/stripe/stripe-ios/assets/105514761/be5fbb61-52a6-4431-aebb-28fd8798bd1a) | ![after-cell-shadow](https://github.com/stripe/stripe-ios/assets/105514761/e610a130-2b30-4c9a-966c-d1d03beeab20) |
