### PR TITLE
Don't allow presenting payment sheet after successfully confirming

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -256,7 +256,10 @@ struct PaymentSheetButtons: View {
                             .frame(alignment: .topLeading)
                         }
                     }.padding(.horizontal)
-                    if let ps = playgroundController.paymentSheet {
+
+                    if let ps = playgroundController.paymentSheet,
+                       (playgroundController.lastPaymentResult == nil ||
+                        playgroundController.lastPaymentResult?.shouldAllowPresentingPaymentSheet() ?? false) {
                         HStack {
                             Button {
                                 psIsPresented = true
@@ -304,7 +307,8 @@ struct PaymentSheetButtons: View {
                         }
                     }.padding(.horizontal)
                     HStack {
-                        if let psfc = playgroundController.paymentSheetFlowController {
+                        if let psfc = playgroundController.paymentSheetFlowController,
+                           (playgroundController.lastPaymentResult == nil || playgroundController.lastPaymentResult?.shouldAllowPresentingPaymentSheet() ?? false) {
                             Button {
                                 psFCOptionsIsPresented = true
                             } label: {
@@ -339,6 +343,17 @@ struct PaymentSheetButtons: View {
                     }
                 }
             }
+        }
+    }
+}
+
+extension PaymentSheetResult {
+    func shouldAllowPresentingPaymentSheet() -> Bool {
+        switch self {
+        case .canceled:
+            return true
+        case .completed, .failed:
+            return false
         }
     }
 }


### PR DESCRIPTION
## Summary
After completing a payment with PS/PS.FlowController we should hide the presentation/confirm controls until user refreshes

## Motivation
Feedback from dogfooding

## Testing
Manual testing

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
