### PR TITLE
Fix a logic error with 3DS2 dismissal

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/BottomSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/BottomSheetViewController.swift
@@ -443,14 +443,12 @@ extension BottomSheetViewController: PaymentSheetAuthenticationContext {
     func present(
         _ authenticationViewController: UIViewController, completion: @escaping () -> Void
     ) {
-        // Remove a blur effect, if any
-        self.removeBlurEffect(animated: true, completion: completion)
-
         let threeDS2ViewController = BottomSheet3DS2ViewController(
             challengeViewController: authenticationViewController, appearance: appearance, isTestMode: isTestMode)
         threeDS2ViewController.delegate = self
         pushContentViewController(threeDS2ViewController)
-        completion()
+        // Remove a blur effect, if any
+        self.removeBlurEffect(animated: true, completion: completion)
     }
 
     func presentPollingVCForAction(action: STPPaymentHandlerActionParams, type: STPPaymentMethodType, safariViewController: SFSafariViewController?) {


### PR DESCRIPTION
## Summary
When initiating a 3DS2 transaction, we invoked the completion block twice. We should only invoke it once.

## Testing
CI, manually in PaymentSheet Example

## Changelog
Will add to release PR
