### PR TITLE
add external podspecs to pod lib lint

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -514,7 +514,7 @@ workflows:
     steps:
     - script@1:
         inputs:
-        - content: pod lib lint --include-podspecs='*.podspec'
+        - content: pod lib lint --include-podspecs='*.podspec' --external-podspecs='ExternalPodspecs/*.podspec'
         title: pod lib lint
     before_run:
     - prep_all

--- a/externalPodspecs/MBCaptureCore.podspec
+++ b/externalPodspecs/MBCaptureCore.podspec
@@ -1,0 +1,37 @@
+Pod::Spec.new do |s|
+  
+  s.name        = "MBCaptureCore"
+  s.version     = "1.2.3"
+  s.summary     = "A delightful Direct API component for document capture"
+  s.homepage    = "http://microblink.com"
+  s.readme      = "https://raw.githubusercontent.com/BlinkID/capture-ios/v1.2.3/README.md"
+  
+  s.description = <<-DESC
+            The BlinkID Capture iOS SDK gives you the ability to auto-capture high quality images of identity documents in a user-friendly way. The SDK provides you with a rectified image of the document that ensures high success rate in extracting document text or verifying the document validity. 
+        DESC
+  
+  s.license     = { 
+        :type => 'commercial',
+        :text => <<-LICENSE
+                © 2023 Microblink Ltd. All rights reserved.
+                LICENSE
+        }
+
+  s.authors     = {
+        "Microblink" => "info@microblink.com",
+        "Jura Skrlec" => "jura.skrlec@microblink.com"
+  }
+
+  s.source      = { 
+        :http => 'https://github.com/BlinkID/capture-ios/releases/download/v1.2.3/CaptureCore.xcframework.zip'
+  }
+
+  s.platform     = :ios
+
+  # ――― MULTI-PLATFORM VALUES ――――――――――――――――――――――――――――――――――――――――――――――――― #
+
+  s.ios.deployment_target = '13.0.0'
+  s.ios.vendored_frameworks = 'CaptureCore.xcframework'
+  s.ios.libraries = 'c++', 'z'
+
+end


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Copy over MBCaptureCore.podspec and add external-podspecs to ensure the dependency is visible while using local unreleased podspecs for `pod lib lint`

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fix CI


## Testing
<!-- How was the code tested? Be as specific as possible. -->
Manually verified - https://app.bitrise.io/build/bcf6835f-cf18-491d-b56d-b568dc4396d6

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
