### PR TITLE
[RUN_LINK_PREFERENCE-241] Remove `link_2024_rebrand_m1` flag

### DIFF
--- a/StripePayments/StripePayments/Source/API Bindings/Models/Shared/LinkSettings.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/Shared/LinkSettings.swift
@@ -25,7 +25,6 @@ import Foundation
     @_spi(STP) public let popupWebviewOption: PopupWebviewOption?
     @_spi(STP) public let passthroughModeEnabled: Bool?
     @_spi(STP) public let disableSignup: Bool?
-    @_spi(STP) public let useRebrand: Bool?
     @_spi(STP) public let linkFlags: [String: Bool]?
 
     @_spi(STP) public let allResponseFields: [AnyHashable: Any]
@@ -36,7 +35,6 @@ import Foundation
         passthroughModeEnabled: Bool?,
         disableSignup: Bool?,
         linkFlags: [String: Bool]?,
-        useRebrand: Bool?,
         allResponseFields: [AnyHashable: Any]
     ) {
         self.fundingSources = fundingSources
@@ -44,7 +42,6 @@ import Foundation
         self.passthroughModeEnabled = passthroughModeEnabled
         self.disableSignup = disableSignup
         self.linkFlags = linkFlags
-        self.useRebrand = useRebrand
         self.allResponseFields = allResponseFields
     }
 
@@ -64,7 +61,6 @@ import Foundation
         let webviewOption = PopupWebviewOption(rawValue: response["link_popup_webview_option"] as? String ?? "")
         let passthroughModeEnabled = response["link_passthrough_mode_enabled"] as? Bool ?? false
         let disableSignup = response["link_mobile_disable_signup"] as? Bool ?? false
-        let useRebrand = response["link_2024_rebrand_m1"] as? Bool
 
         // Collect the flags for the URL generator
         let linkFlags = response.reduce(into: [String: Bool]()) { partialResult, element in
@@ -79,7 +75,6 @@ import Foundation
             passthroughModeEnabled: passthroughModeEnabled,
             disableSignup: disableSignup,
             linkFlags: linkFlags,
-            useRebrand: useRebrand,
             allResponseFields: response
         ) as? Self
     }


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Remove remaining `link_2024_rebrand_m1` flag usage since has been rolled out for >1 month. Posted in [#ios-eng](https://stripe.slack.com/archives/C09LXC5CZ/p1716565003488089) to make sure change is safe

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
[RUN_LINK_PREFERENCE-241](https://jira.corp.stripe.com/browse/RUN_LINK_PREFERENCE-241)

## Testing
<!-- How was the code tested? Be as specific as possible. -->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
