### PR TITLE
Fix query param double encoding on iOS 17

### DIFF
--- a/StripeCore/StripeCore/Source/Helpers/URLEncoder.swift
+++ b/StripeCore/StripeCore/Source/Helpers/URLEncoder.swift
@@ -35,56 +35,10 @@ import Foundation
         return newString
     }
 
+    @objc(queryStringFromParameters:)
     public class func queryString(from parameters: [String: Any]) -> String {
         return query(parameters)
     }
-
-    public class func makeURL(withQueryParams params: [String: Any]) -> [URLQueryItem] {
-        return params.keys.sorted().flatMap {
-            urlQueryComponents(with: $0, value: params[$0] as Any)
-        }
-    }
-}
-
-/// Returns a
-/// - Parameter key:
-private func urlQueryComponents(with key: String, value: Any) -> [URLQueryItem] {
-    func unwrap<T>(_ any: T) -> Any {
-        let mirror = Mirror(reflecting: any)
-        guard mirror.displayStyle == .optional, let first = mirror.children.first else {
-            return any
-        }
-        return first.value
-    }
-
-    var components = [URLQueryItem]()
-    switch value {
-    case let dictionary as [String: Any]:
-        for nestedKey in dictionary.keys.sorted() {
-            let value = dictionary[nestedKey]!
-            components += urlQueryComponents(with: "\(key)[\(nestedKey)]", value: value)
-        }
-    case let array as [Any]:
-        for (index, value) in array.enumerated() {
-            components += urlQueryComponents(with: "\(key)[\(index)]", value: value)
-        }
-    case let number as NSNumber:
-        if number.isBool {
-            components.append(URLQueryItem(name: key, value: number.boolValue ? "true" : "false"))
-        } else {
-            components.append(URLQueryItem(name: key, value: "\(number)"))
-        }
-    case let bool as Bool:
-        components.append(URLQueryItem(name: key, value: bool ? "true" : "false"))
-    case let set as Set<AnyHashable>:
-        for value in Array(set) {
-            components += urlQueryComponents(with: "\(key)", value: value)
-        }
-    default:
-        let unwrappedValue = unwrap(value)
-        components.append(URLQueryItem(name: key, value: "\(unwrappedValue)"))
-    }
-    return components
 }
 
 // MARK: -
@@ -104,7 +58,7 @@ struct Key {
 ///   - value: Value of the query component.
 ///
 /// - Returns: The percent-escaped, URL encoded query string components.
-private func urlQueryComponents(fromKey key: String, value: Any) -> [(String, String)] {
+private func queryComponents(fromKey key: String, value: Any) -> [(String, String)] {
     func unwrap<T>(_ any: T) -> Any {
         let mirror = Mirror(reflecting: any)
         guard mirror.displayStyle == .optional, let first = mirror.children.first else {
@@ -119,11 +73,11 @@ private func urlQueryComponents(fromKey key: String, value: Any) -> [(String, St
         for nestedKey in dictionary.keys.sorted() {
             let value = dictionary[nestedKey]!
             let escapedNestedKey = escape(nestedKey)
-            components += urlQueryComponents(fromKey: "\(key)[\(escapedNestedKey)]", value: value)
+            components += queryComponents(fromKey: "\(key)[\(escapedNestedKey)]", value: value)
         }
     case let array as [Any]:
         for (index, value) in array.enumerated() {
-            components += urlQueryComponents(fromKey: "\(key)[\(index)]", value: value)
+            components += queryComponents(fromKey: "\(key)[\(index)]", value: value)
         }
     case let number as NSNumber:
         if number.isBool {
@@ -135,7 +89,7 @@ private func urlQueryComponents(fromKey key: String, value: Any) -> [(String, St
         components.append((key, escape(bool ? "true" : "false")))
     case let set as Set<AnyHashable>:
         for value in Array(set) {
-            components += urlQueryComponents(fromKey: "\(key)", value: value)
+            components += queryComponents(fromKey: "\(key)", value: value)
         }
     default:
         let unwrappedValue = unwrap(value)
@@ -158,7 +112,7 @@ private func query(_ parameters: [String: Any]) -> String {
 
     for key in parameters.keys.sorted(by: <) {
         let value = parameters[key]!
-        components += urlQueryComponents(fromKey: escape(key), value: value)
+        components += queryComponents(fromKey: escape(key), value: value)
     }
     return components.map { "\($0)=\($1)" }.joined(separator: "&")
 }

--- a/StripeCore/StripeCoreTests/Categories/NSMutableURLRequest+StripeTest.swift
+++ b/StripeCore/StripeCoreTests/Categories/NSMutableURLRequest+StripeTest.swift
@@ -33,4 +33,36 @@ class NSMutableURLRequest_StripeTest: XCTestCase {
 
         XCTAssertEqual(request?.url?.absoluteString, "https://example.com?a=b&foo=bar")
     }
+
+    func testAddParametersToURL_encodesSpecialCharacters() {
+        let baseURL = URL(string: "https://example.com")!
+        struct TestCase {
+            let parameters: [String: Any]
+            let expectedURL: String
+        }
+        // These test cases expected values were generated using SDK v23.22.0 pre-iOS 17.
+        // They don't comply with RFC 3986, but they are correct/expected in the sense that they've worked in practice when used w/ the Stripe API.
+        let testcases: [TestCase] = [
+            .init(parameters: ["~!@W#$%^&*()-=+[]{}/?\\": "~!@W#$%^&*()-=+[]{}/?\\"], expectedURL: "https://example.com?~%21%40W%23%24%25%5E%26%2A%28%29-%3D%2B%5B%5D%7B%7D/?%5C=~%21%40W%23%24%25%5E%26%2A%28%29-%3D%2B%5B%5D%7B%7D/?%5C"),
+            .init(parameters: ["name": "John Doe"], expectedURL: "https://example.com?name=John%20Doe"),
+            .init(parameters: ["bool_flag": true], expectedURL: "https://example.com?bool_flag=true"),
+            .init(parameters: ["return_url": "https://foo.com?src=bar"], expectedURL: "https://example.com?return_url=https%3A//foo.com?src%3Dbar"),
+            .init(parameters: [
+                "mpe_config": [
+                    "nested_list": ["A", "B", "C"],
+                    "appearance_config": [
+                        "toggle": true,
+                    ],
+                    "name": "John Doe",
+                    "return_url": "https://foo.com?src=bar",
+                ],
+            ], expectedURL: "https://example.com?mpe_config%5Bappearance_config%5D%5Btoggle%5D=true&mpe_config%5Bname%5D=John%20Doe&mpe_config%5Bnested_list%5D%5B0%5D=A&mpe_config%5Bnested_list%5D%5B1%5D=B&mpe_config%5Bnested_list%5D%5B2%5D=C&mpe_config%5Breturn_url%5D=https%3A//foo.com?src%3Dbar"),
+            .init(parameters: ["locale": "en-US"], expectedURL: "https://example.com?locale=en-US"),
+        ]
+        for testcase in testcases {
+            var request = URLRequest(url: baseURL)
+            request.stp_addParameters(toURL: testcase.parameters)
+            XCTAssertEqual(request.url?.absoluteString, testcase.expectedURL)
+        }
+    }
 }


### PR DESCRIPTION
## Summary
Uses `CFURLCreateWithString` instead of `URL(string:)` because the latter [changed its implementation ](https://developer.apple.com/documentation/foundation/url/3126806-init)in iOS 17 to automatically encode the string according to RFC 3986, which ends up double encoding certain characters. More details in comments of https://jira.corp.stripe.com/browse/MOBILESDK-1335. 

## Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-1658
https://jira.corp.stripe.com/browse/MOBILESDK-1335

## Testing
Ran NSMutableURLRequest+StripeTest on iOS 14, 15, 16, 17

## Changelog
Not user facing.