### PR TITLE
Remove PaymentSheet Link delegate methods called after confirmation

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
@@ -255,7 +255,22 @@ extension PaymentSheet: PaymentSheetViewControllerDelegate {
                 if case let .failed(error) = result {
                     self.mostRecentError = error
                 }
-                completion(result, deferredIntentConfirmationType)
+
+                if case .link = paymentOption {
+                    // End special Link blur animation before calling completion
+                    switch result {
+                    case .canceled, .failed:
+                        self.bottomSheetViewController.removeBlurEffect(animated: true) {
+                            completion(result, deferredIntentConfirmationType)
+                        }
+                    case .completed:
+                        self.bottomSheetViewController.transitionSpinnerToComplete(animated: true) {
+                            completion(result, deferredIntentConfirmationType)
+                        }
+                    }
+                } else {
+                    completion(result, deferredIntentConfirmationType)
+                }
             }
         }
 
@@ -282,22 +297,6 @@ extension PaymentSheet: PaymentSheetViewControllerDelegate {
         paymentSheetViewController.dismiss(animated: true) {
             self.completion?(result)
         }
-    }
-    func paymentSheetViewControllerFinishedOnPay(_ paymentSheetViewController: PaymentSheetViewController,
-                                                 completion: (() -> Void)? = nil) {
-        self.bottomSheetViewController.transitionSpinnerToComplete(animated: true) {
-            completion?()
-        }
-    }
-
-    func paymentSheetViewControllerCanceledOnPay(_ paymentSheetViewController: PaymentSheetViewController,
-                                                 completion: (() -> Void)? = nil) {
-        self.bottomSheetViewController.removeBlurEffect(animated: true, completion: completion)
-    }
-    func paymentSheetViewControllerFailedOnPay(_ paymentSheetViewController: PaymentSheetViewController,
-                                               result: PaymentSheetResult,
-                                               completion: (() -> Void)? = nil) {
-        self.bottomSheetViewController.removeBlurEffect(animated: true, completion: completion)
     }
 
     func paymentSheetViewControllerDidCancel(_ paymentSheetViewController: PaymentSheetViewController) {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -29,22 +29,6 @@ protocol PaymentSheetViewControllerDelegate: AnyObject {
     func paymentSheetViewControllerDidSelectPayWithLink(
         _ paymentSheetViewController: PaymentSheetViewController
     )
-
-    func paymentSheetViewControllerFinishedOnPay(
-        _ paymentSheetViewController: PaymentSheetViewController,
-        completion: (() -> Void)?
-    )
-
-    func paymentSheetViewControllerCanceledOnPay(
-        _ paymentSheetViewController: PaymentSheetViewController,
-        completion: (() -> Void)?
-    )
-
-    func paymentSheetViewControllerFailedOnPay(
-        _ paymentSheetViewController: PaymentSheetViewController,
-        result: PaymentSheetResult,
-        completion: (() -> Void)?
-    )
 }
 
 /// For internal SDK use only
@@ -523,7 +507,6 @@ class PaymentSheetViewController: UIViewController {
                 case .canceled:
                     // Do nothing, keep customer on payment sheet
                     self.updateUI()
-                    self.delegate?.paymentSheetViewControllerCanceledOnPay(self, completion: nil)
                 case .failed(let error):
                     #if !canImport(CompositorServices)
                     UINotificationFeedbackGenerator().notificationOccurred(.error)
@@ -533,29 +516,25 @@ class PaymentSheetViewController: UIViewController {
                     // Handle error
                     if PaymentSheetError.isUnrecoverable(error: error) {
                         self.delegate?.paymentSheetViewControllerDidFinish(self, result: result)
-                    } else {
-                        self.delegate?.paymentSheetViewControllerFailedOnPay(self, result: result, completion: nil)
                     }
                     self.updateUI()
                     UIAccessibility.post(notification: .layoutChanged, argument: self.errorLabel)
                 case .completed:
-                    self.delegate?.paymentSheetViewControllerFinishedOnPay(self) {
-                        // We're done!
-                        let delay: TimeInterval =
-                        self.presentedViewController?.isBeingDismissed == true ? 1 : 0
-                        // Hack: PaymentHandler calls the completion block while SafariVC is still being dismissed - "wait" until it's finished before updating UI
-                        DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+                    // We're done!
+                    let delay: TimeInterval =
+                    self.presentedViewController?.isBeingDismissed == true ? 1 : 0
+                    // Hack: PaymentHandler calls the completion block while SafariVC is still being dismissed - "wait" until it's finished before updating UI
+                    DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
 #if !canImport(CompositorServices)
-                            UINotificationFeedbackGenerator().notificationOccurred(.success)
+                        UINotificationFeedbackGenerator().notificationOccurred(.success)
 #endif
-                            if animateBuyButton {
-                                self.buyButton.update(state: .succeeded, animated: true) {
-                                    // Wait a bit before closing the sheet
-                                    self.delegate?.paymentSheetViewControllerDidFinish(self, result: .completed)
-                                }
-                            } else {
+                        if animateBuyButton {
+                            self.buyButton.update(state: .succeeded, animated: true) {
+                                // Wait a bit before closing the sheet
                                 self.delegate?.paymentSheetViewControllerDidFinish(self, result: .completed)
                             }
+                        } else {
+                            self.delegate?.paymentSheetViewControllerDidFinish(self, result: .completed)
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
The old flow had unnecessary back and forth between PaymentSheet (PS) and PaymentSheetViewController (PSVC). PSVC was invoking these delegate methods to inform PS that confirmation had finished, but PS was the one who finished the confirmation in the first place! It can simply directly handle Link animations after finishing confirmation before passing control to PSVC.

Small improvement - old code used to wait for the Link spinner to show success animation before continuing, even if Link wasn't used. New code only does that for Link.

## Motivation
Reduce code that vertical mode has to handle.

## Testing
Manually tested cancel, failed payment, successful payment.


https://github.com/stripe/stripe-ios/assets/47796191/779e19ff-b116-4c8f-8d2a-0aad68046ae4


https://github.com/stripe/stripe-ios/assets/47796191/687c5af6-e8ec-4a0f-9db4-fa4b9abe93be


https://github.com/stripe/stripe-ios/assets/47796191/7922af9d-6a19-4086-9825-1b30d9e74bbc


## Changelog
No user facing change.
