### PR TITLE
Detect strings that have overlapping ranges to avoid segfault

### DIFF
--- a/Stripe/StripeiOSTests/STPStringUtilsTest.swift
+++ b/Stripe/StripeiOSTests/STPStringUtilsTest.swift
@@ -92,6 +92,38 @@ class STPStringUtilsTest: XCTestCase {
         }
         waitForExpectations(timeout: 1)
     }
+    func testParseRangeWithOverlappingRanges() {
+        let exp = self.expectation(description: "Parsed")
+        STPStringUtils.parseRanges(
+            from: "<a>Test <b>string</b></a>",
+            withTags: Set(["a", "b"])
+        ) { string, tagMap in
+            XCTAssertEqual(string, "Test string")
+            XCTAssertTrue(tagMap.isEmpty)
+            exp.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+    func testHasOverlappingRanges_singleItem() {
+        let ranges: [NSValue: String] = [
+            NSValue(range: NSRange(location: 0, length: 2)): "a",
+        ]
+        XCTAssertFalse(STPStringUtils.hasOverlappingRanges(ranges: ranges))
+    }
+    func testHasOverlappingRanges_nonOverlapping() {
+        let ranges: [NSValue: String] = [
+            NSValue(range: NSRange(location: 0, length: 2)): "a",
+            NSValue(range: NSRange(location: 2, length: 1)): "b",
+        ]
+        XCTAssertFalse(STPStringUtils.hasOverlappingRanges(ranges: ranges))
+    }
+    func testHasOverlappingRanges_overlapping() {
+        let ranges: [NSValue: String] = [
+            NSValue(range: NSRange(location: 0, length: 2)): "a",
+            NSValue(range: NSRange(location: 1, length: 1)): "b",
+        ]
+        XCTAssert(STPStringUtils.hasOverlappingRanges(ranges: ranges))
+    }
 
     func testExpirationDateStrings() {
         XCTAssertEqual(STPStringUtils.expirationDateString(from: "12/1995"), "12/95")


### PR DESCRIPTION
## Summary
Detect if there are overlapping ranges, if so, return an undecorated string

## Motivation
Has a potential for causing a segfault

## Testing
Added tests
manually verified

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
