### PR TITLE
Fix bug where CVC recollection toggle animation in PaymentSheet somet…

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/BottomSheet/BottomSheetPresentationAnimator.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/BottomSheet/BottomSheetPresentationAnimator.swift
@@ -46,7 +46,14 @@ class BottomSheetPresentationAnimator: NSObject {
         }) { didComplete in
             // Calls viewDidAppear and viewDidDisappear
             fromVC.endAppearanceTransition()
-            transitionContext.completeTransition(didComplete)
+            // If the toVC is a BottomSheetViewController in the middle of setting its contentVC, wait until its animation finishes before completing the transition. Otherwise, `viewDidAppear` is called before the VC has fully transitioned onto the screen.
+            if let bottomSheetController = toVC as? BottomSheetViewController, bottomSheetController.isAnimatingSetContentViewController {
+                bottomSheetController.onSetContentViewControllerCompletion = {
+                    transitionContext.completeTransition(didComplete)
+                }
+            } else {
+                transitionContext.completeTransition(didComplete)
+            }
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/BottomSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/BottomSheetViewController.swift
@@ -65,6 +65,10 @@ class BottomSheetViewController: UIViewController, BottomSheetPresentable {
         }
     }
 
+    /// These two vars help `BottomSheetPresentationAnimator` coordinate its transition with `setContentViewController`, which can interfere if `setContent..` is called while `BottomSheetPresentationAnimator` is mid-transition
+    var isAnimatingSetContentViewController: Bool = false
+    var onSetContentViewControllerCompletion: (() -> Void)?
+
     func pushContentViewController(_ contentViewController: BottomSheetContentViewController) {
         contentStack.insert(contentViewController, at: 0)
         self.contentViewController = contentViewController
@@ -94,6 +98,7 @@ class BottomSheetViewController: UIViewController, BottomSheetPresentable {
             guard self.contentViewController !== oldContentViewController else {
                 return
             }
+            isAnimatingSetContentViewController = true
 
             // This is a hack to get the animation right.
             // Instead of allowing the height change to implicitly occur within
@@ -162,6 +167,11 @@ class BottomSheetViewController: UIViewController, BottomSheetPresentable {
 
                 // We shouldn't need this constraint anymore.
                 self.manualHeightConstraint.isActive = false
+
+                // Reset animation state and call the completion block
+                self.isAnimatingSetContentViewController = false
+                self.onSetContentViewControllerCompletion?()
+                self.onSetContentViewControllerCompletion = nil
             })
         }
     }


### PR DESCRIPTION
…imes occurs before the view has fully transitioned.

This happens when the load completes before the sheet has completed its presentation.
Order of events:
1. BottomSheet presentation starts (BottomSheetPresentationAnimator) w/ the loading VC as its content.
1. Load completes, triggers BottomSheetViewController to set its contentViewController, kicking off a transition animation.
1. Before ^ finishes, BottomSheet presentation completes. It's unaware that its content is still transitioning, so it calls completeTransition too early, which triggers viewDidAppear too early, which causes this jank.

Looks like:
<img src="https://github.com/user-attachments/assets/8a9b55b6-c86a-4fe7-ae15-29f78575690b" width="300">


## Testing
Manually tested

## Changelog
Bug never shipped. This only started becoming an issue w/ https://github.com/stripe/stripe-ios/pull/3783

