### PR TITLE
Make FC selectedPaymentMethodType optional, define it clearly for App…

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -534,7 +534,7 @@ internal protocol FlowControllerViewController: BottomSheetContentViewController
     var error: Error? { get }
     var intent: Intent { get }
     var selectedPaymentOption: PaymentOption? { get }
-    // TODO: This should be nullable instead of vending .unknown
-    var selectedPaymentMethodType: PaymentSheet.PaymentMethodType { get }
+    /// The type of the Stripe payment method that's currently selected in the UI for new and saved PMs. Returns nil for Link and Apple Pay.
+    var selectedPaymentMethodType: PaymentSheet.PaymentMethodType? { get }
     var delegate: FlowControllerViewControllerDelegate? { get set }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
@@ -13,8 +13,7 @@ import UIKit
 
 class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewController {
     var selectedPaymentOption: PaymentSheet.PaymentOption?
-    /// The type of the payment method that's currently selected in the UI, or unknown if no payment method is selected.
-    var selectedPaymentMethodType: PaymentSheet.PaymentMethodType = .stripe(.unknown)
+    var selectedPaymentMethodType: PaymentSheet.PaymentMethodType?
     weak var delegate: FlowControllerViewControllerDelegate?
     let loadResult: PaymentSheetLoader.LoadResult
     let configuration: PaymentSheet.Configuration


### PR DESCRIPTION
…le Pay and Link

## Summary
Refactored the ill-defined `selectedPaymentMethodType` property on FC VC. 

## Motivation
Code cleanup

## Testing
I audited usage of this property - it's not used that much, mostly to determine if the PM requires mandates.  Relying on existing tests.

## Changelog
Not user facing