### PR TITLE
Fix test playground + customerID settings

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -81,8 +81,6 @@ struct PaymentSheetTestPlayground: View {
                         SettingView(setting: $playgroundController.settings.mode)
                         SettingPickerView(setting: $playgroundController.settings.integrationType)
                         SettingView(setting: customerModeBinding)
-                        TextField("CustomerId", text: customerIdBinding)
-                            .disabled(true)
                         SettingPickerView(setting: $playgroundController.settings.currency)
                         SettingPickerView(setting: merchantCountryBinding)
                         SettingView(setting: $playgroundController.settings.apmsEnabled)
@@ -144,22 +142,7 @@ struct PaymentSheetTestPlayground: View {
         Binding<PaymentSheetTestPlaygroundSettings.CustomerMode> {
             return playgroundController.settings.customerMode
         } set: { newMode in
-            playgroundController.settings.customerId = nil
             playgroundController.settings.customerMode = newMode
-        }
-    }
-    var customerIdBinding: Binding<String> {
-        Binding<String> {
-            switch playgroundController.settings.customerMode {
-            case .guest:
-                return ""
-            case .new:
-                return playgroundController.settings.customerId ?? ""
-            case .returning:
-                return playgroundController.settings.customerId ?? ""
-            }
-        } set: { newString in
-            playgroundController.settings.customerId = (newString != "") ? newString : nil
         }
     }
     var merchantCountryBinding: Binding<PaymentSheetTestPlaygroundSettings.MerchantCountry> {

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetBillingCollectionUITests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetBillingCollectionUITests.swift
@@ -452,8 +452,8 @@ class PaymentSheetBillingCollectionLPMUITests: PaymentSheetBillingCollectionUITe
         )
         checkoutButton.tap()
 
-        XCTAssertTrue(app.buttons["Pay ₹50.99"].waitForExistence(timeout: 5))
         let payButton = app.buttons["Pay ₹50.99"]
+        XCTAssertTrue(app.buttons["Pay ₹50.99"].waitForExistence(timeout: 10))
 
         let cell = try XCTUnwrap(scroll(collectionView: app.collectionViews.firstMatch, toFindCellWithId: "UPI"))
         cell.tap()
@@ -497,8 +497,8 @@ class PaymentSheetBillingCollectionLPMUITests: PaymentSheetBillingCollectionUITe
         )
         checkoutButton.tap()
 
-        XCTAssertTrue(app.buttons["Pay ₹50.99"].waitForExistence(timeout: 5))
         let payButton = app.buttons["Pay ₹50.99"]
+        XCTAssertTrue(payButton.waitForExistence(timeout: 10))
 
         let cell = try XCTUnwrap(scroll(collectionView: app.collectionViews.firstMatch, toFindCellWithId: "UPI"))
         cell.tap()
@@ -578,6 +578,7 @@ class PaymentSheetBillingCollectionLPMUITests: PaymentSheetBillingCollectionUITe
         checkoutButton.tap()
 
         let payButton = app.buttons["Pay ₹50.99"]
+        XCTAssertTrue(payButton.waitForExistence(timeout: 10))
         let cell = try XCTUnwrap(scroll(collectionView: app.collectionViews.firstMatch, toFindCellWithId: "UPI"))
         cell.tap()
 
@@ -623,6 +624,7 @@ class PaymentSheetBillingCollectionLPMUITests: PaymentSheetBillingCollectionUITe
         checkoutButton.tap()
 
         let payButton = app.buttons["Pay ₹50.99"]
+        XCTAssertTrue(payButton.waitForExistence(timeout: 10))
         let cell = try XCTUnwrap(scroll(collectionView: app.collectionViews.firstMatch, toFindCellWithId: "UPI"))
         cell.tap()
 

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -390,6 +390,7 @@ class PaymentSheetStandardUITests: PaymentSheetUITestCase {
         app.buttons["Present PaymentSheet"].tap()
 
         let payButton = app.buttons["Pay ₹50.99"]
+        XCTAssertTrue(payButton.waitForExistence(timeout: 10))
         guard let upi = scroll(collectionView: app.collectionViews.firstMatch, toFindCellWithId: "UPI") else {
             XCTFail()
             return

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
@@ -186,7 +186,7 @@ extension STPAPIClient {
 
         let parameters: [String: Any] = [
             "credentials": [
-                "consumer_session_client_secret": consumerSessionClientSecret
+                "consumer_session_client_secret": consumerSessionClientSecret,
             ],
             "request_surface": "ios_payment_element",
         ]
@@ -236,7 +236,7 @@ extension STPAPIClient {
 
         let parameters: [String: Any] = [
             "credentials": [
-                "consumer_session_client_secret": consumerSessionClientSecret
+                "consumer_session_client_secret": consumerSessionClientSecret,
             ],
             "request_surface": "ios_payment_element",
         ]


### PR DESCRIPTION
# Summary
Test playground was reloading too many times in tests unnecessarily. This is because load was modifying settings.customerId, which was causing it to reload (when autoreload is on).  

The problem is that load completion should never touch settings, that's an infinite loop waiting to happen. It doesn't make sense for customerID to be in the settings object anyways, since it's not a setting - it can't be set, it's just a readonly view of the current customer ID.


# Motivation
Was looking at why UPI tests were flaking sometimes https://jira.corp.stripe.com/browse/RUN_MOBILESDK-2975 

I _think_ there's a possible cause that looks like:

We modify settings.customerID when the load finishes -> we stop spinning and show the "Present PaymentSheet" -> The test sees "Present PaymentSheet" become enabled -> we autoreload because the settings changed -> we start spinning -> The test tries to tap "Present PaymentSheet" and fails

Hopefully this PR reduces/eliminates the flake.  