### PR TITLE
Increase limit of number of spms for PS & CS

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerAdapter/CustomerAdapter.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerAdapter/CustomerAdapter.swift
@@ -168,7 +168,8 @@ open class StripeCustomerAdapter: CustomerAdapter {
             apiClient.listPaymentMethods(
                 forCustomer: customerEphemeralKey.id,
                 using: customerEphemeralKey.ephemeralKeySecret,
-                types: savedPaymentMethodTypes
+                types: savedPaymentMethodTypes,
+                limit: 100
             ) { paymentMethods, error in
                 guard var paymentMethods, error == nil else {
                     let error = error ?? PaymentSheetError.unexpectedResponseFromStripeAPI // TODO: make a better default error

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -278,7 +278,8 @@ final class PaymentSheetLoader {
             configuration.apiClient.listPaymentMethods(
                 forCustomer: customerID,
                 using: ephemeralKey,
-                types: savedPaymentMethodTypes
+                types: savedPaymentMethodTypes,
+                limit: 100
             ) { paymentMethods, error in
                 guard var paymentMethods, error == nil else {
                     let error = error ?? PaymentSheetError.fetchPaymentMethodsFailure

--- a/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+Payments.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+Payments.swift
@@ -1110,6 +1110,7 @@ extension STPAPIClient {
         forCustomer customerID: String,
         using ephemeralKeySecret: String,
         types: [STPPaymentMethodType] = [.card],
+        limit: Int? = nil,
         completion: @escaping STPPaymentMethodsCompletionBlock
     ) {
         let header = authorizationHeader(using: ephemeralKeySecret)
@@ -1125,10 +1126,13 @@ extension STPAPIClient {
 
         for type in types {
             group.enter()
-            let params = [
+            var params: [String: Any?] = [
                 "customer": customerID,
                 "type": STPPaymentMethod.string(from: type),
             ]
+            if let limit {
+                params["limit"] = limit
+            }
             APIRequest<STPPaymentMethodListDeserializer>.getWith(
                 self,
                 endpoint: APIEndpointPaymentMethods,


### PR DESCRIPTION
## Summary
Increasing limit of payment methods that can be returned for PS & CS

## Motivation
Virtual cards can quickly increase beyond the default limit of 10, there by shadowing real saved cards.

## Testing
Manual testing

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
