### PR TITLE
Fix error code link in migration guide

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -286,7 +286,7 @@ STPAPIClient *client = [[STPAPIClient alloc] initWithPublishableKey:publishableK
 
 ### Handling errors
 
-See [StripeError.h](https://github.com/stripe/stripe-ios/blob/master/Stripe/PublicHeaders/Stripe/StripeError.h) for a list of error codes that may be returned from the Stripe API.
+See [our documentation](https://docs.stripe.com/error-codes) for a list of error codes that may be returned from the Stripe API.
 
 ### Validating STPCards
 


### PR DESCRIPTION
## Summary
Previous link was dead

## Motivation
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-2992

## Testing
Clicking the link

## Changelog
N/A
