### PR TITLE
Fix animation when switching between payment methods

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSectionWithScanner/CVCRecollectionElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSectionWithScanner/CVCRecollectionElement.swift
@@ -64,6 +64,9 @@ final class CVCRecollectionElement: Element {
     var validationState: ElementValidationState {
         return cvcRecollectionView.textFieldElement.validationState
     }
+    func clearTextFields() {
+        self.cvcRecollectionView.textFieldElement.setText("")
+    }
 }
 
 extension CVCRecollectionElement: ElementDelegate {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/PaymentMethodElement/PaymentMethodElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/PaymentMethodElement/PaymentMethodElement.swift
@@ -26,6 +26,8 @@ extension PaymentMethodElement {
         for element in getAllUnwrappedSubElements() {
             if let element = element as? TextFieldElement {
                 element.setText("")
+            } else if let element = element as? CVCRecollectionElement {
+                element.clearTextFields()
             }
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
@@ -512,6 +512,7 @@ extension SavedPaymentOptionsViewController: UICollectionViewDataSource, UIColle
             )
         }
         updateMandateView()
+        cvcFormElement.clearTextFields()
         updateFormElement()
         delegate?.didUpdateSelection(viewController: self, paymentMethodSelection: viewModel)
     }


### PR DESCRIPTION
## Summary
When you have two cards, and type in an incomplete cvc on card1, and attempt to switch to card 2, you can see the error animating in for a split second.

## Motivation
Visual polish

## Testing
manual

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
