### PR TITLE
Fix spurious Link popup error

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkWebController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkWebController.swift
@@ -176,9 +176,9 @@ final class PayWithLinkWebController: NSObject, ASWebAuthenticationPresentationC
         }
         do {
             let result = try LinkPopupURLParser.result(with: returnURL)
-            switch result.link_status {
-            case .complete:
-                let paymentOption = PaymentOption.link(option: PaymentSheet.LinkConfirmOption.withPaymentMethod(paymentMethod: result.pm))
+            switch result {
+            case .complete(let pm):
+                let paymentOption = PaymentOption.link(option: PaymentSheet.LinkConfirmOption.withPaymentMethod(paymentMethod: pm))
 
                 STPAnalyticsClient.sharedClient.logLinkPopupSuccess(sessionType: self.context.intent.linkPopupWebviewOption)
                 UserDefaults.standard.markLinkAsUsed()

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Utils/LinkPopupURLParser.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Utils/LinkPopupURLParser.swift
@@ -6,25 +6,29 @@
 import Foundation
 import StripePayments
 
-struct LinkResult {
-    enum LinkStatus: String {
-        case complete
-        case logout
-    }
-    let link_status: LinkStatus
-    let pm: STPPaymentMethod
+enum LinkResult {
+    case complete(STPPaymentMethod)
+    case logout
 }
 
 class LinkPopupURLParser {
     static func result(with resultURL: URL) throws -> LinkResult {
         let components = URLComponents(url: resultURL, resolvingAgainstBaseURL: false)
-        guard let statusItem = components?.queryItems?.first(where: { $0.name == "link_status" })?.value,
-              let status = LinkResult.LinkStatus(rawValue: statusItem),
-              let pmItem = components?.queryItems?.first(where: { $0.name == "pm" })?.value else {
+        guard let status = components?.queryItems?.first(where: { $0.name == "link_status" })?.value else {
             throw LinkPopupURLParserError.invalidURLParams
         }
-        let pm = try STPPaymentMethod.decodedObject(base64: pmItem)
-        return LinkResult(link_status: status, pm: pm)
+        switch status {
+        case "complete":
+            guard let pmItem = components?.queryItems?.first(where: { $0.name == "pm" })?.value else {
+                throw LinkPopupURLParserError.invalidURLParams
+            }
+            let pm = try STPPaymentMethod.decodedObject(base64: pmItem)
+            return .complete(pm)
+        case "logout":
+            return .logout
+        default:
+            throw LinkPopupURLParserError.invalidURLParams
+        }
     }
 
     static func redactedURLForLogging(url: URL?) -> URL? {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkPopupURLParserTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkPopupURLParserTests.swift
@@ -17,12 +17,17 @@ import XCTest
 class LinkPopupURLParserTests: XCTestCase {
     let testURL = URL(string: "link-popup://complete?link_status=complete&pm=eyJpZCI6InBtXzFOSjNWakx1NW8zUDE4WnB5VG9iYng2VSIsIm9iamVjdCI6InBheW1lbnRfbWV0aG9kIiwiYmlsbGluZ19kZXRhaWxzIjp7ImFkZHJlc3MiOnsiY2l0eSI6bnVsbCwiY291bnRyeSI6bnVsbCwibGluZTEiOm51bGwsImxpbmUyIjpudWxsLCJwb3N0YWxfY29kZSI6bnVsbCwic3RhdGUiOm51bGx9LCJlbWFpbCI6bnVsbCwibmFtZSI6bnVsbCwicGhvbmUiOm51bGx9LCJjYXJkIjp7ImJyYW5kIjoidmlzYSIsImNoZWNrcyI6eyJhZGRyZXNzX2xpbmUxX2NoZWNrIjpudWxsLCJhZGRyZXNzX3Bvc3RhbF9jb2RlX2NoZWNrIjpudWxsLCJjdmNfY2hlY2siOm51bGx9LCJjb3VudHJ5IjpudWxsLCJleHBfbW9udGgiOjQsImV4cF95ZWFyIjoyMDI0LCJmdW5kaW5nIjoiY3JlZGl0IiwiZ2VuZXJhdGVkX2Zyb20iOm51bGwsImxhc3Q0IjoiMDAwMCIsIm5ldHdvcmtzIjp7ImF2YWlsYWJsZSI6WyJ2aXNhIl0sInByZWZlcnJlZCI6bnVsbH0sInRocmVlX2Rfc2VjdXJlX3VzYWdlIjp7InN1cHBvcnRlZCI6dHJ1ZX0sIndhbGxldCI6eyJkeW5hbWljX2xhc3Q0IjpudWxsLCJsaW5rIjp7fSwidHlwZSI6ImxpbmsifX0sImNyZWF0ZWQiOjE2ODY3ODY4MzksImN1c3RvbWVyIjpudWxsLCJsaXZlbW9kZSI6ZmFsc2UsInR5cGUiOiJjYXJkIn0g")!
 
+    let testURLLogout = URL(string: "link-popup://complete?link_status=logout&session_id=abc123-123-145")!
+
     func testBasicPMParsing() {
         let result = try! LinkPopupURLParser.result(with: testURL)
-        XCTAssertEqual(result.link_status, .complete)
-        XCTAssertEqual(result.pm.stripeId, "pm_1NJ3VjLu5o3P18ZpyTobbx6U")
-        XCTAssertEqual(result.pm.card?.expMonth, 4)
-        XCTAssertEqual(result.pm.card?.last4, "0000")
+        guard case let .complete(pm) = result else {
+            XCTFail("Couldn't decode PM")
+            return
+        }
+        XCTAssertEqual(pm.stripeId, "pm_1NJ3VjLu5o3P18ZpyTobbx6U")
+        XCTAssertEqual(pm.card?.expMonth, 4)
+        XCTAssertEqual(pm.card?.last4, "0000")
     }
 
     func testNoPMFails() {
@@ -32,6 +37,14 @@ class LinkPopupURLParserTests: XCTestCase {
             XCTFail("Should not succeed")
         } catch {
             XCTAssertEqual(error as! LinkPopupURLParserError, LinkPopupURLParserError.invalidURLParams)
+        }
+    }
+
+    func testLogout() {
+        let result = try! LinkPopupURLParser.result(with: testURLLogout)
+        guard case .logout = result else {
+            XCTFail("Couldn't decode logout response")
+            return
         }
     }
 


### PR DESCRIPTION
## Summary
Refactor this code to handle Link URLs without PMs correctly.

## Motivation
When the "log out" action occurred, we incorrectly threw an error.

## Testing
In PaymentSheet Example, existing tests.