### PR TITLE
Don't send error analytic every time "terms" is clicked

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Views/LinkLegalTermsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Views/LinkLegalTermsView.swift
@@ -144,11 +144,13 @@ extension LinkLegalTermsView: UITextViewDelegate {
 
         let handled = delegate?.legalTermsView(self, didTapOnLinkWithURL: URL) ?? false
 
-        let errorAnalytic = ErrorAnalytic(event: .unexpectedPaymentSheetError,
-                                          error: Error.linkLegalTermsViewUITextViewDelegate)
-        STPAnalyticsClient.sharedClient.log(analytic: errorAnalytic)
-        stpAssert(handled, "Link not handled by delegate")
-
+        if !handled {
+            let errorAnalytic = ErrorAnalytic(event: .unexpectedPaymentSheetError,
+                                              error: Error.linkLegalTermsViewUITextViewDelegate)
+            STPAnalyticsClient.sharedClient.log(analytic: errorAnalytic)
+            stpAssert(false, "Link not handled by delegate")
+        }
+        
         // If not handled by the delegate, let the system handle the link.
         return !handled
     }


### PR DESCRIPTION
## Summary
This error should only be sent if the URL fails to launch.

## Motivation
Unnecessary alerts

## Testing
Tested in PS Example
