### PR TITLE
[Identity] Remove delay start and check blur when barcode is detected

### DIFF
--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/ImageScanner/DocumentScanner/DocumentScanner.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/ImageScanner/DocumentScanner/DocumentScanner.swift
@@ -28,9 +28,6 @@ final class DocumentScanner {
     private let analyticsClient: IdentityAnalyticsClient
     private var hasSeenMBRunnerError: Bool = false
     private let sheetController: VerificationSheetControllerProtocol
-    private var shouldStartScan: Bool = false
-    private var scheduledAsync: Bool = false
-    static let delayStart: DispatchTimeInterval = .seconds(3)
 
     /// Initializes a DocumentScanner with detectors.
     ///
@@ -120,15 +117,6 @@ extension DocumentScanner: ImageScanner {
         sampleBuffer: CMSampleBuffer,
         cameraProperties: CameraSession.DeviceProperties?
     ) -> Future<DocumentScannerOutput?> {
-        if !self.shouldStartScan {
-            if !self.scheduledAsync {
-                self.scheduledAsync = true
-                DispatchQueue.main.asyncAfter(deadline: .now() + DocumentScanner.delayStart) { [weak self] in
-                    self?.shouldStartScan = true
-                }
-            }
-            return Promise(value: nil)
-        }
         do {
             // Scan for ID Document Classification
             guard let idDetectorOutput = try self.idDetector.scanImage(pixelBuffer: pixelBuffer) else {
@@ -242,8 +230,6 @@ extension DocumentScanner: ImageScanner {
         barcodeDetector?.reset()
         idDetector.metricsTracker?.reset()
         mbDetector?.reset()
-        shouldStartScan = false
-        scheduledAsync = false
     }
 }
 

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/ImageScanner/DocumentScanner/DocumentScannerOutput.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/ImageScanner/DocumentScanner/DocumentScannerOutput.swift
@@ -79,7 +79,8 @@ enum DocumentScannerOutput: Equatable {
             // If the barcode is clear enough to decode, then that's good enough and
             // it doesn't matter if the MotionBlurDetector believes there's motion blur
             // just need to make sure the zoom level is ok
-            return idDetectorOutput.computeZoomLevel() == .ok
+            return blurResult.isBlurry != true
+                && idDetectorOutput.computeZoomLevel() == .ok
         } else {
             return idDetectorOutput.classification.matchesDocument(side: side)
                 && cameraProperties?.isAdjustingFocus != true


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Remove delay start and check blur when barcode is detected.
Instead, chage the blur threshold from server side to ensure a clear image is captured

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
