### PR TITLE
Financial Connections: removed confirmation alert from terminal error screen(s)

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Error/ErrorViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Error/ErrorViewController.swift
@@ -25,6 +25,7 @@ protocol ErrorViewControllerDelegate: AnyObject {
 final class ErrorViewController: UIViewController {
 
     private let dataSource: ErrorDataSource
+    private(set) var isTerminal = false
 
     weak var delegate: ErrorViewControllerDelegate?
 
@@ -185,6 +186,8 @@ final class ErrorViewController: UIViewController {
                 )
             }
         } else {
+            isTerminal = true
+
             dataSource.analyticsClient.logUnexpectedError(
                 error,
                 errorName: "UnexpectedErrorPaneError",

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -94,9 +94,12 @@ class NativeFlowController {
                 .paneFromViewController(navigationController.topViewController)
         )
 
-        let showConfirmationAlert =
-            !(navigationController.topViewController is ConsentViewController
-                || navigationController.topViewController is SuccessViewController)
+        let showConfirmationAlert = !(
+            navigationController.topViewController is ConsentViewController
+            || navigationController.topViewController is SuccessViewController
+            || navigationController.topViewController is TerminalErrorViewController
+            || ((navigationController.topViewController as? ErrorViewController)?.isTerminal == true)
+        )
 
         let finishClosingAuthFlow = { [weak self] in
             self?.closeAuthFlow()


### PR DESCRIPTION
## Summary

As per feedback, removed an alert from a screen that shows a "terminal error" (an error that requires to close the auth flow anyway)

![Screenshot 2024-03-14 at 3 09 10 PM](https://github.com/stripe/stripe-ios/assets/105514761/851ff137-c357-480c-94fc-0148f7ceb070)

## Testing

Ran also tests:

```
FinancialConnectionsNetworkingUITests
    ✓ testNativeNetworkingTestMode (76.047 seconds)
FinancialConnectionsUITests
    ✓ testDataLiveModeOAuthNativeAuthFlow (31.750 seconds)
    ✓ testDataLiveModeOAuthWebAuthFlow (25.800 seconds)
    ✓ testDataTestModeOAuthNativeAuthFlow (23.693 seconds)
    ✓ testPaymentTestModeLegacyNativeAuthFlow (23.074 seconds)
    ✓ testPaymentTestModeManualEntryNativeAuthFlow (25.829 seconds)
    ✓ testSearchInLiveModeNativeAuthFlow (29.865 seconds)

Executed 7 tests, with 0 failures (0 unexpected) in 236.058 (236.069) seconds
```

### Before

https://github.com/stripe/stripe-ios/assets/105514761/e49c5c93-3bc1-4d03-bf2b-d70ca94d734b

### After

https://github.com/stripe/stripe-ios/assets/105514761/8177f143-4ab8-4a60-a95d-e72df0e4d6a3
