### PR TITLE
[FC] Add logging to FlowRouter decision

### DIFF
--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
@@ -61,6 +61,7 @@ import Foundation
     case financialConnectionsSheetPresented = "stripeios.financialconnections.sheet.presented"
     case financialConnectionsSheetClosed = "stripeios.financialconnections.sheet.closed"
     case financialConnectionsSheetFailed = "stripeios.financialconnections.sheet.failed"
+    case financialConnectionsSheetFlowDetermined = "stripeios.financialconnections.sheet.flow_determined"
     case financialConnectionsSheetInitialSynchronizeStarted = "stripeios.financialconnections.sheet.initial_synchronize.started"
     case financialConnectionsSheetInitialSynchronizeCompleted = "stripeios.financialconnections.sheet.initial_synchronize.completed"
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsSheetAnalytics.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsSheetAnalytics.swift
@@ -42,6 +42,21 @@ struct FinancialConnectionsSheetClosedAnalytic: FinancialConnectionsSheetAnalyti
     }
 }
 
+/// Logged when the financial connections sheet flow is determined
+struct FinancialConnectionsSheetFlowDetermined: FinancialConnectionsSheetAnalytic {
+    let event = STPAnalyticEvent.financialConnectionsSheetFlowDetermined
+    let clientSecret: String
+    let flow: FlowRouter.Flow
+    let killswitchActive: Bool
+
+    var additionalParams: [String: Any] {
+        [
+            "flow": flow.rawValue,
+            "killswitchActive": killswitchActive,
+        ]
+    }
+}
+
 /// Logged if there's an error presenting the sheet
 struct FinancialConnectionsSheetFailedAnalytic: FinancialConnectionsSheetAnalytic {
     let event = STPAnalyticEvent.financialConnectionsSheetFailed


### PR DESCRIPTION
Resolves [BANKCON-11464](https://jira.corp.stripe.com/browse/BANKCON-11464)

## Summary

This refactors the financial connections `FlowRouter` to provide a `Flow` enum, which is then logged (via the V1 analytics logger). We log when a flow has been decided, including what the flow is and whether or not the native killswitch is active.

## Motivation

Improves observability into which flow is being used in the financial connections sheet.

## Testing

N/a

## Changelog

N/a
