### PR TITLE
Analytics helper method to extract details about Errors 

### DIFF
--- a/StripeCore/StripeCore.xcodeproj/project.pbxproj
+++ b/StripeCore/StripeCore.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		AE26BFFBE9B1242E10CA052F /* STPAnalyticsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DD5B6F1152FD1C4A508A103 /* STPAnalyticsClient.swift */; };
 		B35FD03DD246CC4DD6C4F3C0 /* Decimal+StripeCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06A516593E48DCFD5D98D702 /* Decimal+StripeCore.swift */; };
 		B6D129B2DC90FA1F8A1F5BCB /* UIActivityIndicatorView+Stripe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599C8A64EB3988BCE32E2B05 /* UIActivityIndicatorView+Stripe.swift */; };
+		B6DBB2BF2BA8C4E400783D15 /* STPAnalyticsClient+Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6DBB2BE2BA8C4E300783D15 /* STPAnalyticsClient+Error.swift */; };
 		C164984958CDC2C9CA4B6316 /* STPAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F9ED2ADD9406CF7534BB6C9 /* STPAPIClient.swift */; };
 		C318A6B6CD599B06DA7CE706 /* NSBundle+Stripe_AppName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E852B53CF75A119D3810B41 /* NSBundle+Stripe_AppName.swift */; };
 		C5BF4B8AE85FF72EC6382EC0 /* NSError+Stripe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E415507B0152B07796114CC /* NSError+Stripe.swift */; };
@@ -281,6 +282,7 @@
 		AF82F68E8D3A8286FD31DB13 /* APIStubbedTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIStubbedTestCase.swift; sourceTree = "<group>"; };
 		B3CA4B1855BF8D2F08F275A9 /* Error_SerializeForLoggingTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Error_SerializeForLoggingTest.swift; sourceTree = "<group>"; };
 		B3F73CA77397EAE70480FF25 /* et-EE */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "et-EE"; path = "et-EE.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		B6DBB2BE2BA8C4E300783D15 /* STPAnalyticsClient+Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "STPAnalyticsClient+Error.swift"; sourceTree = "<group>"; };
 		B8B76840742D2CAF2931355A /* URLSession+Retry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSession+Retry.swift"; sourceTree = "<group>"; };
 		BC5151C3B6CB4130E9C259A6 /* NSCharacterSet+StripeCore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSCharacterSet+StripeCore.swift"; sourceTree = "<group>"; };
 		BCF062352C38A5173260C46A /* StripeServiceError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StripeServiceError.swift; sourceTree = "<group>"; };
@@ -502,6 +504,7 @@
 		66BA4CFF0FEE2E4813FB4D31 /* Analytics */ = {
 			isa = PBXGroup;
 			children = (
+				B6DBB2BE2BA8C4E300783D15 /* STPAnalyticsClient+Error.swift */,
 				ABF11F814A986AA710410FF8 /* Analytic.swift */,
 				7B890F162E1C247D5CA1A9E6 /* AnalyticLoggableError.swift */,
 				192E71FE64C5FDE929992CC4 /* AnalyticsClientV2.swift */,
@@ -978,6 +981,7 @@
 				F628BBE9FDA9D3A217ACA753 /* STPNumericStringValidator.swift in Sources */,
 				C9B6C451F9A46C9FB031CE95 /* STPURLCallbackHandler.swift in Sources */,
 				A62AEDF871AC89489FE19A13 /* ServerErrorMapper.swift in Sources */,
+				B6DBB2BF2BA8C4E400783D15 /* STPAnalyticsClient+Error.swift in Sources */,
 				62FD088E003BE06F5413FB4F /* StripeCoreBundleLocator.swift in Sources */,
 				17CE96B50813CF626293CBF9 /* URLEncoder.swift in Sources */,
 				0709F5D265CC641E6DE1011D /* URLSession+Retry.swift in Sources */,

--- a/StripeCore/StripeCore/Source/Analytics/Analytic.swift
+++ b/StripeCore/StripeCore/Source/Analytics/Analytic.swift
@@ -15,7 +15,8 @@ import Foundation
 }
 
 /// An error analytic that can be logged to our analytics system.
-@_spi(STP) public protocol ErrorAnalytic: Analytic {
+/// TODO: Delete this and replace users with ErrorAnalytic or directly call the desired serialize method.
+@_spi(STP) public protocol ErrorAnalyticProtocol: Analytic {
     var error: Error { get }
 }
 

--- a/StripeCore/StripeCore/Source/Analytics/Analytic.swift
+++ b/StripeCore/StripeCore/Source/Analytics/Analytic.swift
@@ -14,12 +14,6 @@ import Foundation
     var params: [String: Any] { get }
 }
 
-/// An error analytic that can be logged to our analytics system.
-/// TODO: Delete this and replace users with ErrorAnalytic or directly call the desired serialize method.
-@_spi(STP) public protocol ErrorAnalyticProtocol: Analytic {
-    var error: Error { get }
-}
-
 /// A generic analytic type.
 ///
 /// - NOTE: This should only be used to support legacy analytics.

--- a/StripeCore/StripeCore/Source/Analytics/AnalyticLoggableError.swift
+++ b/StripeCore/StripeCore/Source/Analytics/AnalyticLoggableError.swift
@@ -93,17 +93,17 @@ where Self: RawRepresentable, Self.RawValue == String {
     /// - For NSErrors, the error domain e.g. “NSURLErrorDomain”.
     static func extractErrorType(from error: Error) -> String {
         if type(of: error) is NSError.Type {
+            // Note: checking `error as NSError` always succeeds because Swift errors are bridged - this ensures the error is an instance of NSError.
             let error = error as NSError
             if error.domain == STPError.stripeDomain, let stripeAPIErrorType = error.userInfo[STPError.stripeErrorTypeKey] as? String {
                 // For Stripe API Error, use the error type key's value
                 return stripeAPIErrorType
             } else {
-                // Default behavior for other errors.
-                // Note: For Swift Error enums, `domain` is the type name
-                // e.g. `LinkURLGeneratorError.noPublishableKey` -> "StripePaymentSheet.LinkURLGeneratorError"
+                // For other NSErrors, use the domain
                 return "\(error.domain)"
             }
         } else {
+            // This is a Swift Error, use the qualified type name e.g. "Swift.DecodingError" or "StripePaymentSheet.PaymentSheetError"
             return String(reflecting: type(of: error))
         }
     }

--- a/StripeCore/StripeCore/Source/Analytics/AnalyticLoggableError.swift
+++ b/StripeCore/StripeCore/Source/Analytics/AnalyticLoggableError.swift
@@ -31,6 +31,8 @@ where Self: RawRepresentable, Self.RawValue == String {
 }
 
 @_spi(STP) extension Error {
+    /// Serialize an Error for logging, suitable for the Identity and Financial Connections SDK.
+    // TODO: Rename to serializeForIdentityAndFinancialConnectionsSDKLogging()
     public func serializeForLogging() -> [String: Any] {
         if let loggableError = self as? AnalyticLoggableError {
             return loggableError.analyticLoggableSerializeForLogging()
@@ -50,7 +52,7 @@ where Self: RawRepresentable, Self.RawValue == String {
         return payload
     }
 
-    /// This is like `serializeForLogging` but returns a single String instead of a dict. 
+    /// This is like `serializeForLogging` but returns a single String instead of a dict.
     /// TODO(MOBILESDK-1547) I don't think pattern is very good but it's here to share between PaymentSheet and STPPaymentContext. Please rethink before spreading its usage.
     public func makeSafeLoggingString() -> String {
         let error = self as NSError
@@ -65,4 +67,78 @@ where Self: RawRepresentable, Self.RawValue == String {
         }
     }
 
+    /// Serialize an Error for logging to q.stripe.com and the `sdk.analytics_events` table
+    ///
+    /// It sends the following fields:
+    /// - error_type: For Stripe API errors, the error’s [type](https://docs.stripe.com/api/errors#errors-type) e.g. “invalid_request_error”.
+    ///           For Swift errors, the fully qualified type name e.g. “StripePaymentSheet.LinkURLGeneratorError”.
+    ///           For NSErrors, the error domain e.g. “NSURLErrorDomain”.
+    /// - error_code: For Stripe API errors, the error's code e.g. "invalid_number".
+    ///            For NSErrors, the error code e.g. “-1009”.
+    ///            For Swift errors, the enum case name as a string for Swift errors e.g. “noPublishableKey”.
+    public func serializeForV1Analytics() -> [String: Any] {
+        let errorType = Self.extractErrorType(from: self)
+        let errorCode = Self.extractErrorCode(from: self)
+
+        return [
+            "error_type": errorType,
+            "error_code": errorCode,
+        ]
+    }
+
+    /// Extracts a value suitable for the `"error_type"` analytic parameter
+    /// - For Stripe API errors, the error’s [type](https://docs.stripe.com/api/errors#errors-type) e.g. “invalid_request_error”.
+    /// - For Swift errors, the fully qualified type name e.g. “StripePaymentSheet.LinkURLGeneratorError”.
+    /// - For NSErrors, the error domain e.g. “NSURLErrorDomain”.
+    static func extractErrorType(from error: Error) -> String {
+        if type(of: error) is NSError.Type {
+            let error = error as NSError
+            if error.domain == STPError.stripeDomain, let stripeAPIErrorType = error.userInfo[STPError.stripeErrorTypeKey] as? String {
+                // For Stripe API Error, use the error type key's value
+                return stripeAPIErrorType
+            } else {
+                // Default behavior for other errors.
+                // Note: For Swift Error enums, `domain` is the type name
+                // e.g. `LinkURLGeneratorError.noPublishableKey` -> "StripePaymentSheet.LinkURLGeneratorError"
+                return "\(error.domain)"
+            }
+        } else {
+            return String(reflecting: type(of: error))
+        }
+    }
+
+    /// Extracts a value suitable for the `"error_code"` analytic parameter
+    /// - For Stripe API errors, the error's code e.g. "invalid_number".
+    /// - For NSErrors, the error code e.g. “-1009”.
+    /// - For Swift errors, the enum case name as a string for Swift errors e.g. “noPublishableKey”.
+    static func extractErrorCode(from error: Error) -> String {
+        // Note: We explicitly avoid using String(describing:) or similar to prevent the edge case where an Error conforms to CustomDebugStringConvertible or similar and puts PII in the `description`
+        let mirror = Mirror(reflecting: error)
+        if let self = self as? (any RawRepresentable), let rawValueString = self.rawValue as? String {
+            // For Swift string enums, use the raw value
+            return rawValueString
+        } else if mirror.displayStyle == .enum {
+            if let caseLabel = mirror.children.first?.label {
+                // For enums with associated values, this returns the name of the case e.g. DecodingError.keyNotFound(...) -> "keyNotFound"
+                return caseLabel
+            } else {
+                // For enum cases without associated values, reflection does not contain the case name. Since enums can't contain stored properties (besides associated values), we can safely assume String(describing:) doesn't contain PII; any PII would need to have been captured in an associated value.
+                return "\(error)"
+            }
+        }
+        let error = error as NSError
+        if error.domain == STPError.stripeDomain, let stripeAPIErrorCode = error.userInfo[STPError.stripeErrorCodeKey] as? String {
+            // For Stripe API Error, use the error code key's value
+            return stripeAPIErrorCode
+        } else {
+            // Default: Cast to Error and use the code.
+            return String((error as NSError).code)
+        }
+    }
+}
+
+extension Error {
+    var errorType: String {
+        return (self as NSError).domain
+    }
 }

--- a/StripeCore/StripeCore/Source/Analytics/AnalyticsClientV2.swift
+++ b/StripeCore/StripeCore/Source/Analytics/AnalyticsClientV2.swift
@@ -72,7 +72,7 @@ import UIKit
         line: UInt?
     ) -> [String: Any] {
 
-        var payload = error.serializeForLogging()
+        var payload = error.serializeForV2Logging()
 
         if let filePath = filePath {
             // The full file path can contain the device name, so only include the file name

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticsClient+Error.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticsClient+Error.swift
@@ -1,0 +1,26 @@
+//
+//  STPAnalyticsClient+Error.swift
+//  StripeCameraCore
+//
+//  Created by Yuki Tokuhiro on 3/18/24.
+//
+
+import Foundation
+
+/// An error analytic that can be logged to our analytics system.
+@_spi(STP) public struct ErrorAnalytic: Analytic, ErrorAnalyticProtocol {
+    public let event: STPAnalyticEvent
+    public let error: Error
+    public var params: [String: Any] {
+        var params = error.serializeForV1Analytics()
+        params.mergeAssertingOnOverwrites(additionalNonPIIParams)
+        return params
+    }
+    let additionalNonPIIParams: [String: Any]
+
+    public init(event: STPAnalyticEvent, error: Error, additionalNonPIIParams: [String: Any] = [:]) {
+        self.event = event
+        self.error = error
+        self.additionalNonPIIParams = additionalNonPIIParams
+    }
+}

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticsClient+Error.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticsClient+Error.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// An error analytic that can be logged to our analytics system.
-@_spi(STP) public struct ErrorAnalytic: Analytic, ErrorAnalyticProtocol {
+@_spi(STP) public struct ErrorAnalytic: Analytic {
     public let event: STPAnalyticEvent
     public let error: Error
     public var params: [String: Any] {

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticsClient.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticsClient.swift
@@ -96,17 +96,7 @@ import UIKit
         payload["additional_info"] = additionalInfo()
         payload["product_usage"] = productUsage.sorted()
 
-        // Attach error information if this is an error analytic
-        if let errorAnalytic = analytic as? ErrorAnalytic {
-            payload["error_dictionary"] = errorAnalytic.error.serializeForLogging()
-        }
-
-        payload.merge(analytic.params) { (commonPayloadValue, analyticPayloadValue) in
-            #if DEBUG
-            assertionFailure("\(analytic.event) is overwriting the common payload value: \(commonPayloadValue)!")
-            #endif
-            return analyticPayloadValue
-        }
+        payload.mergeAssertingOnOverwrites(analytic.params)
         return payload
     }
 

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticsClient.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticsClient.swift
@@ -101,7 +101,12 @@ import UIKit
             payload["error_dictionary"] = errorAnalytic.error.serializeForLogging()
         }
 
-        payload.merge(analytic.params) { (_, new) in new }
+        payload.merge(analytic.params) { (commonPayloadValue, analyticPayloadValue) in
+            #if DEBUG
+            assertionFailure("\(analytic.event) is overwriting the common payload value: \(commonPayloadValue)!")
+            #endif
+            return analyticPayloadValue
+        }
         return payload
     }
 

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticsClient.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticsClient.swift
@@ -35,6 +35,7 @@ import UIKit
     private(set) var urlSession: URLSession = URLSession(
         configuration: StripeAPIConfiguration.sharedUrlSessionConfiguration
     )
+    let url = URL(string: "https://q.stripe.com")!
 
     @objc public class func tokenType(fromParameters parameters: [AnyHashable: Any]) -> String? {
         let parameterKeys = parameters.keys
@@ -72,8 +73,6 @@ import UIKit
             return NSClassFromString("XCTest") != nil
         #endif
     }
-
-    // MARK: - Card Scanning
 
     @objc public class func shouldCollectAnalytics() -> Bool {
         return !isSimulatorOrTest
@@ -121,9 +120,7 @@ import UIKit
         delegate?.analyticsClientDidLog(analyticsClient: self, payload: payload)
         #endif
 
-        guard type(of: self).shouldCollectAnalytics(),
-              let url = URL(string: "https://q.stripe.com")
-        else {
+        guard type(of: self).shouldCollectAnalytics() else {
             // Don't send the analytic, but add it to `_testLogHistory` if we're in a test.
             if NSClassFromString("XCTest") != nil {
                 _testLogHistory.append(payload)

--- a/StripeCore/StripeCore/Source/Categories/Dictionary+Stripe.swift
+++ b/StripeCore/StripeCore/Source/Categories/Dictionary+Stripe.swift
@@ -44,6 +44,16 @@ extension Dictionary {
         }
         return newDict
     }
+
+    @inlinable public mutating func mergeAssertingOnOverwrites(_ other: [Key: Value]) {
+        merge(other) { a, b in
+#if DEBUG
+assertionFailure("Dictionary merge is overwriting a key with values: \(a) and \(b)!")
+#endif
+            return a
+        }
+    }
+
 }
 
 extension Dictionary where Value == Any {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsSheetAnalytics.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsSheetAnalytics.swift
@@ -37,13 +37,13 @@ struct FinancialConnectionsSheetClosedAnalytic: FinancialConnectionsSheetAnalyti
 
     var additionalParams: [String: Any] {
         return [
-            "session_result": result
+            "session_result": result,
         ]
     }
 }
 
 /// Logged if there's an error presenting the sheet
-struct FinancialConnectionsSheetFailedAnalytic: FinancialConnectionsSheetAnalytic, ErrorAnalytic {
+struct FinancialConnectionsSheetFailedAnalytic: FinancialConnectionsSheetAnalytic {
     let event = STPAnalyticEvent.financialConnectionsSheetFailed
     let clientSecret: String
     let additionalParams: [String: Any] = [:]

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsAnalyticsTest.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsAnalyticsTest.swift
@@ -19,7 +19,7 @@ final class FinancialConnectionsSheetAnalyticsTest: XCTestCase {
         )
         XCTAssertNotNil(analytic.error)
 
-        let errorDict = analytic.error.serializeForLogging()
+        let errorDict = analytic.error.serializeForV2Logging()
         XCTAssertNil(errorDict["user_info"])
         XCTAssertEqual(errorDict["code"] as? Int, 0)
         XCTAssertEqual(errorDict["domain"] as? String, "Stripe.FinancialConnectionsSheetError")

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/VerificationSheetFlowControllerError.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/VerificationSheetFlowControllerError.swift
@@ -69,7 +69,7 @@ extension VerificationSheetFlowControllerError: AnalyticLoggableError {
                 "type": "no_document_uploader",
             ]
         case .unknown(let error):
-            return error.serializeForLogging()
+            return error.serializeForV2Logging()
         }
 
         payload["domain"] = (self as NSError).domain

--- a/StripeIdentity/StripeIdentity/Source/VerificationSheetAnalytics.swift
+++ b/StripeIdentity/StripeIdentity/Source/VerificationSheetAnalytics.swift
@@ -38,13 +38,13 @@ struct VerificationSheetClosedAnalytic: VerificationSheetAnalytic {
 
     var additionalParams: [String: Any] {
         return [
-            "session_result": sessionResult
+            "session_result": sessionResult,
         ]
     }
 }
 
 /// Logged if there's an error presenting the sheet
-struct VerificationSheetFailedAnalytic: VerificationSheetAnalytic, ErrorAnalytic {
+struct VerificationSheetFailedAnalytic: VerificationSheetAnalytic {
     let event = STPAnalyticEvent.verificationSheetFailed
     let verificationSessionId: String?
     let additionalParams: [String: Any] = [:]

--- a/StripeIdentity/StripeIdentityTests/Unit/VerificationSheetAnalyticsTest.swift
+++ b/StripeIdentity/StripeIdentityTests/Unit/VerificationSheetAnalyticsTest.swift
@@ -20,7 +20,7 @@ final class VerificationSheetAnalyticsTest: XCTestCase {
         )
         XCTAssertNotNil(analytic.error)
 
-        let errorDict = analytic.error.serializeForLogging()
+        let errorDict = analytic.error.serializeForV2Logging()
         XCTAssertNil(errorDict["user_info"])
         XCTAssertEqual(errorDict["code"] as? Int, 1)
         XCTAssertEqual(

--- a/StripePaymentSheet/StripePaymentSheetTests/STPAnalyticsClient+PaymentSheetTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/STPAnalyticsClient+PaymentSheetTests.swift
@@ -28,6 +28,7 @@ class STPAnalyticsClientPaymentSheetTest: XCTestCase {
         }
 
         case foo
+        case bar
     }
 
     func testMakeSafeLoggingString() {
@@ -41,8 +42,8 @@ class STPAnalyticsClientPaymentSheetTest: XCTestCase {
              "cardError"),
             (NSError(domain: STPError.stripeDomain, code: STPErrorCode.invalidRequestError.rawValue),
              "invalidRequestError"),
-            (MyError.foo,
-             "StripePaymentSheetTests.STPAnalyticsClientPaymentSheetTest.MyError, 0"),
+            (MyError.bar,
+             "StripePaymentSheetTests.STPAnalyticsClientPaymentSheetTest.MyError, 1"),
 
         ]
         for testCase in testCases {

--- a/StripePayments/StripePayments/Source/Internal/Analytics/Analytic+Payments.swift
+++ b/StripePayments/StripePayments/Source/Internal/Analytics/Analytic+Payments.swift
@@ -19,7 +19,7 @@ struct GenericPaymentAnalytic: PaymentAnalytic {
 }
 
 /// Represents a generic payment error analytic
-struct GenericPaymentErrorAnalytic: PaymentAnalytic, ErrorAnalyticProtocol {
+struct GenericPaymentErrorAnalytic: PaymentAnalytic {
     let event: STPAnalyticEvent
     let paymentConfiguration: NSObject?
     let additionalParams: [String: Any]

--- a/StripePayments/StripePayments/Source/Internal/Analytics/Analytic+Payments.swift
+++ b/StripePayments/StripePayments/Source/Internal/Analytics/Analytic+Payments.swift
@@ -19,7 +19,7 @@ struct GenericPaymentAnalytic: PaymentAnalytic {
 }
 
 /// Represents a generic payment error analytic
-struct GenericPaymentErrorAnalytic: PaymentAnalytic, ErrorAnalytic {
+struct GenericPaymentErrorAnalytic: PaymentAnalytic, ErrorAnalyticProtocol {
     let event: STPAnalyticEvent
     let paymentConfiguration: NSObject?
     let additionalParams: [String: Any]


### PR DESCRIPTION
## Summary
Added helpers so that you can send analytics for errors like this:
```
struct MyError: Error {
  case foo
  case bar
}

analyticsClient.log(event: ErrorAnalytic(event: .someErrorEvent, error: MyError.foo))
```

Under the hood, it extracts error_type and error_code from the error in a standardized way for different errors. 

A future PR will let allow Errors to declare extra details to be logged or override `error_code` and `error_type`.

## Motivation


## Testing
See unit tests

## Changelog
Not user facing
