### PR TITLE
Apply fixes to commit scripts for latest tart/packer version

### DIFF
--- a/ci_scripts/pod_tools.rb
+++ b/ci_scripts/pod_tools.rb
@@ -60,15 +60,13 @@ def capture_retrying(cmd, max_retries: 10)
   retries = 0
   loop do
     stdout, stderr, status = Open3.capture3(cmd)
-    if !status.success? && retries <= max_retries
-      retries += 1
-      delay = [2**retries, 32].min
-      puts "Something went wrong. Trying again in #{delay} seconds..."
-      sleep(delay)
-      puts 'Retrying...'
-    else
-      return stdout, stderr, status
-    end
+    return stdout, stderr, status unless !status.success? && retries <= max_retries
+
+    retries += 1
+    delay = [2**retries, 32].min
+    puts "Something went wrong. Trying again in #{delay} seconds..."
+    sleep(delay)
+    puts 'Retrying...'
   end
 end
 
@@ -79,7 +77,7 @@ def push_retrying(podspec, expected_pod_version, max_retries: 10)
       puts "No need to push: #{podspec}.  Latest version is already #{expected_pod_version}"
       return true
     end
-    system("pod trunk push #{podspec} --synchronous")
+    system("pod trunk push #{podspec} --synchronous --allow-warnings")
     success = $?.success?
     return success unless !success && retries <= max_retries
 


### PR DESCRIPTION
## Summary
* Allow Cocoapods warnings, as Xcode 15 has a non-suppressable warning when building our combined Objective-C/Swift target: `WARN | [StripePayments/Stripe3DS2] xcodebuild: /var/folders/ff/_zpjygb51v7_f4nj9zqdkm640000gn/T/CocoaPods-Lint-20231128-51573-vz9cuq-StripePayments/App/main.m:4:9: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]`
* Use the correct `packer init` command
* Set `, config: false` in the SSH gem, as some laptops have a misconfigured .sshconfig and are pointing this request to github.com.
* Lint the scripts

## Motivation
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-2762

## Testing
During last deploy