### PR TITLE
reset instructional test when staying in scanning state for 1 second

### DIFF
--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/DocumentCaptureViewController.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/DocumentCaptureViewController.swift
@@ -60,6 +60,7 @@ final class DocumentCaptureViewController: IdentityFlowViewController {
         lastScanningInstructionText = nil
         lastScanningInstructionTextUpdate = Date.distantPast
     }
+    private var resetScanningInstructionTextTimer: Timer?
 
     var viewModel: DocumentCaptureView.ViewModel {
         switch imageScanningSession.state {
@@ -81,6 +82,11 @@ final class DocumentCaptureViewController: IdentityFlowViewController {
                 newScanningInstructionText = scanningInstructionText(for: documentSide, documentScannerOutput: documentScannerOutput)
                 lastScanningInstructionText = newScanningInstructionText
                 lastScanningInstructionTextUpdate = now
+
+                resetScanningInstructionTextTimer?.invalidate()
+                resetScanningInstructionTextTimer  = Timer.scheduledTimer(withTimeInterval: 1, repeats: false) { [weak self] _ in
+                    self?.updateUI()
+                }
             } else {
                 if let lastScanningInstructionText = lastScanningInstructionText {
                     newScanningInstructionText = lastScanningInstructionText


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Reset instructional text while in `scanning` state for a while


## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Better UX

## Testing
<!-- How was the code tested? Be as specific as possible. -->


| Before  | After |
| ------------- | ------------- |
| ![insBefore](https://github.com/stripe/stripe-ios/assets/79880926/abdc62e4-4d53-4211-a41e-6bdc96eeb158) | ![insAfter](https://github.com/stripe/stripe-ios/assets/79880926/97d7b8b5-8f09-49dd-b81e-f09b92feb3d8) |









## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
