### PR TITLE
Dismiss customerSheet w/ cancel if a PM is not supported

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlayground.swift
@@ -59,6 +59,16 @@ struct CustomerSheetTestPlayground: View {
                         SettingView(setting: $playgroundController.settings.autoreload)
                         TextField("headerTextForSelectionScreen", text: headerTextForSelectionScreenBinding)
                         SettingView(setting: $playgroundController.settings.allowsRemovalOfLastSavedPaymentMethod)
+                        HStack {
+                            Text("Macros").font(.headline)
+                            Spacer()
+                            Button {
+                                playgroundController.didTapSetToUnsupported()
+                            } label: {
+                                Text("SetPMLink")
+                                    .font(.callout.smallCaps())
+                            }.buttonStyle(.bordered)
+                        }
                     }
                     Divider()
                     Group {

--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundController.swift
@@ -35,6 +35,7 @@ class CustomerSheetTestPlaygroundController: ObservableObject {
     }
 
     var customerSheet: CustomerSheet?
+    var _customerAdapter: CustomerAdapter?
     var backend: CustomerSheetBackend!
     var currentEndpoint: String = defaultEndpoint
     var appearance = PaymentSheet.Appearance.default
@@ -58,6 +59,16 @@ class CustomerSheetTestPlaygroundController: ObservableObject {
         self.settings = CustomerSheetTestPlaygroundSettings.defaultValues()
         self.appearance = PaymentSheet.Appearance.default
         load()
+    }
+    func didTapSetToUnsupported() {
+        Task {
+            do {
+                try await _customerAdapter?.setSelectedPaymentOption(paymentOption: .link)
+                self.load()
+            } catch {
+                // no-op
+            }
+        }
     }
 
     func appearanceButtonTapped() {
@@ -241,6 +252,7 @@ extension CustomerSheetTestPlaygroundController {
                     print("Failed to initalize CustomerAdapter")
                     return
                 }
+                self._customerAdapter = customerAdapter
                 self.customerSheet = CustomerSheet(configuration: configuration, customer: customerAdapter)
 
                 // Retrieve selected PM

--- a/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
@@ -46,7 +46,7 @@ class CustomerSheetUITest: XCTestCase {
         XCTAssertTrue(paymentMethodButton.waitForExistence(timeout: 60.0))
     }
 
-    func testCustomerSheetStandard_applePayOn_addCard() throws {
+    func testCustomerSheetStandard_applePayOn_addCard_ensureCanDismissOnUnsupportedPaymentMethod() throws {
         var settings = CustomerSheetTestPlaygroundSettings.defaultValues()
         settings.customerMode = .new
         settings.applePay = .on
@@ -70,6 +70,15 @@ class CustomerSheetUITest: XCTestCase {
 
         let paymentMethodButton = app.staticTexts["Success: ••••4242, selected"]  // The card should be saved now
         XCTAssertTrue(paymentMethodButton.waitForExistence(timeout: 60.0))
+
+        dismissAlertView(alertBody: "Success: ••••4242, selected", alertTitle: "Complete", buttonToTap: "OK")
+
+        // Piggy back on the original test to ensure we can dismiss the sheet if we have an unsupported payment method
+        app.buttons["SetPMLink"].tap()
+        app.staticTexts["None"].waitForExistenceAndTap()
+        app.buttons["Close"].waitForExistenceAndTap()
+
+        dismissAlertView(alertBody: "Success: payment method not set, canceled", alertTitle: "Complete", buttonToTap: "OK")
     }
 
     func testCustomerSheetStandard_applePayOn_selectApplePay() throws {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsViewController.swift
@@ -754,7 +754,9 @@ class CustomerSavedPaymentMethodsViewController: UIViewController {
                     }
                 }
             default:
-                assertionFailure("Selected payment method was something other than a saved payment method or apple pay")
+                self.delegate?.savedPaymentMethodsViewControllerDidFinish(self) {
+                    self.csCompletion?(.canceled(nil))
+                }
             }
 
         } else {


### PR DESCRIPTION
## Summary
When canceling, Dismiss CustomerSheet if the original payment method was unknown.

## Motivation
users can select a pm that is unsupported and attempt to cancel the sheet.

## Testing
- Manual testing
- added automated ui test
