### PR TITLE
Fix IDR currency formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## PaymentSheet
 * [Fixed] Fixed an issue where certain cobranded cards showed a generic card icon instead of using the other card brand.
+* [Fixed] Fixed an issue where amounts with currency=IDR were displayed as-is, instead of dropping the last two digits.
 
 ## 23.27.6 2024-06-25
 ### All

--- a/Stripe/StripeiOSTests/NSString+StripeTest.swift
+++ b/Stripe/StripeiOSTests/NSString+StripeTest.swift
@@ -91,5 +91,14 @@ class NSString_StripeTest: XCTestCase {
             ),
             "ZZZ 10.99"
         )
+
+        XCTAssertEqual(
+            String.localizedAmountDisplayString(
+                for: 1000,
+                currency: "IDR",
+                locale: Locale(identifier: "en_US")
+            ),
+            "IDR 10"
+        )
     }
 }

--- a/StripePayments/StripePayments/Source/Internal/Categories/NSDecimalNumber+Stripe_Currency.swift
+++ b/StripePayments/StripePayments/Source/Internal/Categories/NSDecimalNumber+Stripe_Currency.swift
@@ -17,6 +17,7 @@ extension NSDecimalNumber {
         "PKR": 2,
         "LAK": 2,
         "RSD": 2,
+        "IDR": 2,
     ]
 
     @objc @_spi(STP) public class func stp_decimalNumber(


### PR DESCRIPTION
## Summary
Stripe Intents w/ IDR currency have amounts with 'decimals' e.g. 1 IDR is considered 1.00 IDR, which is represented as amount = 100.

We should divide the amount by 100 before displaying e.g. Stripe amount=100 should display as 1 IDR

## Motivation
https://github.com/stripe/stripe-ios/issues/3747
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-3360

## Testing
See unit test

PaymentSheet w/ 1000 IDR Stripe amount:
![CleanShot 2024-07-08 at 11 38 49@2x](https://github.com/stripe/stripe-ios/assets/47796191/34ebff4b-4c8e-471d-8007-e93944d26efc)

Apple Pay:
![CleanShot 2024-07-08 at 11 39 18@2x](https://github.com/stripe/stripe-ios/assets/47796191/fb2e6603-7e49-4e80-8b8f-97992a01385a)


## Changelog
See CHANGELOG