### PR TITLE
Instant Debits: added link_context to some payment sheet logs

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -48,6 +48,22 @@ extension PaymentSheet {
                 return paymentMethod
             }
         }
+
+        // Both "Link" and "Instant Debits" use the same payment method type
+        // of "link." To differentiate between the two in metrics, we sometimes
+        // need a "link_context."
+        var linkContext: String? {
+            if case .link = self {
+                return "wallet"
+            } else if
+                case .new(let confirmParams) = self,
+                confirmParams.instantDebitsLinkedBank != nil
+            {
+                return "instant_debits"
+            } else {
+                return nil
+            }
+        }
     }
 
     /// A class that presents the individual steps of a payment flow

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
@@ -36,6 +36,7 @@ extension STPAnalyticsClient {
         deferredIntentConfirmationType: DeferredIntentConfirmationType?,
         paymentMethodTypeAnalyticsValue: String? = nil,
         error: Error? = nil,
+        linkContext: String? = nil,
         apiClient: STPAPIClient
     ) {
         var success = false
@@ -64,6 +65,7 @@ extension STPAnalyticsClient {
             error: error,
             deferredIntentConfirmationType: deferredIntentConfirmationType,
             paymentMethodTypeAnalyticsValue: paymentMethodTypeAnalyticsValue,
+            linkContext: linkContext,
             apiClient: apiClient
         )
     }
@@ -143,9 +145,16 @@ extension STPAnalyticsClient {
         }
     }
 
-    func logPaymentSheetConfirmButtonTapped(paymentMethodTypeIdentifier: String) {
+    func logPaymentSheetConfirmButtonTapped(
+        paymentMethodTypeIdentifier: String,
+        linkContext: String? = nil
+    ) {
         let duration = AnalyticsHelper.shared.getDuration(for: .formShown)
-        logPaymentSheetEvent(event: .paymentSheetConfirmButtonTapped, duration: duration, paymentMethodTypeAnalyticsValue: paymentMethodTypeIdentifier)
+        logPaymentSheetEvent(
+            event: .paymentSheetConfirmButtonTapped,
+            duration: duration, paymentMethodTypeAnalyticsValue: paymentMethodTypeIdentifier,
+            linkContext: linkContext
+        )
     }
 
     enum DeferredIntentConfirmationType: String {
@@ -300,6 +309,7 @@ extension STPAnalyticsClient {
         error: Error? = nil,
         deferredIntentConfirmationType: DeferredIntentConfirmationType? = nil,
         paymentMethodTypeAnalyticsValue: String? = nil,
+        linkContext: String? = nil,
         params: [String: Any] = [:],
         apiClient: STPAPIClient = .shared
     ) {
@@ -316,6 +326,7 @@ extension STPAnalyticsClient {
         additionalParams["is_decoupled"] = intentConfig != nil
         additionalParams["deferred_intent_confirmation_type"] = deferredIntentConfirmationType?.rawValue
         additionalParams["selected_lpm"] = paymentMethodTypeAnalyticsValue
+        additionalParams["link_context"] = linkContext
 
         if let error {
             additionalParams.mergeAssertingOnOverwrites(error.serializeForV1Analytics())

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -450,7 +450,10 @@ class PaymentSheetViewController: UIViewController, PaymentSheetViewControllerPr
             }
             paymentOption = selectedPaymentOption
         }
-        STPAnalyticsClient.sharedClient.logPaymentSheetConfirmButtonTapped(paymentMethodTypeIdentifier: paymentOption.paymentMethodTypeAnalyticsValue)
+        STPAnalyticsClient.sharedClient.logPaymentSheetConfirmButtonTapped(
+            paymentMethodTypeIdentifier: paymentOption.paymentMethodTypeAnalyticsValue,
+            linkContext: paymentOption.linkContext
+        )
         pay(with: paymentOption, animateBuyButton: true)
     }
 
@@ -481,6 +484,7 @@ class PaymentSheetViewController: UIViewController, PaymentSheetViewControllerPr
                     deferredIntentConfirmationType: deferredIntentConfirmationType,
                     paymentMethodTypeAnalyticsValue: paymentOption.paymentMethodTypeAnalyticsValue,
                     error: result.error,
+                    linkContext: paymentOption.linkContext,
                     apiClient: self.configuration.apiClient
                 )
 


### PR DESCRIPTION
## Summary

Today, there's an issue where it's not easy to distinguish between "Link" and "Instant Debits" in metrics because they both use the "link" payment method. This PR adds a "link_context" to some metric logging to help distinguish between "Link" and "Instant Debits." The code tries to imitate what Android is already doing:
- https://github.com/stripe/stripe-android/pull/8382/files#diff-25047a570b80aaccb7028233681fb7213439cb9b2113f21d57b0aa6e1840774aR564-R569

## Testing

I looked at what the events were logging:

see "link_context" in `mc_confirm_button_tapped`:

```
LOG ANALYTICS: mc_confirm_button_tapped - [(key: "selected_lpm", value: "link"), (key: "pay_var", value: "paymentsheet"), (key: "ocr_type", value: "none"), (key: "locale", value: "en_US"), (key: "link_context", value: "instant_debits"), (key: "is_decoupled", value: false), (key: "duration", value: 65.77), (key: "apple_pay_enabled", value: 1)]
```


see "link_context" in `mc_complete_payment_newpm_success`:

```
LOG ANALYTICS: mc_complete_payment_newpm_success - [(key: "selected_lpm", value: "link"), (key: "pay_var", value: "paymentsheet"), (key: "ocr_type", value: "none"), (key: "locale", value: "en_US"), (key: "link_session_type", value: "shared"), (key: "link_enabled", value: true), (key: "link_context", value: "instant_debits"), (key: "is_decoupled", value: false), (key: "duration", value: 110.44), (key: "currency", value: "usd"), (key: "apple_pay_enabled", value: 1), (key: "active_link_session", value: false)]
```