### PR TITLE
Financial Connections: fixed end to end tests for V3

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnections Example.xcodeproj/project.pbxproj
+++ b/Example/FinancialConnections Example/FinancialConnections Example.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		5AA50D95EC1C2489AD98071E /* PlaygroundMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B379D3A9F9EA11716D5AEB3 /* PlaygroundMainView.swift */; };
 		5B38135D1C37FC1812F4203A /* StripeUICore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ADFEE494187576194F8B46BB /* StripeUICore.framework */; };
 		5C1B372D1660E856988156DA /* StripeUICore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = ADFEE494187576194F8B46BB /* StripeUICore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		6AC6B40D2B880EEA000A4B32 /* XCTestCase+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC6B40C2B880EEA000A4B32 /* XCTestCase+Extensions.swift */; };
 		6AF9C66D47F81DD9B103FB64 /* StripeCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 03E7365D673694C8D7EDFB20 /* StripeCore.framework */; };
 		828A3C3A555F9B2ABAEF3E95 /* WebViewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65FBE9DBF6CBB07AE2D5B1DA /* WebViewViewController.swift */; };
 		82D499E3F32FB4663D26EBA6 /* XCUIElement+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01EFB9C0699FEB532FFE57D9 /* XCUIElement+Extensions.swift */; };
@@ -94,6 +95,7 @@
 		5B675DEF4776CDFF8309DEB8 /* Project-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Project-Debug.xcconfig"; sourceTree = "<group>"; };
 		5C02DB1648E15A6591FD56E1 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		65FBE9DBF6CBB07AE2D5B1DA /* WebViewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewViewController.swift; sourceTree = "<group>"; };
+		6AC6B40C2B880EEA000A4B32 /* XCTestCase+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Extensions.swift"; sourceTree = "<group>"; };
 		701003016E153D5DF2B00442 /* FinancialConnections-Example-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "FinancialConnections-Example-Debug.xcconfig"; sourceTree = "<group>"; };
 		74959BBB33DB4A570E2B4FD3 /* FinancialConnectionsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsUITests.swift; sourceTree = "<group>"; };
 		76B43732FE4180268DAA8355 /* FinancialConnectionsExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FinancialConnectionsExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -228,6 +230,7 @@
 				834A69D9D7EB90A1319B26F1 /* Info.plist */,
 				E43F3C346DE28D65F7575D58 /* XCUIApplication+Extensions.swift */,
 				01EFB9C0699FEB532FFE57D9 /* XCUIElement+Extensions.swift */,
+				6AC6B40C2B880EEA000A4B32 /* XCTestCase+Extensions.swift */,
 			);
 			path = FinancialConnectionsUITests;
 			sourceTree = "<group>";
@@ -362,6 +365,7 @@
 			files = (
 				E180626EEE466989BE92D5B7 /* FinancialConnectionsNetworkingUITests.swift in Sources */,
 				DE4B6A7CCEBD39684733A892 /* FinancialConnectionsUITests.swift in Sources */,
+				6AC6B40D2B880EEA000A4B32 /* XCTestCase+Extensions.swift in Sources */,
 				09B82E32FC066FC442BD945D /* XCUIApplication+Extensions.swift in Sources */,
 				82D499E3F32FB4663D26EBA6 /* XCUIElement+Extensions.swift in Sources */,
 			);

--- a/Example/FinancialConnections Example/FinancialConnections Example/AppDelegate.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/AppDelegate.swift
@@ -17,7 +17,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
-        // Override point for customization after application launch.
+#if targetEnvironment(simulator)
+        if ProcessInfo.processInfo.environment["UITesting"] != nil {
+            // disable animations for UI tests which makes them a lot faster
+            UIView.setAnimationsEnabled(false)
+        }
+#endif
         return true
     }
 

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
@@ -60,7 +60,7 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         app.fc_playgroundShowAuthFlowButton.tap()
         app.fc_nativeConsentAgreeButton.tap()
 
-        let featuredLegacyTestInstitution = app.collectionViews.staticTexts["Test OAuth Institution"]
+        let featuredLegacyTestInstitution = app.tables.cells.staticTexts["Test OAuth Institution"]
         XCTAssertTrue(featuredLegacyTestInstitution.waitForExistence(timeout: 60.0))
         featuredLegacyTestInstitution.tap()
 
@@ -72,12 +72,12 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
 
         app.fc_nativeAccountPickerLinkAccountsButton.tap()
 
-        let emailTextField = app.textFields["Email"]
+        let emailTextField = app.textFields["email_text_field"]
         XCTAssertTrue(emailTextField.waitForExistence(timeout: 120.0))  // wait for synchronize to complete
         emailTextField.tap()
         emailTextField.typeText(emailAddress)
 
-        let phoneTextField = app.textFields["Phone number"]
+        let phoneTextField = app.textFields["phone_text_field"]
         XCTAssertTrue(phoneTextField.waitForExistence(timeout: 120.0))  // wait for lookup to complete
         phoneTextField.tap()
         phoneTextField.typeText("4015006000")
@@ -134,9 +134,9 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         app.fc_playgroundShowAuthFlowButton.tap()
         app.fc_nativeConsentAgreeButton.tap()
 
-        let continueWithEmailButton = app.scrollViews.otherElements.staticTexts[emailAddress]
-        XCTAssertTrue(continueWithEmailButton.waitForExistence(timeout: 60.0))
-        continueWithEmailButton.tap()
+        let linkContinueButton = app.buttons["link_continue_button"]
+        XCTAssertTrue(linkContinueButton.waitForExistence(timeout: 60.0))
+        linkContinueButton.tap()
 
         let verificationOTPTextView = app.scrollViews.otherElements.textViews["Code field"]
         XCTAssertTrue(verificationOTPTextView.waitForExistence(timeout: 60.0))
@@ -168,22 +168,5 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
             app.fc_playgroundSuccessAlertView.staticTexts.containing(NSPredicate(format: "label CONTAINS 'StripeBank'")).firstMatch
                 .exists
         )
-    }
-}
-
-extension XCTestCase {
-
-    fileprivate func clear(textField: XCUIElement) {
-        wait(timeout: 1.5) // wait for keyboard to appear, otherwise `textField.coordinate` may select the wrong spot
-        while
-            let text = textField.value as? String,
-            !text.isEmpty,
-            text != textField.placeholderValue
-        {
-            let middleCoordinate = textField.coordinate(withNormalizedOffset: CGVector(dx: 0.50, dy: 0.50))
-            middleCoordinate.tap()
-            let deleteString = String(repeating: XCUIKeyboardKey.delete.rawValue, count: text.count)
-            textField.typeText(deleteString)
-        }
     }
 }

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
@@ -38,7 +38,7 @@ final class FinancialConnectionsUITests: XCTestCase {
         app.fc_playgroundShowAuthFlowButton.tap()
         app.fc_nativeConsentAgreeButton.tap()
 
-        let featuredLegacyTestInstitution = app.collectionViews.staticTexts["Test OAuth Institution"]
+        let featuredLegacyTestInstitution = app.tables.cells.staticTexts["Test OAuth Institution"]
         XCTAssertTrue(featuredLegacyTestInstitution.waitForExistence(timeout: 60.0))
         featuredLegacyTestInstitution.tap()
 
@@ -66,7 +66,7 @@ final class FinancialConnectionsUITests: XCTestCase {
         app.fc_playgroundShowAuthFlowButton.tap()
         app.fc_nativeConsentAgreeButton.tap()
 
-        let featuredLegacyTestInstitution = app.collectionViews.staticTexts["Test Institution"]
+        let featuredLegacyTestInstitution = app.tables.cells.staticTexts["Test Institution"]
         XCTAssertTrue(featuredLegacyTestInstitution.waitForExistence(timeout: 60.0))
         featuredLegacyTestInstitution.tap()
 
@@ -96,7 +96,10 @@ final class FinancialConnectionsUITests: XCTestCase {
 
         app.fc_playgroundShowAuthFlowButton.tap()
 
-        let manuallyVerifyLabel = app.otherElements["consent_manually_verify_label"]
+        let manuallyVerifyLabel = app
+            .otherElements["consent_manually_verify_label"]
+            .links
+            .firstMatch
         XCTAssertTrue(manuallyVerifyLabel.waitForExistence(timeout: 120.0))
         manuallyVerifyLabel.tap()
 
@@ -125,9 +128,7 @@ final class FinancialConnectionsUITests: XCTestCase {
         XCTAssertTrue(manualEntryContinueButton.waitForExistence(timeout: 120.0))
         manualEntryContinueButton.tap()
 
-        let manualEntrySuccessDoneButton = app.buttons["manual_entry_success_done_button"]
-        XCTAssertTrue(manualEntrySuccessDoneButton.waitForExistence(timeout: 120.0))
-        manualEntrySuccessDoneButton.tap()
+        app.fc_nativeSuccessDoneButton.tap()
 
         XCTAssert(app.fc_playgroundSuccessAlertView.exists)
     }
@@ -152,19 +153,19 @@ final class FinancialConnectionsUITests: XCTestCase {
         let institutionButton: XCUIElement?
         let institutionName: String?
         let chaseBankName = "Chase"
-        let chaseInstitutionButton = app.cells[chaseBankName]
+        let chaseInstitutionButton = app.tables.staticTexts[chaseBankName]
         if chaseInstitutionButton.waitForExistence(timeout: 10) {
             institutionButton = chaseInstitutionButton
             institutionName = chaseBankName
         } else {
             let bankOfAmericaBankName = "Bank of America"
-            let bankOfAmericaInstitutionButton = app.cells[bankOfAmericaBankName]
+            let bankOfAmericaInstitutionButton = app.tables.staticTexts[bankOfAmericaBankName]
             if bankOfAmericaInstitutionButton.waitForExistence(timeout: 10) {
                 institutionButton = bankOfAmericaInstitutionButton
                 institutionName = bankOfAmericaBankName
             } else {
                 let wellsFargoBankName = "Wells Fargo"
-                let wellsFargoInstitutionButton = app.cells[wellsFargoBankName]
+                let wellsFargoInstitutionButton = app.tables.staticTexts[wellsFargoBankName]
                 if wellsFargoInstitutionButton.waitForExistence(timeout: 10) {
                     institutionButton = wellsFargoInstitutionButton
                     institutionName = wellsFargoBankName
@@ -200,9 +201,9 @@ final class FinancialConnectionsUITests: XCTestCase {
                 .firstMatch
             XCTAssertTrue(institutionWebViewText.waitForExistence(timeout: 120.0))
 
-            let secureWebViewCancelButton = app.buttons["Cancel"]
-            XCTAssertTrue(secureWebViewCancelButton.waitForExistence(timeout: 60.0))
-            secureWebViewCancelButton.tap()
+            app.fc_secureWebViewCancelButton.tap()
+
+            app.fc_nativePrepaneCancelButton.tap()
         }
         // (2) bank IS under maintenance
         else {
@@ -218,12 +219,9 @@ final class FinancialConnectionsUITests: XCTestCase {
         XCTAssertTrue(navigationBarCloseButton.waitForExistence(timeout: 60.0))
         navigationBarCloseButton.tap()
 
-        let cancelAlert = app.alerts["Are you sure you want to cancel?"]
-        XCTAssertTrue(cancelAlert.waitForExistence(timeout: 60.0))
-
-        let cancelAlertButon = app.alerts.buttons["Yes, cancel"]
-        XCTAssertTrue(cancelAlertButon.waitForExistence(timeout: 60.0))
-        cancelAlertButon.tap()
+        let exitConfirmationOKButton = app.buttons["close_confirmation_ok"]
+        XCTAssertTrue(exitConfirmationOKButton.waitForExistence(timeout: 5))
+        exitConfirmationOKButton.tap()
 
         let playgroundCancelAlert = app.alerts["Cancelled"]
         XCTAssertTrue(playgroundCancelAlert.waitForExistence(timeout: 60.0))
@@ -257,27 +255,26 @@ final class FinancialConnectionsUITests: XCTestCase {
         // they don't get featured
         let institutionButton: XCUIElement?
         let institutionName: String?
-        let chaseBankName = "Chase"
-        let chaseInstitutionButton = app.webViews.buttons[chaseBankName]
-        if chaseInstitutionButton.waitForExistence(timeout: 10) {
-            institutionButton = chaseInstitutionButton
-            institutionName = chaseBankName
+        let capitalOneBankName = "Capital One"
+        let capitalOneInstitutionButton = app.webViews
+            .buttons
+            .containing(NSPredicate(format: "label CONTAINS '\(capitalOneBankName)'"))
+            .firstMatch
+        if capitalOneInstitutionButton.waitForExistence(timeout: 10) {
+            institutionButton = capitalOneInstitutionButton
+            institutionName = capitalOneBankName
         } else {
-            let bankOfAmericaBankName = "Bank of America"
-            let bankOfAmericaInstitutionButton = app.webViews.buttons[bankOfAmericaBankName]
-            if bankOfAmericaInstitutionButton.waitForExistence(timeout: 10) {
-                institutionButton = bankOfAmericaInstitutionButton
-                institutionName = bankOfAmericaBankName
+            let wellsFargoBankName = "Wells Fargo"
+            let wellsFargoInstitutionButton = app.webViews
+                .buttons
+                .containing(NSPredicate(format: "label CONTAINS '\(wellsFargoBankName)'"))
+                .firstMatch
+            if wellsFargoInstitutionButton.waitForExistence(timeout: 10) {
+                institutionButton = wellsFargoInstitutionButton
+                institutionName = wellsFargoBankName
             } else {
-                let wellsFargoBankName = "Wells Fargo"
-                let wellsFargoInstitutionButton = app.webViews.buttons[wellsFargoBankName]
-                if wellsFargoInstitutionButton.waitForExistence(timeout: 10) {
-                    institutionButton = wellsFargoInstitutionButton
-                    institutionName = wellsFargoBankName
-                } else {
-                    institutionButton = nil
-                    institutionName = nil
-                }
+                institutionButton = nil
+                institutionName = nil
             }
         }
         guard let institutionButton = institutionButton, let institutionName = institutionName else {
@@ -301,9 +298,9 @@ final class FinancialConnectionsUITests: XCTestCase {
 
             // check that the WebView loaded
             var predicateString = "label CONTAINS '\(institutionName)'"
-            if institutionName == "Chase" {
-                // Chase does not contain the word "Chase" on their log-in page
-                predicateString = "label CONTAINS 'username' OR label CONTAINS 'password'"
+            if institutionName == capitalOneBankName {
+                // Capital One does not contain the word "Capital One" on their log-in page
+                predicateString = "label CONTAINS 'Username' OR label CONTAINS 'Password'"
             }
             let institutionWebViewText = app.webViews
                 .staticTexts
@@ -321,9 +318,7 @@ final class FinancialConnectionsUITests: XCTestCase {
             XCTAssertTrue(errorViewText.waitForExistence(timeout: 10))
         }
 
-        let secureWebViewCancelButton = app.buttons["Cancel"]
-        XCTAssertTrue(secureWebViewCancelButton.waitForExistence(timeout: 60.0))
-        secureWebViewCancelButton.tap()
+        app.fc_secureWebViewCancelButton.tap()
 
         let playgroundCancelAlert = app.alerts["Cancelled"]
         XCTAssertTrue(playgroundCancelAlert.waitForExistence(timeout: 60.0))
@@ -357,7 +352,23 @@ final class FinancialConnectionsUITests: XCTestCase {
 
         // (1) bank is NOT under maintenance
         if app.fc_nativePrepaneContinueButton_noWait.waitForExistence(timeout: 60) {
-            // do nothing...prepane is there
+            // close prepane
+            app.fc_nativePrepaneCancelButton.tap()
+
+            searchBarTextField.tap()
+            clear(textField: searchBarTextField)
+            searchBarTextField.typeText("testing123")
+
+            let institutionSearchNoResultsSubtitle = app
+                .otherElements["institution_search_no_results_subtitle"]
+                .links
+                .firstMatch
+            XCTAssertTrue(institutionSearchNoResultsSubtitle.waitForExistence(timeout: 120.0))
+            institutionSearchNoResultsSubtitle.tap()
+
+            // check that manual entry screen is opened
+            let manualEntryContinueButton = app.buttons["manual_entry_continue_button"]
+            XCTAssertTrue(manualEntryContinueButton.waitForExistence(timeout: 60.0))
         }
         // (2) bank IS under maintenance
         else {
@@ -367,22 +378,9 @@ final class FinancialConnectionsUITests: XCTestCase {
                 .containing(NSPredicate(format: "label CONTAINS 'unavailable' OR label CONTAINS 'maintenance' OR label CONTAINS 'scheduled'"))
                 .firstMatch
             XCTAssertTrue(errorViewText.waitForExistence(timeout: 10))
+
+            // 'cancel' the test as the bank is under the maintenance
         }
-
-        let backButton = app.navigationBars["fc_navigation_bar"].buttons["Back"]
-        XCTAssertTrue(backButton.waitForExistence(timeout: 60.0))
-        backButton.tap()
-
-        searchBarTextField.tap()
-        searchBarTextField.typeText("testing123")
-
-        let institutionSearchFooterView = app.otherElements["institution_search_footer_view"]
-        XCTAssertTrue(institutionSearchFooterView.waitForExistence(timeout: 120.0))
-        institutionSearchFooterView.tap()
-
-        // check that manual entry screen is opened
-        let manualEntryContinueButton = app.buttons["manual_entry_continue_button"]
-        XCTAssertTrue(manualEntryContinueButton.waitForExistence(timeout: 60.0))
     }
 }
 

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/XCTestCase+Extensions.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/XCTestCase+Extensions.swift
@@ -1,0 +1,26 @@
+//
+//  XCTestCase+Extensions.swift
+//  FinancialConnectionsUITests
+//
+//  Created by Krisjanis Gaidis on 2/22/24.
+//
+
+import Foundation
+import XCTest
+
+extension XCTestCase {
+
+    func clear(textField: XCUIElement) {
+        wait(timeout: 1.5) // wait for keyboard to appear, otherwise `textField.coordinate` may select the wrong spot
+        while
+            let text = textField.value as? String,
+            !text.isEmpty,
+            text != textField.placeholderValue
+        {
+            let middleCoordinate = textField.coordinate(withNormalizedOffset: CGVector(dx: 0.50, dy: 0.50))
+            middleCoordinate.tap()
+            let deleteString = String(repeating: XCUIKeyboardKey.delete.rawValue, count: text.count)
+            textField.typeText(deleteString)
+        }
+    }
+}

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIApplication+Extensions.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIApplication+Extensions.swift
@@ -80,6 +80,12 @@ extension XCUIApplication {
         return prepaneContinueButton
     }
 
+    var fc_nativePrepaneCancelButton: XCUIElement {
+        let prepaneCancelButton = buttons["prepane_cancel_button"]
+        XCTAssertTrue(prepaneCancelButton.waitForExistence(timeout: 5), "Failed to press/open Partner Auth Prepane cancel button - \(#function) waiting failed")
+        return prepaneCancelButton
+    }
+
     var fc_nativeAccountPickerLinkAccountsButton: XCUIElement {
         let accountPickerLinkAccountsButton = buttons["account_picker_link_accounts_button"]
         XCTAssertTrue(accountPickerLinkAccountsButton.waitForExistence(timeout: 120.0), "Failed to open Account Picker pane - \(#function) waiting failed")  // wait for accounts to fetch
@@ -90,6 +96,12 @@ extension XCUIApplication {
         let successDoneButton = buttons["success_done_button"]
         XCTAssertTrue(successDoneButton.waitForExistence(timeout: 120.0), "Failed to open Success pane - \(#function) waiting failed")  // wait for accounts to link
         return successDoneButton
+    }
+
+    var fc_secureWebViewCancelButton: XCUIElement {
+        let secureWebViewCancelButton = otherElements["TopBrowserBar"].buttons["Cancel"]
+        XCTAssertTrue(secureWebViewCancelButton.waitForExistence(timeout: 5.0), "Failed to close secure browser - \(#function) waiting failed")  // wait for accounts to link
+        return secureWebViewCancelButton
     }
 
     func dismissKeyboard() {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionNoResultsView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionNoResultsView.swift
@@ -52,6 +52,7 @@ final class InstitutionNoResultsView: UIView {
             showLinkUnderline: false,
             alignCenter: true
         )
+        subtitleLabel.accessibilityIdentifier = "institution_search_no_results_subtitle"
         if let didSelectManuallyEnterDetails = didSelectManuallyEnterDetails {
             let subtitleText = STPLocalizedString(
                 "Try searching another bank or %@",

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupViewController.swift
@@ -66,6 +66,7 @@ final class NetworkingLinkLoginWarmupViewController: SheetViewController {
                         "Continue with Link",
                         "A button title. This button, when pressed, will automatically log-in the user with their e-mail to Link (one-click checkout provider)."
                     ),
+                    accessibilityIdentifier: "link_continue_button",
                     action: { [weak self] in
                         self?.didSelectContinue()
                     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/EmailTextField.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/EmailTextField.swift
@@ -31,6 +31,7 @@ final class EmailTextField: UIView {
             .containerHorizontalStackView
             .addArrangedSubview(activityIndicator)
         textField.delegate = self
+        textField.textField.accessibilityIdentifier = "email_text_field"
         return textField
     }()
     private let activityIndicator: ActivityIndicator = {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/PhoneTextField.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/PhoneTextField.swift
@@ -38,6 +38,7 @@ final class PhoneTextField: UIView {
                 trailing: 16
             )
         textField.delegate = self
+        textField.textField.accessibilityIdentifier = "phone_text_field"
         return textField
     }()
     private let countryCodeSelectorView: PhoneCountryCodeSelectorView

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PrepaneViews.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PrepaneViews.swift
@@ -85,6 +85,7 @@ final class PrepaneViews {
                                 return "Cancel" // TODO: when Financial Connections starts supporting localization, change this to `String.Localized.cancel`
                             }
                         }(),
+                        accessibilityIdentifier: "prepane_cancel_button",
                         action: didSelectCancel
                     )
                 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/CloseConfirmationViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/CloseConfirmationViewController.swift
@@ -47,6 +47,7 @@ final class CloseConfirmationViewController: SheetViewController {
                         "Yes, exit",
                         "A button title. The user encounters it as part of a confirmation sheet when trying to exit a screen. Pressing it will exit the screen, and cancel the process of connecting the users bank account."
                     ),
+                    accessibilityIdentifier: "close_confirmation_ok",
                     action: { [weak self] in
                         guard let self = self else { return }
                         self.dismiss(


### PR DESCRIPTION
## Summary

^ as we redesigned the flow, we also changed how UI tests should interact; this code adapts UI tests to the new V3 design (none of this code should affect production)

## Testing

Run command:

```
bitrise run financial-connections-stability-tests
```

Results:
```
FinancialConnectionsNetworkingUITests
    ✓ testNativeNetworkingTestMode (75.007 seconds)
FinancialConnectionsUITests
    ✓ testDataLiveModeOAuthNativeAuthFlow (33.780 seconds)
    ✓ testDataLiveModeOAuthWebAuthFlow (23.903 seconds)
    ✓ testDataTestModeOAuthNativeAuthFlow (23.184 seconds)
    ✓ testPaymentTestModeLegacyNativeAuthFlow (23.581 seconds)
    ✓ testPaymentTestModeManualEntryNativeAuthFlow (26.266 seconds)
    ✓ testSearchInLiveModeNativeAuthFlow (28.372 seconds)
```