### PR TITLE
[FC - Singleton] Create FinancialConnectionsTheme and apply to primary button

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
+++ b/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		492651662C24C9E7001DDBCA /* TestModeAutofillBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 492651652C24C9E7001DDBCA /* TestModeAutofillBannerView.swift */; };
 		492651682C25C0C2001DDBCA /* info@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 492651672C25C0C2001DDBCA /* info@3x.png */; };
 		494D62072C45B9B700106519 /* link_logo@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 494D62062C45B9B700106519 /* link_logo@3x.png */; };
+		495539F02C485D2900543D18 /* FinancialConnectionsTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495539EF2C485D2900543D18 /* FinancialConnectionsTheme.swift */; };
 		496A6AE72C29E0BB00D34F8E /* testmode@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 496A6AE62C29E0BB00D34F8E /* testmode@3x.png */; };
 		4A0D015C978BD79BBFE6CE57 /* ManualEntryDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4C39F5F9AF440B13F51A81 /* ManualEntryDataSource.swift */; };
 		4A537AE0C50CAFF3889EFE28 /* UIViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7E41313B709F87B549D85F /* UIViewController+Extensions.swift */; };
@@ -313,6 +314,7 @@
 		492651652C24C9E7001DDBCA /* TestModeAutofillBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestModeAutofillBannerView.swift; sourceTree = "<group>"; };
 		492651672C25C0C2001DDBCA /* info@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "info@3x.png"; sourceTree = "<group>"; };
 		494D62062C45B9B700106519 /* link_logo@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "link_logo@3x.png"; sourceTree = "<group>"; };
+		495539EF2C485D2900543D18 /* FinancialConnectionsTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsTheme.swift; sourceTree = "<group>"; };
 		496A6AE62C29E0BB00D34F8E /* testmode@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testmode@3x.png"; sourceTree = "<group>"; };
 		4A7B146AA6BF44921A249DB8 /* EmptyFinancialConnectionsAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyFinancialConnectionsAPIClient.swift; sourceTree = "<group>"; };
 		4AFBF95DAE0783010A17EB58 /* FinancialConnectionsSession_only_accounts.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = FinancialConnectionsSession_only_accounts.json; sourceTree = "<group>"; };
@@ -738,6 +740,7 @@
 				ACEF0BAF1A5BBA3061C15A09 /* FinancialConnectionsSession.swift */,
 				429F985168AE9F9D700AE37B /* FinancialConnectionsSessionManifest.swift */,
 				4667E3861CDEC3A41B757714 /* FinancialConnectionsSynchronize.swift */,
+				495539EF2C485D2900543D18 /* FinancialConnectionsTheme.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1390,6 +1393,7 @@
 				99F41681B77ECB0090F34E31 /* SFSafariViewController+Extensions.swift in Sources */,
 				AA80602323C28AFAC391358D /* TimeInterval+Extensions.swift in Sources */,
 				E637387728FA1597B1B51E5D /* UIImage+Extensions.swift in Sources */,
+				495539F02C485D2900543D18 /* FinancialConnectionsTheme.swift in Sources */,
 				486E50E6CB90208AB98C031E /* UIImageView+Extensions.swift in Sources */,
 				F0FB346A0F86C3561CD3C048 /* UITableView+Extensions.swift in Sources */,
 				A34AB3AC6D071605CABFFC9B /* UIViewController+KeyboardAvoiding.swift in Sources */,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsTheme.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsTheme.swift
@@ -1,0 +1,58 @@
+//
+//  FinancialConnectionsTheme.swift
+//  StripeFinancialConnections
+//
+//  Created by Mat Schmid on 2024-07-17.
+//
+
+import UIKit
+
+class FinancialConnectionsTheme {
+    static let current = FinancialConnectionsTheme()
+    private var theme: FinancialConnectionsSessionManifest.Theme?
+
+    // Ensures the shared instance `.current` is used.
+    private init() {}
+
+    func setTheme(_ theme: FinancialConnectionsSessionManifest.Theme?) {
+        self.theme = theme
+    }
+
+    // MARK: Theme values
+
+    var logo: Image {
+        switch theme {
+        case .linkLight:
+            return .link_logo
+        case .light, .dashboardLight, .unparsable, .none:
+            return .stripe_logo
+        }
+    }
+
+    var primaryColor: UIColor {
+        switch theme {
+        case .linkLight:
+            return .linkGreen200
+        case .light, .dashboardLight, .unparsable, .none:
+            return .brand500
+        }
+    }
+
+    var primaryButtonTextColor: UIColor {
+        switch theme {
+        case .linkLight:
+            return .linkGreen900
+        case .light, .dashboardLight, .unparsable, .none:
+            return .white
+        }
+    }
+
+    var logoColor: UIColor {
+        switch theme {
+        case .linkLight:
+            return .linkGreen900
+        case .light, .dashboardLight, .unparsable, .none:
+            return .textActionPrimary
+        }
+    }
+}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/FinancialConnectionsNavigationController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/FinancialConnectionsNavigationController.swift
@@ -148,7 +148,6 @@ extension FinancialConnectionsNavigationController {
         _ navigationItem: UINavigationItem?,
         closeItem: UIBarButtonItem,
         shouldHideLogo: Bool,
-        theme: FinancialConnectionsSessionManifest.Theme?,
         isTestMode: Bool
     ) {
         let iconHeight: CGFloat = 20
@@ -174,19 +173,9 @@ extension FinancialConnectionsNavigationController {
         let logoView: UIImageView? = {
             guard !shouldHideLogo else { return nil }
 
-            let logo: Image
-            let tint: UIColor
-            switch theme {
-            case .linkLight:
-                logo = .link_logo
-                tint = .linkGreen900
-            case .light, .dashboardLight, .unparsable, .none:
-                logo = .stripe_logo
-                tint = .textActionPrimary
-            }
-
-            let logoImage = UIImageView(image: logo.makeImage(template: true))
-            logoImage.tintColor = tint
+            let theme = FinancialConnectionsTheme.current
+            let logoImage = UIImageView(image: theme.logo.makeImage(template: true))
+            logoImage.tintColor = theme.logoColor
             logoImage.contentMode = .scaleAspectFit
             logoImage.sizeToFit()
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostController.swift
@@ -99,6 +99,7 @@ extension HostController: HostViewControllerDelegate {
         didFetch synchronizePayload: FinancialConnectionsSynchronize
     ) {
         delegate?.hostController(self, didReceiveEvent: FinancialConnectionsEvent(name: .open))
+        FinancialConnectionsTheme.current.setTheme(synchronizePayload.manifest.theme)
 
         let flowRouter = FlowRouter(
             synchronizePayload: synchronizePayload,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/UIColor+Extensions.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/UIColor+Extensions.swift
@@ -171,6 +171,10 @@ extension UIColor {
         return UIColor(red: 26 / 255.0, green: 197 / 255.0, blue: 155 / 255.0, alpha: 1)  // #1ac59b
     }
 
+    static var linkGreen200: UIColor {
+        return UIColor(red: 0 / 255.0, green: 214 / 255.0, blue: 111 / 255.0, alpha: 1)  // #00D66F
+    }
+
     static var linkGreen900: UIColor {
         return UIColor(red: 1 / 255.0, green: 30 / 255.0, blue: 15 / 255.0, alpha: 1)  // #011E0F
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -156,7 +156,6 @@ extension NativeFlowController {
                         reducedBranding: self.dataManager.reducedBranding,
                         merchantLogo: self.dataManager.merchantLogo
                     ),
-                    theme: self.dataManager.manifest.theme,
                     isTestMode: self.dataManager.manifest.isTestMode
                 )
             }
@@ -203,7 +202,6 @@ extension NativeFlowController {
                         reducedBranding: self.dataManager.reducedBranding,
                         merchantLogo: self.dataManager.merchantLogo
                     ),
-                    theme: self.dataManager.manifest.theme,
                     isTestMode: self.dataManager.manifest.isTestMode
                 )
                 self.navigationController.pushViewController(viewController, animated: animated)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/Button+Extensions.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/Button+Extensions.swift
@@ -33,15 +33,16 @@ extension Button {
 extension Button.Configuration {
 
     fileprivate static var financialConnectionsPrimary: Button.Configuration {
+        let theme = FinancialConnectionsTheme.current
         var primaryButtonConfiguration = Button.Configuration.primary()
         primaryButtonConfiguration.font = FinancialConnectionsFont.label(.largeEmphasized).uiFont
         primaryButtonConfiguration.cornerRadius = 12.0
         // default
-        primaryButtonConfiguration.backgroundColor = .brand500
-        primaryButtonConfiguration.foregroundColor = .white
+        primaryButtonConfiguration.backgroundColor = theme.primaryColor
+        primaryButtonConfiguration.foregroundColor = theme.primaryButtonTextColor
         // disabled
-        primaryButtonConfiguration.disabledBackgroundColor = .brand500
-        primaryButtonConfiguration.disabledForegroundColor = .neutral0.withAlphaComponent(0.4)
+        primaryButtonConfiguration.disabledBackgroundColor = theme.primaryColor
+        primaryButtonConfiguration.disabledForegroundColor = theme.primaryButtonTextColor.withAlphaComponent(0.4)
         // pressed
         primaryButtonConfiguration.colorTransforms.highlightedBackground = .darken(amount: 0.23)  // this tries to simulate `brand600`
         primaryButtonConfiguration.colorTransforms.highlightedForeground = nil


### PR DESCRIPTION
## Summary

This is an approach to theming the Financial Connections primary button using a singleton approach.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing

| Financial Connections | Instant Debits |
|--------|--------|
| ![Simulator Screenshot - iPhone 12 mini - 2024-07-17 at 16 10 02](https://github.com/user-attachments/assets/56aa4280-e989-4f3b-b884-3a78faf8359b) | ![Simulator Screenshot - iPhone 12 mini - 2024-07-17 at 16 09 47](https://github.com/user-attachments/assets/a31cc446-1145-46c0-b7f8-e1095427b43c) | 

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->