### PR TITLE
Fix 3DS2 privacy manifest in podspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## x.x.x x-x-x
+### Payments
+* [Fixed] An issue where the PrivacyInfo.xcprivacy was not bundled with StripePayments when installing with Cocoapods. 
+
 ## 23.27.0 2024-04-08
 ### Payments
 * [Added] Support for Alma bindings.

--- a/StripePayments.podspec
+++ b/StripePayments.podspec
@@ -21,6 +21,6 @@ Pod::Spec.new do |s|
   s.dependency                       'StripeCore', s.version.to_s
   s.subspec 'Stripe3DS2' do |sp|
     sp.source_files = 'Stripe3DS2/Stripe3DS2/**/*.{h,m}'
-    sp.resource_bundles = { 'Stripe3DS2' => ['Stripe3DS2/Stripe3DS2/Resources/**/*.{lproj,png,xcassets}'] }
+    sp.resource_bundles = { 'Stripe3DS2' => ['Stripe3DS2/Stripe3DS2/Resources/**/*.{lproj,png,xcassets}', 'Stripe3DS2/Stripe3DS2/PrivacyInfo.xcprivacy'] }
   end
 end


### PR DESCRIPTION
## Summary
- Adds the 3DS2 privacy manifest to the podspec for StripePayments

## Motivation
https://github.com/stripe/stripe-ios/issues/3521

## Testing
Manual

## Changelog
See diff
