### PR TITLE
Normalize expiration year for consumer endpoint

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
@@ -112,7 +112,11 @@ extension STPAPIClient {
 
         var card = STPFormEncoder.dictionary(forObject: cardParams)["card"] as? [AnyHashable: Any]
         card?["cvc"] = nil // payment_details doesn't store cvc
-
+        // Consumer endpoint expects a 4-digit card year
+        if let exp_year = card?["exp_year"] as? Int {
+            card?["exp_year"] = CardExpiryDate.normalizeYear(exp_year)
+        }
+        
         let parameters: [String: Any] = [
             "credentials": ["consumer_session_client_secret": consumerSessionClientSecret],
             "request_surface": "ios_payment_element",

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
@@ -116,7 +116,7 @@ extension STPAPIClient {
         if let exp_year = card?["exp_year"] as? Int {
             card?["exp_year"] = CardExpiryDate.normalizeYear(exp_year)
         }
-        
+
         let parameters: [String: Any] = [
             "credentials": ["consumer_session_client_secret": consumerSessionClientSecret],
             "request_surface": "ios_payment_element",


### PR DESCRIPTION
## Summary
Send a 4 digit year to the consumer endpoint.

## Motivation
It only requires this in livemode, unfortunately.

## Testing
Existing tests should pass