### PR TITLE
Add interface for adopting CustomerSession in CustomerSheet

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlayground.swift
@@ -38,6 +38,7 @@ struct CustomerSheetTestPlayground: View {
                             }.buttonStyle(.bordered)
                         }
                         SettingView(setting: $playgroundController.settings.customerMode)
+                        SettingView(setting: $playgroundController.settings.customerKeyType)
                         TextField("CustomerId", text: customerIdBinding)
                     }
                     Group {

--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlayground.swift
@@ -38,7 +38,7 @@ struct CustomerSheetTestPlayground: View {
                             }.buttonStyle(.bordered)
                         }
                         SettingView(setting: $playgroundController.settings.customerMode)
-                        SettingView(setting: $playgroundController.settings.customerKeyType)
+                        SettingView(setting: customerKeyTypeBinding)
                         TextField("CustomerId", text: customerIdBinding)
                     }
                     Group {
@@ -52,7 +52,7 @@ struct CustomerSheetTestPlayground: View {
                             }.buttonStyle(.bordered)
                         }
                         SettingPickerView(setting: merchantCountryBinding)
-                        SettingView(setting: $playgroundController.settings.paymentMethodMode)
+                        SettingView(setting: paymentMethodModeBinding)
                         SettingView(setting: $playgroundController.settings.applePay)
                         SettingView(setting: $playgroundController.settings.defaultBillingAddress)
                         SettingView(setting: $playgroundController.settings.preferredNetworksEnabled)
@@ -81,7 +81,28 @@ struct CustomerSheetTestPlayground: View {
                 .environmentObject(playgroundController)
         }
     }
-
+    var customerKeyTypeBinding: Binding<CustomerSheetTestPlaygroundSettings.CustomerKeyType> {
+        Binding<CustomerSheetTestPlaygroundSettings.CustomerKeyType> {
+            return playgroundController.settings.customerKeyType
+        } set: { newKeyType in
+            // If switching to customerSession preselect setupIntent
+            if playgroundController.settings.customerKeyType.rawValue != newKeyType.rawValue && newKeyType == .customerSession {
+                playgroundController.settings.paymentMethodMode = .setupIntent
+            }
+            playgroundController.settings.customerKeyType = newKeyType
+        }
+    }
+    var paymentMethodModeBinding: Binding<CustomerSheetTestPlaygroundSettings.PaymentMethodMode> {
+        Binding<CustomerSheetTestPlaygroundSettings.PaymentMethodMode> {
+            return playgroundController.settings.paymentMethodMode
+        } set: { newPaymentMethodMode in
+            // If switching to createAndAttach, ensure using legacy customer ephemeralKey
+            if playgroundController.settings.paymentMethodMode.rawValue != newPaymentMethodMode.rawValue && newPaymentMethodMode == .createAndAttach {
+                playgroundController.settings.customerKeyType = .legacy
+            }
+            playgroundController.settings.paymentMethodMode = newPaymentMethodMode
+        }
+    }
     var merchantCountryBinding: Binding<CustomerSheetTestPlaygroundSettings.MerchantCountry> {
         Binding<CustomerSheetTestPlaygroundSettings.MerchantCountry> {
             return playgroundController.settings.merchantCountryCode

--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundController.swift
@@ -216,7 +216,7 @@ extension CustomerSheetTestPlaygroundController {
             }
             let ephemeralKey = json["customerEphemeralKeySecret"]
             let customerSessionClientSecret = json["customerSessionClientSecret"]
-            guard (ephemeralKey != nil || customerSessionClientSecret != nil) else {
+            guard ephemeralKey != nil || customerSessionClientSecret != nil else {
                 DispatchQueue.main.async {
                     self.isLoading = false
                     self.currentlyRenderedSettings = self.settings

--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundController.swift
@@ -135,12 +135,14 @@ class CustomerSheetTestPlaygroundController: ObservableObject {
         case .setupIntent:
             if let customerSessionClientSecret {
                 customerAdapter = StripeCustomerAdapter(customerSessionClientSecretProvider: {
+                    // This should be a block that fetches this from your server
                     return .init(customerId: customerId, clientSecret: customerSessionClientSecret)
                 }, setupIntentClientSecretProvider: {
                     return try await self.backend.createSetupIntent(customerId: customerId, merchantCountryCode: self.settings.merchantCountryCode.rawValue)
                 })
             } else {
                 customerAdapter = StripeCustomerAdapter(customerEphemeralKeyProvider: {
+                    // This should be a block that fetches this from your server
                     return .init(customerId: customerId, ephemeralKeySecret: ephemeralKey!)
                 }, setupIntentClientSecretProvider: {
                     return try await self.backend.createSetupIntent(customerId: customerId, merchantCountryCode: self.settings.merchantCountryCode.rawValue)
@@ -148,6 +150,7 @@ class CustomerSheetTestPlaygroundController: ObservableObject {
             }
         case .createAndAttach:
             customerAdapter = StripeCustomerAdapter(customerEphemeralKeyProvider: {
+                // This should be a block that fetches this from your server
                 return .init(customerId: customerId, ephemeralKeySecret: ephemeralKey!)
             }, setupIntentClientSecretProvider: nil)
         }
@@ -217,6 +220,7 @@ extension CustomerSheetTestPlaygroundController {
                 DispatchQueue.main.async {
                     self.isLoading = false
                     self.currentlyRenderedSettings = self.settings
+                    print("Error: Backend did not return a customerSessionClientSecret or customerEphemeralKeySecret")
                 }
                 return
             }

--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundController.swift
@@ -8,8 +8,7 @@ import Combine
 import SwiftUI
 
 class CustomerSheetTestPlaygroundController: ObservableObject {
-//    static let defaultEndpoint = "https://stp-mobile-playground-backend-v7.stripedemos.com"
-    static let defaultEndpoint = "http://127.0.0.1:8081"
+    static let defaultEndpoint = "https://stp-mobile-playground-backend-v7.stripedemos.com"
 
     @Published var settings: CustomerSheetTestPlaygroundSettings
     @Published var currentlyRenderedSettings: CustomerSheetTestPlaygroundSettings

--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundSettings.swift
@@ -13,6 +13,12 @@ public struct CustomerSheetTestPlaygroundSettings: Codable, Equatable {
         case returning
         case customID
     }
+    enum CustomerKeyType: String, PickerEnum {
+        static var enumName: String { "CustomerKeyType" }
+
+        case legacy
+        case customerSession = "customer_session"
+    }
     enum PaymentMethodMode: String, PickerEnum {
         static var enumName: String { "PaymentMethodMode" }
 
@@ -101,6 +107,7 @@ public struct CustomerSheetTestPlaygroundSettings: Codable, Equatable {
 
     var customerMode: CustomerMode
     var customerId: String?
+    var customerKeyType: CustomerKeyType
     var paymentMethodMode: PaymentMethodMode
     var applePay: ApplePay
     var headerTextForSelectionScreen: String?
@@ -119,6 +126,7 @@ public struct CustomerSheetTestPlaygroundSettings: Codable, Equatable {
     static func defaultValues() -> CustomerSheetTestPlaygroundSettings {
         return CustomerSheetTestPlaygroundSettings(customerMode: .new,
                                                    customerId: nil,
+                                                   customerKeyType: .legacy,
                                                    paymentMethodMode: .setupIntent,
                                                    applePay: .on,
                                                    headerTextForSelectionScreen: nil,

--- a/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
@@ -216,7 +216,7 @@ class CustomerSheetUITest: XCTestCase {
         let selectButtonFinal = app.staticTexts["••••4444"]
         XCTAssertTrue(selectButtonFinal.waitForExistence(timeout: 60.0))
     }
-    func testAddPaymentMethod_createAndAttach_reInitAdddViewController() throws {
+    func testAddPaymentMethod_createAndAttach_reInitAddViewController() throws {
         var settings = CustomerSheetTestPlaygroundSettings.defaultValues()
         settings.customerMode = .new
         settings.applePay = .on
@@ -380,7 +380,58 @@ class CustomerSheetUITest: XCTestCase {
         let selectButtonFinal = app.staticTexts["None"]
         XCTAssertTrue(selectButtonFinal.waitForExistence(timeout: 60.0))
     }
+    func testAddTwoPaymentMethods_thenUseCustomerSessionOnePM() throws {
+        var settings = CustomerSheetTestPlaygroundSettings.defaultValues()
+        settings.customerMode = .new
+        settings.applePay = .on
+        loadPlayground(
+            app,
+            settings
+        )
 
+        presentCSAndAddCardFrom(buttonLabel: "None")
+        presentCSAndAddCardFrom(buttonLabel: "••••4242")
+
+        // Reload
+        app.buttons["Reload"].tap()
+
+        // Present Sheet
+        let selectButton = app.staticTexts["••••4242"]
+        XCTAssertTrue(selectButton.waitForExistence(timeout: 60.0))
+        selectButton.tap()
+
+        let editButton = app.staticTexts["Edit"]
+        XCTAssertTrue(editButton.waitForExistence(timeout: 60.0))
+
+        // Assert there are two payment methods using legacy customer ephemeral key
+        // value == 2, 1 value on playground + 2 payment method
+        XCTAssertEqual(app.staticTexts.matching(identifier: "••••4242").count, 3)
+        app.buttons["Close"].tap()
+        dismissAlertView(alertBody: "Success: ••••4242, canceled", alertTitle: "Complete", buttonToTap: "OK")
+
+        // Switch to use customer session
+        app.buttons["customer_session"].tap()
+
+        // TODO: Use default payment method from elements/sessions payload
+        let selectButton2 = app.staticTexts["None"]
+        XCTAssertTrue(selectButton2.waitForExistence(timeout: 60.0))
+        selectButton2.tap()
+
+        // Wait for sheet to present
+        XCTAssertTrue(editButton.waitForExistence(timeout: 60.0))
+
+        // Requires FF: elements_enable_read_allow_redisplay, to return "1", otherwise 0
+        XCTAssertEqual(app.staticTexts.matching(identifier: "••••4242").count, 1)
+
+        let closeButton = app.buttons["Close"]
+        XCTAssertTrue(closeButton.waitForExistence(timeout: 60.0))
+        closeButton.tap()
+
+        dismissAlertView(alertBody: "Success: payment method not set, canceled", alertTitle: "Complete", buttonToTap: "OK")
+
+        let selectButtonFinal = app.staticTexts["None"]
+        XCTAssertTrue(selectButtonFinal.waitForExistence(timeout: 60.0))
+    }
     func testNoPrevPM_AddPM_noApplePay_closeInsteadOfConfirming() throws {
         var settings = CustomerSheetTestPlaygroundSettings.defaultValues()
         settings.customerMode = .new

--- a/Stripe/StripeiOSTests/CustomerAdapterTests.swift
+++ b/Stripe/StripeiOSTests/CustomerAdapterTests.swift
@@ -110,7 +110,7 @@ class CustomerAdapterTests: APIStubbedTestCase {
                 with: elementsSessionJSON.data(using: .utf8)!,
                 options: []
             ) as! [AnyHashable: Any]
-            if var customer = elementSession["customer"] as? [AnyHashable:Any],
+            if var customer = elementSession["customer"] as? [AnyHashable: Any],
                paymentMethodJSONs != nil {
                 customer["payment_methods"] = paymentMethodJSONs
                 elementSession["customer"] = customer

--- a/Stripe/StripeiOSTests/CustomerAdapterTests.swift
+++ b/Stripe/StripeiOSTests/CustomerAdapterTests.swift
@@ -10,7 +10,7 @@ import OHHTTPStubsSwift
 @_spi(STP) @testable import StripeCore
 @testable import StripeCoreTestUtils
 @_spi(STP) @testable import StripePayments
-@_spi(STP) @testable import StripePaymentSheet
+@_spi(STP) @_spi(CustomerSessionBetaAccess) @testable import StripePaymentSheet
 @_spi(STP) @testable import StripePaymentsTestUtils
 import XCTest
 
@@ -67,10 +67,10 @@ class CustomerAdapterTests: APIStubbedTestCase {
                 }
                 """
             var pmList =
-                try! JSONSerialization.jsonObject(
-                    with: paymentMethodsJSON.data(using: .utf8)!,
-                    options: []
-                ) as! [AnyHashable: Any]
+            try! JSONSerialization.jsonObject(
+                with: paymentMethodsJSON.data(using: .utf8)!,
+                options: []
+            ) as! [AnyHashable: Any]
             // Only send the example cards for a card request
             if urlRequest.url?.absoluteString.contains("card") ?? false {
                 pmList["data"] = paymentMethodJSONs
@@ -78,6 +78,44 @@ class CustomerAdapterTests: APIStubbedTestCase {
                 pmList["data"] = paymentMethodJSONs
             }
             return HTTPStubsResponse(jsonObject: pmList, statusCode: 200, headers: nil)
+        }
+    }
+    func stubElementsSession(
+        paymentMethodJSONs: [[AnyHashable: Any]]?
+    ) {
+        stub { urlRequest in
+            return urlRequest.url?.absoluteString.contains("/v1/elements/sessions") ?? false
+        } response: { _ in
+            let elementsSessionJSON = """
+                {
+                  "payment_method_preference": {"ordered_payment_method_types": ["card"],
+                                                "country_code": "US"
+                                               },
+                  "ordered_payment_method_types" : ["card"],
+                  "session_id": "123",
+                  "apple_pay_preference": "enabled",
+                  "customer": {"payment_methods": [
+                               ],
+                               "customer_session": {
+                                  "id": "cuss_654321",
+                                  "livemode": false,
+                                  "api_key": "ek_12345",
+                                  "api_key_expiry": 1899787184,
+                                  "customer": "cus_12345"
+                                }
+                              }
+                }
+                """
+            var elementSession = try! JSONSerialization.jsonObject(
+                with: elementsSessionJSON.data(using: .utf8)!,
+                options: []
+            ) as! [AnyHashable: Any]
+            if var customer = elementSession["customer"] as? [AnyHashable:Any],
+               paymentMethodJSONs != nil {
+                customer["payment_methods"] = paymentMethodJSONs
+                elementSession["customer"] = customer
+            }
+            return HTTPStubsResponse(jsonObject: elementSession, statusCode: 200, headers: nil)
         }
     }
 
@@ -102,6 +140,26 @@ class CustomerAdapterTests: APIStubbedTestCase {
         await fulfillment(of: [exp])
     }
 
+    func testGetOrCreateCustomerSessionErrorForwardedToFetchPMs() async throws {
+        let exp = expectation(description: "fetchPMs")
+        let expectedError = NSError(domain: "test", code: 123, userInfo: nil)
+
+        let sut = StripeCustomerAdapter(customerSessionClientSecretProvider: {
+            throw NSError(domain: "test", code: 123, userInfo: nil)
+        }, setupIntentClientSecretProvider: {
+            return "si_12345"
+        })
+
+        do {
+            _ = try await sut.fetchPaymentMethods()
+        } catch {
+            XCTAssertEqual((error as NSError?)?.domain, "test")
+            XCTAssertEqual((error as NSError?)?.code, 123)
+            exp.fulfill()
+        }
+        await fulfillment(of: [exp])
+    }
+
     let exampleKey = CustomerEphemeralKey(customerId: "abc123", ephemeralKeySecret: "ek_123")
 
     func testFetchPMs() async throws {
@@ -115,6 +173,24 @@ class CustomerAdapterTests: APIStubbedTestCase {
 
         let ekm = MockEphemeralKeyEndpoint(exampleKey)
         let sut = StripeCustomerAdapter(customerEphemeralKeyProvider: ekm.getEphemeralKey, apiClient: apiClient)
+        let pms = try await sut.fetchPaymentMethods()
+
+        XCTAssertEqual(pms.count, 1)
+        XCTAssertEqual(pms[0].stripeId, expectedPaymentMethods[0].stripeId)
+    }
+
+    func testFetchPMs_customerSessions() async throws {
+        let expectedPaymentMethods = [STPFixtures.paymentMethod()]
+        let expectedPaymentMethodsJSON = [STPFixtures.paymentMethodJSON()]
+        let apiClient = stubbedAPIClient()
+
+        stubElementsSession(paymentMethodJSONs: expectedPaymentMethodsJSON)
+
+        let sut = StripeCustomerAdapter(customerSessionClientSecretProvider: {
+            return .init(customerId: "cus_12345", clientSecret: "cuss_54321")
+        }, setupIntentClientSecretProvider: {
+            return "si_12345"
+        }, apiClient: apiClient)
         let pms = try await sut.fetchPaymentMethods()
 
         XCTAssertEqual(pms.count, 1)
@@ -141,6 +217,25 @@ class CustomerAdapterTests: APIStubbedTestCase {
         XCTAssertEqual(pms.count, 2)
         XCTAssertEqual(pms[0].stripeId, expectedPaymentMethods_card[0].stripeId)
         XCTAssertEqual(pms[1].stripeId, expectedPaymentMethods_usbank[0].stripeId)
+    }
+
+    func testFetchPMs_CardAndUSBankAccount_customerSessions() async throws {
+        let expectedPaymentMethods = [STPFixtures.paymentMethod(), STPFixtures.bankAccountPaymentMethod()]
+        let expectedPaymentMethodsJSON = [STPFixtures.paymentMethodJSON(), STPFixtures.bankAccountPaymentMethodJSON()]
+        let apiClient = stubbedAPIClient()
+
+        stubElementsSession(paymentMethodJSONs: expectedPaymentMethodsJSON)
+
+        let sut = StripeCustomerAdapter(customerSessionClientSecretProvider: {
+            return .init(customerId: "cus_12345", clientSecret: "cuss_54321")
+        }, setupIntentClientSecretProvider: {
+            return "si_12345"
+        }, apiClient: apiClient)
+        let pms = try await sut.fetchPaymentMethods()
+
+        XCTAssertEqual(pms.count, 2)
+        XCTAssertEqual(pms[0].stripeId, expectedPaymentMethods[0].stripeId)
+        XCTAssertEqual(pms[1].stripeId, expectedPaymentMethods[1].stripeId)
     }
 
     func testAttachPM() async throws {

--- a/Stripe/StripeiOSTests/CustomerAdapterTests.swift
+++ b/Stripe/StripeiOSTests/CustomerAdapterTests.swift
@@ -142,7 +142,6 @@ class CustomerAdapterTests: APIStubbedTestCase {
 
     func testGetOrCreateCustomerSessionErrorForwardedToFetchPMs() async throws {
         let exp = expectation(description: "fetchPMs")
-        let expectedError = NSError(domain: "test", code: 123, userInfo: nil)
 
         let sut = StripeCustomerAdapter(customerSessionClientSecretProvider: {
             throw NSError(domain: "test", code: 123, userInfo: nil)

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPAPIClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPAPIClient+PaymentSheet.swift
@@ -116,10 +116,14 @@ extension STPAPIClient {
         )
     }
 
-    func retrieveElementsSessionForCustomerSheet(paymentMethodTypes: [String]?) async throws -> STPElementsSession {
+    func retrieveElementsSessionForCustomerSheet(paymentMethodTypes: [String]?, customerSessionClientSecret: CustomerSessionClientSecret?) async throws -> STPElementsSession {
         var parameters: [String: Any] = [:]
         parameters["type"] = "deferred_intent"
         parameters["locale"] = Locale.current.toLanguageTag()
+
+        if let customerSessionClientSecret {
+            parameters["customer_session_client_secret"] = customerSessionClientSecret.clientSecret
+        }
 
         var deferredIntent = [String: Any]()
         deferredIntent["mode"] = "setup"

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerAdapter/CustomerAdapter.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerAdapter/CustomerAdapter.swift
@@ -115,8 +115,6 @@ public struct CustomerSessionClientSecret {
     }
 }
 
-
-
 extension StripeCustomerAdapter {
     internal enum CustomerAccessProvider {
         case legacyCustomerEphemeralKey(CustomerEphemeralKey)
@@ -128,6 +126,7 @@ extension StripeCustomerAdapter {
         case customerSession(CustomerSessionClientSecret, STPElementsSession)
     }
 }
+
 extension StripeCustomerAdapter {
     struct ClaimedCustomerSession {
         public let id: String
@@ -312,9 +311,8 @@ open class StripeCustomerAdapter: CustomerAdapter {
         let config = try customerEphemeralKey.customerAdapterConfiguration()
         return try await withCheckedThrowingContinuation({ continuation in
             if config.shouldRemoveDuplicates {
-                apiClient.detachPaymentMethodRemoveDuplicates(paymentMethodId,
-                                              customerId: config.customerId,
-                                              fromCustomerUsing: config.ephemeralKey) { error in
+                // TODO: Call detachPaymentMethodRemoveDuplicates after removing unsynced payment methods
+                apiClient.detachPaymentMethod(paymentMethodId, fromCustomerUsing: config.ephemeralKey) { error in
                     if let error = error {
                         continuation.resume(throwing: error)
                         return

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerAdapter/CustomerAdapter.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerAdapter/CustomerAdapter.swift
@@ -103,11 +103,11 @@ public struct CustomerEphemeralKey {
 public struct CustomerSessionClientSecret {
     /// The identifier of the Stripe Customer object.
     /// See https://stripe.com/docs/api/customers/object#customer_object-id
-    public let customerId: String
+    internal let customerId: String
 
     /// Customer session client secret
     /// See: https://docs.corp.stripe.com/api/customer_sessions/object
-    public let clientSecret: String
+    internal let clientSecret: String
 
     public init(customerId: String, clientSecret: String) {
         self.customerId = customerId

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerAdapter/CustomerAdapter.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerAdapter/CustomerAdapter.swift
@@ -99,12 +99,49 @@ public struct CustomerEphemeralKey {
     }
 }
 
+@_spi(CustomerSessionBetaAccess)
+public struct CustomerSessionClientSecret {
+    /// The identifier of the Stripe Customer object.
+    /// See https://stripe.com/docs/api/customers/object#customer_object-id
+    public let customerId: String
+
+    /// Customer session client secret
+    /// See: https://docs.corp.stripe.com/api/customer_sessions/object
+    public let clientSecret: String
+
+    public init(customerId: String, clientSecret: String) {
+        self.customerId = customerId
+        self.clientSecret = clientSecret
+    }
+}
+
+
+
+extension StripeCustomerAdapter {
+    internal enum CustomerAccessProvider {
+        case legacyCustomerEphemeralKey(CustomerEphemeralKey)
+        case customerSession(CustomerSessionClientSecret)
+    }
+
+    internal enum ResolvedCustomerAccess {
+        case legacyCustomerEphemeralKey(CustomerEphemeralKey)
+        case customerSession(CustomerSessionClientSecret, STPElementsSession)
+    }
+}
+extension StripeCustomerAdapter {
+    struct ClaimedCustomerSession {
+        public let id: String
+        public let ephemeralKeySecret: String
+    }
+}
+
 /// A `StripeCustomerAdapter` retrieves and updates a Stripe customer and their attached
 /// payment methods using an ephemeral key, a short-lived API key scoped to a specific
 /// customer object. If your current user logs out of your app and a new user logs in,
 /// be sure to create a new instance of `StripeCustomerAdapter`.
 open class StripeCustomerAdapter: CustomerAdapter {
-    let customerEphemeralKeyProvider: (() async throws -> CustomerEphemeralKey)
+    let customerEphemeralKeyProvider: (() async throws -> CustomerEphemeralKey)?
+    let customerSessionClientSecretProvider: (() async throws -> CustomerSessionClientSecret)?
     let setupIntentClientSecretProvider: (() async throws -> String)?
     let apiClient: STPAPIClient
     public let paymentMethodTypes: [String]?
@@ -122,26 +159,82 @@ open class StripeCustomerAdapter: CustomerAdapter {
                 apiClient: STPAPIClient = .shared) {
         STPAnalyticsClient.sharedClient.addClass(toProductUsageIfNecessary: StripeCustomerAdapter.self)
         self.customerEphemeralKeyProvider = customerEphemeralKeyProvider
+        self.customerSessionClientSecretProvider = nil
         self.setupIntentClientSecretProvider = setupIntentClientSecretProvider
         self.apiClient = apiClient
         self.paymentMethodTypes = paymentMethodTypes
     }
 
+    @_spi(CustomerSessionBetaAccess)
+    public init(customerSessionClientSecretProvider: @escaping () async throws -> CustomerSessionClientSecret,
+                setupIntentClientSecretProvider: (() async throws -> String)? = nil,
+                paymentMethodTypes: [String]? = nil,
+                apiClient: STPAPIClient = .shared) {
+        self.customerSessionClientSecretProvider = customerSessionClientSecretProvider
+        self.customerEphemeralKeyProvider = nil
+        self.setupIntentClientSecretProvider = setupIntentClientSecretProvider
+        self.apiClient = apiClient
+        self.paymentMethodTypes = paymentMethodTypes
+    }
+
+    func customerInformationAccessor() async throws -> CustomerAccessProvider {
+        if let customerSessionClientSecretProvider {
+            let response = try await customerSessionClientSecretProvider()
+            return .customerSession(response)
+        } else if let customerEphemeralKeyProvider {
+            let response = try await customerEphemeralKeyProvider()
+            return .legacyCustomerEphemeralKey(response)
+        }
+        throw CustomerSheetError.unknown(debugDescription: "customerSessionAccessProvider && customerEphemeralKeyProvider nil")
+    }
+
     private struct CachedCustomerEphemeralKey {
-        let customerEphemeralKey: CustomerEphemeralKey
+        struct StripeCustomerAdapterConfiguration {
+            let customerId: String
+            let ephemeralKey: String
+            let shouldRemoveDuplicates: Bool
+        }
+
+        let resolvedCustomerAccess: ResolvedCustomerAccess
         let cacheDate = Date()
+        func customerAdapterConfiguration() throws -> StripeCustomerAdapterConfiguration {
+            switch resolvedCustomerAccess {
+            case .customerSession(let customerSession, let elementsSession):
+                guard let apiKey = elementsSession.customer?.customerSession.apiKey else {
+                    throw CustomerSheetError.unknown(debugDescription: "Unable to resolve customerSession")
+                }
+                return StripeCustomerAdapterConfiguration(customerId: customerSession.customerId, ephemeralKey: apiKey, shouldRemoveDuplicates: true)
+            case .legacyCustomerEphemeralKey(let ephemeralKey):
+                return StripeCustomerAdapterConfiguration(customerId: ephemeralKey.id, ephemeralKey: ephemeralKey.ephemeralKeySecret, shouldRemoveDuplicates: false)
+            }
+        }
     }
 
     private var _cachedEphemeralKey: CachedCustomerEphemeralKey?
-    var customerEphemeralKey: CustomerEphemeralKey {
+    private var customerEphemeralKey: CachedCustomerEphemeralKey {
         get async throws {
             if let cachedKey = _cachedEphemeralKey,
-               cachedKey.cacheDate + CachedCustomerMaxAge > Date() {
-                return cachedKey.customerEphemeralKey
+                cachedKey.cacheDate + CachedCustomerMaxAge > Date() {
+                return cachedKey
             }
-            let newKey = try await self.customerEphemeralKeyProvider()
-            _cachedEphemeralKey = CachedCustomerEphemeralKey(customerEphemeralKey: newKey)
-            return newKey
+            let newAccessor = try await self.customerInformationAccessor()
+            switch newAccessor {
+            case .customerSession(let customerSessionClientSecret):
+                let elementsSessionResponse = try await self.apiClient.retrieveElementsSessionForCustomerSheet(paymentMethodTypes: nil,
+                                                                                                               customerSessionClientSecret: customerSessionClientSecret)
+                guard let apiKey = elementsSessionResponse.customer?.customerSession.apiKey,
+                      !apiKey.isEmpty else {
+                    throw CustomerSheetError.unknown(debugDescription: "Failed to claim CustomerSession")
+                }
+                let tempCachedCustomerEphemeralkey = CachedCustomerEphemeralKey(resolvedCustomerAccess: .customerSession(customerSessionClientSecret, elementsSessionResponse))
+                _cachedEphemeralKey = tempCachedCustomerEphemeralkey
+                return tempCachedCustomerEphemeralkey
+
+            case .legacyCustomerEphemeralKey(let customerEphemeralKey):
+                let tempCachedCustomerEphemeralkey = CachedCustomerEphemeralKey(resolvedCustomerAccess: .legacyCustomerEphemeralKey(customerEphemeralKey))
+                _cachedEphemeralKey = tempCachedCustomerEphemeralkey
+                return tempCachedCustomerEphemeralkey
+            }
         }
     }
 
@@ -150,49 +243,60 @@ open class StripeCustomerAdapter: CustomerAdapter {
     }
 
     open func fetchPaymentMethods() async throws -> [STPPaymentMethod] {
+        // Note: Querying for specific types of payment methods is an optimization
+        // Eventually, when we query a single endpoint for all payment methods,
+        // paymentMethodTypes will be used as a client side filter
+        var savedPaymentMethodTypes = CustomerSheet.supportedPaymentMethods
+        if let paymentMethodTypes = self.paymentMethodTypes {
+            switch CustomerSheet.customerSheetSupportedPaymentMethodTypes(paymentMethodTypes) {
+            case .success(let types):
+                if let types, !types.isEmpty {
+                    savedPaymentMethodTypes = types
+                }
+            case .failure(let error):
+                throw error
+            }
+        }
         let customerEphemeralKey = try await customerEphemeralKey
-        return try await withCheckedThrowingContinuation({ continuation in
-
-            // Note: Querying for specific types of payment methods is an optimization
-            // Eventually, when we query a single endpoint for all payment methods,
-            // paymentMethodTypes will be used as a client side filter
-            var savedPaymentMethodTypes = CustomerSheet.supportedPaymentMethods
-            if let paymentMethodTypes = self.paymentMethodTypes {
-                switch CustomerSheet.customerSheetSupportedPaymentMethodTypes(paymentMethodTypes) {
-                case .success(let types):
-                    if let types, !types.isEmpty {
-                        savedPaymentMethodTypes = types
+        switch customerEphemeralKey.resolvedCustomerAccess {
+        case .legacyCustomerEphemeralKey(let customerEphemeralKey):
+            return try await withCheckedThrowingContinuation({ continuation in
+                apiClient.listPaymentMethods(
+                    forCustomer: customerEphemeralKey.id,
+                    using: customerEphemeralKey.ephemeralKeySecret,
+                    types: savedPaymentMethodTypes
+                ) { paymentMethods, error in
+                    guard var paymentMethods, error == nil else {
+                        let error = error ?? PaymentSheetError.unexpectedResponseFromStripeAPI // TODO: make a better default error
+                        continuation.resume(throwing: error)
+                        return
                     }
-                case .failure(let error):
-                    continuation.resume(throwing: error)
-                    return
+                    // Remove cards that originated from Apple or Google Pay
+                    paymentMethods = paymentMethods.filter { paymentMethod in
+                        let isAppleOrGooglePay = paymentMethod.type == .card && [.applePay, .googlePay].contains(paymentMethod.card?.wallet?.type)
+                        return !isAppleOrGooglePay
+                    }
+                    continuation.resume(with: .success(paymentMethods))
                 }
-            }
+            })
 
-            apiClient.listPaymentMethods(
-                forCustomer: customerEphemeralKey.id,
-                using: customerEphemeralKey.ephemeralKeySecret,
-                types: savedPaymentMethodTypes
-            ) { paymentMethods, error in
-                guard var paymentMethods, error == nil else {
-                    let error = error ?? PaymentSheetError.unexpectedResponseFromStripeAPI // TODO: make a better default error
-                    continuation.resume(throwing: error)
-                    return
-                }
-                // Remove cards that originated from Apple or Google Pay
-                paymentMethods = paymentMethods.filter { paymentMethod in
-                    let isAppleOrGooglePay = paymentMethod.type == .card && [.applePay, .googlePay].contains(paymentMethod.card?.wallet?.type)
-                    return !isAppleOrGooglePay
-                }
-                continuation.resume(with: .success(paymentMethods))
-            }
-        })
+        case .customerSession(let customerSessionClientSecret, _):
+            let elementsSessionResponse = try await self.apiClient.retrieveElementsSessionForCustomerSheet(paymentMethodTypes: savedPaymentMethodTypes.map { $0.identifier },
+                                                                                                           customerSessionClientSecret: customerSessionClientSecret)
+            let paymentMethods = elementsSessionResponse.customer?.paymentMethods ?? []
+            return paymentMethods
+        }
     }
 
     open func attachPaymentMethod(_ paymentMethodId: String) async throws {
-        let customerEphemeralKey = try await customerEphemeralKey
+        let customerEphemeralKey = try await customerEphemeralKey.resolvedCustomerAccess
+        guard case .legacyCustomerEphemeralKey(let customerEphemeralKey) = customerEphemeralKey else {
+            throw CustomerSheetError.unknown(debugDescription: "Attempting to use a customerSession w/ attachPaymentMethod is not supported")
+        }
         return try await withCheckedThrowingContinuation({ continuation in
-            apiClient.attachPaymentMethod(paymentMethodId, customerID: customerEphemeralKey.id, ephemeralKeySecret: customerEphemeralKey.ephemeralKeySecret) { error in
+            apiClient.attachPaymentMethod(paymentMethodId,
+                                          customerID: customerEphemeralKey.id,
+                                          ephemeralKeySecret: customerEphemeralKey.ephemeralKeySecret) { error in
                 if let error = error {
                     continuation.resume(throwing: error)
                     return
@@ -204,27 +308,43 @@ open class StripeCustomerAdapter: CustomerAdapter {
 
     open func detachPaymentMethod(paymentMethodId: String) async throws {
         let customerEphemeralKey = try await customerEphemeralKey
+
+        let config = try customerEphemeralKey.customerAdapterConfiguration()
         return try await withCheckedThrowingContinuation({ continuation in
-            apiClient.detachPaymentMethod(paymentMethodId, fromCustomerUsing: customerEphemeralKey.ephemeralKeySecret) { error in
-                if let error = error {
-                    continuation.resume(throwing: error)
-                    return
+            if config.shouldRemoveDuplicates {
+                apiClient.detachPaymentMethodRemoveDuplicates(paymentMethodId,
+                                              customerId: config.customerId,
+                                              fromCustomerUsing: config.ephemeralKey) { error in
+                    if let error = error {
+                        continuation.resume(throwing: error)
+                        return
+                    }
+                    continuation.resume()
                 }
-                continuation.resume()
+            } else {
+                apiClient.detachPaymentMethod(paymentMethodId, fromCustomerUsing: config.ephemeralKey) { error in
+                    if let error = error {
+                        continuation.resume(throwing: error)
+                        return
+                    }
+                    continuation.resume()
+                }
             }
         })
     }
 
     open func setSelectedPaymentOption(paymentOption: CustomerPaymentOption?) async throws {
         let customerEphemeralKey = try await customerEphemeralKey
+        let config = try customerEphemeralKey.customerAdapterConfiguration()
 
-        CustomerPaymentOption.setDefaultPaymentMethod(paymentOption, forCustomer: customerEphemeralKey.id)
+        CustomerPaymentOption.setDefaultPaymentMethod(paymentOption, forCustomer: config.customerId)
     }
 
     open func fetchSelectedPaymentOption() async throws -> CustomerPaymentOption? {
         let customerEphemeralKey = try await customerEphemeralKey
 
-        return CustomerPaymentOption.defaultPaymentMethod(for: customerEphemeralKey.id)
+        let config = try customerEphemeralKey.customerAdapterConfiguration()
+        return CustomerPaymentOption.defaultPaymentMethod(for: config.customerId)
     }
 
     open func setupIntentClientSecretForCustomerAttach() async throws -> String {
@@ -237,9 +357,10 @@ open class StripeCustomerAdapter: CustomerAdapter {
     open func updatePaymentMethod(paymentMethodId: String,
                                   paymentMethodUpdateParams: STPPaymentMethodUpdateParams) async throws -> STPPaymentMethod {
         let customerEphemeralKey = try await customerEphemeralKey
+        let config = try customerEphemeralKey.customerAdapterConfiguration()
         return try await apiClient.updatePaymentMethod(with: paymentMethodId,
                                                        paymentMethodUpdateParams: paymentMethodUpdateParams,
-                                                       ephemeralKeySecret: customerEphemeralKey.ephemeralKeySecret)
+                                                       ephemeralKeySecret: config.ephemeralKey)
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerAdapter/CustomerAdapter.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerAdapter/CustomerAdapter.swift
@@ -167,7 +167,7 @@ open class StripeCustomerAdapter: CustomerAdapter {
 
     @_spi(CustomerSessionBetaAccess)
     public init(customerSessionClientSecretProvider: @escaping () async throws -> CustomerSessionClientSecret,
-                setupIntentClientSecretProvider: (() async throws -> String)? = nil,
+                setupIntentClientSecretProvider: @escaping (() async throws -> String),
                 paymentMethodTypes: [String]? = nil,
                 apiClient: STPAPIClient = .shared) {
         self.customerSessionClientSecretProvider = customerSessionClientSecretProvider

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerAdapter/CustomerAdapter.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerAdapter/CustomerAdapter.swift
@@ -127,13 +127,6 @@ extension StripeCustomerAdapter {
     }
 }
 
-extension StripeCustomerAdapter {
-    struct ClaimedCustomerSession {
-        public let id: String
-        public let ephemeralKeySecret: String
-    }
-}
-
 /// A `StripeCustomerAdapter` retrieves and updates a Stripe customer and their attached
 /// payment methods using an ephemeral key, a short-lived API key scoped to a specific
 /// customer object. If your current user logs out of your app and a new user logs in,
@@ -176,7 +169,7 @@ open class StripeCustomerAdapter: CustomerAdapter {
         self.paymentMethodTypes = paymentMethodTypes
     }
 
-    func customerInformationAccessor() async throws -> CustomerAccessProvider {
+    func customerAccessProvider() async throws -> CustomerAccessProvider {
         if let customerSessionClientSecretProvider {
             let response = try await customerSessionClientSecretProvider()
             return .customerSession(response)
@@ -216,8 +209,8 @@ open class StripeCustomerAdapter: CustomerAdapter {
                 cachedKey.cacheDate + CachedCustomerMaxAge > Date() {
                 return cachedKey
             }
-            let newAccessor = try await self.customerInformationAccessor()
-            switch newAccessor {
+
+            switch try await self.customerAccessProvider() {
             case .customerSession(let customerSessionClientSecret):
                 let elementsSessionResponse = try await self.apiClient.retrieveElementsSessionForCustomerSheet(paymentMethodTypes: nil,
                                                                                                                customerSessionClientSecret: customerSessionClientSecret)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheet.swift
@@ -167,7 +167,6 @@ extension CustomerSheet {
             do {
                 async let paymentMethodsResult = try customerAdapter.fetchPaymentMethods()
                 async let selectedPaymentMethodResult = try self.customerAdapter.fetchSelectedPaymentOption()
-                // TODO Pass through claimed info.
                 async let elementsSessionResult = try self.configuration.apiClient.retrieveElementsSessionForCustomerSheet(paymentMethodTypes: self.customerAdapter.paymentMethodTypes, customerSessionClientSecret: nil)
 
                 // Ensure local specs are loaded prior to the ones from elementSession

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheet.swift
@@ -167,7 +167,8 @@ extension CustomerSheet {
             do {
                 async let paymentMethodsResult = try customerAdapter.fetchPaymentMethods()
                 async let selectedPaymentMethodResult = try self.customerAdapter.fetchSelectedPaymentOption()
-                async let elementsSessionResult = try self.configuration.apiClient.retrieveElementsSessionForCustomerSheet(paymentMethodTypes: self.customerAdapter.paymentMethodTypes)
+                // TODO Pass through claimed info.
+                async let elementsSessionResult = try self.configuration.apiClient.retrieveElementsSessionForCustomerSheet(paymentMethodTypes: self.customerAdapter.paymentMethodTypes, customerSessionClientSecret: nil)
 
                 // Ensure local specs are loaded prior to the ones from elementSession
                 await loadFormSpecs()


### PR DESCRIPTION
## Summary
Add interface for adopting CustomerSession in CustomerSheet behind CustomerSessionBetaAccess.  This PR will be followed up by at least two PRs before it is functional.
* Refresh payment method list after adding a new payment method
* Call `detachPaymentMethodRemoveDuplicates` instead of detachPaymentMethod

## Motivation
CustomerSession Adoption

## Testing
Added tests

## Changelog
Not needed for beta
