### PR TITLE
Pass through stripeAccount when presenting PayWithLinkWebController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## x.x.x x-x-x
 ### Payments
 * [Fixed] Improved reliability when paying or setting up with Cash App Pay.
+* [Fixed] Passing stripeAccount context when presenting PayWithLinkWebController for connected accounts
 
 ## 23.28.0 2024-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## x.x.x x-x-x
 ### Payments
 * [Fixed] Improved reliability when paying or setting up with Cash App Pay.
-* [Fixed] Passing stripeAccount context when presenting PayWithLinkWebController for connected accounts
+* [Fixed] Pass stripeAccount context when presenting PayWithLinkWebController for connected accounts
 
 ## 23.28.0 2024-07-08
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Utils/LinkURLGenerator.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Utils/LinkURLGenerator.swift
@@ -85,6 +85,7 @@ class LinkURLGenerator {
 
         return LinkURLParams(paymentObject: paymentObjectType,
                              publishableKey: publishableKey,
+                             stripeAccount: configuration.apiClient.stripeAccount,
                              paymentUserAgent: PaymentsSDKVariant.paymentUserAgent,
                              merchantInfo: merchantInfo,
                              customerInfo: customerInfo,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkURLGeneratorTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkURLGeneratorTests.swift
@@ -17,6 +17,7 @@ import XCTest
 class LinkURLGeneratorTests: XCTestCase {
     let testParams = LinkURLParams(paymentObject: .link_payment_method,
                                    publishableKey: "pk_test_123",
+                                   stripeAccount: "acct_1234",
                                    paymentUserAgent: "test",
                                    merchantInfo: LinkURLParams.MerchantInfo(businessName: "Test test", country: "US"),
                                    customerInfo: LinkURLParams.CustomerInfo(country: "US", email: "test@example.com"),
@@ -31,7 +32,7 @@ class LinkURLGeneratorTests: XCTestCase {
 
     func testURLCreation() {
         let url = try! LinkURLGenerator.url(params: testParams)
-        XCTAssertEqual(url.absoluteString, "https://checkout.link.com/#eyJjdXN0b21lckluZm8iOnsiY291bnRyeSI6IlVTIiwiZW1haWwiOiJ0ZXN0QGV4YW1wbGUuY29tIn0sImV4cGVyaW1lbnRzIjp7fSwiZmxhZ3MiOnt9LCJpbnRlZ3JhdGlvblR5cGUiOiJtb2JpbGUiLCJpbnRlbnRNb2RlIjoicGF5bWVudCIsImxvY2FsZSI6ImVuLVVTIiwibG9nZ2VyTWV0YWRhdGEiOnt9LCJtZXJjaGFudEluZm8iOnsiYnVzaW5lc3NOYW1lIjoiVGVzdCB0ZXN0IiwiY291bnRyeSI6IlVTIn0sInBhdGgiOiJtb2JpbGVfcGF5IiwicGF5bWVudEluZm8iOnsiYW1vdW50IjoxMDAsImN1cnJlbmN5IjoiVVNEIn0sInBheW1lbnRPYmplY3QiOiJsaW5rX3BheW1lbnRfbWV0aG9kIiwicGF5bWVudFVzZXJBZ2VudCI6InRlc3QiLCJwdWJsaXNoYWJsZUtleSI6InBrX3Rlc3RfMTIzIiwic2V0dXBGdXR1cmVVc2FnZSI6ZmFsc2V9")
+        XCTAssertEqual(url.absoluteString, "https://checkout.link.com/#eyJjdXN0b21lckluZm8iOnsiY291bnRyeSI6IlVTIiwiZW1haWwiOiJ0ZXN0QGV4YW1wbGUuY29tIn0sImV4cGVyaW1lbnRzIjp7fSwiZmxhZ3MiOnt9LCJpbnRlZ3JhdGlvblR5cGUiOiJtb2JpbGUiLCJpbnRlbnRNb2RlIjoicGF5bWVudCIsImxvY2FsZSI6ImVuLVVTIiwibG9nZ2VyTWV0YWRhdGEiOnt9LCJtZXJjaGFudEluZm8iOnsiYnVzaW5lc3NOYW1lIjoiVGVzdCB0ZXN0IiwiY291bnRyeSI6IlVTIn0sInBhdGgiOiJtb2JpbGVfcGF5IiwicGF5bWVudEluZm8iOnsiYW1vdW50IjoxMDAsImN1cnJlbmN5IjoiVVNEIn0sInBheW1lbnRPYmplY3QiOiJsaW5rX3BheW1lbnRfbWV0aG9kIiwicGF5bWVudFVzZXJBZ2VudCI6InRlc3QiLCJwdWJsaXNoYWJsZUtleSI6InBrX3Rlc3RfMTIzIiwic2V0dXBGdXR1cmVVc2FnZSI6ZmFsc2UsInN0cmlwZUFjY291bnQiOiJhY2N0XzEyMzQifQ==")
     }
 
     func testURLCreationRegularUnicode() {


### PR DESCRIPTION
## Summary
Passes through stripeAccount parameter when presenting the PayWithLinkWebController

## Motivation
Connected accounts support w/ payment

## Testing
updated unit test

## Changelog
Updated