### PR TITLE
Financial Connections: improved auto fill phone number handling for networking

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/PhoneCountryCodePickerView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/PhoneCountryCodePickerView.swift
@@ -45,10 +45,11 @@ final class PhoneCountryCodePickerView: UIView, UIPickerViewDelegate, UIPickerVi
     init(defaultCountryCode: String?) {
         let locale = Locale.current
         let rowItems = CreateCountryCodeRowItems(locale: locale)
-        let defaultCountryCode = defaultCountryCode ?? locale.stp_regionCode ?? ""
+        let defaultCountryCode = defaultCountryCode ?? locale.stp_regionCode ?? "US"
         self.rowItems = rowItems
-        self.selectedRow = rowItems.firstIndex(
-            where: { $0.countryCode == defaultCountryCode }
+        self.selectedRow = IndexInCountryCodeRowItems(
+            rowItems,
+            forCountryCode: defaultCountryCode
         ) ?? 0
         super.init(frame: .zero)
         clipsToBounds = true
@@ -69,7 +70,7 @@ final class PhoneCountryCodePickerView: UIView, UIPickerViewDelegate, UIPickerVi
         // adjusted pickerview to selected row
         if pickerView.selectedRow(inComponent: 0) != selectedRow {
             pickerView.reloadComponent(0)
-            pickerView.selectRow(selectedRow, inComponent: 0, animated: false)
+            selectRow(selectedRow)
         }
     }
 
@@ -83,6 +84,21 @@ final class PhoneCountryCodePickerView: UIView, UIPickerViewDelegate, UIPickerVi
         var intrinsicContentSize = super.intrinsicContentSize
         intrinsicContentSize.height = height
         return intrinsicContentSize
+    }
+
+    func selectCountryCode(_ countryCode: String) {
+        guard let row = IndexInCountryCodeRowItems(
+            rowItems,
+            forCountryCode: countryCode
+        ) else {
+            return
+        }
+        selectRow(row)
+        selectedRow = row
+    }
+
+    private func selectRow(_ row: Int) {
+        pickerView.selectRow(row, inComponent: 0, animated: false)
     }
 
     // MARK: - UIPickerViewDataSource
@@ -116,6 +132,15 @@ final class PhoneCountryCodePickerView: UIView, UIPickerViewDelegate, UIPickerVi
     ) {
         selectedRow = row
     }
+}
+
+private func IndexInCountryCodeRowItems(
+    _ countryCodeRowItems: [CountryCodeRowItem],
+    forCountryCode countryCode: String
+) -> Int? {
+    return countryCodeRowItems.firstIndex(
+        where: { $0.countryCode == countryCode }
+    )
 }
 
 private struct CountryCodeRowItem {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/PhoneCountryCodeSelectorView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/PhoneCountryCodeSelectorView.swift
@@ -106,6 +106,11 @@ final class PhoneCountryCodeSelectorView: UIView {
         return invisbleTextField.endEditing(force)
     }
 
+    func selectCountryCode(_ countryCode: String) {
+        // this will fire `PhoneCountryCodePickerViewDelegate`
+        pickerView.selectCountryCode(countryCode)
+    }
+
     private func updateLabelsBasedOffSelectedCountryCode() {
         flagLabel.setText(String.countryFlagEmoji(for: selectedCountryCode) ?? "🇺🇸")
         countryCodeLabel.setText(PhoneNumber.Metadata.metadata(for: selectedCountryCode)?.prefix ?? "")


### PR DESCRIPTION
## Summary

This PR improves how phone autofill works (see the before video on how its failing today). Specifically, phone autofill right now does not handle prefixes.

## Testing

Aside from videos below, I also:
1) ran end to end tests (passed)
2) tested prefilling 
3) tested typing phone number

### Before (auto fill does not work)

https://github.com/stripe/stripe-ios/assets/105514761/8472552f-2bce-4a01-b813-e27dc6e9a999

### After (auto fill works great)

Also tried with copy-paste.

https://github.com/stripe/stripe-ios/assets/105514761/c5e88852-2e10-4170-be7e-ee57b59adb0a


