### PR TITLE
Payment Sheet: for FC and ID, added hosted_surface parameter, and improved parameter passing

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -288,11 +288,15 @@ extension PaymentMethodFormViewController {
                 self.delegate?.updateErrorLabel(for: genericError)
             }
         }
+        let additionalParameters: [String: Any] = [
+            "hosted_surface": "payment_element",
+        ]
         switch intent {
         case .paymentIntent(_, let paymentIntent):
             client.collectBankAccountForPayment(
                 clientSecret: paymentIntent.clientSecret,
                 returnURL: configuration.returnURL,
+                additionalParameters: additionalParameters,
                 onEvent: nil,
                 params: params,
                 from: viewController,
@@ -302,6 +306,7 @@ extension PaymentMethodFormViewController {
             client.collectBankAccountForSetup(
                 clientSecret: setupIntent.clientSecret,
                 returnURL: configuration.returnURL,
+                additionalParameters: additionalParameters,
                 onEvent: nil,
                 params: params,
                 from: viewController,
@@ -325,6 +330,7 @@ extension PaymentMethodFormViewController {
                 amount: amount,
                 currency: currency,
                 onBehalfOf: intentConfig.onBehalfOf,
+                additionalParameters: additionalParameters,
                 from: viewController,
                 financialConnectionsCompletion: financialConnectionsCompletion
             )
@@ -373,11 +379,17 @@ extension PaymentMethodFormViewController {
                 self.delegate?.updateErrorLabel(for: genericError)
             }
         }
+        let additionalParameters: [String: Any] = [
+            "product": "instant_debits",
+            "attach_required": true,
+            "hosted_surface": "payment_element",
+        ]
         switch intent {
         case .paymentIntent(_, let paymentIntent):
             client.collectBankAccountForPayment(
                 clientSecret: paymentIntent.clientSecret,
                 returnURL: configuration.returnURL,
+                additionalParameters: additionalParameters,
                 onEvent: nil,
                 params: params,
                 from: viewController,
@@ -387,6 +399,7 @@ extension PaymentMethodFormViewController {
             client.collectBankAccountForSetup(
                 clientSecret: setupIntent.clientSecret,
                 returnURL: configuration.returnURL,
+                additionalParameters: additionalParameters,
                 onEvent: nil,
                 params: params,
                 from: viewController,

--- a/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+LinkAccountSession.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+LinkAccountSession.swift
@@ -106,12 +106,6 @@ public extension STPAPIClient {
         if let customerEmailAddress = customerEmailAddress {
             parameters["payment_method_data[billing_details][email]"] = customerEmailAddress
         }
-        // handle instant debits
-        if paymentMethodType == .link {
-            parameters["hosted_surface"] = "payment_element"
-            parameters["product"] = "instant_debits"
-            parameters["attach_required"] = true
-        }
 
         APIRequest<LinkAccountSession>.post(
             with: self,

--- a/StripePayments/StripePayments/Source/Helpers/STPBankAccountCollector.swift
+++ b/StripePayments/StripePayments/Source/Helpers/STPBankAccountCollector.swift
@@ -187,6 +187,7 @@ public class STPBankAccountCollector: NSObject {
     @_spi(STP) public func collectBankAccountForPayment(
         clientSecret: String,
         returnURL: String?,
+        additionalParameters: [String: Any] = [:],
         onEvent: ((FinancialConnectionsEvent) -> Void)?,
         params: STPCollectBankAccountParams,
         from viewController: UIViewController,
@@ -204,6 +205,7 @@ public class STPBankAccountCollector: NSObject {
         _collectBankAccountForPayment(
             clientSecret: clientSecret,
             returnURL: returnURL,
+            additionalParameters: additionalParameters,
             onEvent: onEvent,
             params: params,
             from: viewController,
@@ -214,6 +216,7 @@ public class STPBankAccountCollector: NSObject {
     private func _collectBankAccountForPayment(
         clientSecret: String,
         returnURL: String?,
+        additionalParameters: [String: Any] = [:],
         onEvent: ((FinancialConnectionsEvent) -> Void)?,
         params: STPCollectBankAccountParams,
         from viewController: UIViewController,
@@ -264,6 +267,7 @@ public class STPBankAccountCollector: NSObject {
             paymentMethodType: params.paymentMethodParams.type,
             customerName: params.paymentMethodParams.billingDetails?.name,
             customerEmailAddress: params.paymentMethodParams.billingDetails?.email,
+            additionalParameteres: additionalParameters,
             completion: linkAccountSessionCallback
         )
     }
@@ -437,6 +441,7 @@ public class STPBankAccountCollector: NSObject {
     @_spi(STP) public func collectBankAccountForSetup(
         clientSecret: String,
         returnURL: String?,
+        additionalParameters: [String: Any] = [:],
         onEvent: ((FinancialConnectionsEvent) -> Void)?,
         params: STPCollectBankAccountParams,
         from viewController: UIViewController,
@@ -454,6 +459,7 @@ public class STPBankAccountCollector: NSObject {
         _collectBankAccountForSetup(
             clientSecret: clientSecret,
             returnURL: returnURL,
+            additionalParameters: additionalParameters,
             onEvent: onEvent,
             params: params,
             from: viewController,
@@ -464,6 +470,7 @@ public class STPBankAccountCollector: NSObject {
     private func _collectBankAccountForSetup(
         clientSecret: String,
         returnURL: String?,
+        additionalParameters: [String: Any] = [:],
         onEvent: ((FinancialConnectionsEvent) -> Void)?,
         params: STPCollectBankAccountParams,
         from viewController: UIViewController,
@@ -512,6 +519,7 @@ public class STPBankAccountCollector: NSObject {
             paymentMethodType: params.paymentMethodParams.type,
             customerName: params.paymentMethodParams.billingDetails?.name,
             customerEmailAddress: params.paymentMethodParams.billingDetails?.email,
+            additionalParameteres: additionalParameters,
             completion: linkAccountSessionCallback
         )
     }
@@ -548,6 +556,7 @@ public class STPBankAccountCollector: NSObject {
         amount: Int?,
         currency: String?,
         onBehalfOf: String?,
+        additionalParameters: [String: Any] = [:],
         from viewController: UIViewController,
         financialConnectionsCompletion: @escaping (
             FinancialConnectionsSDKResult?, LinkAccountSession?, NSError?
@@ -572,7 +581,8 @@ public class STPBankAccountCollector: NSObject {
             sessionId: sessionId,
             amount: amount,
             currency: currency,
-            onBehalfOf: onBehalfOf
+            onBehalfOf: onBehalfOf,
+            additionalParameters: additionalParameters
         ) { linkAccountSession, error in
             if let error {
                 financialConnectionsCompletion(nil, nil, error as NSError)


### PR DESCRIPTION
## Summary

^ this PR:
1) Adds a "hosted_surface" parameter so backend can better identify who is making the call on what surface
2) improves/fixes some parameter passing as part of this

## Testing

CI tests go through these flows, so if CI passes for this PR, we should be in a pretty good standing. Also ran some of these tests locally. 

Here is also an example of Instant Debits  where we had hard-coded logic, and we can see it appear here even though its not hard-coded:

![Screenshot 2024-06-13 at 9 53 55 AM](https://github.com/stripe/stripe-ios/assets/105514761/4dc33828-4cf0-4522-8bd0-83da9411326e)
