### PR TITLE
Refactor, DRY AddPaymentMethodViewController

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
+++ b/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
@@ -208,6 +208,7 @@
 		B63B2CF32BFBEE7B003810F3 /* VerticalPaymentMethodListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B63B2CF22BFBEE7B003810F3 /* VerticalPaymentMethodListViewController.swift */; };
 		B63B2CF52BFBEEAD003810F3 /* PaymentMethodFormViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B63B2CF42BFBEEAD003810F3 /* PaymentMethodFormViewController.swift */; };
 		B63B2CF72BFC116A003810F3 /* VerticalPaymentSheetViewControllerSnapshotTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B63B2CF62BFC116A003810F3 /* VerticalPaymentSheetViewControllerSnapshotTest.swift */; };
+		B65B42972C013DED00EC565D /* PaymentMethodFormViewControllerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B65B42962C013DED00EC565D /* PaymentMethodFormViewControllerTest.swift */; };
 		B65FE7092BED33EA009A73FC /* VerticalPaymentMethodListViewSnapshotTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B65FE7082BED33EA009A73FC /* VerticalPaymentMethodListViewSnapshotTest.swift */; };
 		B667BF0B2BF2B7C60050EFD8 /* RowButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B667BF0A2BF2B7C60050EFD8 /* RowButton.swift */; };
 		B6859A882BE54CD30018E06C /* PaymentSheetVerticalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6859A872BE54CD30018E06C /* PaymentSheetVerticalViewController.swift */; };
@@ -552,6 +553,7 @@
 		B63B2CF22BFBEE7B003810F3 /* VerticalPaymentMethodListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalPaymentMethodListViewController.swift; sourceTree = "<group>"; };
 		B63B2CF42BFBEEAD003810F3 /* PaymentMethodFormViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaymentMethodFormViewController.swift; sourceTree = "<group>"; };
 		B63B2CF62BFC116A003810F3 /* VerticalPaymentSheetViewControllerSnapshotTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalPaymentSheetViewControllerSnapshotTest.swift; sourceTree = "<group>"; };
+		B65B42962C013DED00EC565D /* PaymentMethodFormViewControllerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodFormViewControllerTest.swift; sourceTree = "<group>"; };
 		B65FE7082BED33EA009A73FC /* VerticalPaymentMethodListViewSnapshotTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalPaymentMethodListViewSnapshotTest.swift; sourceTree = "<group>"; };
 		B667BF0A2BF2B7C60050EFD8 /* RowButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RowButton.swift; sourceTree = "<group>"; };
 		B667E074D30964FABC64B552 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -1375,6 +1377,7 @@
 				619AF0882BF56F9100D1C981 /* VerticalSavedPaymentMethodsViewControllerTests.swift */,
 				AA8F7F2824DFC78268ED6459 /* PaymentSheet+DeferredAPITest.swift */,
 				135B7354260E0E7CADCF3426 /* PaymentSheetAddressTests.swift */,
+				B65B42962C013DED00EC565D /* PaymentMethodFormViewControllerTest.swift */,
 				357B9EB0751819566843117E /* PaymentSheetDeferredValidatorTests.swift */,
 				5F884F7A5FF4FC6D0E24E6FC /* PaymentSheetErrorTest.swift */,
 				B63B2CF02BF8313D003810F3 /* VerticalPaymentMethodListViewTest.swift */,
@@ -1682,6 +1685,7 @@
 				34CF08CBC636F596B8BA4C12 /* TextFieldElement+CardTest.swift in Sources */,
 				52B734BA0B91706F37025523 /* STPAnalyticsClient+PaymentSheetTests.swift in Sources */,
 				AE8EF3966E7BABDFC3B426ED /* PaymentSheet+DashboardConfirmParamsTest.swift in Sources */,
+				B65B42972C013DED00EC565D /* PaymentMethodFormViewControllerTest.swift in Sources */,
 				C28450436BDA52BE9BE3BDC3 /* PaymentSheetConfigurationTests.swift in Sources */,
 				F1A350D67665949CF91A0C02 /* CustomerSheetConfigurationTests.swift in Sources */,
 			);

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
@@ -267,8 +267,7 @@ class AddPaymentMethodViewController: UIViewController {
             paymentMethod: type,
             previousCustomerInput: previousCustomerInput,
             offerSaveToLinkWhenSupported: offerSaveToLinkWhenSupported,
-            linkAccount: LinkAccountContext.shared.account,
-            cardBrandChoiceEligible: intent.cardBrandChoiceEligible
+            linkAccount: LinkAccountContext.shared.account
         ).make()
         formElement.delegate = self
         return formElement

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
@@ -55,33 +55,7 @@ class AddPaymentMethodViewController: UIViewController {
         return paymentMethodTypesView.selected
     }
     var paymentOption: PaymentOption? {
-        if let linkEnabledElement = paymentMethodFormElement as? LinkEnabledPaymentMethodElement {
-            return linkEnabledElement.makePaymentOption()
-        } else if let instantDebitsFormElement = paymentMethodFormElement as? InstantDebitsPaymentMethodElement {
-            // we use `.instantDebits` payment method locally to display a
-            // new button, but the actual payment method is `.link`, so
-            // here we change it for the intent confirmation process
-            let paymentMethodParams = STPPaymentMethodParams(type: .link)
-            let intentConfirmParams = IntentConfirmParams(
-                params: paymentMethodParams,
-                type: .stripe(.link)
-            )
-            if let confirmParams = instantDebitsFormElement.updateParams(params: intentConfirmParams) {
-                return .new(confirmParams: confirmParams)
-            } else {
-                return nil
-            }
-        }
-
-        let params = IntentConfirmParams(type: selectedPaymentMethodType)
-        params.setDefaultBillingDetailsIfNecessary(for: configuration)
-        if let params = paymentMethodFormElement.updateParams(params: params) {
-            if case .external(let paymentMethod) = selectedPaymentMethodType {
-                return .external(paymentMethod: paymentMethod, billingDetails: params.paymentMethodParams.nonnil_billingDetails)
-            }
-            return .new(confirmParams: params)
-        }
-        return nil
+        return paymentMethodFormViewController.paymentOption
     }
 
     var overrideCallToAction: ConfirmButton.CallToActionType? {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -60,7 +60,6 @@ class PaymentSheetFormFactory {
         addressSpecProvider: AddressSpecProvider = .shared,
         offerSaveToLinkWhenSupported: Bool = false,
         linkAccount: PaymentSheetLinkAccount? = nil,
-        cardBrandChoiceEligible: Bool = false,
         analyticsClient: STPAnalyticsClient = .sharedClient
     ) {
         self.init(configuration: configuration,
@@ -69,7 +68,7 @@ class PaymentSheetFormFactory {
                   addressSpecProvider: addressSpecProvider,
                   offerSaveToLinkWhenSupported: offerSaveToLinkWhenSupported,
                   linkAccount: linkAccount,
-                  cardBrandChoiceEligible: cardBrandChoiceEligible,
+                  cardBrandChoiceEligible: intent.cardBrandChoiceEligible,
                   supportsLinkCard: intent.supportsLinkCard,
                   isPaymentIntent: intent.isPaymentIntent,
                   isSettingUp: intent.isSettingUp,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -59,7 +59,7 @@ final class PaymentSheetLoader {
                 }
 
                 // Clear the payment method form cache
-                PaymentMethodFormViewController.formCache = [:]
+                PaymentMethodFormViewController.clearFormCache()
 
                 // List the Customer's saved PaymentMethods
                 async let savedPaymentMethods = fetchSavedPaymentMethods(intent: intent, configuration: configuration)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -58,6 +58,9 @@ final class PaymentSheetLoader {
                     }
                 }
 
+                // Clear the payment method form cache
+                PaymentMethodFormViewController.formCache = [:]
+
                 // List the Customer's saved PaymentMethods
                 async let savedPaymentMethods = fetchSavedPaymentMethods(intent: intent, configuration: configuration)
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -147,7 +147,7 @@ extension PaymentMethodFormViewController {
     /// This caches forms for payment methods so that customers don't have to re-enter details
     /// This class expects the formCache to be invalidated (cleared) when we load PaymentSheet; we assume the form generated for a given PM type _does not change_ at any point after load.
     static var formCache: [PaymentSheet.PaymentMethodType: PaymentMethodElement] = [:]
-    
+
     static func clearFormCache() {
         formCache = [:]
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -10,10 +10,20 @@
 @_spi(STP) import StripeUICore
 import UIKit
 
+protocol PaymentMethodFormViewControllerDelegate: AnyObject {
+    func didUpdate(_ viewController: PaymentMethodFormViewController)
+    func updateErrorLabel(for error: Error?)
+}
+
 class PaymentMethodFormViewController: UIViewController {
+    /// This caches forms for payment methods so that customers don't have to re-enter details
+    /// This class expects the formCache to be invalidated (cleared) when we load PaymentSheet; we assume the form generated for a given PM type _does not change_ at any point after load.
+    static var formCache: [PaymentSheet.PaymentMethodType: PaymentMethodElement] = [:]
+
     let form: PaymentMethodElement
     let paymentMethodType: PaymentSheet.PaymentMethodType
     let configuration: PaymentSheet.Configuration
+    weak var delegate: PaymentMethodFormViewControllerDelegate?
     var paymentOption: PaymentOption? {
         // TODO Copied from AddPaymentMethodViewController but this seems wrong; we shouldn't have such divergent paths for link and instant debits. Where is the setDefaultBillingDetailsIfNecessary call, for example?
         if let linkEnabledElement = form as? LinkEnabledPaymentMethodElement {
@@ -49,11 +59,34 @@ class PaymentMethodFormViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
-    init(type: PaymentSheet.PaymentMethodType, form: PaymentMethodElement, configuration: PaymentSheet.Configuration) {
+    init(type: PaymentSheet.PaymentMethodType, intent: Intent, previousCustomerInput: IntentConfirmParams?, configuration: PaymentSheet.Configuration, isLinkEnabled: Bool, delegate: PaymentMethodFormViewControllerDelegate) {
         self.paymentMethodType = type
-        self.form = form
+        self.delegate = delegate
         self.configuration = configuration
+        let shouldOfferLinkSignup: Bool = {
+            guard isLinkEnabled && !intent.disableLinkSignup else {
+                return false
+            }
+
+            let isAccountNotRegisteredOrMissing = LinkAccountContext.shared.account.flatMap({ !$0.isRegistered }) ?? true
+            return isAccountNotRegisteredOrMissing && !UserDefaults.standard.customerHasUsedLink
+        }()
+
+        if let form = Self.formCache[type] {
+            self.form = form
+        } else {
+            self.form = PaymentSheetFormFactory(
+                intent: intent,
+                configuration: .paymentSheet(configuration),
+                paymentMethod: paymentMethodType,
+                previousCustomerInput: previousCustomerInput,
+                offerSaveToLinkWhenSupported: shouldOfferLinkSignup,
+                linkAccount: LinkAccountContext.shared.account
+            ).make()
+            Self.formCache[type] = form
+        }
         super.init(nibName: nil, bundle: nil)
+        form.delegate = self
     }
 
     override func viewDidLoad() {
@@ -85,5 +118,29 @@ class PaymentMethodFormViewController: UIViewController {
             }
             addressSection.delegate = delegate
         }
+    }
+
+    // TODO: Move handleCollect* methods from AddPaymentMethodViewController to here
+}
+
+// MARK: - ElementDelegate
+
+extension PaymentMethodFormViewController: ElementDelegate {
+    func continueToNextField(element: Element) {
+        delegate?.didUpdate(self)
+    }
+
+    func didUpdate(element: Element) {
+        STPAnalyticsClient.sharedClient.logPaymentSheetFormInteracted(paymentMethodTypeIdentifier: paymentMethodType.identifier)
+        delegate?.didUpdate(self)
+        animateHeightChange()
+    }
+}
+
+// MARK: - PresentingViewControllerDelegate
+
+extension PaymentMethodFormViewController: PresentingViewControllerDelegate {
+    func presentViewController(viewController: UIViewController, completion: (() -> Void)?) {
+        present(viewController, animated: true, completion: completion)
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -16,10 +16,6 @@ protocol PaymentMethodFormViewControllerDelegate: AnyObject {
 }
 
 class PaymentMethodFormViewController: UIViewController {
-    /// This caches forms for payment methods so that customers don't have to re-enter details
-    /// This class expects the formCache to be invalidated (cleared) when we load PaymentSheet; we assume the form generated for a given PM type _does not change_ at any point after load.
-    static var formCache: [PaymentSheet.PaymentMethodType: PaymentMethodElement] = [:]
-
     let form: PaymentMethodElement
     let paymentMethodType: PaymentSheet.PaymentMethodType
     let configuration: PaymentSheet.Configuration
@@ -142,5 +138,17 @@ extension PaymentMethodFormViewController: ElementDelegate {
 extension PaymentMethodFormViewController: PresentingViewControllerDelegate {
     func presentViewController(viewController: UIViewController, completion: (() -> Void)?) {
         present(viewController, animated: true, completion: completion)
+    }
+}
+
+// MARK: - Form cache
+
+extension PaymentMethodFormViewController {
+    /// This caches forms for payment methods so that customers don't have to re-enter details
+    /// This class expects the formCache to be invalidated (cleared) when we load PaymentSheet; we assume the form generated for a given PM type _does not change_ at any point after load.
+    static var formCache: [PaymentSheet.PaymentMethodType: PaymentMethodElement] = [:]
+    
+    static func clearFormCache() {
+        formCache = [:]
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -225,7 +225,8 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
         self.addPaymentMethodViewController = AddPaymentMethodViewController(
             intent: intent,
             configuration: configuration,
-            previousCustomerInput: previousNewPaymentMethodParams // Restore the customer's previous new payment method input
+            previousCustomerInput: previousNewPaymentMethodParams, // Restore the customer's previous new payment method input
+            isLinkEnabled: isLinkEnabled
         )
         super.init(nibName: nil, bundle: nil)
         self.savedPaymentOptionsViewController.delegate = self
@@ -613,15 +614,6 @@ extension PaymentSheetFlowControllerViewController: AddPaymentMethodViewControll
     func didUpdate(_ viewController: AddPaymentMethodViewController) {
         error = nil  // clear error
         updateUI()
-    }
-
-    func shouldOfferLinkSignup(_ viewController: AddPaymentMethodViewController) -> Bool {
-        guard isLinkEnabled && !intent.disableLinkSignup else {
-            return false
-        }
-
-        let isAccountNotRegisteredOrMissing = LinkAccountContext.shared.account.flatMap({ !$0.isRegistered }) ?? true
-        return isAccountNotRegisteredOrMissing && !UserDefaults.standard.customerHasUsedLink
     }
 
     func updateErrorLabel(for error: Error?) {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
@@ -91,11 +91,11 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
         view.addAndPinSubview(stackView, insets: .init(top: 0, leading: 0, bottom: PaymentSheetUI.defaultSheetMargins.bottom, trailing: 0))
         // If we have only one row in the vertical list and it collects user input, display the form instead of the payment method list.
         let firstPaymentMethodType = paymentMethodTypes[0]
-        let form = makeForm(paymentMethodType: firstPaymentMethodType)
-        if paymentMethodListViewController.rowCount == 1 && form.collectsUserInput {
-            let paymentMethodFormViewController = PaymentMethodFormViewController(type: firstPaymentMethodType, form: form, configuration: configuration)
-            self.paymentMethodFormViewController = paymentMethodFormViewController
-            add(childViewController: paymentMethodFormViewController, containerView: paymentContainerView)
+        // TODO: Handle offerSaveToLinkWhenSupported, previousCustomerInput, delegate
+        let pmFormVC = PaymentMethodFormViewController(type: firstPaymentMethodType, intent: intent, previousCustomerInput: nil, configuration: configuration, isLinkEnabled: false, delegate: self)
+        if paymentMethodListViewController.rowCount == 1 && pmFormVC.form.collectsUserInput {
+            self.paymentMethodFormViewController = pmFormVC
+            add(childViewController: pmFormVC, containerView: paymentContainerView)
         } else {
             add(childViewController: paymentMethodListViewController, containerView: paymentContainerView)
         }
@@ -113,15 +113,6 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
         )
         vc.delegate = self
         bottomSheetController?.pushContentViewController(vc)
-    }
-
-    func makeForm(paymentMethodType: PaymentSheet.PaymentMethodType) -> PaymentMethodElement {
-        return PaymentSheetFormFactory(
-            intent: intent,
-            configuration: .paymentSheet(configuration),
-            paymentMethod: paymentMethodType
-            // TODO: previousCustomerInput, offerSaveToLinkWhenSupported, linkAccount
-        ).make()
     }
 }
 
@@ -173,27 +164,27 @@ extension PaymentSheetVerticalViewController: VerticalPaymentMethodListViewContr
         case .applePay, .link:
             return true
         case let .new(paymentMethodType: paymentMethodType):
-            let form = makeForm(paymentMethodType: paymentMethodType)
-            if form.collectsUserInput {
-                // The payment method form collects user input, display it
-                // 1. Create the PM form VC
-                let paymentMethodFormVC: PaymentMethodFormViewController = {
-                    if let currentPaymentMethodFormVC = paymentMethodFormViewController, paymentMethodType == currentPaymentMethodFormVC.paymentMethodType {
-                        // Reuse the existing payment method form so that the customer doesn't have to type their details in again
-                        return currentPaymentMethodFormVC
-                    } else {
-                        return PaymentMethodFormViewController(type: paymentMethodType, form: form, configuration: configuration)
-                    }
-                }()
-                paymentMethodFormViewController = paymentMethodFormVC
-                // 2. Switch the main content to the form
-                switchContentIfNecessary(to: paymentMethodFormVC, containerView: paymentContainerView)
+            // If we can, reuse the existing payment method form so that the customer doesn't have to type their details in again
+            if let currentPaymentMethodFormVC = paymentMethodFormViewController, paymentMethodType == currentPaymentMethodFormVC.paymentMethodType {
+                // Switch the main content to the form
+                switchContentIfNecessary(to: currentPaymentMethodFormVC, containerView: paymentContainerView)
                 navigationBar.setStyle(.back(showAdditionalButton: false))
-                // 3. Return false so the payment method isn't selected in the list; this implicitly keeps the most recently selected payment method as selected.
+                // Return false so the payment method isn't selected in the list; this implicitly keeps the most recently selected payment method as selected.
                 return false
             } else {
-                // Otherwise, return true so the payment method appears selected in the list
-                return true
+                // Otherwise, create the form and decide whether we should display it or not
+                let pmFormVC = PaymentMethodFormViewController(type: paymentMethodType, intent: intent, previousCustomerInput: nil, configuration: configuration, isLinkEnabled: false, delegate: self)
+
+                if pmFormVC.form.collectsUserInput {
+                    // The payment method form collects user input, display it
+                    self.paymentMethodFormViewController = pmFormVC
+                    switchContentIfNecessary(to: pmFormVC, containerView: paymentContainerView)
+                    navigationBar.setStyle(.back(showAdditionalButton: false))
+                    return false
+                } else {
+                    // Otherwise, return true so the payment method appears selected in the list
+                   return true
+                }
             }
         case .saved:
             // TODO(porter) Look for taps on the "view more" button
@@ -218,5 +209,15 @@ extension PaymentSheetVerticalViewController: SheetNavigationBarDelegate {
         view.endEditing(true)
         switchContentIfNecessary(to: paymentMethodListViewController, containerView: paymentContainerView)
         navigationBar.setStyle(.close(showAdditionalButton: false))
+    }
+}
+
+extension PaymentSheetVerticalViewController: PaymentMethodFormViewControllerDelegate {
+    func didUpdate(_ viewController: PaymentMethodFormViewController) {
+        // TODO
+    }
+
+    func updateErrorLabel(for error: (any Error)?) {
+        // TODO
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
@@ -93,7 +93,7 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
         let firstPaymentMethodType = paymentMethodTypes[0]
         let form = makeForm(paymentMethodType: firstPaymentMethodType)
         if paymentMethodListViewController.rowCount == 1 && form.collectsUserInput {
-            let paymentMethodFormViewController = PaymentMethodFormViewController(type: firstPaymentMethodType, form: form)
+            let paymentMethodFormViewController = PaymentMethodFormViewController(type: firstPaymentMethodType, form: form, configuration: configuration)
             self.paymentMethodFormViewController = paymentMethodFormViewController
             add(childViewController: paymentMethodFormViewController, containerView: paymentContainerView)
         } else {
@@ -177,7 +177,7 @@ extension PaymentSheetVerticalViewController: VerticalPaymentMethodListViewContr
                         // Reuse the existing payment method form so that the customer doesn't have to type their details in again
                         return currentPaymentMethodFormVC
                     } else {
-                        return PaymentMethodFormViewController(type: paymentMethodType, form: form)
+                        return PaymentMethodFormViewController(type: paymentMethodType, form: form, configuration: configuration)
                     }
                 }()
                 paymentMethodFormViewController = paymentMethodFormVC
@@ -209,6 +209,8 @@ extension PaymentSheetVerticalViewController: SheetNavigationBarDelegate {
     }
 
     func sheetNavigationBarDidBack(_ sheetNavigationBar: SheetNavigationBar) {
+        // Hide the keyboard if it appeared and switch back to the vertical list
+        view.endEditing(true)
         switchContentIfNecessary(to: paymentMethodListViewController, containerView: paymentContainerView)
         navigationBar.setStyle(.close(showAdditionalButton: false))
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
@@ -116,7 +116,12 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
     }
 
     func makeForm(paymentMethodType: PaymentSheet.PaymentMethodType) -> PaymentMethodElement {
-        return PaymentSheetFormFactory(intent: intent, configuration: .paymentSheet(configuration), paymentMethod: paymentMethodType).make()
+        return PaymentSheetFormFactory(
+            intent: intent,
+            configuration: .paymentSheet(configuration),
+            paymentMethod: paymentMethodType
+            // TODO: previousCustomerInput, offerSaveToLinkWhenSupported, linkAccount
+        ).make()
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -68,6 +68,7 @@ class PaymentSheetViewController: UIViewController, PaymentSheetViewControllerPr
         return AddPaymentMethodViewController(
             intent: intent,
             configuration: configuration,
+            isLinkEnabled: isLinkEnabled,
             delegate: self
         )
     }()
@@ -658,15 +659,6 @@ extension PaymentSheetViewController: AddPaymentMethodViewControllerDelegate {
     func didUpdate(_ viewController: AddPaymentMethodViewController) {
         error = nil  // clear error
         updateUI()
-    }
-
-    func shouldOfferLinkSignup(_ viewController: AddPaymentMethodViewController) -> Bool {
-        guard isLinkEnabled && !intent.disableLinkSignup else {
-            return false
-        }
-
-        let isAccountNotRegisteredOrMissing = LinkAccountContext.shared.account.flatMap({ !$0.isRegistered }) ?? true
-        return isAccountNotRegisteredOrMissing && !UserDefaults.standard.customerHasUsedLink
     }
 
     func updateErrorLabel(for error: Error?) {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/AddPaymentMethodViewControllerSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/AddPaymentMethodViewControllerSnapshotTests.swift
@@ -38,7 +38,7 @@ final class AddPaymentMethodViewControllerSnapshotTests: STPSnapshotTestCase {
         // ...and a "Save this card" checkbox...
         config.customer = .init(id: "id", ephemeralKeySecret: "ek")
         // ...the AddPMVC should show the card type selected with the form pre-filled with the previous input
-        let sut = AddPaymentMethodViewController(intent: intent, configuration: config, previousCustomerInput: previousCustomerInput)
+        let sut = AddPaymentMethodViewController(intent: intent, configuration: config, previousCustomerInput: previousCustomerInput, isLinkEnabled: false)
         STPSnapshotVerifyView(sut.view, autoSizingHeightForWidth: 375)
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/FlowControllerStateTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/FlowControllerStateTests.swift
@@ -26,7 +26,7 @@ class FlowControllerStateTests: XCTestCase {
         config.apiClient.publishableKey = "pk_123"
         let intent = Intent.deferredIntent(elementsSession: STPElementsSession.emptyElementsSession, intentConfig: intentConfig)
         let apmvcDelegate = StubAPMVCDelegate(expectation: exp)
-        _ = AddPaymentMethodViewController(intent: intent, configuration: config, delegate: apmvcDelegate)
+        _ = AddPaymentMethodViewController(intent: intent, configuration: config, isLinkEnabled: true, delegate: apmvcDelegate)
         waitForExpectations(timeout: 0.1)
     }
 }
@@ -39,11 +39,6 @@ class StubAPMVCDelegate: AddPaymentMethodViewControllerDelegate {
 
     func didUpdate(_ viewController: StripePaymentSheet.AddPaymentMethodViewController) {
         expectation.fulfill()
-    }
-
-    func shouldOfferLinkSignup(_ viewController: StripePaymentSheet.AddPaymentMethodViewController) -> Bool {
-        expectation.fulfill()
-        return true
     }
 
     func updateErrorLabel(for: Error?) {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentMethodFormViewControllerTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentMethodFormViewControllerTest.swift
@@ -5,10 +5,10 @@
 //  Created by Yuki Tokuhiro on 5/24/24.
 //
 
-import XCTest
 import StripeCoreTestUtils
 @_spi(STP) @testable import StripePaymentSheet
 @_spi(STP) import StripeUICore
+import XCTest
 
 final class PaymentMethodFormViewControllerTest: XCTestCase {
 
@@ -25,7 +25,7 @@ final class PaymentMethodFormViewControllerTest: XCTestCase {
     func testUpdatesFormWithLatestShippingDetails() {
         // Given a Configuration w/ shipping details...
         var configuration = PaymentSheet.Configuration._testValue_MostPermissive()
-        var shippingDetails: AddressViewController.AddressDetails? = nil
+        var shippingDetails: AddressViewController.AddressDetails?
         configuration.shippingDetails = {
             return shippingDetails
         }
@@ -36,7 +36,7 @@ final class PaymentMethodFormViewControllerTest: XCTestCase {
         // ...PaymentMethodFormVC...
         let form = PaymentSheetFormFactory(intent: ._testPaymentIntent(paymentMethodTypes: [.card]), configuration: .paymentSheet(configuration), paymentMethod: .stripe(.card)).make()
         let sut = PaymentMethodFormViewController(type: .stripe(.card), form: form, configuration: configuration)
-        
+
         // ...should fill its address fields with the shipping address
         sut.beginAppearanceTransition(true, animated: false)
         sut.endAppearanceTransition()

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentMethodFormViewControllerTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentMethodFormViewControllerTest.swift
@@ -1,0 +1,55 @@
+//
+//  PaymentMethodFormViewControllerTest.swift
+//  StripePaymentSheetTests
+//
+//  Created by Yuki Tokuhiro on 5/24/24.
+//
+
+import XCTest
+import StripeCoreTestUtils
+@_spi(STP) @testable import StripePaymentSheet
+@_spi(STP) import StripeUICore
+
+final class PaymentMethodFormViewControllerTest: XCTestCase {
+
+    override func setUp() {
+        let expectation = expectation(description: "Load specs")
+        AddressSpecProvider.shared.loadAddressSpecs {
+            FormSpecProvider.shared.load { _ in
+                expectation.fulfill()
+            }
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    func testUpdatesFormWithLatestShippingDetails() {
+        // Given a Configuration w/ shipping details...
+        var configuration = PaymentSheet.Configuration._testValue_MostPermissive()
+        var shippingDetails: AddressViewController.AddressDetails? = nil
+        configuration.shippingDetails = {
+            return shippingDetails
+        }
+        // ...and collects billing address...
+        configuration.billingDetailsCollectionConfiguration = .init(address: .full)
+        // ...and no default billing address...
+        XCTAssertEqual(configuration.defaultBillingDetails, PaymentSheet.Configuration().defaultBillingDetails)
+        // ...PaymentMethodFormVC...
+        let form = PaymentSheetFormFactory(intent: ._testPaymentIntent(paymentMethodTypes: [.card]), configuration: .paymentSheet(configuration), paymentMethod: .stripe(.card)).make()
+        let sut = PaymentMethodFormViewController(type: .stripe(.card), form: form, configuration: configuration)
+        
+        // ...should fill its address fields with the shipping address
+        sut.beginAppearanceTransition(true, animated: false)
+        sut.endAppearanceTransition()
+        XCTAssertEqual(sut.form.getTextFieldElement("Address line 1")?.text, "")
+
+        // ...and updating the shipping address...
+        shippingDetails = AddressViewController.AddressDetails(address: .init(country: "US", line1: "Updated line1"))
+
+        // ...and simulating a re-display of the form...
+        sut.beginAppearanceTransition(true, animated: false)
+        sut.endAppearanceTransition()
+
+        // ...should update its address fields with the shipping address
+        XCTAssertEqual(sut.form.getTextFieldElement("Address line 1")?.text, "Updated line1")
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentMethodFormViewControllerTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentMethodFormViewControllerTest.swift
@@ -34,8 +34,7 @@ final class PaymentMethodFormViewControllerTest: XCTestCase {
         // ...and no default billing address...
         XCTAssertEqual(configuration.defaultBillingDetails, PaymentSheet.Configuration().defaultBillingDetails)
         // ...PaymentMethodFormVC...
-        let form = PaymentSheetFormFactory(intent: ._testPaymentIntent(paymentMethodTypes: [.card]), configuration: .paymentSheet(configuration), paymentMethod: .stripe(.card)).make()
-        let sut = PaymentMethodFormViewController(type: .stripe(.card), form: form, configuration: configuration)
+        let sut = PaymentMethodFormViewController(type: .stripe(.card), intent: ._testPaymentIntent(paymentMethodTypes: [.card]), previousCustomerInput: nil, configuration: configuration, isLinkEnabled: false, delegate: self)
 
         // ...should fill its address fields with the shipping address
         sut.beginAppearanceTransition(true, animated: false)
@@ -51,5 +50,15 @@ final class PaymentMethodFormViewControllerTest: XCTestCase {
 
         // ...should update its address fields with the shipping address
         XCTAssertEqual(sut.form.getTextFieldElement("Address line 1")?.text, "Updated line1")
+    }
+}
+
+extension PaymentMethodFormViewControllerTest: PaymentMethodFormViewControllerDelegate {
+    func didUpdate(_ viewController: StripePaymentSheet.PaymentMethodFormViewController) {
+
+    }
+
+    func updateErrorLabel(for error: (any Error)?) {
+
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentMethodFormViewControllerTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentMethodFormViewControllerTest.swift
@@ -16,6 +16,7 @@ final class PaymentMethodFormViewControllerTest: XCTestCase {
         let expectation = expectation(description: "Load specs")
         AddressSpecProvider.shared.loadAddressSpecs {
             FormSpecProvider.shared.load { _ in
+                PaymentMethodFormViewController.clearFormCache()
                 expectation.fulfill()
             }
         }


### PR DESCRIPTION
## Summary
`AddPaymentMethodViewController` (APMVC) originally controlled both the form *and* the horizontal list of PMs, all in one. 

This PR **moves** form-related logic from APMVC to `PaymentMethodFormViewController` (PMFVC), so that it can be reused by vertical mode.  It also makes APMVC **use* PMFVC.

Some big bits of logic that was moved:
- Creating paymentOption from form. Link and Instant Debits both have special hacks.
- Default billing <> shipping address code in viewWillAppear

## Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-2130

## Testing

- Form cache is reset on load
- US Bank and others preserve details when switching between forms
- Shipping details updates form

## Changelog
Not user facing