### PR TITLE
Updated support for MobilePay bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## x.x.x xxxx-xx-xx
+### Payments
+* [Added] Updated support for MobilePay bindings.
+
 ## 23.27.2 2024-05-06
 ### CardScan
 * [Changed] ScannedCard to allow access for expiryMonth, expiryYear and name.

--- a/Example/Non-Card Payment Examples/Non-Card Payment Examples.xcodeproj/project.pbxproj
+++ b/Example/Non-Card Payment Examples/Non-Card Payment Examples.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		617C1C822BB4940500B10AC5 /* AlmaExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617C1C812BB4940500B10AC5 /* AlmaExampleViewController.swift */; };
 		61951FBB2B8674EC005F90BE /* AmazonPayExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61951FBA2B8674EC005F90BE /* AmazonPayExampleViewController.swift */; };
 		61E1CA232BD6B9DF00A421AE /* MultibancoExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E1CA222BD6B9DE00A421AE /* MultibancoExampleViewController.swift */; };
+		6BA4B9182BF3E2AF00D1F21D /* MobilePayExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA4B9172BF3E2AF00D1F21D /* MobilePayExampleViewController.swift */; };
 		6BF09625088A9D5009307E38 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 8CE9A736DA9941DECAD86F1B /* Localizable.strings */; };
 		7347961ABF706602E2915A53 /* USBankAccountConnectionsExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32C7B53B74E206CF2A2DF38C /* USBankAccountConnectionsExampleViewController.swift */; };
 		80466B86A1F4896FE7811E9D /* GrabPayExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311E3343A1F8432A0B56CEA5 /* GrabPayExampleViewController.swift */; };
@@ -123,6 +124,7 @@
 		61E1CA222BD6B9DE00A421AE /* MultibancoExampleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultibancoExampleViewController.swift; sourceTree = "<group>"; };
 		64F13592DB0CDD803283B035 /* StripePayments.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripePayments.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		673900BEF4553912511DBFE3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		6BA4B9172BF3E2AF00D1F21D /* MobilePayExampleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobilePayExampleViewController.swift; sourceTree = "<group>"; };
 		6CA51E7BD0D4D1E0B94075FE /* Stripe.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Stripe.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7EB5EE88F3BCE3D52302C896 /* Non-Card-Payment-Examples-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Non-Card-Payment-Examples-Release.xcconfig"; sourceTree = "<group>"; };
 		7F068CC4E3F81CB0E96CED03 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -249,6 +251,7 @@
 				61951FBA2B8674EC005F90BE /* AmazonPayExampleViewController.swift */,
 				617C1C812BB4940500B10AC5 /* AlmaExampleViewController.swift */,
 				61E1CA222BD6B9DE00A421AE /* MultibancoExampleViewController.swift */,
+				6BA4B9172BF3E2AF00D1F21D /* MobilePayExampleViewController.swift */,
 				05FF02CFBFA8863282D020E0 /* AppDelegate.h */,
 				A83C61D70652D6E6ED09230B /* AppDelegate.m */,
 				C2D98BF0E8488281BB3607A6 /* ApplePayExampleViewController.h */,
@@ -451,6 +454,7 @@
 				88AE1CED5467E828AE738B62 /* SwishExampleViewController.swift in Sources */,
 				7347961ABF706602E2915A53 /* USBankAccountConnectionsExampleViewController.swift in Sources */,
 				07E1B52EA12E4F9789013E8C /* USBankAccountExampleViewController.swift in Sources */,
+				6BA4B9182BF3E2AF00D1F21D /* MobilePayExampleViewController.swift in Sources */,
 				616358522C3A1FCD579F2B37 /* WeChatPayExampleViewController.m in Sources */,
 				975D189CB2E61E7C1871F0DA /* iDEALExampleViewController.m in Sources */,
 				4331C8C4F8BA76E560F420DF /* main.m in Sources */,

--- a/Example/Non-Card Payment Examples/Non-Card Payment Examples/BrowseExamplesViewController.m
+++ b/Example/Non-Card Payment Examples/Non-Card Payment Examples/BrowseExamplesViewController.m
@@ -47,7 +47,7 @@
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
-    return 31;
+    return 32;
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
@@ -145,6 +145,9 @@
             break;
         case 30:
             cell.textLabel.text = @"Multibanco";
+            break;
+        case 31:
+            cell.textLabel.text = @"MobilePay";
             break;
     }
     return cell;
@@ -342,6 +345,12 @@
         }
         case 30: {
             MultibancoExampleViewController *exampleVC = [MultibancoExampleViewController new];
+            exampleVC.delegate = self;
+            viewController = exampleVC;
+            break;
+        }
+        case 31: {
+            MobilePayExampleViewController *exampleVC = [MobilePayExampleViewController new];
             exampleVC.delegate = self;
             viewController = exampleVC;
             break;

--- a/Example/Non-Card Payment Examples/Non-Card Payment Examples/MobilePayExampleViewController.swift
+++ b/Example/Non-Card Payment Examples/Non-Card Payment Examples/MobilePayExampleViewController.swift
@@ -1,0 +1,117 @@
+//
+//  MobilePayExampleViewController.swift
+//  Non-Card Payment Examples
+//
+
+import Foundation
+import Stripe
+import UIKit
+
+class MobilePayExampleViewController: UIViewController {
+    @objc weak var delegate: ExampleViewControllerDelegate?
+    var inProgress: Bool = false {
+        didSet {
+            navigationController?.navigationBar.isUserInteractionEnabled = !inProgress
+            payButton.isEnabled = !inProgress
+            inProgress
+                ? activityIndicatorView.startAnimating() : activityIndicatorView.stopAnimating()
+        }
+    }
+
+    // UI
+    lazy var activityIndicatorView = {
+        return UIActivityIndicatorView(style: .medium)
+    }()
+    lazy var payButton: UIButton = {
+        let button = UIButton(type: .roundedRect)
+        button.setTitle("Pay with MobilePay", for: .normal)
+        button.addTarget(self, action: #selector(didTapPayButton), for: .touchUpInside)
+        return button
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .white
+        title = "MobilePay"
+        [payButton, activityIndicatorView].forEach { subview in
+            view.addSubview(subview)
+            subview.translatesAutoresizingMaskIntoConstraints = false
+        }
+
+        let constraints = [
+            payButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            payButton.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+
+            activityIndicatorView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            activityIndicatorView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+        ]
+        NSLayoutConstraint.activate(constraints)
+    }
+
+    @objc func didTapPayButton() {
+        guard STPAPIClient.shared.publishableKey != nil else {
+            delegate?.exampleViewController(
+                self,
+                didFinishWithMessage: "Please set a Stripe Publishable Key in Constants.m"
+            )
+            return
+        }
+        inProgress = true
+        pay()
+    }
+}
+
+// MARK: -
+extension MobilePayExampleViewController {
+    @objc func pay() {
+        // 1. Create an MobilePay PaymentIntent
+        MyAPIClient.shared().createPaymentIntent(
+            completion: { (_, clientSecret, error) in
+                guard let clientSecret = clientSecret else {
+                    self.delegate?.exampleViewController(self, didFinishWithError: error)
+                    return
+                }
+
+                // 2. Confirm the payment and redirect the user to Mobilepay
+                let billingDetails = STPPaymentMethodBillingDetails()
+                billingDetails.email = "tester@example.com"
+                let paymentIntentParams = STPPaymentIntentParams(clientSecret: clientSecret)
+                paymentIntentParams.paymentMethodParams = STPPaymentMethodParams(
+                    mobilePay: STPPaymentMethodMobilePayParams(),
+                    billingDetails: billingDetails,
+                    metadata: nil
+                )
+                paymentIntentParams.returnURL = "payments-example://safepay/"
+
+                STPPaymentHandler.shared().confirmPayment(
+                    paymentIntentParams,
+                    with: self
+                ) { (status, _, error) in
+                    switch status {
+                    case .canceled:
+                        self.delegate?.exampleViewController(
+                            self,
+                            didFinishWithMessage: "Cancelled"
+                        )
+                    case .failed:
+                        self.delegate?.exampleViewController(self, didFinishWithError: error)
+                    case .succeeded:
+                        self.delegate?.exampleViewController(
+                            self,
+                            didFinishWithMessage: "Payment successfully created."
+                        )
+                    @unknown default:
+                        fatalError()
+                    }
+                }
+            },
+            additionalParameters: "supported_payment_methods=mobilepay&currency=eur"
+        )
+    }
+}
+
+extension MobilePayExampleViewController: STPAuthenticationContext {
+    func authenticationPresentingViewController() -> UIViewController {
+        self
+    }
+}

--- a/Stripe/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe/Stripe.xcodeproj/project.pbxproj
@@ -157,6 +157,8 @@
 		68318DB86DFCD19505FC47BA /* NSURLComponents_StripeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CD20E00EAD41091B71ABD5 /* NSURLComponents_StripeTest.swift */; };
 		687517E7FE02FFB96DCE2328 /* STPEphemeralKeyManagerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C645F78B3EFFAA083B6FD3E9 /* STPEphemeralKeyManagerTest.swift */; };
 		69AC1EDE2A3C03B1D980CA54 /* STPPaymentOptionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9A1BB31C7B514984231125B /* STPPaymentOptionsViewController.swift */; };
+		6BA4B91A2BF433B200D1F21D /* STPPaymentMethodMobilePayParamsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA4B9192BF433B200D1F21D /* STPPaymentMethodMobilePayParamsTests.swift */; };
+		6BA4B91C2BF4343B00D1F21D /* STPPaymentMethodMobilePayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA4B91B2BF4343B00D1F21D /* STPPaymentMethodMobilePayTests.swift */; };
 		6BC5EC2D2B4609FF00CC75E8 /* LinkInlineSignupElementSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BC5EC2C2B4609FF00CC75E8 /* LinkInlineSignupElementSnapshotTests.swift */; };
 		6BF6ECC4A4E61E2FFC3EA20B /* STPAPIClient+BasicUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E8AFAE24610EC983727F860 /* STPAPIClient+BasicUI.swift */; };
 		6E7AD3CCC966A7F34922B172 /* NSDictionary+StripeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D07275F94914B7E7937D24FE /* NSDictionary+StripeTest.swift */; };
@@ -628,6 +630,8 @@
 		69BD038947E8E2376A0D240B /* STPCardScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPCardScanner.swift; sourceTree = "<group>"; };
 		6A9E7B637A8747431B38FD1D /* STPCardValidationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPCardValidationState.swift; sourceTree = "<group>"; };
 		6B7A947152A728EB2CBC4DB2 /* STPSourceReceiverTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPSourceReceiverTest.swift; sourceTree = "<group>"; };
+		6BA4B9192BF433B200D1F21D /* STPPaymentMethodMobilePayParamsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPPaymentMethodMobilePayParamsTests.swift; sourceTree = "<group>"; };
+		6BA4B91B2BF4343B00D1F21D /* STPPaymentMethodMobilePayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPPaymentMethodMobilePayTests.swift; sourceTree = "<group>"; };
 		6BC5EC2C2B4609FF00CC75E8 /* LinkInlineSignupElementSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkInlineSignupElementSnapshotTests.swift; sourceTree = "<group>"; };
 		6C7B8DACB0A7294BC235E3BC /* STPPaymentIntentLastPaymentErrorTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPPaymentIntentLastPaymentErrorTest.swift; sourceTree = "<group>"; };
 		6CC0B1FC92A573AAEA4F4E94 /* STPSetupIntentConfirmParamsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPSetupIntentConfirmParamsTest.swift; sourceTree = "<group>"; };
@@ -1297,6 +1301,8 @@
 				9B83930B631CF8EADFB606D6 /* STPPaymentMethodiDEALTest.swift */,
 				47E12A0CBFA259A032F7AF0C /* STPPaymentMethodKlarnaParamsTests.swift */,
 				4FD94FF270165D699DA89B24 /* STPPaymentMethodKlarnaTests.swift */,
+				6BA4B9192BF433B200D1F21D /* STPPaymentMethodMobilePayParamsTests.swift */,
+				6BA4B91B2BF4343B00D1F21D /* STPPaymentMethodMobilePayTests.swift */,
 				D41081066DC4465734F7FCD7 /* STPPaymentMethodNetBankingParamsTest.swift */,
 				739934737B9A09775CD278C9 /* STPPaymentMethodNetBankingTests.swift */,
 				1E2638F7AA0906914117C2D5 /* STPPaymentMethodOptionsTest.swift */,
@@ -1746,6 +1752,7 @@
 				AD9B9F3FF697D4A3892E86F2 /* PaymentAnalyticTest.swift in Sources */,
 				C861BB9EAAD04949E338D7FF /* PaymentTypeCellSnapshotTests.swift in Sources */,
 				BC694A1642DC30D530B60635 /* RotatingCardBrandsViewSnapshotTests.swift in Sources */,
+				6BA4B91C2BF4343B00D1F21D /* STPPaymentMethodMobilePayTests.swift in Sources */,
 				C5D295FE9988CA80ABA57801 /* RotatingCardBrandsViewTests.swift in Sources */,
 				BEC0435570B9199B918ED4DA /* STPAPIClient+LinkAccountSessionTest.swift in Sources */,
 				7D2C0D1BF455625997CBC33B /* STPAPIClientNetworkBridgeTest.swift in Sources */,
@@ -1916,6 +1923,7 @@
 				385CAC4D2FF119D2E925916B /* STPPostalCodeInputTextFieldFormatterTests.swift in Sources */,
 				9B1AC278FDCDABF26C5E468C /* STPPostalCodeInputTextFieldSnapshotTests.swift in Sources */,
 				4E31B1864DA407598FB1BBC6 /* STPPostalCodeInputTextFieldTests.swift in Sources */,
+				6BA4B91A2BF433B200D1F21D /* STPPaymentMethodMobilePayParamsTests.swift in Sources */,
 				91558F51B87C72E745244958 /* STPPostalCodeInputTextFieldValidatorTests.swift in Sources */,
 				6FCA954C32AB351F902BA876 /* STPPostalCodeValidatorTest.swift in Sources */,
 				3172C789DF2CE133ECA359D7 /* STPPushProvisioningDetailsFunctionalTest.swift in Sources */,

--- a/Stripe/StripeiOSTests/STPPaymentMethodMobilePayParamsTests.swift
+++ b/Stripe/StripeiOSTests/STPPaymentMethodMobilePayParamsTests.swift
@@ -1,0 +1,42 @@
+//
+//  STPPaymentMethodMobilePayParamsTests.swift
+//  StripeiOSTests
+//
+
+import Foundation
+import StripeCoreTestUtils
+
+@testable@_spi(STP) import Stripe
+@testable@_spi(STP) import StripeCore
+@testable@_spi(STP) import StripePayments
+@testable@_spi(STP) import StripePaymentSheet
+@testable@_spi(STP) import StripePaymentsUI
+
+class STPPaymentMethodMobilePayParamsTests: XCTestCase {
+
+    func testCreateMobilePayPaymentMethod() throws {
+        let mobilePayParams = STPPaymentMethodMobilePayParams()
+
+        let params = STPPaymentMethodParams(
+            mobilePay: mobilePayParams,
+            billingDetails: nil,
+            metadata: nil
+        )
+
+        let exp = expectation(description: "Payment Method MobilePay create")
+
+        let client = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
+        client.createPaymentMethod(with: params) {
+            (paymentMethod: STPPaymentMethod?, error: Error?) in
+            exp.fulfill()
+
+            XCTAssertNil(error)
+            XCTAssertNotNil(paymentMethod, "Payment method should be populated")
+            XCTAssertEqual(paymentMethod?.type, .mobilePay, "Incorrect PaymentMethod type")
+            XCTAssertNotNil(paymentMethod?.mobilePay, "The `mobilepay` property must be populated")
+        }
+
+        self.waitForExpectations(timeout: STPTestingNetworkRequestTimeout)
+    }
+
+}

--- a/Stripe/StripeiOSTests/STPPaymentMethodMobilePayTests.swift
+++ b/Stripe/StripeiOSTests/STPPaymentMethodMobilePayTests.swift
@@ -1,0 +1,38 @@
+//
+//  STPPaymentMethodMobilePayTests.swift
+//  StripeiOSTests
+//
+
+@testable import Stripe
+import StripeCoreTestUtils
+import XCTest
+
+class STPPaymentMethodMobilePayTests: XCTestCase {
+
+    static let mobilePayPaymentIntentClientSecret = "pi_3PGVQJKG6vc7r7YC1Xs7oiWw_secret_5cqzEtQ059azmV1GmkLRA7Lvt"
+
+    func _retrieveMobilePayJSON(_ completion: @escaping ([AnyHashable: Any]?) -> Void) {
+        let client = STPAPIClient(publishableKey: STPTestingFRPublishableKey)
+        client.retrievePaymentIntent(
+            withClientSecret: Self.mobilePayPaymentIntentClientSecret,
+            expand: ["payment_method"]
+        ) { paymentIntent, _ in
+            XCTAssertNotNil(paymentIntent?.paymentMethod?.allResponseFields["mobilepay"])
+            let mobilePayJson = try? XCTUnwrap(paymentIntent?.paymentMethod?.mobilePay?.allResponseFields)
+            completion(mobilePayJson)
+        }
+    }
+
+    func testObjectDecoding() {
+        let retrieveJSON = XCTestExpectation(description: "Retrieve JSON")
+
+        _retrieveMobilePayJSON({ json in
+            let mobilePay = STPPaymentMethodMobilePay.decodedObject(fromAPIResponse: json)
+            XCTAssertNotNil(mobilePay, "Failed to decode JSON")
+            retrieveJSON.fulfill()
+        })
+
+        wait(for: [retrieveJSON], timeout: STPTestingNetworkRequestTimeout)
+    }
+
+}

--- a/StripePayments/StripePayments.xcodeproj/project.pbxproj
+++ b/StripePayments/StripePayments.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 		68F9810F66FB2D6B278429D7 /* STPAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740C01696C56E269129C86CF /* STPAddress.swift */; };
 		6AF719654B7BC4062C1AF65C /* STPPaymentMethodAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3403BA8AC9DAEAAEF288879 /* STPPaymentMethodAddress.swift */; };
 		6B55465E2BDAFEF900CA88F6 /* STPPaymentMethodAllowRedisplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B55465D2BDAFEF900CA88F6 /* STPPaymentMethodAllowRedisplay.swift */; };
+		6BA4B9162BF3E0C900D1F21D /* STPPaymentMethodMobilePay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA4B9152BF3E0C900D1F21D /* STPPaymentMethodMobilePay.swift */; };
 		6BE5D7C3F86951E73DAAEB6B /* STPThreeDSCustomizationSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B458CF0D5A7EE56A02D750F2 /* STPThreeDSCustomizationSettings.swift */; };
 		6F09091B2E770D0072201C45 /* StripePayments+Export.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64C6DBBF4EED92890747C305 /* StripePayments+Export.swift */; };
 		6F3835CEBF9618207F8332AA /* STPPaymentMethodBacsDebit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C040209FB6165F70AA7E97 /* STPPaymentMethodBacsDebit.swift */; };
@@ -437,6 +438,7 @@
 		69C77D6D92668C1E541E3C0F /* hu */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hu; path = hu.lproj/Localizable.strings; sourceTree = "<group>"; };
 		6A7CE39E853BD92ABE59F8EA /* StripeiOS-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "StripeiOS-Debug.xcconfig"; sourceTree = "<group>"; };
 		6B55465D2BDAFEF900CA88F6 /* STPPaymentMethodAllowRedisplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPPaymentMethodAllowRedisplay.swift; sourceTree = "<group>"; };
+		6BA4B9152BF3E0C900D1F21D /* STPPaymentMethodMobilePay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPPaymentMethodMobilePay.swift; sourceTree = "<group>"; };
 		6BF260394EEC61199F0EABF8 /* STPPaymentMethodEnums.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPPaymentMethodEnums.swift; sourceTree = "<group>"; };
 		6C360F4D54167F6A484B8D9F /* STPTestAPIClient+Swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "STPTestAPIClient+Swift.swift"; sourceTree = "<group>"; };
 		6CC7BD1E3971B7E4EAE98F40 /* STPThreeDSLabelCustomization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPThreeDSLabelCustomization.swift; sourceTree = "<group>"; };
@@ -1094,6 +1096,7 @@
 				B9F83C7EDA9903D041E4C001 /* STPPaymentMethodKlarnaParams.swift */,
 				E99B164CDD13E8F5C9CAD349 /* STPPaymentMethodLink.swift */,
 				3E397BCD2C450E4770A278DA /* STPPaymentMethodLinkParams.swift */,
+				6BA4B9152BF3E0C900D1F21D /* STPPaymentMethodMobilePay.swift */,
 				92A9741EA9B8FD4301DEB5FD /* STPPaymentMethodMobilePayParams.swift */,
 				48A73DA27ABEC6115513F315 /* STPPaymentMethodNetBanking.swift */,
 				80DC82D6BCE42502F71F8796 /* STPPaymentMethodNetBankingParams.swift */,
@@ -1450,6 +1453,7 @@
 				6F3835CEBF9618207F8332AA /* STPPaymentMethodBacsDebit.swift in Sources */,
 				2BFBE84BD5718D4D8D4718D8 /* STPPaymentMethodBacsDebitParams.swift in Sources */,
 				17083CBB3962C5ADB155EEF4 /* STPPaymentMethodBancontact.swift in Sources */,
+				6BA4B9162BF3E0C900D1F21D /* STPPaymentMethodMobilePay.swift in Sources */,
 				34B8762E977C25C6F715C7C6 /* STPPaymentMethodBancontactParams.swift in Sources */,
 				754AA58F8D3AE8431E01D47E /* STPPaymentMethodBoleto.swift in Sources */,
 				01328A80E436C968E4545922 /* STPPaymentMethodBoletoParams.swift in Sources */,

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethod.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethod.swift
@@ -88,6 +88,8 @@ public class STPPaymentMethod: NSObject, STPAPIResponseDecodable {
     @objc private(set) public var alma: STPPaymentMethodAlma?
     /// If this is a Multibanco PaymentMethod (i.e. `self.type == STPPaymentMethodTypeMultibanco`), this contains additional details.
     @objc private(set) public var multibanco: STPPaymentMethodMultibanco?
+    /// If this is a MobilePay PaymentMethod (i.e. `self.type == STPPaymentMethodTypeMobilePay`), this contains additional details.
+    @objc private(set) public var mobilePay: STPPaymentMethodMobilePay?
 
     /// The ID of the Customer to which this PaymentMethod is saved. Nil when the PaymentMethod has not been saved to a Customer.
     @objc private(set) public var customerId: String?
@@ -150,6 +152,7 @@ public class STPPaymentMethod: NSObject, STPAPIResponseDecodable {
             "amazon_pay = \(String(describing: amazonPay))",
             "alma = \(String(describing: alma))",
             "multibanco = \(String(describing: multibanco))",
+            "mobilePay = \(String(describing: mobilePay))",
             "liveMode = \(liveMode ? "YES" : "NO")",
             "type = \(allResponseFields["type"] as? String ?? "")",
         ]
@@ -318,6 +321,9 @@ public class STPPaymentMethod: NSObject, STPAPIResponseDecodable {
         )
         paymentMethod.multibanco = STPPaymentMethodMultibanco.decodedObject(
             fromAPIResponse: dict.stp_dictionary(forKey: "multibanco")
+        )
+        paymentMethod.mobilePay = STPPaymentMethodMobilePay.decodedObject(
+            fromAPIResponse: dict.stp_dictionary(forKey: "mobilepay")
         )
 
         return paymentMethod

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/Types/STPPaymentMethodMobilePay.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/Types/STPPaymentMethodMobilePay.swift
@@ -1,0 +1,42 @@
+//
+//  STPPaymentMethodMobilePay.swift
+//  StripePayments
+//
+
+import Foundation
+
+/// The MobilePay Payment Method.
+/// - seealso: https://stripe.com/docs/api/payment_methods/object#payment_method_object-mobilepay
+public class STPPaymentMethodMobilePay: NSObject, STPAPIResponseDecodable {
+    /// :nodoc:
+    @objc private(set) public var allResponseFields: [AnyHashable: Any] = [:]
+
+    // MARK: - Description
+    /// :nodoc:
+    @objc public override var description: String {
+        let props = [
+            // Object
+            String(format: "%@: %p", NSStringFromClass(STPPaymentMethodMobilePay.self), self)
+        ]
+
+        return "<\(props.joined(separator: "; "))>"
+    }
+
+    // MARK: - STPAPIResponseDecodeable
+    @objc
+    /// :nodoc:
+    public static func decodedObject(fromAPIResponse response: [AnyHashable: Any]?) -> Self? {
+        guard let response = response else {
+            return nil
+        }
+
+        return self.init(dictionary: response)
+    }
+
+    required init?(
+        dictionary dict: [AnyHashable: Any]
+    ) {
+        super.init()
+        allResponseFields = dict
+    }
+}


### PR DESCRIPTION
## Summary
We had only partial support (params), for mobile pay bindings. This adds deserialization support and associated tests 

## Motivation
Missed the first time around. need to add support.

## Testing
Added tests to deserialize PI w/ client secret

## Changelog
Updated.