### PR TITLE
Financial Connections: to the playground example app, added token flow support

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundConfiguration.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundConfiguration.swift
@@ -202,6 +202,7 @@ final class PlaygroundConfiguration {
     enum UseCase: String, CaseIterable, Identifiable, Hashable {
         case data = "data"
         case paymentIntent = "payment_intent"
+        case token = "token"
 
         var id: String {
             return rawValue

--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundView.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundView.swift
@@ -73,14 +73,17 @@ struct PlaygroundView: View {
                         }
                     }
 
-                    Section(header: Text("Customer")) {
+                    Section(header: Text(viewModel.useCase.wrappedValue == .token ? "Account" : "Customer")) {
                         TextField("Email (ex. existing Link consumer)", text: viewModel.email)
                             .keyboardType(.emailAddress)
                             .autocapitalization(.none)
                             .accessibility(identifier: "playground-email")
-                        TextField("Phone", text: viewModel.phone)
-                            .keyboardType(.phonePad)
-                            .accessibility(identifier: "playground-phone")
+
+                        if viewModel.useCase.wrappedValue != .token {
+                            TextField("Phone", text: viewModel.phone)
+                                .keyboardType(.phonePad)
+                                .accessibility(identifier: "playground-phone")
+                        }
                     }
 
                     Section(header: Text("PERMISSIONS")) {


### PR DESCRIPTION
## Summary

This PR added another way to use Financial Connections from the example/playground app:

![Simulator Screenshot - iPhone 15 Pro - 2024-06-14 at 15 41 58](https://github.com/stripe/stripe-ios/assets/105514761/cb84375f-8fd5-4349-8678-759c61a2193a)

## Testing

ℹ️ note that this is only modifying example/testing code

Ran UI tests to make sure I didn't break anything `bitrise run financial-connections-stability-tests`:

```
FinancialConnectionsNetworkingUITests
    ✓ testNativeNetworkingTestMode (111.517 seconds)
    ✓ testNativeNetworkingTestModeSignUpWithMultiSelectAndPrefilledEmail (31.660 seconds)
    ✓ testNativeNetworkingTestModeSignUpWithPrefilledEmailAndPhone (24.035 seconds)
FinancialConnectionsUITests
    ✓ testDataLiveModeOAuthNativeAuthFlow (29.428 seconds)
    ✓ testDataLiveModeOAuthWebAuthFlow (19.424 seconds)
    ✓ testDataTestModeOAuthNativeAuthFlow (20.291 seconds)
    ✓ testPaymentSearchInLiveModeNativeAuthFlow (26.188 seconds)
    ✓ testPaymentTestModeLegacyNativeAuthFlow (19.567 seconds)
    ✓ testPaymentTestModeManualEntryNativeAuthFlow (24.384 seconds)

	 Executed 9 tests, with 0 failures (0 unexpected) in 306.496 (306.507) seconds
```


Video of the flow working:

https://github.com/stripe/stripe-ios/assets/105514761/cbef3a26-3b2b-43d6-ab97-d65d52c4e2c0
