### PR TITLE
Log payment method type on luxeSpecSerializeFailure

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/STPAnalyticsClient+LUXE.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/STPAnalyticsClient+LUXE.swift
@@ -16,8 +16,8 @@ extension STPAnalyticsClient {
         self.logPaymentSheetEvent(event: .luxeUnknownActionsFailure)
     }
 
-    func logLUXESpecSerilizeFailure(error: Error?) {
-        self.logPaymentSheetEvent(event: .luxeSpecSerializeFailure, error: error)
+    func logLUXESpecSerilizeFailure(error: Error?, paymentMethod: String) {
+        self.logPaymentSheetEvent(event: .luxeSpecSerializeFailure, error: error, params: ["payment_method": paymentMethod])
     }
 
     func logImageSelectorIconDownloadedIfNeeded(paymentMethod: PaymentSheet.PaymentMethodType) {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/FormSpec/FormSpecProvider.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/FormSpec/FormSpecProvider.swift
@@ -74,7 +74,8 @@ class FormSpecProvider {
                 }
                 self.formSpecs[decodedFormSpec.type] = decodedFormSpec
             } catch {
-                STPAnalyticsClient.sharedClient.logLUXESpecSerilizeFailure(error: error)
+                let paymentMethodType = formSpec["type"] as? String ?? ""
+                STPAnalyticsClient.sharedClient.logLUXESpecSerilizeFailure(error: error, paymentMethod: paymentMethodType)
                 decodedSuccessfully = false
             }
         }


### PR DESCRIPTION
## Summary
Adding payment method type to luxeSpecSerializeFailure

## Motivation
Additional info when debugging this issue

## Testing
Ran existing tests

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
