### PR TITLE
[BANKCON-11626] FC - Theming icons and text

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsTheme.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsTheme.swift
@@ -40,7 +40,7 @@ extension FinancialConnectionsTheme {
         }
     }
 
-    var primaryButtonTextColor: UIColor {
+    var primaryAccentColor: UIColor {
         switch self {
         case .linkLight:
             return .linkGreen900
@@ -55,6 +55,33 @@ extension FinancialConnectionsTheme {
             return .linkGreen900
         case .light:
             return .textActionPrimary
+        }
+    }
+
+    var iconTintColor: UIColor {
+        switch self {
+        case .linkLight:
+            return .linkGreen500
+        case .light:
+            return .iconActionPrimary
+        }
+    }
+
+    var iconBackgroundColor: UIColor {
+        switch self {
+        case .linkLight:
+            return .linkGreen50
+        case .light:
+            return .brand25
+        }
+    }
+
+    var textActionColor: UIColor {
+        switch self {
+        case .linkLight:
+            return .linkGreen500
+        case .light:
+            return .brand600
         }
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/TestModeAutofillBannerView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/TestModeAutofillBannerView.swift
@@ -32,6 +32,7 @@ class TestModeAutofillBannerView: UIView {
     }
 
     private let context: Context
+    private let theme: FinancialConnectionsTheme
     private let didTapAutofill: () -> Void
 
     // MARK: - Subviews
@@ -71,7 +72,7 @@ class TestModeAutofillBannerView: UIView {
     private lazy var autofillDataButton: UIButton = {
         let button = UIButton()
         button.setTitle(context.buttonLabel, for: .normal)
-        button.setTitleColor(.textActionPrimary, for: .normal)
+        button.setTitleColor(theme.textActionColor, for: .normal)
         button.titleLabel?.textAlignment = .right
         button.titleLabel?.font = FinancialConnectionsFont.label(.mediumEmphasized).uiFont
         button.addTarget(self, action: #selector(autofillTapped), for: .touchUpInside)
@@ -88,8 +89,9 @@ class TestModeAutofillBannerView: UIView {
 
     // MARK: - Init and setup
 
-    init(context: Context, didTapAutofill: @escaping () -> Void) {
+    init(context: Context, theme: FinancialConnectionsTheme, didTapAutofill: @escaping () -> Void) {
         self.context = context
+        self.theme = theme
         self.didTapAutofill = didTapAutofill
         super.init(frame: .zero)
         setupLayout()
@@ -133,9 +135,10 @@ import SwiftUI
 
 private struct TestModeAutofillBannerViewRepresentable: UIViewRepresentable {
     let bannerContext: TestModeAutofillBannerView.Context
+    let theme: FinancialConnectionsTheme
 
     func makeUIView(context: Context) -> TestModeAutofillBannerView {
-        TestModeAutofillBannerView(context: bannerContext, didTapAutofill: {})
+        TestModeAutofillBannerView(context: bannerContext, theme: theme, didTapAutofill: {})
     }
 
     func updateUIView(_ uiView: TestModeAutofillBannerView, context: Context) {}
@@ -144,12 +147,16 @@ private struct TestModeAutofillBannerViewRepresentable: UIViewRepresentable {
 struct TestModeAutofillBannerView_Previews: PreviewProvider {
     static var previews: some View {
         VStack(spacing: 20) {
-            TestModeAutofillBannerViewRepresentable(bannerContext: .account)
+            TestModeAutofillBannerViewRepresentable(bannerContext: .account, theme: .light)
                 .frame(height: 38)
 
-            TestModeAutofillBannerViewRepresentable(bannerContext: .otp)
+            TestModeAutofillBannerViewRepresentable(bannerContext: .otp, theme: .light)
+                .frame(height: 38)
+
+            TestModeAutofillBannerViewRepresentable(bannerContext: .otp, theme: .linkLight)
                 .frame(height: 38)
         }
+        .padding()
     }
 }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/UIColor+Extensions.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/UIColor+Extensions.swift
@@ -143,7 +143,7 @@ extension UIColor {
         return UIColor(red: 103 / 255.0, green: 93 / 255.0, blue: 255 / 255.0, alpha: 1)  // #675dff
     }
 
-    private static var brand600: UIColor {
+    static var brand600: UIColor {
         return UIColor(red: 83 / 255.0, green: 58 / 255.0, blue: 253 / 255.0, alpha: 1)  // #533afd
     }
 
@@ -163,16 +163,16 @@ extension UIColor {
         return UIColor(red: 34 / 255.0, green: 132 / 255.0, blue: 3 / 255.0, alpha: 1)  // #228403
     }
 
-    static var legacyLinkBrand200: UIColor {
-        return UIColor(red: 166 / 255.0, green: 251 / 255.0, blue: 221 / 255.0, alpha: 1)  // #a6fbdd
-    }
-
-    static var legacyLinkBrand600: UIColor {
-        return UIColor(red: 26 / 255.0, green: 197 / 255.0, blue: 155 / 255.0, alpha: 1)  // #1ac59b
+    static var linkGreen50: UIColor {
+        return UIColor(red: 230 / 255.0, green: 255 / 255.0, blue: 237 / 255.0, alpha: 1)  // #e6ffed
     }
 
     static var linkGreen200: UIColor {
         return UIColor(red: 0 / 255.0, green: 214 / 255.0, blue: 111 / 255.0, alpha: 1)  // #00D66F
+    }
+
+    static var linkGreen500: UIColor {
+        return UIColor(red: 0 / 255.0, green: 133 / 255.0, blue: 69 / 255.0, alpha: 1)  // #008545
     }
 
     static var linkGreen900: UIColor {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionPickerViewController.swift
@@ -99,7 +99,8 @@ class InstitutionPickerViewController: UIViewController {
         let institutionTableView = InstitutionTableView(
             frame: view.bounds,
             allowManualEntry: dataSource.manifest.allowManualEntry,
-            institutionSearchDisabled: dataSource.manifest.institutionSearchDisabled
+            institutionSearchDisabled: dataSource.manifest.institutionSearchDisabled,
+            theme: dataSource.manifest.theme
         )
         institutionTableView.delegate = self
         return institutionTableView

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionTableFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionTableFooterView.swift
@@ -17,6 +17,7 @@ final class InstitutionTableFooterView: UIView {
         title: String,
         subtitle: String?,
         image: Image,
+        theme: FinancialConnectionsTheme,
         didSelect: @escaping () -> Void
     ) {
         self.didSelect = didSelect
@@ -26,7 +27,8 @@ final class InstitutionTableFooterView: UIView {
         institutionCellView.customize(
             iconView: RoundedIconView(
                 image: .image(image),
-                style: .rounded
+                style: .rounded,
+                theme: theme
             ),
             title: title,
             subtitle: subtitle
@@ -75,12 +77,14 @@ private struct InstitutionTableFooterViewUIViewRepresentable: UIViewRepresentabl
     let title: String
     let subtitle: String
     let image: Image
+    let theme: FinancialConnectionsTheme
 
     func makeUIView(context: Context) -> InstitutionTableFooterView {
         InstitutionTableFooterView(
             title: title,
             subtitle: subtitle,
             image: image,
+            theme: theme,
             didSelect: {}
         )
     }
@@ -96,14 +100,24 @@ struct InstitutionTableFooterView_Previews: PreviewProvider {
             InstitutionTableFooterViewUIViewRepresentable(
                 title: "Don't see your bank?",
                 subtitle: "Enter your bank account and routing numbers",
-                image: .search
+                image: .search,
+                theme: .light
             )
             .frame(maxHeight: 100)
 
             InstitutionTableFooterViewUIViewRepresentable(
                 title: "No results",
                 subtitle: "Double check your spelling and search terms",
-                image: .cancel_circle
+                image: .cancel_circle,
+                theme: .light
+            )
+            .frame(maxHeight: 100)
+
+            InstitutionTableFooterViewUIViewRepresentable(
+                title: "No results",
+                subtitle: "Double check your spelling and search terms",
+                image: .cancel_circle,
+                theme: .linkLight
             )
             .frame(maxHeight: 100)
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionTableView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/InstitutionPicker/InstitutionTableView.swift
@@ -34,6 +34,7 @@ final class InstitutionTableView: UIView {
 
     private let allowManualEntry: Bool
     private let institutionSearchDisabled: Bool
+    private let theme: FinancialConnectionsTheme
     let tableView: UITableView
     private let dataSource: UITableViewDiffableDataSource<Section, FinancialConnectionsInstitution>
     weak var delegate: InstitutionTableViewDelegate?
@@ -63,6 +64,7 @@ final class InstitutionTableView: UIView {
                 "The subtitle of a button that appears at the bottom of search results. It appears when a user is searching for their bank. The purpose of the button is to give users the option to enter their bank account numbers manually (ex. routing and account number)."
             ),
             image: .add,
+            theme: theme,
             didSelect: { [weak self] in
                 guard let self = self else { return }
                 FeedbackGeneratorAdapter.buttonTapped()
@@ -85,6 +87,7 @@ final class InstitutionTableView: UIView {
                 ),
                 subtitle: nil,
                 image: .search,
+                theme: theme,
                 didSelect: { [weak self] in
                     guard let self = self else { return }
                     FeedbackGeneratorAdapter.buttonTapped()
@@ -100,10 +103,12 @@ final class InstitutionTableView: UIView {
     init(
         frame: CGRect,
         allowManualEntry: Bool,
-        institutionSearchDisabled: Bool
+        institutionSearchDisabled: Bool,
+        theme: FinancialConnectionsTheme
     ) {
         self.allowManualEntry = allowManualEntry
         self.institutionSearchDisabled = institutionSearchDisabled
+        self.theme = theme
         let cellIdentifier = "\(InstitutionTableViewCell.self)"
         tableView = UITableView(frame: frame)
         dataSource = UITableViewDiffableDataSource(tableView: tableView) { tableView, _, institution in

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/ManualEntry/ManualEntryFormView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/ManualEntry/ManualEntryFormView.swift
@@ -88,7 +88,7 @@ final class ManualEntryFormView: UIView {
         return (routingNumberTextField.text, accountNumberTextField.text)
     }
 
-    init(isTestMode: Bool) {
+    init(isTestMode: Bool, theme: FinancialConnectionsTheme) {
         super.init(frame: .zero)
 
         let contentVerticalStackView = UIStackView()
@@ -96,6 +96,7 @@ final class ManualEntryFormView: UIView {
         if isTestMode {
             let testModeBannerView = TestModeAutofillBannerView(
                 context: .account,
+                theme: theme,
                 didTapAutofill: applyTestModeValues
             )
             contentVerticalStackView.addArrangedSubview(testModeBannerView)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/ManualEntry/ManualEntryViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/ManualEntry/ManualEntryViewController.swift
@@ -25,7 +25,10 @@ final class ManualEntryViewController: UIViewController {
     weak var delegate: ManualEntryViewControllerDelegate?
 
     private lazy var manualEntryFormView: ManualEntryFormView = {
-        let manualEntryFormView = ManualEntryFormView(isTestMode: dataSource.manifest.isTestMode)
+        let manualEntryFormView = ManualEntryFormView(
+            isTestMode: dataSource.manifest.isTestMode,
+            theme: dataSource.manifest.theme
+        )
         manualEntryFormView.delegate = self
         return manualEntryFormView
     }()

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupBodyView.swift
@@ -59,7 +59,7 @@ private func CreateAvatarView(email: String) -> UIView {
     let diameter: CGFloat = 36
 
     let circleView = UIView()
-    circleView.backgroundColor = .legacyLinkBrand200
+    circleView.backgroundColor = .linkGreen200
     circleView.layer.cornerRadius = diameter / 2
     circleView.translatesAutoresizingMaskIntoConstraints = false
     NSLayoutConstraint.activate([
@@ -69,7 +69,7 @@ private func CreateAvatarView(email: String) -> UIView {
 
     let letterLabel = AttributedLabel(
         font: .body(.small),
-        textColor: .legacyLinkBrand600
+        textColor: .linkGreen900
     )
     letterLabel.setText(String(email.uppercased().first ?? "E"))
     circleView.addSubview(letterLabel)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupViewController.swift
@@ -43,7 +43,8 @@ final class NetworkingLinkLoginWarmupViewController: SheetViewController {
             withContentView: PaneLayoutView.createContentView(
                 iconView: RoundedIconView(
                     image: .image(.person),
-                    style: .circle
+                    style: .circle,
+                    theme: dataSource.manifest.theme
                 ),
                 title: STPLocalizedString(
                     "Continue with Link",

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationDataSource.swift
@@ -51,7 +51,8 @@ final class NetworkingLinkStepUpVerificationDataSourceImplementation: Networking
             apiClient: apiClient,
             clientSecret: clientSecret,
             analyticsClient: analyticsClient,
-            isTestMode: manifest.isTestMode
+            isTestMode: manifest.isTestMode,
+            theme: manifest.theme
         )
         self.networkingOTPDataSource = networkingOTPDataSource
         networkingOTPDataSource.delegate = self

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationDataSource.swift
@@ -52,7 +52,8 @@ final class NetworkingLinkVerificationDataSourceImplementation: NetworkingLinkVe
             apiClient: apiClient,
             clientSecret: clientSecret,
             analyticsClient: analyticsClient,
-            isTestMode: manifest.isTestMode
+            isTestMode: manifest.isTestMode,
+            theme: manifest.theme
         )
         self.networkingOTPDataSource = networkingOTPDataSource
         networkingOTPDataSource.delegate = self

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationDataSource.swift
@@ -53,7 +53,8 @@ final class NetworkingSaveToLinkVerificationDataSourceImplementation: Networking
             apiClient: apiClient,
             clientSecret: clientSecret,
             analyticsClient: analyticsClient,
-            isTestMode: manifest.isTestMode
+            isTestMode: manifest.isTestMode,
+            theme: manifest.theme
         )
         self.networkingOTPDataSource = networkingOTPDataSource
         networkingOTPDataSource.delegate = self

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/Button+Extensions.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/Button+Extensions.swift
@@ -38,10 +38,10 @@ extension StripeUICore.Button.Configuration {
         primaryButtonConfiguration.cornerRadius = 12.0
         // default
         primaryButtonConfiguration.backgroundColor = theme.primaryColor
-        primaryButtonConfiguration.foregroundColor = theme.primaryButtonTextColor
+        primaryButtonConfiguration.foregroundColor = theme.primaryAccentColor
         // disabled
         primaryButtonConfiguration.disabledBackgroundColor = theme.primaryColor
-        primaryButtonConfiguration.disabledForegroundColor = theme.primaryButtonTextColor.withAlphaComponent(0.4)
+        primaryButtonConfiguration.disabledForegroundColor = theme.primaryAccentColor.withAlphaComponent(0.4)
         // pressed
         primaryButtonConfiguration.colorTransforms.highlightedBackground = .darken(amount: 0.23)  // this tries to simulate `brand600`
         primaryButtonConfiguration.colorTransforms.highlightedForeground = nil

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/CloseConfirmationViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/CloseConfirmationViewController.swift
@@ -30,7 +30,8 @@ final class CloseConfirmationViewController: SheetViewController {
             withContentView: PaneLayoutView.createContentView(
                 iconView: RoundedIconView(
                     image: .image(.panel_arrow_right),
-                    style: .circle
+                    style: .circle,
+                    theme: theme
                 ),
                 title: STPLocalizedString(
                     "Exit without connecting?",

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/DataAccessNoticeViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/DataAccessNoticeViewController.swift
@@ -55,7 +55,8 @@ final class DataAccessNoticeViewController: SheetViewController {
             withContentView: PaneLayoutView.createContentView(
                 iconView: RoundedIconView(
                     image: .imageUrl(dataAccessNotice.icon?.default),
-                    style: .circle
+                    style: .circle,
+                    theme: theme
                 ),
                 title: dataAccessNotice.title,
                 subtitle: firstSubtitle,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/LegalDetailsNoticeViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/LegalDetailsNoticeViewController.swift
@@ -36,12 +36,14 @@ final class LegalDetailsNoticeViewController: SheetViewController {
             withContentView: PaneLayoutView.createContentView(
                 iconView: RoundedIconView(
                     image: .imageUrl(legalDetailsNotice.icon?.default),
-                    style: .circle
+                    style: .circle,
+                    theme: theme
                 ),
                 title: legalDetailsNotice.title,
                 subtitle: legalDetailsNotice.subtitle,
                 contentView: CreateMultiLinkView(
                     linkItems: legalDetailsNotice.body.links,
+                    theme: theme,
                     didSelectURL: didSelectUrl
                 ),
                 isSheet: true
@@ -65,6 +67,7 @@ final class LegalDetailsNoticeViewController: SheetViewController {
 
 private func CreateMultiLinkView(
     linkItems: [FinancialConnectionsLegalDetailsNotice.Body.Link],
+    theme: FinancialConnectionsTheme,
     didSelectURL: @escaping (URL) -> Void
 ) -> UIView {
     let verticalStackView = HitTestStackView()
@@ -76,6 +79,7 @@ private func CreateMultiLinkView(
             CreateSingleLinkView(
                 title: linkItem.title,
                 content: linkItem.content,
+                theme: theme,
                 didSelectURL: didSelectURL
             )
         )
@@ -87,6 +91,7 @@ private func CreateMultiLinkView(
 private func CreateSingleLinkView(
     title: String,
     content: String?,
+    theme: FinancialConnectionsTheme,
     didSelectURL: @escaping (URL) -> Void
 ) -> UIView {
     let verticalLabelStackView = HitTestStackView()
@@ -99,7 +104,7 @@ private func CreateSingleLinkView(
         boldFont: titleLabelFont,
         linkFont: titleLabelFont,
         textColor: .textDefault,
-        linkColor: .textActionPrimaryFocused,
+        linkColor: theme.textActionColor,
         showLinkUnderline: false
     )
     titleLabel.setText(title, action: didSelectURL)
@@ -112,7 +117,7 @@ private func CreateSingleLinkView(
             boldFont: contentFont,
             linkFont: contentFont,
             textColor: .textSubdued,
-            linkColor: .textActionPrimaryFocused,
+            linkColor: theme.textActionColor,
             showLinkUnderline: false
         )
         contentLabel.setText(content, action: didSelectURL)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPDataSource.swift
@@ -16,6 +16,7 @@ protocol NetworkingOTPDataSource: AnyObject {
     var otpType: String { get }
     var analyticsClient: FinancialConnectionsAnalyticsClient { get }
     var isTestMode: Bool { get }
+    var theme: FinancialConnectionsTheme { get }
     var pane: FinancialConnectionsSessionManifest.NextPane { get }
 
     func lookupConsumerSession() -> Future<LookupConsumerSessionResponse>
@@ -41,6 +42,7 @@ final class NetworkingOTPDataSourceImplementation: NetworkingOTPDataSource {
     private let clientSecret: String
     let analyticsClient: FinancialConnectionsAnalyticsClient
     let isTestMode: Bool
+    let theme: FinancialConnectionsTheme
     weak var delegate: NetworkingOTPDataSourceDelegate?
 
     init(
@@ -53,7 +55,8 @@ final class NetworkingOTPDataSourceImplementation: NetworkingOTPDataSource {
         apiClient: FinancialConnectionsAPIClient,
         clientSecret: String,
         analyticsClient: FinancialConnectionsAnalyticsClient,
-        isTestMode: Bool
+        isTestMode: Bool,
+        theme: FinancialConnectionsTheme
     ) {
         self.otpType = otpType
         self.emailAddress = emailAddress
@@ -65,6 +68,7 @@ final class NetworkingOTPDataSourceImplementation: NetworkingOTPDataSource {
         self.clientSecret = clientSecret
         self.analyticsClient = analyticsClient
         self.isTestMode = isTestMode
+        self.theme = theme
     }
 
     func lookupConsumerSession() -> Future<LookupConsumerSessionResponse> {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
@@ -43,6 +43,7 @@ final class NetworkingOTPView: UIView {
         if dataSource.isTestMode {
             let testModeBanner = TestModeAutofillBannerView(
                 context: .otp,
+                theme: dataSource.theme,
                 didTapAutofill: applyTestModeValue
             )
             otpVerticalStackView.addArrangedSubview(testModeBanner)
@@ -65,9 +66,8 @@ final class NetworkingOTPView: UIView {
             ),
             theme: theme
         )
-        otpTextField.tintColor = .textBrand
+        otpTextField.tintColor = dataSource.theme.primaryColor
         otpTextField.addTarget(self, action: #selector(otpTextFieldDidChange), for: .valueChanged)
-        otpTextField.tintColor = .textActionPrimaryFocused
         return otpTextField
     }()
     private lazy var theme: ElementsUITheme = {
@@ -108,7 +108,7 @@ final class NetworkingOTPView: UIView {
 
         if show {
             let activityIndicator = ActivityIndicator(size: .medium)
-            activityIndicator.color = .iconActionPrimary
+            activityIndicator.color = dataSource.theme.primaryColor
             activityIndicator.startAnimating()
             let loadingView = UIStackView(
                 arrangedSubviews: [activityIndicator]
@@ -241,3 +241,48 @@ final class NetworkingOTPView: UIView {
         otpTextFieldDidChange()
     }
 }
+
+#if DEBUG
+
+import SwiftUI
+
+private struct NetowrkingOTPViewRepresentable: UIViewRepresentable {
+    let theme: FinancialConnectionsTheme
+
+    func makeUIView(context: Context) -> NetworkingOTPView {
+        NetworkingOTPView(dataSource: NetworkingOTPDataSourceImplementation(
+            otpType: "",
+            emailAddress: "",
+            customEmailType: nil,
+            connectionsMerchantName: nil,
+            pane: .networkingLinkVerification,
+            consumerSession: nil,
+            apiClient: STPAPIClient.shared,
+            clientSecret: "",
+            analyticsClient: FinancialConnectionsAnalyticsClient(),
+            isTestMode: false,
+            theme: theme
+        ))
+    }
+
+    func updateUIView(_ uiView: NetworkingOTPView, context: Context) {
+        uiView.otpTextField.value = "123"
+        uiView.otpTextField.becomeFirstResponder()
+    }
+}
+
+struct NetowrkingOTPView_Previews: PreviewProvider {
+    static var previews: some View {
+        NetowrkingOTPViewRepresentable(theme: .light)
+            .frame(height: 58)
+            .padding()
+            .previewDisplayName("Light theme")
+
+        NetowrkingOTPViewRepresentable(theme: .linkLight)
+            .frame(height: 58)
+            .padding()
+            .previewDisplayName("Link Light theme")
+    }
+}
+
+#endif

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/RoundedIconView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/RoundedIconView.swift
@@ -21,7 +21,7 @@ final class RoundedIconView: UIView {
         case circle
     }
 
-    init(image: ImageType, style: Style) {
+    init(image: ImageType, style: Style, theme: FinancialConnectionsTheme) {
         super.init(frame: .zero)
         let diameter: CGFloat = 56
         let cornerRadius: CGFloat
@@ -32,7 +32,7 @@ final class RoundedIconView: UIView {
             cornerRadius = diameter / 2
         }
 
-        backgroundColor = .brand25
+        backgroundColor = theme.iconBackgroundColor
         layer.cornerRadius = cornerRadius
 
         translatesAutoresizingMaskIntoConstraints = false
@@ -42,7 +42,7 @@ final class RoundedIconView: UIView {
         ])
 
         let iconImageView = UIImageView()
-        iconImageView.tintColor = .iconActionPrimary
+        iconImageView.tintColor = theme.iconTintColor
         switch image {
         case .image(let image):
             iconImageView.image = image.makeImage(template: true)
@@ -76,11 +76,13 @@ private struct RoundedIconViewUIViewRepresentable: UIViewRepresentable {
 
     let image: Image
     let style: RoundedIconView.Style
+    let theme: FinancialConnectionsTheme
 
     func makeUIView(context: Context) -> RoundedIconView {
         RoundedIconView(
             image: .image(image),
-            style: style
+            style: style,
+            theme: theme
         )
     }
 
@@ -95,13 +97,29 @@ struct RoundedIconView_Previews: PreviewProvider {
 
                 RoundedIconViewUIViewRepresentable(
                     image: .search,
-                    style: .rounded
+                    style: .rounded,
+                    theme: .light
+                )
+                .frame(width: 56, height: 56)
+
+                RoundedIconViewUIViewRepresentable(
+                    image: .search,
+                    style: .rounded,
+                    theme: .linkLight
                 )
                 .frame(width: 56, height: 56)
 
                 RoundedIconViewUIViewRepresentable(
                     image: .cancel_circle,
-                    style: .circle
+                    style: .circle,
+                    theme: .light
+                )
+                .frame(width: 56, height: 56)
+
+                RoundedIconViewUIViewRepresentable(
+                    image: .cancel_circle,
+                    style: .circle,
+                    theme: .linkLight
                 )
                 .frame(width: 56, height: 56)
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Success/SuccessViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Success/SuccessViewController.swift
@@ -43,7 +43,8 @@ final class SuccessViewController: UIViewController {
                 // manual entry has "0" linked accounts count
                 isLinkingOneAccount: (dataSource.linkedAccountsCount == 0 || dataSource.linkedAccountsCount == 1),
                 showSaveToLinkFailedNotice: showSaveToLinkFailedNotice
-            )
+            ),
+            theme: dataSource.manifest.theme
         )
         contentView.addSubview(bodyView)
 
@@ -112,7 +113,7 @@ final class SuccessViewController: UIViewController {
     }
 }
 
-private func CreateBodyView(subtitle: String?) -> UIView {
+private func CreateBodyView(subtitle: String?, theme: FinancialConnectionsTheme) -> UIView {
     let titleLabel = AttributedLabel(
         font: .heading(.extraLarge),
         textColor: .textDefault
@@ -144,7 +145,7 @@ private func CreateBodyView(subtitle: String?) -> UIView {
 
     let bodyVerticalStackView = UIStackView(
         arrangedSubviews: [
-            CreateIconView(),
+            CreateIconView(theme: theme),
             labelVerticalStackView,
         ]
     )
@@ -167,9 +168,9 @@ private func CreateBodyView(subtitle: String?) -> UIView {
     return bodyVerticalStackView
 }
 
-private func CreateIconView() -> UIView {
+private func CreateIconView(theme: FinancialConnectionsTheme) -> UIView {
     let iconContainerView = UIView()
-    iconContainerView.backgroundColor = .iconActionPrimary
+    iconContainerView.backgroundColor = theme.primaryColor
     let iconRadius: CGFloat = 56
     iconContainerView.layer.cornerRadius = iconRadius/2
     iconContainerView.translatesAutoresizingMaskIntoConstraints = false
@@ -179,7 +180,7 @@ private func CreateIconView() -> UIView {
     ])
 
     let iconImageView = UIImageView()
-    iconImageView.image = Image.check.makeImage().withTintColor(.white)
+    iconImageView.image = Image.check.makeImage().withTintColor(theme.primaryAccentColor)
     iconContainerView.addSubview(iconImageView)
     iconImageView.translatesAutoresizingMaskIntoConstraints = false
     NSLayoutConstraint.activate([

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/TerminalError/TerminalErrorView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/TerminalError/TerminalErrorView.swift
@@ -19,7 +19,8 @@ func TerminalErrorView(
         contentView: PaneLayoutView.createContentView(
             iconView: RoundedIconView(
                 image: .image(.warning_triangle),
-                style: .circle
+                style: .circle,
+                theme: theme
             ),
             title: STPLocalizedString(
                 "Something went wrong",


### PR DESCRIPTION
## Summary

This updates various icons and text around the flow according to the `theme` we get back in the manifest. Specifically, we update:

- `RoundedIconView` tint and background color
- `TestModeAutofillBannerView` button text color
- `NetworkingLinkLoginWarmupPane` user avatar to use the new Link colors
    - Note: This updates the avatar to use the new Link color no matter the flow, and removes the legacy Link colors from the project.
- `LegalDetailsNoticeViewController` link text colors
- `NetworkingOTPView` to use the theme's color for the borders

## Motivation

Alignment with the [Instant Debits figma](https://www.figma.com/design/wXQ8NJApqSJiLmxxANDRTs/%E2%9C%A8-Connections-3.0?node-id=787-114662&t=C9zgpIX82HpMQJuU-0)

## Testing

Lots of manual testing - I'll post screenshots inline of each component with changes.

## Changelog

N/a