### PR TITLE
Remove link instant debits dead code

### DIFF
--- a/Stripe/StripeiOS/Source/STPPaymentMethod+BasicUI.swift
+++ b/Stripe/StripeiOS/Source/STPPaymentMethod+BasicUI.swift
@@ -69,7 +69,7 @@ extension STPPaymentMethod: STPPaymentOption {
             .bacsDebit, .SEPADebit, .iDEAL, .FPX, .cardPresent, .giropay, .EPS, .payPal,
             .przelewy24, .bancontact,
             .OXXO, .sofort, .grabPay, .netBanking, .UPI, .afterpayClearpay, .blik,
-            .weChatPay, .boleto, .klarna, .linkInstantDebit, .affirm, .cashApp, .paynow, .zip, .revolutPay, .amazonPay,
+            .weChatPay, .boleto, .klarna, .affirm, .cashApp, .paynow, .zip, .revolutPay, .amazonPay,
             .alma, .mobilePay, .konbini, .promptPay, .swish, .twint, .multibanco,
             .unknown:
             return false

--- a/Stripe/StripeiOS/Source/STPPaymentMethodParams+BasicUI.swift
+++ b/Stripe/StripeiOS/Source/STPPaymentMethodParams+BasicUI.swift
@@ -38,7 +38,7 @@ extension STPPaymentMethodParams: STPPaymentOption {
             return true
         case .alipay, .AUBECSDebit, .bacsDebit, .SEPADebit, .iDEAL, .FPX, .cardPresent, .giropay,
             .grabPay, .EPS, .przelewy24, .bancontact, .netBanking, .OXXO, .payPal, .sofort, .UPI,
-            .afterpayClearpay, .blik, .weChatPay, .boleto, .klarna, .linkInstantDebit, .affirm, .cashApp, .paynow,
+            .afterpayClearpay, .blik, .weChatPay, .boleto, .klarna, .affirm, .cashApp, .paynow,
             .zip, .revolutPay, .amazonPay, .alma, .mobilePay, .konbini, .promptPay, .swish, .twint, .multibanco,
             .unknown:
             return false

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/en.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/en.lproj/Localizable.strings
@@ -10,9 +10,6 @@
 /* Text for a button that, when tapped, displays another screen where the customer can add a new payment method */
 "Add a payment method" = "Add a payment method";
 
-/* Button prompt to add a bank account as a payment method. */
-"Add bank account" = "Add bank account";
-
 /* Title shown above a view allowing the customer to save their first card. */
 "Add card" = "Add card";
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkPaymentController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkPaymentController.swift
@@ -91,7 +91,6 @@ import UIKit
     private init(intentSecret: PaymentSheet.InitializationMode, returnURL: String?, billingDetails: PaymentSheet.BillingDetails?) {
         self.mode = intentSecret
         var configuration = PaymentSheet.Configuration()
-        configuration.linkPaymentMethodsOnly = true
         configuration.returnURL = returnURL
         if let billingDetails = billingDetails {
             configuration.defaultBillingDetails = billingDetails

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
@@ -89,8 +89,7 @@ class AddPaymentMethodViewController: UIViewController {
         return view
     }()
     private lazy var paymentMethodDetailsContainerView: DynamicHeightContainerView = {
-        // when displaying link, we aren't in the bottom/payment sheet so pin to top for height changes
-        let view = DynamicHeightContainerView(pinnedDirection: configuration.linkPaymentMethodsOnly ? .top : .bottom)
+        let view = DynamicHeightContainerView(pinnedDirection: .bottom)
         view.directionalLayoutMargins = PaymentSheetUI.defaultMargins
         return view
     }()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -117,15 +117,6 @@ extension PaymentSheet {
         {
             var recommendedStripePaymentMethodTypes = intent.recommendedPaymentMethodTypes
 
-            if configuration.linkPaymentMethodsOnly {
-                // If we're in the Link modal, manually add Link payment methods
-                // and let the support calls decide if they're allowed
-                let allLinkPaymentMethods: [STPPaymentMethodType] = [.card, .linkInstantDebit]
-                for method in allLinkPaymentMethods where !recommendedStripePaymentMethodTypes.contains(method) {
-                    recommendedStripePaymentMethodTypes.append(method)
-                }
-            }
-
             if
                 recommendedStripePaymentMethodTypes.contains(.link),
                 !recommendedStripePaymentMethodTypes.contains(.USBankAccount),
@@ -144,8 +135,7 @@ extension PaymentSheet {
                     paymentMethod: paymentMethodType,
                     configuration: configuration,
                     intent: intent,
-                    supportedPaymentMethods: configuration.linkPaymentMethodsOnly
-                        ? PaymentSheet.supportedLinkPaymentMethods : PaymentSheet.supportedPaymentMethods
+                    supportedPaymentMethods: PaymentSheet.supportedPaymentMethods
                 )
 
                 if logAvailability && availabilityStatus != .supported {
@@ -235,8 +225,7 @@ extension PaymentSheet {
                     case .bacsDebit:
                         return [.returnURL, .userSupportsDelayedPaymentMethods]
                     case .cardPresent, .blik, .weChatPay, .grabPay, .FPX, .giropay, .przelewy24, .EPS,
-                        .netBanking, .OXXO, .afterpayClearpay, .UPI, .link, .linkInstantDebit,
-                        .affirm, .paynow, .zip, .alma, .mobilePay, .unknown, .alipay, .konbini, .promptPay, .swish, .twint, .multibanco:
+                        .netBanking, .OXXO, .afterpayClearpay, .UPI, .link, .affirm, .paynow, .zip, .alma, .mobilePay, .unknown, .alipay, .konbini, .promptPay, .swish, .twint, .multibanco:
                         return [.unsupportedForSetup]
                     @unknown default:
                         return [.unsupportedForSetup]
@@ -248,7 +237,7 @@ extension PaymentSheet {
                     case .blik, .card, .cardPresent, .UPI, .weChatPay, .paynow, .promptPay:
                         return []
                     case .alipay, .EPS, .FPX, .giropay, .grabPay, .netBanking, .payPal, .przelewy24, .klarna,
-                            .linkInstantDebit, .bancontact, .iDEAL, .cashApp, .affirm, .zip, .revolutPay, .amazonPay, .alma, .mobilePay, .swish, .twint:
+                            .bancontact, .iDEAL, .cashApp, .affirm, .zip, .revolutPay, .amazonPay, .alma, .mobilePay, .swish, .twint:
                         return [.returnURL]
                     case .USBankAccount:
                         return [

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentOption+Images.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentOption+Images.swift
@@ -146,7 +146,7 @@ extension STPPaymentMethodType {
     /// light/dark agnostic icons
     var iconRequiresTinting: Bool {
         switch self {
-        case .card, .AUBECSDebit, .USBankAccount, .linkInstantDebit, .konbini, .boleto, .instantDebits:
+        case .card, .AUBECSDebit, .USBankAccount, .konbini, .boleto, .instantDebits:
             return true
         default:
             return false
@@ -180,7 +180,7 @@ extension STPPaymentMethodType {
                 return .pm_type_paypal
             case .AUBECSDebit:
                 return .pm_type_aubecsdebit
-            case .USBankAccount, .linkInstantDebit, .instantDebits:
+            case .USBankAccount, .instantDebits:
                 return .pm_type_us_bank
             case .UPI:
                 return .pm_type_upi

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
@@ -38,12 +38,6 @@ extension PaymentSheet {
         .twint,
         .multibanco,
     ]
-
-    /// An unordered list of paymentMethodtypes that can be used with Link in PaymentSheet
-    /// - Note: This is a var because it depends on the authenticated Link user
-    ///
-    /// :nodoc:
-    internal static var supportedLinkPaymentMethods: [STPPaymentMethodType] = []
 }
 
 // MARK: - PaymentMethodRequirementProvider

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
@@ -196,9 +196,6 @@ extension PaymentSheet {
         /// The layout of payment methods in PaymentSheet. Defaults to `.horizontal`.
         /// - Seealso: `PaymentSheet.PaymentMethodLayout` for the list of available layouts.
         @_spi(STP) public var paymentMethodLayout: PaymentMethodLayout = .horizontal
-
-        // MARK: Internal
-        internal var linkPaymentMethodsOnly: Bool = false
     }
 
     /// Defines the layout orientations available for displaying payment methods in PaymentSheet.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
@@ -24,8 +24,7 @@ extension PaymentSheetFormFactory {
         // Make section titled "Contact Information" w/ phone and email if merchant requires it.
         let optionalPhoneAndEmailInformationSection: SectionElement? = {
             let emailElement: Element? = configuration.billingDetailsCollectionConfiguration.email == .always ? makeEmail() : nil
-            // Link can't collect phone.
-            let shouldIncludePhone = !configuration.linkPaymentMethodsOnly && configuration.billingDetailsCollectionConfiguration.phone == .always
+            let shouldIncludePhone = configuration.billingDetailsCollectionConfiguration.phone == .always
             let phoneElement: Element? = shouldIncludePhone ? makePhone() : nil
             let contactInformationElements = [emailElement, phoneElement].compactMap { $0 }
             guard !contactInformationElements.isEmpty else {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -136,8 +136,6 @@ class PaymentSheetFormFactory {
         // 1. Custom, one-off forms
         if paymentMethod == .card {
             return makeCard(cardBrandChoiceEligible: cardBrandChoiceEligible)
-        } else if paymentMethod == .linkInstantDebit {
-            return ConnectionsElement()
         } else if paymentMethod == .USBankAccount {
             return makeUSBankAccount(merchantName: configuration.merchantDisplayName)
         } else if paymentMethod == .UPI {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactoryConfig.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactoryConfig.swift
@@ -27,14 +27,6 @@ enum PaymentSheetFormFactoryConfig {
             return config.merchantDisplayName
         }
     }
-    var linkPaymentMethodsOnly: Bool {
-        switch self {
-        case .paymentSheet(let config):
-            return config.linkPaymentMethodsOnly
-        case .customerSheet:
-            return false
-        }
-    }
     var overrideCountry: String? {
         switch self {
         case .paymentSheet(let config):

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -136,7 +136,7 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
         case .selectingSaved:
             return .customWithLock(title: String.Localized.continue)
         case .addingNew:
-            return .add(paymentMethodType: selectedPaymentMethodType ?? .stripe(.unknown))
+            return .continue
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/ConfirmButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/ConfirmButton.swift
@@ -37,7 +37,7 @@ class ConfirmButton: UIView {
     }
     enum CallToActionType {
         case pay(amount: Int, currency: String)
-        case add(paymentMethodType: PaymentSheet.PaymentMethodType)
+        case `continue`
         case setup
         case custom(title: String)
         case customWithLock(title: String)
@@ -292,13 +292,6 @@ class ConfirmButton: UIView {
         lazy var spinner: CheckProgressView = {
             return CheckProgressView(frame: CGRect(origin: .zero, size: spinnerSize))
         }()
-        lazy var addIcon: UIImageView = {
-            let image = Image.icon_plus.makeImage(template: true)
-            let icon = UIImageView(image: image)
-            icon.setContentCompressionResistancePriority(.required, for: .horizontal)
-            return icon
-        }()
-
         var foregroundColor: UIColor = .white {
             didSet {
                 foregroundColorDidChange()
@@ -317,7 +310,7 @@ class ConfirmButton: UIView {
             isAccessibilityElement = true
 
             // Add views
-            let views = ["titleLabel": titleLabel, "lockIcon": lockIcon, "spinnyView": spinner, "addIcon": addIcon]
+            let views = ["titleLabel": titleLabel, "lockIcon": lockIcon, "spinnyView": spinner]
             views.values.forEach {
                 $0.translatesAutoresizingMaskIntoConstraints = false
                 addSubview($0)
@@ -330,14 +323,10 @@ class ConfirmButton: UIView {
                 equalTo: centerXAnchor)
             titleLabelCenterXConstraint.priority = .defaultLow
             NSLayoutConstraint.activate([
-                // Add icon
-                addIcon.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
-                addIcon.centerYAnchor.constraint(equalTo: centerYAnchor),
-
                 // Label
                 titleLabelCenterXConstraint,
                 titleLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
-                titleLabel.leadingAnchor.constraint(greaterThanOrEqualTo: addIcon.trailingAnchor),
+                titleLabel.leadingAnchor.constraint(greaterThanOrEqualTo: layoutMarginsGuide.leadingAnchor),
 
                 // Lock icon
                 lockIcon.leadingAnchor.constraint(greaterThanOrEqualTo: titleLabel.trailingAnchor, constant: 8),
@@ -378,7 +367,7 @@ class ConfirmButton: UIView {
                 switch status {
                 case .enabled, .disabled, .spinnerWithInteractionDisabled:
                     switch callToAction {
-                    case .add:
+                    case .continue:
                         return String.Localized.continue
                     case let .pay(amount, currency):
                         let localizedAmount = String.localizedAmountDisplayString(
@@ -410,18 +399,14 @@ class ConfirmButton: UIView {
 
             // Show/hide lock and add icons
             switch callToAction {
-            case .add:
+            case .continue:
                 lockIcon.isHidden = true
-                addIcon.isHidden = true
             case .custom:
                 lockIcon.isHidden = true
-                addIcon.isHidden = true
             case .customWithLock:
                 lockIcon.isHidden = false
-                addIcon.isHidden = true
             case .pay, .setup:
                 lockIcon.isHidden = false
-                addIcon.isHidden = true
             }
 
             // Update accessibility information
@@ -481,11 +466,9 @@ class ConfirmButton: UIView {
                 switch status {
                 case .disabled, .enabled:
                     self.lockIcon.alpha = self.titleLabel.alpha
-                    self.addIcon.alpha = self.titleLabel.alpha
                     self.spinner.alpha = 0
                 case .processing, .spinnerWithInteractionDisabled:
                     self.lockIcon.alpha = 0
-                    self.addIcon.alpha = 0
                     self.spinner.alpha = 1
                     self.spinnerCenteredToLockConstraint.isActive = true
                     self.spinnerCenteredConstraint.isActive = false
@@ -542,7 +525,6 @@ class ConfirmButton: UIView {
         private func foregroundColorDidChange() {
             titleLabel.textColor = foregroundColor
             lockIcon.tintColor = foregroundColor
-            addIcon.tintColor = foregroundColor
             spinner.color = foregroundColor
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/ConfirmButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/ConfirmButton.swift
@@ -378,12 +378,8 @@ class ConfirmButton: UIView {
                 switch status {
                 case .enabled, .disabled, .spinnerWithInteractionDisabled:
                     switch callToAction {
-                    case .add(let paymentMethodType):
-                        if paymentMethodType == .stripe(.linkInstantDebit) {
-                            return STPLocalizedString("Add bank account", "Button prompt to add a bank account as a payment method.")
-                        } else {
-                            return String.Localized.continue
-                        }
+                    case .add:
+                        return String.Localized.continue
                     case let .pay(amount, currency):
                         let localizedAmount = String.localizedAmountDisplayString(
                             for: amount, currency: currency)
@@ -414,9 +410,9 @@ class ConfirmButton: UIView {
 
             // Show/hide lock and add icons
             switch callToAction {
-            case .add(let paymentMethodType):
+            case .add:
                 lockIcon.isHidden = true
-                addIcon.isHidden = paymentMethodType != .stripe(.linkInstantDebit)
+                addIcon.isHidden = true
             case .custom:
                 lockIcon.isHidden = true
                 addIcon.isHidden = true

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodEnums.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodEnums.swift
@@ -60,8 +60,6 @@ import Foundation
     case link
     /// A Klarna payment method.
     case klarna
-    /// A Link Instant Debit payment method
-    case linkInstantDebit
     /// An Affirm payment method
     case affirm
     /// A US Bank Account payment method (ACH)
@@ -146,8 +144,6 @@ import Foundation
             return STPLocalizedString("Link", "Link Payment Method type brand name")
         case .klarna:
             return STPLocalizedString("Klarna", "Payment Method type brand name")
-        case .linkInstantDebit:
-            return instantDebitsDisplayName
         case .affirm:
             return STPLocalizedString("Affirm", "Payment Method type brand name")
         case .USBankAccount:
@@ -242,8 +238,6 @@ import Foundation
             return "link"
         case .klarna:
             return "klarna"
-        case .linkInstantDebit:
-            return "link_instant_debits"
         case .affirm:
             return "affirm"
         case .USBankAccount:

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodParams.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodParams.swift
@@ -741,7 +741,6 @@ public class STPPaymentMethodParams: NSObject, STPFormEncodable {
             .blik,
             .weChatPay,
             .link,
-            .linkInstantDebit,
             .USBankAccount,
             .cashApp,
             .revolutPay,
@@ -1262,7 +1261,7 @@ extension STPPaymentMethodParams {
             alma = STPPaymentMethodAlmaParams()
         case .multibanco:
             multibanco = STPPaymentMethodMultibancoParams()
-        case .cardPresent, .linkInstantDebit, .paynow, .zip, .konbini, .promptPay, .twint, .instantDebits:
+        case .cardPresent, .paynow, .zip, .konbini, .promptPay, .twint, .instantDebits:
             // These payment methods don't have any params
             break
         case .unknown:
@@ -1330,8 +1329,6 @@ extension STPPaymentMethodParams {
             return "Link"
         case .klarna:
             return "Klarna"
-        case .linkInstantDebit:
-            return "Bank"
         case .affirm:
             return "Affirm"
         case .USBankAccount:

--- a/StripePayments/StripePayments/Source/Categories/Enums+CustomStringConvertible.swift
+++ b/StripePayments/StripePayments/Source/Categories/Enums+CustomStringConvertible.swift
@@ -505,8 +505,6 @@ extension STPPaymentMethodType: CustomStringConvertible {
             return "klarna"
         case .link:
             return "link"
-        case .linkInstantDebit:
-            return "linkInstantDebit"
         case .netBanking:
             return "netBanking"
         case .payPal:

--- a/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
@@ -720,7 +720,6 @@ public class STPPaymentHandler: NSObject {
             .link,
             .klarna,
             .affirm,
-            .linkInstantDebit,
             .cashApp,
             .paynow,
             .zip,


### PR DESCRIPTION
## Summary
"link_instant_debits" isn't a real payment method type and there's only one way it can end up as a type in our code - when `configuration.linkPaymentMethodsOnly = true`, it's injected into PaymentSheet's payment method types list.

LinkPaymentController does this, but LinkPaymentController never actually invokes PaymentSheet or uses `linkInstantDebits` as a type, so all this code is dead.

## Motivation
Clean up code, reduce surface area for vertical mode.

## Testing
Tested LinkPaymentController manually.

## Changelog
Not user facing