### PR TITLE
Instant Debits: fixed instant debits bank icon in dark mode

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentOption+Images.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentOption+Images.swift
@@ -146,7 +146,7 @@ extension STPPaymentMethodType {
     /// light/dark agnostic icons
     var iconRequiresTinting: Bool {
         switch self {
-        case .card, .AUBECSDebit, .USBankAccount, .linkInstantDebit, .konbini, .boleto:
+        case .card, .AUBECSDebit, .USBankAccount, .linkInstantDebit, .konbini, .boleto, .instantDebits:
             return true
         default:
             return false


### PR DESCRIPTION
## Summary

The instant debits "Bank" icon was not the right color in dark mode. This PR fixes that. See test plan ("Before") where the bank icon is dark-on-dark where it says "Bank" as payment method.

## Testing

| Before | After |
| --- | --- | 
| ![before_dark](https://github.com/stripe/stripe-ios/assets/105514761/8d22244b-e11f-4d54-981d-33080cac8f8e) | ![Simulator Screenshot - iPhone 15 Pro - 2024-05-29 at 10 58 01](https://github.com/stripe/stripe-ios/assets/105514761/e48e3785-f772-4d5b-8c18-92836c389e0b) |
| ![before_light](https://github.com/stripe/stripe-ios/assets/105514761/fa0844c9-b66d-4509-856f-6939ce7a56bf) | ![Simulator Screenshot - iPhone 15 Pro - 2024-05-29 at 10 58 07](https://github.com/stripe/stripe-ios/assets/105514761/5f7f5fb8-19e3-4d29-a0cb-e1fe4ea3148f) |


