### PR TITLE
[BANKCON-11475] FC - Add LinkLoginPane to client-side synchronize model

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
+++ b/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		495539EE2C484DC200543D18 /* FinancialConnectionsTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495539ED2C484DC200543D18 /* FinancialConnectionsTheme.swift */; };
 		496A6AE72C29E0BB00D34F8E /* testmode@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 496A6AE62C29E0BB00D34F8E /* testmode@3x.png */; };
 		497142BC2C514B08000DFA64 /* FlowRouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 497142BB2C514B08000DFA64 /* FlowRouterTests.swift */; };
+		49AC518C2C52DE2C00B712CC /* FinancialConnectionsLinkLoginPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49AC518B2C52DE2C00B712CC /* FinancialConnectionsLinkLoginPane.swift */; };
 		4A0D015C978BD79BBFE6CE57 /* ManualEntryDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4C39F5F9AF440B13F51A81 /* ManualEntryDataSource.swift */; };
 		4A537AE0C50CAFF3889EFE28 /* UIViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7E41313B709F87B549D85F /* UIViewController+Extensions.swift */; };
 		4DC8EB63806434ABF4C9CC43 /* add@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 782A419DCF59BE6AB6439D04 /* add@3x.png */; };
@@ -318,6 +319,7 @@
 		495539ED2C484DC200543D18 /* FinancialConnectionsTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsTheme.swift; sourceTree = "<group>"; };
 		496A6AE62C29E0BB00D34F8E /* testmode@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testmode@3x.png"; sourceTree = "<group>"; };
 		497142BB2C514B08000DFA64 /* FlowRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowRouterTests.swift; sourceTree = "<group>"; };
+		49AC518B2C52DE2C00B712CC /* FinancialConnectionsLinkLoginPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsLinkLoginPane.swift; sourceTree = "<group>"; };
 		4A7B146AA6BF44921A249DB8 /* EmptyFinancialConnectionsAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyFinancialConnectionsAPIClient.swift; sourceTree = "<group>"; };
 		4AFBF95DAE0783010A17EB58 /* FinancialConnectionsSession_only_accounts.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = FinancialConnectionsSession_only_accounts.json; sourceTree = "<group>"; };
 		4BFCD9C339634B71FC8F85E9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -743,6 +745,7 @@
 				429F985168AE9F9D700AE37B /* FinancialConnectionsSessionManifest.swift */,
 				4667E3861CDEC3A41B757714 /* FinancialConnectionsSynchronize.swift */,
 				495539ED2C484DC200543D18 /* FinancialConnectionsTheme.swift */,
+				49AC518B2C52DE2C00B712CC /* FinancialConnectionsLinkLoginPane.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1259,6 +1262,7 @@
 				460C7685096AA6C693309647 /* FinancialConnectionsAuthSession.swift in Sources */,
 				AB5AFAC3C70D6195075DE5AE /* FinancialConnectionsBulletPoint.swift in Sources */,
 				B9A24A47454134F2B869C969 /* FinancialConnectionsConsent.swift in Sources */,
+				49AC518C2C52DE2C00B712CC /* FinancialConnectionsLinkLoginPane.swift in Sources */,
 				CBF7BE2271D309F2B1E794CC /* FinancialConnectionsDataAccessNotice.swift in Sources */,
 				F67624595BD2CD7B6793BFDA /* FinancialConnectionsImage.swift in Sources */,
 				07712610C7D2F484AAB96982 /* FinancialConnectionsInstitution.swift in Sources */,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsLinkLoginPane.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsLinkLoginPane.swift
@@ -1,0 +1,15 @@
+//
+//  FinancialConnectionsLinkLoginPane.swift
+//  StripeFinancialConnections
+//
+//  Created by Mat Schmid on 2024-07-25.
+//
+
+import Foundation
+
+struct FinancialConnectionsLinkLoginPane: Decodable {
+    let title: String
+    let body: String
+    let aboveCta: String
+    let cta: String
+}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsSynchronize.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsSynchronize.swift
@@ -15,6 +15,7 @@ struct FinancialConnectionsSynchronize: Decodable {
     struct Text: Decodable {
         let consentPane: FinancialConnectionsConsent?
         let networkingLinkSignupPane: FinancialConnectionsNetworkingLinkSignup?
+        let linkLoginPane: FinancialConnectionsLinkLoginPane?
     }
 
     struct VisualUpdate: Decodable {


### PR DESCRIPTION
## Summary

This adds the `link_login_pane` model to the client side synchronize response model. It should mirror the [backend model](https://stripe.sourcegraphcloud.com/git.corp.stripe.com/stripe-internal/pay-server/-/blob/lib/bank_connections/text/data/link_login_pane.rb).

## Motivation

Support the link login pane for native instant debits.

## Testing

Made sure the model is populated when launching native instant debits: 

<img width="1032" alt="Screenshot 2024-07-25 at 3 27 53 PM" src="https://github.com/user-attachments/assets/3188ab94-30e0-4fe2-a642-063bd50d99a4">

## Changelog

N/a