### PR TITLE
Financial Connections: fixed a UI test failing.

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
@@ -181,8 +181,8 @@ final class FinancialConnectionsUITests: XCTestCase {
             // check that the WebView loaded
             var predicateString = "label CONTAINS '\(institutionName)'"
             if institutionName == "Chase" {
-                // Chase does not contain the word "Chase" on their log-in page
-                predicateString = "label CONTAINS 'username' OR label CONTAINS 'password'"
+                // Chase (usually) does not contain the word "Chase" on their log-in page
+                predicateString = "label CONTAINS '\(institutionName)' OR label CONTAINS 'username' OR label CONTAINS 'password'"
             }
             let institutionWebViewText = app.webViews
                 .staticTexts


### PR DESCRIPTION
## Summary

A bank changed their UX with a temporary pop-up and this caused UI test to fail. This PR modifies the logic to be more robust, and fixes the error.

## Testing

I ran the UI test that was failing and now it succeeds: 

![Screenshot 2024-05-21 at 3 10 14 PM](https://github.com/stripe/stripe-ios/assets/105514761/9d0e72b8-b7fe-4fe8-8811-5f51bd74376a)
