### PR TITLE
Fixed USBank and Financial Connections tests due to the "Success" test institution being reordered

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
@@ -44,10 +44,7 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
 
         app.fc_nativePrepaneContinueButton.tap()
 
-        let successInstitution = app.scrollViews.staticTexts["Success"]
-        XCTAssertTrue(successInstitution.waitForExistence(timeout: 60.0))
-        successInstitution.tap()
-
+        // "Success" institution is automatically selected in the Account Picker
         app.fc_nativeConnectAccountsButton.tap()
 
         let emailTextField = app.textFields["email_text_field"]

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
@@ -60,11 +60,9 @@ final class FinancialConnectionsUITests: XCTestCase {
         XCTAssertTrue(featuredLegacyTestInstitution.waitForExistence(timeout: 60.0))
         featuredLegacyTestInstitution.tap()
 
-        let successAccountRow = app.scrollViews.staticTexts["Success"]
-        XCTAssertTrue(successAccountRow.waitForExistence(timeout: 60.0))
-        successAccountRow.tap()
-
+        // "Success" institution is automatically selected as the first one
         app.fc_nativeConnectAccountsButton.tap()
+
         app.fc_nativeSuccessDoneButton.tap()
 
         // ensure alert body contains "Stripe Bank" (AKA one bank is linked)

--- a/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
@@ -586,8 +586,8 @@ class CustomerSheetUITest: XCTestCase {
         // Go through connections flow
         app.buttons["consent_agree_button"].tap()
         app.staticTexts["Test Institution"].forceTapElement()
-        app.staticTexts["Success"].waitForExistenceAndTap(timeout: timeout)
-        app.buttons["connect_accounts_button"].tap()
+        // "Success" institution is automatically selected because its the first
+        app.buttons["connect_accounts_button"].waitForExistenceAndTap(timeout: timeout)
 
         let notNowButton = app.buttons["Not now"]
         if notNowButton.waitForExistence(timeout: timeout) {
@@ -608,7 +608,7 @@ class CustomerSheetUITest: XCTestCase {
         XCTAssertTrue(confirmButton.waitForExistence(timeout: timeout))
         confirmButton.tap()
 
-        dismissAlertView(alertBody: "Success: ••••1113, selected", alertTitle: "Complete", buttonToTap: "OK")
+        dismissAlertView(alertBody: "Success: ••••6789, selected", alertTitle: "Complete", buttonToTap: "OK")
     }
     func testCustomerSheetStandard_applePayOff_addUSBankAccount_customerSession() throws {
         var settings = CustomerSheetTestPlaygroundSettings.defaultValues()
@@ -630,8 +630,8 @@ class CustomerSheetUITest: XCTestCase {
         // Go through connections flow
         app.buttons["consent_agree_button"].tap()
         app.staticTexts["Test Institution"].forceTapElement()
-        app.staticTexts["Success"].waitForExistenceAndTap(timeout: timeout)
-        app.buttons["connect_accounts_button"].tap()
+        // "Success" institution is automatically selected because its the first
+        app.buttons["connect_accounts_button"].waitForExistenceAndTap(timeout: timeout)
 
         let notNowButton = app.buttons["Not now"]
         if notNowButton.waitForExistence(timeout: timeout) {
@@ -652,7 +652,7 @@ class CustomerSheetUITest: XCTestCase {
         XCTAssertTrue(confirmButton.waitForExistence(timeout: timeout))
         confirmButton.tap()
 
-        dismissAlertView(alertBody: "Success: ••••1113, selected", alertTitle: "Complete", buttonToTap: "OK")
+        dismissAlertView(alertBody: "Success: ••••6789, selected", alertTitle: "Complete", buttonToTap: "OK")
     }
     func testCustomerSheetStandard_applePayOff_addSepa() throws {
         var settings = CustomerSheetTestPlaygroundSettings.defaultValues()
@@ -714,8 +714,8 @@ class CustomerSheetUITest: XCTestCase {
         // Go through connections flow
         app.buttons["consent_agree_button"].tap()
         app.staticTexts["Test Institution"].forceTapElement()
-        app.staticTexts["Success"].waitForExistenceAndTap(timeout: timeout)
-        app.buttons["connect_accounts_button"].tap()
+        // "Success" institution is automatically selected because its the first
+        app.buttons["connect_accounts_button"].waitForExistenceAndTap(timeout: 10)
 
         let notNowButton = app.buttons["Not now"]
         if notNowButton.waitForExistence(timeout: timeout) {
@@ -736,7 +736,7 @@ class CustomerSheetUITest: XCTestCase {
         XCTAssertTrue(confirmButton.waitForExistence(timeout: timeout))
         confirmButton.tap()
 
-        dismissAlertView(alertBody: "Success: ••••1113, selected", alertTitle: "Complete", buttonToTap: "OK")
+        dismissAlertView(alertBody: "Success: ••••6789, selected", alertTitle: "Complete", buttonToTap: "OK")
     }
     func testCustomerSheetStandard_applePayOff_addUSBankAccount_MicroDeposit() throws {
         var settings = CustomerSheetTestPlaygroundSettings.defaultValues()

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -3335,8 +3335,8 @@ extension PaymentSheetUITestCase {
         // Go through connections flow
         app.buttons["Agree and continue"].tap()
         app.staticTexts["Test Institution"].forceTapElement()
-        app.staticTexts["Success"].waitForExistenceAndTap(timeout: 10)
-        app.buttons["connect_accounts_button"].tap()
+        // "Success" institution is automatically selected because its the first
+        app.buttons["connect_accounts_button"].waitForExistenceAndTap(timeout: 10)
 
         let notNowButton = app.buttons["Not now"]
         if notNowButton.waitForExistence(timeout: 10.0) {
@@ -3355,7 +3355,7 @@ extension PaymentSheetUITestCase {
         // Reload and pay with the now-saved us bank account
         reload(app, settings: settings)
         app.buttons["Present PaymentSheet"].tap()
-        XCTAssertTrue(app.buttons["••••1113"].waitForExistenceAndTap())
+        XCTAssertTrue(app.buttons["••••6789"].waitForExistenceAndTap())
         XCTAssertTrue(app.buttons[confirmButtonText].waitForExistenceAndTap())
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10))
     }


### PR DESCRIPTION
## Summary

Fixed USBank and Financial Connections tests due to the "Success" test institution being reordered.

## Testing

1. I ran the tests locally to test the changes
2. Make sure this PR's tests pass
3. Run `bitrise run financial-connections-stability-tests`:

```
FinancialConnectionsNetworkingUITests
    ✓ testNativeNetworkingTestMode (126.803 seconds)
    ✓ testNativeNetworkingTestModeSignUpWithMultiSelectAndPrefilledEmail (32.064 seconds)
FinancialConnectionsUITests
    ✓ testDataLiveModeOAuthNativeAuthFlow (29.584 seconds)
    ✓ testDataLiveModeOAuthWebAuthFlow (20.291 seconds)
    ✓ testDataTestModeOAuthNativeAuthFlow (21.000 seconds)
    ✓ testPaymentSearchInLiveModeNativeAuthFlow (25.355 seconds)
    ✓ testPaymentTestModeLegacyNativeAuthFlow (19.193 seconds)
    ✓ testPaymentTestModeManualEntryNativeAuthFlow (24.572 seconds)
```