### PR TITLE
Financial Connections: added more networking UI tests and improved their reliability

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnections Example.xcodeproj/project.pbxproj
+++ b/Example/FinancialConnections Example/FinancialConnections Example.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		5AA50D95EC1C2489AD98071E /* PlaygroundMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B379D3A9F9EA11716D5AEB3 /* PlaygroundMainView.swift */; };
 		5B38135D1C37FC1812F4203A /* StripeUICore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ADFEE494187576194F8B46BB /* StripeUICore.framework */; };
 		5C1B372D1660E856988156DA /* StripeUICore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = ADFEE494187576194F8B46BB /* StripeUICore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		6A6C23172BBCC6210083FF66 /* XCUIGestureVelocity+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A6C23162BBCC6210083FF66 /* XCUIGestureVelocity+Extensions.swift */; };
 		6AC6B40D2B880EEA000A4B32 /* XCTestCase+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC6B40C2B880EEA000A4B32 /* XCTestCase+Extensions.swift */; };
 		6AF9C66D47F81DD9B103FB64 /* StripeCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 03E7365D673694C8D7EDFB20 /* StripeCore.framework */; };
 		828A3C3A555F9B2ABAEF3E95 /* WebViewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65FBE9DBF6CBB07AE2D5B1DA /* WebViewViewController.swift */; };
@@ -95,6 +96,7 @@
 		5B675DEF4776CDFF8309DEB8 /* Project-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Project-Debug.xcconfig"; sourceTree = "<group>"; };
 		5C02DB1648E15A6591FD56E1 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		65FBE9DBF6CBB07AE2D5B1DA /* WebViewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewViewController.swift; sourceTree = "<group>"; };
+		6A6C23162BBCC6210083FF66 /* XCUIGestureVelocity+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIGestureVelocity+Extensions.swift"; sourceTree = "<group>"; };
 		6AC6B40C2B880EEA000A4B32 /* XCTestCase+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Extensions.swift"; sourceTree = "<group>"; };
 		701003016E153D5DF2B00442 /* FinancialConnections-Example-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "FinancialConnections-Example-Debug.xcconfig"; sourceTree = "<group>"; };
 		74959BBB33DB4A570E2B4FD3 /* FinancialConnectionsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsUITests.swift; sourceTree = "<group>"; };
@@ -231,6 +233,7 @@
 				E43F3C346DE28D65F7575D58 /* XCUIApplication+Extensions.swift */,
 				01EFB9C0699FEB532FFE57D9 /* XCUIElement+Extensions.swift */,
 				6AC6B40C2B880EEA000A4B32 /* XCTestCase+Extensions.swift */,
+				6A6C23162BBCC6210083FF66 /* XCUIGestureVelocity+Extensions.swift */,
 			);
 			path = FinancialConnectionsUITests;
 			sourceTree = "<group>";
@@ -368,6 +371,7 @@
 				6AC6B40D2B880EEA000A4B32 /* XCTestCase+Extensions.swift in Sources */,
 				09B82E32FC066FC442BD945D /* XCUIApplication+Extensions.swift in Sources */,
 				82D499E3F32FB4663D26EBA6 /* XCUIElement+Extensions.swift in Sources */,
+				6A6C23172BBCC6210083FF66 /* XCUIGestureVelocity+Extensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundMainView.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundMainView.swift
@@ -100,7 +100,7 @@ struct PlaygroundMainView: View {
 
                     // extra space so keyboard doesn't cover the "CUSTOM KEYS" section
                     // (SwiftUI, depending on iOS version, doesn't handle keyboard)
-                    Spacer(minLength: 100)
+                    Spacer(minLength: 60)
                 }
                 VStack {
                     Button(action: viewModel.didSelectShow) {

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
@@ -20,10 +20,15 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
     }
 
+//    func testy() {
+//        executeNativeNetworkingTestModeAddBankAccount(emailAddress: "apr1@test.com")
+//    }
+    
     func testNativeNetworkingTestMode() throws {
         let emailAddresss = "\(UUID().uuidString)@UITestForIOS.com"
         executeNativeNetworkingTestModeSignUpFlowTest(emailAddress: emailAddresss)
         executeNativeNetworkingTestModeSignInFlowTest(emailAddress: emailAddresss)
+        executeNativeNetworkingTestModeAddBankAccount(emailAddress: emailAddresss)
     }
 
     private func executeNativeNetworkingTestModeSignUpFlowTest(emailAddress: String) {
@@ -69,7 +74,7 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         XCTAssertTrue(successInstitution.waitForExistence(timeout: 60.0))
         successInstitution.tap()
 
-        app.fc_nativeAccountPickerLinkAccountsButton.tap()
+        app.fc_nativeConnectAccountsButton.tap()
 
         let emailTextField = app.textFields["email_text_field"]
         XCTAssertTrue(emailTextField.waitForExistence(timeout: 120.0))  // wait for synchronize to complete
@@ -163,6 +168,73 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         // ensure alert body contains "Stripe Bank" (AKA one bank is linked)
         XCTAssert(
             app.fc_playgroundSuccessAlertView.staticTexts.containing(NSPredicate(format: "label CONTAINS 'StripeBank'")).firstMatch
+                .exists
+        )
+    }
+    
+    private func executeNativeNetworkingTestModeAddBankAccount(emailAddress: String) {
+        let app = XCUIApplication.fc_launch()
+
+        app.fc_playgroundCell.tap()
+
+        let dataSegmentPickerButton = app.segmentedControls.buttons["Networking"]
+        XCTAssertTrue(dataSegmentPickerButton.waitForExistence(timeout: 60.0))
+        dataSegmentPickerButton.tap()
+
+        app.fc_playgroundNativeButton.tap()
+
+        let enableTestModeSwitch = app.fc_playgroundEnableTestModeSwitch
+        enableTestModeSwitch.turnSwitch(on: true)
+
+        let playgroundEmailTextField = app.textFields["playground-email"]
+        XCTAssertTrue(playgroundEmailTextField.waitForExistence(timeout: 60.0))
+        playgroundEmailTextField.tap()
+        clear(textField: playgroundEmailTextField)
+        playgroundEmailTextField.typeText(emailAddress)
+        app.dismissKeyboard() // dismiss keyboard (warning: ensure keyboard is visible if manually testing)
+        
+        let multiSelectSwitch = app.switches["networking-multi-select"]
+        XCTAssertTrue(multiSelectSwitch.waitForExistence(timeout: 60.0))
+        multiSelectSwitch.turnSwitch(on: false)
+        
+        app.swipeUp(velocity: .slow) // swipe to see permissions
+        app.switches["playground-ownership-permission"].turnSwitch(on: false)
+        app.switches["playground-balances-permission"].turnSwitch(on: false)
+        app.switches["playground-transactions-permission"].turnSwitch(on: false)
+        
+        app.fc_playgroundShowAuthFlowButton.tap()
+        app.fc_nativeConsentAgreeButton.tap()
+
+        let linkContinueButton = app.buttons["link_continue_button"]
+        XCTAssertTrue(linkContinueButton.waitForExistence(timeout: 60.0))
+        linkContinueButton.tap()
+
+        let verificationOTPTextView = app.scrollViews.otherElements.textViews["Code field"]
+        XCTAssertTrue(verificationOTPTextView.waitForExistence(timeout: 60.0))
+        verificationOTPTextView.tap()
+        verificationOTPTextView.typeText("111111")
+        
+        let addBankAccountButton = app.scrollViews.otherElements["add_bank_account"]
+        XCTAssertTrue(addBankAccountButton.waitForExistence(timeout: 120.0)) // need to wait for various API calls to appear
+        addBankAccountButton.tap()
+        
+        // wait for search bar to appear
+        _ = app.fc_searchBarTextField
+        
+        app.swipeUp(velocity: .slow) // swipe to see all institutions
+        
+        app.fc_nativeFeaturedInstitution(name: "Data cannot be shared through Link").tap()
+        
+        let bankAccountName = "Insufficient Funds"
+        app.fc_nativeBankAccount(name: bankAccountName).tap()
+        
+        app.fc_nativeConnectAccountsButton.tap()
+
+        app.fc_nativeSuccessDoneButton.tap()
+
+        // ensure alert body contains "Stripe Bank" (AKA one bank is linked)
+        XCTAssert(
+            app.fc_playgroundSuccessAlertView.staticTexts.containing(NSPredicate(format: "label CONTAINS '\(bankAccountName)'")).firstMatch
                 .exists
         )
     }

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
@@ -39,7 +39,7 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         let enableTestModeSwitch = app.fc_playgroundEnableTestModeSwitch
         enableTestModeSwitch.turnSwitch(on: true)
 
-        app.swipeUp(velocity: .slow) // swipe to see email
+        app.scrollDown() // see email
         let playgroundEmailTextField = app.textFields["playground-email"]
         XCTAssertTrue(playgroundEmailTextField.waitForExistence(timeout: 60.0))
         playgroundEmailTextField.tap()
@@ -50,7 +50,7 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         XCTAssertTrue(multiSelectSwitch.waitForExistence(timeout: 60.0))
         multiSelectSwitch.turnSwitch(on: false)
 
-        app.swipeUp(velocity: .slow) // swipe to see permissions
+        app.scrollDown() // see permissions
         app.switches["playground-transactions-permission"].turnSwitch(on: true)
 
         app.fc_playgroundShowAuthFlowButton.tap()
@@ -114,7 +114,7 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         let enableTestModeSwitch = app.fc_playgroundEnableTestModeSwitch
         enableTestModeSwitch.turnSwitch(on: true)
 
-        app.swipeUp(velocity: .slow) // swipe to see email
+        app.scrollDown() // see email
         let playgroundEmailTextField = app.textFields["playground-email"]
         XCTAssertTrue(playgroundEmailTextField.waitForExistence(timeout: 60.0))
         playgroundEmailTextField.tap()
@@ -122,7 +122,7 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         playgroundEmailTextField.typeText(emailAddress)
         app.dismissKeyboard() // dismiss keyboard (warning: ensure keyboard is visible if manually testing)
 
-        app.swipeUp(velocity: .slow) // swipe to see permissions
+        app.scrollDown() // see permissions
         app.switches["playground-transactions-permission"].turnSwitch(on: true)
 
         app.fc_playgroundShowAuthFlowButton.tap()
@@ -181,7 +181,7 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         let enableTestModeSwitch = app.fc_playgroundEnableTestModeSwitch
         enableTestModeSwitch.turnSwitch(on: true)
 
-        app.swipeUp(velocity: .slow) // swipe to see email
+        app.scrollDown() // see email
         let playgroundEmailTextField = app.textFields["playground-email"]
         XCTAssertTrue(playgroundEmailTextField.waitForExistence(timeout: 60.0))
         playgroundEmailTextField.tap()
@@ -193,7 +193,7 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         XCTAssertTrue(multiSelectSwitch.waitForExistence(timeout: 60.0))
         multiSelectSwitch.turnSwitch(on: false)
 
-        app.swipeUp(velocity: .slow) // swipe to see permissions
+        app.scrollDown() // see permissions
         app.switches["playground-ownership-permission"].turnSwitch(on: false)
         app.switches["playground-balances-permission"].turnSwitch(on: false)
         app.switches["playground-transactions-permission"].turnSwitch(on: false)
@@ -217,7 +217,7 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         // wait for search bar to appear
         _ = app.fc_searchBarTextField
 
-        app.swipeUp(velocity: .slow) // swipe to see all institutions
+        app.scrollDown() // see all institutions
 
         app.fc_nativeFeaturedInstitution(name: "Data cannot be shared through Link").tap()
 
@@ -251,7 +251,7 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         let enableTestModeSwitch = app.fc_playgroundEnableTestModeSwitch
         enableTestModeSwitch.turnSwitch(on: true)
 
-        app.swipeUp(velocity: .slow) // swipe to see email
+        app.scrollDown() // see email
         let playgroundEmailTextField = app.textFields["playground-email"]
         XCTAssertTrue(playgroundEmailTextField.waitForExistence(timeout: 60.0))
         playgroundEmailTextField.tap()
@@ -263,7 +263,7 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         XCTAssertTrue(multiSelectSwitch.waitForExistence(timeout: 60.0))
         multiSelectSwitch.turnSwitch(on: true)
 
-        app.swipeUp(velocity: .slow) // swipe to see permissions
+        app.scrollDown() // see permissions
         app.switches["playground-ownership-permission"].turnSwitch(on: true)
 
         app.fc_playgroundShowAuthFlowButton.tap()

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
@@ -39,6 +39,7 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         let enableTestModeSwitch = app.fc_playgroundEnableTestModeSwitch
         enableTestModeSwitch.turnSwitch(on: true)
 
+        app.swipeUp(velocity: .slow) // swipe to see email
         let playgroundEmailTextField = app.textFields["playground-email"]
         XCTAssertTrue(playgroundEmailTextField.waitForExistence(timeout: 60.0))
         playgroundEmailTextField.tap()
@@ -49,11 +50,8 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         XCTAssertTrue(multiSelectSwitch.waitForExistence(timeout: 60.0))
         multiSelectSwitch.turnSwitch(on: false)
 
-        app.swipeUp(velocity: .slow)
-
-        let playgroundTransactionsPermissionsSwitch = app.switches["playground-transactions-permission"]
-        XCTAssertTrue(playgroundTransactionsPermissionsSwitch.waitForExistence(timeout: 60.0))
-        playgroundTransactionsPermissionsSwitch.turnSwitch(on: true)
+        app.swipeUp(velocity: .slow) // swipe to see permissions
+        app.switches["playground-transactions-permission"].turnSwitch(on: true)
 
         app.fc_playgroundShowAuthFlowButton.tap()
         app.fc_nativeConsentAgreeButton.tap()
@@ -116,6 +114,7 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         let enableTestModeSwitch = app.fc_playgroundEnableTestModeSwitch
         enableTestModeSwitch.turnSwitch(on: true)
 
+        app.swipeUp(velocity: .slow) // swipe to see email
         let playgroundEmailTextField = app.textFields["playground-email"]
         XCTAssertTrue(playgroundEmailTextField.waitForExistence(timeout: 60.0))
         playgroundEmailTextField.tap()
@@ -123,9 +122,8 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         playgroundEmailTextField.typeText(emailAddress)
         app.dismissKeyboard() // dismiss keyboard (warning: ensure keyboard is visible if manually testing)
 
-        let playgroundTransactionsPermissionsSwitch = app.switches["playground-transactions-permission"]
-        XCTAssertTrue(playgroundTransactionsPermissionsSwitch.waitForExistence(timeout: 60.0))
-        playgroundTransactionsPermissionsSwitch.turnSwitch(on: true)
+        app.swipeUp(velocity: .slow) // swipe to see permissions
+        app.switches["playground-transactions-permission"].turnSwitch(on: true)
 
         app.fc_playgroundShowAuthFlowButton.tap()
         app.fc_nativeConsentAgreeButton.tap()
@@ -183,6 +181,7 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         let enableTestModeSwitch = app.fc_playgroundEnableTestModeSwitch
         enableTestModeSwitch.turnSwitch(on: true)
 
+        app.swipeUp(velocity: .slow) // swipe to see email
         let playgroundEmailTextField = app.textFields["playground-email"]
         XCTAssertTrue(playgroundEmailTextField.waitForExistence(timeout: 60.0))
         playgroundEmailTextField.tap()
@@ -252,6 +251,7 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         let enableTestModeSwitch = app.fc_playgroundEnableTestModeSwitch
         enableTestModeSwitch.turnSwitch(on: true)
 
+        app.swipeUp(velocity: .slow) // swipe to see email
         let playgroundEmailTextField = app.textFields["playground-email"]
         XCTAssertTrue(playgroundEmailTextField.waitForExistence(timeout: 60.0))
         playgroundEmailTextField.tap()

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
@@ -39,18 +39,18 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         let enableTestModeSwitch = app.fc_playgroundEnableTestModeSwitch
         enableTestModeSwitch.turnSwitch(on: true)
 
-        app.scrollDown() // see email
+        app.fc_scrollDown() // see email
         let playgroundEmailTextField = app.textFields["playground-email"]
         XCTAssertTrue(playgroundEmailTextField.waitForExistence(timeout: 60.0))
         playgroundEmailTextField.tap()
         clear(textField: playgroundEmailTextField)
-        app.dismissKeyboard() // dismiss keyboard (warning: ensure keyboard is visible if manually testing)
+        app.fc_dismissKeyboard() // dismiss keyboard (warning: ensure keyboard is visible if manually testing)
 
         let multiSelectSwitch = app.switches["networking-multi-select"]
         XCTAssertTrue(multiSelectSwitch.waitForExistence(timeout: 60.0))
         multiSelectSwitch.turnSwitch(on: false)
 
-        app.scrollDown() // see permissions
+        app.fc_scrollDown() // see permissions
         app.switches["playground-transactions-permission"].turnSwitch(on: true)
 
         app.fc_playgroundShowAuthFlowButton.tap()
@@ -87,10 +87,12 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         saveToLinkButon.tap()
 
         let successPaneDoneButton = app.fc_nativeSuccessDoneButton
-        // this ensures that save to Link was successful...
-        // ...we want to check AFTER success screen has rendered with the "Done" button
-        XCTAssert(!app.staticTexts.containing(NSPredicate(format: "label CONTAINS 'could not be saved to Link'")).firstMatch
-            .exists)
+
+        // ensure that there wasn't a Link failure
+        //
+        // unexpected text: "Your account was connected, but couldn't be saved to Link"
+        XCTAssert(!app.textViews.containing(NSPredicate(format: "label CONTAINS 'but'")).firstMatch.exists)
+
         successPaneDoneButton.tap()
 
         // ensure alert body contains "Stripe Bank" (AKA one bank is linked)
@@ -114,15 +116,15 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         let enableTestModeSwitch = app.fc_playgroundEnableTestModeSwitch
         enableTestModeSwitch.turnSwitch(on: true)
 
-        app.scrollDown() // see email
+        app.fc_scrollDown() // see email
         let playgroundEmailTextField = app.textFields["playground-email"]
         XCTAssertTrue(playgroundEmailTextField.waitForExistence(timeout: 60.0))
         playgroundEmailTextField.tap()
         clear(textField: playgroundEmailTextField)
         playgroundEmailTextField.typeText(emailAddress)
-        app.dismissKeyboard() // dismiss keyboard (warning: ensure keyboard is visible if manually testing)
+        app.fc_dismissKeyboard() // dismiss keyboard (warning: ensure keyboard is visible if manually testing)
 
-        app.scrollDown() // see permissions
+        app.fc_scrollDown() // see permissions
         app.switches["playground-transactions-permission"].turnSwitch(on: true)
 
         app.fc_playgroundShowAuthFlowButton.tap()
@@ -151,10 +153,12 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         stepUpVerificationOTPTextView.typeText("111111")
 
         let successPaneDoneButton = app.fc_nativeSuccessDoneButton
-        // this ensures that save to Link was successful...
-        // ...we want to check AFTER success screen has rendered with the "Done" button
-        XCTAssert(!app.staticTexts.containing(NSPredicate(format: "label CONTAINS 'could not be saved to Link'")).firstMatch
-            .exists)
+
+        // ensure that there wasn't a Link failure
+        //
+        // unexpected text: "Your account was connected, but couldn't be saved to Link"
+        XCTAssert(!app.textViews.containing(NSPredicate(format: "label CONTAINS 'but'")).firstMatch.exists)
+
         successPaneDoneButton.tap()
 
         // ensure alert body contains "Stripe Bank" (AKA one bank is linked)
@@ -181,19 +185,19 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         let enableTestModeSwitch = app.fc_playgroundEnableTestModeSwitch
         enableTestModeSwitch.turnSwitch(on: true)
 
-        app.scrollDown() // see email
+        app.fc_scrollDown() // see email
         let playgroundEmailTextField = app.textFields["playground-email"]
         XCTAssertTrue(playgroundEmailTextField.waitForExistence(timeout: 60.0))
         playgroundEmailTextField.tap()
         clear(textField: playgroundEmailTextField)
         playgroundEmailTextField.typeText(emailAddress)
-        app.dismissKeyboard() // dismiss keyboard (warning: ensure keyboard is visible if manually testing)
+        app.fc_dismissKeyboard() // dismiss keyboard (warning: ensure keyboard is visible if manually testing)
 
         let multiSelectSwitch = app.switches["networking-multi-select"]
         XCTAssertTrue(multiSelectSwitch.waitForExistence(timeout: 60.0))
         multiSelectSwitch.turnSwitch(on: false)
 
-        app.scrollDown() // see permissions
+        app.fc_scrollDown() // see permissions
         app.switches["playground-ownership-permission"].turnSwitch(on: false)
         app.switches["playground-balances-permission"].turnSwitch(on: false)
         app.switches["playground-transactions-permission"].turnSwitch(on: false)
@@ -217,7 +221,7 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         // wait for search bar to appear
         _ = app.fc_searchBarTextField
 
-        app.scrollDown() // see all institutions
+        app.fc_scrollDown() // see all institutions
 
         app.fc_nativeFeaturedInstitution(name: "Data cannot be shared through Link").tap()
 
@@ -251,19 +255,19 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         let enableTestModeSwitch = app.fc_playgroundEnableTestModeSwitch
         enableTestModeSwitch.turnSwitch(on: true)
 
-        app.scrollDown() // see email
+        app.fc_scrollDown() // see email
         let playgroundEmailTextField = app.textFields["playground-email"]
         XCTAssertTrue(playgroundEmailTextField.waitForExistence(timeout: 60.0))
         playgroundEmailTextField.tap()
         clear(textField: playgroundEmailTextField)
         playgroundEmailTextField.typeText(emailAddress)
-        app.dismissKeyboard() // dismiss keyboard (warning: ensure keyboard is visible if manually testing)
+        app.fc_dismissKeyboard() // dismiss keyboard (warning: ensure keyboard is visible if manually testing)
 
         let multiSelectSwitch = app.switches["networking-multi-select"]
         XCTAssertTrue(multiSelectSwitch.waitForExistence(timeout: 60.0))
         multiSelectSwitch.turnSwitch(on: true)
 
-        app.scrollDown() // see permissions
+        app.fc_scrollDown() // see permissions
         app.switches["playground-ownership-permission"].turnSwitch(on: true)
 
         app.fc_playgroundShowAuthFlowButton.tap()
@@ -286,12 +290,19 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
 
         app.fc_nativeConnectAccountsButton.tap()
 
-        // this ensures that save to Link was successful
-        // expected text: "Your account was connected, and saved with Link."
-        XCTAssert(!app.staticTexts.containing(NSPredicate(format: "label CONTAINS 'Link' AND NOT label CONTAINS 'could not be saved to Link'")).firstMatch
-            .exists)
+        let successDoneButton = app.fc_nativeSuccessDoneButton
 
-        app.fc_nativeSuccessDoneButton.tap()
+        // ensures that save to Link was successful
+        //
+        // expected text: "Your account was connected, and saved with Link."
+        XCTAssert(app.textViews.containing(NSPredicate(format: "label CONTAINS 'Link'")).firstMatch.exists)
+
+        // ensure that the Link text wasn't a failure
+        //
+        // unexpected text: "Your account was connected, but couldn't be saved to Link"
+        XCTAssert(!app.textViews.containing(NSPredicate(format: "label CONTAINS 'but'")).firstMatch.exists)
+
+        successDoneButton.tap()
 
         // multiple banks should be checked
         XCTAssert(
@@ -300,6 +311,90 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         )
         XCTAssert(
             app.fc_playgroundSuccessAlertView.staticTexts.containing(NSPredicate(format: "label CONTAINS '\(bankAccountName)'")).firstMatch
+                .exists
+        )
+    }
+
+    func testNativeNetworkingTestModeSignUpWithMultiSelectAndPrefilledEmail() {
+        let emailAddress = "\(UUID().uuidString)@UITestForIOS.com"
+
+        let app = XCUIApplication.fc_launch()
+
+        app.fc_playgroundCell.tap()
+
+        let dataSegmentPickerButton = app.segmentedControls.buttons["Networking"]
+        XCTAssertTrue(dataSegmentPickerButton.waitForExistence(timeout: 60.0))
+        dataSegmentPickerButton.tap()
+
+        app.fc_playgroundNativeButton.tap()
+
+        let enableTestModeSwitch = app.fc_playgroundEnableTestModeSwitch
+        enableTestModeSwitch.turnSwitch(on: true)
+
+        app.fc_scrollDown() // see email
+        let playgroundEmailTextField = app.textFields["playground-email"]
+        XCTAssertTrue(playgroundEmailTextField.waitForExistence(timeout: 60.0))
+        playgroundEmailTextField.tap()
+        clear(textField: playgroundEmailTextField)
+        playgroundEmailTextField.typeText(emailAddress)
+        app.fc_dismissKeyboard() // dismiss keyboard (warning: ensure keyboard is visible if manually testing)
+
+        let multiSelectSwitch = app.switches["networking-multi-select"]
+        XCTAssertTrue(multiSelectSwitch.waitForExistence(timeout: 60.0))
+        multiSelectSwitch.turnSwitch(on: true)
+
+        app.fc_scrollDown() // see permissions
+        app.switches["playground-transactions-permission"].turnSwitch(on: true)
+
+        app.fc_playgroundShowAuthFlowButton.tap()
+        app.fc_nativeConsentAgreeButton.tap()
+
+        let featuredLegacyTestInstitution = app.tables.cells.staticTexts["Test OAuth Institution"]
+        XCTAssertTrue(featuredLegacyTestInstitution.waitForExistence(timeout: 60.0))
+        featuredLegacyTestInstitution.tap()
+
+        app.fc_nativePrepaneContinueButton.tap()
+
+        // all accounts will be selected by default
+
+        app.fc_nativeConnectAccountsButton.tap()
+
+        // email will already be pre-filled
+
+        let phoneTextField = app.textFields["phone_text_field"]
+        XCTAssertTrue(phoneTextField.waitForExistence(timeout: 120.0))  // wait for lookup to complete
+        phoneTextField.tap()
+        phoneTextField.typeText("4015006000")
+
+        let phoneTextFieldToolbarDoneButton = app.toolbars["Toolbar"].buttons["Done"]
+        XCTAssertTrue(phoneTextFieldToolbarDoneButton.waitForExistence(timeout: 60.0))
+        phoneTextFieldToolbarDoneButton.tap()
+
+        let saveToLinkButon = app.buttons["Save to Link"]
+        XCTAssertTrue(saveToLinkButon.waitForExistence(timeout: 120.0))  // glitch app can take time to lload
+        saveToLinkButon.tap()
+
+        let successPaneDoneButton = app.fc_nativeSuccessDoneButton
+
+        // ensures that save to Link was successful
+        //
+        // expected text: "Your account was connected, and saved with Link."
+        XCTAssert(app.textViews.containing(NSPredicate(format: "label CONTAINS 'Link'")).firstMatch.exists)
+
+        // ensure that the Link text wasn't a failure
+        //
+        // unexpected text: "Your account was connected, but couldn't be saved to Link"
+        XCTAssert(!app.textViews.containing(NSPredicate(format: "label CONTAINS 'but'")).firstMatch.exists)
+
+        successPaneDoneButton.tap()
+
+        // multiple banks should be checked
+        XCTAssert(
+            app.fc_playgroundSuccessAlertView.staticTexts.containing(NSPredicate(format: "label CONTAINS 'Success'")).firstMatch
+                .exists
+        )
+        XCTAssert(
+            app.fc_playgroundSuccessAlertView.staticTexts.containing(NSPredicate(format: "label CONTAINS 'Insufficient Funds'")).firstMatch
                 .exists
         )
     }

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
@@ -38,7 +38,7 @@ final class FinancialConnectionsUITests: XCTestCase {
         featuredLegacyTestInstitution.tap()
 
         app.fc_nativePrepaneContinueButton.tap()
-        app.fc_nativeAccountPickerLinkAccountsButton.tap()
+        app.fc_nativeConnectAccountsButton.tap()
         app.fc_nativeSuccessDoneButton.tap()
 
         // ensure alert body contains "Stripe Bank" (AKA one bank is linked)
@@ -69,7 +69,7 @@ final class FinancialConnectionsUITests: XCTestCase {
         XCTAssertTrue(successAccountRow.waitForExistence(timeout: 60.0))
         successAccountRow.tap()
 
-        app.fc_nativeAccountPickerLinkAccountsButton.tap()
+        app.fc_nativeConnectAccountsButton.tap()
         app.fc_nativeSuccessDoneButton.tap()
 
         // ensure alert body contains "Stripe Bank" (AKA one bank is linked)
@@ -332,11 +332,7 @@ final class FinancialConnectionsUITests: XCTestCase {
         app.fc_playgroundShowAuthFlowButton.tap()
         app.fc_nativeConsentAgreeButton.tap()
 
-        let searchBarTextField = app
-            .tables
-            .otherElements
-            .textFields["search_bar_text_field"]
-        XCTAssertTrue(searchBarTextField.waitForExistence(timeout: 120.0))
+        let searchBarTextField = app.fc_searchBarTextField
         searchBarTextField.tap()
         searchBarTextField.typeText("Bank of America")
 

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIApplication+Extensions.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIApplication+Extensions.swift
@@ -143,6 +143,10 @@ extension XCUIApplication {
         return bankAccount
     }
 
+    func scrollDown() {
+        swipeUp(velocity: .verySlow)
+    }
+
     func dismissKeyboard() {
         let returnKey = keyboards.buttons["return"]
         if returnKey.exists && returnKey.isHittable {

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIApplication+Extensions.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIApplication+Extensions.swift
@@ -143,11 +143,11 @@ extension XCUIApplication {
         return bankAccount
     }
 
-    func scrollDown() {
+    func fc_scrollDown() {
         swipeUp(velocity: .verySlow)
     }
 
-    func dismissKeyboard() {
+    func fc_dismissKeyboard() {
         let returnKey = keyboards.buttons["return"]
         if returnKey.exists && returnKey.isHittable {
             returnKey.tap()

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIApplication+Extensions.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIApplication+Extensions.swift
@@ -104,9 +104,10 @@ extension XCUIApplication {
         return prepaneCancelButton
     }
 
-    var fc_nativeAccountPickerLinkAccountsButton: XCUIElement {
-        let accountPickerLinkAccountsButton = buttons["account_picker_link_accounts_button"]
+    var fc_nativeConnectAccountsButton: XCUIElement {
+        let accountPickerLinkAccountsButton = buttons["connect_accounts_button"]
         XCTAssertTrue(accountPickerLinkAccountsButton.waitForExistence(timeout: 120.0), "Failed to open Account Picker pane - \(#function) waiting failed")  // wait for accounts to fetch
+        XCTAssert(accountPickerLinkAccountsButton.isEnabled, "no account selected")
         return accountPickerLinkAccountsButton
     }
 
@@ -121,7 +122,27 @@ extension XCUIApplication {
         XCTAssertTrue(secureWebViewCancelButton.waitForExistence(timeout: 5.0), "Failed to close secure browser - \(#function) waiting failed")  // wait for accounts to link
         return secureWebViewCancelButton
     }
-
+    
+    var fc_searchBarTextField: XCUIElement {
+        let searchBarTextField = tables
+            .otherElements
+            .textFields["search_bar_text_field"]
+        XCTAssertTrue(searchBarTextField.waitForExistence(timeout: 120.0))
+        return searchBarTextField
+    }
+    
+    func fc_nativeFeaturedInstitution(name: String) -> XCUIElement {
+        let featuredTestInstitution = tables.cells.staticTexts[name]
+        XCTAssertTrue(featuredTestInstitution.waitForExistence(timeout: 60.0))
+        return featuredTestInstitution
+    }
+    
+    func fc_nativeBankAccount(name: String) -> XCUIElement {
+        let bankAccount = scrollViews.staticTexts[name]
+        XCTAssertTrue(bankAccount.waitForExistence(timeout: 120.0))
+        return bankAccount
+    }
+    
     func dismissKeyboard() {
         let returnKey = keyboards.buttons["return"]
         if returnKey.exists && returnKey.isHittable {

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIApplication+Extensions.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIApplication+Extensions.swift
@@ -122,7 +122,7 @@ extension XCUIApplication {
         XCTAssertTrue(secureWebViewCancelButton.waitForExistence(timeout: 5.0), "Failed to close secure browser - \(#function) waiting failed")  // wait for accounts to link
         return secureWebViewCancelButton
     }
-    
+
     var fc_searchBarTextField: XCUIElement {
         let searchBarTextField = tables
             .otherElements
@@ -130,19 +130,19 @@ extension XCUIApplication {
         XCTAssertTrue(searchBarTextField.waitForExistence(timeout: 120.0))
         return searchBarTextField
     }
-    
+
     func fc_nativeFeaturedInstitution(name: String) -> XCUIElement {
         let featuredTestInstitution = tables.cells.staticTexts[name]
         XCTAssertTrue(featuredTestInstitution.waitForExistence(timeout: 60.0))
         return featuredTestInstitution
     }
-    
+
     func fc_nativeBankAccount(name: String) -> XCUIElement {
         let bankAccount = scrollViews.staticTexts[name]
         XCTAssertTrue(bankAccount.waitForExistence(timeout: 120.0))
         return bankAccount
     }
-    
+
     func dismissKeyboard() {
         let returnKey = keyboards.buttons["return"]
         if returnKey.exists && returnKey.isHittable {

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIGestureVelocity+Extensions.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIGestureVelocity+Extensions.swift
@@ -1,0 +1,13 @@
+//
+//  XCUIGestureVelocity+Extensions.swift
+//  FinancialConnectionsUITests
+//
+//  Created by Krisjanis Gaidis on 4/2/24.
+//
+
+import Foundation
+import XCTest
+
+extension XCUIGestureVelocity {
+    static let verySlow: XCUIGestureVelocity = XCUIGestureVelocity(300)
+}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerFooterView.swift
@@ -21,7 +21,7 @@ final class AccountPickerFooterView: UIView {
         NSLayoutConstraint.activate([
             linkAccountsButton.heightAnchor.constraint(equalToConstant: 56)
         ])
-        linkAccountsButton.accessibilityIdentifier = "account_picker_link_accounts_button"
+        linkAccountsButton.accessibilityIdentifier = "connect_accounts_button"
         return linkAccountsButton
     }()
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/AccountUpdateRequiredViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/AccountUpdateRequiredViewController.swift
@@ -55,6 +55,7 @@ final class AccountUpdateRequiredViewController: SheetViewController {
             footerView: PaneLayoutView.createFooterView(
                 primaryButtonConfiguration: PaneLayoutView.ButtonConfiguration(
                     title: "Continue", // TODO: when Financial Connections starts supporting localization, change this to `String.Localized.continue`
+                    accessibilityIdentifier: "account_update_required_continue_button",
                     action: didSelectContinue
                 ),
                 secondaryButtonConfiguration: PaneLayoutView.ButtonConfiguration(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerBodyView.swift
@@ -75,6 +75,7 @@ final class LinkAccountPickerBodyView: UIView {
                 self.delegate?.linkAccountPickerBodyViewSelectedNewBankAccount(self)
             }
         )
+        newAccountRowView.accessibilityIdentifier = "add_bank_account"
         verticalStackView.addArrangedSubview(newAccountRowView)
 
         addAndPinSubview(verticalStackView)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerFooterView.swift
@@ -24,6 +24,7 @@ final class LinkAccountPickerFooterView: UIView {
         NSLayoutConstraint.activate([
             connectAccountButton.heightAnchor.constraint(equalToConstant: 56)
         ])
+        connectAccountButton.accessibilityIdentifier = "connect_accounts_button"
         return connectAccountButton
     }()
 


### PR DESCRIPTION
## Summary

^  added more networking UI tests and improved their reliability

**this is just changing testing code** (except for accessibility identifier)

## Testing

Ran a bunch of tests `bitrise run financial-connections-stability-tests`:


```
FinancialConnectionsNetworkingUITests
    ✓ testNativeNetworkingTestMode (205.028 seconds)
    ✓ testNativeNetworkingTestModeSignUpWithMultiSelectAndPrefilledEmail (53.369 seconds)
FinancialConnectionsUITests
    ✓ testDataLiveModeOAuthNativeAuthFlow (38.676 seconds)
    ✓ testDataLiveModeOAuthWebAuthFlow (24.849 seconds)
    ✓ testDataTestModeOAuthNativeAuthFlow (27.328 seconds)
    ✓ testPaymentTestModeLegacyNativeAuthFlow (26.861 seconds)
    ✓ testPaymentTestModeManualEntryNativeAuthFlow (29.975 seconds)
    ✓ testSearchInLiveModeNativeAuthFlow (32.580 seconds)
```