### PR TITLE
[BANKCON-11624] FC - Theme spinner view

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsTheme.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsTheme.swift
@@ -93,15 +93,22 @@ extension FinancialConnectionsTheme {
             return .brand600
         }
     }
-}
 
-extension FinancialConnectionsTheme? {
     var spinnerColor: UIColor {
         switch self {
         case .linkLight:
             return .linkGreen200
         case .light:
             return .brand500
+        }
+    }
+}
+
+extension FinancialConnectionsTheme? {
+    var spinnerColor: UIColor {
+        switch self {
+        case .some(let theme):
+            return theme.spinnerColor
         case .none:
             return .neutral200
         }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsTheme.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsTheme.swift
@@ -94,3 +94,16 @@ extension FinancialConnectionsTheme {
         }
     }
 }
+
+extension FinancialConnectionsTheme? {
+    var spinnerColor: UIColor {
+        switch self {
+        case .linkLight:
+            return .linkGreen200
+        case .light:
+            return .brand500
+        case .none:
+            return .neutral200
+        }
+    }
+}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostViewController.swift
@@ -43,7 +43,8 @@ final class HostViewController: UIViewController {
         return item
     }()
 
-    private let loadingView = LoadingView(frame: .zero)
+    // We haven't loaded the manifest yet, so we use a nil theme to show a neutral-colored spinner.
+    private let loadingView = LoadingView(frame: .zero, theme: nil)
 
     // MARK: - Properties
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/LoadingView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/LoadingView.swift
@@ -11,6 +11,8 @@ import UIKit
 
 class LoadingView: UIView {
 
+    private let theme: FinancialConnectionsTheme?
+
     // MARK: - Subview Properties
 
     private lazy var errorLabel: UILabel = {
@@ -44,11 +46,14 @@ class LoadingView: UIView {
         return stackView
     }()
 
-    private let spinnerView = SpinnerView(shouldStartAnimating: false)
+    private lazy var spinnerView = {
+        SpinnerView(theme: theme, shouldStartAnimating: false)
+    }()
 
     // MARK: - Init
 
-    override init(frame: CGRect) {
+    init(frame: CGRect, theme: FinancialConnectionsTheme?) {
+        self.theme = theme
         super.init(frame: frame)
 
         errorView.addArrangedSubview(errorLabel)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AttachLinkedPaymentAccount/AttachLinkedPaymentAccountViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AttachLinkedPaymentAccount/AttachLinkedPaymentAccountViewController.swift
@@ -81,7 +81,7 @@ final class AttachLinkedPaymentAccountViewController: UIViewController {
     }
 
     private func attachLinkedAccountIdToLinkAccountSession() {
-        let loadingView = SpinnerView()
+        let loadingView = SpinnerView(theme: dataSource.manifest.theme)
         view.addAndPinSubviewToSafeArea(loadingView)
 
         let pollingStartDate = Date()

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionCellView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionCellView.swift
@@ -10,7 +10,7 @@ import Foundation
 import UIKit
 
 final class InstitutionCellView: UIView {
-    private let theme: FinancialConnectionsTheme?
+    private let theme: FinancialConnectionsTheme!
 
     private lazy var horizontalStackView: UIStackView = {
         let horizontalStackView = UIStackView()
@@ -73,7 +73,7 @@ final class InstitutionCellView: UIView {
         return activityIndicator
     }()
 
-    init(theme: FinancialConnectionsTheme?) {
+    init(theme: FinancialConnectionsTheme) {
         self.theme = theme
         super.init(frame: .zero)
         backgroundColor = .clear

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionCellView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionCellView.swift
@@ -10,7 +10,7 @@ import Foundation
 import UIKit
 
 final class InstitutionCellView: UIView {
-    private let theme: FinancialConnectionsTheme!
+    private let theme: FinancialConnectionsTheme
 
     private lazy var horizontalStackView: UIStackView = {
         let horizontalStackView = UIStackView()

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionCellView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionCellView.swift
@@ -10,6 +10,7 @@ import Foundation
 import UIKit
 
 final class InstitutionCellView: UIView {
+    private let theme: FinancialConnectionsTheme?
 
     private lazy var horizontalStackView: UIStackView = {
         let horizontalStackView = UIStackView()
@@ -52,7 +53,7 @@ final class InstitutionCellView: UIView {
     private var iconView: UIView?
     private lazy var loadingView: ActivityIndicator = {
         let activityIndicator = ActivityIndicator(size: .medium)
-        activityIndicator.color = .iconActionPrimary
+        activityIndicator.color = theme.spinnerColor
         activityIndicator.startAnimating()
 
         // re-size `ActivityIndicator` to a size we desire
@@ -72,8 +73,9 @@ final class InstitutionCellView: UIView {
         return activityIndicator
     }()
 
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    init(theme: FinancialConnectionsTheme?) {
+        self.theme = theme
+        super.init(frame: .zero)
         backgroundColor = .clear
         addAndPinSubview(horizontalStackView)
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionTableFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionTableFooterView.swift
@@ -23,7 +23,7 @@ final class InstitutionTableFooterView: UIView {
         self.didSelect = didSelect
         super.init(frame: .zero)
 
-        let institutionCellView = InstitutionCellView()
+        let institutionCellView = InstitutionCellView(theme: theme)
         institutionCellView.customize(
             iconView: RoundedIconView(
                 image: .image(image),

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionTableView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionTableView.swift
@@ -120,7 +120,7 @@ final class InstitutionTableView: UIView {
                     "Unable to dequeue cell \(InstitutionTableViewCell.self) with cell identifier \(cellIdentifier)"
                 )
             }
-            cell.customize(with: institution)
+            cell.customize(with: institution, theme: theme)
             return cell
         }
         dataSource.defaultRowAnimation = .fade

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionTableViewCell.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionTableViewCell.swift
@@ -10,14 +10,12 @@ import Foundation
 import UIKit
 
 final class InstitutionTableViewCell: UITableViewCell {
-    private var theme: FinancialConnectionsTheme!
-
     private lazy var institutionIconView: InstitutionIconView = {
         return InstitutionIconView()
     }()
-    private lazy var institutionCellView: InstitutionCellView = {
-        return InstitutionCellView(theme: theme)
-    }()
+
+    private var institutionCellView: InstitutionCellView?
+
     private lazy var overlayView: UIView = {
         let overlayView = UIView()
         overlayView.backgroundColor = .customBackgroundColor.withAlphaComponent(0.8)
@@ -51,7 +49,7 @@ final class InstitutionTableViewCell: UITableViewCell {
     }
 
     func showLoadingView(_ show: Bool) {
-        institutionCellView.showLoadingView(show)
+        institutionCellView?.showLoadingView(show)
     }
 
     func showOverlayView(_ show: Bool) {
@@ -75,7 +73,7 @@ final class InstitutionTableViewCell: UITableViewCell {
 extension InstitutionTableViewCell {
 
     func customize(with institution: FinancialConnectionsInstitution, theme: FinancialConnectionsTheme) {
-        self.theme = theme
+        let institutionCellView = InstitutionCellView(theme: theme)
         institutionIconView.setImageUrl(institution.icon?.default)
 
         institutionCellView.customize(
@@ -84,7 +82,11 @@ extension InstitutionTableViewCell {
             subtitle: AuthFlowHelpers.formatUrlString(institution.url)
         )
 
+        // Ensure the cell view isn't added to superview more than once.
+        self.institutionCellView?.removeFromSuperview()
         contentView.addAndPinSubview(institutionCellView)
+
+        self.institutionCellView = institutionCellView
     }
 }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionTableViewCell.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionTableViewCell.swift
@@ -10,12 +10,13 @@ import Foundation
 import UIKit
 
 final class InstitutionTableViewCell: UITableViewCell {
+    private var theme: FinancialConnectionsTheme?
 
     private lazy var institutionIconView: InstitutionIconView = {
         return InstitutionIconView()
     }()
     private lazy var institutionCellView: InstitutionCellView = {
-        return InstitutionCellView()
+        return InstitutionCellView(theme: theme)
     }()
     private lazy var overlayView: UIView = {
         let overlayView = UIView()
@@ -27,7 +28,6 @@ final class InstitutionTableViewCell: UITableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         adjustBackgroundColor(isHighlighted: false)
-        contentView.addAndPinSubview(institutionCellView)
     }
 
     required init?(coder: NSCoder) {
@@ -74,7 +74,8 @@ final class InstitutionTableViewCell: UITableViewCell {
 
 extension InstitutionTableViewCell {
 
-    func customize(with institution: FinancialConnectionsInstitution) {
+    func customize(with institution: FinancialConnectionsInstitution, theme: FinancialConnectionsTheme?) {
+        self.theme = theme
         institutionIconView.setImageUrl(institution.icon?.default)
 
         institutionCellView.customize(
@@ -82,6 +83,8 @@ extension InstitutionTableViewCell {
             title: institution.name,
             subtitle: AuthFlowHelpers.formatUrlString(institution.url)
         )
+
+        contentView.addAndPinSubview(institutionCellView)
     }
 }
 
@@ -94,6 +97,7 @@ private struct InstitutionTableViewCellUIViewRepresentable: UIViewRepresentable 
 
     let showLoadingView: Bool
     let showOverlayView: Bool
+    let theme: FinancialConnectionsTheme
 
     func makeUIView(context: Context) -> InstitutionTableViewCell {
         InstitutionTableViewCell(style: .default, reuseIdentifier: "test")
@@ -108,7 +112,8 @@ private struct InstitutionTableViewCellUIViewRepresentable: UIViewRepresentable 
                 url: "https://www.bankofamerica.com/",
                 icon: nil,
                 logo: nil
-            )
+            ),
+            theme: theme
         )
         uiView.showLoadingView(showLoadingView)
         uiView.showOverlayView(showOverlayView)
@@ -121,17 +126,26 @@ struct InstitutionTableViewCell_Previews: PreviewProvider {
         VStack(spacing: 20) {
             InstitutionTableViewCellUIViewRepresentable(
                 showLoadingView: false,
-                showOverlayView: false
+                showOverlayView: false,
+                theme: .light
             ).frame(width: 343, height: 72)
 
             InstitutionTableViewCellUIViewRepresentable(
                 showLoadingView: true,
-                showOverlayView: false
+                showOverlayView: false,
+                theme: .light
+            ).frame(width: 343, height: 72)
+
+            InstitutionTableViewCellUIViewRepresentable(
+                showLoadingView: true,
+                showOverlayView: false,
+                theme: .linkLight
             ).frame(width: 343, height: 72)
 
             InstitutionTableViewCellUIViewRepresentable(
                 showLoadingView: false,
-                showOverlayView: true
+                showOverlayView: true,
+                theme: .light
             ).frame(width: 343, height: 72)
             Spacer()
         }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionTableViewCell.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionTableViewCell.swift
@@ -10,7 +10,7 @@ import Foundation
 import UIKit
 
 final class InstitutionTableViewCell: UITableViewCell {
-    private var theme: FinancialConnectionsTheme?
+    private var theme: FinancialConnectionsTheme!
 
     private lazy var institutionIconView: InstitutionIconView = {
         return InstitutionIconView()
@@ -74,7 +74,7 @@ final class InstitutionTableViewCell: UITableViewCell {
 
 extension InstitutionTableViewCell {
 
-    func customize(with institution: FinancialConnectionsInstitution, theme: FinancialConnectionsTheme?) {
+    func customize(with institution: FinancialConnectionsInstitution, theme: FinancialConnectionsTheme) {
         self.theme = theme
         institutionIconView.setImageUrl(institution.icon?.default)
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -1286,6 +1286,7 @@ private func CreatePaneViewController(
         let resetFlowDataSource = ResetFlowDataSourceImplementation(
             apiClient: dataManager.apiClient,
             clientSecret: dataManager.clientSecret,
+            manifest: dataManager.manifest,
             analyticsClient: dataManager.analyticsClient
         )
         let resetFlowViewController = ResetFlowViewController(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
@@ -34,7 +34,7 @@ final class NetworkingLinkSignupViewController: UIViewController {
     weak var delegate: NetworkingLinkSignupViewControllerDelegate?
 
     private lazy var loadingView: SpinnerView = {
-        return SpinnerView()
+        return SpinnerView(theme: dataSource.manifest.theme)
     }()
     private lazy var formView: NetworkingLinkSignupBodyFormView = {
         let formView = NetworkingLinkSignupBodyFormView(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationDataSource.swift
@@ -9,6 +9,7 @@ import Foundation
 @_spi(STP) import StripeCore
 
 protocol NetworkingLinkStepUpVerificationDataSource: AnyObject {
+    var manifest: FinancialConnectionsSessionManifest { get }
     var consumerSession: ConsumerSessionData { get }
     var analyticsClient: FinancialConnectionsAnalyticsClient { get }
     var networkingOTPDataSource: NetworkingOTPDataSource { get }
@@ -21,9 +22,9 @@ final class NetworkingLinkStepUpVerificationDataSourceImplementation: Networking
 
     private(set) var consumerSession: ConsumerSessionData
     private let selectedAccountIds: [String]
-    private let manifest: FinancialConnectionsSessionManifest
     private let apiClient: FinancialConnectionsAPIClient
     private let clientSecret: String
+    let manifest: FinancialConnectionsSessionManifest
     let analyticsClient: FinancialConnectionsAnalyticsClient
     let networkingOTPDataSource: NetworkingOTPDataSource
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationViewController.swift
@@ -30,7 +30,7 @@ final class NetworkingLinkStepUpVerificationViewController: UIViewController {
     weak var delegate: NetworkingLinkStepUpVerificationViewControllerDelegate?
 
     private lazy var fullScreenLoadingView: UIView = {
-        return SpinnerView()
+        return SpinnerView(theme: dataSource.manifest.theme)
     }()
     private lazy var bodyView: NetworkingLinkStepUpVerificationBodyView = {
         let bodyView = NetworkingLinkStepUpVerificationBodyView(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationViewController.swift
@@ -28,7 +28,7 @@ final class NetworkingLinkVerificationViewController: UIViewController {
     weak var delegate: NetworkingLinkVerificationViewControllerDelegate?
 
     private lazy var loadingView: UIView = {
-        return SpinnerView()
+        return SpinnerView(theme: dataSource.manifest.theme)
     }()
     private lazy var otpView: NetworkingOTPView = {
         let otpView = NetworkingOTPView(dataSource: dataSource.networkingOTPDataSource)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationViewController.swift
@@ -28,7 +28,7 @@ final class NetworkingSaveToLinkVerificationViewController: UIViewController {
     weak var delegate: NetworkingSaveToLinkVerificationViewControllerDelegate?
 
     private lazy var loadingView: SpinnerView = {
-        return SpinnerView()
+        return SpinnerView(theme: dataSource.manifest.theme)
     }()
     private lazy var otpView: NetworkingOTPView = {
         let otpView = NetworkingOTPView(dataSource: dataSource.networkingOTPDataSource)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthViewController.swift
@@ -189,7 +189,7 @@ final class PartnerAuthViewController: SheetViewController {
         // note that this is purposefully separate from `showLoadingView`
         // function because it avoids animation glitches where
         // `showLoadingView(false)` can remove the loading view
-        let loadingView = SpinnerView()
+        let loadingView = SpinnerView(theme: dataSource.manifest.theme)
         self.legacyLoadingView = loadingView
         view.addAndPinSubviewToSafeArea(loadingView)
     }
@@ -534,7 +534,7 @@ final class PartnerAuthViewController: SheetViewController {
             continueStateViews?.showLoadingView(show)
         } else {
             if show {
-                let loadingView = SpinnerView()
+                let loadingView = SpinnerView(theme: dataSource.manifest.theme)
                 self.loadingView = loadingView
                 view.addAndPinSubviewToSafeArea(loadingView)
             }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/ResetFlow/ResetFlowDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/ResetFlow/ResetFlowDataSource.swift
@@ -9,6 +9,7 @@ import Foundation
 @_spi(STP) import StripeCore
 
 protocol ResetFlowDataSource: AnyObject {
+    var manifest: FinancialConnectionsSessionManifest { get }
     var analyticsClient: FinancialConnectionsAnalyticsClient { get }
 
     func markLinkingMoreAccounts() -> Promise<FinancialConnectionsSessionManifest>
@@ -18,15 +19,18 @@ final class ResetFlowDataSourceImplementation: ResetFlowDataSource {
 
     private let apiClient: FinancialConnectionsAPIClient
     private let clientSecret: String
+    let manifest: FinancialConnectionsSessionManifest
     let analyticsClient: FinancialConnectionsAnalyticsClient
 
     init(
         apiClient: FinancialConnectionsAPIClient,
         clientSecret: String,
+        manifest: FinancialConnectionsSessionManifest,
         analyticsClient: FinancialConnectionsAnalyticsClient
     ) {
         self.apiClient = apiClient
         self.clientSecret = clientSecret
+        self.manifest = manifest
         self.analyticsClient = analyticsClient
     }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/ResetFlow/ResetFlowViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/ResetFlow/ResetFlowViewController.swift
@@ -48,7 +48,7 @@ final class ResetFlowViewController: UIViewController {
             .analyticsClient
             .logPaneLoaded(pane: .resetFlow)
 
-        let loadingView = SpinnerView()
+        let loadingView = SpinnerView(theme: dataSource.manifest.theme)
         view.addAndPinSubviewToSafeArea(loadingView)
 
         dataSource.markLinkingMoreAccounts()

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/SpinnerView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/SpinnerView.swift
@@ -11,10 +11,16 @@ import UIKit
 
 final class SpinnerView: UIView {
 
-    private let imageView = UIImageView(image: Image.spinner.makeImage())
+    private let theme: FinancialConnectionsTheme?
+    private lazy var imageView: UIImageView = {
+        let imageView = UIImageView(image: Image.spinner.makeImage(template: true))
+        imageView.tintColor = theme.spinnerColor
+        return imageView
+    }()
     private let animationKey = "animation_key"
 
-    init(shouldStartAnimating: Bool = true) {
+    init(theme: FinancialConnectionsTheme?, shouldStartAnimating: Bool = true) {
+        self.theme = theme
         super.init(frame: .zero)
         addSubview(imageView)
         imageView.translatesAutoresizingMaskIntoConstraints = false
@@ -51,9 +57,10 @@ final class SpinnerView: UIView {
 import SwiftUI
 
 private struct SpinnerViewUIViewRepresentable: UIViewRepresentable {
+    let theme: FinancialConnectionsTheme?
 
     func makeUIView(context: Context) -> SpinnerView {
-        SpinnerView()
+        SpinnerView(theme: theme)
     }
 
     func updateUIView(_ uiView: SpinnerView, context: Context) {}
@@ -61,7 +68,11 @@ private struct SpinnerViewUIViewRepresentable: UIViewRepresentable {
 
 struct SpinnerView_Previews: PreviewProvider {
     static var previews: some View {
-        SpinnerViewUIViewRepresentable()
+        VStack {
+            SpinnerViewUIViewRepresentable(theme: .light)
+            SpinnerViewUIViewRepresentable(theme: .linkLight)
+            SpinnerViewUIViewRepresentable(theme: nil)
+        }
     }
 }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsWebFlowViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsWebFlowViewController.swift
@@ -84,7 +84,8 @@ final class FinancialConnectionsWebFlowViewController: UIViewController {
         return item
     }()
 
-    private let loadingView = LoadingView(frame: .zero)
+    // Use nil theme so the spinner view doesn't flash to the theme's color before launching the webview.
+    private let loadingView = LoadingView(frame: .zero, theme: nil)
 
     // MARK: - Init
 


### PR DESCRIPTION
## Summary

This themes the financial connections `SpinnerView` based on the manifest's `theme`. It supports:
- `light`: Stripe colors
- `linkLight`: Link colors
- `null`: Neutral colors

> [!NOTE]  
> We support a null theme here because there is a spinner is shown while the manifest is being fetched. 

## Motivation

Alignment with the [Instant Debits figma](https://www.figma.com/design/wXQ8NJApqSJiLmxxANDRTs/%E2%9C%A8-Connections-3.0?node-id=787-114662&t=C9zgpIX82HpMQJuU-0)

## Testing

Manual testing:

- Neutral-themed spinner is shown on the initial loading screen, no matter the flow.
- Stripe themed spinners shown on the FC experience.
- Link themed spinners shown on the ID experience.

https://github.com/user-attachments/assets/5a8f686e-9245-4eb6-a0d8-3808da3885fc

## Changelog

N/a
