### PR TITLE
Fix navigation bar tint in UI Examples sample app

### DIFF
--- a/Example/UI Examples/UI Examples/Source/BrowseViewController.swift
+++ b/Example/UI Examples/UI Examples/Source/BrowseViewController.swift
@@ -85,7 +85,6 @@ class BrowseViewController: UITableViewController, STPAddCardViewControllerDeleg
         title = "Stripe UI Examples"
         tableView.tableFooterView = UIView()
         tableView.rowHeight = 60
-        navigationController?.navigationBar.isTranslucent = false
     }
 
     // MARK: UITableViewDelegate


### PR DESCRIPTION
## Summary

This fixes a small issue with the navigation bar in the UI Examples sample app.

| Before | After |
|--------|--------|
| ![Simulator Screenshot - iPhone 15 - 2024-06-14 at 18 20 15](https://github.com/stripe/stripe-ios/assets/172562065/d4aec1b2-e0a0-4b61-8ae1-adfc62122737) | ![Simulator Screenshot - iPhone 15 - 2024-06-14 at 18 44 46](https://github.com/stripe/stripe-ios/assets/172562065/6e259aab-b6e2-45e8-9105-23086d578f03) |