### PR TITLE
Make BottomSheetViewController setContent... complete presentation tr…

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/BottomSheet/BottomSheetPresentationAnimator.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/BottomSheet/BottomSheetPresentationAnimator.swift
@@ -40,17 +40,27 @@ class BottomSheetPresentationAnimator: NSObject {
         toVC.view.frame = transitionContext.finalFrame(for: toVC)
         toVC.view.frame.origin.y = transitionContext.containerView.frame.height
 
+        // Set the work to complete the transition on the BottomSheetViewController.
+        // Either we will invoke it in the presentation completion block, 
+        // or BottomSheetViewController will invoke it before transitioning to other content
+        if let bottomSheetController = toVC as? BottomSheetViewController {
+            bottomSheetController.completeBottomSheetPresentationTransition = { [weak bottomSheetController] didComplete in
+                transitionContext.completeTransition(didComplete)
+                bottomSheetController?.completeBottomSheetPresentationTransition = nil
+            }
+        }
+
         Self.animate({
             transitionContext.containerView.setNeedsLayout()
             transitionContext.containerView.layoutIfNeeded()
         }) { didComplete in
             // Calls viewDidAppear and viewDidDisappear
             fromVC.endAppearanceTransition()
-            // If the toVC is a BottomSheetViewController in the middle of setting its contentVC, wait until its animation finishes before completing the transition. Otherwise, `viewDidAppear` is called before the VC has fully transitioned onto the screen.
-            if let bottomSheetController = toVC as? BottomSheetViewController, bottomSheetController.isAnimatingSetContentViewController {
-                bottomSheetController.onSetContentViewControllerCompletion = {
-                    transitionContext.completeTransition(didComplete)
-                }
+
+            // Complete transition if it hasn't already been completed
+            if let bottomSheetController = toVC as? BottomSheetViewController,
+               let completePresentationTransition = bottomSheetController.completeBottomSheetPresentationTransition {
+                completePresentationTransition(didComplete)
             } else {
                 transitionContext.completeTransition(didComplete)
             }


### PR DESCRIPTION
…ansition if one is in progress before transitioning content 

## Summary
A) When we present the sheet, we need to call transitionContext.completeTransition when the presentation completes
 You must call this method after your animations have completed to notify the system that the transition animation is done.
B) When we transition content within the sheet, we need to call endAppearanceTransition.
 If you are implementing a custom container controller, use this method to tell the child that the view transition is complete.
Both of these methods end up calling viewDidAppear.

If loading finishes after the sheet finishes presenting, it's fine - (A) only invokes the loading VC's viewDidAppear.
If loading finishes before, both (A) and (B) invoke the content VC's viewDidAppear

Solution: Make sure (A) is finished before starting (B). That means (A) invokes `viewDidAppear` on the loading VC.

## Motivation
 fix an issue where viewDidAppear is called twice


## Testing
Manually tested via lots of print statements. Checked both the path where loading finishes *after* presentation completes and *before*.

Tested CVC recollection viewDidAppear -> CVC toggle to make sure I didn't regress that (https://github.com/stripe/stripe-ios/pull/3805)

## Changelog
Not user facing