### PR TITLE
Financial Connections: improved link verification otp loader

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationViewController.swift
@@ -193,11 +193,7 @@ extension NetworkingLinkStepUpVerificationViewController: NetworkingOTPViewDeleg
     }
 
     func networkingOTPViewDidConfirmVerification(_ view: NetworkingOTPView) {
-        // we could call `showSmallLoadingView(false)` here but we do
-        // not because next step will be to transition to a different
-        // screen and its better to keep showing the loading to
-        // avoid the animation lag
-
+        showSmallLoadingView(true)
         dataSource.markLinkStepUpAuthenticationVerified()
             .observe { [weak self] result in
                 guard let self = self else { return }
@@ -230,6 +226,14 @@ extension NetworkingLinkStepUpVerificationViewController: NetworkingOTPViewDeleg
                                     // this shouldn't happen, but in case it does, we navigate to `institutionPicker` so user
                                     // could still have a chance at successfully connecting their account
                                     self.delegate?.networkingLinkStepUpVerificationViewControllerEncounteredSoftError(self)
+                                }
+
+                                // only hide loading view after animation
+                                // to next screen has completed
+                                DispatchQueue.main.asyncAfter(
+                                    deadline: .now() + 1.0
+                                ) { [weak self] in
+                                    self?.showSmallLoadingView(false)
                                 }
                             case .failure(let error):
                                 self.dataSource

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationViewController.swift
@@ -163,6 +163,7 @@ extension NetworkingLinkVerificationViewController: NetworkingOTPViewDelegate {
     }
 
     func networkingOTPViewDidConfirmVerification(_ view: NetworkingOTPView) {
+        view.showLoadingView(true)
         dataSource.markLinkVerified()
             .observe { [weak self] result in
                 guard let self = self else { return }
@@ -205,6 +206,14 @@ extension NetworkingLinkVerificationViewController: NetworkingOTPViewDelegate {
                                         pane: .networkingLinkVerification
                                     )
                                 self.requestNextPane(manifest.nextPane)
+                            }
+
+                            // only hide loading view after animation
+                            // to next screen has completed
+                            DispatchQueue.main.asyncAfter(
+                                deadline: .now() + 1.0
+                            ) { [weak view] in
+                                view?.showLoadingView(false)
                             }
                         }
                 case .failure(let error):

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationViewController.swift
@@ -133,6 +133,7 @@ extension NetworkingSaveToLinkVerificationViewController: NetworkingOTPViewDeleg
     }
 
     func networkingOTPViewDidConfirmVerification(_ view: NetworkingOTPView) {
+        view.showLoadingView(true)
         dataSource.saveToLink()
             .observe { [weak self] result in
                 guard let self = self else { return }
@@ -167,6 +168,14 @@ extension NetworkingSaveToLinkVerificationViewController: NetworkingOTPViewDeleg
                         saveToLinkWithStripeSucceeded: false,
                         error: error
                     )
+                }
+
+                // only hide loading view after animation
+                // to next screen has completed
+                DispatchQueue.main.asyncAfter(
+                    deadline: .now() + 1.0
+                ) { [weak view] in
+                    view?.showLoadingView(false)
                 }
             }
 


### PR DESCRIPTION
## Summary

These PR's simply extend the "loading spinner" to go longer instead of disappearing prematurely.

## Testing

### Login Verification 

#### Before

https://github.com/stripe/stripe-ios/assets/105514761/01f0f1fd-255a-4ccd-96c1-92426d608bbf

#### After

https://github.com/stripe/stripe-ios/assets/105514761/7a916c0b-5356-4698-8b8d-a9ffe8a7319c


### Step Up Verification

#### Before

https://github.com/stripe/stripe-ios/assets/105514761/5f0a8237-0b05-4ac8-b867-dd9cf322c213

#### After

https://github.com/stripe/stripe-ios/assets/105514761/5ceb6192-4932-4433-b7f9-c63f47c9b093


### Save To Link Verification

#### Before

https://github.com/stripe/stripe-ios/assets/105514761/338a8050-b3cc-4c05-a967-26e33be55fee

#### After

https://github.com/stripe/stripe-ios/assets/105514761/9773543e-ec17-43cc-b2f0-0a1859923d4f
