### PR TITLE
Reanimate FC consent dots view on app foreground

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentViewController.swift
@@ -67,10 +67,6 @@ class ConsentViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .customBackgroundColor
@@ -108,13 +104,6 @@ class ConsentViewController: UIViewController {
         paneLayoutView.addTo(view: view)
 
         dataSource.analyticsClient.logPaneLoaded(pane: .consent)
-    }
-
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        // this fixes an issue where presenting a UIViewController
-        // on top of ConsentViewController would stop the dot animation
-        consentLogoView?.animateDots()
 
         NotificationCenter.default.addObserver(
             self,
@@ -122,6 +111,13 @@ class ConsentViewController: UIViewController {
             name: UIApplication.willEnterForegroundNotification,
             object: nil
         )
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        // this fixes an issue where presenting a UIViewController
+        // on top of ConsentViewController would stop the dot animation
+        consentLogoView?.animateDots()
     }
 
     @objc private func appWillEnterForeground() {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentViewController.swift
@@ -67,6 +67,10 @@ class ConsentViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .customBackgroundColor
@@ -110,6 +114,19 @@ class ConsentViewController: UIViewController {
         super.viewWillAppear(animated)
         // this fixes an issue where presenting a UIViewController
         // on top of ConsentViewController would stop the dot animation
+        consentLogoView?.animateDots()
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(appWillEnterForeground),
+            name: UIApplication.willEnterForegroundNotification,
+            object: nil
+        )
+    }
+
+    @objc private func appWillEnterForeground() {
+        // Fixes an issue where the dot animation was stopped when the app
+        // was backgrounded, then reopened.
         consentLogoView?.animateDots()
     }
 


### PR DESCRIPTION
## Summary

This fixes an issue where the consent logo view dots animation would be stopped and not restarted when the app was backgrounded, then returned to the foreground.

## Motivation

✨

## Testing

Verified the animation properly continues after the app is foregrounded:

https://github.com/stripe/stripe-ios/assets/172562065/6ecba189-f29a-4cde-9f1c-19bd95742713

## Changelog

N/a
