### PR TITLE
Check if merchant is CBC eligible for remove only

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
@@ -143,7 +143,7 @@ class VerticalSavedPaymentMethodsViewController: UIViewController {
         // Put in remove only mode and don't show the option to update PMs if:
         // 1. We only have 1 payment method
         // 2. The customer can't update the card brand 
-        self.isRemoveOnlyMode = paymentMethods.count == 1 && (paymentMethods.filter { $0.isCoBrandedCard }.isEmpty || !isCBCEligible)
+        self.isRemoveOnlyMode = paymentMethods.count == 1 && (!paymentMethods[0].isCoBrandedCard || !isCBCEligible)
         super.init(nibName: nil, bundle: nil)
         self.paymentMethodRows = buildPaymentMethodRows(paymentMethods: paymentMethods)
         setInitialState(selectedPaymentMethod: selectedPaymentMethod)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
@@ -140,9 +140,9 @@ class VerticalSavedPaymentMethodsViewController: UIViewController {
         self.configuration = configuration
         self.paymentMethodRemove = paymentMethodRemove
         self.isCBCEligible = isCBCEligible
-        // Put in remove only mode if:
+        // Put in remove only mode and don't show the option to update PMs if:
         // 1. We only have 1 payment method
-        // 2. AND We do not have a CBC card OR we are not CBC eligible
+        // 2. The customer can't update the card brand 
         self.isRemoveOnlyMode = paymentMethods.count == 1 && (paymentMethods.filter { $0.isCoBrandedCard }.isEmpty || !isCBCEligible)
         super.init(nibName: nil, bundle: nil)
         self.paymentMethodRows = buildPaymentMethodRows(paymentMethods: paymentMethods)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
@@ -140,7 +140,10 @@ class VerticalSavedPaymentMethodsViewController: UIViewController {
         self.configuration = configuration
         self.paymentMethodRemove = paymentMethodRemove
         self.isCBCEligible = isCBCEligible
-        self.isRemoveOnlyMode = paymentMethods.count == 1 && paymentMethods.filter { $0.isCoBrandedCard }.isEmpty
+        // Put in remove only mode if:
+        // 1. We only have 1 payment method
+        // 2. AND We do not have a CBC card OR we are not CBC eligible
+        self.isRemoveOnlyMode = paymentMethods.count == 1 && (paymentMethods.filter { $0.isCoBrandedCard }.isEmpty || !isCBCEligible)
         super.init(nibName: nil, bundle: nil)
         self.paymentMethodRows = buildPaymentMethodRows(paymentMethods: paymentMethods)
         setInitialState(selectedPaymentMethod: selectedPaymentMethod)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/VerticalSavedPaymentMethodsViewControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/VerticalSavedPaymentMethodsViewControllerTests.swift
@@ -129,4 +129,59 @@ class VerticalSavedPaymentMethodsViewControllerTests: XCTestCase {
                                                                        isCBCEligible: true)
         XCTAssertTrue(viewController.canEdit)
     }
+
+    // MARK: Remove only mode
+
+    func testIsRemoveOnlyMode_singlePaymentMethod_isNotCBCEligible_returnsTrue() {
+        configuration.allowsRemovalOfLastSavedPaymentMethod = true
+        let singlePaymentMethods = [STPPaymentMethod._testCard()]
+        let viewController = VerticalSavedPaymentMethodsViewController(configuration: configuration,
+                                                                       selectedPaymentMethod: singlePaymentMethods.first,
+                                                                       paymentMethods: singlePaymentMethods,
+                                                                       paymentMethodRemove: true,
+                                                                       isCBCEligible: false)
+
+        // The card is NOT co-branded and, we can't edit, enter remove only mode
+        XCTAssertTrue(viewController.isRemoveOnlyMode)
+    }
+
+    func testIsRemoveOnlyMode_singlePaymentMethod_isCBCEligible_returnsTrue() {
+        configuration.allowsRemovalOfLastSavedPaymentMethod = true
+        let singlePaymentMethods = [STPPaymentMethod._testCard()]
+        let viewController = VerticalSavedPaymentMethodsViewController(configuration: configuration,
+                                                                       selectedPaymentMethod: singlePaymentMethods.first,
+                                                                       paymentMethods: singlePaymentMethods,
+                                                                       paymentMethodRemove: true,
+                                                                       isCBCEligible: true)
+
+        // The card is NOT co-branded and, we can't edit, enter remove only mode
+        XCTAssertTrue(viewController.isRemoveOnlyMode)
+    }
+
+    func testIsRemoveOnlyMode_singleCobrandedPaymentMethod_isCBCEligible_returnsFalse() {
+        configuration.allowsRemovalOfLastSavedPaymentMethod = true
+        let singlePaymentMethods = [STPPaymentMethod._testCardCoBranded()]
+        let viewController = VerticalSavedPaymentMethodsViewController(configuration: configuration,
+                                                                       selectedPaymentMethod: singlePaymentMethods.first,
+                                                                       paymentMethods: singlePaymentMethods,
+                                                                       paymentMethodRemove: true,
+                                                                       isCBCEligible: true)
+
+        // The card is co-branded and the merchant is CBC eligible, we can edit, don't enter remove only mode
+        XCTAssertFalse(viewController.isRemoveOnlyMode)
+    }
+
+    func testIsRemoveOnlyMode_singleCobrandedPaymentMethod_isNotCBCEligible_returnsFalse() {
+        configuration.allowsRemovalOfLastSavedPaymentMethod = true
+        let singlePaymentMethods = [STPPaymentMethod._testCardCoBranded()]
+        let viewController = VerticalSavedPaymentMethodsViewController(configuration: configuration,
+                                                                       selectedPaymentMethod: singlePaymentMethods.first,
+                                                                       paymentMethods: singlePaymentMethods,
+                                                                       paymentMethodRemove: true,
+                                                                       isCBCEligible: false)
+
+        // The card is co-branded but the merchant is NOT CBC eligible, we can't edit, enter remove only mode
+        XCTAssertTrue(viewController.isRemoveOnlyMode)
+    }
+
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/VerticalSavedPaymentMethodsViewControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/VerticalSavedPaymentMethodsViewControllerTests.swift
@@ -94,7 +94,8 @@ class VerticalSavedPaymentMethodsViewControllerTests: XCTestCase {
                                                                        paymentMethods: singlePaymentMethods,
                                                                        paymentMethodRemove: true,
                                                                        isCBCEligible: false)
-        XCTAssertTrue(viewController.canEdit)
+        XCTAssertFalse(viewController.canEdit)
+        XCTAssertTrue(viewController.isRemoveOnlyMode)
     }
 
     func testCanEdit_singlePaymentMethod_disallowsLastRemoval_returnsFalse() {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/VerticalSavedPaymentMethodsViewControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/VerticalSavedPaymentMethodsViewControllerTests.swift
@@ -87,15 +87,15 @@ class VerticalSavedPaymentMethodsViewControllerTests: XCTestCase {
         XCTAssertTrue(viewController.isRemoveOnlyMode)
     }
 
-    func testCanEdit_singleRemovableAndEditablePaymentMethod_returnsTrue() {
+    func testCanEdit_singleRemovableCoBrandedCard_returnsFalse() {
         let singlePaymentMethods = [STPPaymentMethod._testCardCoBranded()]
         let viewController = VerticalSavedPaymentMethodsViewController(configuration: configuration,
                                                                        selectedPaymentMethod: singlePaymentMethods.first,
                                                                        paymentMethods: singlePaymentMethods,
                                                                        paymentMethodRemove: true,
                                                                        isCBCEligible: false)
-        XCTAssertFalse(viewController.canEdit)
-        XCTAssertTrue(viewController.isRemoveOnlyMode)
+        XCTAssertFalse(viewController.canEdit) // Can't edit, merchant is not eligible for CBC
+        XCTAssertTrue(viewController.isRemoveOnlyMode) // Only operation we can make with a single payment method in this case is remove
     }
 
     func testCanEdit_singlePaymentMethod_disallowsLastRemoval_returnsFalse() {


### PR DESCRIPTION
## Summary
- Handle the case where we have a co-branded card as the only saved payment method, but the merchant isn't CBC eligible.

## Motivation
- 🐛 bash

## Testing
- Manual
- New unit tests

## Changelog
N/A
