### PR TITLE
Instant Debits: switched Instant Debits payment method to be more correct in when its enabled

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsWebFlowViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsWebFlowViewController.swift
@@ -165,7 +165,9 @@ extension FinancialConnectionsWebFlowViewController {
                         {
                             let instantDebitsLinkedBank = InstantDebitsLinkedBankImplementation(
                                 paymentMethodId: paymentMethodId,
-                                bankName: Self.extractValue(from: returnUrl, key: "bank_name"),
+                                bankName: Self.extractValue(from: returnUrl, key: "bank_name")?
+                                // backend can return "+" instead of a more-common encoding of "%20" for spaces
+                                    .replacingOccurrences(of: "+", with: " "),
                                 last4: Self.extractValue(from: returnUrl, key: "last4")
                             )
                             self.notifyDelegateOfSuccess(result: .instantDebits(instantDebitsLinkedBank))
@@ -293,9 +295,7 @@ extension FinancialConnectionsWebFlowViewController {
             .queryItems?
             .first(where: { $0.name == key })?
             .value?
-            .removingPercentEncoding?
-        // backend can return "+" instead of a more-common encoding of "%20" for spaces
-            .replacingOccurrences(of: "+", with: " ")
+            .removingPercentEncoding
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
@@ -23,6 +23,7 @@ extension PaymentSheet {
         .klarna, .afterpayClearpay, .affirm,
         .iDEAL, .bancontact, .sofort, .SEPADebit, .EPS, .giropay, .przelewy24,
         .USBankAccount,
+        .instantDebits,
         .AUBECSDebit,
         .UPI,
         .cashApp,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactoryTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactoryTest.swift
@@ -1154,6 +1154,11 @@ class PaymentSheetFormFactoryTest: XCTestCase {
             var form = factory.make()
             if let wrapper = form as? PaymentMethodElementWrapper<FormElement> {
                 form = wrapper.element
+            } else if
+                let wrapper = form as? ContainerElement,
+                let _form = wrapper.elements.first as? FormElement
+            {
+                form = _form
             }
 
             guard let form = form as? FormElement else {


### PR DESCRIPTION
## Summary

^

This [Slack thread](https://stripe.slack.com/archives/C02HQBW38JX/p1717178825321049?thread_ts=1717108585.415089&cid=C02HQBW38JX) brought up a need to double check whether the Instant Debits logic is the same as Android, and this PR modifies the logic of whether to add `.instantDebits` just a little bit. 

Note that Instant Debits is still not released to users and is in active development.

## Testing

I ran the UI tests manually myself which check Instant Debits end-to-end (payment and setup intents):

![Screenshot 2024-05-31 at 11 48 27 AM](https://github.com/stripe/stripe-ios/assets/105514761/b99d4fa3-e281-4ab5-a1d5-9df4a8ffdd95)

These tests will also be run on this PR by Bitrise!