### PR TITLE
Fix unconditionally printing warning in stpAssert(..)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Payments
 * [Added] Updated support for MobilePay bindings.
 * [Changed] Improved reliability and UX when paying with Cash App Pay.
+* [Fixed] Fixed printing spurious STPAssertionFailure warnings.
 
 ## 23.27.2 2024-05-06
 ### CardScan

--- a/StripeCore/StripeCore/Source/Helpers/STPAssert.swift
+++ b/StripeCore/StripeCore/Source/Helpers/STPAssert.swift
@@ -38,6 +38,8 @@ import Foundation
     #if ENABLE_STPASSERTIONFAILURE
     assert(condition(), message(), file: file, line: line)
     #else
-    print("⚠️ STPAssertionFailure: \(message()) in \(file) on line \(line)")
+    if !condition() {
+        print("⚠️ STPAssertionFailure: \(message()) in \(file) on line \(line)")
+    }
     #endif
 }


### PR DESCRIPTION
🤦

## Testing
Manually tested when ENABLE_STPASSERTIOFAILURE is false

## Changelog
[Fixed] Fixed printing spurious STPAssertionFailure warnings.