### PR TITLE
Financial Connections: for networking manual entry, added support to save to link

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
@@ -89,7 +89,7 @@ protocol FinancialConnectionsAPIClient {
 
     func saveAccountsToNetworkAndLink(
         shouldPollAccounts: Bool,
-        selectedAccounts: [FinancialConnectionsPartnerAccount],
+        selectedAccounts: [FinancialConnectionsPartnerAccount]?,
         emailAddress: String?,
         phoneNumber: String?,
         country: String?,
@@ -486,7 +486,7 @@ extension STPAPIClient: FinancialConnectionsAPIClient {
 
     func saveAccountsToNetworkAndLink(
         shouldPollAccounts: Bool,
-        selectedAccounts: [FinancialConnectionsPartnerAccount],
+        selectedAccounts: [FinancialConnectionsPartnerAccount]?,
         emailAddress: String?,
         phoneNumber: String?,
         country: String?,
@@ -504,7 +504,7 @@ extension STPAPIClient: FinancialConnectionsAPIClient {
                 emailAddress: emailAddress,
                 phoneNumber: phoneNumber,
                 country: country,
-                selectedAccountIds: selectedAccounts.map({ $0.id }),
+                selectedAccountIds: selectedAccounts?.map({ $0.id }),
                 consumerSessionClientSecret: consumerSessionClientSecret,
                 clientSecret: clientSecret
             )
@@ -517,8 +517,8 @@ extension STPAPIClient: FinancialConnectionsAPIClient {
                 )
             }
         }
-        let linkedAccountIds = selectedAccounts.compactMap({ $0.linkedAccountId })
         if
+            let linkedAccountIds = selectedAccounts?.compactMap({ $0.linkedAccountId }),
             shouldPollAccounts,
             !linkedAccountIds.isEmpty
         {
@@ -583,15 +583,15 @@ extension STPAPIClient: FinancialConnectionsAPIClient {
         emailAddress: String?,
         phoneNumber: String?,
         country: String?,
-        selectedAccountIds: [String],
+        selectedAccountIds: [String]?,
         consumerSessionClientSecret: String?,
         clientSecret: String
     ) -> Future<FinancialConnectionsSessionManifest> {
         var body: [String: Any] = [
             "client_secret": clientSecret,
-            "selected_accounts": selectedAccountIds,
             "expand": ["active_auth_session"],
         ]
+        body["selected_accounts"] = selectedAccountIds // null for manual entry
         body["email_address"] = emailAddress?
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -1127,24 +1127,19 @@ private func CreatePaneViewController(
         manualEntryViewController.delegate = nativeFlowController
         viewController = manualEntryViewController
     case .networkingLinkSignupPane:
-        if let selectedAccounts = dataManager.linkedAccounts {
-            let networkingLinkSignupDataSource = NetworkingLinkSignupDataSourceImplementation(
-                manifest: dataManager.manifest,
-                selectedAccounts: selectedAccounts,
-                returnURL: dataManager.returnURL,
-                apiClient: dataManager.apiClient,
-                clientSecret: dataManager.clientSecret,
-                analyticsClient: dataManager.analyticsClient
-            )
-            let networkingLinkSignupViewController = NetworkingLinkSignupViewController(
-                dataSource: networkingLinkSignupDataSource
-            )
-            networkingLinkSignupViewController.delegate = nativeFlowController
-            viewController = networkingLinkSignupViewController
-        } else {
-            assertionFailure("Code logic error. Missing parameters for \(pane).")
-            viewController = nil
-        }
+        let networkingLinkSignupDataSource = NetworkingLinkSignupDataSourceImplementation(
+            manifest: dataManager.manifest,
+            selectedAccounts: dataManager.linkedAccounts,
+            returnURL: dataManager.returnURL,
+            apiClient: dataManager.apiClient,
+            clientSecret: dataManager.clientSecret,
+            analyticsClient: dataManager.analyticsClient
+        )
+        let networkingLinkSignupViewController = NetworkingLinkSignupViewController(
+            dataSource: networkingLinkSignupDataSource
+        )
+        networkingLinkSignupViewController.delegate = nativeFlowController
+        viewController = networkingLinkSignupViewController
     case .networkingLinkVerification:
         if let accountholderCustomerEmailAddress = dataManager.manifest.accountholderCustomerEmailAddress {
             let networkingLinkVerificationDataSource = NetworkingLinkVerificationDataSourceImplementation(
@@ -1163,13 +1158,12 @@ private func CreatePaneViewController(
         }
     case .networkingSaveToLinkVerification:
         if
-            let consumerSession = dataManager.consumerSession,
-            let selectedAccounts = dataManager.linkedAccounts
+            let consumerSession = dataManager.consumerSession
         {
             let networkingSaveToLinkVerificationDataSource = NetworkingSaveToLinkVerificationDataSourceImplementation(
                 manifest: dataManager.manifest,
                 consumerSession: consumerSession,
-                selectedAccounts: selectedAccounts,
+                selectedAccounts: dataManager.linkedAccounts,
                 apiClient: dataManager.apiClient,
                 clientSecret: dataManager.clientSecret,
                 analyticsClient: dataManager.analyticsClient

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupDataSource.swift
@@ -24,7 +24,7 @@ protocol NetworkingLinkSignupDataSource: AnyObject {
 final class NetworkingLinkSignupDataSourceImplementation: NetworkingLinkSignupDataSource {
 
     let manifest: FinancialConnectionsSessionManifest
-    private let selectedAccounts: [FinancialConnectionsPartnerAccount]
+    private let selectedAccounts: [FinancialConnectionsPartnerAccount]?
     private let returnURL: String?
     private let apiClient: FinancialConnectionsAPIClient
     private let clientSecret: String
@@ -32,7 +32,7 @@ final class NetworkingLinkSignupDataSourceImplementation: NetworkingLinkSignupDa
 
     init(
         manifest: FinancialConnectionsSessionManifest,
-        selectedAccounts: [FinancialConnectionsPartnerAccount],
+        selectedAccounts: [FinancialConnectionsPartnerAccount]?,
         returnURL: String?,
         apiClient: FinancialConnectionsAPIClient,
         clientSecret: String,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationDataSource.swift
@@ -24,7 +24,7 @@ final class NetworkingSaveToLinkVerificationDataSourceImplementation: Networking
 
     let manifest: FinancialConnectionsSessionManifest
     private(set) var consumerSession: ConsumerSessionData
-    private let selectedAccounts: [FinancialConnectionsPartnerAccount]
+    private let selectedAccounts: [FinancialConnectionsPartnerAccount]?
     private let apiClient: FinancialConnectionsAPIClient
     private let clientSecret: String
     let analyticsClient: FinancialConnectionsAnalyticsClient
@@ -33,7 +33,7 @@ final class NetworkingSaveToLinkVerificationDataSourceImplementation: Networking
     init(
         manifest: FinancialConnectionsSessionManifest,
         consumerSession: ConsumerSessionData,
-        selectedAccounts: [FinancialConnectionsPartnerAccount],
+        selectedAccounts: [FinancialConnectionsPartnerAccount]?,
         apiClient: FinancialConnectionsAPIClient,
         clientSecret: String,
         analyticsClient: FinancialConnectionsAnalyticsClient

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
@@ -120,7 +120,7 @@ class EmptyFinancialConnectionsAPIClient: FinancialConnectionsAPIClient {
 
     func saveAccountsToNetworkAndLink(
         shouldPollAccounts: Bool,
-        selectedAccounts: [FinancialConnectionsPartnerAccount],
+        selectedAccounts: [FinancialConnectionsPartnerAccount]?,
         emailAddress: String?,
         phoneNumber: String?,
         country: String?,


### PR DESCRIPTION
## Summary

This PR:
- Changes the `saveToLink` API to accept NULL selected accounts for networking manual entry. When it's NULL, we assume its networking manual entry. 

Context:
- Financial Connections is implementing support for "networking manual entry." This feature allows a user to enter their manually entered account _once_, and then we will allow them to reuse it later through Link. 
- This is just one PR of many where each PR will be merged to a feature branch `fc-networkingmanualentry`.
- It's expected that this PR may have some gaps or TODO's because its going to a feature branch. That being said, we still want to make sure there's no glaring logic issues/bugs. 

## Testing

This video shows me entering an account manually, the code offering me to "network" it (add to Link), and then after I link another real bank account, I can see both accounts:

https://github.com/stripe/stripe-ios/assets/105514761/3d799607-9189-4e17-b09f-f3b446873575


This shows the end of the video where we see the extra manually entered account (note that the spacing/layout is a separate discussion from this PR):

![Simulator Screenshot - iPhone 15 Pro - 2024-06-18 at 13 46 52](https://github.com/stripe/stripe-ios/assets/105514761/273b01c2-caec-4fe8-843d-f5f086457c7d)
