### PR TITLE
Adds coupon support to STPApplePayContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Payments
 * [Fixed] An issue where the correct card brand was not being displayed for card brand choice in STPPaymentOptionsViewController and STPPaymentContext.
+* [Added] Adds coupon support to STPApplePayContext with a new `didChangeCouponCode` delegate method (h/t @JoeyLeeMEA).
 
 ## PaymentSheet
 * [Fixed] Fixed an issue where certain cobranded cards showed a generic card icon instead of using the other card brand.


### PR DESCRIPTION
## Summary
Dupe of https://github.com/stripe/stripe-ios/issues/2278 w/ tests - unfortunately I can't figure out how to run bitrise on this old PR.

## Testing
See unit test.

## Changelog
See CHANGELOG
