### PR TITLE
Financial Connections: to customer sheet, added a hosted_surface of customer_sheet

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerAddPaymentMethodViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerAddPaymentMethodViewController.swift
@@ -312,9 +312,13 @@ extension CustomerAddPaymentMethodViewController {
             }
         }
 
+        let additionalParameters: [String: Any] = [
+            "hosted_surface": "customer_sheet",
+        ]
         client.collectBankAccountForSetup(
             clientSecret: clientSecret,
             returnURL: configuration.returnURL,
+            additionalParameters: additionalParameters,
             onEvent: nil,
             params: params,
             from: viewController,


### PR DESCRIPTION
## Summary

This PR adds extra logging/info to backend.

Original iOS PR (added "hosted_surface" of "payment_element"): https://github.com/stripe/stripe-ios/pull/3653

Android PR: https://github.com/stripe/stripe-android/pull/8602

[Slack thread](https://stripe.slack.com/archives/C02KW8G938W/p1718223254190369)

## Testing

Here we can see the param passed:

<img width="1510" alt="Screenshot 2024-07-03 at 2 39 54 PM" src="https://github.com/stripe/stripe-ios/assets/105514761/8b35220f-9a41-48eb-8a4c-742dc08a0b27">

Here is a video of the flow working (AND we/payment-team also have UI tests for customer sheet w/ US Bank Account):

https://github.com/stripe/stripe-ios/assets/105514761/7b63927b-8d38-46dd-a30f-a2b0bde16923
