### PR TITLE
Attempting to fix deleting multiple payment methods on iOS18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## X.Y.Z X-Y-Z
 ### PaymentSheet
 * [Fixed] Fixed a scroll issue with native 3DS2 authentication screen when the keyboard appears.
+* [Fixed] iOS 18 Compatibility with removing multiple saved payment methods
 
 ## 23.28.1 2024-07-16
 ### Payments

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentMethodCollectionView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentMethodCollectionView.swift
@@ -28,7 +28,7 @@ class SavedPaymentMethodCollectionView: UICollectionView {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .horizontal
         layout.sectionInset = UIEdgeInsets(
-            top: 0, left: PaymentSheetUI.defaultPadding, bottom: 0,
+            top: -6, left: PaymentSheetUI.defaultPadding, bottom: 0,
             right: PaymentSheetUI.defaultPadding)
         layout.itemSize = cellSize
         layout.minimumInteritemSpacing = 12

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentMethodCollectionView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentMethodCollectionView.swift
@@ -15,7 +15,7 @@ import UIKit
 
 // MARK: - Constants
 /// Entire cell size
-private let cellSize: CGSize = CGSize(width: 100, height: 88)
+private let cellSize: CGSize = CGSize(width: 106, height: 94)
 /// Size of the rounded rectangle that contains the PM logo
 let roundedRectangleSize = CGSize(width: 100, height: 64)
 private let paymentMethodLogoSize: CGSize = CGSize(width: 54, height: 40)
@@ -32,6 +32,7 @@ class SavedPaymentMethodCollectionView: UICollectionView {
             right: PaymentSheetUI.defaultPadding)
         layout.itemSize = cellSize
         layout.minimumInteritemSpacing = 12
+        layout.minimumLineSpacing = 4
         super.init(frame: .zero, collectionViewLayout: layout)
 
         showsHorizontalScrollIndicator = false
@@ -148,9 +149,9 @@ extension SavedPaymentMethodCollectionView {
                 contentView.addSubview($0)
             }
             NSLayoutConstraint.activate([
-                shadowRoundedRectangle.topAnchor.constraint(equalTo: contentView.topAnchor),
+                shadowRoundedRectangle.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 6),
                 shadowRoundedRectangle.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-                shadowRoundedRectangle.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+                shadowRoundedRectangle.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -6),
                 shadowRoundedRectangle.widthAnchor.constraint(
                     equalToConstant: roundedRectangleSize.width),
                 shadowRoundedRectangle.heightAnchor.constraint(
@@ -184,9 +185,9 @@ extension SavedPaymentMethodCollectionView {
                     equalTo: shadowRoundedRectangle.bottomAnchor, constant: 6),
 
                 accessoryButton.trailingAnchor.constraint(
-                    equalTo: shadowRoundedRectangle.trailingAnchor, constant: 6),
+                    equalTo: contentView.trailingAnchor, constant: 0),
                 accessoryButton.topAnchor.constraint(
-                    equalTo: shadowRoundedRectangle.topAnchor, constant: -6),
+                    equalTo: contentView.topAnchor, constant: 0),
             ])
         }
 
@@ -205,17 +206,6 @@ extension SavedPaymentMethodCollectionView {
             didSet {
                 update()
             }
-        }
-
-        override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
-            let translatedPoint = accessoryButton.convert(point, from: self)
-
-            // Ensures taps on the accessory button are handled properly as it lives outside its cells' bounds
-            if accessoryButton.bounds.contains(translatedPoint) && !accessoryButton.isHidden {
-                return accessoryButton.hitTest(translatedPoint, with: event)
-            }
-
-            return super.hitTest(point, with: event)
         }
 
         // MARK: - Internal Methods


### PR DESCRIPTION
## Summary
There seems to be an incompatibility with calling self.collectionView.reloadData() in the completion block of self.collectionView.performBatchUpdates, while using hitTest() in iOS 18.  Effectively you can tap a cell that is no longer a part of the collectionView, which will cause awkward behavior in our SDK.

## Motivation
iOS 18 compat

## Testing

## Changelog
[Fixed] iOS 18 Compatibility with removing multiple saved payment methods
