### PR TITLE
Financial Connections: for v3, various polish fixes

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentLogoView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentLogoView.swift
@@ -88,18 +88,26 @@ final class ConsentLogoView: UIView {
 }
 
 private func CreateRoundedLogoView(urlString: String) -> UIView {
+    let cornerRadius: CGFloat = 16.0
+    let shadowContainerView = UIView()
+    shadowContainerView.layer.shadowColor = UIColor.black.cgColor
+    shadowContainerView.layer.shadowOpacity = 0.18
+    shadowContainerView.layer.shadowOffset = CGSize(width: 0, height: 3)
+    shadowContainerView.layer.shadowRadius = 5
+    shadowContainerView.layer.cornerRadius = cornerRadius
     let radius: CGFloat = 72.0
     let imageView = UIImageView()
     imageView.contentMode = .scaleAspectFill
     imageView.clipsToBounds = true
-    imageView.layer.cornerRadius = 16.0
+    imageView.layer.cornerRadius = cornerRadius
     imageView.setImage(with: urlString)
     imageView.translatesAutoresizingMaskIntoConstraints = false
     NSLayoutConstraint.activate([
         imageView.widthAnchor.constraint(equalToConstant: radius),
         imageView.heightAnchor.constraint(equalToConstant: radius),
     ])
-    return imageView
+    shadowContainerView.addAndPinSubview(imageView)
+    return shadowContainerView
 }
 
 private func CreateEllipsisView(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionPickerViewController.swift
@@ -403,6 +403,10 @@ extension InstitutionPickerViewController: InstitutionTableViewDelegate {
     }
 
     func institutionTableViewDidSelectSearchForMoreBanks(_ tableView: InstitutionTableView) {
+        tableView.tableView.scrollRectToVisible(
+            searchBar.frame,
+            animated: true
+        )
         searchBar.becomeFirstResponder()
     }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionPickerViewController.swift
@@ -243,7 +243,7 @@ extension InstitutionPickerViewController {
         institutionTableView.showError(false, isUserSearching: true)
 
         guard !searchQuery.isEmpty else {
-            searchBar.updateSearchingIndicator(false)
+            showLoadingView(false)
             // clear data because search query is empty
             institutionTableView.load(
                 institutions: dataSource.featuredInstitutions,
@@ -252,7 +252,7 @@ extension InstitutionPickerViewController {
             return
         }
 
-        searchBar.updateSearchingIndicator(true)
+        showLoadingView(true)
         let newFetchInstitutionsDispatchWorkItem = DispatchWorkItem(block: { [weak self] in
             guard let self = self else { return }
 
@@ -329,7 +329,7 @@ extension InstitutionPickerViewController {
                                 )
                         }
                     }
-                    self.searchBar.updateSearchingIndicator(false)
+                    showLoadingView(false)
                 }
         })
         self.fetchInstitutionsDispatchWorkItem = newFetchInstitutionsDispatchWorkItem

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionSearchBar.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionSearchBar.swift
@@ -177,25 +177,6 @@ final class InstitutionSearchBar: UIView {
             height: 1 / UIScreen.main.nativeScale
         )
     }
-
-    func updateSearchingIndicator(_ isSearching: Bool) {
-        guard isSearching else {
-            searchIconView.layer.removeAnimation(forKey: "pulseAnimation")
-            return
-        }
-        guard searchIconView.layer.animation(forKey: "pulseAnimation") == nil else {
-            return
-        }
-
-        let opacityAnimation = CABasicAnimation(keyPath: "opacity")
-        opacityAnimation.fromValue = 0.6
-        opacityAnimation.toValue = 0.3
-        opacityAnimation.repeatCount = .infinity
-        opacityAnimation.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeInEaseOut)
-        opacityAnimation.duration = 0.3
-        opacityAnimation.autoreverses = true
-        searchIconView.layer.add(opacityAnimation, forKey: "pulseAnimation")
-    }
 }
 
 // MARK: - UITextFieldDelegate

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionTableLoadingView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionTableLoadingView.swift
@@ -13,6 +13,7 @@ final class InstitutionTableLoadingView: UIView {
 
     init() {
         super.init(frame: UIScreen.main.bounds)
+        backgroundColor = .customBackgroundColor
         let verticalStackView = UIStackView(
             arrangedSubviews: (0..<10).map({ _ in
                 ShimmeringInstitutionRowView()

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PrepaneImageView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PrepaneImageView.swift
@@ -132,6 +132,7 @@ private final class GIFImageView: UIView, WKNavigationDelegate {
         webView.scrollView.isScrollEnabled = false
         webView.isUserInteractionEnabled = false
         webView.loadHTMLString(htmlString, baseURL: nil)
+        webView.backgroundColor = .customBackgroundColor
         addAndPinSubview(webView)
     }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/Button+Extensions.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/Button+Extensions.swift
@@ -19,11 +19,11 @@ extension Button {
     static func primary() -> StripeUICore.Button {
         let button = Button(configuration: .financialConnectionsPrimary)
         button.layer.shadowColor = UIColor.black.cgColor
-        button.layer.shadowRadius = 1.5 / UIScreen.main.nativeScale
-        button.layer.shadowOpacity = 0.23
+        button.layer.shadowRadius = 5 / UIScreen.main.nativeScale
+        button.layer.shadowOpacity = 0.25
         button.layer.shadowOffset = CGSize(
             width: 0,
-            height: 1 / UIScreen.main.nativeScale
+            height: 2 / UIScreen.main.nativeScale
         )
         return button
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
@@ -50,7 +50,7 @@ final class NetworkingOTPView: UIView {
                 enableDigitGrouping: false,
                 font: UIFont.systemFont(ofSize: 28, weight: .regular),
                 itemCornerRadius: 12,
-                itemHeight: 56
+                itemHeight: 58
             ),
             theme: theme
         )

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/ShimmeringView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/ShimmeringView.swift
@@ -20,14 +20,14 @@ class ShimmeringView: UIView {
     }
 
     private func startShimmering() {
-        self.alpha = 0.30
+        self.alpha = 1.0
 
         UIView.animate(
             withDuration: 1.0,
             delay: 1.0,
             options: [.autoreverse, .repeat, .allowUserInteraction],
             animations: {
-                self.alpha = 1.0
+                self.alpha = 0.3
             },
             completion: nil
         )


### PR DESCRIPTION
## Summary

This PR contains various other polish fixes:
- fixed an issue where dark mode prepane would flash a dark background for institution  GIF.
- added better scroll behavior for pressing on search for more banks from institution picker.
- increased OTP height by 2 px.
- changed the institution picker loading animations.
- added shadow to consent logos and made primary button shadow stronger.

## Testing

### Added shadow to logo and more shadow to primary button

| Before | After |
| --- | --- | 
| ![before_Logo_button_shadow](https://github.com/stripe/stripe-ios/assets/105514761/df2956c9-849c-485a-92d7-0d5c631f6d75) | ![afteR_logo_button_shadow](https://github.com/stripe/stripe-ios/assets/105514761/60f4f46f-5e69-4bdd-bd13-e53ad5eb6280) |

### Fixed an issue where programatically selecting search bar would scroll to the search bar oddly

| Before | After |
| --- | --- | 
| ![before_pressing_search_more](https://github.com/stripe/stripe-ios/assets/105514761/3325510d-1865-4a2b-b9f6-acc880dce355) | ![aftter_pressing_ssearch_more](https://github.com/stripe/stripe-ios/assets/105514761/c14fc738-7d8b-4334-8d6c-fe56e95f81a6) |

### Fixed an issue where a black overlay would temporarily appear while a GIF/image is loading

| Before | After |
| --- | --- | 
| <img width="435" alt="before_gif_dark" src="https://github.com/stripe/stripe-ios/assets/105514761/3a84d98a-796d-477c-9ded-63e5ac740d1e"> | <img width="435" alt="after_gif_dark" src="https://github.com/stripe/stripe-ios/assets/105514761/8cdecfc9-4205-41f5-b525-d4ca8f625872"> |

### Added different institution loaders (design request)

Not sure if actually better but that was the request 🤷 

#### Before

https://github.com/stripe/stripe-ios/assets/105514761/0ce80a21-886f-4902-9baa-aa8bb66100df

#### After

https://github.com/stripe/stripe-ios/assets/105514761/979f9b0d-2604-4814-bb20-df4344c7a12e
