### PR TITLE
Rework PollingVC to complete its action when dismissal animation has …

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheet.swift
@@ -122,7 +122,7 @@ public class CustomerSheet {
                 // bottom sheet (i.e. Link) to be dismissed all at the same time.
                 presentingViewController.dismiss(animated: true)
             }
-            self.bottomSheetViewController.contentStack = [self.loadingViewController]
+            self.bottomSheetViewController.setViewControllers([self.loadingViewController])
             self.completion = nil
         }
         self.completion = completion
@@ -197,7 +197,7 @@ public class CustomerSheet {
                                                                                     cbcEligible: cbcEligible,
                                                                                     csCompletion: self.csCompletion,
                                                                                     delegate: self)
-                self.bottomSheetViewController.contentStack = [savedPaymentSheetVC]
+                self.bottomSheetViewController.setViewControllers([savedPaymentSheetVC])
             }
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
@@ -171,12 +171,12 @@ public class PaymentSheet {
                         return verticalVC
                     }
                 }()
-                self.bottomSheetViewController.contentStack = [paymentSheetVC]
+                self.bottomSheetViewController.setViewControllers([paymentSheetVC])
             case .failure(let error):
                 completion(.failed(error: error))
             }
         }
-        self.bottomSheetViewController.contentStack = [self.loadingViewController]
+        self.bottomSheetViewController.setViewControllers([self.loadingViewController])
         presentingViewController.presentAsBottomSheet(bottomSheetViewController, appearance: configuration.appearance)
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -479,8 +479,7 @@ class PaymentSheetViewController: UIViewController, PaymentSheetViewControllerPr
                     UIAccessibility.post(notification: .layoutChanged, argument: self.errorLabel)
                 case .completed:
                     // We're done!
-                    let delay: TimeInterval =
-                    self.presentedViewController?.isBeingDismissed == true ? 1 : 0
+                    let delay: TimeInterval = self.presentedViewController?.isBeingDismissed == true ? 1 : 0
                     // Hack: PaymentHandler calls the completion block while SafariVC is still being dismissed - "wait" until it's finished before updating UI
                     DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
 #if !canImport(CompositorServices)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PollingViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PollingViewController.swift
@@ -348,10 +348,7 @@ extension PollingViewController: IntentStatusPollerDelegate {
             setErrorStateWorkItem.cancel() // cancel the error work item incase it was scheduled
             currentAction.paymentIntent = paymentIntent // update the local copy of the intent with the latest from the server
             dismiss {
-                // Wait a short amount of time before completing the action to ensure smooth animations
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                    self.currentAction.complete(with: .succeeded, error: nil)
-                }
+                self.currentAction.complete(with: .succeeded, error: nil)
             }
         } else if paymentIntent.status != .requiresAction {
             // an error occured to take the intent out of requires action


### PR DESCRIPTION
…completed, instead of 0.2 seconds after it starts dismissing.

Required refactoring `BottomSheetContentViewController` to accept a completion block in its `pop` method.

## Motivation
1. When the polling VC finishes, it completes its action and the confirm call *before*  it finishes dismissing itself.  
2. PaymentSheet animates the buy button to success.
3. The PollingVC finishes dismissing and PaymentSheet sub-VC's viewDidAppear triggers a call to `updateUI()`.

https://github.com/user-attachments/assets/3bc165b1-14a2-4dfe-b35d-45ff1c5ad70e

## Testing
Manually tested Blik (which uses PollingVC), 3DS2, and P24 (uses SFSafariVC).

## Changelog
This is probably a regression from https://github.com/stripe/stripe-ios/pull/3783 that didn't ship.
