### PR TITLE
[BANKCON-11668] FC - Theme account picker row

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsTheme.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsTheme.swift
@@ -102,6 +102,15 @@ extension FinancialConnectionsTheme {
             return .brand500
         }
     }
+
+    var borderColor: UIColor {
+        switch self {
+        case .linkLight:
+            return .linkGreen200
+        case .light:
+            return .brand600
+        }
+    }
 }
 
 extension FinancialConnectionsTheme? {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerSelectionListView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerSelectionListView.swift
@@ -21,6 +21,7 @@ final class AccountPickerSelectionListView: UIView {
     private let selectionType: AccountPickerSelectionType
     private let enabledAccounts: [FinancialConnectionsPartnerAccount]
     private let disabledAccounts: [FinancialConnectionsPartnerAccount]
+    private let theme: FinancialConnectionsTheme
     weak var delegate: AccountPickerSelectionListViewDelegate?
 
     private lazy var verticalStackView: UIStackView = {
@@ -33,11 +34,13 @@ final class AccountPickerSelectionListView: UIView {
     init(
         selectionType: AccountPickerSelectionType,
         enabledAccounts: [FinancialConnectionsPartnerAccount],
-        disabledAccounts: [FinancialConnectionsPartnerAccount]
+        disabledAccounts: [FinancialConnectionsPartnerAccount],
+        theme: FinancialConnectionsTheme
     ) {
         self.selectionType = selectionType
         self.enabledAccounts = enabledAccounts
         self.disabledAccounts = disabledAccounts
+        self.theme = theme
         super.init(frame: .zero)
         addAndPinSubviewToSafeArea(verticalStackView)
     }
@@ -56,6 +59,7 @@ final class AccountPickerSelectionListView: UIView {
         enabledAccounts.forEach { account in
             let accountRowView = AccountPickerRowView(
                 isDisabled: false,
+                theme: theme,
                 didSelect: { [weak self] in
                     guard let self = self else { return }
                     var selectedAccounts = selectedAccounts
@@ -85,6 +89,7 @@ final class AccountPickerSelectionListView: UIView {
         disabledAccounts.forEach { disabledAccount in
             let accountRowView = AccountPickerRowView(
                 isDisabled: true,
+                theme: theme,
                 didSelect: {
                     // can't select disabled accounts
                 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerSelectionView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerSelectionView.swift
@@ -26,13 +26,15 @@ final class AccountPickerSelectionView: UIView {
         enabledAccounts: [FinancialConnectionsPartnerAccount],
         disabledAccounts: [FinancialConnectionsPartnerAccount],
         institution: FinancialConnectionsInstitution,
+        theme: FinancialConnectionsTheme,
         delegate: AccountPickerSelectionViewDelegate
     ) {
         self.delegate = delegate
         self.listView = AccountPickerSelectionListView(
             selectionType: selectionType,
             enabledAccounts: enabledAccounts,
-            disabledAccounts: disabledAccounts
+            disabledAccounts: disabledAccounts,
+            theme: theme
         )
         super.init(frame: .zero)
         listView.delegate = self

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerViewController.swift
@@ -269,6 +269,7 @@ final class AccountPickerViewController: UIViewController {
             enabledAccounts: enabledAccounts,
             disabledAccounts: disabledAccounts,
             institution: dataSource.institution,
+            theme: dataSource.manifest.theme,
             delegate: self
         )
         self.accountPickerSelectionView = accountPickerSelectionView

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/CheckboxView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/CheckboxView.swift
@@ -11,11 +11,12 @@ import UIKit
 
 final class CheckboxView: UIView {
 
-    private let checkboxImageView: UIImageView = {
+    private let theme: FinancialConnectionsTheme
+    private lazy var checkboxImageView: UIImageView = {
         let checkboxImageView = UIImageView()
         checkboxImageView.contentMode = .scaleAspectFit
         checkboxImageView.image = Image.check.makeImage()
-            .withTintColor(.iconActionPrimary, renderingMode: .alwaysOriginal)
+            .withTintColor(theme.primaryColor, renderingMode: .alwaysOriginal)
         return checkboxImageView
     }()
 
@@ -25,7 +26,8 @@ final class CheckboxView: UIView {
         }
     }
 
-    init() {
+    init(theme: FinancialConnectionsTheme) {
+        self.theme = theme
         super.init(frame: .zero)
         addAndPinSubview(checkboxImageView)
         isSelected = false  // fire off setter to draw

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerBodyView.swift
@@ -25,7 +25,8 @@ final class LinkAccountPickerBodyView: UIView {
 
     init(
         accountTuples: [FinancialConnectionsAccountTuple],
-        addNewAccount: FinancialConnectionsNetworkingAccountPicker.AddNewAccount
+        addNewAccount: FinancialConnectionsNetworkingAccountPicker.AddNewAccount,
+        theme: FinancialConnectionsTheme
     ) {
         super.init(frame: .zero)
 
@@ -37,6 +38,7 @@ final class LinkAccountPickerBodyView: UIView {
         accountTuples.forEach { accountTuple in
             let accountRowView = AccountPickerRowView(
                 isDisabled: !accountTuple.accountPickerAccount.allowSelection,
+                theme: theme,
                 didSelect: { [weak self] in
                     guard let self = self else { return }
                     self.delegate?.linkAccountPickerBodyView(
@@ -193,7 +195,8 @@ private struct LinkAccountPickerBodyViewUIViewRepresentable: UIViewRepresentable
                 icon: FinancialConnectionsImage(
                     default: "https://b.stripecdn.com/connections-statics-srv/assets/SailIcon--add-purple-3x.png"
                 )
-            )
+            ),
+            theme: .light
         )
     }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
@@ -153,7 +153,8 @@ final class LinkAccountPickerViewController: UIViewController {
 
         let bodyView = LinkAccountPickerBodyView(
             accountTuples: accountTuples,
-            addNewAccount: networkingAccountPicker.addNewAccount
+            addNewAccount: networkingAccountPicker.addNewAccount,
+            theme: dataSource.manifest.theme
         )
         bodyView.delegate = self
         self.bodyView = bodyView

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/AccountPickerRowView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/AccountPickerRowView.swift
@@ -11,12 +11,13 @@ import UIKit
 
 final class AccountPickerRowView: UIView {
 
+    private let theme: FinancialConnectionsTheme
     private let didSelect: () -> Void
     private var isSelected: Bool = false {
         didSet {
             layer.cornerRadius = 12
             if isSelected {
-                layer.borderColor = UIColor.textActionPrimaryFocused.cgColor
+                layer.borderColor = theme.borderColor.cgColor
                 layer.borderWidth = 2
                 let shadowWidthOffset: CGFloat = 0
                 layer.shadowPath = CGPath(
@@ -52,7 +53,7 @@ final class AccountPickerRowView: UIView {
         return InstitutionIconView()
     }()
     private lazy var checkboxView: CheckboxView = {
-        let selectionView = CheckboxView()
+        let selectionView = CheckboxView(theme: theme)
         selectionView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             selectionView.widthAnchor.constraint(equalToConstant: 16),
@@ -66,8 +67,10 @@ final class AccountPickerRowView: UIView {
 
     init(
         isDisabled: Bool,
+        theme: FinancialConnectionsTheme,
         didSelect: @escaping () -> Void
     ) {
+        self.theme = theme
         self.didSelect = didSelect
         super.init(frame: .zero)
 
@@ -165,6 +168,7 @@ private struct AccountPickerRowViewUIViewRepresentable: UIViewRepresentable {
     let balanceString: String?
     let isSelected: Bool
     let isDisabled: Bool
+    let theme: FinancialConnectionsTheme
 
     init(
         institutionIconUrl: String? = nil,
@@ -172,7 +176,8 @@ private struct AccountPickerRowViewUIViewRepresentable: UIViewRepresentable {
         subtitle: String?,
         balanceString: String?,
         isSelected: Bool,
-        isDisabled: Bool
+        isDisabled: Bool,
+        theme: FinancialConnectionsTheme = .light
     ) {
         self.institutionIconUrl = institutionIconUrl
         self.title = title
@@ -180,11 +185,13 @@ private struct AccountPickerRowViewUIViewRepresentable: UIViewRepresentable {
         self.balanceString = balanceString
         self.isSelected = isSelected
         self.isDisabled = isDisabled
+        self.theme = theme
     }
 
     func makeUIView(context: Context) -> AccountPickerRowView {
         let view = AccountPickerRowView(
             isDisabled: isDisabled,
+            theme: theme,
             didSelect: {}
         )
         view.set(
@@ -230,6 +237,14 @@ struct AccountPickerRowView_Previews: PreviewProvider {
                         balanceString: nil,
                         isSelected: true,
                         isDisabled: false
+                    ).frame(height: 76)
+                    AccountPickerRowViewUIViewRepresentable(
+                        title: "Link Light Theme",
+                        subtitle: "••••6789",
+                        balanceString: nil,
+                        isSelected: true,
+                        isDisabled: false,
+                        theme: .linkLight
                     ).frame(height: 76)
                     AccountPickerRowViewUIViewRepresentable(
                         title: "Joint Checking Very Long Name To Truncate",


### PR DESCRIPTION
## Summary

This themes the account picker row (border and checkmark) based on the manifest's `theme`.

## Motivation

Alignment with the [Instant Debits figma](https://www.figma.com/design/wXQ8NJApqSJiLmxxANDRTs/%E2%9C%A8-Connections-3.0?node-id=787-116343&t=nyJkRpJD2WpZ1MAp-4)

## Testing

| Financial Connections | Instant Debits |
|--------|--------|
| ![Simulator Screenshot - iPhone 15 - 2024-07-24 at 16 56 44](https://github.com/user-attachments/assets/d92d42a6-0b4c-4c95-af79-01a6c95d4ecb) |![Simulator Screenshot - iPhone 15 - 2024-07-24 at 16 50 03](https://github.com/user-attachments/assets/58ad750a-e2f8-4263-aecf-acbe13864080) | 

## Changelog

N/a