### PR TITLE
Financial Connections: for networking manual entry, added support for showing NetworkingLinkWarmup pane from consent manual entry button.

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentViewController.swift
@@ -12,7 +12,10 @@ import SafariServices
 import UIKit
 
 protocol ConsentViewControllerDelegate: AnyObject {
-    func consentViewControllerDidSelectManuallyVerify(_ viewController: ConsentViewController)
+    func consentViewController(
+        _ viewController: ConsentViewController,
+        didRequestNextPane nextPane: FinancialConnectionsSessionManifest.NextPane
+    )
     func consentViewController(
         _ viewController: ConsentViewController,
         didConsentWithManifest manifest: FinancialConnectionsSessionManifest
@@ -147,7 +150,10 @@ class ConsentViewController: UIViewController {
             analyticsClient: dataSource.analyticsClient,
             handleStripeScheme: { urlHost in
                 if urlHost == "manual-entry" {
-                    delegate?.consentViewControllerDidSelectManuallyVerify(self)
+                    delegate?.consentViewController(
+                        self,
+                        didRequestNextPane: .manualEntry
+                    )
                 } else if urlHost == "data-access-notice" {
                     if let dataAccessNotice = dataSource.consent.dataAccessNotice {
                         let dataAccessNoticeViewController = DataAccessNoticeViewController(
@@ -167,6 +173,11 @@ class ConsentViewController: UIViewController {
                         }
                     )
                     legalDetailsNoticeViewController.present(on: self)
+                } else if urlHost == "link-login" {
+                    delegate?.consentViewController(
+                        self,
+                        didRequestNextPane: .networkingLinkLoginWarmup
+                    )
                 }
             }
         )

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -513,8 +513,15 @@ extension NativeFlowController: ConsentViewControllerDelegate {
         }
     }
 
-    func consentViewControllerDidSelectManuallyVerify(_ viewController: ConsentViewController) {
-        pushPane(.manualEntry, animated: true)
+    func consentViewController(
+        _ viewController: ConsentViewController,
+        didRequestNextPane nextPane: FinancialConnectionsSessionManifest.NextPane
+    ) {
+        if nextPane == .networkingLinkLoginWarmup {
+            presentPaneAsSheet(nextPane)
+        } else {
+            pushPane(nextPane, animated: true)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

This PR:
- This PR added support for showing NetworkingLinkWarmup pane from consent manual entry button.
- We try to replicate the [Stripe.js PR here](https://git.corp.stripe.com/stripe-internal/stripe-js-v3/pull/23020). [Backend PR](https://git.corp.stripe.com/stripe-internal/pay-server/pull/848671/files#diff-a831a45a63a579a45504762c3a72f5ff1addc44a208f2b75173f7a7607988e0cR299)

[JIRA](https://jira.corp.stripe.com/browse/BANKCON-11418)

Context:
- Financial Connections is implementing support for "networking manual entry." This feature allows a user to enter their manually entered account _once_, and then we will allow them to reuse it later through Link. 
- This is just one PR of many where each PR will be merged to a feature branch `fc-networkingmanualentry`.
- It's expected that this PR may have some gaps or TODO's because its going to a feature branch. That being said, we still want to make sure there's no glaring logic issues/bugs. 

## Testing

### The Networking Link Warm Up Pane drawer showing up

https://github.com/stripe/stripe-ios/assets/105514761/66ef2b05-fd66-4e6b-b631-1263b92f9e83

### The Straight-To-Manual-Entry Also Works

https://github.com/stripe/stripe-ios/assets/105514761/b3cd8812-579c-4f67-b778-571b1ebc6de2
