### PR TITLE
Attempt to improve ui test run time

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
@@ -873,9 +873,7 @@ class CustomerSheetUITest: XCTestCase {
         XCTAssertTrue(app.staticTexts["••••1001"].waitForExistence(timeout: timeout))
         XCTAssertTrue(app.images["carousel_card_cartes_bancaires"].waitForExistence(timeout: timeout))
 
-        let editButton = app.staticTexts["Edit"]
-        XCTAssertTrue(editButton.waitForExistence(timeout: timeout))
-        editButton.tap()
+        app.staticTexts["Edit"].waitForExistenceAndTap(timeout: timeout)
 
         // Saved card should show the edit icon since it is co-branded
         XCTAssertTrue(app.buttons["CircularButton.Edit"].waitForExistenceAndTap(timeout: timeout))
@@ -898,12 +896,14 @@ class CustomerSheetUITest: XCTestCase {
         confirmRemoval.tap()
 
         // Verify card is removed
-        app.buttons["Done"].waitForExistenceAndTap(timeout: timeout)
         app.buttons["Close"].waitForExistenceAndTap(timeout: timeout)
         app.buttons["Reload"].waitForExistenceAndTap(timeout: timeout)
         app.buttons["Payment method"].waitForExistenceAndTap(timeout: timeout)
-        // Card is no longer saved
-        XCTAssertFalse(app.staticTexts["••••1001"].waitForExistence(timeout: timeout))
+
+        // Card is no longer saved - Wait for ApplePay is a signal the view has loaded, then wait 0.5
+        // up to 0.5 seconds to ensure card is not there
+        XCTAssertTrue(app.collectionViews.staticTexts["Apple Pay"].waitForExistence(timeout: timeout))
+        XCTAssertFalse(app.staticTexts["••••1001"].waitForExistence(timeout: 0.5))
     }
 
     func testCardBrandChoiceWithPreferredNetworks() throws {
@@ -1018,6 +1018,9 @@ class CustomerSheetUITest: XCTestCase {
         // Remove the 4242 saved PM
         XCTAssertNotNil(scroll(collectionView: app.collectionViews.firstMatch, toFindButtonWithId: "CircularButton.Remove")?.tap())
         XCTAssertTrue(app.alerts.buttons["Remove"].waitForExistenceAndTap())
+
+        // Wait for alert view to disappear and removal animation to finish
+        sleep(1)
 
         // Should be able to edit CBC enabled PM even though it's the only one
         XCTAssertTrue(app.buttons["CircularButton.Edit"].waitForExistenceAndTap(timeout: timeout))

--- a/Example/PaymentSheet Example/PaymentSheetUITest/LinkPaymentControllerUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/LinkPaymentControllerUITest.swift
@@ -91,7 +91,7 @@ class LinkPaymentControllerUITest: XCTestCase {
             .withOffset(CGVector(dx: 0, dy: -130))
             .tap()
 
-        sleep(1) // wait for modal to disappear before pressing Buy
+        sleep(3) // wait for modal to disappear before pressing Buy
 
         // Back to "LinkPaymentController"
         app.buttons["Buy"].waitForExistenceAndTap(timeout: timeout)

--- a/Example/PaymentSheet Example/PaymentSheetUITest/XCUITest+Utilities.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/XCUITest+Utilities.swift
@@ -33,6 +33,11 @@ extension XCUIElement {
 
     @discardableResult
     func waitForExistenceAndTap(timeout: TimeInterval = 4.0) -> Bool {
+        if exists {
+            forceTapElement()
+            return true
+        }
+
         guard waitForExistence(timeout: timeout) else {
             return false
         }


### PR DESCRIPTION
## Summary
Noticed that waitforExistance can take up to 2 seconds to execute, but exists takes ~40ms to run.  If the item exits, we should forcibly tap it.  It introduced some flakiness in some tests, which I have fixed.

This change reduces the time spent on UI tests.
Assuming ui-tests-1 was taking about 26:53 and ui-tests-2 was taking about 25:39 minutes, I believe this saves about~20 seconds on ui-tests-1, ~2 minutes on ui-tests-2.

## Motivation
Reduce CI build time.

## Testing
Relying on CI

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
