### PR TITLE
STPPaymentHandler sends start and finished analytics for confirm/handleNextAction

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -244,7 +244,7 @@ class PaymentSheetStandardUITests: PaymentSheetUITestCase {
         let sessionID = analyticsLog.first![string: "session_id"]
         XCTAssertTrue(!sessionID!.isEmpty)
         for analytic in analyticsLog {
-            if analytic[string: "event"] == "stripeios.payment_intent_confirmation" {
+            if analytic[string: "event"]!.starts(with: "stripeios.") {
                 continue
             }
             XCTAssertEqual(analytic[string: "session_id"], sessionID)
@@ -1459,8 +1459,8 @@ class PaymentSheetDeferredUITests: PaymentSheetUITestCase {
         XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
 
         XCTAssertEqual(
-            analyticsLog.suffix(6).map({ $0[string: "event"] }),
-            ["mc_form_interacted", "mc_card_number_completed", "mc_confirm_button_tapped", "stripeios.payment_method_creation", "stripeios.payment_intent_confirmation", "mc_complete_payment_newpm_success"]
+            analyticsLog.suffix(8).map({ $0[string: "event"] }),
+            ["mc_form_interacted", "mc_card_number_completed", "mc_confirm_button_tapped", "stripeios.payment_method_creation", "stripeios.paymenthandler.confirm.started", "stripeios.payment_intent_confirmation", "stripeios.paymenthandler.confirm.finished", "mc_complete_payment_newpm_success"]
         )
 
         // Make sure they all have the same session id

--- a/Stripe/StripeiOSTests/STPPaymentHandlerFunctionalTest.swift
+++ b/Stripe/StripeiOSTests/STPPaymentHandlerFunctionalTest.swift
@@ -6,6 +6,7 @@
 //
 
 @testable import Stripe
+@_spi(STP) @testable import StripeCore
 @_spi(STP) @testable import StripePayments
 @_spi(STP) @testable import StripePaymentsTestUtils
 import XCTest
@@ -189,5 +190,155 @@ final class STPPaymentHandlerFunctionalSwiftTest: XCTestCase, STPAuthenticationC
             }
         }
         self.waitForExpectations(timeout: 10)
+    }
+
+    func test_confirm_payment_intent_sends_analytic() {
+        // Confirming a hardcoded already-confirmed PI with invalid params...
+        let paymentIntentParams = STPPaymentIntentParams(clientSecret: "pi_3P20wFFY0qyl6XeW0dSOQ6W7_secret_9V8GkrCOt1MEW8SBmAaGnmT6A", paymentMethodType: .card)
+        let paymentHandlerExpectation = expectation(description: "paymentHandlerExpectation")
+        STPPaymentHandler.sharedHandler.apiClient = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
+        let analyticsClient = STPAnalyticsClient()
+        STPPaymentHandler.sharedHandler.analyticsClient = analyticsClient
+        STPPaymentHandler.shared().confirmPayment(paymentIntentParams, with: self) { (_, _, _) in
+            // ...should send these analytics
+            paymentHandlerExpectation.fulfill()
+            let firstAnalytic = analyticsClient._testLogHistory.first
+            XCTAssertEqual(firstAnalytic?["event"] as? String, STPAnalyticEvent.paymentHandlerConfirmStarted.rawValue)
+            XCTAssertEqual(firstAnalytic?["intent_id"] as? String, "pi_3P20wFFY0qyl6XeW0dSOQ6W7")
+            XCTAssertEqual(firstAnalytic?["payment_method_type"] as? String, "card")
+            let lastAnalytic = analyticsClient._testLogHistory.last
+            XCTAssertEqual(lastAnalytic?["event"] as? String, STPAnalyticEvent.paymentHandlerConfirmFinished.rawValue)
+            XCTAssertEqual(lastAnalytic?["intent_id"] as? String, "pi_3P20wFFY0qyl6XeW0dSOQ6W7")
+            XCTAssertEqual(lastAnalytic?["status"] as? String, "failed")
+            XCTAssertEqual(lastAnalytic?["payment_method_type"] as? String, "card")
+            XCTAssertEqual(lastAnalytic?["error_type"] as? String, "invalid_request_error")
+            XCTAssertEqual(lastAnalytic?["error_code"] as? String, "payment_intent_unexpected_state")
+        }
+        waitForExpectations(timeout: 10)
+    }
+
+    func test_confirm_setup_intent_sends_analytic() {
+        let setupIntentParams = STPSetupIntentConfirmParams(clientSecret: "seti_1P1xLBFY0qyl6XeWc7c2LrMK_secret_PrgithiYFFPH0NVGP1BK7Oy9OU3mrDT", paymentMethodType: .card)
+        // Confirming a hardcoded already-confirmed SI with invalid params...
+        setupIntentParams.paymentMethodParams = STPPaymentMethodParams(type: .card)
+
+        let paymentHandlerExpectation = expectation(description: "paymentHandlerExpectation")
+        STPPaymentHandler.sharedHandler.apiClient = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
+        let analyticsClient = STPAnalyticsClient()
+        STPPaymentHandler.sharedHandler.analyticsClient = analyticsClient
+        STPPaymentHandler.shared().confirmSetupIntent(setupIntentParams, with: self) { (_, _, _) in
+            // ...should send these analytics
+            paymentHandlerExpectation.fulfill()
+            let firstAnalytic = analyticsClient._testLogHistory.first
+            XCTAssertEqual(firstAnalytic?["event"] as? String, STPAnalyticEvent.paymentHandlerConfirmStarted.rawValue)
+            XCTAssertEqual(firstAnalytic?["intent_id"] as? String, "seti_1P1xLBFY0qyl6XeWc7c2LrMK")
+            XCTAssertEqual(firstAnalytic?["payment_method_type"] as? String, "card")
+            let lastAnalytic = analyticsClient._testLogHistory.last
+            XCTAssertEqual(lastAnalytic?["event"] as? String, STPAnalyticEvent.paymentHandlerConfirmFinished.rawValue)
+            XCTAssertEqual(lastAnalytic?["intent_id"] as? String, "seti_1P1xLBFY0qyl6XeWc7c2LrMK")
+            XCTAssertEqual(lastAnalytic?["status"] as? String, "failed")
+            XCTAssertEqual(lastAnalytic?["payment_method_type"] as? String, "card")
+            XCTAssertEqual(lastAnalytic?["error_type"] as? String, "invalid_request_error")
+            XCTAssertEqual(lastAnalytic?["error_code"] as? String, "parameter_missing")
+        }
+        waitForExpectations(timeout: 10)
+    }
+
+    func test_handle_next_action_payment_intent_sends_analytic() {
+        // Calling handleNextAction(forPayment:) with an invalid PI client secret...
+        let paymentHandlerExpectation = expectation(description: "paymentHandlerExpectation")
+        STPPaymentHandler.sharedHandler.apiClient = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
+        let analyticsClient = STPAnalyticsClient()
+        STPPaymentHandler.sharedHandler.analyticsClient = analyticsClient
+        STPPaymentHandler.shared().handleNextAction(forPayment: "pi_3P232pFY0qyl6XeW0FFRtE0A_secret_foo", with: self, returnURL: nil) { (_, _, _) in
+            // ...should send these analytics
+            paymentHandlerExpectation.fulfill()
+            let firstAnalytic = analyticsClient._testLogHistory.first
+            XCTAssertEqual(firstAnalytic?["event"] as? String, STPAnalyticEvent.paymentHandlerHandleNextActionStarted.rawValue)
+            XCTAssertEqual(firstAnalytic?["intent_id"] as? String, "pi_3P232pFY0qyl6XeW0FFRtE0A")
+            let lastAnalytic = analyticsClient._testLogHistory.last
+            XCTAssertEqual(lastAnalytic?["event"] as? String, STPAnalyticEvent.paymentHandlerHandleNextActionFinished.rawValue)
+            XCTAssertEqual(lastAnalytic?["intent_id"] as? String, "pi_3P232pFY0qyl6XeW0FFRtE0A")
+            XCTAssertEqual(lastAnalytic?["status"] as? String, "failed")
+            XCTAssertEqual(lastAnalytic?["error_type"] as? String, "invalid_request_error")
+            XCTAssertEqual(lastAnalytic?["error_code"] as? String, "payment_intent_invalid_parameter")
+        }
+        waitForExpectations(timeout: 10)
+    }
+
+    func test_handle_next_action_2_payment_intent_sends_analytic() {
+        // Calling handleNextAction(for:) with a STPPaymentIntent w/ an unknown next action...
+        let paymentHandlerExpectation = expectation(description: "paymentHandlerExpectation")
+        var piJSON = STPTestUtils.jsonNamed("PaymentIntent")
+        piJSON![jsonDict: "next_action"]!["type"] = "foo"
+        let paymentIntent = STPPaymentIntent.decodedObject(fromAPIResponse: piJSON)!
+
+        STPPaymentHandler.sharedHandler.apiClient = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
+        let analyticsClient = STPAnalyticsClient()
+        STPPaymentHandler.sharedHandler.analyticsClient = analyticsClient
+        STPPaymentHandler.shared().handleNextAction(for: paymentIntent, with: self, returnURL: nil) { (_, _, _) in
+            // ...should send these analytics
+            paymentHandlerExpectation.fulfill()
+            let firstAnalytic = analyticsClient._testLogHistory.first
+            XCTAssertEqual(firstAnalytic?["event"] as? String, STPAnalyticEvent.paymentHandlerHandleNextActionStarted.rawValue)
+            XCTAssertEqual(firstAnalytic?["intent_id"] as? String, "pi_1Cl15wIl4IdHmuTbCWrpJXN6")
+            let lastAnalytic = analyticsClient._testLogHistory.last
+            XCTAssertEqual(lastAnalytic?["event"] as? String, STPAnalyticEvent.paymentHandlerHandleNextActionFinished.rawValue)
+            XCTAssertEqual(lastAnalytic?["intent_id"] as? String, "pi_1Cl15wIl4IdHmuTbCWrpJXN6")
+            XCTAssertEqual(lastAnalytic?["status"] as? String, "failed")
+            XCTAssertEqual(lastAnalytic?["error_type"] as? String, "STPPaymentHandlerErrorDomain")
+            XCTAssertEqual(lastAnalytic?["error_code"] as? String, "0")
+        }
+        waitForExpectations(timeout: 10)
+    }
+
+    func test_handle_next_action_setup_intent_sends_analytic() {
+        // Calling handleNextAction(forSetupIntent:) with an invalid SI client secret...
+        let paymentHandlerExpectation = expectation(description: "paymentHandlerExpectation")
+        STPPaymentHandler.sharedHandler.apiClient = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
+        let analyticsClient = STPAnalyticsClient()
+        STPPaymentHandler.sharedHandler.analyticsClient = analyticsClient
+        STPPaymentHandler.shared().handleNextAction(forSetupIntent: "seti_3P232pFY0qyl6XeW0FFRtE0A_secret_foo", with: self, returnURL: nil) { (_, _, _) in
+            // ...should send these analytics
+            paymentHandlerExpectation.fulfill()
+            let firstAnalytic = analyticsClient._testLogHistory.first
+            XCTAssertEqual(firstAnalytic?["event"] as? String, STPAnalyticEvent.paymentHandlerHandleNextActionStarted.rawValue)
+            XCTAssertEqual(firstAnalytic?["intent_id"] as? String, "seti_3P232pFY0qyl6XeW0FFRtE0A")
+            let lastAnalytic = analyticsClient._testLogHistory.last
+            XCTAssertEqual(lastAnalytic?["event"] as? String, STPAnalyticEvent.paymentHandlerHandleNextActionFinished.rawValue)
+            XCTAssertEqual(lastAnalytic?["intent_id"] as? String, "seti_3P232pFY0qyl6XeW0FFRtE0A")
+            XCTAssertEqual(lastAnalytic?["status"] as? String, "failed")
+            XCTAssertEqual(lastAnalytic?["error_type"] as? String, "invalid_request_error")
+            XCTAssertEqual(lastAnalytic?["error_code"] as? String, "resource_missing")
+        }
+        waitForExpectations(timeout: 10)
+    }
+
+    func test_handle_next_action_2_setup_intent_sends_analytic() {
+        // Calling handleNextAction(for:) with a STPSetupIntent w/ an unknown next action...
+        let paymentHandlerExpectation = expectation(description: "paymentHandlerExpectation")
+        var siJSON = STPTestUtils.jsonNamed("SetupIntent")!
+        siJSON[jsonDict: "next_action"]!["type"] = "foo"
+        siJSON[jsonDict: "next_action"]!["type"] = "foo"
+        siJSON["payment_method"] = STPTestUtils.jsonNamed("CardPaymentMethod")!
+        let setupIntent = STPSetupIntent.decodedObject(fromAPIResponse: siJSON)!
+
+        STPPaymentHandler.sharedHandler.apiClient = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
+        let analyticsClient = STPAnalyticsClient()
+        STPPaymentHandler.sharedHandler.analyticsClient = analyticsClient
+        STPPaymentHandler.shared().handleNextAction(for: setupIntent, with: self, returnURL: nil) { (_, _, _) in
+            // ...should send these analytics
+            paymentHandlerExpectation.fulfill()
+            let firstAnalytic = analyticsClient._testLogHistory.first
+            XCTAssertEqual(firstAnalytic?["event"] as? String, STPAnalyticEvent.paymentHandlerHandleNextActionStarted.rawValue)
+            XCTAssertEqual(firstAnalytic?["intent_id"] as? String, "seti_123456789")
+            let lastAnalytic = analyticsClient._testLogHistory.last
+            XCTAssertEqual(lastAnalytic?["event"] as? String, STPAnalyticEvent.paymentHandlerHandleNextActionFinished.rawValue)
+            XCTAssertEqual(lastAnalytic?["intent_id"] as? String, "seti_123456789")
+            XCTAssertEqual(lastAnalytic?["status"] as? String, "failed")
+            XCTAssertEqual(lastAnalytic?["error_type"] as? String, "STPPaymentHandlerErrorDomain")
+            XCTAssertEqual(lastAnalytic?["error_code"] as? String, "0")
+        }
+        waitForExpectations(timeout: 10)
     }
 }

--- a/Stripe/StripeiOSTests/STPPaymentHandlerFunctionalTest.swift
+++ b/Stripe/StripeiOSTests/STPPaymentHandlerFunctionalTest.swift
@@ -192,14 +192,16 @@ final class STPPaymentHandlerFunctionalSwiftTest: XCTestCase, STPAuthenticationC
         self.waitForExpectations(timeout: 10)
     }
 
+    // MARK: - Test payment handler sends analytics
+
     func test_confirm_payment_intent_sends_analytic() {
         // Confirming a hardcoded already-confirmed PI with invalid params...
         let paymentIntentParams = STPPaymentIntentParams(clientSecret: "pi_3P20wFFY0qyl6XeW0dSOQ6W7_secret_9V8GkrCOt1MEW8SBmAaGnmT6A", paymentMethodType: .card)
         let paymentHandlerExpectation = expectation(description: "paymentHandlerExpectation")
-        STPPaymentHandler.sharedHandler.apiClient = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
+        let paymentHandler = STPPaymentHandler(apiClient: STPAPIClient(publishableKey: STPTestingDefaultPublishableKey))
         let analyticsClient = STPAnalyticsClient()
-        STPPaymentHandler.sharedHandler.analyticsClient = analyticsClient
-        STPPaymentHandler.shared().confirmPayment(paymentIntentParams, with: self) { (_, _, _) in
+        paymentHandler.analyticsClient = analyticsClient
+        paymentHandler.confirmPayment(paymentIntentParams, with: self) { (_, _, _) in
             // ...should send these analytics
             paymentHandlerExpectation.fulfill()
             let firstAnalytic = analyticsClient._testLogHistory.first
@@ -223,10 +225,10 @@ final class STPPaymentHandlerFunctionalSwiftTest: XCTestCase, STPAuthenticationC
         setupIntentParams.paymentMethodParams = STPPaymentMethodParams(type: .card)
 
         let paymentHandlerExpectation = expectation(description: "paymentHandlerExpectation")
-        STPPaymentHandler.sharedHandler.apiClient = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
+        let paymentHandler = STPPaymentHandler(apiClient: STPAPIClient(publishableKey: STPTestingDefaultPublishableKey))
         let analyticsClient = STPAnalyticsClient()
-        STPPaymentHandler.sharedHandler.analyticsClient = analyticsClient
-        STPPaymentHandler.shared().confirmSetupIntent(setupIntentParams, with: self) { (_, _, _) in
+        paymentHandler.analyticsClient = analyticsClient
+        paymentHandler.confirmSetupIntent(setupIntentParams, with: self) { (_, _, _) in
             // ...should send these analytics
             paymentHandlerExpectation.fulfill()
             let firstAnalytic = analyticsClient._testLogHistory.first
@@ -247,10 +249,10 @@ final class STPPaymentHandlerFunctionalSwiftTest: XCTestCase, STPAuthenticationC
     func test_handle_next_action_payment_intent_sends_analytic() {
         // Calling handleNextAction(forPayment:) with an invalid PI client secret...
         let paymentHandlerExpectation = expectation(description: "paymentHandlerExpectation")
-        STPPaymentHandler.sharedHandler.apiClient = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
+        let paymentHandler = STPPaymentHandler(apiClient: STPAPIClient(publishableKey: STPTestingDefaultPublishableKey))
         let analyticsClient = STPAnalyticsClient()
-        STPPaymentHandler.sharedHandler.analyticsClient = analyticsClient
-        STPPaymentHandler.shared().handleNextAction(forPayment: "pi_3P232pFY0qyl6XeW0FFRtE0A_secret_foo", with: self, returnURL: nil) { (_, _, _) in
+        paymentHandler.analyticsClient = analyticsClient
+        paymentHandler.handleNextAction(forPayment: "pi_3P232pFY0qyl6XeW0FFRtE0A_secret_foo", with: self, returnURL: nil) { (_, _, _) in
             // ...should send these analytics
             paymentHandlerExpectation.fulfill()
             let firstAnalytic = analyticsClient._testLogHistory.first
@@ -273,10 +275,10 @@ final class STPPaymentHandlerFunctionalSwiftTest: XCTestCase, STPAuthenticationC
         piJSON![jsonDict: "next_action"]!["type"] = "foo"
         let paymentIntent = STPPaymentIntent.decodedObject(fromAPIResponse: piJSON)!
 
-        STPPaymentHandler.sharedHandler.apiClient = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
+        let paymentHandler = STPPaymentHandler(apiClient: STPAPIClient(publishableKey: STPTestingDefaultPublishableKey))
         let analyticsClient = STPAnalyticsClient()
-        STPPaymentHandler.sharedHandler.analyticsClient = analyticsClient
-        STPPaymentHandler.shared().handleNextAction(for: paymentIntent, with: self, returnURL: nil) { (_, _, _) in
+        paymentHandler.analyticsClient = analyticsClient
+        paymentHandler.handleNextAction(for: paymentIntent, with: self, returnURL: nil) { (_, _, _) in
             // ...should send these analytics
             paymentHandlerExpectation.fulfill()
             let firstAnalytic = analyticsClient._testLogHistory.first
@@ -295,10 +297,10 @@ final class STPPaymentHandlerFunctionalSwiftTest: XCTestCase, STPAuthenticationC
     func test_handle_next_action_setup_intent_sends_analytic() {
         // Calling handleNextAction(forSetupIntent:) with an invalid SI client secret...
         let paymentHandlerExpectation = expectation(description: "paymentHandlerExpectation")
-        STPPaymentHandler.sharedHandler.apiClient = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
+        let paymentHandler = STPPaymentHandler(apiClient: STPAPIClient(publishableKey: STPTestingDefaultPublishableKey))
         let analyticsClient = STPAnalyticsClient()
-        STPPaymentHandler.sharedHandler.analyticsClient = analyticsClient
-        STPPaymentHandler.shared().handleNextAction(forSetupIntent: "seti_3P232pFY0qyl6XeW0FFRtE0A_secret_foo", with: self, returnURL: nil) { (_, _, _) in
+        paymentHandler.analyticsClient = analyticsClient
+        paymentHandler.handleNextAction(forSetupIntent: "seti_3P232pFY0qyl6XeW0FFRtE0A_secret_foo", with: self, returnURL: nil) { (_, _, _) in
             // ...should send these analytics
             paymentHandlerExpectation.fulfill()
             let firstAnalytic = analyticsClient._testLogHistory.first
@@ -323,10 +325,10 @@ final class STPPaymentHandlerFunctionalSwiftTest: XCTestCase, STPAuthenticationC
         siJSON["payment_method"] = STPTestUtils.jsonNamed("CardPaymentMethod")!
         let setupIntent = STPSetupIntent.decodedObject(fromAPIResponse: siJSON)!
 
-        STPPaymentHandler.sharedHandler.apiClient = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
+        let paymentHandler = STPPaymentHandler(apiClient: STPAPIClient(publishableKey: STPTestingDefaultPublishableKey))
         let analyticsClient = STPAnalyticsClient()
-        STPPaymentHandler.sharedHandler.analyticsClient = analyticsClient
-        STPPaymentHandler.shared().handleNextAction(for: setupIntent, with: self, returnURL: nil) { (_, _, _) in
+        paymentHandler.analyticsClient = analyticsClient
+        paymentHandler.handleNextAction(for: setupIntent, with: self, returnURL: nil) { (_, _, _) in
             // ...should send these analytics
             paymentHandlerExpectation.fulfill()
             let firstAnalytic = analyticsClient._testLogHistory.first

--- a/Stripe/StripeiOSTests/STPPaymentHandlerFunctionalTest.swift
+++ b/Stripe/StripeiOSTests/STPPaymentHandlerFunctionalTest.swift
@@ -203,7 +203,6 @@ final class STPPaymentHandlerFunctionalSwiftTest: XCTestCase, STPAuthenticationC
         paymentHandler.analyticsClient = analyticsClient
         paymentHandler.confirmPayment(paymentIntentParams, with: self) { (_, _, _) in
             // ...should send these analytics
-            paymentHandlerExpectation.fulfill()
             let firstAnalytic = analyticsClient._testLogHistory.first
             XCTAssertEqual(firstAnalytic?["event"] as? String, STPAnalyticEvent.paymentHandlerConfirmStarted.rawValue)
             XCTAssertEqual(firstAnalytic?["intent_id"] as? String, "pi_3P20wFFY0qyl6XeW0dSOQ6W7")
@@ -215,6 +214,7 @@ final class STPPaymentHandlerFunctionalSwiftTest: XCTestCase, STPAuthenticationC
             XCTAssertEqual(lastAnalytic?["payment_method_type"] as? String, "card")
             XCTAssertEqual(lastAnalytic?["error_type"] as? String, "invalid_request_error")
             XCTAssertEqual(lastAnalytic?["error_code"] as? String, "payment_intent_unexpected_state")
+            paymentHandlerExpectation.fulfill()
         }
         waitForExpectations(timeout: 10)
     }
@@ -230,7 +230,6 @@ final class STPPaymentHandlerFunctionalSwiftTest: XCTestCase, STPAuthenticationC
         paymentHandler.analyticsClient = analyticsClient
         paymentHandler.confirmSetupIntent(setupIntentParams, with: self) { (_, _, _) in
             // ...should send these analytics
-            paymentHandlerExpectation.fulfill()
             let firstAnalytic = analyticsClient._testLogHistory.first
             XCTAssertEqual(firstAnalytic?["event"] as? String, STPAnalyticEvent.paymentHandlerConfirmStarted.rawValue)
             XCTAssertEqual(firstAnalytic?["intent_id"] as? String, "seti_1P1xLBFY0qyl6XeWc7c2LrMK")
@@ -242,6 +241,7 @@ final class STPPaymentHandlerFunctionalSwiftTest: XCTestCase, STPAuthenticationC
             XCTAssertEqual(lastAnalytic?["payment_method_type"] as? String, "card")
             XCTAssertEqual(lastAnalytic?["error_type"] as? String, "invalid_request_error")
             XCTAssertEqual(lastAnalytic?["error_code"] as? String, "parameter_missing")
+            paymentHandlerExpectation.fulfill()
         }
         waitForExpectations(timeout: 10)
     }
@@ -254,7 +254,6 @@ final class STPPaymentHandlerFunctionalSwiftTest: XCTestCase, STPAuthenticationC
         paymentHandler.analyticsClient = analyticsClient
         paymentHandler.handleNextAction(forPayment: "pi_3P232pFY0qyl6XeW0FFRtE0A_secret_foo", with: self, returnURL: nil) { (_, _, _) in
             // ...should send these analytics
-            paymentHandlerExpectation.fulfill()
             let firstAnalytic = analyticsClient._testLogHistory.first
             XCTAssertEqual(firstAnalytic?["event"] as? String, STPAnalyticEvent.paymentHandlerHandleNextActionStarted.rawValue)
             XCTAssertEqual(firstAnalytic?["intent_id"] as? String, "pi_3P232pFY0qyl6XeW0FFRtE0A")
@@ -264,6 +263,7 @@ final class STPPaymentHandlerFunctionalSwiftTest: XCTestCase, STPAuthenticationC
             XCTAssertEqual(lastAnalytic?["status"] as? String, "failed")
             XCTAssertEqual(lastAnalytic?["error_type"] as? String, "invalid_request_error")
             XCTAssertEqual(lastAnalytic?["error_code"] as? String, "payment_intent_invalid_parameter")
+            paymentHandlerExpectation.fulfill()
         }
         waitForExpectations(timeout: 10)
     }
@@ -280,7 +280,6 @@ final class STPPaymentHandlerFunctionalSwiftTest: XCTestCase, STPAuthenticationC
         paymentHandler.analyticsClient = analyticsClient
         paymentHandler.handleNextAction(for: paymentIntent, with: self, returnURL: nil) { (_, _, _) in
             // ...should send these analytics
-            paymentHandlerExpectation.fulfill()
             let firstAnalytic = analyticsClient._testLogHistory.first
             XCTAssertEqual(firstAnalytic?["event"] as? String, STPAnalyticEvent.paymentHandlerHandleNextActionStarted.rawValue)
             XCTAssertEqual(firstAnalytic?["intent_id"] as? String, "pi_1Cl15wIl4IdHmuTbCWrpJXN6")
@@ -290,6 +289,7 @@ final class STPPaymentHandlerFunctionalSwiftTest: XCTestCase, STPAuthenticationC
             XCTAssertEqual(lastAnalytic?["status"] as? String, "failed")
             XCTAssertEqual(lastAnalytic?["error_type"] as? String, "STPPaymentHandlerErrorDomain")
             XCTAssertEqual(lastAnalytic?["error_code"] as? String, "0")
+            paymentHandlerExpectation.fulfill()
         }
         waitForExpectations(timeout: 10)
     }
@@ -302,7 +302,6 @@ final class STPPaymentHandlerFunctionalSwiftTest: XCTestCase, STPAuthenticationC
         paymentHandler.analyticsClient = analyticsClient
         paymentHandler.handleNextAction(forSetupIntent: "seti_3P232pFY0qyl6XeW0FFRtE0A_secret_foo", with: self, returnURL: nil) { (_, _, _) in
             // ...should send these analytics
-            paymentHandlerExpectation.fulfill()
             let firstAnalytic = analyticsClient._testLogHistory.first
             XCTAssertEqual(firstAnalytic?["event"] as? String, STPAnalyticEvent.paymentHandlerHandleNextActionStarted.rawValue)
             XCTAssertEqual(firstAnalytic?["intent_id"] as? String, "seti_3P232pFY0qyl6XeW0FFRtE0A")
@@ -312,6 +311,7 @@ final class STPPaymentHandlerFunctionalSwiftTest: XCTestCase, STPAuthenticationC
             XCTAssertEqual(lastAnalytic?["status"] as? String, "failed")
             XCTAssertEqual(lastAnalytic?["error_type"] as? String, "invalid_request_error")
             XCTAssertEqual(lastAnalytic?["error_code"] as? String, "resource_missing")
+            paymentHandlerExpectation.fulfill()
         }
         waitForExpectations(timeout: 10)
     }
@@ -330,7 +330,6 @@ final class STPPaymentHandlerFunctionalSwiftTest: XCTestCase, STPAuthenticationC
         paymentHandler.analyticsClient = analyticsClient
         paymentHandler.handleNextAction(for: setupIntent, with: self, returnURL: nil) { (_, _, _) in
             // ...should send these analytics
-            paymentHandlerExpectation.fulfill()
             let firstAnalytic = analyticsClient._testLogHistory.first
             XCTAssertEqual(firstAnalytic?["event"] as? String, STPAnalyticEvent.paymentHandlerHandleNextActionStarted.rawValue)
             XCTAssertEqual(firstAnalytic?["intent_id"] as? String, "seti_123456789")
@@ -340,6 +339,7 @@ final class STPPaymentHandlerFunctionalSwiftTest: XCTestCase, STPAuthenticationC
             XCTAssertEqual(lastAnalytic?["status"] as? String, "failed")
             XCTAssertEqual(lastAnalytic?["error_type"] as? String, "STPPaymentHandlerErrorDomain")
             XCTAssertEqual(lastAnalytic?["error_code"] as? String, "0")
+            paymentHandlerExpectation.fulfill()
         }
         waitForExpectations(timeout: 10)
     }

--- a/Stripe/StripeiOSTests/STPPaymentHandlerTests.swift
+++ b/Stripe/StripeiOSTests/STPPaymentHandlerTests.swift
@@ -76,8 +76,21 @@ class STPPaymentHandlerStubbedTests: STPNetworkStubbingTestCase {
 
         let paymentHandlerExpectation = expectation(description: "paymentHandlerExpectation")
         STPPaymentHandler.shared().checkCanPresentInTest = true
+        let analyticsClient = STPAnalyticsClient()
+        STPPaymentHandler.sharedHandler.analyticsClient = analyticsClient
         STPPaymentHandler.shared().confirmPayment(paymentIntentParams, with: self) {
             (status, paymentIntent, error) in
+            let firstAnalytic = analyticsClient._testLogHistory.first
+            XCTAssertEqual(firstAnalytic?["event"] as? String, STPAnalyticEvent.paymentHandlerConfirmStarted.rawValue)
+            XCTAssertEqual(firstAnalytic?["intent_id"] as? String, paymentIntentParams.stripeId)
+            XCTAssertEqual(firstAnalytic?["payment_method_type"] as? String, "card")
+            let lastAnalytic = analyticsClient._testLogHistory.last
+            XCTAssertEqual(lastAnalytic?["event"] as? String, STPAnalyticEvent.paymentHandlerConfirmFinished.rawValue)
+            XCTAssertEqual(lastAnalytic?["intent_id"] as? String, paymentIntentParams.stripeId)
+            XCTAssertEqual(lastAnalytic?["status"] as? String, "failed")
+            XCTAssertEqual(lastAnalytic?["payment_method_type"] as? String, "card")
+            XCTAssertEqual(lastAnalytic?["error_type"] as? String, "STPPaymentHandlerErrorDomain")
+            XCTAssertEqual(lastAnalytic?["error_code"] as? String, "8")
             XCTAssertTrue(status == .failed)
             XCTAssertNotNil(paymentIntent)
             XCTAssertNotNil(error)

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
@@ -34,6 +34,10 @@ import Foundation
     case _3DS2ChallengeFlowCompleted = "stripeios.3ds2_challenge_flow_completed"
     case _3DS2ChallengeFlowErrored = "stripeios.3ds2_challenge_flow_errored"
     case _3DS2RedirectUserCanceled = "stripeios.3ds2_redirect_canceled"
+    case paymentHandlerConfirmStarted = "stripeios.paymenthandler.confirm.started"
+    case paymentHandlerConfirmFinished = "stripeios.paymenthandler.confirm.finished"
+    case paymentHandlerHandleNextActionStarted = "stripeios.paymenthandler.handle_next_action.started"
+    case paymentHandlerHandleNextActionFinished = "stripeios.paymenthandler.handle_next_action.finished"
 
     // MARK: - Card Metadata
     case cardMetadataLoadedTooSlow = "stripeios.card_metadata_loaded_too_slow"

--- a/StripeCore/StripeCore/Source/Categories/Dictionary+Stripe.swift
+++ b/StripeCore/StripeCore/Source/Categories/Dictionary+Stripe.swift
@@ -45,15 +45,19 @@ extension Dictionary {
         return newDict
     }
 
-    @inlinable public mutating func mergeAssertingOnOverwrites(_ other: [Key: Value]) {
+    public mutating func mergeAssertingOnOverwrites(_ other: [Key: Value]) {
         merge(other) { a, b in
-#if DEBUG
-assertionFailure("Dictionary merge is overwriting a key with values: \(a) and \(b)!")
-#endif
+            stpAssertionFailure("Dictionary merge is overwriting a key with values: \(a) and \(b)!")
             return a
         }
     }
 
+    public func mergingAssertingOnOverwrites<S>(_ other: S) -> [Key: Value] where S: Sequence, S.Element == (Key, Value) {
+        merging(other) { a, b in
+            stpAssertionFailure("Dictionary merge is overwriting a key with values: \(a) and \(b)!")
+            return a
+        }
+    }
 }
 
 extension Dictionary where Value == Any {

--- a/StripePayments/StripePayments.xcodeproj/project.pbxproj
+++ b/StripePayments/StripePayments.xcodeproj/project.pbxproj
@@ -162,6 +162,7 @@
 		B24F9DB6EC9AFE830AAA8433 /* STPSourceParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 671A215709E2F67C3BB77DC0 /* STPSourceParams.swift */; };
 		B472CF82B4F1CE69F308DC68 /* Analytic+Payments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C0D28FA0893E3DF7D3F0A44 /* Analytic+Payments.swift */; };
 		B59B706A4935CAAC42113526 /* STPPaymentIntentLastPaymentError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5212EA8107E8CEC838262D99 /* STPPaymentIntentLastPaymentError.swift */; };
+		B62DF5202BBE4C3B009ED445 /* STPAnalyticsClient+STPPaymentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B62DF51F2BBE4C3B009ED445 /* STPAnalyticsClient+STPPaymentHandler.swift */; };
 		B6E825D62FBA049BF4FAF5E3 /* STPConnectAccountAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3628526271ABA16C3994EE /* STPConnectAccountAddress.swift */; };
 		B756C47DB92853FE963FEA2D /* STPAPIClient+ApplePay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1022A3EF6E7E45DCC798CE69 /* STPAPIClient+ApplePay.swift */; };
 		B7C7040F66A5BBA92AA3E311 /* STPCardValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC3901183AED6DD81C61BA10 /* STPCardValidator.swift */; };
@@ -510,6 +511,7 @@
 		B458CF0D5A7EE56A02D750F2 /* STPThreeDSCustomizationSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPThreeDSCustomizationSettings.swift; sourceTree = "<group>"; };
 		B49A0767F78E4D4371484EC1 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		B4DE2906FF317F92A547EAE5 /* SWHttpTrafficRecorder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SWHttpTrafficRecorder.m; sourceTree = "<group>"; };
+		B62DF51F2BBE4C3B009ED445 /* STPAnalyticsClient+STPPaymentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "STPAnalyticsClient+STPPaymentHandler.swift"; sourceTree = "<group>"; };
 		B649A131C87FCE592A5C8485 /* hr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hr; path = hr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		B6D767E04616B7035A8769C1 /* STPConnectAccountIndividualParams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPConnectAccountIndividualParams.swift; sourceTree = "<group>"; };
 		B71B50D1ABEA53CE45BAFA74 /* STPPaymentIntentShippingDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPPaymentIntentShippingDetails.swift; sourceTree = "<group>"; };
@@ -883,6 +885,7 @@
 			children = (
 				E8D7E95C2E3AFDC73944ACE1 /* STPAuthenticationContext.swift */,
 				4793029D06EBFBCB62CF48DC /* STPPaymentHandler.swift */,
+				B62DF51F2BBE4C3B009ED445 /* STPAnalyticsClient+STPPaymentHandler.swift */,
 				A34532BE5AE969B943477E83 /* STPThreeDSButtonCustomization.swift */,
 				B458CF0D5A7EE56A02D750F2 /* STPThreeDSCustomizationSettings.swift */,
 				BFA320893378702C28DC8FD0 /* STPThreeDSFooterCustomization.swift */,
@@ -1497,6 +1500,7 @@
 				DEFE4E522D5E082084A33A14 /* STPConnectAccountIndividualParams.swift in Sources */,
 				617C1C842BB4962500B10AC5 /* STPPaymentMethodAlmaParams.swift in Sources */,
 				DB9AEA286985F3C64B0F4035 /* STPConnectAccountParams.swift in Sources */,
+				B62DF5202BBE4C3B009ED445 /* STPAnalyticsClient+STPPaymentHandler.swift in Sources */,
 				13DA3803BEF593A2126A0A99 /* STPContactField.swift in Sources */,
 				15867BBB56A73E740FE5CC4E /* STPCustomer.swift in Sources */,
 				EA3D613104589DA964C35073 /* STPFPXBankBrand.swift in Sources */,

--- a/StripePayments/StripePayments/Source/PaymentHandler/STPAnalyticsClient+STPPaymentHandler.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPAnalyticsClient+STPPaymentHandler.swift
@@ -51,12 +51,12 @@ extension STPPaymentHandler {
 
     // MARK: - Confirm completed
 
-    func logConfirmPaymentIntentCompleted(paymentIntentID: String?, paymentIntent: STPPaymentIntent?, status: STPPaymentHandlerActionStatus, paymentMethodType: STPPaymentMethodType?, error: Error?) {
+    func logConfirmPaymentIntentCompleted(paymentIntentID: String?, status: STPPaymentHandlerActionStatus, paymentMethodType: STPPaymentMethodType?, error: Error?) {
         let analytic = Analytic(event: .paymentHandlerConfirmFinished, intentID: paymentIntentID, status: status, paymentMethodType: paymentMethodType?.identifier, error: error)
         analyticsClient.log(analytic: analytic, apiClient: apiClient)
     }
 
-    func logConfirmSetupIntentCompleted(setupIntentID: String?, setupIntent: STPSetupIntent?, status: STPPaymentHandlerActionStatus, paymentMethodType: STPPaymentMethodType?, error: Error?) {
+    func logConfirmSetupIntentCompleted(setupIntentID: String?, status: STPPaymentHandlerActionStatus, paymentMethodType: STPPaymentMethodType?, error: Error?) {
         let analytic = Analytic(event: .paymentHandlerConfirmFinished, intentID: setupIntentID, status: status, paymentMethodType: paymentMethodType?.identifier, error: error)
         analyticsClient.log(analytic: analytic, apiClient: apiClient)
     }

--- a/StripePayments/StripePayments/Source/PaymentHandler/STPAnalyticsClient+STPPaymentHandler.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPAnalyticsClient+STPPaymentHandler.swift
@@ -1,0 +1,75 @@
+//
+//  STPAnalyticsClient+STPPaymentHandler.swift
+//  StripePayments
+//
+//  Created by Yuki Tokuhiro on 4/3/24.
+//
+
+@_spi(STP) import StripeCore
+
+extension STPPaymentHandlerActionStatus {
+    var stringValue: String {
+        switch self {
+        case .canceled:
+            return "canceled"
+        case .failed:
+            return "failed"
+        case .succeeded:
+            return "succeeded"
+        }
+    }
+}
+
+extension STPPaymentHandler {
+    struct Analytic: StripeCore.Analytic {
+        let event: StripeCore.STPAnalyticEvent
+        let intentID: String?
+        let status: STPPaymentHandlerActionStatus?
+        let paymentMethodType: String?
+        let error: Error?
+
+        var params: [String: Any] {
+            var params: [String: Any] = error?.serializeForV1Analytics() ?? [:]
+            params["intent_id"] = intentID
+            params["status"] = status?.stringValue
+            params["payment_method_type"] = paymentMethodType
+            return params
+        }
+    }
+
+    // MARK: - Confirm started
+
+    func logConfirmSetupIntentStarted(setupIntentID: String?, confirmParams: STPSetupIntentConfirmParams) {
+        let analytic = Analytic(event: .paymentHandlerConfirmStarted, intentID: setupIntentID, status: nil, paymentMethodType: confirmParams.paymentMethodType?.identifier, error: nil)
+        analyticsClient.log(analytic: analytic, apiClient: apiClient)
+    }
+
+    func logConfirmPaymentIntentStarted(paymentIntentID: String?, paymentParams: STPPaymentIntentParams) {
+        let analytic = Analytic(event: .paymentHandlerConfirmStarted, intentID: paymentIntentID, status: nil, paymentMethodType: paymentParams.paymentMethodType?.identifier, error: nil)
+        analyticsClient.log(analytic: analytic, apiClient: apiClient)
+    }
+
+    // MARK: - Confirm completed
+
+    func logConfirmPaymentIntentCompleted(paymentIntentID: String?, paymentIntent: STPPaymentIntent?, status: STPPaymentHandlerActionStatus, paymentMethodType: STPPaymentMethodType?, error: Error?) {
+        let analytic = Analytic(event: .paymentHandlerConfirmFinished, intentID: paymentIntentID, status: status, paymentMethodType: paymentMethodType?.identifier, error: error)
+        analyticsClient.log(analytic: analytic, apiClient: apiClient)
+    }
+
+    func logConfirmSetupIntentCompleted(setupIntentID: String?, setupIntent: STPSetupIntent?, status: STPPaymentHandlerActionStatus, paymentMethodType: STPPaymentMethodType?, error: Error?) {
+        let analytic = Analytic(event: .paymentHandlerConfirmFinished, intentID: setupIntentID, status: status, paymentMethodType: paymentMethodType?.identifier, error: error)
+        analyticsClient.log(analytic: analytic, apiClient: apiClient)
+    }
+
+    // MARK: - Handle next action
+
+    func logHandleNextActionStarted(intentID: String?, paymentMethodType: STPPaymentMethodType?) {
+        let analytic = Analytic(event: .paymentHandlerHandleNextActionStarted, intentID: intentID, status: nil, paymentMethodType: paymentMethodType?.identifier, error: nil)
+        analyticsClient.log(analytic: analytic, apiClient: apiClient)
+    }
+
+    func logHandleNextActionFinished(intentID: String?, status: STPPaymentHandlerActionStatus, paymentMethodType: STPPaymentMethodType?, error: Error?) {
+        let analytic = Analytic(event: .paymentHandlerHandleNextActionFinished, intentID: intentID, status: status, paymentMethodType: paymentMethodType?.identifier, error: error)
+        analyticsClient.log(analytic: analytic, apiClient: apiClient)
+    }
+}

--- a/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
@@ -175,7 +175,7 @@ public class STPPaymentHandler: NSObject {
         logConfirmPaymentIntentStarted(paymentIntentID: paymentIntentID, paymentParams: paymentParams)
         // Overwrite completion to send an analytic before calling the caller-supplied completion
         let completion: STPPaymentHandlerActionPaymentIntentCompletionBlock = { [weak self] status, paymentIntent, error in
-            self?.logConfirmPaymentIntentCompleted(paymentIntentID: paymentIntentID, paymentIntent: paymentIntent, status: status, paymentMethodType: paymentParams.paymentMethodType, error: error)
+            self?.logConfirmPaymentIntentCompleted(paymentIntentID: paymentIntentID, status: status, paymentMethodType: paymentParams.paymentMethodType, error: error)
             completion(status, paymentIntent, error)
         }
         if Self.inProgress {
@@ -454,7 +454,7 @@ public class STPPaymentHandler: NSObject {
         logConfirmSetupIntentStarted(setupIntentID: setupIntentID, confirmParams: setupIntentConfirmParams)
         // Overwrite completion to send an analytic before calling the caller-supplied completion
         let completion: STPPaymentHandlerActionSetupIntentCompletionBlock = { [weak self] status, setupIntent, error in
-            self?.logConfirmSetupIntentCompleted(setupIntentID: setupIntentID, setupIntent: setupIntent, status: status, paymentMethodType: setupIntentConfirmParams.paymentMethodType, error: error)
+            self?.logConfirmSetupIntentCompleted(setupIntentID: setupIntentID, status: status, paymentMethodType: setupIntentConfirmParams.paymentMethodType, error: error)
             completion(status, setupIntent, error)
         }
 

--- a/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
@@ -532,6 +532,7 @@ public class STPPaymentHandler: NSObject {
         completion: @escaping STPPaymentHandlerActionSetupIntentCompletionBlock
     ) {
         if !STPSetupIntentConfirmParams.isClientSecretValid(setupIntentClientSecret) {
+            assertionFailure("`STPPaymentHandler.handleNextAction` was called with an invalid client secret. See https://docs.stripe.com/api/payment_intents/object#setup_intent_object-client_secret")
             completion(.failed, nil, _error(for: .invalidClientSecret))
             return
         }
@@ -848,9 +849,6 @@ public class STPPaymentHandler: NSObject {
 
         case .canceled:
             action.complete(with: STPPaymentHandlerActionStatus.canceled, error: nil)
-
-        @unknown default:
-            fatalError()
         }
         return false
     }


### PR DESCRIPTION
## Summary
Sends analytics at the beginning and end of the 6 "public" STPPaymentHandler methods
- Confirm*Intent
- handleNextAction

## Motivation
See https://docs.google.com/document/d/1r_DS7mDLlrwThcvX8CBUqUBRVejeVDy05Ejth8gnBGI/edit?pli=1#heading=h.ldraz5ezrfx4

## Testing
One test for each method, checking that the start/finished analytics are sent.

## Changelog
Not user facing
