### PR TITLE
Remove `connections_consent_combined_logo` experiment check

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowDataManager.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowDataManager.swift
@@ -38,13 +38,6 @@ protocol NativeFlowDataManager: AnyObject {
 
 class NativeFlowAPIDataManager: NativeFlowDataManager {
 
-    private lazy var consentCombinedLogoExperiment: ExperimentHelper = {
-        return ExperimentHelper(
-            experimentName: "connections_consent_combined_logo",
-            manifest: manifest,
-            analyticsClient: analyticsClient
-        )
-    }()
     var manifest: FinancialConnectionsSessionManifest {
         didSet {
             didUpdateManifest()
@@ -57,21 +50,16 @@ class NativeFlowAPIDataManager: NativeFlowDataManager {
         return visualUpdate.reducedBranding
     }
     var merchantLogo: [String]? {
-        if consentCombinedLogoExperiment.isEnabled(logExposure: true) {
-            let merchantLogo = visualUpdate.merchantLogo
-            if merchantLogo.isEmpty || merchantLogo.count == 2 || merchantLogo.count == 3 {
-                // show merchant logo inside of consent pane
-                return visualUpdate.merchantLogo
-            } else {
-                // if `merchantLogo.count > 3`, that is an invalid case
-                //
-                // we want to log experiment exposure regardless because
-                // if experiment is not working fine (ex. returns 1 or 4 logos)
-                // then the "cost" of those bugs should show up in the `treatment` data
-                return nil
-            }
+        let merchantLogo = visualUpdate.merchantLogo
+        if merchantLogo.isEmpty || merchantLogo.count == 2 || merchantLogo.count == 3 {
+            // show merchant logo inside of consent pane
+            return visualUpdate.merchantLogo
         } else {
-            // show the "control" experience of showing logo in the nav bar
+            // if `merchantLogo.count > 3`, that is an invalid case
+            //
+            // we want to log experiment exposure regardless because
+            // if experiment is not working fine (ex. returns 1 or 4 logos)
+            // then the "cost" of those bugs should show up in the `treatment` data
             return nil
         }
     }


### PR DESCRIPTION
## Summary

Looks like the server is [always returning `treatment`](https://livegrep.corp.stripe.com/view/stripe-internal/pay-server/lib/bank_connections/experiments/constants.rb#L75-82) for this experiment now, so it is safe to remove it from the client code, and keep the "enabled" behaviour.

[Web](https://livegrep.corp.stripe.com/search/stripe?q=connections_consent_combined_logo%20path%3Av3&fold_case=auto&regex=false&context=true) is also not checking if this experiment is enabled anymore in V3.

## Motivation

Removes completed experiments & keeps us in sync with web.

## Testing

Manually verified everything still works as it did when the experiment was considered enabled.

## Changelog

N/a
