### PR TITLE
[BANKCON-11625] FC - Theme textfields

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsTheme.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsTheme.swift
@@ -49,6 +49,15 @@ extension FinancialConnectionsTheme {
         }
     }
 
+    var textFieldFocusedColor: UIColor {
+        switch self {
+        case .linkLight:
+            return .linkGreen200
+        case .light:
+            return .brand600
+        }
+    }
+
     var logoColor: UIColor {
         switch self {
         case .linkLight:

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/ManualEntry/ManualEntryFormView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/ManualEntry/ManualEntryFormView.swift
@@ -41,7 +41,8 @@ final class ManualEntryFormView: UIView {
             placeholder: STPLocalizedString(
                 "Routing number",
                 "The title of a user-input-field that appears when a user is manually entering their bank account information. It instructs user to type the routing number."
-            )
+            ),
+            theme: theme
         )
         routingNumberTextField.textField.keyboardType = .numberPad
         routingNumberTextField.delegate = self
@@ -50,7 +51,11 @@ final class ManualEntryFormView: UIView {
     }()
     private lazy var accountNumberTextField: RoundedTextField = {
         let accountNumberTextField = RoundedTextField(
-            placeholder: STPLocalizedString("Account number", "The title of a user-input-field that appears when a user is manually entering their bank account information. It instructs user to type the account number.")
+            placeholder: STPLocalizedString(
+                "Account number",
+                "The title of a user-input-field that appears when a user is manually entering their bank account information. It instructs user to type the account number."
+            ),
+            theme: theme
         )
         accountNumberTextField.textField.keyboardType = .numberPad
         accountNumberTextField.delegate = self
@@ -62,7 +67,8 @@ final class ManualEntryFormView: UIView {
             placeholder: STPLocalizedString(
                 "Confirm account number",
                 "The title of a user-input-field that appears when a user is manually entering their bank account information. It instructs user to re-type the account number to confirm it."
-            )
+            ),
+            theme: theme
         )
         accountNumberConfirmationTextField.textField.keyboardType = .numberPad
         accountNumberConfirmationTextField.delegate = self
@@ -70,6 +76,7 @@ final class ManualEntryFormView: UIView {
         return accountNumberConfirmationTextField
     }()
 
+    private let theme: FinancialConnectionsTheme
     private var didEndEditingOnceRoutingNumberTextField = false
     private var didEndEditingOnceAccountNumberTextField = false
     private var didEndEditingOnceAccountNumberConfirmationTextField = false
@@ -89,6 +96,7 @@ final class ManualEntryFormView: UIView {
     }
 
     init(isTestMode: Bool, theme: FinancialConnectionsTheme) {
+        self.theme = theme
         super.init(frame: .zero)
 
         let contentVerticalStackView = UIStackView()

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/EmailTextField.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/EmailTextField.swift
@@ -20,9 +20,14 @@ protocol EmailTextFieldDelegate: AnyObject {
 
 final class EmailTextField: UIView {
 
+    private let theme: FinancialConnectionsTheme
     fileprivate lazy var textField: RoundedTextField = {
         let textField = RoundedTextField(
-            placeholder: STPLocalizedString("Email address", "The title of a user-input-field that appears when a user is signing up to Link (a payment service). It instructs user to type an email address.")
+            placeholder: STPLocalizedString(
+                "Email address",
+                "The title of a user-input-field that appears when a user is signing up to Link (a payment service). It instructs user to type an email address."
+            ),
+            theme: theme
         )
         textField.textField.keyboardType = .emailAddress
         textField.textField.textContentType = .emailAddress
@@ -57,7 +62,8 @@ final class EmailTextField: UIView {
 
     weak var delegate: EmailTextFieldDelegate?
 
-    init() {
+    init(theme: FinancialConnectionsTheme) {
+        self.theme = theme
         super.init(frame: .zero)
         addAndPinSubview(textField)
     }
@@ -140,9 +146,10 @@ private struct EmailTextFieldUIViewRepresentable: UIViewRepresentable {
 
     let text: String
     let isLoading: Bool
+    let theme: FinancialConnectionsTheme
 
     func makeUIView(context: Context) -> EmailTextField {
-        EmailTextField()
+        EmailTextField(theme: theme)
     }
 
     func updateUIView(
@@ -165,22 +172,26 @@ struct EmailTextField_Previews: PreviewProvider {
             VStack(spacing: 16) {
                 EmailTextFieldUIViewRepresentable(
                     text: "",
-                    isLoading: false
+                    isLoading: false,
+                    theme: .light
                 ).frame(height: 56)
 
                 EmailTextFieldUIViewRepresentable(
                     text: "test@test.com",
-                    isLoading: false
+                    isLoading: false,
+                    theme: .light
                 ).frame(height: 56)
 
                 EmailTextFieldUIViewRepresentable(
                     text: "test@test-very-long-name-thats-very-long.com",
-                    isLoading: true
+                    isLoading: true,
+                    theme: .light
                 ).frame(height: 56)
 
                 EmailTextFieldUIViewRepresentable(
                     text: "wrongemail@wronger",
-                    isLoading: false
+                    isLoading: false,
+                    theme: .light
                 ).frame(height: 90)
 
                 Spacer()

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupBodyFormView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupBodyFormView.swift
@@ -23,6 +23,7 @@ protocol NetworkingLinkSignupBodyFormViewDelegate: AnyObject {
 final class NetworkingLinkSignupBodyFormView: UIView {
 
     private let accountholderPhoneNumber: String?
+    private let theme: FinancialConnectionsTheme
     weak var delegate: NetworkingLinkSignupBodyFormViewDelegate?
 
     private lazy var verticalStackView: UIStackView = {
@@ -34,19 +35,20 @@ final class NetworkingLinkSignupBodyFormView: UIView {
         return verticalStackView
     }()
     private(set) lazy var emailTextField: EmailTextField = {
-       let emailTextField = EmailTextField()
+       let emailTextField = EmailTextField(theme: theme)
         emailTextField.delegate = self
         return emailTextField
     }()
     private(set) lazy var phoneTextField: PhoneTextField = {
-       let phoneTextField = PhoneTextField(defaultPhoneNumber: accountholderPhoneNumber)
+       let phoneTextField = PhoneTextField(defaultPhoneNumber: accountholderPhoneNumber, theme: theme)
         phoneTextField.delegate = self
         return phoneTextField
     }()
     private var debounceEmailTimer: Timer?
     private var lastValidEmail: String?
 
-    init(accountholderPhoneNumber: String?) {
+    init(accountholderPhoneNumber: String?, theme: FinancialConnectionsTheme) {
+        self.theme = theme
         self.accountholderPhoneNumber = accountholderPhoneNumber
         super.init(frame: .zero)
         addAndPinSubview(verticalStackView)
@@ -160,7 +162,7 @@ import SwiftUI
 private struct NetworkingLinkSignupBodyFormViewUIViewRepresentable: UIViewRepresentable {
 
     func makeUIView(context: Context) -> NetworkingLinkSignupBodyFormView {
-        NetworkingLinkSignupBodyFormView(accountholderPhoneNumber: nil)
+        NetworkingLinkSignupBodyFormView(accountholderPhoneNumber: nil, theme: .light)
     }
 
     func updateUIView(_ uiView: NetworkingLinkSignupBodyFormView, context: Context) {}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
@@ -38,7 +38,8 @@ final class NetworkingLinkSignupViewController: UIViewController {
     }()
     private lazy var formView: NetworkingLinkSignupBodyFormView = {
         let formView = NetworkingLinkSignupBodyFormView(
-            accountholderPhoneNumber: dataSource.manifest.accountholderPhoneNumber
+            accountholderPhoneNumber: dataSource.manifest.accountholderPhoneNumber,
+            theme: dataSource.manifest.theme
         )
         formView.delegate = self
         return formView

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/PhoneTextField.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/PhoneTextField.swift
@@ -22,7 +22,8 @@ final class PhoneTextField: UIView {
     fileprivate lazy var textField: RoundedTextField = {
         let textField = RoundedTextField(
             placeholder: STPLocalizedString("Phone number", "The title of a user-input-field that appears when a user is signing up to Link (a payment service). It instructs user to type a phone number."),
-            showDoneToolbar: true
+            showDoneToolbar: true,
+            theme: theme
         )
         textField.textField.keyboardType = .phonePad
         textField.textField.textContentType = .telephoneNumber
@@ -43,6 +44,7 @@ final class PhoneTextField: UIView {
         return textField
     }()
     private let countryCodeSelectorView: PhoneCountryCodeSelectorView
+    private let theme: FinancialConnectionsTheme
     // we will only start validating as user
     // types once editing ends
     fileprivate var didEndEditingOnce = false
@@ -74,7 +76,7 @@ final class PhoneTextField: UIView {
 
     weak var delegate: PhoneTextFieldDelegate?
 
-    init(defaultPhoneNumber: String?) {
+    init(defaultPhoneNumber: String?, theme: FinancialConnectionsTheme) {
         var defaultPhoneNumber = defaultPhoneNumber
         var defaultCountryCode: String?
         if let _defaultPhoneNumber = defaultPhoneNumber, let e164PhoneNumber = PhoneNumber.fromE164(_defaultPhoneNumber) {
@@ -84,6 +86,7 @@ final class PhoneTextField: UIView {
         self.countryCodeSelectorView = PhoneCountryCodeSelectorView(
             defaultCountryCode: defaultCountryCode
         )
+        self.theme = theme
         super.init(frame: .zero)
         countryCodeSelectorView.delegate = self
         addAndPinSubview(textField)
@@ -215,7 +218,7 @@ private struct PhoneTextFieldUIViewRepresentable: UIViewRepresentable {
     let defaultPhoneNumber: String
 
     func makeUIView(context: Context) -> PhoneTextField {
-        PhoneTextField(defaultPhoneNumber: defaultPhoneNumber)
+        PhoneTextField(defaultPhoneNumber: defaultPhoneNumber, theme: .light)
     }
 
     func updateUIView(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/RoundedTextField.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/RoundedTextField.swift
@@ -101,7 +101,7 @@ final class RoundedTextField: UIView {
         var theme: ElementsUITheme = .default
         theme.colors = {
             var colors = ElementsUITheme.Color()
-            colors.primary = self.theme.textFieldFocusedColor
+            colors.primary = self.theme.primaryColor
             colors.secondaryText = .textSubdued
             return colors
         }()

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/RoundedTextField.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/RoundedTextField.swift
@@ -26,6 +26,7 @@ protocol RoundedTextFieldDelegate: AnyObject {
 final class RoundedTextField: UIView {
 
     private let showDoneToolbar: Bool
+    private let theme: FinancialConnectionsTheme
 
     // Used to optionally add an error message
     // at the bottom of the text field
@@ -100,7 +101,7 @@ final class RoundedTextField: UIView {
         var theme: ElementsUITheme = .default
         theme.colors = {
             var colors = ElementsUITheme.Color()
-            colors.primary = .brand500
+            colors.primary = self.theme.textFieldFocusedColor
             colors.secondaryText = .textSubdued
             return colors
         }()
@@ -135,9 +136,11 @@ final class RoundedTextField: UIView {
     init(
         placeholder: String,
         footerText: String? = nil,
-        showDoneToolbar: Bool = false
+        showDoneToolbar: Bool = false,
+        theme: FinancialConnectionsTheme
     ) {
         self.showDoneToolbar = showDoneToolbar
+        self.theme = theme
         super.init(frame: .zero)
         addAndPinSubview(verticalStackView)
         textField.placeholder = placeholder
@@ -194,7 +197,7 @@ final class RoundedTextField: UIView {
             containerHorizontalStackView.layer.borderWidth = 2.0
         } else {
             if highlighted {
-                containerHorizontalStackView.layer.borderColor = UIColor.textActionPrimaryFocused.cgColor
+                containerHorizontalStackView.layer.borderColor = theme.textFieldFocusedColor.cgColor
                 containerHorizontalStackView.layer.borderWidth = 2.0
             } else {
                 containerHorizontalStackView.layer.borderColor = UIColor.borderNeutral.cgColor
@@ -655,15 +658,22 @@ private struct RoundedTextFieldUIViewRepresentable: UIViewRepresentable {
     let placeholder: String
     let footerText: String?
     let errorText: String?
+    let isFocused: Bool
+    let theme: FinancialConnectionsTheme
 
     func makeUIView(context: Context) -> RoundedTextField {
         RoundedTextField(
             placeholder: placeholder,
-            footerText: footerText
+            footerText: footerText,
+            theme: theme
         )
     }
 
     func updateUIView(_ uiView: RoundedTextField, context: Context) {
+        if isFocused {
+            _ = uiView.becomeFirstResponder()
+        }
+
         uiView.errorText = errorText
     }
 }
@@ -675,37 +685,70 @@ struct RoundedTextField_Previews: PreviewProvider {
                 RoundedTextFieldUIViewRepresentable(
                     placeholder: "Routing number",
                     footerText: nil,
-                    errorText: nil
+                    errorText: nil,
+                    isFocused: false,
+                    theme: .light
                 )
                 .frame(height: 56)
                 RoundedTextFieldUIViewRepresentable(
                     placeholder: "Account number",
                     footerText: "Your account can be checkings or savings.",
-                    errorText: nil
+                    errorText: nil,
+                    isFocused: false,
+                    theme: .light
                 )
                 .frame(height: 80)
                 RoundedTextFieldUIViewRepresentable(
                     placeholder: "Confirm account number",
                     footerText: nil,
-                    errorText: nil
+                    errorText: nil,
+                    isFocused: false,
+                    theme: .light
                 )
                 .frame(height: 56)
                 RoundedTextFieldUIViewRepresentable(
                     placeholder: "Routing number",
                     footerText: nil,
-                    errorText: "Routing number is required."
+                    errorText: "Routing number is required.",
+                    isFocused: false,
+                    theme: .light
                 )
                 .frame(height: 80)
                 RoundedTextFieldUIViewRepresentable(
                     placeholder: "Account number",
                     footerText: "Your account can be checkings or savings.",
-                    errorText: "Account number is required."
+                    errorText: "Account number is required.",
+                    isFocused: false,
+                    theme: .light
                 )
                 .frame(height: 80)
                 Spacer()
             }
             .padding()
             .background(Color(UIColor.customBackgroundColor))
+
+            // Use separate devices to showcase highlighted state
+            RoundedTextFieldUIViewRepresentable(
+                placeholder: "Light theme",
+                footerText: nil,
+                errorText: nil,
+                isFocused: true,
+                theme: .light
+            )
+            .frame(height: 56)
+            .padding()
+            .previewDisplayName("Focused - Light theme")
+
+            RoundedTextFieldUIViewRepresentable(
+                placeholder: "Link Light theme",
+                footerText: nil,
+                errorText: nil,
+                isFocused: true,
+                theme: .linkLight
+            )
+            .frame(height: 56)
+            .padding()
+            .previewDisplayName("Focused - Link Light theme")
         }
     }
 }


### PR DESCRIPTION
## Summary

This themes the financial connections `RoundedTextField` highlighted state, based on the manifest's theme.

## Motivation

Alignment with the [Instant Debits figma](https://www.figma.com/design/wXQ8NJApqSJiLmxxANDRTs/%E2%9C%A8-Connections-3.0?node-id=791-99467&t=HT7VHACA6DyEV2Ly-4)

## Testing

| Financial Connections | Instant Debits |
|--------|--------|
| ![Simulator Screenshot - iPhone 15 - 2024-07-22 at 16 22 47](https://github.com/user-attachments/assets/a50b0d5f-4000-44c9-b2b9-eeebc4a3ca8c) | ![Simulator Screenshot - iPhone 15 - 2024-07-22 at 16 24 03](https://github.com/user-attachments/assets/4bf2617f-b59c-475a-8db9-531b56b71c78) | 

## Changelog

N/a