### PR TITLE
STPaymentHandler sends more error details in analytics

### DIFF
--- a/Stripe/StripeiOSTests/STPPaymentHandlerFunctionalTest.swift
+++ b/Stripe/StripeiOSTests/STPPaymentHandlerFunctionalTest.swift
@@ -288,7 +288,12 @@ final class STPPaymentHandlerFunctionalSwiftTest: XCTestCase, STPAuthenticationC
             XCTAssertEqual(lastAnalytic?["intent_id"] as? String, "pi_1Cl15wIl4IdHmuTbCWrpJXN6")
             XCTAssertEqual(lastAnalytic?["status"] as? String, "failed")
             XCTAssertEqual(lastAnalytic?["error_type"] as? String, "STPPaymentHandlerErrorDomain")
-            XCTAssertEqual(lastAnalytic?["error_code"] as? String, "0")
+            XCTAssertEqual(lastAnalytic?["error_code"] as? String, "unsupportedAuthenticationErrorCode")
+            XCTAssertEqual(lastAnalytic?["error_details"] as? [String: String], [
+                "NSLocalizedDescription": "There was an unexpected error -- try again in a few seconds",
+                "com.stripe.lib:ErrorMessageKey": "The SDK doesn\'t recognize the PaymentIntent action type.",
+                "STPIntentAction": "unknown",
+            ])
             paymentHandlerExpectation.fulfill()
         }
         waitForExpectations(timeout: 10)
@@ -338,7 +343,12 @@ final class STPPaymentHandlerFunctionalSwiftTest: XCTestCase, STPAuthenticationC
             XCTAssertEqual(lastAnalytic?["intent_id"] as? String, "seti_123456789")
             XCTAssertEqual(lastAnalytic?["status"] as? String, "failed")
             XCTAssertEqual(lastAnalytic?["error_type"] as? String, "STPPaymentHandlerErrorDomain")
-            XCTAssertEqual(lastAnalytic?["error_code"] as? String, "0")
+            XCTAssertEqual(lastAnalytic?["error_code"] as? String, "unsupportedAuthenticationErrorCode")
+            XCTAssertEqual(lastAnalytic?["error_details"] as? [String: String], [
+                "NSLocalizedDescription": "There was an unexpected error -- try again in a few seconds",
+                "com.stripe.lib:ErrorMessageKey": "The SDK doesn\'t recognize the PaymentIntent action type.",
+                "STPIntentAction": "unknown",
+            ])
             paymentHandlerExpectation.fulfill()
         }
         waitForExpectations(timeout: 10)

--- a/Stripe/StripeiOSTests/STPPaymentHandlerTests.swift
+++ b/Stripe/StripeiOSTests/STPPaymentHandlerTests.swift
@@ -90,7 +90,7 @@ class STPPaymentHandlerStubbedTests: STPNetworkStubbingTestCase {
             XCTAssertEqual(lastAnalytic?["status"] as? String, "failed")
             XCTAssertEqual(lastAnalytic?["payment_method_type"] as? String, "card")
             XCTAssertEqual(lastAnalytic?["error_type"] as? String, "STPPaymentHandlerErrorDomain")
-            XCTAssertEqual(lastAnalytic?["error_code"] as? String, "8")
+            XCTAssertEqual(lastAnalytic?["error_code"] as? String, "requiresAuthenticationContextErrorCode")
             XCTAssertTrue(status == .failed)
             XCTAssertNotNil(paymentIntent)
             XCTAssertNotNil(error)

--- a/StripeCore/StripeCore/Source/Analytics/AnalyticLoggableError.swift
+++ b/StripeCore/StripeCore/Source/Analytics/AnalyticLoggableError.swift
@@ -11,14 +11,14 @@ import Foundation
 /// Conform your Error to this protocol to override the parameters that get logged when you either:
 /// 1. Use `ErrorAnalytic` to send error analytics.
 /// 2. Build your own `Analytic` and use `serializeForV1Analytics`.
-protocol AnalyticLoggableError: Error {
+@_spi(STP) public protocol AnalyticLoggableError: Error {
     /// The value used for `"error_type"` in the analytics payload.
     /// The default implementation uses `Error.extractErrorType`
-    var errorType: String { get }
+    var analyticsErrorType: String { get }
 
     /// The value used for `"error_code"` in the analytics payload.
     /// The default implementation uses `Error.errorCode`
-    var errorCode: String { get }
+    var analyticsErrorCode: String { get }
 
     /// Additional, non-PII/PDE details about the error.
     /// If non-empty, this is sent as the value for `"error_details"` in the analytics payload.
@@ -26,12 +26,12 @@ protocol AnalyticLoggableError: Error {
 }
 
 // MARK: Default implementation
-extension AnalyticLoggableError {
-    var errorType: String {
+@_spi(STP) extension AnalyticLoggableError {
+    var analyticsErrorType: String {
         Self.extractErrorType(from: self)
     }
 
-    var errorCode: String {
+    var analyticsErrorCode: String {
         Self.extractErrorCode(from: self)
     }
 
@@ -71,14 +71,14 @@ extension AnalyticLoggableError where Self: Error {}
     public func serializeForV1Analytics() -> [String: Any] {
         let errorType: String = {
             if let analyticLoggableError = self as? AnalyticLoggableError {
-                analyticLoggableError.errorType
+                analyticLoggableError.analyticsErrorType
             } else {
                 Self.extractErrorType(from: self)
             }
         }()
         let errorCode: String = {
             if let analyticLoggableError = self as? AnalyticLoggableError {
-                analyticLoggableError.errorCode
+                analyticLoggableError.analyticsErrorCode
             } else {
                 Self.extractErrorCode(from: self)
             }

--- a/StripeCore/StripeCoreTests/Analytics/AnalyticLoggableErrorTest.swift
+++ b/StripeCore/StripeCoreTests/Analytics/AnalyticLoggableErrorTest.swift
@@ -124,10 +124,10 @@ class AnalyticLoggableErrorTest: XCTestCase {
             }
 
             // ...and overriding everything...
-            var errorType: String {
+            var analyticsErrorType: String {
                 return "overriden error type"
             }
-            var errorCode: String {
+            var analyticsErrorCode: String {
                 return "overridden error code"
             }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/FormSpec/FormSpecPaymentHandler.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/FormSpec/FormSpecPaymentHandler.swift
@@ -130,8 +130,8 @@ extension STPPaymentHandler {
                     with: STPPaymentHandlerActionStatus.failed,
                     error: _error(
                         for: .unsupportedAuthenticationErrorCode,
-                        userInfo: [
-                            "STPIntentAction": action.nextAction()?.description ?? ""
+                        loggingSafeUserInfo: [
+                            "STPIntentAction": action.nextAction()?.description ?? "",
                         ]
                     )
                 )
@@ -143,8 +143,8 @@ extension STPPaymentHandler {
                 with: .failed,
                 error: _error(
                     for: .intentStatusErrorCode,
-                    userInfo: [
-                        "STPIntentAction": action.nextAction()?.description ?? ""
+                    loggingSafeUserInfo: [
+                        "STPIntentAction": action.nextAction()?.description ?? "",
                     ]
                 )
             )

--- a/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
@@ -225,6 +225,7 @@ public class STPPaymentHandler: NSObject {
                 if error == nil && successIntentState {
                     completion(.succeeded, paymentIntent, nil)
                 } else {
+                    // TODO: Just make this an unexpectedErrorCode
                     let errorMessage = "STPPaymentHandler status is succeeded, but the PI is not in a success state or there was an error."
                     assertionFailure(errorMessage)
                     let errorAnalytic = ErrorAnalytic(event: .unexpectedPaymentHandlerError, error: InternalError.invalidState, additionalNonPIIParams: [
@@ -420,7 +421,7 @@ public class STPPaymentHandler: NSObject {
                 paymentIntent,
                 _error(
                     for: .intentStatusErrorCode,
-                    userInfo: [
+                    loggingSafeUserInfo: [
                         STPError.errorMessageKey:
                             "Confirm the PaymentIntent on the backend before calling handleNextActionForPayment:withAuthenticationContext:completion.",
                     ]
@@ -678,7 +679,7 @@ public class STPPaymentHandler: NSObject {
                 setupIntent,
                 _error(
                     for: .intentStatusErrorCode,
-                    userInfo: [
+                    loggingSafeUserInfo: [
                         STPError.errorMessageKey:
                             "Confirm the SetupIntent on the backend before calling handleNextActionForSetupIntent:withAuthenticationContext:completion.",
                     ]
@@ -850,8 +851,8 @@ public class STPPaymentHandler: NSObject {
                 with: STPPaymentHandlerActionStatus.failed,
                 error: _error(
                     for: .intentStatusErrorCode,
-                    userInfo: [
-                        "STPSetupIntent": setupIntent.description,
+                    loggingSafeUserInfo: [
+                        "error_message": "Unknown SetupIntent status",
                     ]
                 )
             )
@@ -871,7 +872,7 @@ public class STPPaymentHandler: NSObject {
                         error: _error(
                             for: .paymentErrorCode,
                             apiErrorCode: lastSetupError.code,
-                            userInfo: [
+                            loggingSafeUserInfo: [
                                 NSLocalizedDescriptionKey: lastSetupError.message ?? "",
                             ]
                         )
@@ -927,8 +928,8 @@ public class STPPaymentHandler: NSObject {
                 with: STPPaymentHandlerActionStatus.failed,
                 error: _error(
                     for: .intentStatusErrorCode,
-                    userInfo: [
-                        "STPPaymentIntent": paymentIntent.description,
+                    loggingSafeUserInfo: [
+                        "error_message": "Unknown PaymentIntent status",
                     ]
                 )
             )
@@ -951,7 +952,7 @@ public class STPPaymentHandler: NSObject {
                         error: _error(
                             for: .paymentErrorCode,
                             apiErrorCode: lastPaymentError.code,
-                            userInfo: [
+                            loggingSafeUserInfo: [
                                 NSLocalizedDescriptionKey: lastPaymentError.message ?? "",
                             ]
                         )
@@ -1017,8 +1018,8 @@ public class STPPaymentHandler: NSObject {
                 with: STPPaymentHandlerActionStatus.failed,
                 error: _error(
                     for: .unsupportedAuthenticationErrorCode,
-                    userInfo: [
-                        "STPIntentAction": authenticationAction.description,
+                    loggingSafeUserInfo: [
+                        "STPIntentAction": authenticationAction.type.stringValue,
                     ]
                 )
             )
@@ -1031,8 +1032,8 @@ public class STPPaymentHandler: NSObject {
                     with: STPPaymentHandlerActionStatus.failed,
                     error: _error(
                         for: .unsupportedAuthenticationErrorCode,
-                        userInfo: [
-                            "STPIntentAction": authenticationAction.description,
+                        loggingSafeUserInfo: [
+                            "STPIntentAction": authenticationAction.type.stringValue,
                         ]
                     )
                 )
@@ -1050,8 +1051,8 @@ public class STPPaymentHandler: NSObject {
                     with: STPPaymentHandlerActionStatus.failed,
                     error: _error(
                         for: .unsupportedAuthenticationErrorCode,
-                        userInfo: [
-                            "STPIntentAction": authenticationAction.description,
+                        loggingSafeUserInfo: [
+                            "STPIntentAction": authenticationAction.type.stringValue,
                         ]
                     )
                 )
@@ -1069,8 +1070,8 @@ public class STPPaymentHandler: NSObject {
                     with: STPPaymentHandlerActionStatus.failed,
                     error: _error(
                         for: .unsupportedAuthenticationErrorCode,
-                        userInfo: [
-                            "STPIntentAction": authenticationAction.description,
+                        loggingSafeUserInfo: [
+                            "STPIntentAction": authenticationAction.type.stringValue,
                         ]
                     )
                 )
@@ -1084,8 +1085,8 @@ public class STPPaymentHandler: NSObject {
                     with: STPPaymentHandlerActionStatus.failed,
                     error: _error(
                         for: .unsupportedAuthenticationErrorCode,
-                        userInfo: [
-                            "STPIntentAction": authenticationAction.description,
+                        loggingSafeUserInfo: [
+                            "STPIntentAction": authenticationAction.type.stringValue,
                         ]
                     )
                 )
@@ -1099,8 +1100,8 @@ public class STPPaymentHandler: NSObject {
                     with: STPPaymentHandlerActionStatus.failed,
                     error: _error(
                         for: .unsupportedAuthenticationErrorCode,
-                        userInfo: [
-                            "STPIntentAction": authenticationAction.description,
+                        loggingSafeUserInfo: [
+                            "STPIntentAction": authenticationAction.type.stringValue,
                         ]
                     )
                 )
@@ -1114,8 +1115,8 @@ public class STPPaymentHandler: NSObject {
                         with: STPPaymentHandlerActionStatus.failed,
                         error: _error(
                             for: .unsupportedAuthenticationErrorCode,
-                            userInfo: [
-                                "STPIntentAction": authenticationAction.description,
+                            loggingSafeUserInfo: [
+                                "STPIntentAction": authenticationAction.type.stringValue,
                             ]
                         )
                     )
@@ -1126,7 +1127,7 @@ public class STPPaymentHandler: NSObject {
                             with: STPPaymentHandlerActionStatus.failed,
                             error: _error(
                                 for: .stripe3DS2ErrorCode,
-                                userInfo: [
+                                loggingSafeUserInfo: [
                                     "description": "Failed to initialize STDSThreeDS2Service.",
                                 ]
                             )
@@ -1157,7 +1158,7 @@ public class STPPaymentHandler: NSObject {
                                     intentID: currentAction.intentStripeID ?? "",
                                     error: self._error(
                                         for: .stripe3DS2ErrorCode,
-                                        userInfo: [
+                                        loggingSafeUserInfo: [
                                             "exception": exception.description,
                                         ]
                                     )
@@ -1167,7 +1168,7 @@ public class STPPaymentHandler: NSObject {
                                 with: STPPaymentHandlerActionStatus.failed,
                                 error: self._error(
                                     for: .stripe3DS2ErrorCode,
-                                    userInfo: [
+                                    loggingSafeUserInfo: [
                                         "exception": exception.description,
                                     ]
                                 )
@@ -1268,8 +1269,8 @@ public class STPPaymentHandler: NSObject {
                                                                 .failed,
                                                             error: self._error(
                                                                 for: .stripe3DS2ErrorCode,
-                                                                userInfo: [
-                                                                    "exception": exception,
+                                                                loggingSafeUserInfo: [
+                                                                    "exception": exception.description,
                                                                 ]
                                                             )
                                                         )
@@ -1313,8 +1314,8 @@ public class STPPaymentHandler: NSObject {
                                         with: STPPaymentHandlerActionStatus.failed,
                                         error: self._error(
                                             for: .unsupportedAuthenticationErrorCode,
-                                            userInfo: [
-                                                "STPIntentAction": authenticationAction.description,
+                                            loggingSafeUserInfo: [
+                                                "STPIntentAction": authenticationAction.type.stringValue,
                                             ]
                                         )
                                     )
@@ -1333,8 +1334,8 @@ public class STPPaymentHandler: NSObject {
                             with: STPPaymentHandlerActionStatus.failed,
                             error: self._error(
                                 for: .unsupportedAuthenticationErrorCode,
-                                userInfo: [
-                                    "STPIntentAction": authenticationAction.description,
+                                loggingSafeUserInfo: [
+                                    "STPIntentAction": authenticationAction.type.stringValue,
                                 ]
                             )
                         )
@@ -1352,17 +1353,14 @@ public class STPPaymentHandler: NSObject {
                     } else {
                         // TOOD : Error
                     }
-
-                @unknown default:
-                    fatalError()
                 }
             } else {
                 currentAction.complete(
                     with: STPPaymentHandlerActionStatus.failed,
                     error: _error(
                         for: .unsupportedAuthenticationErrorCode,
-                        userInfo: [
-                            "STPIntentAction": authenticationAction.description,
+                        loggingSafeUserInfo: [
+                            "STPIntentAction": authenticationAction.type.stringValue,
                         ]
                     )
                 )
@@ -1414,8 +1412,8 @@ public class STPPaymentHandler: NSObject {
                     with: STPPaymentHandlerActionStatus.failed,
                     error: _error(
                         for: .unsupportedAuthenticationErrorCode,
-                        userInfo: [
-                            "STPIntentAction": authenticationAction.description,
+                        loggingSafeUserInfo: [
+                            "STPIntentAction": authenticationAction.type.stringValue,
                         ]
                     )
                 )
@@ -1443,8 +1441,8 @@ public class STPPaymentHandler: NSObject {
                     with: STPPaymentHandlerActionStatus.failed,
                     error: _error(
                         for: .unsupportedAuthenticationErrorCode,
-                        userInfo: [
-                            "STPIntentAction": authenticationAction.description,
+                        loggingSafeUserInfo: [
+                            "STPIntentAction": authenticationAction.type.stringValue,
                         ]
                     )
                 )
@@ -1806,7 +1804,7 @@ public class STPPaymentHandler: NSObject {
                         with: STPPaymentHandlerActionStatus.failed,
                         error: self._error(
                             for: .requiredAppNotAvailable,
-                            userInfo: [
+                            loggingSafeUserInfo: [
                                 "STPIntentAction": currentAction.description,
                             ]
                         )
@@ -1901,10 +1899,10 @@ public class STPPaymentHandler: NSObject {
         if !canPresent {
             error = _error(
                 for: .requiresAuthenticationContextErrorCode,
-                userInfo: errorMessage != nil
+                loggingSafeUserInfo: errorMessage != nil
                     ? [
                         STPError.errorMessageKey: errorMessage ?? "",
-                    ] : nil
+                    ] : [:]
             )
         }
         return canPresent
@@ -2097,12 +2095,13 @@ public class STPPaymentHandler: NSObject {
     }
 
     // MARK: - Errors
+    /// - Parameter loggingSafeUserInfo: Error details that are safe to log i.e. don't contain PII/PDE or secrets.
     @_spi(STP) public func _error(
         for errorCode: STPPaymentHandlerErrorCode,
         apiErrorCode: String? = nil,
-        userInfo additionalUserInfo: [AnyHashable: Any]? = nil
+        loggingSafeUserInfo: [String: String] = [:]
     ) -> NSError {
-        var userInfo: [AnyHashable: Any] = additionalUserInfo ?? [:]
+        var userInfo = loggingSafeUserInfo
         switch errorCode {
         // 3DS(2) flow expected user errors
         case .notAuthenticatedErrorCode:
@@ -2177,11 +2176,29 @@ public class STPPaymentHandler: NSObject {
             userInfo[NSLocalizedDescriptionKey] =
                 userInfo[NSLocalizedDescriptionKey] ?? NSError.stp_unexpectedErrorMessage()
         }
-        return NSError(
-            domain: STPPaymentHandler.errorDomain,
-            code: errorCode.rawValue,
-            userInfo: userInfo as? [String: Any]
-        )
+        return STPPaymentHandlerError(code: errorCode, loggingSafeUserInfo: userInfo) as NSError
+    }
+}
+
+/// STPPaymentHandler errors (i.e. errors that are created by the STPPaymentHandler class and have a corresponding STPPaymentHandlerErrorCode) used to be NSErrors.
+/// This struct exists so that these errors can be Swift errors to conform to AnalyticLoggableError, while still looking like the old NSErrors to users (i.e. same domain and code).
+struct STPPaymentHandlerError: Error, CustomNSError, AnalyticLoggableError {
+    // AnalyticLoggableError properties
+    let analyticsErrorType: String = errorDomain
+    let analyticsErrorCode: String
+    let additionalNonPIIErrorDetails: [String: Any]
+
+    // CustomNSError properties, to not break old behavior when this was an NSError
+    static let errorDomain: String = STPPaymentHandler.errorDomain
+    let errorUserInfo: [String: Any]
+    let errorCode: Int
+
+    init(code: STPPaymentHandlerErrorCode, loggingSafeUserInfo: [String: String]) {
+        errorCode = code.rawValue
+        // Set analytics error code to the description (e.g. "invalidClientSecret")
+        analyticsErrorCode = code.description
+        errorUserInfo = loggingSafeUserInfo
+        additionalNonPIIErrorDetails = loggingSafeUserInfo
     }
 }
 
@@ -2289,7 +2306,7 @@ extension STPPaymentHandler {
                     with: STPPaymentHandlerActionStatus.failed,
                     error: self._error(
                         for: .notAuthenticatedErrorCode,
-                        userInfo: [
+                        loggingSafeUserInfo: [
                             "transaction_status": transactionStatus,
                         ]
                     )


### PR DESCRIPTION
## Summary
- STPPaymentHandlerErrorDomain errors are now a Swift error under the hood instead of NSError. This lets it conform to AnalyticsLoggableError so that we can log the details contained in userInfo.
- Audited userInfo of ^ errors and modified so that they are safe to log. 

## Testing
Updated unit tests to reflect the additional details that sometimes get sent in analytics and the improved error_code values (from e.g. "8" to "requiresAuthenticationContextErrorCode")

## Changelog
Not user facing. 
