### PR TITLE
Fix analyticsLog reloading entire test playground - this caused an in…

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -11,6 +11,7 @@ import SwiftUI
 @available(iOS 15.0, *)
 struct PaymentSheetTestPlayground: View {
     @StateObject var playgroundController: PlaygroundController
+    @StateObject var analyticsLogObserver: AnalyticsLogObserver = .shared
     @State var showingQRSheet = false
 
     init(settings: PaymentSheetTestPlaygroundSettings) {
@@ -59,7 +60,7 @@ struct PaymentSheetTestPlayground: View {
                     Group {
                         HStack {
                             if ProcessInfo.processInfo.environment["UITesting"] != nil {
-                                AnalyticsLogForTesting(analyticsLog: $playgroundController.analyticsLog)
+                                AnalyticsLogForTesting(analyticsLog: $analyticsLogObserver.analyticsLog)
                             }
                             Text("Backend")
                                 .font(.headline)

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -275,8 +275,6 @@ class PlaygroundController: ObservableObject {
     var addressViewController: AddressViewController?
     var appearance = PaymentSheet.Appearance.default
     var currentDataTask: URLSessionDataTask?
-    /// All analytic events sent by the SDK since the playground was loaded.
-    @Published var analyticsLog: [[String: Any]] = []
 
     func makeAlertController() -> UIAlertController {
         let alertController = UIAlertController(
@@ -471,7 +469,7 @@ extension PlaygroundController {
             }
 
             DispatchQueue.main.async {
-                self.analyticsLog.removeAll()
+                AnalyticsLogObserver.shared.analyticsLog.removeAll()
                 self.lastPaymentResult = nil
                 self.clientSecret = json["intentClientSecret"]
                 self.ephemeralKey = json["customerEphemeralKeySecret"]
@@ -657,7 +655,7 @@ extension PaymentSheet.IntentConfiguration.Mode {
 extension PlaygroundController: STPAnalyticsClientDelegate {
     func analyticsClientDidLog(analyticsClient: StripeCore.STPAnalyticsClient, payload: [String: Any]) {
         DispatchQueue.main.async {
-            self.analyticsLog.append(payload)
+            AnalyticsLogObserver.shared.analyticsLog.append(payload)
         }
     }
 }
@@ -724,4 +722,12 @@ extension AddressViewController.AddressDetails {
 
         return [name, formatter.string(from: postalAddress), phone].compactMap { $0 }.joined(separator: "\n")
     }
+}
+
+// MARK: - Analytics observer
+
+class AnalyticsLogObserver: ObservableObject {
+    static let shared: AnalyticsLogObserver = .init()
+    /// All analytic events sent by the SDK since the playground was loaded.
+    @Published var analyticsLog: [[String: Any]] = []
 }


### PR DESCRIPTION
…finite loop where paymentOptions could fire an analytic.

Very open to other ways of doing this, this was just the most expedient given my lack of SwiftUI knowledge. 

## Testing
Manually tested

## Changelog
Not user facing