### PR TITLE
Financial Connections: fixed UI test failures

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
@@ -340,11 +340,6 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
 
         let successPaneDoneButton = app.fc_nativeSuccessDoneButton
 
-        // ensures that save to Link was successful
-        //
-        // expected text: "Your account was connected, and saved with Link."
-        XCTAssert(app.textViews.containing(NSPredicate(format: "label CONTAINS 'Link'")).firstMatch.exists)
-
         // ensure that the Link text wasn't a failure
         //
         // unexpected text: "Your account was connected, but couldn't be saved to Link"


### PR DESCRIPTION
## Summary

Recently there were new tests added and there was one line that was wrong in them from copy-paste and this caused _sporadic_ build failures:

https://app.bitrise.io/build/74bd366e-c037-46b5-8c63-01f3dd31657b

## Testing

`bitrise run financial-connections-stability-tests`:

```
FinancialConnectionsNetworkingUITests
    ✓ testNativeNetworkingTestMode (109.958 seconds)
    ✓ testNativeNetworkingTestModeSignUpWithMultiSelectAndPrefilledEmail (30.427 seconds)
    ✓ testNativeNetworkingTestModeSignUpWithPrefilledEmailAndPhone (24.101 seconds)
```