### PR TITLE
Poll for Swish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## x.x.x x-x-x
+### All
+* [Fixed] Improved reliability when paying with Swish.
+
 ## 23.27.5 2024-06-20
 ### PaymentSheet
 * [Fixed] An issue that was preventing users from completing checkout with SetupIntents and PaymentIntents using `setup_future_usage` for the following payment method types: Amazon Pay, Cash App Pay, PayPal, and Revolut Pay.

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodEnums.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodEnums.swift
@@ -288,6 +288,17 @@ extension STPPaymentMethodType {
         }
     }
 
+    var pollingInterval: TimeInterval {
+        switch self {
+        case .amazonPay, .cashApp:
+            return 3
+        case .swish:
+            return 1
+        default:
+            return 0
+        }
+    }
+
     var supportsRefreshing: Bool {
         switch self {
         // Payment methods such as CashApp implement app-to-app redirects that bypass the "redirect trampoline" too give a more seamless user experience for app-to-app.

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodEnums.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodEnums.swift
@@ -277,25 +277,20 @@ import Foundation
 extension STPPaymentMethodType: CaseIterable { }
 
 extension STPPaymentMethodType {
-    var requiresPolling: Bool {
-        switch self {
-        // Payment methods such as AmazonPay and other app-to-app redirects that bypass the "redirect trampoline" to give a more seamless user experience for app-to-app.
-        // However, when returning to the merchant app in this scenario, the intent often isn't updated instantaneously, requiring polling for intent status updates.
-        case .amazonPay, .cashApp, .swish:
-            return true
-        default:
-            return false
-        }
+    struct PollingRequirement {
+      var pollingInterval: TimeInterval
     }
 
-    var pollingInterval: TimeInterval {
+    /// If non-nil, Intents with this PM type do not update immediately after the next action is handled and require us to poll and this property contains the information needed to poll.
+    var pollingRequirement: PollingRequirement? {
         switch self {
-        case .amazonPay, .cashApp:
-            return 3
+        // Note: Card only requires polling for 3DS2 web-based transactions
+        case .card, .amazonPay, .cashApp:
+            return PollingRequirement(pollingInterval: 3)
         case .swish:
-            return 1
+            return PollingRequirement(pollingInterval: 1)
         default:
-            return 0
+            return nil
         }
     }
 

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodEnums.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodEnums.swift
@@ -281,7 +281,7 @@ extension STPPaymentMethodType {
         switch self {
         // Payment methods such as AmazonPay and other app-to-app redirects that bypass the "redirect trampoline" to give a more seamless user experience for app-to-app.
         // However, when returning to the merchant app in this scenario, the intent often isn't updated instantaneously, requiring polling for intent status updates.
-        case .amazonPay, .cashApp:
+        case .amazonPay, .cashApp, .swish:
             return true
         default:
             return false

--- a/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
@@ -1494,7 +1494,7 @@ public class STPPaymentHandler: NSObject {
                                     // If this is a web-based 3DS2 transaction that is still in requires_action, we may just need to refresh the PI a few more times.
                                     // Also retry a few times for app redirects, the redirect flow is fast and sometimes the intent doesn't update quick enough
                                     let shouldRetryForCard = paymentMethod.type == .card && paymentIntent.nextAction?.type == .useStripeSDK
-                                    let shouldRetryForAppRedirect = paymentMethod.type.pollingRequirement != nil
+                                    let shouldRetryForAppRedirect = paymentMethod.type.pollingRequirement != nil && paymentMethod.type != .card
                                     if retryCount > 0
                                         && (shouldRetryForCard || shouldRetryForAppRedirect)
                                     {
@@ -1564,7 +1564,7 @@ public class STPPaymentHandler: NSObject {
                             // If this is a web-based 3DS2 transaction that is still in requires_action, we may just need to refresh the SI a few more times.
                             // Also retry a few times for Cash App, the redirect flow is fast and sometimes the intent doesn't update quick enough
                             let shouldRetryForCard = paymentMethod.type == .card && setupIntent.nextAction?.type == .useStripeSDK
-                            let shouldRetryForAppRedirect = paymentMethod.type.pollingRequirement != nil
+                            let shouldRetryForAppRedirect = paymentMethod.type.pollingRequirement != nil && paymentMethod.type != .card
                             if retryCount > 0
                                 && (shouldRetryForCard || shouldRetryForAppRedirect) {
                                 guard let pollingRequirement = paymentMethod.type.pollingRequirement else {

--- a/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
@@ -1494,14 +1494,7 @@ public class STPPaymentHandler: NSObject {
                                     // If this is a web-based 3DS2 transaction that is still in requires_action, we may just need to refresh the PI a few more times.
                                     // Also retry a few times for app redirects, the redirect flow is fast and sometimes the intent doesn't update quick enough
                                     let shouldRetryForCard = paymentMethod.type == .card && paymentIntent.nextAction?.type == .useStripeSDK
-                                    let shouldRetryForAppRedirect = paymentMethod.type.pollingRequirement != nil && paymentMethod.type != .card
-                                    if retryCount > 0
-                                        && (shouldRetryForCard || shouldRetryForAppRedirect)
-                                    {
-                                        guard let pollingRequirement = paymentMethod.type.pollingRequirement else {
-                                            stpAssert(false, "Unexpectedly found a nil polling requirement for a payment that requires polling.")
-                                            return
-                                        }
+                                    if retryCount > 0, paymentMethod.type != .card || shouldRetryForCard, let pollingRequirement = paymentMethod.type.pollingRequirement {
                                         self._retryAfterDelay(retryCount: retryCount, delayTime: pollingRequirement.pollingInterval) {
                                             self._retrieveAndCheckIntentForCurrentAction(
                                                 retryCount: retryCount - 1
@@ -1564,13 +1557,7 @@ public class STPPaymentHandler: NSObject {
                             // If this is a web-based 3DS2 transaction that is still in requires_action, we may just need to refresh the SI a few more times.
                             // Also retry a few times for Cash App, the redirect flow is fast and sometimes the intent doesn't update quick enough
                             let shouldRetryForCard = paymentMethod.type == .card && setupIntent.nextAction?.type == .useStripeSDK
-                            let shouldRetryForAppRedirect = paymentMethod.type.pollingRequirement != nil && paymentMethod.type != .card
-                            if retryCount > 0
-                                && (shouldRetryForCard || shouldRetryForAppRedirect) {
-                                guard let pollingRequirement = paymentMethod.type.pollingRequirement else {
-                                    stpAssert(false, "Unexpectedly found a nil polling requirement for a setup that requires polling.")
-                                    return
-                                }
+                            if retryCount > 0, paymentMethod.type != .card || shouldRetryForCard, let pollingRequirement = paymentMethod.type.pollingRequirement {
                                 self._retryAfterDelay(retryCount: retryCount, delayTime: pollingRequirement.pollingInterval) {
                                     self._retrieveAndCheckIntentForCurrentAction(
                                         retryCount: retryCount - 1

--- a/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
@@ -1494,11 +1494,15 @@ public class STPPaymentHandler: NSObject {
                                     // If this is a web-based 3DS2 transaction that is still in requires_action, we may just need to refresh the PI a few more times.
                                     // Also retry a few times for app redirects, the redirect flow is fast and sometimes the intent doesn't update quick enough
                                     let shouldRetryForCard = paymentMethod.type == .card && paymentIntent.nextAction?.type == .useStripeSDK
-                                    let shouldRetryForAppRedirect = paymentMethod.type.requiresPolling
+                                    let shouldRetryForAppRedirect = paymentMethod.type.pollingRequirement != nil
                                     if retryCount > 0
                                         && (shouldRetryForCard || shouldRetryForAppRedirect)
                                     {
-                                        self._retryAfterDelay(retryCount: retryCount, delayTime: paymentMethod.type.pollingInterval) {
+                                        guard let pollingRequirement = paymentMethod.type.pollingRequirement else {
+                                            stpAssert(false, "Unexpectedly found a nil polling requirement for a payment that requires polling.")
+                                            return
+                                        }
+                                        self._retryAfterDelay(retryCount: retryCount, delayTime: pollingRequirement.pollingInterval) {
                                             self._retrieveAndCheckIntentForCurrentAction(
                                                 retryCount: retryCount - 1
                                             )
@@ -1560,10 +1564,14 @@ public class STPPaymentHandler: NSObject {
                             // If this is a web-based 3DS2 transaction that is still in requires_action, we may just need to refresh the SI a few more times.
                             // Also retry a few times for Cash App, the redirect flow is fast and sometimes the intent doesn't update quick enough
                             let shouldRetryForCard = paymentMethod.type == .card && setupIntent.nextAction?.type == .useStripeSDK
-                            let shouldRetryForAppRedirect = paymentMethod.type.requiresPolling
+                            let shouldRetryForAppRedirect = paymentMethod.type.pollingRequirement != nil
                             if retryCount > 0
                                 && (shouldRetryForCard || shouldRetryForAppRedirect) {
-                                self._retryAfterDelay(retryCount: retryCount, delayTime: paymentMethod.type.pollingInterval) {
+                                guard let pollingRequirement = paymentMethod.type.pollingRequirement else {
+                                    stpAssert(false, "Unexpectedly found a nil polling requirement for a setup that requires polling.")
+                                    return
+                                }
+                                self._retryAfterDelay(retryCount: retryCount, delayTime: pollingRequirement.pollingInterval) {
                                     self._retrieveAndCheckIntentForCurrentAction(
                                         retryCount: retryCount - 1
                                     )

--- a/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
@@ -1407,10 +1407,7 @@ public class STPPaymentHandler: NSObject {
         return resultingUrl
     }
 
-    func _retryAfterDelay(retryCount: Int, block: @escaping STPVoidBlock) {
-        // Add some backoff time:
-        let delayTime = TimeInterval(3)
-
+    func _retryAfterDelay(retryCount: Int, delayTime: TimeInterval = 3, block: @escaping STPVoidBlock) {
         DispatchQueue.main.asyncAfter(deadline: .now() + delayTime) {
             block()
         }
@@ -1501,7 +1498,7 @@ public class STPPaymentHandler: NSObject {
                                     if retryCount > 0
                                         && (shouldRetryForCard || shouldRetryForAppRedirect)
                                     {
-                                        self._retryAfterDelay(retryCount: retryCount) {
+                                        self._retryAfterDelay(retryCount: retryCount, delayTime: paymentMethod.type.pollingInterval) {
                                             self._retrieveAndCheckIntentForCurrentAction(
                                                 retryCount: retryCount - 1
                                             )
@@ -1566,7 +1563,7 @@ public class STPPaymentHandler: NSObject {
                             let shouldRetryForAppRedirect = paymentMethod.type.requiresPolling
                             if retryCount > 0
                                 && (shouldRetryForCard || shouldRetryForAppRedirect) {
-                                self._retryAfterDelay(retryCount: retryCount) {
+                                self._retryAfterDelay(retryCount: retryCount, delayTime: paymentMethod.type.pollingInterval) {
                                     self._retrieveAndCheckIntentForCurrentAction(
                                         retryCount: retryCount - 1
                                     )


### PR DESCRIPTION
## Summary
- Roughly 60% of the time the Swish API returns the intent in the `requires_action` state instead of the most up to date state. We start polling to account for this delay.
- To combat this we poll every second for five seconds.

## Motivation
- ir-copper-deep

## Testing
- Manual

## Changelog
See diff