### PR TITLE
Financial Connections: for networking manual entry, fixed missing backend URL selecting in text

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
@@ -198,12 +198,7 @@ final class LinkAccountPickerViewController: UIViewController {
                         theme: dataSource.manifest.theme,
                         didSelectUrl: { [weak self] url in
                             guard let self = self else { return }
-                            AuthFlowHelpers.handleURLInTextFromBackend(
-                                url: url,
-                                pane: .linkAccountPicker,
-                                analyticsClient: self.dataSource.analyticsClient,
-                                handleURL: { _, _ in }
-                            )
+                            self.didSelectURLInTextFromBackend(url)
                         }
                     )
                     dataAccessNoticeViewController.present(on: self)
@@ -341,6 +336,15 @@ final class LinkAccountPickerViewController: UIViewController {
             }
         }
     }
+
+    private func didSelectURLInTextFromBackend(_ url: URL) {
+        AuthFlowHelpers.handleURLInTextFromBackend(
+            url: url,
+            pane: .linkAccountPicker,
+            analyticsClient: self.dataSource.analyticsClient,
+            handleURL: { _, _ in }
+        )
+    }
 }
 
 // MARK: - LinkAccountPickerBodyViewDelegate
@@ -369,7 +373,10 @@ extension LinkAccountPickerViewController: LinkAccountPickerBodyViewDelegate {
                     didSelectPrimaryButton: { genericInfoViewController in
                         genericInfoViewController.dismiss(animated: true)
                     },
-                    didSelectURL: { _ in } // TODO(kgaidis): fix handling URL
+                    didSelectURL: { [weak self] url in
+                        guard let self = self else { return }
+                        self.didSelectURLInTextFromBackend(url)
+                    }
                 )
                 genericInfoViewController.present(on: self)
             } else {
@@ -538,8 +545,9 @@ extension LinkAccountPickerViewController: LinkAccountPickerBodyViewDelegate {
                                 animated: true
                             )
                         },
-                        didSelectURL: { _ in
-                            // TODO(kgaidis): fix handling URL
+                        didSelectURL: { [weak self] url in
+                            guard let self = self else { return }
+                            self.didSelectURLInTextFromBackend(url)
                         },
                         willDismissSheet: willDismissSheet
                     )


### PR DESCRIPTION
## Summary

^ there were some TODO's that needed patching

## Testing

Tested the code hitting and opening website as expected:

<img width="1297" alt="Screenshot 2024-07-26 at 11 12 34 AM" src="https://github.com/user-attachments/assets/be0a9872-d92e-47a8-bfd2-7ae28c89173b">
