### PR TITLE
Financial Connections: started adding various haptic feedback in the auth flow

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
+++ b/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		6A1D43052B17AD76005A1EB0 /* InstitutionTableFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1D43042B17AD76005A1EB0 /* InstitutionTableFooterView.swift */; };
 		6A1D43072B17AE37005A1EB0 /* RoundedIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1D43062B17AE37005A1EB0 /* RoundedIconView.swift */; };
 		6A1D43092B17CB04005A1EB0 /* InstitutionNoResultsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1D43082B17CB04005A1EB0 /* InstitutionNoResultsView.swift */; };
+		6A26A3AB2B991A4D00215510 /* FeedbackGeneratorAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A26A3AA2B991A4D00215510 /* FeedbackGeneratorAdapter.swift */; };
 		6A43202A2B7E8C5400A67A70 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A4320292B7E8C5400A67A70 /* Constants.swift */; };
 		6A732C9A2B61C51C00828CB1 /* ShimmeringView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A732C992B61C51C00828CB1 /* ShimmeringView.swift */; };
 		6A732C9C2B61C56A00828CB1 /* InstitutionTableLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A732C9B2B61C56A00828CB1 /* InstitutionTableLoadingView.swift */; };
@@ -346,6 +347,7 @@
 		6A1D43042B17AD76005A1EB0 /* InstitutionTableFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstitutionTableFooterView.swift; sourceTree = "<group>"; };
 		6A1D43062B17AE37005A1EB0 /* RoundedIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedIconView.swift; sourceTree = "<group>"; };
 		6A1D43082B17CB04005A1EB0 /* InstitutionNoResultsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstitutionNoResultsView.swift; sourceTree = "<group>"; };
+		6A26A3AA2B991A4D00215510 /* FeedbackGeneratorAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackGeneratorAdapter.swift; sourceTree = "<group>"; };
 		6A4320292B7E8C5400A67A70 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		6A732C992B61C51C00828CB1 /* ShimmeringView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShimmeringView.swift; sourceTree = "<group>"; };
 		6A732C9B2B61C56A00828CB1 /* InstitutionTableLoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstitutionTableLoadingView.swift; sourceTree = "<group>"; };
@@ -941,6 +943,7 @@
 				591E8073D2AD30115ABDB60F /* BulletPointLabelView.swift */,
 				4E4A84F0646AD673029CB6FC /* Button+Extensions.swift */,
 				6A7814102B32462100168992 /* CloseConfirmationViewController.swift */,
+				6A26A3AA2B991A4D00215510 /* FeedbackGeneratorAdapter.swift */,
 				A00D518C15FF3FAED7C193C2 /* HitTestStackView.swift */,
 				F669BB8F3DA862C425897705 /* HitTestView.swift */,
 				939D10B20D3ECA7BF7021BF8 /* InstitutionIconView.swift */,
@@ -1285,6 +1288,7 @@
 				E4D00DB842047E595DD85BEF /* CheckboxView.swift in Sources */,
 				6A1D43032B16B3DC005A1EB0 /* InstitutionCellView.swift in Sources */,
 				6A1D43072B17AE37005A1EB0 /* RoundedIconView.swift in Sources */,
+				6A26A3AB2B991A4D00215510 /* FeedbackGeneratorAdapter.swift in Sources */,
 				716E12A9AC0B790F14FB72C6 /* AccountNumberRetrievalErrorView.swift in Sources */,
 				3446145FCA3278D51A9D4B80 /* AttachLinkedPaymentAccountDataSource.swift in Sources */,
 				E3F62D2F9C344A1178030E8E /* AttachLinkedPaymentAccountViewController.swift in Sources */,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsAnalyticsClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsAnalyticsClient.swift
@@ -118,6 +118,7 @@ extension FinancialConnectionsAnalyticsClient {
         eventName: String,
         pane: FinancialConnectionsSessionManifest.NextPane
     ) {
+        FeedbackGeneratorAdapter.errorOccurred()
         FinancialConnectionsEvent
             .events(fromError: error)
             .forEach { event in

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerViewController.swift
@@ -474,6 +474,7 @@ extension AccountPickerViewController: AccountPickerSelectionViewDelegate {
         _ view: AccountPickerSelectionView,
         didSelectAccounts selectedAccounts: [FinancialConnectionsPartnerAccount]
     ) {
+        FeedbackGeneratorAdapter.selectionChanged()
         logAccountSelectOrDeselect(selectedAccounts: selectedAccounts)
         dataSource.updateSelectedAccounts(selectedAccounts)
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionPickerViewController.swift
@@ -159,6 +159,7 @@ class InstitutionPickerViewController: UIViewController {
     }
 
     private func didSelectInstitution(_ institution: FinancialConnectionsInstitution) {
+        FeedbackGeneratorAdapter.selectionChanged()
         delegate?.institutionPickerViewController(self, didSelect: institution)
 
         searchBar.resignFirstResponder()

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionSearchBar.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionSearchBar.swift
@@ -147,6 +147,7 @@ final class InstitutionSearchBar: UIView {
     }
 
     @objc private func didSelectClearButton() {
+        FeedbackGeneratorAdapter.buttonTapped()
         text = ""
     }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionTableView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionTableView.swift
@@ -65,6 +65,7 @@ final class InstitutionTableView: UIView {
             image: .add,
             didSelect: { [weak self] in
                 guard let self = self else { return }
+                FeedbackGeneratorAdapter.buttonTapped()
                 self.delegate?.institutionTableView(
                     self,
                     didSelectManuallyAddYourAccountWithInstitutions: self.institutions
@@ -86,6 +87,7 @@ final class InstitutionTableView: UIView {
                 image: .search,
                 didSelect: { [weak self] in
                     guard let self = self else { return }
+                    FeedbackGeneratorAdapter.buttonTapped()
                     self.delegate?.institutionTableViewDidSelectSearchForMoreBanks(self)
                 }
             )

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
@@ -358,6 +358,7 @@ extension LinkAccountPickerViewController: LinkAccountPickerBodyViewDelegate {
         _ view: LinkAccountPickerBodyView,
         didSelectAccount selectedAccountTuple: FinancialConnectionsAccountTuple
     ) {
+        FeedbackGeneratorAdapter.selectionChanged()
         dataSource
             .analyticsClient
             .log(
@@ -372,6 +373,7 @@ extension LinkAccountPickerViewController: LinkAccountPickerBodyViewDelegate {
     }
 
     func linkAccountPickerBodyViewSelectedNewBankAccount(_ view: LinkAccountPickerBodyView) {
+        FeedbackGeneratorAdapter.buttonTapped()
         dataSource
             .analyticsClient
             .log(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -87,6 +87,7 @@ class NativeFlowController {
     }
 
     @objc private func didSelectNavigationBarCloseButton() {
+        FeedbackGeneratorAdapter.buttonTapped()
         dataManager.analyticsClient.log(
             eventName: "click.nav_bar.close",
             pane: FinancialConnectionsAnalyticsClient

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupFooterView.swift
@@ -71,7 +71,7 @@ class NetworkingLinkSignupFooterView: HitTestView {
     }()
 
     private lazy var notNowButton: StripeUICore.Button = {
-        let saveToLinkButton = Button(configuration: .financialConnectionsSecondary)
+        let saveToLinkButton = Button.secondary()
         saveToLinkButton.title = notNowButtonText
         saveToLinkButton.addTarget(self, action: #selector(didSelectNotNowButton), for: .touchUpInside)
         saveToLinkButton.translatesAutoresizingMaskIntoConstraints = false

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/AttributedTextView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/AttributedTextView.swift
@@ -166,6 +166,7 @@ extension AttributedTextView: UITextViewDelegate {
         interaction: UITextItemInteraction
     ) -> Bool {
         if let linkAction = linkURLStringToAction[URL.absoluteString] {
+            FeedbackGeneratorAdapter.buttonTapped()
             linkAction(URL)
             return false
         } else {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/Button+Extensions.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/Button+Extensions.swift
@@ -72,6 +72,10 @@ private final class ButtonFeedbackGeneratorHandler: NSObject {
         FeedbackGeneratorAdapter.buttonTapped()
     }
 
+    // `associatedObjectKey` is a unique address when accessed
+    // via `&`, so we just map a key ("random address") to
+    // a value (or "instance variable") `buttonFeedbackGeneratorHandler`
+    // so we can retain it to fire `didTouchUpInside` func
     private static var associatedObjectKey: UInt8 = 0
     static func attach(toButton button: UIControl) {
         let buttonFeedbackGeneratorHandler = ButtonFeedbackGeneratorHandler()

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/FeedbackGeneratorAdapter.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/FeedbackGeneratorAdapter.swift
@@ -1,0 +1,30 @@
+//
+//  FeedbackGeneratorAdapter.swift
+//  StripeFinancialConnections
+//
+//  Created by Krisjanis Gaidis on 3/6/24.
+//
+
+import Foundation
+import UIKit
+
+final class FeedbackGeneratorAdapter {
+
+    private init() {}
+
+    static func buttonTapped() {
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+    }
+
+    static func selectionChanged() {
+        UISelectionFeedbackGenerator().selectionChanged()
+    }
+
+    static func errorOccurred() {
+        UINotificationFeedbackGenerator().notificationOccurred(.error)
+    }
+
+    static func successOccurred() {
+        UINotificationFeedbackGenerator().notificationOccurred(.success)
+    }
+}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/PaneLayoutView/PaneLayoutView+Extensions.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/PaneLayoutView/PaneLayoutView+Extensions.swift
@@ -195,7 +195,7 @@ extension PaneLayoutView {
 
         var secondaryButtonReference: StripeUICore.Button?
         if let secondaryButtonConfiguration = secondaryButtonConfiguration {
-            let secondaryButton = Button(configuration: FinancialConnectionsSecondaryButtonConfiguration())
+            let secondaryButton = Button.secondary()
             secondaryButtonReference = secondaryButton
             secondaryButton.title = secondaryButtonConfiguration.title
             secondaryButton.accessibilityIdentifier = secondaryButtonConfiguration.accessibilityIdentifier

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Success/SuccessViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Success/SuccessViewController.swift
@@ -100,6 +100,15 @@ final class SuccessViewController: UIViewController {
                 )
         }
     }
+
+    private var didFireFeedbackGenerator = false
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        if !didFireFeedbackGenerator {
+            didFireFeedbackGenerator = true
+            FeedbackGeneratorAdapter.successOccurred()
+        }
+    }
 }
 
 private func CreateBodyView(subtitle: String?) -> UIView {


### PR DESCRIPTION
## Summary

^ started adding various haptic feedback in the auth flow; its based off this [design spec](https://www.figma.com/file/wXQ8NJApqSJiLmxxANDRTs/%E2%9C%A8-Connections-3.0?type=design&node-id=1540-119569&mode=design&t=5gSqvYY85cwgOf0u-0)

## Testing

I tested all of these on device so difficult to show a test plan.

None the less, I ran `bitrise run financial-connections-stability-tests` as a check that there's no odd unexpected crashes (ex. associated object logic can get tricky etc.):

```
FinancialConnectionsNetworkingUITests
    ✓ testNativeNetworkingTestMode (76.738 seconds)
FinancialConnectionsUITests
    ✓ testDataLiveModeOAuthNativeAuthFlow (32.025 seconds)
    ✓ testDataLiveModeOAuthWebAuthFlow (24.193 seconds)
    ✓ testDataTestModeOAuthNativeAuthFlow (23.275 seconds)
    ✓ testPaymentTestModeLegacyNativeAuthFlow (24.569 seconds)
    ✓ testPaymentTestModeManualEntryNativeAuthFlow (26.279 seconds)
    ✓ testSearchInLiveModeNativeAuthFlow (29.515 seconds)
```