### PR TITLE
Add interface for adopting CustomerSession in PaymentSheet

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -80,6 +80,7 @@ struct PaymentSheetTestPlayground: View {
                         }
                         SettingView(setting: $playgroundController.settings.mode)
                         SettingPickerView(setting: $playgroundController.settings.integrationType)
+                        SettingView(setting: $playgroundController.settings.customerKeyType)
                         SettingView(setting: customerModeBinding)
                         SettingPickerView(setting: $playgroundController.settings.currency)
                         SettingPickerView(setting: merchantCountryBinding)

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -71,6 +71,12 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
         case new
         case returning
     }
+    enum CustomerKeyType: String, PickerEnum {
+        static var enumName: String { "CustomerKeyType" }
+
+        case legacy
+        case customerSession = "customer_session"
+    }
 
     enum Currency: String, PickerEnum {
         static var enumName: String { "Currency" }
@@ -246,6 +252,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
 
     var uiStyle: UIStyle
     var mode: Mode
+    var customerKeyType: CustomerKeyType
     var integrationType: IntegrationType
     var customerMode: CustomerMode
     var currency: Currency
@@ -278,6 +285,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
         return PaymentSheetTestPlaygroundSettings(
             uiStyle: .paymentSheet,
             mode: .payment,
+            customerKeyType: .legacy,
             integrationType: .normal,
             customerMode: .guest,
             currency: .usd,

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -88,7 +88,7 @@ class PlaygroundController: ObservableObject {
     }
     var customerConfiguration: PaymentSheet.CustomerConfiguration? {
         guard settings.customerMode != .guest,
-              let customerId = self.settings.customerId else {
+              let customerId = self.customerId else {
             return nil
         }
         switch self.settings.customerKeyType {

--- a/Stripe/StripeiOSTests/STPPaymentMethodFunctionalTest.swift
+++ b/Stripe/StripeiOSTests/STPPaymentMethodFunctionalTest.swift
@@ -113,6 +113,7 @@ class STPPaymentMethodFunctionalTest: XCTestCase {
 
         // Clean up, detach the payment method as a customer can only have 400 payment methods saved
         try await client.detachPaymentMethod(paymentMethod.stripeId,
+                                             customerId: nil,
                                              fromCustomerUsing: customerAndEphemeralKey.ephemeralKeySecret,
                                              shouldRemoveDuplicates: false)
      }

--- a/Stripe/StripeiOSTests/STPPaymentMethodFunctionalTest.swift
+++ b/Stripe/StripeiOSTests/STPPaymentMethodFunctionalTest.swift
@@ -117,8 +117,10 @@ class STPPaymentMethodFunctionalTest: XCTestCase {
 
         // Clean up, detach the payment method as a customer can only have 400 payment methods saved
         try await client.detachPaymentMethod(paymentMethod.stripeId,
-                                             fromCustomerUsing: customerAndEphemeralKey.ephemeralKeySecret)
+                                             fromCustomerUsing: customerAndEphemeralKey.ephemeralKeySecret,
+                                             shouldRemoveDuplicates: false)
      }
+    // TODO: Add Function to test w/ customerSession
 
     func testCreateBacsPaymentMethod() {
         let client = STPAPIClient(publishableKey: "pk_test_z6Ct4bpx0NUjHii0rsi4XZBf00jmM8qA28")

--- a/Stripe/StripeiOSTests/STPPaymentMethodFunctionalTest.swift
+++ b/Stripe/StripeiOSTests/STPPaymentMethodFunctionalTest.swift
@@ -13,10 +13,6 @@ import StripeCoreTestUtils
 @testable import StripePaymentsTestUtils
 
 class STPPaymentMethodFunctionalTest: XCTestCase {
-    override func setUp() {
-        super.setUp()
-    }
-
     func testCreateCardPaymentMethod() {
         let client = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
         let card = STPPaymentMethodCardParams()

--- a/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
+++ b/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
@@ -117,6 +117,8 @@
 		68F13446778AF2CAA631ACDE /* PaymentSheet+DeferredAPITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8F7F2824DFC78268ED6459 /* PaymentSheet+DeferredAPITest.swift */; };
 		694A3B36AC19FC1F87EF0CB1 /* CustomerSheetPaymentMethodAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F42DA5892E8E4C28D434AEA7 /* CustomerSheetPaymentMethodAvailabilityTests.swift */; };
 		6A529F76ECB33C9154314C1F /* STPAnalyticsClient+LUXE.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B5AAA4347A6918EC267210 /* STPAnalyticsClient+LUXE.swift */; };
+		6B31B9B82B9019730064E210 /* ElementsCustomer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B31B9B72B9019730064E210 /* ElementsCustomer.swift */; };
+		6B31B9BA2B90FCE60064E210 /* CustomerSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B31B9B92B90FCE60064E210 /* CustomerSession.swift */; };
 		6B7E675071649AE3047D388C /* PaymentSheetFormFactoryConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A21CC86104388EFE07CB37D /* PaymentSheetFormFactoryConfig.swift */; };
 		6BA8D3342B0C1F79008C51FF /* CVCRecollectionElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA8D3332B0C1F79008C51FF /* CVCRecollectionElement.swift */; };
 		6BA8D3362B0C1F9B008C51FF /* CVCReconfirmationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA8D3352B0C1F9B008C51FF /* CVCReconfirmationViewController.swift */; };
@@ -427,6 +429,8 @@
 		67A8D073B075B32BECCD905A /* form_specs.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = form_specs.json; sourceTree = "<group>"; };
 		68C3318ED094D63626740234 /* InstantDebitsOnlyFinancialConnectionsAuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstantDebitsOnlyFinancialConnectionsAuthManager.swift; sourceTree = "<group>"; };
 		6A065CEE8A7BCE60FC9D50BF /* el-GR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "el-GR"; path = "el-GR.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		6B31B9B72B9019730064E210 /* ElementsCustomer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElementsCustomer.swift; sourceTree = "<group>"; };
+		6B31B9B92B90FCE60064E210 /* CustomerSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerSession.swift; sourceTree = "<group>"; };
 		6B680A2FF197F612D065F16C /* PaymentSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSheet.swift; sourceTree = "<group>"; };
 		6B9A346A7A4290BAA7BCA1A2 /* PaymentMethodTypeCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodTypeCollectionView.swift; sourceTree = "<group>"; };
 		6BA8D3332B0C1F79008C51FF /* CVCRecollectionElement.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CVCRecollectionElement.swift; sourceTree = "<group>"; };
@@ -679,6 +683,8 @@
 				2BFA5FA03C7093654EC6926F /* ExternalPaymentMethod.swift */,
 				CC3498CF4AEAA8F169616CDF /* STPCardBrandChoice.swift */,
 				5CA2D5E6CAA2990D88F64A4D /* STPElementsSession.swift */,
+				6B31B9B72B9019730064E210 /* ElementsCustomer.swift */,
+				6B31B9B92B90FCE60064E210 /* CustomerSession.swift */,
 			);
 			path = "v1-elements-sessions";
 			sourceTree = "<group>";
@@ -1643,6 +1649,7 @@
 				235687C1FBE7417C48F99EE3 /* LinkLegalTermsView.swift in Sources */,
 				262850706DA3ECCDC0E5E38F /* LinkMoreInfoView.swift in Sources */,
 				FA565C353EAD9D94B39CFE16 /* AddressViewController+Configuration.swift in Sources */,
+				6B31B9B82B9019730064E210 /* ElementsCustomer.swift in Sources */,
 				0E72F76E2B2D28ED72F6A60B /* AddressViewController.swift in Sources */,
 				82EA15D695BB070F2336CCAB /* BottomSheetPresentable.swift in Sources */,
 				CD19725E26DBDB9960D828CB /* BottomSheetPresentationAnimator.swift in Sources */,
@@ -1726,6 +1733,7 @@
 				2E4C37C73AD202C8A3DD2E4E /* LoadingViewController.swift in Sources */,
 				A8ECBDF889E258F03B86BC2E /* PaymentSheetFlowControllerViewController.swift in Sources */,
 				247A8FEE5184E5976720599E /* PaymentSheetViewController.swift in Sources */,
+				6B31B9BA2B90FCE60064E210 /* CustomerSession.swift in Sources */,
 				4DDECA1F7EC6B624C00D549E /* PollingViewController.swift in Sources */,
 				59BE39C4C3992DBB6A698390 /* PollingViewModel.swift in Sources */,
 				F7BCE78B8F782979FD5EE323 /* SepaMandateViewController.swift in Sources */,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPAPIClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPAPIClient+PaymentSheet.swift
@@ -8,17 +8,21 @@
 
 import Foundation
 @_spi(STP) import StripeCore
-@_spi(STP) import StripePayments
+@_spi(CustomerSessionBetaAccess) @_spi(STP) import StripePayments
 
 extension STPAPIClient {
     typealias STPIntentCompletionBlock = ((Result<Intent, Error>) -> Void)
 
     func makeElementsSessionsParams(mode: PaymentSheet.InitializationMode,
-                                    epmConfiguration: PaymentSheet.ExternalPaymentMethodConfiguration?) -> [String: Any] {
+                                    epmConfiguration: PaymentSheet.ExternalPaymentMethodConfiguration?,
+                                    customerAccessProvider: PaymentSheet.CustomerAccessProvider?) -> [String: Any] {
         var parameters: [String: Any] = [
             "locale": Locale.current.toLanguageTag(),
             "external_payment_methods": epmConfiguration?.externalPaymentMethods.compactMap { $0.lowercased() } ?? [],
         ]
+        if case .customerSession(let clientSecret) = customerAccessProvider {
+            parameters["customer_session_client_secret"] = clientSecret
+        }
         switch mode {
         case .deferredIntent(let intentConfig):
             parameters["type"] = "deferred_intent"
@@ -63,7 +67,9 @@ extension STPAPIClient {
         let elementsSession = try await APIRequest<STPElementsSession>.getWith(
             self,
             endpoint: APIEndpointElementsSessions,
-            parameters: makeElementsSessionsParams(mode: .paymentIntentClientSecret(paymentIntentClientSecret), epmConfiguration: configuration.externalPaymentMethodConfiguration)
+            parameters: makeElementsSessionsParams(mode: .paymentIntentClientSecret(paymentIntentClientSecret),
+                                                   epmConfiguration: configuration.externalPaymentMethodConfiguration,
+                                                   customerAccessProvider: configuration.customer?.customerAccessProvider)
         )
         // The v1/elements/sessions response contains a PaymentIntent hash that we parse out into a PaymentIntent
         guard
@@ -82,7 +88,9 @@ extension STPAPIClient {
         let elementsSession = try await APIRequest<STPElementsSession>.getWith(
             self,
             endpoint: APIEndpointElementsSessions,
-            parameters: makeElementsSessionsParams(mode: .setupIntentClientSecret(setupIntentClientSecret), epmConfiguration: configuration.externalPaymentMethodConfiguration)
+            parameters: makeElementsSessionsParams(mode: .setupIntentClientSecret(setupIntentClientSecret),
+                                                   epmConfiguration: configuration.externalPaymentMethodConfiguration,
+                                                   customerAccessProvider: configuration.customer?.customerAccessProvider)
         )
         // The v1/elements/sessions response contains a SetupIntent hash that we parse out into a SetupIntent
         guard
@@ -98,7 +106,9 @@ extension STPAPIClient {
         withIntentConfig intentConfig: PaymentSheet.IntentConfiguration,
         configuration: PaymentSheet.Configuration
     ) async throws -> STPElementsSession {
-        let parameters = makeElementsSessionsParams(mode: .deferredIntent(intentConfig), epmConfiguration: configuration.externalPaymentMethodConfiguration)
+        let parameters = makeElementsSessionsParams(mode: .deferredIntent(intentConfig),
+                                                    epmConfiguration: configuration.externalPaymentMethodConfiguration,
+                                                    customerAccessProvider: configuration.customer?.customerAccessProvider)
         return try await APIRequest<STPElementsSession>.getWith(
             self,
             endpoint: APIEndpointElementsSessions,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/CustomerSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/CustomerSession.swift
@@ -13,9 +13,6 @@ struct CustomerSession: Decodable, Equatable, Hashable {
     let apiKey: String
     let apiKeyExpiry: Int
     let customer: String
-//may need this later
-    //   let components: https://livegrep.corp.stripe.com/view/stripe-internal/pay-server/api/lib/customer_session/resource/components_client_resource.rb#L8
-
 
     /// Helper method to decode the `v1/elements/sessions` response's `external_payment_methods_data` hash.
     /// - Parameter response: The value of the `external_payment_methods_data` key in the `v1/elements/sessions` response.

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/CustomerSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/CustomerSession.swift
@@ -1,0 +1,33 @@
+//
+//  CustomerSession.swift
+//  StripePaymentSheet
+//
+
+import Foundation
+
+/// CustomerSession information, delivered in the `v1/elements/sessions` response.
+/// - Seealso: https://git.corp.stripe.com/stripe-internal/pay-server/blob/master/api/lib/customer_session/resource/customer_session_client_resource.rb
+struct CustomerSession: Decodable, Equatable, Hashable {
+    let id: String
+    let liveMode: Bool
+    let apiKey: String
+    let apiKeyExpiry: Int
+    let customer: String
+//may need this later
+    //   let components: https://livegrep.corp.stripe.com/view/stripe-internal/pay-server/api/lib/customer_session/resource/components_client_resource.rb#L8
+
+
+    /// Helper method to decode the `v1/elements/sessions` response's `external_payment_methods_data` hash.
+    /// - Parameter response: The value of the `external_payment_methods_data` key in the `v1/elements/sessions` response.
+    public static func decoded(fromAPIResponse response: [AnyHashable: Any]?) -> CustomerSession? {
+        guard let response,
+              let id = response["id"] as? String,
+              let liveMode = response["livemode"] as? Bool,
+              let apiKey = response["api_key"] as? String,
+              let apiKeyExpiry = response["api_key_expiry"] as? Int,
+              let customer = response["customer"] as? String else {
+            return nil
+        }
+        return CustomerSession(id: id, liveMode: liveMode, apiKey: apiKey, apiKeyExpiry: apiKeyExpiry, customer: customer)
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/ElementsCustomer.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/ElementsCustomer.swift
@@ -1,0 +1,42 @@
+//
+//  ElementsCustomer.swift
+//  StripePaymentSheet
+//
+
+import Foundation
+@_spi(STP) import StripeCore
+@_spi(STP) import StripePayments
+
+/// Elements Customer, delivered in the `v1/elements/sessions` response.
+/// - Seealso: https://git.corp.stripe.com/stripe-internal/pay-server/blob/master/lib/elements/api/resources/elements_customer_resource.rb
+struct ElementsCustomer: Equatable, Hashable {
+
+    let paymentMethods: [STPPaymentMethod]
+    let defaultPaymentMethod: String?
+    let customerSession: CustomerSession
+
+    /// Helper method to decode the `v1/elements/sessions` response's `customer` hash.
+    /// - Parameter response: The value of the `customer` key in the `v1/elements/sessions` response.
+    public static func decoded(fromAPIResponse response: [AnyHashable: Any]?) -> ElementsCustomer? {
+        // Required fields
+        guard let response,
+              let paymentMethodsArray = response["payment_methods"] as? [[AnyHashable: Any]],
+              let customerSessionDict = response["customer_session"] as? [AnyHashable: Any],
+              let customerSession = CustomerSession.decoded(fromAPIResponse: customerSessionDict)
+        else {
+            return nil
+        }
+
+        var paymentMethods: [STPPaymentMethod] = []
+        for paymentMethodJSON in paymentMethodsArray {
+            let paymentMethod = STPPaymentMethod.decodedObject(fromAPIResponse: paymentMethodJSON)
+            if let paymentMethod = paymentMethod {
+                paymentMethods.append(paymentMethod)
+            }
+        }
+
+        // Optional
+        let defaultPaymentMethod = response["default_payment_method"] as? String
+        return ElementsCustomer(paymentMethods: paymentMethods, defaultPaymentMethod: defaultPaymentMethod, customerSession: customerSession)
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
@@ -43,6 +43,8 @@ final class STPElementsSession: NSObject {
     /// An ordered list of external payment methods to display
     let externalPaymentMethods: [ExternalPaymentMethod]
 
+    let customer: ElementsCustomer?
+
     /// A flag that indicates that this instance was created as a best-effort
     let isBackupInstance: Bool
 
@@ -60,6 +62,7 @@ final class STPElementsSession: NSObject {
         cardBrandChoice: STPCardBrandChoice?,
         isApplePayEnabled: Bool,
         externalPaymentMethods: [ExternalPaymentMethod],
+        customer: ElementsCustomer?,
         isBackupInstance: Bool = false
     ) {
         self.allResponseFields = allResponseFields
@@ -73,6 +76,7 @@ final class STPElementsSession: NSObject {
         self.cardBrandChoice = cardBrandChoice
         self.isApplePayEnabled = isApplePayEnabled
         self.externalPaymentMethods = externalPaymentMethods
+        self.customer = customer
         self.isBackupInstance = isBackupInstance
         super.init()
     }
@@ -106,6 +110,7 @@ final class STPElementsSession: NSObject {
             cardBrandChoice: STPCardBrandChoice.decodedObject(fromAPIResponse: [:]),
             isApplePayEnabled: true,
             externalPaymentMethods: [],
+            customer: nil,
             isBackupInstance: true
         )
     }
@@ -128,6 +133,19 @@ extension STPElementsSession: STPAPIResponseDecodable {
         let cardBrandChoice = STPCardBrandChoice.decodedObject(fromAPIResponse: response["card_brand_choice"] as? [AnyHashable: Any])
         let applePayPreference = response["apple_pay_preference"] as? String
         let isApplePayEnabled = applePayPreference != "disabled"
+        let customer: ElementsCustomer? = {
+            let customerDataKey = "customer"
+            guard response[customerDataKey] != nil, !(response[customerDataKey] is NSNull) else {
+                return nil
+            }
+            guard let customerJSON = response[customerDataKey] as? [AnyHashable: Any],
+                  let decoded = ElementsCustomer.decoded(fromAPIResponse: customerJSON) else {
+                // TODO: Log deserialization error
+                return nil
+            }
+            return decoded
+        }()
+
         let externalPaymentMethods: [ExternalPaymentMethod] = {
             let externalPaymentMethodDataKey = "external_payment_method_data"
             guard response[externalPaymentMethodDataKey] != nil, !(response[externalPaymentMethodDataKey] is NSNull) else {
@@ -158,7 +176,8 @@ extension STPElementsSession: STPAPIResponseDecodable {
             paymentMethodSpecs: response["payment_method_specs"] as? [[AnyHashable: Any]],
             cardBrandChoice: cardBrandChoice,
             isApplePayEnabled: isApplePayEnabled,
-            externalPaymentMethods: externalPaymentMethods
+            externalPaymentMethods: externalPaymentMethods,
+            customer: customer
         )
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerAdapter/CustomerAdapter.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerAdapter/CustomerAdapter.swift
@@ -205,7 +205,7 @@ open class StripeCustomerAdapter: CustomerAdapter {
     open func detachPaymentMethod(paymentMethodId: String) async throws {
         let customerEphemeralKey = try await customerEphemeralKey
         return try await withCheckedThrowingContinuation({ continuation in
-            apiClient.detachPaymentMethod(paymentMethodId, fromCustomerUsing: customerEphemeralKey.ephemeralKeySecret) { error in
+            apiClient.detachPaymentMethod(paymentMethodId, customerId: customerEphemeralKey.id, fromCustomerUsing: customerEphemeralKey.ephemeralKeySecret, shouldRemoveDuplicates: false) { error in
                 if let error = error {
                     continuation.resume(throwing: error)
                     return

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -606,7 +606,7 @@ extension PaymentSheetViewController: SavedPaymentOptionsViewControllerDelegate 
                          paymentMethodSelection: SavedPaymentOptionsViewController.Selection,
                          updateParams: STPPaymentMethodUpdateParams) async throws -> STPPaymentMethod {
         guard case .saved(let paymentMethod) = paymentMethodSelection,
-            let ephemeralKey = configuration.customer?.ephemeralKeySecret
+              let ephemeralKey = configuration.customer?.ephemeralKeySecretBasedOn(intent: intent)
         else {
             throw PaymentSheetError.unknown(debugDescription: "Failed to read ephemeral key secret")
         }
@@ -638,13 +638,21 @@ extension PaymentSheetViewController: SavedPaymentOptionsViewControllerDelegate 
         paymentMethodSelection: SavedPaymentOptionsViewController.Selection
     ) {
         guard case .saved(let paymentMethod) = paymentMethodSelection,
-            let ephemeralKey = configuration.customer?.ephemeralKeySecret
+              let ephemeralKey = configuration.customer?.ephemeralKeySecretBasedOn(intent: intent)
         else {
             return
         }
+        var shouldRemoveDuplicates = false
+        if let customerAccessProvider = configuration.customer?.customerAccessProvider,
+           case .customerSession = customerAccessProvider,
+           paymentMethod.type == .card {
+            shouldRemoveDuplicates = true
+        }
         configuration.apiClient.detachPaymentMethod(
             paymentMethod.stripeId,
-            fromCustomerUsing: ephemeralKey
+            customerId: configuration.customer?.id,
+            fromCustomerUsing: ephemeralKey,
+            shouldRemoveDuplicates: shouldRemoveDuplicates
         ) { (_) in
             // no-op
         }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPAPIClient+PaymentSheetTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPAPIClient+PaymentSheetTest.swift
@@ -27,7 +27,7 @@ class STPAPIClient_PaymentSheetTest: XCTestCase {
         var config = PaymentSheet.Configuration()
         config.externalPaymentMethodConfiguration = .init(externalPaymentMethods: ["external_foo", "external_bar"], externalPaymentMethodConfirmHandler: { _, _, _ in })
 
-        let parameters = STPAPIClient(publishableKey: "pk_test").makeElementsSessionsParams(mode: .deferredIntent(intentConfig), epmConfiguration: config.externalPaymentMethodConfiguration)
+        let parameters = STPAPIClient(publishableKey: "pk_test").makeElementsSessionsParams(mode: .deferredIntent(intentConfig), epmConfiguration: config.externalPaymentMethodConfiguration, customerAccessProvider: nil)
         XCTAssertEqual(parameters["key"] as? String, "pk_test")
         XCTAssertEqual(parameters["locale"] as? String, Locale.current.toLanguageTag())
         XCTAssertEqual(parameters["external_payment_methods"] as? [String], ["external_foo", "external_bar"])
@@ -50,7 +50,7 @@ class STPAPIClient_PaymentSheetTest: XCTestCase {
                                                             onBehalfOf: "acct_connect",
                                                             confirmHandler: { _, _, _ in })
 
-        let parameters = STPAPIClient(publishableKey: "pk_test").makeElementsSessionsParams(mode: .deferredIntent(intentConfig), epmConfiguration: nil)
+        let parameters = STPAPIClient(publishableKey: "pk_test").makeElementsSessionsParams(mode: .deferredIntent(intentConfig), epmConfiguration: nil, customerAccessProvider: nil)
         XCTAssertEqual(parameters["key"] as? String, "pk_test")
         XCTAssertEqual(parameters["locale"] as? String, Locale.current.toLanguageTag())
         XCTAssertEqual(parameters["external_payment_methods"] as? [String], [])

--- a/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+Payments.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+Payments.swift
@@ -1091,29 +1091,113 @@ extension STPAPIClient {
             completion(shared_allPaymentMethods, shared_lastError)
         }
     }
-
     @_spi(STP) public func detachPaymentMethod(
         _ paymentMethodID: String,
+        customerId: String?,
         fromCustomerUsing ephemeralKeySecret: String,
+        shouldRemoveDuplicates: Bool,
         completion: @escaping STPErrorBlock
     ) {
-        let endpoint = "\(APIEndpointPaymentMethods)/\(paymentMethodID)/detach"
-        APIRequest<STPPaymentMethod>.post(
-            with: self,
-            endpoint: endpoint,
-            additionalHeaders: authorizationHeader(using: ephemeralKeySecret),
-            parameters: [:]
-        ) { _, _, error in
-            completion(error)
+        let fetchPaymentMethods: (String) async throws -> [STPPaymentMethod] = { customerId in
+            try await withCheckedThrowingContinuation { continuation in
+                self.listPaymentMethods(forCustomer: customerId,
+                                        using: ephemeralKeySecret,
+                                        types: [.card]) { paymentMethods, error in
+                    guard let paymentMethods, error == nil else {
+                        let error = error ?? NSError.stp_genericFailedToParseResponseError()
+                        continuation.resume(throwing: error)
+                        return
+                    }
+                    continuation.resume(returning: paymentMethods)
+                }
+            }
+        }
+        let detachPaymentMethod: (String) async throws -> Void = { paymentMethodID in
+            try await withCheckedThrowingContinuation { continuation in
+                let endpoint = "\(APIEndpointPaymentMethods)/\(paymentMethodID)/detach"
+                APIRequest<STPPaymentMethod>.post(
+                    with: self,
+                    endpoint: endpoint,
+                    additionalHeaders: self.authorizationHeader(using: ephemeralKeySecret),
+                    parameters: [:]
+                ) { _, _, error in
+                    if let error {
+                        continuation.resume(throwing: error)
+                        return
+                    }
+                    continuation.resume()
+                }
+            }
+        }
+        // TODO: Remove this logic when we stand up an endpoint to do this
+        let detachMulitplePaymentMethods: ([STPPaymentMethod]) async -> Error? = { allPaymentMethodsToDelete in
+            var errors: [Error] = []
+            await withTaskGroup(of: (Error?).self) { group in
+                for paymentMethod in allPaymentMethodsToDelete {
+                    group.addTask {
+                        do {
+                            try await detachPaymentMethod(paymentMethod.stripeId)
+                        } catch {
+                            return error
+                        }
+                        return nil
+                    }
+                }
+                for await error in group {
+                    if let error {
+                        errors.append(error)
+                    }
+                }
+            }
+            if errors.isEmpty {
+                return nil
+            } else {
+                // TODO: Throw only the first? maybe all of them?
+                return errors.first
+            }
+        }
+
+        Task {
+            do {
+                if let customerId, shouldRemoveDuplicates {
+                    let allCardPaymentMethods = try await fetchPaymentMethods(customerId)
+                    let requestedPMToDelete = allCardPaymentMethods.filter({ $0.stripeId == paymentMethodID}).first
+                    guard let requestedPMToDelete else {
+                        // Payment method doesnt exist anymore, nothing to do
+                        completion(nil)
+                        return
+                    }
+
+                    let allPaymentMethodsToDelete: [STPPaymentMethod] = allCardPaymentMethods
+                        .filter({$0.type == .card})
+                        .filter({$0.card?.fingerprint == requestedPMToDelete.card?.fingerprint})
+                    let error = await detachMulitplePaymentMethods(allPaymentMethodsToDelete)
+                    completion(error)
+                } else {
+                    do {
+                        try await detachPaymentMethod(paymentMethodID)
+                        completion(nil)
+                    } catch {
+                        completion(error)
+                    }
+                }
+            } catch {
+                completion(error)
+            }
         }
     }
 
     @_spi(STP) public func detachPaymentMethod(
         _ paymentMethodID: String,
-        fromCustomerUsing ephemeralKeySecret: String
+        customerId: String?,
+        fromCustomerUsing ephemeralKeySecret: String,
+        shouldRemoveDuplicates: Bool
     ) async throws {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) -> Void in
-            detachPaymentMethod(paymentMethodID, fromCustomerUsing: ephemeralKeySecret) { error in
+            detachPaymentMethod(paymentMethodID,
+                                customerId: customerId,
+                                fromCustomerUsing: ephemeralKeySecret,
+                                shouldRemoveDuplicates: shouldRemoveDuplicates) { error in
                 if let error = error {
                     continuation.resume(throwing: error)
                 } else {

--- a/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+Payments.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+Payments.swift
@@ -1161,7 +1161,7 @@ extension STPAPIClient {
             do {
                 if let customerId, shouldRemoveDuplicates {
                     let allCardPaymentMethods = try await fetchPaymentMethods(customerId)
-                    let requestedPMToDelete = allCardPaymentMethods.filter({ $0.stripeId == paymentMethodID}).first
+                    let requestedPMToDelete = allCardPaymentMethods.filter({ $0.stripeId == paymentMethodID }).first
                     guard let requestedPMToDelete else {
                         // Payment method doesnt exist anymore, nothing to do
                         completion(nil)
@@ -1169,8 +1169,8 @@ extension STPAPIClient {
                     }
 
                     let allPaymentMethodsToDelete: [STPPaymentMethod] = allCardPaymentMethods
-                        .filter({$0.type == .card})
-                        .filter({$0.card?.fingerprint == requestedPMToDelete.card?.fingerprint})
+                        .filter({ $0.type == .card })
+                        .filter({ $0.card?.fingerprint == requestedPMToDelete.card?.fingerprint })
                     let error = await detachMulitplePaymentMethods(allPaymentMethodsToDelete)
                     completion(error)
                 } else {


### PR DESCRIPTION
## Summary
Add a Beta interface for accepting a CustomerSession client secret.

## Motivation
Unlock additional features.

## Testing
manual testing.

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
