### PR TITLE
Update vertical layout API, stop using import @testable in playground

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -15,7 +15,7 @@ import PassKit
 @_spi(STP) import StripeCore
 @_spi(STP) import StripePayments
 @_spi(CustomerSessionBetaAccess) @_spi(EarlyAccessCVCRecollectionFeature) import StripePaymentSheet
-@testable @_spi(STP) @_spi(PaymentSheetSkipConfirmation) import StripePaymentSheet
+@_spi(STP) @_spi(PaymentSheetSkipConfirmation) import StripePaymentSheet
 @_spi(ExperimentalAllowsRemovalOfLastSavedPaymentMethodAPI) import StripePaymentSheet
 import SwiftUI
 import UIKit
@@ -168,9 +168,9 @@ class PlaygroundController: ObservableObject {
 
         switch settings.layout {
         case .horizontal:
-            configuration.appearance.layout = .horizontal
+            configuration.paymentMethodLayout = .horizontal
         case .vertical:
-            configuration.appearance.layout = .vertical
+            configuration.paymentMethodLayout = .vertical
         }
         return configuration
     }

--- a/Stripe.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Stripe.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -38,5 +38,5 @@
       }
     }
   ],
-  "version" : 3
+  "version" : 2
 }

--- a/Stripe.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Stripe.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -38,5 +38,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
@@ -154,7 +154,7 @@ public class PaymentSheet {
             case .success(let loadResult):
                 // Set the PaymentSheetViewController as the content of our bottom sheet
                 let paymentSheetVC: PaymentSheetViewControllerProtocol = {
-                    switch self.configuration.appearance.layout {
+                    switch self.configuration.paymentMethodLayout {
                     case .horizontal:
                         return PaymentSheetViewController(
                             configuration: self.configuration,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetAppearance.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetAppearance.swift
@@ -210,12 +210,5 @@ public extension PaymentSheet {
             /// - Note: If `nil`, `appearance.shadow` will be used as the primary button shadow
             public var shadow: Shadow?
         }
-
-        // MARK: - Experimental Vertical Mode
-        internal enum Layout {
-            case horizontal
-            case vertical
-        }
-        internal var layout: Layout = .horizontal
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
@@ -167,9 +167,6 @@ extension PaymentSheet {
         /// Initializes a Configuration with default values
         public init() {}
 
-        // MARK: Internal
-        internal var linkPaymentMethodsOnly: Bool = false
-
         /// Override country for test purposes
         @_spi(STP) public var userOverrideCountry: String?
 
@@ -196,6 +193,22 @@ extension PaymentSheet {
         /// If true (the default), the customer can delete all saved payment methods.
         /// If false, the customer can't delete if they only have one saved payment method remaining.
         @_spi(ExperimentalAllowsRemovalOfLastSavedPaymentMethodAPI) public var allowsRemovalOfLastSavedPaymentMethod = true
+
+        /// The layout of payment methods in PaymentSheet. Defaults to `.horizontal`.
+        /// - Seealso: `PaymentSheet.PaymentMethodLayout` for the list of available layouts.
+        @_spi(STP) public var paymentMethodLayout: PaymentMethodLayout = .horizontal
+
+        // MARK: Internal
+        internal var linkPaymentMethodsOnly: Bool = false
+    }
+
+    /// Defines the layout orientations available for displaying payment methods in PaymentSheet.
+    @_spi(STP) public enum PaymentMethodLayout {
+        /// Payment methods are arranged horizontally. Users can swipe left or right to navigate through different payment methods.
+        case horizontal
+
+        /// Payment methods are arranged vertically. Users can scroll up or down to navigate through different payment methods.
+        case vertical
     }
 
     internal enum CustomerAccessProvider {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -453,7 +453,7 @@ extension PaymentSheet {
             loadResult: PaymentSheetLoader.LoadResult,
             previousPaymentOption: PaymentOption? = nil
         ) -> FlowControllerViewControllerProtocol {
-            switch configuration.appearance.layout {
+            switch configuration.paymentMethodLayout {
             case .horizontal:
                 return PaymentSheetFlowControllerViewController(
                     configuration: configuration,


### PR DESCRIPTION
## Summary
Update API per https://docs.google.com/document/d/1ZVVxyD5Ue6Xmh54JXf5r3rRCUBPxas01vl7if-FaO_M/edit

Also removes @testable import, which breaks testflight and profiler.

## Testing
Existing tests

## Changelog
Not user facing
