### PR TITLE
Financial Connections: added support for connected accounts in DataAccessNotice

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsDataAccessNotice.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsDataAccessNotice.swift
@@ -10,13 +10,18 @@ import Foundation
 struct FinancialConnectionsDataAccessNotice: Decodable {
     let icon: FinancialConnectionsImage?
     let title: String
+    let connectedAccountNotice: ConnectedAccountNotice?
     let subtitle: String?
     let body: Body
-    let connectedAccountNotice: String?
     let disclaimer: String?
     let cta: String
 
     struct Body: Decodable {
         let bullets: [FinancialConnectionsBulletPoint]
+    }
+
+    struct ConnectedAccountNotice: Decodable {
+        let subtitle: String
+        let body: Body
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PrepaneViews.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PrepaneViews.swift
@@ -198,9 +198,9 @@ private class PrepanePreviewView: UIView {
             dataAccessNotice: FinancialConnectionsDataAccessNotice(
                 icon: nil,
                 title: "",
+                connectedAccountNotice: nil,
                 subtitle: nil,
                 body: FinancialConnectionsDataAccessNotice.Body(bullets: []),
-                connectedAccountNotice: nil,
                 disclaimer: nil,
                 cta: "OK"
             )

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/DataAccessNoticeViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/DataAccessNoticeViewController.swift
@@ -34,8 +34,8 @@ final class DataAccessNoticeViewController: SheetViewController {
         let contentView: UIView
         if let connectedAccountNotice = dataAccessNotice.connectedAccountNotice {
             firstSubtitle = connectedAccountNotice.subtitle
-            contentView = CreateConnectedAccountsContentView(
-                connectedAccountsBulletItems: connectedAccountNotice.body.bullets,
+            contentView = CreateConnectedAccountContentView(
+                connectedAccountBulletItems: connectedAccountNotice.body.bullets,
                 secondSubtitle: dataAccessNotice.subtitle,
                 merchantBulletItems: dataAccessNotice.body.bullets,
                 didSelectURL: didSelectUrl
@@ -75,8 +75,8 @@ final class DataAccessNoticeViewController: SheetViewController {
     }
 }
 
-private func CreateConnectedAccountsContentView(
-    connectedAccountsBulletItems: [FinancialConnectionsBulletPoint],
+private func CreateConnectedAccountContentView(
+    connectedAccountBulletItems: [FinancialConnectionsBulletPoint],
     secondSubtitle: String?,
     merchantBulletItems: [FinancialConnectionsBulletPoint],
     didSelectURL: @escaping (URL) -> Void
@@ -86,7 +86,7 @@ private func CreateConnectedAccountsContentView(
     verticalStackView.spacing = 24
     verticalStackView.addArrangedSubview(
         CreateMultiBulletinView(
-            bulletItems: connectedAccountsBulletItems,
+            bulletItems: connectedAccountBulletItems,
             didSelectURL: didSelectURL
         )
     )

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/DataAccessNoticeViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/DataAccessNoticeViewController.swift
@@ -29,6 +29,25 @@ final class DataAccessNoticeViewController: SheetViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        let firstSubtitle: String?
+        let contentView: UIView
+        if let connectedAccountNotice = dataAccessNotice.connectedAccountNotice {
+            firstSubtitle = connectedAccountNotice.subtitle
+            contentView = CreateConnectedAccountsContentView(
+                connectedAccountsBulletItems: connectedAccountNotice.body.bullets,
+                secondSubtitle: dataAccessNotice.subtitle,
+                merchantBulletItems: dataAccessNotice.body.bullets,
+                didSelectURL: didSelectUrl
+            )
+        } else {
+            firstSubtitle = dataAccessNotice.subtitle
+            contentView = CreateMultiBulletinView(
+                bulletItems: dataAccessNotice.body.bullets,
+                didSelectURL: didSelectUrl
+            )
+        }
+
         setup(
             withContentView: PaneLayoutView.createContentView(
                 iconView: RoundedIconView(
@@ -36,11 +55,8 @@ final class DataAccessNoticeViewController: SheetViewController {
                     style: .circle
                 ),
                 title: dataAccessNotice.title,
-                subtitle: dataAccessNotice.subtitle,
-                contentView: CreateMultiBulletinView(
-                    bulletItems: dataAccessNotice.body.bullets,
-                    didSelectURL: didSelectUrl
-                ),
+                subtitle: firstSubtitle,
+                contentView: contentView,
                 isSheet: true
             ),
             footerView: PaneLayoutView.createFooterView(
@@ -57,6 +73,40 @@ final class DataAccessNoticeViewController: SheetViewController {
             ).footerView
         )
     }
+}
+
+private func CreateConnectedAccountsContentView(
+    connectedAccountsBulletItems: [FinancialConnectionsBulletPoint],
+    secondSubtitle: String?,
+    merchantBulletItems: [FinancialConnectionsBulletPoint],
+    didSelectURL: @escaping (URL) -> Void
+) -> UIView {
+    let verticalStackView = HitTestStackView()
+    verticalStackView.axis = .vertical
+    verticalStackView.spacing = 24
+    verticalStackView.addArrangedSubview(
+        CreateMultiBulletinView(
+            bulletItems: connectedAccountsBulletItems,
+            didSelectURL: didSelectURL
+        )
+    )
+    if let secondSubtitle = secondSubtitle {
+        let secondSubtitleLabel = AttributedTextView(
+            font: .body(.medium),
+            boldFont: .body(.mediumEmphasized),
+            linkFont: .body(.mediumEmphasized),
+            textColor: .textDefault
+        )
+        secondSubtitleLabel.setText(secondSubtitle)
+        verticalStackView.addArrangedSubview(secondSubtitleLabel)
+    }
+    verticalStackView.addArrangedSubview(
+        CreateMultiBulletinView(
+            bulletItems: merchantBulletItems,
+            didSelectURL: didSelectURL
+        )
+    )
+    return verticalStackView
 }
 
 private func CreateMultiBulletinView(
@@ -133,3 +183,104 @@ private func CreateSingleBulletinView(
     horizontalStackView.alignment = .top
     return horizontalStackView
 }
+
+#if DEBUG
+
+import SwiftUI
+
+private struct DataAccessNoticeViewControllerRepresentable: UIViewControllerRepresentable {
+    let dataAccessNotice: FinancialConnectionsDataAccessNotice
+
+    func makeUIViewController(context: Context) -> DataAccessNoticeViewController {
+        DataAccessNoticeViewController(
+            dataAccessNotice: dataAccessNotice,
+            didSelectUrl: { _  in })
+    }
+
+    func updateUIViewController(
+        _ viewController: DataAccessNoticeViewController,
+        context: Context
+    ) {}
+}
+
+struct DataAccessNoticeViewController_Previews: PreviewProvider {
+    static var previews: some View {
+        DataAccessNoticeViewControllerRepresentable(
+            dataAccessNotice: FinancialConnectionsDataAccessNotice(
+                icon: FinancialConnectionsImage(
+                    default: "https://b.stripecdn.com/connections-statics-srv/assets/SailIcon--platform-stripeBrand-3x.png"
+                ),
+                title: "Data sharing",
+                connectedAccountNotice: nil,
+                subtitle: "[Merchant] will have access to the following data and related insights:",
+                body: FinancialConnectionsDataAccessNotice.Body(
+                    bullets: [
+                        FinancialConnectionsBulletPoint(
+                            icon: FinancialConnectionsImage(
+                                default: "https://b.stripecdn.com/connections-statics-srv/assets/SailIcon--bank-primary-3x.png"
+                            ),
+                            title: "Account details"
+                        ),
+                        FinancialConnectionsBulletPoint(
+                            icon: FinancialConnectionsImage(
+                                default: "https://b.stripecdn.com/connections-statics-srv/assets/SailIcon--balance-primary-3x.png"
+                            ),
+                            title: "Balances"
+                        ),
+                    ]
+                ),
+                disclaimer: "Learn about [data shared with Stripe](https://test.com) and [how to disconnect](https://test.com)",
+                cta: "OK"
+            )
+        )
+
+        DataAccessNoticeViewControllerRepresentable(
+            dataAccessNotice: FinancialConnectionsDataAccessNotice(
+                icon: FinancialConnectionsImage(
+                    default: "https://b.stripecdn.com/connections-statics-srv/assets/SailIcon--platform-stripeBrand-3x.png"
+                ),
+                title: "Data sharing",
+                connectedAccountNotice: FinancialConnectionsDataAccessNotice.ConnectedAccountNotice(
+                    subtitle: "[Connected account] will have access to the following data and related insights:",
+                    body: FinancialConnectionsDataAccessNotice.Body(
+                        bullets: [
+                            FinancialConnectionsBulletPoint(
+                                icon: FinancialConnectionsImage(
+                                    default: "https://b.stripecdn.com/connections-statics-srv/assets/SailIcon--bank-primary-3x.png"
+                                ),
+                                title: "[C] Account details"
+                            ),
+                            FinancialConnectionsBulletPoint(
+                                icon: FinancialConnectionsImage(
+                                    default: "https://b.stripecdn.com/connections-statics-srv/assets/SailIcon--balance-primary-3x.png"
+                                ),
+                                title: "[C] Balances"
+                            ),
+                        ]
+                    )
+                ),
+                subtitle: "[Merchant] will have access to the following data and related insights:",
+                body: FinancialConnectionsDataAccessNotice.Body(
+                    bullets: [
+                        FinancialConnectionsBulletPoint(
+                            icon: FinancialConnectionsImage(
+                                default: "https://b.stripecdn.com/connections-statics-srv/assets/SailIcon--bank-primary-3x.png"
+                            ),
+                            title: "Account details"
+                        ),
+                        FinancialConnectionsBulletPoint(
+                            icon: FinancialConnectionsImage(
+                                default: "https://b.stripecdn.com/connections-statics-srv/assets/SailIcon--balance-primary-3x.png"
+                            ),
+                            title: "Balances"
+                        ),
+                    ]
+                ),
+                disclaimer: "Learn about [data shared with Stripe](https://test.com) and [how to disconnect](https://test.com)",
+                cta: "OK"
+            )
+        )
+    }
+}
+
+#endif


### PR DESCRIPTION
## Summary

Added a new addition to "data access notice" (these are designs):

![Screenshot 2024-03-05 at 3 49 03 PM](https://github.com/stripe/stripe-ios/assets/105514761/42cbb14a-9a6b-4a9a-8a4c-9d34302f42c8)


## Testing

### Testing Making Sure Old Version Didn't Break

| Before | After |
| --- | --- |
| ![before_standard_live](https://github.com/stripe/stripe-ios/assets/105514761/f8cb137f-2d11-49f8-ab5f-51941660d642) | ![after_standard_live](https://github.com/stripe/stripe-ios/assets/105514761/b461c6fc-5aed-40b3-ba06-d0e45dcc07d0) |

### Testing The New Addition  Using SwiftUI

![Screenshot 2024-03-05 at 3 48 29 PM](https://github.com/stripe/stripe-ios/assets/105514761/b545aea8-7e07-4a2e-9720-24bce0c79ed9)
