### PR TITLE
Avoid animating dots while running tests

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentLogoView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentLogoView.swift
@@ -58,6 +58,12 @@ final class ConsentLogoView: UIView {
     }
 
     func animateDots() {
+#if targetEnvironment(simulator)
+        if ProcessInfo.processInfo.environment["UITesting"] != nil {
+            return
+        }
+#endif
+
         guard let multipleDotView = multipleDotView else {
             return
         }


### PR DESCRIPTION
## Summary
Avoid animating dots in FC consent page when running tests in emulator

## Motivation
This is causing ui tests to slow down.

## Testing
Manual

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
