### PR TITLE
Fix iPad animation when moving from Apple Pay to PaymentSheet

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/RotatingCardBrandsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/RotatingCardBrandsView.swift
@@ -194,7 +194,11 @@ class RotatingCardBrandsView: UIView {
     override func didMoveToWindow() {
         super.didMoveToWindow()
         if window != nil {
-            startAnimating()
+            // If we don't wait, we end up clobbering the system's formSheet background fade animation on iPad
+            // when opening PaymentSheet, opening Apple Pay, then cancelling Apple Pay.
+            DispatchQueue.main.async {
+                self.startAnimating()
+            }
         } else {
             stopAnimating()
         }


### PR DESCRIPTION
## Summary
When cancelling Apple Pay and returning to PaymentSheet on iPad, the system's fade-in animation underneath the form sheet is inexplicably following the transition animation from the rotating card brand view, and waits for the brand to rotate once before executing.

I've dug into this a fair amount and tried rebuilding the RotatingCardBrandView, but in the end it seems like any UIViewPropertyAnimator causes this behavior. As a hacky workaround, we'll just wait for one turn of the runloop before kicking off our animation.

## Motivation
Fixing a small visual issue on iPad

## Testing
In PaymentSheet Example

## Changelog
None