### PR TITLE
[FC] Add endpoint methods for Instant Debits flow

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
@@ -148,15 +148,12 @@ protocol FinancialConnectionsAPIClient {
         requestSurface: String,
         emailAddress: String,
         phoneNumber: String,
-        country: String,
-        paymentIntentId: String?,
-        merchantPublishableKey: String
+        country: String
     ) -> Future<LinkSignUpResponse>
 
     func attachLinkConsumerToLinkAccountSession(
         requestSurface: String,
         linkAccountSession: String,
-        merchantPublishableKey: String,
         consumerSessionClientSecret: String
     ) -> Future<AttachLinkConsumerToLinkAccountSessionResponse>
 }
@@ -730,9 +727,7 @@ extension STPAPIClient: FinancialConnectionsAPIClient {
         requestSurface: String, // "ios_instant_debits"
         emailAddress: String,
         phoneNumber: String,
-        country: String,
-        paymentIntentId: String?,
-        merchantPublishableKey: String
+        country: String
     ) -> Future<LinkSignUpResponse> {
         var parameters: [String: Any] = [
             "request_surface": requestSurface,
@@ -744,13 +739,10 @@ extension STPAPIClient: FinancialConnectionsAPIClient {
             "country_inferring_method": "PHONE_NUMBER",
             "locale": Locale.current.toLanguageTag(),
             "consent_action": "entered_phone_number_clicked_save_to_link",
-            "key": merchantPublishableKey,
         ]
 
-        if let paymentIntentId {
-            parameters["financial_incentive"] = [
-                "payment_intent": paymentIntentId
-            ]
+        if let publishableKey {
+            parameters["key"] = publishableKey
         }
         return post(resource: APIEndpointLinkAccountsSignUp, parameters: parameters)
     }
@@ -758,17 +750,19 @@ extension STPAPIClient: FinancialConnectionsAPIClient {
     func attachLinkConsumerToLinkAccountSession(
         requestSurface: String,
         linkAccountSession: String,
-        merchantPublishableKey: String,
         consumerSessionClientSecret: String
     ) -> Future<AttachLinkConsumerToLinkAccountSessionResponse> {
-        let parameters: [String: Any] = [
+        var parameters: [String: Any] = [
             "request_surface": requestSurface,
             "link_account_session": linkAccountSession,
-            "key": merchantPublishableKey,
             "credentials": [
                 "consumer_session_client_secret": consumerSessionClientSecret
             ],
         ]
+
+        if let publishableKey {
+            parameters["key"] = publishableKey
+        }
         return post(resource: APIEndpointAttachLinkConsumerToLinkAccountSession, parameters: parameters)
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/ConsumerSession/ConsumerSessionModels.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/ConsumerSession/ConsumerSessionModels.swift
@@ -19,6 +19,17 @@ struct LookupConsumerSessionResponse: Decodable {
     let accountId: String?
 }
 
+struct LinkSignUpResponse: Decodable {
+    let accountId: String
+    let publishableKey: String
+    let consumerSession: ConsumerSessionData
+}
+
+struct AttachLinkConsumerToLinkAccountSessionResponse: Decodable {
+    let id: String
+    let clientSecret: String
+}
+
 struct ConsumerSessionResponse: Decodable {
     let consumerSession: ConsumerSessionData
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/ConsumerSession/ConsumerSessionModels.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/ConsumerSession/ConsumerSessionModels.swift
@@ -22,6 +22,7 @@ struct LookupConsumerSessionResponse: Decodable {
 struct LinkSignUpResponse: Decodable {
     let accountId: String
     let publishableKey: String
+    let authSessionClientSecret: String
     let consumerSession: ConsumerSessionData
 }
 

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
@@ -193,4 +193,21 @@ class EmptyFinancialConnectionsAPIClient: FinancialConnectionsAPIClient {
     ) -> Future<FinancialConnectionsSessionManifest> {
         return Promise<StripeFinancialConnections.FinancialConnectionsSessionManifest>()
     }
+
+    func linkAccountSignUp(
+        requestSurface: String,
+        emailAddress: String,
+        phoneNumber: String,
+        country: String
+    ) -> Future<LinkSignUpResponse> {
+        return Promise<StripeFinancialConnections.LinkSignUpResponse>()
+    }
+
+    func attachLinkConsumerToLinkAccountSession(
+        requestSurface: String,
+        linkAccountSession: String,
+        consumerSessionClientSecret: String
+    ) -> Future<AttachLinkConsumerToLinkAccountSessionResponse> {
+        return Promise<StripeFinancialConnections.AttachLinkConsumerToLinkAccountSessionResponse>()
+    }
 }


### PR DESCRIPTION
## Summary

This adds methods for two new endpoints we will hit in the Native Instant Debits flow:

- `consumers/accounts/sign_up`: For the New User Experience. Called from the Link Login pane when the email entered is not an existing Link account. [Source](https://docs.google.com/document/d/1k0tv4jUxL9QSxni1QEo-ZiHG_HDCX9gAMo2qKE8kqbQ/edit#bookmark=id.ky0jnwhllp5j).
- `consumers/attach_link_consumer_to_link_account_session`: For the Return User Experience. When a user has verified their account, we call this to attach the Link account with the Link Account Session. [Source](https://docs.google.com/document/d/1k0tv4jUxL9QSxni1QEo-ZiHG_HDCX9gAMo2qKE8kqbQ/edit#bookmark=id.lv94ssf6gpfb).

## Motivation

Preparing to build the Link Login pane!

## Testing

Nothing functional changed.

## Changelog

N/a