### PR TITLE
Show mandate if being reused

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/VerticalMandateView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/VerticalMandateView.swift
@@ -46,12 +46,12 @@ final class VerticalMandateView: UIView {
         guard let form = formProvider(paymentMethodType) else {
             return
         }
-        
+
         if form.collectsUserInput && !state.isReusing {
             // If it collects user input and is not being re-used, the mandate will be displayed in the form and not here
             return
         }
-        
+
         // Get the mandate from the form, if available
         // 🙋‍♂️ Note: assumes mandates are SimpleMandateElement!
         guard let mandateElement = form.getAllUnwrappedSubElements().compactMap({ $0 as? SimpleMandateElement }).first else {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/VerticalMandateView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/VerticalMandateView.swift
@@ -10,7 +10,11 @@
 import UIKit
 
 final class VerticalMandateView: UIView {
-    var paymentMethodType: PaymentSheet.PaymentMethodType? {
+    struct State {
+        let paymentMethodType: PaymentSheet.PaymentMethodType?
+        let isReusing: Bool
+    }
+    var state: State? {
         didSet {
             updateUI()
         }
@@ -34,18 +38,20 @@ final class VerticalMandateView: UIView {
         // Remove old mandate view, if any
         mandateView?.removeFromSuperview()
         mandateView = nil
-        guard let paymentMethodType else {
+        guard let state, let paymentMethodType = state.paymentMethodType else {
             return
         }
 
         // Generate the form
-        guard
-            let form = formProvider(paymentMethodType),
-            !form.collectsUserInput
-        else {
-            // If it collects user input, the mandate will be displayed in the form and not here
+        guard let form = formProvider(paymentMethodType) else {
             return
         }
+        
+        if form.collectsUserInput && !state.isReusing {
+            // If it collects user input and is not being re-used, the mandate will be displayed in the form and not here
+            return
+        }
+        
         // Get the mandate from the form, if available
         // 🙋‍♂️ Note: assumes mandates are SimpleMandateElement!
         guard let mandateElement = form.getAllUnwrappedSubElements().compactMap({ $0 as? SimpleMandateElement }).first else {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
@@ -235,7 +235,8 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
     }
 
     func updateMandate(animated: Bool = true) {
-        self.mandateView.paymentMethodType = self.selectedPaymentMethodType
+        self.mandateView.state = VerticalMandateView.State(paymentMethodType: self.selectedPaymentMethodType,
+                                                           isReusing: selectedPaymentOption?.savedPaymentMethod != nil)
         self.mandateView.layoutIfNeeded()
         if animated {
             animateHeightChange {


### PR DESCRIPTION
## Summary
- For saved payment methods like SEPA that show a mandate, we were not showing them. We need to take into account if the payment method is being re-used as well.
- We need a separate fix for US bank account since the mandate isn't technically a part of the form

### Horizontal for reference
![Simulator Screenshot - iPhone 15 - 2024-07-02 at 12 05 19](https://github.com/stripe/stripe-ios/assets/88012362/f5cee34f-0c68-434c-b37a-22c23ab564ef)

### After fix
https://github.com/stripe/stripe-ios/assets/88012362/df522959-2ca6-4791-adb2-2876f71b45f4



## Motivation
🐛 

## Testing
- Manual

## Changelog
N/A
