### PR TITLE
Add clientSide checks for format of customerSessionClientSecret

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheet.swift
@@ -360,5 +360,10 @@ public struct CustomerSessionClientSecret {
     public init(customerId: String, clientSecret: String) {
         self.customerId = customerId
         self.clientSecret = clientSecret
+
+        stpAssert(!clientSecret.hasPrefix("ek_"),
+                  "Argument looks like an Ephemeral Key secret, but expecting a CustomerSession client secret. See CustomerSession API: https://docs.stripe.com/api/customer_sessions/create")
+        stpAssert(clientSecret.hasPrefix("cuss_"),
+                  "Argument does not look like a CustomerSession client secret. See CustomerSession API: https://docs.stripe.com/api/customer_sessions/create")
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
@@ -236,6 +236,11 @@ extension PaymentSheet {
             self.id = id
             self.customerAccessProvider = .customerSession(customerSessionClientSecret)
             self.ephemeralKeySecret = ""
+
+            stpAssert(!customerSessionClientSecret.hasPrefix("ek_"),
+                      "Argument looks like an Ephemeral Key secret, but expecting a CustomerSession client secret. See CustomerSession API: https://docs.stripe.com/api/customer_sessions/create")
+            stpAssert(customerSessionClientSecret.hasPrefix("cuss_"),
+                      "Argument does not look like a CustomerSession client secret. See CustomerSession API: https://docs.stripe.com/api/customer_sessions/create")
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentMethodManagerTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentMethodManagerTest.swift
@@ -66,7 +66,7 @@ final class SavedPaymentMethodManagerTests: XCTestCase {
 
     func testDetachPaymentMethod_withCustomerSession() {
         var configuration = configuration
-        configuration.customer = .init(id: "cus_test123", customerSessionClientSecret: "session_123")
+        configuration.customer = .init(id: "cus_test123", customerSessionClientSecret: "cuss_secret_238742")
 
         let listPaymentMethodsExpectation = stubListPaymentMethods(customerId: configuration.customer!.id,
                                                                    ephemeralKey: ephemeralKey)


### PR DESCRIPTION
## Summary
Adds client side validation for CustomerSession client secret

## Motivation
Prevent user integration errors

## Testing
Manual testing, and relying on existing ui tests

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
