### PR TITLE
Fix typo in P24 bank name

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Resources/JSON/form_specs.json
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/JSON/form_specs.json
@@ -621,7 +621,7 @@
                         "api_value": "noble_pay"
                     },
                     {
-                        "display_text": "PBac z iPKO (PKO+BP)",
+                        "display_text": "Płać z iPKO (PKO BP)",
                         "api_value": "pbac_z_ipko"
                     },
                     {


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This updates the name of a P24 bank name which was originally misspelled.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

A dev reached out to us on Discord pointing out the typo in the bank name.

## Testing
<!-- How was the code tested? Be as specific as possible. -->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
