### PR TITLE
Handle selection of payment method in vertical list

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
+++ b/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
@@ -201,6 +201,9 @@
 		B4679C9095BCD53CCC2C7D25 /* StripeCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E41AA4E90E5BB28D588FDE51 /* StripeCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		B55EFA2557B5BE39CC12E357 /* STPPaymentMethod+PaymentSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 813E88EE408666654EF835E2 /* STPPaymentMethod+PaymentSheet.swift */; };
 		B626EE932BF2872200B05B05 /* PaymentMethodTypeImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B626EE922BF2872200B05B05 /* PaymentMethodTypeImageView.swift */; };
+		B63B2CF12BF8313D003810F3 /* VerticalPaymentMethodListViewTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B63B2CF02BF8313D003810F3 /* VerticalPaymentMethodListViewTest.swift */; };
+		B63B2CF32BFBEE7B003810F3 /* VerticalPaymentMethodListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B63B2CF22BFBEE7B003810F3 /* VerticalPaymentMethodListViewController.swift */; };
+		B63B2CF52BFBEEAD003810F3 /* PaymentMethodFormViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B63B2CF42BFBEEAD003810F3 /* PaymentMethodFormViewController.swift */; };
 		B65FE7092BED33EA009A73FC /* VerticalPaymentMethodListViewSnapshotTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B65FE7082BED33EA009A73FC /* VerticalPaymentMethodListViewSnapshotTest.swift */; };
 		B667BF0B2BF2B7C60050EFD8 /* RowButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B667BF0A2BF2B7C60050EFD8 /* RowButton.swift */; };
 		B6859A882BE54CD30018E06C /* PaymentSheetVerticalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6859A872BE54CD30018E06C /* PaymentSheetVerticalViewController.swift */; };
@@ -538,6 +541,9 @@
 		B54274B9DEB3F1B0906127D1 /* et-EE */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "et-EE"; path = "et-EE.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		B61FFE76D0960C7F1E34B405 /* PaymentSheetAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSheetAppearance.swift; sourceTree = "<group>"; };
 		B626EE922BF2872200B05B05 /* PaymentMethodTypeImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodTypeImageView.swift; sourceTree = "<group>"; };
+		B63B2CF02BF8313D003810F3 /* VerticalPaymentMethodListViewTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalPaymentMethodListViewTest.swift; sourceTree = "<group>"; };
+		B63B2CF22BFBEE7B003810F3 /* VerticalPaymentMethodListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalPaymentMethodListViewController.swift; sourceTree = "<group>"; };
+		B63B2CF42BFBEEAD003810F3 /* PaymentMethodFormViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaymentMethodFormViewController.swift; sourceTree = "<group>"; };
 		B65FE7082BED33EA009A73FC /* VerticalPaymentMethodListViewSnapshotTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalPaymentMethodListViewSnapshotTest.swift; sourceTree = "<group>"; };
 		B667BF0A2BF2B7C60050EFD8 /* RowButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RowButton.swift; sourceTree = "<group>"; };
 		B667E074D30964FABC64B552 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -899,6 +905,7 @@
 				73853A55045C53AF2BBB8489 /* BottomSheetViewController.swift */,
 				6BA8D3352B0C1F9B008C51FF /* CVCReconfirmationViewController.swift */,
 				51FF291A25EA43D4D100983B /* LoadingViewController.swift */,
+				B63B2CF42BFBEEAD003810F3 /* PaymentMethodFormViewController.swift */,
 				107DAAB4492531735377AA7C /* PaymentSheetFlowControllerViewController.swift */,
 				0CACEA8571301D469FF07741 /* PaymentSheetViewController.swift */,
 				101DFBD8D19B7B182CDD8882 /* PollingViewController.swift */,
@@ -1132,6 +1139,7 @@
 				B6859A872BE54CD30018E06C /* PaymentSheetVerticalViewController.swift */,
 				B667BF0A2BF2B7C60050EFD8 /* RowButton.swift */,
 				B6A154F82BEC1E8D00238D1F /* VerticalPaymentMethodListView.swift */,
+				B63B2CF22BFBEE7B003810F3 /* VerticalPaymentMethodListViewController.swift */,
 			);
 			path = "Vertical Main Screen";
 			sourceTree = "<group>";
@@ -1350,6 +1358,7 @@
 				135B7354260E0E7CADCF3426 /* PaymentSheetAddressTests.swift */,
 				357B9EB0751819566843117E /* PaymentSheetDeferredValidatorTests.swift */,
 				5F884F7A5FF4FC6D0E24E6FC /* PaymentSheetErrorTest.swift */,
+				B63B2CF02BF8313D003810F3 /* VerticalPaymentMethodListViewTest.swift */,
 				35853BC78F9E64F5729EAE1E /* PaymentSheetExternalPaymentMethodTests.swift */,
 				EACC9F3AE667BDD05D6A0561 /* PaymentSheetFlowControllerViewControllerSnapshotTests.swift */,
 				4D595AA033BC84CB4E1C277F /* PaymentSheetFormFactorySnapshotTest.swift */,
@@ -1602,6 +1611,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E5C7667A08EA85C0FF12523D /* AddPaymentMethodViewControllerSnapshotTests.swift in Sources */,
+				B63B2CF12BF8313D003810F3 /* VerticalPaymentMethodListViewTest.swift in Sources */,
 				61CB0BD02BED985100E24A4C /* VerticalSavedPaymentMethodsViewControllerSnapshotTests.swift in Sources */,
 				8180BC3615767F896E2F9355 /* AddressViewControllerSnapshotTests.swift in Sources */,
 				B65FE7092BED33EA009A73FC /* VerticalPaymentMethodListViewSnapshotTest.swift in Sources */,
@@ -1664,6 +1674,7 @@
 				0FB52E5B87B1854B28362BF3 /* STPAnalyticsClient+CustomerSheet.swift in Sources */,
 				6A529F76ECB33C9154314C1F /* STPAnalyticsClient+LUXE.swift in Sources */,
 				06976DDC67A61176FC54AA76 /* Data+SHA256.swift in Sources */,
+				B63B2CF52BFBEEAD003810F3 /* PaymentMethodFormViewController.swift in Sources */,
 				108846A3D8EFD1D4DCC0DDBC /* NSAttributedString+Stripe.swift in Sources */,
 				B55EFA2557B5BE39CC12E357 /* STPPaymentMethod+PaymentSheet.swift in Sources */,
 				3CB64564D5B6F092A2A3A5BE /* STPPaymentMethodParams+PaymentSheet.swift in Sources */,
@@ -1775,6 +1786,7 @@
 				727874C468C0E1CD3653C91A /* PaymentSheetError.swift in Sources */,
 				45F8109B55B9013945ACB2C6 /* PaymentSheetFlowController.swift in Sources */,
 				209FF56603EE6FC381BB58F1 /* FormSpec.swift in Sources */,
+				B63B2CF32BFBEE7B003810F3 /* VerticalPaymentMethodListViewController.swift in Sources */,
 				D592BEF7679F39A4DE26E5AF /* FormSpecProvider.swift in Sources */,
 				D39475E63F8372FFDB0F06EA /* PaymentSheetFormFactory+BLIK.swift in Sources */,
 				B99DA5A48A9EF5E352DDA872 /* PaymentSheetFormFactory+Boleto.swift in Sources */,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton.swift
@@ -24,6 +24,7 @@ class RowButton: UIView {
         self.didTap = didTap
         self.shadowRoundedRect = ShadowedRoundedRectangle(appearance: appearance)
         super.init(frame: .zero)
+        accessibilityIdentifier = text
 
         // Label and sublabel
         let labelsStackView = UIStackView(arrangedSubviews: [

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/VerticalPaymentMethodListViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/VerticalPaymentMethodListViewController.swift
@@ -1,0 +1,49 @@
+//
+//  VerticalPaymentMethodListViewController.swift
+//  StripePaymentSheet
+//
+//  Created by Yuki Tokuhiro on 5/20/24.
+//
+
+@_spi(STP) import StripeUICore
+import UIKit
+
+protocol VerticalPaymentMethodListViewControllerDelegate: AnyObject {
+    /// - Returns: Whether or not the payment method row button should appear selected.
+    func didTapPaymentMethod(_ selection: VerticalPaymentMethodListSelection) -> Bool
+    // TODO: didSelectEdit/ViewMore
+}
+
+/// A simple container VC for the VerticalPaymentMethodListView, which displays payment options in a vertical list.
+class VerticalPaymentMethodListViewController: UIViewController {
+    weak var delegate: VerticalPaymentMethodListViewControllerDelegate?
+    let listView: VerticalPaymentMethodListView
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    init(savedPaymentMethod: STPPaymentMethod?, paymentMethodTypes: [PaymentSheet.PaymentMethodType], shouldShowApplePay: Bool, shouldShowLink: Bool, appearance: PaymentSheet.Appearance, delegate: VerticalPaymentMethodListViewControllerDelegate) {
+        self.delegate = delegate
+        self.listView = VerticalPaymentMethodListView(
+            savedPaymentMethod: savedPaymentMethod,
+            paymentMethodTypes: paymentMethodTypes,
+            shouldShowApplePay: shouldShowApplePay,
+            shouldShowLink: shouldShowLink,
+            appearance: appearance
+        )
+        super.init(nibName: nil, bundle: nil)
+        self.listView.delegate = self
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view = listView
+    }
+}
+
+extension VerticalPaymentMethodListViewController: VerticalPaymentMethodListViewDelegate {
+    func didTapPaymentMethod(_ selection: VerticalPaymentMethodListSelection) -> Bool {
+        return delegate?.didTapPaymentMethod(selection) ?? false
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -1,0 +1,40 @@
+//
+//  PaymentMethodFormViewController.swift
+//  StripePaymentSheet
+//
+//  Created by Yuki Tokuhiro on 5/16/24.
+//
+
+@_spi(STP) import StripeUICore
+import UIKit
+
+class PaymentMethodFormViewController: UIViewController {
+    let form: PaymentMethodElement
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    init(form: PaymentMethodElement) {
+        self.form = form
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view = form.view
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        _ = self.form.beginEditing()
+    }
+
+    override func willMove(toParent parent: UIViewController?) {
+        super.willMove(toParent: parent)
+        // viewWillAppear is called too late (when the dismissal animation is done), so we override this method instead
+        if parent == nil {
+            view.endEditing(true)
+        }
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/PaymentSheetUIKitAdditions.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/PaymentSheetUIKitAdditions.swift
@@ -105,14 +105,18 @@ extension UIViewController {
                 }
             )
         } else {
-            addChild(toVC)
-            containerView.addPinnedSubview(toVC.view)
-            containerView.updateHeight()
-            toVC.didMove(toParent: self)
+            add(childViewController: toVC, containerView: containerView)
             containerView.setNeedsLayout()
             containerView.layoutIfNeeded()
             UIAccessibility.post(notification: .screenChanged, argument: toVC.view)
         }
+    }
+
+    func add(childViewController: UIViewController, containerView: DynamicHeightContainerView) {
+        addChild(childViewController)
+        containerView.addPinnedSubview(childViewController.view)
+        containerView.updateHeight()
+        childViewController.didMove(toParent: self)
     }
 
     func remove(childViewController: UIViewController) {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/VerticalPaymentMethodListViewSnapshotTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/VerticalPaymentMethodListViewSnapshotTest.swift
@@ -38,22 +38,22 @@ final class VerticalPaymentMethodListViewSnapshotTest: STPSnapshotTestCase {
     ]
 
     func testNoSavedPM_noApplePayLink() {
-        let sut = VerticalPaymentMethodListView(savedPaymentMethod: nil, paymentMethodTypes: paymentMethods.map { .stripe($0) }, shouldShowApplePay: false, shouldShowLink: false, appearance: .default, delegate: self)
+        let sut = VerticalPaymentMethodListView(savedPaymentMethod: nil, paymentMethodTypes: paymentMethods.map { .stripe($0) }, shouldShowApplePay: false, shouldShowLink: false, appearance: .default)
         STPSnapshotVerifyView(sut, autoSizingHeightForWidth: 375)
     }
 
     func testSavedCard_noApplePayLink() {
-        let sut = VerticalPaymentMethodListView(savedPaymentMethod: ._testCard(), paymentMethodTypes: paymentMethods.map { .stripe($0) }, shouldShowApplePay: false, shouldShowLink: false, appearance: .default, delegate: self)
+        let sut = VerticalPaymentMethodListView(savedPaymentMethod: ._testCard(), paymentMethodTypes: paymentMethods.map { .stripe($0) }, shouldShowApplePay: false, shouldShowLink: false, appearance: .default)
         STPSnapshotVerifyView(sut, autoSizingHeightForWidth: 375)
     }
 
     func testSavedCard_ApplePayLink() {
-        let sut = VerticalPaymentMethodListView(savedPaymentMethod: ._testCard(), paymentMethodTypes: paymentMethods.map { .stripe($0) }, shouldShowApplePay: true, shouldShowLink: true, appearance: .default, delegate: self)
+        let sut = VerticalPaymentMethodListView(savedPaymentMethod: ._testCard(), paymentMethodTypes: paymentMethods.map { .stripe($0) }, shouldShowApplePay: true, shouldShowLink: true, appearance: .default)
         STPSnapshotVerifyView(sut, autoSizingHeightForWidth: 375)
     }
 
     func testDarkMode() {
-        let sut = VerticalPaymentMethodListView(savedPaymentMethod: ._testCard(), paymentMethodTypes: paymentMethods.map { .stripe($0) }, shouldShowApplePay: true, shouldShowLink: true, appearance: .default, delegate: self)
+        let sut = VerticalPaymentMethodListView(savedPaymentMethod: ._testCard(), paymentMethodTypes: paymentMethods.map { .stripe($0) }, shouldShowApplePay: true, shouldShowLink: true, appearance: .default)
         let window = UIWindow()
         window.isHidden = false
         window.addAndPinSubview(sut, insets: .zero)
@@ -62,16 +62,10 @@ final class VerticalPaymentMethodListViewSnapshotTest: STPSnapshotTestCase {
     }
 
     func testAppearance() {
-        let sut = VerticalPaymentMethodListView(savedPaymentMethod: ._testCard(), paymentMethodTypes: paymentMethods.map { .stripe($0) }, shouldShowApplePay: true, shouldShowLink: true, appearance: ._testMSPaintTheme, delegate: self)
+        let sut = VerticalPaymentMethodListView(savedPaymentMethod: ._testCard(), paymentMethodTypes: paymentMethods.map { .stripe($0) }, shouldShowApplePay: true, shouldShowLink: true, appearance: ._testMSPaintTheme)
         let window = UIWindow()
         window.isHidden = false
         window.addAndPinSubview(sut, insets: .zero)
         STPSnapshotVerifyView(window, autoSizingHeightForWidth: 375)
-    }
-}
-
-extension VerticalPaymentMethodListViewSnapshotTest: VerticalPaymentMethodListViewDelegate {
-    func didSelectPaymentMethod(_ selection: StripePaymentSheet.VerticalPaymentMethodListView.Selection) {
-        // no-op
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/VerticalPaymentMethodListViewTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/VerticalPaymentMethodListViewTest.swift
@@ -1,0 +1,58 @@
+//
+//  VerticalPaymentMethodListViewTest.swift
+//  StripePaymentSheetTests
+//
+//  Created by Yuki Tokuhiro on 5/17/24.
+//
+
+import StripeCoreTestUtils
+@_spi(STP) @testable import StripePaymentSheet
+@_spi(STP) import StripeUICore
+import XCTest
+
+final class VerticalPaymentMethodListViewTest: XCTestCase {
+    var didTapPaymentMethodReturnValue: Bool = false
+
+    func testCurrentSelection() {
+        let savedPaymentMethod = STPPaymentMethod._testCard()
+        // Given a list view with a saved card...
+        let sut = VerticalPaymentMethodListView(savedPaymentMethod: savedPaymentMethod, paymentMethodTypes: [.stripe(.card)], shouldShowApplePay: true, shouldShowLink: true, appearance: .default, delegate: self)
+        // ...the current selection should be the saved PM
+        let savedPMButton = sut.getRowButton(accessibilityIdentifier: "••••4242")
+        XCTAssertEqual(sut.currentSelection, .saved(paymentMethod: savedPaymentMethod))
+        XCTAssertTrue(savedPMButton.isSelected)
+
+        // Selecting Apple Pay...
+        didTapPaymentMethodReturnValue = true // (and mocking `didTapPaymentMethod` to return true)
+        let applePayRowButton = sut.getRowButton(accessibilityIdentifier: "Apple Pay")
+        sut.didTap(rowButton: applePayRowButton, selection: .applePay)
+        // ...should change the current selection from the saved PM...
+        XCTAssertFalse(savedPMButton.isSelected)
+        // ...to Apple Pay.
+        XCTAssertEqual(sut.currentSelection, .applePay)
+        XCTAssertTrue(applePayRowButton.isSelected)
+
+        // Selecting card...
+        didTapPaymentMethodReturnValue = false // (and mocking `didTapPaymentMethod` to return false)
+        let cardButton = sut.getRowButton(accessibilityIdentifier: "Card")
+        sut.didTap(rowButton: cardButton, selection: .new(paymentMethodType: .stripe(.card)))
+        // ...should not change the current selection...
+        XCTAssertFalse(cardButton.isSelected)
+        // ...and Apple Pay should remain selected
+        XCTAssertEqual(sut.currentSelection, .applePay)
+        XCTAssertTrue(applePayRowButton.isSelected)
+    }
+
+}
+
+extension VerticalPaymentMethodListViewTest: VerticalPaymentMethodListViewDelegate {
+    func didTapPaymentMethod(_ selection: StripePaymentSheet.VerticalPaymentMethodListSelection) -> Bool {
+        return didTapPaymentMethodReturnValue
+    }
+}
+
+extension VerticalPaymentMethodListView {
+    func getRowButton(accessibilityIdentifier: String) -> RowButton {
+        return stackView.arrangedSubviews.compactMap { $0 as? RowButton }.first { $0.accessibilityIdentifier == accessibilityIdentifier }!
+    }
+}


### PR DESCRIPTION
## Summary
Tapping payment method vertical list either makes it selected or displays the payment method form.



https://github.com/stripe/stripe-ios/assets/47796191/3a7244e6-ee0b-469f-95df-7b7dccaa05d7

## Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-2066

## Testing
<!-- How was the code tested? Be as specific as possible. -->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
