### PR TITLE
When you tap a saved PM, Apple Pay, or Link, PaymentSheet no longer s…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## X.X.X
 ### PaymentSheet
 * [Fixed] When confirming a SetupIntent with Link, "Set up" will be shown as the confirm button text instead of "Pay".
+* [Changed] Tapping a saved PM/Apple Pay/Link no longer sets it as the default; they are only set as the default after you successfully confirm.
 
 ### All
 * Added a [Privacy Manifest](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files).

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
@@ -497,20 +497,6 @@ extension SavedPaymentOptionsViewController: UICollectionViewDataSource, UIColle
         selectedViewModelIndex = indexPath.item
         let viewModel = viewModels[indexPath.item]
 
-        switch viewModel {
-        case .add:
-            // Should have been handled in shouldSelectItemAt: before we got here!
-            assertionFailure()
-        case .applePay:
-            CustomerPaymentOption.setDefaultPaymentMethod(.applePay, forCustomer: configuration.customerID)
-        case .link:
-            CustomerPaymentOption.setDefaultPaymentMethod(.link, forCustomer: configuration.customerID)
-        case .saved(let paymentMethod):
-            CustomerPaymentOption.setDefaultPaymentMethod(
-                .stripeId(paymentMethod.stripeId),
-                forCustomer: configuration.customerID
-            )
-        }
         updateMandateView()
         cvcFormElement.clearTextFields()
         updateFormElement()


### PR DESCRIPTION
…ets it as the default. They are only set as the default after you successfully confirm.

## Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-1855

## Testing
TBD

## Changelog
* [Changed] Tapping a saved PM/Apple Pay/Link no longer sets it as the default; they are only set as the default after you successfully confirm.
