### PR TITLE
[FC] Add logging to synchronize API call

### DIFF
--- a/StripeCore/StripeCore.xcodeproj/project.pbxproj
+++ b/StripeCore/StripeCore.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		4506A7016EA7C45796D3A30D /* STPLocalizedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 758B9C9C2252A91FE4221702 /* STPLocalizedString.swift */; };
 		45DAE581F74EF7E11C64212B /* InstallMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E64986F72C7BD8B1105A95 /* InstallMethod.swift */; };
 		48A6CCB4008A5060C2655C5F /* XCTestCase+Stripe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DE48D0086BED21F9E837D0B /* XCTestCase+Stripe.swift */; };
+		4910B9282C3D8F3F00B030D4 /* Result+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4910B9272C3D8F3F00B030D4 /* Result+Extensions.swift */; };
 		4B2FAC57E03D8654A177C408 /* Dictionary+Stripe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7727AEEFD2FC880BADDA1872 /* Dictionary+Stripe.swift */; };
 		53D46A03B77577EE21F4B166 /* StripeCodableTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FCE36551600C3E53BEAF8F0 /* StripeCodableTest.swift */; };
 		552DA7969984C443617DBC3E /* STPMultipartFormDataPart.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C72BA9C44FF60A0E7BEF76 /* STPMultipartFormDataPart.swift */; };
@@ -221,6 +222,7 @@
 		45F11FF08733CF61D880640D /* UserDefaults+PaymentsCore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+PaymentsCore.swift"; sourceTree = "<group>"; };
 		4689F6B4384244D9FD282560 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		48A3D6592296104A1512AE92 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
+		4910B9272C3D8F3F00B030D4 /* Result+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+Extensions.swift"; sourceTree = "<group>"; };
 		49424775D3233411D9C2473B /* StripeCodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StripeCodable.swift; sourceTree = "<group>"; };
 		49538DBF8457D96707A2DA56 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4A8030BF88608CA86E295F18 /* Enums+CustomStringConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Enums+CustomStringConvertible.swift"; sourceTree = "<group>"; };
@@ -592,6 +594,7 @@
 				DEA5353BC5359E08128E116A /* StripeCoreBundleLocator.swift */,
 				C51179DB520568C246BF3AF0 /* URLEncoder.swift */,
 				B8B76840742D2CAF2931355A /* URLSession+Retry.swift */,
+				4910B9272C3D8F3F00B030D4 /* Result+Extensions.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -981,6 +984,7 @@
 				45DAE581F74EF7E11C64212B /* InstallMethod.swift in Sources */,
 				096274D0729AA8849FAD103C /* PaymentsSDKVariant.swift in Sources */,
 				DA5A05459309B9B77ACDD736 /* STPDeviceUtils.swift in Sources */,
+				4910B9282C3D8F3F00B030D4 /* Result+Extensions.swift in Sources */,
 				83790210FFC2DD764C042C8E /* STPDispatchFunctions.swift in Sources */,
 				72DA29CA8A750E8B00DBF3D4 /* STPError.swift in Sources */,
 				F628BBE9FDA9D3A217ACA753 /* STPNumericStringValidator.swift in Sources */,

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
@@ -61,6 +61,8 @@ import Foundation
     case financialConnectionsSheetPresented = "stripeios.financialconnections.sheet.presented"
     case financialConnectionsSheetClosed = "stripeios.financialconnections.sheet.closed"
     case financialConnectionsSheetFailed = "stripeios.financialconnections.sheet.failed"
+    case financialConnectionsSheetInitialSynchronizeStarted = "stripeios.financialconnections.sheet.initial_synchronize.started"
+    case financialConnectionsSheetInitialSynchronizeCompleted = "stripeios.financialconnections.sheet.initial_synchronize.completed"
 
     // MARK: - PaymentSheet Init
     case mcInitCustomCustomer = "mc_custom_init_customer"

--- a/StripeCore/StripeCore/Source/Helpers/Result+Extensions.swift
+++ b/StripeCore/StripeCore/Source/Helpers/Result+Extensions.swift
@@ -1,0 +1,24 @@
+//
+//  Result+Extensions.swift
+//  StripeCore
+//
+//  Created by Mat Schmid on 2024-07-09.
+//
+
+import Foundation
+
+@_spi(STP) public extension Result {
+    /// Whether or not the result is a success.
+    var success: Bool {
+        switch self {
+        case .success: true
+        case .failure: false
+        }
+    }
+
+    /// Returns the error if the result is a failure.
+    var error: Error? {
+        guard case .failure(let error) = self else { return nil }
+        return error
+    }
+}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsSheetAnalytics.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsSheetAnalytics.swift
@@ -50,6 +50,29 @@ struct FinancialConnectionsSheetFailedAnalytic: FinancialConnectionsSheetAnalyti
     let error: Error
 }
 
+/// Logged at the begining of the initial `synchronize` API call.
+struct FinancialConnectionsSheetInitialSynchronizeStarted: FinancialConnectionsSheetAnalytic {
+    let event = STPAnalyticEvent.financialConnectionsSheetInitialSynchronizeStarted
+    let clientSecret: String
+    let additionalParams: [String: Any] = [:]
+}
+
+/// Logged when the initial `synchronize` API call completes. Includes whether or not the call was a success, and the error otherwise.
+struct FinancialConnectionsSheetInitialSynchronizeCompleted: FinancialConnectionsSheetAnalytic {
+    let event = STPAnalyticEvent.financialConnectionsSheetInitialSynchronizeCompleted
+    let clientSecret: String
+    let success: Bool
+    let possibleError: Error?
+
+    var additionalParams: [String: Any] {
+        var params: [String: Any] = ["success": success]
+        if let error = possibleError {
+            params["error"] = error.serializeForV1Analytics()
+        }
+        return params
+    }
+}
+
 /// Helper to determine if we should log a failed analytic or closed analytic from the sheet's completion block
 struct FinancialConnectionsSheetCompletionAnalytic {
     /// Returns either a `FinancialConnectionsSheetClosedAnalytic` or `FinancialConnectionsSheetFailedAnalytic` depending on the result

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostController.swift
@@ -39,16 +39,18 @@ class HostController {
 
     // MARK: - Properties
 
-    private let api: FinancialConnectionsAPIClient
+    private let apiClient: STPAPIClient
     private let clientSecret: String
     private let returnURL: String?
     private let analyticsClient: FinancialConnectionsAnalyticsClient
+    private let analyticsClientV1: STPAnalyticsClientProtocol
 
     private var nativeFlowController: NativeFlowController?
     lazy var hostViewController = HostViewController(
+        analyticsClientV1: analyticsClientV1,
         clientSecret: clientSecret,
         returnURL: returnURL,
-        apiClient: api,
+        apiClient: apiClient,
         delegate: self
     )
     lazy var navigationController = FinancialConnectionsNavigationController(rootViewController: hostViewController)
@@ -58,13 +60,15 @@ class HostController {
     // MARK: - Init
 
     init(
-        api: FinancialConnectionsAPIClient,
+        apiClient: STPAPIClient,
+        analyticsClientV1: STPAnalyticsClientProtocol,
         clientSecret: String,
         returnURL: String?,
         publishableKey: String?,
         stripeAccount: String?
     ) {
-        self.api = api
+        self.apiClient = apiClient
+        self.analyticsClientV1 = analyticsClientV1
         self.clientSecret = clientSecret
         self.returnURL = returnURL
         self.analyticsClient = FinancialConnectionsAnalyticsClient()
@@ -121,7 +125,7 @@ extension HostController: HostViewControllerDelegate {
                 visualUpdate: synchronizePayload.visual,
                 returnURL: returnURL,
                 consentPaneModel: synchronizePayload.text?.consentPane,
-                apiClient: api,
+                apiClient: apiClient,
                 clientSecret: clientSecret,
                 analyticsClient: analyticsClient
             )
@@ -154,15 +158,15 @@ private extension HostController {
             )
         )
 
-        let accountFetcher = FinancialConnectionsAccountAPIFetcher(api: api, clientSecret: clientSecret)
+        let accountFetcher = FinancialConnectionsAccountAPIFetcher(api: apiClient, clientSecret: clientSecret)
         let sessionFetcher = FinancialConnectionsSessionAPIFetcher(
-            api: api,
+            api: apiClient,
             clientSecret: clientSecret,
             accountFetcher: accountFetcher
         )
         let webFlowViewController = FinancialConnectionsWebFlowViewController(
             clientSecret: clientSecret,
-            apiClient: api,
+            apiClient: apiClient,
             manifest: manifest,
             sessionFetcher: sessionFetcher,
             returnURL: returnURL

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostViewController.swift
@@ -49,8 +49,9 @@ final class HostViewController: UIViewController {
 
     weak var delegate: HostViewControllerDelegate?
 
+    private let analyticsClientV1: STPAnalyticsClientProtocol
     private let clientSecret: String
-    private let apiClient: FinancialConnectionsAPIClient
+    private let apiClient: STPAPIClient
     private let returnURL: String?
 
     private var lastError: Error?
@@ -58,11 +59,13 @@ final class HostViewController: UIViewController {
     // MARK: - Init
 
     init(
+        analyticsClientV1: STPAnalyticsClientProtocol,
         clientSecret: String,
         returnURL: String?,
-        apiClient: FinancialConnectionsAPIClient,
+        apiClient: STPAPIClient,
         delegate: HostViewControllerDelegate?
     ) {
+        self.analyticsClientV1 = analyticsClientV1
         self.clientSecret = clientSecret
         self.returnURL = returnURL
         self.apiClient = apiClient
@@ -99,6 +102,12 @@ extension HostViewController {
     private func getManifest() {
         loadingView.errorView.isHidden = true
         loadingView.showLoading(true)
+
+        analyticsClientV1.log(
+            analytic: FinancialConnectionsSheetInitialSynchronizeStarted(clientSecret: clientSecret),
+            apiClient: apiClient
+        )
+
         apiClient
             .synchronize(
                 clientSecret: clientSecret,
@@ -106,6 +115,16 @@ extension HostViewController {
             )
             .observe { [weak self] result in
                 guard let self = self else { return }
+
+                analyticsClientV1.log(
+                    analytic: FinancialConnectionsSheetInitialSynchronizeCompleted(
+                        clientSecret: clientSecret,
+                        success: result.success,
+                        possibleError: result.error
+                    ),
+                    apiClient: apiClient
+                )
+
                 switch result {
                 case .success(let synchronizePayload):
                     self.lastError = nil

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/FinancialConnectionsSheet.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/FinancialConnectionsSheet.swift
@@ -205,7 +205,8 @@ final public class FinancialConnectionsSheet {
         }
 
         hostController = HostController(
-            api: apiClient,
+            apiClient: apiClient,
+            analyticsClientV1: analyticsClient,
             clientSecret: financialConnectionsSessionClientSecret,
             returnURL: returnURL,
             publishableKey: apiClient.publishableKey,

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsSheetTests.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsSheetTests.swift
@@ -20,6 +20,7 @@ class FinancialConnectionsSheetTests: XCTestCase {
     private let mockViewController = UIViewController()
     private let mockClientSecret = "las_123345"
     private let mockAnalyticsClient = MockAnalyticsClient()
+    private let mockApiClient = APIStubbedTestCase.stubbedAPIClient()
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -46,7 +47,8 @@ class FinancialConnectionsSheetTests: XCTestCase {
 
         // Mock that financialConnections is completed
         let host = HostController(
-            api: EmptyFinancialConnectionsAPIClient(),
+            apiClient: mockApiClient,
+            analyticsClientV1: mockAnalyticsClient,
             clientSecret: "test",
             returnURL: nil,
             publishableKey: "test",


### PR DESCRIPTION
Resolves part of [BANKCON-11464](https://jira.corp.stripe.com/browse/BANKCON-11464)

## Summary

This adds some V1 logging to our call to the `synchronize` API. We log:
- At the beginning of the API call
- When the API call completes. Also includes these parameters:
    - Name of class which called `synchronize`.
    -  Whether or not the API call resulted in a success.

## Motivation

Improves observability into our synchronize call. We'll know when we executed this request, and when it fails.

## Testing

N/a

## Changelog

N/a