### PR TITLE
Prevent link from showing up when pk is userkey

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
+++ b/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
@@ -119,6 +119,7 @@
 		6A529F76ECB33C9154314C1F /* STPAnalyticsClient+LUXE.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B5AAA4347A6918EC267210 /* STPAnalyticsClient+LUXE.swift */; };
 		6B31B9B82B9019730064E210 /* ElementsCustomer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B31B9B72B9019730064E210 /* ElementsCustomer.swift */; };
 		6B31B9BA2B90FCE60064E210 /* CustomerSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B31B9B92B90FCE60064E210 /* CustomerSession.swift */; };
+		6B6B70482BABA1F3009A29B3 /* IntentTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6B70472BABA1F3009A29B3 /* IntentTest.swift */; };
 		6B7E675071649AE3047D388C /* PaymentSheetFormFactoryConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A21CC86104388EFE07CB37D /* PaymentSheetFormFactoryConfig.swift */; };
 		6BA8D3342B0C1F79008C51FF /* CVCRecollectionElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA8D3332B0C1F79008C51FF /* CVCRecollectionElement.swift */; };
 		6BA8D3362B0C1F9B008C51FF /* CVCReconfirmationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA8D3352B0C1F9B008C51FF /* CVCReconfirmationViewController.swift */; };
@@ -432,6 +433,7 @@
 		6B31B9B72B9019730064E210 /* ElementsCustomer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElementsCustomer.swift; sourceTree = "<group>"; };
 		6B31B9B92B90FCE60064E210 /* CustomerSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerSession.swift; sourceTree = "<group>"; };
 		6B680A2FF197F612D065F16C /* PaymentSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSheet.swift; sourceTree = "<group>"; };
+		6B6B70472BABA1F3009A29B3 /* IntentTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntentTest.swift; sourceTree = "<group>"; };
 		6B9A346A7A4290BAA7BCA1A2 /* PaymentMethodTypeCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodTypeCollectionView.swift; sourceTree = "<group>"; };
 		6BA8D3332B0C1F79008C51FF /* CVCRecollectionElement.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CVCRecollectionElement.swift; sourceTree = "<group>"; };
 		6BA8D3352B0C1F9B008C51FF /* CVCReconfirmationViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CVCReconfirmationViewController.swift; sourceTree = "<group>"; };
@@ -1282,6 +1284,7 @@
 				73FB30705EC36BD0868904A2 /* Elements+TestHelpers.swift */,
 				64C8F350CDB5A29F62E86592 /* FlowControllerStateTests.swift */,
 				990304EF35A0EE37DCE20D5B /* IntentStatusPollerTest.swift */,
+				6B6B70472BABA1F3009A29B3 /* IntentTest.swift */,
 				FCA28FF8CD5BA829A44CDCE7 /* Link */,
 				33B8F21A22FA091BC9D2924B /* LinkStubs.swift */,
 				C830FEC205E7162FF4D414BE /* PaymentMethodMessagingViewFunctionalTest.swift */,
@@ -1569,6 +1572,7 @@
 				ABE13E65678673EC4DE14EF4 /* PaymentSheetLinkAccountTests.swift in Sources */,
 				142C03879DC4CD43BB743022 /* PaymentSheetLoaderStubbedTest.swift in Sources */,
 				1C70F42915587CBF883E01DD /* PaymentSheetLoaderTest.swift in Sources */,
+				6B6B70482BABA1F3009A29B3 /* IntentTest.swift in Sources */,
 				96B31ABDA593F9C7FC3DBF79 /* PaymentSheetPaymentMethodTypeTest.swift in Sources */,
 				041E3F2DFDFD8FA7D3353CDB /* PaymentSheetSnapshotTests.swift in Sources */,
 				1330B53140DE10F641A82099 /* PaymentSheetViewControllerSnapshotTests.swift in Sources */,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/Intent+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/Intent+Link.swift
@@ -9,17 +9,20 @@
 @_spi(STP) import StripePayments
 
 extension Intent {
-    var supportsLink: Bool {
+    func supportsLink(_ publishableKeyIsUserKey: Bool) -> Bool {
+        guard !publishableKeyIsUserKey else {
+            return false
+        }
         // Either Link is an allowed Payment Method in the elements/sessions response, or passthrough mode (Link as a Card PM) is allowed
         return recommendedPaymentMethodTypes.contains(.link) || linkPassthroughModeEnabled
     }
 
-    var supportsLinkCard: Bool {
-        return supportsLink && (linkFundingSources?.contains(.card) ?? false) || linkPassthroughModeEnabled
+    func supportsLinkCard(_ publishableKeyIsUserKey: Bool) -> Bool {
+        return supportsLink(publishableKeyIsUserKey) && (linkFundingSources?.contains(.card) ?? false) || linkPassthroughModeEnabled
     }
 
-    var onlySupportsLinkBank: Bool {
-        return supportsLink && (linkFundingSources == [.bankAccount])
+    func onlySupportsLinkBank(_ publishableKeyIsUserKey: Bool) -> Bool {
+        return supportsLink(publishableKeyIsUserKey) && (linkFundingSources == [.bankAccount])
     }
 
     var linkFlags: [String: Bool] {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -364,7 +364,7 @@ extension PaymentSheet {
                         isCustom: true,
                         paymentMethod: paymentOption.analyticsValue,
                         result: result,
-                        linkEnabled: intent.supportsLink,
+                        linkEnabled: intent.supportsLink(configuration.apiClient.publishableKeyIsUserKey),
                         activeLinkSession: LinkAccountContext.shared.account?.sessionState == .verified,
                         linkSessionType: intent.linkPopupWebviewOption,
                         currency: intent.currency,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -96,7 +96,7 @@ class PaymentSheetFormFactory {
                   offerSaveToLinkWhenSupported: offerSaveToLinkWhenSupported,
                   linkAccount: linkAccount,
                   cardBrandChoiceEligible: cardBrandChoiceEligible,
-                  supportsLinkCard: intent.supportsLinkCard,
+                  supportsLinkCard: intent.supportsLinkCard(configuration.apiClient.publishableKeyIsUserKey),
                   isPaymentIntent: intent.isPaymentIntent,
                   currency: intent.currency,
                   amount: intent.amount,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactoryConfig.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactoryConfig.swift
@@ -101,4 +101,13 @@ enum PaymentSheetFormFactoryConfig {
             return config.isUsingBillingAddressCollection()
         }
     }
+
+    var apiClient: STPAPIClient {
+        switch self {
+        case .paymentSheet(let config):
+            return config.apiClient
+        case .customerSheet(let config):
+            return config.apiClient
+        }
+    }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -93,7 +93,7 @@ final class PaymentSheetLoader {
                     showLink: isFlowController ? isLinkEnabled : false
                 )
                 analyticsClient.logPaymentSheetLoadSucceeded(loadingStartDate: loadingStartDate,
-                                                             linkEnabled: intent.supportsLink, defaultPaymentMethod: paymentOptionsViewModels.stp_boundSafeObject(at: defaultSelectedIndex))
+                                                             linkEnabled: intent.supportsLink(configuration.apiClient.publishableKeyIsUserKey), defaultPaymentMethod: paymentOptionsViewModels.stp_boundSafeObject(at: defaultSelectedIndex))
                 if isFlowController {
                     AnalyticsHelper.shared.startTimeMeasurement(.checkout)
                 }
@@ -119,7 +119,7 @@ final class PaymentSheetLoader {
     // MARK: - Helpers
 
     static func isLinkEnabled(intent: Intent, configuration: PaymentSheet.Configuration) -> Bool {
-        guard intent.supportsLink else {
+        guard intent.supportsLink(configuration.apiClient.publishableKeyIsUserKey) else {
             return false
         }
         return !configuration.isUsingBillingAddressCollection()
@@ -146,7 +146,7 @@ final class PaymentSheetLoader {
 
     static func lookupLinkAccount(intent: Intent, configuration: PaymentSheet.Configuration) async throws -> PaymentSheetLinkAccount? {
         // Only lookup the consumer account if Link is supported
-        guard intent.supportsLink else {
+        guard intent.supportsLink(configuration.apiClient.publishableKeyIsUserKey) else {
             return nil
         }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -291,7 +291,7 @@ class PaymentSheetFlowControllerViewController: UIViewController {
         STPAnalyticsClient.sharedClient.logPaymentSheetShow(
             isCustom: true,
             paymentMethod: mode.analyticsValue,
-            linkEnabled: intent.supportsLink,
+            linkEnabled: intent.supportsLink(configuration.apiClient.publishableKeyIsUserKey),
             activeLinkSession: LinkAccountContext.shared.account?.sessionState == .verified,
             currency: intent.currency,
             intentConfig: intent.intentConfig,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -275,7 +275,7 @@ class PaymentSheetViewController: UIViewController {
         STPAnalyticsClient.sharedClient.logPaymentSheetShow(
             isCustom: false,
             paymentMethod: mode.analyticsValue,
-            linkEnabled: intent.supportsLink,
+            linkEnabled: intent.supportsLink(configuration.apiClient.publishableKeyIsUserKey),
             activeLinkSession: LinkAccountContext.shared.account?.sessionState == .verified,
             currency: intent.currency,
             intentConfig: intent.intentConfig,
@@ -499,7 +499,7 @@ class PaymentSheetViewController: UIViewController {
                     isCustom: false,
                     paymentMethod: paymentOption.analyticsValue,
                     result: result,
-                    linkEnabled: self.intent.supportsLink,
+                    linkEnabled: self.intent.supportsLink(self.configuration.apiClient.publishableKeyIsUserKey),
                     activeLinkSession: LinkAccountContext.shared.account?.sessionState == .verified,
                     linkSessionType: self.intent.linkPopupWebviewOption,
                     currency: self.intent.currency,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/IntentTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/IntentTest.swift
@@ -1,0 +1,72 @@
+//
+//  IntentTest.swift
+//  StripePaymentSheetTests
+//
+
+import Foundation
+@_spi(STP) import StripeCore
+@testable import StripePaymentSheet
+import XCTest
+
+final class IntentTest: XCTestCase {
+
+    func testSupportsLink_pkUser_linkPM() throws {
+        let config = PaymentSheet.Configuration()
+        let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 100, currency: "USD")) { _, _, _ in
+            // Nothing
+        }
+        config.apiClient.publishableKey = "pk_123"
+        let intent = Intent.deferredIntent(elementsSession: STPElementsSession.elementsSessionWithLinkEnabled(),
+                                           intentConfig: intentConfig)
+        XCTAssertTrue(intent.supportsLink(config.apiClient.publishableKeyIsUserKey))
+    }
+    func testSupportsLink_ukUser_linkPM() throws {
+        let config = PaymentSheet.Configuration()
+        let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 100, currency: "USD")) { _, _, _ in
+            // Nothing
+        }
+        config.apiClient.publishableKey = "uk_123"
+        let intent = Intent.deferredIntent(elementsSession: STPElementsSession.elementsSessionWithLinkEnabled(),
+                                           intentConfig: intentConfig)
+        XCTAssertFalse(intent.supportsLink(config.apiClient.publishableKeyIsUserKey))
+    }
+    func testSupportsLink_pkUser_NolinkPM() throws {
+        let config = PaymentSheet.Configuration()
+        let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 100, currency: "USD")) { _, _, _ in
+            // Nothing
+        }
+        config.apiClient.publishableKey = "pk_123"
+        let intent = Intent.deferredIntent(elementsSession: STPElementsSession.elementsSessionWithLinkDisabled(),
+                                           intentConfig: intentConfig)
+        XCTAssertFalse(intent.supportsLink(config.apiClient.publishableKeyIsUserKey))
+    }
+    func testSupportsLink_ukUser_NolinkPM() throws {
+        let config = PaymentSheet.Configuration()
+        let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 100, currency: "USD")) { _, _, _ in
+            // Nothing
+        }
+        config.apiClient.publishableKey = "uk_123"
+        let intent = Intent.deferredIntent(elementsSession: STPElementsSession.elementsSessionWithLinkDisabled(),
+                                           intentConfig: intentConfig)
+        XCTAssertFalse(intent.supportsLink(config.apiClient.publishableKeyIsUserKey))
+    }
+}
+
+extension STPElementsSession {
+    static func elementsSessionWithLinkEnabled() -> STPElementsSession {
+        let apiResponse: [String: Any] = ["payment_method_preference": ["ordered_payment_method_types": ["card", "link"],
+                                                                        "country_code": "US", ] as [String: Any],
+                                          "session_id": "123",
+                                          "apple_pay_preference": "enabled",
+        ]
+        return STPElementsSession.decodedObject(fromAPIResponse: apiResponse)!
+    }
+    static func elementsSessionWithLinkDisabled() -> STPElementsSession {
+        let apiResponse: [String: Any] = ["payment_method_preference": ["ordered_payment_method_types": ["card"],
+                                                                        "country_code": "US", ] as [String: Any],
+                                          "session_id": "123",
+                                          "apple_pay_preference": "enabled",
+        ]
+        return STPElementsSession.decodedObject(fromAPIResponse: apiResponse)!
+    }
+}


### PR DESCRIPTION
## Summary
Prevent link as a PM when pk is a user key

## Motivation
Link should not be enabled in this use case

## Testing
Added unit tests

