### PR TITLE
Fix PaymentHandler reporting certain next action payment errors as unexpected errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## x.x.x x-x-x
 ### PaymentSheet
 * [Added] Support for Multibanco with PaymentIntents.
+* [Fixed] Fixed an issue where STPPaymentHandler sometimes reported errors using `unexpectedErrorCode` instead of a more specific error when customers fail a PaymentIntent next action.
 
 ### Payments
 * [Added] Support for Multibanco bindings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## x.x.x x-x-x
 ### PaymentSheet
 * [Added] Support for Multibanco with PaymentIntents.
-* [Fixed] Fixed an issue where STPPaymentHandler sometimes reported errors using `unexpectedErrorCode` instead of a more specific error when customers fail a PaymentIntent next action.
+* [Fixed] Fixed an issue where STPPaymentHandler sometimes reported errors using `unexpectedErrorCode` instead of a more specific error when customers fail a next action.
 
 ### Payments
 * [Added] Support for Multibanco bindings.

--- a/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
@@ -1455,9 +1455,9 @@ public class STPPaymentHandler: NSObject {
                     currentAction.apiClient.retrievePaymentIntent(
                         withClientSecret: currentAction.paymentIntent.clientSecret,
                         expand: ["payment_method"]
-                    ) { paymentIntent, error in
-                        guard let paymentIntent, let paymentMethod = paymentIntent.paymentMethod, error == nil else {
-                            let error = error ?? self._error(for: .unexpectedErrorCode, loggingSafeErrorMessage: "Missing PaymentIntent or paymentIntent.paymentMethod.")
+                    ) { [self] paymentIntent, error in
+                        guard let paymentIntent, error == nil else {
+                            let error = error ?? self._error(for: .unexpectedErrorCode, loggingSafeErrorMessage: "Missing PaymentIntent.")
                             currentAction.complete(
                                 with: STPPaymentHandlerActionStatus.failed,
                                 error: error as NSError
@@ -1468,6 +1468,7 @@ public class STPPaymentHandler: NSObject {
                         // If the transaction is still unexpectedly processing, refresh the PaymentIntent
                         // This could happen if, for example, a payment is approved in an SFSafariViewController, the user closes the sheet, and the approval races with this fetch.
                         if
+                            let paymentMethod = paymentIntent.paymentMethod,
                             !STPPaymentHandler._isProcessingIntentSuccess(for: paymentMethod.type),
                             paymentIntent.status == .processing && retryCount > 0
                         {
@@ -1488,6 +1489,13 @@ public class STPPaymentHandler: NSObject {
                                 forAction: currentAction
                             )
                             if requiresAction {
+                                guard let paymentMethod = paymentIntent.paymentMethod else {
+                                    currentAction.complete(
+                                        with: STPPaymentHandlerActionStatus.failed,
+                                        error: self._error(for: .unexpectedErrorCode, loggingSafeErrorMessage: "PaymentIntent requires action but missing PaymentMethod.")
+                                    )
+                                    return
+                                }
                                 // If the status is still RequiresAction, the user exited from the redirect before the
                                 // payment intent was updated. Consider it a cancel, unless it's a valid terminal next action
                                 if self.isNextActionSuccessState(


### PR DESCRIPTION
## Summary
The changes in #3497 have a bug where failing to complete the next action incorrectly report an unexpected error if there is no API-provided error, instead of reporting the last payment error. 

## Testing
Manually tested. Doesn't affect 3DS2, but does affect CashApp. 
Before: error string is "The operation couldn't be completed (STPPaymentHandlerErrorDomain error 12.)"
After: error string is "The customer declined this payment."

## Changelog
[Fixed] Fixed an issue where STPPaymentHandler sometimes reported errors using `unexpectedErrorCode` instead of a more specific error when customers fail a PaymentIntent next action.