### PR TITLE
Add unit tests for canEditPaymentMethods

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
+++ b/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
@@ -134,6 +134,8 @@
 		6B28A6B92BE9712500B47DBF /* CustomerSessionAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B28A6B82BE9712500B47DBF /* CustomerSessionAdapter.swift */; };
 		6B31B9B82B9019730064E210 /* ElementsCustomer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B31B9B72B9019730064E210 /* ElementsCustomer.swift */; };
 		6B31B9BA2B90FCE60064E210 /* CustomerSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B31B9B92B90FCE60064E210 /* CustomerSession.swift */; };
+		6B50BCEE2C29EE1F009702FB /* SavedPaymentOptionsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B50BCED2C29EE1F009702FB /* SavedPaymentOptionsViewControllerTests.swift */; };
+		6B50BCF02C29F888009702FB /* CustomerSavedPaymentMethodsCollectionViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B50BCEF2C29F888009702FB /* CustomerSavedPaymentMethodsCollectionViewControllerTests.swift */; };
 		6B7E675071649AE3047D388C /* PaymentSheetFormFactoryConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A21CC86104388EFE07CB37D /* PaymentSheetFormFactoryConfig.swift */; };
 		6BA8D3342B0C1F79008C51FF /* CVCRecollectionElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA8D3332B0C1F79008C51FF /* CVCRecollectionElement.swift */; };
 		6BA8D3362B0C1F9B008C51FF /* CVCReconfirmationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA8D3352B0C1F9B008C51FF /* CVCReconfirmationViewController.swift */; };
@@ -471,6 +473,8 @@
 		6B28A6B82BE9712500B47DBF /* CustomerSessionAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerSessionAdapter.swift; sourceTree = "<group>"; };
 		6B31B9B72B9019730064E210 /* ElementsCustomer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElementsCustomer.swift; sourceTree = "<group>"; };
 		6B31B9B92B90FCE60064E210 /* CustomerSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerSession.swift; sourceTree = "<group>"; };
+		6B50BCED2C29EE1F009702FB /* SavedPaymentOptionsViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedPaymentOptionsViewControllerTests.swift; sourceTree = "<group>"; };
+		6B50BCEF2C29F888009702FB /* CustomerSavedPaymentMethodsCollectionViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerSavedPaymentMethodsCollectionViewControllerTests.swift; sourceTree = "<group>"; };
 		6B680A2FF197F612D065F16C /* PaymentSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSheet.swift; sourceTree = "<group>"; };
 		6B9A346A7A4290BAA7BCA1A2 /* PaymentMethodTypeCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodTypeCollectionView.swift; sourceTree = "<group>"; };
 		6BA8D3332B0C1F79008C51FF /* CVCRecollectionElement.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CVCRecollectionElement.swift; sourceTree = "<group>"; };
@@ -707,6 +711,7 @@
 				F42DA5892E8E4C28D434AEA7 /* CustomerSheetPaymentMethodAvailabilityTests.swift */,
 				ED7ABCE56539213DCE501C54 /* CustomerSheetTests.swift */,
 				D7D7F7F19F4C2E89B8F9DF65 /* CustomerSheetConfigurationTests.swift */,
+				6B50BCEF2C29F888009702FB /* CustomerSavedPaymentMethodsCollectionViewControllerTests.swift */,
 			);
 			path = CustomerSheet;
 			sourceTree = "<group>";
@@ -1416,6 +1421,7 @@
 				82C21D5722BDEB8BAA71F69F /* PaymentSheet+DashboardConfirmParamsTest.swift */,
 				E83494558F0C93C5B05A1DFB /* PaymentSheetConfigurationTests.swift */,
 				316B33112B5F171C0008D2E5 /* UserDefaults+StripePaymentSheetTest.swift */,
+				6B50BCED2C29EE1F009702FB /* SavedPaymentOptionsViewControllerTests.swift */,
 			);
 			path = PaymentSheet;
 			sourceTree = "<group>";
@@ -1674,6 +1680,7 @@
 				44D0F92C4AA2DF0C9DC4C9B4 /* PaymentSheetLPMConfirmFlowTests.swift in Sources */,
 				ABE13E65678673EC4DE14EF4 /* PaymentSheetLinkAccountTests.swift in Sources */,
 				142C03879DC4CD43BB743022 /* PaymentSheetLoaderStubbedTest.swift in Sources */,
+				6B50BCF02C29F888009702FB /* CustomerSavedPaymentMethodsCollectionViewControllerTests.swift in Sources */,
 				1C70F42915587CBF883E01DD /* PaymentSheetLoaderTest.swift in Sources */,
 				96B31ABDA593F9C7FC3DBF79 /* PaymentSheetPaymentMethodTypeTest.swift in Sources */,
 				041E3F2DFDFD8FA7D3353CDB /* PaymentSheetSnapshotTests.swift in Sources */,
@@ -1696,6 +1703,7 @@
 				52B734BA0B91706F37025523 /* STPAnalyticsClient+PaymentSheetTests.swift in Sources */,
 				AE8EF3966E7BABDFC3B426ED /* PaymentSheet+DashboardConfirmParamsTest.swift in Sources */,
 				B65B42972C013DED00EC565D /* PaymentMethodFormViewControllerTest.swift in Sources */,
+				6B50BCEE2C29EE1F009702FB /* SavedPaymentOptionsViewControllerTests.swift in Sources */,
 				C28450436BDA52BE9BE3BDC3 /* PaymentSheetConfigurationTests.swift in Sources */,
 				F1A350D67665949CF91A0C02 /* CustomerSheetConfigurationTests.swift in Sources */,
 			);

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewControllerTests.swift
@@ -1,0 +1,312 @@
+//
+//  CustomerSavedPaymentMethodsCollectionViewControllerTests.swift
+//  StripePaymentSheetTests
+//
+
+@testable import StripePaymentSheet
+import XCTest
+
+class CustomerSavedPaymentMethodsCollectionViewControllerTests: XCTestCase {
+    var customerSheetConfiguration: CustomerSheet.Configuration = {
+        return CustomerSheet.Configuration()
+    }()
+
+    func testCanEditPaymentMethods_noPMs() {
+        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: true,
+                                          paymentMethodRemove: true)
+        let controller = customerSavedPaymentMethods(configuration,
+                                                     savedPaymentMethods: [],
+                                                     cbcEligible: true)
+        XCTAssertFalse(controller.canEditPaymentMethods)
+    }
+
+    // MARK: - Single Card, cbcEligible
+    func testCanEditPaymentMethods_singlePM_removeLast0_remove0() {
+        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: false,
+                                          paymentMethodRemove: false)
+        let controller = customerSavedPaymentMethods(configuration,
+                                                     savedPaymentMethods: [STPPaymentMethod._testCard()],
+                                                     cbcEligible: true)
+        XCTAssertFalse(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_singlePM_removeLast0_remove1() {
+        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: false,
+                                          paymentMethodRemove: true)
+        let controller = customerSavedPaymentMethods(configuration,
+                                                     savedPaymentMethods: [STPPaymentMethod._testCard()],
+                                                     cbcEligible: true)
+        XCTAssertFalse(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_singlePM_removeLast1_remove0() {
+        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: true,
+                                          paymentMethodRemove: false)
+        let controller = customerSavedPaymentMethods(configuration,
+                                                     savedPaymentMethods: [STPPaymentMethod._testCard()],
+                                                     cbcEligible: true)
+        XCTAssertFalse(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_singlePM_removeLast1_remove1() {
+        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: true,
+                                          paymentMethodRemove: true)
+        let controller = customerSavedPaymentMethods(configuration,
+                                                     savedPaymentMethods: [STPPaymentMethod._testCard()],
+                                                     cbcEligible: true)
+        XCTAssertTrue(controller.canEditPaymentMethods)
+    }
+
+    // MARK: - Single Card, !cbcEligible
+    func testCanEditPaymentMethods_singlePM_removeLast0_remove0_notCBCEligible() {
+        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: false,
+                                          paymentMethodRemove: false)
+        let controller = customerSavedPaymentMethods(configuration,
+                                                     savedPaymentMethods: [STPPaymentMethod._testCard()],
+                                                     cbcEligible: false)
+        XCTAssertFalse(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_singlePM_removeLast0_remove1_notCBCEligible() {
+        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: false,
+                                          paymentMethodRemove: true)
+        let controller = customerSavedPaymentMethods(configuration,
+                                                     savedPaymentMethods: [STPPaymentMethod._testCard()],
+                                                     cbcEligible: false)
+        XCTAssertFalse(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_singlePM_removeLast1_remove0_notCBCEligible() {
+        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: true,
+                                          paymentMethodRemove: false)
+        let controller = customerSavedPaymentMethods(configuration,
+                                                     savedPaymentMethods: [STPPaymentMethod._testCard()],
+                                                     cbcEligible: false)
+        XCTAssertFalse(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_singlePM_removeLast1_remove1_notCBCEligible() {
+        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: true,
+                                          paymentMethodRemove: true)
+        let controller = customerSavedPaymentMethods(configuration,
+                                                     savedPaymentMethods: [STPPaymentMethod._testCard()],
+                                                     cbcEligible: false)
+        XCTAssertTrue(controller.canEditPaymentMethods)
+    }
+
+    // MARK: - Single Card, w/ Co-branded, cbcEligible
+    func testCanEditPaymentMethods_singleCBCPM_removeLast0_remove0() {
+        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: false,
+                                          paymentMethodRemove: false)
+        let controller = customerSavedPaymentMethods(configuration,
+                                                     savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()],
+                                                     cbcEligible: true)
+        XCTAssertTrue(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_singleCBCPM_removeLast0_remove1() {
+        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: false,
+                                          paymentMethodRemove: true)
+        let controller = customerSavedPaymentMethods(configuration,
+                                                     savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()],
+                                                     cbcEligible: true)
+        XCTAssertTrue(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_singleCBCPM_removeLast1_remove0() {
+        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: true,
+                                          paymentMethodRemove: false)
+        let controller = customerSavedPaymentMethods(configuration,
+                                                     savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()],
+                                                     cbcEligible: true)
+        XCTAssertTrue(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_singleCBCPM_removeLast1_remove1() {
+        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: true,
+                                          paymentMethodRemove: true)
+        let controller = customerSavedPaymentMethods(configuration,
+                                                     savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()],
+                                                     cbcEligible: true)
+        XCTAssertTrue(controller.canEditPaymentMethods)
+    }
+    // MARK: - Single Card, w/ Co-branded, !cbcEligible
+    func testCanEditPaymentMethods_singleCBCPM_removeLast0_remove0_notCBCEligible() {
+        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: false,
+                                          paymentMethodRemove: false)
+        let controller = customerSavedPaymentMethods(configuration,
+                                                     savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()],
+                                                     cbcEligible: false)
+        XCTAssertFalse(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_singleCBCPM_removeLast0_remove1_notCBCEligible() {
+        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: false,
+                                          paymentMethodRemove: true)
+        let controller = customerSavedPaymentMethods(configuration,
+                                                     savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()],
+                                                     cbcEligible: false)
+        XCTAssertFalse(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_singleCBCPM_removeLast1_remove0_notCBCEligible() {
+        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: true,
+                                          paymentMethodRemove: false)
+        let controller = customerSavedPaymentMethods(configuration,
+                                                     savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()],
+                                                     cbcEligible: false)
+        XCTAssertFalse(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_singleCBCPM_removeLast1_remove1_notCBCEligible() {
+        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: true,
+                                          paymentMethodRemove: true)
+        let controller = customerSavedPaymentMethods(configuration,
+                                                     savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()],
+                                                     cbcEligible: false)
+        XCTAssertTrue(controller.canEditPaymentMethods)
+    }
+
+    // MARK: - Two Cards, cbcEligible
+    func testCanEditPaymentMethods_TwoPM_removeLast0_remove0() {
+        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: false,
+                                          paymentMethodRemove: false)
+        let controller = customerSavedPaymentMethods(configuration,
+                                                     savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()],
+                                                     cbcEligible: true)
+        XCTAssertFalse(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_TwoPM_removeLast0_remove1() {
+        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: false,
+                                          paymentMethodRemove: true)
+        let controller = customerSavedPaymentMethods(configuration,
+                                                     savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()],
+                                                     cbcEligible: true)
+        XCTAssertTrue(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_TwoPM_removeLast1_remove0() {
+        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: true,
+                                          paymentMethodRemove: false)
+        let controller = customerSavedPaymentMethods(configuration,
+                                                     savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()],
+                                                     cbcEligible: true)
+        XCTAssertFalse(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_TwoPM_removeLast1_remove1() {
+        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: true,
+                                          paymentMethodRemove: true)
+        let controller = customerSavedPaymentMethods(configuration,
+                                                     savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()],
+                                                     cbcEligible: true)
+        XCTAssertTrue(controller.canEditPaymentMethods)
+    }
+
+    // MARK: - Two Cards, cbcEligible, !cbcEligible
+    func testCanEditPaymentMethods_TwoPM_removeLast0_remove0_notCBCEligible() {
+        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: false,
+                                          paymentMethodRemove: false)
+        let controller = customerSavedPaymentMethods(configuration,
+                                                     savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()],
+                                                     cbcEligible: false)
+        XCTAssertFalse(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_TwoPM_removeLast0_remove1_notCBCEligible() {
+        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: false,
+                                          paymentMethodRemove: true)
+        let controller = customerSavedPaymentMethods(configuration,
+                                                     savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()],
+                                                     cbcEligible: false)
+        XCTAssertTrue(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_TwoPM_removeLast1_remove0_notCBCEligible() {
+        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: true,
+                                          paymentMethodRemove: false)
+        let controller = customerSavedPaymentMethods(configuration,
+                                                     savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()],
+                                                     cbcEligible: false)
+        XCTAssertFalse(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_TwoPM_removeLast1_remove1_notCBCEligible() {
+        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: true,
+                                          paymentMethodRemove: true)
+        let controller = customerSavedPaymentMethods(configuration,
+                                                     savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()],
+                                                     cbcEligible: false)
+        XCTAssertTrue(controller.canEditPaymentMethods)
+    }
+
+    // MARK: - Two Cards, w/ Co-branded, cbcEligible
+    func testCanEditPaymentMethods_TwoPMCBC_removeLast0_remove0() {
+        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: false,
+                                          paymentMethodRemove: false)
+        let controller = customerSavedPaymentMethods(configuration,
+                                                     savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()],
+                                                     cbcEligible: true)
+        XCTAssertTrue(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_TwoPMCBC_removeLast0_remove1() {
+        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: false,
+                                          paymentMethodRemove: true)
+        let controller = customerSavedPaymentMethods(configuration,
+                                                     savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()],
+                                                     cbcEligible: true)
+        XCTAssertTrue(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_TwoPMCBC_removeLast1_remove0() {
+        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: true,
+                                          paymentMethodRemove: false)
+        let controller = customerSavedPaymentMethods(configuration,
+                                                     savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()],
+                                                     cbcEligible: true)
+        XCTAssertTrue(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_TwoPMCBC_removeLast1_remove1() {
+        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: true,
+                                          paymentMethodRemove: true)
+        let controller = customerSavedPaymentMethods(configuration,
+                                                     savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()],
+                                                     cbcEligible: true)
+        XCTAssertTrue(controller.canEditPaymentMethods)
+    }
+
+    // MARK: - Two Cards, w/ Co-branded, !cbcEligible
+    func testCanEditPaymentMethods_TwoPMCBC_removeLast0_remove0_notCBCEligible() {
+        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: false,
+                                          paymentMethodRemove: false)
+        let controller = customerSavedPaymentMethods(configuration,
+                                                     savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()],
+                                                     cbcEligible: false)
+        XCTAssertFalse(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_TwoPMCBC_removeLast0_remove1_notCBCEligible() {
+        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: false,
+                                          paymentMethodRemove: true)
+        let controller = customerSavedPaymentMethods(configuration,
+                                                     savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()],
+                                                     cbcEligible: false)
+        XCTAssertTrue(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_TwoPMCBC_removeLast1_remove0_notCBCEligible() {
+        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: true,
+                                          paymentMethodRemove: false)
+        let controller = customerSavedPaymentMethods(configuration,
+                                                     savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()],
+                                                     cbcEligible: false)
+        XCTAssertFalse(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_TwoPMCBC_removeLast1_remove1_notCBCEligible() {
+        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: true,
+                                          paymentMethodRemove: true)
+        let controller = customerSavedPaymentMethods(configuration,
+                                                     savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()],
+                                                     cbcEligible: false)
+        XCTAssertTrue(controller.canEditPaymentMethods)
+    }
+
+    func configuration(allowsRemovalOfLastSavedPaymentMethod: Bool,
+                       paymentMethodRemove: Bool) -> CustomerSavedPaymentMethodsCollectionViewController.Configuration {
+        return CustomerSavedPaymentMethodsCollectionViewController.Configuration(showApplePay: false,
+                                                                                 allowsRemovalOfLastSavedPaymentMethod: allowsRemovalOfLastSavedPaymentMethod,
+                                                                                 paymentMethodRemove: paymentMethodRemove,
+                                                                                 isTestMode: true)
+    }
+    func customerSavedPaymentMethods(_ configuration: CustomerSavedPaymentMethodsCollectionViewController.Configuration,
+                                     savedPaymentMethods: [STPPaymentMethod],
+                                     cbcEligible: Bool) -> CustomerSavedPaymentMethodsCollectionViewController {
+        return CustomerSavedPaymentMethodsCollectionViewController(savedPaymentMethods: savedPaymentMethods,
+                                                                   selectedPaymentMethodOption: nil,
+                                                                   mostRecentlyAddedPaymentMethod: nil,
+                                                                   savedPaymentMethodsConfiguration: customerSheetConfiguration,
+                                                                   configuration: configuration,
+                                                                   appearance: .default,
+                                                                   cbcEligible: cbcEligible, delegate: nil)
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentOptionsViewControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentOptionsViewControllerTests.swift
@@ -1,0 +1,320 @@
+//
+//  SavedPaymentOptionsViewControllerTests.swift
+//  StripePaymentSheetTests
+//
+
+@testable import StripePaymentSheet
+import XCTest
+
+class SavedPaymentOptionsViewControllerTests: XCTestCase {
+
+    lazy var paymentSheetConfiguration: PaymentSheet.Configuration = {
+        return PaymentSheet.Configuration._testValue_MostPermissive()
+    }()
+
+    func testCanEditPaymentMethods_noPMs() {
+        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: true,
+                                                      allowsRemovalOfPaymentMethods: true)
+        let controller = savedPaymentOptionsController(configuration,
+                                                       savedPaymentMethods: [],
+                                                       cbcEligible: true)
+        XCTAssertFalse(controller.canEditPaymentMethods)
+    }
+
+    // MARK: - Single Card, cbcEligible
+    func testCanEditPaymentMethods_singlePM_removeLast0_remove0() {
+        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: false,
+                                                      allowsRemovalOfPaymentMethods: false)
+        let controller = savedPaymentOptionsController(configuration,
+                                                       savedPaymentMethods: [STPPaymentMethod._testCard()],
+                                                       cbcEligible: true)
+        XCTAssertFalse(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_singlePM_removeLast0_remove1() {
+        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: true,
+                                                      allowsRemovalOfPaymentMethods: false)
+        let controller = savedPaymentOptionsController(configuration,
+                                                       savedPaymentMethods: [STPPaymentMethod._testCard()],
+                                                       cbcEligible: true)
+        XCTAssertFalse(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_singlePM_removeLast1_remove0() {
+        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: false,
+                                                      allowsRemovalOfPaymentMethods: true)
+        let controller = savedPaymentOptionsController(configuration,
+                                                       savedPaymentMethods: [STPPaymentMethod._testCard()],
+                                                       cbcEligible: true)
+        XCTAssertFalse(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_singlePM_removeLast1_remove1() {
+        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: true,
+                                                      allowsRemovalOfPaymentMethods: true)
+        let controller = savedPaymentOptionsController(configuration,
+                                                       savedPaymentMethods: [STPPaymentMethod._testCard()],
+                                                       cbcEligible: true)
+        XCTAssertTrue(controller.canEditPaymentMethods)
+    }
+
+    // MARK: - Single Card, !cbcEligible
+    func testCanEditPaymentMethods_singlePM_removeLast0_remove0_notCBCEligible() {
+        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: false,
+                                                      allowsRemovalOfPaymentMethods: false)
+        let controller = savedPaymentOptionsController(configuration,
+                                                       savedPaymentMethods: [STPPaymentMethod._testCard()],
+                                                       cbcEligible: false)
+        XCTAssertFalse(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_singlePM_removeLast0_remove1_notCBCEligible() {
+        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: true,
+                                                      allowsRemovalOfPaymentMethods: false)
+        let controller = savedPaymentOptionsController(configuration,
+                                                       savedPaymentMethods: [STPPaymentMethod._testCard()],
+                                                       cbcEligible: false)
+        XCTAssertFalse(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_singlePM_removeLast1_remove0_notCBCEligible() {
+        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: false,
+                                                      allowsRemovalOfPaymentMethods: true)
+        let controller = savedPaymentOptionsController(configuration,
+                                                       savedPaymentMethods: [STPPaymentMethod._testCard()],
+                                                       cbcEligible: false)
+        XCTAssertFalse(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_singlePM_removeLast1_remove1_notCBCEligible() {
+        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: true,
+                                                      allowsRemovalOfPaymentMethods: true)
+        let controller = savedPaymentOptionsController(configuration,
+                                                       savedPaymentMethods: [STPPaymentMethod._testCard()],
+                                                       cbcEligible: false)
+        XCTAssertTrue(controller.canEditPaymentMethods)
+    }
+
+    // MARK: - Single Card, w/ Co-branded, cbcEligible
+    func testCanEditPaymentMethods_singleCBCPM_removeLast0_remove0() {
+        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: false,
+                                                      allowsRemovalOfPaymentMethods: false)
+        let controller = savedPaymentOptionsController(configuration,
+                                                       savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()],
+                                                       cbcEligible: true)
+        XCTAssertTrue(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_singleCBCPM_removeLast0_remove1() {
+        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: true,
+                                                      allowsRemovalOfPaymentMethods: false)
+        let controller = savedPaymentOptionsController(configuration,
+                                                       savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()],
+                                                       cbcEligible: true)
+        XCTAssertTrue(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_singleCBCPM_removeLast1_remove0() {
+        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: false,
+                                                      allowsRemovalOfPaymentMethods: true)
+        let controller = savedPaymentOptionsController(configuration,
+                                                       savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()],
+                                                       cbcEligible: true)
+        XCTAssertTrue(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_singleCBCPM_removeLast1_remove1() {
+        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: true,
+                                                      allowsRemovalOfPaymentMethods: true)
+        let controller = savedPaymentOptionsController(configuration,
+                                                       savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()],
+                                                       cbcEligible: true)
+        XCTAssertTrue(controller.canEditPaymentMethods)
+    }
+
+    // MARK: - Single Card, w/ Co-branded, !cbcEligible
+    func testCanEditPaymentMethods_singleCBCPM_removeLast0_remove0_notCBCEligible() {
+        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: false,
+                                                      allowsRemovalOfPaymentMethods: false)
+        let controller = savedPaymentOptionsController(configuration,
+                                                       savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()],
+                                                       cbcEligible: false)
+        XCTAssertFalse(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_singleCBCPM_removeLast0_remove1_notCBCEligible() {
+        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: true,
+                                                      allowsRemovalOfPaymentMethods: false)
+        let controller = savedPaymentOptionsController(configuration,
+                                                       savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()],
+                                                       cbcEligible: false)
+        XCTAssertFalse(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_singleCBCPM_removeLast1_remove0_notCBCEligible() {
+        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: false,
+                                                      allowsRemovalOfPaymentMethods: true)
+        let controller = savedPaymentOptionsController(configuration,
+                                                       savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()],
+                                                       cbcEligible: false)
+        XCTAssertFalse(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_singleCBCPM_removeLast1_remove1_notCBCEligible() {
+        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: true,
+                                                      allowsRemovalOfPaymentMethods: true)
+        let controller = savedPaymentOptionsController(configuration,
+                                                       savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()],
+                                                       cbcEligible: false)
+        XCTAssertTrue(controller.canEditPaymentMethods)
+    }
+
+    // MARK: - Two Cards, cbcEligible
+    func testCanEditPaymentMethods_TwoPM_removeLast0_remove0() {
+        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: false,
+                                                      allowsRemovalOfPaymentMethods: false)
+        let controller = savedPaymentOptionsController(configuration,
+                                                       savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()],
+                                                       cbcEligible: true)
+        XCTAssertFalse(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_TwoPM_removeLast0_remove1() {
+        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: true,
+                                                      allowsRemovalOfPaymentMethods: false)
+        let controller = savedPaymentOptionsController(configuration,
+                                                       savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()],
+                                                       cbcEligible: true)
+        XCTAssertFalse(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_TwoPM_removeLast1_remove0() {
+        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: false,
+                                                      allowsRemovalOfPaymentMethods: true)
+        let controller = savedPaymentOptionsController(configuration,
+                                                       savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()],
+                                                       cbcEligible: true)
+        XCTAssertTrue(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_TwoPM_removeLast1_remove1() {
+        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: true,
+                                                      allowsRemovalOfPaymentMethods: true)
+        let controller = savedPaymentOptionsController(configuration,
+                                                       savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()],
+                                                       cbcEligible: true)
+        XCTAssertTrue(controller.canEditPaymentMethods)
+    }
+
+    // MARK: - Two Cards, !cbcEligible
+    func testCanEditPaymentMethods_TwoPM_removeLast0_remove0_notCBCEligible() {
+        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: false,
+                                                      allowsRemovalOfPaymentMethods: false)
+        let controller = savedPaymentOptionsController(configuration,
+                                                       savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()],
+                                                       cbcEligible: false)
+        XCTAssertFalse(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_TwoPM_removeLast0_remove1_notCBCEligible() {
+        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: true,
+                                                      allowsRemovalOfPaymentMethods: false)
+        let controller = savedPaymentOptionsController(configuration,
+                                                       savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()],
+                                                       cbcEligible: false)
+        XCTAssertFalse(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_TwoPM_removeLast1_remove0_notCBCEligible() {
+        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: false,
+                                                      allowsRemovalOfPaymentMethods: true)
+        let controller = savedPaymentOptionsController(configuration,
+                                                       savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()],
+                                                       cbcEligible: false)
+        XCTAssertTrue(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_TwoPM_removeLast1_remove1_notCBCEligible() {
+        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: true,
+                                                      allowsRemovalOfPaymentMethods: true)
+        let controller = savedPaymentOptionsController(configuration,
+                                                       savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()],
+                                                       cbcEligible: false)
+        XCTAssertTrue(controller.canEditPaymentMethods)
+    }
+
+    // MARK: - Two Cards, w/ Co-branded, cbcEligible
+    func testCanEditPaymentMethods_TwoPMCBC_removeLast0_remove0() {
+        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: false,
+                                                      allowsRemovalOfPaymentMethods: false)
+        let controller = savedPaymentOptionsController(configuration,
+                                                       savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()],
+                                                       cbcEligible: true)
+        XCTAssertTrue(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_TwoPMCBC_removeLast0_remove1() {
+        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: true,
+                                                      allowsRemovalOfPaymentMethods: false)
+        let controller = savedPaymentOptionsController(configuration,
+                                                       savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()],
+                                                       cbcEligible: true)
+        XCTAssertTrue(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_TwoPMCBC_removeLast1_remove0() {
+        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: false,
+                                                      allowsRemovalOfPaymentMethods: true)
+        let controller = savedPaymentOptionsController(configuration,
+                                                       savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()],
+                                                       cbcEligible: true)
+        XCTAssertTrue(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_TwoPMCBC_removeLast1_remove1() {
+        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: true,
+                                                      allowsRemovalOfPaymentMethods: true)
+        let controller = savedPaymentOptionsController(configuration,
+                                                       savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()],
+                                                       cbcEligible: true)
+        XCTAssertTrue(controller.canEditPaymentMethods)
+    }
+
+    // MARK: - Two Cards, w/ Co-branded, !cbcEligible
+    func testCanEditPaymentMethods_TwoPMCBC_removeLast0_remove0_notCBCEligible() {
+        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: false,
+                                                      allowsRemovalOfPaymentMethods: false)
+        let controller = savedPaymentOptionsController(configuration,
+                                                       savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()],
+                                                       cbcEligible: false)
+        XCTAssertFalse(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_TwoPMCBC_removeLast0_remove1_notCBCEligible() {
+        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: true,
+                                                      allowsRemovalOfPaymentMethods: false)
+        let controller = savedPaymentOptionsController(configuration,
+                                                       savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()],
+                                                       cbcEligible: false)
+        XCTAssertFalse(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_TwoPMCBC_removeLast1_remove0_notCBCEligible() {
+        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: false,
+                                                      allowsRemovalOfPaymentMethods: true)
+        let controller = savedPaymentOptionsController(configuration,
+                                                       savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()],
+                                                       cbcEligible: false)
+        XCTAssertTrue(controller.canEditPaymentMethods)
+    }
+    func testCanEditPaymentMethods_TwoPMCBC_removeLast1_remove1_notCBCEligible() {
+        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: true,
+                                                      allowsRemovalOfPaymentMethods: true)
+        let controller = savedPaymentOptionsController(configuration,
+                                                       savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()],
+                                                       cbcEligible: false)
+        XCTAssertTrue(controller.canEditPaymentMethods)
+    }
+
+    // MARK: Helpers
+    func savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: Bool, allowsRemovalOfPaymentMethods: Bool) -> SavedPaymentOptionsViewController.Configuration {
+        return SavedPaymentOptionsViewController.Configuration(customerID: "cus_123",
+                                                               showApplePay: true,
+                                                               showLink: true,
+                                                               removeSavedPaymentMethodMessage: nil,
+                                                               merchantDisplayName: "abc",
+                                                               isCVCRecollectionEnabled: true,
+                                                               isTestMode: true,
+                                                               allowsRemovalOfLastSavedPaymentMethod: allowsRemovalOfLastSavedPaymentMethod,
+                                                               allowsRemovalOfPaymentMethods: allowsRemovalOfPaymentMethods)
+    }
+
+    func savedPaymentOptionsController(_ configuration: SavedPaymentOptionsViewController.Configuration,
+                                       savedPaymentMethods: [STPPaymentMethod],
+                                       cbcEligible: Bool) -> SavedPaymentOptionsViewController {
+        return SavedPaymentOptionsViewController(savedPaymentMethods: savedPaymentMethods,
+                                                 configuration: configuration,
+                                                 paymentSheetConfiguration: paymentSheetConfiguration,
+                                                 intent: Intent._testValue(),
+                                                 appearance: .default,
+                                                 cbcEligible: cbcEligible,
+                                                 delegate: nil)
+    }
+}


### PR DESCRIPTION
## Summary
Adding unit tests for canEditPaymentMethods

## Motivation
Follow on to #3577

## Testing
Added exhaustive unit tests

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
