### PR TITLE
Fix issue with generating App Privacy report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ### Payments
 * [Added] Support for Alma bindings.
 
+### All
+* [Fixed] Fixed an issue with generating App Privacy reports.
+
 ## 23.26.0 2024-03-25
 ### PaymentSheet
 * [Fixed] When confirming a SetupIntent with Link, "Set up" will be shown as the confirm button text instead of "Pay".

--- a/Example/PaymentSheet Example/PaymentSheet Example/PrivacyInfo.xcprivacy
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PrivacyInfo.xcprivacy
@@ -2,6 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeProductInteraction</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+	</array>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>

--- a/StripeCore/StripeCore/PrivacyInfo.xcprivacy
+++ b/StripeCore/StripeCore/PrivacyInfo.xcprivacy
@@ -2,6 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeProductInteraction</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+	</array>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
## Summary
Xcode returns an error in the privacy report when an xcprivacy file lists `NSPrivacyAccessedAPITypes` but not `NSPrivacyCollectedDataTypes`. StripeCore itself doesn't collect any of these data types without the other frameworks, but we'll add "Product Interaction" to silence the warning, as StripeCore is involved in analytics.

## Motivation
https://github.com/stripe/stripe-ios/issues/3468

## Testing
Generated App Privacy report in Xcode.

## Changelog
Added entry.