### PR TITLE
Remove Linkv2 SPI Flag

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -31,7 +31,6 @@ struct PaymentSheetTestPlayground: View {
         }
         Group {
             SettingView(setting: $playgroundController.settings.linkEnabled)
-            SettingView(setting: $playgroundController.settings.linkV2Allowed)
             SettingView(setting: $playgroundController.settings.userOverrideCountry)
             SettingView(setting: $playgroundController.settings.externalPayPalEnabled)
             SettingView(setting: $playgroundController.settings.preferredNetworksEnabled)

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -161,13 +161,6 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
         case off
     }
 
-    enum LinkV2Allowed: String, PickerEnum {
-        static var enumName: String { "Link v2 Allowed" }
-
-        case on
-        case off
-    }
-
     enum UserOverrideCountry: String, PickerEnum {
         static var enumName: String { "UserOverrideCountry (debug only)" }
 
@@ -265,7 +258,6 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
     var allowsDelayedPMs: AllowsDelayedPMs
     var defaultBillingAddress: DefaultBillingAddress
     var linkEnabled: LinkEnabled
-    var linkV2Allowed: LinkV2Allowed
     var userOverrideCountry: UserOverrideCountry
     var customCtaLabel: String?
     var checkoutEndpoint: String?
@@ -297,7 +289,6 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
             allowsDelayedPMs: .off,
             defaultBillingAddress: .off,
             linkEnabled: .off,
-            linkV2Allowed: .off,
             userOverrideCountry: .off,
             customCtaLabel: nil,
             checkoutEndpoint: Self.defaultCheckoutEndpoint,

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -104,7 +104,6 @@ class PlaygroundController: ObservableObject {
         configuration.applePay = applePayConfiguration
         configuration.customer = customerConfiguration
         configuration.appearance = appearance
-        configuration.allowLinkV2Features = settings.linkV2Allowed == .on
         if settings.userOverrideCountry != .off {
             configuration.userOverrideCountry = settings.userOverrideCountry.rawValue
         }

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -2097,7 +2097,8 @@ class PaymentSheetDeferredServerSideUITests: PaymentSheetUITestCase {
         XCTAssertTrue(confirmRemoval.waitForExistence(timeout: 60.0))
         confirmRemoval.tap()
 
-        XCTAssertTrue(app.cells.count == 1)
+        // Should still show "+ Add" and Link
+        XCTAssertEqual(app.cells.count, 2)
     }
 
     // MARK: - External PayPal 

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -2579,7 +2579,6 @@ class PaymentSheetLinkUITests: PaymentSheetUITestCase {
         settings.customerMode = .guest
         settings.apmsEnabled = .on
         settings.linkEnabled = .on
-        settings.linkV2Allowed = .on
 
         loadPlayground(app, settings)
         app.buttons["Present PaymentSheet"].waitForExistenceAndTap()
@@ -2592,7 +2591,6 @@ class PaymentSheetLinkUITests: PaymentSheetUITestCase {
         settings.customerMode = .guest
         settings.apmsEnabled = .on
         settings.linkEnabled = .on
-        settings.linkV2Allowed = .on
         settings.defaultBillingAddress = .on // the email on the default billings details is signed up for Link
 
         loadPlayground(app, settings)
@@ -2613,7 +2611,6 @@ class PaymentSheetLinkUITests: PaymentSheetUITestCase {
         settings.customerMode = .new
         settings.apmsEnabled = .on
         settings.linkEnabled = .on
-        settings.linkV2Allowed = .on
 
         loadPlayground(app, settings)
         app.buttons["Present PaymentSheet"].waitForExistenceAndTap()
@@ -2626,7 +2623,6 @@ class PaymentSheetLinkUITests: PaymentSheetUITestCase {
         settings.customerMode = .new
         settings.apmsEnabled = .on
         settings.linkEnabled = .on
-        settings.linkV2Allowed = .on
         settings.defaultBillingAddress = .on // the email on the default billings details is signed up for Link
 
         loadPlayground(app, settings)
@@ -2647,7 +2643,6 @@ class PaymentSheetLinkUITests: PaymentSheetUITestCase {
         settings.customerMode = .new
         settings.apmsEnabled = .on
         settings.linkEnabled = .on
-        settings.linkV2Allowed = .on
 
         loadPlayground(app, settings)
         app.buttons["Present PaymentSheet"].waitForExistenceAndTap()
@@ -2674,7 +2669,6 @@ class PaymentSheetLinkUITests: PaymentSheetUITestCase {
         settings.customerMode = .new
         settings.apmsEnabled = .on
         settings.linkEnabled = .on
-        settings.linkV2Allowed = .on
         settings.defaultBillingAddress = .on // the email on the default billings details is signed up for Link
 
         loadPlayground(app, settings)
@@ -2707,7 +2701,6 @@ class PaymentSheetLinkUITests: PaymentSheetUITestCase {
         settings.customerMode = .guest
         settings.apmsEnabled = .on
         settings.linkEnabled = .on
-        settings.linkV2Allowed = .on
         settings.applePayEnabled = .off
 
         loadPlayground(app, settings)
@@ -2722,7 +2715,6 @@ class PaymentSheetLinkUITests: PaymentSheetUITestCase {
         settings.customerMode = .guest
         settings.apmsEnabled = .on
         settings.linkEnabled = .on
-        settings.linkV2Allowed = .on
         settings.applePayEnabled = .off
         settings.defaultBillingAddress = .on // the email on the default billings details is signed up for Link
 
@@ -2747,7 +2739,6 @@ class PaymentSheetLinkUITests: PaymentSheetUITestCase {
         settings.customerMode = .new
         settings.apmsEnabled = .on
         settings.linkEnabled = .on
-        settings.linkV2Allowed = .on
         settings.applePayEnabled = .off
 
         loadPlayground(app, settings)
@@ -2762,7 +2753,6 @@ class PaymentSheetLinkUITests: PaymentSheetUITestCase {
         settings.customerMode = .new
         settings.apmsEnabled = .on
         settings.linkEnabled = .on
-        settings.linkV2Allowed = .on
         settings.applePayEnabled = .off
         settings.defaultBillingAddress = .on // the email on the default billings details is signed up for Link
 
@@ -2787,7 +2777,6 @@ class PaymentSheetLinkUITests: PaymentSheetUITestCase {
         settings.customerMode = .new
         settings.apmsEnabled = .on
         settings.linkEnabled = .on
-        settings.linkV2Allowed = .on
         settings.applePayEnabled = .off
 
         loadPlayground(app, settings)
@@ -2816,7 +2805,6 @@ class PaymentSheetLinkUITests: PaymentSheetUITestCase {
         settings.customerMode = .new
         settings.apmsEnabled = .on
         settings.linkEnabled = .on
-        settings.linkV2Allowed = .on
         settings.applePayEnabled = .on
 
         loadPlayground(app, settings)
@@ -2847,7 +2835,6 @@ class PaymentSheetLinkUITests: PaymentSheetUITestCase {
         settings.customerMode = .new
         settings.apmsEnabled = .on
         settings.linkEnabled = .on
-        settings.linkV2Allowed = .on
         settings.applePayEnabled = .off
         settings.defaultBillingAddress = .on // the email on the default billings details is signed up for Link
 
@@ -2877,7 +2864,6 @@ class PaymentSheetLinkUITests: PaymentSheetUITestCase {
         settings.customerMode = .new
         settings.apmsEnabled = .on
         settings.linkEnabled = .on
-        settings.linkV2Allowed = .on
         settings.applePayEnabled = .on
         settings.defaultBillingAddress = .on // the email on the default billings details is signed up for Link
 
@@ -2894,7 +2880,6 @@ class PaymentSheetLinkUITests: PaymentSheetUITestCase {
         settings.customerMode = .guest
         settings.apmsEnabled = .on
         settings.linkEnabled = .on
-        settings.linkV2Allowed = .on
         settings.userOverrideCountry = .GB
 
         loadPlayground(app, settings)

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/Intent+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/Intent+Link.swift
@@ -9,17 +9,17 @@
 @_spi(STP) import StripePayments
 
 extension Intent {
-    func supportsLink(allowV2Features: Bool) -> Bool {
+    var supportsLink: Bool {
         // Either Link is an allowed Payment Method in the elements/sessions response, or passthrough mode (Link as a Card PM) is allowed
-        return recommendedPaymentMethodTypes.contains(.link) || (linkPassthroughModeEnabled && allowV2Features)
+        return recommendedPaymentMethodTypes.contains(.link) || linkPassthroughModeEnabled
     }
 
-    func supportsLinkCard(allowV2Features: Bool) -> Bool {
-        return supportsLink(allowV2Features: allowV2Features) && (linkFundingSources?.contains(.card) ?? false) || (linkPassthroughModeEnabled && allowV2Features)
+    var supportsLinkCard: Bool {
+        return supportsLink && (linkFundingSources?.contains(.card) ?? false) || linkPassthroughModeEnabled
     }
 
     var onlySupportsLinkBank: Bool {
-        return supportsLink(allowV2Features: false) && (linkFundingSources == [.bankAccount])
+        return supportsLink && (linkFundingSources == [.bankAccount])
     }
 
     var linkFlags: [String: Bool] {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
@@ -167,9 +167,6 @@ extension PaymentSheet {
         // MARK: Internal
         internal var linkPaymentMethodsOnly: Bool = false
 
-        /// If enabled, PaymentSheet will offer V2 Link features, such as passthrough mode
-        @_spi(STP) public var allowLinkV2Features: Bool = false
-
         /// Override country for test purposes
         @_spi(STP) public var userOverrideCountry: String?
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -364,7 +364,7 @@ extension PaymentSheet {
                         isCustom: true,
                         paymentMethod: paymentOption.analyticsValue,
                         result: result,
-                        linkEnabled: intent.supportsLink(allowV2Features: configuration.allowLinkV2Features),
+                        linkEnabled: intent.supportsLink,
                         activeLinkSession: LinkAccountContext.shared.account?.sessionState == .verified,
                         linkSessionType: intent.linkPopupWebviewOption,
                         currency: intent.currency,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
@@ -20,7 +20,7 @@ extension PaymentSheetFormFactory {
                 merchantDisplayName: configuration.merchantDisplayName
             )
         )
-        let shouldDisplaySPMSaveCheckbox: Bool = saveMode == .userSelectable && (configuration.allowLinkV2Features || !canSaveToLink)
+        let shouldDisplaySPMSaveCheckbox: Bool = saveMode == .userSelectable
 
         // Make section titled "Contact Information" w/ phone and email if merchant requires it.
         let optionalPhoneAndEmailInformationSection: SectionElement? = {
@@ -98,7 +98,7 @@ extension PaymentSheetFormFactory {
                 configuration: configuration,
                 linkAccount: linkAccount,
                 country: countryCode,
-                showCheckbox: !(shouldDisplaySPMSaveCheckbox && configuration.allowLinkV2Features)
+                showCheckbox: !shouldDisplaySPMSaveCheckbox
             )
         } else {
             return cardFormElement

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -44,7 +44,6 @@ class PaymentSheetFormFactory {
     var canSaveToLink: Bool {
         return (supportsLinkCard &&
                 paymentMethod == .stripe(.card) &&
-                (configuration.allowLinkV2Features || saveMode != .userSelectable) &&
                 !configuration.isUsingBillingAddressCollection)
     }
 
@@ -97,7 +96,7 @@ class PaymentSheetFormFactory {
                   offerSaveToLinkWhenSupported: offerSaveToLinkWhenSupported,
                   linkAccount: linkAccount,
                   cardBrandChoiceEligible: cardBrandChoiceEligible,
-                  supportsLinkCard: intent.supportsLinkCard(allowV2Features: configuration.allowLinkV2Features),
+                  supportsLinkCard: intent.supportsLinkCard,
                   isPaymentIntent: intent.isPaymentIntent,
                   currency: intent.currency,
                   amount: intent.amount,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactoryConfig.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactoryConfig.swift
@@ -35,14 +35,6 @@ enum PaymentSheetFormFactoryConfig {
             return false
         }
     }
-    var allowLinkV2Features: Bool {
-        switch self {
-        case .paymentSheet(let config):
-            return config.allowLinkV2Features
-        case .customerSheet:
-            return false
-        }
-    }
     var overrideCountry: String? {
         switch self {
         case .paymentSheet(let config):

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -90,7 +90,7 @@ final class PaymentSheetLoader {
                     showLink: isFlowController ? isLinkEnabled : false
                 )
                 analyticsClient.logPaymentSheetLoadSucceeded(loadingStartDate: loadingStartDate,
-                                                             linkEnabled: intent.supportsLink(allowV2Features: configuration.allowLinkV2Features), defaultPaymentMethod: paymentOptionsViewModels.stp_boundSafeObject(at: defaultSelectedIndex))
+                                                             linkEnabled: intent.supportsLink, defaultPaymentMethod: paymentOptionsViewModels.stp_boundSafeObject(at: defaultSelectedIndex))
                 if isFlowController {
                     AnalyticsHelper.shared.startTimeMeasurement(.checkout)
                 }
@@ -116,7 +116,7 @@ final class PaymentSheetLoader {
     // MARK: - Helpers
 
     static func isLinkEnabled(intent: Intent, configuration: PaymentSheet.Configuration) -> Bool {
-        guard intent.supportsLink(allowV2Features: configuration.allowLinkV2Features) else {
+        guard intent.supportsLink else {
             return false
         }
         return !configuration.isUsingBillingAddressCollection()
@@ -143,7 +143,7 @@ final class PaymentSheetLoader {
 
     static func lookupLinkAccount(intent: Intent, configuration: PaymentSheet.Configuration) async throws -> PaymentSheetLinkAccount? {
         // Only lookup the consumer account if Link is supported
-        guard intent.supportsLink(allowV2Features: configuration.allowLinkV2Features) else {
+        guard intent.supportsLink else {
             return nil
         }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -273,7 +273,7 @@ class PaymentSheetFlowControllerViewController: UIViewController {
         STPAnalyticsClient.sharedClient.logPaymentSheetShow(
             isCustom: true,
             paymentMethod: mode.analyticsValue,
-            linkEnabled: intent.supportsLink(allowV2Features: configuration.allowLinkV2Features),
+            linkEnabled: intent.supportsLink,
             activeLinkSession: LinkAccountContext.shared.account?.sessionState == .verified,
             currency: intent.currency,
             intentConfig: intent.intentConfig,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -275,7 +275,7 @@ class PaymentSheetViewController: UIViewController {
         STPAnalyticsClient.sharedClient.logPaymentSheetShow(
             isCustom: false,
             paymentMethod: mode.analyticsValue,
-            linkEnabled: intent.supportsLink(allowV2Features: configuration.allowLinkV2Features),
+            linkEnabled: intent.supportsLink,
             activeLinkSession: LinkAccountContext.shared.account?.sessionState == .verified,
             currency: intent.currency,
             intentConfig: intent.intentConfig,
@@ -499,7 +499,7 @@ class PaymentSheetViewController: UIViewController {
                     isCustom: false,
                     paymentMethod: paymentOption.analyticsValue,
                     result: result,
-                    linkEnabled: self.intent.supportsLink(allowV2Features: self.configuration.allowLinkV2Features),
+                    linkEnabled: self.intent.supportsLink,
                     activeLinkSession: LinkAccountContext.shared.account?.sessionState == .verified,
                     linkSessionType: self.intent.linkPopupWebviewOption,
                     currency: self.intent.currency,


### PR DESCRIPTION
## Summary
Removes client-side Link v2 gate, which will allow Link V2 features for anyone in the server-side gate.

## Motivation
Preparing for Link V2 launch.

## Testing
Existing CI tests

## Changelog
Not yet