### PR TITLE
Financial Connections: changed the initial loading spinner

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostViewController.swift
@@ -38,7 +38,8 @@ final class HostViewController: UIViewController {
             target: self,
             action: #selector(didTapClose)
         )
-        item.tintColor = .textDisabled
+        item.tintColor = .iconDefault
+        item.imageInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 5)
         return item
     }()
 
@@ -97,7 +98,7 @@ final class HostViewController: UIViewController {
 extension HostViewController {
     private func getManifest() {
         loadingView.errorView.isHidden = true
-        loadingView.activityIndicatorView.stp_startAnimatingAndShow()
+        loadingView.showLoading(true)
         apiClient
             .synchronize(
                 clientSecret: clientSecret,
@@ -116,7 +117,7 @@ extension HostViewController {
                             self.delegate?.hostViewController(self, didReceiveEvent: event)
                         }
 
-                    self.loadingView.activityIndicatorView.stp_stopAnimatingAndHide()
+                    self.loadingView.showLoading(false)
                     self.loadingView.errorView.isHidden = false
                     self.lastError = error
                 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/LoadingView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/LoadingView.swift
@@ -44,11 +44,7 @@ class LoadingView: UIView {
         return stackView
     }()
 
-    internal let activityIndicatorView: UIActivityIndicatorView = {
-        let activityIndicatorView = UIActivityIndicatorView()
-        activityIndicatorView.style = .large
-        return activityIndicatorView
-    }()
+    private let spinnerView = SpinnerView(shouldStartAnimating: false)
 
     // MARK: - Init
 
@@ -58,11 +54,9 @@ class LoadingView: UIView {
         errorView.addArrangedSubview(errorLabel)
         errorView.addArrangedSubview(tryAgainButton)
         addSubview(errorView)
-        addSubview(activityIndicatorView)
 
         // Add constraints
         errorView.translatesAutoresizingMaskIntoConstraints = false
-        activityIndicatorView.translatesAutoresizingMaskIntoConstraints = false
 
         tryAgainButton.setContentHuggingPriority(.required, for: .vertical)
         tryAgainButton.setContentCompressionResistancePriority(.required, for: .vertical)
@@ -70,14 +64,22 @@ class LoadingView: UIView {
         errorLabel.setContentCompressionResistancePriority(.required, for: .vertical)
 
         NSLayoutConstraint.activate([
-            // Center activity indicator
-            activityIndicatorView.centerYAnchor.constraint(equalTo: centerYAnchor),
-            activityIndicatorView.centerXAnchor.constraint(equalTo: centerXAnchor),
-
             // Pin error view to top
             errorView.centerYAnchor.constraint(equalTo: centerYAnchor),
             errorView.centerXAnchor.constraint(equalTo: centerXAnchor),
         ])
+
+        addAndPinSubview(spinnerView)
+        showLoading(false)
+    }
+
+    func showLoading(_ showLoading: Bool) {
+        spinnerView.isHidden = !showLoading
+        if showLoading {
+            spinnerView.startAnimating()
+        } else {
+            spinnerView.stopAnimating()
+        }
     }
 
     required init?(coder: NSCoder) {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/SpinnerView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/SpinnerView.swift
@@ -11,10 +11,11 @@ import UIKit
 
 final class SpinnerView: UIView {
 
-    init() {
-        super.init(frame: .zero)
+    private let imageView = UIImageView(image: Image.spinner.makeImage())
+    private let animationKey = "animation_key"
 
-        let imageView = UIImageView(image: Image.spinner.makeImage())
+    init(shouldStartAnimating: Bool = true) {
+        super.init(frame: .zero)
         addSubview(imageView)
         imageView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -22,12 +23,22 @@ final class SpinnerView: UIView {
             imageView.centerYAnchor.constraint(equalTo: centerYAnchor),
         ])
 
+        if shouldStartAnimating {
+            startAnimating()
+        }
+    }
+
+    func startAnimating() {
         let rotatingAnimation = CABasicAnimation(keyPath: "transform.rotation.z")
         rotatingAnimation.byValue = 2 * Float.pi
         rotatingAnimation.duration = 0.7
         rotatingAnimation.isAdditive = true
         rotatingAnimation.repeatCount = .infinity
-        imageView.layer.add(rotatingAnimation, forKey: "animation_key")
+        imageView.layer.add(rotatingAnimation, forKey: animationKey)
+    }
+
+    func stopAnimating() {
+        imageView.layer.removeAnimation(forKey: animationKey)
     }
 
     required init?(coder: NSCoder) {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsWebFlowViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsWebFlowViewController.swift
@@ -78,7 +78,8 @@ final class FinancialConnectionsWebFlowViewController: UIViewController {
             target: self,
             action: #selector(didTapClose)
         )
-        item.tintColor = .textDisabled
+        item.tintColor = .iconDefault
+        item.imageInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 5)
         return item
     }()
 
@@ -145,13 +146,13 @@ extension FinancialConnectionsWebFlowViewController {
         additionalQueryParameters: String? = nil
     ) {
         guard authSessionManager == nil else { return }
-        loadingView.activityIndicatorView.stp_startAnimatingAndShow()
+        loadingView.showLoading(true)
         authSessionManager = AuthenticationSessionManager(manifest: manifest, window: view.window)
         authSessionManager?
             .start(additionalQueryParameters: additionalQueryParameters)
             .observe(using: { [weak self] (result) in
                 guard let self = self else { return }
-                self.loadingView.activityIndicatorView.stp_stopAnimatingAndHide()
+                self.loadingView.showLoading(false)
                 switch result {
                 case .success(.success):
                     self.fetchSession()
@@ -178,13 +179,13 @@ extension FinancialConnectionsWebFlowViewController {
     }
 
     private func fetchSession(userDidCancelInNative: Bool = false, webCancelled: Bool = false) {
-        loadingView.activityIndicatorView.stp_startAnimatingAndShow()
+        loadingView.showLoading(true)
         loadingView.errorView.isHidden = true
         sessionFetcher
             .fetchSession()
             .observe { [weak self] (result) in
                 guard let self = self else { return }
-                self.loadingView.activityIndicatorView.stp_stopAnimatingAndHide()
+                self.loadingView.showLoading(false)
                 switch result {
                 case .success(let session):
                     if userDidCancelInNative {


### PR DESCRIPTION
## Summary

When the Financial Connections Auth Flow appears, we show a loading state. This changes the loading state spinner.

## Testing

### Before

https://github.com/stripe/stripe-ios/assets/105514761/b6ed5274-dbcc-46fa-982c-d6de4aac231d

### After

https://github.com/stripe/stripe-ios/assets/105514761/9453712e-65e9-48a8-9ed9-7e84fef78acb
