### PR TITLE
Add `theme` to FC Manifest model

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsSessionManifest.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsSessionManifest.swift
@@ -63,44 +63,52 @@ struct FinancialConnectionsSessionManifest: Decodable {
         }
     }
 
+    enum Theme: String, SafeEnumCodable, Equatable {
+        case light = "light"
+        case dashboardLight = "dashboard_light"
+        case linkLight = "link_light"
+        case unparsable
+    }
+
     // MARK: - Properties
 
+    let accountholderCustomerEmailAddress: String?
     let accountholderIsLinkConsumer: Bool?
+    let accountholderPhoneNumber: String?
+    let accountholderToken: String?
+    let accountDisconnectionMethod: AccountDisconnectionMethod?
+    let activeAuthSession: FinancialConnectionsAuthSession?
     let activeInstitution: FinancialConnectionsInstitution?
     let allowManualEntry: Bool
+    let assignmentEventId: String?
     let businessName: String?
+    let cancelUrl: String?
     let consentRequired: Bool
     let customManualEntryHandling: Bool
     let disableLinkMoreAccounts: Bool
+    let displayText: DisplayText?
+    let experimentAssignments: [String: String]?
+    let features: [String: Bool]?
     let hostedAuthUrl: String?
-    let successUrl: String?
-    let cancelUrl: String?
-    let activeAuthSession: FinancialConnectionsAuthSession?
     let initialInstitution: FinancialConnectionsInstitution?
     let instantVerificationDisabled: Bool
     let institutionSearchDisabled: Bool
+    let isEndUserFacing: Bool?
     let isLinkWithStripe: Bool?
     let isNetworkingUserFlow: Bool?
     let isStripeDirect: Bool?
     let livemode: Bool
+    let manualEntryMode: ManualEntryMode
     let manualEntryUsesMicrodeposits: Bool
     let nextPane: NextPane
-    let permissions: [StripeAPI.FinancialConnectionsAccount.Permissions]
-    let singleAccount: Bool
     let paymentMethodType: FinancialConnectionsPaymentMethodType?
-    let accountDisconnectionMethod: AccountDisconnectionMethod?
-    let isEndUserFacing: Bool?
+    let permissions: [StripeAPI.FinancialConnectionsAccount.Permissions]
     let product: String
-    let accountholderToken: String?
-    let features: [String: Bool]?
-    let experimentAssignments: [String: String]?
-    let assignmentEventId: String?
+    let singleAccount: Bool
     let skipSuccessPane: Bool?
-    let manualEntryMode: ManualEntryMode
-    let accountholderCustomerEmailAddress: String?
-    let accountholderPhoneNumber: String?
     let stepUpAuthenticationRequired: Bool?
-    let displayText: DisplayText?
+    let successUrl: String?
+    let theme: Theme?
 
     var shouldAttachLinkedPaymentMethod: Bool {
         return (paymentMethodType != nil)


### PR DESCRIPTION
## Summary

This adds the [theme](https://livegrep.corp.stripe.com/view/stripe-internal/pay-server/lib/bank_connections/auth_session/data/theme.rb#L16) field to our Financial Connections Manifest model. The enum values reflect those on the [server side](https://livegrep.corp.stripe.com/view/stripe-internal/pay-server/lib/bank_connections/auth_session/data/theme.rb#L14-18).

> [!NOTE]  
> Drive-by fix up: Sorts the fields in the manifest model alphabetically.

## Motivation

We will soon be supporting the theme values sent from the server.

## Testing

Manually tested to ensure the new `theme` field is populated, and has the expected value for the Financial Connections product (aka `payment_flows`):

<img width="1192" alt="Screenshot 2024-07-15 at 10 23 01 AM" src="https://github.com/user-attachments/assets/d2a15409-fe83-4a6a-88ce-423fb4447981">

and for Instant Debits:

<img width="1192" alt="Screenshot 2024-07-15 at 10 23 28 AM" src="https://github.com/user-attachments/assets/5f2cb51f-4623-46d6-8650-65c48b3751fa">

## Changelog

N/a
