### PR TITLE
Send client side default payment method to resolve de-dupe logic

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
@@ -418,16 +418,16 @@ class CustomerSheetUITest: XCTestCase {
         paymentMethodRedisplayFilters.waitForExistenceAndTap()
         app.buttons["unspecified"].waitForExistenceAndTap()
 
-        // TODO: Use default payment method from elements/sessions payload
-        let selectButton2 = app.staticTexts["None"]
+        let selectButton2 = app.staticTexts["••••4242"]
         XCTAssertTrue(selectButton2.waitForExistence(timeout: timeout))
         selectButton2.tap()
 
         // Wait for sheet to present
         XCTAssertTrue(editButton.waitForExistence(timeout: timeout))
 
-        // Requires FF: elements_enable_read_allow_redisplay, to return "1", otherwise 0
-        XCTAssertEqual(app.staticTexts.matching(identifier: "••••4242").count, 1)
+        // Requires FF: elements_enable_read_allow_redisplay, to return "2", otherwise 0
+        // value == 2, 1 value on playground + 1 payment method
+        XCTAssertEqual(app.staticTexts.matching(identifier: "••••4242").count, 2)
 
         XCTAssertTrue(app.staticTexts["Edit"].waitForExistenceAndTap())
         XCTAssertTrue(app.staticTexts["Done"].waitForExistence(timeout: 1)) // Sanity check "Done" button is there

--- a/Stripe/StripeiOSTests/STPPaymentMethodFunctionalTest.swift
+++ b/Stripe/StripeiOSTests/STPPaymentMethodFunctionalTest.swift
@@ -144,9 +144,13 @@ class STPPaymentMethodFunctionalTest: XCTestCase {
                                                                                                merchantCountry: nil)
         var configuration = PaymentSheet.Configuration()
         configuration.customer = PaymentSheet.CustomerConfiguration(id: cscs.customer, customerSessionClientSecret: cscs.customerSessionClientSecret)
-        let elementSession = try await client.retrieveElementsSession(withIntentConfig: .init(mode: .payment(amount: 5000, currency: "usd", setupFutureUsage: .offSession, captureMethod: .automatic), confirmHandler: { _, _, _ in
-            // no-op
-        }), configuration: configuration)
+        let elementSession = try await client.retrieveElementsSession(
+            withIntentConfig: .init(mode: .payment(amount: 5000, currency: "usd", setupFutureUsage: .offSession, captureMethod: .automatic),
+                                    confirmHandler: { _, _, _ in
+                                        // no-op
+                                    }),
+            clientDefaultPaymentMethod: nil,
+            configuration: configuration)
 
         // Requires FF: elements_enable_read_allow_redisplay, to return "1", otherwise 0
         XCTAssertEqual(elementSession.customer?.paymentMethods.count, 1)

--- a/Stripe/StripeiOSTests/STPPaymentMethodFunctionalTest.swift
+++ b/Stripe/StripeiOSTests/STPPaymentMethodFunctionalTest.swift
@@ -149,18 +149,20 @@ class STPPaymentMethodFunctionalTest: XCTestCase {
                                     confirmHandler: { _, _, _ in
                                         // no-op
                                     }),
-            clientDefaultPaymentMethod: nil,
+            clientDefaultPaymentMethod: paymentMethod2.stripeId,
             configuration: configuration)
 
         // Requires FF: elements_enable_read_allow_redisplay, to return "1", otherwise 0
         XCTAssertEqual(elementSession.customer?.paymentMethods.count, 1)
+        XCTAssertEqual(elementSession.customer?.paymentMethods.first?.stripeId, paymentMethod2.stripeId)
+        XCTAssertEqual(elementSession.customer?.defaultPaymentMethod, paymentMethod2.stripeId)
 
         // Official endpoint should have two payment methods
         let fetchedPaymentMethods = try await fetchPaymentMethods(client: client, customerAndEphemeralKey: customerAndEphemeralKey)
         XCTAssertEqual(fetchedPaymentMethods.count, 2)
 
         // Clean up, detach both payment methods
-        try await client.detachPaymentMethodRemoveDuplicates(paymentMethod1.stripeId,
+        try await client.detachPaymentMethodRemoveDuplicates(paymentMethod2.stripeId,
                                              customerId: customerAndEphemeralKey.customer,
                                              fromCustomerUsing: customerAndEphemeralKey.ephemeralKeySecret)
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPAPIClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPAPIClient+PaymentSheet.swift
@@ -15,6 +15,7 @@ extension STPAPIClient {
 
     func makeElementsSessionsParams(mode: PaymentSheet.InitializationMode,
                                     epmConfiguration: PaymentSheet.ExternalPaymentMethodConfiguration?,
+                                    clientDefaultPaymentMethod: String?,
                                     customerAccessProvider: PaymentSheet.CustomerAccessProvider?) -> [String: Any] {
         var parameters: [String: Any] = [
             "locale": Locale.current.toLanguageTag(),
@@ -22,6 +23,9 @@ extension STPAPIClient {
         ]
         if case .customerSession(let clientSecret) = customerAccessProvider {
             parameters["customer_session_client_secret"] = clientSecret
+        }
+        if let clientDefaultPaymentMethod {
+            parameters["client_default_payment_method"] = clientDefaultPaymentMethod
         }
         switch mode {
         case .deferredIntent(let intentConfig):
@@ -62,6 +66,7 @@ extension STPAPIClient {
 
     func retrieveElementsSession(
         paymentIntentClientSecret: String,
+        clientDefaultPaymentMethod: String?,
         configuration: PaymentSheet.Configuration
     ) async throws -> (STPPaymentIntent, STPElementsSession) {
         let elementsSession = try await APIRequest<STPElementsSession>.getWith(
@@ -69,6 +74,7 @@ extension STPAPIClient {
             endpoint: APIEndpointElementsSessions,
             parameters: makeElementsSessionsParams(mode: .paymentIntentClientSecret(paymentIntentClientSecret),
                                                    epmConfiguration: configuration.externalPaymentMethodConfiguration,
+                                                   clientDefaultPaymentMethod: clientDefaultPaymentMethod,
                                                    customerAccessProvider: configuration.customer?.customerAccessProvider)
         )
         // The v1/elements/sessions response contains a PaymentIntent hash that we parse out into a PaymentIntent
@@ -83,6 +89,7 @@ extension STPAPIClient {
 
     func retrieveElementsSession(
         setupIntentClientSecret: String,
+        clientDefaultPaymentMethod: String?,
         configuration: PaymentSheet.Configuration
     ) async throws -> (STPSetupIntent, STPElementsSession) {
         let elementsSession = try await APIRequest<STPElementsSession>.getWith(
@@ -90,6 +97,7 @@ extension STPAPIClient {
             endpoint: APIEndpointElementsSessions,
             parameters: makeElementsSessionsParams(mode: .setupIntentClientSecret(setupIntentClientSecret),
                                                    epmConfiguration: configuration.externalPaymentMethodConfiguration,
+                                                   clientDefaultPaymentMethod: clientDefaultPaymentMethod,
                                                    customerAccessProvider: configuration.customer?.customerAccessProvider)
         )
         // The v1/elements/sessions response contains a SetupIntent hash that we parse out into a SetupIntent
@@ -104,10 +112,12 @@ extension STPAPIClient {
 
     func retrieveElementsSession(
         withIntentConfig intentConfig: PaymentSheet.IntentConfiguration,
+        clientDefaultPaymentMethod: String?,
         configuration: PaymentSheet.Configuration
     ) async throws -> STPElementsSession {
         let parameters = makeElementsSessionsParams(mode: .deferredIntent(intentConfig),
                                                     epmConfiguration: configuration.externalPaymentMethodConfiguration,
+                                                    clientDefaultPaymentMethod: clientDefaultPaymentMethod,
                                                     customerAccessProvider: configuration.customer?.customerAccessProvider)
         return try await APIRequest<STPElementsSession>.getWith(
             self,
@@ -116,13 +126,19 @@ extension STPAPIClient {
         )
     }
 
-    func retrieveElementsSessionForCustomerSheet(paymentMethodTypes: [String]?, customerSessionClientSecret: CustomerSessionClientSecret?) async throws -> STPElementsSession {
+    func retrieveElementsSessionForCustomerSheet(paymentMethodTypes: [String]?,
+                                                 clientDefaultPaymentMethod: String?,
+                                                 customerSessionClientSecret: CustomerSessionClientSecret?) async throws -> STPElementsSession {
         var parameters: [String: Any] = [:]
         parameters["type"] = "deferred_intent"
         parameters["locale"] = Locale.current.toLanguageTag()
 
         if let customerSessionClientSecret {
             parameters["customer_session_client_secret"] = customerSessionClientSecret.clientSecret
+        }
+
+        if let clientDefaultPaymentMethod {
+            parameters["client_default_payment_method"] = clientDefaultPaymentMethod
         }
 
         var deferredIntent = [String: Any]()

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPAPIClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPAPIClient+PaymentSheet.swift
@@ -129,6 +129,19 @@ extension STPAPIClient {
     func retrieveElementsSessionForCustomerSheet(paymentMethodTypes: [String]?,
                                                  clientDefaultPaymentMethod: String?,
                                                  customerSessionClientSecret: CustomerSessionClientSecret?) async throws -> STPElementsSession {
+
+        let parameters = makeElementsSessionsParamsForCustomerSheet(paymentMethodTypes: paymentMethodTypes,
+                                                                    clientDefaultPaymentMethod: clientDefaultPaymentMethod,
+                                                                    customerSessionClientSecret: customerSessionClientSecret)
+        return try await APIRequest<STPElementsSession>.getWith(
+            self,
+            endpoint: APIEndpointElementsSessions,
+            parameters: parameters
+        )
+    }
+    func makeElementsSessionsParamsForCustomerSheet(paymentMethodTypes: [String]?,
+                                                    clientDefaultPaymentMethod: String?,
+                                                    customerSessionClientSecret: CustomerSessionClientSecret?) -> [String: Any] {
         var parameters: [String: Any] = [:]
         parameters["type"] = "deferred_intent"
         parameters["locale"] = Locale.current.toLanguageTag()
@@ -147,12 +160,7 @@ extension STPAPIClient {
             deferredIntent["payment_method_types"] = paymentMethodTypes
         }
         parameters["deferred_intent"] = deferredIntent
-
-        return try await APIRequest<STPElementsSession>.getWith(
-            self,
-            endpoint: APIEndpointElementsSessions,
-            parameters: parameters
-        )
+        return parameters
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSessionAdapter/CustomerSessionAdapter.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSessionAdapter/CustomerSessionAdapter.swift
@@ -75,12 +75,25 @@ class CustomerSessionAdapter {
         }
     }
 
-    private func elementsSession(customerSessionClientSecret: CustomerSessionClientSecret) async throws -> STPElementsSession{
+    private func elementsSession(customerSessionClientSecret: CustomerSessionClientSecret) async throws -> STPElementsSession {
+        let clientDefaultPaymentMethod = fetchClientDefaultPaymentMethod(for: customerSessionClientSecret.customerId)
         return try await self.configuration.apiClient.retrieveElementsSessionForCustomerSheet(paymentMethodTypes: intentConfiguration.paymentMethodTypes,
+                                                                                              clientDefaultPaymentMethod: clientDefaultPaymentMethod,
                                                                                               customerSessionClientSecret: customerSessionClientSecret)
     }
 }
 extension CustomerSessionAdapter {
+    func fetchClientDefaultPaymentMethod(for customerId: String) -> String? {
+        guard let defaultPaymentMethod = fetchSelectedPaymentOption(for: customerId),
+           case .stripeId(let stripePaymentMethodId) = defaultPaymentMethod else {
+            return nil
+        }
+        return stripePaymentMethodId
+    }
+
+    func fetchSelectedPaymentOption(for customerId: String) -> CustomerPaymentOption? {
+        return CustomerPaymentOption.defaultPaymentMethod(for: customerId)
+    }
 
     func detachPaymentMethod(paymentMethodId: String) async throws {
         let cachedCustomerSessionClientSecret = try await cachedCustomerSessionClientSecret()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsViewController.swift
@@ -527,7 +527,9 @@ class CustomerSavedPaymentMethodsViewController: UIViewController {
 
     private func fetchSetupIntent(clientSecret: String) async -> (STPSetupIntent, STPElementsSession)? {
         do {
-            return try await configuration.apiClient.retrieveElementsSession(setupIntentClientSecret: clientSecret, configuration: .init())
+            return try await configuration.apiClient.retrieveElementsSession(setupIntentClientSecret: clientSecret,
+                                                                             clientDefaultPaymentMethod: nil,
+                                                                             configuration: .init())
         } catch {
             STPAnalyticsClient.sharedClient.logCSAddPaymentMethodViaSetupIntentFailure()
             self.error = error

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetDataSource.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetDataSource.swift
@@ -40,7 +40,8 @@ class CustomerSheetDataSource {
 
                 // Ensure local specs are loaded prior to the ones from elementSession
                 await loadFormSpecs()
-                let paymentOption = CustomerPaymentOption.defaultPaymentMethod(for: try await customerSessionClientSecret.customerId)
+                let customerId = try await customerSessionClientSecret.customerId
+                let paymentOption = customerSessionAdapter.fetchSelectedPaymentOption(for: customerId)
                 let elementSession = try await elementsSessionResult
 
                 // Override with specs from elementSession
@@ -59,7 +60,9 @@ class CustomerSheetDataSource {
             do {
                 async let paymentMethodsResult = try customerAdapter.fetchPaymentMethods()
                 async let selectedPaymentMethodResult = try customerAdapter.fetchSelectedPaymentOption()
-                async let elementsSessionResult = try self.configuration.apiClient.retrieveElementsSessionForCustomerSheet(paymentMethodTypes: customerAdapter.paymentMethodTypes, customerSessionClientSecret: nil)
+                async let elementsSessionResult = try self.configuration.apiClient.retrieveElementsSessionForCustomerSheet(paymentMethodTypes: customerAdapter.paymentMethodTypes,
+                                                                                                                           clientDefaultPaymentMethod: nil,
+                                                                                                                           customerSessionClientSecret: nil)
 
                 // Ensure local specs are loaded prior to the ones from elementSession
                 await loadFormSpecs()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -181,12 +181,16 @@ final class PaymentSheetLoader {
 
     static func fetchIntent(mode: PaymentSheet.InitializationMode, configuration: PaymentSheet.Configuration, analyticsClient: STPAnalyticsClient) async throws -> Intent {
         let intent: Intent
+        let clientDefaultPaymentMethod = defaultStripePaymentMethodId(forCustomerID: configuration.customer?.id)
+
         switch mode {
         case .paymentIntentClientSecret(let clientSecret):
             let paymentIntent: STPPaymentIntent
             let elementsSession: STPElementsSession
             do {
-                (paymentIntent, elementsSession) = try await configuration.apiClient.retrieveElementsSession(paymentIntentClientSecret: clientSecret, configuration: configuration)
+                (paymentIntent, elementsSession) = try await configuration.apiClient.retrieveElementsSession(paymentIntentClientSecret: clientSecret,
+                                                                                                             clientDefaultPaymentMethod: clientDefaultPaymentMethod,
+                                                                                                             configuration: configuration)
             } catch let error {
                 analyticsClient.logPaymentSheetEvent(event: .paymentSheetElementsSessionLoadFailed, error: error)
                 // Fallback to regular retrieve PI when retrieve PI with preferences fails
@@ -202,7 +206,9 @@ final class PaymentSheetLoader {
             let setupIntent: STPSetupIntent
             let elementsSession: STPElementsSession
             do {
-                (setupIntent, elementsSession) = try await configuration.apiClient.retrieveElementsSession(setupIntentClientSecret: clientSecret, configuration: configuration)
+                (setupIntent, elementsSession) = try await configuration.apiClient.retrieveElementsSession(setupIntentClientSecret: clientSecret,
+                                                                                                           clientDefaultPaymentMethod: clientDefaultPaymentMethod,
+                                                                                                           configuration: configuration)
             } catch let error {
                 analyticsClient.logPaymentSheetEvent(event: .paymentSheetElementsSessionLoadFailed, error: error)
                 // Fallback to regular retrieve SI when retrieve SI with preferences fails
@@ -216,7 +222,9 @@ final class PaymentSheetLoader {
             intent = .setupIntent(elementsSession: elementsSession, setupIntent: setupIntent)
         case .deferredIntent(let intentConfig):
             do {
-                let elementsSession = try await configuration.apiClient.retrieveElementsSession(withIntentConfig: intentConfig, configuration: configuration)
+                let elementsSession = try await configuration.apiClient.retrieveElementsSession(withIntentConfig: intentConfig,
+                                                                                                clientDefaultPaymentMethod: clientDefaultPaymentMethod,
+                                                                                                configuration: configuration)
                 intent = .deferredIntent(elementsSession: elementsSession, intentConfig: intentConfig)
             } catch let error as NSError where error == NSError.stp_genericFailedToParseResponseError() {
                 // Most errors are useful and should be reported back to the merchant to help them debug their integration (e.g. bad connection, unknown parameter, invalid api key).
@@ -241,6 +249,14 @@ final class PaymentSheetLoader {
             print(message)
         }
         return intent
+    }
+
+    static func defaultStripePaymentMethodId(forCustomerID customerID: String?) -> String? {
+        guard let defaultPaymentMethod = CustomerPaymentOption.defaultPaymentMethod(for: customerID),
+              case .stripeId(let paymentMethodId) = defaultPaymentMethod else {
+            return nil
+        }
+        return paymentMethodId
     }
 
     static let savedPaymentMethodTypes: [STPPaymentMethodType] = [.card, .USBankAccount, .SEPADebit]

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPAPIClient+PaymentSheetTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPAPIClient+PaymentSheetTest.swift
@@ -27,7 +27,7 @@ class STPAPIClient_PaymentSheetTest: XCTestCase {
         var config = PaymentSheet.Configuration()
         config.externalPaymentMethodConfiguration = .init(externalPaymentMethods: ["external_foo", "external_bar"], externalPaymentMethodConfirmHandler: { _, _, _ in })
 
-        let parameters = STPAPIClient(publishableKey: "pk_test").makeElementsSessionsParams(mode: .deferredIntent(intentConfig), epmConfiguration: config.externalPaymentMethodConfiguration, customerAccessProvider: .customerSession("cs_12345"))
+        let parameters = STPAPIClient(publishableKey: "pk_test").makeElementsSessionsParams(mode: .deferredIntent(intentConfig), epmConfiguration: config.externalPaymentMethodConfiguration, clientDefaultPaymentMethod: nil, customerAccessProvider: .customerSession("cs_12345"))
         XCTAssertEqual(parameters["key"] as? String, "pk_test")
         XCTAssertEqual(parameters["locale"] as? String, Locale.current.toLanguageTag())
         XCTAssertEqual(parameters["external_payment_methods"] as? [String], ["external_foo", "external_bar"])
@@ -51,7 +51,7 @@ class STPAPIClient_PaymentSheetTest: XCTestCase {
                                                             onBehalfOf: "acct_connect",
                                                             confirmHandler: { _, _, _ in })
 
-        let parameters = STPAPIClient(publishableKey: "pk_test").makeElementsSessionsParams(mode: .deferredIntent(intentConfig), epmConfiguration: nil, customerAccessProvider: .legacyCustomerEphemeralKey("ek_12345"))
+        let parameters = STPAPIClient(publishableKey: "pk_test").makeElementsSessionsParams(mode: .deferredIntent(intentConfig), epmConfiguration: nil, clientDefaultPaymentMethod: nil, customerAccessProvider: .legacyCustomerEphemeralKey("ek_12345"))
         XCTAssertEqual(parameters["key"] as? String, "pk_test")
         XCTAssertEqual(parameters["locale"] as? String, Locale.current.toLanguageTag())
         XCTAssertEqual(parameters["external_payment_methods"] as? [String], [])

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPAPIClient+PaymentSheetTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPAPIClient+PaymentSheetTest.swift
@@ -11,7 +11,7 @@ import XCTest
 
 @testable@_spi(STP) import StripeCore
 @testable@_spi(STP) import StripePayments
-@testable@_spi(STP) import StripePaymentSheet
+@testable@_spi(STP)@_spi(CustomerSessionBetaAccess) import StripePaymentSheet
 @testable@_spi(STP) import StripePaymentsUI
 
 class STPAPIClient_PaymentSheetTest: XCTestCase {
@@ -27,11 +27,12 @@ class STPAPIClient_PaymentSheetTest: XCTestCase {
         var config = PaymentSheet.Configuration()
         config.externalPaymentMethodConfiguration = .init(externalPaymentMethods: ["external_foo", "external_bar"], externalPaymentMethodConfirmHandler: { _, _, _ in })
 
-        let parameters = STPAPIClient(publishableKey: "pk_test").makeElementsSessionsParams(mode: .deferredIntent(intentConfig), epmConfiguration: config.externalPaymentMethodConfiguration, clientDefaultPaymentMethod: nil, customerAccessProvider: .customerSession("cs_12345"))
+        let parameters = STPAPIClient(publishableKey: "pk_test").makeElementsSessionsParams(mode: .deferredIntent(intentConfig), epmConfiguration: config.externalPaymentMethodConfiguration, clientDefaultPaymentMethod: "pm_12345", customerAccessProvider: .customerSession("cs_12345"))
         XCTAssertEqual(parameters["key"] as? String, "pk_test")
         XCTAssertEqual(parameters["locale"] as? String, Locale.current.toLanguageTag())
         XCTAssertEqual(parameters["external_payment_methods"] as? [String], ["external_foo", "external_bar"])
         XCTAssertEqual(parameters["customer_session_client_secret"] as? String, "cs_12345")
+        XCTAssertEqual(parameters["client_default_payment_method"] as? String, "pm_12345")
 
         let deferredIntent = try XCTUnwrap(parameters["deferred_intent"] as?  [String: Any])
         XCTAssertEqual(deferredIntent["payment_method_types"] as? [String], ["card", "cashapp"])
@@ -57,6 +58,7 @@ class STPAPIClient_PaymentSheetTest: XCTestCase {
         XCTAssertEqual(parameters["external_payment_methods"] as? [String], [])
         XCTAssertNil(parameters["payment_method_configurations"])
         XCTAssertNil(parameters["customer_session_client_secret"])
+        XCTAssertNil(parameters["client_default_payment_method"])
 
         let deferredIntent = try XCTUnwrap(parameters["deferred_intent"] as?  [String: Any])
         XCTAssertEqual(deferredIntent["payment_method_types"] as? [String], ["card", "cashapp"])
@@ -64,5 +66,38 @@ class STPAPIClient_PaymentSheetTest: XCTestCase {
         XCTAssertEqual(deferredIntent["mode"] as? String, "setup")
         XCTAssertEqual(deferredIntent["currency"] as? String, "USD")
         XCTAssertEqual(deferredIntent["setup_future_usage"] as? String, "off_session")
+    }
+
+    func testMakeElementsSessionsParamsForCustomerSheet() throws {
+        let parameters = STPAPIClient(publishableKey: "pk_test").makeElementsSessionsParamsForCustomerSheet(
+            paymentMethodTypes: ["card"],
+            clientDefaultPaymentMethod: "pm_12345",
+            customerSessionClientSecret: CustomerSessionClientSecret(customerId: "cus_12345", clientSecret: "cuss_54321"))
+
+        XCTAssertEqual(parameters["type"] as? String, "deferred_intent")
+        XCTAssertEqual(parameters["locale"] as? String, Locale.current.toLanguageTag())
+        XCTAssertEqual(parameters["customer_session_client_secret"] as? String, "cuss_54321")
+        XCTAssertEqual(parameters["client_default_payment_method"] as? String, "pm_12345")
+
+        let deferredIntent = try XCTUnwrap(parameters["deferred_intent"] as?  [String: Any])
+        XCTAssertEqual(deferredIntent["mode"] as? String, "setup")
+        XCTAssertEqual(deferredIntent["payment_method_types"] as? [String], ["card"])
+
+    }
+    func testMakeElementsSessionsParamsForCustomerSheet_nilable() throws {
+        let parameters = STPAPIClient(publishableKey: "pk_test").makeElementsSessionsParamsForCustomerSheet(
+            paymentMethodTypes: nil,
+            clientDefaultPaymentMethod: nil,
+            customerSessionClientSecret: nil)
+
+        XCTAssertEqual(parameters["type"] as? String, "deferred_intent")
+        XCTAssertEqual(parameters["locale"] as? String, Locale.current.toLanguageTag())
+        XCTAssertNil(parameters["customer_session_client_secret"])
+        XCTAssertNil(parameters["client_default_payment_method"])
+
+        let deferredIntent = try XCTUnwrap(parameters["deferred_intent"] as?  [String: Any])
+        XCTAssertEqual(deferredIntent["mode"] as? String, "setup")
+        XCTAssertNil(deferredIntent["payment_method_types"])
+
     }
 }


### PR DESCRIPTION
## Summary
Send client side default payment method to elements/session to resolve de-duping logic

## Motivation
Resolve issue with duplicate payment methods.

## Testing
Manual testing & added tests

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
