### PR TITLE
Instant Debits Only: added UI tests to Instant Debits Only integration

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example-Shard1.xctestplan
+++ b/Example/PaymentSheet Example/PaymentSheet Example-Shard1.xctestplan
@@ -26,6 +26,7 @@
     {
       "parallelizable" : true,
       "skippedTests" : [
+        "LinkPaymentControllerUITest",
         "PaymentSheetDeferredServerSideUITests",
         "PaymentSheetDeferredUIBankAccountTests",
         "PaymentSheetDeferredUITests",

--- a/Example/PaymentSheet Example/PaymentSheet Example.xcodeproj/project.pbxproj
+++ b/Example/PaymentSheet Example/PaymentSheet Example.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		56EF0879D7EAC041B147680C /* ExampleLinkPaymentCheckoutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D423EEB2C6C8BB05D632BBD /* ExampleLinkPaymentCheckoutViewController.swift */; };
 		5AF35F9FA7106ACD4E4F360F /* PaymentSheetBillingCollectionUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 083DF3A89B26704DA21858DB /* PaymentSheetBillingCollectionUITests.swift */; };
 		65D034E37B345C1B64785451 /* StripeCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1FD1F5193E4A361EA9E8FED3 /* StripeCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		6A5CCDA42C0E6F5D003306A4 /* LinkPaymentControllerUITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A5CCDA32C0E6F5D003306A4 /* LinkPaymentControllerUITest.swift */; };
 		6BA8D3322B0C1E24008C51FF /* ExampleSwiftUICustomPaymentFlowCVCRecollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA8D3312B0C1E24008C51FF /* ExampleSwiftUICustomPaymentFlowCVCRecollection.swift */; };
 		75D1997DA514F6DB82FF1CFC /* StripePaymentSheet.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 240DDF52B887E788853A838B /* StripePaymentSheet.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		79E8C77C99A25E38F96747F1 /* PaymentSheetTestPlaygroundSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1261A6BDCDB7E81D08F137F0 /* PaymentSheetTestPlaygroundSettings.swift */; };
@@ -187,6 +188,7 @@
 		5E4DD63AD5E9B8153E04EF7C /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/Main.strings"; sourceTree = "<group>"; };
 		63237DF22FD4600B9D2E8071 /* StripeApplePay.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripeApplePay.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6891CC1208EA3F4DE934760E /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
+		6A5CCDA32C0E6F5D003306A4 /* LinkPaymentControllerUITest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkPaymentControllerUITest.swift; sourceTree = "<group>"; };
 		6BA8D3312B0C1E24008C51FF /* ExampleSwiftUICustomPaymentFlowCVCRecollection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExampleSwiftUICustomPaymentFlowCVCRecollection.swift; sourceTree = "<group>"; };
 		6CD01636EA3B4C6F84E9CC86 /* PaymentSheetUITest-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "PaymentSheetUITest-Release.xcconfig"; sourceTree = "<group>"; };
 		6E4F3FA49534E745C5EDC1C0 /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
@@ -405,6 +407,7 @@
 				DD340D0C93E93B9E9DB7691F /* PaymentSheetTestPlaygroundSettings.swift */,
 				5CA299EAF5914484195167EB /* PaymentSheetUITest.swift */,
 				36BB679CF53EEF943F0BAAC9 /* XCUITest+Utilities.swift */,
+				6A5CCDA32C0E6F5D003306A4 /* LinkPaymentControllerUITest.swift */,
 			);
 			path = PaymentSheetUITest;
 			sourceTree = "<group>";
@@ -641,6 +644,7 @@
 				5AF35F9FA7106ACD4E4F360F /* PaymentSheetBillingCollectionUITests.swift in Sources */,
 				2CD71F097C7CD0D9BFC7499D /* PaymentSheetTestPlaygroundSettings.swift in Sources */,
 				540F279CE5B41C122AD1DEF6 /* PaymentSheetUITest.swift in Sources */,
+				6A5CCDA42C0E6F5D003306A4 /* LinkPaymentControllerUITest.swift in Sources */,
 				EE0FA73AAB80863583C69D70 /* XCUITest+Utilities.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkPaymentCheckoutViewController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkPaymentCheckoutViewController.swift
@@ -26,8 +26,9 @@ class ExampleLinkPaymentCheckoutViewController: UIViewController {
 
     let billingDetails: PaymentSheet.BillingDetails = {
         var billingDetails = PaymentSheet.BillingDetails()
-        billingDetails.email = "test@example.com"
-        billingDetails.phone = "+15551232414567"
+        // uncomment to test prefilled email
+        // billingDetails.email = "test@example.com"
+        // billingDetails.phone = "+15551232414567"
         return billingDetails
     }()
 

--- a/Example/PaymentSheet Example/PaymentSheetUITest/LinkPaymentControllerUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/LinkPaymentControllerUITest.swift
@@ -1,0 +1,100 @@
+//
+//  LinkPaymentControllerUITest.swift
+//  PaymentSheetUITest
+//
+//  Created by Krisjanis Gaidis on 6/3/24.
+//
+
+import XCTest
+
+class LinkPaymentControllerUITest: XCTestCase {
+    fileprivate var app: XCUIApplication!
+    fileprivate let timeout: TimeInterval = 10
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        app = XCUIApplication()
+        app.launchEnvironment = ["UITesting": "true"]
+    }
+
+    func testInstantDebitsOnlyLinkPaymentController() {
+        app.launch()
+
+        // PaymentSheet Example
+        app.staticTexts["LinkPaymentController"].tap()
+
+        // LinkPaymentController
+        let paymentMethodButton = app.buttons["SelectPaymentMethodButton"]
+        let paymentMethodButtonEnabledExpectation = expectation(
+            for: NSPredicate(format: "enabled == true"),
+            evaluatedWith: paymentMethodButton
+        )
+        wait(for: [paymentMethodButtonEnabledExpectation], timeout: 60, enforceOrder: true)
+        paymentMethodButton.tap()
+
+        // "Consent" pane
+        app.buttons["Agree and continue"].waitForExistenceAndTap(timeout: timeout)
+
+        // "Sign Up" pane
+        app.textFields
+            .matching(NSPredicate(format: "label CONTAINS 'Email address'"))
+            .firstMatch
+            .waitForExistenceAndTap(timeout: 10)
+        let email = "linkpaymentcontrolleruitest-\(UUID().uuidString)@example.com"
+        app.typeText(email + XCUIKeyboardKey.return.rawValue)
+        app.textFields["Phone number"].tap()
+        // the `XCUIKeyboardKey.return.rawValue` will automatically
+        // press the "Continue with Link" button to proceed to next
+        // screen
+        app.typeText("4015006000" + XCUIKeyboardKey.return.rawValue)
+
+        // "Institution Picker" pane
+        let searchTextField = app.textFields
+            .matching(NSPredicate(format: "label CONTAINS 'Search'"))
+            .firstMatch
+        searchTextField.waitForExistenceAndTap(timeout: 10)
+        app.typeText("Test Institution" + XCUIKeyboardKey.return.rawValue)
+        searchTextField
+            .coordinate(
+                withNormalizedOffset: CGVector(
+                    dx: 0.5,
+                    // bottom of search text field
+                    dy: 1.0
+                )
+            )
+        // at this point, we searched "Test Institution"
+        // and the only search result is "Test Institution,"
+        // so here we guess that 80 pixels below search bar
+        // there will be a "Test Institution"
+        //
+        // we do this "guess" because every other method of
+        // selecting the institution did not work on iOS 17
+            .withOffset(CGVector(dx: 0, dy: 80))
+            .tap()
+
+        // "Account Picker" pane
+        _ = app.staticTexts["Select account"].waitForExistence(timeout: 10)
+        app.buttons["Connect account"].tap()
+
+        // "Success" pane
+        XCTAssert(app.staticTexts["Success"].waitForExistence(timeout: 10))
+        // XCUITest had problems tapping the Done button in success pane,
+        // so here we tap the Done button by estimating coordinates
+        app.coordinate(
+            // this locates the middle of the bottom of the app
+            withNormalizedOffset: CGVector(dx: 0.5, dy: 1.0)
+        )
+        // we then navigate from the bottom to the "Done" button
+            .withOffset(CGVector(dx: 0, dy: -130))
+            .tap()
+
+        sleep(1) // wait for modal to disappear before pressing Buy
+
+        // Back to "LinkPaymentController"
+        app.buttons["Buy"].waitForExistenceAndTap(timeout: timeout)
+        XCTAssert(app.alerts.staticTexts["Your order is confirmed!"].waitForExistence(timeout: timeout))
+    }
+}


### PR DESCRIPTION
## Summary

^ all of this is example/test code

[JIRA task](https://jira.corp.stripe.com/browse/RUN_BANKCON_MOBILE-68)

## Testing

Ran the test and it passed:

![Screenshot 2024-06-04 at 1 44 06 PM](https://github.com/stripe/stripe-ios/assets/105514761/e7154624-7b13-4167-97f6-deafba8c983e)

Ran the test in this PR and it passed:

https://app.bitrise.io/build/47c3afe2-4a1d-4588-97ab-8d8e8f5f69f1?tab=log

![Screenshot 2024-06-04 at 2 52 18 PM](https://github.com/stripe/stripe-ios/assets/105514761/47b678e0-e871-4bb5-92ad-a4240a844c03)

How the UI test looks like visually:

https://github.com/stripe/stripe-ios/assets/105514761/1052b646-61b6-4ba6-bd71-bceea39b5d68
