### PR TITLE
Financial Connections: changed some logic around how cancels from OAuth are handled IF no status is returned

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthViewController.swift
@@ -235,24 +235,14 @@ final class PartnerAuthViewController: SheetViewController {
                 completionHandler: { [weak self] isSuccess in
                     guard let self = self else { return }
                     if !isSuccess {
-                        self.dataSource.recordAuthSessionEvent(
-                            eventName: "cancel",
-                            authSessionId: authSession.id
-                        )
-
-                        // cancel current auth session
-                        self.dataSource.cancelPendingAuthSessionIfNeeded()
-
-                        // whether legacy or OAuth, we always go back
-                        // if we got an explicit cancel from backend
-                        self.navigateBack()
+                        handleAuthSessionCancel(authSession, nil)
                     }
                 }
             )
         }
     }
 
-    private func handleAuthSessionCompletionWithNoStatus(
+    private func handleAuthSessionCancel(
         _ authSession: FinancialConnectionsAuthSession,
         _ error: Error?
     ) {
@@ -428,7 +418,7 @@ final class PartnerAuthViewController: SheetViewController {
                         completionHandler: { [weak self] isSuccess in
                             guard let self = self else { return }
                             if !isSuccess {
-                                self.handleAuthSessionCompletionWithNoStatus(authSession, error)
+                                self.handleAuthSessionCancel(authSession, error)
                             }
                         }
                     )
@@ -677,7 +667,7 @@ extension PartnerAuthViewController: STPURLCallbackListener {
             handleAuthSessionCompletionWithStatus(status, authSession)
         } else {
             logUrlReceived(url, status: nil, authSessionId: authSession.id)
-            handleAuthSessionCompletionWithNoStatus(authSession, nil)
+            handleAuthSessionCancel(authSession, nil)
         }
     }
 


### PR DESCRIPTION
## Summary

This is a relatively minor change where if a user is using an OAuth institution, AND they cancel it from the OAuth window, we will now "retry" (keep showing the "prepane" [the screen that shows a Continue button to the bank]) rather than "cancel" (go back to the screen with institutions).

## Testing

99% of this code can be analyzed by reading the code (small change), but here are videos below showing the effect

### Before

https://github.com/stripe/stripe-ios/assets/105514761/1cc515bb-4233-41a8-aeca-96ef84d6d3dc

### After

https://github.com/stripe/stripe-ios/assets/105514761/2c252106-956e-4f77-a743-9a82dc6a68e8
