### PR TITLE
Financial Connections: for networking manual entry, fixed step up verification

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -980,7 +980,7 @@ extension NativeFlowController: NetworkingLinkStepUpVerificationViewControllerDe
 
     func networkingLinkStepUpVerificationViewController(
         _ viewController: NetworkingLinkStepUpVerificationViewController,
-        didCompleteVerificationWithInstitution institution: FinancialConnectionsInstitution
+        didCompleteVerificationWithInstitution institution: FinancialConnectionsInstitution?
     ) {
         dataManager.institution = institution
         pushPane(.success, animated: true)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationViewController.swift
@@ -13,7 +13,7 @@ import UIKit
 protocol NetworkingLinkStepUpVerificationViewControllerDelegate: AnyObject {
     func networkingLinkStepUpVerificationViewController(
         _ viewController: NetworkingLinkStepUpVerificationViewController,
-        didCompleteVerificationWithInstitution institution: FinancialConnectionsInstitution
+        didCompleteVerificationWithInstitution institution: FinancialConnectionsInstitution?
     )
     func networkingLinkStepUpVerificationViewController(
         _ viewController: NetworkingLinkStepUpVerificationViewController,
@@ -217,16 +217,11 @@ extension NetworkingLinkStepUpVerificationViewController: NetworkingOTPViewDeleg
                                         pane: .networkingLinkStepUpVerification
                                     )
 
-                                if let institution = institutionList.data.first {
-                                    self.delegate?.networkingLinkStepUpVerificationViewController(
-                                        self,
-                                        didCompleteVerificationWithInstitution: institution
-                                    )
-                                } else {
-                                    // this shouldn't happen, but in case it does, we navigate to `institutionPicker` so user
-                                    // could still have a chance at successfully connecting their account
-                                    self.delegate?.networkingLinkStepUpVerificationViewControllerEncounteredSoftError(self)
-                                }
+                                self.delegate?.networkingLinkStepUpVerificationViewController(
+                                    self,
+                                    // networking manual entry will not return an institution
+                                    didCompleteVerificationWithInstitution: institutionList.data.first
+                                )
 
                                 // only hide loading view after animation
                                 // to next screen has completed


### PR DESCRIPTION
## Summary

^ there was an issue where previous code required institutions to be returned but we no longer need that (particularly for manual entry)

## Testing

Video that shows that step up verification works OK:


https://github.com/user-attachments/assets/83d96bd9-b982-49a7-8e4b-2bf4b491d682

