### PR TITLE
Don't deserialize luxe specs for backup elementSession instances

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
@@ -43,6 +43,9 @@ final class STPElementsSession: NSObject {
     /// An ordered list of external payment methods to display
     let externalPaymentMethods: [ExternalPaymentMethod]
 
+    /// A flag that indicates that this instance was created as a best-effort
+    let isBackupInstance: Bool
+
     let allResponseFields: [AnyHashable: Any]
 
     private init(
@@ -56,7 +59,8 @@ final class STPElementsSession: NSObject {
         paymentMethodSpecs: [[AnyHashable: Any]]?,
         cardBrandChoice: STPCardBrandChoice?,
         isApplePayEnabled: Bool,
-        externalPaymentMethods: [ExternalPaymentMethod]
+        externalPaymentMethods: [ExternalPaymentMethod],
+        isBackupInstance: Bool = false
     ) {
         self.allResponseFields = allResponseFields
         self.sessionID = sessionID
@@ -69,6 +73,7 @@ final class STPElementsSession: NSObject {
         self.cardBrandChoice = cardBrandChoice
         self.isApplePayEnabled = isApplePayEnabled
         self.externalPaymentMethods = externalPaymentMethods
+        self.isBackupInstance = isBackupInstance
         super.init()
     }
 
@@ -100,7 +105,8 @@ final class STPElementsSession: NSObject {
             paymentMethodSpecs: nil,
             cardBrandChoice: STPCardBrandChoice.decodedObject(fromAPIResponse: [:]),
             isApplePayEnabled: true,
-            externalPaymentMethods: []
+            externalPaymentMethods: [],
+            isBackupInstance: true
         )
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -54,11 +54,15 @@ final class PaymentSheetLoader {
                 // Overwrite the form specs that were already loaded from disk
                 switch intent {
                 case .paymentIntent(let elementsSession, _):
-                    _ = FormSpecProvider.shared.loadFrom(elementsSession.paymentMethodSpecs as Any)
+                    if !elementsSession.isBackupInstance {
+                        _ = FormSpecProvider.shared.loadFrom(elementsSession.paymentMethodSpecs as Any)
+                    }
                 case .setupIntent:
                     break // Not supported
                 case .deferredIntent(elementsSession: let elementsSession, intentConfig: _):
-                    _ = FormSpecProvider.shared.loadFrom(elementsSession.paymentMethodSpecs as Any)
+                    if !elementsSession.isBackupInstance {
+                        _ = FormSpecProvider.shared.loadFrom(elementsSession.paymentMethodSpecs as Any)
+                    }
                 }
 
                 // Load link account session. Continue without Link if it errors.


### PR DESCRIPTION
## Summary
If the call to elementSessions fails, the SDK creates a backup instance of ElementsSession, which results in attempting to deserialize nil and emits an error.

## Motivation
We should avoid deserializing if we know that we failed the initial call.

## Testing
Manually, unfortunately.  Writing a test seems for this seems very difficult.
