### PR TITLE
STPBankAccountCollector analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 23.27.0 2024-04-08
 ### Payments
 * [Added] Support for Alma bindings.
+* [Fixed] STPBankAccountCollector errors now use "STPBankAccountCollectorErrorDomain" instead of "STPPaymentHandlerErrorDomain".
 
 ### All
 * [Fixed] Fixed an issue with generating App Privacy reports.

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
@@ -235,6 +235,10 @@ import Foundation
     case biCardNumberCompleted = "bi_card_number_completed"
     case biDoneButtonTapped = "bi_done_button_tapped"
 
+    // MARK: - STPBankAccountCollector
+    case bankAccountCollectorStarted = "stripeios.bankaccountcollector.started"
+    case bankAccountCollectorFinished = "stripeios.bankaccountcollector.finished"
+
     // MARK: - Unexpected errors
     // These errors should _never happen_ and indicate a problem with the SDK or the Stripe backend.
     case unexpectedPaymentSheetFormFactoryError = "unexpected_error.paymentsheet.formfactory"

--- a/StripePayments/StripePayments/Source/Helpers/STPBankAccountCollector.swift
+++ b/StripePayments/StripePayments/Source/Helpers/STPBankAccountCollector.swift
@@ -47,27 +47,6 @@ public class STPBankAccountCollector: NSObject {
     public typealias STPCollectBankAccountForPaymentCompletionBlock = (STPPaymentIntent?, NSError?)
         -> Void
 
-    private func error(
-        for errorCode: STPCollectBankAccountError,
-        loggingSafeErrorMessage: String? = nil
-    ) -> NSError {
-        var userInfo: [String: Any] = [:]
-        switch errorCode {
-        case .financialConnectionsSDKNotLinked:
-            userInfo[STPError.errorMessageKey] =
-                "StripeFinancialConnections SDK has not been linked into your project"
-        case .invalidClientSecret:
-            userInfo[STPError.errorMessageKey] = "Unable to parse client secret"
-        case .unexpectedError:
-            userInfo[STPError.errorMessageKey] = NSError.stp_unexpectedErrorMessage()
-        }
-        return NSError(
-            domain: STPPaymentHandler.errorDomain,
-            code: errorCode.rawValue,
-            userInfo: userInfo
-        )
-    }
-
     /// Presents a modal from the viewController to collect bank account
     /// and if completed successfully, link your bank account to a PaymentIntent
     /// - Parameters:
@@ -140,8 +119,15 @@ public class STPBankAccountCollector: NSObject {
         onEvent: ((FinancialConnectionsEvent) -> Void)?,
         completion: @escaping STPCollectBankAccountForPaymentCompletionBlock
     ) {
-        guard let paymentIntentID = STPPaymentIntent.id(fromClientSecret: clientSecret) else {
-            completion(nil, error(for: .invalidClientSecret))
+        let paymentIntentID = STPPaymentIntent.id(fromClientSecret: clientSecret)
+        logCollectBankAccountStarted(type: .payment, intentID: paymentIntentID)
+        // Overwrite completion to send an analytic before calling the caller-supplied completion
+        let completion: (FinancialConnectionsSDKResult?, STPPaymentIntent?, NSError?) -> Void = { result, paymentIntent, error in
+            self.logCollectBankAccountFinished(type: .payment, intentID: paymentIntent?.stripeId, linkAccountSessionID: nil, financialConnectionsSDKResult: result, error: error)
+            completion(paymentIntent, error)
+        }
+        guard let paymentIntentID else {
+            completion(nil, nil, error(for: .invalidClientSecret))
             return
         }
         let financialConnectionsCompletion:
@@ -150,15 +136,15 @@ public class STPBankAccountCollector: NSObject {
                 linkAccountSession,
                 error in
                 if let error {
-                    completion(nil, error)
+                    completion(result, nil, error)
                     return
                 }
                 guard let result else {
-                    completion(nil, self.error(for: .unexpectedError, loggingSafeErrorMessage: "collectBankAccountForPayment() completed without a result"))
+                    completion(result, nil, self.error(for: .unexpectedError, loggingSafeErrorMessage: "collectBankAccountForPayment() completed without a result"))
                     return
                 }
                 guard let linkAccountSession else {
-                    completion(nil, self.error(for: .unexpectedError, loggingSafeErrorMessage: "collectBankAccountForPayment() completed without a link account session"))
+                    completion(result, nil, self.error(for: .unexpectedError, loggingSafeErrorMessage: "collectBankAccountForPayment() completed without a link account session"))
                     return
                 }
 
@@ -167,26 +153,27 @@ public class STPBankAccountCollector: NSObject {
                     self.attachLinkAccountSessionToPaymentIntent(
                         paymentIntentID: paymentIntentID,
                         clientSecret: clientSecret,
-                        linkAccountSession: linkAccountSession,
-                        completion: completion
-                    )
+                        linkAccountSession: linkAccountSession
+                    ) { paymentIntent, error in
+                        completion(result, paymentIntent, error)
+                    }
                 case .cancelled:
                     self.apiClient.retrievePaymentIntent(withClientSecret: clientSecret) {
                         intent,
                         error in
-                        if let intent = intent {
-                            completion(intent, nil)
+                        if let intent {
+                            completion(result, intent, nil)
                         } else if let error {
-                            completion(nil, error as NSError)
+                            completion(result, nil, error as NSError)
                         } else {
-                            completion(nil, self.error(for: .unexpectedError, loggingSafeErrorMessage: "Canceled and retrieved PI without an error or intent"))
+                            completion(result, nil, self.error(for: .unexpectedError, loggingSafeErrorMessage: "Canceled and retrieved PI without an error or intent"))
                         }
                     }
                 case .failed(let error):
-                    completion(nil, error as NSError)
+                    completion(result, nil, error as NSError)
                 }
             }
-        collectBankAccountForPayment(
+        _collectBankAccountForPayment(
             clientSecret: clientSecret,
             returnURL: returnURL,
             onEvent: onEvent,
@@ -197,6 +184,33 @@ public class STPBankAccountCollector: NSObject {
     }
 
     @_spi(STP) public func collectBankAccountForPayment(
+        clientSecret: String,
+        returnURL: String?,
+        onEvent: ((FinancialConnectionsEvent) -> Void)?,
+        params: STPCollectBankAccountParams,
+        from viewController: UIViewController,
+        financialConnectionsCompletion: @escaping (
+            FinancialConnectionsSDKResult?, LinkAccountSession?, NSError?
+        ) -> Void
+    ) {
+        let paymentIntentID = STPPaymentIntent.id(fromClientSecret: clientSecret)
+        logCollectBankAccountStarted(type: .payment, intentID: paymentIntentID)
+        // Overwrite completion to send an analytic before calling the caller-supplied completion
+        let financialConnectionsCompletion: (FinancialConnectionsSDKResult?, LinkAccountSession?, NSError?) -> Void = { result, linkAccountSession, error in
+            self.logCollectBankAccountFinished(type: .payment, intentID: paymentIntentID, linkAccountSessionID: linkAccountSession?.stripeID, financialConnectionsSDKResult: result, error: error)
+            financialConnectionsCompletion(result, linkAccountSession, error)
+        }
+        _collectBankAccountForPayment(
+            clientSecret: clientSecret,
+            returnURL: returnURL,
+            onEvent: onEvent,
+            params: params,
+            from: viewController,
+            financialConnectionsCompletion: financialConnectionsCompletion
+        )
+    }
+
+    private func _collectBankAccountForPayment(
         clientSecret: String,
         returnURL: String?,
         onEvent: ((FinancialConnectionsEvent) -> Void)?,
@@ -356,8 +370,15 @@ public class STPBankAccountCollector: NSObject {
         onEvent: ((FinancialConnectionsEvent) -> Void)?,
         completion: @escaping STPCollectBankAccountForSetupCompletionBlock
     ) {
-        guard let setupIntentID = STPSetupIntent.id(fromClientSecret: clientSecret) else {
-            completion(nil, error(for: .invalidClientSecret))
+        let setupIntentID = STPSetupIntent.id(fromClientSecret: clientSecret)
+        logCollectBankAccountStarted(type: .setup, intentID: setupIntentID)
+        // Overwrite completion to send an analytic before calling the caller-supplied completion
+        let completion: (FinancialConnectionsSDKResult?, STPSetupIntent?, NSError?) -> Void = { result, setupIntent, error in
+            self.logCollectBankAccountFinished(type: .setup, intentID: setupIntent?.stripeID, linkAccountSessionID: nil, financialConnectionsSDKResult: result, error: error)
+            completion(setupIntent, error)
+        }
+        guard let setupIntentID else {
+            completion(nil, nil, error(for: .invalidClientSecret))
             return
         }
         let financialConnectionsCompletion:
@@ -366,15 +387,15 @@ public class STPBankAccountCollector: NSObject {
                 linkAccountSession,
                 error in
                 if let error {
-                    completion(nil, error as NSError)
+                    completion(result, nil, error as NSError)
                     return
                 }
                 guard let result else {
-                    completion(nil, self.error(for: .unexpectedError, loggingSafeErrorMessage: "Completed without a result"))
+                    completion(result, nil, self.error(for: .unexpectedError, loggingSafeErrorMessage: "Completed without a result"))
                     return
                 }
                 guard let linkAccountSession else {
-                    completion(nil, self.error(for: .unexpectedError, loggingSafeErrorMessage: "collectBankAccountForSetup() completed without a link account session"))
+                    completion(result, nil, self.error(for: .unexpectedError, loggingSafeErrorMessage: "collectBankAccountForSetup() completed without a link account session"))
                     return
                 }
                 switch result {
@@ -382,23 +403,24 @@ public class STPBankAccountCollector: NSObject {
                     self.attachLinkAccountSessionToSetupIntent(
                         setupIntentID: setupIntentID,
                         clientSecret: clientSecret,
-                        linkAccountSession: linkAccountSession,
-                        completion: completion
-                    )
+                        linkAccountSession: linkAccountSession
+                    ) { setupIntent, error in
+                        completion(result, setupIntent, error)
+                    }
                 case .cancelled:
                     self.apiClient.retrieveSetupIntent(withClientSecret: clientSecret) {
                         intent,
                         error in
                         if let intent = intent {
-                            completion(intent, nil)
+                            completion(result, intent, nil)
                         } else if let error {
-                            completion(nil, error as NSError)
+                            completion(result, nil, error as NSError)
                         } else {
-                            completion(nil, self.error(for: .unexpectedError, loggingSafeErrorMessage: "Canceled and retrieved SI without an error or intent"))
+                            completion(result, nil, self.error(for: .unexpectedError, loggingSafeErrorMessage: "Canceled and retrieved SI without an error or intent"))
                         }
                     }
                 case .failed(let error):
-                    completion(nil, error as NSError)
+                    completion(result, nil, error as NSError)
                 }
             }
         collectBankAccountForSetup(
@@ -412,6 +434,33 @@ public class STPBankAccountCollector: NSObject {
     }
 
     @_spi(STP) public func collectBankAccountForSetup(
+        clientSecret: String,
+        returnURL: String?,
+        onEvent: ((FinancialConnectionsEvent) -> Void)?,
+        params: STPCollectBankAccountParams,
+        from viewController: UIViewController,
+        financialConnectionsCompletion: @escaping (
+            FinancialConnectionsSDKResult?, LinkAccountSession?, NSError?
+        ) -> Void
+    ) {
+        let setupIntentID = STPSetupIntent.id(fromClientSecret: clientSecret)
+        logCollectBankAccountStarted(type: .setup, intentID: setupIntentID)
+        // Overwrite completion to send an analytic before calling the caller-supplied completion
+        let financialConnectionsCompletion: (FinancialConnectionsSDKResult?, LinkAccountSession?, NSError?) -> Void = { result, linkAccountSession, error in
+            self.logCollectBankAccountFinished(type: .setup, intentID: setupIntentID, linkAccountSessionID: linkAccountSession?.stripeID, financialConnectionsSDKResult: result, error: error)
+            financialConnectionsCompletion(result, linkAccountSession, error)
+        }
+        _collectBankAccountForSetup(
+            clientSecret: clientSecret,
+            returnURL: returnURL,
+            onEvent: onEvent,
+            params: params,
+            from: viewController,
+            financialConnectionsCompletion: financialConnectionsCompletion
+        )
+    }
+
+    private func _collectBankAccountForSetup(
         clientSecret: String,
         returnURL: String?,
         onEvent: ((FinancialConnectionsEvent) -> Void)?,
@@ -503,6 +552,13 @@ public class STPBankAccountCollector: NSObject {
             FinancialConnectionsSDKResult?, LinkAccountSession?, NSError?
         ) -> Void
     ) {
+        logCollectBankAccountStarted(type: .deferred, intentID: nil)
+        // Overwrite completion to send an analytic before calling the caller-supplied completion
+        let financialConnectionsCompletion: (FinancialConnectionsSDKResult?, LinkAccountSession?, NSError?) -> Void = { result, linkAccountSession, error in
+            self.logCollectBankAccountFinished(type: .deferred, intentID: nil, linkAccountSessionID: linkAccountSession?.stripeID, financialConnectionsSDKResult: result, error: error)
+            financialConnectionsCompletion(result, linkAccountSession, error)
+        }
+
         guard
             let financialConnectionsAPI = FinancialConnectionsSDKAvailability.financialConnections()
         else {
@@ -535,5 +591,95 @@ public class STPBankAccountCollector: NSObject {
                 financialConnectionsCompletion(result, linkAccountSession, nil)
             }
         }
+    }
+}
+
+// MARK: - Error
+extension STPBankAccountCollector {
+    private func error(
+        for errorCode: STPCollectBankAccountError,
+        loggingSafeErrorMessage: String? = nil
+    ) -> NSError {
+        var userInfo: [String: String] = [:]
+        switch errorCode {
+        case .financialConnectionsSDKNotLinked:
+            userInfo[STPError.errorMessageKey] =
+                "StripeFinancialConnections SDK has not been linked into your project"
+        case .invalidClientSecret:
+            userInfo[STPError.errorMessageKey] = "Unable to parse client secret"
+        case .unexpectedError:
+            userInfo[STPError.errorMessageKey] = loggingSafeErrorMessage
+        }
+        return STPBankAccountCollectorError(code: errorCode, loggingSafeUserInfo: userInfo) as NSError
+    }
+}
+
+/// STPBankAccountCollector errors (i.e. errors that are created by the STPBankAccountCollector class and have a corresponding STPCollectBankAccountError) used to be NSErrors.
+/// This struct exists so that these errors can be Swift errors to conform to AnalyticLoggableError, while still looking like the old NSErrors to users (i.e. same domain and code).
+struct STPBankAccountCollectorError: Error, CustomNSError, AnalyticLoggableError {
+    // AnalyticLoggableError properties
+    let analyticsErrorType: String = errorDomain
+    let analyticsErrorCode: String
+    let additionalNonPIIErrorDetails: [String: Any]
+
+    // CustomNSError properties, to not break old behavior when this was an NSError
+    static let errorDomain: String = "STPBankAccountCollectorErrorDomain"
+    let errorUserInfo: [String: Any]
+    let errorCode: Int
+
+    init(code: STPCollectBankAccountError, loggingSafeUserInfo: [String: String]) {
+        errorCode = code.rawValue
+        // Set analytics error code to the description (e.g. "invalidClientSecret")
+        analyticsErrorCode = code.description
+        errorUserInfo = loggingSafeUserInfo
+        additionalNonPIIErrorDetails = loggingSafeUserInfo
+    }
+}
+
+// MARK: - Analytic
+extension STPBankAccountCollector {
+    fileprivate struct Analytic: StripeCore.Analytic {
+        let event: StripeCore.STPAnalyticEvent
+        let intentID: String?
+        let linkAccountSessionID: String?
+        let intentType: IntentType
+        let financialConnectionsSDKResult: FinancialConnectionsSDKResult?
+        let error: Error?
+
+        var params: [String: Any] {
+            var params: [String: Any] = error?.serializeForV1Analytics() ?? [:]
+            params["intent_id"] = intentID
+            params["intent_type"] = intentType.rawValue
+            params["link_account_session_id"] = linkAccountSessionID
+            params["fc_sdk_result"] = {
+                switch financialConnectionsSDKResult {
+                case nil:
+                    return nil
+                case .cancelled:
+                    return "cancelled"
+                case .completed:
+                    return "completed"
+                case .failed:
+                    return "failed"
+                }
+            }()
+            return params
+        }
+
+    }
+    enum IntentType: String {
+        case payment
+        case setup
+        case deferred
+    }
+
+    func logCollectBankAccountStarted(type: IntentType, intentID: String?) {
+        let analytic = Analytic(event: .bankAccountCollectorStarted, intentID: intentID, linkAccountSessionID: nil, intentType: type, financialConnectionsSDKResult: nil, error: nil)
+        STPAnalyticsClient.sharedClient.log(analytic: analytic, apiClient: self.apiClient)
+    }
+
+    func logCollectBankAccountFinished(type: IntentType, intentID: String?, linkAccountSessionID: String?, financialConnectionsSDKResult: FinancialConnectionsSDKResult?, error: Error?) {
+        let analytic = Analytic(event: .bankAccountCollectorFinished, intentID: intentID, linkAccountSessionID: linkAccountSessionID, intentType: type, financialConnectionsSDKResult: financialConnectionsSDKResult, error: error)
+        STPAnalyticsClient.sharedClient.log(analytic: analytic, apiClient: self.apiClient)
     }
 }

--- a/StripePayments/StripePayments/Source/Helpers/STPBankAccountCollector.swift
+++ b/StripePayments/StripePayments/Source/Helpers/STPBankAccountCollector.swift
@@ -391,7 +391,7 @@ public class STPBankAccountCollector: NSObject {
                     return
                 }
                 guard let result else {
-                    completion(result, nil, self.error(for: .unexpectedError, loggingSafeErrorMessage: "Completed without a result"))
+                    completion(result, nil, self.error(for: .unexpectedError, loggingSafeErrorMessage: "collectBankAccountForSetup() completed without a result"))
                     return
                 }
                 guard let linkAccountSession else {


### PR DESCRIPTION
## Summary
- Adds "start" and "finish" analytics to all APIs, similar to `STPPaymentHandler`.
- Make STPBankAccountCollector use unexpectedError code for unexpected errors i.e. errors that we don't expect to occur. 
- Make STPBankAccountCollector _stop_ wrapping all errors originating outside of the class under its own error domain and using the "unexpectedError" code for them; it now vends those errors directly.

## Testing
Manually tested PaymentSheet.  Added a ticket for writing tests for this class here: https://jira.corp.stripe.com/browse/MOBILESDK-1944

## Changelog
* [Fixed] STPBankAccountCollector errors now use "STPBankAccountCollectorErrorDomain" instead of "STPPaymentHandlerErrorDomain".
