### PR TITLE
Better format `ordered_lpms` in metrics

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
@@ -128,7 +128,7 @@ extension STPAnalyticsClient {
         }()
         let params = ["selected_lpm": defaultPaymentMethodAnalyticsValue,
                       "intent_type": intentAnalyticsValue,
-                      "ordered_lpms": orderedPaymentMethodTypes.map({ $0.identifier }),
+                      "ordered_lpms": orderedPaymentMethodTypes.map({ $0.identifier }).joined(separator: ","),
         ] as [String: Any]
 
         logPaymentSheetEvent(


### PR DESCRIPTION
## Summary
- Zoolander injests an array of strings in a weird way making it hard to query. 
- Currently looks like `"ordered_lpms[0]":"card","ordered_lpms[1]":"paypal"`
- Will now look like `"ordered_lpms"="card,paypal,amazon_pay"

## Motivation
Easier query

## Testing
Manual

## Changelog
N/A
