### PR TITLE
Financial Connections: added poll_account_numbers API and implemented in saveToLink parts

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnections Example.xcodeproj/project.pbxproj
+++ b/Example/FinancialConnections Example/FinancialConnections Example.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		5AA50D95EC1C2489AD98071E /* PlaygroundMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B379D3A9F9EA11716D5AEB3 /* PlaygroundMainView.swift */; };
 		5B38135D1C37FC1812F4203A /* StripeUICore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ADFEE494187576194F8B46BB /* StripeUICore.framework */; };
 		5C1B372D1660E856988156DA /* StripeUICore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = ADFEE494187576194F8B46BB /* StripeUICore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		6A6C23172BBCC6210083FF66 /* XCUIGestureVelocity+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A6C23162BBCC6210083FF66 /* XCUIGestureVelocity+Extensions.swift */; };
 		6AC6B40D2B880EEA000A4B32 /* XCTestCase+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC6B40C2B880EEA000A4B32 /* XCTestCase+Extensions.swift */; };
 		6AF9C66D47F81DD9B103FB64 /* StripeCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 03E7365D673694C8D7EDFB20 /* StripeCore.framework */; };
 		828A3C3A555F9B2ABAEF3E95 /* WebViewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65FBE9DBF6CBB07AE2D5B1DA /* WebViewViewController.swift */; };
@@ -95,6 +96,7 @@
 		5B675DEF4776CDFF8309DEB8 /* Project-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Project-Debug.xcconfig"; sourceTree = "<group>"; };
 		5C02DB1648E15A6591FD56E1 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		65FBE9DBF6CBB07AE2D5B1DA /* WebViewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewViewController.swift; sourceTree = "<group>"; };
+		6A6C23162BBCC6210083FF66 /* XCUIGestureVelocity+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIGestureVelocity+Extensions.swift"; sourceTree = "<group>"; };
 		6AC6B40C2B880EEA000A4B32 /* XCTestCase+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Extensions.swift"; sourceTree = "<group>"; };
 		701003016E153D5DF2B00442 /* FinancialConnections-Example-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "FinancialConnections-Example-Debug.xcconfig"; sourceTree = "<group>"; };
 		74959BBB33DB4A570E2B4FD3 /* FinancialConnectionsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsUITests.swift; sourceTree = "<group>"; };
@@ -231,6 +233,7 @@
 				E43F3C346DE28D65F7575D58 /* XCUIApplication+Extensions.swift */,
 				01EFB9C0699FEB532FFE57D9 /* XCUIElement+Extensions.swift */,
 				6AC6B40C2B880EEA000A4B32 /* XCTestCase+Extensions.swift */,
+				6A6C23162BBCC6210083FF66 /* XCUIGestureVelocity+Extensions.swift */,
 			);
 			path = FinancialConnectionsUITests;
 			sourceTree = "<group>";
@@ -368,6 +371,7 @@
 				6AC6B40D2B880EEA000A4B32 /* XCTestCase+Extensions.swift in Sources */,
 				09B82E32FC066FC442BD945D /* XCUIApplication+Extensions.swift in Sources */,
 				82D499E3F32FB4663D26EBA6 /* XCUIElement+Extensions.swift in Sources */,
+				6A6C23172BBCC6210083FF66 /* XCUIGestureVelocity+Extensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundMainView.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundMainView.swift
@@ -71,6 +71,7 @@ struct PlaygroundMainView: View {
                                     .accessibility(identifier: "playground-email")
 
                                 Toggle("Enable Multi Select", isOn: $viewModel.enableNetworkingMultiSelect)
+                                    .accessibility(identifier: "networking-multi-select")
                             }
                         } else if viewModel.customScenario == .customKeys {
                             TextField("Public Key (pk_)", text: $viewModel.customPublicKey)

--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundMainView.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundMainView.swift
@@ -100,7 +100,7 @@ struct PlaygroundMainView: View {
 
                     // extra space so keyboard doesn't cover the "CUSTOM KEYS" section
                     // (SwiftUI, depending on iOS version, doesn't handle keyboard)
-                    Spacer(minLength: 100)
+                    Spacer(minLength: 60)
                 }
                 VStack {
                     Button(action: viewModel.didSelectShow) {

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
@@ -10,20 +10,19 @@ import XCTest
 
 final class FinancialConnectionsNetworkingUITests: XCTestCase {
 
-    override func setUpWithError() throws {
-        try super.setUpWithError()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-
-        // In UI tests it is usually best to stop immediately when a failure occurs.
-        continueAfterFailure = false
-
-        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
-    }
-
     func testNativeNetworkingTestMode() throws {
         let emailAddresss = "\(UUID().uuidString)@UITestForIOS.com"
         executeNativeNetworkingTestModeSignUpFlowTest(emailAddress: emailAddresss)
         executeNativeNetworkingTestModeSignInFlowTest(emailAddress: emailAddresss)
+        let bankAccountName = "Insufficient Funds"
+        executeNativeNetworkingTestModeAddBankAccount(
+            emailAddress: emailAddresss,
+            bankAccountName: bankAccountName
+        )
+        executeNativeNetworkingTestModeUpdateRequired(
+            emailAddress: emailAddresss,
+            bankAccountName: bankAccountName
+        )
     }
 
     private func executeNativeNetworkingTestModeSignUpFlowTest(emailAddress: String) {
@@ -40,21 +39,19 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         let enableTestModeSwitch = app.fc_playgroundEnableTestModeSwitch
         enableTestModeSwitch.turnSwitch(on: true)
 
+        app.fc_scrollDown() // see email
         let playgroundEmailTextField = app.textFields["playground-email"]
         XCTAssertTrue(playgroundEmailTextField.waitForExistence(timeout: 60.0))
         playgroundEmailTextField.tap()
         clear(textField: playgroundEmailTextField)
-        app.dismissKeyboard() // dismiss keyboard (warning: ensure keyboard is visible if manually testing)
+        app.fc_dismissKeyboard() // dismiss keyboard (warning: ensure keyboard is visible if manually testing)
 
         let multiSelectSwitch = app.switches["networking-multi-select"]
         XCTAssertTrue(multiSelectSwitch.waitForExistence(timeout: 60.0))
         multiSelectSwitch.turnSwitch(on: false)
 
-        app.swipeUp(velocity: .slow)
-
-        let playgroundTransactionsPermissionsSwitch = app.switches["playground-transactions-permission"]
-        XCTAssertTrue(playgroundTransactionsPermissionsSwitch.waitForExistence(timeout: 60.0))
-        playgroundTransactionsPermissionsSwitch.turnSwitch(on: true)
+        app.fc_scrollDown() // see permissions
+        app.switches["playground-transactions-permission"].turnSwitch(on: true)
 
         app.fc_playgroundShowAuthFlowButton.tap()
         app.fc_nativeConsentAgreeButton.tap()
@@ -69,7 +66,7 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         XCTAssertTrue(successInstitution.waitForExistence(timeout: 60.0))
         successInstitution.tap()
 
-        app.fc_nativeAccountPickerLinkAccountsButton.tap()
+        app.fc_nativeConnectAccountsButton.tap()
 
         let emailTextField = app.textFields["email_text_field"]
         XCTAssertTrue(emailTextField.waitForExistence(timeout: 120.0))  // wait for synchronize to complete
@@ -90,10 +87,12 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         saveToLinkButon.tap()
 
         let successPaneDoneButton = app.fc_nativeSuccessDoneButton
-        // this ensures that save to Link was successful...
-        // ...we want to check AFTER success screen has rendered with the "Done" button
-        XCTAssert(!app.staticTexts.containing(NSPredicate(format: "label CONTAINS 'could not be saved to Link'")).firstMatch
-            .exists)
+
+        // ensure that there wasn't a Link failure
+        //
+        // unexpected text: "Your account was connected, but couldn't be saved to Link"
+        XCTAssert(!app.textViews.containing(NSPredicate(format: "label CONTAINS 'but'")).firstMatch.exists)
+
         successPaneDoneButton.tap()
 
         // ensure alert body contains "Stripe Bank" (AKA one bank is linked)
@@ -117,16 +116,16 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         let enableTestModeSwitch = app.fc_playgroundEnableTestModeSwitch
         enableTestModeSwitch.turnSwitch(on: true)
 
+        app.fc_scrollDown() // see email
         let playgroundEmailTextField = app.textFields["playground-email"]
         XCTAssertTrue(playgroundEmailTextField.waitForExistence(timeout: 60.0))
         playgroundEmailTextField.tap()
         clear(textField: playgroundEmailTextField)
         playgroundEmailTextField.typeText(emailAddress)
-        app.dismissKeyboard() // dismiss keyboard (warning: ensure keyboard is visible if manually testing)
+        app.fc_dismissKeyboard() // dismiss keyboard (warning: ensure keyboard is visible if manually testing)
 
-        let playgroundTransactionsPermissionsSwitch = app.switches["playground-transactions-permission"]
-        XCTAssertTrue(playgroundTransactionsPermissionsSwitch.waitForExistence(timeout: 60.0))
-        playgroundTransactionsPermissionsSwitch.turnSwitch(on: true)
+        app.fc_scrollDown() // see permissions
+        app.switches["playground-transactions-permission"].turnSwitch(on: true)
 
         app.fc_playgroundShowAuthFlowButton.tap()
         app.fc_nativeConsentAgreeButton.tap()
@@ -154,15 +153,248 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         stepUpVerificationOTPTextView.typeText("111111")
 
         let successPaneDoneButton = app.fc_nativeSuccessDoneButton
-        // this ensures that save to Link was successful...
-        // ...we want to check AFTER success screen has rendered with the "Done" button
-        XCTAssert(!app.staticTexts.containing(NSPredicate(format: "label CONTAINS 'could not be saved to Link'")).firstMatch
-            .exists)
+
+        // ensure that there wasn't a Link failure
+        //
+        // unexpected text: "Your account was connected, but couldn't be saved to Link"
+        XCTAssert(!app.textViews.containing(NSPredicate(format: "label CONTAINS 'but'")).firstMatch.exists)
+
         successPaneDoneButton.tap()
 
         // ensure alert body contains "Stripe Bank" (AKA one bank is linked)
         XCTAssert(
             app.fc_playgroundSuccessAlertView.staticTexts.containing(NSPredicate(format: "label CONTAINS 'StripeBank'")).firstMatch
+                .exists
+        )
+    }
+
+    private func executeNativeNetworkingTestModeAddBankAccount(
+        emailAddress: String,
+        bankAccountName: String
+    ) {
+        let app = XCUIApplication.fc_launch()
+
+        app.fc_playgroundCell.tap()
+
+        let dataSegmentPickerButton = app.segmentedControls.buttons["Networking"]
+        XCTAssertTrue(dataSegmentPickerButton.waitForExistence(timeout: 60.0))
+        dataSegmentPickerButton.tap()
+
+        app.fc_playgroundNativeButton.tap()
+
+        let enableTestModeSwitch = app.fc_playgroundEnableTestModeSwitch
+        enableTestModeSwitch.turnSwitch(on: true)
+
+        app.fc_scrollDown() // see email
+        let playgroundEmailTextField = app.textFields["playground-email"]
+        XCTAssertTrue(playgroundEmailTextField.waitForExistence(timeout: 60.0))
+        playgroundEmailTextField.tap()
+        clear(textField: playgroundEmailTextField)
+        playgroundEmailTextField.typeText(emailAddress)
+        app.fc_dismissKeyboard() // dismiss keyboard (warning: ensure keyboard is visible if manually testing)
+
+        let multiSelectSwitch = app.switches["networking-multi-select"]
+        XCTAssertTrue(multiSelectSwitch.waitForExistence(timeout: 60.0))
+        multiSelectSwitch.turnSwitch(on: false)
+
+        app.fc_scrollDown() // see permissions
+        app.switches["playground-ownership-permission"].turnSwitch(on: false)
+        app.switches["playground-balances-permission"].turnSwitch(on: false)
+        app.switches["playground-transactions-permission"].turnSwitch(on: false)
+
+        app.fc_playgroundShowAuthFlowButton.tap()
+        app.fc_nativeConsentAgreeButton.tap()
+
+        let linkContinueButton = app.buttons["link_continue_button"]
+        XCTAssertTrue(linkContinueButton.waitForExistence(timeout: 60.0))
+        linkContinueButton.tap()
+
+        let verificationOTPTextView = app.scrollViews.otherElements.textViews["Code field"]
+        XCTAssertTrue(verificationOTPTextView.waitForExistence(timeout: 60.0))
+        verificationOTPTextView.tap()
+        verificationOTPTextView.typeText("111111")
+
+        let addBankAccountButton = app.scrollViews.otherElements["add_bank_account"]
+        XCTAssertTrue(addBankAccountButton.waitForExistence(timeout: 120.0)) // need to wait for various API calls to appear
+        addBankAccountButton.tap()
+
+        // wait for search bar to appear
+        _ = app.fc_searchBarTextField
+
+        app.fc_scrollDown() // see all institutions
+
+        app.fc_nativeFeaturedInstitution(name: "Data cannot be shared through Link").tap()
+
+        app.fc_nativeBankAccount(name: bankAccountName).tap()
+
+        app.fc_nativeConnectAccountsButton.tap()
+
+        app.fc_nativeSuccessDoneButton.tap()
+
+        // ensure alert body contains "Stripe Bank" (AKA one bank is linked)
+        XCTAssert(
+            app.fc_playgroundSuccessAlertView.staticTexts.containing(NSPredicate(format: "label CONTAINS '\(bankAccountName)'")).firstMatch
+                .exists
+        )
+    }
+
+    private func executeNativeNetworkingTestModeUpdateRequired(
+        emailAddress: String,
+        bankAccountName: String
+    ) {
+        let app = XCUIApplication.fc_launch()
+
+        app.fc_playgroundCell.tap()
+
+        let dataSegmentPickerButton = app.segmentedControls.buttons["Networking"]
+        XCTAssertTrue(dataSegmentPickerButton.waitForExistence(timeout: 60.0))
+        dataSegmentPickerButton.tap()
+
+        app.fc_playgroundNativeButton.tap()
+
+        let enableTestModeSwitch = app.fc_playgroundEnableTestModeSwitch
+        enableTestModeSwitch.turnSwitch(on: true)
+
+        app.fc_scrollDown() // see email
+        let playgroundEmailTextField = app.textFields["playground-email"]
+        XCTAssertTrue(playgroundEmailTextField.waitForExistence(timeout: 60.0))
+        playgroundEmailTextField.tap()
+        clear(textField: playgroundEmailTextField)
+        playgroundEmailTextField.typeText(emailAddress)
+        app.fc_dismissKeyboard() // dismiss keyboard (warning: ensure keyboard is visible if manually testing)
+
+        let multiSelectSwitch = app.switches["networking-multi-select"]
+        XCTAssertTrue(multiSelectSwitch.waitForExistence(timeout: 60.0))
+        multiSelectSwitch.turnSwitch(on: true)
+
+        app.fc_scrollDown() // see permissions
+        app.switches["playground-ownership-permission"].turnSwitch(on: true)
+
+        app.fc_playgroundShowAuthFlowButton.tap()
+        app.fc_nativeConsentAgreeButton.tap()
+
+        let linkContinueButton = app.buttons["link_continue_button"]
+        XCTAssertTrue(linkContinueButton.waitForExistence(timeout: 60.0))
+        linkContinueButton.tap()
+
+        let verificationOTPTextView = app.scrollViews.otherElements.textViews["Code field"]
+        XCTAssertTrue(verificationOTPTextView.waitForExistence(timeout: 60.0))
+        verificationOTPTextView.tap()
+        verificationOTPTextView.typeText("111111")
+
+        app.fc_nativeBankAccount(name: bankAccountName).tap()
+
+        let accountUpdateRequiredContinueButton = app.buttons["account_update_required_continue_button"]
+        XCTAssertTrue(accountUpdateRequiredContinueButton.waitForExistence(timeout: 1))
+        accountUpdateRequiredContinueButton.tap()
+
+        app.fc_nativeConnectAccountsButton.tap()
+
+        let successDoneButton = app.fc_nativeSuccessDoneButton
+
+        // ensures that save to Link was successful
+        //
+        // expected text: "Your account was connected, and saved with Link."
+        XCTAssert(app.textViews.containing(NSPredicate(format: "label CONTAINS 'Link'")).firstMatch.exists)
+
+        // ensure that the Link text wasn't a failure
+        //
+        // unexpected text: "Your account was connected, but couldn't be saved to Link"
+        XCTAssert(!app.textViews.containing(NSPredicate(format: "label CONTAINS 'but'")).firstMatch.exists)
+
+        successDoneButton.tap()
+
+        // multiple banks should be checked
+        XCTAssert(
+            app.fc_playgroundSuccessAlertView.staticTexts.containing(NSPredicate(format: "label CONTAINS 'Success'")).firstMatch
+                .exists
+        )
+        XCTAssert(
+            app.fc_playgroundSuccessAlertView.staticTexts.containing(NSPredicate(format: "label CONTAINS '\(bankAccountName)'")).firstMatch
+                .exists
+        )
+    }
+
+    func testNativeNetworkingTestModeSignUpWithMultiSelectAndPrefilledEmail() {
+        let emailAddress = "\(UUID().uuidString)@UITestForIOS.com"
+
+        let app = XCUIApplication.fc_launch()
+
+        app.fc_playgroundCell.tap()
+
+        let dataSegmentPickerButton = app.segmentedControls.buttons["Networking"]
+        XCTAssertTrue(dataSegmentPickerButton.waitForExistence(timeout: 60.0))
+        dataSegmentPickerButton.tap()
+
+        app.fc_playgroundNativeButton.tap()
+
+        let enableTestModeSwitch = app.fc_playgroundEnableTestModeSwitch
+        enableTestModeSwitch.turnSwitch(on: true)
+
+        app.fc_scrollDown() // see email
+        let playgroundEmailTextField = app.textFields["playground-email"]
+        XCTAssertTrue(playgroundEmailTextField.waitForExistence(timeout: 60.0))
+        playgroundEmailTextField.tap()
+        clear(textField: playgroundEmailTextField)
+        playgroundEmailTextField.typeText(emailAddress)
+        app.fc_dismissKeyboard() // dismiss keyboard (warning: ensure keyboard is visible if manually testing)
+
+        let multiSelectSwitch = app.switches["networking-multi-select"]
+        XCTAssertTrue(multiSelectSwitch.waitForExistence(timeout: 60.0))
+        multiSelectSwitch.turnSwitch(on: true)
+
+        app.fc_scrollDown() // see permissions
+        app.switches["playground-transactions-permission"].turnSwitch(on: true)
+
+        app.fc_playgroundShowAuthFlowButton.tap()
+        app.fc_nativeConsentAgreeButton.tap()
+
+        let featuredLegacyTestInstitution = app.tables.cells.staticTexts["Test OAuth Institution"]
+        XCTAssertTrue(featuredLegacyTestInstitution.waitForExistence(timeout: 60.0))
+        featuredLegacyTestInstitution.tap()
+
+        app.fc_nativePrepaneContinueButton.tap()
+
+        // all accounts will be selected by default
+
+        app.fc_nativeConnectAccountsButton.tap()
+
+        // email will already be pre-filled
+
+        let phoneTextField = app.textFields["phone_text_field"]
+        XCTAssertTrue(phoneTextField.waitForExistence(timeout: 120.0))  // wait for lookup to complete
+        phoneTextField.tap()
+        phoneTextField.typeText("4015006000")
+
+        let phoneTextFieldToolbarDoneButton = app.toolbars["Toolbar"].buttons["Done"]
+        XCTAssertTrue(phoneTextFieldToolbarDoneButton.waitForExistence(timeout: 60.0))
+        phoneTextFieldToolbarDoneButton.tap()
+
+        let saveToLinkButon = app.buttons["Save to Link"]
+        XCTAssertTrue(saveToLinkButon.waitForExistence(timeout: 120.0))  // glitch app can take time to lload
+        saveToLinkButon.tap()
+
+        let successPaneDoneButton = app.fc_nativeSuccessDoneButton
+
+        // ensures that save to Link was successful
+        //
+        // expected text: "Your account was connected, and saved with Link."
+        XCTAssert(app.textViews.containing(NSPredicate(format: "label CONTAINS 'Link'")).firstMatch.exists)
+
+        // ensure that the Link text wasn't a failure
+        //
+        // unexpected text: "Your account was connected, but couldn't be saved to Link"
+        XCTAssert(!app.textViews.containing(NSPredicate(format: "label CONTAINS 'but'")).firstMatch.exists)
+
+        successPaneDoneButton.tap()
+
+        // multiple banks should be checked
+        XCTAssert(
+            app.fc_playgroundSuccessAlertView.staticTexts.containing(NSPredicate(format: "label CONTAINS 'Success'")).firstMatch
+                .exists
+        )
+        XCTAssert(
+            app.fc_playgroundSuccessAlertView.staticTexts.containing(NSPredicate(format: "label CONTAINS 'Insufficient Funds'")).firstMatch
                 .exists
         )
     }

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
@@ -46,6 +46,12 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         clear(textField: playgroundEmailTextField)
         app.dismissKeyboard() // dismiss keyboard (warning: ensure keyboard is visible if manually testing)
 
+        let multiSelectSwitch = app.switches["networking-multi-select"]
+        XCTAssertTrue(multiSelectSwitch.waitForExistence(timeout: 60.0))
+        multiSelectSwitch.turnSwitch(on: false)
+
+        app.swipeUp(velocity: .slow)
+
         let playgroundTransactionsPermissionsSwitch = app.switches["playground-transactions-permission"]
         XCTAssertTrue(playgroundTransactionsPermissionsSwitch.waitForExistence(timeout: 60.0))
         playgroundTransactionsPermissionsSwitch.turnSwitch(on: true)

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
@@ -38,7 +38,7 @@ final class FinancialConnectionsUITests: XCTestCase {
         featuredLegacyTestInstitution.tap()
 
         app.fc_nativePrepaneContinueButton.tap()
-        app.fc_nativeAccountPickerLinkAccountsButton.tap()
+        app.fc_nativeConnectAccountsButton.tap()
         app.fc_nativeSuccessDoneButton.tap()
 
         // ensure alert body contains "Stripe Bank" (AKA one bank is linked)
@@ -69,7 +69,7 @@ final class FinancialConnectionsUITests: XCTestCase {
         XCTAssertTrue(successAccountRow.waitForExistence(timeout: 60.0))
         successAccountRow.tap()
 
-        app.fc_nativeAccountPickerLinkAccountsButton.tap()
+        app.fc_nativeConnectAccountsButton.tap()
         app.fc_nativeSuccessDoneButton.tap()
 
         // ensure alert body contains "Stripe Bank" (AKA one bank is linked)
@@ -332,11 +332,7 @@ final class FinancialConnectionsUITests: XCTestCase {
         app.fc_playgroundShowAuthFlowButton.tap()
         app.fc_nativeConsentAgreeButton.tap()
 
-        let searchBarTextField = app
-            .tables
-            .otherElements
-            .textFields["search_bar_text_field"]
-        XCTAssertTrue(searchBarTextField.waitForExistence(timeout: 120.0))
+        let searchBarTextField = app.fc_searchBarTextField
         searchBarTextField.tap()
         searchBarTextField.typeText("Bank of America")
 

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIApplication+Extensions.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIApplication+Extensions.swift
@@ -104,9 +104,10 @@ extension XCUIApplication {
         return prepaneCancelButton
     }
 
-    var fc_nativeAccountPickerLinkAccountsButton: XCUIElement {
-        let accountPickerLinkAccountsButton = buttons["account_picker_link_accounts_button"]
+    var fc_nativeConnectAccountsButton: XCUIElement {
+        let accountPickerLinkAccountsButton = buttons["connect_accounts_button"]
         XCTAssertTrue(accountPickerLinkAccountsButton.waitForExistence(timeout: 120.0), "Failed to open Account Picker pane - \(#function) waiting failed")  // wait for accounts to fetch
+        XCTAssert(accountPickerLinkAccountsButton.isEnabled, "no account selected")
         return accountPickerLinkAccountsButton
     }
 
@@ -122,7 +123,31 @@ extension XCUIApplication {
         return secureWebViewCancelButton
     }
 
-    func dismissKeyboard() {
+    var fc_searchBarTextField: XCUIElement {
+        let searchBarTextField = tables
+            .otherElements
+            .textFields["search_bar_text_field"]
+        XCTAssertTrue(searchBarTextField.waitForExistence(timeout: 120.0))
+        return searchBarTextField
+    }
+
+    func fc_nativeFeaturedInstitution(name: String) -> XCUIElement {
+        let featuredTestInstitution = tables.cells.staticTexts[name]
+        XCTAssertTrue(featuredTestInstitution.waitForExistence(timeout: 60.0))
+        return featuredTestInstitution
+    }
+
+    func fc_nativeBankAccount(name: String) -> XCUIElement {
+        let bankAccount = scrollViews.staticTexts[name]
+        XCTAssertTrue(bankAccount.waitForExistence(timeout: 120.0))
+        return bankAccount
+    }
+
+    func fc_scrollDown() {
+        swipeUp(velocity: .verySlow)
+    }
+
+    func fc_dismissKeyboard() {
         let returnKey = keyboards.buttons["return"]
         if returnKey.exists && returnKey.isHittable {
             returnKey.tap()

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIGestureVelocity+Extensions.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIGestureVelocity+Extensions.swift
@@ -1,0 +1,13 @@
+//
+//  XCUIGestureVelocity+Extensions.swift
+//  FinancialConnectionsUITests
+//
+//  Created by Krisjanis Gaidis on 4/2/24.
+//
+
+import Foundation
+import XCTest
+
+extension XCUIGestureVelocity {
+    static let verySlow: XCUIGestureVelocity = XCUIGestureVelocity(300)
+}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
@@ -523,8 +523,7 @@ extension STPAPIClient: FinancialConnectionsAPIClient {
             !linkedAccountIds.isEmpty
         {
             return pollAccountNumbersForSelectedAccounts(
-                linkedAccountIds: linkedAccountIds,
-                clientSecret: clientSecret
+                linkedAccountIds: linkedAccountIds
             )
             .chained { _ in
                 return saveAccountsToLinkHandler()
@@ -535,8 +534,7 @@ extension STPAPIClient: FinancialConnectionsAPIClient {
     }
 
     private func pollAccountNumbersForSelectedAccounts(
-        linkedAccountIds: [String],
-        clientSecret: String
+        linkedAccountIds: [String]
     ) -> Future<EmptyResponse> {
         let body: [String: Any] = [
             "linked_accounts": linkedAccountIds,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
@@ -100,15 +100,6 @@ protocol FinancialConnectionsAPIClient {
         customSuccessPaneMessage: String?
     )>
 
-    func saveAccountsToLink(
-        emailAddress: String?,
-        phoneNumber: String?,
-        country: String?,
-        selectedAccountIds: [String],
-        consumerSessionClientSecret: String?,
-        clientSecret: String
-    ) -> Future<FinancialConnectionsSessionManifest>
-
     func disableNetworking(
         disabledReason: String?,
         clientSecret: String
@@ -572,7 +563,7 @@ extension STPAPIClient: FinancialConnectionsAPIClient {
         return pollingHelper.startPollingApiCall()
     }
 
-    func saveAccountsToLink(
+    private func saveAccountsToLink(
         emailAddress: String?,
         phoneNumber: String?,
         country: String?,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsPartnerAccount.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsPartnerAccount.swift
@@ -12,7 +12,7 @@ struct FinancialConnectionsPartnerAccount: Decodable {
     let id: String
     let name: String
     let displayableAccountNumbers: String?
-    let linkedAccountId: String?  // determines whether we show a "Linked" label
+    let linkedAccountId: String?
     let balanceAmount: Int?
     let currency: String?
     let supportedPaymentMethodTypes: [FinancialConnectionsPaymentMethodType]

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerFooterView.swift
@@ -21,7 +21,7 @@ final class AccountPickerFooterView: UIView {
         NSLayoutConstraint.activate([
             linkAccountsButton.heightAnchor.constraint(equalToConstant: 56)
         ])
-        linkAccountsButton.accessibilityIdentifier = "account_picker_link_accounts_button"
+        linkAccountsButton.accessibilityIdentifier = "connect_accounts_button"
         return linkAccountsButton
     }()
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/AccountUpdateRequiredViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/AccountUpdateRequiredViewController.swift
@@ -55,6 +55,7 @@ final class AccountUpdateRequiredViewController: SheetViewController {
             footerView: PaneLayoutView.createFooterView(
                 primaryButtonConfiguration: PaneLayoutView.ButtonConfiguration(
                     title: "Continue", // TODO: when Financial Connections starts supporting localization, change this to `String.Localized.continue`
+                    accessibilityIdentifier: "account_update_required_continue_button",
                     action: didSelectContinue
                 ),
                 secondaryButtonConfiguration: PaneLayoutView.ButtonConfiguration(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerBodyView.swift
@@ -75,6 +75,7 @@ final class LinkAccountPickerBodyView: UIView {
                 self.delegate?.linkAccountPickerBodyViewSelectedNewBankAccount(self)
             }
         )
+        newAccountRowView.accessibilityIdentifier = "add_bank_account"
         verticalStackView.addArrangedSubview(newAccountRowView)
 
         addAndPinSubview(verticalStackView)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerFooterView.swift
@@ -24,6 +24,7 @@ final class LinkAccountPickerFooterView: UIView {
         NSLayoutConstraint.activate([
             connectAccountButton.heightAnchor.constraint(equalToConstant: 56)
         ])
+        connectAccountButton.accessibilityIdentifier = "connect_accounts_button"
         return connectAccountButton
     }()
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -1121,10 +1121,10 @@ private func CreatePaneViewController(
         manualEntryViewController.delegate = nativeFlowController
         viewController = manualEntryViewController
     case .networkingLinkSignupPane:
-        if let linkedAccountIds = dataManager.linkedAccounts?.map({ $0.id }) {
+        if let selectedAccounts = dataManager.linkedAccounts {
             let networkingLinkSignupDataSource = NetworkingLinkSignupDataSourceImplementation(
                 manifest: dataManager.manifest,
-                selectedAccountIds: linkedAccountIds,
+                selectedAccounts: selectedAccounts,
                 returnURL: dataManager.returnURL,
                 apiClient: dataManager.apiClient,
                 clientSecret: dataManager.clientSecret,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -632,9 +632,11 @@ extension NativeFlowController: AccountPickerViewControllerDelegate {
     func accountPickerViewController(
         _ viewController: AccountPickerViewController,
         didSelectAccounts selectedAccounts: [FinancialConnectionsPartnerAccount],
-        nextPane: FinancialConnectionsSessionManifest.NextPane
+        nextPane: FinancialConnectionsSessionManifest.NextPane,
+        customSuccessPaneMessage: String?
     ) {
         dataManager.linkedAccounts = selectedAccounts
+        dataManager.customSuccessPaneMessage = customSuccessPaneMessage
 
         // this prevents an unnecessary push transition when presenting `attachLinkedPaymentAccount`
         //

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -935,11 +935,13 @@ extension NativeFlowController: LinkAccountPickerViewControllerDelegate {
 extension NativeFlowController: NetworkingSaveToLinkVerificationViewControllerDelegate {
     func networkingSaveToLinkVerificationViewControllerDidFinish(
         _ viewController: NetworkingSaveToLinkVerificationViewController,
-        saveToLinkWithStripeSucceeded: Bool?
+        saveToLinkWithStripeSucceeded: Bool?,
+        customSuccessPaneMessage: String?
     ) {
         if saveToLinkWithStripeSucceeded != nil {
             dataManager.saveToLinkWithStripeSucceeded = saveToLinkWithStripeSucceeded
         }
+        dataManager.customSuccessPaneMessage = customSuccessPaneMessage
         pushPane(.success, animated: true)
     }
 
@@ -1158,12 +1160,12 @@ private func CreatePaneViewController(
     case .networkingSaveToLinkVerification:
         if
             let consumerSession = dataManager.consumerSession,
-            let selectedAccountIds = dataManager.linkedAccounts?.map({ $0.id })
+            let selectedAccounts = dataManager.linkedAccounts
         {
             let networkingSaveToLinkVerificationDataSource = NetworkingSaveToLinkVerificationDataSourceImplementation(
                 manifest: dataManager.manifest,
                 consumerSession: consumerSession,
-                selectedAccountIds: selectedAccountIds,
+                selectedAccounts: selectedAccounts,
                 apiClient: dataManager.apiClient,
                 clientSecret: dataManager.clientSecret,
                 analyticsClient: dataManager.analyticsClient

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
@@ -201,11 +201,11 @@ final class NetworkingLinkSignupViewController: UIViewController {
         .observe { [weak self] result in
             guard let self = self else { return }
             switch result {
-            case .success(let manifest):
+            case .success(let customSuccessPaneMessage):
                 self.delegate?.networkingLinkSignupViewControllerDidFinish(
                     self,
                     saveToLinkWithStripeSucceeded: true,
-                    customSuccessPaneMessage: manifest.displayText?.successPane?.subCaption,
+                    customSuccessPaneMessage: customSuccessPaneMessage,
                     withError: nil
                 )
             case .failure(let error):

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
@@ -118,15 +118,22 @@ class EmptyFinancialConnectionsAPIClient: FinancialConnectionsAPIClient {
         return Promise<EmptyResponse>()
     }
 
-    func saveAccountsToLink(
+    func saveAccountsToNetworkAndLink(
+        shouldPollAccounts: Bool,
+        selectedAccounts: [FinancialConnectionsPartnerAccount],
         emailAddress: String?,
         phoneNumber: String?,
         country: String?,
-        selectedAccountIds: [String],
         consumerSessionClientSecret: String?,
         clientSecret: String
-    ) -> Future<StripeFinancialConnections.FinancialConnectionsSessionManifest> {
-        return Promise<StripeFinancialConnections.FinancialConnectionsSessionManifest>()
+    ) -> Future<(
+        manifest: FinancialConnectionsSessionManifest,
+        customSuccessPaneMessage: String?
+    )> {
+        return Promise<(
+            manifest: FinancialConnectionsSessionManifest,
+            customSuccessPaneMessage: String?
+        )>()
     }
 
     func disableNetworking(


### PR DESCRIPTION
## Summary

This PR depends on the following implementation of multi-select support for networking:
- https://github.com/stripe/stripe-ios/pull/3458

## Testing

### Test Polling Being Executed

This breakpoint proves that:
1. Polling code was executed
2. It returned success

![Screenshot 2024-04-01 at 2 02 58 PM](https://github.com/stripe/stripe-ios/assets/105514761/74c297e8-f42d-4e33-8709-e04f3defcc80)

### AccountPickerVC SaveAccountsToLink Succeeded

https://github.com/stripe/stripe-ios/assets/105514761/6b21920f-192e-4d61-a249-84aad53396c3

### NetworkingLinkSignupViewController SaveAccountsToLink Succeeded

https://github.com/stripe/stripe-ios/assets/105514761/a3b41eb2-c389-4ee1-a731-3bf64ed07be0

### NetworkingSaveToLinkVerificationVC SaveAccountsToLink Succeeded

https://github.com/stripe/stripe-ios/assets/105514761/42c986d4-d4c6-48a8-bc51-1fb00adde98c
