### PR TITLE
Remove assertion in FlowController

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -508,8 +508,6 @@ extension PaymentSheetFlowControllerViewController: BottomSheetContentViewContro
 extension PaymentSheetFlowControllerViewController: SavedPaymentOptionsViewControllerDelegate {
     func didUpdate(_ viewController: SavedPaymentOptionsViewController) {
         // no-op
-        assertionFailure("Used to bubble up CVC Input. This should never happen for FlowController")
-
     }
     func didSelectUpdate(viewController: SavedPaymentOptionsViewController,
                          paymentMethodSelection: SavedPaymentOptionsViewController.Selection,


### PR DESCRIPTION
## Summary
This was true during development initially but is no longer the case.  This is safe to do, because there is a hidden cvc element there, that is being accessed to set the text field as nil.

## Motivation
Crashing for development mode

## Testing
manual testing

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
