### PR TITLE
Improve bottom sheet push/pop transition animation by making old cont…

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/BottomSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/BottomSheetViewController.swift
@@ -92,12 +92,8 @@ class BottomSheetViewController: UIViewController, BottomSheetPresentable {
 
             // Take a snapshot of the old content and add it to our container - we'll fade it out
             let oldView = oldContentViewController.view!
-            let renderer = UIGraphicsImageRenderer(size: oldView.bounds.size)
-            let image = renderer.image { _ in
-                oldView.drawHierarchy(in: oldView.bounds, afterScreenUpdates: false)
-            }
-            let imageView = UIImageView(image: image)
-            contentContainerView.addSubview(imageView)
+            let oldViewImage = oldView.snapshotView(afterScreenUpdates: false) ?? UIView()
+            contentContainerView.addSubview(oldViewImage)
 
             // Remove the old VC
             oldContentViewController.view.removeFromSuperview()
@@ -133,7 +129,7 @@ class BottomSheetViewController: UIViewController, BottomSheetPresentable {
             // Now animate to the correct height.
             UIView.animate(withDuration: 0.2) {
                 // Fade old content snapshot out
-                imageView.alpha = 0
+                oldViewImage.alpha = 0
             }
             animateHeightChange(forceAnimation: true, {
                 // Fade new content in
@@ -141,7 +137,7 @@ class BottomSheetViewController: UIViewController, BottomSheetPresentable {
                 self.manualHeightConstraint.constant = newHeight
             }, completion: {_ in
                 // Remove the old content snapshot
-                imageView.removeFromSuperview()
+                oldViewImage.removeFromSuperview()
 
                 // Inform accessibility
                 UIAccessibility.post(notification: .screenChanged, argument: self.contentViewController.view)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/BottomSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/BottomSheetViewController.swift
@@ -90,14 +90,23 @@ class BottomSheetViewController: UIViewController, BottomSheetPresentable {
             // First, get the old height of the content + navigation bar + safe area.
             manualHeightConstraint.constant = oldContentViewController.view.frame.size.height + navigationBarContainerView.bounds.size.height + view.safeAreaInsets.bottom
 
+            // Take a snapshot of the old content and add it to our container - we'll fade it out
+            let oldView = oldContentViewController.view!
+            let renderer = UIGraphicsImageRenderer(size: oldView.bounds.size)
+            let image = renderer.image { _ in
+                oldView.drawHierarchy(in: oldView.bounds, afterScreenUpdates: false)
+            }
+            let imageView = UIImageView(image: image)
+            contentContainerView.addSubview(imageView)
+
             // Remove the old VC
             oldContentViewController.view.removeFromSuperview()
             oldContentViewController.removeFromParent()
 
             // Add the new VC
             addChild(contentViewController)
-            self.contentContainerView.addArrangedSubview(self.contentViewController.view)
-            self.contentViewController.didMove(toParent: self)
+            contentContainerView.addArrangedSubview(self.contentViewController.view)
+            contentViewController.didMove(toParent: self)
             if let presentationController = rootParent.presentationController
                 as? BottomSheetPresentationController
             {
@@ -106,26 +115,37 @@ class BottomSheetViewController: UIViewController, BottomSheetPresentable {
             }
 
             scrollView.contentInsetAdjustmentBehavior = .never
-            self.contentContainerView.layoutIfNeeded()
-            self.scrollView.layoutIfNeeded()
-            self.scrollView.updateConstraintsIfNeeded()
+            contentContainerView.layoutIfNeeded()
+            scrollView.layoutIfNeeded()
+            scrollView.updateConstraintsIfNeeded()
             oldContentViewController.navigationBar.removeFromSuperview()
             navigationBarContainerView.addArrangedSubview(contentViewController.navigationBar)
             navigationBarContainerView.layoutIfNeeded()
             // Layout is mostly completed at this point. The new height is the navigation bar + content + the unsafe area at the bottom.
-            let newHeight = self.contentViewController.view.bounds.size.height + navigationBarContainerView.bounds.size.height + view.safeAreaInsets.bottom
+            let newHeight = contentViewController.view.bounds.size.height + navigationBarContainerView.bounds.size.height + view.safeAreaInsets.bottom
 
             // Force the old height, then force a layout pass
-            if self.modalPresentationStyle == .custom { // Only if we're using the custom presentation style (e.g. pinned to the bottom)
+            if modalPresentationStyle == .custom { // Only if we're using the custom presentation style (e.g. pinned to the bottom)
                 manualHeightConstraint.isActive = true
             }
-            self.rootParent.presentationController?.containerView?.layoutIfNeeded()
-            self.contentViewController.view.alpha = 0
+            rootParent.presentationController?.containerView?.layoutIfNeeded()
+            contentViewController.view.alpha = 0
             // Now animate to the correct height.
+            UIView.animate(withDuration: 0.2) {
+                // Fade old content snapshot out
+                imageView.alpha = 0
+            }
             animateHeightChange(forceAnimation: true, {
+                // Fade new content in
                 self.contentViewController.view.alpha = 1
                 self.manualHeightConstraint.constant = newHeight
             }, completion: {_ in
+                // Remove the old content snapshot
+                imageView.removeFromSuperview()
+
+                // Inform accessibility
+                UIAccessibility.post(notification: .screenChanged, argument: self.contentViewController.view)
+
                 // We shouldn't need this constraint anymore.
                 self.manualHeightConstraint.isActive = false
                 self.contentViewController.didFinishAnimatingHeight()


### PR DESCRIPTION
…ent fade out

## Summary
Before:
https://github.com/stripe/stripe-ios/assets/47796191/e1522cc1-e4bd-4198-bc7f-219158edaf35

After:
https://github.com/stripe/stripe-ios/assets/47796191/5e83743b-765f-4555-83fd-6531e6bb0a1a

## Motivation
Animation to vertical saved PM screen felt too abrupt, this makes it feel a bit smoother.

## Testing
Manual. Loading screen -> content transition looks fine.

## Changelog
N/A