### PR TITLE
Fix LinkLegalTermsView mistakenly always sending error analytic when …

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Views/LinkLegalTermsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Views/LinkLegalTermsView.swift
@@ -144,10 +144,12 @@ extension LinkLegalTermsView: UITextViewDelegate {
 
         let handled = delegate?.legalTermsView(self, didTapOnLinkWithURL: URL) ?? false
 
-        let errorAnalytic = ErrorAnalytic(event: .unexpectedPaymentSheetError,
-                                          error: Error.linkLegalTermsViewUITextViewDelegate)
-        STPAnalyticsClient.sharedClient.log(analytic: errorAnalytic)
-        stpAssert(handled, "Link not handled by delegate")
+        if !handled {
+            let errorAnalytic = ErrorAnalytic(event: .unexpectedPaymentSheetError,
+                                              error: Error.linkLegalTermsViewUITextViewDelegate)
+            STPAnalyticsClient.sharedClient.log(analytic: errorAnalytic)
+            stpAssertionFailure("Link not handled by delegate")
+        }
 
         // If not handled by the delegate, let the system handle the link.
         return !handled


### PR DESCRIPTION
…opening url

## Testing
Manually tested

## Changelog
Not user facing