### PR TITLE
Fix relative links for generated docs mapped back to github

### DIFF
--- a/StripePayments/README.md
+++ b/StripePayments/README.md
@@ -7,11 +7,11 @@ If you need to accept card payments, we advise using the [StripePaymentSheet](..
 ## Table of contents
 
 <!--ts-->
-* [Requirements](#requirements)
-* [Getting started](#getting-started)
-   * [Integration](#integration)
-   * [Example](#example)
-* [Manual linking](#manual-linking)
+* [Requirements](#Requirements)
+* [Getting started](#Getting-started)
+   * [Integration](#Integration)
+   * [Example](#Example)
+* [Manual linking](#Manual-linking)
 
 <!--te-->
 
@@ -23,11 +23,11 @@ The StripePayments module is compatible with apps targeting iOS 13.0 or above.
 
 #### Integration
 
-Get started with our [📚 integration guides](https://stripe.com/docs/payments/payment-methods/overview) and [example projects](/Example), or [📘 browse the SDK reference](https://stripe.dev/stripe-ios/stripe-payments/index.html) for fine-grained documentation of all the classes and methods in the SDK.
+Get started with our [📚 integration guides](https://stripe.com/docs/payments/payment-methods/overview) and [example projects](../Example), or [📘 browse the SDK reference](https://stripe.dev/stripe-ios/stripe-payments/index.html) for fine-grained documentation of all the classes and methods in the SDK.
 
 #### Example
 
-- [Non-Card Payment Examples](/Example/Non-Card%20Payment%20Examples)
+- [Non-Card Payment Examples](../Example/Non-Card%20Payment%20Examples)
   - This example demonstrates how to manually accept various payment methods using the Stripe API.
 
 ## Manual linking

--- a/StripePaymentsUI/README.md
+++ b/StripePaymentsUI/README.md
@@ -4,18 +4,18 @@ The StripePaymentsUI module contains UI elements and API bindings for building a
 
 It contains:
 
-* [STPPaymentCardTextField](https://stripe.dev/stripe-ios/stripe-payments-ui/Classes/STPPaymentCardTextField.html), a single-line interface for users to input their credit card details.
-* [STPCardFormView](https://stripe.dev/stripe-ios/stripe-payments-ui/Classes/STPCardFormView.html), a multi-line interface for users to input their credit card details.
-* [STPAUBECSDebitFormView](https://stripe.dev/stripe-ios/stripe-payments-ui/Classes/STPAUBECSDebitFormView.html), a UIControl that contains all of the necessary fields and legal text for collecting AU BECS Debit payments.
+* [STPPaymentCardTextField](https://stripe.dev/stripe-ios/stripepaymentsui/documentation/stripepaymentsui/stppaymentcardtextfield/), a single-line interface for users to input their credit card details.
+* [STPCardFormView](https://stripe.dev/stripe-ios/stripepaymentsui/documentation/stripepaymentsui/stpcardformview), a multi-line interface for users to input their credit card details.
+* [STPAUBECSDebitFormView](https://stripe.dev/stripe-ios/stripepaymentsui/documentation/stripepaymentsui/stpaubecsdebitformview), a UIControl that contains all of the necessary fields and legal text for collecting AU BECS Debit payments.
 
 ## Table of contents
 
 <!--ts-->
-* [Requirements](#requirements)
-* [Getting started](#getting-started)
-   * [Integration](#integration)
-   * [Example](#example)
-* [Manual linking](#manual-linking)
+* [Requirements](#Requirements)
+* [Getting started](#Getting-started)
+   * [Integration](#Integration)
+   * [Example](#Example)
+* [Manual linking](#Manual-linking)
 
 <!--te-->
 
@@ -27,7 +27,7 @@ The StripePaymentsUI module is compatible with apps targeting iOS 13.0 or above.
 
 ### Integration
 
-Get started with our [📚 integration guides](https://stripe.com/docs/payments/accept-a-payment?platform=ios&ui=custom) and [example projects](/Example), or [📘 browse the SDK reference](https://stripe.dev/stripe-ios/stripe-payments-ui/index.html) for fine-grained documentation of all the classes and methods in the SDK.
+Get started with our [📚 integration guides](https://stripe.com/docs/payments/accept-a-payment?platform=ios&ui=custom) and [example projects](/Example), or [📘 browse the SDK reference](https://stripe.dev/stripe-ios/stripepaymentsui/documentation/stripepaymentsui) for fine-grained documentation of all the classes and methods in the SDK.
 
 ### Example
 


### PR DESCRIPTION
## Summary
Fix generated docs mapping back into github

## Motivation
internal request

## Testing
Tested locally via `./ci_scripts/build_documentation.rb --preview` 

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
