### PR TITLE
Don't select Link phone number field when hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [Fixed] Fixed a scroll issue with native 3DS2 authentication screen when the keyboard appears.
 * [Added] When a card is saved (ie you're using a PaymentIntent + setup_future_usage or SetupIntent), legal disclaimer text now appears below the form indicating the card can be charged for future payments.
 * [Fixed] iOS 18 Compatibility with removing multiple saved payment methods
+* [Fixed] Fixed an issue where the keyboard could focus on a hidden phone number field.
 
 
 ## 23.28.1 2024-07-16

--- a/StripeUICore/StripeUICore/Source/Elements/ContainerElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/ContainerElement.swift
@@ -59,7 +59,9 @@ extension ContainerElement {
             .dropFirst() // Drop `element` too
         for next in remainingElements {
             // Don't auto select hidden elements
-            if !(next is SectionElement.HiddenElement), next.beginEditing() {
+            if !(next is SectionElement.HiddenElement), 
+                !next.view.isHidden,
+                next.beginEditing() {
                 UIAccessibility.post(notification: .screenChanged, argument: next.view)
                 return
             }

--- a/StripeUICore/StripeUICore/Source/Elements/ContainerElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/ContainerElement.swift
@@ -59,7 +59,7 @@ extension ContainerElement {
             .dropFirst() // Drop `element` too
         for next in remainingElements {
             // Don't auto select hidden elements
-            if !(next is SectionElement.HiddenElement), 
+            if !(next is SectionElement.HiddenElement),
                 !next.view.isHidden,
                 next.beginEditing() {
                 UIAccessibility.post(notification: .screenChanged, argument: next.view)


### PR DESCRIPTION
## Summary
If an element is hidden, don't select it.

## Motivation
Fixes an issue where the phone number field becomes the first responder after the email address is entered, even if the phone number field is invisible.

## Testing
PS Example

## Changelog
Added Fixed entry