### PR TITLE
Financial Connections: fixed a minor bug with reset flow

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -709,7 +709,20 @@ extension NativeFlowController: ResetFlowViewControllerDelegate {
         assert(navigationController.topViewController is ResetFlowViewController)
         if navigationController.topViewController is ResetFlowViewController {
             // remove ResetFlowViewController from the navigation stack
-            navigationController.popViewController(animated: false)
+            if navigationController.viewControllers.count == 1 {
+                // there's a chance that `ResetFlowViewController`
+                // is the only VC on the stack and `popViewController`
+                // will not work
+                //
+                // scenario:
+                // 1. be returning Link consumer
+                // 2. press "Not Now" from warm up pane
+                // 3. go through reset flow
+                //    (ex. select down bank scheduled > select another bank)
+                navigationController.setViewControllers([], animated: false)
+            } else {
+                navigationController.popViewController(animated: false)
+            }
         }
 
         // reset all the state because we are starting


### PR DESCRIPTION
## Summary

There was this odd bug where one could get stuck on an "empty pane" if they went through a very specific sequence of steps. This PR makes sure user can't encounter this flow.

## Testing

### Before (user stuck at pane at the end)

https://github.com/stripe/stripe-ios/assets/105514761/1c961453-3bd2-4584-876f-b12aafff5da8

### After (user can't get to this pane so they can't get stuck)

https://github.com/stripe/stripe-ios/assets/105514761/8fd75739-024e-4a1e-87a3-ab2320d41f54
