### PR TITLE
Financial Connections: fixed sheet bottom cover overlapping with the footer button

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/SheetViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/SheetViewController.swift
@@ -41,6 +41,8 @@ class SheetViewController: UIViewController {
         contentStackView.axis = .vertical
         contentStackView.spacing = 0
         contentStackView.layer.cornerRadius = Self.cornerRadius
+        // only round the corners of top left and top right corners
+        contentStackView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
         contentStackView.clipsToBounds = true
         if panePresentationStyle == .sheet {
             contentStackView.addArrangedSubview(handleView)
@@ -359,13 +361,22 @@ class SheetViewController: UIViewController {
         view.insertSubview(extensionBottomView, at: 0)
         extensionBottomView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            extensionBottomView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -Self.cornerRadius),
+            extensionBottomView.topAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.bottomAnchor,
+                // if we put this at "0" there will be a "glitchy gap"
+                // while moving the drawer, so we set it to a higher
+                // value to fix this gap
+                //
+                // it needs to be smaller than the bottom padding of
+                // the footer view
+                constant: -4
+            ),
             extensionBottomView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             extensionBottomView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            // the value is estimated...ideally it should cover corner radius,
-            // bottom safe area insets, and some extra to account for "pulling"
-            // the sheet up beyond the size of it on screen
-            extensionBottomView.heightAnchor.constraint(equalToConstant: Self.cornerRadius + 100),
+            // the value is estimated...ideally it should cover bottom safe area insets,
+            // and some extra to account for "pulling" the sheet up beyond the size
+            // of it on screen
+            extensionBottomView.heightAnchor.constraint(equalToConstant: 100),
         ])
     }
 


### PR DESCRIPTION
## Summary

When moving the "sheet" up, there would be a gap covering over the button, and this PR fixes this.

## Testing


### Before

![Simulator Screenshot - iPhone SE (3rd generation) - 2024-02-29 at 11 26 09](https://github.com/stripe/stripe-ios/assets/105514761/defc889f-dfa0-4e3e-b10c-d7da5fc95194)

https://github.com/stripe/stripe-ios/assets/105514761/0c15df33-334a-414f-8d27-cbb25cb3b942

### After

https://github.com/stripe/stripe-ios/assets/105514761/3ed36e69-74c1-4032-b1af-c3c05563dc79

https://github.com/stripe/stripe-ios/assets/105514761/1af5f851-eef6-4c07-9642-b3cde40ae296