### PR TITLE
Improve stripecore.stripeerror loggability

### DIFF
--- a/StripeCore/StripeCore/Source/API Bindings/STPAPIClient.swift
+++ b/StripeCore/StripeCore/Source/API Bindings/STPAPIClient.swift
@@ -522,7 +522,7 @@ extension STPAPIClient {
     }
 
     /// Decodes request data to see if it can be parsed as a Stripe error.
-    private static func decodeStripeErrorResponse(
+    static func decodeStripeErrorResponse(
         data: Data,
         response: URLResponse?
     ) -> StripeError? {
@@ -534,6 +534,8 @@ extension STPAPIClient {
             var apiError = decodedErrorResponse.error
         {
             apiError.statusCode = (response as? HTTPURLResponse)?.statusCode
+            apiError.requestID = (response as? HTTPURLResponse)?.value(forHTTPHeaderField: "request-id")
+
             decodedError = StripeError.apiError(apiError)
         }
 

--- a/StripeCore/StripeCore/Source/API Bindings/StripeError.swift
+++ b/StripeCore/StripeCore/Source/API Bindings/StripeError.swift
@@ -22,6 +22,29 @@ import Foundation
     }
 }
 
+extension StripeError: AnalyticLoggableError {
+    public var additionalNonPIIErrorDetails: [String: Any] {
+        [:]
+    }
+    public var analyticsErrorCode: String {
+        switch self {
+        case .invalidRequest:
+            "invalidRequest"
+        case .apiError(let stripeAPIError):
+            stripeAPIError.code ?? ""
+        }
+    }
+
+    public var analyticsErrorType: String {
+        switch self {
+        case .invalidRequest:
+            return String(reflecting: type(of: self))
+        case .apiError(let stripeAPIError):
+            return stripeAPIError.type.rawValue
+        }
+    }
+}
+
 // MARK: - LocalizedError
 
 extension StripeError: LocalizedError {

--- a/StripeCore/StripeCore/Source/API Bindings/StripeServiceError.swift
+++ b/StripeCore/StripeCore/Source/API Bindings/StripeServiceError.swift
@@ -31,6 +31,8 @@ import Foundation
     @_spi(STP) public var param: String?
     /// The response’s HTTP status code.
     @_spi(STP) public var statusCode: Int?
+    /// The Stripe API request ID, if available. Looks like `req_123`.
+    @_spi(STP) public var requestID: String?
 
     // More information may be available in `allResponseFields`, including
     // the PaymentIntent or PaymentMethod.

--- a/StripeCore/StripeCore/Source/Analytics/AnalyticLoggableError.swift
+++ b/StripeCore/StripeCore/Source/Analytics/AnalyticLoggableError.swift
@@ -74,7 +74,7 @@ extension AnalyticLoggableError where Self: Error {}
         ]
         params["request_id"] = Self.extractStripeAPIRequestID(from: self)
 
-        if let analyticLoggableError = self as? AnalyticLoggableError {
+        if let analyticLoggableError = self as? AnalyticLoggableError, !analyticLoggableError.additionalNonPIIErrorDetails.isEmpty {
             params["error_details"] = analyticLoggableError.additionalNonPIIErrorDetails
         }
         return params
@@ -131,6 +131,8 @@ extension AnalyticLoggableError where Self: Error {}
         let error = error as NSError
         if error.domain == STPError.stripeDomain {
             return error.userInfo[STPError.stripeRequestIDKey] as? String
+        } else if let error = error as? StripeCore.StripeError, case let .apiError(apiError) = error {
+            return apiError.requestID
         } else {
             return nil
         }

--- a/StripeCore/StripeCoreTests/Analytics/AnalyticLoggableErrorTest.swift
+++ b/StripeCore/StripeCoreTests/Analytics/AnalyticLoggableErrorTest.swift
@@ -111,6 +111,36 @@ class AnalyticLoggableErrorTest: XCTestCase {
                 "error_code": "-1009",
             ]
         )
+
+        // StripeCore.StripeError
+        func CreateStripeError() -> StripeError {
+            let errorJson: [String: Any] = [
+                "error": [
+                    "type": "card_error",
+                    "message": "Your card number is incorrect.",
+                    "code": "incorrect_number",
+                ],
+            ]
+            let errorJsonData = try! JSONSerialization.data(
+                withJSONObject: errorJson,
+                options: [.prettyPrinted]
+            )
+            let decodedErrorResponse: StripeAPIErrorResponse = try! StripeJSONDecoder.decode(
+                jsonData: errorJsonData
+            )
+            var apiError = decodedErrorResponse.error!
+            apiError.statusCode = 402
+            return StripeError.apiError(apiError)
+        }
+        let stripeCoreStripeError = CreateStripeError()
+        XCTAssertEqual(
+            stripeCoreStripeError.serializeForV1Analytics() as? [String: String],
+            [
+                "error_type": "card_error",
+                "error_code": "incorrect_number",
+                "request_id": "req_123",
+            ]
+        )
     }
 
     func testAnalyticLoggableError() {

--- a/StripeCore/StripeCoreTests/Analytics/AnalyticLoggableErrorTest.swift
+++ b/StripeCore/StripeCoreTests/Analytics/AnalyticLoggableErrorTest.swift
@@ -32,15 +32,32 @@ class AnalyticLoggableErrorTest: XCTestCase {
 
     func testSerializeForV1Logging() {
         // Stripe API Error
-        let stripeAPIError = NSError.stp_error(fromStripeResponse: [
+        let stripeAPIErrorJSON = [
             "error": [
                 "type": "card_error",
                 "message": "Your card number is incorrect.",
                 "code": "incorrect_number",
             ],
-        ], httpResponse: HTTPURLResponse(url: URL(string: "https://api.stripe.com/v1/some_endpoint")!, statusCode: 402, httpVersion: nil, headerFields: ["request-id": "req_123"]))!
+        ]
+        let stripeAPIErrorHTTPResponse = HTTPURLResponse(url: URL(string: "https://api.stripe.com/v1/some_endpoint")!, statusCode: 402, httpVersion: nil, headerFields: ["request-id": "req_123"])
+        let stripeAPIError = NSError.stp_error(fromStripeResponse: stripeAPIErrorJSON, httpResponse: stripeAPIErrorHTTPResponse)!
         XCTAssertEqual(
             stripeAPIError.serializeForV1Analytics() as? [String: String],
+            [
+                "error_type": "card_error",
+                "error_code": "incorrect_number",
+                "request_id": "req_123",
+            ]
+        )
+
+        // StripeCore.StripeError.stripeAPIError - same as above, but different type
+        let stripeAPIErrorJSONData = try! JSONSerialization.data(
+            withJSONObject: stripeAPIErrorJSON,
+            options: [.prettyPrinted]
+        )
+        let stripeCoreStripeError = STPAPIClient.decodeStripeErrorResponse(data: stripeAPIErrorJSONData, response: stripeAPIErrorHTTPResponse)!
+        XCTAssertEqual(
+            stripeCoreStripeError.serializeForV1Analytics() as? [String: String],
             [
                 "error_type": "card_error",
                 "error_code": "incorrect_number",
@@ -109,36 +126,6 @@ class AnalyticLoggableErrorTest: XCTestCase {
             [
                 "error_type": "NSURLErrorDomain",
                 "error_code": "-1009",
-            ]
-        )
-
-        // StripeCore.StripeError
-        func CreateStripeError() -> StripeError {
-            let errorJson: [String: Any] = [
-                "error": [
-                    "type": "card_error",
-                    "message": "Your card number is incorrect.",
-                    "code": "incorrect_number",
-                ],
-            ]
-            let errorJsonData = try! JSONSerialization.data(
-                withJSONObject: errorJson,
-                options: [.prettyPrinted]
-            )
-            let decodedErrorResponse: StripeAPIErrorResponse = try! StripeJSONDecoder.decode(
-                jsonData: errorJsonData
-            )
-            var apiError = decodedErrorResponse.error!
-            apiError.statusCode = 402
-            return StripeError.apiError(apiError)
-        }
-        let stripeCoreStripeError = CreateStripeError()
-        XCTAssertEqual(
-            stripeCoreStripeError.serializeForV1Analytics() as? [String: String],
-            [
-                "error_type": "card_error",
-                "error_code": "incorrect_number",
-                "request_id": "req_123",
             ]
         )
     }


### PR DESCRIPTION
## Summary
Conform StripeCore.StripeError to AnalyticLoggableError and add requestID when we log it.

## Motivation
I forgot StripeCore.StripeError is another representation of the same underlying Stripe API error. Today StripeCore.StripeError get logged with `error_type = StripeCore.StripeError` and  `error_code = apiError`.

In comparison, other Stripe API errors use the actual API error's type, code, and request ID. 

## Testing
See unit test

## Changelog
not user facing