### PR TITLE
Financial Connections: for server driven UX, implemented GenericInfoBodyView bullets

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsGenericInfoScreen.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsGenericInfoScreen.swift
@@ -36,6 +36,7 @@ struct FinancialConnectionsGenericInfoScreen: Decodable {
         enum BodyEntry: Decodable {
             case text(TextBodyEntry)
             case image(ImageBodyEntry)
+            case bullets(BulletsBodyEntry)
             case unparasable
 
             public init(from decoder: Decoder) throws {
@@ -48,6 +49,8 @@ struct FinancialConnectionsGenericInfoScreen: Decodable {
                     self = .text(value)
                 } else if type == .image, let value = try? container.decode(ImageBodyEntry.self) {
                     self = .image(value)
+                } else if type == .bullets, let value = try? container.decode(BulletsBodyEntry.self) {
+                    self = .bullets(value)
                 } else {
                     self = .unparasable
                 }
@@ -60,6 +63,7 @@ struct FinancialConnectionsGenericInfoScreen: Decodable {
                 enum BodyEntryType: String, Codable {
                     case text = "text"
                     case image = "image"
+                    case bullets = "bullets"
                 }
 
                 enum CodingKeys: String, CodingKey {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/GenericInfoScreen/GenericInfoBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/GenericInfoScreen/GenericInfoBodyView.swift
@@ -28,6 +28,11 @@ func GenericInfoBodyView(
             )
         case .image(let imageBodyEntry):
             entryView = ImageBodyEntryView(imageBodyEntry)
+        case .bullets(let bulletsBodyEntry):
+            entryView = BulletsBodyEntryView(
+                bulletsBodyEntry,
+                didSelectURL: didSelectURL
+            )
         case .unparasable:
             entryView = nil // skip
         }
@@ -38,6 +43,8 @@ func GenericInfoBodyView(
     // check `isEmpty` in case we were not able to handle any entry type
     return verticalStackView.arrangedSubviews.isEmpty ? nil : verticalStackView
 }
+
+// MARK: - Text
 
 private func TextBodyEntryView(
     _ textBodyEntry: FinancialConnectionsGenericInfoScreen.Body.TextBodyEntry,
@@ -87,6 +94,8 @@ private func TextBodyEntryView(
     return textView
 }
 
+// MARK: - Image
+
 private func ImageBodyEntryView(
     _ imageBodyEntry: FinancialConnectionsGenericInfoScreen.Body.ImageBodyEntry
 ) -> UIView? {
@@ -125,6 +134,81 @@ private class AutoResizableImageView: UIImageView {
         }
     }
 }
+
+// MARK: - Bullets
+
+private func BulletsBodyEntryView(
+    _ bulletsBodyEntry: FinancialConnectionsGenericInfoScreen.Body.BulletsBodyEntry,
+    didSelectURL: @escaping (URL) -> Void
+) -> UIView? {
+    guard !bulletsBodyEntry.bullets.isEmpty else {
+        return nil
+    }
+    let verticalStackView = HitTestStackView()
+    verticalStackView.axis = .vertical
+    verticalStackView.spacing = 16
+    bulletsBodyEntry.bullets.forEach { genericBulletPoint in
+        verticalStackView.addArrangedSubview(
+            SingleBulletPointView(
+                title: genericBulletPoint.title,
+                content: genericBulletPoint.content,
+                iconUrlString: genericBulletPoint.icon?.default,
+                didSelectUrl: didSelectURL
+            )
+        )
+    }
+    return verticalStackView
+}
+
+private func SingleBulletPointView(
+    title: String?,
+    content: String?,
+    iconUrlString: String?,
+    didSelectUrl: @escaping (URL) -> Void
+) -> UIView {
+    let horizontalStackView = HitTestStackView()
+    let labelView = BulletPointLabelView(
+        title: title,
+        content: content,
+        didSelectURL: didSelectUrl
+    )
+    if let iconUrlString {
+        horizontalStackView.addArrangedSubview(
+            {
+                let imageView = UIImageView()
+                imageView.contentMode = .scaleAspectFit
+                imageView.setImage(with: iconUrlString)
+                imageView.translatesAutoresizingMaskIntoConstraints = false
+                let imageDiameter: CGFloat = 20
+                NSLayoutConstraint.activate([
+                    imageView.widthAnchor.constraint(equalToConstant: imageDiameter),
+                    imageView.heightAnchor.constraint(equalToConstant: imageDiameter),
+                ])
+                // add padding to the `imageView` so the
+                // image is aligned with the label
+                let paddingStackView = UIStackView(
+                    arrangedSubviews: [imageView]
+                )
+                paddingStackView.isLayoutMarginsRelativeArrangement = true
+                paddingStackView.directionalLayoutMargins = NSDirectionalEdgeInsets(
+                    // center the image in the middle of the first line height
+                    top: max(0, (labelView.topLineHeight - imageDiameter) / 2),
+                    leading: 0,
+                    bottom: 0,
+                    trailing: 0
+                )
+                return paddingStackView
+            }()
+        )
+    }
+    horizontalStackView.addArrangedSubview(labelView)
+    horizontalStackView.axis = .horizontal
+    horizontalStackView.spacing = 16
+    horizontalStackView.alignment = .top
+    return horizontalStackView
+}
+
+// MARK: - SwiftUI Preview
 
 #if DEBUG
 
@@ -211,6 +295,35 @@ struct GenericInfoBodyView_Previews: PreviewProvider {
                                 text: "^^^ Image Item Expected Above ^^^",
                                 alignment: .center,
                                 size: nil
+                            )
+                        ),
+                        .bullets(
+                            FinancialConnectionsGenericInfoScreen.Body.BulletsBodyEntry(
+                                id: "",
+                                bullets: [
+                                    .init(
+                                        id: "",
+                                        icon: FinancialConnectionsImage(
+                                            default: "https://b.stripecdn.com/connections-statics-srv/assets/SailIcon--lock-primary-3x.png"
+                                        ),
+                                        title: "Bullet Title",
+                                        content: "Bullet Content"
+                                    ),
+                                    .init(
+                                        id: "String",
+                                        icon: nil,
+                                        title: "Bullet Title",
+                                        content: nil
+                                    ),
+                                    .init(
+                                        id: "",
+                                        icon: FinancialConnectionsImage(
+                                            default: "https://b.stripecdn.com/connections-statics-srv/assets/SailIcon--lock-primary-3x.png"
+                                        ),
+                                        title: nil,
+                                        content: "Stripe will allow Goldilocks to access only the [data requested](https://www.stripe.com). We never share your login details with them."
+                                    ),
+                                ]
                             )
                         ),
                     ]


### PR DESCRIPTION
## Summary

This PR:
- This PR added support for `BulletsBodyEntry` server-driven-ux coming for `GenericInfoScreen` model. 

Context:
- Financial Connections is implementing support for "networking manual entry." This feature allows a user to enter their manually entered account _once_, and then we will allow them to reuse it later through Link. 
- This is just one PR of many where each PR will be merged to a feature branch `fc-networkingmanualentry`.
- It's expected that this PR may have some gaps or TODO's because its going to a feature branch. That being said, we still want to make sure there's no glaring logic issues/bugs. 

## Testing

### SwiftUI Preview (at the bottom are bullets)

this code does not get executed in prod unfortunately

<img width="397" alt="image" src="https://github.com/user-attachments/assets/bdcd7183-0291-43df-b796-e98ae94c695a">
