### PR TITLE
Declare UserDefaults in PaymentSheet Example privacy manifest

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PrivacyInfo.xcprivacy
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PrivacyInfo.xcprivacy
@@ -6,6 +6,14 @@
 	<array>
 		<dict>
 			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>1C8F.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
 			<string>NSPrivacyAccessedAPICategoryActiveKeyboards</string>
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>


### PR DESCRIPTION
## Summary
Declare UserDefaults in PaymentSheet Example's privacy manifest.

## Motivation
Silence a warning in TestFlight submission.
