### PR TITLE
Update SavedPaymentOptionsViewController's eventing

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
@@ -31,6 +31,7 @@ protocol SavedPaymentOptionsViewControllerDelegate: AnyObject {
 @objc(STP_Internal_SavedPaymentOptionsViewController)
 class SavedPaymentOptionsViewController: UIViewController {
     enum Error: Swift.Error {
+        case collectionViewDidSelectItemAtAdd
         case unableToDequeueReusableCell
         case paymentOptionCellDidSelectEditOnNonSavedItem
         case paymentOptionCellDidSelectRemoveOnNonSavedItem
@@ -508,8 +509,10 @@ extension SavedPaymentOptionsViewController: UICollectionViewDataSource, UIColle
 
         switch viewModel {
         case .add:
-            // Assert loudly, should have been handled in shouldSelectItemAt: before we got here!
-            assertionFailure()
+            let errorAnalytic = ErrorAnalytic(event: .unexpectedPaymentSheetError,
+                                              error: Error.collectionViewDidSelectItemAtAdd)
+            STPAnalyticsClient.sharedClient.log(analytic: errorAnalytic)
+            stpAssertionFailure()
         case .applePay:
             CustomerPaymentOption.setDefaultPaymentMethod(.applePay, forCustomer: configuration.customerID)
         case .link:


### PR DESCRIPTION
## Summary
Updating SavedPaymentOptionsViewController's assert to stpAssertionFailure and send event

## Motivation
This would be a coding error on our part

## Testing
None

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
