### PR TITLE
[FC] Minor theme fixes

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/EmailTextField.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/EmailTextField.swift
@@ -39,10 +39,10 @@ final class EmailTextField: UIView {
         textField.textField.accessibilityIdentifier = "email_text_field"
         return textField
     }()
-    private let activityIndicator: ActivityIndicator = {
+    private lazy var activityIndicator: ActivityIndicator = {
         let activityIndicator = ActivityIndicator(size: .medium)
         activityIndicator.setContentCompressionResistancePriority(.required, for: .horizontal)
-        activityIndicator.color = .iconActionPrimary
+        activityIndicator.color = theme.spinnerColor
         return activityIndicator
     }()
     fileprivate var didEndEditingOnce = false
@@ -193,6 +193,18 @@ struct EmailTextField_Previews: PreviewProvider {
                     isLoading: false,
                     theme: .light
                 ).frame(height: 90)
+
+                EmailTextFieldUIViewRepresentable(
+                    text: "light@theme.com",
+                    isLoading: true,
+                    theme: .light
+                ).frame(height: 56)
+
+                EmailTextFieldUIViewRepresentable(
+                    text: "linklight@theme.com",
+                    isLoading: true,
+                    theme: .linkLight
+                ).frame(height: 56)
 
                 Spacer()
             }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationBodyView.swift
@@ -12,6 +12,7 @@ import UIKit
 
 final class NetworkingLinkStepUpVerificationBodyView: UIView {
 
+    private let theme: FinancialConnectionsTheme
     private let didSelectResendCode: () -> Void
 
     // `UIStackView` is used only for padding
@@ -30,9 +31,11 @@ final class NetworkingLinkStepUpVerificationBodyView: UIView {
     }()
 
     init(
+        theme: FinancialConnectionsTheme,
         otpView: UIView,
         didSelectResendCode: @escaping () -> Void
     ) {
+        self.theme = theme
         self.didSelectResendCode = didSelectResendCode
         super.init(frame: .zero)
         let verticalStackView = UIStackView(
@@ -59,6 +62,7 @@ final class NetworkingLinkStepUpVerificationBodyView: UIView {
         if show {
             footnoteStackView.addArrangedSubview(
                 CreateResendCodeLabel(
+                    theme: theme,
                     didSelect: didSelectResendCode
                 )
             )
@@ -67,13 +71,14 @@ final class NetworkingLinkStepUpVerificationBodyView: UIView {
 }
 
 private func CreateResendCodeLabel(
+    theme: FinancialConnectionsTheme,
     didSelect: @escaping () -> Void
 ) -> UIView {
     let resendCodeLabel = AttributedTextView(
         font: .label(.medium),
         boldFont: .label(.mediumEmphasized),
         linkFont: .label(.mediumEmphasized),
-        textColor: .textActionPrimary,
+        textColor: theme.textActionColor,
         showLinkUnderline: false,
         alignCenter: false
     )
@@ -96,9 +101,11 @@ private func CreateResendCodeLabel(
 import SwiftUI
 
 private struct NetworkingLinkStepUpVerificationBodyViewUIViewRepresentable: UIViewRepresentable {
+    let theme: FinancialConnectionsTheme
 
     func makeUIView(context: Context) -> NetworkingLinkStepUpVerificationBodyView {
         NetworkingLinkStepUpVerificationBodyView(
+            theme: theme,
             otpView: UIView(),
             didSelectResendCode: {}
         )
@@ -111,7 +118,10 @@ struct NetworkingLinkStepUpVerificationBodyView_Previews: PreviewProvider {
     static var previews: some View {
         VStack(alignment: .leading) {
             Spacer()
-            NetworkingLinkStepUpVerificationBodyViewUIViewRepresentable()
+            NetworkingLinkStepUpVerificationBodyViewUIViewRepresentable(theme: .light)
+                .frame(maxHeight: 100)
+                .padding()
+            NetworkingLinkStepUpVerificationBodyViewUIViewRepresentable(theme: .linkLight)
                 .frame(maxHeight: 100)
                 .padding()
             Spacer()

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationViewController.swift
@@ -34,6 +34,7 @@ final class NetworkingLinkStepUpVerificationViewController: UIViewController {
     }()
     private lazy var bodyView: NetworkingLinkStepUpVerificationBodyView = {
         let bodyView = NetworkingLinkStepUpVerificationBodyView(
+            theme: dataSource.manifest.theme,
             otpView: otpView,
             didSelectResendCode: { [weak self] in
                 self?.didSelectResendCode()


### PR DESCRIPTION
## Summary

This fixes two views in the Financial Connections flow where we weren't theming to the correct experience.

- `EmailTextField`: Theme loading indicator
- `NetworkingLinkStepUpVerificationBodyView`: Theme `Resend code` button

## Motivation

Show the correct theme colors! 💅 

## Testing

Manual testing with SwiftUI previews - see code comments!

## Changelog

N/a