### PR TITLE
Add support for all EPMs to playground

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -40,7 +40,7 @@ struct PaymentSheetTestPlayground: View {
         Group {
             SettingView(setting: $playgroundController.settings.linkEnabled)
             SettingView(setting: $playgroundController.settings.userOverrideCountry)
-            SettingView(setting: $playgroundController.settings.externalPayPalEnabled)
+            SettingView(setting: $playgroundController.settings.externalPaymentMethods)
             SettingView(setting: $playgroundController.settings.preferredNetworksEnabled)
             SettingView(setting: $playgroundController.settings.allowsRemovalOfLastSavedPaymentMethod)
         }

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -288,6 +288,17 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
         case paypal
         case all
         case off
+
+        var paymentMethods: [String]? {
+            switch self {
+            case .paypal:
+                return ["external_paypal"]
+            case .all:
+                return ExternalPaymentMethods.allExternalPaymentMethods
+            case .off:
+                return nil
+            }
+        }
     }
 
     enum PreferredNetworksEnabled: String, PickerEnum {

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -219,10 +219,75 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
     }
     enum ExternalPaymentMethods: String, PickerEnum {
         static let enumName: String = "External PMs"
+        // Based on https://git.corp.stripe.com/stripe-internal/stripe-js-v3/blob/55d7fd10/src/externalPaymentMethods/constants.ts#L13
+        static let allExternalPaymentMethods = [
+            "external_aplazame",
+            "external_atone",
+            "external_au_easy_payment",
+            "external_au_pay",
+            "external_azupay",
+            "external_bank_pay",
+            "external_benefit",
+            "external_billie",
+            "external_bitcash",
+            "external_bizum",
+            "external_catch",
+            "external_dapp",
+            "external_dbarai",
+            "external_divido",
+            "external_famipay",
+            "external_fawry",
+            "external_fonix",
+            "external_gcash",
+            "external_grabpay_later",
+            "external_interac",
+            "external_iwocapay",
+            "external_kbc",
+            "external_knet",
+            "external_kriya",
+            "external_laybuy",
+            "external_line_pay",
+            "external_merpay",
+            "external_momo",
+            "external_mondu",
+            "external_net_cash",
+            "external_nexi_pay",
+            "external_octopus",
+            "external_oney",
+            "external_paidy",
+            "external_pay_easy",
+            "external_payconiq",
+            "external_paypal",
+            "external_paypay",
+            "external_paypo",
+            "external_paysafecard",
+            "external_picpay",
+            "external_planpay",
+            "external_pledg",
+            "external_postepay",
+            "external_postfinance",
+            "external_rakuten_pay",
+            "external_samsung_pay",
+            "external_satispay",
+            "external_scalapay",
+            "external_sequra",
+            "external_sezzle",
+            "external_shopback_paylater",
+            "external_softbank_carrier_payment",
+            "external_tabby",
+            "external_tng_ewallet",
+            "external_toss_pay",
+            "external_truelayer",
+            "external_twint",
+            "external_venmo",
+            "external_walley",
+            "external_webmoney",
+            "external_younited_pay",
+        ]
 
         case paypal
         case venmo
-        case both
+        case all
         case off
     }
 

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -286,7 +286,6 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
         ]
 
         case paypal
-        case venmo
         case all
         case off
     }

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -217,10 +217,12 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
         case on
         case off
     }
-    enum ExternalPayPalEnabled: String, PickerEnum {
-        static let enumName: String = "External PayPal"
+    enum ExternalPaymentMethods: String, PickerEnum {
+        static let enumName: String = "External PMs"
 
-        case on
+        case paypal
+        case venmo
+        case both
         case off
     }
 
@@ -272,7 +274,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
     var paymentMethodConfigurationId: String?
     var checkoutEndpoint: String?
     var autoreload: Autoreload
-    var externalPayPalEnabled: ExternalPayPalEnabled
+    var externalPaymentMethods: ExternalPaymentMethods
     var preferredNetworksEnabled: PreferredNetworksEnabled
     var requireCVCRecollection: RequireCVCRecollectionEnabled
     var allowsRemovalOfLastSavedPaymentMethod: AllowsRemovalOfLastSavedPaymentMethodEnabled
@@ -305,7 +307,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
             paymentMethodConfigurationId: nil,
             checkoutEndpoint: Self.defaultCheckoutEndpoint,
             autoreload: .on,
-            externalPayPalEnabled: .off,
+            externalPaymentMethods: .off,
             preferredNetworksEnabled: .off,
             requireCVCRecollection: .off,
             allowsRemovalOfLastSavedPaymentMethod: .on,

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -107,7 +107,7 @@ class PlaygroundController: ObservableObject {
     var configuration: PaymentSheet.Configuration {
         var configuration = PaymentSheet.Configuration()
         configuration.externalPaymentMethodConfiguration = externalPaymentMethodConfiguration
-        configuration.paymentMethodOrder = ["card", "external_paypal"]
+        configuration.paymentMethodOrder = ["card", "external_paypal", "external_venmo"]
         configuration.merchantDisplayName = "Example, Inc."
         configuration.applePay = applePayConfiguration
         configuration.customer = customerConfiguration

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -234,11 +234,25 @@ class PlaygroundController: ObservableObject {
     }
 
     var externalPaymentMethodConfiguration: PaymentSheet.ExternalPaymentMethodConfiguration? {
-        guard settings.externalPayPalEnabled == .on else {
+        guard settings.externalPaymentMethods != .off else {
             return nil
         }
+
+        let externalPaymentMethods: [String] = {
+            switch settings.externalPaymentMethods {
+            case .paypal:
+                return ["external_paypal"]
+            case .venmo:
+                return ["external_venmo"]
+            case .both:
+                return ["external_paypal", "external_venmo"]
+            case .off:
+                return [] // handled above
+            }
+        }()
+
         return .init(
-            externalPaymentMethods: ["external_paypal"]
+            externalPaymentMethods: externalPaymentMethods
         ) { [weak self] externalPaymentMethodType, billingDetails, completion in
             self?.handleExternalPaymentMethod(type: externalPaymentMethodType, billingDetails: billingDetails, completion: completion)
         }

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -107,7 +107,7 @@ class PlaygroundController: ObservableObject {
     var configuration: PaymentSheet.Configuration {
         var configuration = PaymentSheet.Configuration()
         configuration.externalPaymentMethodConfiguration = externalPaymentMethodConfiguration
-        configuration.paymentMethodOrder = ["card", "external_paypal", "external_venmo"]
+        configuration.paymentMethodOrder = ["card", "external_paypal"]
         configuration.merchantDisplayName = "Example, Inc."
         configuration.applePay = applePayConfiguration
         configuration.customer = customerConfiguration
@@ -242,8 +242,6 @@ class PlaygroundController: ObservableObject {
             switch settings.externalPaymentMethods {
             case .paypal:
                 return ["external_paypal"]
-            case .venmo:
-                return ["external_venmo"]
             case .all:
                 return PaymentSheetTestPlaygroundSettings.ExternalPaymentMethods.allExternalPaymentMethods
             case .off:

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -107,7 +107,12 @@ class PlaygroundController: ObservableObject {
     var configuration: PaymentSheet.Configuration {
         var configuration = PaymentSheet.Configuration()
         configuration.externalPaymentMethodConfiguration = externalPaymentMethodConfiguration
-        configuration.paymentMethodOrder = ["card", "external_paypal"]
+        switch settings.externalPaymentMethods {
+        case .paypal:
+            configuration.paymentMethodOrder = ["card", "external_paypal"]
+        case .off, .all: // When using all EPMs, alphabetize the order by not setting `paymentMethodOrder`.
+            break
+        }
         configuration.merchantDisplayName = "Example, Inc."
         configuration.applePay = applePayConfiguration
         configuration.customer = customerConfiguration
@@ -234,20 +239,9 @@ class PlaygroundController: ObservableObject {
     }
 
     var externalPaymentMethodConfiguration: PaymentSheet.ExternalPaymentMethodConfiguration? {
-        guard settings.externalPaymentMethods != .off else {
+        guard let externalPaymentMethods = settings.externalPaymentMethods.paymentMethods else {
             return nil
         }
-
-        let externalPaymentMethods: [String] = {
-            switch settings.externalPaymentMethods {
-            case .paypal:
-                return ["external_paypal"]
-            case .all:
-                return PaymentSheetTestPlaygroundSettings.ExternalPaymentMethods.allExternalPaymentMethods
-            case .off:
-                return [] // handled above
-            }
-        }()
 
         return .init(
             externalPaymentMethods: externalPaymentMethods

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -244,8 +244,8 @@ class PlaygroundController: ObservableObject {
                 return ["external_paypal"]
             case .venmo:
                 return ["external_venmo"]
-            case .both:
-                return ["external_paypal", "external_venmo"]
+            case .all:
+                return PaymentSheetTestPlaygroundSettings.ExternalPaymentMethods.allExternalPaymentMethods
             case .off:
                 return [] // handled above
             }

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -2118,7 +2118,7 @@ class PaymentSheetDeferredServerSideUITests: PaymentSheetUITestCase {
     // MARK: - External PayPal 
     func testExternalPaypalPaymentSheet() throws {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
-        settings.externalPaymentMethods = .paypal
+        settings.externalPayPalEnabled = .paypal
 
         loadPlayground(app, settings)
 
@@ -2145,7 +2145,7 @@ class PaymentSheetDeferredServerSideUITests: PaymentSheetUITestCase {
 
     func testExternalPaypalPaymentSheetFlowController() throws {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
-        settings.externalPaymentMethods = .paypal
+        settings.externalPayPalEnabled = .paypal
         settings.uiStyle = .flowController
 
         loadPlayground(app, settings)
@@ -2159,67 +2159,6 @@ class PaymentSheetDeferredServerSideUITests: PaymentSheetUITestCase {
         app.buttons["Confirm"].tap()
 
         XCTAssertNotNil(app.staticTexts["Confirm external_paypal?"])
-        app.buttons["Cancel"].tap()
-        XCTAssertNotNil(app.staticTexts["Payment canceled."])
-
-        let payButton = app.buttons["Confirm"]
-        payButton.tap()
-        app.buttons["Fail"].tap()
-        XCTAssertTrue(app.staticTexts["Payment failed: Error Domain= Code=0 \"Something went wrong!\" UserInfo={NSLocalizedDescription=Something went wrong!}"].waitForExistence(timeout: 5.0))
-
-        payButton.tap()
-        app.alerts.buttons["Confirm"].tap()
-        XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 5.0))
-    }
-
-    // MARK: - Multiple external payment methods/external Venmo
-    func testMultipleExternalPaymentMethodsPaymentSheet() throws {
-        var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
-        settings.externalPaymentMethods = .all // test multiple external payment methods can load
-
-        loadPlayground(app, settings)
-
-        app.buttons["Present PaymentSheet"].waitForExistenceAndTap()
-
-        let payButton = app.buttons["Pay $50.99"]
-        // Assert PayPal is visible when using both external payment methods
-        XCTAssertTrue(scroll(collectionView: app.collectionViews.firstMatch, toFindCellWithId: "PayPal")?.waitForExistence(timeout: 5.0) ?? false)
-        guard let venmo = scroll(collectionView: app.collectionViews.firstMatch, toFindCellWithId: "Venmo") else {
-            XCTFail()
-            return
-        }
-        venmo.tap()
-        payButton.tap()
-        XCTAssertNotNil(app.staticTexts["Confirm external_venmo?"])
-        app.buttons["Cancel"].tap()
-
-        payButton.tap()
-        app.buttons["Fail"].tap()
-        XCTAssertTrue(app.staticTexts["Something went wrong!"].waitForExistence(timeout: 5.0))
-
-        payButton.tap()
-        app.buttons["Confirm"].tap()
-        XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 5.0))
-    }
-
-    func testMultipleExternalPaymentMethodsPaymentSheetFlowController() throws {
-        var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
-        settings.externalPaymentMethods = .all // test multiple external payment methods can load
-        settings.uiStyle = .flowController
-
-        loadPlayground(app, settings)
-
-        app.buttons["Payment method"].waitForExistenceAndTap()
-        app.buttons["+ Add"].waitForExistenceAndTap()
-
-        // Assert PayPal is visible when using both external payment methods
-        XCTAssertTrue(scroll(collectionView: app.collectionViews.firstMatch, toFindCellWithId: "PayPal")?.waitForExistence(timeout: 5.0) ?? false)
-        scroll(collectionView: app.collectionViews.firstMatch, toFindCellWithId: "Venmo")?.waitForExistenceAndTap()
-
-        app.buttons["Continue"].tap()
-        app.buttons["Confirm"].tap()
-
-        XCTAssertNotNil(app.staticTexts["Confirm external_venmo?"])
         app.buttons["Cancel"].tap()
         XCTAssertNotNil(app.staticTexts["Payment canceled."])
 

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -2118,7 +2118,7 @@ class PaymentSheetDeferredServerSideUITests: PaymentSheetUITestCase {
     // MARK: - External PayPal 
     func testExternalPaypalPaymentSheet() throws {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
-        settings.externalPayPalEnabled = .paypal
+        settings.externalPaymentMethods = .paypal
 
         loadPlayground(app, settings)
 
@@ -2145,7 +2145,7 @@ class PaymentSheetDeferredServerSideUITests: PaymentSheetUITestCase {
 
     func testExternalPaypalPaymentSheetFlowController() throws {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
-        settings.externalPayPalEnabled = .paypal
+        settings.externalPaymentMethods = .paypal
         settings.uiStyle = .flowController
 
         loadPlayground(app, settings)

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -2175,7 +2175,7 @@ class PaymentSheetDeferredServerSideUITests: PaymentSheetUITestCase {
     // MARK: - Multiple external payment methods/external Venmo
     func testMultipleExternalPaymentMethodsPaymentSheet() throws {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
-        settings.externalPaymentMethods = .both // test multiple external payment methods can load
+        settings.externalPaymentMethods = .all // test multiple external payment methods can load
 
         loadPlayground(app, settings)
 
@@ -2204,7 +2204,7 @@ class PaymentSheetDeferredServerSideUITests: PaymentSheetUITestCase {
 
     func testMultipleExternalPaymentMethodsPaymentSheetFlowController() throws {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
-        settings.externalPaymentMethods = .both // test multiple external payment methods can load
+        settings.externalPaymentMethods = .all // test multiple external payment methods can load
         settings.uiStyle = .flowController
 
         loadPlayground(app, settings)

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -2118,7 +2118,7 @@ class PaymentSheetDeferredServerSideUITests: PaymentSheetUITestCase {
     // MARK: - External PayPal 
     func testExternalPaypalPaymentSheet() throws {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
-        settings.externalPayPalEnabled = .on
+        settings.externalPaymentMethods = .paypal
 
         loadPlayground(app, settings)
 
@@ -2145,7 +2145,7 @@ class PaymentSheetDeferredServerSideUITests: PaymentSheetUITestCase {
 
     func testExternalPaypalPaymentSheetFlowController() throws {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
-        settings.externalPayPalEnabled = .on
+        settings.externalPaymentMethods = .paypal
         settings.uiStyle = .flowController
 
         loadPlayground(app, settings)

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -2171,6 +2171,67 @@ class PaymentSheetDeferredServerSideUITests: PaymentSheetUITestCase {
         app.alerts.buttons["Confirm"].tap()
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 5.0))
     }
+
+    // MARK: - External Venmo/multiple external payment methods
+    func testExternalVenmoPaymentSheet() throws {
+        var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
+        settings.externalPaymentMethods = .both // test multiple external payment methods can load
+
+        loadPlayground(app, settings)
+
+        app.buttons["Present PaymentSheet"].waitForExistenceAndTap()
+
+        let payButton = app.buttons["Pay $50.99"]
+        // Assert PayPal is visible when using both external payment methods
+        XCTAssertTrue(scroll(collectionView: app.collectionViews.firstMatch, toFindCellWithId: "PayPal")?.waitForExistence(timeout: 5.0) ?? false)
+        guard let venmo = scroll(collectionView: app.collectionViews.firstMatch, toFindCellWithId: "Venmo") else {
+            XCTFail()
+            return
+        }
+        venmo.tap()
+        payButton.tap()
+        XCTAssertNotNil(app.staticTexts["Confirm external_venmo?"])
+        app.buttons["Cancel"].tap()
+
+        payButton.tap()
+        app.buttons["Fail"].tap()
+        XCTAssertTrue(app.staticTexts["Something went wrong!"].waitForExistence(timeout: 5.0))
+
+        payButton.tap()
+        app.buttons["Confirm"].tap()
+        XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 5.0))
+    }
+
+    func testExternalVenmoPaymentSheetFlowController() throws {
+        var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
+        settings.externalPaymentMethods = .both // test multiple external payment methods can load
+        settings.uiStyle = .flowController
+
+        loadPlayground(app, settings)
+
+        app.buttons["Payment method"].waitForExistenceAndTap()
+        app.buttons["+ Add"].waitForExistenceAndTap()
+
+        // Assert PayPal is visible when using both external payment methods
+        XCTAssertTrue(scroll(collectionView: app.collectionViews.firstMatch, toFindCellWithId: "PayPal")?.waitForExistence(timeout: 5.0) ?? false)
+        scroll(collectionView: app.collectionViews.firstMatch, toFindCellWithId: "Venmo")?.waitForExistenceAndTap()
+
+        app.buttons["Continue"].tap()
+        app.buttons["Confirm"].tap()
+
+        XCTAssertNotNil(app.staticTexts["Confirm external_venmo?"])
+        app.buttons["Cancel"].tap()
+        XCTAssertNotNil(app.staticTexts["Payment canceled."])
+
+        let payButton = app.buttons["Confirm"]
+        payButton.tap()
+        app.buttons["Fail"].tap()
+        XCTAssertTrue(app.staticTexts["Payment failed: Error Domain= Code=0 \"Something went wrong!\" UserInfo={NSLocalizedDescription=Something went wrong!}"].waitForExistence(timeout: 5.0))
+
+        payButton.tap()
+        app.alerts.buttons["Confirm"].tap()
+        XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 5.0))
+    }
     // MARK: - Customer Session
     func testDedupedPaymentMethods_paymentSheet() throws {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -2156,6 +2156,11 @@ class PaymentSheetDeferredServerSideUITests: PaymentSheetUITestCase {
         scroll(collectionView: app.collectionViews.firstMatch, toFindCellWithId: "PayPal")?.waitForExistenceAndTap()
 
         app.buttons["Continue"].tap()
+
+        // Verify EPMs vend the correct PaymentOptionDisplayData
+        XCTAssertTrue(app.staticTexts["PayPal"].waitForExistence(timeout: 5.0))
+        XCTAssertTrue(app.staticTexts["external_paypal"].waitForExistence(timeout: 5.0))
+
         app.buttons["Confirm"].tap()
 
         XCTAssertNotNil(app.staticTexts["Confirm external_paypal?"])

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -2172,8 +2172,8 @@ class PaymentSheetDeferredServerSideUITests: PaymentSheetUITestCase {
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 5.0))
     }
 
-    // MARK: - External Venmo/multiple external payment methods
-    func testExternalVenmoPaymentSheet() throws {
+    // MARK: - Multiple external payment methods/external Venmo
+    func testMultipleExternalPaymentMethodsPaymentSheet() throws {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
         settings.externalPaymentMethods = .both // test multiple external payment methods can load
 
@@ -2202,7 +2202,7 @@ class PaymentSheetDeferredServerSideUITests: PaymentSheetUITestCase {
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 5.0))
     }
 
-    func testExternalVenmoPaymentSheetFlowController() throws {
+    func testMultipleExternalPaymentMethodsPaymentSheetFlowController() throws {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
         settings.externalPaymentMethods = .both // test multiple external payment methods can load
         settings.uiStyle = .flowController


### PR DESCRIPTION
## Summary
- Adds the ability to use external Venmo and all other EPMs in the playground


https://github.com/stripe/stripe-ios/assets/88012362/3ee088f4-c015-4e39-8642-12ce28804df2




## Motivation
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-3097

## Testing
- Manual
- Some new UI tests

## Changelog
N/A
