### PR TITLE
Financial Connections: for networking manual entry, added a drawer for disabled accounts in LinkAccountPicker

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
+++ b/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
@@ -85,6 +85,8 @@
 		6A1D43092B17CB04005A1EB0 /* InstitutionNoResultsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1D43082B17CB04005A1EB0 /* InstitutionNoResultsView.swift */; };
 		6A26A3AB2B991A4D00215510 /* FeedbackGeneratorAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A26A3AA2B991A4D00215510 /* FeedbackGeneratorAdapter.swift */; };
 		6A384A842C24DD720044AB99 /* FinancialConnectionsGenericInfoScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A384A832C24DD720044AB99 /* FinancialConnectionsGenericInfoScreen.swift */; };
+		6A3DA1F52C34A37F005C3F6E /* GenericInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A3DA1F42C34A37F005C3F6E /* GenericInfoViewController.swift */; };
+		6A3DA1F72C34B254005C3F6E /* GenericInfoFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A3DA1F62C34B254005C3F6E /* GenericInfoFooterView.swift */; };
 		6A43202A2B7E8C5400A67A70 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A4320292B7E8C5400A67A70 /* Constants.swift */; };
 		6A732C9A2B61C51C00828CB1 /* ShimmeringView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A732C992B61C51C00828CB1 /* ShimmeringView.swift */; };
 		6A732C9C2B61C56A00828CB1 /* InstitutionTableLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A732C9B2B61C56A00828CB1 /* InstitutionTableLoadingView.swift */; };
@@ -363,6 +365,8 @@
 		6A1D43082B17CB04005A1EB0 /* InstitutionNoResultsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstitutionNoResultsView.swift; sourceTree = "<group>"; };
 		6A26A3AA2B991A4D00215510 /* FeedbackGeneratorAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackGeneratorAdapter.swift; sourceTree = "<group>"; };
 		6A384A832C24DD720044AB99 /* FinancialConnectionsGenericInfoScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsGenericInfoScreen.swift; sourceTree = "<group>"; };
+		6A3DA1F42C34A37F005C3F6E /* GenericInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericInfoViewController.swift; sourceTree = "<group>"; };
+		6A3DA1F62C34B254005C3F6E /* GenericInfoFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericInfoFooterView.swift; sourceTree = "<group>"; };
 		6A4320292B7E8C5400A67A70 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		6A732C992B61C51C00828CB1 /* ShimmeringView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShimmeringView.swift; sourceTree = "<group>"; };
 		6A732C9B2B61C56A00828CB1 /* InstitutionTableLoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstitutionTableLoadingView.swift; sourceTree = "<group>"; };
@@ -765,6 +769,15 @@
 			path = LinkAccountPicker;
 			sourceTree = "<group>";
 		};
+		6A3DA1F32C34A32D005C3F6E /* GenericInfoScreen */ = {
+			isa = PBXGroup;
+			children = (
+				6A3DA1F42C34A37F005C3F6E /* GenericInfoViewController.swift */,
+				6A3DA1F62C34B254005C3F6E /* GenericInfoFooterView.swift */,
+			);
+			path = GenericInfoScreen;
+			sourceTree = "<group>";
+		};
 		6A7814162B361C1900168992 /* PaneLayoutView */ = {
 			isa = PBXGroup;
 			children = (
@@ -955,6 +968,7 @@
 		C0C2FC181FFA71CFAA6F3148 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				6A3DA1F32C34A32D005C3F6E /* GenericInfoScreen */,
 				6A7814162B361C1900168992 /* PaneLayoutView */,
 				7E5623CA300ADBCBE8B33E69 /* NetworkingOTPView */,
 				EE64D5A17913CF4AAD855A9A /* AttributedLabel.swift */,
@@ -1247,6 +1261,7 @@
 				432463EBF562CDDC6D3DC252 /* BankAccountToken.swift in Sources */,
 				6A732CA82B69C34F00828CB1 /* PhoneCountryCodeSelectorView.swift in Sources */,
 				6A732CAA2B69CCDD00828CB1 /* PhoneCountryCodePickerView.swift in Sources */,
+				6A3DA1F52C34A37F005C3F6E /* GenericInfoViewController.swift in Sources */,
 				FBF513C7F73002FA30CC7C21 /* ConsumerSessionModels.swift in Sources */,
 				EC74B719F0FA1A977EF4708C /* FinancialConnectionsAccount.swift in Sources */,
 				460C7685096AA6C693309647 /* FinancialConnectionsAuthSession.swift in Sources */,
@@ -1357,6 +1372,7 @@
 				3AC5CA5F5529B55026342A54 /* NetworkingLinkSignupDataSource.swift in Sources */,
 				6A13B9862B4CD04100FFA327 /* RetrieveAccountsLoadingView.swift in Sources */,
 				8DC6C2A239456994091BF3EE /* NetworkingLinkSignupFooterView.swift in Sources */,
+				6A3DA1F72C34B254005C3F6E /* GenericInfoFooterView.swift in Sources */,
 				54B51EA1F75B9607D7C29B08 /* NetworkingLinkSignupViewController.swift in Sources */,
 				3F835D5A1C797C1C9BCF05D0 /* NetworkingLinkStepUpVerificationBodyView.swift in Sources */,
 				11782289208971CCAA1037A5 /* NetworkingLinkStepUpVerificationDataSource.swift in Sources */,

--- a/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
+++ b/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		6A1D43072B17AE37005A1EB0 /* RoundedIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1D43062B17AE37005A1EB0 /* RoundedIconView.swift */; };
 		6A1D43092B17CB04005A1EB0 /* InstitutionNoResultsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1D43082B17CB04005A1EB0 /* InstitutionNoResultsView.swift */; };
 		6A26A3AB2B991A4D00215510 /* FeedbackGeneratorAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A26A3AA2B991A4D00215510 /* FeedbackGeneratorAdapter.swift */; };
+		6A384A842C24DD720044AB99 /* FinancialConnectionsGenericInfoScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A384A832C24DD720044AB99 /* FinancialConnectionsGenericInfoScreen.swift */; };
 		6A43202A2B7E8C5400A67A70 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A4320292B7E8C5400A67A70 /* Constants.swift */; };
 		6A732C9A2B61C51C00828CB1 /* ShimmeringView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A732C992B61C51C00828CB1 /* ShimmeringView.swift */; };
 		6A732C9C2B61C56A00828CB1 /* InstitutionTableLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A732C9B2B61C56A00828CB1 /* InstitutionTableLoadingView.swift */; };
@@ -361,6 +362,7 @@
 		6A1D43062B17AE37005A1EB0 /* RoundedIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedIconView.swift; sourceTree = "<group>"; };
 		6A1D43082B17CB04005A1EB0 /* InstitutionNoResultsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstitutionNoResultsView.swift; sourceTree = "<group>"; };
 		6A26A3AA2B991A4D00215510 /* FeedbackGeneratorAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackGeneratorAdapter.swift; sourceTree = "<group>"; };
+		6A384A832C24DD720044AB99 /* FinancialConnectionsGenericInfoScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsGenericInfoScreen.swift; sourceTree = "<group>"; };
 		6A4320292B7E8C5400A67A70 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		6A732C992B61C51C00828CB1 /* ShimmeringView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShimmeringView.swift; sourceTree = "<group>"; };
 		6A732C9B2B61C56A00828CB1 /* InstitutionTableLoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstitutionTableLoadingView.swift; sourceTree = "<group>"; };
@@ -735,6 +737,7 @@
 				ACEF0BAF1A5BBA3061C15A09 /* FinancialConnectionsSession.swift */,
 				429F985168AE9F9D700AE37B /* FinancialConnectionsSessionManifest.swift */,
 				4667E3861CDEC3A41B757714 /* FinancialConnectionsSynchronize.swift */,
+				6A384A832C24DD720044AB99 /* FinancialConnectionsGenericInfoScreen.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1272,6 +1275,7 @@
 				C61D5957D3276991795F7D16 /* FinancialConnectionsSheetAnalytics.swift in Sources */,
 				D3AB52D5AE87FE51642C50C1 /* ExperimentHelper.swift in Sources */,
 				6A13B9FA2B4E182A00FFA327 /* SpinnerView.swift in Sources */,
+				6A384A842C24DD720044AB99 /* FinancialConnectionsGenericInfoScreen.swift in Sources */,
 				0D56BD448019185656DF9310 /* FinancialConnectionsCustomManualEntryRequiredError.swift in Sources */,
 				6E6E30D01D4E9629DB07E97B /* FinancialConnectionsNavigationController.swift in Sources */,
 				01C820ECDBFC041A741A5499 /* FlowRouter.swift in Sources */,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsGenericInfoScreen.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsGenericInfoScreen.swift
@@ -1,0 +1,131 @@
+//
+//  FinancialConnectionsGenericInfoScreen.swift
+//  StripeFinancialConnections
+//
+//  Created by Krisjanis Gaidis on 6/20/24.
+//
+
+import Foundation
+
+struct FinancialConnectionsGenericInfoScreen: Decodable {
+
+    let id: String
+    let header: Header?
+    let body: Body?
+    let footer: Footer?
+    let options: Options?
+
+    struct Header: Decodable {
+        let title: String?
+        let subtitle: String?
+        let icon: FinancialConnectionsImage?
+        let alignment: Alignment?
+
+        enum Alignment: String, Decodable {
+            case left = "left"
+            case center = "center"
+            case right = "right"
+        }
+    }
+
+    struct Body: Decodable {
+
+        let entries: [BodyEntry]
+
+        enum BodyEntry: Decodable {
+            case text(TextBodyEntry)
+            case image(ImageBodyEntry)
+            case unparasable
+
+            public init(from decoder: Decoder) throws {
+                let type = try? decoder
+                    .container(keyedBy: TypeDecodingContainer.CodingKeys.self)
+                    .decode(TypeDecodingContainer.self, forKey: .type)
+                    .type
+                let container = try decoder.singleValueContainer()
+                if type == .text, let value = try? container.decode(TextBodyEntry.self) {
+                    self = .text(value)
+                } else {
+                    self = .unparasable
+                }
+            }
+
+            // this struct is here
+            private struct TypeDecodingContainer: Codable {
+                let type: BodyEntryType
+
+                enum BodyEntryType: String, Codable {
+                    case text = "text"
+                    case image = "image"
+                }
+
+                enum CodingKeys: String, CodingKey {
+                    case type
+                }
+            }
+        }
+
+        struct TextBodyEntry: Decodable {
+
+            let id: String
+            let text: String
+            let alignment: Alignment?
+            let size: Size?
+
+            enum Alignment: String, Decodable {
+                case left = "left"
+                case center = "center"
+                case right = "right"
+            }
+
+            enum Size: String, Decodable {
+                case xsmall = "x-small"
+                case small = "small"
+                case medium = "medium"
+            }
+        }
+
+        struct ImageBodyEntry: Decodable {
+            let id: String
+            let image: FinancialConnectionsImage
+            let alt: String
+        }
+
+        struct BulletsBodyEntry: Decodable {
+            let id: String
+            let bullets: [GenericBulletPoint]
+
+            struct GenericBulletPoint: Decodable {
+                let id: String
+                let icon: FinancialConnectionsImage?
+                let title: String?
+                let content: String?
+            }
+        }
+    }
+
+    struct Footer: Decodable {
+        let disclaimer: String?
+        let primaryCta: GenericInfoAction?
+        let secondaryCta: GenericInfoAction?
+        let belowCta: GenericInfoAction?
+
+        struct GenericInfoAction: Decodable {
+            let id: String
+            let label: String
+            let icon: FinancialConnectionsImage?
+            let action: String?
+            let testId: String?
+        }
+    }
+
+    struct Options: Decodable {
+        let fullWidthContent: Bool?
+        let verticalAlignment: VerticalAlignment?
+
+        enum VerticalAlignment: String, Decodable {
+            case `default` = "default"
+            case centered = "centered"
+        }
+    }
+}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsGenericInfoScreen.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsGenericInfoScreen.swift
@@ -108,7 +108,7 @@ struct FinancialConnectionsGenericInfoScreen: Decodable {
         let disclaimer: String?
         let primaryCta: GenericInfoAction?
         let secondaryCta: GenericInfoAction?
-        let belowCta: GenericInfoAction?
+        let belowCta: String?
 
         struct GenericInfoAction: Decodable {
             let id: String

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsGenericInfoScreen.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsGenericInfoScreen.swift
@@ -45,6 +45,8 @@ struct FinancialConnectionsGenericInfoScreen: Decodable {
                 let container = try decoder.singleValueContainer()
                 if type == .text, let value = try? container.decode(TextBodyEntry.self) {
                     self = .text(value)
+                } else if type == .image, let value = try? container.decode(ImageBodyEntry.self) {
+                    self = .image(value)
                 } else {
                     self = .unparasable
                 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsNetworkedAccountsResponse.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsNetworkedAccountsResponse.swift
@@ -42,5 +42,6 @@ struct FinancialConnectionsNetworkingAccountPicker: Decodable {
         // trailing icon on the account row
         let icon: FinancialConnectionsImage?
         let selectionCtaIcon: FinancialConnectionsImage?
+        let drawerOnSelection: FinancialConnectionsGenericInfoScreen?
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsNetworkedAccountsResponse.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsNetworkedAccountsResponse.swift
@@ -43,5 +43,6 @@ struct FinancialConnectionsNetworkingAccountPicker: Decodable {
         let icon: FinancialConnectionsImage?
         let selectionCtaIcon: FinancialConnectionsImage?
         let drawerOnSelection: FinancialConnectionsGenericInfoScreen?
+        let accountIcon: FinancialConnectionsImage?
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerSelectionListView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerSelectionListView.swift
@@ -56,6 +56,7 @@ final class AccountPickerSelectionListView: UIView {
         enabledAccounts.forEach { account in
             let accountRowView = AccountPickerRowView(
                 isDisabled: false,
+                isFaded: false,
                 didSelect: { [weak self] in
                     guard let self = self else { return }
                     var selectedAccounts = selectedAccounts
@@ -85,6 +86,7 @@ final class AccountPickerSelectionListView: UIView {
         disabledAccounts.forEach { disabledAccount in
             let accountRowView = AccountPickerRowView(
                 isDisabled: true,
+                isFaded: true,
                 didSelect: {
                     // can't select disabled accounts
                 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerBodyView.swift
@@ -36,7 +36,8 @@ final class LinkAccountPickerBodyView: UIView {
         // add account rows
         accountTuples.forEach { accountTuple in
             let accountRowView = AccountPickerRowView(
-                isDisabled: !accountTuple.accountPickerAccount.allowSelection,
+                isDisabled: !accountTuple.accountPickerAccount.allowSelection && accountTuple.accountPickerAccount.drawerOnSelection == nil,
+                isFaded: !accountTuple.accountPickerAccount.allowSelection,
                 didSelect: { [weak self] in
                     guard let self = self else { return }
                     self.delegate?.linkAccountPickerBodyView(
@@ -49,7 +50,7 @@ final class LinkAccountPickerBodyView: UIView {
                 forAccount: accountTuple.partnerAccount
             )
             accountRowView.set(
-                institutionIconUrl: accountTuple.partnerAccount.institution?.icon?.default,
+                institutionIconUrl: accountTuple.partnerAccount.institution?.icon?.default ?? accountTuple.accountPickerAccount.icon?.default,
                 title: rowTitles.accountName,
                 subtitle: {
                     if let caption = accountTuple.accountPickerAccount.caption {
@@ -58,6 +59,7 @@ final class LinkAccountPickerBodyView: UIView {
                         return rowTitles.accountNumbers
                     }
                 }(),
+                underlineSubtitle: accountTuple.accountPickerAccount.drawerOnSelection != nil,
                 balanceString:
                     (accountTuple.accountPickerAccount.caption == nil) ? rowTitles.balanceString : nil,
                 isSelected: false // initially nothing is selected
@@ -112,7 +114,8 @@ private struct LinkAccountPickerBodyViewUIViewRepresentable: UIViewRepresentable
                         caption: nil,
                         selectionCta: nil,
                         icon: nil,
-                        selectionCtaIcon: nil
+                        selectionCtaIcon: nil,
+                        drawerOnSelection: nil
                     ),
                     partnerAccount: FinancialConnectionsPartnerAccount(
                         id: "abc",
@@ -146,7 +149,8 @@ private struct LinkAccountPickerBodyViewUIViewRepresentable: UIViewRepresentable
                         icon: FinancialConnectionsImage(
                             default: "https://b.stripecdn.com/connections-statics-srv/assets/SailIcon--warning-orange-3x.png"
                         ),
-                        selectionCtaIcon: nil
+                        selectionCtaIcon: nil,
+                        drawerOnSelection: nil
                     ),
                     partnerAccount: FinancialConnectionsPartnerAccount(
                         id: "abc",
@@ -170,7 +174,8 @@ private struct LinkAccountPickerBodyViewUIViewRepresentable: UIViewRepresentable
                         caption: nil,
                         selectionCta: nil,
                         icon: nil,
-                        selectionCtaIcon: nil
+                        selectionCtaIcon: nil,
+                        drawerOnSelection: nil
                     ),
                     partnerAccount: FinancialConnectionsPartnerAccount(
                         id: "abc",

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerBodyView.swift
@@ -50,7 +50,7 @@ final class LinkAccountPickerBodyView: UIView {
                 forAccount: accountTuple.partnerAccount
             )
             accountRowView.set(
-                institutionIconUrl: accountTuple.partnerAccount.institution?.icon?.default ?? accountTuple.accountPickerAccount.icon?.default,
+                institutionIconUrl: (accountTuple.accountPickerAccount.accountIcon?.default ?? accountTuple.partnerAccount.institution?.icon?.default ?? accountTuple.accountPickerAccount.icon?.default),
                 title: rowTitles.accountName,
                 subtitle: {
                     if let caption = accountTuple.accountPickerAccount.caption {
@@ -115,7 +115,8 @@ private struct LinkAccountPickerBodyViewUIViewRepresentable: UIViewRepresentable
                         selectionCta: nil,
                         icon: nil,
                         selectionCtaIcon: nil,
-                        drawerOnSelection: nil
+                        drawerOnSelection: nil,
+                        accountIcon: nil
                     ),
                     partnerAccount: FinancialConnectionsPartnerAccount(
                         id: "abc",
@@ -150,7 +151,8 @@ private struct LinkAccountPickerBodyViewUIViewRepresentable: UIViewRepresentable
                             default: "https://b.stripecdn.com/connections-statics-srv/assets/SailIcon--warning-orange-3x.png"
                         ),
                         selectionCtaIcon: nil,
-                        drawerOnSelection: nil
+                        drawerOnSelection: nil,
+                        accountIcon: nil
                     ),
                     partnerAccount: FinancialConnectionsPartnerAccount(
                         id: "abc",
@@ -175,7 +177,8 @@ private struct LinkAccountPickerBodyViewUIViewRepresentable: UIViewRepresentable
                         selectionCta: nil,
                         icon: nil,
                         selectionCtaIcon: nil,
-                        drawerOnSelection: nil
+                        drawerOnSelection: nil,
+                        accountIcon: nil
                     ),
                     partnerAccount: FinancialConnectionsPartnerAccount(
                         id: "abc",

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
@@ -83,6 +83,7 @@ final class LinkAccountPickerViewController: UIViewController {
     private weak var bodyView: LinkAccountPickerBodyView?
     private weak var footerView: LinkAccountPickerFooterView?
     private weak var lastAccountUpdateRequiredViewController: UIViewController?
+    private weak var lastDrawerOnSelectionViewController: UIViewController?
 
     init(dataSource: LinkAccountPickerDataSource) {
         self.dataSource = dataSource
@@ -355,9 +356,16 @@ extension LinkAccountPickerViewController: LinkAccountPickerBodyViewDelegate {
         let selectedPartnerAccount = selectedAccountTuple.partnerAccount
 
         if let drawerOnSelection = selectedAccountTuple.accountPickerAccount.drawerOnSelection {
-
-            // TODO: show the drawer
-            print(drawerOnSelection)
+            let genericInfoViewController = GenericInfoViewController(
+                genericInfoScreen: drawerOnSelection,
+                panePresentationStyle: .sheet,
+                didSelectPrimaryButton: { [weak self] in
+                    self?.lastDrawerOnSelectionViewController?.dismiss(animated: true)
+                },
+                didSelectURL: { _ in } // TODO(kgaidis): fix handling URL
+            )
+            genericInfoViewController.present(on: self)
+            lastDrawerOnSelectionViewController = genericInfoViewController
 
             if !selectedAccountTuple.accountPickerAccount.allowSelection {
                 // if the account is not selectable, then we return early

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
@@ -83,7 +83,6 @@ final class LinkAccountPickerViewController: UIViewController {
     private weak var bodyView: LinkAccountPickerBodyView?
     private weak var footerView: LinkAccountPickerFooterView?
     private weak var lastAccountUpdateRequiredViewController: UIViewController?
-    private weak var lastDrawerOnSelectionViewController: UIViewController?
 
     init(dataSource: LinkAccountPickerDataSource) {
         self.dataSource = dataSource
@@ -359,13 +358,12 @@ extension LinkAccountPickerViewController: LinkAccountPickerBodyViewDelegate {
             let genericInfoViewController = GenericInfoViewController(
                 genericInfoScreen: drawerOnSelection,
                 panePresentationStyle: .sheet,
-                didSelectPrimaryButton: { [weak self] in
-                    self?.lastDrawerOnSelectionViewController?.dismiss(animated: true)
+                didSelectPrimaryButton: { genericInfoViewController in
+                    genericInfoViewController.dismiss(animated: true)
                 },
                 didSelectURL: { _ in } // TODO(kgaidis): fix handling URL
             )
             genericInfoViewController.present(on: self)
-            lastDrawerOnSelectionViewController = genericInfoViewController
 
             if !selectedAccountTuple.accountPickerAccount.allowSelection {
                 // if the account is not selectable, then we return early

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
@@ -354,6 +354,17 @@ extension LinkAccountPickerViewController: LinkAccountPickerBodyViewDelegate {
 
         let selectedPartnerAccount = selectedAccountTuple.partnerAccount
 
+        if let drawerOnSelection = selectedAccountTuple.accountPickerAccount.drawerOnSelection {
+
+            // TODO: show the drawer
+            print(drawerOnSelection)
+
+            if !selectedAccountTuple.accountPickerAccount.allowSelection {
+                // if the account is not selectable, then we return early
+                return
+            }
+        }
+
         // unselecting
         if
             // unselecting in single account flow is not allowed

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/AccountPickerRowLabelView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/AccountPickerRowLabelView.swift
@@ -71,6 +71,7 @@ final class AccountPickerRowLabelView: UIView {
     func set(
         title: String,
         subtitle: String?,
+        underlineSubtitle: Bool = false,
         balanceString: String? = nil
     ) {
         titleLabel.text = title
@@ -79,7 +80,10 @@ final class AccountPickerRowLabelView: UIView {
         subtitleLabel.removeFromSuperview()
         subtitleBalanceView.removeFromSuperview()
         if let subtitle = subtitle {
-            subtitleLabel.text = subtitle
+            subtitleLabel.setText(
+                subtitle,
+                underline: underlineSubtitle
+            )
             horizontalSubtitleStackView.addArrangedSubview(subtitleLabel)
         }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/AccountPickerRowView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/AccountPickerRowView.swift
@@ -66,6 +66,7 @@ final class AccountPickerRowView: UIView {
 
     init(
         isDisabled: Bool,
+        isFaded: Bool,
         didSelect: @escaping () -> Void
     ) {
         self.didSelect = didSelect
@@ -74,7 +75,7 @@ final class AccountPickerRowView: UIView {
         // necessary so the shadow does not appear under text
         backgroundColor = .customBackgroundColor
 
-        if isDisabled {
+        if isFaded {
             horizontalStackView.alpha = 0.25
         }
         addAndPinSubviewToSafeArea(horizontalStackView)
@@ -108,6 +109,7 @@ final class AccountPickerRowView: UIView {
         institutionIconUrl: String? = nil,
         title: String,
         subtitle: String?,
+        underlineSubtitle: Bool = false,
         balanceString: String? = nil,
         isSelected: Bool
     ) {
@@ -124,6 +126,7 @@ final class AccountPickerRowView: UIView {
         labelView.set(
             title: title,
             subtitle: subtitle,
+            underlineSubtitle: underlineSubtitle,
             balanceString: balanceString
         )
         set(isSelected: isSelected)
@@ -165,6 +168,7 @@ private struct AccountPickerRowViewUIViewRepresentable: UIViewRepresentable {
     let balanceString: String?
     let isSelected: Bool
     let isDisabled: Bool
+    let isFaded: Bool
 
     init(
         institutionIconUrl: String? = nil,
@@ -172,7 +176,8 @@ private struct AccountPickerRowViewUIViewRepresentable: UIViewRepresentable {
         subtitle: String?,
         balanceString: String?,
         isSelected: Bool,
-        isDisabled: Bool
+        isDisabled: Bool,
+        isFaded: Bool
     ) {
         self.institutionIconUrl = institutionIconUrl
         self.title = title
@@ -180,11 +185,13 @@ private struct AccountPickerRowViewUIViewRepresentable: UIViewRepresentable {
         self.balanceString = balanceString
         self.isSelected = isSelected
         self.isDisabled = isDisabled
+        self.isFaded = isFaded
     }
 
     func makeUIView(context: Context) -> AccountPickerRowView {
         let view = AccountPickerRowView(
             isDisabled: isDisabled,
+            isFaded: isFaded,
             didSelect: {}
         )
         view.set(
@@ -222,35 +229,40 @@ struct AccountPickerRowView_Previews: PreviewProvider {
                         subtitle: "••••6789",
                         balanceString: nil,
                         isSelected: true,
-                        isDisabled: false
+                        isDisabled: false,
+                        isFaded: false
                     ).frame(height: 88)
                     AccountPickerRowViewUIViewRepresentable(
                         title: "Joint Checking Very Long Name To Truncate",
                         subtitle: "••••6789",
                         balanceString: nil,
                         isSelected: true,
-                        isDisabled: false
+                        isDisabled: false,
+                        isFaded: false
                     ).frame(height: 76)
                     AccountPickerRowViewUIViewRepresentable(
                         title: "Joint Checking Very Long Name To Truncate",
                         subtitle: "••••6789",
                         balanceString: "$3285.53",
                         isSelected: false,
-                        isDisabled: false
+                        isDisabled: false,
+                        isFaded: false
                     ).frame(height: 76)
                     AccountPickerRowViewUIViewRepresentable(
                         title: "Joint Checking",
                         subtitle: nil,
                         balanceString: "$3285.53",
                         isSelected: false,
-                        isDisabled: false
+                        isDisabled: false,
+                        isFaded: false
                     ).frame(height: 76)
                     AccountPickerRowViewUIViewRepresentable(
                         title: "Joint Checking",
                         subtitle: "Not available",
                         balanceString: nil,
                         isSelected: false,
-                        isDisabled: true
+                        isDisabled: true,
+                        isFaded: true
                     ).frame(height: 76)
                 }.padding()
             }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/AttributedLabel.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/AttributedLabel.swift
@@ -69,20 +69,28 @@ final class AttributedLabel: UILabel {
         }
     }
 
-    func setText(_ text: String) {
+    func setText(_ text: String, underline: Bool = false) {
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.minimumLineHeight = customFont.lineHeight
         paragraphStyle.maximumLineHeight = customFont.lineHeight
         if let customTextAlignment = customTextAlignment {
             paragraphStyle.alignment = customTextAlignment
         }
+
         let string = NSMutableAttributedString(
             string: text,
-            attributes: [
-                .paragraphStyle: paragraphStyle,
-                .font: customFont.uiFont,
-                .foregroundColor: customTextColor,
-            ]
+            attributes: {
+                var attributes: [NSAttributedString.Key: Any] = [
+                    .paragraphStyle: paragraphStyle,
+                    .font: customFont.uiFont,
+                    .foregroundColor: customTextColor,
+                ]
+                if underline {
+                    attributes[.underlineColor] = customTextColor
+                    attributes[.underlineStyle] = NSUnderlineStyle.single.rawValue
+                }
+                return attributes
+            }()
         )
         attributedText = string
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/GenericInfoScreen/GenericInfoFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/GenericInfoScreen/GenericInfoFooterView.swift
@@ -1,0 +1,106 @@
+//
+//  GenericInfoFooterView.swift
+//  StripeFinancialConnections
+//
+//  Created by Krisjanis Gaidis on 7/2/24.
+//
+
+import Foundation
+import UIKit
+
+func GenericInfoFooterView(
+    footer: FinancialConnectionsGenericInfoScreen.Footer?,
+    didSelectPrimaryButton: @escaping () -> Void,
+    didSelectSecondaryButton: @escaping () -> Void,
+    didSelectURL: @escaping (URL) -> Void
+) -> UIView? {
+    if let footer {
+        let primaryButtonConfiguration: PaneLayoutView.ButtonConfiguration?
+        if let primaryCta = footer.primaryCta {
+            primaryButtonConfiguration = PaneLayoutView.ButtonConfiguration(
+                title: primaryCta.label,
+                action: didSelectPrimaryButton
+            )
+        } else {
+            primaryButtonConfiguration = nil
+        }
+        let secondaryButtonConfiguration: PaneLayoutView.ButtonConfiguration?
+        if let secondaryCta = footer.secondaryCta {
+            secondaryButtonConfiguration = PaneLayoutView.ButtonConfiguration(
+                title: secondaryCta.label,
+                action: didSelectSecondaryButton
+            )
+        } else {
+            secondaryButtonConfiguration = nil
+        }
+        return PaneLayoutView.createFooterView(
+            primaryButtonConfiguration: primaryButtonConfiguration,
+            secondaryButtonConfiguration: secondaryButtonConfiguration,
+            topText: footer.disclaimer,
+            bottomText: footer.belowCta,
+            didSelectURL: didSelectURL
+        ).footerView
+    } else {
+        return nil
+    }
+}
+
+#if DEBUG
+
+import SwiftUI
+
+@available(iOS 14.0, *)
+private struct GenericInfoFooterViewUIViewRepresentable: UIViewRepresentable {
+
+    let footer: FinancialConnectionsGenericInfoScreen.Footer
+
+    func makeUIView(context: Context) -> UIView {
+        GenericInfoFooterView(
+            footer: footer,
+            didSelectPrimaryButton: {},
+            didSelectSecondaryButton: {},
+            didSelectURL: { _ in }
+        )!
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {
+        uiView.sizeToFit()
+    }
+}
+
+@available(iOS 14.0, *)
+struct GenericInfoFooterView_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack {
+            GenericInfoFooterViewUIViewRepresentable(
+                footer: FinancialConnectionsGenericInfoScreen.Footer(
+                    disclaimer: "Disclaimer Text",
+                    primaryCta: FinancialConnectionsGenericInfoScreen
+                        .Footer
+                        .GenericInfoAction(
+                            id: UUID().uuidString,
+                            label: "Primary CTA",
+                            icon: nil,
+                            action: "primary_cta_action",
+                            testId: nil
+                        ),
+                    secondaryCta: FinancialConnectionsGenericInfoScreen
+                        .Footer
+                        .GenericInfoAction(
+                            id: UUID().uuidString,
+                            label: "Secondary CTA",
+                            icon: nil,
+                            action: "secondary_cta_action",
+                            testId: nil
+                        ),
+                    belowCta: "[Below CTA](stripe://link_here)"
+                )
+            )
+            .frame(maxHeight: 228)
+            .background(Color.red.opacity(0.1))
+        }
+        .padding()
+    }
+}
+
+#endif

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/GenericInfoScreen/GenericInfoFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/GenericInfoScreen/GenericInfoFooterView.swift
@@ -14,35 +14,34 @@ func GenericInfoFooterView(
     didSelectSecondaryButton: @escaping () -> Void,
     didSelectURL: @escaping (URL) -> Void
 ) -> UIView? {
-    if let footer {
-        let primaryButtonConfiguration: PaneLayoutView.ButtonConfiguration?
-        if let primaryCta = footer.primaryCta {
-            primaryButtonConfiguration = PaneLayoutView.ButtonConfiguration(
-                title: primaryCta.label,
-                action: didSelectPrimaryButton
-            )
-        } else {
-            primaryButtonConfiguration = nil
-        }
-        let secondaryButtonConfiguration: PaneLayoutView.ButtonConfiguration?
-        if let secondaryCta = footer.secondaryCta {
-            secondaryButtonConfiguration = PaneLayoutView.ButtonConfiguration(
-                title: secondaryCta.label,
-                action: didSelectSecondaryButton
-            )
-        } else {
-            secondaryButtonConfiguration = nil
-        }
-        return PaneLayoutView.createFooterView(
-            primaryButtonConfiguration: primaryButtonConfiguration,
-            secondaryButtonConfiguration: secondaryButtonConfiguration,
-            topText: footer.disclaimer,
-            bottomText: footer.belowCta,
-            didSelectURL: didSelectURL
-        ).footerView
-    } else {
+    guard let footer else {
         return nil
     }
+    let primaryButtonConfiguration: PaneLayoutView.ButtonConfiguration?
+    if let primaryCta = footer.primaryCta {
+        primaryButtonConfiguration = PaneLayoutView.ButtonConfiguration(
+            title: primaryCta.label,
+            action: didSelectPrimaryButton
+        )
+    } else {
+        primaryButtonConfiguration = nil
+    }
+    let secondaryButtonConfiguration: PaneLayoutView.ButtonConfiguration?
+    if let secondaryCta = footer.secondaryCta {
+        secondaryButtonConfiguration = PaneLayoutView.ButtonConfiguration(
+            title: secondaryCta.label,
+            action: didSelectSecondaryButton
+        )
+    } else {
+        secondaryButtonConfiguration = nil
+    }
+    return PaneLayoutView.createFooterView(
+        primaryButtonConfiguration: primaryButtonConfiguration,
+        secondaryButtonConfiguration: secondaryButtonConfiguration,
+        topText: footer.disclaimer,
+        bottomText: footer.belowCta,
+        didSelectURL: didSelectURL
+    ).footerView
 }
 
 #if DEBUG

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/GenericInfoScreen/GenericInfoViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/GenericInfoScreen/GenericInfoViewController.swift
@@ -1,0 +1,63 @@
+//
+//  GenericInfoViewController.swift
+//  StripeFinancialConnections
+//
+//  Created by Krisjanis Gaidis on 7/2/24.
+//
+
+import Foundation
+import UIKit
+
+final class GenericInfoViewController: SheetViewController {
+
+    private let genericInfoScreen: FinancialConnectionsGenericInfoScreen
+    private let didSelectPrimaryButton: () -> Void
+    private let didSelectSecondaryButton: () -> Void
+    private let didSelectURL: (URL) -> Void
+
+    init(
+        genericInfoScreen: FinancialConnectionsGenericInfoScreen,
+        panePresentationStyle: PanePresentationStyle,
+        didSelectPrimaryButton: @escaping () -> Void,
+        didSelectSecondaryButton: (() -> Void)? = nil,
+        didSelectURL: @escaping (URL) -> Void
+    ) {
+        self.genericInfoScreen = genericInfoScreen
+        self.didSelectPrimaryButton = didSelectPrimaryButton
+        self.didSelectSecondaryButton = didSelectSecondaryButton ?? {}
+        self.didSelectURL = didSelectURL
+        super.init(panePresentationStyle: panePresentationStyle)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setup(
+            withContentView: PaneLayoutView.createContentView(
+                iconView: {
+                    if let imageUrl = genericInfoScreen.header?.icon?.default {
+                        return RoundedIconView(
+                            image: .imageUrl(imageUrl),
+                            style: .circle
+                        )
+                    } else {
+                        return nil
+                    }
+                }(),
+                title: genericInfoScreen.header?.title,
+                subtitle: genericInfoScreen.header?.subtitle,
+                contentView: nil, // TODO(kgaidis): add support for content view
+                isSheet: (panePresentationStyle == .sheet)
+            ),
+            footerView: GenericInfoFooterView(
+                footer: genericInfoScreen.footer,
+                didSelectPrimaryButton: didSelectPrimaryButton,
+                didSelectSecondaryButton: didSelectSecondaryButton,
+                didSelectURL: didSelectURL
+            )
+        )
+    }
+}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/GenericInfoScreen/GenericInfoViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/GenericInfoScreen/GenericInfoViewController.swift
@@ -11,20 +11,20 @@ import UIKit
 final class GenericInfoViewController: SheetViewController {
 
     private let genericInfoScreen: FinancialConnectionsGenericInfoScreen
-    private let didSelectPrimaryButton: () -> Void
-    private let didSelectSecondaryButton: () -> Void
+    private let didSelectPrimaryButton: (_ genericInfoViewController: GenericInfoViewController) -> Void
+    private let didSelectSecondaryButton: (_ genericInfoViewController: GenericInfoViewController) -> Void
     private let didSelectURL: (URL) -> Void
 
     init(
         genericInfoScreen: FinancialConnectionsGenericInfoScreen,
         panePresentationStyle: PanePresentationStyle,
-        didSelectPrimaryButton: @escaping () -> Void,
-        didSelectSecondaryButton: (() -> Void)? = nil,
+        didSelectPrimaryButton: @escaping (_ genericInfoViewController: GenericInfoViewController) -> Void,
+        didSelectSecondaryButton: ((_ genericInfoViewController: GenericInfoViewController) -> Void)? = nil,
         didSelectURL: @escaping (URL) -> Void
     ) {
         self.genericInfoScreen = genericInfoScreen
         self.didSelectPrimaryButton = didSelectPrimaryButton
-        self.didSelectSecondaryButton = didSelectSecondaryButton ?? {}
+        self.didSelectSecondaryButton = didSelectSecondaryButton ?? { _ in }
         self.didSelectURL = didSelectURL
         super.init(panePresentationStyle: panePresentationStyle)
     }
@@ -54,8 +54,14 @@ final class GenericInfoViewController: SheetViewController {
             ),
             footerView: GenericInfoFooterView(
                 footer: genericInfoScreen.footer,
-                didSelectPrimaryButton: didSelectPrimaryButton,
-                didSelectSecondaryButton: didSelectSecondaryButton,
+                didSelectPrimaryButton: { [weak self] in
+                    guard let self else { return }
+                    didSelectPrimaryButton(self)
+                },
+                didSelectSecondaryButton: { [weak self] in
+                    guard let self else { return }
+                    didSelectSecondaryButton(self)
+                },
                 didSelectURL: didSelectURL
             )
         )

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/PaneLayoutView/PaneLayoutView+Extensions.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/PaneLayoutView/PaneLayoutView+Extensions.swift
@@ -145,6 +145,7 @@ extension PaneLayoutView {
         primaryButtonConfiguration: PaneLayoutView.ButtonConfiguration?,
         secondaryButtonConfiguration: PaneLayoutView.ButtonConfiguration? = nil,
         topText: String? = nil,
+        bottomText: String? = nil,
         didSelectURL: ((URL) -> Void)? = nil
     ) -> (footerView: UIView?, primaryButton: StripeUICore.Button?, secondaryButton: StripeUICore.Button?) {
         guard
@@ -209,6 +210,24 @@ extension PaneLayoutView {
                 secondaryButton.heightAnchor.constraint(equalToConstant: 56)
             ])
             footerStackView.addArrangedSubview(secondaryButton)
+        }
+
+        if let bottomText {
+            let bottomTextLabel = AttributedTextView(
+                font: .label(.small),
+                boldFont: .label(.smallEmphasized),
+                linkFont: .label(.small),
+                textColor: .textDefault,
+                alignCenter: true
+            )
+            bottomTextLabel.setText(
+                bottomText,
+                action: didSelectURL ?? { _ in }
+            )
+            if let lastView = footerStackView.arrangedSubviews.last {
+                footerStackView.setCustomSpacing(24, after: lastView)
+            }
+            footerStackView.addArrangedSubview(bottomTextLabel)
         }
 
         let paddingStackView = HitTestStackView(


### PR DESCRIPTION
## Summary

This PR:
- This PR adds a new "drawer/sheet" to LinkAccount Picker for the networking manual entry project.
- We try to replicate the [Stripe.js PR here](https://git.corp.stripe.com/stripe-internal/stripe-js-v3/pull/21998).

<img width="331" alt="Screenshot 2024-07-03 at 10 05 44 AM" src="https://github.com/stripe/stripe-ios/assets/105514761/c53963ed-f69f-47af-9681-8d2949addcd0">

[JIRA](https://jira.corp.stripe.com/browse/BANKCON-11261)

Context:
- Financial Connections is implementing support for "networking manual entry." This feature allows a user to enter their manually entered account _once_, and then we will allow them to reuse it later through Link. 
- This is just one PR of many where each PR will be merged to a feature branch `fc-networkingmanualentry`.
- It's expected that this PR may have some gaps or TODO's because its going to a feature branch. That being said, we still want to make sure there's no glaring logic issues/bugs. 

## Testing

### Video of Drawer (using data)

https://github.com/stripe/stripe-ios/assets/105514761/66de13ed-631f-4d6d-b891-6e2b26e5ff65

### GenericInfoFooterView

<img width="275" alt="Screenshot 2024-07-03 at 10 06 58 AM" src="https://github.com/stripe/stripe-ios/assets/105514761/1e84cb18-6bed-4edb-b7ee-1249b7c1620c">

### UI Tests

Ran `bitrise run financial-connections-stability-tests` and passed:

```
FinancialConnectionsNetworkingUITests
    ✓ testNativeNetworkingTestMode (142.097 seconds)
    ✓ testNativeNetworkingTestModeSignUpWithMultiSelectAndPrefilledEmail (32.753 seconds)
    ✓ testNativeNetworkingTestModeSignUpWithPrefilledEmailAndPhone (24.318 seconds)
FinancialConnectionsUITests
    ✓ testDataLiveModeOAuthNativeAuthFlow (29.027 seconds)
    ✓ testDataLiveModeOAuthWebAuthFlow (20.233 seconds)
    ✓ testDataTestModeOAuthNativeAuthFlow (20.803 seconds)
    ✓ testPaymentSearchInLiveModeNativeAuthFlow (25.867 seconds)
    ✓ testPaymentTestModeLegacyNativeAuthFlow (19.842 seconds)
    ✓ testPaymentTestModeManualEntryAutofill (14.907 seconds)
    ✓ testPaymentTestModeManualEntryNativeAuthFlow (24.661 seconds)


	 Executed 10 tests, with 0 failures (0 unexpected) in 354.508 (354.521) seconds
```