### PR TITLE
Financial Connections: changed verification screen logic to match v3

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -928,8 +928,7 @@ extension NativeFlowController: LinkAccountPickerViewControllerDelegate {
 extension NativeFlowController: NetworkingSaveToLinkVerificationViewControllerDelegate {
     func networkingSaveToLinkVerificationViewControllerDidFinish(
         _ viewController: NetworkingSaveToLinkVerificationViewController,
-        saveToLinkWithStripeSucceeded: Bool?,
-        error: Error?
+        saveToLinkWithStripeSucceeded: Bool?
     ) {
         if saveToLinkWithStripeSucceeded != nil {
             dataManager.saveToLinkWithStripeSucceeded = saveToLinkWithStripeSucceeded


### PR DESCRIPTION
## Summary

^ this modifies logic of "Verification" screens to match that of new web code

## Testing

### NetworkingSaveToLinkVerificationViewController

https://github.com/stripe/stripe-ios/assets/105514761/0fa0958a-bb59-413f-aac0-8444748a925b

### NetworkingLinkVerificationViewController

https://github.com/stripe/stripe-ios/assets/105514761/343ec92a-dc0b-4dc3-85ea-13960dedff51
