### PR TITLE
[FC] Remove `accountholder_token` requirement for experiments

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsAnalyticsClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsAnalyticsClient.swift
@@ -68,7 +68,7 @@ final class FinancialConnectionsAnalyticsClient {
     public func logExposure(
         experimentName: String,
         assignmentEventId: String,
-        accountholderToken: String
+        accountholderToken: String?
     ) {
         var parameters = additionalParameters
         parameters["experiment_retrieved"] = experimentName

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/ExperimentHelper.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/ExperimentHelper.swift
@@ -16,7 +16,7 @@ final class ExperimentHelper {
     private var didLogExposure = false
 
     private var isExperimentValid: Bool {
-        return experimentVariant != nil && manifest.assignmentEventId != nil && manifest.accountholderToken != nil
+        return experimentVariant != nil && manifest.assignmentEventId != nil
     }
     private var experimentVariant: String? {
         return manifest.experimentAssignments?[experimentName]
@@ -52,17 +52,13 @@ final class ExperimentHelper {
             assertionFailure("`isExperimentValid` should ensure `assignmentEventId` is non-null")
             return
         }
-        guard let accountholderToken = manifest.accountholderToken else {
-            assertionFailure("`isExperimentValid` should ensure `accountholderToken` is non-null")
-            return
-        }
 
         if !didLogExposure {
             didLogExposure = true
             analyticsClient.logExposure(
                 experimentName: experimentName,
                 assignmentEventId: assignmentEventId,
-                accountholderToken: accountholderToken
+                accountholderToken: manifest.accountholderToken
             )
         }
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/FlowRouter.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/FlowRouter.swift
@@ -44,6 +44,10 @@ class FlowRouter {
 
     var flow: Flow {
         if synchronizePayload.manifest.isProductInstantDebits {
+            if ProcessInfo.processInfo.environment["UITesting"] != nil {
+                // Show web instant debits flow while UITesting for now.
+                return .webInstantDebits
+            }
             return exampleAppSdkOverride.shouldUseNativeFlow ? .nativeInstantDebits : .webInstantDebits
         } else {
             logExposureIfNeeded()

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/FlowRouter.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/FlowRouter.swift
@@ -34,8 +34,8 @@ class FlowRouter {
 
     var flow: Flow {
         guard synchronizePayload.manifest.isProductInstantDebits == false else {
-            // We currently only support Instant Debits via a web flow.
-            return .webInstantDebits
+            // Only show Native Instant Debits from the example app, when native is selected.
+            return exampleAppNativeOverrideEnabled ? .nativeInstantDebits : .webInstantDebits
         }
 
         logExposureIfNeeded()
@@ -54,12 +54,18 @@ class FlowRouter {
 
     // MARK: - Private
 
-    private var shouldUseNative: Bool {
-        if let isNativeEnabled = UserDefaults.standard.value(
+    private var exampleAppNativeOverrideEnabled: Bool {
+        if let nativeOverride = UserDefaults.standard.value(
             forKey: "FINANCIAL_CONNECTIONS_EXAMPLE_APP_ENABLE_NATIVE"
         ) as? Bool {
-            return isNativeEnabled
+            return nativeOverride
         }
+        return false
+    }
+
+    private var shouldUseNative: Bool {
+        // Override all other conditions if the example app has native selected.
+        if exampleAppNativeOverrideEnabled { return true }
 
         // if this version is killswitched by server, fallback to webview.
         if killswitchActive { return false }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostController.swift
@@ -116,14 +116,9 @@ extension HostController: HostViewControllerDelegate {
         )
 
         switch flow {
-        case .webInstantDebits:
+        case .webInstantDebits, .webFinancialConnections:
             continueWithWebFlow(synchronizePayload.manifest)
-        case .nativeInstantDebits:
-            // Not currently supported.
-            break
-        case .webFinancialConnections:
-            continueWithWebFlow(synchronizePayload.manifest)
-        case .nativeFinancialConnections:
+        case .nativeInstantDebits, .nativeFinancialConnections:
             continueWithNativeFlow(synchronizePayload)
         }
     }


### PR DESCRIPTION
## Summary

This removes the requirement for a non-null `accountholder_token` in order to consider an experiment valid. The reason for doing this is a little long-winded:

----

I came across an issue when launching the native instant debits flow where the merchant logos were not being shown on the consent pane. The manifest we get back from the synchronize call comes back with 2 merchant logos (as expected), however they are being filtered out on the client [here](https://github.com/stripe/stripe-ios/blob/95637c6972af71151c97befcf9223d2255ee6008/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowDataManager.swift#L75). What's happening here is that the `consentCombinedLogoExperiment.isEnabled(logExposure: true)` condition is returning false even though the `connections_consent_combined_logo` experiment assignment in the manifest is `treatment`. The boiled-down manifest essentially looks like this:

```json
{
  "accountholder_token": null,
  "experiment_assignments": {
    "connections_consent_combined_logo": "treatment"
  },
  "merchant_logo": [
    "https://b.stripecdn.com/connections-statics-srv/assets/SailIcon--business-primary-4x.png",
    "https://b.stripecdn.com/connections-statics-srv/assets/BrandIcon--link2024-4x.png"
  ]
}
```

So because of that missing `accountholder_token` we're not showing the merchant logos ([source](https://github.com/stripe/stripe-ios/blob/98660acbb66e1d1cf290a6ff89dc68e1fd4bfd38/StripeFinancialConnections/StripeFinancialConnections/Source/Common/ExperimentHelper.swift#L19)). I'm thinking we could either:
1. Override the `consentCombinedLogoExperiment.isEnabled` condition for the native instant debits flow.
2. No longer require the `accountholder_token` be non-null to consider an experiment as enabled.

----

So - here's a PR for option 2!

## Motivation

An `accountholder_token` is not provided in the `synchronize` call for the instant debits flow. This allows us to continue to consider experiments as valid for that flow.

## Testing

| Before | After |
|--------|--------|
| ![Simulator Screenshot - iPhone 12 mini - 2024-07-17 at 11 25 21](https://github.com/user-attachments/assets/13142eed-4a62-483d-a585-ccdb9b83f418) | ![Simulator Screenshot - iPhone 12 mini - 2024-07-17 at 11 25 06](https://github.com/user-attachments/assets/096378c8-1343-478f-ac62-ccfa727ee1b5) | 

## Changelog

N/a
