### PR TITLE
Instant Debits: Polished the flow

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -3381,7 +3381,7 @@ extension PaymentSheetUITestCase {
         app.buttons["Present PaymentSheet"].tap()
 
         // Select "Bank Account"
-        guard let bankAccount = scroll(collectionView: app.collectionViews.firstMatch, toFindCellWithId: "Bank Account") else {
+        guard let bankAccount = scroll(collectionView: app.collectionViews.firstMatch, toFindCellWithId: "Bank") else {
             XCTFail()
             return
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -53,6 +53,11 @@ class PaymentSheetFormFactory {
         return configuration.appearance.asElementsTheme
     }
 
+    private static let PayByBankDescriptionText = STPLocalizedString(
+        "Pay with your bank account in just a few steps.",
+        "US Bank Account copy title for Mobile payment element form"
+    )
+
     convenience init(
         intent: Intent,
         configuration: PaymentSheetFormFactoryConfig,
@@ -709,7 +714,7 @@ extension PaymentSheetFormFactory {
                     return nil // customer sheet is not supported
                 case .paymentSheet:
                     return makeSectionTitleLabelWith(
-                        text: "Pay with your bank account in just a few steps." // TODO(kgaidis): localize string
+                        text: Self.PayByBankDescriptionText
                     )
                 }
             }(),
@@ -729,10 +734,7 @@ extension PaymentSheetFormFactory {
             )
         case .paymentSheet:
             return makeSectionTitleLabelWith(
-                text: STPLocalizedString(
-                    "Pay with your bank account in just a few steps.",
-                    "US Bank Account copy title for Mobile payment element form"
-                )
+                text: Self.PayByBankDescriptionText
             )
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/InstantDebitsPaymentMethodElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/InstantDebitsPaymentMethodElement.swift
@@ -35,14 +35,13 @@ final class InstantDebitsPaymentMethodElement: ContainerElement {
     var mandateString: NSMutableAttributedString? {
         var string: String?
         if linkedBank != nil {
-            // TODO(kgaidis): localize
-            string = "By continuing, you agree to authorize payments pursuant to <terms>these terms</terms>."
+            string = USBankAccountPaymentMethodElement.ContinueMandateText
         } else {
             string = nil
         }
         if let string {
             let links = [
-                "terms": URL(string: "https://stripe.com/legal/ach-payments/authorization")!,
+                "terms": URL(string: "https://link.com/terms/ach-authorization")!,
             ]
             let mutableString = STPStringUtils.applyLinksToString(
                 template: string,

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodEnums.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodEnums.swift
@@ -97,6 +97,7 @@ import Foundation
 
     /// Localized display name for this payment method type
     @_spi(STP) public var displayName: String {
+        let instantDebitsDisplayName = STPLocalizedString("Bank", "Link Instant Debit payment method display name")
         switch self {
         case .alipay:
             return STPLocalizedString("Alipay", "Payment Method type brand name")
@@ -146,7 +147,7 @@ import Foundation
         case .klarna:
             return STPLocalizedString("Klarna", "Payment Method type brand name")
         case .linkInstantDebit:
-            return STPLocalizedString("Bank", "Link Instant Debit payment method display name")
+            return instantDebitsDisplayName
         case .affirm:
             return STPLocalizedString("Affirm", "Payment Method type brand name")
         case .USBankAccount:
@@ -181,7 +182,7 @@ import Foundation
         case .multibanco:
             return "Multibanco"
         case .instantDebits:
-            return "Bank Account"
+            return instantDebitsDisplayName
         case .cardPresent,
             .unknown:
             return STPLocalizedString("Unknown", "Default missing source type label")

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodParams.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodParams.swift
@@ -1345,7 +1345,7 @@ extension STPPaymentMethodParams {
         case .multibanco:
             return "Multibanco"
         case .instantDebits:
-            return "Bank Account"
+            return "Bank"
         case .cardPresent, .unknown:
             return STPLocalizedString("Unknown", "Default missing source type label")
         case .paynow, .zip, .amazonPay, .alma, .mobilePay, .konbini, .promptPay, .swish:


### PR DESCRIPTION
## Summary

^ small code polish around Instant Debits (both code and non-code)

## Testing

### Start Flow

| Before | After |
| --- | --- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-05-24 at 15 10 12](https://github.com/stripe/stripe-ios/assets/105514761/d2db5841-7cb2-427e-ba0c-92ff7381dca7) | ![Simulator Screenshot - iPhone 15 Pro - 2024-05-24 at 15 03 44](https://github.com/stripe/stripe-ios/assets/105514761/4874f4ff-4718-477e-ac2e-f032ba37167d) | 

### End Flow 

| Before | After |
| --- | --- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-05-24 at 15 10 30](https://github.com/stripe/stripe-ios/assets/105514761/5d6f378c-06b1-4024-938c-96e74964f63f) | ![Simulator Screenshot - iPhone 15 Pro - 2024-05-24 at 15 04 06](https://github.com/stripe/stripe-ios/assets/105514761/84220651-eeef-4f04-85fa-00c9eb5b5f36) |
