### PR TITLE
Re-enable 3DS2 test, fix keyboard bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## X.Y.Z X-Y-Z
+### PaymentSheet
+* [Fixed] Fixed a scroll issue with native 3DS2 authentication screen when the keyboard appears.
+
 ## 23.28.1 2024-07-16
 ### Payments
 * [Fixed] Improved reliability when paying or setting up with Cash App Pay.

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -424,26 +424,25 @@ class PaymentSheetStandardUITests: PaymentSheetUITestCase {
         XCTAssertTrue(blikCTAText.waitForExistence(timeout: 10.0))
     }
 
-//    func test3DS2Card_alwaysAuthenticate() throws {
-//        app.launch()
-//        app.staticTexts["PaymentSheet"].tap()
-//        let buyButton = app.staticTexts["Buy"]
-//        XCTAssertTrue(buyButton.waitForExistence(timeout: 60.0))
-//        buyButton.tap()
-//
-//        // Card number from https://docs.stripe.com/testing#regulatory-cards
-//        try! fillCardData(app, cardNumber: "4000002760003184")
-//        app.buttons["Pay €9.73"].tap()
-//        TODO(RUN_MOBILESDK-3222) Renable this test and figure out why we are going to the web flow rather than the native flow in test mode
-//        let challengeCodeTextField = app.textFields["STDSTextField"]
-//        XCTAssertTrue(challengeCodeTextField.waitForExistenceAndTap())
-//        challengeCodeTextField.typeText("424242")
-//        app.buttons["COMPLETE"].waitForExistenceAndTap()
-//        let successText = app.alerts.staticTexts["Your order is confirmed!"]
-//        XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
-//        let okButton = app.alerts.scrollViews.otherElements.buttons["OK"]
-//        okButton.tap()
-//    }
+    func test3DS2Card_alwaysAuthenticate() throws {
+        app.launch()
+        app.staticTexts["PaymentSheet"].tap()
+        let buyButton = app.staticTexts["Buy"]
+        XCTAssertTrue(buyButton.waitForExistence(timeout: 60.0))
+        buyButton.tap()
+
+        // Card number from https://docs.stripe.com/testing#regulatory-cards
+        try! fillCardData(app, cardNumber: "4000002760003184")
+        app.buttons["Pay €9.73"].tap()
+        let challengeCodeTextField = app.textFields["STDSTextField"]
+        XCTAssertTrue(challengeCodeTextField.waitForExistenceAndTap())
+        challengeCodeTextField.typeText("424242")
+        app.buttons["Submit"].waitForExistenceAndTap()
+        let successText = app.alerts.staticTexts["Your order is confirmed!"]
+        XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
+        let okButton = app.alerts.scrollViews.otherElements.buttons["OK"]
+        okButton.tap()
+    }
 }
 
 class PaymentSheetStandardLPMUITests: PaymentSheetUITestCase {

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -436,7 +436,7 @@ class PaymentSheetStandardUITests: PaymentSheetUITestCase {
         app.buttons["Pay €9.73"].tap()
         let challengeCodeTextField = app.textFields["STDSTextField"]
         XCTAssertTrue(challengeCodeTextField.waitForExistenceAndTap())
-        challengeCodeTextField.typeText("424242")
+        challengeCodeTextField.typeText("424242" + XCUIKeyboardKey.return.rawValue)
         app.buttons["Submit"].waitForExistenceAndTap()
         let successText = app.alerts.staticTexts["Your order is confirmed!"]
         XCTAssertTrue(successText.waitForExistence(timeout: 10.0))

--- a/Stripe3DS2/Stripe3DS2/STDSChallengeResponseViewController.m
+++ b/Stripe3DS2/Stripe3DS2/STDSChallengeResponseViewController.m
@@ -479,15 +479,8 @@ static NSString * const kHTMLStringLoadingURL = @"about:blank";
     // Get the keyboard’s frame at the end of its animation.
     CGRect keyboardFrameEnd = [[userInfo objectForKey:UIKeyboardFrameEndUserInfoKey] CGRectValue];
 
-    // In iOS 16.1 and later, the keyboard notification object is the screen the keyboard appears on.
-    // Use that screen to get the coordinate space to convert from.
-    id<UICoordinateSpace> fromCoordinateSpace = [(UIScreen *)notification.object coordinateSpace];
-
-    // Get your view's coordinate space.
-    id<UICoordinateSpace> toCoordinateSpace = self.view;
-
     // Convert the keyboard's frame from the screen's coordinate space to your view's coordinate space.
-    keyboardFrameEnd = [fromCoordinateSpace convertRect:keyboardFrameEnd toCoordinateSpace:toCoordinateSpace];
+    keyboardFrameEnd = [self.view convertRect:keyboardFrameEnd fromView:nil];
     
     // Get the intersection between the keyboard's frame and the view's bounds to work with the
     // part of the keyboard that overlaps your view.


### PR DESCRIPTION
## Summary
I tried to re-enable the 3DS2 test on a whim, since I was looking at the test below it.

I noticed the test card was working again and the test could be re-enabled, but noticed this bug.

AFAICT this bug has existed since GA of PaymentSheet!  STDSCHallengeResponseVC is hardcoded to adjust its scrollview insets by the height of the keyboard, but it's displayed inside BottomSheetVC, which _also_ adjusts its own scrollview insets.

Before:
https://github.com/user-attachments/assets/f222f1b5-e442-4112-b7a0-c685ac7a8a3c

After:
https://github.com/user-attachments/assets/153d8b52-6a24-4bbd-b2a2-af639303d723


## Testing
Manual

## Changelog
See CHANGELOG
