### PR TITLE
Protect followRedirects from public usage outside of STP

### DIFF
--- a/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
@@ -1423,7 +1423,7 @@ public class STPPaymentHandler: NSObject {
         }
     }
 
-    public func followRedirects(to url: URL, urlSession: URLSession) -> URL {
+   @_spi(STP) public func followRedirects(to url: URL, urlSession: URLSession) -> URL {
         let urlRequest = URLRequest(url: url)
         let blockingDataTaskSemaphore = DispatchSemaphore(value: 0)
 


### PR DESCRIPTION
## Summary
- This function should not be public.

## Motivation
https://stripe.slack.com/archives/C06SHF7KHQC/p1712357089770979

## Testing
Project compiled

## Changelog
N/A