### PR TITLE
[FC] Remove animated dots on consent pane for Instant Debits

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentLogoView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentLogoView.swift
@@ -31,9 +31,6 @@ final class ConsentLogoView: UIView {
 
                 let isLastLogo = (i == merchantLogo.count - 1)
                 if !isLastLogo, showsAnimatedDots {
-                    // spacing between logos + ellipsis view
-                    horizontalStackView.spacing = 0
-
                     let ellipsisViewTuple = CreateEllipsisView(
                         leftLogoUrl:
                             merchantLogo[i],

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentLogoView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentLogoView.swift
@@ -16,12 +16,10 @@ final class ConsentLogoView: UIView {
 
     private var multipleDotView: UIView?
 
-    init(merchantLogo: [String]) {
+    init(merchantLogo: [String], showsAnimatedDots: Bool) {
         super.init(frame: .zero)
         let horizontalStackView = UIStackView()
         horizontalStackView.axis = .horizontal
-        // spacing between logos + ellipsis view
-        horizontalStackView.spacing = 0
         horizontalStackView.alignment = .center
 
         if merchantLogo.count == 2 || merchantLogo.count == 3 {
@@ -32,7 +30,10 @@ final class ConsentLogoView: UIView {
                 )
 
                 let isLastLogo = (i == merchantLogo.count - 1)
-                if !isLastLogo {
+                if !isLastLogo, showsAnimatedDots {
+                    // spacing between logos + ellipsis view
+                    horizontalStackView.spacing = 0
+
                     let ellipsisViewTuple = CreateEllipsisView(
                         leftLogoUrl:
                             merchantLogo[i],
@@ -46,6 +47,11 @@ final class ConsentLogoView: UIView {
                 }
             }
         }
+
+        if !showsAnimatedDots {
+            horizontalStackView.spacing = 16
+        }
+
         addAndPinSubview(
             CreateCenteringView(
                 centeredView: horizontalStackView
@@ -344,12 +350,15 @@ import SwiftUI
 
 private struct ConsentLogoViewUIViewRepresentable: UIViewRepresentable {
 
+    var showsAnimatedDots: Bool
+
     func makeUIView(context: Context) -> ConsentLogoView {
         ConsentLogoView(
             merchantLogo: [
                 "https://stripe-camo.global.ssl.fastly.net/a2f7a55341b7cdb849d5b2d68a465f95cc06ee6ec2449ea468b3623a61c17393/68747470733a2f2f66696c65732e7374726970652e636f6d2f6c696e6b732f4d44423859574e6a64463878546d5978575664445356553457474a6f52326c5966475a7358327870646d56664d58526f617a5a526454523354573144566a4a4e57584659526d6c3161464646303077384f5a645a3166",
                 "https://b.stripecdn.com/connections-statics-srv/assets/BrandIcon--stripe-4x.png",
-            ]
+            ],
+            showsAnimatedDots: showsAnimatedDots
         )
     }
 
@@ -359,8 +368,9 @@ private struct ConsentLogoViewUIViewRepresentable: UIViewRepresentable {
 struct ConsentLogoView_Previews: PreviewProvider {
     static var previews: some View {
         VStack(alignment: .center) {
-            ConsentLogoViewUIViewRepresentable()
+            ConsentLogoViewUIViewRepresentable(showsAnimatedDots: true)
             Spacer()
+            ConsentLogoViewUIViewRepresentable(showsAnimatedDots: false)
         }
         .padding()
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentViewController.swift
@@ -84,7 +84,11 @@ class ConsentViewController: UIViewController {
                     trailing: 24
                 )
                 if let merchantLogo = dataSource.merchantLogo {
-                    let consentLogoView = ConsentLogoView(merchantLogo: merchantLogo)
+                    let showsAnimatedDots = dataSource.manifest.isLinkWithStripe != true
+                    let consentLogoView = ConsentLogoView(
+                        merchantLogo: merchantLogo,
+                        showsAnimatedDots: showsAnimatedDots
+                    )
                     self.consentLogoView = consentLogoView
                     verticalStackView.addArrangedSubview(consentLogoView)
                 }


### PR DESCRIPTION
## Summary

Per the Instant Debits flow specs, we're removing the animated dots between the merchant logos in the consent pane. It should only be removed for instant debits, and not financial connections.

This also reduces the spacing between the logos to 16px for the instant debits flow. [Stripe.js source](https://git.corp.stripe.com/stripe-internal/stripe-js-v3/blob/9d39b4299f487b2c573b9fb661d24721a3790c21/src/linkedAccounts/inner/components/panes/v3/ConsentPane/content/ConsentPaneLogos/index.tsx#L23-L25)

## Motivation

Consistency with web and android!

## Testing

| Financial Connections | Instant Debits |
|--------|--------|
| <img src="https://github.com/user-attachments/assets/678d6617-f92a-4480-ae15-d8c30c271094"> | <img src="https://github.com/user-attachments/assets/72f3e5c6-8e74-4341-866c-f0a59e8c3145"> | 

## Changelog

N/a
