### PR TITLE
Financial Connections: fixed an issue where LinkAccountPicker could unnecessarily reload images on each selection

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/AccountPickerRowView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/AccountPickerRowView.swift
@@ -126,6 +126,10 @@ final class AccountPickerRowView: UIView {
             subtitle: subtitle,
             balanceString: balanceString
         )
+        set(isSelected: isSelected)
+    }
+
+    func set(isSelected: Bool) {
         self.isSelected = isSelected
     }
 


### PR DESCRIPTION
## Summary

^ 

fixed an issue where LinkAccountPicker could unnecessarily reload images on each selection

previously, this was coded to be very "reactive," which was OK, but caused this weird glitch around iamges

## Testing

### Before (notice the images sometimes reload to show the placeholder)

https://github.com/stripe/stripe-ios/assets/105514761/49a32012-8316-41c0-8588-e925db556906

### After (no lag around images/selection)

https://github.com/stripe/stripe-ios/assets/105514761/89dc2a55-5c1d-4a4e-aa8c-378d21d456d0

### Ran UI Tests

`bitrise run financial-connections-stability-tests`:

```
FinancialConnectionsNetworkingUITests
    ✓ testNativeNetworkingTestMode (76.548 seconds)
FinancialConnectionsUITests
    ✓ testDataLiveModeOAuthNativeAuthFlow (33.283 seconds)
    ✓ testDataLiveModeOAuthWebAuthFlow (25.626 seconds)
    ✓ testDataTestModeOAuthNativeAuthFlow (22.699 seconds)
    ✓ testPaymentTestModeLegacyNativeAuthFlow (23.410 seconds)
    ✓ testPaymentTestModeManualEntryNativeAuthFlow (26.256 seconds)
    ✓ testSearchInLiveModeNativeAuthFlow (29.562 seconds)

Executed 7 tests, with 0 failures (0 unexpected) in 237.384 (237.390) seconds
```