### PR TITLE
Send analytics events on simulator but not during tests

### DIFF
--- a/Stripe/StripeiOS/Source/STPAnalyticsClient+BasicUI.swift
+++ b/Stripe/StripeiOS/Source/STPAnalyticsClient+BasicUI.swift
@@ -100,9 +100,6 @@ extension STPPaymentContext {
             }
 
             var params: [String: Any] = ["selected_lpm": paymentMethodType]
-            if STPAnalyticsClient.isSimulatorOrTest {
-                params["is_development"] = true
-            }
             if let error {
                 params["error_message"] = error.makeSafeLoggingString()
             }

--- a/Stripe/StripeiOSTests/STPAnalyticsClientPaymentSheetTest.swift
+++ b/Stripe/StripeiOSTests/STPAnalyticsClientPaymentSheetTest.swift
@@ -187,7 +187,7 @@ class STPAnalyticsClientPaymentSheetTest: XCTestCase {
         let payload = client.payload(from: analytic, apiClient: apiClient)
 
         // verify
-        XCTAssertEqual(16, payload.count)
+        XCTAssertEqual(17, payload.count)
         XCTAssertNotNil(payload["device_type"] as? String)
         XCTAssertEqual("Wi-Fi", payload["network_type"] as? String)
         // In xctest, this is the version of Xcode
@@ -208,6 +208,7 @@ class STPAnalyticsClientPaymentSheetTest: XCTestCase {
         XCTAssertEqual(STPAPIClient.STPSDKVersion, payload["bindings_version"] as? String)
         XCTAssertEqual("testVal", payload["testKey"] as? String)
         XCTAssertEqual("X", payload["install"] as? String)
+        XCTAssertTrue(payload["is_development"] as? Bool ?? false)
 
         let additionalInfo = try XCTUnwrap(payload["additional_info"] as? [String])
         XCTAssertEqual(1, additionalInfo.count)

--- a/Stripe/StripeiOSTests/STPAnalyticsClientPaymentsTest.swift
+++ b/Stripe/StripeiOSTests/STPAnalyticsClientPaymentsTest.swift
@@ -44,7 +44,7 @@ class STPAnalyticsClientPaymentsTest: XCTestCase {
         let mockAnalytic = MockAnalytic()
         let payload = client.payload(from: mockAnalytic)
 
-        XCTAssertEqual(payload.count, 14)
+        XCTAssertEqual(payload.count, 15)
 
         // Verify event name is included
         XCTAssertEqual(payload["event"] as? String, mockAnalytic.event.rawValue)
@@ -61,6 +61,9 @@ class STPAnalyticsClientPaymentsTest: XCTestCase {
 
         // Verify install method is Xcode
         XCTAssertEqual(payload["install"] as? String, "X")
+
+        // Verify is_development
+        XCTAssertTrue(payload["is_development"] as? Bool ?? false)
     }
 
     // MARK: - Error tests

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticsClient.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticsClient.swift
@@ -66,18 +66,6 @@ import UIKit
         additionalInfoSet.removeAll()
     }
 
-    public static var isSimulatorOrTest: Bool {
-        #if targetEnvironment(simulator)
-            return true
-        #else
-            return NSClassFromString("XCTest") != nil
-        #endif
-    }
-
-    @objc public class func shouldCollectAnalytics() -> Bool {
-        return !isSimulatorOrTest
-    }
-
     public func additionalInfo() -> [String] {
         return additionalInfoSet.sorted()
     }
@@ -115,11 +103,9 @@ import UIKit
         delegate?.analyticsClientDidLog(analyticsClient: self, payload: payload)
         #endif
 
-        guard type(of: self).shouldCollectAnalytics() else {
-            // Don't send the analytic, but add it to `_testLogHistory` if we're in a test.
-            if NSClassFromString("XCTest") != nil {
-                _testLogHistory.append(payload)
-            }
+        // Don't send the analytic, but add it to `_testLogHistory` if we're in a test.
+        guard NSClassFromString("XCTest") == nil else {
+            _testLogHistory.append(payload)
             return
         }
 

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticsClient.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticsClient.swift
@@ -66,6 +66,18 @@ import UIKit
         additionalInfoSet.removeAll()
     }
 
+    public static var isSimulatorOrTest: Bool {
+        #if targetEnvironment(simulator)
+            return true
+        #else
+            return NSClassFromString("XCTest") != nil
+        #endif
+    }
+
+    @objc public class func shouldCollectAnalytics() -> Bool {
+        return NSClassFromString("XCTest") == nil
+    }
+
     public func additionalInfo() -> [String] {
         return additionalInfoSet.sorted()
     }
@@ -104,7 +116,7 @@ import UIKit
         #endif
 
         // Don't send the analytic, but add it to `_testLogHistory` if we're in a test.
-        guard NSClassFromString("XCTest") == nil else {
+        guard type(of: self).shouldCollectAnalytics() else {
             _testLogHistory.append(payload)
             return
         }

--- a/StripeCore/StripeCoreTests/Analytics/STPAnalyticsClientTest.swift
+++ b/StripeCore/StripeCoreTests/Analytics/STPAnalyticsClientTest.swift
@@ -13,8 +13,8 @@ import XCTest
 
 class STPAnalyticsClientTest: XCTestCase {
 
-    func testShouldCollectAnalytics_alwaysFalseInTest() {
-        XCTAssertFalse(STPAnalyticsClient.shouldCollectAnalytics())
+    func testIsUnitOrUITest_alwaysTrueInTest() {
+        XCTAssertTrue(STPAnalyticsClient.isUnitOrUITest)
     }
 
     func testShouldRedactLiveKeyFromLog() {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/STPAnalyticsClient+Address.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/STPAnalyticsClient+Address.swift
@@ -17,10 +17,6 @@ extension STPAnalyticsClient {
         apiClient: STPAPIClient
     ) {
         var additionalParams = [:] as [String: Any]
-        if Self.isSimulatorOrTest {
-            additionalParams["is_development"] = true
-        }
-
         additionalParams["address_data_blob"] = addressAnalyticData?.analyticsPayload
 
         let analytic = AddressAnalytic(event: event,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
@@ -304,10 +304,6 @@ extension STPAnalyticsClient {
         apiClient: STPAPIClient = .shared
     ) {
         var additionalParams = [:] as [String: Any]
-        if Self.isSimulatorOrTest {
-            additionalParams["is_development"] = true
-        }
-
         additionalParams["duration"] = duration
         additionalParams["link_enabled"] = linkEnabled
         additionalParams["active_link_session"] = activeLinkSession


### PR DESCRIPTION
## Summary
- Updates the `STPAnalyticsClient` to only send analytics if we are not in a test. Now includes sending when running from a simulator.
- Intentionally does not update the V2 analytics client as that is used outside the scope of our team.
- Left in place the `STPAnalyticsClientDelegate` so our playground can still inspect analytics logs easily.

## Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-1903

## Testing
Manual

## Changelog
N/A
