### PR TITLE
Adjust allow_redisplay values when using CustomerSession

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
@@ -211,15 +211,20 @@ extension STPElementsSession {
 
 extension STPElementsSession {
     func savePaymentMethodConsentBehavior() -> PaymentSheetFormFactory.SavePaymentMethodConsentBehavior {
-        guard let paymentMethodSave = paymentSheetPaymentMethodSave() else {
+        guard let paymentMethodSave = customerSessionPaymentSheetPaymentMethodSave() else {
             return .legacy
         }
         return paymentMethodSave
         ? .paymentSheetWithCustomerSessionPaymentMethodSaveEnabled
         : .paymentSheetWithCustomerSessionPaymentMethodSaveDisabled
-
     }
-    func paymentSheetPaymentMethodSave() -> Bool? {
+
+    /// Returns the value on CustomerSession's components.payment_sheet.features.payment_method_save
+    /// - Returns:
+    /// -   true, if the value of payment_method_save == "enabled",
+    /// -   false, if the value of payment_method_save == "disabled",
+    /// -   nil, if CustomerSession is not available (using legacy ephemeral key, or payment_sheet component is not enabled)
+    func customerSessionPaymentSheetPaymentMethodSave() -> Bool? {
         guard let customerSession = customer?.customerSession,
               customerSession.paymentSheetComponent.enabled,
               let features = customerSession.paymentSheetComponent.features else {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
@@ -211,20 +211,20 @@ extension STPElementsSession {
 
 extension STPElementsSession {
     func savePaymentMethodConsentBehavior() -> PaymentSheetFormFactory.SavePaymentMethodConsentBehavior {
-        if let customerSession = customer?.customerSession {
-            if customerSession.paymentSheetComponent.enabled,
-               let features = customerSession.paymentSheetComponent.features {
-                return features.paymentMethodSave ? .paymentSheetWithCustomerSessionPaymentMethodSaveEnabled
-                                                  : .paymentSheetWithCustomerSessionPaymentMethodSaveDisabled
-            } else {
-                // CustomerSession exists, but payment_sheet component is not available. This can happen
-                // if a merchant creates a CustomerSession with the wrong component. This is effectively
-                // an integration error. Defaulting to .legacy and sending 'unspecified' seems like the
-                // most appropriate thing to do.
-                return .legacy
-            }
-        } else {
+        guard let paymentMethodSave = paymentSheetPaymentMethodSave() else {
             return .legacy
         }
+        return paymentMethodSave
+        ? .paymentSheetWithCustomerSessionPaymentMethodSaveEnabled
+        : .paymentSheetWithCustomerSessionPaymentMethodSaveDisabled
+
+    }
+    func paymentSheetPaymentMethodSave() -> Bool? {
+        guard let customerSession = customer?.customerSession,
+              customerSession.paymentSheetComponent.enabled,
+              let features = customerSession.paymentSheetComponent.features else {
+            return nil
+        }
+        return features.paymentMethodSave
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerAddPaymentMethodViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerAddPaymentMethodViewController.swift
@@ -35,8 +35,7 @@ class CustomerAddPaymentMethodViewController: UIViewController {
         let params = IntentConfirmParams(type: selectedPaymentMethodType)
         params.setDefaultBillingDetailsIfNecessary(for: configuration)
         if let params = paymentMethodFormElement.updateParams(params: params) {
-            params.setAllowRedisplay(for: savePaymentMethodConsentBehavior,
-                                     isSettingUp: true)
+            params.setAllowRedisplayForCustomerSheet(savePaymentMethodConsentBehavior)
             return .new(confirmParams: params)
         }
         return nil

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerAddPaymentMethodViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerAddPaymentMethodViewController.swift
@@ -35,7 +35,8 @@ class CustomerAddPaymentMethodViewController: UIViewController {
         let params = IntentConfirmParams(type: selectedPaymentMethodType)
         params.setDefaultBillingDetailsIfNecessary(for: configuration)
         if let params = paymentMethodFormElement.updateParams(params: params) {
-            params.setAllowRedisplay(for: savePaymentMethodConsentBehavior)
+            params.setAllowRedisplay(for: savePaymentMethodConsentBehavior,
+                                     isSettingUp: true)
             return .new(confirmParams: params)
         }
         return nil

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/LinkEnabledPaymentMethodElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/LinkEnabledPaymentMethodElement.swift
@@ -66,7 +66,7 @@ final class LinkEnabledPaymentMethodElement: ContainerElement {
         guard let params = updateParams(params: .init(type: .stripe(paymentMethodType))) else {
             return nil
         }
-        params.setAllowRedisplay(paymentMethodSave: intent.elementsSession.paymentSheetPaymentMethodSave(),
+        params.setAllowRedisplay(paymentMethodSave: intent.elementsSession.customerSessionPaymentSheetPaymentMethodSave(),
                                  isSettingUp: intent.isSettingUp)
 
         switch inlineSignupElement.action {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/LinkEnabledPaymentMethodElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/LinkEnabledPaymentMethodElement.swift
@@ -66,7 +66,8 @@ final class LinkEnabledPaymentMethodElement: ContainerElement {
         guard let params = updateParams(params: .init(type: .stripe(paymentMethodType))) else {
             return nil
         }
-        params.setAllowRedisplay(for: intent.elementsSession.savePaymentMethodConsentBehavior())
+        params.setAllowRedisplay(for: intent.elementsSession.savePaymentMethodConsentBehavior(),
+                                 isSettingUp: intent.isSettingUp)
 
         switch inlineSignupElement.action {
         case .signupAndPay(let account, let phoneNumber, let legalName):

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/LinkEnabledPaymentMethodElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/LinkEnabledPaymentMethodElement.swift
@@ -66,7 +66,8 @@ final class LinkEnabledPaymentMethodElement: ContainerElement {
         guard let params = updateParams(params: .init(type: .stripe(paymentMethodType))) else {
             return nil
         }
-        params.setAllowRedisplay(for: intent)
+        params.setAllowRedisplay(paymentMethodSave: intent.elementsSession.paymentSheetPaymentMethodSave(),
+                                 isSettingUp: intent.isSettingUp)
 
         switch inlineSignupElement.action {
         case .signupAndPay(let account, let phoneNumber, let legalName):

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/LinkEnabledPaymentMethodElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/LinkEnabledPaymentMethodElement.swift
@@ -66,8 +66,7 @@ final class LinkEnabledPaymentMethodElement: ContainerElement {
         guard let params = updateParams(params: .init(type: .stripe(paymentMethodType))) else {
             return nil
         }
-        params.setAllowRedisplay(for: intent.elementsSession.savePaymentMethodConsentBehavior(),
-                                 isSettingUp: intent.isSettingUp)
+        params.setAllowRedisplay(for: intent)
 
         switch inlineSignupElement.action {
         case .signupAndPay(let account, let phoneNumber, let legalName):

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfirmParams.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfirmParams.swift
@@ -112,18 +112,11 @@ class IntentConfirmParams {
         case .paymentSheetWithCustomerSessionPaymentMethodSaveDisabled:
             switch saveForFutureUseCheckboxState {
             case .hidden:
-                if isSettingUp {
-                    // For PI+SFU & SI:
-                    paymentMethodParams.allowRedisplay = .limited
-                }
+                // For PI+SFU & SI:
+                paymentMethodParams.allowRedisplay = .limited
             case .deselected:
-                if isSettingUp {
-                    // For PI+SFU & SI:
-                    paymentMethodParams.allowRedisplay = .limited
-                } else {
-                    // For PI w/out SFU
-                    paymentMethodParams.allowRedisplay = .unspecified
-                }
+                // For PI w/out SFU
+                paymentMethodParams.allowRedisplay = .unspecified
             case .selected:
                 // For PI, off-session during confirm
                 paymentMethodParams.allowRedisplay = .always

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfirmParams.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfirmParams.swift
@@ -103,7 +103,8 @@ class IntentConfirmParams {
             paymentMethodParams.nonnil_billingDetails.address = STPPaymentMethodAddress(address: defaultBillingDetails.address)
         }
     }
-    func setAllowRedisplay(for savePaymentMethodConsentBehavior: PaymentSheetFormFactory.SavePaymentMethodConsentBehavior) {
+    func setAllowRedisplay(for savePaymentMethodConsentBehavior: PaymentSheetFormFactory.SavePaymentMethodConsentBehavior,
+                           isSettingUp: Bool) {
         switch savePaymentMethodConsentBehavior {
         case .legacy:
             // Always send unspecified
@@ -111,11 +112,18 @@ class IntentConfirmParams {
         case .paymentSheetWithCustomerSessionPaymentMethodSaveDisabled:
             switch saveForFutureUseCheckboxState {
             case .hidden:
-                // For PI+SFU & SI:
-                paymentMethodParams.allowRedisplay = .limited
+                if isSettingUp {
+                    // For PI+SFU & SI:
+                    paymentMethodParams.allowRedisplay = .limited
+                }
             case .deselected:
-                // For PI w/out SFU
-                paymentMethodParams.allowRedisplay = .limited
+                if isSettingUp {
+                    // For PI+SFU & SI:
+                    paymentMethodParams.allowRedisplay = .limited
+                } else {
+                    // For PI w/out SFU
+                    paymentMethodParams.allowRedisplay = .unspecified
+                }
             case .selected:
                 // For PI, off-session during confirm
                 paymentMethodParams.allowRedisplay = .always
@@ -124,8 +132,10 @@ class IntentConfirmParams {
             // Checkbox is shown for all cases: PI, PI+SFU, SI
             if saveForFutureUseCheckboxState == .selected {
                 paymentMethodParams.allowRedisplay = .always
-            } else if saveForFutureUseCheckboxState == .deselected {
+            } else if saveForFutureUseCheckboxState == .deselected && isSettingUp {
                 paymentMethodParams.allowRedisplay = .limited
+            } else if saveForFutureUseCheckboxState == .deselected && !isSettingUp {
+                paymentMethodParams.allowRedisplay = .unspecified
             }
         case .customerSheetWithCustomerSession:
             // UX (CustomerSheet) implies consent based on the UX

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfirmParams.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfirmParams.swift
@@ -115,7 +115,7 @@ class IntentConfirmParams {
                 // For PI+SFU & SI:
                 paymentMethodParams.allowRedisplay = .limited
             case .deselected:
-                // For PI w/out SFU
+                // For PI w/out SFU (PM not attached to customer)
                 paymentMethodParams.allowRedisplay = .unspecified
             case .selected:
                 // For PI, off-session during confirm
@@ -128,6 +128,7 @@ class IntentConfirmParams {
             } else if saveForFutureUseCheckboxState == .deselected && isSettingUp {
                 paymentMethodParams.allowRedisplay = .limited
             } else if saveForFutureUseCheckboxState == .deselected && !isSettingUp {
+                // For PI w/out SFU (PM not attached to customer)
                 paymentMethodParams.allowRedisplay = .unspecified
             }
         case .customerSheetWithCustomerSession:

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfirmParams.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfirmParams.swift
@@ -103,19 +103,17 @@ class IntentConfirmParams {
             paymentMethodParams.nonnil_billingDetails.address = STPPaymentMethodAddress(address: defaultBillingDetails.address)
         }
     }
-    func setAllowRedisplay(for intent: Intent) {
-        guard let customer = intent.elementsSession.customer,
-              customer.customerSession.paymentSheetComponent.enabled,
-        let features = customer.customerSession.paymentSheetComponent.features else {
+    func setAllowRedisplay(paymentMethodSave: Bool?,
+                           isSettingUp: Bool) {
+        guard let paymentMethodSave else {
             // Legacy Ephemeral Key
             paymentMethodParams.allowRedisplay = .unspecified
             return
         }
 
         // Customer Session is enabled
-        let paymentMethodSaveEnabled = features.paymentMethodSave
-        if paymentMethodSaveEnabled {
-            if intent.isSettingUp {
+        if paymentMethodSave {
+            if isSettingUp {
                 if saveForFutureUseCheckboxState == .selected {
                     paymentMethodParams.allowRedisplay = .always
                 } else if saveForFutureUseCheckboxState == .deselected {
@@ -129,7 +127,7 @@ class IntentConfirmParams {
                 }
             }
         } else {
-            if intent.isSettingUp {
+            if isSettingUp {
                 // Checkbox is hidden
                 paymentMethodParams.allowRedisplay = .limited
             } else {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -44,8 +44,7 @@ class PaymentMethodFormViewController: UIViewController {
         let params = IntentConfirmParams(type: paymentMethodType)
         params.setDefaultBillingDetailsIfNecessary(for: configuration)
         if let params = form.updateParams(params: params) {
-            params.setAllowRedisplay(for: intent.elementsSession.savePaymentMethodConsentBehavior(),
-                                     isSettingUp: intent.isSettingUp)
+            params.setAllowRedisplay(for: intent)
             if case .external(let paymentMethod) = paymentMethodType {
                 return .external(paymentMethod: paymentMethod, billingDetails: params.paymentMethodParams.nonnil_billingDetails)
             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -44,7 +44,8 @@ class PaymentMethodFormViewController: UIViewController {
         let params = IntentConfirmParams(type: paymentMethodType)
         params.setDefaultBillingDetailsIfNecessary(for: configuration)
         if let params = form.updateParams(params: params) {
-            params.setAllowRedisplay(for: intent)
+            params.setAllowRedisplay(paymentMethodSave: intent.elementsSession.paymentSheetPaymentMethodSave(),
+                                     isSettingUp: intent.isSettingUp)
             if case .external(let paymentMethod) = paymentMethodType {
                 return .external(paymentMethod: paymentMethod, billingDetails: params.paymentMethodParams.nonnil_billingDetails)
             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -44,7 +44,7 @@ class PaymentMethodFormViewController: UIViewController {
         let params = IntentConfirmParams(type: paymentMethodType)
         params.setDefaultBillingDetailsIfNecessary(for: configuration)
         if let params = form.updateParams(params: params) {
-            params.setAllowRedisplay(paymentMethodSave: intent.elementsSession.paymentSheetPaymentMethodSave(),
+            params.setAllowRedisplay(paymentMethodSave: intent.elementsSession.customerSessionPaymentSheetPaymentMethodSave(),
                                      isSettingUp: intent.isSettingUp)
             if case .external(let paymentMethod) = paymentMethodType {
                 return .external(paymentMethod: paymentMethod, billingDetails: params.paymentMethodParams.nonnil_billingDetails)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -44,7 +44,8 @@ class PaymentMethodFormViewController: UIViewController {
         let params = IntentConfirmParams(type: paymentMethodType)
         params.setDefaultBillingDetailsIfNecessary(for: configuration)
         if let params = form.updateParams(params: params) {
-            params.setAllowRedisplay(for: intent.elementsSession.savePaymentMethodConsentBehavior())
+            params.setAllowRedisplay(for: intent.elementsSession.savePaymentMethodConsentBehavior(),
+                                     isSettingUp: intent.isSettingUp)
             if case .external(let paymentMethod) = paymentMethodType {
                 return .external(paymentMethod: paymentMethod, billingDetails: params.paymentMethodParams.nonnil_billingDetails)
             }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/IntentConfirmParamsTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/IntentConfirmParamsTest.swift
@@ -23,7 +23,7 @@ class IntentConfirmParamsTest: XCTestCase {
 
         intentConfirmParams.setAllowRedisplay(for: .paymentSheetWithCustomerSessionPaymentMethodSaveDisabled, isSettingUp: true)
 
-        XCTAssertEqual(.limited, intentConfirmParams.paymentMethodParams.allowRedisplay)
+        XCTAssertEqual(.unspecified, intentConfirmParams.paymentMethodParams.allowRedisplay)
     }
     func testSetAllowRedisplay_saveDisabled_pi_selected_settingUp() {
         let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
@@ -96,7 +96,7 @@ class IntentConfirmParamsTest: XCTestCase {
         // This isn't a real use case. If payment_method_save == disabled, and checkbox is hidden, then settingUp should be true
         intentConfirmParams.setAllowRedisplay(for: .paymentSheetWithCustomerSessionPaymentMethodSaveDisabled, isSettingUp: false)
 
-        XCTAssertEqual(.unspecified, intentConfirmParams.paymentMethodParams.allowRedisplay)
+        XCTAssertEqual(.limited, intentConfirmParams.paymentMethodParams.allowRedisplay)
     }
     func testSetAllowRedisplay_saveEnabled_pi_deselected_notSettingUp() {
         let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/IntentConfirmParamsTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/IntentConfirmParamsTest.swift
@@ -14,179 +14,51 @@ class IntentConfirmParamsTest: XCTestCase {
     func testSetAllowRedisplay_legacySI() {
         let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
 
-        let elementsSession = STPElementsSession.emptyElementsSession
-
-        let intent = Intent.setupIntent(elementsSession: elementsSession, setupIntent: STPFixtures.setupIntent())
         intentConfirmParams.saveForFutureUseCheckboxState = .hidden
-        intentConfirmParams.setAllowRedisplay(for: intent)
+        intentConfirmParams.setAllowRedisplay(paymentMethodSave: nil, isSettingUp: true)
 
         XCTAssertEqual(.unspecified, intentConfirmParams.paymentMethodParams.allowRedisplay)
     }
     func testSetAllowRedisplay_legacyPI_selected() {
         let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
 
-        let elementsSession = STPElementsSession.emptyElementsSession
-
-        let intent = Intent.paymentIntent(elementsSession: elementsSession, paymentIntent: STPFixtures.paymentIntent())
         intentConfirmParams.saveForFutureUseCheckboxState = .selected
-        intentConfirmParams.setAllowRedisplay(for: intent)
+        intentConfirmParams.setAllowRedisplay(paymentMethodSave: nil, isSettingUp: false)
 
         XCTAssertEqual(.unspecified, intentConfirmParams.paymentMethodParams.allowRedisplay)
     }
     func testSetAllowRedisplay_legacyPI_deselected() {
         let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
 
-        let elementsSession = STPElementsSession.emptyElementsSession
-
-        let intent = Intent.paymentIntent(elementsSession: elementsSession, paymentIntent: STPFixtures.paymentIntent())
         intentConfirmParams.saveForFutureUseCheckboxState = .deselected
-        intentConfirmParams.setAllowRedisplay(for: intent)
-
-        XCTAssertEqual(.unspecified, intentConfirmParams.paymentMethodParams.allowRedisplay)
-    }
-    func testSetAllowRedisplay_legacyPISFU_deselected() {
-        let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
-
-        let elementsSession = STPElementsSession.emptyElementsSession
-        let paymentIntent = STPFixtures.paymentIntent(paymentMethodTypes: ["card"], setupFutureUsage: .offSession)
-        let intent = Intent.paymentIntent(elementsSession: elementsSession, paymentIntent: paymentIntent)
-        intentConfirmParams.saveForFutureUseCheckboxState = .hidden
-        intentConfirmParams.setAllowRedisplay(for: intent)
+        intentConfirmParams.setAllowRedisplay(paymentMethodSave: nil, isSettingUp: false)
 
         XCTAssertEqual(.unspecified, intentConfirmParams.paymentMethodParams.allowRedisplay)
     }
 
-    // MARK: CustomerSession, SetupIntent
+    // MARK: CustomerSession, PI+SFU & SetupIntent
     func testSetAllowRedisplay_SI_saveEnabled_selected() {
         let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
-        let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["card"],
-                                                            customerSessionData: [
-                                                                "payment_sheet": [
-                                                                    "enabled": true,
-                                                                    "features": ["payment_method_save": "enabled",
-                                                                                 "payment_method_remove": "enabled",
-                                                                                ],
-                                                                ],
-                                                                "customer_sheet": [
-                                                                    "enabled": false
-                                                                ],
-                                                            ])
-
-        let intent = Intent.setupIntent(elementsSession: elementsSession, setupIntent: STPFixtures.setupIntent())
         intentConfirmParams.saveForFutureUseCheckboxState = .selected
 
-        intentConfirmParams.setAllowRedisplay(for: intent)
+        intentConfirmParams.setAllowRedisplay(paymentMethodSave: true, isSettingUp: true)
 
         XCTAssertEqual(.always, intentConfirmParams.paymentMethodParams.allowRedisplay)
     }
     func testSetAllowRedisplay_SI_saveEnabled_deselected() {
         let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
-        let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["card"],
-                                                            customerSessionData: [
-                                                                "payment_sheet": [
-                                                                    "enabled": true,
-                                                                    "features": ["payment_method_save": "enabled",
-                                                                                 "payment_method_remove": "enabled",
-                                                                                ],
-                                                                ],
-                                                                "customer_sheet": [
-                                                                    "enabled": false
-                                                                ],
-                                                            ])
-        let intent = Intent.setupIntent(elementsSession: elementsSession, setupIntent: STPFixtures.setupIntent())
         intentConfirmParams.saveForFutureUseCheckboxState = .deselected
 
-        intentConfirmParams.setAllowRedisplay(for: intent)
+        intentConfirmParams.setAllowRedisplay(paymentMethodSave: true, isSettingUp: true)
 
         XCTAssertEqual(.limited, intentConfirmParams.paymentMethodParams.allowRedisplay)
     }
 
     func testSetAllowRedisplay_SI_saveDisabled() {
         let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
-        let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["card"],
-                                                            customerSessionData: [
-                                                                "payment_sheet": [
-                                                                    "enabled": true,
-                                                                    "features": ["payment_method_save": "disabled",
-                                                                                 "payment_method_remove": "enabled",
-                                                                                ],
-                                                                ],
-                                                                "customer_sheet": [
-                                                                    "enabled": false
-                                                                ],
-                                                            ])
-        let intent = Intent.setupIntent(elementsSession: elementsSession, setupIntent: STPFixtures.setupIntent())
         intentConfirmParams.saveForFutureUseCheckboxState = .hidden
 
-        intentConfirmParams.setAllowRedisplay(for: intent)
-
-        XCTAssertEqual(.limited, intentConfirmParams.paymentMethodParams.allowRedisplay)
-    }
-
-    // MARK: CustomerSession, PISFU
-    func testSetAllowRedisplay_PISFU_saveEnabled_selected() {
-        let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
-        let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["card"],
-                                                            customerSessionData: [
-                                                                "payment_sheet": [
-                                                                    "enabled": true,
-                                                                    "features": ["payment_method_save": "enabled",
-                                                                                 "payment_method_remove": "enabled",
-                                                                                ],
-                                                                ],
-                                                                "customer_sheet": [
-                                                                    "enabled": false
-                                                                ],
-                                                            ])
-        let paymentIntent = STPFixtures.paymentIntent(paymentMethodTypes: ["card"], setupFutureUsage: .offSession)
-        let intent = Intent.paymentIntent(elementsSession: elementsSession, paymentIntent: paymentIntent)
-        intentConfirmParams.saveForFutureUseCheckboxState = .selected
-
-        intentConfirmParams.setAllowRedisplay(for: intent)
-
-        XCTAssertEqual(.always, intentConfirmParams.paymentMethodParams.allowRedisplay)
-    }
-    func testSetAllowRedisplay_PISFU_saveEnabled_deselected() {
-        let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
-        let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["card"],
-                                                            customerSessionData: [
-                                                                "payment_sheet": [
-                                                                    "enabled": true,
-                                                                    "features": ["payment_method_save": "enabled",
-                                                                                 "payment_method_remove": "enabled",
-                                                                                ],
-                                                                ],
-                                                                "customer_sheet": [
-                                                                    "enabled": false
-                                                                ],
-                                                            ])
-        let paymentIntent = STPFixtures.paymentIntent(paymentMethodTypes: ["card"], setupFutureUsage: .offSession)
-        let intent = Intent.paymentIntent(elementsSession: elementsSession, paymentIntent: paymentIntent)
-        intentConfirmParams.saveForFutureUseCheckboxState = .deselected
-
-        intentConfirmParams.setAllowRedisplay(for: intent)
-
-        XCTAssertEqual(.limited, intentConfirmParams.paymentMethodParams.allowRedisplay)
-    }
-    func testSetAllowRedisplay_PISFU_saveDisabled() {
-        let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
-        let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["card"],
-                                                            customerSessionData: [
-                                                                "payment_sheet": [
-                                                                    "enabled": true,
-                                                                    "features": ["payment_method_save": "disabled",
-                                                                                 "payment_method_remove": "enabled",
-                                                                                ],
-                                                                ],
-                                                                "customer_sheet": [
-                                                                    "enabled": false
-                                                                ],
-                                                            ])
-        let paymentIntent = STPFixtures.paymentIntent(paymentMethodTypes: ["card"], setupFutureUsage: .offSession)
-        let intent = Intent.paymentIntent(elementsSession: elementsSession, paymentIntent: paymentIntent)
-        intentConfirmParams.saveForFutureUseCheckboxState = .hidden
-
-        intentConfirmParams.setAllowRedisplay(for: intent)
+        intentConfirmParams.setAllowRedisplay(paymentMethodSave: false, isSettingUp: true)
 
         XCTAssertEqual(.limited, intentConfirmParams.paymentMethodParams.allowRedisplay)
     }
@@ -194,85 +66,33 @@ class IntentConfirmParamsTest: XCTestCase {
     // MARK: CustomerSession, Payment Intents
     func testSetAllowRedisplay_PI_saveEnabled_deselected() {
         let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
-        let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["card"],
-                                                            customerSessionData: [
-                                                                "payment_sheet": [
-                                                                    "enabled": true,
-                                                                    "features": ["payment_method_save": "enabled",
-                                                                                 "payment_method_remove": "enabled",
-                                                                                ],
-                                                                ],
-                                                                "customer_sheet": [
-                                                                    "enabled": false
-                                                                ],
-                                                            ])
-        let intent = Intent.paymentIntent(elementsSession: elementsSession, paymentIntent: STPFixtures.paymentIntent())
         intentConfirmParams.saveForFutureUseCheckboxState = .deselected
 
-        intentConfirmParams.setAllowRedisplay(for: intent)
+        intentConfirmParams.setAllowRedisplay(paymentMethodSave: true, isSettingUp: false)
 
         XCTAssertEqual(.unspecified, intentConfirmParams.paymentMethodParams.allowRedisplay)
     }
     func testSetAllowRedisplay_PI_saveEnabled_selected() {
         let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
-        let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["card"],
-                                                            customerSessionData: [
-                                                                "payment_sheet": [
-                                                                    "enabled": true,
-                                                                    "features": ["payment_method_save": "enabled",
-                                                                                 "payment_method_remove": "enabled",
-                                                                                ],
-                                                                ],
-                                                                "customer_sheet": [
-                                                                    "enabled": false
-                                                                ],
-                                                            ])
-        let intent = Intent.paymentIntent(elementsSession: elementsSession, paymentIntent: STPFixtures.paymentIntent())
         intentConfirmParams.saveForFutureUseCheckboxState = .selected
 
-        intentConfirmParams.setAllowRedisplay(for: intent)
+        intentConfirmParams.setAllowRedisplay(paymentMethodSave: true, isSettingUp: false)
 
         XCTAssertEqual(.always, intentConfirmParams.paymentMethodParams.allowRedisplay)
     }
     func testSetAllowRedisplay_PI_saveDisabled_deselected() {
         let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
-        let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["card"],
-                                                            customerSessionData: [
-                                                                "payment_sheet": [
-                                                                    "enabled": true,
-                                                                    "features": ["payment_method_save": "disabled",
-                                                                                 "payment_method_remove": "enabled",
-                                                                                ],
-                                                                ],
-                                                                "customer_sheet": [
-                                                                    "enabled": false
-                                                                ],
-                                                            ])
-        let intent = Intent.paymentIntent(elementsSession: elementsSession, paymentIntent: STPFixtures.paymentIntent())
         intentConfirmParams.saveForFutureUseCheckboxState = .deselected
 
-        intentConfirmParams.setAllowRedisplay(for: intent)
+        intentConfirmParams.setAllowRedisplay(paymentMethodSave: false, isSettingUp: false)
 
         XCTAssertEqual(.unspecified, intentConfirmParams.paymentMethodParams.allowRedisplay)
     }
     func testSetAllowRedisplay_PI_saveDisabled_selected() {
         let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
-        let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["card"],
-                                                            customerSessionData: [
-                                                                "payment_sheet": [
-                                                                    "enabled": true,
-                                                                    "features": ["payment_method_save": "disabled",
-                                                                                 "payment_method_remove": "enabled",
-                                                                                ],
-                                                                ],
-                                                                "customer_sheet": [
-                                                                    "enabled": false
-                                                                ],
-                                                            ])
-        let intent = Intent.paymentIntent(elementsSession: elementsSession, paymentIntent: STPFixtures.paymentIntent())
         intentConfirmParams.saveForFutureUseCheckboxState = .selected
 
-        intentConfirmParams.setAllowRedisplay(for: intent)
+        intentConfirmParams.setAllowRedisplay(paymentMethodSave: false, isSettingUp: false)
 
         XCTAssertEqual(.always, intentConfirmParams.paymentMethodParams.allowRedisplay)
     }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/IntentConfirmParamsTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/IntentConfirmParamsTest.swift
@@ -10,57 +10,115 @@ import StripePaymentsTestUtils
 import XCTest
 
 class IntentConfirmParamsTest: XCTestCase {
-    func testSetAllowRedisplay_legacy() {
+    func testSetAllowRedisplay_legacy_settingUp() {
         let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
 
-        intentConfirmParams.setAllowRedisplay(for: .legacy)
+        intentConfirmParams.setAllowRedisplay(for: .legacy, isSettingUp: true)
 
         XCTAssertEqual(.unspecified, intentConfirmParams.paymentMethodParams.allowRedisplay)
     }
-    func testSetAllowRedisplay_saveDisabled_pi_deselected() {
+    func testSetAllowRedisplay_saveDisabled_pi_deselected_settingUp() {
         let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
         intentConfirmParams.saveForFutureUseCheckboxState = .deselected
 
-        intentConfirmParams.setAllowRedisplay(for: .paymentSheetWithCustomerSessionPaymentMethodSaveDisabled)
+        intentConfirmParams.setAllowRedisplay(for: .paymentSheetWithCustomerSessionPaymentMethodSaveDisabled, isSettingUp: true)
 
         XCTAssertEqual(.limited, intentConfirmParams.paymentMethodParams.allowRedisplay)
     }
-    func testSetAllowRedisplay_saveDisabled_pi_selected() {
+    func testSetAllowRedisplay_saveDisabled_pi_selected_settingUp() {
         let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
         intentConfirmParams.saveForFutureUseCheckboxState = .selected
 
-        intentConfirmParams.setAllowRedisplay(for: .paymentSheetWithCustomerSessionPaymentMethodSaveDisabled)
+        intentConfirmParams.setAllowRedisplay(for: .paymentSheetWithCustomerSessionPaymentMethodSaveDisabled, isSettingUp: true)
 
         XCTAssertEqual(.always, intentConfirmParams.paymentMethodParams.allowRedisplay)
     }
-    func testSetAllowRedisplay_saveDisabled_hidden() {
+    func testSetAllowRedisplay_saveDisabled_hidden_settingUp() {
         let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
         intentConfirmParams.saveForFutureUseCheckboxState = .hidden
 
-        intentConfirmParams.setAllowRedisplay(for: .paymentSheetWithCustomerSessionPaymentMethodSaveDisabled)
+        intentConfirmParams.setAllowRedisplay(for: .paymentSheetWithCustomerSessionPaymentMethodSaveDisabled, isSettingUp: true)
 
         XCTAssertEqual(.limited, intentConfirmParams.paymentMethodParams.allowRedisplay)
     }
-    func testSetAllowRedisplay_saveEnabled_pi_deselected() {
+    func testSetAllowRedisplay_saveEnabled_pi_deselected_settingUp() {
         let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
         intentConfirmParams.saveForFutureUseCheckboxState = .deselected
 
-        intentConfirmParams.setAllowRedisplay(for: .paymentSheetWithCustomerSessionPaymentMethodSaveEnabled)
+        intentConfirmParams.setAllowRedisplay(for: .paymentSheetWithCustomerSessionPaymentMethodSaveEnabled, isSettingUp: true)
 
         XCTAssertEqual(.limited, intentConfirmParams.paymentMethodParams.allowRedisplay)
     }
-    func testSetAllowRedisplay_saveEnabled_pi_selected() {
+    func testSetAllowRedisplay_saveEnabled_pi_selected_settingUp() {
         let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
         intentConfirmParams.saveForFutureUseCheckboxState = .selected
 
-        intentConfirmParams.setAllowRedisplay(for: .paymentSheetWithCustomerSessionPaymentMethodSaveEnabled)
+        intentConfirmParams.setAllowRedisplay(for: .paymentSheetWithCustomerSessionPaymentMethodSaveEnabled, isSettingUp: true)
 
         XCTAssertEqual(.always, intentConfirmParams.paymentMethodParams.allowRedisplay)
     }
-    func testSetAllowRedisplay_customerSession() {
+    func testSetAllowRedisplay_customerSession_settingUp() {
         let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
 
-        intentConfirmParams.setAllowRedisplay(for: .customerSheetWithCustomerSession)
+        intentConfirmParams.setAllowRedisplay(for: .customerSheetWithCustomerSession, isSettingUp: true)
+
+        XCTAssertEqual(.always, intentConfirmParams.paymentMethodParams.allowRedisplay)
+    }
+
+    // MARK: Not setting up
+    func testSetAllowRedisplay_legacy_notSettingUp() {
+        let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
+
+        intentConfirmParams.setAllowRedisplay(for: .legacy, isSettingUp: false)
+
+        XCTAssertEqual(.unspecified, intentConfirmParams.paymentMethodParams.allowRedisplay)
+    }
+    func testSetAllowRedisplay_saveDisabled_pi_deselected_notSettingUp() {
+        let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
+        intentConfirmParams.saveForFutureUseCheckboxState = .deselected
+
+        intentConfirmParams.setAllowRedisplay(for: .paymentSheetWithCustomerSessionPaymentMethodSaveDisabled, isSettingUp: false)
+
+        XCTAssertEqual(.unspecified, intentConfirmParams.paymentMethodParams.allowRedisplay)
+    }
+    func testSetAllowRedisplay_saveDisabled_pi_selected_notSettingUp() {
+        let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
+        intentConfirmParams.saveForFutureUseCheckboxState = .selected
+
+        intentConfirmParams.setAllowRedisplay(for: .paymentSheetWithCustomerSessionPaymentMethodSaveDisabled, isSettingUp: false)
+
+        XCTAssertEqual(.always, intentConfirmParams.paymentMethodParams.allowRedisplay)
+    }
+    func testSetAllowRedisplay_saveDisabled_hidden_notSettingUp() {
+        let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
+        intentConfirmParams.saveForFutureUseCheckboxState = .hidden
+
+        // This isn't a real use case. If payment_method_save == disabled, and checkbox is hidden, then settingUp should be true
+        intentConfirmParams.setAllowRedisplay(for: .paymentSheetWithCustomerSessionPaymentMethodSaveDisabled, isSettingUp: false)
+
+        XCTAssertEqual(.unspecified, intentConfirmParams.paymentMethodParams.allowRedisplay)
+    }
+    func testSetAllowRedisplay_saveEnabled_pi_deselected_notSettingUp() {
+        let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
+        intentConfirmParams.saveForFutureUseCheckboxState = .deselected
+
+        intentConfirmParams.setAllowRedisplay(for: .paymentSheetWithCustomerSessionPaymentMethodSaveEnabled, isSettingUp: false)
+
+        XCTAssertEqual(.unspecified, intentConfirmParams.paymentMethodParams.allowRedisplay)
+    }
+    func testSetAllowRedisplay_saveEnabled_pi_selected_notSettingUp() {
+        let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
+        intentConfirmParams.saveForFutureUseCheckboxState = .selected
+
+        intentConfirmParams.setAllowRedisplay(for: .paymentSheetWithCustomerSessionPaymentMethodSaveEnabled, isSettingUp: false)
+
+        XCTAssertEqual(.always, intentConfirmParams.paymentMethodParams.allowRedisplay)
+    }
+    func testSetAllowRedisplay_customerSession_notSettingUp() {
+        let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
+
+        // This isn't a real use case. customerSheetWithCustomerSession is always setting up. Nonetheless, we should default to .always.
+        intentConfirmParams.setAllowRedisplay(for: .customerSheetWithCustomerSession, isSettingUp: false)
 
         XCTAssertEqual(.always, intentConfirmParams.paymentMethodParams.allowRedisplay)
     }


### PR DESCRIPTION
## Summary
Adjust allow_redisplay values when using CustomerSession

## Motivation
When not saving a payment method to a customer, we were specifying limited. This should have been unspecified

## Testing
Added unit tests

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
