### PR TITLE
support running IDDetector and MBDetector together

### DIFF
--- a/StripeIdentity/StripeIdentity/Source/Analytics/IdentityAnalyticsClient.swift
+++ b/StripeIdentity/StripeIdentity/Source/Analytics/IdentityAnalyticsClient.swift
@@ -62,6 +62,7 @@ final class IdentityAnalyticsClient {
         // MARK: Microblink
         case mbStatus = "mb_status"
         case mbError = "mb_error"
+        case mbCaptureStatus = "mb_capture_status"
         // MARK: Experiment
         case experimentExposure = "preloaded_experiment_retrieved"
     }
@@ -575,6 +576,19 @@ final class IdentityAnalyticsClient {
                     filePath: filePath,
                     line: line
                 ),
+            ],
+            verificationPage: try? sheetController.verificationPageResponse?.get()
+        )
+    }
+
+    func logMbCaptureStatus(
+        capturedByMb: Bool,
+        sheetController: VerificationSheetControllerProtocol
+    ) {
+        logAnalytic(
+            .mbCaptureStatus,
+            metadata: [
+                "captured_by_mb": capturedByMb
             ],
             verificationPage: try? sheetController.verificationPageResponse?.get()
         )

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/DocumentCaptureViewController+Strings.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/DocumentCaptureViewController+Strings.swift
@@ -52,7 +52,7 @@ extension DocumentCaptureViewController {
             case (_, true, .tooFar):
                 return String.Localized.move_closer
             }
-        case .some(.modern(_, let mbResult, _)):
+        case .some(.modern(_, _, _, _, _, let mbResult)):
             guard case let .capturing(captureFeedback) = mbResult else {
                 if side == .front {
                     return String.Localized.position_in_center

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/DocumentCaptureViewController.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/DocumentCaptureViewController.swift
@@ -560,8 +560,12 @@ extension DocumentCaptureViewController: ImageScanningSessionDelegate {
                 expectedClassification: documentSide,
                 capturedData: UIImage(cgImage: image)
             )
-        case .modern(_, let mbResult, _):
+        case .modern(_, _, _, _, let blurResult, let mbResult):
+            sheetController?.analyticsClient.updateBlurScore(blurResult.variance, for: documentSide)
             if case let .captured(original, transformed, _) = mbResult, let originalCGImage = original.cgImage, let croppedCGImage = transformed.cgImage {
+                if let sheetController {
+                    sheetController.analyticsClient.logMbCaptureStatus(capturedByMb: true, sheetController: sheetController)
+                }
                 documentUploader.uploadImagesFromMB(
                     for: documentSide,
                     originalImage: originalCGImage,
@@ -577,6 +581,9 @@ extension DocumentCaptureViewController: ImageScanningSessionDelegate {
                 )
 
             } else {
+                if let sheetController {
+                    sheetController.analyticsClient.logMbCaptureStatus(capturedByMb: false, sheetController: sheetController)
+                }
                 documentUploader.uploadImages(
                     for: documentSide,
                     originalImage: image,


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Analyze the result of IDDetector and MBDetector and return whenever either returns positive result

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Better user capture experience - when MB doesn't support a certain type, use IDDetector instead.
See [this](https://docs.google.com/document/d/1LyVYV4mLaozxjJu-wkMojDdAkV8NajQ_E8NVNAQAGK4/edit#bookmark=id.w07dal7n2i8v) internal doc for more details

Related Android - https://github.com/stripe/stripe-android/pull/8179
## Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
