### PR TITLE
Financial Connections: for networking manual entry, added support for networking warm up pane Not Now

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
+++ b/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
@@ -91,6 +91,7 @@
 		6A3DA1F52C34A37F005C3F6E /* GenericInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A3DA1F42C34A37F005C3F6E /* GenericInfoViewController.swift */; };
 		6A3DA1F72C34B254005C3F6E /* GenericInfoFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A3DA1F62C34B254005C3F6E /* GenericInfoFooterView.swift */; };
 		6A43202A2B7E8C5400A67A70 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A4320292B7E8C5400A67A70 /* Constants.swift */; };
+		6A6F989C2C4F1BF00035C03D /* CreatePaneParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A6F989B2C4F1BF00035C03D /* CreatePaneParameters.swift */; };
 		6A732C9A2B61C51C00828CB1 /* ShimmeringView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A732C992B61C51C00828CB1 /* ShimmeringView.swift */; };
 		6A732C9C2B61C56A00828CB1 /* InstitutionTableLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A732C9B2B61C56A00828CB1 /* InstitutionTableLoadingView.swift */; };
 		6A732C9E2B64787E00828CB1 /* LinkAccountPickerLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A732C9D2B64787E00828CB1 /* LinkAccountPickerLoadingView.swift */; };
@@ -374,6 +375,7 @@
 		6A3DA1F42C34A37F005C3F6E /* GenericInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericInfoViewController.swift; sourceTree = "<group>"; };
 		6A3DA1F62C34B254005C3F6E /* GenericInfoFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericInfoFooterView.swift; sourceTree = "<group>"; };
 		6A4320292B7E8C5400A67A70 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		6A6F989B2C4F1BF00035C03D /* CreatePaneParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePaneParameters.swift; sourceTree = "<group>"; };
 		6A732C992B61C51C00828CB1 /* ShimmeringView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShimmeringView.swift; sourceTree = "<group>"; };
 		6A732C9B2B61C56A00828CB1 /* InstitutionTableLoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstitutionTableLoadingView.swift; sourceTree = "<group>"; };
 		6A732C9D2B64787E00828CB1 /* LinkAccountPickerLoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkAccountPickerLoadingView.swift; sourceTree = "<group>"; };
@@ -1007,6 +1009,7 @@
 				6A13B9F92B4E182A00FFA327 /* SpinnerView.swift */,
 				6A732C992B61C51C00828CB1 /* ShimmeringView.swift */,
 				6A3739152C4060BD00D1F765 /* AutoResizableUIView.swift */,
+				6A6F989B2C4F1BF00035C03D /* CreatePaneParameters.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -1296,6 +1299,7 @@
 				6944E131D351784058C7D734 /* FinancialConnectionsPaymentMethodType.swift in Sources */,
 				1C043C73281C0856D2C979C6 /* FinancialConnectionsSession.swift in Sources */,
 				9E0044ABEC04E2A8C50E3658 /* FinancialConnectionsSessionManifest.swift in Sources */,
+				6A6F989C2C4F1BF00035C03D /* CreatePaneParameters.swift in Sources */,
 				D936C8A9F6E018DB144A5B0A /* FinancialConnectionsSynchronize.swift in Sources */,
 				15EC9F36187C341800164428 /* FinancialConnectionsAnalyticsClient.swift in Sources */,
 				C61D5957D3276991795F7D16 /* FinancialConnectionsSheetAnalytics.swift in Sources */,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
@@ -102,6 +102,7 @@ protocol FinancialConnectionsAPIClient {
 
     func disableNetworking(
         disabledReason: String?,
+        clientSuggestedNextPaneOnDisableNetworking: String?,
         clientSecret: String
     ) -> Future<FinancialConnectionsSessionManifest>
 
@@ -539,6 +540,7 @@ extension STPAPIClient: FinancialConnectionsAPIClient {
                 case .failure(let error):
                     self.disableNetworking(
                         disabledReason: "account_numbers_not_available",
+                        clientSuggestedNextPaneOnDisableNetworking: nil,
                         clientSecret: clientSecret
                     ).observe { _ in } // ignoring return is intentional
 
@@ -604,6 +606,7 @@ extension STPAPIClient: FinancialConnectionsAPIClient {
 
     func disableNetworking(
         disabledReason: String?,
+        clientSuggestedNextPaneOnDisableNetworking: String?,
         clientSecret: String
     ) -> Future<FinancialConnectionsSessionManifest> {
         var body: [String: Any] = [
@@ -611,6 +614,7 @@ extension STPAPIClient: FinancialConnectionsAPIClient {
             "expand": ["active_auth_session"],
         ]
         body["disabled_reason"] = disabledReason
+        body["client_requested_next_pane_on_disable_networking"] = clientSuggestedNextPaneOnDisableNetworking
         return post(resource: APIEndpointDisableNetworking, parameters: body)
     }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerViewController.swift
@@ -108,7 +108,7 @@ final class AccountPickerViewController: UIViewController {
                                 url: url,
                                 pane: .accountPicker,
                                 analyticsClient: self.dataSource.analyticsClient,
-                                handleStripeScheme: { _ in }
+                                handleURL: { _, _ in }
                             )
                         }
                     )

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentViewController.swift
@@ -14,7 +14,8 @@ import UIKit
 protocol ConsentViewControllerDelegate: AnyObject {
     func consentViewController(
         _ viewController: ConsentViewController,
-        didRequestNextPane nextPane: FinancialConnectionsSessionManifest.NextPane
+        didRequestNextPane nextPane: FinancialConnectionsSessionManifest.NextPane,
+        nextPaneOrDrawerOnSecondaryCta: String?
     )
     func consentViewController(
         _ viewController: ConsentViewController,
@@ -165,11 +166,12 @@ class ConsentViewController: UIViewController {
             url: url,
             pane: .consent,
             analyticsClient: dataSource.analyticsClient,
-            handleStripeScheme: { urlHost in
+            handleURL: { urlHost, nextPaneOrDrawerOnSecondaryCta in
                 if urlHost == "manual-entry" {
                     delegate?.consentViewController(
                         self,
-                        didRequestNextPane: .manualEntry
+                        didRequestNextPane: .manualEntry,
+                        nextPaneOrDrawerOnSecondaryCta: nextPaneOrDrawerOnSecondaryCta
                     )
                 } else if urlHost == "data-access-notice" {
                     if let dataAccessNotice = dataSource.consent.dataAccessNotice {
@@ -193,7 +195,8 @@ class ConsentViewController: UIViewController {
                 } else if urlHost == "link-login" {
                     delegate?.consentViewController(
                         self,
-                        didRequestNextPane: .networkingLinkLoginWarmup
+                        didRequestNextPane: .networkingLinkLoginWarmup,
+                        nextPaneOrDrawerOnSecondaryCta: nextPaneOrDrawerOnSecondaryCta
                     )
                 }
             }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
@@ -200,7 +200,7 @@ final class LinkAccountPickerViewController: UIViewController {
                                 url: url,
                                 pane: .linkAccountPicker,
                                 analyticsClient: self.dataSource.analyticsClient,
-                                handleStripeScheme: { _ in }
+                                handleURL: { _, _ in }
                             )
                         }
                     )

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -166,6 +166,7 @@ extension NativeFlowController {
 
     private func pushPane(
         _ pane: FinancialConnectionsSessionManifest.NextPane,
+        parameters: CreatePaneParameters? = nil,
         animated: Bool,
         // useful for cases where we want to prevent the user from navigating back
         //
@@ -180,6 +181,7 @@ extension NativeFlowController {
         } else {
             let paneViewController = CreatePaneViewController(
                 pane: pane,
+                parameters: parameters,
                 nativeFlowController: self,
                 dataManager: dataManager
             )
@@ -216,10 +218,12 @@ extension NativeFlowController {
     }
 
     private func presentPaneAsSheet(
-        _ pane: FinancialConnectionsSessionManifest.NextPane
+        _ pane: FinancialConnectionsSessionManifest.NextPane,
+        parameters: CreatePaneParameters? = nil
     ) {
         let paneViewController = CreatePaneViewController(
             pane: pane,
+            parameters: parameters,
             nativeFlowController: self,
             dataManager: dataManager,
             panePresentationStyle: .sheet
@@ -514,12 +518,16 @@ extension NativeFlowController: ConsentViewControllerDelegate {
 
     func consentViewController(
         _ viewController: ConsentViewController,
-        didRequestNextPane nextPane: FinancialConnectionsSessionManifest.NextPane
+        didRequestNextPane nextPane: FinancialConnectionsSessionManifest.NextPane,
+        nextPaneOrDrawerOnSecondaryCta: String?
     ) {
+        let parameters = CreatePaneParameters(
+            nextPaneOrDrawerOnSecondaryCta: nextPaneOrDrawerOnSecondaryCta
+        )
         if nextPane == .networkingLinkLoginWarmup {
-            presentPaneAsSheet(nextPane)
+            presentPaneAsSheet(nextPane, parameters: parameters)
         } else {
-            pushPane(nextPane, animated: true)
+            pushPane(nextPane, parameters: parameters, animated: true)
         }
     }
 }
@@ -1014,6 +1022,7 @@ extension NativeFlowController: ErrorViewControllerDelegate {
 
 private func CreatePaneViewController(
     pane: FinancialConnectionsSessionManifest.NextPane,
+    parameters: CreatePaneParameters? = nil,
     nativeFlowController: NativeFlowController,
     dataManager: NativeFlowDataManager,
     panePresentationStyle: PanePresentationStyle = .fullscreen
@@ -1272,7 +1281,8 @@ private func CreatePaneViewController(
             manifest: dataManager.manifest,
             apiClient: dataManager.apiClient,
             clientSecret: dataManager.clientSecret,
-            analyticsClient: dataManager.analyticsClient
+            analyticsClient: dataManager.analyticsClient,
+            nextPaneOrDrawerOnSecondaryCta: parameters?.nextPaneOrDrawerOnSecondaryCta
         )
         let networkingLinkWarmupViewController = NetworkingLinkLoginWarmupViewController(
             dataSource: networkingLinkWarmupDataSource,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupDataSource.swift
@@ -21,22 +21,26 @@ final class NetworkingLinkLoginWarmupDataSourceImplementation: NetworkingLinkLog
     private let apiClient: FinancialConnectionsAPIClient
     private let clientSecret: String
     let analyticsClient: FinancialConnectionsAnalyticsClient
+    private let nextPaneOrDrawerOnSecondaryCta: String?
 
     init(
         manifest: FinancialConnectionsSessionManifest,
         apiClient: FinancialConnectionsAPIClient,
         clientSecret: String,
-        analyticsClient: FinancialConnectionsAnalyticsClient
+        analyticsClient: FinancialConnectionsAnalyticsClient,
+        nextPaneOrDrawerOnSecondaryCta: String?
     ) {
         self.manifest = manifest
         self.apiClient = apiClient
         self.clientSecret = clientSecret
         self.analyticsClient = analyticsClient
+        self.nextPaneOrDrawerOnSecondaryCta = nextPaneOrDrawerOnSecondaryCta
     }
 
     func disableNetworking() -> Future<FinancialConnectionsSessionManifest> {
         return apiClient.disableNetworking(
             disabledReason: "returning_consumer_opt_out",
+            clientSuggestedNextPaneOnDisableNetworking: nextPaneOrDrawerOnSecondaryCta,
             clientSecret: clientSecret
         )
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
@@ -237,7 +237,7 @@ final class NetworkingLinkSignupViewController: UIViewController {
             url: url,
             pane: .networkingLinkSignupPane,
             analyticsClient: dataSource.analyticsClient,
-            handleStripeScheme: { urlHost in
+            handleURL: { urlHost, _ in
                 if urlHost == "legal-details-notice", let legalDetailsNotice {
                     let legalDetailsNoticeViewController = LegalDetailsNoticeViewController(
                         legalDetailsNotice: legalDetailsNotice,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthViewController.swift
@@ -545,7 +545,7 @@ final class PartnerAuthViewController: SheetViewController {
             url: url,
             pane: .partnerAuth,
             analyticsClient: dataSource.analyticsClient,
-            handleStripeScheme: { urlHost in
+            handleURL: { urlHost, _ in
                 if urlHost == "data-access-notice" {
                     if let dataAccessNoticeModel = dataSource.pendingAuthSession?.display?.text?.oauthPrepane?.dataAccessNotice {
                         let dataAccessNoticeViewController = DataAccessNoticeViewController(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/AuthFlowHelpers.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/AuthFlowHelpers.swift
@@ -36,10 +36,17 @@ final class AuthFlowHelpers {
         url: URL,
         pane: FinancialConnectionsSessionManifest.NextPane,
         analyticsClient: FinancialConnectionsAnalyticsClient,
-        handleStripeScheme: (_ urlHost: String?) -> Void
+        handleURL: (_ urlHost: String?, _ nextPaneOrDrawerOnSecondaryCta: String?) -> Void
     ) {
-        if let urlParameters = URLComponents(url: url, resolvingAgainstBaseURL: true),
-            let eventName = urlParameters.queryItems?.first(where: { $0.name == "eventName" })?.value
+        let internalLinkToPaneId: [String: String] = [
+            "manual-entry": "manual_entry"
+        ]
+        let urlParameters = URLComponents(url: url, resolvingAgainstBaseURL: true)
+        if
+            let urlParameters,
+            let eventName = urlParameters.queryItems?.first(
+                where: { $0.name == "eventName" }
+            )?.value
         {
             analyticsClient
                 .log(
@@ -48,8 +55,18 @@ final class AuthFlowHelpers {
                 )
         }
 
+        var nextPaneOrDrawerOnSecondaryCta: String?
+        if
+            let urlParameters,
+            let _nextPaneOrDrawerOnSecondaryCta = urlParameters.queryItems?.first(
+                where: { $0.name == "nextPaneOrDrawerOnSecondaryCta" }
+            )?.value
+        {
+            nextPaneOrDrawerOnSecondaryCta = internalLinkToPaneId[_nextPaneOrDrawerOnSecondaryCta]
+        }
+
         if url.scheme == "stripe" {
-            handleStripeScheme(url.host)
+            handleURL(url.host, nextPaneOrDrawerOnSecondaryCta)
         } else {
             SFSafariViewController.present(url: url)
         }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/CreatePaneParameters.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/CreatePaneParameters.swift
@@ -1,0 +1,20 @@
+//
+//  CreatePaneParameters.swift
+//  StripeFinancialConnections
+//
+//  Created by Krisjanis Gaidis on 7/22/24.
+//
+
+import Foundation
+
+// A bag of extra parameters we can pass to `CreatePaneViewController` function
+// that creates new pane view controllers. This avoids preserving state in
+// `NativeFlowDataManager` where the state might be outdated after a specific
+// pane push.
+struct CreatePaneParameters {
+    let nextPaneOrDrawerOnSecondaryCta: String?
+
+    init(nextPaneOrDrawerOnSecondaryCta: String? = nil) {
+        self.nextPaneOrDrawerOnSecondaryCta = nextPaneOrDrawerOnSecondaryCta
+    }
+}


### PR DESCRIPTION
## Summary

This PR:
- This PR adds support for manual entry networking opt out. Press "Manually verify instead" > warm up pane presents > press "Not Now" (this then leads to manual entry INSTEAD OF institution picker as it does now).
- The way this works is that 1) we extract parameter from URL of pressing manual entry 2) we pass that parameter to warm up pane 3) when user presses Not Now, we pass that parameter to disableNetworking 4) disableNetworking/backend will return manual entry INSTEAD OF institution picker.

Context:
- Financial Connections is implementing support for "networking manual entry." This feature allows a user to enter their manually entered account _once_, and then we will allow them to reuse it later through Link. 
- This is just one PR of many where each PR will be merged to a feature branch `fc-networkingmanualentry`.
- It's expected that this PR may have some gaps or TODO's because its going to a feature branch. That being said, we still want to make sure there's no glaring logic issues/bugs. 

## Testing

### New Flow (manual entry "Now Now")

In this video, I am pressing the manual entry button at the bottom:

https://github.com/user-attachments/assets/98c15134-cc76-4999-afef-e96ea970082e

### Usual Flow (consent/institution picker "Not Now")

https://github.com/user-attachments/assets/9033c563-6ea1-42a2-a280-096583129397
