### PR TITLE
Financial Connections: for networking manual entry, fixed a bug where the manual entry account would not get attached to Link account

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
@@ -69,7 +69,8 @@ protocol FinancialConnectionsAPIClient {
     func attachBankAccountToLinkAccountSession(
         clientSecret: String,
         accountNumber: String,
-        routingNumber: String
+        routingNumber: String,
+        consumerSessionClientSecret: String?
     ) -> Future<FinancialConnectionsPaymentAccountResource>
 
     func attachLinkedAccountIdToLinkAccountSession(
@@ -388,12 +389,14 @@ extension STPAPIClient: FinancialConnectionsAPIClient {
     func attachBankAccountToLinkAccountSession(
         clientSecret: String,
         accountNumber: String,
-        routingNumber: String
+        routingNumber: String,
+        consumerSessionClientSecret: String?
     ) -> Future<FinancialConnectionsPaymentAccountResource> {
         return attachPaymentAccountToLinkAccountSession(
             clientSecret: clientSecret,
             accountNumber: accountNumber,
-            routingNumber: routingNumber
+            routingNumber: routingNumber,
+            consumerSessionClientSecret: consumerSessionClientSecret
         )
     }
 
@@ -419,6 +422,7 @@ extension STPAPIClient: FinancialConnectionsAPIClient {
         var body: [String: Any] = [
             "client_secret": clientSecret,
         ]
+        body["consumer_session_client_secret"] = consumerSessionClientSecret  // optional for Link
         if let accountNumber = accountNumber, let routingNumber = routingNumber {
             body["type"] = "bank_account"
             body["bank_account"] = [
@@ -430,7 +434,6 @@ extension STPAPIClient: FinancialConnectionsAPIClient {
             body["linked_account"] = [
                 "id": linkedAccountId,
             ]
-            body["consumer_session_client_secret"] = consumerSessionClientSecret  // optional for Link
         } else {
             assertionFailure()
             return Promise(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/ManualEntry/ManualEntryDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/ManualEntry/ManualEntryDataSource.swift
@@ -24,17 +24,20 @@ final class ManualEntryDataSourceImplementation: ManualEntryDataSource {
     private let clientSecret: String
     let manifest: FinancialConnectionsSessionManifest
     let analyticsClient: FinancialConnectionsAnalyticsClient
+    private let consumerSessionClientSecret: String?
 
     init(
         apiClient: FinancialConnectionsAPIClient,
         clientSecret: String,
         manifest: FinancialConnectionsSessionManifest,
-        analyticsClient: FinancialConnectionsAnalyticsClient
+        analyticsClient: FinancialConnectionsAnalyticsClient,
+        consumerSessionClientSecret: String?
     ) {
         self.apiClient = apiClient
         self.clientSecret = clientSecret
         self.manifest = manifest
         self.analyticsClient = analyticsClient
+        self.consumerSessionClientSecret = consumerSessionClientSecret
     }
 
     func attachBankAccountToLinkAccountSession(
@@ -44,7 +47,8 @@ final class ManualEntryDataSourceImplementation: ManualEntryDataSource {
         return apiClient.attachBankAccountToLinkAccountSession(
             clientSecret: clientSecret,
             accountNumber: accountNumber,
-            routingNumber: routingNumber
+            routingNumber: routingNumber,
+            consumerSessionClientSecret: consumerSessionClientSecret
         )
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -1139,7 +1139,8 @@ private func CreatePaneViewController(
             apiClient: dataManager.apiClient,
             clientSecret: dataManager.clientSecret,
             manifest: dataManager.manifest,
-            analyticsClient: dataManager.analyticsClient
+            analyticsClient: dataManager.analyticsClient,
+            consumerSessionClientSecret: dataManager.consumerSession?.clientSecret
         )
         let manualEntryViewController = ManualEntryViewController(dataSource: dataSource)
         manualEntryViewController.delegate = nativeFlowController


### PR DESCRIPTION
## Summary

This PR:
- This PR fixed a bug where the manual entry account would not get attached to Link account.

Context:
- Financial Connections is implementing support for "networking manual entry." This feature allows a user to enter their manually entered account _once_, and then we will allow them to reuse it later through Link. 
- This is just one PR of many where each PR will be merged to a feature branch `fc-networkingmanualentry`.
- It's expected that this PR may have some gaps or TODO's because its going to a feature branch. That being said, we still want to make sure there's no glaring logic issues/bugs. 

## Testing

This video shows how the "Manual Entry" account appears at the end of the video for a brand new Link account:

https://github.com/user-attachments/assets/55864886-c6f5-4792-bbcf-9a5b6ba1a62e
