### PR TITLE
[FC] Add instant debits support to the playground app

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundConfiguration.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundConfiguration.swift
@@ -31,6 +31,42 @@ final class PlaygroundConfiguration {
         }
     }
 
+    // MARK: - Experience
+
+    enum Experience: String, CaseIterable, Identifiable, Hashable {
+        case financialConnections = "financial_connections"
+        case instantDebits = "instant_debits"
+
+        var displayName: String {
+            switch self {
+            case .financialConnections: "Financial Connections"
+            case .instantDebits: "Instant Debits"
+            }
+        }
+
+        var id: String {
+            return rawValue
+        }
+    }
+
+    private static let experienceKey = "experience"
+
+    var experience: Experience {
+        get {
+            if
+                let sdkTypeString = configurationStore[Self.experienceKey] as? String,
+                let sdkType = Experience(rawValue: sdkTypeString)
+            {
+                return sdkType
+            } else {
+                return .financialConnections
+            }
+        }
+        set {
+            configurationStore[Self.experienceKey] = newValue.rawValue
+        }
+    }
+
     // MARK: - SDK Type
 
     enum SDKType: String, CaseIterable, Identifiable, Hashable {
@@ -346,6 +382,15 @@ final class PlaygroundConfiguration {
             self.sdkType = sdkType
         } else {
             self.sdkType = .native
+        }
+
+        if
+            let experienceString = dictionary[Self.experienceKey] as? String,
+            let experience = Experience(rawValue: experienceString)
+        {
+            self.experience = experience
+        } else {
+            self.experience = .financialConnections
         }
 
         if

--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundView.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundView.swift
@@ -17,6 +17,18 @@ struct PlaygroundView: View {
         ZStack {
             VStack {
                 Form {
+                    Section(header: Text("Experience")) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Picker("Select Experience", selection: viewModel.experience) {
+                                ForEach(PlaygroundConfiguration.Experience.allCases) {
+                                    Text($0.displayName)
+                                        .tag($0)
+                                }
+                            }
+                            .pickerStyle(.segmented)
+                        }
+                    }
+
                     Section(header: Text("Select SDK Type")) {
                         VStack(alignment: .leading, spacing: 4) {
                             Picker("Select SDK Type", selection: viewModel.sdkType) {
@@ -63,13 +75,20 @@ struct PlaygroundView: View {
 
                     Section(header: Text("Select Use Case")) {
                         VStack(alignment: .leading, spacing: 4) {
-                            Picker("Select Use Case", selection: viewModel.useCase) {
-                                ForEach(PlaygroundConfiguration.UseCase.allCases) {
-                                    Text($0.rawValue.capitalized.replacingOccurrences(of: "_", with: " "))
-                                        .tag($0)
+                            if viewModel.experience.wrappedValue == .instantDebits {
+                                Text("Instant debits only supports the _Payment Intent_ use case.")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            } else {
+                                Picker("Select Use Case", selection: viewModel.useCase) {
+                                    ForEach(PlaygroundConfiguration.UseCase.allCases) {
+                                        Text($0.rawValue.capitalized.replacingOccurrences(of: "_", with: " "))
+                                            .tag($0)
+                                    }
                                 }
+                                .pickerStyle(.segmented)
                             }
-                            .pickerStyle(.segmented)
+
                         }
                     }
 

--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundView.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundView.swift
@@ -73,13 +73,9 @@ struct PlaygroundView: View {
                         }
                     }
 
-                    Section(header: Text("Select Use Case")) {
-                        VStack(alignment: .leading, spacing: 4) {
-                            if viewModel.experience.wrappedValue == .instantDebits {
-                                Text("Instant debits only supports the _Payment Intent_ use case.")
-                                    .font(.caption)
-                                    .foregroundColor(.secondary)
-                            } else {
+                    if viewModel.experience.wrappedValue == .financialConnections {
+                        Section(header: Text("Select Use Case")) {
+                            VStack(alignment: .leading, spacing: 4) {
                                 Picker("Select Use Case", selection: viewModel.useCase) {
                                     ForEach(PlaygroundConfiguration.UseCase.allCases) {
                                         Text($0.rawValue.capitalized.replacingOccurrences(of: "_", with: " "))
@@ -88,7 +84,6 @@ struct PlaygroundView: View {
                                 }
                                 .pickerStyle(.segmented)
                             }
-
                         }
                     }
 
@@ -196,6 +191,7 @@ struct PlaygroundView: View {
         .navigationTitle("Playground")
         .navigationBarTitleDisplayMode(.inline)
         .gesture(DragGesture().onChanged(hideKeyboard))
+        .animation(.easeIn(duration: 1), value: viewModel.experience.wrappedValue)
     }
 
     private func hideKeyboard(_ value: DragGesture.Value) {

--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundViewModel.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundViewModel.swift
@@ -23,6 +23,22 @@ final class PlaygroundViewModel: ObservableObject {
 
     let playgroundConfiguration = PlaygroundConfiguration.shared
 
+    var experience: Binding<PlaygroundConfiguration.Experience> {
+        Binding(
+            get: {
+                self.playgroundConfiguration.experience
+            },
+            set: { newValue in
+                self.playgroundConfiguration.experience = newValue
+                if newValue == .instantDebits {
+                    // Instant debits only supports the payment intent use case.
+                    self.playgroundConfiguration.useCase = .paymentIntent
+                }
+                self.objectWillChange.send()
+            }
+        )
+    }
+
     var sdkType: Binding<PlaygroundConfiguration.SDKType> {
         Binding(
             get: {

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
@@ -30,7 +30,7 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         let app = XCUIApplication.fc_launch(
             playgroundConfigurationString:
 """
-{"use_case":"payment_intent","sdk_type":"native","test_mode":true,"merchant":"networking","payment_method_permission":true,"email":""}
+{"use_case":"payment_intent","experience":"financial_connections","sdk_type":"native","test_mode":true,"merchant":"networking","payment_method_permission":true,"email":""}
 """
         )
 
@@ -87,7 +87,7 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         let app = XCUIApplication.fc_launch(
             playgroundConfigurationString:
 """
-{"use_case":"payment_intent","sdk_type":"native","test_mode":true,"merchant":"networking","payment_method_permission":true,"transactions_permission":true,"email":"\(emailAddress)"}
+{"use_case":"payment_intent","experience":"financial_connections","sdk_type":"native","test_mode":true,"merchant":"networking","payment_method_permission":true,"transactions_permission":true,"email":"\(emailAddress)"}
 """
         )
 
@@ -138,7 +138,7 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         let app = XCUIApplication.fc_launch(
             playgroundConfigurationString:
 """
-{"use_case":"payment_intent","sdk_type":"native","test_mode":true,"merchant":"networking","payment_method_permission":true,"transactions_permission":true,"email":"\(emailAddress)"}
+{"use_case":"payment_intent","experience":"financial_connections","sdk_type":"native","test_mode":true,"merchant":"networking","payment_method_permission":true,"transactions_permission":true,"email":"\(emailAddress)"}
 """
         )
 
@@ -190,7 +190,7 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         let app = XCUIApplication.fc_launch(
             playgroundConfigurationString:
 """
-{"use_case":"payment_intent","sdk_type":"native","test_mode":true,"merchant":"networking","payment_method_permission":true,"email":"\(emailAddress)"}
+{"use_case":"payment_intent","experience":"financial_connections","sdk_type":"native","test_mode":true,"merchant":"networking","payment_method_permission":true,"email":"\(emailAddress)"}
 """
         )
 
@@ -240,7 +240,7 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         let app = XCUIApplication.fc_launch(
             playgroundConfigurationString:
 """
-{"use_case":"data","sdk_type":"native","test_mode":true,"merchant":"networking","payment_method_permission":true,"ownership_permission":true,"balances_permission":true,"transactions_permission":true,"email":"\(emailAddress)"}
+{"use_case":"data","experience":"financial_connections","sdk_type":"native","test_mode":true,"merchant":"networking","payment_method_permission":true,"ownership_permission":true,"balances_permission":true,"transactions_permission":true,"email":"\(emailAddress)"}
 """
         )
 
@@ -297,7 +297,7 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         let app = XCUIApplication.fc_launch(
             playgroundConfigurationString:
 """
-{"use_case":"data","sdk_type":"native","test_mode":true,"merchant":"networking","payment_method_permission":true,"ownership_permission":true,"balances_permission":true,"transactions_permission":true,"email":"\(emailAddress)"}
+{"use_case":"data","experience":"financial_connections","sdk_type":"native","test_mode":true,"merchant":"networking","payment_method_permission":true,"ownership_permission":true,"balances_permission":true,"transactions_permission":true,"email":"\(emailAddress)"}
 """
         )
 
@@ -362,7 +362,7 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         let app = XCUIApplication.fc_launch(
             playgroundConfigurationString:
 """
-{"use_case":"payment_intent","sdk_type":"native","test_mode":true,"merchant":"networking","transactions_permission":true,"email":"\(emailAddress)","phone":"4015006000"}
+{"use_case":"payment_intent","experience":"financial_connections","sdk_type":"native","test_mode":true,"merchant":"networking","transactions_permission":true,"email":"\(emailAddress)","phone":"4015006000"}
 """
         )
 

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
@@ -391,6 +391,29 @@ final class FinancialConnectionsUITests: XCTestCase {
             // 'cancel' the test as the bank is under the maintenance
         }
     }
+
+    func testWebInstantDebitsFlow() throws {
+        let app = XCUIApplication.fc_launch(
+            playgroundConfigurationString:
+"""
+{"use_case":"payment_intent","experience":"instant_debits","sdk_type":"web","test_mode":true,"merchant":"default","payment_method_permission":true}
+"""
+        )
+
+        app.fc_playgroundCell.tap()
+        app.fc_playgroundShowAuthFlowButton.tap()
+
+        let usesLinkText = app.webViews
+            .staticTexts
+            .containing(NSPredicate(format: "label CONTAINS 'uses Link to connect your account'"))
+            .firstMatch
+        XCTAssertTrue(usesLinkText.waitForExistence(timeout: 120.0))  // glitch app can take time to load
+
+        app.fc_secureWebViewCancelButton.tap()
+
+        let playgroundCancelAlert = app.alerts["Cancelled"]
+        XCTAssertTrue(playgroundCancelAlert.waitForExistence(timeout: 10.0))
+    }
 }
 
 extension XCTestCase {

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
@@ -19,7 +19,7 @@ final class FinancialConnectionsUITests: XCTestCase {
         let app = XCUIApplication.fc_launch(
             playgroundConfigurationString:
 """
-{"use_case":"data","sdk_type":"native","test_mode":true,"merchant":"default","payment_method_permission":true}
+{"use_case":"data","experience":"financial_connections","sdk_type":"native","test_mode":true,"merchant":"default","payment_method_permission":true}
 """
         )
 
@@ -47,7 +47,7 @@ final class FinancialConnectionsUITests: XCTestCase {
         let app = XCUIApplication.fc_launch(
             playgroundConfigurationString:
 """
-{"use_case":"payment_intent","sdk_type":"native","test_mode":true,"merchant":"default","payment_method_permission":true}
+{"use_case":"payment_intent","experience":"financial_connections","sdk_type":"native","test_mode":true,"merchant":"default","payment_method_permission":true}
 """
         )
 
@@ -76,7 +76,7 @@ final class FinancialConnectionsUITests: XCTestCase {
         let app = XCUIApplication.fc_launch(
             playgroundConfigurationString:
 """
-{"use_case":"payment_intent","sdk_type":"native","test_mode":true,"merchant":"default","payment_method_permission":true}
+{"use_case":"payment_intent","experience":"financial_connections","sdk_type":"native","test_mode":true,"merchant":"default","payment_method_permission":true}
 """
         )
 
@@ -124,7 +124,7 @@ final class FinancialConnectionsUITests: XCTestCase {
         let app = XCUIApplication.fc_launch(
             playgroundConfigurationString:
 """
-{"use_case":"payment_intent","sdk_type":"native","test_mode":true,"merchant":"default","payment_method_permission":true}
+{"use_case":"payment_intent","experience":"financial_connections","sdk_type":"native","test_mode":true,"merchant":"default","payment_method_permission":true}
 """
         )
 
@@ -153,7 +153,7 @@ final class FinancialConnectionsUITests: XCTestCase {
         let app = XCUIApplication.fc_launch(
             playgroundConfigurationString:
 """
-{"use_case":"data","sdk_type":"native","test_mode":false,"merchant":"default","payment_method_permission":true}
+{"use_case":"data","experience":"financial_connections","sdk_type":"native","test_mode":false,"merchant":"default","payment_method_permission":true}
 """
         )
 
@@ -247,7 +247,7 @@ final class FinancialConnectionsUITests: XCTestCase {
         let app = XCUIApplication.fc_launch(
             playgroundConfigurationString:
 """
-{"use_case":"data","sdk_type":"web","test_mode":false,"merchant":"default","payment_method_permission":true}
+{"use_case":"data","experience":"financial_connections","sdk_type":"web","test_mode":false,"merchant":"default","payment_method_permission":true}
 """
         )
 
@@ -338,7 +338,7 @@ final class FinancialConnectionsUITests: XCTestCase {
         let app = XCUIApplication.fc_launch(
             playgroundConfigurationString:
 """
-{"use_case":"payment_intent","sdk_type":"native","test_mode":false,"merchant":"default","payment_method_permission":true}
+{"use_case":"payment_intent","experience":"financial_connections","sdk_type":"native","test_mode":false,"merchant":"default","payment_method_permission":true}
 """
         )
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/FinancialConnectionsSheet.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/FinancialConnectionsSheet.swift
@@ -143,13 +143,20 @@ final public class FinancialConnectionsSheet {
                     switch completedResult {
                     case .financialConnections(let session):
                         completion(.completed(session: session))
-                    case .instantDebits:
-                        let errorDescription = "Instant Debits is not supported via this interface."
-                        assertionFailure(errorDescription)
+                    case .instantDebits(let linkedBank):
+                        // TODO(mats): Add support for instant debits.
+                        let errorDescription = "Instant Debits is not currently supported via this interface."
+                        let sessionInfo =
+                        """
+                        paymentMethodId=\(linkedBank.paymentMethodId)
+                        bankName=\(linkedBank.bankName ?? "N/A")
+                        last4=\(linkedBank.last4 ?? "N/A")
+                        """
+
                         completion(
                             .failed(
                                 error: FinancialConnectionsSheetError
-                                    .unknown(debugDescription: errorDescription)
+                                    .unknown(debugDescription: "\(errorDescription)\n\n\(sessionInfo)")
                             )
                         )
                     }


### PR DESCRIPTION
## Summary

This adds support for the instant debits experience in the Financial Connections playground app. This currently only exists as a web view, and is not yet officially supported by the SDK.

> [!NOTE]  
> The Instant Debits flow only supports the _Payment Intent_ use case. For convenience, when Instant Debits is selected, we automatically set the use case to `.paymentIntent`.

In order to support this on the [server side](https://glitch.com/edit/#!/financial-connections-playground-ios), we pass in `{ "product": "intant_debits" }` as a parameter to the `/link_account_sessions` API when the experience value is set to `instant_debits`.

## Motivation

This will allow for easily testing the Instant Debits flow.

## Testing

- Ensured the existing Financial Connections flow is unaffected
- Ensured the new Instant Debit flow is launched and works* as expected

*Session output will still display a failure alert. This is expected _for now_.

https://github.com/stripe/stripe-ios/assets/172562065/e0d5e8ca-2b87-4e3e-a42b-93d09e9887fe

## Changelog

N/a
