### PR TITLE
[FC] Fetch next pane after Partner OAuth flow completes

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -607,7 +607,15 @@ extension NativeFlowController: PartnerAuthViewControllerDelegate {
         // animate for OAuth since we make the authorize call in that case
         // and already have the same loading screen.
         let shouldAnimate = !authSession.isOauthNonOptional
-        pushPane(.accountPicker, animated: shouldAnimate)
+
+        // For OAuth sessions, we will get the next pane provided by the auth session.
+        // If for some reason this returns the `.partnerAuth` flow, we fallback to the
+        // `.accountPicker` pane to prevent an infinite loop.
+        if authSession.isOauthNonOptional, authSession.nextPane != .partnerAuth {
+            pushPane(authSession.nextPane, animated: shouldAnimate)
+        } else {
+            pushPane(.accountPicker, animated: shouldAnimate)
+        }
     }
 
     func partnerAuthViewController(


### PR DESCRIPTION
## Summary

Rather than hardcoding `.accountPicker` to being the next pane after the partner OAuth flow, we now use the next pane provided by the auth session. While this still ends up being the account picker pane, this behaviour might change in the future.

This follows the same logic as [Android](https://github.com/stripe/stripe-android/blob/dbe603bf97131b768fce61d9bef383d0f79df960/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel.kt#L401-L413) and as [Web](https://git.corp.stripe.com/stripe-internal/stripe-js-v3/blob/0c73259223d174e53cb4803556f44685b8326672/src/linkedAccounts/inner/components/panes/v3/PartnerAuthPane/lib/useCompletionCallbacks/useOnSuccess.ts#L50-L67), however, here in the iOS flow we've already fetched the latest auth session when the partner OAuth flow completes ([here](https://github.com/stripe/stripe-ios/blob/5af414ed84b11a5eafa9a8972969267cdb0a2f25/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthViewController.swift#L490-L517)). 

## Motivation

The goal here is to keep the behaviour consistent between platforms 👬

## Testing

Ensured the partner OAuth flow still works as expected (while hitting the new code path), and the legacy auth flow continues to work the same as before: 

https://github.com/stripe/stripe-ios/assets/172562065/38970b7a-96ea-420c-beae-8575754eec29


## Changelog

N/a