### PR TITLE
Send payment_method_allow_redisplay_filter

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -450,6 +450,7 @@ extension PlaygroundController {
             "customer_session_payment_method_save": "enabled",
             "customer_session_payment_method_remove": "enabled",
             "customer_session_payment_method_redisplay": "enabled",
+            "customer_session_payment_method_allow_redisplay_filters": ["unspecified", "limited", "always"],
             //            "set_shipping_address": true // Uncomment to make server vend PI with shipping address populated
         ] as [String: Any]
         if let supportedPaymentMethods = settingsToLoad.supportedPaymentMethods {


### PR DESCRIPTION
## Summary
Sends default value for payment_method_allow_redisplay_filter, which will be customizable in a future PRs

## Motivation
To make backend deployments for our merchant server easier, we should be sending this flag as well.

## Testing
Manual testing

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
