### PR TITLE
Fix flakey 6200000000000005 IntegrationTesterUITest

### DIFF
--- a/Testers/IntegrationTester/IntegrationTesterUITests/IntegrationTesterUITests.swift
+++ b/Testers/IntegrationTester/IntegrationTesterUITests/IntegrationTesterUITests.swift
@@ -287,6 +287,7 @@ class IntegrationTesterUITests: XCTestCase {
         numberField.tap()
         numberField.typeText(number)
         let expField = app.textFields["expiration date"]
+        _ = expField.waitForExistence(timeout: 10)
         expField.typeText("1228")
         if STPCardValidator.brand(forNumber: number) == .amex {
             let cvcField = app.textFields["CVV"]


### PR DESCRIPTION
It seems like this test sometimes flakes when the BIN service takes too long and the SDK doesn't autoadvance in time, but I'm not sure.