### PR TITLE
Add sessionid to all events

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -244,9 +244,6 @@ class PaymentSheetStandardUITests: PaymentSheetUITestCase {
         let sessionID = analyticsLog.first![string: "session_id"]
         XCTAssertTrue(!sessionID!.isEmpty)
         for analytic in analyticsLog {
-            if analytic[string: "event"]!.starts(with: "stripeios.") {
-                continue
-            }
             XCTAssertEqual(analytic[string: "session_id"], sessionID)
         }
         // Make sure the appropriate events have "selected_lpm" = "card"
@@ -1467,9 +1464,6 @@ class PaymentSheetDeferredUITests: PaymentSheetUITestCase {
         let sessionID = analyticsLog.first![string: "session_id"]
         XCTAssertTrue(!sessionID!.isEmpty)
         for analytic in analyticsLog {
-            if (analytic["event"] as! String).starts(with: "stripeios") {
-                continue
-            }
             XCTAssertEqual(analytic[string: "session_id"], sessionID)
         }
 

--- a/Stripe/StripeiOS/Source/STPAnalyticsClient+BasicUI.swift
+++ b/Stripe/StripeiOS/Source/STPAnalyticsClient+BasicUI.swift
@@ -12,12 +12,10 @@ import Foundation
 extension STPPaymentContext {
     final class AnalyticsLogger {
         let analyticsClient = STPAnalyticsClient.sharedClient
-        let sessionID: String = UUID().uuidString.lowercased()
         var apiClient: STPAPIClient = .shared
         var product: String
         lazy var commonParameters: [String: Any] = {
             [
-                "session_id": sessionID,
                 "product": product,
             ]
         }()

--- a/Stripe/StripeiOS/Source/STPPaymentContext.swift
+++ b/Stripe/StripeiOS/Source/STPPaymentContext.swift
@@ -97,6 +97,7 @@ public class STPPaymentContext: NSObject, STPAuthenticationContext,
         theme: STPTheme
     ) {
         STPAnalyticsClient.sharedClient.addClass(toProductUsageIfNecessary: STPPaymentContext.self)
+        AnalyticsHelper.shared.generateSessionID()
         self.configuration = configuration
         self.apiAdapter = apiAdapter
         self.theme = theme

--- a/Stripe/StripeiOSTests/STPAnalyticsClientPaymentSheetTest.swift
+++ b/Stripe/StripeiOSTests/STPAnalyticsClientPaymentSheetTest.swift
@@ -172,6 +172,9 @@ class STPAnalyticsClientPaymentSheetTest: XCTestCase {
     }
 
     func testPaymentSheetAnalyticPayload() throws {
+        // Ensure there is a sessionID
+        AnalyticsHelper.shared.generateSessionID()
+
         // setup
         let analytic = PaymentSheetAnalytic(
             event: STPAnalyticEvent.mcInitCompleteApplePay,
@@ -187,7 +190,7 @@ class STPAnalyticsClientPaymentSheetTest: XCTestCase {
         let payload = client.payload(from: analytic, apiClient: apiClient)
 
         // verify
-        XCTAssertEqual(17, payload.count)
+        XCTAssertEqual(18, payload.count)
         XCTAssertNotNil(payload["device_type"] as? String)
         XCTAssertEqual("Wi-Fi", payload["network_type"] as? String)
         // In xctest, this is the version of Xcode
@@ -209,6 +212,7 @@ class STPAnalyticsClientPaymentSheetTest: XCTestCase {
         XCTAssertEqual("testVal", payload["testKey"] as? String)
         XCTAssertEqual("X", payload["install"] as? String)
         XCTAssertTrue(payload["is_development"] as? Bool ?? false)
+        XCTAssertEqual(36, (payload["session_id"] as? String)?.count ?? 0)
 
         let additionalInfo = try XCTUnwrap(payload["additional_info"] as? [String])
         XCTAssertEqual(1, additionalInfo.count)

--- a/Stripe/StripeiOSTests/STPAnalyticsClientPaymentsTest.swift
+++ b/Stripe/StripeiOSTests/STPAnalyticsClientPaymentsTest.swift
@@ -39,12 +39,14 @@ class STPAnalyticsClientPaymentsTest: XCTestCase {
     }
 
     func testPayloadFromAnalytic() throws {
+        AnalyticsHelper.shared.generateSessionID()
+
         client.addAdditionalInfo("test_additional_info")
 
         let mockAnalytic = MockAnalytic()
         let payload = client.payload(from: mockAnalytic)
 
-        XCTAssertEqual(payload.count, 15)
+        XCTAssertEqual(payload.count, 16)
 
         // Verify event name is included
         XCTAssertEqual(payload["event"] as? String, mockAnalytic.event.rawValue)

--- a/StripeCore/StripeCore.xcodeproj/project.pbxproj
+++ b/StripeCore/StripeCore.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		677951C643328D76E46720A5 /* StripeAPIConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32CB3702691056D3404A8C5F /* StripeAPIConfiguration.swift */; };
 		6A52ABC06783A90B9E339948 /* StripeFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73CE623A81057C4063A1E0C4 /* StripeFile.swift */; };
 		6B4156FCFAEDD1C73DC6EDAD /* iOSSnapshotTestCase in Frameworks */ = {isa = PBXBuildFile; platformFilters = (ios, maccatalyst, ); productRef = 23D22B2C40BA7C182BCE50B2 /* iOSSnapshotTestCase */; };
+		6B9C7B832BC73B1C007D5A28 /* AnalyticsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9C7B822BC73B1C007D5A28 /* AnalyticsHelper.swift */; };
 		6D68B868938BAB15A843B33C /* TestJSONEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF290DF69F5FD1004BBDECA /* TestJSONEncoder.swift */; };
 		6ED5C41DBDAB475BF1119E98 /* UnknownFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64635404BD4D5D62486A7626 /* UnknownFields.swift */; };
 		700E9DAD0407455F11F9F03E /* StripeCoreTestUtils.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A4F598BF353D8335B0340D5 /* StripeCoreTestUtils.framework */; };
@@ -236,6 +237,7 @@
 		625636EFF4844186C7A31FAF /* ro-RO */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "ro-RO"; path = "ro-RO.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		64635404BD4D5D62486A7626 /* UnknownFields.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnknownFields.swift; sourceTree = "<group>"; };
 		66CC52EF207F05E0EFAEACD8 /* NSMutableURLRequest+StripeTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSMutableURLRequest+StripeTest.swift"; sourceTree = "<group>"; };
+		6B9C7B822BC73B1C007D5A28 /* AnalyticsHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHelper.swift; sourceTree = "<group>"; };
 		6CDBCD70CB220014972B49A5 /* PluginDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginDetector.swift; sourceTree = "<group>"; };
 		6E852B53CF75A119D3810B41 /* NSBundle+Stripe_AppName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSBundle+Stripe_AppName.swift"; sourceTree = "<group>"; };
 		6EEB07003465364DBAFA7DEB /* zh-HK */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-HK"; path = "zh-HK.lproj/Localizable.strings"; sourceTree = "<group>"; };
@@ -513,6 +515,7 @@
 			children = (
 				B6DBB2BE2BA8C4E300783D15 /* STPAnalyticsClient+Error.swift */,
 				ABF11F814A986AA710410FF8 /* Analytic.swift */,
+				6B9C7B822BC73B1C007D5A28 /* AnalyticsHelper.swift */,
 				7B890F162E1C247D5CA1A9E6 /* AnalyticLoggableError.swift */,
 				B67F2CA12BAB8B690011E34A /* AnalyticLoggableErrorV2.swift */,
 				192E71FE64C5FDE929992CC4 /* AnalyticsClientV2.swift */,
@@ -1005,6 +1008,7 @@
 				3B27DDDDC91F1599BF1469BB /* UserDefaults+PaymentsCore.swift in Sources */,
 				B6D129B2DC90FA1F8A1F5BCB /* UIActivityIndicatorView+Stripe.swift in Sources */,
 				DF1EC524A1915E344687F5AC /* UIFont+Stripe.swift in Sources */,
+				6B9C7B832BC73B1C007D5A28 /* AnalyticsHelper.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/StripeCore/StripeCore/Source/Analytics/AnalyticsHelper.swift
+++ b/StripeCore/StripeCore/Source/Analytics/AnalyticsHelper.swift
@@ -1,47 +1,44 @@
 //
 //  AnalyticsHelper.swift
-//  StripePaymentSheet
-//
-//  Created by Ramon Torres on 2/22/22.
-//  Copyright © 2022 Stripe, Inc. All rights reserved.
+//  StripeCore
 //
 
 import Foundation
 
-final class AnalyticsHelper {
-    enum TimeMeasurement {
+@_spi(STP) public class AnalyticsHelper {
+    @_spi(STP) public enum TimeMeasurement {
         case checkout
         case linkSignup
         case linkPopup
         case formShown
     }
 
-    static let shared = AnalyticsHelper()
+    @_spi(STP) public static let shared = AnalyticsHelper()
 
-    private(set) var sessionID: String?
+    @_spi(STP) public private(set) var sessionID: String?
 
     private let timeProvider: () -> Date
 
     private var startTimes: [TimeMeasurement: Date] = [:]
 
     /// Used to ensure we only send one `mc_form_interacted` event per `mc_form_shown` to avoid spamming.
-    var didSendPaymentSheetFormInteractedEventAfterFormShown: Bool = false
+    @_spi(STP) public var didSendPaymentSheetFormInteractedEventAfterFormShown: Bool = false
 
     init(timeProvider: @escaping () -> Date = Date.init) {
         self.timeProvider = timeProvider
     }
 
-    func generateSessionID() {
+    @_spi(STP) public func generateSessionID() {
         let uuid = UUID()
         // Convert the UUID to lowercase to comply with RFC 4122 and ITU-T X.667.
         sessionID = uuid.uuidString.lowercased()
     }
 
-    func startTimeMeasurement(_ measurement: TimeMeasurement) {
+    @_spi(STP) public func startTimeMeasurement(_ measurement: TimeMeasurement) {
         startTimes[measurement] = timeProvider()
     }
 
-    func getDuration(for measurement: TimeMeasurement) -> TimeInterval? {
+    @_spi(STP) public func getDuration(for measurement: TimeMeasurement) -> TimeInterval? {
         guard let startTime = startTimes[measurement] else {
             // Return `nil` if the time measurement hasn't started.
             return nil

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticsClient.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticsClient.swift
@@ -148,6 +148,7 @@ extension STPAnalyticsClient {
         payload["network_type"] = NetworkDetector.getConnectionType()
         payload["install"] = InstallMethod.current.rawValue
         payload["publishable_key"] = apiClient.sanitizedPublishableKey ?? "unknown"
+        payload["session_id"] = AnalyticsHelper.shared.sessionID ?? ""
         if STPAnalyticsClient.isSimulatorOrTest {
             payload["is_development"] = true
         }

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticsClient.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticsClient.swift
@@ -148,7 +148,7 @@ extension STPAnalyticsClient {
         payload["network_type"] = NetworkDetector.getConnectionType()
         payload["install"] = InstallMethod.current.rawValue
         payload["publishable_key"] = apiClient.sanitizedPublishableKey ?? "unknown"
-        payload["session_id"] = AnalyticsHelper.shared.sessionID ?? ""
+        payload["session_id"] = AnalyticsHelper.shared.sessionID
         if STPAnalyticsClient.isSimulatorOrTest {
             payload["is_development"] = true
         }

--- a/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
+++ b/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
@@ -65,7 +65,6 @@
 		37F750E1C99D6257E845A66E /* BacsDDMandateViewSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE92D55DA4B4D449734B2917 /* BacsDDMandateViewSnapshotTests.swift */; };
 		395CFB782E1F93789A260434 /* StripePaymentSheet.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 2E42F31D392C0AED757D6239 /* StripePaymentSheet.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		3A52CFA2F9D0E1C677F4EEA4 /* PaymentSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B680A2FF197F612D065F16C /* PaymentSheet.swift */; };
-		3BAF910D2D3E23FF2A29B013 /* AnalyticsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A052EDC8CC0A4601696E1B /* AnalyticsHelper.swift */; };
 		3CB64564D5B6F092A2A3A5BE /* STPPaymentMethodParams+PaymentSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 103844C9B831A4F01793C304 /* STPPaymentMethodParams+PaymentSheet.swift */; };
 		3D3607748436E625FF6CF921 /* PaymentSheet+APITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0B7F6E25D93C0C0ACE3B3D /* PaymentSheet+APITest.swift */; };
 		3D4497A6A1CB151C4B75A68F /* StripeCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E41AA4E90E5BB28D588FDE51 /* StripeCore.framework */; };
@@ -333,7 +332,6 @@
 		11E117C348836EF631BD2DB8 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		135B7354260E0E7CADCF3426 /* PaymentSheetAddressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSheetAddressTests.swift; sourceTree = "<group>"; };
 		13FB3274557B85BA4C9FA6C0 /* LinkLegalTermsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkLegalTermsView.swift; sourceTree = "<group>"; };
-		14A052EDC8CC0A4601696E1B /* AnalyticsHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHelper.swift; sourceTree = "<group>"; };
 		15854DCE06F859BB426E9C9A /* StripePaymentsTestUtils.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripePaymentsTestUtils.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		169C7CCB7A003FEDEA598095 /* StripeCoreTestUtils.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripeCoreTestUtils.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1ADE49E72DD5EDA448D12D88 /* PollingViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollingViewTests.swift; sourceTree = "<group>"; };
@@ -771,7 +769,6 @@
 		472ABC949910C340197A4F78 /* Analytics */ = {
 			isa = PBXGroup;
 			children = (
-				14A052EDC8CC0A4601696E1B /* AnalyticsHelper.swift */,
 				AF8380C1DAA262CD5EFDBB8C /* STPAnalyticsClient+Address.swift */,
 				3468D11C30A9552923952FF3 /* STPAnalyticsClient+CustomerSheet.swift */,
 				83B5AAA4347A6918EC267210 /* STPAnalyticsClient+LUXE.swift */,
@@ -1594,7 +1591,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3BAF910D2D3E23FF2A29B013 /* AnalyticsHelper.swift in Sources */,
 				4E5A3324BBD882A780925E2B /* STPAnalyticsClient+Address.swift in Sources */,
 				0FB52E5B87B1854B28362BF3 /* STPAnalyticsClient+CustomerSheet.swift in Sources */,
 				6A529F76ECB33C9154314C1F /* STPAnalyticsClient+LUXE.swift in Sources */,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
@@ -310,7 +310,6 @@ extension STPAnalyticsClient {
         if let linkSessionType = linkSessionType {
             additionalParams["link_session_type"] = linkSessionType.rawValue
         }
-        additionalParams["session_id"] = AnalyticsHelper.shared.sessionID
         additionalParams["mpe_config"] = configuration?.analyticPayload
         additionalParams["locale"] = Locale.autoupdatingCurrent.identifier
         additionalParams["currency"] = currency


### PR DESCRIPTION
## Summary
* Move SessionID to StripeCore -- doing so requires multiple `@_spi(STP)` to make this only accessible by internal packages.
* Remove `additionalParams["session_id"]` from STPAnalyticsClient+PaymentSheet to avoid having to merge values
* Addition of `additionalParams["session_id"]` in `commonPayload`



## Motivation
Analytics improvements

## Testing
Manual testing

## Changelog
No user facing changes