### PR TITLE
Financial Connections: more improvements to GenericInfoScreen by adding TextBodyEntry

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
+++ b/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
@@ -84,6 +84,8 @@
 		6A1D43072B17AE37005A1EB0 /* RoundedIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1D43062B17AE37005A1EB0 /* RoundedIconView.swift */; };
 		6A1D43092B17CB04005A1EB0 /* InstitutionNoResultsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1D43082B17CB04005A1EB0 /* InstitutionNoResultsView.swift */; };
 		6A26A3AB2B991A4D00215510 /* FeedbackGeneratorAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A26A3AA2B991A4D00215510 /* FeedbackGeneratorAdapter.swift */; };
+		6A3739142C40558900D1F765 /* GenericInfoBodyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A3739132C40558900D1F765 /* GenericInfoBodyView.swift */; };
+		6A3739162C4060BD00D1F765 /* AutoResizableUIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A3739152C4060BD00D1F765 /* AutoResizableUIView.swift */; };
 		6A384A842C24DD720044AB99 /* FinancialConnectionsGenericInfoScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A384A832C24DD720044AB99 /* FinancialConnectionsGenericInfoScreen.swift */; };
 		6A3DA1F52C34A37F005C3F6E /* GenericInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A3DA1F42C34A37F005C3F6E /* GenericInfoViewController.swift */; };
 		6A3DA1F72C34B254005C3F6E /* GenericInfoFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A3DA1F62C34B254005C3F6E /* GenericInfoFooterView.swift */; };
@@ -364,6 +366,8 @@
 		6A1D43062B17AE37005A1EB0 /* RoundedIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedIconView.swift; sourceTree = "<group>"; };
 		6A1D43082B17CB04005A1EB0 /* InstitutionNoResultsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstitutionNoResultsView.swift; sourceTree = "<group>"; };
 		6A26A3AA2B991A4D00215510 /* FeedbackGeneratorAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackGeneratorAdapter.swift; sourceTree = "<group>"; };
+		6A3739132C40558900D1F765 /* GenericInfoBodyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericInfoBodyView.swift; sourceTree = "<group>"; };
+		6A3739152C4060BD00D1F765 /* AutoResizableUIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoResizableUIView.swift; sourceTree = "<group>"; };
 		6A384A832C24DD720044AB99 /* FinancialConnectionsGenericInfoScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsGenericInfoScreen.swift; sourceTree = "<group>"; };
 		6A3DA1F42C34A37F005C3F6E /* GenericInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericInfoViewController.swift; sourceTree = "<group>"; };
 		6A3DA1F62C34B254005C3F6E /* GenericInfoFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericInfoFooterView.swift; sourceTree = "<group>"; };
@@ -773,6 +777,7 @@
 			isa = PBXGroup;
 			children = (
 				6A3DA1F42C34A37F005C3F6E /* GenericInfoViewController.swift */,
+				6A3739132C40558900D1F765 /* GenericInfoBodyView.swift */,
 				6A3DA1F62C34B254005C3F6E /* GenericInfoFooterView.swift */,
 			);
 			path = GenericInfoScreen;
@@ -998,6 +1003,7 @@
 				6A13B9832B48BF4300FFA327 /* AccountPickerRowLabelView.swift */,
 				6A13B9F92B4E182A00FFA327 /* SpinnerView.swift */,
 				6A732C992B61C51C00828CB1 /* ShimmeringView.swift */,
+				6A3739152C4060BD00D1F765 /* AutoResizableUIView.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -1263,6 +1269,7 @@
 				6A732CAA2B69CCDD00828CB1 /* PhoneCountryCodePickerView.swift in Sources */,
 				6A3DA1F52C34A37F005C3F6E /* GenericInfoViewController.swift in Sources */,
 				FBF513C7F73002FA30CC7C21 /* ConsumerSessionModels.swift in Sources */,
+				6A3739142C40558900D1F765 /* GenericInfoBodyView.swift in Sources */,
 				EC74B719F0FA1A977EF4708C /* FinancialConnectionsAccount.swift in Sources */,
 				460C7685096AA6C693309647 /* FinancialConnectionsAuthSession.swift in Sources */,
 				AB5AFAC3C70D6195075DE5AE /* FinancialConnectionsBulletPoint.swift in Sources */,
@@ -1371,6 +1378,7 @@
 				6A13B9842B48BF4300FFA327 /* AccountPickerRowLabelView.swift in Sources */,
 				3AC5CA5F5529B55026342A54 /* NetworkingLinkSignupDataSource.swift in Sources */,
 				6A13B9862B4CD04100FFA327 /* RetrieveAccountsLoadingView.swift in Sources */,
+				6A3739162C4060BD00D1F765 /* AutoResizableUIView.swift in Sources */,
 				8DC6C2A239456994091BF3EE /* NetworkingLinkSignupFooterView.swift in Sources */,
 				6A3DA1F72C34B254005C3F6E /* GenericInfoFooterView.swift in Sources */,
 				54B51EA1F75B9607D7C29B08 /* NetworkingLinkSignupViewController.swift in Sources */,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsGenericInfoScreen.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsGenericInfoScreen.swift
@@ -96,7 +96,7 @@ struct FinancialConnectionsGenericInfoScreen: Decodable {
             let alt: String
         }
 
-        struct BulletsBodyEntry: Decodable {
+        struct BulletsBodyEntry: Decodable { // TODO(kgaidis): implement the bullets body entry as a type
             let id: String
             let bullets: [GenericBulletPoint]
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/FinancialConnectionsFont.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/FinancialConnectionsFont.swift
@@ -51,6 +51,10 @@ struct FinancialConnectionsFont {
     }
 
     enum BodyToken {
+        /// 12 size / 16 line height / 400 weight
+        case extraSmall
+        /// 12 size / 16 line height / 600 weight
+        case extraSmallEmphasized
         /// 14 size / 20 line height / 400 weight
         case small
         /// 14 size / 20 line height / 600 weight
@@ -65,6 +69,14 @@ struct FinancialConnectionsFont {
         let lineHeight: CGFloat
         let appleTextStyle: UIFont.TextStyle
         switch token {
+        case .extraSmall:
+            font = UIFont.systemFont(ofSize: 12, weight: .regular)
+            lineHeight = 16
+            appleTextStyle = .caption1
+        case .extraSmallEmphasized:
+            font = UIFont.systemFont(ofSize: 12, weight: .bold)
+            lineHeight = 16
+            appleTextStyle = .caption1
         case .small:
             font = UIFont.systemFont(ofSize: 14, weight: .regular)
             lineHeight = 20

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerFooterView.swift
@@ -46,7 +46,6 @@ final class AccountPickerFooterView: UIView {
                     isNetworking: false,
                     font: .label(.small),
                     boldFont: .label(.smallEmphasized),
-                    alignCenter: true,
                     didSelectLearnMore: didSelectMerchantDataAccessLearnMore
                 ),
                 linkAccountsButton,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentFooterView.swift
@@ -44,7 +44,7 @@ class ConsentFooterView: HitTestView {
             boldFont: .label(.smallEmphasized),
             linkFont: .label(.small),
             textColor: .textDefault,
-            alignCenter: true
+            alignment: .center
         )
         termsAndPrivacyPolicyLabel.setText(
             aboveCtaText,
@@ -73,7 +73,7 @@ class ConsentFooterView: HitTestView {
                 boldFont: .label(.smallEmphasized),
                 linkFont: .label(.small),
                 textColor: .textDefault,
-                alignCenter: true
+                alignment: .center
             )
             manuallyVerifyLabel.setText(
                 belowCtaText,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentViewController.swift
@@ -33,7 +33,7 @@ class ConsentViewController: UIViewController {
             boldFont: .heading(.extraLarge),
             linkFont: .heading(.extraLarge),
             textColor: .textDefault,
-            alignCenter: true
+            alignment: .center
         )
         titleLabel.setText(
             dataSource.consent.title,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionNoResultsView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionNoResultsView.swift
@@ -50,7 +50,7 @@ final class InstitutionNoResultsView: UIView {
             textColor: .textDefault,
             linkColor: .textActionPrimaryFocused,
             showLinkUnderline: false,
-            alignCenter: true
+            alignment: .center
         )
         subtitleLabel.accessibilityIdentifier = "institution_search_no_results_subtitle"
         if let didSelectManuallyEnterDetails = didSelectManuallyEnterDetails {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerFooterView.swift
@@ -47,7 +47,7 @@ final class LinkAccountPickerFooterView: UIView {
                 boldFont: .label(.smallEmphasized),
                 linkFont: .label(.small),
                 textColor: .textDefault,
-                alignCenter: true
+                alignment: .center
             )
             merchantDataAccessLabel.setText(
                 aboveCta,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/ManualEntry/ManualEntryFormView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/ManualEntry/ManualEntryFormView.swift
@@ -144,7 +144,7 @@ final class ManualEntryFormView: UIView {
                 linkFont: .label(.medium),
                 textColor: .textFeedbackCritical,
                 linkColor: .textFeedbackCritical,
-                alignCenter: true
+                alignment: .center
             )
             errorLabel.setText(text)
             let paddingStackView = UIStackView(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupFooterView.swift
@@ -41,7 +41,7 @@ class NetworkingLinkSignupFooterView: HitTestView {
             boldFont: .label(.smallEmphasized),
             linkFont: .label(.small),
             textColor: .textDefault,
-            alignCenter: true
+            alignment: .center
         )
         termsAndPrivacyPolicyLabel.setText(
             aboveCtaText,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationBodyView.swift
@@ -74,8 +74,7 @@ private func CreateResendCodeLabel(
         boldFont: .label(.mediumEmphasized),
         linkFont: .label(.mediumEmphasized),
         textColor: .textActionPrimary,
-        showLinkUnderline: false,
-        alignment: .center
+        showLinkUnderline: false
     )
     let text = STPLocalizedString(
         "Resend code",

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationBodyView.swift
@@ -75,7 +75,7 @@ private func CreateResendCodeLabel(
         linkFont: .label(.mediumEmphasized),
         textColor: .textActionPrimary,
         showLinkUnderline: false,
-        alignCenter: false
+        alignment: .center
     )
     let text = STPLocalizedString(
         "Resend code",

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/AttributedTextView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/AttributedTextView.swift
@@ -26,7 +26,7 @@ final class AttributedTextView: HitTestView {
     private let boldFont: FinancialConnectionsFont
     private let linkFont: FinancialConnectionsFont
     private let textColor: UIColor
-    private let alignCenter: Bool
+    private let alignment: NSTextAlignment?
     private let textView: IncreasedHitTestTextView
     private var linkURLStringToAction: [String: (URL) -> Void] = [:]
 
@@ -38,7 +38,7 @@ final class AttributedTextView: HitTestView {
         // links are the same color as the text by default
         linkColor: UIColor? = nil,
         showLinkUnderline: Bool = true,
-        alignCenter: Bool = false
+        alignment: NSTextAlignment? = nil
     ) {
         let linkColor = linkColor ?? textColor
         let textContainer = NSTextContainer(size: .zero)
@@ -54,7 +54,7 @@ final class AttributedTextView: HitTestView {
         self.boldFont = boldFont
         self.linkFont = linkFont
         self.textColor = textColor
-        self.alignCenter = alignCenter
+        self.alignment = alignment
         super.init(frame: .zero)
         textView.isScrollEnabled = false
         textView.delaysContentTouches = false
@@ -123,8 +123,8 @@ final class AttributedTextView: HitTestView {
         links: [LinkDescriptor]
     ) {
         let paragraphStyle = NSMutableParagraphStyle()
-        if alignCenter {
-            paragraphStyle.alignment = .center
+        if let alignment {
+            paragraphStyle.alignment = alignment
         }
         paragraphStyle.minimumLineHeight = font.lineHeight
         paragraphStyle.maximumLineHeight = font.lineHeight

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/AutoResizableUIView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/AutoResizableUIView.swift
@@ -1,0 +1,81 @@
+//
+//  AutoResizableUIView.swift
+//  StripeFinancialConnections
+//
+//  Created by Krisjanis Gaidis on 7/11/24.
+//
+
+import Foundation
+import SwiftUI
+import UIKit
+
+//
+// These are only used for SwiftUI previews so no need to expose outside of DEBUG.
+//
+#if DEBUG
+
+/// This helps to auto-resize UIView's placed in SwiftUI. Otherwise,
+/// the UIView's tend to stretch the full height of the screen.
+///
+/// If wrapping the `UIView` with `AutoResizableUIView` doesn't help,
+/// also call `applyAutoResizableUIViewModifier` to your SwiftUI view.
+class AutoResizableUIView<ContentView: UIView>: UIView {
+    var contentView: ContentView
+
+    init(contentView: ContentView) {
+        self.contentView = contentView
+        super.init(frame: .zero)
+        backgroundColor = .clear
+        addSubview(contentView)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private var height: CGFloat = .zero {
+        didSet {
+            invalidateIntrinsicContentSize()
+        }
+    }
+
+    override var intrinsicContentSize: CGSize {
+        CGSize(
+            width: UIView.noIntrinsicMetric,
+            height: height
+        )
+    }
+
+    override var frame: CGRect {
+        didSet {
+            guard frame != oldValue else {
+                return
+            }
+            contentView.frame = bounds
+            contentView.layoutIfNeeded()
+
+            let targetFrameSize = CGSize(
+                width: frame.width,
+                height: UIView.layoutFittingCompressedSize.height
+            )
+            height = contentView.systemLayoutSizeFitting(
+                targetFrameSize,
+                withHorizontalFittingPriority: .required,
+                verticalFittingPriority: .fittingSizeLevel
+            ).height
+        }
+    }
+}
+
+extension View {
+    /// Helper for use with `AutoResizableUIView`. Apply it to the SwitUI view that's
+    /// being created via `UIViewRepresentable`.
+    func applyAutoResizableUIViewModifier() -> some View {
+        fixedSize(
+            horizontal: false,
+            vertical: true
+        )
+    }
+}
+
+#endif

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/GenericInfoScreen/GenericInfoBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/GenericInfoScreen/GenericInfoBodyView.swift
@@ -12,10 +12,10 @@ func GenericInfoBodyView(
     body: FinancialConnectionsGenericInfoScreen.Body?,
     didSelectURL: @escaping (URL) -> Void
 ) -> UIView? {
-    guard  let body, !body.entries.isEmpty else {
+    guard let body, !body.entries.isEmpty else {
         return nil
     }
-    let verticalStackView = UIStackView()
+    let verticalStackView = HitTestStackView()
     verticalStackView.axis = .vertical
     verticalStackView.spacing = 0
     for entry in body.entries {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/GenericInfoScreen/GenericInfoBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/GenericInfoScreen/GenericInfoBodyView.swift
@@ -19,59 +19,73 @@ func GenericInfoBodyView(
     verticalStackView.axis = .vertical
     verticalStackView.spacing = 0
     for entry in body.entries {
+        let entryView: UIView?
         switch entry {
         case .text(let textBodyEntry):
-            let font: FinancialConnectionsFont
-            let boldFont: FinancialConnectionsFont
-            let textColor: UIColor
-            switch textBodyEntry.size {
-            case .xsmall:
-                font = .body(.extraSmall)
-                boldFont = .body(.extraSmallEmphasized)
-                textColor = .textSubdued
-            case .small:
-                font = .body(.small)
-                boldFont = .body(.smallEmphasized)
-                textColor = .textSubdued
-            case .medium: fallthrough
-            case .unparsable: fallthrough
-            case .none:
-                font = .body(.medium)
-                boldFont = .body(.mediumEmphasized)
-                textColor = .textDefault
-            }
-            let textView = AttributedTextView(
-                font: font,
-                boldFont: boldFont,
-                linkFont: font,
-                textColor: textColor,
-                alignment: {
-                    switch textBodyEntry.alignment {
-                    case .left:
-                        return .left
-                    case .center:
-                        return .center
-                    case .right:
-                        return .right
-                    case .unparsable: fallthrough
-                    case .none:
-                        return nil
-                    }
-                }()
+            entryView = TextBodyEntryView(
+                textBodyEntry,
+                didSelectURL: didSelectURL
             )
-            textView.setText(
-                textBodyEntry.text,
-                action: didSelectURL
-            )
-            verticalStackView.addArrangedSubview(textView)
         case .image(let image):
-            print(image)
+            _ = image
+            entryView = nil // TODO(kgaidis): implement ImageBodyEntry support
         case .unparasable:
-            break // skip
+            entryView = nil // skip
+        }
+        if let entryView {
+            verticalStackView.addArrangedSubview(entryView)
         }
     }
     // check `isEmpty` in case we were not able to handle any entry type
     return verticalStackView.arrangedSubviews.isEmpty ? nil : verticalStackView
+}
+
+private func TextBodyEntryView(
+    _ textBodyEntry: FinancialConnectionsGenericInfoScreen.Body.TextBodyEntry,
+    didSelectURL: @escaping (URL) -> Void
+) -> UIView {
+    let font: FinancialConnectionsFont
+    let boldFont: FinancialConnectionsFont
+    let textColor: UIColor
+    switch textBodyEntry.size {
+    case .xsmall:
+        font = .body(.extraSmall)
+        boldFont = .body(.extraSmallEmphasized)
+        textColor = .textSubdued
+    case .small:
+        font = .body(.small)
+        boldFont = .body(.smallEmphasized)
+        textColor = .textSubdued
+    case .medium: fallthrough
+    case .unparsable: fallthrough
+    case .none:
+        font = .body(.medium)
+        boldFont = .body(.mediumEmphasized)
+        textColor = .textDefault
+    }
+    let textView = AttributedTextView(
+        font: font,
+        boldFont: boldFont,
+        linkFont: font,
+        textColor: textColor,
+        alignment: {
+            switch textBodyEntry.alignment {
+            case .center:
+                return .center
+            case .right:
+                return .right
+            case .left: fallthrough
+            case .unparsable: fallthrough
+            case .none:
+                return .left
+            }
+        }()
+    )
+    textView.setText(
+        textBodyEntry.text,
+        action: didSelectURL
+    )
+    return textView
 }
 
 #if DEBUG

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/GenericInfoScreen/GenericInfoBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/GenericInfoScreen/GenericInfoBodyView.swift
@@ -1,0 +1,149 @@
+//
+//  GenericInfoBodyView.swift
+//  StripeFinancialConnections
+//
+//  Created by Krisjanis Gaidis on 7/11/24.
+//
+
+import Foundation
+import UIKit
+
+func GenericInfoBodyView(
+    body: FinancialConnectionsGenericInfoScreen.Body?,
+    didSelectURL: @escaping (URL) -> Void
+) -> UIView? {
+    guard  let body, !body.entries.isEmpty else {
+        return nil
+    }
+    let verticalStackView = UIStackView()
+    verticalStackView.axis = .vertical
+    verticalStackView.spacing = 0
+    for entry in body.entries {
+        switch entry {
+        case .text(let textBodyEntry):
+            let font: FinancialConnectionsFont
+            let boldFont: FinancialConnectionsFont
+            let textColor: UIColor
+            switch textBodyEntry.size {
+            case .xsmall:
+                font = .body(.extraSmall)
+                boldFont = .body(.extraSmallEmphasized)
+                textColor = .textSubdued
+            case .small:
+                font = .body(.small)
+                boldFont = .body(.smallEmphasized)
+                textColor = .textSubdued
+            case .medium: fallthrough
+            case .unparsable: fallthrough
+            case .none:
+                font = .body(.medium)
+                boldFont = .body(.mediumEmphasized)
+                textColor = .textDefault
+            }
+            let textView = AttributedTextView(
+                font: font,
+                boldFont: boldFont,
+                linkFont: font,
+                textColor: textColor,
+                alignment: {
+                    switch textBodyEntry.alignment {
+                    case .left:
+                        return .left
+                    case .center:
+                        return .center
+                    case .right:
+                        return .right
+                    case .unparsable: fallthrough
+                    case .none:
+                        return nil
+                    }
+                }()
+            )
+            textView.setText(
+                textBodyEntry.text,
+                action: didSelectURL
+            )
+            verticalStackView.addArrangedSubview(textView)
+        case .image(let image):
+            print(image)
+        case .unparasable:
+            break // skip
+        }
+    }
+    // check `isEmpty` in case we were not able to handle any entry type
+    return verticalStackView.arrangedSubviews.isEmpty ? nil : verticalStackView
+}
+
+#if DEBUG
+
+import SwiftUI
+
+@available(iOS 14.0, *)
+private struct GenericInfoBodyViewUIViewRepresentable: UIViewRepresentable {
+
+    let body: FinancialConnectionsGenericInfoScreen.Body
+
+    func makeUIView(context: Context) -> UIView {
+        return AutoResizableUIView(
+            contentView: GenericInfoBodyView(
+                body: body,
+                didSelectURL: { _ in }
+            )!
+        )
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {
+        uiView.sizeToFit()
+    }
+}
+
+@available(iOS 14.0, *)
+struct GenericInfoBodyView_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack {
+            GenericInfoBodyViewUIViewRepresentable(
+                body: FinancialConnectionsGenericInfoScreen.Body(
+                    entries: [
+                        .text(
+                            FinancialConnectionsGenericInfoScreen.Body.TextBodyEntry(
+                                id: "",
+                                text: "Text - Alignment(nil) - Size (nil)",
+                                alignment: nil,
+                                size: nil
+                            )
+                        ),
+                        .text(
+                            FinancialConnectionsGenericInfoScreen.Body.TextBodyEntry(
+                                id: "",
+                                text: "Text - Alignment(left) - Size (xsmall)",
+                                alignment: .left,
+                                size: .xsmall
+                            )
+                        ),
+                        .text(
+                            FinancialConnectionsGenericInfoScreen.Body.TextBodyEntry(
+                                id: "",
+                                text: "Text - Alignment(center) - Size (small)",
+                                alignment: .center,
+                                size: .small
+                            )
+                        ),
+                        .text(
+                            FinancialConnectionsGenericInfoScreen.Body.TextBodyEntry(
+                                id: "",
+                                text: "Text - Alignment(right) - Size (medium)",
+                                alignment: .right,
+                                size: .medium
+                            )
+                        ),
+                    ]
+                )
+            )
+            .applyAutoResizableUIViewModifier()
+            .padding()
+            Spacer()
+        }
+    }
+}
+
+#endif

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/GenericInfoScreen/GenericInfoViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/GenericInfoScreen/GenericInfoViewController.swift
@@ -49,6 +49,19 @@ final class GenericInfoViewController: SheetViewController {
                 }(),
                 title: genericInfoScreen.header?.title,
                 subtitle: genericInfoScreen.header?.subtitle,
+                headerAlignment: {
+                    let headerAlignment = genericInfoScreen.header?.alignment
+                    switch headerAlignment {
+                    case .center:
+                        return .center
+                    case .right:
+                        return .trailing
+                    case .left: fallthrough
+                    case .unparsable: fallthrough
+                    case .none:
+                        return .leading
+                    }
+                }(),
                 contentView: nil, // TODO(kgaidis): add support for content view
                 isSheet: (panePresentationStyle == .sheet)
             ),

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/GenericInfoScreen/GenericInfoViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/GenericInfoScreen/GenericInfoViewController.swift
@@ -62,7 +62,10 @@ final class GenericInfoViewController: SheetViewController {
                         return .leading
                     }
                 }(),
-                contentView: nil, // TODO(kgaidis): add support for content view
+                contentView: GenericInfoBodyView(
+                    body: genericInfoScreen.body,
+                    didSelectURL: didSelectURL
+                ),
                 isSheet: (panePresentationStyle == .sheet)
             ),
             footerView: GenericInfoFooterView(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/MerchantDataAccessView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/MerchantDataAccessView.swift
@@ -80,7 +80,7 @@ final class MerchantDataAccessView: HitTestView {
             boldFont: boldFont,
             linkFont: font,
             textColor: .textDefault,
-            alignCenter: alignCenter
+            alignment: .center
         )
         label.setText(
             finalString,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/MerchantDataAccessView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/MerchantDataAccessView.swift
@@ -20,7 +20,6 @@ final class MerchantDataAccessView: HitTestView {
         isNetworking: Bool,
         font: FinancialConnectionsFont,
         boldFont: FinancialConnectionsFont,
-        alignCenter: Bool,
         didSelectLearnMore: @escaping (URL) -> Void
     ) {
         super.init(frame: .zero)
@@ -174,7 +173,6 @@ private struct MerchantDataAccessViewUIViewRepresentable: UIViewRepresentable {
             isNetworking: false,
             font: .body(.small),
             boldFont: .body(.smallEmphasized),
-            alignCenter: Bool.random(),
             didSelectLearnMore: { _ in }
         )
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
@@ -136,7 +136,7 @@ final class NetworkingOTPView: UIView {
                 linkFont: .label(.medium),
                 textColor: .textFeedbackCritical,
                 linkColor: .textFeedbackCritical,
-                alignCenter: true
+                alignment: .center
             )
             errorLabel.setText(errorText)
             let errorView = UIStackView(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/PaneLayoutView/PaneLayoutView+Extensions.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/PaneLayoutView/PaneLayoutView+Extensions.swift
@@ -169,7 +169,7 @@ extension PaneLayoutView {
                 boldFont: .label(.smallEmphasized),
                 linkFont: .label(.small),
                 textColor: .textDefault,
-                alignCenter: true
+                alignment: .center
             )
             topTextLabel.setText(
                 topText,
@@ -221,7 +221,7 @@ extension PaneLayoutView {
                 boldFont: .label(.smallEmphasized),
                 linkFont: .label(.small),
                 textColor: .textDefault,
-                alignCenter: true
+                alignment: .center
             )
             bottomTextLabel.setText(
                 bottomText,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/PaneLayoutView/PaneLayoutView+Extensions.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/PaneLayoutView/PaneLayoutView+Extensions.swift
@@ -17,6 +17,7 @@ extension PaneLayoutView {
         iconView: UIView?,
         title: String?,
         subtitle: String?,
+        headerAlignment: UIStackView.Alignment = .leading,
         contentView: UIView?,
         isSheet: Bool = false
     ) -> UIView {
@@ -27,6 +28,7 @@ extension PaneLayoutView {
             let headerView = createHeaderView(
                 iconView: iconView,
                 title: title,
+                alignment: headerAlignment,
                 isSheet: isSheet
             )
             verticalStackView.addArrangedSubview(headerView)
@@ -45,12 +47,13 @@ extension PaneLayoutView {
     static func createHeaderView(
         iconView: UIView?,
         title: String?,
+        alignment: UIStackView.Alignment = .leading,
         isSheet: Bool = false
     ) -> UIView {
         let headerStackView = HitTestStackView()
         headerStackView.axis = .vertical
         headerStackView.spacing = 16
-        headerStackView.alignment = .leading
+        headerStackView.alignment = alignment
         if let iconView = iconView {
             headerStackView.addArrangedSubview(iconView)
         }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Success/SuccessViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Success/SuccessViewController.swift
@@ -135,7 +135,7 @@ private func CreateBodyView(subtitle: String?) -> UIView {
             boldFont: .body(.mediumEmphasized),
             linkFont: .body(.medium),
             textColor: .textDefault,
-            alignCenter: true
+            alignment: .center
         )
         subtitleLabel.setText(subtitle)
         labelVerticalStackView.addArrangedSubview(subtitleLabel)


### PR DESCRIPTION
## Summary

This PR:
- This PR added support for `TextBodyEntry` server-driven-ux coming for `GenericInfoScreen` model. 

Context:
- Financial Connections is implementing support for "networking manual entry." This feature allows a user to enter their manually entered account _once_, and then we will allow them to reuse it later through Link. 
- This is just one PR of many where each PR will be merged to a feature branch `fc-networkingmanualentry`.
- It's expected that this PR may have some gaps or TODO's because its going to a feature branch. That being said, we still want to make sure there's no glaring logic issues/bugs. 

## Testing

SwiftUI preview:

<img width="587" alt="image" src="https://github.com/user-attachments/assets/0edb482c-4b31-41bd-9542-63e93413af35">

Also made sure the code that gets this model does not crash/is-not-effected (note that it does not utilize the body at all, unfortunately):

<img width="405" alt="image" src="https://github.com/user-attachments/assets/4cee411a-e037-4623-94c2-d628f7527b61">
