### PR TITLE
[FC] Create FinancialConnectionsTheme and apply to primary button

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
+++ b/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		492651662C24C9E7001DDBCA /* TestModeAutofillBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 492651652C24C9E7001DDBCA /* TestModeAutofillBannerView.swift */; };
 		492651682C25C0C2001DDBCA /* info@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 492651672C25C0C2001DDBCA /* info@3x.png */; };
 		494D62072C45B9B700106519 /* link_logo@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 494D62062C45B9B700106519 /* link_logo@3x.png */; };
+		495539EE2C484DC200543D18 /* FinancialConnectionsTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495539ED2C484DC200543D18 /* FinancialConnectionsTheme.swift */; };
 		496A6AE72C29E0BB00D34F8E /* testmode@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 496A6AE62C29E0BB00D34F8E /* testmode@3x.png */; };
 		4A0D015C978BD79BBFE6CE57 /* ManualEntryDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4C39F5F9AF440B13F51A81 /* ManualEntryDataSource.swift */; };
 		4A537AE0C50CAFF3889EFE28 /* UIViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7E41313B709F87B549D85F /* UIViewController+Extensions.swift */; };
@@ -313,6 +314,7 @@
 		492651652C24C9E7001DDBCA /* TestModeAutofillBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestModeAutofillBannerView.swift; sourceTree = "<group>"; };
 		492651672C25C0C2001DDBCA /* info@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "info@3x.png"; sourceTree = "<group>"; };
 		494D62062C45B9B700106519 /* link_logo@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "link_logo@3x.png"; sourceTree = "<group>"; };
+		495539ED2C484DC200543D18 /* FinancialConnectionsTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsTheme.swift; sourceTree = "<group>"; };
 		496A6AE62C29E0BB00D34F8E /* testmode@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testmode@3x.png"; sourceTree = "<group>"; };
 		4A7B146AA6BF44921A249DB8 /* EmptyFinancialConnectionsAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyFinancialConnectionsAPIClient.swift; sourceTree = "<group>"; };
 		4AFBF95DAE0783010A17EB58 /* FinancialConnectionsSession_only_accounts.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = FinancialConnectionsSession_only_accounts.json; sourceTree = "<group>"; };
@@ -738,6 +740,7 @@
 				ACEF0BAF1A5BBA3061C15A09 /* FinancialConnectionsSession.swift */,
 				429F985168AE9F9D700AE37B /* FinancialConnectionsSessionManifest.swift */,
 				4667E3861CDEC3A41B757714 /* FinancialConnectionsSynchronize.swift */,
+				495539ED2C484DC200543D18 /* FinancialConnectionsTheme.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1390,6 +1393,7 @@
 				99F41681B77ECB0090F34E31 /* SFSafariViewController+Extensions.swift in Sources */,
 				AA80602323C28AFAC391358D /* TimeInterval+Extensions.swift in Sources */,
 				E637387728FA1597B1B51E5D /* UIImage+Extensions.swift in Sources */,
+				495539EE2C484DC200543D18 /* FinancialConnectionsTheme.swift in Sources */,
 				486E50E6CB90208AB98C031E /* UIImageView+Extensions.swift in Sources */,
 				F0FB346A0F86C3561CD3C048 /* UITableView+Extensions.swift in Sources */,
 				A34AB3AC6D071605CABFFC9B /* UIViewController+KeyboardAvoiding.swift in Sources */,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsSessionManifest.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsSessionManifest.swift
@@ -63,6 +63,13 @@ struct FinancialConnectionsSessionManifest: Decodable {
         }
     }
 
+    enum Theme: String, SafeEnumCodable, Equatable {
+        case light = "light"
+        case dashboardLight = "dashboard_light"
+        case linkLight = "link_light"
+        case unparsable
+    }
+
     // MARK: - Properties
 
     let accountholderCustomerEmailAddress: String?
@@ -101,7 +108,11 @@ struct FinancialConnectionsSessionManifest: Decodable {
     let skipSuccessPane: Bool?
     let stepUpAuthenticationRequired: Bool?
     let successUrl: String?
-    let theme: FinancialConnectionsTheme?
+
+    private let _theme: Theme?
+    var theme: FinancialConnectionsTheme {
+        FinancialConnectionsTheme(from: _theme)
+    }
 
     var shouldAttachLinkedPaymentMethod: Bool {
         return (paymentMethodType != nil)
@@ -113,5 +124,47 @@ struct FinancialConnectionsSessionManifest: Decodable {
 
     var isTestMode: Bool {
         !livemode
+    }
+
+    // MARK: - Coding Keys
+
+    enum CodingKeys: String, CodingKey {
+        case accountholderCustomerEmailAddress
+        case accountholderIsLinkConsumer
+        case accountholderPhoneNumber
+        case accountholderToken
+        case accountDisconnectionMethod
+        case activeAuthSession
+        case activeInstitution
+        case allowManualEntry
+        case assignmentEventId
+        case businessName
+        case cancelUrl
+        case consentRequired
+        case customManualEntryHandling
+        case disableLinkMoreAccounts
+        case displayText
+        case experimentAssignments
+        case features
+        case hostedAuthUrl
+        case initialInstitution
+        case instantVerificationDisabled
+        case institutionSearchDisabled
+        case isEndUserFacing
+        case isLinkWithStripe
+        case isNetworkingUserFlow
+        case isStripeDirect
+        case livemode
+        case manualEntryMode
+        case manualEntryUsesMicrodeposits
+        case nextPane
+        case paymentMethodType
+        case permissions
+        case product
+        case singleAccount
+        case skipSuccessPane
+        case stepUpAuthenticationRequired
+        case successUrl
+        case _theme = "theme"
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsSessionManifest.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsSessionManifest.swift
@@ -63,13 +63,6 @@ struct FinancialConnectionsSessionManifest: Decodable {
         }
     }
 
-    enum Theme: String, SafeEnumCodable, Equatable {
-        case light = "light"
-        case dashboardLight = "dashboard_light"
-        case linkLight = "link_light"
-        case unparsable
-    }
-
     // MARK: - Properties
 
     let accountholderCustomerEmailAddress: String?
@@ -108,7 +101,7 @@ struct FinancialConnectionsSessionManifest: Decodable {
     let skipSuccessPane: Bool?
     let stepUpAuthenticationRequired: Bool?
     let successUrl: String?
-    let theme: Theme?
+    let theme: FinancialConnectionsTheme?
 
     var shouldAttachLinkedPaymentMethod: Bool {
         return (paymentMethodType != nil)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsTheme.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsTheme.swift
@@ -1,0 +1,53 @@
+//
+//  FinancialConnectionsTheme.swift
+//  StripeFinancialConnections
+//
+//  Created by Mat Schmid on 2024-07-17.
+//
+
+import UIKit
+
+enum FinancialConnectionsTheme: String, SafeEnumCodable, Equatable {
+    case light = "light"
+    case dashboardLight = "dashboard_light"
+    case linkLight = "link_light"
+    case unparsable
+}
+
+extension FinancialConnectionsTheme? {
+    var logo: Image {
+        switch self {
+        case .linkLight:
+            return .link_logo
+        case .light, .dashboardLight, .unparsable, .none:
+            return .stripe_logo
+        }
+    }
+
+    var primaryColor: UIColor {
+        switch self {
+        case .linkLight:
+            return .linkGreen200
+        case .light, .dashboardLight, .unparsable, .none:
+            return .brand500
+        }
+    }
+
+    var primaryButtonTextColor: UIColor {
+        switch self {
+        case .linkLight:
+            return .linkGreen900
+        case .light, .dashboardLight, .unparsable, .none:
+            return .white
+        }
+    }
+
+    var logoColor: UIColor {
+        switch self {
+        case .linkLight:
+            return .linkGreen900
+        case .light, .dashboardLight, .unparsable, .none:
+            return .textActionPrimary
+        }
+    }
+}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsTheme.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsTheme.swift
@@ -7,19 +7,26 @@
 
 import UIKit
 
-enum FinancialConnectionsTheme: String, SafeEnumCodable, Equatable {
-    case light = "light"
-    case dashboardLight = "dashboard_light"
-    case linkLight = "link_light"
-    case unparsable
+enum FinancialConnectionsTheme: String, Equatable {
+    case light
+    case linkLight
+
+    init(from theme: FinancialConnectionsSessionManifest.Theme?) {
+        switch theme {
+        case .linkLight:
+            self = .linkLight
+        case .light, .dashboardLight, .unparsable, .none:
+            self = .light
+        }
+    }
 }
 
-extension FinancialConnectionsTheme? {
+extension FinancialConnectionsTheme {
     var logo: Image {
         switch self {
         case .linkLight:
             return .link_logo
-        case .light, .dashboardLight, .unparsable, .none:
+        case .light:
             return .stripe_logo
         }
     }
@@ -28,7 +35,7 @@ extension FinancialConnectionsTheme? {
         switch self {
         case .linkLight:
             return .linkGreen200
-        case .light, .dashboardLight, .unparsable, .none:
+        case .light:
             return .brand500
         }
     }
@@ -37,7 +44,7 @@ extension FinancialConnectionsTheme? {
         switch self {
         case .linkLight:
             return .linkGreen900
-        case .light, .dashboardLight, .unparsable, .none:
+        case .light:
             return .white
         }
     }
@@ -46,7 +53,7 @@ extension FinancialConnectionsTheme? {
         switch self {
         case .linkLight:
             return .linkGreen900
-        case .light, .dashboardLight, .unparsable, .none:
+        case .light:
             return .textActionPrimary
         }
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/FinancialConnectionsNavigationController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/FinancialConnectionsNavigationController.swift
@@ -148,7 +148,7 @@ extension FinancialConnectionsNavigationController {
         _ navigationItem: UINavigationItem?,
         closeItem: UIBarButtonItem,
         shouldHideLogo: Bool,
-        theme: FinancialConnectionsSessionManifest.Theme?,
+        theme: FinancialConnectionsTheme?,
         isTestMode: Bool
     ) {
         let iconHeight: CGFloat = 20
@@ -174,19 +174,8 @@ extension FinancialConnectionsNavigationController {
         let logoView: UIImageView? = {
             guard !shouldHideLogo else { return nil }
 
-            let logo: Image
-            let tint: UIColor
-            switch theme {
-            case .linkLight:
-                logo = .link_logo
-                tint = .linkGreen900
-            case .light, .dashboardLight, .unparsable, .none:
-                logo = .stripe_logo
-                tint = .textActionPrimary
-            }
-
-            let logoImage = UIImageView(image: logo.makeImage(template: true))
-            logoImage.tintColor = tint
+            let logoImage = UIImageView(image: theme.logo.makeImage(template: true))
+            logoImage.tintColor = theme.logoColor
             logoImage.contentMode = .scaleAspectFit
             logoImage.sizeToFit()
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/FinancialConnectionsNavigationController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/FinancialConnectionsNavigationController.swift
@@ -148,7 +148,7 @@ extension FinancialConnectionsNavigationController {
         _ navigationItem: UINavigationItem?,
         closeItem: UIBarButtonItem,
         shouldHideLogo: Bool,
-        theme: FinancialConnectionsTheme?,
+        theme: FinancialConnectionsTheme,
         isTestMode: Bool
     ) {
         let iconHeight: CGFloat = 20

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/UIColor+Extensions.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/UIColor+Extensions.swift
@@ -163,12 +163,16 @@ extension UIColor {
         return UIColor(red: 34 / 255.0, green: 132 / 255.0, blue: 3 / 255.0, alpha: 1)  // #228403
     }
 
-    static var linkBrand200: UIColor {
+    static var legacyLinkBrand200: UIColor {
         return UIColor(red: 166 / 255.0, green: 251 / 255.0, blue: 221 / 255.0, alpha: 1)  // #a6fbdd
     }
 
-    static var linkBrand600: UIColor {
+    static var legacyLinkBrand600: UIColor {
         return UIColor(red: 26 / 255.0, green: 197 / 255.0, blue: 155 / 255.0, alpha: 1)  // #1ac59b
+    }
+
+    static var linkGreen200: UIColor {
+        return UIColor(red: 0 / 255.0, green: 214 / 255.0, blue: 111 / 255.0, alpha: 1)  // #00D66F
     }
 
     static var linkGreen900: UIColor {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerAccountLoadErrorView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerAccountLoadErrorView.swift
@@ -14,6 +14,7 @@ final class AccountPickerAccountLoadErrorView: UIView {
 
     init(
         institution: FinancialConnectionsInstitution,
+        theme: FinancialConnectionsTheme?,
         didSelectAnotherBank: @escaping () -> Void,
         didSelectTryAgain: (() -> Void)?,  // if nil, don't show button
         didSelectEnterBankDetailsManually: (() -> Void)?  // if nil, don't show button
@@ -79,7 +80,8 @@ final class AccountPickerAccountLoadErrorView: UIView {
             ),
             footerView: PaneLayoutView.createFooterView(
                 primaryButtonConfiguration: primaryButtonConfiguration,
-                secondaryButtonConfiguration: secondaryButtonConfiguration
+                secondaryButtonConfiguration: secondaryButtonConfiguration,
+                theme: theme
             ).footerView
         )
         paneLayoutView.addTo(view: self)
@@ -97,6 +99,7 @@ import SwiftUI
 private struct AccountPickerAccountLoadErrorViewUIViewRepresentable: UIViewRepresentable {
 
     let institutionName: String
+    let theme: FinancialConnectionsTheme?
     let didSelectTryAgain: (() -> Void)?
     let didSelectEnterBankDetailsManually: (() -> Void)?
 
@@ -109,6 +112,7 @@ private struct AccountPickerAccountLoadErrorViewUIViewRepresentable: UIViewRepre
                 icon: nil,
                 logo: nil
             ),
+            theme: theme,
             didSelectAnotherBank: {},
             didSelectTryAgain: didSelectTryAgain,
             didSelectEnterBankDetailsManually: didSelectEnterBankDetailsManually
@@ -122,24 +126,28 @@ struct AccountPickerAccountLoadErrorView_Previews: PreviewProvider {
     static var previews: some View {
         AccountPickerAccountLoadErrorViewUIViewRepresentable(
             institutionName: "Chase",
+            theme: .light,
             didSelectTryAgain: {},
             didSelectEnterBankDetailsManually: {}
         )
 
         AccountPickerAccountLoadErrorViewUIViewRepresentable(
             institutionName: "Ally",
+            theme: .light,
             didSelectTryAgain: nil,
             didSelectEnterBankDetailsManually: {}
         )
 
         AccountPickerAccountLoadErrorViewUIViewRepresentable(
             institutionName: "Chase",
+            theme: .light,
             didSelectTryAgain: {},
             didSelectEnterBankDetailsManually: nil
         )
 
         AccountPickerAccountLoadErrorViewUIViewRepresentable(
             institutionName: "Chase",
+            theme: .light,
             didSelectTryAgain: nil,
             didSelectEnterBankDetailsManually: nil
         )

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerAccountLoadErrorView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerAccountLoadErrorView.swift
@@ -14,7 +14,7 @@ final class AccountPickerAccountLoadErrorView: UIView {
 
     init(
         institution: FinancialConnectionsInstitution,
-        theme: FinancialConnectionsTheme?,
+        theme: FinancialConnectionsTheme,
         didSelectAnotherBank: @escaping () -> Void,
         didSelectTryAgain: (() -> Void)?,  // if nil, don't show button
         didSelectEnterBankDetailsManually: (() -> Void)?  // if nil, don't show button
@@ -99,7 +99,7 @@ import SwiftUI
 private struct AccountPickerAccountLoadErrorViewUIViewRepresentable: UIViewRepresentable {
 
     let institutionName: String
-    let theme: FinancialConnectionsTheme?
+    let theme: FinancialConnectionsTheme
     let didSelectTryAgain: (() -> Void)?
     let didSelectEnterBankDetailsManually: (() -> Void)?
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerFooterView.swift
@@ -12,10 +12,11 @@ import UIKit
 final class AccountPickerFooterView: UIView {
 
     private let singleAccount: Bool
+    private let theme: FinancialConnectionsTheme?
     private let didSelectLinkAccounts: () -> Void
 
     private lazy var linkAccountsButton: Button = {
-        let linkAccountsButton = Button.primary()
+        let linkAccountsButton = Button.primary(theme: theme)
         linkAccountsButton.addTarget(self, action: #selector(didSelectLinkAccountsButton), for: .touchUpInside)
         linkAccountsButton.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -30,10 +31,12 @@ final class AccountPickerFooterView: UIView {
         businessName: String?,
         permissions: [StripeAPI.FinancialConnectionsAccount.Permissions],
         singleAccount: Bool,
+        theme: FinancialConnectionsTheme?,
         didSelectLinkAccounts: @escaping () -> Void,
         didSelectMerchantDataAccessLearnMore: @escaping (URL) -> Void
     ) {
         self.singleAccount = singleAccount
+        self.theme = theme
         self.didSelectLinkAccounts = didSelectLinkAccounts
         super.init(frame: .zero)
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerFooterView.swift
@@ -12,7 +12,7 @@ import UIKit
 final class AccountPickerFooterView: UIView {
 
     private let singleAccount: Bool
-    private let theme: FinancialConnectionsTheme?
+    private let theme: FinancialConnectionsTheme
     private let didSelectLinkAccounts: () -> Void
 
     private lazy var linkAccountsButton: Button = {
@@ -31,7 +31,7 @@ final class AccountPickerFooterView: UIView {
         businessName: String?,
         permissions: [StripeAPI.FinancialConnectionsAccount.Permissions],
         singleAccount: Bool,
-        theme: FinancialConnectionsTheme?,
+        theme: FinancialConnectionsTheme,
         didSelectLinkAccounts: @escaping () -> Void,
         didSelectMerchantDataAccessLearnMore: @escaping (URL) -> Void
     ) {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerNoAccountEligibleErrorView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerNoAccountEligibleErrorView.swift
@@ -19,6 +19,7 @@ final class AccountPickerNoAccountEligibleErrorView: UIView {
         institutionSkipAccountSelection: Bool,
         numberOfIneligibleAccounts: Int,
         paymentMethodType: FinancialConnectionsPaymentMethodType,
+        theme: FinancialConnectionsTheme?,
         didSelectAnotherBank: @escaping () -> Void
     ) {
         super.init(frame: .zero)
@@ -141,7 +142,8 @@ final class AccountPickerNoAccountEligibleErrorView: UIView {
                         }
                     }(),
                     action: didSelectAnotherBank
-                )
+                ),
+                theme: theme
             ).footerView
         )
         paneLayoutView.addTo(view: self)
@@ -177,6 +179,7 @@ private struct AccountPickerNoAccountEligibleErrorViewUIViewRepresentable: UIVie
             institutionSkipAccountSelection: institutionSkipAccountSelection,
             numberOfIneligibleAccounts: numberOfIneligibleAccounts,
             paymentMethodType: paymentMethodType,
+            theme: .light,
             didSelectAnotherBank: {}
         )
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerNoAccountEligibleErrorView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerNoAccountEligibleErrorView.swift
@@ -19,7 +19,7 @@ final class AccountPickerNoAccountEligibleErrorView: UIView {
         institutionSkipAccountSelection: Bool,
         numberOfIneligibleAccounts: Int,
         paymentMethodType: FinancialConnectionsPaymentMethodType,
-        theme: FinancialConnectionsTheme?,
+        theme: FinancialConnectionsTheme,
         didSelectAnotherBank: @escaping () -> Void
     ) {
         super.init(frame: .zero)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerViewController.swift
@@ -77,6 +77,7 @@ final class AccountPickerViewController: UIViewController {
             businessName: businessName,
             permissions: dataSource.manifest.permissions,
             singleAccount: dataSource.manifest.singleAccount,
+            theme: dataSource.manifest.theme,
             didSelectLinkAccounts: { [weak self] in
                 guard let self = self else {
                     return
@@ -102,6 +103,7 @@ final class AccountPickerViewController: UIViewController {
                 if let dataAccessNotice = self.dataSource.dataAccessNotice {
                     let dataAccessNoticeViewController = DataAccessNoticeViewController(
                         dataAccessNotice: dataAccessNotice,
+                        theme: self.dataSource.manifest.theme,
                         didSelectUrl: { [weak self] url in
                             guard let self = self else { return }
                             AuthFlowHelpers.handleURLInTextFromBackend(
@@ -235,6 +237,7 @@ final class AccountPickerViewController: UIViewController {
                                 ?? false,
                             numberOfIneligibleAccounts: numberOfIneligibleAccounts,
                             paymentMethodType: self.dataSource.manifest.paymentMethodType ?? .usBankAccount,
+                            theme: self.dataSource.manifest.theme,
                             didSelectAnotherBank: self.didSelectAnotherBank
                         )
                         // the user will never enter this instance of `AccountPickerViewController`
@@ -328,6 +331,7 @@ final class AccountPickerViewController: UIViewController {
     private func showAccountLoadErrorView(error: Error) {
         let errorView = AccountPickerAccountLoadErrorView(
             institution: dataSource.institution,
+            theme: dataSource.manifest.theme,
             didSelectAnotherBank: didSelectAnotherBank,
             didSelectTryAgain: didSelectTryAgain,
             didSelectEnterBankDetailsManually: didSelectManualEntry

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AttachLinkedPaymentAccount/AccountNumberRetrievalErrorView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AttachLinkedPaymentAccount/AccountNumberRetrievalErrorView.swift
@@ -15,7 +15,7 @@ final class AccountNumberRetrievalErrorView: UIView {
 
     init(
         institution: FinancialConnectionsInstitution,
-        theme: FinancialConnectionsTheme?,
+        theme: FinancialConnectionsTheme,
         didSelectAnotherBank: @escaping () -> Void,
         didSelectEnterBankDetailsManually: (() -> Void)?  // if nil, don't show button
     ) {
@@ -80,7 +80,7 @@ import SwiftUI
 private struct AccountNumberRetrievalErrorViewUIViewRepresentable: UIViewRepresentable {
 
     let institutionName: String
-    let theme: FinancialConnectionsTheme?
+    let theme: FinancialConnectionsTheme
     let didSelectEnterBankDetailsManually: (() -> Void)?
 
     func makeUIView(context: Context) -> AccountNumberRetrievalErrorView {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AttachLinkedPaymentAccount/AccountNumberRetrievalErrorView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AttachLinkedPaymentAccount/AccountNumberRetrievalErrorView.swift
@@ -15,6 +15,7 @@ final class AccountNumberRetrievalErrorView: UIView {
 
     init(
         institution: FinancialConnectionsInstitution,
+        theme: FinancialConnectionsTheme?,
         didSelectAnotherBank: @escaping () -> Void,
         didSelectEnterBankDetailsManually: (() -> Void)?  // if nil, don't show button
     ) {
@@ -60,7 +61,8 @@ final class AccountNumberRetrievalErrorView: UIView {
                     } else {
                         return nil
                     }
-                }()
+                }(),
+                theme: theme
             ).footerView
         )
         paneLayoutView.addTo(view: self)
@@ -78,6 +80,7 @@ import SwiftUI
 private struct AccountNumberRetrievalErrorViewUIViewRepresentable: UIViewRepresentable {
 
     let institutionName: String
+    let theme: FinancialConnectionsTheme?
     let didSelectEnterBankDetailsManually: (() -> Void)?
 
     func makeUIView(context: Context) -> AccountNumberRetrievalErrorView {
@@ -89,6 +92,7 @@ private struct AccountNumberRetrievalErrorViewUIViewRepresentable: UIViewReprese
                 icon: nil,
                 logo: nil
             ),
+            theme: theme,
             didSelectAnotherBank: {},
             didSelectEnterBankDetailsManually: didSelectEnterBankDetailsManually
         )
@@ -101,11 +105,13 @@ struct AccountNumberRetrievalErrorView_Previews: PreviewProvider {
     static var previews: some View {
         AccountNumberRetrievalErrorViewUIViewRepresentable(
             institutionName: "Chase",
+            theme: .light,
             didSelectEnterBankDetailsManually: {}
         )
 
         AccountNumberRetrievalErrorViewUIViewRepresentable(
             institutionName: "Bank of America",
+            theme: .light,
             didSelectEnterBankDetailsManually: nil
         )
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AttachLinkedPaymentAccount/AttachLinkedPaymentAccountViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AttachLinkedPaymentAccount/AttachLinkedPaymentAccountViewController.swift
@@ -127,6 +127,7 @@ final class AttachLinkedPaymentAccountViewController: UIViewController {
                     {
                         let errorView = AccountNumberRetrievalErrorView(
                             institution: self.dataSource.institution,
+                            theme: self.dataSource.manifest.theme,
                             didSelectAnotherBank: self.didSelectAnotherBank,
                             didSelectEnterBankDetailsManually: self.didSelectManualEntry
                         )
@@ -142,6 +143,7 @@ final class AttachLinkedPaymentAccountViewController: UIViewController {
                         // something unknown happened here, allow a retry
                         let errorView = AccountPickerAccountLoadErrorView(
                             institution: self.dataSource.institution,
+                            theme: self.dataSource.manifest.theme,
                             didSelectAnotherBank: self.didSelectAnotherBank,
                             didSelectTryAgain: self.didSelectTryAgain,
                             didSelectEnterBankDetailsManually: self.didSelectManualEntry

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentFooterView.swift
@@ -13,7 +13,7 @@ import UIKit
 class ConsentFooterView: HitTestView {
 
     private let agreeButtonText: String
-    private let theme: FinancialConnectionsTheme?
+    private let theme: FinancialConnectionsTheme
     private let didSelectAgree: () -> Void
 
     private lazy var agreeButton: StripeUICore.Button = {
@@ -32,7 +32,7 @@ class ConsentFooterView: HitTestView {
         aboveCtaText: String,
         ctaText: String,
         belowCtaText: String?,
-        theme: FinancialConnectionsTheme?,
+        theme: FinancialConnectionsTheme,
         didSelectAgree: @escaping () -> Void,
         didSelectURL: @escaping (URL) -> Void
     ) {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentFooterView.swift
@@ -13,10 +13,11 @@ import UIKit
 class ConsentFooterView: HitTestView {
 
     private let agreeButtonText: String
+    private let theme: FinancialConnectionsTheme?
     private let didSelectAgree: () -> Void
 
     private lazy var agreeButton: StripeUICore.Button = {
-        let agreeButton = Button.primary()
+        let agreeButton = Button.primary(theme: theme)
         agreeButton.title = agreeButtonText
         agreeButton.addTarget(self, action: #selector(didSelectAgreeButton), for: .touchUpInside)
         agreeButton.translatesAutoresizingMaskIntoConstraints = false
@@ -31,10 +32,12 @@ class ConsentFooterView: HitTestView {
         aboveCtaText: String,
         ctaText: String,
         belowCtaText: String?,
+        theme: FinancialConnectionsTheme?,
         didSelectAgree: @escaping () -> Void,
         didSelectURL: @escaping (URL) -> Void
     ) {
         self.agreeButtonText = ctaText
+        self.theme = theme
         self.didSelectAgree = didSelectAgree
         super.init(frame: .zero)
         backgroundColor = .customBackgroundColor
@@ -112,6 +115,7 @@ private struct ConsentFooterViewUIViewRepresentable: UIViewRepresentable {
                 "You agree to Stripe's [Terms](https://stripe.com/legal/end-users#linked-financial-account-terms) and [Privacy Policy](https://stripe.com/privacy). [Learn more](https://stripe.com/privacy-center/legal#linking-financial-accounts)",
             ctaText: "Agree",
             belowCtaText: "[Manually verify instead](https://www.stripe.com) (takes 1-2 business days)",
+            theme: .light,
             didSelectAgree: {},
             didSelectURL: { _ in }
         )

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentViewController.swift
@@ -48,6 +48,7 @@ class ConsentViewController: UIViewController {
             aboveCtaText: dataSource.consent.aboveCta,
             ctaText: dataSource.consent.cta,
             belowCtaText: dataSource.consent.belowCta,
+            theme: dataSource.manifest.theme,
             didSelectAgree: { [weak self] in
                 self?.didSelectAgree()
             },
@@ -169,6 +170,7 @@ class ConsentViewController: UIViewController {
                     if let dataAccessNotice = dataSource.consent.dataAccessNotice {
                         let dataAccessNoticeViewController = DataAccessNoticeViewController(
                             dataAccessNotice: dataAccessNotice,
+                            theme: dataSource.manifest.theme,
                             didSelectUrl: { [weak self] url in
                                 self?.didSelectURLInTextFromBackend(url)
                             }
@@ -179,6 +181,7 @@ class ConsentViewController: UIViewController {
                     let legalDetailsNoticeModel = dataSource.consent.legalDetailsNotice
                     let legalDetailsNoticeViewController = LegalDetailsNoticeViewController(
                         legalDetailsNotice: legalDetailsNoticeModel,
+                        theme: dataSource.manifest.theme,
                         didSelectUrl: { [weak self] url in
                             self?.didSelectURLInTextFromBackend(url)
                         }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Error/ErrorViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Error/ErrorViewController.swift
@@ -133,7 +133,8 @@ final class ErrorViewController: UIViewController {
                                 guard let self = self else { return }
                                 self.delegate?.errorViewControllerDidSelectManualEntry(self)
                             }
-                        ) : nil
+                        ) : nil,
+                        theme: dataSource.manifest.theme
                     ).footerView
                 ).createView()
                 dataSource.analyticsClient.logExpectedError(
@@ -176,7 +177,8 @@ final class ErrorViewController: UIViewController {
                                 guard let self else { return }
                                 self.delegate?.errorViewControllerDidSelectManualEntry(self)
                             }
-                        ) : nil
+                        ) : nil,
+                        theme: dataSource.manifest.theme
                     ).footerView
                 ).createView()
                 dataSource.analyticsClient.logExpectedError(
@@ -198,6 +200,7 @@ final class ErrorViewController: UIViewController {
             // what's wrong, so show a generic error
             errorView = TerminalErrorView(
                 allowManualEntry: dataSource.manifest.allowManualEntry,
+                theme: dataSource.manifest.theme,
                 didSelectManualEntry: { [weak self] in
                     guard let self else { return }
                     self.delegate?.errorViewControllerDidSelectManualEntry(self)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/AccountUpdateRequiredViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/AccountUpdateRequiredViewController.swift
@@ -11,17 +11,20 @@ import UIKit
 final class AccountUpdateRequiredViewController: SheetViewController {
 
     private let institution: FinancialConnectionsInstitution?
+    private let theme: FinancialConnectionsTheme?
     private let didSelectContinue: () -> Void
     private let didSelectCancel: () -> Void
     private let willDismissSheet: () -> Void
 
     init(
         institution: FinancialConnectionsInstitution?,
+        theme: FinancialConnectionsTheme?,
         didSelectContinue: @escaping () -> Void,
         didSelectCancel: @escaping () -> Void,
         willDismissSheet: @escaping () -> Void
     ) {
         self.institution = institution
+        self.theme = theme
         self.didSelectContinue = didSelectContinue
         self.didSelectCancel = didSelectCancel
         self.willDismissSheet = willDismissSheet
@@ -61,7 +64,8 @@ final class AccountUpdateRequiredViewController: SheetViewController {
                 secondaryButtonConfiguration: PaneLayoutView.ButtonConfiguration(
                     title: "Cancel", // TODO: when Financial Connections starts supporting localization, change this to `String.Localized.cancel`
                     action: didSelectCancel
-                )
+                ),
+                theme: theme
             ).footerView
         )
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/AccountUpdateRequiredViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/AccountUpdateRequiredViewController.swift
@@ -11,14 +11,14 @@ import UIKit
 final class AccountUpdateRequiredViewController: SheetViewController {
 
     private let institution: FinancialConnectionsInstitution?
-    private let theme: FinancialConnectionsTheme?
+    private let theme: FinancialConnectionsTheme
     private let didSelectContinue: () -> Void
     private let didSelectCancel: () -> Void
     private let willDismissSheet: () -> Void
 
     init(
         institution: FinancialConnectionsInstitution?,
-        theme: FinancialConnectionsTheme?,
+        theme: FinancialConnectionsTheme,
         didSelectContinue: @escaping () -> Void,
         didSelectCancel: @escaping () -> Void,
         willDismissSheet: @escaping () -> Void

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerFooterView.swift
@@ -13,7 +13,7 @@ final class LinkAccountPickerFooterView: UIView {
 
     private let defaultCta: String
     private let singleAccount: Bool
-    private let theme: FinancialConnectionsTheme?
+    private let theme: FinancialConnectionsTheme
     private let didSelectConnectAccount: () -> Void
 
     private lazy var connectAccountButton: Button = {
@@ -35,7 +35,7 @@ final class LinkAccountPickerFooterView: UIView {
         businessName: String?,
         permissions: [StripeAPI.FinancialConnectionsAccount.Permissions],
         singleAccount: Bool,
-        theme: FinancialConnectionsTheme?,
+        theme: FinancialConnectionsTheme,
         didSelectConnectAccount: @escaping () -> Void,
         didSelectMerchantDataAccessLearnMore: @escaping (URL) -> Void
     ) {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerFooterView.swift
@@ -13,10 +13,11 @@ final class LinkAccountPickerFooterView: UIView {
 
     private let defaultCta: String
     private let singleAccount: Bool
+    private let theme: FinancialConnectionsTheme?
     private let didSelectConnectAccount: () -> Void
 
     private lazy var connectAccountButton: Button = {
-        let connectAccountButton = Button.primary()
+        let connectAccountButton = Button.primary(theme: theme)
         connectAccountButton.title = defaultCta
         connectAccountButton.isEnabled = false // disable by default
         connectAccountButton.addTarget(self, action: #selector(didSelectLinkAccountsButton), for: .touchUpInside)
@@ -34,11 +35,13 @@ final class LinkAccountPickerFooterView: UIView {
         businessName: String?,
         permissions: [StripeAPI.FinancialConnectionsAccount.Permissions],
         singleAccount: Bool,
+        theme: FinancialConnectionsTheme?,
         didSelectConnectAccount: @escaping () -> Void,
         didSelectMerchantDataAccessLearnMore: @escaping (URL) -> Void
     ) {
         self.defaultCta = defaultCta
         self.singleAccount = singleAccount
+        self.theme = theme
         self.didSelectConnectAccount = didSelectConnectAccount
         super.init(frame: .zero)
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
@@ -181,6 +181,7 @@ final class LinkAccountPickerViewController: UIViewController {
             businessName: businessName,
             permissions: dataSource.manifest.permissions,
             singleAccount: dataSource.manifest.singleAccount,
+            theme: dataSource.manifest.theme,
             didSelectConnectAccount: { [weak self] in
                 guard let self = self else {
                     return
@@ -196,6 +197,7 @@ final class LinkAccountPickerViewController: UIViewController {
                 if let dataAccessNotice = self.dataSource.dataAccessNotice {
                     let dataAccessNoticeViewController = DataAccessNoticeViewController(
                         dataAccessNotice: dataAccessNotice,
+                        theme: dataSource.manifest.theme,
                         didSelectUrl: { [weak self] url in
                             guard let self = self else { return }
                             AuthFlowHelpers.handleURLInTextFromBackend(
@@ -483,6 +485,7 @@ extension LinkAccountPickerViewController: LinkAccountPickerBodyViewDelegate {
 
                 let accountUpdateRequiredViewController = AccountUpdateRequiredViewController(
                     institution: selectedPartnerAccount.institution,
+                    theme: dataSource.manifest.theme,
                     didSelectContinue: { [weak self] in
                         guard let self else { return }
                         // delay deselecting accounts while we animate to the

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/ManualEntry/ManualEntryFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/ManualEntry/ManualEntryFooterView.swift
@@ -11,10 +11,11 @@ import UIKit
 
 final class ManualEntryFooterView: UIView {
 
+    private let theme: FinancialConnectionsTheme?
     private let didSelectContinue: () -> Void
 
     private(set) lazy var continueButton: Button = {
-        let continueButton = Button.primary()
+        let continueButton = Button.primary(theme: theme)
         continueButton.title = "Submit"  // TODO(kgaidis): localize
         continueButton.addTarget(self, action: #selector(didSelectContinueButton), for: .touchUpInside)
         continueButton.translatesAutoresizingMaskIntoConstraints = false
@@ -25,7 +26,8 @@ final class ManualEntryFooterView: UIView {
         return continueButton
     }()
 
-    init(didSelectContinue: @escaping () -> Void) {
+    init(theme: FinancialConnectionsTheme?, didSelectContinue: @escaping () -> Void) {
+        self.theme = theme
         self.didSelectContinue = didSelectContinue
         super.init(frame: .zero)
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/ManualEntry/ManualEntryFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/ManualEntry/ManualEntryFooterView.swift
@@ -11,7 +11,7 @@ import UIKit
 
 final class ManualEntryFooterView: UIView {
 
-    private let theme: FinancialConnectionsTheme?
+    private let theme: FinancialConnectionsTheme
     private let didSelectContinue: () -> Void
 
     private(set) lazy var continueButton: Button = {
@@ -26,7 +26,7 @@ final class ManualEntryFooterView: UIView {
         return continueButton
     }()
 
-    init(theme: FinancialConnectionsTheme?, didSelectContinue: @escaping () -> Void) {
+    init(theme: FinancialConnectionsTheme, didSelectContinue: @escaping () -> Void) {
         self.theme = theme
         self.didSelectContinue = didSelectContinue
         super.init(frame: .zero)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/ManualEntry/ManualEntryViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/ManualEntry/ManualEntryViewController.swift
@@ -31,6 +31,7 @@ final class ManualEntryViewController: UIViewController {
     }()
     private lazy var footerView: ManualEntryFooterView = {
         let manualEntryFooterView = ManualEntryFooterView(
+            theme: dataSource.manifest.theme,
             didSelectContinue: { [weak self] in
                 self?.didSelectContinue()
             }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -106,6 +106,7 @@ class NativeFlowController {
         }
         if showConfirmationAlert {
             let closeConfirmationViewController = CloseConfirmationViewController(
+                theme: dataManager.manifest.theme,
                 didSelectClose: {
                     finishClosingAuthFlow()
                 }
@@ -1296,7 +1297,8 @@ private func CreatePaneViewController(
         if let terminalError = dataManager.terminalError {
             let terminalErrorViewController = TerminalErrorViewController(
                 error: terminalError,
-                allowManualEntry: dataManager.manifest.allowManualEntry
+                allowManualEntry: dataManager.manifest.allowManualEntry,
+                theme: dataManager.manifest.theme
             )
             terminalErrorViewController.delegate = nativeFlowController
             viewController = terminalErrorViewController

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupBodyView.swift
@@ -59,7 +59,7 @@ private func CreateAvatarView(email: String) -> UIView {
     let diameter: CGFloat = 36
 
     let circleView = UIView()
-    circleView.backgroundColor = .linkBrand200
+    circleView.backgroundColor = .legacyLinkBrand200
     circleView.layer.cornerRadius = diameter / 2
     circleView.translatesAutoresizingMaskIntoConstraints = false
     NSLayoutConstraint.activate([
@@ -69,7 +69,7 @@ private func CreateAvatarView(email: String) -> UIView {
 
     let letterLabel = AttributedLabel(
         font: .body(.small),
-        textColor: .linkBrand600
+        textColor: .legacyLinkBrand600
     )
     letterLabel.setText(String(email.uppercased().first ?? "E"))
     circleView.addSubview(letterLabel)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupViewController.swift
@@ -79,7 +79,8 @@ final class NetworkingLinkLoginWarmupViewController: SheetViewController {
                     action: { [weak self] in
                         self?.didSelectSkip()
                     }
-                )
+                ),
+                theme: dataSource.manifest.theme
             ).footerView
         )
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupFooterView.swift
@@ -15,7 +15,7 @@ class NetworkingLinkSignupFooterView: HitTestView {
     private let aboveCtaText: String
     private let saveToLinkButtonText: String
     private let notNowButtonText: String
-    private let theme: FinancialConnectionsTheme?
+    private let theme: FinancialConnectionsTheme
     private let didSelectSaveToLink: () -> Void
     private let didSelectNotNow: () -> Void
     private let didSelectURL: (URL) -> Void
@@ -86,7 +86,7 @@ class NetworkingLinkSignupFooterView: HitTestView {
         aboveCtaText: String,
         saveToLinkButtonText: String,
         notNowButtonText: String,
-        theme: FinancialConnectionsTheme?,
+        theme: FinancialConnectionsTheme,
         didSelectSaveToLink: @escaping () -> Void,
         didSelectNotNow: @escaping () -> Void,
         didSelectURL: @escaping (URL) -> Void

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupFooterView.swift
@@ -15,6 +15,7 @@ class NetworkingLinkSignupFooterView: HitTestView {
     private let aboveCtaText: String
     private let saveToLinkButtonText: String
     private let notNowButtonText: String
+    private let theme: FinancialConnectionsTheme?
     private let didSelectSaveToLink: () -> Void
     private let didSelectNotNow: () -> Void
     private let didSelectURL: (URL) -> Void
@@ -60,7 +61,7 @@ class NetworkingLinkSignupFooterView: HitTestView {
     }()
 
     private lazy var saveToLinkButton: StripeUICore.Button = {
-        let saveToLinkButton = Button.primary()
+        let saveToLinkButton = Button.primary(theme: theme)
         saveToLinkButton.title = saveToLinkButtonText
         saveToLinkButton.addTarget(self, action: #selector(didSelectSaveToLinkButton), for: .touchUpInside)
         saveToLinkButton.translatesAutoresizingMaskIntoConstraints = false
@@ -85,6 +86,7 @@ class NetworkingLinkSignupFooterView: HitTestView {
         aboveCtaText: String,
         saveToLinkButtonText: String,
         notNowButtonText: String,
+        theme: FinancialConnectionsTheme?,
         didSelectSaveToLink: @escaping () -> Void,
         didSelectNotNow: @escaping () -> Void,
         didSelectURL: @escaping (URL) -> Void
@@ -92,6 +94,7 @@ class NetworkingLinkSignupFooterView: HitTestView {
         self.aboveCtaText = aboveCtaText
         self.saveToLinkButtonText = saveToLinkButtonText
         self.notNowButtonText = notNowButtonText
+        self.theme = theme
         self.didSelectSaveToLink = didSelectSaveToLink
         self.didSelectNotNow = didSelectNotNow
         self.didSelectURL = didSelectURL
@@ -132,6 +135,7 @@ private struct NetworkingLinkSignupFooterViewUIViewRepresentable: UIViewRepresen
             aboveCtaText: "By saving your account to Link, you agree to Link’s [Terms](https://link.co/terms) and [Privacy Policy](https://link.co/privacy)",
             saveToLinkButtonText: "Save to Link",
             notNowButtonText: "Not now",
+            theme: .light,
             didSelectSaveToLink: {},
             didSelectNotNow: {},
             didSelectURL: { _ in }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
@@ -111,6 +111,7 @@ final class NetworkingLinkSignupViewController: UIViewController {
             aboveCtaText: networkingLinkSignup.aboveCta,
             saveToLinkButtonText: networkingLinkSignup.cta,
             notNowButtonText: networkingLinkSignup.skipCta,
+            theme: dataSource.manifest.theme,
             didSelectSaveToLink: { [weak self] in
                 self?.didSelectSaveToLink()
             },
@@ -241,6 +242,7 @@ final class NetworkingLinkSignupViewController: UIViewController {
                 if urlHost == "legal-details-notice", let legalDetailsNotice {
                     let legalDetailsNoticeViewController = LegalDetailsNoticeViewController(
                         legalDetailsNotice: legalDetailsNotice,
+                        theme: dataSource.manifest.theme,
                         didSelectUrl: { [weak self] url in
                             self?.didSelectURLInTextFromBackend(
                                 url,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationViewController.swift
@@ -84,7 +84,8 @@ final class NetworkingSaveToLinkVerificationViewController: UIViewController {
                             customSuccessPaneMessage: nil
                         )
                     }
-                ) : nil
+                ) : nil,
+                theme: dataSource.manifest.theme
             ).footerView
         )
         paneLayoutView.addTo(view: view)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthViewController.swift
@@ -135,6 +135,7 @@ final class PartnerAuthViewController: SheetViewController {
                 prepaneModel: prepaneModel,
                 isRepairSession: false, // TODO(kgaidis): change this for repair sessions
                 panePresentationStyle: panePresentationStyle,
+                theme: dataSource.manifest.theme,
                 didSelectURL: { [weak self] url in
                     self?.didSelectURLInTextFromBackend(url)
                 },
@@ -289,6 +290,7 @@ final class PartnerAuthViewController: SheetViewController {
         }
         let continueStateViews = ContinueStateViews(
             institutionImageUrl: institution.icon?.default,
+            theme: dataSource.manifest.theme,
             didSelectContinue: { [weak self] in
                 guard let self else { return }
                 self.dataSource.analyticsClient.log(
@@ -550,6 +552,7 @@ final class PartnerAuthViewController: SheetViewController {
                     if let dataAccessNoticeModel = dataSource.pendingAuthSession?.display?.text?.oauthPrepane?.dataAccessNotice {
                         let dataAccessNoticeViewController = DataAccessNoticeViewController(
                             dataAccessNotice: dataAccessNoticeModel,
+                            theme: dataSource.manifest.theme,
                             didSelectUrl: { [weak self] url in
                                 self?.didSelectURLInTextFromBackend(url)
                             }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PrepaneViews.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PrepaneViews.swift
@@ -34,6 +34,7 @@ final class PrepaneViews {
         prepaneModel: FinancialConnectionsOAuthPrepane,
         isRepairSession: Bool,
         panePresentationStyle: PanePresentationStyle,
+        theme: FinancialConnectionsTheme?,
         didSelectURL: @escaping (URL) -> Void,
         didSelectContinue: @escaping () -> Void,
         didSelectCancel: @escaping () -> Void
@@ -89,7 +90,8 @@ final class PrepaneViews {
                         action: didSelectCancel
                     )
                 }
-            }()
+            }(),
+            theme: theme
         )
         self.footerView = footerViewTuple.footerView
         self.primaryButton = footerViewTuple.primaryButton
@@ -207,6 +209,7 @@ private class PrepanePreviewView: UIView {
         ),
         isRepairSession: false,
         panePresentationStyle: .sheet,
+        theme: .light,
         didSelectURL: { _ in },
         didSelectContinue: {},
         didSelectCancel: {}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PrepaneViews.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PrepaneViews.swift
@@ -34,7 +34,7 @@ final class PrepaneViews {
         prepaneModel: FinancialConnectionsOAuthPrepane,
         isRepairSession: Bool,
         panePresentationStyle: PanePresentationStyle,
-        theme: FinancialConnectionsTheme?,
+        theme: FinancialConnectionsTheme,
         didSelectURL: @escaping (URL) -> Void,
         didSelectContinue: @escaping () -> Void,
         didSelectCancel: @escaping () -> Void

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/Button+Extensions.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/Button+Extensions.swift
@@ -9,7 +9,7 @@ import Foundation
 @_spi(STP) import StripeUICore
 import UIKit
 
-extension Button {
+extension StripeUICore.Button {
     static func primary(theme: FinancialConnectionsTheme?) -> StripeUICore.Button {
         let button = Button(configuration: .financialConnectionsPrimary(theme: theme))
         button.layer.shadowColor = UIColor.black.cgColor
@@ -30,9 +30,9 @@ extension Button {
     }
 }
 
-extension Button.Configuration {
+extension StripeUICore.Button.Configuration {
 
-    fileprivate static func financialConnectionsPrimary(theme: FinancialConnectionsTheme?) -> Button.Configuration {
+    fileprivate static func financialConnectionsPrimary(theme: FinancialConnectionsTheme?) -> StripeUICore.Button.Configuration {
         var primaryButtonConfiguration = Button.Configuration.primary()
         primaryButtonConfiguration.font = FinancialConnectionsFont.label(.largeEmphasized).uiFont
         primaryButtonConfiguration.cornerRadius = 12.0
@@ -48,7 +48,7 @@ extension Button.Configuration {
         return primaryButtonConfiguration
     }
 
-    fileprivate static var financialConnectionsSecondary: Button.Configuration {
+    fileprivate static var financialConnectionsSecondary: StripeUICore.Button.Configuration {
         var secondaryButtonConfiguration = Button.Configuration.secondary()
         secondaryButtonConfiguration.font = FinancialConnectionsFont.label(.largeEmphasized).uiFont
         secondaryButtonConfiguration.cornerRadius = 12.0
@@ -92,3 +92,63 @@ private final class ButtonFeedbackGeneratorHandler: NSObject {
         )
     }
 }
+
+#if DEBUG
+
+import SwiftUI
+
+private struct PrimaryButtonViewRepresentable: UIViewRepresentable {
+    let theme: FinancialConnectionsTheme
+    let enabled: Bool
+
+    func makeUIView(context: Context) -> StripeUICore.Button {
+        let button = StripeUICore.Button.primary(theme: theme)
+        button.title = "primary | \(theme.rawValue) | \(enabled ? "enabled" : "disabled")"
+        return button
+    }
+
+    func updateUIView(_ uiView: StripeUICore.Button, context: Context) {
+        uiView.isEnabled = enabled
+    }
+}
+
+private struct SecondaryButtonViewRepresentable: UIViewRepresentable {
+    let enabled: Bool
+
+    func makeUIView(context: Context) -> StripeUICore.Button {
+        let button = StripeUICore.Button.secondary()
+        button.title = "secondary | \(enabled ? "enabled" : "disabled")"
+        return button
+    }
+
+    func updateUIView(_ uiView: StripeUICore.Button, context: Context) {
+        uiView.isEnabled = enabled
+    }
+}
+
+struct ButtonViewRepresentable_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack(spacing: 20) {
+            PrimaryButtonViewRepresentable(theme: .light, enabled: true)
+                .frame(height: 64)
+                .padding()
+            PrimaryButtonViewRepresentable(theme: .light, enabled: false)
+                .frame(height: 64)
+                .padding()
+            PrimaryButtonViewRepresentable(theme: .linkLight, enabled: true)
+                .frame(height: 64)
+                .padding()
+            PrimaryButtonViewRepresentable(theme: .linkLight, enabled: false)
+                .frame(height: 64)
+                .padding()
+            SecondaryButtonViewRepresentable(enabled: true)
+                .frame(height: 64)
+                .padding()
+            SecondaryButtonViewRepresentable(enabled: false)
+                .frame(height: 64)
+                .padding()
+        }
+    }
+}
+
+#endif

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/Button+Extensions.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/Button+Extensions.swift
@@ -10,7 +10,7 @@ import Foundation
 import UIKit
 
 extension StripeUICore.Button {
-    static func primary(theme: FinancialConnectionsTheme?) -> StripeUICore.Button {
+    static func primary(theme: FinancialConnectionsTheme) -> StripeUICore.Button {
         let button = Button(configuration: .financialConnectionsPrimary(theme: theme))
         button.layer.shadowColor = UIColor.black.cgColor
         button.layer.shadowRadius = 5 / UIScreen.main.nativeScale
@@ -32,7 +32,7 @@ extension StripeUICore.Button {
 
 extension StripeUICore.Button.Configuration {
 
-    fileprivate static func financialConnectionsPrimary(theme: FinancialConnectionsTheme?) -> StripeUICore.Button.Configuration {
+    fileprivate static func financialConnectionsPrimary(theme: FinancialConnectionsTheme) -> StripeUICore.Button.Configuration {
         var primaryButtonConfiguration = Button.Configuration.primary()
         primaryButtonConfiguration.font = FinancialConnectionsFont.label(.largeEmphasized).uiFont
         primaryButtonConfiguration.cornerRadius = 12.0

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/Button+Extensions.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/Button+Extensions.swift
@@ -10,8 +10,8 @@ import Foundation
 import UIKit
 
 extension Button {
-    static func primary() -> StripeUICore.Button {
-        let button = Button(configuration: .financialConnectionsPrimary)
+    static func primary(theme: FinancialConnectionsTheme?) -> StripeUICore.Button {
+        let button = Button(configuration: .financialConnectionsPrimary(theme: theme))
         button.layer.shadowColor = UIColor.black.cgColor
         button.layer.shadowRadius = 5 / UIScreen.main.nativeScale
         button.layer.shadowOpacity = 0.25
@@ -32,16 +32,16 @@ extension Button {
 
 extension Button.Configuration {
 
-    fileprivate static var financialConnectionsPrimary: Button.Configuration {
+    fileprivate static func financialConnectionsPrimary(theme: FinancialConnectionsTheme?) -> Button.Configuration {
         var primaryButtonConfiguration = Button.Configuration.primary()
         primaryButtonConfiguration.font = FinancialConnectionsFont.label(.largeEmphasized).uiFont
         primaryButtonConfiguration.cornerRadius = 12.0
         // default
-        primaryButtonConfiguration.backgroundColor = .brand500
-        primaryButtonConfiguration.foregroundColor = .white
+        primaryButtonConfiguration.backgroundColor = theme.primaryColor
+        primaryButtonConfiguration.foregroundColor = theme.primaryButtonTextColor
         // disabled
-        primaryButtonConfiguration.disabledBackgroundColor = .brand500
-        primaryButtonConfiguration.disabledForegroundColor = .neutral0.withAlphaComponent(0.4)
+        primaryButtonConfiguration.disabledBackgroundColor = theme.primaryColor
+        primaryButtonConfiguration.disabledForegroundColor = theme.primaryButtonTextColor.withAlphaComponent(0.4)
         // pressed
         primaryButtonConfiguration.colorTransforms.highlightedBackground = .darken(amount: 0.23)  // this tries to simulate `brand600`
         primaryButtonConfiguration.colorTransforms.highlightedForeground = nil

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/CloseConfirmationViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/CloseConfirmationViewController.swift
@@ -11,10 +11,10 @@ import UIKit
 
 final class CloseConfirmationViewController: SheetViewController {
 
-    private let theme: FinancialConnectionsTheme?
+    private let theme: FinancialConnectionsTheme
     private let didSelectClose: () -> Void
 
-    init(theme: FinancialConnectionsTheme?, didSelectClose: @escaping () -> Void) {
+    init(theme: FinancialConnectionsTheme, didSelectClose: @escaping () -> Void) {
         self.theme = theme
         self.didSelectClose = didSelectClose
         super.init()

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/CloseConfirmationViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/CloseConfirmationViewController.swift
@@ -11,9 +11,11 @@ import UIKit
 
 final class CloseConfirmationViewController: SheetViewController {
 
+    private let theme: FinancialConnectionsTheme?
     private let didSelectClose: () -> Void
 
-    init(didSelectClose: @escaping () -> Void) {
+    init(theme: FinancialConnectionsTheme?, didSelectClose: @escaping () -> Void) {
+        self.theme = theme
         self.didSelectClose = didSelectClose
         super.init()
     }
@@ -68,7 +70,8 @@ final class CloseConfirmationViewController: SheetViewController {
                             }
                         )
                     }
-                )
+                ),
+                theme: theme
             ).footerView
         )
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/DataAccessNoticeViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/DataAccessNoticeViewController.swift
@@ -12,13 +12,16 @@ import UIKit
 final class DataAccessNoticeViewController: SheetViewController {
 
     private let dataAccessNotice: FinancialConnectionsDataAccessNotice
+    private let theme: FinancialConnectionsTheme?
     private let didSelectUrl: (URL) -> Void
 
     init(
         dataAccessNotice: FinancialConnectionsDataAccessNotice,
+        theme: FinancialConnectionsTheme?,
         didSelectUrl: @escaping (URL) -> Void
     ) {
         self.dataAccessNotice = dataAccessNotice
+        self.theme = theme
         self.didSelectUrl = didSelectUrl
         super.init()
     }
@@ -69,6 +72,7 @@ final class DataAccessNoticeViewController: SheetViewController {
                 ),
                 secondaryButtonConfiguration: nil,
                 topText: dataAccessNotice.disclaimer,
+                theme: theme,
                 didSelectURL: didSelectUrl
             ).footerView
         )
@@ -194,6 +198,7 @@ private struct DataAccessNoticeViewControllerRepresentable: UIViewControllerRepr
     func makeUIViewController(context: Context) -> DataAccessNoticeViewController {
         DataAccessNoticeViewController(
             dataAccessNotice: dataAccessNotice,
+            theme: .light,
             didSelectUrl: { _  in })
     }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/DataAccessNoticeViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/DataAccessNoticeViewController.swift
@@ -12,12 +12,12 @@ import UIKit
 final class DataAccessNoticeViewController: SheetViewController {
 
     private let dataAccessNotice: FinancialConnectionsDataAccessNotice
-    private let theme: FinancialConnectionsTheme?
+    private let theme: FinancialConnectionsTheme
     private let didSelectUrl: (URL) -> Void
 
     init(
         dataAccessNotice: FinancialConnectionsDataAccessNotice,
-        theme: FinancialConnectionsTheme?,
+        theme: FinancialConnectionsTheme,
         didSelectUrl: @escaping (URL) -> Void
     ) {
         self.dataAccessNotice = dataAccessNotice

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/LegalDetailsNoticeViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/LegalDetailsNoticeViewController.swift
@@ -12,12 +12,12 @@ import UIKit
 final class LegalDetailsNoticeViewController: SheetViewController {
 
     private let legalDetailsNotice: FinancialConnectionsLegalDetailsNotice
-    private let theme: FinancialConnectionsTheme?
+    private let theme: FinancialConnectionsTheme
     private let didSelectUrl: (URL) -> Void
 
     init(
         legalDetailsNotice: FinancialConnectionsLegalDetailsNotice,
-        theme: FinancialConnectionsTheme?,
+        theme: FinancialConnectionsTheme,
         didSelectUrl: @escaping (URL) -> Void
     ) {
         self.legalDetailsNotice = legalDetailsNotice

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/LegalDetailsNoticeViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/LegalDetailsNoticeViewController.swift
@@ -12,13 +12,16 @@ import UIKit
 final class LegalDetailsNoticeViewController: SheetViewController {
 
     private let legalDetailsNotice: FinancialConnectionsLegalDetailsNotice
+    private let theme: FinancialConnectionsTheme?
     private let didSelectUrl: (URL) -> Void
 
     init(
         legalDetailsNotice: FinancialConnectionsLegalDetailsNotice,
+        theme: FinancialConnectionsTheme?,
         didSelectUrl: @escaping (URL) -> Void
     ) {
         self.legalDetailsNotice = legalDetailsNotice
+        self.theme = theme
         self.didSelectUrl = didSelectUrl
         super.init()
     }
@@ -53,6 +56,7 @@ final class LegalDetailsNoticeViewController: SheetViewController {
                 ),
                 secondaryButtonConfiguration: nil,
                 topText: legalDetailsNotice.disclaimer,
+                theme: theme,
                 didSelectURL: didSelectUrl
             ).footerView
         )

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/PaneLayoutView/PaneLayoutView+Extensions.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/PaneLayoutView/PaneLayoutView+Extensions.swift
@@ -145,6 +145,7 @@ extension PaneLayoutView {
         primaryButtonConfiguration: PaneLayoutView.ButtonConfiguration?,
         secondaryButtonConfiguration: PaneLayoutView.ButtonConfiguration? = nil,
         topText: String? = nil,
+        theme: FinancialConnectionsTheme?,
         didSelectURL: ((URL) -> Void)? = nil
     ) -> (footerView: UIView?, primaryButton: StripeUICore.Button?, secondaryButton: StripeUICore.Button?) {
         guard
@@ -177,7 +178,7 @@ extension PaneLayoutView {
 
         var primaryButtonReference: StripeUICore.Button?
         if let primaryButtonConfiguration = primaryButtonConfiguration {
-            let primaryButton = Button.primary()
+            let primaryButton = Button.primary(theme: theme)
             primaryButtonReference = primaryButton
             primaryButton.title = primaryButtonConfiguration.title
             primaryButton.accessibilityIdentifier = primaryButtonConfiguration.accessibilityIdentifier

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/PaneLayoutView/PaneLayoutView+Extensions.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/PaneLayoutView/PaneLayoutView+Extensions.swift
@@ -145,7 +145,7 @@ extension PaneLayoutView {
         primaryButtonConfiguration: PaneLayoutView.ButtonConfiguration?,
         secondaryButtonConfiguration: PaneLayoutView.ButtonConfiguration? = nil,
         topText: String? = nil,
-        theme: FinancialConnectionsTheme?,
+        theme: FinancialConnectionsTheme,
         didSelectURL: ((URL) -> Void)? = nil
     ) -> (footerView: UIView?, primaryButton: StripeUICore.Button?, secondaryButton: StripeUICore.Button?) {
         guard

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/SpinnerView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/SpinnerView.swift
@@ -11,7 +11,7 @@ import UIKit
 
 final class SpinnerView: UIView {
 
-    private let imageView = UIImageView(image: Image.spinner.makeImage(template: true))
+    private let imageView = UIImageView(image: Image.spinner.makeImage())
     private let animationKey = "animation_key"
 
     init(shouldStartAnimating: Bool = true) {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/SpinnerView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/SpinnerView.swift
@@ -11,7 +11,7 @@ import UIKit
 
 final class SpinnerView: UIView {
 
-    private let imageView = UIImageView(image: Image.spinner.makeImage())
+    private let imageView = UIImageView(image: Image.spinner.makeImage(template: true))
     private let animationKey = "animation_key"
 
     init(shouldStartAnimating: Bool = true) {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Success/SuccessFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Success/SuccessFooterView.swift
@@ -12,7 +12,7 @@ import UIKit
 
 final class SuccessFooterView: UIView {
 
-    private let theme: FinancialConnectionsTheme?
+    private let theme: FinancialConnectionsTheme
     private let didSelectDone: (SuccessFooterView) -> Void
 
     private lazy var doneButton: Button = {
@@ -28,7 +28,7 @@ final class SuccessFooterView: UIView {
     }()
 
     init(
-        theme: FinancialConnectionsTheme?,
+        theme: FinancialConnectionsTheme,
         didSelectDone: @escaping (SuccessFooterView) -> Void
     ) {
         self.theme = theme

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Success/SuccessFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Success/SuccessFooterView.swift
@@ -12,10 +12,11 @@ import UIKit
 
 final class SuccessFooterView: UIView {
 
+    private let theme: FinancialConnectionsTheme?
     private let didSelectDone: (SuccessFooterView) -> Void
 
     private lazy var doneButton: Button = {
-        let doneButton = Button.primary()
+        let doneButton = Button.primary(theme: theme)
         doneButton.title = "Done"  // TODO: replace with UIButton.doneButtonTitle once the SDK is localized
         doneButton.addTarget(self, action: #selector(didSelectDoneButton), for: .touchUpInside)
         doneButton.translatesAutoresizingMaskIntoConstraints = false
@@ -27,8 +28,10 @@ final class SuccessFooterView: UIView {
     }()
 
     init(
+        theme: FinancialConnectionsTheme?,
         didSelectDone: @escaping (SuccessFooterView) -> Void
     ) {
+        self.theme = theme
         self.didSelectDone = didSelectDone
         super.init(frame: .zero)
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Success/SuccessViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Success/SuccessViewController.swift
@@ -48,6 +48,7 @@ final class SuccessViewController: UIViewController {
         contentView.addSubview(bodyView)
 
         let footerView = SuccessFooterView(
+            theme: dataSource.manifest.theme,
             didSelectDone: { [weak self] footerView in
                 guard let self = self else { return }
                 // we NEVER set isLoading to `false` because

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/TerminalError/TerminalErrorView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/TerminalError/TerminalErrorView.swift
@@ -11,7 +11,7 @@ import UIKit
 
 func TerminalErrorView(
     allowManualEntry: Bool,
-    theme: FinancialConnectionsTheme?,
+    theme: FinancialConnectionsTheme,
     didSelectManualEntry: @escaping () -> Void,
     didSelectClose: @escaping () -> Void
 ) -> UIView {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/TerminalError/TerminalErrorView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/TerminalError/TerminalErrorView.swift
@@ -11,6 +11,7 @@ import UIKit
 
 func TerminalErrorView(
     allowManualEntry: Bool,
+    theme: FinancialConnectionsTheme?,
     didSelectManualEntry: @escaping () -> Void,
     didSelectClose: @escaping () -> Void
 ) -> UIView {
@@ -56,7 +57,8 @@ func TerminalErrorView(
                         }
                     )
                 }
-            }()
+            }(),
+            theme: theme
         ).footerView
     ).createView()
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/TerminalError/TerminalErrorViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/TerminalError/TerminalErrorViewController.swift
@@ -19,11 +19,13 @@ final class TerminalErrorViewController: UIViewController {
 
     private let error: Error
     private let allowManualEntry: Bool
+    private let theme: FinancialConnectionsTheme?
     weak var delegate: TerminalErrorViewControllerDelegate?
 
-    init(error: Error, allowManualEntry: Bool) {
+    init(error: Error, allowManualEntry: Bool, theme: FinancialConnectionsTheme?) {
         self.error = error
         self.allowManualEntry = allowManualEntry
+        self.theme = theme
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -38,6 +40,7 @@ final class TerminalErrorViewController: UIViewController {
 
         let terminalErrorView = TerminalErrorView(
             allowManualEntry: true,
+            theme: theme,
             didSelectManualEntry: { [weak self] in
                 guard let self = self else { return }
                 self.delegate?.terminalErrorViewControllerDidSelectManualEntry(self)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/TerminalError/TerminalErrorViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/TerminalError/TerminalErrorViewController.swift
@@ -19,10 +19,10 @@ final class TerminalErrorViewController: UIViewController {
 
     private let error: Error
     private let allowManualEntry: Bool
-    private let theme: FinancialConnectionsTheme?
+    private let theme: FinancialConnectionsTheme
     weak var delegate: TerminalErrorViewControllerDelegate?
 
-    init(error: Error, allowManualEntry: Bool, theme: FinancialConnectionsTheme?) {
+    init(error: Error, allowManualEntry: Bool, theme: FinancialConnectionsTheme) {
         self.error = error
         self.allowManualEntry = allowManualEntry
         self.theme = theme

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Web/ContinueStateView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Web/ContinueStateView.swift
@@ -18,7 +18,7 @@ final class ContinueStateViews {
 
     init(
         institutionImageUrl: String?,
-        theme: FinancialConnectionsTheme?,
+        theme: FinancialConnectionsTheme,
         didSelectContinue: @escaping () -> Void,
         didSelectCancel: (() -> Void)? = nil
     ) {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Web/ContinueStateView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Web/ContinueStateView.swift
@@ -18,6 +18,7 @@ final class ContinueStateViews {
 
     init(
         institutionImageUrl: String?,
+        theme: FinancialConnectionsTheme?,
         didSelectContinue: @escaping () -> Void,
         didSelectCancel: (() -> Void)? = nil
     ) {
@@ -55,7 +56,8 @@ final class ContinueStateViews {
                 } else {
                     return nil
                 }
-            }()
+            }(),
+            theme: theme
         )
         self.footerView = footerViewTuple.footerView
         self.primaryButton = footerViewTuple.primaryButton

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsWebFlowViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsWebFlowViewController.swift
@@ -37,6 +37,7 @@ final class FinancialConnectionsWebFlowViewController: UIViewController {
     private lazy var continueStateView: UIView = {
         let continueStateViews = ContinueStateViews(
             institutionImageUrl: nil,
+            theme: manifest.theme,
             didSelectContinue: { [weak self] in
                 guard let self else { return }
                 if let url = self.lastOpenedNativeURL {


### PR DESCRIPTION
## Summary

This is the first PR of many for theming the Financial Connections flow based on the `theme` value we receive in the `synchronize` call. Specifically, this themes the primary button, and also updates the navigation bar theme values to be centralized in `FinancialConnectionsTheme`. 

This touches many files, as with dependency injection we need to pass in this value from view controllers down to the view builders.

## Motivation

Alignment with the [Instant Debits figma](https://www.figma.com/design/wXQ8NJApqSJiLmxxANDRTs/%E2%9C%A8-Connections-3.0?node-id=787-114662&t=C9zgpIX82HpMQJuU-0)

## Testing

Manually ensured the primary button colors in the Financial Connections flow are unchanged, and are using the appropriate colors in the Instant Debits flow.

| Financial Connections | Instant Debits |
|--------|--------|
| ![Simulator Screenshot - iPhone 12 mini - 2024-07-17 at 16 10 02](https://github.com/user-attachments/assets/56aa4280-e989-4f3b-b884-3a78faf8359b) | ![Simulator Screenshot - iPhone 12 mini - 2024-07-17 at 16 09 47](https://github.com/user-attachments/assets/a31cc446-1145-46c0-b7f8-e1095427b43c) | 

## Changelog

N/a