### PR TITLE
Fix link phone number country bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## x.x.x xxxx-xx-xx
 ### PaymentSheet
 * [Changed] Improved reliability and UX when paying with Cash App Pay.
+* [Fixed] Fixed an issue where changing the country of a phone number would not update the UI when the phone number's validity changed.
 
 ### Payments
 * [Added] Updated support for MobilePay bindings.

--- a/StripeUICore/StripeUICore/Source/Validators/PhoneNumber.swift
+++ b/StripeUICore/StripeUICore/Source/Validators/PhoneNumber.swift
@@ -436,6 +436,6 @@ import UIKit
 
 extension PhoneNumber: Equatable {
     public static func == (lhs: PhoneNumber, rhs: PhoneNumber) -> Bool {
-        return lhs.number == rhs.number
+        return lhs.number == rhs.number && lhs.countryCode == rhs.countryCode
     }
 }

--- a/StripeUICore/StripeUICore/Source/Validators/PhoneNumber.swift
+++ b/StripeUICore/StripeUICore/Source/Validators/PhoneNumber.swift
@@ -436,6 +436,6 @@ import UIKit
 
 extension PhoneNumber: Equatable {
     public static func == (lhs: PhoneNumber, rhs: PhoneNumber) -> Bool {
-        return lhs.number == rhs.number && lhs.countryCode == rhs.countryCode
+        return lhs.string(as: .e164) == rhs.string(as: .e164)
     }
 }

--- a/StripeUICore/StripeUICoreTests/Unit/Validators/PhoneNumberTests.swift
+++ b/StripeUICore/StripeUICoreTests/Unit/Validators/PhoneNumberTests.swift
@@ -191,7 +191,7 @@ class PhoneNumberTests: XCTestCase {
             PhoneNumber(number: "08022223333", countryCode: "JP"),
             PhoneNumber(number: "08022223333", countryCode: "US")
         )
-        XCTAssertNotEqual(
+        XCTAssertEqual(
             PhoneNumber(number: "+08022223333", countryCode: "US"),
             PhoneNumber(number: "08022223333", countryCode: "US")
         )

--- a/StripeUICore/StripeUICoreTests/Unit/Validators/PhoneNumberTests.swift
+++ b/StripeUICore/StripeUICoreTests/Unit/Validators/PhoneNumberTests.swift
@@ -182,4 +182,18 @@ class PhoneNumberTests: XCTestCase {
         XCTAssertEqual(PhoneNumber.fromE164(number, locale: .init(identifier: "ar_LB"))?.countryCode, "US")
     }
 
+    func testEquals() {
+        XCTAssertEqual(
+            PhoneNumber(number: "08022223333", countryCode: "JP"),
+            PhoneNumber(number: "08022223333", countryCode: "JP")
+        )
+        XCTAssertNotEqual(
+            PhoneNumber(number: "08022223333", countryCode: "JP"),
+            PhoneNumber(number: "08022223333", countryCode: "US")
+        )
+        XCTAssertNotEqual(
+            PhoneNumber(number: "+08022223333", countryCode: "US"),
+            PhoneNumber(number: "08022223333", countryCode: "US")
+        )
+    }
 }


### PR DESCRIPTION
## Summary
Fixed an issue where changing the country of a phone number would not update the UI when the phone number's validity changed.

## Motivation
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-3197

## Testing
Manually tested the Link signup correctly disables the buy button when changing the country such that it invalidates the phone number e.g. going from US valid phone number -> changing country to AR.

## Changelog
See changelog
