### PR TITLE
Animate Buy button when paying with Link

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
@@ -347,7 +347,7 @@ extension PaymentSheet: PayWithLinkWebControllerDelegate {
             self.bottomSheetViewController.startSpinner()
             let psvc = self.findPaymentSheetViewController()
             psvc?.clearTextFields()
-            psvc?.pay(with: paymentOption, animateBuybutton: false)
+            psvc?.pay(with: paymentOption, animateBuyButton: true)
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -491,13 +491,13 @@ class PaymentSheetViewController: UIViewController {
             paymentOption = selectedPaymentOption
         }
         STPAnalyticsClient.sharedClient.logPaymentSheetConfirmButtonTapped(paymentMethodTypeIdentifier: paymentOption.paymentMethodTypeAnalyticsValue)
-        pay(with: paymentOption, animateBuybutton: true)
+        pay(with: paymentOption, animateBuyButton: true)
     }
 
-    func pay(with paymentOption: PaymentOption, animateBuybutton: Bool) {
+    func pay(with paymentOption: PaymentOption, animateBuyButton: Bool) {
         view.endEditing(true)
         isPaymentInFlight = true
-        shouldAnimateBuyButton = animateBuybutton
+        shouldAnimateBuyButton = animateBuyButton
         // Clear any errors
         error = nil
         updateUI()
@@ -554,7 +554,7 @@ class PaymentSheetViewController: UIViewController {
 #if !canImport(CompositorServices)
                             UINotificationFeedbackGenerator().notificationOccurred(.success)
 #endif
-                            if animateBuybutton {
+                            if animateBuyButton {
                                 self.buyButton.update(state: .succeeded, animated: true) {
                                     // Wait a bit before closing the sheet
                                     self.delegate?.paymentSheetViewControllerDidFinish(self, result: .completed)
@@ -576,7 +576,7 @@ extension PaymentSheetViewController: WalletHeaderViewDelegate {
 
     func walletHeaderViewApplePayButtonTapped(_ header: WalletHeaderView) {
         set(error: nil)
-        pay(with: .applePay, animateBuybutton: true)
+        pay(with: .applePay, animateBuyButton: true)
     }
 
     func walletHeaderViewPayWithLinkTapped(_ header: WalletHeaderView) {


### PR DESCRIPTION
## Summary
- Previously we were not animating the "Buy" button when paying with Link. This resulted in a weird no-animation completion when paying with 3DS2.
- We don't use the blur view in this case as it gets pretty hacky.
- A consequence of this is you can see the "Buy" button animate under the blur view in normal transactions too.


https://github.com/stripe/stripe-ios/assets/88012362/ee7761c8-b13b-4c06-b1d4-b7b0c698cd49



## Motivation
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-2987

## Testing
- Manual

## Changelog
N/A
