### PR TITLE
Send Unexpected PaymentSheet Error in FormFactory

### DIFF
--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
@@ -230,4 +230,7 @@ import Foundation
     case biFormInteracted = "bi_form_interacted"
     case biCardNumberCompleted = "bi_card_number_completed"
     case biDoneButtonTapped = "bi_done_button_tapped"
+    
+    // MARK: - PaymentSheet errors
+    case paymentSheetFormFactoryError = "paymentsheet.formfactory.error"
 }

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
@@ -231,6 +231,7 @@ import Foundation
     case biCardNumberCompleted = "bi_card_number_completed"
     case biDoneButtonTapped = "bi_done_button_tapped"
 
-    // MARK: - PaymentSheet errors
-    case paymentSheetFormFactoryError = "paymentsheet.formfactory.error"
+    // MARK: - Unexpected errors
+    // These errors should _never happen_ and indicate a problem with the SDK or the Stripe backend.
+    case unexpectedPaymentSheetFormFactoryError = "unexpected_error.paymentsheet.formfactory"
 }

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
@@ -230,7 +230,7 @@ import Foundation
     case biFormInteracted = "bi_form_interacted"
     case biCardNumberCompleted = "bi_card_number_completed"
     case biDoneButtonTapped = "bi_done_button_tapped"
-    
+
     // MARK: - PaymentSheet errors
     case paymentSheetFormFactoryError = "paymentsheet.formfactory.error"
 }

--- a/StripeCore/StripeCore/Source/Helpers/STPAssert.swift
+++ b/StripeCore/StripeCore/Source/Helpers/STPAssert.swift
@@ -7,10 +7,23 @@
 
 import Foundation
 
+/// A very barebones way to test stpasserts in XCTest.
+@_spi(STP) public class STPAssertTestUtil {
+    /// If set to `true` in an XCTest, the next assertion that fires populates `_testExpectAssertMessage` instead of crashing and resets this flag to `false`.
+    public static var shouldSuppressNextSTPAlert: Bool = false
+    /// The message of the assertion that fired when `_testExpectAssert` was `true`.
+    public static var lastAssertMessage: String = ""
+}
+
 /// A wrapper that only calls `assertionFailure` when the `ENABLE_STPASSERTIONFAILURE` compiler flag is set.
 /// Use this for assertions that should not trigger in merchant apps.
 @inlinable @_spi(STP) public func stpAssertionFailure(_ message: @autoclosure () -> String = String(), file: StaticString = #file, line: UInt = #line) {
     #if ENABLE_STPASSERTIONFAILURE
+    if NSClassFromString("XCTest") != nil && STPAssertTestUtil.shouldSuppressNextSTPAlert {
+        STPAssertTestUtil.shouldSuppressNextSTPAlert = false
+        STPAssertTestUtil.lastAssertMessage = message()
+        return
+    }
     assertionFailure(message(), file: file, line: line)
     #else
     print("⚠️ STPAssertionFailure: \(message()) in \(file) on line \(line)")

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -18,6 +18,10 @@ import UIKit
  `IntentConfirmParams`.
  */
 class PaymentSheetFormFactory {
+    enum Error: Swift.Error {
+        case missingFormSpec
+    }
+    
     enum SaveMode {
         /// We can't save the PaymentMethod. e.g., Payment mode without a customer
         case none
@@ -188,6 +192,8 @@ class PaymentSheetFormFactory {
 
         guard let spec = FormSpecProvider.shared.formSpec(for: paymentMethod.identifier) else {
             assertionFailure("Failed to get form spec!")
+            let errorAnalytic = ErrorAnalytic(event: .paymentSheetFormFactoryError, error: Error.missingFormSpec, additionalNonPIIParams: ["payment_method": paymentMethod.identifier])
+            STPAnalyticsClient.sharedClient.log(analytic: errorAnalytic)
             return FormElement(elements: [], theme: theme)
         }
         if paymentMethod == .iDEAL {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -21,7 +21,7 @@ class PaymentSheetFormFactory {
     enum Error: Swift.Error {
         case missingFormSpec
     }
-    
+
     enum SaveMode {
         /// We can't save the PaymentMethod. e.g., Payment mode without a customer
         case none
@@ -44,6 +44,7 @@ class PaymentSheetFormFactory {
     let amount: Int?
     let countryCode: String?
     let cardBrandChoiceEligible: Bool
+    let analyticsClient: STPAnalyticsClient
 
     var canSaveToLink: Bool {
         return (supportsLinkCard &&
@@ -63,7 +64,8 @@ class PaymentSheetFormFactory {
         addressSpecProvider: AddressSpecProvider = .shared,
         offerSaveToLinkWhenSupported: Bool = false,
         linkAccount: PaymentSheetLinkAccount? = nil,
-        cardBrandChoiceEligible: Bool = false
+        cardBrandChoiceEligible: Bool = false,
+        analyticsClient: STPAnalyticsClient = .sharedClient
     ) {
         func saveModeFor(merchantRequiresSave: Bool) -> SaveMode {
             let hasCustomer = configuration.hasCustomer
@@ -105,7 +107,8 @@ class PaymentSheetFormFactory {
                   currency: intent.currency,
                   amount: intent.amount,
                   countryCode: intent.countryCode(overrideCountry: configuration.overrideCountry),
-                  saveMode: saveMode)
+                  saveMode: saveMode,
+                  analyticsClient: analyticsClient)
     }
 
     required init(
@@ -121,7 +124,8 @@ class PaymentSheetFormFactory {
         currency: String?,
         amount: Int?,
         countryCode: String?,
-        saveMode: SaveMode
+        saveMode: SaveMode,
+        analyticsClient: STPAnalyticsClient = .sharedClient
     ) {
         self.configuration = configuration
         self.paymentMethod = paymentMethod
@@ -141,6 +145,7 @@ class PaymentSheetFormFactory {
         self.countryCode = countryCode
         self.saveMode = saveMode
         self.cardBrandChoiceEligible = cardBrandChoiceEligible
+        self.analyticsClient = analyticsClient
     }
 
     func make() -> PaymentMethodElement {
@@ -191,9 +196,9 @@ class PaymentSheetFormFactory {
         }
 
         guard let spec = FormSpecProvider.shared.formSpec(for: paymentMethod.identifier) else {
-            assertionFailure("Failed to get form spec!")
+            stpAssertionFailure("Failed to get form spec for \(paymentMethod.identifier)!")
             let errorAnalytic = ErrorAnalytic(event: .paymentSheetFormFactoryError, error: Error.missingFormSpec, additionalNonPIIParams: ["payment_method": paymentMethod.identifier])
-            STPAnalyticsClient.sharedClient.log(analytic: errorAnalytic)
+            analyticsClient.log(analytic: errorAnalytic)
             return FormElement(elements: [], theme: theme)
         }
         if paymentMethod == .iDEAL {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -197,7 +197,7 @@ class PaymentSheetFormFactory {
 
         guard let spec = FormSpecProvider.shared.formSpec(for: paymentMethod.identifier) else {
             stpAssertionFailure("Failed to get form spec for \(paymentMethod.identifier)!")
-            let errorAnalytic = ErrorAnalytic(event: .paymentSheetFormFactoryError, error: Error.missingFormSpec, additionalNonPIIParams: ["payment_method": paymentMethod.identifier])
+            let errorAnalytic = ErrorAnalytic(event: .unexpectedPaymentSheetFormFactoryError, error: Error.missingFormSpec, additionalNonPIIParams: ["payment_method": paymentMethod.identifier])
             analyticsClient.log(analytic: errorAnalytic)
             return FormElement(elements: [], theme: theme)
         }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactoryTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactoryTest.swift
@@ -1353,7 +1353,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         _ = factory.make()
         XCTAssertEqual(STPAssertTestUtil.lastAssertMessage, "Failed to get form spec for card_present!")
         let errorAnalytic = analyticsClient._testLogHistory.first!
-        XCTAssertEqual(errorAnalytic["event"] as? String, STPAnalyticEvent.paymentSheetFormFactoryError.rawValue)
+        XCTAssertEqual(errorAnalytic["event"] as? String, STPAnalyticEvent.unexpectedPaymentSheetFormFactoryError.rawValue)
         XCTAssertEqual(errorAnalytic["payment_method"] as? String, "card_present")
         XCTAssertEqual(errorAnalytic["error_code"] as? String, "missingFormSpec")
     }


### PR DESCRIPTION
## Summary
- Sends an error analytic when PaymentSheet.FormFactory fails to create a form spec
- Adds an extremely rudimentary way to test stpasserts

## Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-1858
https://docs.google.com/document/d/1r_DS7mDLlrwThcvX8CBUqUBRVejeVDy05Ejth8gnBGI/edit?pli=1

## Testing
See unit test

## Changelog
Not user facing
