### PR TITLE
Financial Connections: for v3, modified account picker logic

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -627,20 +627,17 @@ extension NativeFlowController: AccountPickerViewControllerDelegate {
 
     func accountPickerViewController(
         _ viewController: AccountPickerViewController,
-        didSelectAccounts selectedAccounts: [FinancialConnectionsPartnerAccount]
+        didSelectAccounts selectedAccounts: [FinancialConnectionsPartnerAccount],
+        nextPane: FinancialConnectionsSessionManifest.NextPane
     ) {
         dataManager.linkedAccounts = selectedAccounts
 
-        let shouldAttachLinkedPaymentAccount = (dataManager.manifest.paymentMethodType != nil)
-        if shouldAttachLinkedPaymentAccount {
-            // this prevents an unnecessary push transition when presenting `attachLinkedPaymentAccount`
-            //
-            // `attachLinkedPaymentAccount` looks the same as the last step of `accountPicker`
-            // so navigating to a "Linking account" loading screen can look buggy to the user
-            pushPane(.attachLinkedPaymentAccount, animated: false)
-        } else {
-            pushPane(.success, animated: true)
-        }
+        // this prevents an unnecessary push transition when presenting `attachLinkedPaymentAccount`
+        //
+        // `attachLinkedPaymentAccount` looks the same as the last step of `accountPicker`
+        // so navigating to a "Linking account" loading screen can look buggy to the user
+        let isAnimated = (nextPane != .attachLinkedPaymentAccount)
+        pushPane(nextPane, animated: isAnimated)
     }
 
     func accountPickerViewControllerDidSelectAnotherBank(_ viewController: AccountPickerViewController) {


### PR DESCRIPTION
## Summary

1) modified some of the logic in the "Account Picker" screen to match that of web (the changes are _not_ visual)
2) added new analytics logs

all of these changes are in purpose of bringing the Native code to be more in parity with web code

Account Picker:
![Simulator Screenshot - iPhone 12 mini - 2024-02-26 at 16 17 02](https://github.com/stripe/stripe-ios/assets/105514761/a6ce0104-65d2-4e8c-a417-6edeced6ea25)


## Testing

This video showcases me going through "3 flows" (data, payments, networking) and it all succeeding:


https://github.com/stripe/stripe-ios/assets/105514761/8de2bd1c-d18a-4323-badb-689cedae2762

