### PR TITLE
CI Fix: Don't use DPM for Zip test

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -698,7 +698,7 @@ class PaymentSheetStandardLPMUITests: PaymentSheetUITestCase {
     func testZipPaymentMethod() throws {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
         settings.customerMode = .new // new customer
-        settings.apmsEnabled = .on
+        settings.apmsEnabled = .off
         settings.currency = .aud
         settings.merchantCountryCode = .AU
         loadPlayground(


### PR DESCRIPTION
## Summary
Disable DPM for the Zip test, Zip is not available in DPM mode for US users.