### PR TITLE
Re-enable refresh for CAP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## x.x.x x-x-x
+### All
+* [Fixed] Improved reliability when paying or setting up with Cash App Pay.
+
 ## 23.28.0 2024-07-08
 
 ### Payments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## x.x.x x-x-x
-### All
+### Payments
 * [Fixed] Improved reliability when paying or setting up with Cash App Pay.
 
 ## 23.28.0 2024-07-08

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -673,10 +673,24 @@ class PaymentSheetStandardLPMUITests: PaymentSheetUITestCase {
         // Attempt payment
         payButton.tap()
 
-        // Close the webview, no need to see the successful pay
+        // Close the webview, to simulate cancel
         let webviewCloseButton = app.otherElements["TopBrowserBar"].buttons["Close"]
         XCTAssertTrue(webviewCloseButton.waitForExistence(timeout: 10.0))
         webviewCloseButton.tap()
+
+        // Tap to attempt a payment, but fail it
+        payButton.waitForExistenceAndTap()
+        let failPaymentText = app.firstDescendant(withLabel: "FAIL TEST PAYMENT")
+        failPaymentText.waitForExistenceAndTap(timeout: 15.0)
+
+        XCTAssertTrue(app.staticTexts["The customer declined this payment."].waitForExistence(timeout: 5.0))
+
+        // Tap to attempt a payment
+        payButton.waitForExistenceAndTap()
+        let approvePaymentText = app.firstDescendant(withLabel: "AUTHORIZE TEST PAYMENT")
+        approvePaymentText.waitForExistenceAndTap(timeout: 15.0)
+
+        XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 15.0))
     }
 
     func testCashAppPaymentMethod_setup() throws {
@@ -703,10 +717,24 @@ class PaymentSheetStandardLPMUITests: PaymentSheetUITestCase {
         // Attempt set up
         setupButton.tap()
 
-        // Close the webview, no need to see the successful set up
+        // Close the webview, to simulate cancel
         let webviewCloseButton = app.otherElements["TopBrowserBar"].buttons["Close"]
         XCTAssertTrue(webviewCloseButton.waitForExistence(timeout: 10.0))
         webviewCloseButton.tap()
+
+        // Tap to attempt a set up, but fail it
+        setupButton.waitForExistenceAndTap()
+        let failSetupText = app.firstDescendant(withLabel: "FAIL TEST SETUP")
+        failSetupText.waitForExistenceAndTap(timeout: 15.0)
+
+        XCTAssertTrue(app.staticTexts["The customer declined this payment."].waitForExistence(timeout: 5.0))
+
+        // Tap to attempt a set up, make it succeed
+        setupButton.waitForExistenceAndTap()
+        let approveSetupText = app.firstDescendant(withLabel: "AUTHORIZE TEST SETUP")
+        approveSetupText.waitForExistenceAndTap(timeout: 15.0)
+
+        XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 15.0))
     }
 
     func testCashAppPaymentMethod_setupFutureUsage() throws {

--- a/Stripe/StripeiOSTests/STPPaymentHandlerRefreshTests.swift
+++ b/Stripe/StripeiOSTests/STPPaymentHandlerRefreshTests.swift
@@ -22,7 +22,7 @@ import XCTest
 class STPPaymentHandlerRefreshTests: XCTestCase {
 
     func testPaymentIntentShouldHitRefreshEndpoint() {
-        let shouldRefresh: [STPPaymentMethodType] = []
+        let shouldRefresh: [STPPaymentMethodType] = [.cashApp]
 
         for paymentMethodType in STPPaymentMethodType.allCases {
             let paymentMethodDict: [AnyHashable: Any] = [
@@ -51,7 +51,7 @@ class STPPaymentHandlerRefreshTests: XCTestCase {
     }
 
     func testSetupIntentShouldHitRefreshEndpoint() {
-        let shouldRefresh: [STPPaymentMethodType] = []
+        let shouldRefresh: [STPPaymentMethodType] = [.cashApp]
 
         for paymentMethodType in STPPaymentMethodType.allCases {
             let paymentMethodDict: [AnyHashable: Any] = [

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodEnums.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodEnums.swift
@@ -286,7 +286,7 @@ extension STPPaymentMethodType {
     var pollingRequirement: PollingRequirement? {
         switch self {
         // Note: Card only requires polling for 3DS2 web-based transactions
-        case .card, .amazonPay, .cashApp:
+        case .card, .amazonPay:
             return PollingRequirement(timeBetweenPollingAttempts: 3)
         case .swish, .twint:
             // We are intentionally polling for Swish and Twint even though they use the redirect trampoline.
@@ -303,9 +303,8 @@ extension STPPaymentMethodType {
         // Payment methods such as CashApp implement app-to-app redirects that bypass the "redirect trampoline" too give a more seamless user experience for app-to-app.
         // However, when returning to the merchant app in this scenario, the intent often isn't updated instantaneously, requiring us to hit the refresh endpoint.
         // Only a small subset of LPMs support refreshing
-        // TODO(porter) Enable refreshing for Cash App when test mode cancel behavior is fixed
         case .cashApp:
-            return false
+            return true
         default:
             return false
         }

--- a/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+Payments.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+Payments.swift
@@ -450,7 +450,7 @@ extension STPAPIClient {
     @_spi(STP) @objc public func refreshPaymentIntent(withClientSecret secret: String,
                                                       completion: @escaping STPPaymentIntentCompletionBlock) {
         let endpoint = "\(paymentIntentEndpoint(from: secret))/refresh"
-        var parameters: [String: Any] = [:]
+        var parameters: [String: Any] = ["expand": ["payment_method"]]
 
         if !publishableKeyIsUserKey {
             parameters["client_secret"] = secret
@@ -761,7 +761,7 @@ extension STPAPIClient {
     @_spi(STP) @objc public func refreshSetupIntent(withClientSecret secret: String,
                                                     completion: @escaping STPSetupIntentCompletionBlock) {
         let endpoint = "\(setupIntentEndpoint(from: secret))/refresh"
-        var parameters: [String: Any] = [:]
+        var parameters: [String: Any] = ["expand": ["payment_method"]]
 
         if !publishableKeyIsUserKey {
             parameters["client_secret"] = secret


### PR DESCRIPTION
## Summary
- Re-enables the refresh endpoint for Cash App Pay
- Disables polling
- Expands the payment method when using the refresh endpoint

## Motivation
https://docs.google.com/document/d/1Wq--3AO9CUEmUBRdktrJil-dgmKuCRTPBNQzgdYjm2o/edit#heading=h.g9hom2g12r6t

## Testing
- Manual in live and test mode
- Updated a few tests

## Changelog
See diff
