### PR TITLE
Financial Connections: made an improvement to force links to always be rendered on the same line.

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/String+Extensions.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/String+Extensions.swift
@@ -65,11 +65,21 @@ extension String {
             let markdownLinkString = (modifiedString as NSString).substring(with: markdownLinkRange)
 
             var replacementString = ""
-            if let substring = markdownLinkString.extractStringInBrackets(),
+            if
+                let linkSubstring = markdownLinkString.extractStringInBrackets(),
                 let urlString = markdownLinkString.extractStringInParentheses()
             {
-                replacementString = substring
-                let linkRange = NSRange(location: markdownLinkRange.location, length: substring.count)
+                // `nonBreakingSpace` ensures links are always on the same line
+                let nonBreakingSpace = "\u{00a0}"
+                let linkSubstring = linkSubstring.replacingOccurrences(
+                    of: " ",
+                    with: nonBreakingSpace
+                )
+                replacementString = linkSubstring
+                let linkRange = NSRange(
+                    location: markdownLinkRange.location,
+                    length: linkSubstring.count
+                )
                 let link = Link(range: linkRange, urlString: urlString)
                 links.append(link)
             }


### PR DESCRIPTION
## Summary

^ 

made an improvement to force links to always be rendered on the same line.

## Testing (see the links in the footer)

I also tested that they are tappable.

| Before | After |
| --- | --- |
| ![before_iphone_15_picker](https://github.com/stripe/stripe-ios/assets/105514761/d5d60c92-6774-4b14-a0af-a8b96aa999b4) | ![after_15_picker](https://github.com/stripe/stripe-ios/assets/105514761/623f8310-34a4-42cf-a160-8bbe537226bf) |
| ![before_iphone_15_consent](https://github.com/stripe/stripe-ios/assets/105514761/9d794f01-f076-4698-bd78-82c2e73a8e42) | ![after_15_consent](https://github.com/stripe/stripe-ios/assets/105514761/836fc318-f7a5-41f3-ab19-7f915e5c0442) | 
| ![before_mini_account_details](https://github.com/stripe/stripe-ios/assets/105514761/6c1afba8-2fef-4610-9f1e-d98db300d3fc) | ![after_mini_account_details](https://github.com/stripe/stripe-ios/assets/105514761/0d56c748-960d-4a59-81a7-102ba7e2c0ad) |






