### PR TITLE
Prevent animation glitch when dismissing during sheet presentation

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/BottomSheet/BottomSheetPresentationController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/BottomSheet/BottomSheetPresentationController.swift
@@ -122,7 +122,11 @@ class BottomSheetPresentationController: UIPresentationController {
     }
 
     @objc func didTapBackgroundView() {
-        presentable?.didTapOrSwipeToDismiss()
+        // This animation isn't cleanly interruptable, don't allow dismissal until it completes.
+        // We're not aware of the animation state ourselves, so we'll check the presentedView for any attached animations.
+        if presentedView.layer.animationKeys()?.count ?? 0 == 0 {
+            presentable?.didTapOrSwipeToDismiss()
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
We'll just prevent the user from tapping out of the sheet if we're currently animating.

## Motivation
RUN_MOBILESDK-3118

## Testing
In PS Example

## Changelog
None