### PR TITLE
Add support for custom default emails to PaymentSheetTestPlayground

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -27,7 +27,15 @@ struct PaymentSheetTestPlayground: View {
             SettingView(setting: $playgroundController.settings.applePayEnabled)
             SettingView(setting: $playgroundController.settings.applePayButtonType)
             SettingView(setting: $playgroundController.settings.allowsDelayedPMs)
+        }
+        Group {
             SettingPickerView(setting: $playgroundController.settings.defaultBillingAddress)
+            if playgroundController.settings.defaultBillingAddress == .customEmail {
+                TextField("Default email", text: customEmailBinding)
+                    .keyboardType(.emailAddress)
+                    .autocorrectionDisabled()
+                    .textInputAutocapitalization(.never)
+            }
         }
         Group {
             SettingView(setting: $playgroundController.settings.linkEnabled)
@@ -131,6 +139,15 @@ struct PaymentSheetTestPlayground: View {
             playgroundController.settings.customCtaLabel = (newString != "") ? newString : nil
         }
     }
+    
+    var customEmailBinding: Binding<String> {
+        Binding<String> {
+            return playgroundController.settings.customEmail ?? ""
+        } set: { newString in
+            playgroundController.settings.customEmail = (newString != "") ? newString : nil
+        }
+    }
+    
     var paymentMethodSettingsBinding: Binding<String> {
         Binding<String> {
             return playgroundController.settings.paymentMethodConfigurationId ?? ""

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -139,7 +139,7 @@ struct PaymentSheetTestPlayground: View {
             playgroundController.settings.customCtaLabel = (newString != "") ? newString : nil
         }
     }
-    
+
     var customEmailBinding: Binding<String> {
         Binding<String> {
             return playgroundController.settings.customEmail ?? ""
@@ -147,7 +147,7 @@ struct PaymentSheetTestPlayground: View {
             playgroundController.settings.customEmail = (newString != "") ? newString : nil
         }
     }
-    
+
     var paymentMethodSettingsBinding: Binding<String> {
         Binding<String> {
             return playgroundController.settings.paymentMethodConfigurationId ?? ""

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -152,6 +152,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
         case on
         case randomEmail
         case randomEmailNoPhone
+        case customEmail
         case off
     }
 
@@ -258,6 +259,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
     var applePayButtonType: ApplePayButtonType
     var allowsDelayedPMs: AllowsDelayedPMs
     var defaultBillingAddress: DefaultBillingAddress
+    var customEmail: String?
     var linkEnabled: LinkEnabled
     var userOverrideCountry: UserOverrideCountry
     var customCtaLabel: String?
@@ -290,6 +292,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
             applePayButtonType: .buy,
             allowsDelayedPMs: .off,
             defaultBillingAddress: .off,
+            customEmail: nil,
             linkEnabled: .off,
             userOverrideCountry: .off,
             customCtaLabel: nil,

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -128,6 +128,8 @@ class PlaygroundController: ObservableObject {
             configuration.defaultBillingDetails.phone = "+13105551234"
         case .randomEmailNoPhone:
             configuration.defaultBillingDetails.email = "test-\(UUID().uuidString)@stripe.com"
+        case .customEmail:
+            configuration.defaultBillingDetails.email = settings.customEmail
         case .off:
             break
         }

--- a/Stripe.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Stripe.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "90e7cfe525f07150cf06f8407b208299fa6618e564c8d50e3cd15ccc64b0211b",
   "pins" : [
     {
       "identity" : "ios-snapshot-test-case",
@@ -28,5 +29,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Stripe.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Stripe.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,4 @@
 {
-  "originHash" : "90e7cfe525f07150cf06f8407b208299fa6618e564c8d50e3cd15ccc64b0211b",
   "pins" : [
     {
       "identity" : "ios-snapshot-test-case",
@@ -29,5 +28,5 @@
       }
     }
   ],
-  "version" : 3
+  "version" : 2
 }


### PR DESCRIPTION
## Summary
Allow specifying a custom default email address in PaymentSheetTestPlayground

## Motivation
Making it easier to test default billing addresses

## Testing
In PaymentSheet Playground