### PR TITLE
Fall back to locale country code in Link createPaymentDetails

### DIFF
--- a/Stripe/StripeiOSTests/ConsumerSessionTests.swift
+++ b/Stripe/StripeiOSTests/ConsumerSessionTests.swift
@@ -141,72 +141,70 @@ class ConsumerSessionTests: XCTestCase {
 
         wait(for: [expectation], timeout: STPTestingNetworkRequestTimeout)
 
-        if let consumerSession = sessionWithKey?.consumerSession {
-            let cardParams = STPPaymentMethodCardParams()
-            cardParams.number = "4242424242424242"
-            cardParams.expMonth = 12
-            cardParams.expYear = NSNumber(
-                value: Calendar.autoupdatingCurrent.component(.year, from: Date()) + 1
-            )
-            cardParams.cvc = "123"
+        let consumerSession = sessionWithKey!.consumerSession
+        let cardParams = STPPaymentMethodCardParams()
+        cardParams.number = "4242424242424242"
+        cardParams.expMonth = 12
+        cardParams.expYear = NSNumber(
+            value: Calendar.autoupdatingCurrent.component(.year, from: Date()) + 1
+        )
+        cardParams.cvc = "123"
 
-            let billingParams = STPPaymentMethodBillingDetails()
-            billingParams.name = "Payments SDK CI"
-            let address = STPPaymentMethodAddress()
-            address.postalCode = "55555"
-            address.country = "US"
-            billingParams.address = address
+        let billingParams = STPPaymentMethodBillingDetails()
+        billingParams.name = "Payments SDK CI"
+        let address = STPPaymentMethodAddress()
+        address.postalCode = "55555"
+        address.country = "US"
+        billingParams.address = address
 
-            let paymentMethodParams = STPPaymentMethodParams.paramsWith(
-                card: cardParams,
-                billingDetails: billingParams,
-                metadata: nil
-            )
+        let paymentMethodParams = STPPaymentMethodParams.paramsWith(
+            card: cardParams,
+            billingDetails: billingParams,
+            metadata: nil
+        )
 
-            let createExpectation = self.expectation(description: "create payment details")
-            let logoutExpectation = self.expectation(description: "logout")
-            let useDetailsAfterLogoutExpectation = self.expectation(description: "try using payment details after logout")
-            consumerSession.createPaymentDetails(
-                paymentMethodParams: paymentMethodParams,
-                with: apiClient,
-                consumerAccountPublishableKey: sessionWithKey?.publishableKey
-            ) { result in
-                switch result {
-                case .success(let createdPaymentDetails):
-                    // If this succeeds, log out...
-                    consumerSession.logout(with: self.apiClient, consumerAccountPublishableKey: sessionWithKey?.publishableKey) { logoutResult in
-                        switch logoutResult {
-                        case .success:
-                            // Try to use the session again, it shouldn't work
-                            consumerSession.createPaymentDetails(paymentMethodParams: paymentMethodParams, with: self.apiClient, consumerAccountPublishableKey: sessionWithKey?.publishableKey) { loggedOutAuthenticatedActionResult in
-                                switch loggedOutAuthenticatedActionResult {
-                                case .success(let success):
-                                    XCTFail("Logout failed to invalidate token")
-                                case .failure(let error):
+        let createExpectation = self.expectation(description: "create payment details")
+        let logoutExpectation = self.expectation(description: "logout")
+        let useDetailsAfterLogoutExpectation = self.expectation(description: "try using payment details after logout")
+        consumerSession.createPaymentDetails(
+            paymentMethodParams: paymentMethodParams,
+            with: apiClient,
+            consumerAccountPublishableKey: sessionWithKey?.publishableKey
+        ) { result in
+            switch result {
+            case .success(let createdPaymentDetails):
+                // If this succeeds, log out...
+                consumerSession.logout(with: self.apiClient, consumerAccountPublishableKey: sessionWithKey?.publishableKey) { logoutResult in
+                    switch logoutResult {
+                    case .success:
+                        // Try to use the session again, it shouldn't work
+                        consumerSession.createPaymentDetails(paymentMethodParams: paymentMethodParams, with: self.apiClient, consumerAccountPublishableKey: sessionWithKey?.publishableKey) { loggedOutAuthenticatedActionResult in
+                            switch loggedOutAuthenticatedActionResult {
+                            case .success(let success):
+                                XCTFail("Logout failed to invalidate token")
+                            case .failure(let error):
 
-                                    guard let stripeError = error as? StripeError,
-                                        case let .apiError(stripeAPIError) = stripeError else {
-                                        XCTFail("Received unexpected error response")
-                                        return
-                                    }
-                                    XCTAssertEqual(stripeAPIError.code, "consumer_session_credentials_invalid")
+                                guard let stripeError = error as? StripeError,
+                                      case let .apiError(stripeAPIError) = stripeError else {
+                                    XCTFail("Received unexpected error response")
+                                    return
                                 }
-                                useDetailsAfterLogoutExpectation.fulfill()
+                                XCTAssertEqual(stripeAPIError.code, "consumer_session_credentials_invalid")
                             }
-                        case .failure(let error):
-                            XCTFail("Logout failed: \(error.nonGenericDescription)")
+                            useDetailsAfterLogoutExpectation.fulfill()
                         }
-                        logoutExpectation.fulfill()
+                    case .failure(let error):
+                        XCTFail("Logout failed: \(error.nonGenericDescription)")
                     }
-                case .failure(let error):
-                    XCTFail("Received error: \(error.nonGenericDescription)")
+                    logoutExpectation.fulfill()
                 }
-
-                createExpectation.fulfill()
+            case .failure(let error):
+                XCTFail("Received error: \(error.nonGenericDescription)")
             }
 
-            waitForExpectations(timeout: STPTestingNetworkRequestTimeout)
+            createExpectation.fulfill()
         }
-    }
 
+        waitForExpectations(timeout: STPTestingNetworkRequestTimeout)
+    }
 }


### PR DESCRIPTION

## Motivation
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-3241

## Testing
Manually tested using the ConsumerSessionTests - if I don't set address.country, the Link flow fails.  After this change, it succeeds.

## Changelog
Not user facing?