### PR TITLE
Financial Connections: for networking manual entry wrote some UI tests

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnections Example.xcodeproj/project.pbxproj
+++ b/Example/FinancialConnections Example/FinancialConnections Example.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		6A5997162BC5C9D9002A44CB /* UserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A5997152BC5C9D9002A44CB /* UserDefaults.swift */; };
 		6A6C23172BBCC6210083FF66 /* XCUIGestureVelocity+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A6C23162BBCC6210083FF66 /* XCUIGestureVelocity+Extensions.swift */; };
 		6A6C23192BBF4BE30083FF66 /* PlaygroundConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A6C23182BBF4BE30083FF66 /* PlaygroundConfiguration.swift */; };
+		6A870D092C5308A500ED4DDC /* XCUIElementQuery+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A870D082C5308A500ED4DDC /* XCUIElementQuery+Extensions.swift */; };
 		6AC6B40D2B880EEA000A4B32 /* XCTestCase+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC6B40C2B880EEA000A4B32 /* XCTestCase+Extensions.swift */; };
 		6AF9C66D47F81DD9B103FB64 /* StripeCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 03E7365D673694C8D7EDFB20 /* StripeCore.framework */; };
 		828A3C3A555F9B2ABAEF3E95 /* WebViewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65FBE9DBF6CBB07AE2D5B1DA /* WebViewViewController.swift */; };
@@ -105,6 +106,7 @@
 		6A5997152BC5C9D9002A44CB /* UserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaults.swift; sourceTree = "<group>"; };
 		6A6C23162BBCC6210083FF66 /* XCUIGestureVelocity+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIGestureVelocity+Extensions.swift"; sourceTree = "<group>"; };
 		6A6C23182BBF4BE30083FF66 /* PlaygroundConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaygroundConfiguration.swift; sourceTree = "<group>"; };
+		6A870D082C5308A500ED4DDC /* XCUIElementQuery+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIElementQuery+Extensions.swift"; sourceTree = "<group>"; };
 		6AC6B40C2B880EEA000A4B32 /* XCTestCase+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Extensions.swift"; sourceTree = "<group>"; };
 		701003016E153D5DF2B00442 /* FinancialConnections-Example-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "FinancialConnections-Example-Debug.xcconfig"; sourceTree = "<group>"; };
 		74959BBB33DB4A570E2B4FD3 /* FinancialConnectionsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsUITests.swift; sourceTree = "<group>"; };
@@ -246,6 +248,7 @@
 				01EFB9C0699FEB532FFE57D9 /* XCUIElement+Extensions.swift */,
 				6AC6B40C2B880EEA000A4B32 /* XCTestCase+Extensions.swift */,
 				6A6C23162BBCC6210083FF66 /* XCUIGestureVelocity+Extensions.swift */,
+				6A870D082C5308A500ED4DDC /* XCUIElementQuery+Extensions.swift */,
 			);
 			path = FinancialConnectionsUITests;
 			sourceTree = "<group>";
@@ -385,6 +388,7 @@
 				E180626EEE466989BE92D5B7 /* FinancialConnectionsNetworkingUITests.swift in Sources */,
 				DE4B6A7CCEBD39684733A892 /* FinancialConnectionsUITests.swift in Sources */,
 				6AC6B40D2B880EEA000A4B32 /* XCTestCase+Extensions.swift in Sources */,
+				6A870D092C5308A500ED4DDC /* XCUIElementQuery+Extensions.swift in Sources */,
 				09B82E32FC066FC442BD945D /* XCUIApplication+Extensions.swift in Sources */,
 				82D499E3F32FB4663D26EBA6 /* XCUIElement+Extensions.swift in Sources */,
 				6A6C23172BBCC6210083FF66 /* XCUIGestureVelocity+Extensions.swift in Sources */,

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
@@ -401,4 +401,62 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
                 .exists
         )
     }
+
+    func testNativeNetworkingManualEntryTestMode() throws {
+        let emailAddresss = "\(UUID().uuidString)@UITestForIOS.com"
+        executeNativeNetworkingManualEntryTestModeSignUpFlowTest(emailAddress: emailAddresss)
+        executeNativeNetworkingManualEntryTestModeSignInFlowTest(emailAddress: emailAddresss)
+    }
+
+    private func executeNativeNetworkingManualEntryTestModeSignUpFlowTest(emailAddress: String) {
+        let app = XCUIApplication.fc_launch(
+            playgroundConfigurationString:
+"""
+{"use_case":"payment_intent","experience":"financial_connections","sdk_type":"native","test_mode":true,"merchant":"networking","payment_method_permission":true,"email":"\(emailAddress)","phone":"4015006000"}
+"""
+        )
+
+        app.fc_playgroundCell.tap()
+        app.fc_playgroundShowAuthFlowButton.tap()
+
+        app.fc_nativeManuallyVerifyLabel.waitForExistenceAndTap()
+
+        // auto-fill manual entry screen
+        app.fc_nativeTestModeAutofillButton.waitForExistenceAndTap()
+
+        app.fc_nativeSaveToLinkButton.waitForExistenceAndTap()
+
+        app.fc_nativeSuccessDoneButton.waitForExistenceAndTap()
+
+        XCTAssert(app.fc_playgroundSuccessAlertView.exists)
+    }
+
+    private func executeNativeNetworkingManualEntryTestModeSignInFlowTest(emailAddress: String) {
+        let app = XCUIApplication.fc_launch(
+            playgroundConfigurationString:
+"""
+{"use_case":"token","experience":"financial_connections","sdk_type":"native","test_mode":true,"merchant":"networking","payment_method_permission":true,"email":"\(emailAddress)"}
+"""
+        )
+
+        app.fc_playgroundCell.tap()
+        app.fc_playgroundShowAuthFlowButton.tap()
+
+        // we expect this to open the warm up pane (a new behavior in networking manual entry)
+        app.fc_nativeManuallyVerifyLabel.waitForExistenceAndTap()
+
+        app.fc_nativeNetworkingWarmupContinueButton.waitForExistenceAndTap()
+
+        // auto-fill OTP
+        app.fc_nativeTestModeAutofillButton.waitForExistenceAndTap()
+
+        // tap manual entry institution
+        app.scrollViews.staticTexts["Test Institution"].waitForExistenceAndTap()
+
+        app.fc_nativeConnectAccountsButton.waitForExistenceAndTap()
+
+        app.fc_nativeSuccessDoneButton.waitForExistenceAndTap()
+
+        XCTAssert(app.fc_playgroundSuccessAlertView.exists)
+    }
 }

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
@@ -131,16 +131,9 @@ final class FinancialConnectionsUITests: XCTestCase {
         app.fc_playgroundCell.tap()
         app.fc_playgroundShowAuthFlowButton.tap()
 
-        let manuallyVerifyLabel = app
-            .otherElements["consent_manually_verify_label"]
-            .links
-            .firstMatch
-        XCTAssertTrue(manuallyVerifyLabel.waitForExistence(timeout: 10.0))
-        manuallyVerifyLabel.tap()
+        app.fc_nativeManuallyVerifyLabel.waitForExistenceAndTap()
 
-        let testModeAutofillButton = app.buttons["test_mode_autofill_button"]
-        XCTAssertTrue(testModeAutofillButton.waitForExistence(timeout: 10.0))
-        testModeAutofillButton.tap()
+        app.fc_nativeTestModeAutofillButton.waitForExistenceAndTap()
 
         app.fc_nativeSuccessDoneButton.tap()
 

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIApplication+Extensions.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIApplication+Extensions.swift
@@ -72,6 +72,27 @@ extension XCUIApplication {
         return consentAgreeButton
     }
 
+    var fc_nativeManuallyVerifyLabel: XCUIElement {
+        let consentManuallyVerifyLabel = otherElements["consent_manually_verify_label"]
+        // wait so `consentManuallyVerifyLabel.links` returns correct values
+        _ = consentManuallyVerifyLabel.waitForExistence(timeout: 10.0)
+        // we need to dig into "links" (instead of just accessing the label directly)
+        // because the label is part-label, part a link, and we want to tap the link
+        //
+        // the `lastMatch` is important for token flows:
+        // - for unknown reason, the "Token" flow label returns "2" links for UI tests (iOS 17.2),
+        //   where only the second one is tappable
+        return consentManuallyVerifyLabel.links.lastMatch
+    }
+
+    var fc_nativeNetworkingWarmupContinueButton: XCUIElement {
+        return buttons["link_continue_button"]
+    }
+
+    var fc_nativeTestModeAutofillButton: XCUIElement {
+        return buttons["test_mode_autofill_button"]
+    }
+
     var fc_nativePrepaneContinueButton_noWait: XCUIElement {
         let prepaneContinueButton = buttons["prepane_continue_button"]
         return prepaneContinueButton
@@ -112,6 +133,10 @@ extension XCUIApplication {
         XCTAssertTrue(accountPickerLinkAccountsButton.waitForExistence(timeout: 120.0), "Failed to open Account Picker pane - \(#function) waiting failed")  // wait for accounts to fetch
         XCTAssert(accountPickerLinkAccountsButton.isEnabled, "no account selected")
         return accountPickerLinkAccountsButton
+    }
+
+    var fc_nativeSaveToLinkButton: XCUIElement {
+        return buttons["Save to Link"]
     }
 
     var fc_nativeSuccessDoneButton: XCUIElement {

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIElement+Extensions.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIElement+Extensions.swift
@@ -45,4 +45,29 @@ extension XCUIElement {
             timeout: 5
         ), "switch failed to change")
     }
+
+    @discardableResult
+    func waitForExistenceAndTap(
+        // standard `URLSession` timeout is 60.0
+        timeout: TimeInterval = 60.0
+    ) -> Bool {
+        if exists || waitForExistence(timeout: timeout) {
+            tapWithForce()
+            return true
+        } else {
+            return false
+        }
+    }
+
+    func tapWithForce() {
+        if isHittable {
+            tap()
+        } else {
+            // Tap the middle of the element.
+            // (Sometimes the edges of rounded buttons aren't tappable in certain web elements.)
+            let coordinate: XCUICoordinate = self.coordinate(
+                withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
+            coordinate.tap()
+        }
+    }
 }

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIElementQuery+Extensions.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIElementQuery+Extensions.swift
@@ -1,0 +1,19 @@
+//
+//  XCUIElementQuery+Extensions.swift
+//  FinancialConnectionsUITests
+//
+//  Created by Krisjanis Gaidis on 7/25/24.
+//
+
+import Foundation
+import XCTest
+
+extension XCUIElementQuery {
+    
+    var lastMatch: XCUIElement {
+        guard count > 0 else {
+            return firstMatch
+        }
+        return element(boundBy: count - 1)
+    }
+}


### PR DESCRIPTION
## Summary

^ this PR introduces some initial UI tests for networking manual entry

## Testing

Run `bitrise run financial-connections-stability-tests`:

```
FinancialConnectionsNetworkingUITests
    ✓ testNativeNetworkingManualEntryTestMode (35.947 seconds)
    ✓ testNativeNetworkingTestMode (134.347 seconds)
    ✓ testNativeNetworkingTestModeSignUpWithMultiSelectAndPrefilledEmail (31.929 seconds)
    ✓ testNativeNetworkingTestModeSignUpWithPrefilledEmailAndPhone (24.751 seconds)
FinancialConnectionsUITests
    ✓ testDataLiveModeOAuthNativeAuthFlow (28.762 seconds)
    ✓ testDataLiveModeOAuthWebAuthFlow (20.726 seconds)
    ✓ testDataTestModeOAuthNativeAuthFlow (20.605 seconds)
    ✓ testPaymentSearchInLiveModeNativeAuthFlow (26.275 seconds)
    ✓ testPaymentTestModeLegacyNativeAuthFlow (19.660 seconds)
    ✓ testPaymentTestModeManualEntryAutofill (14.103 seconds)
    ✓ testPaymentTestModeManualEntryNativeAuthFlow (24.382 seconds)
    ✓ testWebInstantDebitsFlow (13.677 seconds)
```

Also ran tests on 17.2 to test iOS 17 too:

<img width="1247" alt="image" src="https://github.com/user-attachments/assets/3ac10d38-0e52-4f0d-b1d9-7646027877f7">