### PR TITLE
Instant Debits: wrote UI tests for Instant Debits

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -96,6 +96,8 @@ struct PaymentSheetTestPlayground: View {
                         SettingPickerView(setting: $playgroundController.settings.currency)
                         SettingPickerView(setting: merchantCountryBinding)
                         SettingView(setting: $playgroundController.settings.apmsEnabled)
+                        TextField("Supported Payment Methods (comma separated)", text: supportedPaymentMethodsBinding)
+                            .autocapitalization(.none)
                     }
                     Divider()
                     Group {
@@ -179,6 +181,18 @@ struct PaymentSheetTestPlayground: View {
         }
     }
 
+    var supportedPaymentMethodsBinding: Binding<String> {
+        Binding<String> {
+            return playgroundController.settings.supportedPaymentMethods ?? ""
+        } set: { newString in
+            playgroundController.settings.supportedPaymentMethods = (newString != "") ? newString : nil
+
+            // for supported payment methods to work, apms must be off
+            if playgroundController.settings.supportedPaymentMethods != nil {
+                playgroundController.settings.apmsEnabled = .off
+            }
+        }
+    }
 }
 
 @available(iOS 14.0, *)

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -349,6 +349,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
     var currency: Currency
     var merchantCountryCode: MerchantCountry
     var apmsEnabled: APMSEnabled
+    var supportedPaymentMethods: String?
 
     var shippingInfo: ShippingInfo
     var applePayEnabled: ApplePayEnabled

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -450,7 +450,10 @@ extension PlaygroundController {
             //            "set_shipping_address": true // Uncomment to make server vend PI with shipping address populated
         ] as [String: Any]
         if let supportedPaymentMethods = settingsToLoad.supportedPaymentMethods {
-            body["supported_payment_methods"] = supportedPaymentMethods.split(separator: ",")
+            body["supported_payment_methods"] = supportedPaymentMethods
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .split(separator: ",")
+                .map({ $0.trimmingCharacters(in: .whitespacesAndNewlines) })
         }
         makeRequest(with: checkoutEndpoint, body: body) { data, response, error in
             // If the completed load state doesn't represent the current state, reload again

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -437,7 +437,7 @@ extension PlaygroundController {
         isLoading = true
         let settingsToLoad = self.settings
 
-        let body = [
+        var body = [
             "customer": customerIdOrType,
             "customer_key_type": settings.customerKeyType.rawValue,
             "currency": settings.currency.rawValue,
@@ -447,9 +447,11 @@ extension PlaygroundController {
             "use_link": settings.linkEnabled == .on,
             "use_manual_confirmation": settings.integrationType == .deferred_mc,
             "require_cvc_recollection": settings.requireCVCRecollection == .on,
-            // "supported_payment_methods": ["card", "link"], // Uncomment to override payment methods (also make sure Automatic PM's is off)
             //            "set_shipping_address": true // Uncomment to make server vend PI with shipping address populated
         ] as [String: Any]
+        if let supportedPaymentMethods = settingsToLoad.supportedPaymentMethods {
+            body["supported_payment_methods"] = supportedPaymentMethods.split(separator: ",")
+        }
         makeRequest(with: checkoutEndpoint, body: body) { data, response, error in
             // If the completed load state doesn't represent the current state, reload again
             if settingsToLoad != self.settings {

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -3427,7 +3427,7 @@ extension PaymentSheetUITestCase {
                 )
             )
         // at this point, we searched "Test Institution"
-        // and the only search result is "Test Instiuttion,"
+        // and the only search result is "Test Institution,"
         // so here we guess that 80 pixels below search bar
         // there will be a "Test Institution"
         //

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -852,17 +852,11 @@ class PaymentSheetStandardLPMUITests: PaymentSheetUITestCase {
     }
 
     func testPaymentIntent_instantDebits() {
-        // UI tests need more fixes to work for iOS 17
-        if #unavailable(iOS 17.0) {
-            _testInstantDebits(mode: .payment)
-        }
+        _testInstantDebits(mode: .payment)
     }
 
     func testSetupIntent_instantDebits() {
-        // UI tests need more fixes to work for iOS 17
-        if #unavailable(iOS 17.0) {
-            _testInstantDebits(mode: .setup)
-        }
+        _testInstantDebits(mode: .setup)
     }
 
     func testUPIPaymentMethod() throws {
@@ -3419,12 +3413,28 @@ extension PaymentSheetUITestCase {
         app.typeText("4015006000" + XCUIKeyboardKey.return.rawValue)
 
         // "Institution Picker" pane
-        let testInstitutionButton = app
-            .buttons
-            .matching(NSPredicate(format: "label CONTAINS 'Test Institution'"))
+        let searchTextField = app.textFields
+            .matching(NSPredicate(format: "label CONTAINS 'Search'"))
             .firstMatch
-        testInstitutionButton.swipeUp()
-        testInstitutionButton.waitForExistenceAndTap(timeout: 10)
+        searchTextField.waitForExistenceAndTap(timeout: 10)
+        app.typeText("Test Institution" + XCUIKeyboardKey.return.rawValue)
+        searchTextField
+            .coordinate(
+                withNormalizedOffset: CGVector(
+                    dx: 0.5,
+                    // bottom of search text field
+                    dy: 1.0
+                )
+            )
+        // at this point, we searched "Test Institution"
+        // and the only search result is "Test Instiuttion,"
+        // so here we guess that 80 pixels below search bar
+        // there will be a "Test Institution"
+        //
+        // we do this "guess" because every other method of
+        // selecting the institution did not work on iOS 17
+            .withOffset(CGVector(dx: 0, dy: 80))
+            .tap()
 
         // "Account Picker" pane
         _ = app.staticTexts["Select account"].waitForExistence(timeout: 10)

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -851,6 +851,20 @@ class PaymentSheetStandardLPMUITests: PaymentSheetUITestCase {
         _testUSBankAccount(mode: .setup, integrationType: .normal)
     }
 
+    func testPaymentIntent_instantDebits() {
+        // UI tests need more fixes to work for iOS 17
+        if #unavailable(iOS 17.0) {
+            _testInstantDebits(mode: .payment)
+        }
+    }
+
+    func testSetupIntent_instantDebits() {
+        // UI tests need more fixes to work for iOS 17
+        if #unavailable(iOS 17.0) {
+            _testInstantDebits(mode: .setup)
+        }
+    }
+
     func testUPIPaymentMethod() throws {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
         settings.customerMode = .new
@@ -3358,6 +3372,79 @@ extension PaymentSheetUITestCase {
         XCTAssertTrue(app.buttons["••••1113"].waitForExistenceAndTap())
         XCTAssertTrue(app.buttons[confirmButtonText].waitForExistenceAndTap())
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10))
+    }
+
+    func _testInstantDebits(mode: PaymentSheetTestPlaygroundSettings.Mode) {
+        var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
+        settings.mode = mode
+        settings.apmsEnabled = .off
+        settings.supportedPaymentMethods = "card,link"
+
+        loadPlayground(
+            app,
+            settings
+        )
+        app.buttons["Present PaymentSheet"].tap()
+
+        // Select "Bank Account"
+        guard let bankAccount = scroll(collectionView: app.collectionViews.firstMatch, toFindCellWithId: "Bank Account") else {
+            XCTFail()
+            return
+        }
+        bankAccount.tap()
+
+        let email = "paymentsheetuitest-\(UUID().uuidString)@example.com"
+
+        // Fill out name and email fields
+        let continueButton = app.buttons["Continue"]
+        XCTAssertFalse(continueButton.isEnabled)
+        app.textFields["Email"].tap()
+        app.typeText(email + XCUIKeyboardKey.return.rawValue)
+        XCTAssertTrue(continueButton.isEnabled)
+        continueButton.tap()
+
+        // "Consent" pane
+        app.buttons["Agree and continue"].waitForExistenceAndTap(timeout: 10)
+
+        // "Sign Up" pane
+        app.textFields
+            .matching(NSPredicate(format: "label CONTAINS 'Email address'"))
+            .firstMatch
+            .waitForExistenceAndTap(timeout: 10)
+        app.typeText(email + XCUIKeyboardKey.return.rawValue)
+        app.textFields["Phone number"].tap()
+        // the `XCUIKeyboardKey.return.rawValue` will automatically
+        // press the "Continue with Link" button to proceed to next
+        // screen
+        app.typeText("4015006000" + XCUIKeyboardKey.return.rawValue)
+
+        // "Institution Picker" pane
+        let testInstitutionButton = app
+            .buttons
+            .matching(NSPredicate(format: "label CONTAINS 'Test Institution'"))
+            .firstMatch
+        testInstitutionButton.swipeUp()
+        testInstitutionButton.waitForExistenceAndTap(timeout: 10)
+
+        // "Account Picker" pane
+        _ = app.staticTexts["Select account"].waitForExistence(timeout: 10)
+        // `swipeUp` is necessary to see the `High Balance` account
+        app.swipeUp()
+        sleep(1) // wait for swipe up to finish
+        app.webViews
+            .buttons
+            .containing(NSPredicate(format: "label CONTAINS 'High Balance'"))
+            .firstMatch
+            .tap()
+        app.buttons["Connect account"].tap()
+
+        // "Success" pane
+        XCTAssert(app.staticTexts["Success"].waitForExistence(timeout: 10))
+        app.buttons["Done"].forceTapWhenHittableInTestCase(self)
+
+        // Back to Payment Sheet
+        app.buttons[mode == .setup ? "Set up" : "Pay $50.99"].waitForExistenceAndTap(timeout: 10)
+        XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10.0))
     }
 
     func payWithApplePay() {


### PR DESCRIPTION
## Summary

This PR adds tests for Instant Debits in Payment Sheet.

This was the PR that introduced Instant Debits:
- https://github.com/stripe/stripe-ios/pull/3528

This PR also introduces a new field in the Payment Sheet app ("supported payment methods"). It's a little funky, but I copied what Android did:
- https://github.com/stripe/stripe-android/pull/8428

## Testing

Tests passed in PR/bitrise (https://app.bitrise.io/build/18ab4632-a2fb-4740-905e-43b319c79fd7):

```
    ✔ testPaymentIntent_instantDebits on 'Clone 2 of iPhone 12 mini - PaymentSheetUITest-Runner (18516)' (41.433 seconds)
    ✔ testSetupIntent_instantDebits on 'Clone 2 of iPhone 12 mini - PaymentSheetUITest-Runner (18516)' (44.803 seconds)
```

Tests passed in Xcode:

![Screenshot 2024-05-16 at 1 24 50 PM](https://github.com/stripe/stripe-ios/assets/105514761/ad9f814d-088d-41f5-a33a-d6f5ab4131ef)

This is the new field:

![Simulator Screenshot - Clone 1 of iPhone 12 mini - 2024-05-16 at 13 21 57](https://github.com/stripe/stripe-ios/assets/105514761/20c7e128-f1a5-4165-8ec3-2af5ab4a9012)

