### PR TITLE
Financial Connections: removed beta tags

### DIFF
--- a/StripeFinancialConnections/README.md
+++ b/StripeFinancialConnections/README.md
@@ -1,4 +1,4 @@
-# <img src="../readme-images/FinancialConnections-light-80x80.png" width="40" /> Stripe Financial Connections iOS SDK (Beta)
+# <img src="../readme-images/FinancialConnections-light-80x80.png" width="40" /> Stripe Financial Connections iOS SDK
 
 Stripe Financial Connections iOS SDK lets your users securely share their financial data by linking their external financial accounts to your business in your iOS app.
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/FinancialConnectionsSheet.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/FinancialConnectionsSheet.swift
@@ -10,7 +10,6 @@ import UIKit
 
 /**
  A drop-in class that presents a sheet for a user to connect their financial accounts.
- This class is in beta; see https://stripe.com/docs/financial-connections for access
  */
 final public class FinancialConnectionsSheet {
 


### PR DESCRIPTION
## Summary

^ removed Financial Connections beta tags as its not in beta

## Testing

1. See that the only thing that's changed is non-production code (just docs)
2. Visit https://stripe.com/financial-connections and see no Beta tags there
3. Code search for beta tags: https://github.com/search?q=repo%3Astripe%2Fstripe-ios+beta+path%3AFinancialConnections&type=code