### PR TITLE
Declare STPPaymentConfiguration shared property with let to prevent swift concurrency issue

### DIFF
--- a/Stripe/StripeiOS/Source/STPPaymentConfiguration.swift
+++ b/Stripe/StripeiOS/Source/STPPaymentConfiguration.swift
@@ -18,7 +18,7 @@ import Foundation
 public class STPPaymentConfiguration: NSObject, NSCopying {
     /// This is a convenience singleton configuration that uses the default values for
     /// every property
-    @objc(sharedConfiguration) public static var shared = STPPaymentConfiguration()
+    @objc(sharedConfiguration) public static let shared = STPPaymentConfiguration()
 
     private var _applePayEnabled = true
     /// The user is allowed to pay with Apple Pay if it's configured and available on their device.


### PR DESCRIPTION
## Summary
Declare `STPPaymentConfiguration` shared property with `let` to prevent swift concurrency error when enabling complete mode for strict concurrency checking in the project that uses this library. 

## Motivation
Here's the error raised by the compiler on the declaration side `@objc(sharedConfiguration) public static var shared = STPPaymentConfiguration()`:
 
`Class property 'shared' is not concurrency-safe because it is non-isolated global shared mutable state; this is an error in Swift 6`.

and here's the error on the use side of `STPPaymentConfiguration.shared`: 

`Reference to class property 'shared' is not concurrency-safe because it involves shared mutable state; this is an error in Swift 6`

Unfortunately, import Stripe using `@preconcurrency import` doesn't fix the issue.
