### PR TITLE
Poll for CAP until refresh endpoint is ready

### DIFF
--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodEnums.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodEnums.swift
@@ -281,7 +281,7 @@ extension STPPaymentMethodType {
         switch self {
         // Payment methods such as AmazonPay and other app-to-app redirects that bypass the "redirect trampoline" to give a more seamless user experience for app-to-app.
         // However, when returning to the merchant app in this scenario, the intent often isn't updated instantaneously, requiring polling for intent status updates.
-        case .amazonPay:
+        case .amazonPay, .cashApp:
             return true
         default:
             return false


### PR DESCRIPTION
## Summary
- Mark CAP as it needs polling until refresh endpoint is ready

## Motivation
- Still need to poll for now

## Testing
- Manual

## Changelog
N/A
