### PR TITLE
Financial Connections: disabled consent animation for UI tests to speed up payments tests

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnections Example/AppDelegate.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/AppDelegate.swift
@@ -17,12 +17,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
-#if targetEnvironment(simulator)
-        if ProcessInfo.processInfo.environment["UITesting"] != nil {
-            // disable animations for UI tests which makes them a lot faster
-            UIView.setAnimationsEnabled(false)
-        }
-#endif
         return true
     }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentLogoView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentLogoView.swift
@@ -58,6 +58,11 @@ final class ConsentLogoView: UIView {
     }
 
     func animateDots() {
+#if targetEnvironment(simulator)
+        if ProcessInfo.processInfo.environment["UITesting"] != nil {
+            return
+        }
+#endif
         guard let multipleDotView = multipleDotView else {
             return
         }


### PR DESCRIPTION
## Summary

While doing Financial Connections V3 redesign, there was an odd hang in some parts of UI tests. Initially, this was fixed by disabling UI animations in Financial Connections Example app. However, payments team experienced the same issues, which led to investigating the root cause, and it was the Consent Pane animation. In this PR, we disable the consent pane animation, instead of all animations for UI tests. 

## Testing

Run `bitrise run financial-connections-stability-tests`:

```
FinancialConnectionsNetworkingUITests
    ✓ testNativeNetworkingTestMode (80.144 seconds)
FinancialConnectionsUITests
    ✓ testDataLiveModeOAuthNativeAuthFlow (38.661 seconds)
    ✓ testDataLiveModeOAuthWebAuthFlow (25.622 seconds)
    ✓ testDataTestModeOAuthNativeAuthFlow (26.921 seconds)
    ✓ testPaymentTestModeLegacyNativeAuthFlow (25.683 seconds)
    ✓ testPaymentTestModeManualEntryNativeAuthFlow (29.602 seconds)
    ✓ testSearchInLiveModeNativeAuthFlow (32.514 seconds)
```

I also ran that command while keeping ALL animations disabled and the time difference is not that bad (if it comes untenable, we'll revisit - some of the difference might be just +/- differences between different runs):

```
FinancialConnectionsNetworkingUITests
    ✓ testNativeNetworkingTestMode (71.391 seconds)
FinancialConnectionsUITests
    ✓ testDataLiveModeOAuthNativeAuthFlow (34.003 seconds)
    ✓ testDataLiveModeOAuthWebAuthFlow (22.539 seconds)
    ✓ testDataTestModeOAuthNativeAuthFlow (24.637 seconds)
    ✓ testPaymentTestModeLegacyNativeAuthFlow (24.119 seconds)
    ✓ testPaymentTestModeManualEntryNativeAuthFlow (26.281 seconds)
    ✓ testSearchInLiveModeNativeAuthFlow (29.918 seconds)
```

In the end, running with animations on is more robust as it can catch issues like this (affects other teams). 