### PR TITLE
Refactor STPPaymentHandlerSetupIntentActionParams.setupIntent to not …

### DIFF
--- a/StripePayments/StripePayments/Source/Internal/STPPaymentHandlerActionParams.swift
+++ b/StripePayments/StripePayments/Source/Internal/STPPaymentHandlerActionParams.swift
@@ -112,11 +112,11 @@ internal class STPPaymentHandlerSetupIntentActionParams: NSObject, STPPaymentHan
     let threeDSCustomizationSettings: STPThreeDSCustomizationSettings
     let setupIntentCompletion: STPPaymentHandlerActionSetupIntentCompletionBlock
     let returnURLString: String?
-    var setupIntent: STPSetupIntent?
+    var setupIntent: STPSetupIntent
     var threeDS2Transaction: STDSTransaction?
 
     var intentStripeID: String? {
-        return setupIntent?.stripeID
+        return setupIntent.stripeID
     }
 
     private var _threeDS2Service: STDSThreeDS2Service?
@@ -129,7 +129,7 @@ internal class STPPaymentHandlerSetupIntentActionParams: NSObject, STPPaymentHan
             STDSSwiftTryCatch.try(
                 {
                     let configParams = STDSConfigParameters()
-                    if !(self.setupIntent?.livemode ?? true) {
+                    if !self.setupIntent.livemode {
                         configParams.addParameterNamed(
                             "kInternalStripeTestingConfigParam",
                             withValue: "Y"
@@ -171,7 +171,7 @@ internal class STPPaymentHandlerSetupIntentActionParams: NSObject, STPPaymentHan
     }
 
     func nextAction() -> STPIntentAction? {
-        return setupIntent?.nextAction
+        return setupIntent.nextAction
     }
 
     func complete(with status: STPPaymentHandlerActionStatus, error: NSError?) {


### PR DESCRIPTION
…be nullable. This was an artifact from when we auto-converted the original objective-c code to swift. See https://github.com/stripe/stripe-ios/blob/572135fe1f1f65c84e382bf7d1e866d07aa1dde4/Stripe/STPPaymentHandlerActionParams.h#L60 - original property is not nullable. 


## Motivation
Instead of handling these guard/assert/error cases where SetupIntent is unexpectedly nil, refactor code to disallow possibility it's nil. 

