### PR TITLE
Remove Identity from Carthage test

### DIFF
--- a/Tests/installation_tests/carthage/CarthageTest.xcodeproj/project.pbxproj
+++ b/Tests/installation_tests/carthage/CarthageTest.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -26,8 +26,6 @@
 		3BD980302741675500B09BCD /* ModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BD9802F2741675500B09BCD /* ModelTests.swift */; };
 		3BD9808F27431DFE00B09BCD /* StripeCardScan.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3BD9808E27431DFE00B09BCD /* StripeCardScan.xcframework */; };
 		3C4D20AD273C673200BC6444 /* StripeFinancialConnections.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C4D20AC273C673200BC6444 /* StripeFinancialConnections.xcframework */; };
-		E63B8ECA27DDB760000A7243 /* StripeIdentityAssetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63B8EC927DDB760000A7243 /* StripeIdentityAssetTests.swift */; };
-		E6A36A5C26BA4E0E002A4427 /* StripeIdentity.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E6A36A5B26BA4E0E002A4427 /* StripeIdentity.xcframework */; };
 		E6AA24ED2744ABE000FD205E /* StripeCameraCore.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E63B6743274344E400CFEDBA /* StripeCameraCore.xcframework */; };
 		E6AA24EE2744ABE000FD205E /* StripeCameraCore.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E63B6743274344E400CFEDBA /* StripeCameraCore.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E6AFFAF526E972950067462F /* StripeUICore.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E6AFFAF426E972950067462F /* StripeUICore.xcframework */; };
@@ -83,7 +81,6 @@
 		3BD9808E27431DFE00B09BCD /* StripeCardScan.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = StripeCardScan.xcframework; path = Carthage/Build/StripeCardScan.xcframework; sourceTree = "<group>"; };
 		3C4D20AC273C673200BC6444 /* StripeFinancialConnections.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = StripeFinancialConnections.xcframework; path = Carthage/Build/StripeFinancialConnections.xcframework; sourceTree = "<group>"; };
 		E63B6743274344E400CFEDBA /* StripeCameraCore.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = StripeCameraCore.xcframework; path = Carthage/Build/StripeCameraCore.xcframework; sourceTree = "<group>"; };
-		E63B8EC927DDB760000A7243 /* StripeIdentityAssetTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StripeIdentityAssetTests.swift; path = ../../shared_unit_tests/StripeIdentity/StripeIdentityAssetTests.swift; sourceTree = "<group>"; };
 		E6A36A5B26BA4E0E002A4427 /* StripeIdentity.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = StripeIdentity.xcframework; path = Carthage/Build/StripeIdentity.xcframework; sourceTree = "<group>"; };
 		E6AFFAF426E972950067462F /* StripeUICore.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = StripeUICore.xcframework; path = Carthage/Build/StripeUICore.xcframework; sourceTree = "<group>"; };
 		E6F05EA92687C76F00614D61 /* StripeCore.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = StripeCore.xcframework; path = Carthage/Build/StripeCore.xcframework; sourceTree = "<group>"; };
@@ -103,7 +100,6 @@
 				31138E7228DBD87D008AF554 /* StripePaymentsUI.xcframework in Frameworks */,
 				3137B69427437E3500CE7F5C /* StripeApplePay.xcframework in Frameworks */,
 				E6AA24ED2744ABE000FD205E /* StripeCameraCore.xcframework in Frameworks */,
-				E6A36A5C26BA4E0E002A4427 /* StripeIdentity.xcframework in Frameworks */,
 				31CA744B25CCC669007FE8BF /* Stripe3DS2.xcframework in Frameworks */,
 				E6AFFAF526E972950067462F /* StripeUICore.xcframework in Frameworks */,
 			);
@@ -164,7 +160,6 @@
 			isa = PBXGroup;
 			children = (
 				3BD9802F2741675500B09BCD /* ModelTests.swift */,
-				E63B8EC927DDB760000A7243 /* StripeIdentityAssetTests.swift */,
 				3B3F01C127445CDE00C53D34 /* StripeUICoreAssetTests.swift */,
 				04E6FCFA1B714AC2000C8759 /* Supporting Files */,
 			);
@@ -312,7 +307,6 @@
 			files = (
 				3B3F01C227445CDE00C53D34 /* StripeUICoreAssetTests.swift in Sources */,
 				3BD980302741675500B09BCD /* ModelTests.swift in Sources */,
-				E63B8ECA27DDB760000A7243 /* StripeIdentityAssetTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tests/installation_tests/carthage/CarthageTest/ViewController.swift
+++ b/Tests/installation_tests/carthage/CarthageTest/ViewController.swift
@@ -10,7 +10,6 @@ import Stripe
 import StripeApplePay
 import StripeCardScan
 import StripeFinancialConnections
-import StripeIdentity
 import UIKit
 
 class ViewController: UIViewController {
@@ -19,10 +18,6 @@ class ViewController: UIViewController {
         super.viewDidLoad()
         StripeAPI.defaultPublishableKey = "test"
         StripeAPI.paymentRequest(withMerchantIdentifier: "test", country: "US", currency: "USD")
-
-        if #available(iOS 14.3, *) {
-            let _ = IdentityVerificationSheet(verificationSessionClientSecret: "test")
-        }
 
         if #available(iOS 12.0, *) {
             let _ = FinancialConnectionsSheet(


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Remove Identity from Carthage installation test as there's no Carthage integration of Identity and the introduction of and `CaptureCore` makes it not working for the current setup.


Note it's still possible to support `CaptureCore` in Carthage by adding a `binary` line pointing to a file referring the hosted `xcframework.zip`.
```
binary "https://somewhere/to/host/CaptureCore.json"
```

content of `CaptureCore.json` - 
```
{
	"1.2.3": "https://b.stripecdn.com/content/CaptureCore.xcframework.zip"
}

```


## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
