### PR TITLE
Fix setting up empty form LPMs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## x.x.x x-x-x
+### PaymentSheet
+* [Fixed] An issue that was preventing users from completing checkout with SetupIntents and PaymentIntents using `setup_future_usage` for the following payment method types: Amazon Pay, Cash App Pay, PayPal, and Revolut Pay.
+
 ## 23.27.4 2024-06-18
 ### PaymentSheet
 * [Fixed] Fixed an issue where when displaying an LPM with no input fields, the sheet would take up the entire height of the screen.

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -707,6 +707,36 @@ class PaymentSheetStandardLPMUITests: PaymentSheetUITestCase {
         XCTAssertTrue(webviewCloseButton.waitForExistence(timeout: 10.0))
         webviewCloseButton.tap()
     }
+    
+    func testCashAppPaymentMethod_setup() throws {
+        var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
+        settings.customerMode = .new
+        settings.apmsEnabled = .on
+        settings.mode = .setup
+        loadPlayground(
+            app,
+            settings
+        )
+
+        app.buttons["Present PaymentSheet"].tap()
+        let setupButton = app.buttons["Set up"]
+
+        // Select Cash App
+        guard let cashApp = scroll(collectionView: app.collectionViews.firstMatch, toFindCellWithId: "Cash App Pay")
+        else {
+            XCTFail()
+            return
+        }
+        cashApp.tap()
+
+        // Attempt set up
+        setupButton.tap()
+
+        // Close the webview, no need to see the successful set up
+        let webviewCloseButton = app.otherElements["TopBrowserBar"].buttons["Close"]
+        XCTAssertTrue(webviewCloseButton.waitForExistence(timeout: 10.0))
+        webviewCloseButton.tap()
+    }
 
     func testUSBankAccountPaymentMethod() throws {
         app.launchEnvironment = app.launchEnvironment.merging(["USE_PRODUCTION_FINANCIAL_CONNECTIONS_SDK": "false"]) { (_, new) in new }

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -707,7 +707,7 @@ class PaymentSheetStandardLPMUITests: PaymentSheetUITestCase {
         XCTAssertTrue(webviewCloseButton.waitForExistence(timeout: 10.0))
         webviewCloseButton.tap()
     }
-    
+
     func testCashAppPaymentMethod_setup() throws {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
         settings.customerMode = .new

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -738,6 +738,212 @@ class PaymentSheetStandardLPMUITests: PaymentSheetUITestCase {
         webviewCloseButton.tap()
     }
 
+    func testCashAppPaymentMethod_setupFutureUsage() throws {
+        var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
+        settings.customerMode = .new
+        settings.apmsEnabled = .on
+        settings.mode = .paymentWithSetup
+        loadPlayground(
+            app,
+            settings
+        )
+
+        app.buttons["Present PaymentSheet"].tap()
+        let payButton = app.buttons["Pay $50.99"]
+
+        // Select Cash App
+        guard let cashApp = scroll(collectionView: app.collectionViews.firstMatch, toFindCellWithId: "Cash App Pay")
+        else {
+            XCTFail()
+            return
+        }
+        cashApp.tap()
+
+        // Attempt to pay
+        payButton.tap()
+
+        // Close the webview, no need to see the successful set up
+        let webviewCloseButton = app.otherElements["TopBrowserBar"].buttons["Close"]
+        XCTAssertTrue(webviewCloseButton.waitForExistence(timeout: 10.0))
+        webviewCloseButton.tap()
+    }
+
+    func testAmazonPayPaymentMethod_setup() throws {
+        var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
+        settings.customerMode = .new
+        settings.apmsEnabled = .on
+        settings.mode = .setup
+        loadPlayground(
+            app,
+            settings
+        )
+
+        app.buttons["Present PaymentSheet"].tap()
+        let setupButton = app.buttons["Set up"]
+
+        // Select Amazon Pay
+        guard let amazonPay = scroll(collectionView: app.collectionViews.firstMatch, toFindCellWithId: "Amazon Pay")
+        else {
+            XCTFail()
+            return
+        }
+        amazonPay.tap()
+
+        // Attempt set up
+        setupButton.tap()
+
+        // Close the webview, no need to see the successful set up
+        let webviewCloseButton = app.otherElements["TopBrowserBar"].buttons["Close"]
+        XCTAssertTrue(webviewCloseButton.waitForExistence(timeout: 10.0))
+        webviewCloseButton.tap()
+    }
+
+    func testAmazonPayPaymentMethod_setupFutureUsage() throws {
+        var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
+        settings.customerMode = .new
+        settings.apmsEnabled = .on
+        settings.mode = .paymentWithSetup
+        loadPlayground(
+            app,
+            settings
+        )
+
+        app.buttons["Present PaymentSheet"].tap()
+        let payButton = app.buttons["Pay $50.99"]
+
+        // Select Amazon Pay
+        guard let amazonPay = scroll(collectionView: app.collectionViews.firstMatch, toFindCellWithId: "Amazon Pay")
+        else {
+            XCTFail()
+            return
+        }
+        amazonPay.tap()
+
+        // Attempt to pay
+        payButton.tap()
+
+        // Close the webview, no need to see the successful set up
+        let webviewCloseButton = app.otherElements["TopBrowserBar"].buttons["Close"]
+        XCTAssertTrue(webviewCloseButton.waitForExistence(timeout: 10.0))
+        webviewCloseButton.tap()
+    }
+
+    func testPayPalPaymentMethod_setup() throws {
+        var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
+        settings.customerMode = .new
+        settings.apmsEnabled = .on
+        settings.merchantCountryCode = .FR
+        settings.currency = .eur
+        settings.mode = .setup
+        loadPlayground(
+            app,
+            settings
+        )
+
+        app.buttons["Present PaymentSheet"].tap()
+        let setupButton = app.buttons["Set up"]
+
+        // Select PayPal
+        guard let payPal = scroll(collectionView: app.collectionViews.firstMatch, toFindCellWithId: "PayPal")
+        else {
+            XCTFail()
+            return
+        }
+        payPal.tap()
+
+        XCTAssertTrue(setupButton.isEnabled)
+    }
+
+    func testPayPalPaymentMethod_setupFutureUsage() throws {
+        var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
+        settings.customerMode = .new
+        settings.apmsEnabled = .on
+        settings.merchantCountryCode = .FR
+        settings.currency = .eur
+        settings.mode = .paymentWithSetup
+        loadPlayground(
+            app,
+            settings
+        )
+
+        app.buttons["Present PaymentSheet"].tap()
+        let payButton = app.buttons["Pay €50.99"]
+
+        // Select PayPal
+        guard let payPal = scroll(collectionView: app.collectionViews.firstMatch, toFindCellWithId: "PayPal")
+        else {
+            XCTFail()
+            return
+        }
+        payPal.tap()
+
+        XCTAssertTrue(payButton.isEnabled)
+    }
+
+    func testRevolutPayPaymentMethod_setup() throws {
+        var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
+        settings.customerMode = .new
+        settings.apmsEnabled = .on
+        settings.merchantCountryCode = .GB
+        settings.currency = .gbp
+        settings.mode = .setup
+        loadPlayground(
+            app,
+            settings
+        )
+
+        app.buttons["Present PaymentSheet"].tap()
+        let setupButton = app.buttons["Set up"]
+
+        // Select Revolut Pay
+        guard let revolut = scroll(collectionView: app.collectionViews.firstMatch, toFindCellWithId: "Revolut Pay")
+        else {
+            XCTFail()
+            return
+        }
+        revolut.tap()
+
+        // Attempt set up
+        setupButton.tap()
+
+        // Close the webview, no need to see the successful set up
+        let webviewCloseButton = app.otherElements["TopBrowserBar"].buttons["Close"]
+        XCTAssertTrue(webviewCloseButton.waitForExistence(timeout: 10.0))
+        webviewCloseButton.tap()
+    }
+
+    func testRvolutPayPaymentMethod_setupFutureUsage() throws {
+        var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
+        settings.customerMode = .new
+        settings.apmsEnabled = .on
+        settings.merchantCountryCode = .GB
+        settings.currency = .gbp
+        settings.mode = .paymentWithSetup
+        loadPlayground(
+            app,
+            settings
+        )
+
+        app.buttons["Present PaymentSheet"].tap()
+        let payButton = app.buttons["Pay $50.99"]
+
+        // Select Revolut Pay
+        guard let revolut = scroll(collectionView: app.collectionViews.firstMatch, toFindCellWithId: "Revolut Pay")
+        else {
+            XCTFail()
+            return
+        }
+        revolut.tap()
+
+        // Attempt to pay
+        payButton.tap()
+
+        // Close the webview, no need to see the successful set up
+        let webviewCloseButton = app.otherElements["TopBrowserBar"].buttons["Close"]
+        XCTAssertTrue(webviewCloseButton.waitForExistence(timeout: 10.0))
+        webviewCloseButton.tap()
+    }
+
     func testUSBankAccountPaymentMethod() throws {
         app.launchEnvironment = app.launchEnvironment.merging(["USE_PRODUCTION_FINANCIAL_CONNECTIONS_SDK": "false"]) { (_, new) in new }
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -925,7 +925,7 @@ class PaymentSheetStandardLPMUITests: PaymentSheetUITestCase {
         )
 
         app.buttons["Present PaymentSheet"].tap()
-        let payButton = app.buttons["Pay $50.99"]
+        let payButton = app.buttons["Pay £50.99"]
 
         // Select Revolut Pay
         guard let revolut = scroll(collectionView: app.collectionViews.firstMatch, toFindCellWithId: "Revolut Pay")

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -109,6 +109,7 @@ class PaymentMethodFormViewController: UIViewController {
         sendEventToSubviews(.viewDidAppear, from: view)
         // The form is cached and could have been shared across other instance of PaymentMethodFormViewController after this instance was initialized, so we set the delegate in viewDidAppear to ensure that the form's delegate is up to date.
         form.delegate = self
+//        delegate?.didUpdate(self) // notify delegate in case of any mandates being displayed
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -109,7 +109,7 @@ class PaymentMethodFormViewController: UIViewController {
         sendEventToSubviews(.viewDidAppear, from: view)
         // The form is cached and could have been shared across other instance of PaymentMethodFormViewController after this instance was initialized, so we set the delegate in viewDidAppear to ensure that the form's delegate is up to date.
         form.delegate = self
-//        delegate?.didUpdate(self) // notify delegate in case of any mandates being displayed
+        delegate?.didUpdate(self) // notify delegate in case of any mandates being displayed
     }
 
     override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
## Summary
- When selecting an LPM in set up or PI+SFU mode that only displays a mandate and takes in no input, the `PaymentMethodFormViewController` would incorrectly return `nil` for it's `paymentOption`. The reason for this is because the `paymentOption` is read by parent view controllers **before** `PaymentMethodFormViewController.viewDidAppear` is invoked. This causes an issue, because we have not yet marked the mandate as viewed until the `PaymentMethodFormViewController.viewDidAppear` is called.
- If a mandate is not yet viewed we return nil, resulting in a nil payment option.

Some code ref:
- https://github.com/stripe/stripe-ios/blob/master/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift#L109
- https://github.com/stripe/stripe-ios/blob/master/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/SimpleMandateElement.swift#L17
- https://github.com/stripe/stripe-ios/blob/master/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/SimpleMandateTextView.swift#L43

To fix this, we notify the delegate we updated once the view appears (and the mandate is marked as viewed) to get a refresh of the payment option, enabling the CTA button.

## Motivation
- https://github.com/stripe/stripe-ios/issues/3683

## Testing
- Manual
- New UI test

## Changelog
See diff
