### PR TITLE
FC Playground - Allow copying output session info

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundView.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundView.swift
@@ -124,7 +124,7 @@ struct PlaygroundView: View {
                     }
 
                     Section(header: Text("Session output")) {
-                        if let output = viewModel.outputTextfieldText {
+                        if let output = viewModel.sessionOutput[.message] {
                             TextEditor(text: .constant(output))
                                 .accessibility(identifier: "playground-session-output-textfield")
                         }
@@ -132,19 +132,19 @@ struct PlaygroundView: View {
                         Button(action: viewModel.copySessionId) {
                             Text("Copy Session ID")
                         }
-                        .disabled(viewModel.outputSessionId == nil)
+                        .disabled(viewModel.sessionOutput[.sessionId] == nil)
                         .accessibility(identifier: "playground-session-output-copy-session-id")
 
                         Button(action: viewModel.copyAccountNames) {
                             Text("Copy Account Names")
                         }
-                        .disabled(viewModel.outputAccountName == nil)
+                        .disabled(viewModel.sessionOutput[.accountNames] == nil)
                         .accessibility(identifier: "playground-session-output-copy-account-names")
 
                         Button(action: viewModel.copyAccountIds) {
                             Text("Copy Account IDs")
                         }
-                        .disabled(viewModel.outputAccountIds == nil)
+                        .disabled(viewModel.sessionOutput[.accountIds] == nil)
                         .accessibility(identifier: "playground-session-output-copy-account-ids")
                     }
                 }

--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundView.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundView.swift
@@ -122,7 +122,33 @@ struct PlaygroundView: View {
                             }
                         }
                     }
+
+                    Section(header: Text("Session output")) {
+                        if let output = viewModel.outputTextfieldText {
+                            TextEditor(text: .constant(output))
+                                .accessibility(identifier: "playground-session-output-textfield")
+                        }
+
+                        Button(action: viewModel.copySessionId) {
+                            Text("Copy Session ID")
+                        }
+                        .disabled(viewModel.outputSessionId == nil)
+                        .accessibility(identifier: "playground-session-output-copy-session-id")
+
+                        Button(action: viewModel.copyAccountNames) {
+                            Text("Copy Account Names")
+                        }
+                        .disabled(viewModel.outputAccountName == nil)
+                        .accessibility(identifier: "playground-session-output-copy-account-names")
+
+                        Button(action: viewModel.copyAccountIds) {
+                            Text("Copy Account IDs")
+                        }
+                        .disabled(viewModel.outputAccountIds == nil)
+                        .accessibility(identifier: "playground-session-output-copy-account-ids")
+                    }
                 }
+
                 VStack {
                     Button(action: viewModel.didSelectShow) {
                         VStack {

--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundViewModel.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundViewModel.swift
@@ -14,6 +14,13 @@ import UIKit
 
 final class PlaygroundViewModel: ObservableObject {
 
+    enum SessionOutputField {
+        case message
+        case sessionId
+        case accountIds
+        case accountNames
+    }
+
     let playgroundConfiguration = PlaygroundConfiguration.shared
 
     var sdkType: Binding<PlaygroundConfiguration.SDKType> {
@@ -179,11 +186,7 @@ final class PlaygroundViewModel: ObservableObject {
     }()
 
     @Published var isLoading: Bool = false
-
-    @Published var outputTextfieldText: String?
-    @Published var outputSessionId: String?
-    @Published var outputAccountName: String?
-    @Published var outputAccountIds: String?
+    @Published var sessionOutput: [SessionOutputField: String] = [:]
 
     private var cancellables: Set<AnyCancellable> = []
 
@@ -235,10 +238,10 @@ account_ids=\(accountIds)
 """
 
                             let message = "\(accountInfos)\n\n\(sessionInfo)"
-                            self?.outputTextfieldText = message
-                            self?.outputSessionId = sessionId
-                            self?.outputAccountName = accountNames.joinedUnlessEmpty
-                            self?.outputAccountIds = accountIds.joinedUnlessEmpty
+                            self?.sessionOutput[.message] = message
+                            self?.sessionOutput[.sessionId] = sessionId
+                            self?.sessionOutput[.accountNames] = accountNames.joinedUnlessEmpty
+                            self?.sessionOutput[.accountIds] = accountIds.joinedUnlessEmpty
 
                             UIAlertController.showAlert(
                                 title: "Success",
@@ -277,18 +280,18 @@ account_ids=\(accountIds)
     }
 
     func copySessionId() {
-        print("Copied session ID to clipboard: \(outputSessionId ?? "n/a")")
-        UIPasteboard.general.string = outputSessionId
+        guard let sessionId = sessionOutput[.sessionId] else { return }
+        UIPasteboard.general.string = sessionId
     }
 
     func copyAccountNames() {
-        print("Copied account names to clipboard: \(outputAccountName ?? "n/a")")
-        UIPasteboard.general.string = outputAccountName
+        guard let accountNames = sessionOutput[.accountNames] else { return }
+        UIPasteboard.general.string = accountNames
     }
 
     func copyAccountIds() {
-        print("Copied account IDs to clipboard: \(outputAccountIds ?? "n/a")")
-        UIPasteboard.general.string = outputAccountIds
+        guard let accountIds = sessionOutput[.accountIds] else { return }
+        UIPasteboard.general.string = accountIds
     }
 }
 


### PR DESCRIPTION
## Summary

This allows copying session info for a Financial Connections flow once it is completed in the playground app.

https://github.com/stripe/stripe-ios/assets/172562065/11b15f99-c7c1-4fd8-a0b7-8cbf9a73b1d0

## Motivation

This will make it easier to diagnose issues with the flow by making IDs and account details easy to export from the playground app.

## Testing

Manually tested the changes. See video posted above!

## Changelog

 N/a