### PR TITLE
Add test which exercises delegate on FlowController

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -2249,6 +2249,12 @@ class PaymentSheetDeferredServerSideUITests: PaymentSheetUITestCase {
         // Shouldn't be able to edit only one saved PM when allowsRemovalOfLastSavedPaymentMethod = .off
         XCTAssertFalse(app.staticTexts["Edit"].waitForExistence(timeout: 1))
 
+        // Ensure we can tap another payment method, which will dismiss Flow Controller
+        app.buttons["Apple Pay"].waitForExistenceAndTap()
+
+        // Re-present the sheet
+        app.staticTexts["apple_pay"].waitForExistenceAndTap()  // The Apple Pay is now the default because we tapped it
+
         // Add another PM
         app.buttons["+ Add"].waitForExistenceAndTap()
         try! fillCardData(app)


### PR DESCRIPTION
## Summary
Adding a test which exercises the no-op in PaymentSheetFlowControllerViewController::didUpdate

## Motivation
We had an assert here, we want to ensure that this code is exercised in our uitests.

## Testing
Update test, added break point in that code to ensure that code is being executed

