### PR TITLE
Fix PaymentSheet and CustomerSheet in SwiftUI on iOS 18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 * [Changed] The "save this card" checkbox is now unchecked by default. To change this behavior, set your PaymentSheet.Configuration.savePaymentMethodOptInBehavior to `.requiresOptOut`.
 * [Fixed] Fixed an issue where PaymentSheet would not present in the iOS 18 beta when using SwiftUI.
 
+### CustomerSheet
+* [Fixed] Fixed an issue where CustomerSheet would not present in the iOS 18 beta when using SwiftUI.
+
 ### Payments
 * [Added] Updated support for MobilePay bindings.
 * [Changed] Some Payment Methods (including Klarna and PayPal) may now authenticate using ASWebAuthenticationSession, enabling these payment methods to share session storage across apps.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### PaymentSheet
 * [Fixed] Fixed an issue where changing the country of a phone number would not update the UI when the phone number's validity changed.
 * [Changed] The "save this card" checkbox is now unchecked by default. To change this behavior, set your PaymentSheet.Configuration.savePaymentMethodOptInBehavior to `.requiresOptOut`.
+* [Fixed] Fixed an issue where PaymentSheet would not present in the iOS 18 beta when using SwiftUI.
 
 ### Payments
 * [Added] Updated support for MobilePay bindings.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheet+SwiftUI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheet+SwiftUI.swift
@@ -4,8 +4,8 @@
 //
 //
 
-import SwiftUI
 @_spi(STP) import StripeCore
+import SwiftUI
 
 extension View {
     /// Presents the customer sheet to select saved payment methods

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheet+SwiftUI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheet+SwiftUI.swift
@@ -5,6 +5,7 @@
 //
 
 import SwiftUI
+@_spi(STP) import StripeCore
 
 extension View {
     /// Presents the customer sheet to select saved payment methods
@@ -16,7 +17,8 @@ extension View {
         customerSheet: CustomerSheet,
         onCompletion: @escaping (CustomerSheet.CustomerSheetResult) -> Void
     ) -> some View {
-        self.modifier(
+        STPAnalyticsClient.sharedClient.addClass(toProductUsageIfNecessary: SwiftUIProduct.self)
+        return self.modifier(
             CustomerSheet.CustomerSheetPresentationModifier(
                 isPresented: isPresented,
                 customerSheet: customerSheet,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+SwiftUI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+SwiftUI.swift
@@ -9,8 +9,8 @@
 //  https://github.com/stleamist/BetterSafariView
 //
 
-import SwiftUI
 @_spi(STP) import StripeCore
+import SwiftUI
 
 extension View {
     /// Presents a sheet for a customer to complete their payment.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+SwiftUI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+SwiftUI.swift
@@ -421,8 +421,8 @@ func findViewController(for uiView: UIView) -> UIViewController? {
 }
 
 func topMostViewController() -> UIViewController? {
-    guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else { return nil }
-    guard let window = windowScene.windows.first(where: { $0.isKeyWindow }) else { return nil }
+    guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+          let window = windowScene.windows.first(where: { $0.isKeyWindow }) else { return nil }
 
     var topController: UIViewController? = window.rootViewController
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+SwiftUI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+SwiftUI.swift
@@ -412,6 +412,16 @@ func findViewController(for uiView: UIView) -> UIViewController? {
     } else if let nextResponder = uiView.next as? UIView {
         return findViewController(for: nextResponder)
     } else {
+        // Can't find a view, attempt to grab the top most view controller
+        let keyWindow = UIApplication.shared.windows.filter {$0.isKeyWindow}.first
+        if var topController = keyWindow?.rootViewController {
+            while let presentedViewController = topController.presentedViewController {
+                topController = presentedViewController
+            }
+
+            return topController
+        }
+        
         return nil
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+SwiftUI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+SwiftUI.swift
@@ -423,17 +423,16 @@ func findViewController(for uiView: UIView) -> UIViewController? {
 func topMostViewController() -> UIViewController? {
     guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else { return nil }
     guard let window = windowScene.windows.first(where: { $0.isKeyWindow }) else { return nil }
-    
+
     var topController: UIViewController? = window.rootViewController
-    
+
     // Traverse presented view controllers to find the top most view controller
     while let presentedViewController = topController?.presentedViewController {
         topController = presentedViewController
     }
-    
+
     return topController
 }
-
 
 // Helper class to track SwiftUI usage
 final class SwiftUIProduct: STPAnalyticsProtocol {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+SwiftUI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+SwiftUI.swift
@@ -22,7 +22,8 @@ extension View {
         paymentSheet: PaymentSheet,
         onCompletion: @escaping (PaymentSheetResult) -> Void
     ) -> some View {
-        self.modifier(
+        STPAnalyticsClient.sharedClient.addClass(toProductUsageIfNecessary: SwiftUIProduct.self)
+        return self.modifier(
             PaymentSheet.PaymentSheetPresentationModifier(
                 isPresented: isPresented,
                 paymentSheet: paymentSheet,
@@ -40,7 +41,8 @@ extension View {
         paymentSheetFlowController: PaymentSheet.FlowController,
         onSheetDismissed: (() -> Void)?
     ) -> some View {
-        self.modifier(
+        STPAnalyticsClient.sharedClient.addClass(toProductUsageIfNecessary: SwiftUIProduct.self)
+        return self.modifier(
             PaymentSheet.PaymentSheetFlowControllerPresentationModifier(
                 isPresented: isPresented,
                 paymentSheetFlowController: paymentSheetFlowController,
@@ -111,7 +113,6 @@ extension PaymentSheet {
             self.paymentSheet = paymentSheet
             self.onCompletion = onCompletion
             self.content = content()
-            STPAnalyticsClient.sharedClient.addClass(toProductUsageIfNecessary: SwiftUIProduct.self)
         }
 
         public var body: some View {
@@ -149,7 +150,6 @@ extension PaymentSheet.FlowController {
             self.paymentSheetFlowController = paymentSheetFlowController
             self.onSheetDismissed = onSheetDismissed
             self.content = content()
-            STPAnalyticsClient.sharedClient.addClass(toProductUsageIfNecessary: SwiftUIProduct.self)
         }
 
         public var body: some View {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+SwiftUI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+SwiftUI.swift
@@ -421,15 +421,19 @@ func findViewController(for uiView: UIView) -> UIViewController? {
 }
 
 func topMostViewController() -> UIViewController? {
-    guard let rootController = UIApplication.shared.windows.first?.rootViewController else {
-        return nil
+    guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else { return nil }
+    guard let window = windowScene.windows.first(where: { $0.isKeyWindow }) else { return nil }
+    
+    var topController: UIViewController? = window.rootViewController
+    
+    // Traverse presented view controllers to find the top most view controller
+    while let presentedViewController = topController?.presentedViewController {
+        topController = presentedViewController
     }
-    var topController: UIViewController = rootController
-    while let newTopController = topController.presentedViewController {
-        topController = newTopController
-    }
+    
     return topController
 }
+
 
 // Helper class to track SwiftUI usage
 final class SwiftUIProduct: STPAnalyticsProtocol {

--- a/StripePaymentsUI/StripePaymentsUI/Source/Internal/Categories/STPCardBrand+PaymentsUI.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/Internal/Categories/STPCardBrand+PaymentsUI.swift
@@ -9,7 +9,7 @@ import Foundation
 @_spi(STP) import StripeUICore
 import UIKit
 
-extension STPCardBrand: @retroactive Comparable {
+extension STPCardBrand: Comparable {
     public static func < (lhs: StripePayments.STPCardBrand, rhs: StripePayments.STPCardBrand) -> Bool {
         return (STPCardBrandUtilities.stringFrom(lhs) ?? "") < (STPCardBrandUtilities.stringFrom(rhs) ?? "")
     }

--- a/StripePaymentsUI/StripePaymentsUI/Source/Internal/Categories/STPCardBrand+PaymentsUI.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/Internal/Categories/STPCardBrand+PaymentsUI.swift
@@ -9,7 +9,7 @@ import Foundation
 @_spi(STP) import StripeUICore
 import UIKit
 
-extension STPCardBrand: Comparable {
+extension STPCardBrand: @retroactive Comparable {
     public static func < (lhs: StripePayments.STPCardBrand, rhs: StripePayments.STPCardBrand) -> Bool {
         return (STPCardBrandUtilities.stringFrom(lhs) ?? "") < (STPCardBrandUtilities.stringFrom(rhs) ?? "")
     }


### PR DESCRIPTION
## Summary
- No view controller was being found to present on. To fix we fallback on the current view controller on the window.
- Fixes for both PaymentSheet and CustomerSheet
- Adds metrics to product usage to track SwiftUI usage.

## Motivation
- Fix PaymentSheet/CustomerSheet <> SwiftUI on iOS 18

## Testing
- Manual on iOS 17.2 and iOS 18

## Changelog
See diff