### PR TITLE
Fix constraint warning

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/BottomSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/BottomSheetViewController.swift
@@ -254,7 +254,7 @@ class BottomSheetViewController: UIViewController, BottomSheetPresentable {
 
     private lazy var manualHeightConstraint: NSLayoutConstraint = {
         let manualHeightConstraint: NSLayoutConstraint = self.view.heightAnchor.constraint(equalToConstant: 0)
-        manualHeightConstraint.priority = .required
+        manualHeightConstraint.priority = .defaultHigh
         return manualHeightConstraint
     }()
 


### PR DESCRIPTION
## Summary
This shouldn't be `required`, as the top of the screen constraint should take priority if the sheet is taller than the screen.

## Motivation
RUN_MOBILESDK-3111

## Testing
Manually in PS Example, existing UI tests should still pass.
