### PR TITLE
Fix build on Xcode 15.3

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundController.swift
@@ -162,7 +162,7 @@ class CustomerSheetTestPlaygroundController: ObservableObject {
             return "returning"
         case .new:
             return "new"
-        case .id:
+        case .customID:
             return self.settings.customerId ?? ""
         }
     }
@@ -221,7 +221,7 @@ extension CustomerSheetTestPlaygroundController {
                     DispatchQueue.main.async {
                         self.paymentOptionSelection = selection
                         self.settings.customerId = customerId
-                        self.settings.customerMode = .id
+                        self.settings.customerMode = .customID
                         self.currentlyRenderedSettings = self.settings
                         self.serializeSettingsToNSUserDefaults()
                         self.isLoading = false
@@ -229,7 +229,7 @@ extension CustomerSheetTestPlaygroundController {
                 } catch {
                     DispatchQueue.main.async {
                         self.settings.customerId = customerId
-                        self.settings.customerMode = .id
+                        self.settings.customerMode = .customID
                         self.currentlyRenderedSettings = self.settings
                         self.serializeSettingsToNSUserDefaults()
                         self.isLoading = false

--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundSettings.swift
@@ -11,7 +11,7 @@ public struct CustomerSheetTestPlaygroundSettings: Codable, Equatable {
 
         case new
         case returning
-        case id
+        case customID
     }
     enum PaymentMethodMode: String, PickerEnum {
         static var enumName: String { "PaymentMethodMode" }


### PR DESCRIPTION
## Summary
This line causes a compiler crash — it seems confused that we named this `id`. Change it to `customID`.

## Motivation
Fix build on Xcode 15.3.

## Testing
Manually in Xcode 15.3 GM