### PR TITLE
FC Playground app - Make keyboard dismissible

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundView.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundView.swift
@@ -176,6 +176,9 @@ struct PlaygroundView: View {
         }
         .navigationTitle("Playground")
         .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            UIScrollView.appearance().keyboardDismissMode = .interactive
+        }
     }
 }
 

--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundView.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundView.swift
@@ -176,9 +176,11 @@ struct PlaygroundView: View {
         }
         .navigationTitle("Playground")
         .navigationBarTitleDisplayMode(.inline)
-        .onAppear {
-            UIScrollView.appearance().keyboardDismissMode = .interactive
-        }
+        .gesture(DragGesture().onChanged(hideKeyboard))
+    }
+
+    private func hideKeyboard(_ value: DragGesture.Value) {
+        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
     }
 }
 


### PR DESCRIPTION
## Summary

This updates the Financial Connections playground app such that the keyboard can now be dismissed interactively. Previously, there was no way to dismiss it, and it would block launching the FC flow.

## Motivation

✨

## Testing

https://github.com/stripe/stripe-ios/assets/172562065/24ad5f89-4ebd-4912-8488-f7d65730ff7a

## Changelog

N/a