### PR TITLE
Link/Instant Debits: updated ExampleLinkPaymentCheckoutVC with a different backend

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkPaymentCheckoutViewController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkPaymentCheckoutViewController.swift
@@ -15,8 +15,8 @@ class ExampleLinkPaymentCheckoutViewController: UIViewController {
     @IBOutlet weak var paymentMethodImage: UIImageView!
     @IBOutlet weak var deferredSwitch: UISwitch!
     var linkPaymentController: LinkPaymentController!
-    let backendCheckoutUrl = "https://abundant-elderly-universe.glitch.me/checkout"  // An example backend endpoint
-    let confirmEndpoint = "https://abundant-elderly-universe.glitch.me/confirm_intent"
+    let backendCheckoutUrl = "https://connections-instant-debits-example.glitch.me/checkout"  // An example backend endpoint
+    let confirmEndpoint = "https://connections-instant-debits-example.glitch.me/confirm_intent"
     private var token = 0
 
     let billingDetails: PaymentSheet.BillingDetails = {


### PR DESCRIPTION
## Summary

^ Link/Instant Debits: updated ExampleLinkPaymentCheckoutVC with a different backend

This is just a small maintenance change. [Slack context](https://stripe.slack.com/archives/C01DNBVURH9/p1713292345814799).

## Testing

https://github.com/stripe/stripe-ios/assets/105514761/3500a573-7ed6-48f0-bfba-ab8447d96f0b
