### PR TITLE
Extract common PaymentSheet initialization parameters

### DIFF
--- a/Stripe/StripeiOSTests/STPAnalyticsClientPaymentSheetTest.swift
+++ b/Stripe/StripeiOSTests/STPAnalyticsClientPaymentSheetTest.swift
@@ -96,11 +96,13 @@ class STPAnalyticsClientPaymentSheetTest: XCTestCase {
         XCTAssertTrue(client.productUsage.contains("PaymentSheet"))
 
         _ = PaymentSheet.FlowController(
-            intent: .paymentIntent(elementsSession: .makeBackupElementsSession(with: STPFixtures.paymentIntent()), paymentIntent: STPFixtures.paymentIntent()),
-            savedPaymentMethods: [],
-            isLinkEnabled: false,
-            isApplePayEnabled: false,
-            configuration: PaymentSheet.Configuration()
+            configuration: PaymentSheet.Configuration(),
+            loadResult: .init(
+                intent: .paymentIntent(elementsSession: .makeBackupElementsSession(with: STPFixtures.paymentIntent()), paymentIntent: STPFixtures.paymentIntent()),
+                savedPaymentMethods: [],
+                isLinkEnabled: false,
+                isApplePayEnabled: false
+            )
         )
         XCTAssertTrue(client.productUsage.contains("PaymentSheet.FlowController"))
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Intent.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Intent.swift
@@ -19,6 +19,7 @@ import UIKit
 
 /// An internal type representing either a PaymentIntent, SetupIntent, or a "deferred Intent"
 enum Intent {
+    // TODO: Extract elementsSession out of this enum - semantically, it is not part of an Intent.
     case paymentIntent(elementsSession: STPElementsSession, paymentIntent: STPPaymentIntent)
     case setupIntent(elementsSession: STPElementsSession, setupIntent: STPSetupIntent)
     case deferredIntent(elementsSession: STPElementsSession, intentConfig: PaymentSheet.IntentConfiguration)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
@@ -151,18 +151,12 @@ public class PaymentSheet {
             isFlowController: false
         ) { result in
             switch result {
-            case .success(let intent, let savedPaymentMethods, let isLinkEnabled, let isApplePayEnabled):
-                let isCVCRecollectionEnabled = intent.cvcRecollectionEnabled
-
+            case .success(let loadResult):
                 // Set the PaymentSheetViewController as the content of our bottom sheet
                 let presentPaymentSheetVC = {
                     let paymentSheetVC = PaymentSheetViewController(
-                        intent: intent,
-                        savedPaymentMethods: savedPaymentMethods,
                         configuration: self.configuration,
-                        isApplePayEnabled: isApplePayEnabled,
-                        isLinkEnabled: isLinkEnabled,
-                        isCVCRecollectionEnabled: isCVCRecollectionEnabled,
+                        loadResult: loadResult,
                         delegate: self
                     )
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -145,18 +145,15 @@ extension PaymentSheet {
         // MARK: - Initializer (Internal)
 
         required init(
-            intent: Intent,
-            savedPaymentMethods: [STPPaymentMethod],
-            isLinkEnabled: Bool,
-            isApplePayEnabled: Bool,
-            configuration: Configuration
+            configuration: Configuration,
+            loadResult: PaymentSheetLoader.LoadResult
         ) {
             STPAnalyticsClient.sharedClient.addClass(toProductUsageIfNecessary: PaymentSheet.FlowController.self)
             STPAnalyticsClient.sharedClient.logPaymentSheetInitialized(isCustom: true,
                                                                        configuration: configuration,
-                                                                       intentConfig: intent.intentConfig)
+                                                                       intentConfig: loadResult.intent.intentConfig)
             self.configuration = configuration
-            self.viewController = Self.makeViewController(intent: intent, savedPaymentMethods: savedPaymentMethods, isLinkEnabled: isLinkEnabled, isApplePayEnabled: isApplePayEnabled, configuration: configuration)
+            self.viewController = Self.makeViewController(configuration: configuration, loadResult: loadResult)
             self.viewController.delegate = self
         }
 
@@ -232,13 +229,11 @@ extension PaymentSheet {
                 isFlowController: true
             ) { result in
                 switch result {
-                case .success(let intent, let paymentMethods, let isLinkEnabled, let isApplePayEnabled):
+                case .success(let loadResult):
                     let flowController = FlowController(
-                        intent: intent,
-                        savedPaymentMethods: paymentMethods,
-                        isLinkEnabled: isLinkEnabled,
-                        isApplePayEnabled: isApplePayEnabled,
-                        configuration: configuration)
+                        configuration: configuration,
+                        loadResult: loadResult
+                    )
 
                     // Synchronously pre-load image into cache.
                     // Accessing flowController.paymentOption has the side-effect of ensuring its `image` property is loaded (e.g. from the internet instead of disk) before we call the completion handler.
@@ -402,7 +397,7 @@ extension PaymentSheet {
                 mode: .deferredIntent(intentConfiguration),
                 configuration: configuration,
                 isFlowController: true
-            ) { [weak self] loadResult in
+            ) { [weak self] result in
                 assert(Thread.isMainThread, "PaymentSheet.FlowController.update load callback must be called from the main thread.")
                 guard let self = self else {
                     assertionFailure("The PaymentSheet.FlowController instance was destroyed during a call to `update(intentConfiguration:completion:)`")
@@ -414,16 +409,13 @@ extension PaymentSheet {
                     return
                 }
 
-                switch loadResult {
-                case .success(let intent, let paymentMethods, let isLinkEnabled, let isApplePayEnabled):
+                switch result {
+                case .success(let loadResult):
                     // 2. Re-initialize PaymentSheetFlowControllerViewController to update the UI to match the newly loaded data e.g. payment method types may have changed.
                     self.viewController = Self.makeViewController(
-                        intent: intent,
-                        savedPaymentMethods: paymentMethods,
-                        previousPaymentOption: self._paymentOption,
-                        isLinkEnabled: isLinkEnabled,
-                        isApplePayEnabled: isApplePayEnabled,
-                        configuration: self.configuration
+                        configuration: self.configuration,
+                        loadResult: loadResult,
+                        previousPaymentOption: self._paymentOption
                     )
                     self.viewController.delegate = self
 
@@ -458,21 +450,14 @@ extension PaymentSheet {
         }
 
         static func makeViewController(
-            intent: Intent,
-            savedPaymentMethods: [STPPaymentMethod],
-            previousPaymentOption: PaymentOption? = nil,
-            isLinkEnabled: Bool,
-            isApplePayEnabled: Bool,
-            configuration: Configuration
+            configuration: Configuration,
+            loadResult: PaymentSheetLoader.LoadResult,
+            previousPaymentOption: PaymentOption? = nil
         ) -> PaymentSheetFlowControllerViewController {
             let vc = PaymentSheetFlowControllerViewController(
-                intent: intent,
-                savedPaymentMethods: savedPaymentMethods,
                 configuration: configuration,
-                previousPaymentOption: previousPaymentOption,
-                isApplePayEnabled: isApplePayEnabled,
-                isLinkEnabled: isLinkEnabled,
-                isCVCRecollectionEnabled: false
+                loadResult: loadResult,
+                previousPaymentOption: previousPaymentOption
             )
             configuration.style.configure(vc)
             return vc

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -170,18 +170,13 @@ class PaymentSheetFlowControllerViewController: UIViewController {
     }
 
     required init(
-        intent: Intent,
-        savedPaymentMethods: [STPPaymentMethod],
         configuration: PaymentSheet.Configuration,
-        previousPaymentOption: PaymentOption? = nil,
-        isApplePayEnabled: Bool,
-        isLinkEnabled: Bool,
-        isCVCRecollectionEnabled: Bool
+        loadResult: PaymentSheetLoader.LoadResult,
+        previousPaymentOption: PaymentOption? = nil
     ) {
-        self.intent = intent
-        self.isApplePayEnabled = isApplePayEnabled
-        self.isLinkEnabled = isLinkEnabled
-
+        self.intent = loadResult.intent
+        self.isApplePayEnabled = loadResult.isApplePayEnabled
+        self.isLinkEnabled = loadResult.isLinkEnabled
         self.configuration = configuration
 
         // Restore the customer's previous payment method. For saved PMs, this happens naturally already, so we just need to handle new payment methods.
@@ -207,19 +202,19 @@ class PaymentSheetFlowControllerViewController: UIViewController {
         }()
         // Default to saved payment selection mode, as long as we aren't restoring a customer's previous new payment method input
         // and they have saved PMs or Apple Pay or Link is enabled
-        self.mode = (previousNewPaymentMethodParams == nil) && (savedPaymentMethods.count > 0 || isApplePayEnabled || isLinkEnabled)
+        self.mode = (previousNewPaymentMethodParams == nil) && (loadResult.savedPaymentMethods.count > 0 || isApplePayEnabled || isLinkEnabled)
                 ? .selectingSaved
                 : .addingNew
 
         self.savedPaymentOptionsViewController = SavedPaymentOptionsViewController(
-            savedPaymentMethods: savedPaymentMethods,
+            savedPaymentMethods: loadResult.savedPaymentMethods,
             configuration: .init(
                 customerID: configuration.customer?.id,
                 showApplePay: isApplePayEnabled,
                 showLink: isLinkEnabled,
                 removeSavedPaymentMethodMessage: configuration.removeSavedPaymentMethodMessage,
                 merchantDisplayName: configuration.merchantDisplayName,
-                isCVCRecollectionEnabled: isCVCRecollectionEnabled,
+                isCVCRecollectionEnabled: loadResult.intent.cvcRecollectionEnabled,
                 isTestMode: configuration.apiClient.isTestmode,
                 allowsRemovalOfLastSavedPaymentMethod: configuration.allowsRemovalOfLastSavedPaymentMethod
             ),

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -182,29 +182,25 @@ class PaymentSheetViewController: UIViewController {
     }
 
     required init(
-        intent: Intent,
-        savedPaymentMethods: [STPPaymentMethod],
         configuration: PaymentSheet.Configuration,
-        isApplePayEnabled: Bool,
-        isLinkEnabled: Bool,
-        isCVCRecollectionEnabled: Bool,
+        loadResult: PaymentSheetLoader.LoadResult,
         delegate: PaymentSheetViewControllerDelegate
     ) {
-        self.intent = intent
+        self.intent = loadResult.intent
         self.configuration = configuration
-        self.isApplePayEnabled = isApplePayEnabled
-        self.isLinkEnabled = isLinkEnabled
-        self.isCVCRecollectionEnabled = isCVCRecollectionEnabled
+        self.isApplePayEnabled = loadResult.isApplePayEnabled
+        self.isLinkEnabled = loadResult.isLinkEnabled
+        self.isCVCRecollectionEnabled = loadResult.intent.cvcRecollectionEnabled
         self.delegate = delegate
         self.savedPaymentOptionsViewController = SavedPaymentOptionsViewController(
-            savedPaymentMethods: savedPaymentMethods,
+            savedPaymentMethods: loadResult.savedPaymentMethods,
             configuration: .init(
                 customerID: configuration.customer?.id,
                 showApplePay: false,
                 showLink: false,
                 removeSavedPaymentMethodMessage: configuration.removeSavedPaymentMethodMessage,
                 merchantDisplayName: configuration.merchantDisplayName,
-                isCVCRecollectionEnabled: isCVCRecollectionEnabled,
+                isCVCRecollectionEnabled: loadResult.intent.cvcRecollectionEnabled,
                 isTestMode: configuration.apiClient.isTestmode,
                 allowsRemovalOfLastSavedPaymentMethod: configuration.allowsRemovalOfLastSavedPaymentMethod
             ),
@@ -214,7 +210,7 @@ class PaymentSheetViewController: UIViewController {
             cbcEligible: intent.cardBrandChoiceEligible
         )
 
-        if savedPaymentMethods.isEmpty {
+        if loadResult.savedPaymentMethods.isEmpty {
             self.mode = .addingNew
         } else {
             self.mode = .selectingSaved

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APITest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APITest.swift
@@ -81,18 +81,18 @@ class PaymentSheetAPITest: XCTestCase {
                     isFlowController: false
                 ) { result in
                     switch result {
-                    case .success(let paymentIntent, let paymentMethods, _, _):
+                    case .success(let loadResult):
                         XCTAssertEqual(
-                            Set(paymentIntent.recommendedPaymentMethodTypes),
+                            Set(loadResult.intent.recommendedPaymentMethodTypes),
                             Set(expected)
                         )
-                        XCTAssertEqual(paymentMethods, [])
+                        XCTAssertEqual(loadResult.savedPaymentMethods, [])
                         // 2. Confirm the intent with a new card
 
                         PaymentSheet.confirm(
                             configuration: self.configuration,
                             authenticationContext: self,
-                            intent: paymentIntent,
+                            intent: loadResult.intent,
                             paymentOption: self.newCardPaymentOption,
                             paymentHandler: self.paymentHandler
                         ) { result, _ in
@@ -163,14 +163,14 @@ class PaymentSheetAPITest: XCTestCase {
             isFlowController: false
         ) { result in
             switch result {
-            case .success(let intent, let paymentMethods, _, _):
+            case .success(let loadResult):
                 XCTAssertEqual(
-                    Set(intent.recommendedPaymentMethodTypes),
+                    Set(loadResult.intent.recommendedPaymentMethodTypes),
                     Set(expected)
                 )
-                XCTAssertEqual(paymentMethods, [])
+                XCTAssertEqual(loadResult.savedPaymentMethods, [])
                 loadExpectation.fulfill()
-                guard case .deferredIntent(elementsSession: let elementsSession, intentConfig: _) = intent else {
+                guard case .deferredIntent(elementsSession: let elementsSession, intentConfig: _) = loadResult.intent else {
                     XCTFail()
                     return
                 }
@@ -229,14 +229,14 @@ class PaymentSheetAPITest: XCTestCase {
             isFlowController: false
         ) { result in
             switch result {
-            case .success(let intent, let paymentMethods, _, _):
+            case .success(let loadResult):
                 XCTAssertEqual(
-                    Set(intent.recommendedPaymentMethodTypes),
+                    Set(loadResult.intent.recommendedPaymentMethodTypes),
                     Set(expected)
                 )
-                XCTAssertEqual(paymentMethods, [])
+                XCTAssertEqual(loadResult.savedPaymentMethods, [])
                 loadExpectation.fulfill()
-                guard case .deferredIntent(elementsSession: let elementsSession, intentConfig: _) = intent else {
+                guard case .deferredIntent(elementsSession: let elementsSession, intentConfig: _) = loadResult.intent else {
                     XCTFail()
                     return
                 }
@@ -285,7 +285,7 @@ class PaymentSheetAPITest: XCTestCase {
                 configuration: self.configuration,
                 isFlowController: false
             ) { result in
-                guard case .success(let paymentIntent, _, _, _) = result else {
+                guard case .success(let loadResult) = result else {
                     XCTFail()
                     return
                 }
@@ -293,7 +293,7 @@ class PaymentSheetAPITest: XCTestCase {
                 PaymentSheet.confirm(
                     configuration: self.configuration,
                     authenticationContext: self,
-                    intent: paymentIntent,
+                    intent: loadResult.intent,
                     paymentOption: .saved(paymentMethod: .init(stripeId: "pm_card_visa", type: .card), confirmParams: nil),
                     paymentHandler: self.paymentHandler
                 ) { result, _ in

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerViewControllerSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerViewControllerSnapshotTests.swift
@@ -13,18 +13,22 @@ import StripeCoreTestUtils
 import XCTest
 
 final class PaymentSheetFlowControllerViewControllerSnapshotTests: STPSnapshotTestCase {
+    func makeTestLoadResult(paymentMethods: [STPPaymentMethod]) -> PaymentSheetLoader.LoadResult {
+        return .init(
+            intent: ._testValue(),
+            savedPaymentMethods: paymentMethods,
+            isLinkEnabled: false,
+            isApplePayEnabled: false
+        )
+    }
 
     func testSavedScreen_card() {
         let paymentMethods = [
             STPPaymentMethod._testCard(),
         ]
         let sut = PaymentSheetFlowControllerViewController(
-            intent: ._testValue(),
-            savedPaymentMethods: paymentMethods,
             configuration: ._testValue_MostPermissive(),
-            isApplePayEnabled: false,
-            isLinkEnabled: false,
-            isCVCRecollectionEnabled: false
+            loadResult: makeTestLoadResult(paymentMethods: paymentMethods)
         )
         sut.view.autosizeHeight(width: 375)
         STPSnapshotVerifyView(sut.view)
@@ -35,12 +39,8 @@ final class PaymentSheetFlowControllerViewControllerSnapshotTests: STPSnapshotTe
             STPPaymentMethod._testUSBankAccount(),
         ]
         let sut = PaymentSheetFlowControllerViewController(
-            intent: ._testValue(),
-            savedPaymentMethods: paymentMethods,
             configuration: ._testValue_MostPermissive(),
-            isApplePayEnabled: false,
-            isLinkEnabled: false,
-            isCVCRecollectionEnabled: false
+            loadResult: makeTestLoadResult(paymentMethods: paymentMethods)
         )
         sut.view.autosizeHeight(width: 375)
         STPSnapshotVerifyView(sut.view)
@@ -51,12 +51,8 @@ final class PaymentSheetFlowControllerViewControllerSnapshotTests: STPSnapshotTe
             STPPaymentMethod._testSEPA(),
         ]
         let sut = PaymentSheetFlowControllerViewController(
-            intent: ._testValue(),
-            savedPaymentMethods: paymentMethods,
             configuration: ._testValue_MostPermissive(),
-            isApplePayEnabled: false,
-            isLinkEnabled: false,
-            isCVCRecollectionEnabled: false
+            loadResult: makeTestLoadResult(paymentMethods: paymentMethods)
         )
         sut.view.autosizeHeight(width: 375)
         STPSnapshotVerifyView(sut.view)
@@ -92,12 +88,8 @@ final class PaymentSheetFlowControllerViewControllerSnapshotTests: STPSnapshotTe
         var configuration: PaymentSheet.Configuration = ._testValue_MostPermissive()
         configuration.primaryButtonLabel = "Submit"
         let sut = PaymentSheetFlowControllerViewController(
-            intent: ._testValue(),
-            savedPaymentMethods: paymentMethods,
             configuration: configuration,
-            isApplePayEnabled: false,
-            isLinkEnabled: false,
-            isCVCRecollectionEnabled: false
+            loadResult: makeTestLoadResult(paymentMethods: paymentMethods)
         )
         sut.view.autosizeHeight(width: 375)
         STPSnapshotVerifyView(sut.view)
@@ -115,12 +107,8 @@ final class PaymentSheetFlowControllerViewControllerSnapshotTests: STPSnapshotTe
         var configuration: PaymentSheet.Configuration = ._testValue_MostPermissive()
         configuration.primaryButtonLabel = "Submit"
         let sut = PaymentSheetFlowControllerViewController(
-            intent: ._testValue(),
-            savedPaymentMethods: [],
             configuration: configuration,
-            isApplePayEnabled: false,
-            isLinkEnabled: false,
-            isCVCRecollectionEnabled: false
+            loadResult: makeTestLoadResult(paymentMethods: [])
         )
         sut.view.autosizeHeight(width: 375)
         STPSnapshotVerifyView(sut.view)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderTest.swift
@@ -34,9 +34,9 @@ final class PaymentSheetLoaderTest: XCTestCase {
         PaymentSheetLoader.load(mode: .paymentIntentClientSecret(clientSecret), configuration: self.configuration, isFlowController: false) { result in
             expectation.fulfill()
             switch result {
-            case .success(let intent, let paymentMethods, _, let isApplePayEnabled):
+            case .success(let loadResult):
                 // ...PaymentSheet should successfully load
-                guard case let .paymentIntent(elementsSession, paymentIntent) = intent else {
+                guard case let .paymentIntent(elementsSession, paymentIntent) = loadResult.intent else {
                     XCTFail()
                     return
                 }
@@ -47,8 +47,8 @@ final class PaymentSheetLoaderTest: XCTestCase {
                 )
                 // Sanity check the PI matches the one we fetched
                 XCTAssertEqual(paymentIntent.clientSecret, clientSecret)
-                XCTAssertEqual(paymentMethods, [])
-                XCTAssertTrue(isApplePayEnabled)
+                XCTAssertEqual(loadResult.savedPaymentMethods, [])
+                XCTAssertTrue(loadResult.isApplePayEnabled)
             case .failure(let error):
                 XCTFail(error.nonGenericDescription)
             }
@@ -67,13 +67,13 @@ final class PaymentSheetLoaderTest: XCTestCase {
             isFlowController: false
         ) { result in
             switch result {
-            case .success(let setupIntent, let paymentMethods, _, let isApplePayEnabled):
+            case .success(let loadResult):
                 XCTAssertEqual(
-                    Set(setupIntent.recommendedPaymentMethodTypes),
+                    Set(loadResult.intent.recommendedPaymentMethodTypes),
                     Set(expected)
                 )
-                XCTAssertEqual(paymentMethods, [])
-                XCTAssertTrue(isApplePayEnabled)
+                XCTAssertEqual(loadResult.savedPaymentMethods, [])
+                XCTAssertTrue(loadResult.isApplePayEnabled)
                 expectation.fulfill()
             case .failure(let error):
                 XCTFail()
@@ -134,12 +134,12 @@ final class PaymentSheetLoaderTest: XCTestCase {
             PaymentSheetLoader.load(mode: .deferredIntent(intentConfig), configuration: self.configuration, isFlowController: true) { result in
                 loadExpectation.fulfill()
                 switch result {
-                case .success(let intent, _, _, let isApplePayEnabled):
-                    guard case .deferredIntent = intent else {
+                case .success(let loadResult):
+                    guard case .deferredIntent = loadResult.intent else {
                         XCTFail()
                         return
                     }
-                    XCTAssertTrue(isApplePayEnabled)
+                    XCTAssertTrue(loadResult.isApplePayEnabled)
                 case .failure(let error):
                     XCTFail("Test case at index \(index) failed: \(error)")
                     print(error)
@@ -220,10 +220,10 @@ final class PaymentSheetLoaderTest: XCTestCase {
         PaymentSheetLoader.load(mode: .deferredIntent(intentConfig), configuration: configuration, isFlowController: true) { result in
             loadExpectation.fulfill()
             switch result {
-            case .success(_, let savedPaymentMethods, _, _):
+            case .success(let loadResult):
                 // ...check that it only loads the one normal saved card
-                XCTAssertEqual(savedPaymentMethods.count, 1)
-                XCTAssertEqual(savedPaymentMethods.first?.stripeId, savedNonApplePayCard)
+                XCTAssertEqual(loadResult.savedPaymentMethods.count, 1)
+                XCTAssertEqual(loadResult.savedPaymentMethods.first?.stripeId, savedNonApplePayCard)
             case .failure:
                 XCTFail()
             }
@@ -245,9 +245,9 @@ final class PaymentSheetLoaderTest: XCTestCase {
         PaymentSheetLoader.load(mode: .paymentIntentClientSecret(clientSecret), configuration: configuration, isFlowController: false) { result in
             expectation.fulfill()
             switch result {
-            case .success(let intent, let paymentMethods, _, let isApplePayEnabled):
+            case .success(let loadResult):
                 // ...PaymentSheet should successfully load
-                guard case let .paymentIntent(elementsSession, paymentIntent) = intent else {
+                guard case let .paymentIntent(elementsSession, paymentIntent) = loadResult.intent else {
                     XCTFail()
                     return
                 }
@@ -262,8 +262,8 @@ final class PaymentSheetLoaderTest: XCTestCase {
                 )
                 // Sanity check the PI matches the one we fetched
                 XCTAssertEqual(paymentIntent.clientSecret, clientSecret)
-                XCTAssertEqual(paymentMethods, [])
-                XCTAssertTrue(isApplePayEnabled)
+                XCTAssertEqual(loadResult.savedPaymentMethods, [])
+                XCTAssertTrue(loadResult.isApplePayEnabled)
             case .failure(let error):
                 XCTFail(error.nonGenericDescription)
             }
@@ -286,16 +286,16 @@ final class PaymentSheetLoaderTest: XCTestCase {
         PaymentSheetLoader.load(mode: .paymentIntentClientSecret(clientSecret), configuration: configuration, isFlowController: true) { result in
             expectation.fulfill()
             switch result {
-            case .success(let intent, let paymentMethods, _, let isApplePayEnabled):
+            case .success(let loadResult):
                 // ...PaymentSheet should *still* successfully load
-                guard case let .paymentIntent(elementsSession, paymentIntent) = intent else {
+                guard case let .paymentIntent(elementsSession, paymentIntent) = loadResult.intent else {
                     XCTFail()
                     return
                 }
                 // Sanity check the PI matches the one we fetched
                 XCTAssertEqual(paymentIntent.clientSecret, clientSecret)
-                XCTAssertEqual(paymentMethods, [])
-                XCTAssertTrue(isApplePayEnabled)
+                XCTAssertEqual(loadResult.savedPaymentMethods, [])
+                XCTAssertTrue(loadResult.isApplePayEnabled)
 
                 // ...with an empty `externalPaymentMethods` property
                 XCTAssertTrue(elementsSession.externalPaymentMethods.isEmpty)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetViewControllerSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetViewControllerSnapshotTests.swift
@@ -12,18 +12,22 @@ import StripeCoreTestUtils
 import XCTest
 
 final class PaymentSheetViewControllerSnapshotTests: STPSnapshotTestCase {
+    func makeTestLoadResult(paymentMethods: [STPPaymentMethod]) -> PaymentSheetLoader.LoadResult {
+        return .init(
+            intent: ._testValue(),
+            savedPaymentMethods: paymentMethods,
+            isLinkEnabled: false,
+            isApplePayEnabled: false
+        )
+    }
 
     func testSavedScreen_card() {
         let paymentMethods = [
             STPPaymentMethod._testCard(),
         ]
         let sut = PaymentSheetViewController(
-            intent: ._testValue(),
-            savedPaymentMethods: paymentMethods,
             configuration: ._testValue_MostPermissive(),
-            isApplePayEnabled: false,
-            isLinkEnabled: false,
-            isCVCRecollectionEnabled: false,
+            loadResult: makeTestLoadResult(paymentMethods: paymentMethods),
             delegate: self
         )
         sut.view.autosizeHeight(width: 375)
@@ -35,12 +39,8 @@ final class PaymentSheetViewControllerSnapshotTests: STPSnapshotTestCase {
             STPPaymentMethod._testUSBankAccount(),
         ]
         let sut = PaymentSheetViewController(
-            intent: ._testValue(),
-            savedPaymentMethods: paymentMethods,
             configuration: ._testValue_MostPermissive(),
-            isApplePayEnabled: false,
-            isLinkEnabled: false,
-            isCVCRecollectionEnabled: false,
+            loadResult: makeTestLoadResult(paymentMethods: paymentMethods),
             delegate: self
         )
         sut.view.autosizeHeight(width: 375)
@@ -52,12 +52,8 @@ final class PaymentSheetViewControllerSnapshotTests: STPSnapshotTestCase {
             STPPaymentMethod._testSEPA(),
         ]
         let sut = PaymentSheetViewController(
-            intent: ._testValue(),
-            savedPaymentMethods: paymentMethods,
             configuration: ._testValue_MostPermissive(),
-            isApplePayEnabled: false,
-            isLinkEnabled: false,
-            isCVCRecollectionEnabled: false,
+            loadResult: makeTestLoadResult(paymentMethods: paymentMethods),
             delegate: self
         )
         sut.view.autosizeHeight(width: 375)


### PR DESCRIPTION
## Summary
Extract common initialization parameters from PS, PS.FC for reuse in vertical mode VC


## Testing
Pure refactor, no behavior change, relying on existing tests.

