### PR TITLE
[BANKCON-11512] Add killswitch for Native Instant Debits flow

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
+++ b/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		494D62072C45B9B700106519 /* link_logo@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 494D62062C45B9B700106519 /* link_logo@3x.png */; };
 		495539EE2C484DC200543D18 /* FinancialConnectionsTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495539ED2C484DC200543D18 /* FinancialConnectionsTheme.swift */; };
 		496A6AE72C29E0BB00D34F8E /* testmode@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 496A6AE62C29E0BB00D34F8E /* testmode@3x.png */; };
+		497142BC2C514B08000DFA64 /* FlowRouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 497142BB2C514B08000DFA64 /* FlowRouterTests.swift */; };
 		4A0D015C978BD79BBFE6CE57 /* ManualEntryDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4C39F5F9AF440B13F51A81 /* ManualEntryDataSource.swift */; };
 		4A537AE0C50CAFF3889EFE28 /* UIViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7E41313B709F87B549D85F /* UIViewController+Extensions.swift */; };
 		4DC8EB63806434ABF4C9CC43 /* add@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 782A419DCF59BE6AB6439D04 /* add@3x.png */; };
@@ -316,6 +317,7 @@
 		494D62062C45B9B700106519 /* link_logo@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "link_logo@3x.png"; sourceTree = "<group>"; };
 		495539ED2C484DC200543D18 /* FinancialConnectionsTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsTheme.swift; sourceTree = "<group>"; };
 		496A6AE62C29E0BB00D34F8E /* testmode@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testmode@3x.png"; sourceTree = "<group>"; };
+		497142BB2C514B08000DFA64 /* FlowRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowRouterTests.swift; sourceTree = "<group>"; };
 		4A7B146AA6BF44921A249DB8 /* EmptyFinancialConnectionsAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyFinancialConnectionsAPIClient.swift; sourceTree = "<group>"; };
 		4AFBF95DAE0783010A17EB58 /* FinancialConnectionsSession_only_accounts.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = FinancialConnectionsSession_only_accounts.json; sourceTree = "<group>"; };
 		4BFCD9C339634B71FC8F85E9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -1039,6 +1041,7 @@
 				965814B0C5F3D13158E610E3 /* SessionFetcherTests.swift */,
 				90A06A97D714450321A5D76D /* SoftLinkTests.swift */,
 				CF731140836AE438C7F4F6AB /* StringExtensionsTests.swift */,
+				497142BB2C514B08000DFA64 /* FlowRouterTests.swift */,
 			);
 			path = StripeFinancialConnectionsTests;
 			sourceTree = "<group>";
@@ -1423,6 +1426,7 @@
 				6744CB1B182C5F7220B0B804 /* AuthFlowHelpersTests.swift in Sources */,
 				39E5D4531961150E9CB3262F /* EmptyFinancialConnectionsAPIClient.swift in Sources */,
 				CB734C25A19D38A87876FB2B /* FinancialConnectionsAnalyticsTest.swift in Sources */,
+				497142BC2C514B08000DFA64 /* FlowRouterTests.swift in Sources */,
 				77D3B375B9DBF80BA209BC99 /* FinancialConnectionsSessionTests.swift in Sources */,
 				846D1D7429B9E414744DEC99 /* FinancialConnectionsSheetTests.swift in Sources */,
 				C19996D0AC7E046DA87B6B32 /* ManualEntryValidatorTests.swift in Sources */,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsSessionManifest.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsSessionManifest.swift
@@ -126,6 +126,84 @@ struct FinancialConnectionsSessionManifest: Decodable {
         !livemode
     }
 
+    init(
+        accountholderCustomerEmailAddress: String? = nil,
+        accountholderIsLinkConsumer: Bool? = nil,
+        accountholderPhoneNumber: String? = nil,
+        accountholderToken: String? = nil,
+        accountDisconnectionMethod: FinancialConnectionsSessionManifest.AccountDisconnectionMethod? = nil,
+        activeAuthSession: FinancialConnectionsAuthSession? = nil,
+        activeInstitution: FinancialConnectionsInstitution? = nil,
+        allowManualEntry: Bool,
+        assignmentEventId: String? = nil,
+        businessName: String? = nil,
+        cancelUrl: String? = nil,
+        consentRequired: Bool,
+        customManualEntryHandling: Bool,
+        disableLinkMoreAccounts: Bool,
+        displayText: FinancialConnectionsSessionManifest.DisplayText? = nil,
+        experimentAssignments: [String: String]? = nil,
+        features: [String: Bool]? = nil,
+        hostedAuthUrl: String? = nil,
+        initialInstitution: FinancialConnectionsInstitution? = nil,
+        instantVerificationDisabled: Bool,
+        institutionSearchDisabled: Bool,
+        isEndUserFacing: Bool? = nil,
+        isLinkWithStripe: Bool? = nil,
+        isNetworkingUserFlow: Bool? = nil,
+        isStripeDirect: Bool? = nil,
+        livemode: Bool,
+        manualEntryMode: FinancialConnectionsSessionManifest.ManualEntryMode,
+        manualEntryUsesMicrodeposits: Bool,
+        nextPane: FinancialConnectionsSessionManifest.NextPane,
+        paymentMethodType: FinancialConnectionsPaymentMethodType? = nil,
+        permissions: [StripeAPI.FinancialConnectionsAccount.Permissions],
+        product: String,
+        singleAccount: Bool,
+        skipSuccessPane: Bool? = nil,
+        stepUpAuthenticationRequired: Bool? = nil,
+        successUrl: String? = nil,
+        _theme: FinancialConnectionsSessionManifest.Theme? = nil
+    ) {
+        self.accountholderCustomerEmailAddress = accountholderCustomerEmailAddress
+        self.accountholderIsLinkConsumer = accountholderIsLinkConsumer
+        self.accountholderPhoneNumber = accountholderPhoneNumber
+        self.accountholderToken = accountholderToken
+        self.accountDisconnectionMethod = accountDisconnectionMethod
+        self.activeAuthSession = activeAuthSession
+        self.activeInstitution = activeInstitution
+        self.allowManualEntry = allowManualEntry
+        self.assignmentEventId = assignmentEventId
+        self.businessName = businessName
+        self.cancelUrl = cancelUrl
+        self.consentRequired = consentRequired
+        self.customManualEntryHandling = customManualEntryHandling
+        self.disableLinkMoreAccounts = disableLinkMoreAccounts
+        self.displayText = displayText
+        self.experimentAssignments = experimentAssignments
+        self.features = features
+        self.hostedAuthUrl = hostedAuthUrl
+        self.initialInstitution = initialInstitution
+        self.instantVerificationDisabled = instantVerificationDisabled
+        self.institutionSearchDisabled = institutionSearchDisabled
+        self.isEndUserFacing = isEndUserFacing
+        self.isLinkWithStripe = isLinkWithStripe
+        self.isNetworkingUserFlow = isNetworkingUserFlow
+        self.isStripeDirect = isStripeDirect
+        self.livemode = livemode
+        self.manualEntryMode = manualEntryMode
+        self.manualEntryUsesMicrodeposits = manualEntryUsesMicrodeposits
+        self.nextPane = nextPane
+        self.paymentMethodType = paymentMethodType
+        self.permissions = permissions
+        self.product = product
+        self.singleAccount = singleAccount
+        self.skipSuccessPane = skipSuccessPane
+        self.stepUpAuthenticationRequired = stepUpAuthenticationRequired
+        self.successUrl = successUrl
+        self._theme = _theme
+    }
+
     // MARK: - Coding Keys
 
     enum CodingKeys: String, CodingKey {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsAnalyticsClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsAnalyticsClient.swift
@@ -18,12 +18,12 @@ protocol FinancialConnectionsAnalyticsClientDelegate: AnyObject {
 
 final class FinancialConnectionsAnalyticsClient {
 
-    private let analyticsClient: AnalyticsClientV2
+    private let analyticsClient: AnalyticsClientV2Protocol
     private var additionalParameters: [String: Any] = [:]
     weak var delegate: FinancialConnectionsAnalyticsClientDelegate?
 
     init(
-        analyticsClient: AnalyticsClientV2 = AnalyticsClientV2(
+        analyticsClient: AnalyticsClientV2Protocol = AnalyticsClientV2(
             clientId: "mobile-clients-linked-accounts",
             origin: "stripe-linked-accounts-ios"
         )

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/FlowRouter.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/FlowRouter.swift
@@ -44,14 +44,10 @@ class FlowRouter {
 
     var flow: Flow {
         if synchronizePayload.manifest.isProductInstantDebits {
-            if ProcessInfo.processInfo.environment["UITesting"] != nil {
-                // Show web instant debits flow while UITesting for now.
-                return .webInstantDebits
-            }
-            return exampleAppSdkOverride.shouldUseNativeFlow ? .nativeInstantDebits : .webInstantDebits
+            return shouldUseNativeInstantDebits ? .nativeInstantDebits : .webInstantDebits
         } else {
             logExposureIfNeeded()
-            return shouldUseNative ? .nativeFinancialConnections : .webFinancialConnections
+            return shouldUseNativeFinancialConnections ? .nativeFinancialConnections : .webFinancialConnections
         }
     }
 
@@ -77,7 +73,7 @@ class FlowRouter {
         return .none
     }
 
-    private var shouldUseNative: Bool {
+    private var shouldUseNativeFinancialConnections: Bool {
         // Override all other conditions if the example app has native or web selected.
         guard case .none = exampleAppSdkOverride else {
             return exampleAppSdkOverride.shouldUseNativeFlow
@@ -90,6 +86,20 @@ class FlowRouter {
         guard let experimentVariant = experimentVariant else { return false }
 
         return experimentVariant == Constants.nativeExperimentTreatment
+    }
+    
+    private var shouldUseNativeInstantDebits: Bool {
+        // Show web instant debits flow while UITesting for now.
+        guard ProcessInfo.processInfo.environment["UITesting"] == nil else {
+            return false
+        }
+        
+        // Override all other conditions if the example app has native or web selected.
+        guard case .none = exampleAppSdkOverride else {
+            return exampleAppSdkOverride.shouldUseNativeFlow
+        }
+        
+        return !killswitchActive
     }
 
     private var experimentVariant: String? {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/FlowRouter.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/FlowRouter.swift
@@ -87,18 +87,18 @@ class FlowRouter {
 
         return experimentVariant == Constants.nativeExperimentTreatment
     }
-    
+
     private var shouldUseNativeInstantDebits: Bool {
         // Show web instant debits flow while UITesting for now.
         guard ProcessInfo.processInfo.environment["UITesting"] == nil else {
             return false
         }
-        
+
         // Override all other conditions if the example app has native or web selected.
         guard case .none = exampleAppSdkOverride else {
             return exampleAppSdkOverride.shouldUseNativeFlow
         }
-        
+
         return !killswitchActive
     }
 

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/FlowRouterTests.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/FlowRouterTests.swift
@@ -1,0 +1,187 @@
+//
+//  FlowRouterTests.swift
+//  StripeFinancialConnectionsTests
+//
+//  Created by Mat Schmid on 2024-07-24.
+//
+
+@_spi(STP) import StripeCoreTestUtils
+@testable import StripeFinancialConnections
+import XCTest
+
+class FlowRouterTests: XCTestCase {
+    private static let exmapleAppNativeOverrideKey = "FINANCIAL_CONNECTIONS_EXAMPLE_APP_ENABLE_NATIVE"
+
+    private enum Experience {
+        case financialConnections
+        case instantDebits
+    }
+
+    var flowRouter: FlowRouter!
+    let mockAnalyticsClient = FinancialConnectionsAnalyticsClient(analyticsClient: MockAnalyticsClientV2())
+
+    override func tearDown() {
+        super.tearDown()
+        flowRouter = nil
+        UserDefaults.standard.removeObject(forKey: Self.exmapleAppNativeOverrideKey)
+    }
+
+    // MARK: Financial Connections
+
+    func testFinancialConnectionsKillswitchActive() {
+        flowRouter = FlowRouter(
+            synchronizePayload: synchronizePayload(
+                experience: .financialConnections,
+                killswitchActive: true,
+                nativeExperimentEnabled: true
+            ),
+            analyticsClient: mockAnalyticsClient
+        )
+
+        XCTAssertEqual(flowRouter.flow, .webFinancialConnections)
+    }
+
+    func testFinancialConnectionsKillswitchNotActive() {
+        flowRouter = FlowRouter(
+            synchronizePayload: synchronizePayload(
+                experience: .financialConnections,
+                killswitchActive: false,
+                nativeExperimentEnabled: true
+            ),
+            analyticsClient: mockAnalyticsClient
+        )
+
+        XCTAssertEqual(flowRouter.flow, .nativeFinancialConnections)
+    }
+
+    func testFinancialConnectionsNativeExperimentDisabled() {
+        flowRouter = FlowRouter(
+            synchronizePayload: synchronizePayload(
+                experience: .financialConnections,
+                killswitchActive: false,
+                nativeExperimentEnabled: false
+            ),
+            analyticsClient: mockAnalyticsClient
+        )
+
+        XCTAssertEqual(flowRouter.flow, .webFinancialConnections)
+    }
+
+    func testFinancialConnectionsNativeSdkOverrideTrue() {
+        UserDefaults.standard.set(true, forKey: Self.exmapleAppNativeOverrideKey)
+
+        flowRouter = FlowRouter(
+            synchronizePayload: synchronizePayload(
+                experience: .financialConnections,
+                killswitchActive: false,
+                nativeExperimentEnabled: false
+            ),
+            analyticsClient: mockAnalyticsClient
+        )
+
+        XCTAssertEqual(flowRouter.flow, .nativeFinancialConnections)
+    }
+
+    func testFinancialConnectionsNativeSdkOverrideFalse() {
+        UserDefaults.standard.set(false, forKey: Self.exmapleAppNativeOverrideKey)
+
+        flowRouter = FlowRouter(
+            synchronizePayload: synchronizePayload(
+                experience: .financialConnections,
+                killswitchActive: false,
+                nativeExperimentEnabled: false
+            ),
+            analyticsClient: mockAnalyticsClient
+        )
+
+        XCTAssertEqual(flowRouter.flow, .webFinancialConnections)
+    }
+
+    // MARK: Instant Debits
+
+    func testInstantDebitsKillswitchActive() {
+        flowRouter = FlowRouter(
+            synchronizePayload: synchronizePayload(
+                experience: .instantDebits,
+                killswitchActive: true,
+                nativeExperimentEnabled: true
+            ),
+            analyticsClient: mockAnalyticsClient
+        )
+
+        XCTAssertEqual(flowRouter.flow, .webInstantDebits)
+    }
+
+    func testInstantDebitsKillswitchNotActive() {
+        flowRouter = FlowRouter(
+            synchronizePayload: synchronizePayload(
+                experience: .instantDebits,
+                killswitchActive: false,
+                nativeExperimentEnabled: true
+            ),
+            analyticsClient: mockAnalyticsClient
+        )
+
+        XCTAssertEqual(flowRouter.flow, .nativeInstantDebits)
+    }
+
+    func testInstantDebitsNativeSdkOverrideTrue() {
+        UserDefaults.standard.set(true, forKey: Self.exmapleAppNativeOverrideKey)
+
+        flowRouter = FlowRouter(
+            synchronizePayload: synchronizePayload(
+                experience: .instantDebits,
+                killswitchActive: false,
+                nativeExperimentEnabled: false
+            ),
+            analyticsClient: mockAnalyticsClient
+        )
+
+        XCTAssertEqual(flowRouter.flow, .nativeInstantDebits)
+    }
+
+    func testInstantDebitsNativeSdkOverrideFalse() {
+        UserDefaults.standard.set(false, forKey: Self.exmapleAppNativeOverrideKey)
+
+        flowRouter = FlowRouter(
+            synchronizePayload: synchronizePayload(
+                experience: .instantDebits,
+                killswitchActive: false,
+                nativeExperimentEnabled: false
+            ),
+            analyticsClient: mockAnalyticsClient
+        )
+
+        XCTAssertEqual(flowRouter.flow, .webInstantDebits)
+    }
+
+    // MARK: Helpers
+
+    private func synchronizePayload(experience: Experience, killswitchActive: Bool, nativeExperimentEnabled: Bool) -> FinancialConnectionsSynchronize {
+        FinancialConnectionsSynchronize(
+            manifest: FinancialConnectionsSessionManifest(
+                allowManualEntry: false,
+                consentRequired: false,
+                customManualEntryHandling: false,
+                disableLinkMoreAccounts: false,
+                experimentAssignments: ["connections_mobile_native": nativeExperimentEnabled ? "treatment" : ""],
+                features: ["bank_connections_mobile_native_version_killswitch": killswitchActive],
+                instantVerificationDisabled: false,
+                institutionSearchDisabled: false,
+                livemode: false,
+                manualEntryMode: .automatic,
+                manualEntryUsesMicrodeposits: false,
+                nextPane: .consent,
+                permissions: [],
+                product: experience == .instantDebits ? "instant_debits" : "connections",
+                singleAccount: true
+            ),
+            text: nil,
+            visual: .init(
+                reducedBranding: false,
+                merchantLogo: [],
+                reduceManualEntryProminenceInErrors: false
+            )
+        )
+    }
+}


### PR DESCRIPTION
Resolves https://jira.corp.stripe.com/browse/BANKCON-11512

## Summary

This makes use of the native experience killswitch (`bank_connections_mobile_native_version_killswitch` in the manifest's `feature` payload) in the native instant debits flow router. If the killswitch is active, we will always show the web instant debits flow.

In the second commit, I also added some unit tests for the `FlowRouter` to make sure everything works as expected.

## Motivation

The killswitch will allow us to remotely deactivate the native experience if we detect an issue with it. 

## Testing

Unit tests added! 

Also in this video you can see that with the `Automatic` flow selected, the Networking merchant, which does not have the killswitch activated (you can see the test merchant `carlosmuvi-us` [here](https://amp.corp.stripe.com/feature-flags/flag/bank_connections_mobile_native_instant_debits_eligible_merchants)), but for a different merchant which has the killswitch activated, they get the web flow:

https://github.com/user-attachments/assets/5c170605-f917-4bc1-92de-7c47af3a4910


## Changelog

N/a
