### PR TITLE
Compare against last common commit

### DIFF
--- a/.github/workflows/verify-public-interface.yml
+++ b/.github/workflows/verify-public-interface.yml
@@ -16,9 +16,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
         with:
             fetch-depth: 0
+      
+      - name: Checkout through merge base
+        uses: rmacklin/fetch-through-merge-base@v0
+        with:
+          ref: ${{ github.head_ref }}
 
       - name: Build frameworks and compare interfaces
         id: build-frameworks-compare-interface

--- a/.github/workflows/verify-public-interface.yml
+++ b/.github/workflows/verify-public-interface.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
             fetch-depth: 0
 

--- a/.github/workflows/verify-public-interface.yml
+++ b/.github/workflows/verify-public-interface.yml
@@ -23,8 +23,10 @@ jobs:
       - name: Checkout through merge base
         uses: rmacklin/fetch-through-merge-base@v0
         with:
-          ref: ${{ github.head_ref }}
-
+          base_ref: ${{ github.event.pull_request.base.ref }}
+          head_ref: ${{ github.event.pull_request.head.sha }}
+          deepen_length: 500
+    
       - name: Build frameworks and compare interfaces
         id: build-frameworks-compare-interface
         run: |

--- a/StripePayments/StripePayments/Source/Internal/API Bindings/STPPaymentMethodListDeserializer.swift
+++ b/StripePayments/StripePayments/Source/Internal/API Bindings/STPPaymentMethodListDeserializer.swift
@@ -38,6 +38,7 @@ import Foundation
                 paymentMethods.append(paymentMethod)
             }
         }
+        // Modify Swift file to trigger CI
         paymentMethodsDeserializer.paymentMethods = paymentMethods
         return paymentMethodsDeserializer
     }

--- a/ci_scripts/api_diff/build_xcframeworks.rb
+++ b/ci_scripts/api_diff/build_xcframeworks.rb
@@ -7,9 +7,8 @@ def checkout_build_generate(branch, archive_name)
   # Checkout old or new version, build and generate API JSON
   puts "Building and generating public interface from #{branch}..."
   if archive_name == "master"
-    base_ref = ENV["GITHUB_BASE_REF"]
     head_ref = ENV['GITHUB_HEAD_REF']
-    system("git checkout $(git merge-base #{head_ref} #{base_ref})")
+    system("git checkout $(git merge-base #{head_ref} #{branch})")
   else 
     system("git checkout #{branch}")
   end

--- a/ci_scripts/api_diff/build_xcframeworks.rb
+++ b/ci_scripts/api_diff/build_xcframeworks.rb
@@ -8,8 +8,8 @@ def checkout_build_generate(branch, archive_name)
   puts "Building and generating public interface from #{branch}..."
   if archive_name == "master"
     head_ref = ENV['GITHUB_HEAD_REF']
-    puts "git checkout $(git merge-base #{branch}) #{head_ref}"
-    system("git checkout $(git merge-base #{branch}) #{head_ref}")
+    commit_sha = system("git merge-base #{branch} #{head_ref}")
+    system("git checkout #{commit_sha}")
   else 
     system("git checkout #{branch}")
   end

--- a/ci_scripts/api_diff/build_xcframeworks.rb
+++ b/ci_scripts/api_diff/build_xcframeworks.rb
@@ -8,7 +8,8 @@ def checkout_build_generate(branch, archive_name)
   puts "Building and generating public interface from #{branch}..."
   if archive_name == "master"
     head_ref = ENV['GITHUB_HEAD_REF']
-    system("git checkout $(git merge-base #{head_ref} #{branch})")
+    puts "git checkout $(git merge-base #{branch}) #{head_ref}"
+    system("git checkout $(git merge-base #{branch}) #{head_ref}")
   else 
     system("git checkout #{branch}")
   end

--- a/ci_scripts/api_diff/build_xcframeworks.rb
+++ b/ci_scripts/api_diff/build_xcframeworks.rb
@@ -6,7 +6,13 @@ require_relative 'get_frameworks'
 def checkout_build_generate(branch, archive_name)
   # Checkout old or new version, build and generate API JSON
   puts "Building and generating public interface from #{branch}..."
-  system("git checkout #{branch}")
+  if archive_name == "master"
+    base_ref = ENV["GITHUB_BASE_REF"]
+    head_ref = ENV['GITHUB_HEAD_REF']
+    system("git checkout $(git merge-base #{head_ref} #{base_ref})")
+  else 
+    system("git checkout #{branch}")
+  end
 
   system("xcodebuild clean archive \
   -quiet \
@@ -30,5 +36,5 @@ def checkout_build_generate(branch, archive_name)
 end
 
 # Run function for master and head_ref
-checkout_build_generate("master", "master")
+checkout_build_generate(ENV["GITHUB_BASE_REF"], "master")
 checkout_build_generate(ENV['GITHUB_HEAD_REF'], "new")


### PR DESCRIPTION
## Summary
- Only compare the public interface with the commit the branch is based off of rather than master. This will ignore cases where master is ahead of the current branch and where the master branch has public API changes.

## Motivation
False positives/not helpful flags
https://github.com/stripe/stripe-ios/pull/3556#pullrequestreview-2037081479

## Testing
See branch commit history

## Changelog
N/A
