### PR TITLE
BottomSheetViewController no longer removes child VC when new content is pushed on top of it

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/BottomSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/BottomSheetViewController.swift
@@ -67,6 +67,10 @@ class BottomSheetViewController: UIViewController, BottomSheetPresentable {
 
         let popped = contentStack.remove(at: 0)
         contentViewController = toVC
+        // If you are implementing your own container view controller, it must call the willMove(toParent:) method of the child view controller before calling the removeFromParent() method, passing in a parent value of nil.
+        // The removeFromParent() method automatically calls the didMove(toParent:) method of the child view controller after it removes the child.
+        popped.willMove(toParent: nil)
+        popped.removeFromParent()
         return popped
     }
 
@@ -96,12 +100,15 @@ class BottomSheetViewController: UIViewController, BottomSheetPresentable {
             contentContainerView.addSubview(oldViewImage)
 
             // Remove the old VC
+            oldContentViewController.beginAppearanceTransition(false, animated: true)
             oldContentViewController.view.removeFromSuperview()
-            oldContentViewController.removeFromParent()
+            oldContentViewController.endAppearanceTransition()
 
             // Add the new VC
+            // When your custom container calls the addChild(_:) method, it automatically calls the willMove(toParent:) method of the view controller to be added as a child before adding it.
             addChild(contentViewController)
             contentContainerView.addArrangedSubview(self.contentViewController.view)
+            // If you are implementing your own container view controller, it must call the didMove(toParent:) method of the child view controller after the transition to the new controller is complete or, if there is no transition, immediately after calling the addChild(_:) method.
             contentViewController.didMove(toParent: self)
             if let presentationController = rootParent.presentationController
                 as? BottomSheetPresentationController


### PR DESCRIPTION
## Summary
BottomSheetVC used to remove child VCs that had new content "pushed" on top of it. That's not how `push`/`pop` works  and it means you can't do stuff like

```
let bottomSheetVC = BottomSheetViewController(content: baseContent)
bottomSheetVC.push(newContent)

baseContent.dismiss(animated: true)
// ^ This line does nothing, baseContent has no parent. BottomSheetVC has one child.
// In contrast, if you push using a regular UINavigationController, it would have two children and baseContent would have a parent.
```

Concretely, this fixes a bug where tapping outside the 'saved pms screen' in vertical mode would not dismiss, because FlowController asks the main vertical VC to dismiss but the main vertical VC has no parent anymore.


## Testing
I put prints in all the view appearance APIs for both the main VC and the pushed VC and made sure they were called correctly.

Manually tested edit card flow and vertical, the two users of pushContentViewController. 

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
