### PR TITLE
Financial Connections: Implemented support for Multi-Select in networking (data flows)

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnections Example.xcodeproj/project.pbxproj
+++ b/Example/FinancialConnections Example/FinancialConnections Example.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		5AA50D95EC1C2489AD98071E /* PlaygroundMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B379D3A9F9EA11716D5AEB3 /* PlaygroundMainView.swift */; };
 		5B38135D1C37FC1812F4203A /* StripeUICore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ADFEE494187576194F8B46BB /* StripeUICore.framework */; };
 		5C1B372D1660E856988156DA /* StripeUICore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = ADFEE494187576194F8B46BB /* StripeUICore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		6A6C23172BBCC6210083FF66 /* XCUIGestureVelocity+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A6C23162BBCC6210083FF66 /* XCUIGestureVelocity+Extensions.swift */; };
 		6AC6B40D2B880EEA000A4B32 /* XCTestCase+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC6B40C2B880EEA000A4B32 /* XCTestCase+Extensions.swift */; };
 		6AF9C66D47F81DD9B103FB64 /* StripeCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 03E7365D673694C8D7EDFB20 /* StripeCore.framework */; };
 		828A3C3A555F9B2ABAEF3E95 /* WebViewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65FBE9DBF6CBB07AE2D5B1DA /* WebViewViewController.swift */; };
@@ -95,6 +96,7 @@
 		5B675DEF4776CDFF8309DEB8 /* Project-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Project-Debug.xcconfig"; sourceTree = "<group>"; };
 		5C02DB1648E15A6591FD56E1 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		65FBE9DBF6CBB07AE2D5B1DA /* WebViewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewViewController.swift; sourceTree = "<group>"; };
+		6A6C23162BBCC6210083FF66 /* XCUIGestureVelocity+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIGestureVelocity+Extensions.swift"; sourceTree = "<group>"; };
 		6AC6B40C2B880EEA000A4B32 /* XCTestCase+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Extensions.swift"; sourceTree = "<group>"; };
 		701003016E153D5DF2B00442 /* FinancialConnections-Example-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "FinancialConnections-Example-Debug.xcconfig"; sourceTree = "<group>"; };
 		74959BBB33DB4A570E2B4FD3 /* FinancialConnectionsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsUITests.swift; sourceTree = "<group>"; };
@@ -231,6 +233,7 @@
 				E43F3C346DE28D65F7575D58 /* XCUIApplication+Extensions.swift */,
 				01EFB9C0699FEB532FFE57D9 /* XCUIElement+Extensions.swift */,
 				6AC6B40C2B880EEA000A4B32 /* XCTestCase+Extensions.swift */,
+				6A6C23162BBCC6210083FF66 /* XCUIGestureVelocity+Extensions.swift */,
 			);
 			path = FinancialConnectionsUITests;
 			sourceTree = "<group>";
@@ -368,6 +371,7 @@
 				6AC6B40D2B880EEA000A4B32 /* XCTestCase+Extensions.swift in Sources */,
 				09B82E32FC066FC442BD945D /* XCUIApplication+Extensions.swift in Sources */,
 				82D499E3F32FB4663D26EBA6 /* XCUIElement+Extensions.swift in Sources */,
+				6A6C23172BBCC6210083FF66 /* XCUIGestureVelocity+Extensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundMainView.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundMainView.swift
@@ -71,6 +71,7 @@ struct PlaygroundMainView: View {
                                     .accessibility(identifier: "playground-email")
 
                                 Toggle("Enable Multi Select", isOn: $viewModel.enableNetworkingMultiSelect)
+                                    .accessibility(identifier: "networking-multi-select")
                             }
                         } else if viewModel.customScenario == .customKeys {
                             TextField("Public Key (pk_)", text: $viewModel.customPublicKey)
@@ -99,7 +100,7 @@ struct PlaygroundMainView: View {
 
                     // extra space so keyboard doesn't cover the "CUSTOM KEYS" section
                     // (SwiftUI, depending on iOS version, doesn't handle keyboard)
-                    Spacer(minLength: 100)
+                    Spacer(minLength: 60)
                 }
                 VStack {
                     Button(action: viewModel.didSelectShow) {

--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundMainView.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundMainView.swift
@@ -69,6 +69,8 @@ struct PlaygroundMainView: View {
                                     .keyboardType(.emailAddress)
                                     .autocapitalization(.none)
                                     .accessibility(identifier: "playground-email")
+
+                                Toggle("Enable Multi Select", isOn: $viewModel.enableNetworkingMultiSelect)
                             }
                         } else if viewModel.customScenario == .customKeys {
                             TextField("Public Key (pk_)", text: $viewModel.customPublicKey)

--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundMainViewModel.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundMainViewModel.swift
@@ -69,6 +69,12 @@ final class PlaygroundMainViewModel: ObservableObject {
         }
     }
 
+    @Published var enableNetworkingMultiSelect: Bool = PlaygroundUserDefaults.enableNetworkingMultiSelect {
+        didSet {
+            PlaygroundUserDefaults.enableNetworkingMultiSelect = enableNetworkingMultiSelect
+        }
+    }
+
     @Published var enableOwnershipPermission: Bool = PlaygroundUserDefaults.enableOwnershipPermission {
         didSet {
             PlaygroundUserDefaults.enableOwnershipPermission = enableOwnershipPermission
@@ -164,6 +170,7 @@ final class PlaygroundMainViewModel: ObservableObject {
             enableTestMode: enableTestMode,
             flow: flow.rawValue,
             email: email,
+            enableNetworkingMultiSelect: enableNetworkingMultiSelect,
             enableOwnershipPermission: enableOwnershipPermission,
             enableBalancesPermission: enableBalancesPermission,
             enableTransactionsPermission: enableTransactionsPermission,
@@ -233,6 +240,7 @@ private func SetupPlayground(
     enableTestMode: Bool,
     flow: String,
     email: String,
+    enableNetworkingMultiSelect: Bool,
     enableOwnershipPermission: Bool,
     enableBalancesPermission: Bool,
     enableTransactionsPermission: Bool,
@@ -256,6 +264,7 @@ private func SetupPlayground(
         requestBody["enable_test_mode"] = enableTestMode
         requestBody["flow"] = flow
         requestBody["email"] = email
+        requestBody["enable_networking_multi_select"] = enableNetworkingMultiSelect
         requestBody["enable_ownership_permission"] = enableOwnershipPermission
         requestBody["enable_balances_permission"] = enableBalancesPermission
         requestBody["enable_transactions_permission"] = enableTransactionsPermission

--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/helpers/PlaygroundUserDefaults.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/helpers/PlaygroundUserDefaults.swift
@@ -41,6 +41,12 @@ final class PlaygroundUserDefaults {
     static var email: String
 
     @UserDefault(
+        key: "FINANCIAL_CONNECTIONS_EXAMPLE_APP_NETWORKING_MULTI_SELECT",
+        defaultValue: false
+    )
+    static var enableNetworkingMultiSelect: Bool
+
+    @UserDefault(
         key: "FINANCIAL_CONNECTIONS_EXAMPLE_APP_ENABLE_OWNERSHIP_PERMISSION",
         defaultValue: false
     )

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
@@ -10,20 +10,19 @@ import XCTest
 
 final class FinancialConnectionsNetworkingUITests: XCTestCase {
 
-    override func setUpWithError() throws {
-        try super.setUpWithError()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-
-        // In UI tests it is usually best to stop immediately when a failure occurs.
-        continueAfterFailure = false
-
-        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
-    }
-
     func testNativeNetworkingTestMode() throws {
         let emailAddresss = "\(UUID().uuidString)@UITestForIOS.com"
         executeNativeNetworkingTestModeSignUpFlowTest(emailAddress: emailAddresss)
         executeNativeNetworkingTestModeSignInFlowTest(emailAddress: emailAddresss)
+        let bankAccountName = "Insufficient Funds"
+        executeNativeNetworkingTestModeAddBankAccount(
+            emailAddress: emailAddresss,
+            bankAccountName: bankAccountName
+        )
+        executeNativeNetworkingTestModeUpdateRequired(
+            emailAddress: emailAddresss,
+            bankAccountName: bankAccountName
+        )
     }
 
     private func executeNativeNetworkingTestModeSignUpFlowTest(emailAddress: String) {
@@ -40,15 +39,19 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         let enableTestModeSwitch = app.fc_playgroundEnableTestModeSwitch
         enableTestModeSwitch.turnSwitch(on: true)
 
+        app.fc_scrollDown() // see email
         let playgroundEmailTextField = app.textFields["playground-email"]
         XCTAssertTrue(playgroundEmailTextField.waitForExistence(timeout: 60.0))
         playgroundEmailTextField.tap()
         clear(textField: playgroundEmailTextField)
-        app.dismissKeyboard() // dismiss keyboard (warning: ensure keyboard is visible if manually testing)
+        app.fc_dismissKeyboard() // dismiss keyboard (warning: ensure keyboard is visible if manually testing)
 
-        let playgroundTransactionsPermissionsSwitch = app.switches["playground-transactions-permission"]
-        XCTAssertTrue(playgroundTransactionsPermissionsSwitch.waitForExistence(timeout: 60.0))
-        playgroundTransactionsPermissionsSwitch.turnSwitch(on: true)
+        let multiSelectSwitch = app.switches["networking-multi-select"]
+        XCTAssertTrue(multiSelectSwitch.waitForExistence(timeout: 60.0))
+        multiSelectSwitch.turnSwitch(on: false)
+
+        app.fc_scrollDown() // see permissions
+        app.switches["playground-transactions-permission"].turnSwitch(on: true)
 
         app.fc_playgroundShowAuthFlowButton.tap()
         app.fc_nativeConsentAgreeButton.tap()
@@ -63,7 +66,7 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         XCTAssertTrue(successInstitution.waitForExistence(timeout: 60.0))
         successInstitution.tap()
 
-        app.fc_nativeAccountPickerLinkAccountsButton.tap()
+        app.fc_nativeConnectAccountsButton.tap()
 
         let emailTextField = app.textFields["email_text_field"]
         XCTAssertTrue(emailTextField.waitForExistence(timeout: 120.0))  // wait for synchronize to complete
@@ -84,10 +87,12 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         saveToLinkButon.tap()
 
         let successPaneDoneButton = app.fc_nativeSuccessDoneButton
-        // this ensures that save to Link was successful...
-        // ...we want to check AFTER success screen has rendered with the "Done" button
-        XCTAssert(!app.staticTexts.containing(NSPredicate(format: "label CONTAINS 'could not be saved to Link'")).firstMatch
-            .exists)
+
+        // ensure that there wasn't a Link failure
+        //
+        // unexpected text: "Your account was connected, but couldn't be saved to Link"
+        XCTAssert(!app.textViews.containing(NSPredicate(format: "label CONTAINS 'but'")).firstMatch.exists)
+
         successPaneDoneButton.tap()
 
         // ensure alert body contains "Stripe Bank" (AKA one bank is linked)
@@ -111,16 +116,16 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         let enableTestModeSwitch = app.fc_playgroundEnableTestModeSwitch
         enableTestModeSwitch.turnSwitch(on: true)
 
+        app.fc_scrollDown() // see email
         let playgroundEmailTextField = app.textFields["playground-email"]
         XCTAssertTrue(playgroundEmailTextField.waitForExistence(timeout: 60.0))
         playgroundEmailTextField.tap()
         clear(textField: playgroundEmailTextField)
         playgroundEmailTextField.typeText(emailAddress)
-        app.dismissKeyboard() // dismiss keyboard (warning: ensure keyboard is visible if manually testing)
+        app.fc_dismissKeyboard() // dismiss keyboard (warning: ensure keyboard is visible if manually testing)
 
-        let playgroundTransactionsPermissionsSwitch = app.switches["playground-transactions-permission"]
-        XCTAssertTrue(playgroundTransactionsPermissionsSwitch.waitForExistence(timeout: 60.0))
-        playgroundTransactionsPermissionsSwitch.turnSwitch(on: true)
+        app.fc_scrollDown() // see permissions
+        app.switches["playground-transactions-permission"].turnSwitch(on: true)
 
         app.fc_playgroundShowAuthFlowButton.tap()
         app.fc_nativeConsentAgreeButton.tap()
@@ -148,15 +153,248 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         stepUpVerificationOTPTextView.typeText("111111")
 
         let successPaneDoneButton = app.fc_nativeSuccessDoneButton
-        // this ensures that save to Link was successful...
-        // ...we want to check AFTER success screen has rendered with the "Done" button
-        XCTAssert(!app.staticTexts.containing(NSPredicate(format: "label CONTAINS 'could not be saved to Link'")).firstMatch
-            .exists)
+
+        // ensure that there wasn't a Link failure
+        //
+        // unexpected text: "Your account was connected, but couldn't be saved to Link"
+        XCTAssert(!app.textViews.containing(NSPredicate(format: "label CONTAINS 'but'")).firstMatch.exists)
+
         successPaneDoneButton.tap()
 
         // ensure alert body contains "Stripe Bank" (AKA one bank is linked)
         XCTAssert(
             app.fc_playgroundSuccessAlertView.staticTexts.containing(NSPredicate(format: "label CONTAINS 'StripeBank'")).firstMatch
+                .exists
+        )
+    }
+
+    private func executeNativeNetworkingTestModeAddBankAccount(
+        emailAddress: String,
+        bankAccountName: String
+    ) {
+        let app = XCUIApplication.fc_launch()
+
+        app.fc_playgroundCell.tap()
+
+        let dataSegmentPickerButton = app.segmentedControls.buttons["Networking"]
+        XCTAssertTrue(dataSegmentPickerButton.waitForExistence(timeout: 60.0))
+        dataSegmentPickerButton.tap()
+
+        app.fc_playgroundNativeButton.tap()
+
+        let enableTestModeSwitch = app.fc_playgroundEnableTestModeSwitch
+        enableTestModeSwitch.turnSwitch(on: true)
+
+        app.fc_scrollDown() // see email
+        let playgroundEmailTextField = app.textFields["playground-email"]
+        XCTAssertTrue(playgroundEmailTextField.waitForExistence(timeout: 60.0))
+        playgroundEmailTextField.tap()
+        clear(textField: playgroundEmailTextField)
+        playgroundEmailTextField.typeText(emailAddress)
+        app.fc_dismissKeyboard() // dismiss keyboard (warning: ensure keyboard is visible if manually testing)
+
+        let multiSelectSwitch = app.switches["networking-multi-select"]
+        XCTAssertTrue(multiSelectSwitch.waitForExistence(timeout: 60.0))
+        multiSelectSwitch.turnSwitch(on: false)
+
+        app.fc_scrollDown() // see permissions
+        app.switches["playground-ownership-permission"].turnSwitch(on: false)
+        app.switches["playground-balances-permission"].turnSwitch(on: false)
+        app.switches["playground-transactions-permission"].turnSwitch(on: false)
+
+        app.fc_playgroundShowAuthFlowButton.tap()
+        app.fc_nativeConsentAgreeButton.tap()
+
+        let linkContinueButton = app.buttons["link_continue_button"]
+        XCTAssertTrue(linkContinueButton.waitForExistence(timeout: 60.0))
+        linkContinueButton.tap()
+
+        let verificationOTPTextView = app.scrollViews.otherElements.textViews["Code field"]
+        XCTAssertTrue(verificationOTPTextView.waitForExistence(timeout: 60.0))
+        verificationOTPTextView.tap()
+        verificationOTPTextView.typeText("111111")
+
+        let addBankAccountButton = app.scrollViews.otherElements["add_bank_account"]
+        XCTAssertTrue(addBankAccountButton.waitForExistence(timeout: 120.0)) // need to wait for various API calls to appear
+        addBankAccountButton.tap()
+
+        // wait for search bar to appear
+        _ = app.fc_searchBarTextField
+
+        app.fc_scrollDown() // see all institutions
+
+        app.fc_nativeFeaturedInstitution(name: "Data cannot be shared through Link").tap()
+
+        app.fc_nativeBankAccount(name: bankAccountName).tap()
+
+        app.fc_nativeConnectAccountsButton.tap()
+
+        app.fc_nativeSuccessDoneButton.tap()
+
+        // ensure alert body contains "Stripe Bank" (AKA one bank is linked)
+        XCTAssert(
+            app.fc_playgroundSuccessAlertView.staticTexts.containing(NSPredicate(format: "label CONTAINS '\(bankAccountName)'")).firstMatch
+                .exists
+        )
+    }
+
+    private func executeNativeNetworkingTestModeUpdateRequired(
+        emailAddress: String,
+        bankAccountName: String
+    ) {
+        let app = XCUIApplication.fc_launch()
+
+        app.fc_playgroundCell.tap()
+
+        let dataSegmentPickerButton = app.segmentedControls.buttons["Networking"]
+        XCTAssertTrue(dataSegmentPickerButton.waitForExistence(timeout: 60.0))
+        dataSegmentPickerButton.tap()
+
+        app.fc_playgroundNativeButton.tap()
+
+        let enableTestModeSwitch = app.fc_playgroundEnableTestModeSwitch
+        enableTestModeSwitch.turnSwitch(on: true)
+
+        app.fc_scrollDown() // see email
+        let playgroundEmailTextField = app.textFields["playground-email"]
+        XCTAssertTrue(playgroundEmailTextField.waitForExistence(timeout: 60.0))
+        playgroundEmailTextField.tap()
+        clear(textField: playgroundEmailTextField)
+        playgroundEmailTextField.typeText(emailAddress)
+        app.fc_dismissKeyboard() // dismiss keyboard (warning: ensure keyboard is visible if manually testing)
+
+        let multiSelectSwitch = app.switches["networking-multi-select"]
+        XCTAssertTrue(multiSelectSwitch.waitForExistence(timeout: 60.0))
+        multiSelectSwitch.turnSwitch(on: true)
+
+        app.fc_scrollDown() // see permissions
+        app.switches["playground-ownership-permission"].turnSwitch(on: true)
+
+        app.fc_playgroundShowAuthFlowButton.tap()
+        app.fc_nativeConsentAgreeButton.tap()
+
+        let linkContinueButton = app.buttons["link_continue_button"]
+        XCTAssertTrue(linkContinueButton.waitForExistence(timeout: 60.0))
+        linkContinueButton.tap()
+
+        let verificationOTPTextView = app.scrollViews.otherElements.textViews["Code field"]
+        XCTAssertTrue(verificationOTPTextView.waitForExistence(timeout: 60.0))
+        verificationOTPTextView.tap()
+        verificationOTPTextView.typeText("111111")
+
+        app.fc_nativeBankAccount(name: bankAccountName).tap()
+
+        let accountUpdateRequiredContinueButton = app.buttons["account_update_required_continue_button"]
+        XCTAssertTrue(accountUpdateRequiredContinueButton.waitForExistence(timeout: 1))
+        accountUpdateRequiredContinueButton.tap()
+
+        app.fc_nativeConnectAccountsButton.tap()
+
+        let successDoneButton = app.fc_nativeSuccessDoneButton
+
+        // ensures that save to Link was successful
+        //
+        // expected text: "Your account was connected, and saved with Link."
+        XCTAssert(app.textViews.containing(NSPredicate(format: "label CONTAINS 'Link'")).firstMatch.exists)
+
+        // ensure that the Link text wasn't a failure
+        //
+        // unexpected text: "Your account was connected, but couldn't be saved to Link"
+        XCTAssert(!app.textViews.containing(NSPredicate(format: "label CONTAINS 'but'")).firstMatch.exists)
+
+        successDoneButton.tap()
+
+        // multiple banks should be checked
+        XCTAssert(
+            app.fc_playgroundSuccessAlertView.staticTexts.containing(NSPredicate(format: "label CONTAINS 'Success'")).firstMatch
+                .exists
+        )
+        XCTAssert(
+            app.fc_playgroundSuccessAlertView.staticTexts.containing(NSPredicate(format: "label CONTAINS '\(bankAccountName)'")).firstMatch
+                .exists
+        )
+    }
+
+    func testNativeNetworkingTestModeSignUpWithMultiSelectAndPrefilledEmail() {
+        let emailAddress = "\(UUID().uuidString)@UITestForIOS.com"
+
+        let app = XCUIApplication.fc_launch()
+
+        app.fc_playgroundCell.tap()
+
+        let dataSegmentPickerButton = app.segmentedControls.buttons["Networking"]
+        XCTAssertTrue(dataSegmentPickerButton.waitForExistence(timeout: 60.0))
+        dataSegmentPickerButton.tap()
+
+        app.fc_playgroundNativeButton.tap()
+
+        let enableTestModeSwitch = app.fc_playgroundEnableTestModeSwitch
+        enableTestModeSwitch.turnSwitch(on: true)
+
+        app.fc_scrollDown() // see email
+        let playgroundEmailTextField = app.textFields["playground-email"]
+        XCTAssertTrue(playgroundEmailTextField.waitForExistence(timeout: 60.0))
+        playgroundEmailTextField.tap()
+        clear(textField: playgroundEmailTextField)
+        playgroundEmailTextField.typeText(emailAddress)
+        app.fc_dismissKeyboard() // dismiss keyboard (warning: ensure keyboard is visible if manually testing)
+
+        let multiSelectSwitch = app.switches["networking-multi-select"]
+        XCTAssertTrue(multiSelectSwitch.waitForExistence(timeout: 60.0))
+        multiSelectSwitch.turnSwitch(on: true)
+
+        app.fc_scrollDown() // see permissions
+        app.switches["playground-transactions-permission"].turnSwitch(on: true)
+
+        app.fc_playgroundShowAuthFlowButton.tap()
+        app.fc_nativeConsentAgreeButton.tap()
+
+        let featuredLegacyTestInstitution = app.tables.cells.staticTexts["Test OAuth Institution"]
+        XCTAssertTrue(featuredLegacyTestInstitution.waitForExistence(timeout: 60.0))
+        featuredLegacyTestInstitution.tap()
+
+        app.fc_nativePrepaneContinueButton.tap()
+
+        // all accounts will be selected by default
+
+        app.fc_nativeConnectAccountsButton.tap()
+
+        // email will already be pre-filled
+
+        let phoneTextField = app.textFields["phone_text_field"]
+        XCTAssertTrue(phoneTextField.waitForExistence(timeout: 120.0))  // wait for lookup to complete
+        phoneTextField.tap()
+        phoneTextField.typeText("4015006000")
+
+        let phoneTextFieldToolbarDoneButton = app.toolbars["Toolbar"].buttons["Done"]
+        XCTAssertTrue(phoneTextFieldToolbarDoneButton.waitForExistence(timeout: 60.0))
+        phoneTextFieldToolbarDoneButton.tap()
+
+        let saveToLinkButon = app.buttons["Save to Link"]
+        XCTAssertTrue(saveToLinkButon.waitForExistence(timeout: 120.0))  // glitch app can take time to lload
+        saveToLinkButon.tap()
+
+        let successPaneDoneButton = app.fc_nativeSuccessDoneButton
+
+        // ensures that save to Link was successful
+        //
+        // expected text: "Your account was connected, and saved with Link."
+        XCTAssert(app.textViews.containing(NSPredicate(format: "label CONTAINS 'Link'")).firstMatch.exists)
+
+        // ensure that the Link text wasn't a failure
+        //
+        // unexpected text: "Your account was connected, but couldn't be saved to Link"
+        XCTAssert(!app.textViews.containing(NSPredicate(format: "label CONTAINS 'but'")).firstMatch.exists)
+
+        successPaneDoneButton.tap()
+
+        // multiple banks should be checked
+        XCTAssert(
+            app.fc_playgroundSuccessAlertView.staticTexts.containing(NSPredicate(format: "label CONTAINS 'Success'")).firstMatch
+                .exists
+        )
+        XCTAssert(
+            app.fc_playgroundSuccessAlertView.staticTexts.containing(NSPredicate(format: "label CONTAINS 'Insufficient Funds'")).firstMatch
                 .exists
         )
     }

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
@@ -38,7 +38,7 @@ final class FinancialConnectionsUITests: XCTestCase {
         featuredLegacyTestInstitution.tap()
 
         app.fc_nativePrepaneContinueButton.tap()
-        app.fc_nativeAccountPickerLinkAccountsButton.tap()
+        app.fc_nativeConnectAccountsButton.tap()
         app.fc_nativeSuccessDoneButton.tap()
 
         // ensure alert body contains "Stripe Bank" (AKA one bank is linked)
@@ -69,7 +69,7 @@ final class FinancialConnectionsUITests: XCTestCase {
         XCTAssertTrue(successAccountRow.waitForExistence(timeout: 60.0))
         successAccountRow.tap()
 
-        app.fc_nativeAccountPickerLinkAccountsButton.tap()
+        app.fc_nativeConnectAccountsButton.tap()
         app.fc_nativeSuccessDoneButton.tap()
 
         // ensure alert body contains "Stripe Bank" (AKA one bank is linked)
@@ -332,11 +332,7 @@ final class FinancialConnectionsUITests: XCTestCase {
         app.fc_playgroundShowAuthFlowButton.tap()
         app.fc_nativeConsentAgreeButton.tap()
 
-        let searchBarTextField = app
-            .tables
-            .otherElements
-            .textFields["search_bar_text_field"]
-        XCTAssertTrue(searchBarTextField.waitForExistence(timeout: 120.0))
+        let searchBarTextField = app.fc_searchBarTextField
         searchBarTextField.tap()
         searchBarTextField.typeText("Bank of America")
 

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIApplication+Extensions.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIApplication+Extensions.swift
@@ -104,9 +104,10 @@ extension XCUIApplication {
         return prepaneCancelButton
     }
 
-    var fc_nativeAccountPickerLinkAccountsButton: XCUIElement {
-        let accountPickerLinkAccountsButton = buttons["account_picker_link_accounts_button"]
+    var fc_nativeConnectAccountsButton: XCUIElement {
+        let accountPickerLinkAccountsButton = buttons["connect_accounts_button"]
         XCTAssertTrue(accountPickerLinkAccountsButton.waitForExistence(timeout: 120.0), "Failed to open Account Picker pane - \(#function) waiting failed")  // wait for accounts to fetch
+        XCTAssert(accountPickerLinkAccountsButton.isEnabled, "no account selected")
         return accountPickerLinkAccountsButton
     }
 
@@ -122,7 +123,31 @@ extension XCUIApplication {
         return secureWebViewCancelButton
     }
 
-    func dismissKeyboard() {
+    var fc_searchBarTextField: XCUIElement {
+        let searchBarTextField = tables
+            .otherElements
+            .textFields["search_bar_text_field"]
+        XCTAssertTrue(searchBarTextField.waitForExistence(timeout: 120.0))
+        return searchBarTextField
+    }
+
+    func fc_nativeFeaturedInstitution(name: String) -> XCUIElement {
+        let featuredTestInstitution = tables.cells.staticTexts[name]
+        XCTAssertTrue(featuredTestInstitution.waitForExistence(timeout: 60.0))
+        return featuredTestInstitution
+    }
+
+    func fc_nativeBankAccount(name: String) -> XCUIElement {
+        let bankAccount = scrollViews.staticTexts[name]
+        XCTAssertTrue(bankAccount.waitForExistence(timeout: 120.0))
+        return bankAccount
+    }
+
+    func fc_scrollDown() {
+        swipeUp(velocity: .verySlow)
+    }
+
+    func fc_dismissKeyboard() {
         let returnKey = keyboards.buttons["return"]
         if returnKey.exists && returnKey.isHittable {
             returnKey.tap()

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIGestureVelocity+Extensions.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIGestureVelocity+Extensions.swift
@@ -1,0 +1,13 @@
+//
+//  XCUIGestureVelocity+Extensions.swift
+//  FinancialConnectionsUITests
+//
+//  Created by Krisjanis Gaidis on 4/2/24.
+//
+
+import Foundation
+import XCTest
+
+extension XCUIGestureVelocity {
+    static let verySlow: XCUIGestureVelocity = XCUIGestureVelocity(300)
+}

--- a/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
@@ -587,7 +587,7 @@ class CustomerSheetUITest: XCTestCase {
         app.buttons["consent_agree_button"].tap()
         app.staticTexts["Test Institution"].forceTapElement()
         app.staticTexts["Success"].waitForExistenceAndTap(timeout: timeout)
-        app.buttons["account_picker_link_accounts_button"].tap()
+        app.buttons["connect_accounts_button"].tap()
 
         let notNowButton = app.buttons["Not now"]
         if notNowButton.waitForExistence(timeout: timeout) {
@@ -631,7 +631,7 @@ class CustomerSheetUITest: XCTestCase {
         app.buttons["consent_agree_button"].tap()
         app.staticTexts["Test Institution"].forceTapElement()
         app.staticTexts["Success"].waitForExistenceAndTap(timeout: timeout)
-        app.buttons["account_picker_link_accounts_button"].tap()
+        app.buttons["connect_accounts_button"].tap()
 
         let notNowButton = app.buttons["Not now"]
         if notNowButton.waitForExistence(timeout: timeout) {
@@ -715,7 +715,7 @@ class CustomerSheetUITest: XCTestCase {
         app.buttons["consent_agree_button"].tap()
         app.staticTexts["Test Institution"].forceTapElement()
         app.staticTexts["Success"].waitForExistenceAndTap(timeout: timeout)
-        app.buttons["account_picker_link_accounts_button"].tap()
+        app.buttons["connect_accounts_button"].tap()
 
         let notNowButton = app.buttons["Not now"]
         if notNowButton.waitForExistence(timeout: timeout) {

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -3207,7 +3207,7 @@ extension PaymentSheetUITestCase {
         app.buttons["Agree and continue"].tap()
         app.staticTexts["Test Institution"].forceTapElement()
         app.staticTexts["Success"].waitForExistenceAndTap(timeout: 10)
-        app.buttons["account_picker_link_accounts_button"].tap()
+        app.buttons["connect_accounts_button"].tap()
 
         let notNowButton = app.buttons["Not now"]
         if notNowButton.waitForExistence(timeout: 10.0) {

--- a/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
+++ b/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
@@ -66,6 +66,7 @@
 		6744CB1B182C5F7220B0B804 /* AuthFlowHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AFC0D3ED86914DC4216CCCA /* AuthFlowHelpersTests.swift */; };
 		691619AE9A989548ABA36535 /* HitTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F669BB8F3DA862C425897705 /* HitTestView.swift */; };
 		6944E131D351784058C7D734 /* FinancialConnectionsPaymentMethodType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 191760EFAA9154C1F168E1D2 /* FinancialConnectionsPaymentMethodType.swift */; };
+		6A044E482BB3866A00D73A3E /* AccountUpdateRequiredViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A044E472BB3866A00D73A3E /* AccountUpdateRequiredViewController.swift */; };
 		6A13B9822B48BD6C00FFA327 /* AccountPickerRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A13B9812B48BD6C00FFA327 /* AccountPickerRowView.swift */; };
 		6A13B9842B48BF4300FFA327 /* AccountPickerRowLabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A13B9832B48BF4300FFA327 /* AccountPickerRowLabelView.swift */; };
 		6A13B9862B4CD04100FFA327 /* RetrieveAccountsLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A13B9852B4CD04100FFA327 /* RetrieveAccountsLoadingView.swift */; };
@@ -338,6 +339,7 @@
 		6652EBE38C47B36962AD370A /* StripeUICore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripeUICore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		66D2857E68EA69AC6F658BEA /* pt-PT */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-PT"; path = "pt-PT.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		66D3CAB53EC9D33831C5A48B /* NetworkingSaveToLinkVerificationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkingSaveToLinkVerificationViewController.swift; sourceTree = "<group>"; };
+		6A044E472BB3866A00D73A3E /* AccountUpdateRequiredViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountUpdateRequiredViewController.swift; sourceTree = "<group>"; };
 		6A13B9812B48BD6C00FFA327 /* AccountPickerRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountPickerRowView.swift; sourceTree = "<group>"; };
 		6A13B9832B48BF4300FFA327 /* AccountPickerRowLabelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountPickerRowLabelView.swift; sourceTree = "<group>"; };
 		6A13B9852B4CD04100FFA327 /* RetrieveAccountsLoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetrieveAccountsLoadingView.swift; sourceTree = "<group>"; };
@@ -742,6 +744,7 @@
 				6A732C9D2B64787E00828CB1 /* LinkAccountPickerLoadingView.swift */,
 				AFF070262170A321F5622CCF /* LinkAccountPickerNewAccountRowView.swift */,
 				1848547B588045C776236B3B /* LinkAccountPickerViewController.swift */,
+				6A044E472BB3866A00D73A3E /* AccountUpdateRequiredViewController.swift */,
 			);
 			path = LinkAccountPicker;
 			sourceTree = "<group>";
@@ -1327,6 +1330,7 @@
 				1E0C39EB65B8CB04F218D0BD /* NetworkingLinkLoginWarmupDataSource.swift in Sources */,
 				F7C10A1AB247D0F6E111DE36 /* NetworkingLinkLoginWarmupViewController.swift in Sources */,
 				5F3C86F23B65CAC56FDDEC90 /* NetworkingLinkSignupBodyFormView.swift in Sources */,
+				6A044E482BB3866A00D73A3E /* AccountUpdateRequiredViewController.swift in Sources */,
 				95B2A73AC5DA9FA64017B3CB /* NetworkingLinkSignupBodyView.swift in Sources */,
 				6A13B9842B48BF4300FFA327 /* AccountPickerRowLabelView.swift in Sources */,
 				3AC5CA5F5529B55026342A54 /* NetworkingLinkSignupDataSource.swift in Sources */,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
@@ -87,14 +87,18 @@ protocol FinancialConnectionsAPIClient {
 
     // MARK: - Networking
 
-    func saveAccountsToLink(
+    func saveAccountsToNetworkAndLink(
+        shouldPollAccounts: Bool,
+        selectedAccounts: [FinancialConnectionsPartnerAccount],
         emailAddress: String?,
         phoneNumber: String?,
         country: String?,
-        selectedAccountIds: [String],
         consumerSessionClientSecret: String?,
         clientSecret: String
-    ) -> Future<FinancialConnectionsSessionManifest>
+    ) -> Future<(
+        manifest: FinancialConnectionsSessionManifest,
+        customSuccessPaneMessage: String?
+    )>
 
     func disableNetworking(
         disabledReason: String?,
@@ -480,7 +484,84 @@ extension STPAPIClient: FinancialConnectionsAPIClient {
 
     // MARK: - Networking
 
-    func saveAccountsToLink(
+    func saveAccountsToNetworkAndLink(
+        shouldPollAccounts: Bool,
+        selectedAccounts: [FinancialConnectionsPartnerAccount],
+        emailAddress: String?,
+        phoneNumber: String?,
+        country: String?,
+        consumerSessionClientSecret: String?,
+        clientSecret: String
+    ) -> Future<(
+        manifest: FinancialConnectionsSessionManifest,
+        customSuccessPaneMessage: String?
+    )> {
+        let saveAccountsToLinkHandler: () -> Future<(
+            manifest: FinancialConnectionsSessionManifest,
+            customSuccessPaneMessage: String?
+        )> = {
+            return self.saveAccountsToLink(
+                emailAddress: emailAddress,
+                phoneNumber: phoneNumber,
+                country: country,
+                selectedAccountIds: selectedAccounts.map({ $0.id }),
+                consumerSessionClientSecret: consumerSessionClientSecret,
+                clientSecret: clientSecret
+            )
+            .chained { manifest in
+                return Promise(
+                    value: (
+                        manifest: manifest,
+                        customSuccessPaneMessage: manifest.displayText?.successPane?.subCaption
+                    )
+                )
+            }
+        }
+        let linkedAccountIds = selectedAccounts.compactMap({ $0.linkedAccountId })
+        if
+            shouldPollAccounts,
+            !linkedAccountIds.isEmpty
+        {
+            return pollAccountNumbersForSelectedAccounts(
+                linkedAccountIds: linkedAccountIds
+            )
+            .chained { _ in
+                return saveAccountsToLinkHandler()
+            }
+        } else {
+            return saveAccountsToLinkHandler()
+        }
+    }
+
+    private func pollAccountNumbersForSelectedAccounts(
+        linkedAccountIds: [String]
+    ) -> Future<EmptyResponse> {
+        let body: [String: Any] = [
+            "linked_accounts": linkedAccountIds,
+        ]
+        let pollingHelper = APIPollingHelper(
+            apiCall: { [weak self] in
+                guard let self = self else {
+                    return Promise(
+                        error: FinancialConnectionsSheetError.unknown(
+                            debugDescription: "STPAPIClient deallocated."
+                        )
+                    )
+                }
+                return self.get(
+                    resource: APIEndpointPollAccountNumbers,
+                    parameters: body
+                )
+            },
+            pollTimingOptions: APIPollingHelper<EmptyResponse>.PollTimingOptions(
+                initialPollDelay: 1.0,
+                maxNumberOfRetries: 20
+            )
+        )
+        return pollingHelper.startPollingApiCall()
+    }
+
+    private func saveAccountsToLink(
         emailAddress: String?,
         phoneNumber: String?,
         country: String?,
@@ -637,3 +718,4 @@ private let APIEndpointNetworkedAccounts = "link_account_sessions/networked_acco
 private let APIEndpointSaveAccountsToLink = "link_account_sessions/save_accounts_to_link"
 private let APIEndpointShareNetworkedAccount = "link_account_sessions/share_networked_account"
 private let APIEndpointConsumerSessions = "connections/link_account_sessions/consumer_sessions"
+private let APIEndpointPollAccountNumbers = "link_account_sessions/poll_account_numbers"

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsPartnerAccount.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsPartnerAccount.swift
@@ -12,7 +12,7 @@ struct FinancialConnectionsPartnerAccount: Decodable {
     let id: String
     let name: String
     let displayableAccountNumbers: String?
-    let linkedAccountId: String?  // determines whether we show a "Linked" label
+    let linkedAccountId: String?
     let balanceAmount: Int?
     let currency: String?
     let supportedPaymentMethodTypes: [FinancialConnectionsPaymentMethodType]

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsSessionManifest.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsSessionManifest.swift
@@ -101,4 +101,8 @@ struct FinancialConnectionsSessionManifest: Decodable {
     let accountholderPhoneNumber: String?
     let stepUpAuthenticationRequired: Bool?
     let displayText: DisplayText?
+
+    var shouldAttachLinkedPaymentMethod: Bool {
+        return (paymentMethodType != nil)
+    }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerDataSource.swift
@@ -30,7 +30,7 @@ protocol AccountPickerDataSource: AnyObject {
     func pollAuthSessionAccounts() -> Future<FinancialConnectionsAuthSessionAccounts>
     func updateSelectedAccounts(_ selectedAccounts: [FinancialConnectionsPartnerAccount])
     func selectAuthSessionAccounts() -> Promise<FinancialConnectionsAuthSessionAccounts>
-    func saveToLink(consumerSessionClientSecret: String) -> Future<Void>
+    func saveAccountsToLink(consumerSessionClientSecret: String) -> Future<Void>
 }
 
 final class AccountPickerDataSourceImplementation: AccountPickerDataSource {
@@ -94,7 +94,7 @@ final class AccountPickerDataSourceImplementation: AccountPickerDataSource {
         )
     }
 
-    func saveToLink(consumerSessionClientSecret: String) -> Future<Void> {
+    func saveAccountsToLink(consumerSessionClientSecret: String) -> Future<Void> {
         return apiClient.saveAccountsToLink(
             emailAddress: nil,
             phoneNumber: nil,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerDataSource.swift
@@ -25,10 +25,12 @@ protocol AccountPickerDataSource: AnyObject {
     var analyticsClient: FinancialConnectionsAnalyticsClient { get }
     var reduceManualEntryProminenceInErrors: Bool { get }
     var dataAccessNotice: FinancialConnectionsDataAccessNotice? { get }
+    var consumerSessionClientSecret: String? { get }
 
     func pollAuthSessionAccounts() -> Future<FinancialConnectionsAuthSessionAccounts>
     func updateSelectedAccounts(_ selectedAccounts: [FinancialConnectionsPartnerAccount])
     func selectAuthSessionAccounts() -> Promise<FinancialConnectionsAuthSessionAccounts>
+    func saveToLink(consumerSessionClientSecret: String) -> Future<Void>
 }
 
 final class AccountPickerDataSourceImplementation: AccountPickerDataSource {
@@ -41,6 +43,7 @@ final class AccountPickerDataSourceImplementation: AccountPickerDataSource {
     let analyticsClient: FinancialConnectionsAnalyticsClient
     let reduceManualEntryProminenceInErrors: Bool
     let dataAccessNotice: FinancialConnectionsDataAccessNotice?
+    let consumerSessionClientSecret: String?
 
     private(set) var selectedAccounts: [FinancialConnectionsPartnerAccount] = [] {
         didSet {
@@ -57,7 +60,8 @@ final class AccountPickerDataSourceImplementation: AccountPickerDataSource {
         institution: FinancialConnectionsInstitution,
         analyticsClient: FinancialConnectionsAnalyticsClient,
         reduceManualEntryProminenceInErrors: Bool,
-        dataAccessNotice: FinancialConnectionsDataAccessNotice?
+        dataAccessNotice: FinancialConnectionsDataAccessNotice?,
+        consumerSessionClientSecret: String?
     ) {
         self.apiClient = apiClient
         self.clientSecret = clientSecret
@@ -67,6 +71,7 @@ final class AccountPickerDataSourceImplementation: AccountPickerDataSource {
         self.analyticsClient = analyticsClient
         self.reduceManualEntryProminenceInErrors = reduceManualEntryProminenceInErrors
         self.dataAccessNotice = dataAccessNotice
+        self.consumerSessionClientSecret = consumerSessionClientSecret
     }
 
     func pollAuthSessionAccounts() -> Future<FinancialConnectionsAuthSessionAccounts> {
@@ -87,6 +92,20 @@ final class AccountPickerDataSourceImplementation: AccountPickerDataSource {
             authSessionId: authSession.id,
             selectedAccountIds: selectedAccounts.map({ $0.id })
         )
+    }
+
+    func saveToLink(consumerSessionClientSecret: String) -> Future<Void> {
+        return apiClient.saveAccountsToLink(
+            emailAddress: nil,
+            phoneNumber: nil,
+            country: nil,
+            selectedAccountIds: selectedAccounts.map({ $0.id }),
+            consumerSessionClientSecret: consumerSessionClientSecret,
+            clientSecret: clientSecret
+        )
+        .chained { _ in
+            return Promise(value: ())
+        }
     }
 }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerFooterView.swift
@@ -21,7 +21,7 @@ final class AccountPickerFooterView: UIView {
         NSLayoutConstraint.activate([
             linkAccountsButton.heightAnchor.constraint(equalToConstant: 56)
         ])
-        linkAccountsButton.accessibilityIdentifier = "account_picker_link_accounts_button"
+        linkAccountsButton.accessibilityIdentifier = "connect_accounts_button"
         return linkAccountsButton
     }()
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerViewController.swift
@@ -392,7 +392,7 @@ final class AccountPickerViewController: UIViewController {
                     // additional step of saving the accounts to Link
                     if
                         self.dataSource.manifest.isNetworkingUserFlow == true,
-                        // make sure current user is a Link consumer
+                        // make sure the current user is a Link consumer
                         self.dataSource.manifest.accountholderIsLinkConsumer == true,
                         // make sure this is not a payment flow; in payment flows,
                         // the AttachLinkedPaymentAccount handles saving to link

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerViewController.swift
@@ -16,7 +16,8 @@ protocol AccountPickerViewControllerDelegate: AnyObject {
         _ viewController: AccountPickerViewController,
         didSelectAccounts selectedAccounts: [FinancialConnectionsPartnerAccount],
         nextPane: FinancialConnectionsSessionManifest.NextPane,
-        customSuccessPaneMessage: String?
+        customSuccessPaneMessage: String?,
+        saveToLinkWithStripeSucceeded: Bool?
     )
     func accountPickerViewControllerDidSelectAnotherBank(_ viewController: AccountPickerViewController)
     func accountPickerViewControllerDidSelectManualEntry(_ viewController: AccountPickerViewController)
@@ -408,11 +409,14 @@ final class AccountPickerViewController: UIViewController {
                         .observe { [weak self] result in
                             guard let self = self else { return }
 
+                            let saveToLinkWithStripeSucceeded: Bool
                             let customSuccessPaneMessage: String?
                             switch result {
                             case .success(let _customSuccessPaneMessage):
+                                saveToLinkWithStripeSucceeded = true
                                 customSuccessPaneMessage = _customSuccessPaneMessage
                             case .failure(let error):
+                                saveToLinkWithStripeSucceeded = false
                                 customSuccessPaneMessage = nil
                                 self.dataSource
                                     .analyticsClient
@@ -426,7 +430,8 @@ final class AccountPickerViewController: UIViewController {
                                 self,
                                 didSelectAccounts: selectedAccounts,
                                 nextPane: .success,
-                                customSuccessPaneMessage: customSuccessPaneMessage
+                                customSuccessPaneMessage: customSuccessPaneMessage,
+                                saveToLinkWithStripeSucceeded: saveToLinkWithStripeSucceeded
                             )
                         }
                     }
@@ -438,7 +443,8 @@ final class AccountPickerViewController: UIViewController {
                             self,
                             didSelectAccounts: selectedAccounts,
                             nextPane: linkedAccounts.nextPane,
-                            customSuccessPaneMessage: nil
+                            customSuccessPaneMessage: nil,
+                            saveToLinkWithStripeSucceeded: nil
                         )
                     }
                 case .failure(let error):

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerViewController.swift
@@ -387,14 +387,20 @@ final class AccountPickerViewController: UIViewController {
                         selectedAccounts = self.dataSource.selectedAccounts
                     }
 
+                    // for data flows (external_api), where the user is already
+                    // determined to be a Link consumer, we need to take an
+                    // additional step of saving the accounts to Link
                     if
                         self.dataSource.manifest.isNetworkingUserFlow == true,
+                        // make sure current user is a Link consumer
                         self.dataSource.manifest.accountholderIsLinkConsumer == true,
+                        // make sure this is not a payment flow; in payment flows,
+                        // the AttachLinkedPaymentAccount handles saving to link
                         !self.dataSource.manifest.shouldAttachLinkedPaymentMethod,
                         selectedAccounts.count > 0,
                         let consumerSessionClientSecret = self.dataSource.consumerSessionClientSecret
                     {
-                        self.dataSource.saveToLink(
+                        self.dataSource.saveAccountsToLink(
                             consumerSessionClientSecret: consumerSessionClientSecret
                         )
                         .observe { [weak self] result in
@@ -416,7 +422,11 @@ final class AccountPickerViewController: UIViewController {
                                 nextPane: .success
                             )
                         }
-                    } else {
+                    }
+                    // for networking payment flows, and networking data flows where
+                    // user will go through Link sign-up (or Link sign-in verification),
+                    // we do not need to call `saveAccountsToLink`
+                    else {
                         self.delegate?.accountPickerViewController(
                             self,
                             didSelectAccounts: selectedAccounts,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/AccountUpdateRequiredViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/AccountUpdateRequiredViewController.swift
@@ -1,0 +1,68 @@
+//
+//  AccountUpdateRequiredViewController.swift
+//  StripeFinancialConnections
+//
+//  Created by Krisjanis Gaidis on 3/26/24.
+//
+
+import Foundation
+import UIKit
+
+final class AccountUpdateRequiredViewController: SheetViewController {
+    
+    private let institution: FinancialConnectionsInstitution?
+    private let didSelectContinue: () -> Void
+    private let didSelectCancel: () -> Void
+    private let willDismissSheet: () -> Void
+    
+    init(
+        institution: FinancialConnectionsInstitution?,
+        didSelectContinue: @escaping () -> Void,
+        didSelectCancel: @escaping () -> Void,
+        willDismissSheet: @escaping () -> Void
+    ) {
+        self.institution = institution
+        self.didSelectContinue = didSelectContinue
+        self.didSelectCancel = didSelectCancel
+        self.willDismissSheet = willDismissSheet
+        super.init(panePresentationStyle: .sheet)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setup(
+            withContentView: PaneLayoutView.createContentView(
+                iconView: {
+                    let institutionIconView = InstitutionIconView()
+                    institutionIconView.setImageUrl(institution?.icon?.default)
+                    return institutionIconView
+                }(),
+                title: "Update required", // TODO: localize
+                subtitle: "Next, you'll be prompted to log in and connect your accounts.",  // TODO: localize
+                contentView: nil,
+                isSheet: true
+            ),
+            footerView: PaneLayoutView.createFooterView(
+                primaryButtonConfiguration: PaneLayoutView.ButtonConfiguration(
+                    title: "Continue",  // TODO: localize
+                    action: didSelectContinue
+                ),
+                secondaryButtonConfiguration: PaneLayoutView.ButtonConfiguration(
+                    title: "Cancel",  // TODO: localize
+                    action: didSelectCancel
+                )
+            ).footerView
+        )
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        if isBeingDismissed {
+            willDismissSheet()
+        }
+    }
+}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/AccountUpdateRequiredViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/AccountUpdateRequiredViewController.swift
@@ -41,18 +41,24 @@ final class AccountUpdateRequiredViewController: SheetViewController {
                     institutionIconView.setImageUrl(institution?.icon?.default)
                     return institutionIconView
                 }(),
-                title: "Update required", // TODO: localize
-                subtitle: "Next, you'll be prompted to log in and connect your accounts.",  // TODO: localize
+                title: STPLocalizedString(
+                    "Update required",
+                    "The title of a screen that allows users to choose whether they want to proceed to update their bank accocunt."
+                ),
+                subtitle: STPLocalizedString(
+                    "Next, you'll be prompted to log in and connect your accounts.",
+                    "The subtitle of a screen that allows users to choose whether they want to proceed to update their bank accocunt."
+                ),
                 contentView: nil,
                 isSheet: true
             ),
             footerView: PaneLayoutView.createFooterView(
                 primaryButtonConfiguration: PaneLayoutView.ButtonConfiguration(
-                    title: "Continue",  // TODO: localize
+                    title: "Continue", // TODO: when Financial Connections starts supporting localization, change this to `String.Localized.continue`
                     action: didSelectContinue
                 ),
                 secondaryButtonConfiguration: PaneLayoutView.ButtonConfiguration(
-                    title: "Cancel",  // TODO: localize
+                    title: "Cancel", // TODO: when Financial Connections starts supporting localization, change this to `String.Localized.cancel`
                     action: didSelectCancel
                 )
             ).footerView

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/AccountUpdateRequiredViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/AccountUpdateRequiredViewController.swift
@@ -55,6 +55,7 @@ final class AccountUpdateRequiredViewController: SheetViewController {
             footerView: PaneLayoutView.createFooterView(
                 primaryButtonConfiguration: PaneLayoutView.ButtonConfiguration(
                     title: "Continue", // TODO: when Financial Connections starts supporting localization, change this to `String.Localized.continue`
+                    accessibilityIdentifier: "account_update_required_continue_button",
                     action: didSelectContinue
                 ),
                 secondaryButtonConfiguration: PaneLayoutView.ButtonConfiguration(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/AccountUpdateRequiredViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/AccountUpdateRequiredViewController.swift
@@ -9,12 +9,12 @@ import Foundation
 import UIKit
 
 final class AccountUpdateRequiredViewController: SheetViewController {
-    
+
     private let institution: FinancialConnectionsInstitution?
     private let didSelectContinue: () -> Void
     private let didSelectCancel: () -> Void
     private let willDismissSheet: () -> Void
-    
+
     init(
         institution: FinancialConnectionsInstitution?,
         didSelectContinue: @escaping () -> Void,
@@ -27,11 +27,11 @@ final class AccountUpdateRequiredViewController: SheetViewController {
         self.willDismissSheet = willDismissSheet
         super.init(panePresentationStyle: .sheet)
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         setup(
@@ -58,7 +58,7 @@ final class AccountUpdateRequiredViewController: SheetViewController {
             ).footerView
         )
     }
-    
+
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         if isBeingDismissed {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerBodyView.swift
@@ -75,6 +75,7 @@ final class LinkAccountPickerBodyView: UIView {
                 self.delegate?.linkAccountPickerBodyViewSelectedNewBankAccount(self)
             }
         )
+        newAccountRowView.accessibilityIdentifier = "add_bank_account"
         verticalStackView.addArrangedSubview(newAccountRowView)
 
         addAndPinSubview(verticalStackView)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerBodyView.swift
@@ -84,11 +84,12 @@ final class LinkAccountPickerBodyView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func selectAccount(_ selectedAccountTuple: FinancialConnectionsAccountTuple?) {
+    func selectAccounts(_ selectedAccounts: [FinancialConnectionsAccountTuple]) {
+        let selectedAccountIds = Set(selectedAccounts.map({ $0.partnerAccount.id }))
         partnerAccountIdToRowView
             .forEach { (partnerAccountId: String, rowView: AccountPickerRowView) in
                 rowView.set(
-                    isSelected: selectedAccountTuple?.partnerAccount.id == partnerAccountId
+                    isSelected: selectedAccountIds.contains(partnerAccountId)
                 )
             }
     }
@@ -196,7 +197,7 @@ private struct LinkAccountPickerBodyViewUIViewRepresentable: UIViewRepresentable
     }
 
     func updateUIView(_ uiView: LinkAccountPickerBodyView, context: Context) {
-        uiView.selectAccount(nil)
+        uiView.selectAccounts([])
     }
 }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerFooterView.swift
@@ -76,8 +76,15 @@ final class LinkAccountPickerFooterView: UIView {
         didSelectConnectAccount()
     }
 
-    func didSelectedAccounts(_ selectedAccounts: [FinancialConnectionsAccountTuple]) {
-        connectAccountButton.title = defaultCta
+    func didSelectAccounts(_ selectedAccounts: [FinancialConnectionsAccountTuple]) {
+        if
+            singleAccount,
+            let selectionCta = selectedAccounts.first?.accountPickerAccount.selectionCta
+        {
+            connectAccountButton.title = selectionCta
+        } else {
+            connectAccountButton.title = defaultCta
+        }
         connectAccountButton.isEnabled = !selectedAccounts.isEmpty
     }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerFooterView.swift
@@ -76,14 +76,9 @@ final class LinkAccountPickerFooterView: UIView {
         didSelectConnectAccount()
     }
 
-    func didSelectedAccount(_ selectedAccountTuple: FinancialConnectionsAccountTuple?) {
-        if let selectionCta = selectedAccountTuple?.accountPickerAccount.selectionCta {
-            connectAccountButton.title = selectionCta
-        } else {
-            connectAccountButton.title = defaultCta
-        }
-
-        connectAccountButton.isEnabled = selectedAccountTuple != nil
+    func didSelectedAccounts(_ selectedAccounts: [FinancialConnectionsAccountTuple]) {
+        connectAccountButton.title = defaultCta
+        connectAccountButton.isEnabled = !selectedAccounts.isEmpty
     }
 
     func showLoadingView(_ show: Bool) {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerFooterView.swift
@@ -24,6 +24,7 @@ final class LinkAccountPickerFooterView: UIView {
         NSLayoutConstraint.activate([
             connectAccountButton.heightAnchor.constraint(equalToConstant: 56)
         ])
+        connectAccountButton.accessibilityIdentifier = "connect_accounts_button"
         return connectAccountButton
     }()
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
@@ -23,11 +23,6 @@ protocol LinkAccountPickerViewControllerDelegate: AnyObject {
 
     func linkAccountPickerViewController(
         _ viewController: LinkAccountPickerViewController,
-        didRequestSuccessPaneWithInstitution institution: FinancialConnectionsInstitution
-    )
-
-    func linkAccountPickerViewController(
-        _ viewController: LinkAccountPickerViewController,
         requestedPartnerAuthWithInstitution institution: FinancialConnectionsInstitution
     )
 
@@ -290,30 +285,11 @@ final class LinkAccountPickerViewController: UIViewController {
                 .observe { [weak self] result in
                     guard let self = self else { return }
                     switch result {
-                    case .success(let institutionList):
-                        if let institution = institutionList.data.first {
-                            self.delegate?.linkAccountPickerViewController(
-                                self,
-                                didRequestSuccessPaneWithInstitution: institution
-                            )
-                        } else {
-                            // this should never happen, but in case it does we want to force a
-                            // a terminal error so user can start again with a fresh state
-                            let error = FinancialConnectionsSheetError.unknown(
-                                debugDescription: "Successfully selected an networked account but no institution was returned."
-                            )
-                            self.dataSource
-                                .analyticsClient
-                                .logUnexpectedError(
-                                    error,
-                                    errorName: "SelectNetworkedAccountNoInstitutionError",
-                                    pane: .linkAccountPicker
-                                )
-                            self.delegate?.linkAccountPickerViewController(
-                                self,
-                                didReceiveTerminalError: error
-                            )
-                        }
+                    case .success:
+                        self.delegate?.linkAccountPickerViewController(
+                            self,
+                            didRequestNextPane: .success
+                        )
                     case .failure(let error):
                         self.dataSource
                             .analyticsClient

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
@@ -263,7 +263,7 @@ final class LinkAccountPickerViewController: UIViewController {
             )
 
         // TODO: remove all the extra logic of partner auth and bank repair!!!!!
-        
+
         if nextPane == .success {
             footerView?.showLoadingView(true)
             // prevent user from accidentally pressing
@@ -361,7 +361,7 @@ extension LinkAccountPickerViewController: LinkAccountPickerBodyViewDelegate {
         didSelectAccount selectedAccountTuple: FinancialConnectionsAccountTuple
     ) {
         FeedbackGeneratorAdapter.selectionChanged()
-        
+
         // unselecting
         if
             // unselecting in multi account flow is not allowed
@@ -381,7 +381,7 @@ extension LinkAccountPickerViewController: LinkAccountPickerBodyViewDelegate {
                     ],
                     pane: .linkAccountPicker
                 )
-            
+
             dataSource.updateSelectedAccounts(
                 dataSource.selectedAccounts.filter(
                     { $0.partnerAccount.id != selectedAccountTuple.partnerAccount.id }
@@ -400,7 +400,7 @@ extension LinkAccountPickerViewController: LinkAccountPickerBodyViewDelegate {
                     ],
                     pane: .linkAccountPicker
                 )
-            
+
             if dataSource.manifest.singleAccount {
                 dataSource.updateSelectedAccounts([selectedAccountTuple])
             } else {
@@ -417,7 +417,7 @@ extension LinkAccountPickerViewController: LinkAccountPickerBodyViewDelegate {
                     // TODO: unselect account when drawer is dismissed
                     // TODO: present drawer
                 }
-                
+
                 dataSource.updateSelectedAccounts(
                     dataSource.selectedAccounts + [selectedAccountTuple]
                 )

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
@@ -376,13 +376,15 @@ extension LinkAccountPickerViewController: LinkAccountPickerBodyViewDelegate {
     ) {
         FeedbackGeneratorAdapter.selectionChanged()
 
+        let selectedPartnerAccount = selectedAccountTuple.partnerAccount
+
         // unselecting
         if
-            // unselecting in multi account flow is not allowed
+            // unselecting in single account flow is not allowed
             !dataSource.manifest.singleAccount,
             // unselect if the account is already selected
             dataSource.selectedAccounts.contains(
-                where: { $0.partnerAccount.id == selectedAccountTuple.partnerAccount.id }
+                where: { $0.partnerAccount.id == selectedPartnerAccount.id }
             )
         {
             dataSource
@@ -390,7 +392,7 @@ extension LinkAccountPickerViewController: LinkAccountPickerBodyViewDelegate {
                 .log(
                     eventName: "click.account_picker.account_unselected",
                     parameters: [
-                        "account": selectedAccountTuple.partnerAccount.id,
+                        "account": selectedPartnerAccount.id,
                         "is_single_account": dataSource.manifest.singleAccount,
                     ],
                     pane: .linkAccountPicker
@@ -398,7 +400,7 @@ extension LinkAccountPickerViewController: LinkAccountPickerBodyViewDelegate {
 
             dataSource.updateSelectedAccounts(
                 dataSource.selectedAccounts.filter(
-                    { $0.partnerAccount.id != selectedAccountTuple.partnerAccount.id }
+                    { $0.partnerAccount.id != selectedPartnerAccount.id }
                 )
             )
         }
@@ -409,7 +411,7 @@ extension LinkAccountPickerViewController: LinkAccountPickerBodyViewDelegate {
                 .log(
                     eventName: "click.account_picker.account_selected",
                     parameters: [
-                        "account": selectedAccountTuple.partnerAccount.id,
+                        "account": selectedPartnerAccount.id,
                         "is_single_account": dataSource.manifest.singleAccount,
                     ],
                     pane: .linkAccountPicker
@@ -426,7 +428,6 @@ extension LinkAccountPickerViewController: LinkAccountPickerBodyViewDelegate {
 
                 // some values for nextPane require immediate action (ie. popping up a sheet for repair)
                 // as opposed to pushing the next pane upon CTA click (ie. step-up verification)
-                let selectedPartnerAccount = selectedAccountTuple.partnerAccount
                 if
                     // repair flow
                     selectedPartnerAccount.nextPaneOnSelection == .bankAuthRepair

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -900,15 +900,6 @@ extension NativeFlowController: LinkAccountPickerViewControllerDelegate {
 
     func linkAccountPickerViewController(
         _ viewController: LinkAccountPickerViewController,
-        didRequestSuccessPaneWithInstitution institution: FinancialConnectionsInstitution
-    ) {
-        assert(dataManager.linkedAccounts?.count == 1, "expected a selected account to be set")
-        dataManager.institution = institution
-        pushPane(.success, animated: true)
-    }
-
-    func linkAccountPickerViewController(
-        _ viewController: LinkAccountPickerViewController,
         requestedPartnerAuthWithInstitution institution: FinancialConnectionsInstitution
     ) {
         dataManager.institution = institution

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -893,9 +893,9 @@ extension NativeFlowController: LinkAccountPickerViewControllerDelegate {
 
     func linkAccountPickerViewController(
         _ viewController: LinkAccountPickerViewController,
-        didSelectAccount selectedAccount: FinancialConnectionsPartnerAccount
+        didSelectAccounts selectedAccounts: [FinancialConnectionsPartnerAccount]
     ) {
-        dataManager.linkedAccounts = [selectedAccount]
+        dataManager.linkedAccounts = selectedAccounts
     }
 
     func linkAccountPickerViewController(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -633,10 +633,14 @@ extension NativeFlowController: AccountPickerViewControllerDelegate {
         _ viewController: AccountPickerViewController,
         didSelectAccounts selectedAccounts: [FinancialConnectionsPartnerAccount],
         nextPane: FinancialConnectionsSessionManifest.NextPane,
-        customSuccessPaneMessage: String?
+        customSuccessPaneMessage: String?,
+        saveToLinkWithStripeSucceeded: Bool?
     ) {
         dataManager.linkedAccounts = selectedAccounts
         dataManager.customSuccessPaneMessage = customSuccessPaneMessage
+        if let saveToLinkWithStripeSucceeded {
+            dataManager.saveToLinkWithStripeSucceeded = saveToLinkWithStripeSucceeded
+        }
 
         // this prevents an unnecessary push transition when presenting `attachLinkedPaymentAccount`
         //

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -1023,7 +1023,8 @@ private func CreatePaneViewController(
                 institution: institution,
                 analyticsClient: dataManager.analyticsClient,
                 reduceManualEntryProminenceInErrors: dataManager.reduceManualEntryProminenceInErrors,
-                dataAccessNotice: dataManager.consentPaneModel?.dataAccessNotice
+                dataAccessNotice: dataManager.consentPaneModel?.dataAccessNotice,
+                consumerSessionClientSecret: dataManager.consumerSession?.clientSecret
             )
             let accountPickerViewController = AccountPickerViewController(dataSource: accountPickerDataSource)
             accountPickerViewController.delegate = nativeFlowController
@@ -1164,12 +1165,12 @@ private func CreatePaneViewController(
     case .networkingSaveToLinkVerification:
         if
             let consumerSession = dataManager.consumerSession,
-            let selectedAccountId = dataManager.linkedAccounts?.map({ $0.id }).first
+            let selectedAccountIds = dataManager.linkedAccounts?.map({ $0.id })
         {
             let networkingSaveToLinkVerificationDataSource = NetworkingSaveToLinkVerificationDataSourceImplementation(
                 manifest: dataManager.manifest,
                 consumerSession: consumerSession,
-                selectedAccountId: selectedAccountId,
+                selectedAccountIds: selectedAccountIds,
                 apiClient: dataManager.apiClient,
                 clientSecret: dataManager.clientSecret,
                 analyticsClient: dataManager.analyticsClient
@@ -1186,11 +1187,11 @@ private func CreatePaneViewController(
     case .networkingLinkStepUpVerification:
         if
             let consumerSession = dataManager.consumerSession,
-            let selectedAccountId = dataManager.linkedAccounts?.map({ $0.id }).first
+            let selectedAccountIds = dataManager.linkedAccounts?.map({ $0.id })
         {
             let networkingLinkStepUpVerificationDataSource = NetworkingLinkStepUpVerificationDataSourceImplementation(
                 consumerSession: consumerSession,
-                selectedAccountId: selectedAccountId,
+                selectedAccountIds: selectedAccountIds,
                 manifest: dataManager.manifest,
                 apiClient: dataManager.apiClient,
                 clientSecret: dataManager.clientSecret,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -632,9 +632,11 @@ extension NativeFlowController: AccountPickerViewControllerDelegate {
     func accountPickerViewController(
         _ viewController: AccountPickerViewController,
         didSelectAccounts selectedAccounts: [FinancialConnectionsPartnerAccount],
-        nextPane: FinancialConnectionsSessionManifest.NextPane
+        nextPane: FinancialConnectionsSessionManifest.NextPane,
+        customSuccessPaneMessage: String?
     ) {
         dataManager.linkedAccounts = selectedAccounts
+        dataManager.customSuccessPaneMessage = customSuccessPaneMessage
 
         // this prevents an unnecessary push transition when presenting `attachLinkedPaymentAccount`
         //
@@ -933,11 +935,13 @@ extension NativeFlowController: LinkAccountPickerViewControllerDelegate {
 extension NativeFlowController: NetworkingSaveToLinkVerificationViewControllerDelegate {
     func networkingSaveToLinkVerificationViewControllerDidFinish(
         _ viewController: NetworkingSaveToLinkVerificationViewController,
-        saveToLinkWithStripeSucceeded: Bool?
+        saveToLinkWithStripeSucceeded: Bool?,
+        customSuccessPaneMessage: String?
     ) {
         if saveToLinkWithStripeSucceeded != nil {
             dataManager.saveToLinkWithStripeSucceeded = saveToLinkWithStripeSucceeded
         }
+        dataManager.customSuccessPaneMessage = customSuccessPaneMessage
         pushPane(.success, animated: true)
     }
 
@@ -1119,10 +1123,10 @@ private func CreatePaneViewController(
         manualEntryViewController.delegate = nativeFlowController
         viewController = manualEntryViewController
     case .networkingLinkSignupPane:
-        if let linkedAccountIds = dataManager.linkedAccounts?.map({ $0.id }) {
+        if let selectedAccounts = dataManager.linkedAccounts {
             let networkingLinkSignupDataSource = NetworkingLinkSignupDataSourceImplementation(
                 manifest: dataManager.manifest,
-                selectedAccountIds: linkedAccountIds,
+                selectedAccounts: selectedAccounts,
                 returnURL: dataManager.returnURL,
                 apiClient: dataManager.apiClient,
                 clientSecret: dataManager.clientSecret,
@@ -1156,12 +1160,12 @@ private func CreatePaneViewController(
     case .networkingSaveToLinkVerification:
         if
             let consumerSession = dataManager.consumerSession,
-            let selectedAccountIds = dataManager.linkedAccounts?.map({ $0.id })
+            let selectedAccounts = dataManager.linkedAccounts
         {
             let networkingSaveToLinkVerificationDataSource = NetworkingSaveToLinkVerificationDataSourceImplementation(
                 manifest: dataManager.manifest,
                 consumerSession: consumerSession,
-                selectedAccountIds: selectedAccountIds,
+                selectedAccounts: selectedAccounts,
                 apiClient: dataManager.apiClient,
                 clientSecret: dataManager.clientSecret,
                 analyticsClient: dataManager.analyticsClient

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
@@ -201,11 +201,11 @@ final class NetworkingLinkSignupViewController: UIViewController {
         .observe { [weak self] result in
             guard let self = self else { return }
             switch result {
-            case .success(let manifest):
+            case .success(let customSuccessPaneMessage):
                 self.delegate?.networkingLinkSignupViewControllerDidFinish(
                     self,
                     saveToLinkWithStripeSucceeded: true,
-                    customSuccessPaneMessage: manifest.displayText?.successPane?.subCaption,
+                    customSuccessPaneMessage: customSuccessPaneMessage,
                     withError: nil
                 )
             case .failure(let error):

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationDataSource.swift
@@ -20,7 +20,7 @@ protocol NetworkingLinkStepUpVerificationDataSource: AnyObject {
 final class NetworkingLinkStepUpVerificationDataSourceImplementation: NetworkingLinkStepUpVerificationDataSource {
 
     private(set) var consumerSession: ConsumerSessionData
-    private let selectedAccountId: String
+    private let selectedAccountIds: [String]
     private let manifest: FinancialConnectionsSessionManifest
     private let apiClient: FinancialConnectionsAPIClient
     private let clientSecret: String
@@ -29,14 +29,14 @@ final class NetworkingLinkStepUpVerificationDataSourceImplementation: Networking
 
     init(
         consumerSession: ConsumerSessionData,
-        selectedAccountId: String,
+        selectedAccountIds: [String],
         manifest: FinancialConnectionsSessionManifest,
         apiClient: FinancialConnectionsAPIClient,
         clientSecret: String,
         analyticsClient: FinancialConnectionsAnalyticsClient
     ) {
         self.consumerSession = consumerSession
-        self.selectedAccountId = selectedAccountId
+        self.selectedAccountIds = selectedAccountIds
         self.manifest = manifest
         self.apiClient = apiClient
         self.clientSecret = clientSecret
@@ -62,7 +62,7 @@ final class NetworkingLinkStepUpVerificationDataSourceImplementation: Networking
 
     func selectNetworkedAccount() -> Future<FinancialConnectionsInstitutionList> {
         return apiClient.selectNetworkedAccounts(
-            selectedAccountIds: [selectedAccountId],
+            selectedAccountIds: selectedAccountIds,
             clientSecret: clientSecret,
             consumerSessionClientSecret: consumerSession.clientSecret
         )

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationDataSource.swift
@@ -24,7 +24,7 @@ final class NetworkingSaveToLinkVerificationDataSourceImplementation: Networking
 
     let manifest: FinancialConnectionsSessionManifest
     private(set) var consumerSession: ConsumerSessionData
-    private let selectedAccountId: String
+    private let selectedAccountIds: [String]
     private let apiClient: FinancialConnectionsAPIClient
     private let clientSecret: String
     let analyticsClient: FinancialConnectionsAnalyticsClient
@@ -33,14 +33,14 @@ final class NetworkingSaveToLinkVerificationDataSourceImplementation: Networking
     init(
         manifest: FinancialConnectionsSessionManifest,
         consumerSession: ConsumerSessionData,
-        selectedAccountId: String,
+        selectedAccountIds: [String],
         apiClient: FinancialConnectionsAPIClient,
         clientSecret: String,
         analyticsClient: FinancialConnectionsAnalyticsClient
     ) {
         self.manifest = manifest
         self.consumerSession = consumerSession
-        self.selectedAccountId = selectedAccountId
+        self.selectedAccountIds = selectedAccountIds
         self.apiClient = apiClient
         self.clientSecret = clientSecret
         self.analyticsClient = analyticsClient
@@ -100,7 +100,7 @@ final class NetworkingSaveToLinkVerificationDataSourceImplementation: Networking
             emailAddress: nil,
             phoneNumber: nil,
             country: nil,
-            selectedAccountIds: [selectedAccountId],
+            selectedAccountIds: selectedAccountIds,
             consumerSessionClientSecret: consumerSession.clientSecret,
             clientSecret: clientSecret
         )

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
@@ -118,15 +118,22 @@ class EmptyFinancialConnectionsAPIClient: FinancialConnectionsAPIClient {
         return Promise<EmptyResponse>()
     }
 
-    func saveAccountsToLink(
+    func saveAccountsToNetworkAndLink(
+        shouldPollAccounts: Bool,
+        selectedAccounts: [FinancialConnectionsPartnerAccount],
         emailAddress: String?,
         phoneNumber: String?,
         country: String?,
-        selectedAccountIds: [String],
         consumerSessionClientSecret: String?,
         clientSecret: String
-    ) -> Future<StripeFinancialConnections.FinancialConnectionsSessionManifest> {
-        return Promise<StripeFinancialConnections.FinancialConnectionsSessionManifest>()
+    ) -> Future<(
+        manifest: FinancialConnectionsSessionManifest,
+        customSuccessPaneMessage: String?
+    )> {
+        return Promise<(
+            manifest: FinancialConnectionsSessionManifest,
+            customSuccessPaneMessage: String?
+        )>()
     }
 
     func disableNetworking(


### PR DESCRIPTION
## Summary

This PR implements support for multi-select in Financial Connections Networking(/Link) flows.

Previously, you only were able to select a single account, now you can select multiple. 

This PR has a follow-up PR here:
- https://github.com/stripe/stripe-ios/pull/3459

## Testing

### Account Required Drawer

![Simulator Screenshot - iPhone 15 Pro - 2024-04-01 at 14 16 28](https://github.com/stripe/stripe-ios/assets/105514761/c157a39e-d245-4ada-90ad-2f2999192d1c)

### LinkAccountPicker Multi Selecting (and other interaction)

https://github.com/stripe/stripe-ios/assets/105514761/37d9b43e-c148-4da1-a7d3-0e323cf99cd8

### Completing The Flow (Connecting 2 Accounts)

https://github.com/stripe/stripe-ios/assets/105514761/2327f801-a99d-496f-a73d-105960909822

### Completing The Flow (Handling Update Required ACcount Which Will Connect Only 1 Of Them)

https://github.com/stripe/stripe-ios/assets/105514761/21a5b17f-5cae-4957-a4fc-05a10299f1c3
