### PR TITLE
Refactor `PaymentOptionCell` out of `UpdateCardViewController`

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
@@ -70,6 +70,15 @@ class SavedPaymentOptionsViewController: UIViewController {
                 return availableNetworks.count > 1
             }
         }
+
+        var savedPaymentMethod: STPPaymentMethod? {
+            switch self {
+            case .applePay, .link, .add:
+                return nil
+            case .saved(paymentMethod: let paymentMethod):
+                return paymentMethod
+            }
+        }
     }
 
     struct Configuration {
@@ -546,8 +555,7 @@ extension SavedPaymentOptionsViewController: PaymentOptionCellDelegate {
             return
         }
 
-        let editVc = UpdateCardViewController(paymentOptionCell: paymentOptionCell,
-                                              paymentMethod: paymentMethod,
+        let editVc = UpdateCardViewController(paymentMethod: paymentMethod,
                                               removeSavedPaymentMethodMessage: configuration.removeSavedPaymentMethodMessage,
                                               appearance: appearance,
                                               hostedSurface: .paymentSheet,
@@ -573,15 +581,14 @@ extension SavedPaymentOptionsViewController: PaymentOptionCellDelegate {
         let alertController = UIAlertController.makeRemoveAlertController(paymentMethod: paymentMethod,
                                                                           removeSavedPaymentMethodMessage: configuration.removeSavedPaymentMethodMessage) { [weak self] in
             guard let self = self else { return }
-            self.removePaymentMethod(paymentOptionCell: paymentOptionCell)
+            self.removePaymentMethod(paymentMethod)
         }
 
         present(alertController, animated: true, completion: nil)
     }
 
-    private func removePaymentMethod(paymentOptionCell: SavedPaymentMethodCollectionView.PaymentOptionCell) {
-        guard let indexPath = collectionView.indexPath(for: paymentOptionCell),
-              case .saved(let paymentMethod) = viewModels[indexPath.row]
+    private func removePaymentMethod(_ paymentMethod: STPPaymentMethod) {
+        guard let row = viewModels.firstIndex(where: { $0.savedPaymentMethod?.stripeId == paymentMethod.stripeId })
         else {
             let errorAnalytic = ErrorAnalytic(event: .unexpectedPaymentSheetError,
                                               error: Error.removePaymentMethodOnNonSavedItem)
@@ -589,6 +596,7 @@ extension SavedPaymentOptionsViewController: PaymentOptionCellDelegate {
             stpAssertionFailure()
             return
         }
+        let indexPath = IndexPath(row: row, section: 0)
         let viewModel = viewModels[indexPath.row]
         self.viewModels.remove(at: indexPath.row)
         // the deletion needs to be in a performBatchUpdates so we make sure it is completed
@@ -619,20 +627,20 @@ extension SavedPaymentOptionsViewController: PaymentOptionCellDelegate {
 
 // MARK: - UpdateCardViewControllerDelegate
 extension SavedPaymentOptionsViewController: UpdateCardViewControllerDelegate {
-    func didRemove(paymentOptionCell: SavedPaymentMethodCollectionView.PaymentOptionCell) {
-        removePaymentMethod(paymentOptionCell: paymentOptionCell)
+    func didRemove(paymentMethod: STPPaymentMethod) {
+        removePaymentMethod(paymentMethod)
     }
 
-    func didUpdate(paymentOptionCell: SavedPaymentMethodCollectionView.PaymentOptionCell,
+    func didUpdate(paymentMethod: STPPaymentMethod,
                    updateParams: STPPaymentMethodUpdateParams) async throws {
-        guard let indexPath = collectionView.indexPath(for: paymentOptionCell),
-              case .saved = viewModels[indexPath.row],
+        guard let row = viewModels.firstIndex(where: { $0.savedPaymentMethod?.stripeId == paymentMethod.stripeId }),
               let delegate = delegate
         else {
             stpAssertionFailure()
             throw PaymentSheetError.unknown(debugDescription: NSError.stp_unexpectedErrorMessage())
         }
 
+        let indexPath = IndexPath(row: row, section: 0)
         let viewModel = viewModels[indexPath.row]
         let updatedPaymentMethod = try await delegate.didSelectUpdate(viewController: self,
                                                     paymentMethodSelection: viewModel,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/UpdateCardViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/UpdateCardViewController.swift
@@ -12,8 +12,8 @@ import Foundation
 import UIKit
 
 protocol UpdateCardViewControllerDelegate: AnyObject {
-    func didRemove(paymentOptionCell: SavedPaymentMethodCollectionView.PaymentOptionCell)
-    func didUpdate(paymentOptionCell: SavedPaymentMethodCollectionView.PaymentOptionCell,
+    func didRemove(paymentMethod: STPPaymentMethod)
+    func didUpdate(paymentMethod: STPPaymentMethod,
                    updateParams: STPPaymentMethodUpdateParams) async throws
 }
 
@@ -22,7 +22,6 @@ protocol UpdateCardViewControllerDelegate: AnyObject {
 final class UpdateCardViewController: UIViewController {
     private let appearance: PaymentSheet.Appearance
     private let paymentMethod: STPPaymentMethod
-    private let paymentOptionCell: SavedPaymentMethodCollectionView.PaymentOptionCell
     private let removeSavedPaymentMethodMessage: String?
     private let isTestMode: Bool
     private let hostedSurface: HostedSurface
@@ -134,14 +133,12 @@ final class UpdateCardViewController: UIViewController {
     }()
 
     // MARK: Overrides
-    init(paymentOptionCell: SavedPaymentMethodCollectionView.PaymentOptionCell,
-         paymentMethod: STPPaymentMethod,
+    init(paymentMethod: STPPaymentMethod,
          removeSavedPaymentMethodMessage: String?,
          appearance: PaymentSheet.Appearance,
          hostedSurface: HostedSurface,
          canRemoveCard: Bool,
          isTestMode: Bool) {
-        self.paymentOptionCell = paymentOptionCell
         self.paymentMethod = paymentMethod
         self.removeSavedPaymentMethodMessage = removeSavedPaymentMethodMessage
         self.appearance = appearance
@@ -196,7 +193,7 @@ final class UpdateCardViewController: UIViewController {
         let alertController = UIAlertController.makeRemoveAlertController(paymentMethod: paymentMethod,
                                                                           removeSavedPaymentMethodMessage: removeSavedPaymentMethodMessage) { [weak self] in
             guard let self = self else { return }
-            self.delegate?.didRemove(paymentOptionCell: self.paymentOptionCell)
+            self.delegate?.didRemove(paymentMethod: self.paymentMethod)
             self.dismiss()
         }
 
@@ -216,7 +213,7 @@ final class UpdateCardViewController: UIViewController {
 
         // Make the API request to update the payment method
         do {
-            try await delegate.didUpdate(paymentOptionCell: paymentOptionCell, updateParams: updateParams)
+            try await delegate.didUpdate(paymentMethod: paymentMethod, updateParams: updateParams)
             dismiss(didUpdate: true)
             STPAnalyticsClient.sharedClient.logPaymentSheetEvent(event: hostedSurface.analyticEvent(for: .updateCardBrand),
                                                                  params: ["selected_card_brand": STPCardBrandUtilities.apiValue(from: selectedBrand)])

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/UpdateCardViewControllerSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/UpdateCardViewControllerSnapshotTests.swift
@@ -25,8 +25,7 @@ final class UpdateCardViewControllerSnapshotTests: STPSnapshotTestCase {
     }
 
     func _test_UpdateCardViewController(darkMode: Bool, appearance: PaymentSheet.Appearance = .default) {
-        let sut = UpdateCardViewController(paymentOptionCell: .init(frame: .zero),
-                                           paymentMethod: STPFixtures.paymentMethod(),
+        let sut = UpdateCardViewController(paymentMethod: STPFixtures.paymentMethod(),
                                            removeSavedPaymentMethodMessage: "Test removal string",
                                            appearance: appearance,
                                            hostedSurface: .paymentSheet,


### PR DESCRIPTION
## Summary
- `UpdateCardViewController` was too tightly coupled to the `PaymentOptionCell` reducing it's ability to be re-used for vertical mode
- Refactors it to only require a `STPPaymentMethod` rather than the actual cell

## Motivation
- Vert mode
- Flexibility

## Testing
- Existing tests

## Changelog
N/A
