### PR TITLE
Prioritize user specified networks for Apple Pay

### DIFF
--- a/Stripe/StripeiOSTests/STPApplePayTest.swift
+++ b/Stripe/StripeiOSTests/STPApplePayTest.swift
@@ -30,6 +30,13 @@ class STPApplePaySwiftTest: XCTestCase {
         StripeAPI.additionalEnabledApplePayNetworks = []
     }
 
+    func testAdditionalPaymentNetworksGetPrepended() {
+        XCTAssertFalse(StripeAPI.supportedPKPaymentNetworks().contains(.cartesBancaires))
+        StripeAPI.additionalEnabledApplePayNetworks = [.cartesBancaires]
+        XCTAssertEqual(StripeAPI.supportedPKPaymentNetworks().first, .cartesBancaires)
+        StripeAPI.additionalEnabledApplePayNetworks = []
+    }
+
     // Tests stp_tokenParameters in StripePayments, not StripeApplePay
     func testStpTokenParameters() {
         let applePay = STPFixtures.applePayPayment()

--- a/StripeCore/StripeCore/Source/API Bindings/StripeAPI.swift
+++ b/StripeCore/StripeCore/Source/API Bindings/StripeAPI.swift
@@ -101,13 +101,13 @@ import PassKit
     }
 
     @_spi(STP) public class func supportedPKPaymentNetworks() -> [PKPaymentNetwork] {
-        return [
+        return additionalEnabledApplePayNetworks + [
             .amex,
             .masterCard,
             .maestro,
             .visa,
             .discover,
-        ] + additionalEnabledApplePayNetworks
+        ]
     }
 
     /// Whether or not this can make Apple Pay payments via a card network supported


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Add `additionalEnabledApplePayNetworks` in front of the default network list at `supportedPKPaymentNetworks()` instead of adding it to the end.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Currently `additionalEnabledApplePayNetworks` that are set by the user are appended to the list of supported networks, having a lower priority than the default networks. 
As Apple Pay prioritizes the networks in order, we would like to make the user's specified networks take precedence over the default networks.

## Testing
<!-- How was the code tested? Be as specific as possible. -->
Automated tests were added to verify the list is in the correct order.

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
[Changed] Apple Pay additionalEnabledApplePayNetworks are now in front of the supported network list.