### PR TITLE
Financial Connections: for server driven UX GenericInfoScreen, added SafeEnumCodable to have safer parsing

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsGenericInfoScreen.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsGenericInfoScreen.swift
@@ -21,10 +21,11 @@ struct FinancialConnectionsGenericInfoScreen: Decodable {
         let icon: FinancialConnectionsImage?
         let alignment: Alignment?
 
-        enum Alignment: String, Decodable {
+        enum Alignment: String, SafeEnumCodable {
             case left = "left"
             case center = "center"
             case right = "right"
+            case unparsable
         }
     }
 
@@ -74,16 +75,18 @@ struct FinancialConnectionsGenericInfoScreen: Decodable {
             let alignment: Alignment?
             let size: Size?
 
-            enum Alignment: String, Decodable {
+            enum Alignment: String, SafeEnumCodable {
                 case left = "left"
                 case center = "center"
                 case right = "right"
+                case unparsable
             }
 
-            enum Size: String, Decodable {
+            enum Size: String, SafeEnumCodable {
                 case xsmall = "x-small"
                 case small = "small"
                 case medium = "medium"
+                case unparsable
             }
         }
 
@@ -125,9 +128,10 @@ struct FinancialConnectionsGenericInfoScreen: Decodable {
         let fullWidthContent: Bool?
         let verticalAlignment: VerticalAlignment?
 
-        enum VerticalAlignment: String, Decodable {
+        enum VerticalAlignment: String, SafeEnumCodable {
             case `default` = "default"
             case centered = "centered"
+            case unparsable
         }
     }
 }


### PR DESCRIPTION
## Summary

This ensures the enum types are safer as this is a new "server driven UX" framework and it could change

[slack discussion here from backend](https://stripe.slack.com/archives/C01DNBVURH9/p1720543981528089?thread_ts=1720198192.666669&cid=C01DNBVURH9)

## Testing

We can see that the screen that decodes this model loads/works:

![Simulator Screenshot - iPhone 15 Pro - 2024-07-09 at 15 38 42](https://github.com/stripe/stripe-ios/assets/105514761/21a0b63a-c535-4b61-8ba7-e214c3c28816)


