### PR TITLE
Link: Use customer billing address country for default country

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Utils/LinkURLGenerator.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Utils/LinkURLGenerator.swift
@@ -46,7 +46,7 @@ class LinkURLGenerator {
         }
 
         // We only expect regionCode to be nil in rare situations with a buggy simulator. Use a default value we can detect server-side.
-        let customerCountryCode = intent.countryCode(overrideCountry: configuration.userOverrideCountry) ?? configuration.defaultBillingDetails.address.country ?? Locale.current.stp_regionCode ?? "US"
+        let customerCountryCode = configuration.defaultBillingDetails.address.country ?? Locale.current.stp_regionCode ?? intent.countryCode(overrideCountry: configuration.userOverrideCountry) ?? "US"
 
         let merchantCountryCode = intent.merchantCountryCode ?? customerCountryCode
 


### PR DESCRIPTION
## Summary
When signing up for Link, use the customer's billing address country as the default country.

## Motivation
RUN_MOBILESDK-3024

## Testing
Tested in PS Example.
