### PR TITLE
Makes the scanned name and expiry date of a card publicly visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## x.x.x x-x-x
+### CardScan
+* [Changed] ScannedCard to allow access for expiryMonth, expiryYear and name.
+
 ### PaymentSheet
 * [Added] Support for Multibanco with PaymentIntents.
 

--- a/StripeCardScan/StripeCardScan/Source/CardVerify/Card Image Verification/ScannedCard.swift
+++ b/StripeCardScan/StripeCardScan/Source/CardVerify/Card Image Verification/ScannedCard.swift
@@ -11,9 +11,9 @@ import Foundation
 /// the card image verification flow
 public struct ScannedCard: Equatable {
     public let pan: String
-    @_spi(STP) public let expiryMonth: String?
-    @_spi(STP) public let expiryYear: String?
-    @_spi(STP) public let name: String?
+    public let expiryMonth: String?
+    public let expiryYear: String?
+    public let name: String?
 
     init(
         pan: String,


### PR DESCRIPTION
## Summary
Remove `@_spi` for `ScannedCard` properties.
Fixes #2484 and #2875

## Motivation
In order to autofill our card entry form we need the scanned details, but for some reason they're blocked from being publicly visible.

## Testing
N/A

## Changelog
[Changed] `ScannedCard` to allow access for `expiryMonth`, `expiryYear` and `name`.