### PR TITLE
Instant Debits: fixed an issue where banks would sometimes have a + sign instead of a space

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsWebFlowViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsWebFlowViewController.swift
@@ -292,7 +292,10 @@ extension FinancialConnectionsWebFlowViewController {
         return components
             .queryItems?
             .first(where: { $0.name == key })?
-            .value?.removingPercentEncoding
+            .value?
+            .removingPercentEncoding?
+        // backend can return "+" instead of a more-common encoding of "%20" for spaces
+            .replacingOccurrences(of: "+", with: " ")
     }
 }
 


### PR DESCRIPTION
## Summary

^ see title where banks with spaces would be returned with a space in between:

```
▿ InstantDebitsLinkedBankImplementation
  - paymentMethodId : "...."
  ▿ bankName : Optional<String>
    - some : "Bank+of+America". //// <----- this is a problem
  ▿ last4 : Optional<String>
    - some : "1234"
```

## Testing

Here in the screenshot we can see that the bank with spaces is now 


| Before | After |
| --- | --- |
| ![Screenshot 2024-05-30 at 3 07 50 PM](https://github.com/stripe/stripe-ios/assets/105514761/e0aea169-7323-4ed9-8fce-aa9ed3bc02d6) | ![IMG_63E00D66962A-1](https://github.com/stripe/stripe-ios/assets/105514761/9a5f3f88-1a83-4328-92ab-3bec0854ccf9) |




