### PR TITLE
Update .`xctestplan`s to use US region and locale

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example-Shard1.xctestplan
+++ b/Example/PaymentSheet Example/PaymentSheet Example-Shard1.xctestplan
@@ -16,6 +16,11 @@
         "value" : "$(SRCROOT)\/..\/..\/Tests\/ReferenceImages"
       }
     ],
+    "locationScenario" : {
+      "identifier" : "San Francisco, CA, USA",
+      "referenceType" : "built-in"
+    },
+    "region" : "US",
     "targetForVariableExpansion" : {
       "containerPath" : "container:PaymentSheet Example.xcodeproj",
       "identifier" : "D017784615929C0DD3717FE8",

--- a/Example/PaymentSheet Example/PaymentSheet Example-Shard2.xctestplan
+++ b/Example/PaymentSheet Example/PaymentSheet Example-Shard2.xctestplan
@@ -16,6 +16,11 @@
         "value" : "$(SRCROOT)\/..\/..\/Tests\/ReferenceImages"
       }
     ],
+    "locationScenario" : {
+      "identifier" : "San Francisco, CA, USA",
+      "referenceType" : "built-in"
+    },
+    "region" : "US",
     "targetForVariableExpansion" : {
       "containerPath" : "container:PaymentSheet Example.xcodeproj",
       "identifier" : "D017784615929C0DD3717FE8",

--- a/Example/PaymentSheet Example/PaymentSheet Example.xctestplan
+++ b/Example/PaymentSheet Example/PaymentSheet Example.xctestplan
@@ -16,6 +16,11 @@
         "value" : "$(SRCROOT)\/..\/..\/Tests\/ReferenceImages"
       }
     ],
+    "locationScenario" : {
+      "identifier" : "San Francisco, CA, USA",
+      "referenceType" : "built-in"
+    },
+    "region" : "US",
     "targetForVariableExpansion" : {
       "containerPath" : "container:PaymentSheet Example.xcodeproj",
       "identifier" : "D017784615929C0DD3717FE8",

--- a/Stripe/StripeiOSTests.xctestplan
+++ b/Stripe/StripeiOSTests.xctestplan
@@ -16,6 +16,11 @@
         "value" : "$(SOURCE_ROOT)\/..\/Tests\/ReferenceImages"
       }
     ],
+    "locationScenario" : {
+      "identifier" : "San Francisco, CA, USA",
+      "referenceType" : "built-in"
+    },
+    "region" : "US",
     "targetForVariableExpansion" : {
       "containerPath" : "container:Stripe.xcodeproj",
       "identifier" : "ADF894AA8F6022D9BED17346",

--- a/Testers/IntegrationTester/IntegrationTester.xctestplan
+++ b/Testers/IntegrationTester/IntegrationTester.xctestplan
@@ -10,6 +10,11 @@
   ],
   "defaultOptions" : {
     "codeCoverage" : false,
+    "locationScenario" : {
+      "identifier" : "San Francisco, CA, USA",
+      "referenceType" : "built-in"
+    },
+    "region" : "US",
     "targetForVariableExpansion" : {
       "containerPath" : "container:IntegrationTester.xcodeproj",
       "identifier" : "A6E2C9F5A9A2B7892FF1BB17",
@@ -19,8 +24,6 @@
   "testTargets" : [
     {
       "parallelizable" : true,
-      "skippedTests" : [
-      ],
       "target" : {
         "containerPath" : "container:IntegrationTester.xcodeproj",
         "identifier" : "2545A867715D3A5AC62E65D7",

--- a/Testers/IntegrationTester/IntegrationTesterUITests/IntegrationTesterUITests.swift
+++ b/Testers/IntegrationTester/IntegrationTesterUITests/IntegrationTesterUITests.swift
@@ -95,13 +95,13 @@ class IntegrationTesterUIPMTests: IntegrationTesterUITests {
         let applePay = XCUIApplication(bundleIdentifier: "com.apple.PassbookUIService")
         _ = applePay.wait(for: .runningForeground, timeout: 10)
 
-        var cardButton = applePay.buttons["Simulated Card - AmEx, ‪•••• 1234‬"]
-        XCTAssertTrue(cardButton.waitForExistence(timeout: 10.0))
-        cardButton.forceTapElement()
+        let amexButton = applePay.buttons["Simulated Card - AmEx, ‪•••• 1234‬"]
+        XCTAssertTrue(amexButton.waitForExistence(timeout: 10.0))
+        amexButton.forceTapElement()
 
-        cardButton = applePay.buttons["Simulated Card - AmEx, ‪•••• 1234‬"].firstMatch
-        XCTAssertTrue(cardButton.waitForExistence(timeout: 10.0))
-        cardButton.forceTapElement()
+        let mastercardButton = applePay.buttons["Simulated Card - MasterCard, ‪•••• 1234‬"].firstMatch
+        XCTAssertTrue(mastercardButton.waitForExistence(timeout: 10.0))
+        mastercardButton.forceTapElement()
 
         let payButton = applePay.buttons["Pay with Passcode"]
         XCTAssertTrue(payButton.waitForExistence(timeout: 10.0))
@@ -341,6 +341,7 @@ class IntegrationTesterUITests: XCTestCase {
         if integrationMethod == .paypal {
             // PayPal uses ASWebAuthenticationSession, tap continue:
             let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+            XCTAssertTrue(springboard.waitForExistence(timeout: 10.0))
             springboard.buttons["Continue"].tap()
         }
 


### PR DESCRIPTION
## Summary

Since I'm based outside of the US, a lot of the UI components are localized slightly differently for me. This caused a lot of UI integration tests to fail.

In order to fix this, and to provide a consistent experience for everyone writing UI tests, this updates all the `.xctestplan` files to specify a US locale.

For example, a lot of integrations tests in the Payments Sheet module look for the charge button and tap it, which looks like this: 

```swift
app.buttons["Pay $50.99"].tap()
```

However, here in Canada, the label actually says `Pay US$50.99`, so this step was always failing.

<img width="396" alt="Screenshot 2024-06-17 at 2 32 03 PM" src="https://github.com/stripe/stripe-ios/assets/172562065/eb69accc-e4dd-4992-a486-69175ad3b002">

Another example is in the billing address form, instead of the `ZIP code` field, we show `Postal code`.

In the second commit, I fix a couple flaky integration tests.

## Testing

There should be no functional changes, and all unit / UI / integration tests should continue to pass.
