### PR TITLE
Make PaymentSheet show PaymentSheetVerticalViewController in vertical mode

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
@@ -153,21 +153,27 @@ public class PaymentSheet {
             switch result {
             case .success(let loadResult):
                 // Set the PaymentSheetViewController as the content of our bottom sheet
-                let presentPaymentSheetVC = {
-                    let paymentSheetVC = PaymentSheetViewController(
-                        configuration: self.configuration,
-                        loadResult: loadResult,
-                        delegate: self
-                    )
-
-                    self.configuration.style.configure(paymentSheetVC)
-
-                    let updateBottomSheet: () -> Void = {
-                        self.bottomSheetViewController.contentStack = [paymentSheetVC]
+                let paymentSheetVC: PaymentSheetViewControllerProtocol = {
+                    switch self.configuration.appearance.layout {
+                    case .horizontal:
+                        return PaymentSheetViewController(
+                            configuration: self.configuration,
+                            loadResult: loadResult,
+                            delegate: self
+                        )
+                    case .vertical:
+                        let verticalVC = PaymentSheetVerticalViewController(
+                            configuration: self.configuration,
+                            loadResult: loadResult,
+                            isFlowController: false
+                        )
+                        verticalVC.paymentSheetDelegate = self
+                        return verticalVC
                     }
-                    updateBottomSheet()
-                }
-                presentPaymentSheetVC()
+                }()
+
+                self.configuration.style.configure(paymentSheetVC)
+                self.bottomSheetViewController.contentStack = [paymentSheetVC]
             case .failure(let error):
                 completion(.failed(error: error))
             }
@@ -238,7 +244,7 @@ public class PaymentSheet {
 extension PaymentSheet: PaymentSheetViewControllerDelegate {
 
     func paymentSheetViewControllerShouldConfirm(
-        _ paymentSheetViewController: PaymentSheetViewController,
+        _ paymentSheetViewController: PaymentSheetViewControllerProtocol,
         with paymentOption: PaymentOption,
         completion: @escaping (PaymentSheetResult, StripeCore.STPAnalyticsClient.DeferredIntentConfirmationType?) -> Void
     ) {
@@ -293,21 +299,19 @@ extension PaymentSheet: PaymentSheetViewControllerDelegate {
         }
     }
 
-    func paymentSheetViewControllerDidFinish(_ paymentSheetViewController: PaymentSheetViewController, result: PaymentSheetResult) {
+    func paymentSheetViewControllerDidFinish(_ paymentSheetViewController: PaymentSheetViewControllerProtocol, result: PaymentSheetResult) {
         paymentSheetViewController.dismiss(animated: true) {
             self.completion?(result)
         }
     }
 
-    func paymentSheetViewControllerDidCancel(_ paymentSheetViewController: PaymentSheetViewController) {
+    func paymentSheetViewControllerDidCancel(_ paymentSheetViewController: PaymentSheetViewControllerProtocol) {
         paymentSheetViewController.dismiss(animated: true) {
             self.completion?(.canceled)
         }
     }
 
-    func paymentSheetViewControllerDidSelectPayWithLink(
-        _ paymentSheetViewController: PaymentSheetViewController
-    ) {
+    func paymentSheetViewControllerDidSelectPayWithLink(_ paymentSheetViewController: PaymentSheetViewControllerProtocol) {
         self.presentPayWithLinkController(
             from: paymentSheetViewController,
             intent: paymentSheetViewController.intent
@@ -376,4 +380,24 @@ private extension PaymentSheet {
         payWithLinkVC.present(over: presentingController)
     }
 
+}
+
+// MARK: - PaymentSheetViewControllerProtocol
+
+internal protocol PaymentSheetViewControllerProtocol: UIViewController, BottomSheetContentViewController {
+    var intent: Intent { get }
+}
+
+protocol PaymentSheetViewControllerDelegate: AnyObject {
+    func paymentSheetViewControllerShouldConfirm(
+        _ paymentSheetViewController: PaymentSheetViewControllerProtocol,
+        with paymentOption: PaymentOption,
+        completion: @escaping (PaymentSheetResult, STPAnalyticsClient.DeferredIntentConfirmationType?) -> Void
+    )
+    func paymentSheetViewControllerDidFinish(
+        _ paymentSheetViewController: PaymentSheetViewControllerProtocol,
+        result: PaymentSheetResult
+    )
+    func paymentSheetViewControllerDidCancel(_ paymentSheetViewController: PaymentSheetViewControllerProtocol)
+    func paymentSheetViewControllerDidSelectPayWithLink(_ paymentSheetViewController: PaymentSheetViewControllerProtocol)
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
@@ -171,8 +171,6 @@ public class PaymentSheet {
                         return verticalVC
                     }
                 }()
-
-                self.configuration.style.configure(paymentSheetVC)
                 self.bottomSheetViewController.contentStack = [paymentSheetVC]
             case .failure(let error):
                 completion(.failed(error: error))

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -104,7 +104,7 @@ extension PaymentSheet {
             return viewController.intent
         }
         lazy var paymentHandler: STPPaymentHandler = { STPPaymentHandler(apiClient: configuration.apiClient, formSpecPaymentHandler: PaymentSheetFormSpecPaymentHandler()) }()
-        var viewController: FlowControllerViewController
+        var viewController: FlowControllerViewControllerProtocol
         private var presentPaymentOptionsCompletion: (() -> Void)?
 
         /// The desired, valid (ie passed client-side checks) payment option from the underlying payment options VC.
@@ -153,7 +153,7 @@ extension PaymentSheet {
                                                                        intentConfig: loadResult.intent.intentConfig)
             self.configuration = configuration
             self.viewController = Self.makeViewController(configuration: configuration, loadResult: loadResult)
-            self.viewController.delegate = self
+            self.viewController.flowControllerDelegate = self
         }
 
         // MARK: - Public methods
@@ -416,7 +416,7 @@ extension PaymentSheet {
                         loadResult: loadResult,
                         previousPaymentOption: self._paymentOption
                     )
-                    self.viewController.delegate = self
+                    self.viewController.flowControllerDelegate = self
 
                     // Synchronously pre-load image into cache
                     // Accessing paymentOption has the side-effect of ensuring its `image` property is loaded (e.g. from the internet instead of disk) before we call the completion handler.
@@ -452,7 +452,7 @@ extension PaymentSheet {
             configuration: Configuration,
             loadResult: PaymentSheetLoader.LoadResult,
             previousPaymentOption: PaymentOption? = nil
-        ) -> FlowControllerViewController {
+        ) -> FlowControllerViewControllerProtocol {
             switch configuration.appearance.layout {
             case .horizontal:
                 return PaymentSheetFlowControllerViewController(
@@ -461,7 +461,7 @@ extension PaymentSheet {
                     previousPaymentOption: previousPaymentOption
                 )
             case .vertical:
-                return PaymentSheetVerticalViewController(configuration: configuration, loadResult: loadResult)
+                return PaymentSheetVerticalViewController(configuration: configuration, loadResult: loadResult, isFlowController: true)
             }
         }
     }
@@ -471,12 +471,12 @@ extension PaymentSheet {
 
 protocol FlowControllerViewControllerDelegate: AnyObject {
     func flowControllerViewControllerShouldClose(
-        _ PaymentSheetFlowControllerViewController: FlowControllerViewController, didCancel: Bool)
+        _ PaymentSheetFlowControllerViewController: FlowControllerViewControllerProtocol, didCancel: Bool)
 }
 
 extension PaymentSheet.FlowController: FlowControllerViewControllerDelegate {
     func flowControllerViewControllerShouldClose(
-        _ flowControllerViewController: FlowControllerViewController,
+        _ flowControllerViewController: FlowControllerViewControllerProtocol,
         didCancel: Bool
     ) {
         if !didCancel {
@@ -527,14 +527,14 @@ class AuthenticationContext: NSObject, PaymentSheetAuthenticationContext {
     }
 }
 
-// MARK: - FlowControllerViewController
+// MARK: - FlowControllerViewControllerProtocol
 
 /// All the things FlowController needs from its UIViewController.
-internal protocol FlowControllerViewController: BottomSheetContentViewController {
+internal protocol FlowControllerViewControllerProtocol: BottomSheetContentViewController {
     var error: Error? { get }
     var intent: Intent { get }
     var selectedPaymentOption: PaymentOption? { get }
     /// The type of the Stripe payment method that's currently selected in the UI for new and saved PMs. Returns nil for Link and Apple Pay.
     var selectedPaymentMethodType: PaymentSheet.PaymentMethodType? { get }
-    var delegate: FlowControllerViewControllerDelegate? { get set }
+    var flowControllerDelegate: FlowControllerViewControllerDelegate? { get set }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -14,7 +14,7 @@ import Foundation
 import UIKit
 
 /// For internal SDK use only
-class PaymentSheetFlowControllerViewController: UIViewController, FlowControllerViewController {
+class PaymentSheetFlowControllerViewController: UIViewController, FlowControllerViewControllerProtocol {
     // MARK: - Internal Properties
     let intent: Intent
     let configuration: PaymentSheet.Configuration
@@ -60,7 +60,7 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
             return addPaymentMethodViewController.selectedPaymentMethodType
         }
     }
-    weak var delegate: FlowControllerViewControllerDelegate?
+    weak var flowControllerDelegate: FlowControllerViewControllerDelegate?
     lazy var navigationBar: SheetNavigationBar = {
         let navBar = SheetNavigationBar(isTestMode: configuration.apiClient.isTestmode,
                                         appearance: configuration.appearance)
@@ -469,12 +469,12 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
         STPAnalyticsClient.sharedClient.logPaymentSheetConfirmButtonTapped(paymentMethodTypeIdentifier: paymentMethodType.identifier)
         switch mode {
         case .selectingSaved:
-            self.delegate?.flowControllerViewControllerShouldClose(self, didCancel: false)
+            self.flowControllerDelegate?.flowControllerViewControllerShouldClose(self, didCancel: false)
         case .addingNew:
             if let buyButtonOverrideBehavior = addPaymentMethodViewController.overrideBuyButtonBehavior {
                 addPaymentMethodViewController.didTapCallToActionButton(behavior: buyButtonOverrideBehavior, from: self)
             } else {
-                self.delegate?.flowControllerViewControllerShouldClose(self, didCancel: false)
+                self.flowControllerDelegate?.flowControllerViewControllerShouldClose(self, didCancel: false)
             }
         }
 
@@ -484,7 +484,7 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
         // When we close the window, unset the hacky Link button. This will reset the PaymentOption to nil, if needed.
         isHackyLinkButtonSelected = false
         // If the customer was adding a new payment method and it's incomplete/invalid, return to the saved PM screen
-        delegate?.flowControllerViewControllerShouldClose(self, didCancel: didCancel)
+        flowControllerDelegate?.flowControllerViewControllerShouldClose(self, didCancel: didCancel)
         if savedPaymentOptionsViewController.isRemovingPaymentMethods {
             savedPaymentOptionsViewController.isRemovingPaymentMethods = false
             configureEditSavedPaymentMethodsButton()
@@ -564,7 +564,7 @@ extension PaymentSheetFlowControllerViewController: SavedPaymentOptionsViewContr
         case .applePay, .link, .saved:
             updateUI()
             if isDismissable, !(selectedPaymentMethodType?.requiresMandateDisplayForSavedSelection ?? false) {
-                delegate?.flowControllerViewControllerShouldClose(self, didCancel: false)
+                flowControllerDelegate?.flowControllerViewControllerShouldClose(self, didCancel: false)
             }
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
@@ -11,16 +11,18 @@
 @_spi(STP) import StripeUICore
 import UIKit
 
-class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewController {
+class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewControllerProtocol, PaymentSheetViewControllerProtocol {
     var selectedPaymentOption: PaymentSheet.PaymentOption?
     var selectedPaymentMethodType: PaymentSheet.PaymentMethodType?
-    weak var delegate: FlowControllerViewControllerDelegate?
     let loadResult: PaymentSheetLoader.LoadResult
     let configuration: PaymentSheet.Configuration
     var intent: Intent {
         return loadResult.intent
     }
     var error: Error?
+    let isFlowController: Bool
+    weak var flowControllerDelegate: FlowControllerViewControllerDelegate?
+    weak var paymentSheetDelegate: PaymentSheetViewControllerDelegate?
 
     // MARK: - UI properties
 
@@ -33,10 +35,11 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
 
     // MARK: - Initializers
 
-    init(configuration: PaymentSheet.Configuration, loadResult: PaymentSheetLoader.LoadResult) {
+    init(configuration: PaymentSheet.Configuration, loadResult: PaymentSheetLoader.LoadResult, isFlowController: Bool) {
         // TODO: Deal with previousPaymentOption
         self.loadResult = loadResult
         self.configuration = configuration
+        self.isFlowController = isFlowController
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -77,7 +80,11 @@ extension PaymentSheetVerticalViewController: BottomSheetContentViewController {
 
     func didTapOrSwipeToDismiss() {
         // TODO
-        delegate?.flowControllerViewControllerShouldClose(self, didCancel: true)
+        if isFlowController {
+            flowControllerDelegate?.flowControllerViewControllerShouldClose(self, didCancel: true)
+        } else {
+            paymentSheetDelegate?.paymentSheetViewControllerDidCancel(self)
+        }
     }
 
     var requiresFullScreen: Bool {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -189,6 +189,8 @@ class PaymentSheetViewController: UIViewController, PaymentSheetViewControllerPr
         super.init(nibName: nil, bundle: nil)
         self.configuration.style.configure(self)
         self.savedPaymentOptionsViewController.delegate = self
+        // TODO: This self.view call should be moved to viewDidLoad
+        self.view.backgroundColor = configuration.appearance.colors.background
     }
 
     deinit {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -187,8 +187,8 @@ class PaymentSheetViewController: UIViewController, PaymentSheetViewControllerPr
         }
 
         super.init(nibName: nil, bundle: nil)
+        self.configuration.style.configure(self)
         self.savedPaymentOptionsViewController.delegate = self
-        self.view.backgroundColor = configuration.appearance.colors.background
     }
 
     deinit {
@@ -199,7 +199,7 @@ class PaymentSheetViewController: UIViewController, PaymentSheetViewControllerPr
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        configuration.style.configure(self)
+        self.view.backgroundColor = configuration.appearance.colors.background
 
         // One stack view contains all our subviews
         let stackView = UIStackView(arrangedSubviews: [

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -13,27 +13,9 @@ import PassKit
 @_spi(STP) import StripeUICore
 import UIKit
 
-protocol PaymentSheetViewControllerDelegate: AnyObject {
-    func paymentSheetViewControllerShouldConfirm(
-        _ paymentSheetViewController: PaymentSheetViewController,
-        with paymentOption: PaymentOption,
-        completion: @escaping (PaymentSheetResult, STPAnalyticsClient.DeferredIntentConfirmationType?) -> Void
-    )
-    func paymentSheetViewControllerDidFinish(
-        _ paymentSheetViewController: PaymentSheetViewController,
-        result: PaymentSheetResult
-    )
-    func paymentSheetViewControllerDidCancel(
-        _ paymentSheetViewController: PaymentSheetViewController
-    )
-    func paymentSheetViewControllerDidSelectPayWithLink(
-        _ paymentSheetViewController: PaymentSheetViewController
-    )
-}
-
 /// For internal SDK use only
 @objc(STP_Internal_PaymentSheetViewController)
-class PaymentSheetViewController: UIViewController {
+class PaymentSheetViewController: UIViewController, PaymentSheetViewControllerProtocol {
     enum PaymentSheetViewControllerError: Error {
         case addingNewNoPaymentOptionOnBuyButtonTap
         case selectingSavedNoPaymentOptionOnBuyButtonTap
@@ -217,6 +199,7 @@ class PaymentSheetViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        configuration.style.configure(self)
 
         // One stack view contains all our subviews
         let stackView = UIStackView(arrangedSubviews: [

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetViewControllerSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetViewControllerSnapshotTests.swift
@@ -62,21 +62,21 @@ final class PaymentSheetViewControllerSnapshotTests: STPSnapshotTestCase {
 }
 
 extension PaymentSheetViewControllerSnapshotTests: PaymentSheetViewControllerDelegate {
-    func paymentSheetViewControllerFinishedOnPay(_ paymentSheetViewController: StripePaymentSheet.PaymentSheetViewController, completion: (() -> Void)?) {
+    func paymentSheetViewControllerFinishedOnPay(_ paymentSheetViewController: StripePaymentSheet.PaymentSheetViewControllerProtocol, completion: (() -> Void)?) {
     }
-    func paymentSheetViewControllerCanceledOnPay(_ paymentSheetViewController: StripePaymentSheet.PaymentSheetViewController, completion: (() -> Void)?) {
+    func paymentSheetViewControllerCanceledOnPay(_ paymentSheetViewController: StripePaymentSheet.PaymentSheetViewControllerProtocol, completion: (() -> Void)?) {
     }
-    func paymentSheetViewControllerFailedOnPay(_ paymentSheetViewController: StripePaymentSheet.PaymentSheetViewController, result: StripePaymentSheet.PaymentSheetResult, completion: (() -> Void)?) {
+    func paymentSheetViewControllerFailedOnPay(_ paymentSheetViewController: StripePaymentSheet.PaymentSheetViewControllerProtocol, result: StripePaymentSheet.PaymentSheetResult, completion: (() -> Void)?) {
     }
-    func paymentSheetViewControllerShouldConfirm(_ paymentSheetViewController: StripePaymentSheet.PaymentSheetViewController, with paymentOption: StripePaymentSheet.PaymentOption, completion: @escaping (StripePaymentSheet.PaymentSheetResult, StripeCore.STPAnalyticsClient.DeferredIntentConfirmationType?) -> Void) {
-    }
-
-    func paymentSheetViewControllerDidFinish(_ paymentSheetViewController: StripePaymentSheet.PaymentSheetViewController, result: StripePaymentSheet.PaymentSheetResult) {
+    func paymentSheetViewControllerShouldConfirm(_ paymentSheetViewController: StripePaymentSheet.PaymentSheetViewControllerProtocol, with paymentOption: StripePaymentSheet.PaymentOption, completion: @escaping (StripePaymentSheet.PaymentSheetResult, StripeCore.STPAnalyticsClient.DeferredIntentConfirmationType?) -> Void) {
     }
 
-    func paymentSheetViewControllerDidCancel(_ paymentSheetViewController: StripePaymentSheet.PaymentSheetViewController) {
+    func paymentSheetViewControllerDidFinish(_ paymentSheetViewController: StripePaymentSheet.PaymentSheetViewControllerProtocol, result: StripePaymentSheet.PaymentSheetResult) {
     }
 
-    func paymentSheetViewControllerDidSelectPayWithLink(_ paymentSheetViewController: StripePaymentSheet.PaymentSheetViewController) {
+    func paymentSheetViewControllerDidCancel(_ paymentSheetViewController: StripePaymentSheet.PaymentSheetViewControllerProtocol) {
+    }
+
+    func paymentSheetViewControllerDidSelectPayWithLink(_ paymentSheetViewController: StripePaymentSheet.PaymentSheetViewControllerProtocol) {
     }
 }


### PR DESCRIPTION
## Summary
Make PaymentSheet show PaymentSheetVerticalViewController in vertical mode.

Abstracts out `PaymentSheetViewController` into `PaymentSheetViewController`

## Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-2009

## Testing
Manual testing for now

## Changelog
Not user facing
