### PR TITLE
Make Element and friends CustomDebugConvertible for easier debugging

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/PaymentMethodElement/PaymentMethodElementWrapper.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/PaymentMethodElement/PaymentMethodElementWrapper.swift
@@ -69,6 +69,9 @@ class PaymentMethodElementWrapper<WrappedElementType: Element> {
         self.init(textFieldElement, defaultsApplier: defaultsApplier, paramsUpdater: paramsUpdater)
     }
 
+    public var debugDescription: String {
+        return String(describing: element)
+    }
 }
 
 // MARK: - PaymentMethodElement

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/SimpleMandateElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/SimpleMandateElement.swift
@@ -14,6 +14,7 @@ class SimpleMandateElement: PaymentMethodElement {
     func updateParams(params: IntentConfirmParams) -> IntentConfirmParams? {
         // Per the contract of the `updateParams(params:)` API (see its docstring), we should only return a non-nil params if we are valid.
         // We are only valid if the customer saw the mandate - either our view was displayed *or* the customer already saw the view
+        // This handles edge cases around the payment method being updated to include or not include a mandate e.g. going from payment -> setup mode. See the `testAppliesPreviousCustomerInput_for_mandate` test for an example.
         if customerAlreadySawMandate || mandateTextView.viewDidAppear {
             params.didDisplayMandate = true
             return params

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfirmParams.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfirmParams.swift
@@ -26,6 +26,7 @@ class IntentConfirmParams {
 
     let paymentMethodParams: STPPaymentMethodParams
     let paymentMethodType: PaymentSheet.PaymentMethodType
+    /// ⚠️ Usage of this is *not compatible* with server-side confirmation!
     let confirmPaymentMethodOptions: STPConfirmPaymentMethodOptions
 
     /// True if the customer opts to save their payment method for future payments.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -22,7 +22,7 @@ class PaymentMethodFormViewController: UIViewController {
     let configuration: PaymentSheet.Configuration
     weak var delegate: PaymentMethodFormViewControllerDelegate?
     var paymentOption: PaymentOption? {
-        // TODO Copied from AddPaymentMethodViewController but this seems wrong; we shouldn't have such divergent paths for link and instant debits. Where is the setDefaultBillingDetailsIfNecessary call, for example?
+        // TODO Copied from AddPaymentMethodViewController but this seems wrong; we shouldn't have a divergent path for link. Where is the setDefaultBillingDetailsIfNecessary call, for example?
         if let linkEnabledElement = form as? LinkEnabledPaymentMethodElement {
             return linkEnabledElement.makePaymentOption(intent: intent)
         }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Elements+TestHelpers.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Elements+TestHelpers.swift
@@ -63,21 +63,3 @@ extension Element {
             .first
     }
 }
-
-extension SectionElement: CustomDebugStringConvertible {
-    public var debugDescription: String {
-        return ["<SectionElement: \(Unmanaged.passUnretained(self).toOpaque())>", title].compactMap { $0 }.joined(separator: " - ")
-    }
-}
-
-extension TextFieldElement: CustomDebugStringConvertible {
-    public var debugDescription: String {
-        return "<TextFieldElement: \(Unmanaged.passUnretained(self).toOpaque())>  -  \"\(configuration.label)\"  -  \(validationState)"
-    }
-}
-
-extension DropdownFieldElement {
-    public override var debugDescription: String {
-        return "<DropdownFieldElement: \(Unmanaged.passUnretained(self).toOpaque())>  -  \"\(label ?? "nil")\"  -  \(validationState)"
-    }
-}

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLPMConfirmFlowTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLPMConfirmFlowTests.swift
@@ -81,7 +81,7 @@ final class PaymentSheet_LPM_ConfirmFlowTests: STPNetworkStubbingTestCase {
             // e.g. iDEAL shouldn't show a mandate or email field for a vanilla payment
             XCTAssertNil(form.getMandateElement())
             XCTAssertNil(form.getTextFieldElement("Email"))
-            // Tip: To help you debug, print out `form.getAllUnwrappedSubElements()`
+            // Tip: To help you debug, run `po form` in the debug console or `call debugPrint(form)`
         }
 
         // If your payment method shows different fields depending on the kind of intent, you can call `_testConfirm` multiple times with different intents.

--- a/StripeUICore/StripeUICore/Source/Elements/ContainerElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/ContainerElement.swift
@@ -70,3 +70,16 @@ extension ContainerElement {
         delegate?.continueToNextField(element: self)
     }
 }
+
+extension ContainerElement {
+    public var debugDescription: String {
+        return "<\(type(of: self)): \(Unmanaged.passUnretained(self).toOpaque())>" + subElementDebugDescription
+    }
+
+    public var subElementDebugDescription: String  {
+        elements.reduce("") { partialResult, element in
+            // 
+            partialResult + "\n└─ \(String(describing: element).replacingOccurrences(of: "└─", with: "   └─"))"
+        }
+    }
+}

--- a/StripeUICore/StripeUICore/Source/Elements/DropdownFieldElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/DropdownFieldElement.swift
@@ -15,8 +15,7 @@ import UIKit
  
  For internal SDK use only
  */
-@objc(STP_Internal_DropdownFieldElement)
-@_spi(STP) public class DropdownFieldElement: NSObject {
+@_spi(STP) public final class DropdownFieldElement {
     public typealias DidPresent = () -> Void
     public typealias DidUpdateSelectedIndex = (Int) -> Void
     public typealias DidTapClose = () -> Void
@@ -81,7 +80,7 @@ import UIKit
 #if targetEnvironment(macCatalyst) || canImport(CompositorServices)
     private(set) lazy var pickerView: UIButton = {
         let button = UIButton()
-        let action = { (action: UIAction) -> Void in
+        let action = { (action: UIAction) in
             self.selectedIndex = Int(action.identifier.rawValue) ?? 0
         }
 
@@ -102,8 +101,8 @@ import UIKit
 #else
     private(set) lazy var pickerView: UIPickerView = {
         let picker = UIPickerView()
-        picker.delegate = self
-        picker.dataSource = self
+        picker.delegate = pickerViewDelegate
+        picker.dataSource = pickerViewDelegate
         return picker
     }()
 #endif
@@ -128,6 +127,7 @@ import UIKit
     private var previouslySelectedIndex: Int
     private let disableDropdownWithSingleElement: Bool
     private let isOptional: Bool
+    lazy var pickerViewDelegate: PickerViewDelegate = { PickerViewDelegate(self) }()
 
     /**
      - Parameters:
@@ -172,7 +172,6 @@ import UIKit
             self.selectedIndex = defaultIndex
         }
         self.previouslySelectedIndex = selectedIndex
-        super.init()
 
         if !items.isEmpty {
             updatePickerField()
@@ -230,33 +229,43 @@ extension DropdownFieldElement: Element {
     }
 }
 
-// MARK: UIPickerViewDelegate
+// MARK: UIPickerViewDelegate & UIPickerViewDataSource
 
-extension DropdownFieldElement: UIPickerViewDelegate {
+extension DropdownFieldElement {
+    // A silly bridge class to work around the fact that UIPickerViewDelegate must be an NSObject
+    class PickerViewDelegate: NSObject, UIPickerViewDelegate, UIPickerViewDataSource {
+        weak var dropdownFieldElement: DropdownFieldElement?
+        init(_ dropdownFieldElement: DropdownFieldElement?) {
+            self.dropdownFieldElement = dropdownFieldElement
+        }
 
-    public func pickerView(_ pickerView: UIPickerView, attributedTitleForRow row: Int, forComponent component: Int) -> NSAttributedString? {
-        let item = items[row]
+        public func pickerView(_ pickerView: UIPickerView, attributedTitleForRow row: Int, forComponent component: Int) -> NSAttributedString? {
+            guard let dropdownFieldElement else { return nil }
+            let item = dropdownFieldElement.items[row]
 
-        guard item.isPlaceholder else { return item.pickerDisplayName }
+            guard item.isPlaceholder else { return item.pickerDisplayName }
 
-        // If this item is marked as a placeholder, apply placeholder text color
-        let attributes: [NSAttributedString.Key: Any] = [.foregroundColor: theme.colors.placeholderText]
-        let placeholderString = NSAttributedString(string: item.pickerDisplayName.string, attributes: attributes)
-        return placeholderString
+            // If this item is marked as a placeholder, apply placeholder text color
+            let attributes: [NSAttributedString.Key: Any] = [.foregroundColor: dropdownFieldElement.theme.colors.placeholderText]
+            let placeholderString = NSAttributedString(string: item.pickerDisplayName.string, attributes: attributes)
+            return placeholderString
+        }
+
+        public func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+            dropdownFieldElement?.pickerView(pickerView, didSelectRow: row, inComponent: component)
+        }
+
+        public func numberOfComponents(in pickerView: UIPickerView) -> Int {
+            return 1
+        }
+
+        public func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+            return dropdownFieldElement?.items.count ?? 0
+        }
     }
 
     public func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
         selectedIndex = row
-    }
-}
-
-extension DropdownFieldElement: UIPickerViewDataSource {
-    public func numberOfComponents(in pickerView: UIPickerView) -> Int {
-        return 1
-    }
-
-    public func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
-        return items.count
     }
 }
 
@@ -286,5 +295,12 @@ extension DropdownFieldElement: PickerFieldViewDelegate {
         // Reset to previously selected index when canceling
         selectedIndex = previouslySelectedIndex
         didTapClose?()
+    }
+}
+
+// MARK: - DebugDescription
+extension DropdownFieldElement {
+    public var debugDescription: String {
+        return "<DropdownFieldElement: \(Unmanaged.passUnretained(self).toOpaque())>; label = \(label ?? "nil"); validationState = \(validationState); rawData = \(rawData)"
     }
 }

--- a/StripeUICore/StripeUICore/Source/Elements/Element.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Element.swift
@@ -16,7 +16,7 @@ import UIKit
  
  Think of this as a light-weight, specialized view controller.
  */
-@_spi(STP) public protocol Element: AnyObject {
+@_spi(STP) public protocol Element: AnyObject, CustomDebugStringConvertible {
     /// - Note: This is set by your parent.
     var delegate: ElementDelegate? { get set }
 
@@ -106,4 +106,10 @@ extension Element {
 
 @_spi(STP) public protocol ElementValidationError: Error {
     var localizedDescription: String { get }
+}
+
+extension Element {
+    public var debugDescription: String {
+        return "<\(type(of: self)): \(Unmanaged.passUnretained(self).toOpaque())>"
+    }
 }

--- a/StripeUICore/StripeUICore/Source/Elements/Section/SectionElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Section/SectionElement.swift
@@ -128,3 +128,10 @@ extension SectionElement {
         }
     }
 }
+
+// MARK: - DebugDescription
+extension SectionElement {
+    public var debugDescription: String {
+        return "<\(type(of: self)): \(Unmanaged.passUnretained(self).toOpaque())>; title = \(title ?? "nil")" + subElementDebugDescription
+    }
+}

--- a/StripeUICore/StripeUICore/Source/Elements/TextField/TextFieldElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/TextField/TextFieldElement.swift
@@ -182,3 +182,10 @@ extension TextFieldElement: TextFieldViewDelegate {
         delegate?.continueToNextField(element: self)
     }
 }
+
+// MARK: - DebugDescription
+extension TextFieldElement {
+    public var debugDescription: String {
+        return "<TextFieldElement: \(Unmanaged.passUnretained(self).toOpaque())>; label = \(configuration.label); text = \(text); validationState = \(validationState)"
+    }
+}


### PR DESCRIPTION
## Summary
Elements now pretty print!

Example of iDEAL form:
<img src="https://github.com/user-attachments/assets/01875b04-fc93-44e9-9da1-f767fead242c" width="300">

Before:
```
(lldb) po form
<FormElement: 0x6000015c4e00>
```

After:
```
(lldb) po form
<FormElement: 0x0000600001377100>
└─ <SectionElement: 0x000000014f53bb60>; title = Contact information
   └─ <TextFieldElement: 0x000000014f53b700>; label = Full name; text = Foo; validationState = valid
   └─ <TextFieldElement: 0x000000014f537f60>; label = Email; text = f@z.c; validationState = valid
└─ <SectionElement: 0x000000013f54d5b0>; title = nil
   └─ <DropdownFieldElement: 0x000000014f53abd0>; label = iDEAL Bank; validationState = valid; rawData = abn_amro
└─ <SimpleMandateElement: 0x0000600003ac8100>
```

## Motivation
Easier debugging. Helps visualize the Element hierarchy.
