### PR TITLE
Fix BI not sending bi_card_number_completed analytic when copy and pa…

### DIFF
--- a/Stripe/StripeiOS/Source/STPAddCardViewController.swift
+++ b/Stripe/StripeiOS/Source/STPAddCardViewController.swift
@@ -584,7 +584,7 @@ public class STPAddCardViewController: STPCoreTableViewController, STPAddressVie
     }
 
     /// Only send card number completed analytic once per time the card number changes from invalid to valid
-    var shouldSendCardNumberCompletedAnalytic = false
+    var shouldSendCardNumberCompletedAnalytic = true
     func sendCardNumberCompletedAnalyticIfNecessary(cardNumber: String?) {
         let isCardNumberValid = STPCardValidator.validationState(forNumber: cardNumber, validatingCardBrand: true) == .valid
         if isCardNumberValid, shouldSendCardNumberCompletedAnalytic {


### PR DESCRIPTION
…sting a card number

## Motivation
Fix the bug!

## Testing
Manually tested BI - copy and pasting a card number, manually entering -> deleting -> re-entering.  

## Changelog
Not user facing
