### PR TITLE
Add entitlements file to PaymentSheet Example app w/ the Apple Pay ca…

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example.xcodeproj/project.pbxproj
+++ b/Example/PaymentSheet Example/PaymentSheet Example.xcodeproj/project.pbxproj
@@ -232,6 +232,7 @@
 		ADBEC0CE822B92C078E5D758 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		B33D2066D7BA7984CABC23A5 /* zh-HK */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-HK"; path = "zh-HK.lproj/LaunchScreen.strings"; sourceTree = "<group>"; };
 		B54E58F2CA450CF49ECD5637 /* CustomerSheetTestPlaygroundController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerSheetTestPlaygroundController.swift; sourceTree = "<group>"; };
+		B69C155A2B9FDCBD009CE667 /* PaymentSheet Example.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = "PaymentSheet Example.entitlements"; path = "PaymentSheet Example/PaymentSheet Example.entitlements"; sourceTree = "<group>"; };
 		B7AFD32B5EAD3BEEEC3D4260 /* ExampleSwiftUIPaymentSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleSwiftUIPaymentSheet.swift; sourceTree = "<group>"; };
 		B7C76D3D1BF7666D1963DD0B /* bg-BG */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "bg-BG"; path = "bg-BG.lproj/LaunchScreen.strings"; sourceTree = "<group>"; };
 		B96951DD278BA611BBCBB10A /* PaymentSheet Example-Shard1.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "PaymentSheet Example-Shard1.xctestplan"; sourceTree = "<group>"; };
@@ -440,6 +441,7 @@
 		C9D5B927CC2F83061D0651E5 = {
 			isa = PBXGroup;
 			children = (
+				B69C155A2B9FDCBD009CE667 /* PaymentSheet Example.entitlements */,
 				ACF2A07E6D470CDF889DE14C /* Project */,
 				66001906438D4343D9E72825 /* Frameworks */,
 				3263B2FC73C06F5F4413D183 /* Products */,
@@ -789,6 +791,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 4609AB90957A6F72852677BF /* PaymentSheet-Example-Release.xcconfig */;
 			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = "PaymentSheet Example/PaymentSheet Example.entitlements";
 				INFOPLIST_FILE = "PaymentSheet Example/Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.stripe.PaymentSheet-Example";
 				PRODUCT_NAME = PaymentSheetExample;
@@ -810,6 +813,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = EFDB8AECB67684ACA122981F /* PaymentSheet-Example-Debug.xcconfig */;
 			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = "PaymentSheet Example/PaymentSheet Example.entitlements";
 				INFOPLIST_FILE = "PaymentSheet Example/Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.stripe.PaymentSheet-Example";
 				PRODUCT_NAME = PaymentSheetExample;


### PR DESCRIPTION
…pability

## Summary
Enable Apple Pay entitlement for PaymentSheet Example testflight builds so that we can play with Apple Pay. We actually already committed the entitlement file to the repo, we just didn't add it to the example project.

## Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-1669

## Testing
- I built a testflight on this branch, installed on my phone, saw Apple Pay in the app
- I didn't touch the Team setting in Signing (I think this is important to allow non-Stripe users to be able to build, right?)
![CleanShot 2024-03-11 at 18 18 34](https://github.com/stripe/stripe-ios/assets/47796191/f914f8cc-85af-4b49-9518-9af6de359fa6)
- I removed my Apple account in Xcode and could still build PaymentSheet Example

## Changelog
not user facing