### PR TITLE
Financial Connections: more improvements to GenericInfoScreen by adding ImageBodyEntry

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/GenericInfoScreen/GenericInfoBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/GenericInfoScreen/GenericInfoBodyView.swift
@@ -26,9 +26,8 @@ func GenericInfoBodyView(
                 textBodyEntry,
                 didSelectURL: didSelectURL
             )
-        case .image(let image):
-            _ = image
-            entryView = nil // TODO(kgaidis): implement ImageBodyEntry support
+        case .image(let imageBodyEntry):
+            entryView = ImageBodyEntryView(imageBodyEntry)
         case .unparasable:
             entryView = nil // skip
         }
@@ -86,6 +85,45 @@ private func TextBodyEntryView(
         action: didSelectURL
     )
     return textView
+}
+
+private func ImageBodyEntryView(
+    _ imageBodyEntry: FinancialConnectionsGenericInfoScreen.Body.ImageBodyEntry
+) -> UIView? {
+    guard let imageUrlString = imageBodyEntry.image.default else {
+        return nil
+    }
+    let imageView = AutoResizableImageView()
+    imageView.setImage(with: imageUrlString)
+    return imageView
+}
+
+// `UIImageView` that will autoresize itself to be
+// full width, but maintain aspect ratio height
+private class AutoResizableImageView: UIImageView {
+
+    override var intrinsicContentSize: CGSize {
+        if let image, image.size.width > 0 {
+            let height = image.size.height * (bounds.width / image.size.width)
+            return CGSize(
+                width: UIView.noIntrinsicMetric,
+                height: height
+            )
+        } else {
+            return CGSize(
+                width: UIView.noIntrinsicMetric,
+                height: 200 // give some height with assumption that an image will load
+            )
+        }
+    }
+
+    override var image: UIImage? {
+        didSet {
+            invalidateIntrinsicContentSize()
+            setNeedsLayout()
+            layoutIfNeeded()
+        }
+    }
 }
 
 #if DEBUG
@@ -148,6 +186,31 @@ struct GenericInfoBodyView_Previews: PreviewProvider {
                                 text: "Text - Alignment(right) - Size (medium)",
                                 alignment: .right,
                                 size: .medium
+                            )
+                        ),
+                        .text(
+                            FinancialConnectionsGenericInfoScreen.Body.TextBodyEntry(
+                                id: "",
+                                text: "vvv Image Item Expected Below vvv",
+                                alignment: .center,
+                                size: nil
+                            )
+                        ),
+                        .image(
+                            FinancialConnectionsGenericInfoScreen.Body.ImageBodyEntry(
+                                id: "",
+                                image: FinancialConnectionsImage(
+                                    default: "https://b.stripecdn.com/connections-statics-srv/assets/BrandIcon--stripe-4x.png"
+                                ),
+                                alt: ""
+                            )
+                        ),
+                        .text(
+                            FinancialConnectionsGenericInfoScreen.Body.TextBodyEntry(
+                                id: "",
+                                text: "^^^ Image Item Expected Above ^^^",
+                                alignment: .center,
+                                size: nil
                             )
                         ),
                     ]


### PR DESCRIPTION
### ⚠️ this builds on the following PR: https://github.com/stripe/stripe-ios/pull/3767

## Summary

This PR:
- This PR added support for `ImageBodyEntry` server-driven-ux coming for `GenericInfoScreen` model. 

Context:
- Financial Connections is implementing support for "networking manual entry." This feature allows a user to enter their manually entered account _once_, and then we will allow them to reuse it later through Link. 
- This is just one PR of many where each PR will be merged to a feature branch `fc-networkingmanualentry`.
- It's expected that this PR may have some gaps or TODO's because its going to a feature branch. That being said, we still want to make sure there's no glaring logic issues/bugs. 

## Testing

### SwiftUI previews of image working:

<img width="469" alt="image" src="https://github.com/user-attachments/assets/8eb97a90-4002-42f2-90ff-21daa155682e">

this code does not get executed in prod unfortunately