### PR TITLE
Add autofill to OTP field while in test mode

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
@@ -14,6 +14,7 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         let emailAddresss = "\(UUID().uuidString)@UITestForIOS.com"
         executeNativeNetworkingTestModeSignUpFlowTest(emailAddress: emailAddresss)
         executeNativeNetworkingTestModeSignInFlowTest(emailAddress: emailAddresss)
+        executeNativeNetworkingTestModeAutofillSignInFlowTest(emailAddress: emailAddresss)
         let bankAccountName = "Insufficient Funds"
         executeNativeNetworkingTestModeAddBankAccount(
             emailAddress: emailAddresss,
@@ -116,6 +117,54 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         XCTAssertTrue(stepUpVerificationOTPTextView.waitForExistence(timeout: 60.0))
         stepUpVerificationOTPTextView.tap()
         stepUpVerificationOTPTextView.typeText("111111")
+
+        let successPaneDoneButton = app.fc_nativeSuccessDoneButton
+
+        // ensure that there wasn't a Link failure
+        //
+        // unexpected text: "Your account was connected, but couldn't be saved to Link"
+        XCTAssert(!app.textViews.containing(NSPredicate(format: "label CONTAINS 'but'")).firstMatch.exists)
+
+        successPaneDoneButton.tap()
+
+        // ensure alert body contains "Stripe Bank" (AKA one bank is linked)
+        XCTAssert(
+            app.fc_playgroundSuccessAlertView.staticTexts.containing(NSPredicate(format: "label CONTAINS 'StripeBank'")).firstMatch
+                .exists
+        )
+    }
+
+    private func executeNativeNetworkingTestModeAutofillSignInFlowTest(emailAddress: String) {
+        let app = XCUIApplication.fc_launch(
+            playgroundConfigurationString:
+"""
+{"use_case":"payment_intent","sdk_type":"native","test_mode":true,"merchant":"networking","payment_method_permission":true,"transactions_permission":true,"email":"\(emailAddress)"}
+"""
+        )
+
+        app.fc_playgroundCell.tap()
+        app.fc_playgroundShowAuthFlowButton.tap()
+
+        app.fc_nativeConsentAgreeButton.tap()
+
+        let linkContinueButton = app.buttons["link_continue_button"]
+        XCTAssertTrue(linkContinueButton.waitForExistence(timeout: 60.0))
+        linkContinueButton.tap()
+
+        let testModeAutofillButton = app.buttons["test_mode_autofill_button"]
+        XCTAssertTrue(testModeAutofillButton.waitForExistence(timeout: 10.0))
+        testModeAutofillButton.tap()
+
+        let successInstitution = app.scrollViews.staticTexts["Success"]
+        XCTAssertTrue(successInstitution.waitForExistence(timeout: 120.0)) // need to wait for various API calls to appear
+        successInstitution.tap()
+
+        let connectAccountButton = app.buttons["Connect account"]
+        XCTAssertTrue(connectAccountButton.waitForExistence(timeout: 60.0))
+        connectAccountButton.tap()
+
+        XCTAssertTrue(testModeAutofillButton.waitForExistence(timeout: 10.0))
+        testModeAutofillButton.tap()
 
         let successPaneDoneButton = app.fc_nativeSuccessDoneButton
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationDataSource.swift
@@ -51,7 +51,7 @@ final class NetworkingLinkStepUpVerificationDataSourceImplementation: Networking
             apiClient: apiClient,
             clientSecret: clientSecret,
             analyticsClient: analyticsClient,
-            isTestmode: manifest.isTestMode
+            isTestMode: manifest.isTestMode
         )
         self.networkingOTPDataSource = networkingOTPDataSource
         networkingOTPDataSource.delegate = self

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationDataSource.swift
@@ -50,7 +50,8 @@ final class NetworkingLinkStepUpVerificationDataSourceImplementation: Networking
             consumerSession: nil,
             apiClient: apiClient,
             clientSecret: clientSecret,
-            analyticsClient: analyticsClient
+            analyticsClient: analyticsClient,
+            isTestmode: manifest.isTestMode
         )
         self.networkingOTPDataSource = networkingOTPDataSource
         networkingOTPDataSource.delegate = self

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationDataSource.swift
@@ -51,7 +51,8 @@ final class NetworkingLinkVerificationDataSourceImplementation: NetworkingLinkVe
             consumerSession: nil,
             apiClient: apiClient,
             clientSecret: clientSecret,
-            analyticsClient: analyticsClient
+            analyticsClient: analyticsClient,
+            isTestmode: manifest.isTestMode
         )
         self.networkingOTPDataSource = networkingOTPDataSource
         networkingOTPDataSource.delegate = self

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationDataSource.swift
@@ -52,7 +52,7 @@ final class NetworkingLinkVerificationDataSourceImplementation: NetworkingLinkVe
             apiClient: apiClient,
             clientSecret: clientSecret,
             analyticsClient: analyticsClient,
-            isTestmode: manifest.isTestMode
+            isTestMode: manifest.isTestMode
         )
         self.networkingOTPDataSource = networkingOTPDataSource
         networkingOTPDataSource.delegate = self

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationDataSource.swift
@@ -54,7 +54,7 @@ final class NetworkingSaveToLinkVerificationDataSourceImplementation: Networking
             apiClient: apiClient,
             clientSecret: clientSecret,
             analyticsClient: analyticsClient,
-            isTestmode: manifest.isTestMode
+            isTestMode: manifest.isTestMode
         )
         self.networkingOTPDataSource = networkingOTPDataSource
         networkingOTPDataSource.delegate = self

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationDataSource.swift
@@ -53,7 +53,8 @@ final class NetworkingSaveToLinkVerificationDataSourceImplementation: Networking
             consumerSession: consumerSession,
             apiClient: apiClient,
             clientSecret: clientSecret,
-            analyticsClient: analyticsClient
+            analyticsClient: analyticsClient,
+            isTestmode: manifest.isTestMode
         )
         self.networkingOTPDataSource = networkingOTPDataSource
         networkingOTPDataSource.delegate = self

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPDataSource.swift
@@ -15,6 +15,7 @@ protocol NetworkingOTPDataSourceDelegate: AnyObject {
 protocol NetworkingOTPDataSource: AnyObject {
     var otpType: String { get }
     var analyticsClient: FinancialConnectionsAnalyticsClient { get }
+    var isTestMode: Bool { get }
     var pane: FinancialConnectionsSessionManifest.NextPane { get }
 
     func lookupConsumerSession() -> Future<LookupConsumerSessionResponse>
@@ -39,6 +40,7 @@ final class NetworkingOTPDataSourceImplementation: NetworkingOTPDataSource {
     private let apiClient: FinancialConnectionsAPIClient
     private let clientSecret: String
     let analyticsClient: FinancialConnectionsAnalyticsClient
+    let isTestMode: Bool
     weak var delegate: NetworkingOTPDataSourceDelegate?
 
     init(
@@ -50,7 +52,8 @@ final class NetworkingOTPDataSourceImplementation: NetworkingOTPDataSource {
         consumerSession: ConsumerSessionData?,
         apiClient: FinancialConnectionsAPIClient,
         clientSecret: String,
-        analyticsClient: FinancialConnectionsAnalyticsClient
+        analyticsClient: FinancialConnectionsAnalyticsClient,
+        isTestmode: Bool
     ) {
         self.otpType = otpType
         self.emailAddress = emailAddress
@@ -61,6 +64,7 @@ final class NetworkingOTPDataSourceImplementation: NetworkingOTPDataSource {
         self.apiClient = apiClient
         self.clientSecret = clientSecret
         self.analyticsClient = analyticsClient
+        self.isTestMode = isTestmode
     }
 
     func lookupConsumerSession() -> Future<LookupConsumerSessionResponse> {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPDataSource.swift
@@ -53,7 +53,7 @@ final class NetworkingOTPDataSourceImplementation: NetworkingOTPDataSource {
         apiClient: FinancialConnectionsAPIClient,
         clientSecret: String,
         analyticsClient: FinancialConnectionsAnalyticsClient,
-        isTestmode: Bool
+        isTestMode: Bool
     ) {
         self.otpType = otpType
         self.emailAddress = emailAddress
@@ -64,7 +64,7 @@ final class NetworkingOTPDataSourceImplementation: NetworkingOTPDataSource {
         self.apiClient = apiClient
         self.clientSecret = clientSecret
         self.analyticsClient = analyticsClient
-        self.isTestMode = isTestmode
+        self.isTestMode = isTestMode
     }
 
     func lookupConsumerSession() -> Future<LookupConsumerSessionResponse> {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
@@ -30,15 +30,26 @@ protocol NetworkingOTPViewDelegate: AnyObject {
 
 final class NetworkingOTPView: UIView {
 
+    enum TestModeValues {
+        static let otp = "000000"
+    }
+
     private let dataSource: NetworkingOTPDataSource
     weak var delegate: NetworkingOTPViewDelegate?
 
     private lazy var verticalStackView: UIStackView = {
-        let otpVerticalStackView = UIStackView(
-            arrangedSubviews: [
-                otpTextField,
-            ]
-        )
+        let otpVerticalStackView = UIStackView()
+
+        if dataSource.isTestMode {
+            let testModeBanner = TestModeAutofillBannerView(
+                context: .otp,
+                didTapAutofill: applyTestModeValue
+            )
+            otpVerticalStackView.addArrangedSubview(testModeBanner)
+        }
+
+        otpVerticalStackView.addArrangedSubview(otpTextField)
+
         otpVerticalStackView.axis = .vertical
         otpVerticalStackView.spacing = 16
         return otpVerticalStackView
@@ -223,5 +234,10 @@ final class NetworkingOTPView: UIView {
                     )
                 }
             }
+    }
+
+    private func applyTestModeValue() {
+        otpTextField.value = TestModeValues.otp
+        otpTextFieldDidChange()
     }
 }


### PR DESCRIPTION
## Summary

This adds the test mode autofill banner (introduced here: https://github.com/stripe/stripe-ios/pull/3689) to OTP screens while in test mode.

## Motivation

This will make navigating through the networking flow much quicker while in test mode. Both web and Android have this implemented already!

## Testing

Added a UI test, and did some manual testing to ensure the autofill button is only shown while in test mode:

https://github.com/stripe/stripe-ios/assets/172562065/a16a1430-bff9-403b-a2e2-dfe9c04a2f72

## Changelog

N/a