### PR TITLE
Make vertical mode set Apple Pay / Link as default, too

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetVerticalUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetVerticalUITest.swift
@@ -28,8 +28,13 @@ class PaymentSheetVerticalUITests: PaymentSheetUITestCase {
         continueButton.tap()
         XCTAssertEqual(paymentMethodButton.label, "Apple Pay, apple_pay")
 
-        // Go back in, select Link
+        // Reload - it should now default to "Apple Pay"
+        reload(app, settings: settings)
+        XCTAssertEqual(paymentMethodButton.label, "Apple Pay, apple_pay")
         paymentMethodButton.tap()
+        XCTAssertTrue(app.buttons["Apple Pay"].isSelected)
+
+        // Select Link - FC paymentOption should change to Link
         app.buttons["Link"].tap()
         continueButton.tap()
         XCTAssertEqual(paymentMethodButton.label, "Link, link")

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
@@ -263,6 +263,7 @@ extension VerticalSavedPaymentMethodsViewController: SavedPaymentMethodRowButton
             .stripeId(paymentMethod.stripeId),
             forCustomer: configuration.customer?.id
         )
+
         // Deselect previous button
         paymentMethodRows.first { $0 != button && $0.isSelected }?.state = .unselected
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
@@ -77,6 +77,7 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
     var isPaymentInFlight: Bool = false
     private var savedPaymentMethods: [STPPaymentMethod]
     let isFlowController: Bool
+    /// Previous customer input - in FlowController's `update` flow, this is the customer input prior to `update`, used so we can restore their state in this VC.
     private var previousPaymentOption: PaymentOption?
     weak var flowControllerDelegate: FlowControllerViewControllerDelegate?
     weak var paymentSheetDelegate: PaymentSheetViewControllerDelegate?
@@ -259,7 +260,7 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
     }
 
     func makePaymentMethodListViewController(selection: VerticalPaymentMethodListSelection?) -> VerticalPaymentMethodListViewController {
-        // Determine the initial selection - either the previous payment option or the last VC's selection
+        // Determine the initial selection - either `selection`, the previous payment option, the last VC's selection, or the customer's default.
         let initialSelection: VerticalPaymentMethodListSelection? = {
             if let selection {
                 return selection
@@ -282,7 +283,7 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
                 }
             case nil:
                 // If there's no previous customer input...
-                if let paymentMethodListViewController, let lastSelection =  paymentMethodListViewController.currentSelection {
+                if let paymentMethodListViewController, let lastSelection = paymentMethodListViewController.currentSelection {
                     // ...use the previous paymentMethodListViewController's selection
                     if case let .saved(paymentMethod: paymentMethod) = lastSelection {
                         // If the previous selection was a saved PM, only use it if it still exists:
@@ -293,8 +294,16 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
                         return lastSelection
                     }
                 }
-                // Default to the first saved payment method, if any
-                return savedPaymentMethods.first.map { .saved(paymentMethod: $0) }
+                // Default to the customer's default or the first saved payment method, if any
+                let customerDefault = CustomerPaymentOption.defaultPaymentMethod(for: configuration.customer?.id)
+                switch customerDefault {
+                case .applePay:
+                    return .applePay
+                case .link:
+                    return .link
+                case .stripeId, nil:
+                    return savedPaymentMethods.first.map { .saved(paymentMethod: $0) }
+                }
             }
         }()
         let savedPaymentMethodAccessoryType = RowButton.RightAccessoryButton.getAccessoryButtonType(
@@ -591,8 +600,12 @@ extension PaymentSheetVerticalViewController: VerticalPaymentMethodListViewContr
         UISelectionFeedbackGenerator().selectionChanged()
 #endif
         switch selection {
-        case .applePay, .link, .saved:
-            break
+        case .applePay:
+            CustomerPaymentOption.setDefaultPaymentMethod(.applePay, forCustomer: configuration.customer?.id)
+        case .link:
+            CustomerPaymentOption.setDefaultPaymentMethod(.link, forCustomer: configuration.customer?.id)
+        case .saved(let paymentMethod):
+            CustomerPaymentOption.setDefaultPaymentMethod(.stripeId(paymentMethod.stripeId), forCustomer: configuration.customer?.id)
         case let .new(paymentMethodType: paymentMethodType):
             let pmFormVC = makeFormVC(paymentMethodType: paymentMethodType)
             if pmFormVC.form.collectsUserInput {


### PR DESCRIPTION
## Motivation
> Paying with apple pay in flow controller doesn’t set it to my default
https://docs.google.com/document/d/11zF9QsvAxEumsDSGP6AY7Mpo6Q6Gj0VIQoDx5VYcPdk/edit?pli=1

## Testing
Added to FC UI test

## Changelog
Not user facing