### PR TITLE
Payment Sheet: for instant debits, removed STPPaymentMethodType.instantDebits in favor of PaymentSheet.PaymentMethodType.instantDebits

### DIFF
--- a/Stripe/StripeiOS/Source/STPPaymentMethod+BasicUI.swift
+++ b/Stripe/StripeiOS/Source/STPPaymentMethod+BasicUI.swift
@@ -62,7 +62,7 @@ extension STPPaymentMethod: STPPaymentOption {
 
     @objc public var isReusable: Bool {
         switch type {
-        case .card, .link, .USBankAccount, .instantDebits:
+        case .card, .link, .USBankAccount:
             return true
         case .alipay,  // Careful! Revisit this if/when we support recurring Alipay
             .AUBECSDebit,

--- a/Stripe/StripeiOS/Source/STPPaymentMethodParams+BasicUI.swift
+++ b/Stripe/StripeiOS/Source/STPPaymentMethodParams+BasicUI.swift
@@ -34,7 +34,7 @@ extension STPPaymentMethodParams: STPPaymentOption {
 
     @objc public var isReusable: Bool {
         switch type {
-        case .card, .link, .USBankAccount, .instantDebits:
+        case .card, .link, .USBankAccount:
             return true
         case .alipay, .AUBECSDebit, .bacsDebit, .SEPADebit, .iDEAL, .FPX, .cardPresent, .giropay,
             .grabPay, .EPS, .przelewy24, .bancontact, .netBanking, .OXXO, .payPal, .sofort, .UPI,

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/en.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/en.lproj/Localizable.strings
@@ -34,6 +34,9 @@
 /* Text for back button */
 "Back" = "Back";
 
+/* A label used in various UIs, including a button that represents a payment method type 'Bank' - where a user can pay with their bank account instead of, say, a credit card. */
+"Bank" = "Bank";
+
 /* Title for collected bank account information */
 "Bank account" = "Bank account";
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Categories/String+Localized.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Categories/String+Localized.swift
@@ -365,4 +365,8 @@ extension String.Localized {
     static var confirm: String {
         STPLocalizedString("Confirm", "Title used for various UIs, including a button that confirms entered payment details or the selection of a payment method.")
     }
+
+    static var bank: String {
+        STPLocalizedString("Bank", "A label used in various UIs, including a button that represents a payment method type 'Bank' - where a user can pay with their bank account instead of, say, a credit card.")
+    }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfirmParams.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfirmParams.swift
@@ -65,6 +65,9 @@ class IntentConfirmParams {
             let params = STPPaymentMethodParams(type: .unknown)
             params.rawTypeString = externalPaymentMethod.type
             self.init(params: params, type: type)
+        case .instantDebits:
+            let params = STPPaymentMethodParams(type: .link)
+            self.init(params: params, type: type)
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -28,7 +28,7 @@ extension PaymentSheet {
             case .external(let externalPaymentMethod):
                 return externalPaymentMethod.label
             case .instantDebits:
-                return STPLocalizedString("Bank", "Link Instant Debit payment method display name")
+                return String.Localized.bank
             }
         }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -171,8 +171,6 @@ extension PaymentSheet {
                 )
                 if availabilityStatus == .supported {
                     recommendedPaymentMethodTypes.append(.instantDebits)
-                } else {
-                    print("[Stripe SDK] Warning: instant_debits requires the StripeFinancialConnections SDK.")
                 }
             }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -227,8 +227,6 @@ extension PaymentSheet {
                         return [.returnURL]
                     case .USBankAccount, .boleto:
                         return [.userSupportsDelayedPaymentMethods]
-                    case .instantDebits:
-                        return [.financialConnectionsSDK]
                     case .sofort, .iDEAL, .bancontact:
                         // n.b. While sofort, iDEAL, and bancontact are themselves not delayed, they turn into SEPA upon save, which IS delayed.
                         return [.returnURL, .userSupportsDelayedPaymentMethods]
@@ -256,8 +254,6 @@ extension PaymentSheet {
                             .userSupportsDelayedPaymentMethods, .financialConnectionsSDK,
                             .validUSBankVerificationMethod,
                         ]
-                    case .instantDebits:
-                        return [.financialConnectionsSDK]
                     case .OXXO, .boleto, .AUBECSDebit, .SEPADebit, .konbini, .multibanco:
                         return [.userSupportsDelayedPaymentMethods]
                     case .bacsDebit, .sofort:

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentOption+Images.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentOption+Images.swift
@@ -150,7 +150,7 @@ extension STPPaymentMethodType {
     /// light/dark agnostic icons
     var iconRequiresTinting: Bool {
         switch self {
-        case .card, .AUBECSDebit, .USBankAccount, .konbini, .boleto, .instantDebits:
+        case .card, .AUBECSDebit, .USBankAccount, .konbini, .boleto:
             return true
         default:
             return false
@@ -184,7 +184,7 @@ extension STPPaymentMethodType {
                 return .pm_type_paypal
             case .AUBECSDebit:
                 return .pm_type_aubecsdebit
-            case .USBankAccount, .instantDebits:
+            case .USBankAccount:
                 return .pm_type_us_bank
             case .UPI:
                 return .pm_type_upi

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
@@ -23,7 +23,6 @@ extension PaymentSheet {
         .klarna, .afterpayClearpay, .affirm,
         .iDEAL, .bancontact, .sofort, .SEPADebit, .EPS, .giropay, .przelewy24,
         .USBankAccount,
-        .instantDebits,
         .AUBECSDebit,
         .UPI,
         .cashApp,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -127,68 +127,68 @@ class PaymentSheetFormFactory {
     }
 
     func make() -> PaymentMethodElement {
-        if case .instantDebits = paymentMethod {
+        switch paymentMethod {
+        case .instantDebits:
             return makeInstantDebits()
-        }
-
-        guard case .stripe(let paymentMethod) = paymentMethod else {
+        case .external:
             return makeExternalPaymentMethodForm()
-        }
-        var additionalElements = [Element]()
+        case .stripe(let paymentMethod):
+            var additionalElements = [Element]()
 
-        // We have two ways to create the form for a payment method
-        // 1. Custom, one-off forms
-        if paymentMethod == .card {
-            return makeCard(cardBrandChoiceEligible: cardBrandChoiceEligible)
-        } else if paymentMethod == .USBankAccount {
-            return makeUSBankAccount(merchantName: configuration.merchantDisplayName)
-        } else if paymentMethod == .UPI {
-            return makeUPI()
-        } else if paymentMethod == .cashApp && isSettingUp {
-            // special case, display mandate for Cash App when setting up or pi+sfu
-            additionalElements = [makeCashAppMandate()]
-        } else if paymentMethod == .payPal && isSettingUp {
-            // Paypal requires mandate when setting up
-            additionalElements = [makePaypalMandate()]
-        } else if paymentMethod == .revolutPay && isSettingUp {
-            // special case, display mandate for revolutPay when setting up or pi+sfu
-            additionalElements = [makeRevolutPayMandate()]
-        } else if paymentMethod == .klarna && isSettingUp {
-            // special case, display mandate for Klarna when setting up or pi+sfu
-            additionalElements = [makeKlarnaMandate()]
-        } else if paymentMethod == .amazonPay && isSettingUp {
-            // special case, display mandate for Amazon Pay when setting up or pi+sfu
-            additionalElements = [makeAmazonPayMandate()]
-        } else if paymentMethod == .bancontact {
-            return makeBancontact()
-        } else if paymentMethod == .bacsDebit {
-            return makeBacsDebit()
-        } else if paymentMethod == .blik {
-            return makeBLIK()
-        } else if paymentMethod == .OXXO {
-            return  makeOXXO()
-        } else if paymentMethod == .konbini {
-            return makeKonbini()
-        } else if paymentMethod == .boleto {
-            return makeBoleto()
-        } else if paymentMethod == .swish {
-            return makeSwish()
-        }
+            // We have two ways to create the form for a payment method
+            // 1. Custom, one-off forms
+            if paymentMethod == .card {
+                return makeCard(cardBrandChoiceEligible: cardBrandChoiceEligible)
+            } else if paymentMethod == .USBankAccount {
+                return makeUSBankAccount(merchantName: configuration.merchantDisplayName)
+            } else if paymentMethod == .UPI {
+                return makeUPI()
+            } else if paymentMethod == .cashApp && isSettingUp {
+                // special case, display mandate for Cash App when setting up or pi+sfu
+                additionalElements = [makeCashAppMandate()]
+            } else if paymentMethod == .payPal && isSettingUp {
+                // Paypal requires mandate when setting up
+                additionalElements = [makePaypalMandate()]
+            } else if paymentMethod == .revolutPay && isSettingUp {
+                // special case, display mandate for revolutPay when setting up or pi+sfu
+                additionalElements = [makeRevolutPayMandate()]
+            } else if paymentMethod == .klarna && isSettingUp {
+                // special case, display mandate for Klarna when setting up or pi+sfu
+                additionalElements = [makeKlarnaMandate()]
+            } else if paymentMethod == .amazonPay && isSettingUp {
+                // special case, display mandate for Amazon Pay when setting up or pi+sfu
+                additionalElements = [makeAmazonPayMandate()]
+            } else if paymentMethod == .bancontact {
+                return makeBancontact()
+            } else if paymentMethod == .bacsDebit {
+                return makeBacsDebit()
+            } else if paymentMethod == .blik {
+                return makeBLIK()
+            } else if paymentMethod == .OXXO {
+                return  makeOXXO()
+            } else if paymentMethod == .konbini {
+                return makeKonbini()
+            } else if paymentMethod == .boleto {
+                return makeBoleto()
+            } else if paymentMethod == .swish {
+                return makeSwish()
+            }
 
-        guard let spec = FormSpecProvider.shared.formSpec(for: paymentMethod.identifier) else {
-            stpAssertionFailure("Failed to get form spec for \(paymentMethod.identifier)!")
-            let errorAnalytic = ErrorAnalytic(event: .unexpectedPaymentSheetFormFactoryError, error: Error.missingFormSpec, additionalNonPIIParams: ["payment_method": paymentMethod.identifier])
-            analyticsClient.log(analytic: errorAnalytic)
-            return FormElement(elements: [], theme: theme)
-        }
-        if paymentMethod == .iDEAL {
-            return makeiDEAL(spec: spec)
-        } else if paymentMethod == .sofort {
-            return makeSofort(spec: spec)
-        }
+            guard let spec = FormSpecProvider.shared.formSpec(for: paymentMethod.identifier) else {
+                stpAssertionFailure("Failed to get form spec for \(paymentMethod.identifier)!")
+                let errorAnalytic = ErrorAnalytic(event: .unexpectedPaymentSheetFormFactoryError, error: Error.missingFormSpec, additionalNonPIIParams: ["payment_method": paymentMethod.identifier])
+                analyticsClient.log(analytic: errorAnalytic)
+                return FormElement(elements: [], theme: theme)
+            }
+            if paymentMethod == .iDEAL {
+                return makeiDEAL(spec: spec)
+            } else if paymentMethod == .sofort {
+                return makeSofort(spec: spec)
+            }
 
-        // 2. Element-based forms defined in JSON
-        return makeFormElementFromSpec(spec: spec, additionalElements: additionalElements)
+            // 2. Element-based forms defined in JSON
+            return makeFormElementFromSpec(spec: spec, additionalElements: additionalElements)
+        }
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -127,6 +127,10 @@ class PaymentSheetFormFactory {
     }
 
     func make() -> PaymentMethodElement {
+        if case .instantDebits = paymentMethod {
+            return makeInstantDebits()
+        }
+
         guard case .stripe(let paymentMethod) = paymentMethod else {
             return makeExternalPaymentMethodForm()
         }
@@ -169,8 +173,6 @@ class PaymentSheetFormFactory {
             return makeBoleto()
         } else if paymentMethod == .swish {
             return makeSwish()
-        } else if paymentMethod == .instantDebits {
-            return makeInstantDebits()
         }
 
         guard let spec = FormSpecProvider.shared.formSpec(for: paymentMethod.identifier) else {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/InstantDebitsPaymentMethodElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/InstantDebitsPaymentMethodElement.swift
@@ -23,6 +23,7 @@ final class InstantDebitsPaymentMethodElement: ContainerElement {
         return [linkedBankInfoSectionElement]
     }
     private let linkedBankInfoSectionElement: SectionElement
+    private let emailElement: TextFieldElement
     private let linkedBankInfoView: BankAccountInfoView
     private var linkedBank: InstantDebitsLinkedBank?
     private let theme: ElementsUITheme
@@ -64,33 +65,16 @@ final class InstantDebitsPaymentMethodElement: ContainerElement {
     }
 
     var enableCTA: Bool {
-        return email != nil
+        return !email.isEmpty
     }
-    var email: String? {
-        // try to get the email from the EmailElement
-        let paymentMethodParams = formElement.updateParams(
-            params: IntentConfirmParams(
-                type: .instantDebits
-            )
-        )?.paymentMethodParams
-        if let email = paymentMethodParams?.nonnil_billingDetails.email {
-            return email
-        } else if
-            configuration
-            .billingDetailsCollectionConfiguration
-            .attachDefaultsToPaymentMethod
-        {
-            // default email
-            return configuration.defaultBillingDetails.email
-        } else {
-            return nil
-        }
+    var email: String {
+        return emailElement.text
     }
 
     init(
         configuration: PaymentSheetFormFactoryConfig,
         titleElement: StaticElement?,
-        emailElement: PaymentMethodElement?,
+        emailElement: PaymentMethodElementWrapper<TextFieldElement>,
         theme: ElementsUITheme = .default
     ) {
         self.configuration = configuration
@@ -100,6 +84,7 @@ final class InstantDebitsPaymentMethodElement: ContainerElement {
             elements: [StaticElement(view: linkedBankInfoView)],
             theme: theme
         )
+        self.emailElement = emailElement.element
         self.linkedBank = nil
         self.linkedBankInfoSectionElement.view.isHidden = true
         self.theme = theme

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/InstantDebitsPaymentMethodElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/InstantDebitsPaymentMethodElement.swift
@@ -70,7 +70,7 @@ final class InstantDebitsPaymentMethodElement: ContainerElement {
         // try to get the email from the EmailElement
         let paymentMethodParams = formElement.updateParams(
             params: IntentConfirmParams(
-                type: .stripe(.instantDebits)
+                type: .instantDebits
             )
         )?.paymentMethodParams
         if let email = paymentMethodParams?.nonnil_billingDetails.email {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -25,20 +25,6 @@ class PaymentMethodFormViewController: UIViewController {
         // TODO Copied from AddPaymentMethodViewController but this seems wrong; we shouldn't have such divergent paths for link and instant debits. Where is the setDefaultBillingDetailsIfNecessary call, for example?
         if let linkEnabledElement = form as? LinkEnabledPaymentMethodElement {
             return linkEnabledElement.makePaymentOption(intent: intent)
-        } else if let instantDebitsFormElement = form as? InstantDebitsPaymentMethodElement {
-            // we use `.instantDebits` payment method locally to display a
-            // new button, but the actual payment method is `.link`, so
-            // here we change it for the intent confirmation process
-            let paymentMethodParams = STPPaymentMethodParams(type: .link)
-            let intentConfirmParams = IntentConfirmParams(
-                params: paymentMethodParams,
-                type: .stripe(.link)
-            )
-            if let confirmParams = instantDebitsFormElement.updateParams(params: intentConfirmParams) {
-                return .new(confirmParams: confirmParams)
-            } else {
-                return nil
-            }
         }
 
         let params = IntentConfirmParams(type: paymentMethodType)
@@ -197,7 +183,7 @@ extension PaymentMethodFormViewController {
             } else {
                 return true
             }
-        } else if paymentMethodType == .stripe(.instantDebits) {
+        } else if paymentMethodType == .instantDebits {
             // only override buy button (show "Continue") IF we don't have a linked bank
             return instantDebitsFormElement?.getLinkedBank() == nil
         }
@@ -209,7 +195,7 @@ extension PaymentMethodFormViewController {
         let isEnabled: Bool = {
             if paymentMethodType == .stripe(.USBankAccount) && usBankAccountFormElement?.canLinkAccount ?? false {
                 true
-            } else if paymentMethodType == .stripe(.instantDebits) && instantDebitsFormElement?.enableCTA ?? false {
+            } else if paymentMethodType == .instantDebits && instantDebitsFormElement?.enableCTA ?? false {
                 true
             } else {
                 false
@@ -235,7 +221,7 @@ extension PaymentMethodFormViewController {
         switch paymentMethodType {
         case .stripe(.USBankAccount):
             handleCollectBankAccount(from: viewController)
-        case .stripe(.instantDebits):
+        case .instantDebits:
             handleCollectInstantDebits(from: viewController)
         default:
             return

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -321,10 +321,7 @@ extension PaymentMethodFormViewController {
     }
 
     private func handleCollectInstantDebits(from viewController: UIViewController) {
-        guard
-            let instantDebitsFormElement,
-            let email = instantDebitsFormElement.email
-        else {
+        guard let instantDebitsFormElement else {
             let errorAnalytic = ErrorAnalytic(
                 event: .unexpectedPaymentSheetError,
                 error: Error.instantDebitsParamsMissing
@@ -335,7 +332,7 @@ extension PaymentMethodFormViewController {
         }
 
         let params = STPCollectBankAccountParams.collectInstantDebitsParams(
-            email: email
+            email: instantDebitsFormElement.email
         )
         let client = STPBankAccountCollector()
         let genericError = PaymentSheetError.accountLinkFailure

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
@@ -37,6 +37,8 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
                     return .new(confirmParams: params)
                 case .external(let type):
                     return .external(paymentMethod: type, billingDetails: params.paymentMethodParams.nonnil_billingDetails)
+                case .instantDebits:
+                    return .new(confirmParams: params)
                 }
             case .saved(paymentMethod: let paymentMethod):
                 return .saved(paymentMethod: paymentMethod, confirmParams: nil)

--- a/StripePayments/StripePayments/Resources/Localizations/en.lproj/Localizable.strings
+++ b/StripePayments/StripePayments/Resources/Localizations/en.lproj/Localizable.strings
@@ -16,9 +16,6 @@
 /* Payment Method type brand name */
 "Bancontact" = "Bancontact";
 
-/* Link Instant Debit payment method display name */
-"Bank" = "Bank";
-
 /* Payment Method type brand name */
 "BLIK" = "BLIK";
 

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodEnums.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodEnums.swift
@@ -88,14 +88,11 @@ import Foundation
     case twint
     /// A Multibanco payment method
     case multibanco
-    /// A Instant Debits payment method
-    case instantDebits
     /// An unknown type.
     case unknown
 
     /// Localized display name for this payment method type
     @_spi(STP) public var displayName: String {
-        let instantDebitsDisplayName = STPLocalizedString("Bank", "Link Instant Debit payment method display name")
         switch self {
         case .alipay:
             return STPLocalizedString("Alipay", "Payment Method type brand name")
@@ -177,8 +174,6 @@ import Foundation
             return "TWINT"
         case .multibanco:
             return "Multibanco"
-        case .instantDebits:
-            return instantDebitsDisplayName
         case .cardPresent,
             .unknown:
             return STPLocalizedString("Unknown", "Default missing source type label")
@@ -268,8 +263,6 @@ import Foundation
             return "twint"
         case .multibanco:
             return "multibanco"
-        case .instantDebits:
-            return "instant_debits"
         }
     }
 }

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodParams.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodParams.swift
@@ -744,7 +744,6 @@ public class STPPaymentMethodParams: NSObject, STPFormEncodable {
             .USBankAccount,
             .cashApp,
             .revolutPay,
-            .instantDebits,
             .unknown:
             return nil
         }
@@ -1261,7 +1260,7 @@ extension STPPaymentMethodParams {
             alma = STPPaymentMethodAlmaParams()
         case .multibanco:
             multibanco = STPPaymentMethodMultibancoParams()
-        case .cardPresent, .paynow, .zip, .konbini, .promptPay, .twint, .instantDebits:
+        case .cardPresent, .paynow, .zip, .konbini, .promptPay, .twint:
             // These payment methods don't have any params
             break
         case .unknown:
@@ -1341,8 +1340,6 @@ extension STPPaymentMethodParams {
             return "TWINT"
         case .multibanco:
             return "Multibanco"
-        case .instantDebits:
-            return "Bank"
         case .cardPresent, .unknown:
             return STPLocalizedString("Unknown", "Default missing source type label")
         case .paynow, .zip, .amazonPay, .alma, .mobilePay, .konbini, .promptPay, .swish:

--- a/StripePayments/StripePayments/Source/Categories/Enums+CustomStringConvertible.swift
+++ b/StripePayments/StripePayments/Source/Categories/Enums+CustomStringConvertible.swift
@@ -523,7 +523,7 @@ extension STPPaymentMethodType: CustomStringConvertible {
             return "swish"
         case .twint:
             return "TWINT"
-        case .paynow, .zip, .revolutPay, .mobilePay, .amazonPay, .alma, .konbini, .promptPay, .instantDebits:
+        case .paynow, .zip, .revolutPay, .mobilePay, .amazonPay, .alma, .konbini, .promptPay:
             // `description` is the value used when this type is converted to a string for debugging purposes, just use the display name.
             return displayName
         case .multibanco:

--- a/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
@@ -731,8 +731,7 @@ public class STPPaymentHandler: NSObject {
             .promptPay,
             .swish,
             .twint,
-            .multibanco,
-            .instantDebits:
+            .multibanco:
             return false
 
         case .unknown:


### PR DESCRIPTION
## Summary

@.yuki-stripe made a comment that the [original Instant Debit implementation](https://github.com/stripe/stripe-ios/pull/3528) should not have added `STPPaymentMethodType.instantDebits`. Instead, it should have added `PaymentSheet.PaymentMethodType.instantDebits`. This PR moves from the previous enum, to the 'new' enum.

## Testing

### Test Payment Intent

<img width="497" alt="image" src="https://github.com/user-attachments/assets/5d48857f-e242-4862-8f7c-49ae263bc08d">

https://github.com/user-attachments/assets/3bd52afa-69fb-4061-ac87-2ab91c0da50c

### Test Setup Intent

<img width="475" alt="image" src="https://github.com/user-attachments/assets/1104c1ca-d049-4904-a756-5f44d799b41b">

https://github.com/user-attachments/assets/331781e3-6397-4738-9be5-d1d5e63ece78
