### PR TITLE
Attempt to improve stability of CustomerSheet UI tests

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
@@ -93,7 +93,7 @@ class CustomerSheetUITest: XCTestCase {
 
         app.staticTexts["None"].waitForExistenceAndTap(timeout: timeout)
 
-        app.collectionViews.staticTexts["Apple Pay"].tap()
+        app.collectionViews.staticTexts["Apple Pay"].waitForExistenceAndTap(timeout: timeout)
 
         let confirmButton = app.buttons["Confirm"]
         XCTAssertTrue(confirmButton.waitForExistence(timeout: timeout))
@@ -359,6 +359,8 @@ class CustomerSheetUITest: XCTestCase {
         editButton.tap()
 
         removeFirstPaymentMethodInList(alertBody: "Mastercard •••• 4444")
+
+        XCTAssertTrue(app.staticTexts["Done"].waitForExistence(timeout: 1)) // Sanity check "Done" button is there
         // ••••4444 is rendered as the PM to remove, as well as the status on the playground
         // Check that it is removed by waiting for there only be one instance
         let elementLabel = "••••4444"
@@ -391,7 +393,7 @@ class CustomerSheetUITest: XCTestCase {
         presentCSAndAddCardFrom(buttonLabel: "••••4242")
 
         // Reload
-        app.buttons["Reload"].tap()
+        app.buttons["Reload"].waitForExistenceAndTap(timeout: timeout)
 
         // Present Sheet
         let selectButton = app.staticTexts["••••4242"]


### PR DESCRIPTION
## Summary
Attempt to improve stability of CustomerSheet UI tests

## Motivation
I noticed that these tests have a slightly higher failure rate in bitrise. Wasn't able to reproduce locally, but seems like the tests could be failing here.

## Testing
executed tests.

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
