### PR TITLE
Track which LPMs are shown and their order on load succeed event

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -92,11 +92,13 @@ final class PaymentSheetLoader {
                     showApplePay: isFlowController ? isApplePayEnabled : false,
                     showLink: isFlowController ? isLinkEnabled : false
                 )
+                let paymentMethodTypes = PaymentSheet.PaymentMethodType.filteredPaymentMethodTypes(from: intent, configuration: configuration, logAvailability: false)
                 analyticsClient.logPaymentSheetLoadSucceeded(
                     loadingStartDate: loadingStartDate,
                     linkEnabled: isLinkEnabled,
                     defaultPaymentMethod: paymentOptionsViewModels.stp_boundSafeObject(at: defaultSelectedIndex),
-                    intentAnalyticsValue: intent.analyticsValue
+                    intentAnalyticsValue: intent.analyticsValue,
+                    orderedPaymentMethodTypes: paymentMethodTypes
                 )
                 if isFlowController {
                     AnalyticsHelper.shared.startTimeMeasurement(.checkout)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
@@ -109,7 +109,8 @@ extension STPAnalyticsClient {
     func logPaymentSheetLoadSucceeded(loadingStartDate: Date,
                                       linkEnabled: Bool,
                                       defaultPaymentMethod: SavedPaymentOptionsViewController.Selection?,
-                                      intentAnalyticsValue: String) {
+                                      intentAnalyticsValue: String,
+                                      orderedPaymentMethodTypes: [PaymentSheet.PaymentMethodType]) {
         let defaultPaymentMethodAnalyticsValue: String = {
             switch defaultPaymentMethod {
             case .applePay:
@@ -125,11 +126,16 @@ extension STPAnalyticsClient {
                 return "none"
             }
         }()
+        let params = ["selected_lpm": defaultPaymentMethodAnalyticsValue,
+                      "intent_type": intentAnalyticsValue,
+                      "ordered_lpms": orderedPaymentMethodTypes.map({ $0.identifier }),
+        ] as [String: Any]
+
         logPaymentSheetEvent(
             event: .paymentSheetLoadSucceeded,
             duration: Date().timeIntervalSince(loadingStartDate),
             linkEnabled: linkEnabled,
-            params: ["selected_lpm": defaultPaymentMethodAnalyticsValue, "intent_type": intentAnalyticsValue]
+            params: params
         )
     }
 


### PR DESCRIPTION
## Summary
- Tracks LPMs shown in payment sheet and their order

## Motivation
- https://jira.corp.stripe.com/browse/RUN_MOBILESDK-3312

## Testing
- Manually (also tested that paymentMethodOrder is respected)

## Changelog
N/A