### PR TITLE
Financial Connections: for networking manual entry, DataAccessNotice is dynamic based off what the user selects

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsNetworkedAccountsResponse.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsNetworkedAccountsResponse.swift
@@ -26,6 +26,8 @@ struct FinancialConnectionsNetworkingAccountPicker: Decodable {
     let defaultCta: String
     let addNewAccount: AddNewAccount
     let accounts: [FinancialConnectionsNetworkingAccountPicker.Account]
+    let aboveCta: String?
+    let multipleAccountTypesSelectedDataAccessNotice: FinancialConnectionsDataAccessNotice?
 
     struct AddNewAccount: Decodable {
         let body: String
@@ -44,5 +46,6 @@ struct FinancialConnectionsNetworkingAccountPicker: Decodable {
         let selectionCtaIcon: FinancialConnectionsImage?
         let drawerOnSelection: FinancialConnectionsGenericInfoScreen?
         let accountIcon: FinancialConnectionsImage?
+        let dataAccessNotice: FinancialConnectionsDataAccessNotice?
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerBodyView.swift
@@ -116,7 +116,8 @@ private struct LinkAccountPickerBodyViewUIViewRepresentable: UIViewRepresentable
                         icon: nil,
                         selectionCtaIcon: nil,
                         drawerOnSelection: nil,
-                        accountIcon: nil
+                        accountIcon: nil,
+                        dataAccessNotice: nil
                     ),
                     partnerAccount: FinancialConnectionsPartnerAccount(
                         id: "abc",
@@ -152,7 +153,8 @@ private struct LinkAccountPickerBodyViewUIViewRepresentable: UIViewRepresentable
                         ),
                         selectionCtaIcon: nil,
                         drawerOnSelection: nil,
-                        accountIcon: nil
+                        accountIcon: nil,
+                        dataAccessNotice: nil
                     ),
                     partnerAccount: FinancialConnectionsPartnerAccount(
                         id: "abc",
@@ -178,7 +180,8 @@ private struct LinkAccountPickerBodyViewUIViewRepresentable: UIViewRepresentable
                         icon: nil,
                         selectionCtaIcon: nil,
                         drawerOnSelection: nil,
-                        accountIcon: nil
+                        accountIcon: nil,
+                        dataAccessNotice: nil
                     ),
                     partnerAccount: FinancialConnectionsPartnerAccount(
                         id: "abc",

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerFooterView.swift
@@ -30,9 +30,7 @@ final class LinkAccountPickerFooterView: UIView {
 
     init(
         defaultCta: String,
-        isStripeDirect: Bool,
-        businessName: String?,
-        permissions: [StripeAPI.FinancialConnectionsAccount.Permissions],
+        aboveCta: String?,
         singleAccount: Bool,
         didSelectConnectAccount: @escaping () -> Void,
         didSelectMerchantDataAccessLearnMore: @escaping (URL) -> Void
@@ -42,21 +40,22 @@ final class LinkAccountPickerFooterView: UIView {
         self.didSelectConnectAccount = didSelectConnectAccount
         super.init(frame: .zero)
 
-        let verticalStackView = HitTestStackView(
-            arrangedSubviews: [
-                MerchantDataAccessView(
-                    isStripeDirect: isStripeDirect,
-                    businessName: businessName,
-                    permissions: permissions,
-                    isNetworking: true,
-                    font: .label(.small),
-                    boldFont: .label(.smallEmphasized),
-                    alignCenter: true,
-                    didSelectLearnMore: didSelectMerchantDataAccessLearnMore
-                ),
-                connectAccountButton,
-            ]
-        )
+        let verticalStackView = HitTestStackView()
+        if let aboveCta {
+            let merchantDataAccessLabel = AttributedTextView(
+                font: .label(.small),
+                boldFont: .label(.smallEmphasized),
+                linkFont: .label(.small),
+                textColor: .textDefault,
+                alignCenter: true
+            )
+            merchantDataAccessLabel.setText(
+                aboveCta,
+                action: didSelectMerchantDataAccessLearnMore
+            )
+            verticalStackView.addArrangedSubview(merchantDataAccessLabel)
+        }
+        verticalStackView.addArrangedSubview(connectAccountButton)
         verticalStackView.axis = .vertical
         verticalStackView.spacing = 16
         verticalStackView.isLayoutMarginsRelativeArrangement = true

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
@@ -177,9 +177,7 @@ final class LinkAccountPickerViewController: UIViewController {
 
         let footerView = LinkAccountPickerFooterView(
             defaultCta: networkingAccountPicker.defaultCta,
-            isStripeDirect: false,
-            businessName: businessName,
-            permissions: dataSource.manifest.permissions,
+            aboveCta: networkingAccountPicker.aboveCta,
             singleAccount: dataSource.manifest.singleAccount,
             didSelectConnectAccount: { [weak self] in
                 guard let self = self else {


### PR DESCRIPTION
## Summary

This PR:
- This PR added support for LinkAccountPicker to change what "DataAccessNotice" is displayed _depending_ on what account is selected.
- We try to replicate the [Stripe.js PR here](https://git.corp.stripe.com/stripe-internal/stripe-js-v3/pull/22025).

[JIRA](https://jira.corp.stripe.com/browse/BANKCON-11260)

Context:
- Financial Connections is implementing support for "networking manual entry." This feature allows a user to enter their manually entered account _once_, and then we will allow them to reuse it later through Link. 
- This is just one PR of many where each PR will be merged to a feature branch `fc-networkingmanualentry`.
- It's expected that this PR may have some gaps or TODO's because its going to a feature branch. That being said, we still want to make sure there's no glaring logic issues/bugs. 

## Testing

### AboveCta

⚠️  note: its expected that the "above_cta" is different now...its coming from backend so its synchronized with what the backend says!

| Before | After |
| --- | --- |
| ![control_picker](https://github.com/stripe/stripe-ios/assets/105514761/1515ac9a-a736-44d6-b0fb-90372d3edade)| ![after_picker](https://github.com/stripe/stripe-ios/assets/105514761/1de6dfed-08fb-48cf-80a7-3d66f8098745) |

### DataAccessNotice for main account

| Before | After |
| --- | --- |
| ![control_data_Sharing](https://github.com/stripe/stripe-ios/assets/105514761/41ef3b07-eae4-4468-aa29-3668b2e6283d) | ![after_data_sharing](https://github.com/stripe/stripe-ios/assets/105514761/fe4a8fa6-6741-43c1-a487-3c68908fff43) |

### Video of the accounts changing upon what is selected

https://github.com/stripe/stripe-ios/assets/105514761/2792f88e-7d5b-4f44-acc7-31fd13bac899
