### PR TITLE
Instant Debits: first iteration of Instant Debits in Payment Sheet

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -445,6 +445,7 @@ extension PlaygroundController {
             "use_link": settings.linkEnabled == .on,
             "use_manual_confirmation": settings.integrationType == .deferred_mc,
             "require_cvc_recollection": settings.requireCVCRecollection == .on,
+            // "supported_payment_methods": ["card", "link"], // Uncomment to override payment methods (also make sure Automatic PM's is off)
             //            "set_shipping_address": true // Uncomment to make server vend PI with shipping address populated
         ] as [String: Any]
         makeRequest(with: checkoutEndpoint, body: body) { data, response, error in

--- a/Stripe.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Stripe.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "a6099f8b6f6e3d4e6a249794b40206685b3930858d8b410d4e86ef38217df380",
   "pins" : [
     {
       "identity" : "capture-core-sp",

--- a/Stripe.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Stripe.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,4 @@
 {
-  "originHash" : "a6099f8b6f6e3d4e6a249794b40206685b3930858d8b410d4e86ef38217df380",
   "pins" : [
     {
       "identity" : "capture-core-sp",

--- a/Stripe/StripeiOS/Source/STPPaymentMethod+BasicUI.swift
+++ b/Stripe/StripeiOS/Source/STPPaymentMethod+BasicUI.swift
@@ -62,7 +62,7 @@ extension STPPaymentMethod: STPPaymentOption {
 
     @objc public var isReusable: Bool {
         switch type {
-        case .card, .link, .USBankAccount:
+        case .card, .link, .USBankAccount, .instantDebits:
             return true
         case .alipay,  // Careful! Revisit this if/when we support recurring Alipay
             .AUBECSDebit,

--- a/Stripe/StripeiOS/Source/STPPaymentMethodParams+BasicUI.swift
+++ b/Stripe/StripeiOS/Source/STPPaymentMethodParams+BasicUI.swift
@@ -34,7 +34,7 @@ extension STPPaymentMethodParams: STPPaymentOption {
 
     @objc public var isReusable: Bool {
         switch type {
-        case .card, .link, .USBankAccount:
+        case .card, .link, .USBankAccount, .instantDebits:
             return true
         case .alipay, .AUBECSDebit, .bacsDebit, .SEPADebit, .iDEAL, .FPX, .cardPresent, .giropay,
             .grabPay, .EPS, .przelewy24, .bancontact, .netBanking, .OXXO, .payPal, .sofort, .UPI,

--- a/StripeCore/StripeCore.xcodeproj/project.pbxproj
+++ b/StripeCore/StripeCore.xcodeproj/project.pbxproj
@@ -46,6 +46,10 @@
 		62FD088E003BE06F5413FB4F /* StripeCoreBundleLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA5353BC5359E08128E116A /* StripeCoreBundleLocator.swift */; };
 		631D09E67497B49BBCA26192 /* UIView+StripeCoreTestingUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4E4C534285F49A97A04D2B8 /* UIView+StripeCoreTestingUtils.swift */; };
 		677951C643328D76E46720A5 /* StripeAPIConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32CB3702691056D3404A8C5F /* StripeAPIConfiguration.swift */; };
+		6A05FB452BCF24100001D128 /* FinancialConnectionsSDKResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A05FB442BCF24100001D128 /* FinancialConnectionsSDKResult.swift */; };
+		6A05FB472BCF24370001D128 /* FinancialConnectionsLinkedBank.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A05FB462BCF24370001D128 /* FinancialConnectionsLinkedBank.swift */; };
+		6A05FB492BCF244A0001D128 /* InstantDebitsLinkedBank.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A05FB482BCF244A0001D128 /* InstantDebitsLinkedBank.swift */; };
+		6A05FB4B2BCF245C0001D128 /* FinancialConnectionsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A05FB4A2BCF245C0001D128 /* FinancialConnectionsEvent.swift */; };
 		6A52ABC06783A90B9E339948 /* StripeFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73CE623A81057C4063A1E0C4 /* StripeFile.swift */; };
 		6B4156FCFAEDD1C73DC6EDAD /* iOSSnapshotTestCase in Frameworks */ = {isa = PBXBuildFile; platformFilters = (ios, maccatalyst, ); productRef = 23D22B2C40BA7C182BCE50B2 /* iOSSnapshotTestCase */; };
 		6B9C7B832BC73B1C007D5A28 /* AnalyticsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9C7B822BC73B1C007D5A28 /* AnalyticsHelper.swift */; };
@@ -56,7 +60,7 @@
 		71CD1AE29AA09552DF61131E /* StripeJSONShared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86C675ABC9D68378DC699DED /* StripeJSONShared.swift */; };
 		72DA29CA8A750E8B00DBF3D4 /* STPError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C51E3FA5EE3587BB7BBC634 /* STPError.swift */; };
 		766FE8E61B44967F057ED424 /* AnalyticLoggableError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B890F162E1C247D5CA1A9E6 /* AnalyticLoggableError.swift */; };
-		772292156A4A80CEA9D9C487 /* ConnectionsSDKInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EC3BCEEECB3E1485B18F0C4 /* ConnectionsSDKInterface.swift */; };
+		772292156A4A80CEA9D9C487 /* FinancialConnectionsSDKInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EC3BCEEECB3E1485B18F0C4 /* FinancialConnectionsSDKInterface.swift */; };
 		79DA4102C501FC2E53D946B5 /* STPAPIClient+ErrorResponseTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E70193A9CA42A0C53E48C1 /* STPAPIClient+ErrorResponseTest.swift */; };
 		8310D598D6D40BAD23880D3F /* StripeCoreTestUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = C666CC926642D7AA76E75B5B /* StripeCoreTestUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		83790210FFC2DD764C042C8E /* STPDispatchFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 591E592C9F3E5D4CB08A1847 /* STPDispatchFunctions.swift */; };
@@ -221,7 +225,7 @@
 		49538DBF8457D96707A2DA56 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4A8030BF88608CA86E295F18 /* Enums+CustomStringConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Enums+CustomStringConvertible.swift"; sourceTree = "<group>"; };
 		4C51E3FA5EE3587BB7BBC634 /* STPError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPError.swift; sourceTree = "<group>"; };
-		4EC3BCEEECB3E1485B18F0C4 /* ConnectionsSDKInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionsSDKInterface.swift; sourceTree = "<group>"; };
+		4EC3BCEEECB3E1485B18F0C4 /* FinancialConnectionsSDKInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsSDKInterface.swift; sourceTree = "<group>"; };
 		4FF290DF69F5FD1004BBDECA /* TestJSONEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestJSONEncoder.swift; sourceTree = "<group>"; };
 		536085BA191EC2942523A7DB /* en-GB */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-GB"; path = "en-GB.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		54D4E87D67740BF3C05638FD /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
@@ -236,6 +240,10 @@
 		64635404BD4D5D62486A7626 /* UnknownFields.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnknownFields.swift; sourceTree = "<group>"; };
 		66CC52EF207F05E0EFAEACD8 /* NSMutableURLRequest+StripeTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSMutableURLRequest+StripeTest.swift"; sourceTree = "<group>"; };
 		6B9C7B822BC73B1C007D5A28 /* AnalyticsHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHelper.swift; sourceTree = "<group>"; };
+		6A05FB442BCF24100001D128 /* FinancialConnectionsSDKResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsSDKResult.swift; sourceTree = "<group>"; };
+		6A05FB462BCF24370001D128 /* FinancialConnectionsLinkedBank.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsLinkedBank.swift; sourceTree = "<group>"; };
+		6A05FB482BCF244A0001D128 /* InstantDebitsLinkedBank.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstantDebitsLinkedBank.swift; sourceTree = "<group>"; };
+		6A05FB4A2BCF245C0001D128 /* FinancialConnectionsEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsEvent.swift; sourceTree = "<group>"; };
 		6CDBCD70CB220014972B49A5 /* PluginDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginDetector.swift; sourceTree = "<group>"; };
 		6E852B53CF75A119D3810B41 /* NSBundle+Stripe_AppName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSBundle+Stripe_AppName.swift"; sourceTree = "<group>"; };
 		6EEB07003465364DBAFA7DEB /* zh-HK */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-HK"; path = "zh-HK.lproj/Localizable.strings"; sourceTree = "<group>"; };
@@ -423,7 +431,11 @@
 		4AD775367138C40FE2C98BAF /* Connections Bindings */ = {
 			isa = PBXGroup;
 			children = (
-				4EC3BCEEECB3E1485B18F0C4 /* ConnectionsSDKInterface.swift */,
+				4EC3BCEEECB3E1485B18F0C4 /* FinancialConnectionsSDKInterface.swift */,
+				6A05FB442BCF24100001D128 /* FinancialConnectionsSDKResult.swift */,
+				6A05FB462BCF24370001D128 /* FinancialConnectionsLinkedBank.swift */,
+				6A05FB482BCF244A0001D128 /* InstantDebitsLinkedBank.swift */,
+				6A05FB4A2BCF245C0001D128 /* FinancialConnectionsEvent.swift */,
 			);
 			path = "Connections Bindings";
 			sourceTree = "<group>";
@@ -923,6 +935,7 @@
 			files = (
 				87274985CE5E750FA8D34648 /* EmptyResponse.swift in Sources */,
 				6A52ABC06783A90B9E339948 /* StripeFile.swift in Sources */,
+				6A05FB472BCF24370001D128 /* FinancialConnectionsLinkedBank.swift in Sources */,
 				9FBA50345D53E82AA974F672 /* STPAPIClient+FileUpload.swift in Sources */,
 				31AD3BDC2B0C23E40080C800 /* Locale+StripeCore.swift in Sources */,
 				C164984958CDC2C9CA4B6316 /* STPAPIClient.swift in Sources */,
@@ -932,6 +945,7 @@
 				DAD4099D03E43A0CA89464CD /* StripeAPI.swift in Sources */,
 				D22FAB2F1AE9AE43C1808747 /* StripeAPIConfiguration+Version.swift in Sources */,
 				677951C643328D76E46720A5 /* StripeAPIConfiguration.swift in Sources */,
+				6A05FB4B2BCF245C0001D128 /* FinancialConnectionsEvent.swift in Sources */,
 				02A26B79617FAE660C9EB506 /* StripeError.swift in Sources */,
 				3B9D69AB1CB61725C7A012B6 /* StripeServiceError.swift in Sources */,
 				95156E152471058151076A51 /* Analytic.swift in Sources */,
@@ -960,7 +974,7 @@
 				970D95FEA3BC216351DE3C5E /* StripeJSONEncoder.swift in Sources */,
 				71CD1AE29AA09552DF61131E /* StripeJSONShared.swift in Sources */,
 				6ED5C41DBDAB475BF1119E98 /* UnknownFields.swift in Sources */,
-				772292156A4A80CEA9D9C487 /* ConnectionsSDKInterface.swift in Sources */,
+				772292156A4A80CEA9D9C487 /* FinancialConnectionsSDKInterface.swift in Sources */,
 				5553D952F91D193D453D777D /* Async.swift in Sources */,
 				CAF857D45689FBEF17627E80 /* BundleLocatorProtocol.swift in Sources */,
 				59CA874015261241AC255907 /* FileDownloader.swift in Sources */,
@@ -973,9 +987,11 @@
 				C9B6C451F9A46C9FB031CE95 /* STPURLCallbackHandler.swift in Sources */,
 				A62AEDF871AC89489FE19A13 /* ServerErrorMapper.swift in Sources */,
 				B6DBB2BF2BA8C4E400783D15 /* STPAnalyticsClient+Error.swift in Sources */,
+				6A05FB452BCF24100001D128 /* FinancialConnectionsSDKResult.swift in Sources */,
 				62FD088E003BE06F5413FB4F /* StripeCoreBundleLocator.swift in Sources */,
 				17CE96B50813CF626293CBF9 /* URLEncoder.swift in Sources */,
 				0709F5D265CC641E6DE1011D /* URLSession+Retry.swift in Sources */,
+				6A05FB492BCF244A0001D128 /* InstantDebitsLinkedBank.swift in Sources */,
 				2991461DD354A6124CCF78DA /* STPLocalizationUtils.swift in Sources */,
 				4506A7016EA7C45796D3A30D /* STPLocalizedString.swift in Sources */,
 				DFF3092E51B6C3ED81AB1448 /* String+Localized.swift in Sources */,

--- a/StripeCore/StripeCore/Source/Connections Bindings/FinancialConnectionsEvent.swift
+++ b/StripeCore/StripeCore/Source/Connections Bindings/FinancialConnectionsEvent.swift
@@ -1,41 +1,11 @@
 //
-//  ConnectionsSDKInterface.swift
+//  FinancialConnectionsEvent.swift
 //  StripeCore
 //
-//  Created by Vardges Avetisyan on 2/24/22.
-//  Copyright © 2022 Stripe, Inc. All rights reserved.
+//  Created by Krisjanis Gaidis on 4/16/24.
 //
 
-import UIKit
-
-@_spi(STP) @frozen public enum FinancialConnectionsSDKResult {
-    case completed(linkedBank: LinkedBank)
-    case cancelled
-    case failed(error: Error)
-}
-
-@_spi(STP) public protocol FinancialConnectionsSDKInterface {
-    init()
-    func presentFinancialConnectionsSheet(
-        apiClient: STPAPIClient,
-        clientSecret: String,
-        returnURL: String?,
-        onEvent: ((FinancialConnectionsEvent) -> Void)?,
-        from presentingViewController: UIViewController,
-        completion: @escaping (FinancialConnectionsSDKResult) -> Void
-    )
-}
-
-// MARK: - Types
-
-@_spi(STP) public protocol LinkedBank {
-    var sessionId: String { get }
-    var accountId: String { get }
-    var displayName: String? { get }
-    var bankName: String? { get }
-    var last4: String? { get }
-    var instantlyVerified: Bool { get }
-}
+import Foundation
 
 public struct FinancialConnectionsEvent {
 

--- a/StripeCore/StripeCore/Source/Connections Bindings/FinancialConnectionsLinkedBank.swift
+++ b/StripeCore/StripeCore/Source/Connections Bindings/FinancialConnectionsLinkedBank.swift
@@ -1,0 +1,17 @@
+//
+//  FinancialConnectionsLinkedBank.swift
+//  StripeCore
+//
+//  Created by Krisjanis Gaidis on 4/16/24.
+//
+
+import Foundation
+
+@_spi(STP) public protocol FinancialConnectionsLinkedBank {
+    var sessionId: String { get }
+    var accountId: String { get }
+    var displayName: String? { get }
+    var bankName: String? { get }
+    var last4: String? { get }
+    var instantlyVerified: Bool { get }
+}

--- a/StripeCore/StripeCore/Source/Connections Bindings/FinancialConnectionsSDKInterface.swift
+++ b/StripeCore/StripeCore/Source/Connections Bindings/FinancialConnectionsSDKInterface.swift
@@ -1,0 +1,21 @@
+//
+//  ConnectionsSDKInterface.swift
+//  StripeCore
+//
+//  Created by Vardges Avetisyan on 2/24/22.
+//  Copyright © 2022 Stripe, Inc. All rights reserved.
+//
+
+import UIKit
+
+@_spi(STP) public protocol FinancialConnectionsSDKInterface {
+    init()
+    func presentFinancialConnectionsSheet(
+        apiClient: STPAPIClient,
+        clientSecret: String,
+        returnURL: String?,
+        onEvent: ((FinancialConnectionsEvent) -> Void)?,
+        from presentingViewController: UIViewController,
+        completion: @escaping (FinancialConnectionsSDKResult) -> Void
+    )
+}

--- a/StripeCore/StripeCore/Source/Connections Bindings/FinancialConnectionsSDKResult.swift
+++ b/StripeCore/StripeCore/Source/Connections Bindings/FinancialConnectionsSDKResult.swift
@@ -1,0 +1,19 @@
+//
+//  FinancialConnectionsSDKResult.swift
+//  StripeCore
+//
+//  Created by Krisjanis Gaidis on 4/16/24.
+//
+
+import Foundation
+
+@_spi(STP) @frozen public enum FinancialConnectionsSDKResult {
+    case completed(Completed)
+    case cancelled
+    case failed(error: Error)
+
+    @_spi(STP) public enum Completed {
+        case financialConnections(FinancialConnectionsLinkedBank)
+        case instantDebits(InstantDebitsLinkedBank)
+    }
+}

--- a/StripeCore/StripeCore/Source/Connections Bindings/InstantDebitsLinkedBank.swift
+++ b/StripeCore/StripeCore/Source/Connections Bindings/InstantDebitsLinkedBank.swift
@@ -1,0 +1,14 @@
+//
+//  InstantDebitsLinkedBank.swift
+//  StripeCore
+//
+//  Created by Krisjanis Gaidis on 4/16/24.
+//
+
+import Foundation
+
+@_spi(STP) public protocol InstantDebitsLinkedBank {
+    var paymentMethodId: String { get }
+    var bankName: String? { get }
+    var last4: String? { get }
+}

--- a/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
+++ b/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
@@ -67,6 +67,8 @@
 		691619AE9A989548ABA36535 /* HitTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F669BB8F3DA862C425897705 /* HitTestView.swift */; };
 		6944E131D351784058C7D734 /* FinancialConnectionsPaymentMethodType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 191760EFAA9154C1F168E1D2 /* FinancialConnectionsPaymentMethodType.swift */; };
 		6A044E482BB3866A00D73A3E /* AccountUpdateRequiredViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A044E472BB3866A00D73A3E /* AccountUpdateRequiredViewController.swift */; };
+		6A05FB412BCF15170001D128 /* FinancialConnectionsLinkedBankImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A05FB402BCF15170001D128 /* FinancialConnectionsLinkedBankImplementation.swift */; };
+		6A05FB432BCF153F0001D128 /* InstantDebitsLinkedBankImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A05FB422BCF153F0001D128 /* InstantDebitsLinkedBankImplementation.swift */; };
 		6A13B9822B48BD6C00FFA327 /* AccountPickerRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A13B9812B48BD6C00FFA327 /* AccountPickerRowView.swift */; };
 		6A13B9842B48BF4300FFA327 /* AccountPickerRowLabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A13B9832B48BF4300FFA327 /* AccountPickerRowLabelView.swift */; };
 		6A13B9862B4CD04100FFA327 /* RetrieveAccountsLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A13B9852B4CD04100FFA327 /* RetrieveAccountsLoadingView.swift */; };
@@ -340,6 +342,8 @@
 		66D2857E68EA69AC6F658BEA /* pt-PT */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-PT"; path = "pt-PT.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		66D3CAB53EC9D33831C5A48B /* NetworkingSaveToLinkVerificationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkingSaveToLinkVerificationViewController.swift; sourceTree = "<group>"; };
 		6A044E472BB3866A00D73A3E /* AccountUpdateRequiredViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountUpdateRequiredViewController.swift; sourceTree = "<group>"; };
+		6A05FB402BCF15170001D128 /* FinancialConnectionsLinkedBankImplementation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsLinkedBankImplementation.swift; sourceTree = "<group>"; };
+		6A05FB422BCF153F0001D128 /* InstantDebitsLinkedBankImplementation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstantDebitsLinkedBankImplementation.swift; sourceTree = "<group>"; };
 		6A13B9812B48BD6C00FFA327 /* AccountPickerRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountPickerRowView.swift; sourceTree = "<group>"; };
 		6A13B9832B48BF4300FFA327 /* AccountPickerRowLabelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountPickerRowLabelView.swift; sourceTree = "<group>"; };
 		6A13B9852B4CD04100FFA327 /* RetrieveAccountsLoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetrieveAccountsLoadingView.swift; sourceTree = "<group>"; };
@@ -634,6 +638,8 @@
 			isa = PBXGroup;
 			children = (
 				248D51F7AADE404E49957DDA /* FinancialConnectionsSDKImplementation.swift */,
+				6A05FB402BCF15170001D128 /* FinancialConnectionsLinkedBankImplementation.swift */,
+				6A05FB422BCF153F0001D128 /* InstantDebitsLinkedBankImplementation.swift */,
 			);
 			path = FinancialConnectionsSDK;
 			sourceTree = "<group>";
@@ -1243,6 +1249,7 @@
 				B271AAF41C9FE6AE392B88D3 /* FinancialConnectionsMixedOAuthParams.swift in Sources */,
 				DAA51ABB496551074DBA1A20 /* FinancialConnectionsNetworkedAccountsResponse.swift in Sources */,
 				6A732CA62B69A46D00828CB1 /* PhoneTextField.swift in Sources */,
+				6A05FB412BCF15170001D128 /* FinancialConnectionsLinkedBankImplementation.swift in Sources */,
 				6FE9F171CF9A5D0EDB2035AA /* FinancialConnectionsNetworkingLinkSignup.swift in Sources */,
 				87198EFD873751CA4E4B5005 /* FinancialConnectionsOAuthPrepane.swift in Sources */,
 				6A732C9E2B64787E00828CB1 /* LinkAccountPickerLoadingView.swift in Sources */,
@@ -1332,6 +1339,7 @@
 				5F3C86F23B65CAC56FDDEC90 /* NetworkingLinkSignupBodyFormView.swift in Sources */,
 				6A044E482BB3866A00D73A3E /* AccountUpdateRequiredViewController.swift in Sources */,
 				95B2A73AC5DA9FA64017B3CB /* NetworkingLinkSignupBodyView.swift in Sources */,
+				6A05FB432BCF153F0001D128 /* InstantDebitsLinkedBankImplementation.swift in Sources */,
 				6A13B9842B48BF4300FFA327 /* AccountPickerRowLabelView.swift in Sources */,
 				3AC5CA5F5529B55026342A54 /* NetworkingLinkSignupDataSource.swift in Sources */,
 				6A13B9862B4CD04100FFA327 /* RetrieveAccountsLoadingView.swift in Sources */,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsConsent.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsConsent.swift
@@ -14,7 +14,7 @@ struct FinancialConnectionsConsent: Decodable {
     let cta: String
     let belowCta: String?
 
-    let dataAccessNotice: FinancialConnectionsDataAccessNotice
+    let dataAccessNotice: FinancialConnectionsDataAccessNotice?
     let legalDetailsNotice: FinancialConnectionsLegalDetailsNotice
 
     struct Body: Decodable {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsSessionManifest.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsSessionManifest.swift
@@ -105,4 +105,8 @@ struct FinancialConnectionsSessionManifest: Decodable {
     var shouldAttachLinkedPaymentMethod: Bool {
         return (paymentMethodType != nil)
     }
+
+    var isProductInstantDebits: Bool {
+        return (product == "instant_debits")
+    }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsSheetAnalytics.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsSheetAnalytics.swift
@@ -55,7 +55,7 @@ struct FinancialConnectionsSheetCompletionAnalytic {
     /// Returns either a `FinancialConnectionsSheetClosedAnalytic` or `FinancialConnectionsSheetFailedAnalytic` depending on the result
     static func make(
         clientSecret: String,
-        result: FinancialConnectionsSheet.Result
+        result: HostControllerResult
     ) -> FinancialConnectionsSheetAnalytic {
         switch result {
         case .completed:

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostController.swift
@@ -8,12 +8,25 @@
 @_spi(STP) import StripeCore
 import UIKit
 
+/// An internal result type that helps us handle both
+/// Financial Connections and Instant Debits
+@_spi(STP) public enum HostControllerResult {
+    case completed(Completed)
+    case failed(error: Error)
+    case canceled
+
+    @_spi(STP) public enum Completed {
+        case financialConnections(StripeAPI.FinancialConnectionsSession)
+        case instantDebits(InstantDebitsLinkedBank)
+    }
+}
+
 protocol HostControllerDelegate: AnyObject {
 
     func hostController(
         _ hostController: HostController,
         viewController: UIViewController,
-        didFinish result: FinancialConnectionsSheet.Result
+        didFinish result: HostControllerResult
     )
 
     func hostController(
@@ -83,38 +96,42 @@ extension HostController: HostViewControllerDelegate {
     ) {
         delegate?.hostController(self, didReceiveEvent: FinancialConnectionsEvent(name: .open))
 
-        let flowRouter = FlowRouter(
-            synchronizePayload: synchronizePayload,
-            analyticsClient: analyticsClient
-        )
-        defer {
-            // no matter how we exit this function
-            // log exposure to one of the variants if appropriate.
-            flowRouter.logExposureIfNeeded()
-        }
-
-        guard flowRouter.shouldUseNative else {
+        if synchronizePayload.manifest.isProductInstantDebits {
             continueWithWebFlow(synchronizePayload.manifest)
-            return
+        } else {
+            let flowRouter = FlowRouter(
+                synchronizePayload: synchronizePayload,
+                analyticsClient: analyticsClient
+            )
+            defer {
+                // no matter how we exit this function
+                // log exposure to one of the variants if appropriate.
+                flowRouter.logExposureIfNeeded()
+            }
+
+            guard flowRouter.shouldUseNative else {
+                continueWithWebFlow(synchronizePayload.manifest)
+                return
+            }
+
+            navigationController.configureAppearanceForNative()
+
+            let dataManager = NativeFlowAPIDataManager(
+                manifest: synchronizePayload.manifest,
+                visualUpdate: synchronizePayload.visual,
+                returnURL: returnURL,
+                consentPaneModel: synchronizePayload.text?.consentPane,
+                apiClient: api,
+                clientSecret: clientSecret,
+                analyticsClient: analyticsClient
+            )
+            nativeFlowController = NativeFlowController(
+                dataManager: dataManager,
+                navigationController: navigationController
+            )
+            nativeFlowController?.delegate = self
+            nativeFlowController?.startFlow()
         }
-
-        navigationController.configureAppearanceForNative()
-
-        let dataManager = NativeFlowAPIDataManager(
-            manifest: synchronizePayload.manifest,
-            visualUpdate: synchronizePayload.visual,
-            returnURL: returnURL,
-            consentPaneModel: synchronizePayload.text?.consentPane,
-            apiClient: api,
-            clientSecret: clientSecret,
-            analyticsClient: analyticsClient
-        )
-        nativeFlowController = NativeFlowController(
-            dataManager: dataManager,
-            navigationController: navigationController
-        )
-        nativeFlowController?.delegate = self
-        nativeFlowController?.startFlow()
     }
 
     func hostViewController(
@@ -161,7 +178,7 @@ extension HostController: FinancialConnectionsWebFlowViewControllerDelegate {
 
     func webFlowViewController(
         _ viewController: FinancialConnectionsWebFlowViewController,
-        didFinish result: FinancialConnectionsSheet.Result
+        didFinish result: HostControllerResult
     ) {
         delegate?.hostController(self, viewController: viewController, didFinish: result)
     }
@@ -185,7 +202,16 @@ extension HostController: NativeFlowControllerDelegate {
             assertionFailure("Navigation stack is empty")
             return
         }
-        delegate?.hostController(self, viewController: viewController, didFinish: result)
+        let hostControllerResult: HostControllerResult
+        switch result {
+        case .completed(let session):
+            hostControllerResult = .completed(.financialConnections(session))
+        case .canceled:
+            hostControllerResult = .canceled
+        case .failed(let error):
+            hostControllerResult = .failed(error: error)
+        }
+        delegate?.hostController(self, viewController: viewController, didFinish: hostControllerResult)
     }
 
     func nativeFlowController(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/FinancialConnectionsSDK/FinancialConnectionsLinkedBankImplementation.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/FinancialConnectionsSDK/FinancialConnectionsLinkedBankImplementation.swift
@@ -1,0 +1,34 @@
+//
+//  FinancialConnectionsLinkedBankImplementation.swift
+//  StripeFinancialConnections
+//
+//  Created by Krisjanis Gaidis on 4/16/24.
+//
+
+@_spi(STP) import StripeCore
+import UIKit
+
+struct FinancialConnectionsLinkedBankImplementation: FinancialConnectionsLinkedBank {
+    public let sessionId: String
+    public let accountId: String
+    public let displayName: String?
+    public let bankName: String?
+    public let last4: String?
+    public let instantlyVerified: Bool
+
+    public init(
+        with sessionId: String,
+        accountId: String,
+        displayName: String?,
+        bankName: String?,
+        last4: String?,
+        instantlyVerified: Bool
+    ) {
+        self.sessionId = sessionId
+        self.accountId = accountId
+        self.displayName = displayName
+        self.bankName = bankName
+        self.last4 = last4
+        self.instantlyVerified = instantlyVerified
+    }
+}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/FinancialConnectionsSDK/FinancialConnectionsSDKImplementation.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/FinancialConnectionsSDK/FinancialConnectionsSDKImplementation.swift
@@ -35,27 +35,32 @@ public class FinancialConnectionsSDKImplementation: FinancialConnectionsSDKInter
             from: presentingViewController,
             completion: { result in
                 switch result {
-                case .completed(let session):
-                    guard let paymentAccount = session.paymentAccount else {
-                        completion(
-                            .failed(
-                                error: FinancialConnectionsSheetError.unknown(
-                                    debugDescription: "PaymentAccount is not set on FinancialConnectionsSession"
+                case .completed(let hostControllerResult):
+                    switch hostControllerResult {
+                    case .financialConnections(let session):
+                        guard let paymentAccount = session.paymentAccount else {
+                            completion(
+                                .failed(
+                                    error: FinancialConnectionsSheetError.unknown(
+                                        debugDescription: "PaymentAccount is not set on FinancialConnectionsSession"
+                                    )
                                 )
                             )
-                        )
-                        return
-                    }
-                    if let linkedBank = self.linkedBankFor(paymentAccount: paymentAccount, session: session) {
-                        completion(.completed(linkedBank: linkedBank))
-                    } else {
-                        completion(
-                            .failed(
-                                error: FinancialConnectionsSheetError.unknown(
-                                    debugDescription: "Unknown PaymentAccount is set on FinancialConnectionsSession"
+                            return
+                        }
+                        if let linkedBank = self.linkedBankFor(paymentAccount: paymentAccount, session: session) {
+                            completion(.completed(.financialConnections(linkedBank)))
+                        } else {
+                            completion(
+                                .failed(
+                                    error: FinancialConnectionsSheetError.unknown(
+                                        debugDescription: "Unknown PaymentAccount is set on FinancialConnectionsSession"
+                                    )
                                 )
                             )
-                        )
+                        }
+                    case .instantDebits(let instantDebitsLinkedBank):
+                        completion(.completed(.instantDebits(instantDebitsLinkedBank)))
                     }
                 case .canceled:
                     completion(.cancelled)
@@ -71,10 +76,10 @@ public class FinancialConnectionsSDKImplementation: FinancialConnectionsSDKInter
     private func linkedBankFor(
         paymentAccount: StripeAPI.FinancialConnectionsSession.PaymentAccount,
         session: StripeAPI.FinancialConnectionsSession
-    ) -> LinkedBank? {
+    ) -> FinancialConnectionsLinkedBank? {
         switch paymentAccount {
         case .linkedAccount(let linkedAccount):
-            return LinkedBankImplementation(
+            return FinancialConnectionsLinkedBankImplementation(
                 with: session.id,
                 accountId: linkedAccount.id,
                 displayName: linkedAccount.displayName,
@@ -83,7 +88,7 @@ public class FinancialConnectionsSDKImplementation: FinancialConnectionsSDKInter
                 instantlyVerified: true
             )
         case .bankAccount(let bankAccount):
-            return LinkedBankImplementation(
+            return FinancialConnectionsLinkedBankImplementation(
                 with: session.id,
                 accountId: bankAccount.id,
                 displayName: bankAccount.bankName,
@@ -94,32 +99,5 @@ public class FinancialConnectionsSDKImplementation: FinancialConnectionsSDKInter
         case .unparsable:
             return nil
         }
-    }
-
-}
-
-// MARK: - LinkedBank Implementation
-struct LinkedBankImplementation: LinkedBank {
-    public let sessionId: String
-    public let accountId: String
-    public let displayName: String?
-    public let bankName: String?
-    public let last4: String?
-    public let instantlyVerified: Bool
-
-    public init(
-        with sessionId: String,
-        accountId: String,
-        displayName: String?,
-        bankName: String?,
-        last4: String?,
-        instantlyVerified: Bool
-    ) {
-        self.sessionId = sessionId
-        self.accountId = accountId
-        self.displayName = displayName
-        self.bankName = bankName
-        self.last4 = last4
-        self.instantlyVerified = instantlyVerified
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/FinancialConnectionsSDK/InstantDebitsLinkedBankImplementation.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/FinancialConnectionsSDK/InstantDebitsLinkedBankImplementation.swift
@@ -1,0 +1,27 @@
+//
+//  InstantDebitsLinkedBankImplementation.swift
+//  StripeFinancialConnections
+//
+//  Created by Krisjanis Gaidis on 4/16/24.
+//
+
+import Foundation
+
+@_spi(STP) import StripeCore
+import UIKit
+
+struct InstantDebitsLinkedBankImplementation: InstantDebitsLinkedBank {
+    public let paymentMethodId: String
+    public let bankName: String?
+    public let last4: String?
+
+    public init(
+        paymentMethodId: String,
+        bankName: String?,
+        last4: String?
+    ) {
+        self.paymentMethodId = paymentMethodId
+        self.bankName = bankName
+        self.last4 = last4
+    }
+}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/FinancialConnectionsSheet.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/FinancialConnectionsSheet.swift
@@ -248,7 +248,8 @@ final public class FinancialConnectionsSheet {
 /// :nodoc:
 extension FinancialConnectionsSheet: HostControllerDelegate {
     func hostController(
-        _ hostController: HostController, viewController: UIViewController,
+        _ hostController: HostController,
+        viewController: UIViewController,
         didFinish result: HostControllerResult
     ) {
         viewController.dismiss(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentViewController.swift
@@ -149,13 +149,15 @@ class ConsentViewController: UIViewController {
                 if urlHost == "manual-entry" {
                     delegate?.consentViewControllerDidSelectManuallyVerify(self)
                 } else if urlHost == "data-access-notice" {
-                    let dataAccessNoticeViewController = DataAccessNoticeViewController(
-                        dataAccessNotice: dataSource.consent.dataAccessNotice,
-                        didSelectUrl: { [weak self] url in
-                            self?.didSelectURLInTextFromBackend(url)
-                        }
-                    )
-                    dataAccessNoticeViewController.present(on: self)
+                    if let dataAccessNotice = dataSource.consent.dataAccessNotice {
+                        let dataAccessNoticeViewController = DataAccessNoticeViewController(
+                            dataAccessNotice: dataAccessNotice,
+                            didSelectUrl: { [weak self] url in
+                                self?.didSelectURLInTextFromBackend(url)
+                            }
+                        )
+                        dataAccessNoticeViewController.present(on: self)
+                    }
                 } else if urlHost == "legal-details-notice" {
                     let legalDetailsNoticeModel = dataSource.consent.legalDetailsNotice
                     let legalDetailsNoticeViewController = LegalDetailsNoticeViewController(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsWebFlowViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsWebFlowViewController.swift
@@ -14,7 +14,7 @@ protocol FinancialConnectionsWebFlowViewControllerDelegate: AnyObject {
 
     func webFlowViewController(
         _ viewController: FinancialConnectionsWebFlowViewController,
-        didFinish result: FinancialConnectionsSheet.Result
+        didFinish result: HostControllerResult
     )
 
     func webFlowViewController(
@@ -136,7 +136,7 @@ final class FinancialConnectionsWebFlowViewController: UIViewController {
 
 extension FinancialConnectionsWebFlowViewController {
 
-    private func notifyDelegate(result: FinancialConnectionsSheet.Result) {
+    private func notifyDelegate(result: HostControllerResult) {
         delegate?.webFlowViewController(self, didFinish: result)
         delegate = nil  // prevent the delegate from being called again
     }
@@ -148,18 +148,49 @@ extension FinancialConnectionsWebFlowViewController {
         guard authSessionManager == nil else { return }
         loadingView.showLoading(true)
         authSessionManager = AuthenticationSessionManager(manifest: manifest, window: view.window)
+        var additionalQueryParameters = additionalQueryParameters
+        if manifest.isProductInstantDebits {
+            additionalQueryParameters = (additionalQueryParameters ?? "") + "&return_payment_method=true"
+        }
         authSessionManager?
             .start(additionalQueryParameters: additionalQueryParameters)
             .observe(using: { [weak self] (result) in
                 guard let self = self else { return }
                 self.loadingView.showLoading(false)
                 switch result {
-                case .success(.success):
-                    self.fetchSession()
+                case .success(.success(let returnUrl)):
+                    if manifest.isProductInstantDebits {
+                        if
+                            let paymentMethodId = Self.extractValue(from: returnUrl, key: "payment_method_id")
+                        {
+                            let instantDebitsLinkedBank = InstantDebitsLinkedBankImplementation(
+                                paymentMethodId: paymentMethodId,
+                                bankName: Self.extractValue(from: returnUrl, key: "bank_name"),
+                                last4: Self.extractValue(from: returnUrl, key: "last4")
+                            )
+                            self.notifyDelegateOfSuccess(result: .instantDebits(instantDebitsLinkedBank))
+                        } else {
+                            self.notifyDelegateOfFailure(
+                                error: FinancialConnectionsSheetError.unknown(
+                                    debugDescription: "payment_method_id was not returned"
+                                )
+                            )
+                        }
+                    } else {
+                        self.fetchSession()
+                    }
                 case .success(.webCancelled):
-                    self.fetchSession(webCancelled: true)
+                    if manifest.isProductInstantDebits {
+                        self.notifyDelegateOfCancel()
+                    } else {
+                        self.fetchSession(webCancelled: true)
+                    }
                 case .success(.nativeCancelled):
-                    self.fetchSession(userDidCancelInNative: true)
+                    if manifest.isProductInstantDebits {
+                        self.notifyDelegateOfCancel()
+                    } else {
+                        self.fetchSession(userDidCancelInNative: true)
+                    }
                 case .failure(let error):
                     self.notifyDelegateOfFailure(error: error)
                 case .success(.redirect(url: let url)):
@@ -195,22 +226,18 @@ extension FinancialConnectionsWebFlowViewController {
                         if !session.accounts.data.isEmpty || session.paymentAccount != nil
                             || session.bankAccountToken != nil
                         {
-                            self.notifyDelegateOfSuccess(session: session)
+                            self.notifyDelegateOfSuccess(result: .financialConnections(session))
                         } else {
-                            self.delegate?.webFlowViewController(
-                                self,
-                                didReceiveEvent: FinancialConnectionsEvent(name: .cancel)
-                            )
-                            self.notifyDelegate(result: .canceled)
+                            self.notifyDelegateOfCancel()
                         }
                     } else if webCancelled {
                         if session.status == .cancelled && session.statusDetails?.cancelled?.reason == .customManualEntry {
                             self.notifyDelegate(result: .failed(error: FinancialConnectionsCustomManualEntryRequiredError()))
                         } else {
-                            self.notifyDelegate(result: .canceled)
+                            self.notifyDelegateOfCancel()
                         }
                     } else {
-                        self.notifyDelegateOfSuccess(session: session)
+                        self.notifyDelegateOfSuccess(result: .financialConnections(session))
                     }
                 case .failure(let error):
                     self.loadingView.errorView.isHidden = false
@@ -219,17 +246,31 @@ extension FinancialConnectionsWebFlowViewController {
             }
     }
 
-    private func notifyDelegateOfSuccess(session: StripeAPI.FinancialConnectionsSession) {
+    private func notifyDelegateOfSuccess(result: HostControllerResult.Completed) {
+        let session: StripeAPI.FinancialConnectionsSession?
+        if case .financialConnections(let wrappedSession) = result {
+            session = wrappedSession
+        } else {
+            session = nil
+        }
         delegate?.webFlowViewController(
             self,
             didReceiveEvent: FinancialConnectionsEvent(
                 name: .success,
                 metadata: FinancialConnectionsEvent.Metadata(
-                    manualEntry: session.paymentAccount?.isManualEntry ?? false
+                    manualEntry: session?.paymentAccount?.isManualEntry ?? false
                 )
             )
         )
-        notifyDelegate(result: .completed(session: session))
+        notifyDelegate(result: .completed(result))
+    }
+
+    private func notifyDelegateOfCancel() {
+        delegate?.webFlowViewController(
+            self,
+            didReceiveEvent: FinancialConnectionsEvent(name: .cancel)
+        )
+        notifyDelegate(result: .canceled)
     }
 
     // all failures except custom manual entry failure
@@ -241,6 +282,17 @@ extension FinancialConnectionsWebFlowViewController {
             }
 
         notifyDelegate(result: .failed(error: error))
+    }
+
+    private static func extractValue(from url: URL, key: String) -> String? {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            assertionFailure("Invalid URL")
+            return nil
+        }
+        return components
+            .queryItems?
+            .first(where: { $0.name == key })?
+            .value?.removingPercentEncoding
     }
 }
 

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsAnalyticsTest.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsAnalyticsTest.swift
@@ -8,7 +8,7 @@
 import XCTest
 
 @_spi(STP) import StripeCore
-@testable import StripeFinancialConnections
+@testable @_spi(STP) import StripeFinancialConnections
 
 final class FinancialConnectionsSheetAnalyticsTest: XCTestCase {
 
@@ -39,7 +39,7 @@ final class FinancialConnectionsSheetAnalyticsTest: XCTestCase {
         )
         let analytic = FinancialConnectionsSheetCompletionAnalytic.make(
             clientSecret: "secret",
-            result: .completed(session: session)
+            result: .completed(.financialConnections(session))
         )
         guard let closedAnalytic = analytic as? FinancialConnectionsSheetClosedAnalytic else {
             return XCTFail("Expected `FinancialConnectionsSheetClosedAnalytic`")

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsSheetTests.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsSheetTests.swift
@@ -7,7 +7,7 @@
 
 @_spi(STP) import StripeCore
 @_spi(STP) import StripeCoreTestUtils
-@testable import StripeFinancialConnections
+@testable @_spi(STP) import StripeFinancialConnections
 import XCTest
 
 class EmptySessionFetcher: FinancialConnectionsSessionFetcher {
@@ -32,7 +32,7 @@ class FinancialConnectionsSheetTests: XCTestCase {
             returnURL: nil,
             analyticsClient: mockAnalyticsClient
         )
-        sheet.present(from: mockViewController) { _ in }
+        sheet.present(from: mockViewController) { (_: FinancialConnectionsSheet.Result) in }
 
         // Verify presented analytic is logged
         XCTAssertEqual(mockAnalyticsClient.loggedAnalytics.count, 1)

--- a/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
+++ b/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
@@ -124,6 +124,7 @@
 		68F13446778AF2CAA631ACDE /* PaymentSheet+DeferredAPITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8F7F2824DFC78268ED6459 /* PaymentSheet+DeferredAPITest.swift */; };
 		694A3B36AC19FC1F87EF0CB1 /* CustomerSheetPaymentMethodAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F42DA5892E8E4C28D434AEA7 /* CustomerSheetPaymentMethodAvailabilityTests.swift */; };
 		6A529F76ECB33C9154314C1F /* STPAnalyticsClient+LUXE.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B5AAA4347A6918EC267210 /* STPAnalyticsClient+LUXE.swift */; };
+		6A5997192BC88E28002A44CB /* InstantDebitsPaymentMethodElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A5997182BC88E28002A44CB /* InstantDebitsPaymentMethodElement.swift */; };
 		6B31B9B82B9019730064E210 /* ElementsCustomer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B31B9B72B9019730064E210 /* ElementsCustomer.swift */; };
 		6B31B9BA2B90FCE60064E210 /* CustomerSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B31B9B92B90FCE60064E210 /* CustomerSession.swift */; };
 		6B7E675071649AE3047D388C /* PaymentSheetFormFactoryConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A21CC86104388EFE07CB37D /* PaymentSheetFormFactoryConfig.swift */; };
@@ -444,6 +445,7 @@
 		67A8D073B075B32BECCD905A /* form_specs.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = form_specs.json; sourceTree = "<group>"; };
 		68C3318ED094D63626740234 /* InstantDebitsOnlyFinancialConnectionsAuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstantDebitsOnlyFinancialConnectionsAuthManager.swift; sourceTree = "<group>"; };
 		6A065CEE8A7BCE60FC9D50BF /* el-GR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "el-GR"; path = "el-GR.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		6A5997182BC88E28002A44CB /* InstantDebitsPaymentMethodElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstantDebitsPaymentMethodElement.swift; sourceTree = "<group>"; };
 		6B31B9B72B9019730064E210 /* ElementsCustomer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElementsCustomer.swift; sourceTree = "<group>"; };
 		6B31B9B92B90FCE60064E210 /* CustomerSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerSession.swift; sourceTree = "<group>"; };
 		6B680A2FF197F612D065F16C /* PaymentSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSheet.swift; sourceTree = "<group>"; };
@@ -875,6 +877,13 @@
 			path = Link;
 			sourceTree = "<group>";
 		};
+		6A5997172BC88E0F002A44CB /* New Group */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = "New Group";
+			sourceTree = "<group>";
+		};
 		6A663AB17CD17C68D7329B6B /* ViewControllers */ = {
 			isa = PBXGroup;
 			children = (
@@ -1118,6 +1127,7 @@
 				3C8E4153CAFF4EC9AC960182 /* AddPaymentMethodViewController.swift */,
 				6B9A346A7A4290BAA7BCA1A2 /* PaymentMethodTypeCollectionView.swift */,
 				E32B3AC4CC1C4F2DEEC5F292 /* WalletHeaderView.swift */,
+				6A5997172BC88E0F002A44CB /* New Group */,
 			);
 			path = "New Payment Method Screen";
 			sourceTree = "<group>";
@@ -1277,6 +1287,7 @@
 			children = (
 				3595F1786387A6B562FA472F /* BankAccountInfoView.swift */,
 				D3F8B6F8B253A009E6216478 /* USBankAccountPaymentMethodElement.swift */,
+				6A5997182BC88E28002A44CB /* InstantDebitsPaymentMethodElement.swift */,
 			);
 			path = USBankAccount;
 			sourceTree = "<group>";
@@ -1757,6 +1768,7 @@
 				6B7E675071649AE3047D388C /* PaymentSheetFormFactoryConfig.swift in Sources */,
 				A8FC75044392659E39677C01 /* PaymentSheetIntentConfiguration.swift in Sources */,
 				5E00512CDFBC1C93781E20AB /* PaymentSheetLoader.swift in Sources */,
+				6A5997192BC88E28002A44CB /* InstantDebitsPaymentMethodElement.swift in Sources */,
 				E5571A970EB9DFC4B690636F /* STPAnalyticsClient+PaymentSheet.swift in Sources */,
 				0B142FE21B861925B513143D /* STPApplePayContext+PaymentSheet.swift in Sources */,
 				6103F2BC2BE45990002D67F8 /* SavedPaymentMethodManager.swift in Sources */,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerAddPaymentMethodViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerAddPaymentMethodViewController.swift
@@ -67,6 +67,8 @@ class CustomerAddPaymentMethodViewController: UIViewController {
         switch overrideBuyButtonBehavior {
         case .LinkUSBankAccount:
             return usBankAccountFormElement?.canLinkAccount ?? false
+        case .instantDebits:
+            return false // instant debits is not supported for customer sheet
         }
     }
 
@@ -249,6 +251,8 @@ extension CustomerAddPaymentMethodViewController {
         switch behavior {
         case .LinkUSBankAccount:
             handleCollectBankAccount(from: viewController, clientSecret: clientSecret)
+        case .instantDebits:
+            assertionFailure("instant debits is not supported for customer sheet")
         }
     }
     func handleCollectBankAccount(from viewController: UIViewController, clientSecret: String) {
@@ -292,8 +296,12 @@ extension CustomerAddPaymentMethodViewController {
             switch financialConnectionsResult {
             case .cancelled:
                 break
-            case .completed(let linkedBank):
-                usBankAccountPaymentMethodElement.setLinkedBank(linkedBank)
+            case .completed(let completedResult):
+                if case .financialConnections(let linkedBank) = completedResult {
+                    usBankAccountPaymentMethodElement.setLinkedBank(linkedBank)
+                } else {
+                    self.delegate?.updateErrorLabel(for: genericError)
+                }
             case .failed:
                 self.delegate?.updateErrorLabel(for: genericError)
             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Intent.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Intent.swift
@@ -60,6 +60,17 @@ enum Intent {
         }
     }
 
+    var isDeferredIntent: Bool {
+        switch self {
+        case .paymentIntent:
+            return false
+        case .setupIntent:
+            return false
+        case .deferredIntent:
+            return true
+        }
+    }
+
     var intentConfig: PaymentSheet.IntentConfiguration? {
         switch self {
         case .deferredIntent(_, let intentConfig):

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfirmParams.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfirmParams.swift
@@ -33,12 +33,11 @@ class IntentConfirmParams {
     /// If `true`, a mandate (e.g. "By continuing you authorize Foo Corp to use your payment details for recurring payments...") was displayed to the customer.
     var didDisplayMandate: Bool = false
 
-    var linkedBank: LinkedBank?
+    var financialConnectionsLinkedBank: FinancialConnectionsLinkedBank?
+    var instantDebitsLinkedBank: InstantDebitsLinkedBank?
 
     var paymentSheetLabel: String {
-        if let linkedBank = linkedBank,
-            let last4 = linkedBank.last4
-        {
+        if let last4 = (financialConnectionsLinkedBank?.last4 ?? instantDebitsLinkedBank?.last4) {
             return "••••\(last4)"
         } else {
             return paymentMethodParams.paymentSheetLabel
@@ -46,9 +45,7 @@ class IntentConfirmParams {
     }
 
     func makeIcon(updateImageHandler: DownloadManager.UpdateImageHandler?) -> UIImage {
-        if let linkedBank = linkedBank,
-            let bankName = linkedBank.bankName
-        {
+        if let bankName = (financialConnectionsLinkedBank?.bankName ?? instantDebitsLinkedBank?.bankName) {
             return PaymentSheetImageLibrary.bankIcon(for: PaymentSheetImageLibrary.bankIconCode(for: bankName))
         } else {
             return paymentMethodParams.makeIcon(updateHandler: updateImageHandler)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -151,6 +151,16 @@ extension PaymentSheet {
                 print("[Stripe SDK]: PaymentSheet could not offer these external payment methods: \(missingExternalPaymentMethods). See https://stripe.com/docs/payments/external-payment-methods#available-external-payment-methods")
             }
 
+            if
+                intent.supportsLink,
+                !recommendedStripePaymentMethodTypes.contains(.USBankAccount),
+                !intent.isDeferredIntent,
+                intent.linkFlags["link_disable_instant_debits_on_mobile"] != true
+                // intent.linkFundingSources?.contains(.bankAccount) == true
+            {
+                recommendedStripePaymentMethodTypes.append(.instantDebits)
+            }
+
             // The full ordered list of recommended payment method types:
             var recommendedPaymentMethodTypes: [PaymentMethodType] =
                 // Stripe PaymentMethod types
@@ -220,7 +230,7 @@ extension PaymentSheet {
                         return [.returnURL, .userSupportsDelayedPaymentMethods]
                     case .cardPresent, .blik, .weChatPay, .grabPay, .FPX, .giropay, .przelewy24, .EPS,
                         .netBanking, .OXXO, .afterpayClearpay, .UPI, .link, .linkInstantDebit,
-                        .affirm, .paynow, .zip, .alma, .mobilePay, .unknown, .alipay, .konbini, .promptPay, .swish, .twint, .multibanco:
+                        .affirm, .paynow, .zip, .alma, .mobilePay, .unknown, .alipay, .konbini, .promptPay, .swish, .twint, .multibanco, .instantDebits:
                         return [.unsupportedForSetup]
                     @unknown default:
                         return [.unsupportedForSetup]
@@ -245,7 +255,7 @@ extension PaymentSheet {
                         return [.returnURL, .userSupportsDelayedPaymentMethods]
                     case .afterpayClearpay:
                         return [.returnURL, .shippingAddress]
-                    case .link, .unknown:
+                    case .link, .unknown, .instantDebits:
                         return [.unsupported]
                     @unknown default:
                         return [.unsupported]

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -155,8 +155,7 @@ extension PaymentSheet {
                 intent.supportsLink,
                 !recommendedStripePaymentMethodTypes.contains(.USBankAccount),
                 !intent.isDeferredIntent,
-                intent.linkFlags["link_disable_instant_debits_on_mobile"] != true
-                // intent.linkFundingSources?.contains(.bankAccount) == true
+                intent.linkFundingSources?.contains(.bankAccount) == true
             {
                 recommendedStripePaymentMethodTypes.append(.instantDebits)
             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentOption+Images.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentOption+Images.swift
@@ -180,7 +180,7 @@ extension STPPaymentMethodType {
                 return .pm_type_paypal
             case .AUBECSDebit:
                 return .pm_type_aubecsdebit
-            case .USBankAccount, .linkInstantDebit:
+            case .USBankAccount, .linkInstantDebit, .instantDebits:
                 return .pm_type_us_bank
             case .UPI:
                 return .pm_type_upi

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -156,6 +156,12 @@ extension PaymentSheet {
                     paymentIntent: paymentIntent,
                     configuration: configuration
                 )
+                if case .new(let confirmParams) = paymentOption {
+                    if let paymentMethodId = confirmParams.instantDebitsLinkedBank?.paymentMethodId {
+                        params.paymentMethodId = paymentMethodId
+                        params.paymentMethodParams = nil
+                    }
+                }
                 paymentHandler.confirmPayment(
                     params,
                     with: authenticationContext,
@@ -177,6 +183,20 @@ extension PaymentSheet {
                     setupIntent: setupIntent,
                     configuration: configuration
                 )
+                if case .new(let confirmParams) = paymentOption {
+                    if let paymentMethodId = confirmParams.instantDebitsLinkedBank?.paymentMethodId {
+                        setupIntentParams.paymentMethodID = paymentMethodId
+                        setupIntentParams.paymentMethodParams = nil
+
+                        let mandateCustomerAcceptanceParams = STPMandateCustomerAcceptanceParams()
+                        let onlineParams = STPMandateOnlineParams(ipAddress: "", userAgent: "")
+                        // Tell Stripe to infer mandate info from client
+                        onlineParams.inferFromClient = true
+                        mandateCustomerAcceptanceParams.onlineParams = onlineParams
+                        mandateCustomerAcceptanceParams.type = .online
+                        setupIntentParams.mandateData = STPMandateDataParams(customerAcceptance: mandateCustomerAcceptanceParams)
+                    }
+                }
                 paymentHandler.confirmSetupIntent(
                     setupIntentParams,
                     with: authenticationContext,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -162,6 +162,8 @@ class PaymentSheetFormFactory {
             return makeBoleto()
         } else if paymentMethod == .swish {
             return makeSwish()
+        } else if paymentMethod == .instantDebits {
+            return makeInstantDebits()
         }
 
         guard let spec = FormSpecProvider.shared.formSpec(for: paymentMethod.identifier) else {
@@ -696,6 +698,32 @@ extension PaymentSheetFormFactory {
         label.textColor = theme.colors.bodyText
         label.numberOfLines = 0
         return StaticElement(view: label)
+    }
+
+    func makeInstantDebits() -> PaymentMethodElement {
+        return InstantDebitsPaymentMethodElement(
+            configuration: configuration,
+            titleElement: {
+                switch configuration {
+                case .customerSheet:
+                    return nil // customer sheet is not supported
+                case .paymentSheet:
+                    return makeSectionTitleLabelWith(
+                        text: STPLocalizedString(
+                            "Pay with your bank account in just a few steps.",
+                            "Instant Debits copy title for Mobile payment element form"
+                        )
+                    )
+                }
+            }(),
+            emailElement: (
+                // TODO: does this email logic make sense?
+                (configuration.billingDetailsCollectionConfiguration.email != .never)
+                ? makeEmail()
+                : nil
+            ),
+            theme: theme
+        )
     }
 
     private func makeUSBankAccountCopyLabel() -> StaticElement {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -709,19 +709,11 @@ extension PaymentSheetFormFactory {
                     return nil // customer sheet is not supported
                 case .paymentSheet:
                     return makeSectionTitleLabelWith(
-                        text: STPLocalizedString(
-                            "Pay with your bank account in just a few steps.",
-                            "Instant Debits copy title for Mobile payment element form"
-                        )
+                        text: "Pay with your bank account in just a few steps." // TODO(kgaidis): localize string
                     )
                 }
             }(),
-            emailElement: (
-                // TODO: does this email logic make sense?
-                (configuration.billingDetailsCollectionConfiguration.email != .never)
-                ? makeEmail()
-                : nil
-            ),
+            emailElement: makeEmail(),
             theme: theme
         )
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/InstantDebitsPaymentMethodElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/InstantDebitsPaymentMethodElement.swift
@@ -1,0 +1,234 @@
+//
+//  InstantDebitsPaymentMethodElement.swift
+//  StripePaymentSheet
+//
+//  Created by Krisjanis Gaidis on 4/11/24.
+//
+
+@_spi(STP) import StripeCore
+@_spi(STP) import StripePayments
+@_spi(STP) import StripePaymentsUI
+@_spi(STP) import StripeUICore
+import UIKit
+
+final class InstantDebitsPaymentMethodElement: Element {
+
+    private let configuration: PaymentSheetFormFactoryConfig
+    private let formElement: FormElement
+
+    private var linkedBankElements: [Element] {
+        return [linkedBankInfoSectionElement]
+    }
+    private let linkedBankInfoSectionElement: SectionElement
+    private let linkedBankInfoView: BankAccountInfoView
+    private var linkedBank: InstantDebitsLinkedBank?
+    private let theme: ElementsUITheme
+    var presentingViewControllerDelegate: PresentingViewControllerDelegate?
+
+    var delegate: ElementDelegate?
+    var view: UIView {
+        return formElement.view
+    }
+    var mandateString: NSMutableAttributedString? {
+        var string: String?
+        if linkedBank != nil {
+            string = STPLocalizedString(
+                "By continuing, you agree to authorize payments pursuant to <terms>these terms</terms>.",
+                "Text providing link to terms for ACH payments"
+            )
+        } else {
+            string = nil
+        }
+        if let string {
+            let links = [
+                "terms": URL(string: "https://stripe.com/legal/ach-payments/authorization")!,
+            ]
+            let mutableString = STPStringUtils.applyLinksToString(
+                template: string,
+                links: links
+            )
+            let style = NSMutableParagraphStyle()
+            style.alignment = .center
+            mutableString.addAttributes(
+                [
+                    .paragraphStyle: style,
+                    .font: UIFont.preferredFont(forTextStyle: .footnote),
+                    .foregroundColor: theme.colors.secondaryText,
+                ],
+                range: NSRange(location: 0, length: mutableString.length)
+            )
+            return mutableString
+        } else {
+            return nil
+        }
+    }
+
+    var enableCTA: Bool {
+        return email != nil
+    }
+    var email: String? {
+        // try to get the email from the EmailElement
+        let paymentMethodParams = formElement.updateParams(
+            params: IntentConfirmParams(
+                type: .stripe(.instantDebits)
+            )
+        )?.paymentMethodParams
+        if let email = paymentMethodParams?.nonnil_billingDetails.email {
+            return email
+        } else if
+            configuration
+            .billingDetailsCollectionConfiguration
+            .attachDefaultsToPaymentMethod
+        {
+            // default email
+            return configuration.defaultBillingDetails.email
+        } else {
+            return nil
+        }
+    }
+
+    init(
+        configuration: PaymentSheetFormFactoryConfig,
+        titleElement: StaticElement?,
+        emailElement: PaymentMethodElement?,
+        theme: ElementsUITheme = .default
+    ) {
+        let willShowEmailField = (configuration.billingDetailsCollectionConfiguration.email != .never)
+        let hasDefaultEmail = (
+            configuration.billingDetailsCollectionConfiguration.attachDefaultsToPaymentMethod
+            && configuration.defaultBillingDetails.email != nil
+        )
+
+        // Fail loudly: This is an integration error
+        assert(
+            // TODO: is it a mandatory step to provide an email???
+            (willShowEmailField || hasDefaultEmail),
+            "If email is not collected, they must be provided through defaults"
+        )
+
+        self.configuration = configuration
+        self.linkedBankInfoView = BankAccountInfoView(frame: .zero, theme: theme)
+        self.linkedBankInfoSectionElement = SectionElement(
+            title: String.Localized.bank_account_sentence_case,
+            elements: [StaticElement(view: linkedBankInfoView)],
+            theme: theme
+        )
+        self.linkedBank = nil
+        self.linkedBankInfoSectionElement.view.isHidden = true
+        self.theme = theme
+
+        let allElements: [Element?] = [
+            titleElement,
+            emailElement,
+            linkedBankInfoSectionElement,
+        ]
+        let autoSectioningElements = allElements.compactMap { $0 }
+        self.formElement = FormElement(
+            autoSectioningElements: autoSectioningElements,
+            theme: theme
+        )
+        formElement.delegate = self
+        linkedBankInfoView.delegate = self
+    }
+
+    func setLinkedBank(_ linkedBank: InstantDebitsLinkedBank) {
+        self.linkedBank = linkedBank
+        if
+            let last4ofBankAccount = linkedBank.last4,
+            let bankName = linkedBank.bankName
+        {
+            linkedBankInfoView.setBankName(text: bankName)
+            linkedBankInfoView.setLastFourOfBank(text: "••••\(last4ofBankAccount)")
+            formElement.setElements(
+                linkedBankElements,
+                hidden: false,
+                animated: true
+            )
+        }
+        self.delegate?.didUpdate(element: self)
+    }
+
+    func getLinkedBank() -> InstantDebitsLinkedBank? {
+        return linkedBank
+    }
+}
+
+// MARK: - BankAccountInfoViewDelegate
+
+extension InstantDebitsPaymentMethodElement: BankAccountInfoViewDelegate {
+
+    func didTapXIcon() {
+        let hideLinkedBankElement = {
+            self.formElement.setElements(
+                self.linkedBankElements,
+                hidden: true,
+                animated: true
+            )
+            self.linkedBank = nil
+            self.delegate?.didUpdate(element: self)
+        }
+
+        // present a confirmation alert
+        if
+           let last4BankAccount = self.linkedBank?.last4,
+           let presentingDelegate = presentingViewControllerDelegate
+        {
+            let didTapRemove = UIAlertAction(
+                title: String.Localized.remove,
+                style: .destructive
+            ) { (_) in
+                hideLinkedBankElement()
+            }
+            let didTapCancel = UIAlertAction(
+                title: String.Localized.cancel,
+                style: .cancel,
+                handler: nil
+            )
+            let alertController = UIAlertController(
+                title: String.Localized.removeBankAccount,
+                message: String(format: String.Localized.removeBankAccountEndingIn, last4BankAccount),
+                preferredStyle: .alert
+            )
+            alertController.addAction(didTapCancel)
+            alertController.addAction(didTapRemove)
+            presentingDelegate.presentViewController(
+                viewController: alertController,
+                completion: nil
+            )
+        }
+        // if we can't present a confirmation alert, just remove
+        else {
+            hideLinkedBankElement()
+        }
+    }
+}
+
+// MARK: - PaymentMethodElement
+
+extension InstantDebitsPaymentMethodElement: PaymentMethodElement {
+
+    // after a bank is linked, this gets hit to update
+    func updateParams(params: IntentConfirmParams) -> IntentConfirmParams? {
+        if
+            let updatedParams = formElement.updateParams(params: params),
+            let linkedBank
+        {
+            updatedParams.instantDebitsLinkedBank = linkedBank
+            return updatedParams
+        }
+        return nil
+    }
+}
+
+// MARK: - ElementDelegate
+
+extension InstantDebitsPaymentMethodElement: ElementDelegate {
+
+    func didUpdate(element: Element) {
+        self.delegate?.didUpdate(element: element)
+    }
+
+    func continueToNextField(element: Element) {
+        self.delegate?.continueToNextField(element: element)
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/InstantDebitsPaymentMethodElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/InstantDebitsPaymentMethodElement.swift
@@ -32,10 +32,8 @@ final class InstantDebitsPaymentMethodElement: Element {
     var mandateString: NSMutableAttributedString? {
         var string: String?
         if linkedBank != nil {
-            string = STPLocalizedString(
-                "By continuing, you agree to authorize payments pursuant to <terms>these terms</terms>.",
-                "Text providing link to terms for ACH payments"
-            )
+            // TODO(kgaidis): localize
+            string = "By continuing, you agree to authorize payments pursuant to <terms>these terms</terms>."
         } else {
             string = nil
         }
@@ -93,19 +91,6 @@ final class InstantDebitsPaymentMethodElement: Element {
         emailElement: PaymentMethodElement?,
         theme: ElementsUITheme = .default
     ) {
-        let willShowEmailField = (configuration.billingDetailsCollectionConfiguration.email != .never)
-        let hasDefaultEmail = (
-            configuration.billingDetailsCollectionConfiguration.attachDefaultsToPaymentMethod
-            && configuration.defaultBillingDetails.email != nil
-        )
-
-        // Fail loudly: This is an integration error
-        assert(
-            // TODO: is it a mandatory step to provide an email???
-            (willShowEmailField || hasDefaultEmail),
-            "If email is not collected, they must be provided through defaults"
-        )
-
         self.configuration = configuration
         self.linkedBankInfoView = BankAccountInfoView(frame: .zero, theme: theme)
         self.linkedBankInfoSectionElement = SectionElement(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/USBankAccountPaymentMethodElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/USBankAccountPaymentMethodElement.swift
@@ -29,7 +29,7 @@ final class USBankAccountPaymentMethodElement: Element {
     private let checkboxElement: PaymentMethodElement?
     private var savingAccount: BoolReference
     private let theme: ElementsUITheme
-    private var linkedBank: LinkedBank? {
+    private var linkedBank: FinancialConnectionsLinkedBank? {
         didSet {
             self.mandateString = Self.attributedMandateText(for: linkedBank, merchantName: merchantName, isSaving: savingAccount.value, configuration: configuration, theme: theme)
         }
@@ -141,7 +141,7 @@ final class USBankAccountPaymentMethodElement: Element {
         }
     }
 
-    func setLinkedBank(_ linkedBank: LinkedBank) {
+    func setLinkedBank(_ linkedBank: FinancialConnectionsLinkedBank) {
         self.linkedBank = linkedBank
         if let last4ofBankAccount = linkedBank.last4,
            let bankName = linkedBank.bankName {
@@ -151,11 +151,11 @@ final class USBankAccountPaymentMethodElement: Element {
         }
         self.delegate?.didUpdate(element: self)
     }
-    func getLinkedBank() -> LinkedBank? {
+    func getLinkedBank() -> FinancialConnectionsLinkedBank? {
         return linkedBank
     }
 
-    class func attributedMandateText(for linkedBank: LinkedBank?,
+    class func attributedMandateText(for linkedBank: FinancialConnectionsLinkedBank?,
                                      merchantName: String,
                                      isSaving: Bool,
                                      configuration: PaymentSheetFormFactoryConfig,
@@ -224,10 +224,12 @@ extension USBankAccountPaymentMethodElement: BankAccountInfoViewDelegate {
 
 extension USBankAccountPaymentMethodElement: PaymentMethodElement {
     func updateParams(params: IntentConfirmParams) -> IntentConfirmParams? {
-        if let updatedParams = self.formElement.updateParams(params: params),
-           let linkedBank = linkedBank {
+        if
+            let updatedParams = self.formElement.updateParams(params: params),
+            let linkedBank = linkedBank
+        {
             updatedParams.paymentMethodParams.usBankAccount?.linkAccountSessionID = linkedBank.sessionId
-            updatedParams.linkedBank = linkedBank
+            updatedParams.financialConnectionsLinkedBank = linkedBank
             return updatedParams
         }
         return nil

--- a/StripePayments/StripePayments/Source/API Bindings/Models/ACH/STPCollectBankAccountParams.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/ACH/STPCollectBankAccountParams.swift
@@ -36,4 +36,20 @@ public class STPCollectBankAccountParams: NSObject {
         paymentMethodParams.type = .USBankAccount
         return STPCollectBankAccountParams(paymentMethodParams: paymentMethodParams)
     }
+
+    /// Configures and returns an instance of `STPCollectBankAccountParams` for Instant Debits
+    /// - Parameters:
+    ///     - email: The customer's email.
+    @objc(collectInstantDebitsParamsWithEmail:)
+    @_spi(STP) public class func collectInstantDebitsParams(
+        email: String?
+    ) -> STPCollectBankAccountParams {
+        let billingDetails = STPPaymentMethodBillingDetails()
+        billingDetails.email = email
+
+        let paymentMethodParams = STPPaymentMethodParams()
+        paymentMethodParams.billingDetails = billingDetails
+        paymentMethodParams.type = .link
+        return STPCollectBankAccountParams(paymentMethodParams: paymentMethodParams)
+    }
 }

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodEnums.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodEnums.swift
@@ -90,6 +90,8 @@ import Foundation
     case twint
     /// A Multibanco payment method
     case multibanco
+    /// A Instant Debits payment method
+    case instantDebits
     /// An unknown type.
     case unknown
 
@@ -178,6 +180,8 @@ import Foundation
             return "TWINT"
         case .multibanco:
             return "Multibanco"
+        case .instantDebits:
+            return "Bank Account"
         case .cardPresent,
             .unknown:
             return STPLocalizedString("Unknown", "Default missing source type label")
@@ -269,6 +273,8 @@ import Foundation
             return "twint"
         case .multibanco:
             return "multibanco"
+        case .instantDebits:
+            return "instant_debits"
         }
     }
 }

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodParams.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodParams.swift
@@ -745,6 +745,7 @@ public class STPPaymentMethodParams: NSObject, STPFormEncodable {
             .USBankAccount,
             .cashApp,
             .revolutPay,
+            .instantDebits,
             .unknown:
             return nil
         }
@@ -1261,7 +1262,7 @@ extension STPPaymentMethodParams {
             alma = STPPaymentMethodAlmaParams()
         case .multibanco:
             multibanco = STPPaymentMethodMultibancoParams()
-        case .cardPresent, .linkInstantDebit, .paynow, .zip, .konbini, .promptPay, .twint:
+        case .cardPresent, .linkInstantDebit, .paynow, .zip, .konbini, .promptPay, .twint, .instantDebits:
             // These payment methods don't have any params
             break
         case .unknown:
@@ -1343,6 +1344,8 @@ extension STPPaymentMethodParams {
             return "TWINT"
         case .multibanco:
             return "Multibanco"
+        case .instantDebits:
+            return "Bank Account"
         case .cardPresent, .unknown:
             return STPLocalizedString("Unknown", "Default missing source type label")
         case .paynow, .zip, .amazonPay, .alma, .mobilePay, .konbini, .promptPay, .swish:

--- a/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+LinkAccountSession.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+LinkAccountSession.swift
@@ -106,6 +106,12 @@ public extension STPAPIClient {
         if let customerEmailAddress = customerEmailAddress {
             parameters["payment_method_data[billing_details][email]"] = customerEmailAddress
         }
+        // handle instant debits
+        if paymentMethodType == .link {
+            parameters["hosted_surface"] = "payment_element"
+            parameters["product"] = "instant_debits"
+            parameters["attach_required"] = true
+        }
 
         APIRequest<LinkAccountSession>.post(
             with: self,

--- a/StripePayments/StripePayments/Source/Categories/Enums+CustomStringConvertible.swift
+++ b/StripePayments/StripePayments/Source/Categories/Enums+CustomStringConvertible.swift
@@ -525,7 +525,7 @@ extension STPPaymentMethodType: CustomStringConvertible {
             return "swish"
         case .twint:
             return "TWINT"
-        case .paynow, .zip, .revolutPay, .mobilePay, .amazonPay, .alma, .konbini, .promptPay:
+        case .paynow, .zip, .revolutPay, .mobilePay, .amazonPay, .alma, .konbini, .promptPay, .instantDebits:
             // `description` is the value used when this type is converted to a string for debugging purposes, just use the display name.
             return displayName
         case .multibanco:

--- a/StripePayments/StripePayments/Source/Internal/Helpers/ConnectionsSDKAvailability.swift
+++ b/StripePayments/StripePayments/Source/Internal/Helpers/ConnectionsSDKAvailability.swift
@@ -56,12 +56,16 @@ final class StubbedConnectionsSDKInterface: FinancialConnectionsSDKInterface {
         completion: @escaping (FinancialConnectionsSDKResult) -> Void
     ) {
         DispatchQueue.main.async {
-            completion(FinancialConnectionsSDKResult.completed(linkedBank: StubbedLinkedBank()))
+            completion(
+                FinancialConnectionsSDKResult.completed(
+                    .financialConnections(StubbedFinancialConnectionsLinkedBank())
+                )
+            )
         }
     }
 }
 
-struct StubbedLinkedBank: LinkedBank {
+struct StubbedFinancialConnectionsLinkedBank: FinancialConnectionsLinkedBank {
     var sessionId: String = "las_123"
 
     var accountId: String = "fca_123"

--- a/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
@@ -743,7 +743,8 @@ public class STPPaymentHandler: NSObject {
             .promptPay,
             .swish,
             .twint,
-            .multibanco:
+            .multibanco,
+            .instantDebits:
             return false
 
         case .unknown:


### PR DESCRIPTION
## Summary

This PR implements the first iteration of Instant Debits in the Payment Sheet. The PR:
1. Adds a new payment method (instant debits) so we could display a new "Bank Account" payment method in the payment sheet
2. If "Bank Account" (Instant Debits) is selected, the code displays UI, and routes through Payment Sheet and Financial Connections

⚠️  Some important notes for reviewing:
- This is just the first iteration. Despite Android equivalent already being landed, we still have a lot of things to resolve and improve before launching to merchants: handle flags for rollout, design, testing, etc.

## Testing

See two videos:

### PaymentIntent Succeeds

https://github.com/stripe/stripe-ios/assets/105514761/dddd0e22-9a9a-4415-8933-0c3aa38368d9

### SetupIntent Succeeds

https://github.com/stripe/stripe-ios/assets/105514761/4ff6341c-a3d4-4d72-b23a-9957959c4873

### Financial Connections Still Works

https://app.bitrise.io/build/30cd250d-0695-4af1-bd81-5c5de2f882f3

```
FinancialConnectionsNetworkingUITests
    ✓ testNativeNetworkingTestMode (111.850 seconds)
    ✓ testNativeNetworkingTestModeSignUpWithMultiSelectAndPrefilledEmail (30.682 seconds)
FinancialConnectionsUITests
    ✓ testDataLiveModeOAuthNativeAuthFlow (29.338 seconds)
    ✓ testDataLiveModeOAuthWebAuthFlow (18.610 seconds)
    ✓ testDataTestModeOAuthNativeAuthFlow (18.501 seconds)
    ✓ testPaymentSearchInLiveModeNativeAuthFlow (26.620 seconds)
    ✓ testPaymentTestModeLegacyNativeAuthFlow (20.153 seconds)
    ✓ testPaymentTestModeManualEntryNativeAuthFlow (24.347 seconds)
```