### PR TITLE
Show rotating card brands when PAN is empty for CBC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * [Added] Added `paymentMethodTypes` in `CustomerAdapter` to control what payment methods are displayed.
 
 ### PaymentSheet
-* [Fixed] The rotating [card brand view](https://docs.stripe.com/co-badged-cards-compliance)) is now shown when card brand choice is enabled if the card number is empty.
+* [Fixed] The rotating [card brand view](https://docs.stripe.com/co-badged-cards-compliance) is now shown when card brand choice is enabled if the card number is empty.
 
 ## 23.24.1 2024-03-05
 ### PaymentSheet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ### CustomerSheet
 * [Added] Added `paymentMethodTypes` in `CustomerAdapter` to control what payment methods are displayed.
 
+### PaymentSheet
+* [Fixed] The rotating [card brand view](https://docs.stripe.com/co-badged-cards-compliance)) is now shown when card brand choice is enabled if the card number is empty.
+
 ## 23.24.1 2024-03-05
 ### PaymentSheet
 * [Fixed] Fixed an assertionFailure that happens when using FlowController and switching between saved payment methods

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/TextField/TextFieldElement+Card.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/TextField/TextFieldElement+Card.swift
@@ -29,8 +29,8 @@ extension TextFieldElement {
         }
 
         func accessoryView(for text: String, theme: ElementsUITheme) -> UIView? {
-            // If CBC is enabled...
-            if let cardBrandDropDown = cardBrandDropDown {
+            // If CBC is enabled and the PAN is not empty...
+            if let cardBrandDropDown = cardBrandDropDown, !text.isEmpty {
                 // Show unknown card brand if we have under 9 pan digits and no card brands
                 if 9 > text.count && cardBrandDropDown.nonPlacerholderItems.isEmpty {
                     return DynamicImageView.makeUnknownCardImageView(theme: theme)


### PR DESCRIPTION
## Summary
- Show rotating card brand view for CBC when PAN is empty

## Motivation
https://github.com/stripe/stripe-ios/issues/3376

## Testing
Manual

## Changelog
See diff
