### PR TITLE
[FC] Show native instant debits flow from the example app

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/FlowRouter.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/FlowRouter.swift
@@ -44,6 +44,10 @@ class FlowRouter {
 
     var flow: Flow {
         if synchronizePayload.manifest.isProductInstantDebits {
+            if ProcessInfo.processInfo.environment["UITesting"] != nil {
+                // Show web instant debits flow while UITesting for now.
+                return .webInstantDebits
+            }
             return exampleAppSdkOverride.shouldUseNativeFlow ? .nativeInstantDebits : .webInstantDebits
         } else {
             logExposureIfNeeded()

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/FlowRouter.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/FlowRouter.swift
@@ -34,8 +34,8 @@ class FlowRouter {
 
     var flow: Flow {
         guard synchronizePayload.manifest.isProductInstantDebits == false else {
-            // We currently only support Instant Debits via a web flow.
-            return .webInstantDebits
+            // Only show Native Instant Debits from the example app, when native is selected.
+            return exampleAppNativeOverrideEnabled ? .nativeInstantDebits : .webInstantDebits
         }
 
         logExposureIfNeeded()
@@ -54,12 +54,18 @@ class FlowRouter {
 
     // MARK: - Private
 
-    private var shouldUseNative: Bool {
-        if let isNativeEnabled = UserDefaults.standard.value(
+    private var exampleAppNativeOverrideEnabled: Bool {
+        if let nativeOverride = UserDefaults.standard.value(
             forKey: "FINANCIAL_CONNECTIONS_EXAMPLE_APP_ENABLE_NATIVE"
         ) as? Bool {
-            return isNativeEnabled
+            return nativeOverride
         }
+        return false
+    }
+
+    private var shouldUseNative: Bool {
+        // Override all other conditions if the example app has native selected.
+        if exampleAppNativeOverrideEnabled { return true }
 
         // if this version is killswitched by server, fallback to webview.
         if killswitchActive { return false }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostController.swift
@@ -116,14 +116,9 @@ extension HostController: HostViewControllerDelegate {
         )
 
         switch flow {
-        case .webInstantDebits:
+        case .webInstantDebits, .webFinancialConnections:
             continueWithWebFlow(synchronizePayload.manifest)
-        case .nativeInstantDebits:
-            // Not currently supported.
-            break
-        case .webFinancialConnections:
-            continueWithWebFlow(synchronizePayload.manifest)
-        case .nativeFinancialConnections:
+        case .nativeInstantDebits, .nativeFinancialConnections:
             continueWithNativeFlow(synchronizePayload)
         }
     }


### PR DESCRIPTION
## Summary

Shows the (still WIP and very buggy) native instant debits flow if and only if launched from the FC example app, and the `Native` SDK type is selected. 

## Motivation

This will let us test the flow while we build it, without exposing it to users.

## Testing

Ensured the Native flow is only shown when the `Native` SDK is selected from the example app:

https://github.com/user-attachments/assets/c0f91f71-d8e2-45fb-8091-5fe8a02b5503

## Changelog

N/a
