### PR TITLE
Financial Connections: for networking, re-enabled email auto-focus

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
@@ -49,7 +49,8 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
 
         let emailTextField = app.textFields["email_text_field"]
         XCTAssertTrue(emailTextField.waitForExistence(timeout: 120.0))  // wait for synchronize to complete
-        emailTextField.tap()
+        // there is no need to tap inside of the e-mail text
+        // field because we auto-focus it
         emailTextField.typeText(emailAddress)
 
         let phoneTextField = app.textFields["phone_text_field"]

--- a/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
@@ -591,6 +591,7 @@ class CustomerSheetUITest: XCTestCase {
 
         let notNowButton = app.buttons["Not now"]
         if notNowButton.waitForExistence(timeout: timeout) {
+            app.typeText(XCUIKeyboardKey.return.rawValue) // dismiss keyboard
             notNowButton.tap()
         }
 
@@ -635,6 +636,7 @@ class CustomerSheetUITest: XCTestCase {
 
         let notNowButton = app.buttons["Not now"]
         if notNowButton.waitForExistence(timeout: timeout) {
+            app.typeText(XCUIKeyboardKey.return.rawValue) // dismiss keyboard
             notNowButton.tap()
         }
 
@@ -719,6 +721,7 @@ class CustomerSheetUITest: XCTestCase {
 
         let notNowButton = app.buttons["Not now"]
         if notNowButton.waitForExistence(timeout: timeout) {
+            app.typeText(XCUIKeyboardKey.return.rawValue) // dismiss keyboard
             notNowButton.tap()
         }
 

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -3349,6 +3349,7 @@ extension PaymentSheetUITestCase {
 
         let notNowButton = app.buttons["Not now"]
         if notNowButton.waitForExistence(timeout: 10.0) {
+            app.typeText(XCUIKeyboardKey.return.rawValue) // dismiss keyboard
             notNowButton.tap()
         }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/EmailTextField.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/EmailTextField.swift
@@ -74,6 +74,10 @@ final class EmailTextField: UIView {
         }
     }
 
+    override func becomeFirstResponder() -> Bool {
+        return textField.becomeFirstResponder()
+    }
+
     override func endEditing(_ force: Bool) -> Bool {
         return textField.endEditing(force)
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupBodyFormView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupBodyFormView.swift
@@ -74,6 +74,10 @@ final class NetworkingLinkSignupBodyFormView: UIView {
         emailTextField.text = emailAddress
     }
 
+    func beginEditingEmailAddressField() {
+        _ = emailTextField.becomeFirstResponder()
+    }
+
     func endEditingEmailAddressField() {
         _ = emailTextField.endEditing(true)
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
@@ -166,6 +166,8 @@ final class NetworkingLinkSignupViewController: UIViewController {
         let emailAddress = dataSource.manifest.accountholderCustomerEmailAddress
         if let emailAddress, !emailAddress.isEmpty {
             formView.prefillEmailAddress(emailAddress)
+        } else {
+            formView.beginEditingEmailAddressField()
         }
 
         assert(self.footerView != nil, "footer view should be initialized as part of displaying content")


### PR DESCRIPTION
## Summary

https://jira.corp.stripe.com/browse/BANKCON-10930

This PR ensures that we auto-focus the email field in Financial Connection Networking Sign Up screen to reduce friction.

[This is a reverse of the following PR](https://github.com/stripe/stripe-ios/pull/2526).

![Simulator Screenshot - iPhone 15 Pro - 2024-05-29 at 13 27 11](https://github.com/stripe/stripe-ios/assets/105514761/6fd790a0-cfc6-4886-a3c6-0562c6b6528e)

## Testing

There's lots of UI tests that ensure this happens (I ran some + build will run some), but here's also a video:

https://github.com/stripe/stripe-ios/assets/105514761/5c415e76-e5f0-4059-ad49-0361b6ceae6f

And this video shows we don't accidentally auto-focus it (when the email is there):

https://github.com/stripe/stripe-ios/assets/105514761/874bb066-8219-447e-b626-daa5ae009797
