### PR TITLE
Financial Connections: for networking sign up, started auto focusing the phone field when email is prefilled.

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundConfiguration.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundConfiguration.swift
@@ -240,6 +240,20 @@ final class PlaygroundConfiguration {
         }
     }
 
+    private static let phoneKey = "phone"
+    var phone: String {
+        get {
+            if let phone = configurationStore[Self.phoneKey] as? String {
+                return phone
+            } else {
+                return ""
+            }
+        }
+        set {
+            configurationStore[Self.phoneKey] = newValue
+        }
+    }
+
     // MARK: - Permissions
 
     private static let balancesPermissionKey = "balances_permission"
@@ -320,6 +334,7 @@ final class PlaygroundConfiguration {
             let dictionary = jsonObject as? [String: Any]
         else {
             // this prevents anyone from overriding the configuration with something wrong
+            assertionFailure("failed to update configuration string")
             return
         }
 
@@ -373,6 +388,12 @@ final class PlaygroundConfiguration {
             self.email = email
         } else {
             self.email = ""
+        }
+
+        if let phone = dictionary[Self.phoneKey] as? String {
+            self.phone = phone
+        } else {
+            self.phone = ""
         }
 
         if let balancesPermission = dictionary[Self.balancesPermissionKey] as? Bool {

--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundView.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundView.swift
@@ -78,6 +78,9 @@ struct PlaygroundView: View {
                             .keyboardType(.emailAddress)
                             .autocapitalization(.none)
                             .accessibility(identifier: "playground-email")
+                        TextField("Phone", text: viewModel.phone)
+                            .keyboardType(.phonePad)
+                            .accessibility(identifier: "playground-phone")
                     }
 
                     Section(header: Text("PERMISSIONS")) {

--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundViewModel.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundViewModel.swift
@@ -99,6 +99,18 @@ final class PlaygroundViewModel: ObservableObject {
         )
     }
 
+    var phone: Binding<String> {
+        Binding(
+            get: {
+                self.playgroundConfiguration.phone
+            },
+            set: {
+                self.playgroundConfiguration.phone = $0
+                self.objectWillChange.send()
+            }
+        )
+    }
+
     var balancesPermission: Binding<Bool> {
         Binding(
             get: {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
@@ -312,24 +312,11 @@ extension NetworkingLinkSignupViewController: NetworkingLinkSignupBodyFormViewDe
                         // first time they enter the e-mail
                         if didShowPhoneNumberFieldForTheFirstTime {
                             let didPrefillPhoneNumber = (self.formView.phoneTextField.phoneNumber?.number ?? "").count > 1
-                            // if the phone number is pre-filled, we don't focus on the phone number field
                             if !didPrefillPhoneNumber {
-                                let didPrefillEmailAddress = {
-                                    if
-                                        let accountholderCustomerEmailAddress = self.dataSource.manifest.accountholderCustomerEmailAddress,
-                                        !accountholderCustomerEmailAddress.isEmpty
-                                    {
-                                        return true
-                                    } else {
-                                        return false
-                                    }
-                                }()
-                                // we don't want to auto-focus the phone number field if we pre-filled the email
-                                if !didPrefillEmailAddress {
-                                    // this disables the "Phone" label animating (we don't want that animation here)
-                                    UIView.performWithoutAnimation {
-                                        self.formView.beginEditingPhoneNumberField()
-                                    }
+                                // this disables the "Phone" label animating (we don't want that animation here)
+                                UIView.performWithoutAnimation {
+                                    // auto-focus the non-prefilled phone field
+                                    self.formView.beginEditingPhoneNumberField()
                                 }
                             } else {
                                 // user is done with e-mail AND phone number, so dismiss the keyboard


### PR DESCRIPTION
## Summary

https://jira.corp.stripe.com/browse/BANKCON-10930

This PR ensures that we auto-focus the phone field IF the email field is prefilled already in the Networking Sign Up pane. The goal is to reduce friction.

[This builds on the following PR.](https://github.com/stripe/stripe-ios/pull/3614)

[And is a reversal of this PR.](https://github.com/stripe/stripe-ios/pull/2528)

[Email PR](https://github.com/stripe/stripe-ios/pull/3614).

## Testing

1. There's a bunch of UI tests that interact with this screen
2. I also wrote an extra UI test
3. There's a video below showing two cases around the phone field

https://github.com/stripe/stripe-ios/assets/105514761/bb8976a8-5321-4801-ad3f-53898bb2f8bc

