### PR TITLE
Persist customerId when restarting payment sheet app

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/AppDelegate.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/AppDelegate.swift
@@ -28,6 +28,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
             // Delete cookies before running UI tests
             PaymentSheet.resetCustomer()
+            PlaygroundController.resetCustomer()
         }
         #endif
 

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -142,6 +142,7 @@ struct PaymentSheetTestPlayground: View {
         Binding<PaymentSheetTestPlaygroundSettings.CustomerMode> {
             return playgroundController.settings.customerMode
         } set: { newMode in
+            PlaygroundController.resetCustomer()
             playgroundController.settings.customerMode = newMode
         }
     }

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -246,7 +246,6 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
 
     var uiStyle: UIStyle
     var mode: Mode
-    var customerId: String?
     var integrationType: IntegrationType
     var customerMode: CustomerMode
     var currency: Currency
@@ -279,7 +278,6 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
         return PaymentSheetTestPlaygroundSettings(
             uiStyle: .paymentSheet,
             mode: .payment,
-            customerId: nil,
             integrationType: .normal,
             customerMode: .guest,
             currency: .usd,

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -308,6 +308,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
     }
 
     static let nsUserDefaultsKey = "PaymentSheetTestPlaygroundSettings"
+    static let nsUserDefaultsCustomerIDKey = "PaymentSheetTestPlaygroundCustomerId"
 
     static let baseEndpoint = "https://stp-mobile-playground-backend-v7.stripedemos.com"
     static var endpointSelectorEndpoint: String {

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -381,6 +381,7 @@ class PlaygroundController: ObservableObject {
 extension PlaygroundController {
     @objc
     func load() {
+        loadLastSavedCustomer()
         serializeSettingsToNSUserDefaults()
         loadBackend()
     }
@@ -654,6 +655,13 @@ extension PlaygroundController {
     func serializeSettingsToNSUserDefaults() {
         let data = try! JSONEncoder().encode(settings)
         UserDefaults.standard.set(data, forKey: PaymentSheetTestPlaygroundSettings.nsUserDefaultsKey)
+
+        if let customerId {
+            let customerIdData = try! JSONEncoder().encode(customerId)
+            UserDefaults.standard.set(customerIdData, forKey: PaymentSheetTestPlaygroundSettings.nsUserDefaultsCustomerIDKey)
+        } else {
+            UserDefaults.standard.removeObject(forKey: PaymentSheetTestPlaygroundSettings.nsUserDefaultsCustomerIDKey)
+        }
     }
 
     static func settingsFromDefaults() -> PaymentSheetTestPlaygroundSettings? {
@@ -666,6 +674,17 @@ extension PlaygroundController {
             }
         }
         return nil
+    }
+
+    func loadLastSavedCustomer() {
+        if let customerIdData = UserDefaults.standard.value(forKey: PaymentSheetTestPlaygroundSettings.nsUserDefaultsCustomerIDKey) as? Data {
+            do {
+                self.customerId = try JSONDecoder().decode(String.self, from: customerIdData)
+            } catch {
+                print("Unable to deserialize customerId")
+                UserDefaults.standard.removeObject(forKey: PaymentSheetTestPlaygroundSettings.nsUserDefaultsCustomerIDKey)
+            }
+        }
     }
 }
 

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -686,6 +686,9 @@ extension PlaygroundController {
             }
         }
     }
+    static func resetCustomer() {
+        UserDefaults.standard.removeObject(forKey: PaymentSheetTestPlaygroundSettings.nsUserDefaultsCustomerIDKey)
+    }
 }
 
 extension AddressViewController.AddressDetails {

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -684,6 +684,8 @@ extension PlaygroundController {
                 print("Unable to deserialize customerId")
                 UserDefaults.standard.removeObject(forKey: PaymentSheetTestPlaygroundSettings.nsUserDefaultsCustomerIDKey)
             }
+        } else {
+            self.customerId = nil
         }
     }
     static func resetCustomer() {


### PR DESCRIPTION
## Summary
Maintains the customerId when restarting the payment sheet app without using our PlaygroundSettings

## Motivation
Quality of life for devs

## Testing
manual testing

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
