### PR TITLE
Financial Connections: added support for success pane text coming from backend for link sign up VC

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsSessionManifest.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsSessionManifest.swift
@@ -55,6 +55,14 @@ struct FinancialConnectionsSessionManifest: Decodable {
         case unparsable
     }
 
+    struct DisplayText: Decodable {
+        let successPane: SuccessPane?
+
+        struct SuccessPane: Decodable {
+            let subCaption: String?
+        }
+    }
+
     // MARK: - Properties
 
     let accountholderIsLinkConsumer: Bool?
@@ -92,4 +100,5 @@ struct FinancialConnectionsSessionManifest: Decodable {
     let accountholderCustomerEmailAddress: String?
     let accountholderPhoneNumber: String?
     let stepUpAuthenticationRequired: Bool?
+    let displayText: DisplayText?
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -746,8 +746,12 @@ extension NativeFlowController: NetworkingLinkSignupViewControllerDelegate {
     func networkingLinkSignupViewControllerDidFinish(
         _ viewController: NetworkingLinkSignupViewController,
         saveToLinkWithStripeSucceeded: Bool?,
+        customSuccessPaneMessage: String?,
         withError error: Error?
     ) {
+        if let customSuccessPaneMessage {
+            dataManager.customSuccessPaneMessage = customSuccessPaneMessage
+        }
         if saveToLinkWithStripeSucceeded != nil {
             dataManager.saveToLinkWithStripeSucceeded = saveToLinkWithStripeSucceeded
         }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupDataSource.swift
@@ -14,7 +14,11 @@ protocol NetworkingLinkSignupDataSource: AnyObject {
 
     func synchronize() -> Future<FinancialConnectionsNetworkingLinkSignup>
     func lookup(emailAddress: String) -> Future<LookupConsumerSessionResponse>
-    func saveToLink(emailAddress: String, phoneNumber: String, countryCode: String) -> Future<Void>
+    func saveToLink(
+        emailAddress: String,
+        phoneNumber: String,
+        countryCode: String
+    ) -> Future<FinancialConnectionsSessionManifest>
 }
 
 final class NetworkingLinkSignupDataSourceImplementation: NetworkingLinkSignupDataSource {
@@ -60,7 +64,11 @@ final class NetworkingLinkSignupDataSourceImplementation: NetworkingLinkSignupDa
         return apiClient.consumerSessionLookup(emailAddress: emailAddress, clientSecret: clientSecret)
     }
 
-    func saveToLink(emailAddress: String, phoneNumber: String, countryCode: String) -> Future<Void> {
+    func saveToLink(
+        emailAddress: String,
+        phoneNumber: String,
+        countryCode: String
+    ) -> Future<FinancialConnectionsSessionManifest> {
         return apiClient.saveAccountsToLink(
             emailAddress: emailAddress,
             phoneNumber: phoneNumber,
@@ -69,8 +77,5 @@ final class NetworkingLinkSignupDataSourceImplementation: NetworkingLinkSignupDa
             consumerSessionClientSecret: nil,
             clientSecret: clientSecret
         )
-        .chained { _ in
-            return Promise(value: ())
-        }
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
@@ -19,6 +19,7 @@ protocol NetworkingLinkSignupViewControllerDelegate: AnyObject {
         _ viewController: NetworkingLinkSignupViewController,
         // nil == we did not perform saveToLink
         saveToLinkWithStripeSucceeded: Bool?,
+        customSuccessPaneMessage: String?,
         withError error: Error?
     )
     func networkingLinkSignupViewController(
@@ -86,6 +87,7 @@ final class NetworkingLinkSignupViewController: UIViewController {
                         self.delegate?.networkingLinkSignupViewControllerDidFinish(
                             self,
                             saveToLinkWithStripeSucceeded: nil,
+                            customSuccessPaneMessage: nil,
                             withError: error
                         )
                     }
@@ -124,6 +126,7 @@ final class NetworkingLinkSignupViewController: UIViewController {
                 self.delegate?.networkingLinkSignupViewControllerDidFinish(
                     self,
                     saveToLinkWithStripeSucceeded: nil,
+                    customSuccessPaneMessage: nil,
                     withError: nil
                 )
             },
@@ -198,10 +201,11 @@ final class NetworkingLinkSignupViewController: UIViewController {
         .observe { [weak self] result in
             guard let self = self else { return }
             switch result {
-            case .success:
+            case .success(let manifest):
                 self.delegate?.networkingLinkSignupViewControllerDidFinish(
                     self,
                     saveToLinkWithStripeSucceeded: true,
+                    customSuccessPaneMessage: manifest.displayText?.successPane?.subCaption,
                     withError: nil
                 )
             case .failure(let error):
@@ -210,6 +214,7 @@ final class NetworkingLinkSignupViewController: UIViewController {
                 self.delegate?.networkingLinkSignupViewControllerDidFinish(
                     self,
                     saveToLinkWithStripeSucceeded: false,
+                    customSuccessPaneMessage: nil,
                     withError: error
                 )
                 self.dataSource.analyticsClient.logUnexpectedError(
@@ -287,6 +292,7 @@ extension NetworkingLinkSignupViewController: NetworkingLinkSignupBodyFormViewDe
                             self.delegate?.networkingLinkSignupViewControllerDidFinish(
                                 self,
                                 saveToLinkWithStripeSucceeded: nil,
+                                customSuccessPaneMessage: nil,
                                 withError: FinancialConnectionsSheetError.unknown(
                                     debugDescription: "No consumer session returned from lookupConsumerSession for emailAddress: \(emailAddress)"
                                 )


### PR DESCRIPTION
## Summary

^ adds support for backend returning text for the last screen ("success pane")

## Testing

This is difficult (or maybe near impossible) to test right now due to complicated backend logic, but adding this anyway for parity with Web code. I manually tested with hard-coding response + double-checked code.

![Simulator Screenshot - iPhone 12 mini - 2024-02-26 at 12 46 37](https://github.com/stripe/stripe-ios/assets/105514761/97826157-308d-40c2-abac-7862c9402ca9)
