### PR TITLE
Allow redisplay tests for customerSheet

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPAPIClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPAPIClient+PaymentSheet.swift
@@ -126,22 +126,23 @@ extension STPAPIClient {
         )
     }
 
-    func retrieveElementsSessionForCustomerSheet(paymentMethodTypes: [String]?,
-                                                 clientDefaultPaymentMethod: String?,
-                                                 customerSessionClientSecret: CustomerSessionClientSecret?) async throws -> STPElementsSession {
+    func retrieveDeferredElementsSessionForCustomerSheet(paymentMethodTypes: [String]?,
+                                                         clientDefaultPaymentMethod: String?,
+                                                         customerSessionClientSecret: CustomerSessionClientSecret?) async throws -> STPElementsSession {
 
-        let parameters = makeElementsSessionsParamsForCustomerSheet(paymentMethodTypes: paymentMethodTypes,
-                                                                    clientDefaultPaymentMethod: clientDefaultPaymentMethod,
-                                                                    customerSessionClientSecret: customerSessionClientSecret)
+        let parameters = makeDeferredElementsSessionsParamsForCustomerSheet(paymentMethodTypes: paymentMethodTypes,
+                                                                            clientDefaultPaymentMethod: clientDefaultPaymentMethod,
+                                                                            customerSessionClientSecret: customerSessionClientSecret)
         return try await APIRequest<STPElementsSession>.getWith(
             self,
             endpoint: APIEndpointElementsSessions,
             parameters: parameters
         )
     }
-    func makeElementsSessionsParamsForCustomerSheet(paymentMethodTypes: [String]?,
-                                                    clientDefaultPaymentMethod: String?,
-                                                    customerSessionClientSecret: CustomerSessionClientSecret?) -> [String: Any] {
+
+    func makeDeferredElementsSessionsParamsForCustomerSheet(paymentMethodTypes: [String]?,
+                                                            clientDefaultPaymentMethod: String?,
+                                                            customerSessionClientSecret: CustomerSessionClientSecret?) -> [String: Any] {
         var parameters: [String: Any] = [:]
         parameters["type"] = "deferred_intent"
         parameters["locale"] = Locale.current.toLanguageTag()
@@ -160,6 +161,39 @@ extension STPAPIClient {
             deferredIntent["payment_method_types"] = paymentMethodTypes
         }
         parameters["deferred_intent"] = deferredIntent
+        return parameters
+    }
+
+    func retrieveElementsSessionForCustomerSheet(setupIntentClientSecret: String,
+                                                 clientDefaultPaymentMethod: String?,
+                                                 customerSessionClientSecret: CustomerSessionClientSecret?) async throws -> STPElementsSession {
+        let parameters = makeElementsSessionsParamsForCustomerSheet(setupIntentClientSecret: setupIntentClientSecret,
+                                                                    clientDefaultPaymentMethod: clientDefaultPaymentMethod,
+                                                                    customerSessionClientSecret: customerSessionClientSecret)
+        return try await APIRequest<STPElementsSession>.getWith(
+            self,
+            endpoint: APIEndpointElementsSessions,
+            parameters: parameters
+        )
+    }
+
+    func makeElementsSessionsParamsForCustomerSheet(setupIntentClientSecret: String,
+                                                    clientDefaultPaymentMethod: String?,
+                                                    customerSessionClientSecret: CustomerSessionClientSecret?) -> [String: Any] {
+        var parameters: [String: Any] = [:]
+        parameters["type"] = "setup_intent"
+        parameters["client_secret"] = setupIntentClientSecret
+        parameters["expand"] = ["payment_method_preference.setup_intent.payment_method"]
+
+        parameters["locale"] = Locale.current.toLanguageTag()
+
+        if let customerSessionClientSecret {
+            parameters["customer_session_client_secret"] = customerSessionClientSecret.clientSecret
+        }
+
+        if let clientDefaultPaymentMethod {
+            parameters["client_default_payment_method"] = clientDefaultPaymentMethod
+        }
         return parameters
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
@@ -239,3 +239,17 @@ extension STPElementsSession {
         return features.paymentMethodSave
     }
 }
+
+extension STPElementsSession {
+    func savePaymentMethodConsentBehaviorForCustomerSheet() -> PaymentSheetFormFactory.SavePaymentMethodConsentBehavior {
+        return customerSessionCustomerSheet() ? .customerSheetWithCustomerSession : .legacy
+    }
+
+    func customerSessionCustomerSheet() -> Bool {
+        guard let customerSession = customer?.customerSession,
+              customerSession.customerSheetComponent.enabled else {
+            return false
+        }
+        return true
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerAddPaymentMethodViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerAddPaymentMethodViewController.swift
@@ -35,7 +35,6 @@ class CustomerAddPaymentMethodViewController: UIViewController {
         let params = IntentConfirmParams(type: selectedPaymentMethodType)
         params.setDefaultBillingDetailsIfNecessary(for: configuration)
         if let params = paymentMethodFormElement.updateParams(params: params) {
-            params.setAllowRedisplayForCustomerSheet(savePaymentMethodConsentBehavior)
             return .new(confirmParams: params)
         }
         return nil

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsViewController.swift
@@ -525,9 +525,7 @@ class CustomerSavedPaymentMethodsViewController: UIViewController {
 
     private func fetchSetupIntent(clientSecret: String) async -> (STPSetupIntent, STPElementsSession)? {
         do {
-            return try await configuration.apiClient.retrieveElementsSession(setupIntentClientSecret: clientSecret,
-                                                                             clientDefaultPaymentMethod: nil,
-                                                                             configuration: .init())
+            return try await self.customerSheetDataSource.fetchElementsSession(setupIntentClientSecret: clientSecret)
         } catch {
             STPAnalyticsClient.sharedClient.logCSAddPaymentMethodViaSetupIntentFailure()
             self.error = error

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheet+API.swift
@@ -13,10 +13,12 @@ import UIKit
 extension CustomerSheet {
     func confirmIntent(
         intent: Intent,
+        elementsSession: STPElementsSession,
         paymentOption: PaymentOption,
         completion: @escaping (InternalCustomerSheetResult) -> Void
     ) {
         CustomerSheet.confirm(intent: intent,
+                              elementsSession: elementsSession,
                               paymentOption: paymentOption,
                               configuration: configuration,
                               paymentHandler: self.paymentHandler,
@@ -25,6 +27,7 @@ extension CustomerSheet {
     }
     static func confirm(
         intent: Intent,
+        elementsSession: STPElementsSession,
         paymentOption: PaymentOption,
         configuration: CustomerSheet.Configuration,
         paymentHandler: STPPaymentHandler,
@@ -51,6 +54,7 @@ extension CustomerSheet {
             }
         if case .new(let confirmParams) = paymentOption,
            case .setupIntent(let setupIntent) = intent {
+            confirmParams.setAllowRedisplayForCustomerSheet(elementsSession.savePaymentMethodConsentBehaviorForCustomerSheet())
             let setupIntentParams = STPSetupIntentConfirmParams(clientSecret: setupIntent.clientSecret)
             setupIntentParams.paymentMethodParams = confirmParams.paymentMethodParams
             setupIntentParams.returnURL = configuration.returnURL

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheet.swift
@@ -221,7 +221,7 @@ public class CustomerSheet {
 }
 
 extension CustomerSheet: CustomerSavedPaymentMethodsViewControllerDelegate {
-    func savedPaymentMethodsViewControllerShouldConfirm(_ intent: Intent, with paymentOption: PaymentOption, completion: @escaping (InternalCustomerSheetResult) -> Void) {
+    func savedPaymentMethodsViewControllerShouldConfirm(_ intent: Intent, elementsSession: STPElementsSession, with paymentOption: PaymentOption, completion: @escaping (InternalCustomerSheetResult) -> Void) {
         guard case .setupIntent = intent else {
             let errorAnalytic = ErrorAnalytic(event: .unexpectedCustomerSheetError,
                                               error: InternalError.expectedSetupIntent)
@@ -230,7 +230,7 @@ extension CustomerSheet: CustomerSavedPaymentMethodsViewControllerDelegate {
             completion(.failed(error: CustomerSheetError.unknown(debugDescription: "No setup intent available")))
             return
         }
-        self.confirmIntent(intent: intent, paymentOption: paymentOption) { result in
+        self.confirmIntent(intent: intent, elementsSession: elementsSession, paymentOption: paymentOption) { result in
             completion(result)
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetDataSource.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetDataSource.swift
@@ -60,9 +60,9 @@ class CustomerSheetDataSource {
             do {
                 async let paymentMethodsResult = try customerAdapter.fetchPaymentMethods()
                 async let selectedPaymentMethodResult = try customerAdapter.fetchSelectedPaymentOption()
-                async let elementsSessionResult = try self.configuration.apiClient.retrieveElementsSessionForCustomerSheet(paymentMethodTypes: customerAdapter.paymentMethodTypes,
-                                                                                                                           clientDefaultPaymentMethod: nil,
-                                                                                                                           customerSessionClientSecret: nil)
+                async let elementsSessionResult = try self.configuration.apiClient.retrieveDeferredElementsSessionForCustomerSheet(paymentMethodTypes: customerAdapter.paymentMethodTypes,
+                                                                                                                                   clientDefaultPaymentMethod: nil,
+                                                                                                                                   customerSessionClientSecret: nil)
 
                 // Ensure local specs are loaded prior to the ones from elementSession
                 await loadFormSpecs()
@@ -134,6 +134,16 @@ extension CustomerSheetDataSource {
             return try await customerAdapter.setupIntentClientSecretForCustomerAttach()
         case .customerSession(let customerSessionAdapter):
             return try await customerSessionAdapter.intentConfiguration.setupIntentClientSecretProvider()
+        }
+    }
+    func fetchElementsSession(setupIntentClientSecret: String) async throws -> (STPSetupIntent, STPElementsSession) {
+        switch dataSource {
+        case .customerAdapter:
+            return try await configuration.apiClient.retrieveElementsSession(setupIntentClientSecret: setupIntentClientSecret,
+                                                                                              clientDefaultPaymentMethod: nil,
+                                                                                              configuration: .init())
+        case .customerSession(let customerSessionAdapter):
+           return try await customerSessionAdapter.elementsSession(setupIntentClientSecret: setupIntentClientSecret)
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/CustomerSheet/CustomerSheet_ConfirmFlowTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/CustomerSheet/CustomerSheet_ConfirmFlowTests.swift
@@ -13,7 +13,7 @@ import XCTest
 @testable@_spi(STP) import StripeUICore
 
 @MainActor
-final class CustomerSheet_ConfirmFlowTests: XCTestCase {
+final class CustomerSheet_ConfirmFlowTests: STPNetworkStubbingTestCase {
     enum MerchantCountry: String {
         case US = "us"
         case FR = "fr"
@@ -37,14 +37,20 @@ final class CustomerSheet_ConfirmFlowTests: XCTestCase {
                 }
             }
         }
+        self.followRedirects = false
     }
 
     func testCardConfirmation() async throws {
-        let customer = "cus_QWYdNyavE2M5ah" // A hardcoded customer on acct_1G6m1pFY0qyl6XeW
+        let merchantCountry = MerchantCountry.US
+        let apiClient = STPAPIClient(publishableKey: merchantCountry.publishableKey)
+        let newCustomer = try await STPTestingAPIClient.shared().fetchCustomerAndEphemeralKey(customerID: nil,
+                                                                                              merchantCountry: merchantCountry.rawValue.lowercased())
         try await _testConfirm(
-            merchantCountry: .US,
+            apiClient: apiClient,
+            merchantCountry: merchantCountry,
             paymentMethodType: .card,
-            customerID: customer) { form in
+            elementsSession: ._testCardValue(),
+            customerID: newCustomer.customer) { form in
             form.getTextFieldElement("Card number")?.setText("4242424242424242")
             form.getTextFieldElement("MM / YY").setText("1232")
             form.getTextFieldElement("CVC").setText("123")
@@ -52,11 +58,16 @@ final class CustomerSheet_ConfirmFlowTests: XCTestCase {
         }
     }
     func testCardConfirmation_FR() async throws {
-        let customer = "cus_QWYglNu3orU2Yb" // A hardcoded customer on acct_acct_1JtgfQKG6vc7r7YC
+        let merchantCountry = MerchantCountry.FR
+        let apiClient = STPAPIClient(publishableKey: merchantCountry.publishableKey)
+        let newCustomer = try await STPTestingAPIClient.shared().fetchCustomerAndEphemeralKey(customerID: nil,
+                                                                                              merchantCountry: merchantCountry.rawValue.lowercased())
         try await _testConfirm(
-            merchantCountry: .FR,
+            apiClient: apiClient,
+            merchantCountry: merchantCountry,
             paymentMethodType: .card,
-            customerID: customer) { form in
+            elementsSession: ._testCardValue(),
+            customerID: newCustomer.customer) { form in
             form.getTextFieldElement("Card number")?.setText("4242424242424242")
             form.getTextFieldElement("MM / YY").setText("1232")
             form.getTextFieldElement("CVC").setText("123")
@@ -65,11 +76,16 @@ final class CustomerSheet_ConfirmFlowTests: XCTestCase {
     }
 
     func testSepaConfirmation() async throws {
-        let customer = "cus_QWYdNyavE2M5ah" // A hardcoded customer on acct_1G6m1pFY0qyl6XeW
+        let merchantCountry = MerchantCountry.US
+        let apiClient = STPAPIClient(publishableKey: merchantCountry.publishableKey)
+        let newCustomer = try await STPTestingAPIClient.shared().fetchCustomerAndEphemeralKey(customerID: nil,
+                                                                                              merchantCountry: merchantCountry.rawValue.lowercased())
         try await _testConfirm(
-            merchantCountry: .US,
+            apiClient: apiClient,
+            merchantCountry: merchantCountry,
             paymentMethodType: .SEPADebit,
-            customerID: customer) { form in
+            elementsSession: ._testCardValue(),
+            customerID: newCustomer.customer) { form in
                 form.getTextFieldElement("Full name")?.setText("John Doe")
                 form.getTextFieldElement("Email")?.setText("test@example.com")
                 form.getTextFieldElement("IBAN")?.setText("DE89370400440532013000")
@@ -164,15 +180,76 @@ final class CustomerSheet_ConfirmFlowTests: XCTestCase {
             })
         await fulfillment(of: [expectation], timeout: 25)
     }
+
+    func testAllowRedisplay_legacy() async throws {
+        let merchantCountry = MerchantCountry.US
+        let apiClient = STPAPIClient(publishableKey: merchantCountry.publishableKey)
+        let newCustomer = try await STPTestingAPIClient.shared().fetchCustomerAndEphemeralKey(customerID: nil,
+                                                                                              merchantCountry: merchantCountry.rawValue.lowercased())
+        guard let clientSecret = try await _testConfirm(apiClient: apiClient,
+                                                        merchantCountry: merchantCountry,
+                                                        paymentMethodType: .card,
+                                                        elementsSession: ._testCardValue(),
+                                                        customerID: newCustomer.customer,
+                                                        formCompleter: ({ form in
+            form.getTextFieldElement("Card number")?.setText("4242424242424242")
+            form.getTextFieldElement("MM / YY").setText("1232")
+            form.getTextFieldElement("CVC").setText("123")
+            form.getTextFieldElement("ZIP").setText("65432")
+        })) else {
+            XCTFail("Failed on confirm")
+            return
+        }
+        try await assertAllowRedisplayValue(apiClient: apiClient,
+                                            confirmedPaymentIntentClientSecret: clientSecret,
+                                            customerResponse: newCustomer,
+                                            expectedAllowRedisplay: .unspecified)
+    }
+    func testAllowRedisplay_customerSession() async throws {
+        let merchantCountry = MerchantCountry.US
+        let apiClient = STPAPIClient(publishableKey: merchantCountry.publishableKey)
+        let newCustomer = try await STPTestingAPIClient.shared().fetchCustomerAndEphemeralKey(customerID: nil,
+                                                                                              merchantCountry: merchantCountry.rawValue.lowercased())
+        let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["card"],
+                                                            customerSessionData: [
+                                                               "payment_sheet": [
+                                                                   "enabled": false,
+                                                               ],
+                                                               "customer_sheet": [
+                                                                   "enabled": true,
+                                                                   "features": ["payment_method_remove": "enabled"],
+                                                               ],
+                                                            ])
+        guard let clientSecret = try await _testConfirm(apiClient: apiClient,
+                                                        merchantCountry: merchantCountry,
+                                                        paymentMethodType: .card,
+                                                        elementsSession: elementsSession,
+                                                        customerID: newCustomer.customer,
+                                                        formCompleter: ({ form in
+            form.getTextFieldElement("Card number")?.setText("4242424242424242")
+            form.getTextFieldElement("MM / YY").setText("1232")
+            form.getTextFieldElement("CVC").setText("123")
+            form.getTextFieldElement("ZIP").setText("65432")
+        })) else {
+            XCTFail("Failed on confirm")
+            return
+        }
+        try await assertAllowRedisplayValue(apiClient: apiClient,
+                                            confirmedPaymentIntentClientSecret: clientSecret,
+                                            customerResponse: newCustomer,
+                                            expectedAllowRedisplay: .always)
+    }
 }
 
 extension CustomerSheet_ConfirmFlowTests {
     @MainActor
-    func _testConfirm(merchantCountry: MerchantCountry = .US,
+    @discardableResult
+    func _testConfirm(apiClient: STPAPIClient,
+                      merchantCountry: MerchantCountry = .US,
                       paymentMethodType: STPPaymentMethodType,
+                      elementsSession: STPElementsSession,
                       customerID: String,
-                      formCompleter: (PaymentMethodElement) -> Void) async throws {
-        let apiClient = STPAPIClient(publishableKey: merchantCountry.publishableKey)
+                      formCompleter: (PaymentMethodElement) -> Void) async throws -> String? {
         let customerSheetConfiguration: CustomerSheet.Configuration = {
             var config = CustomerSheet.Configuration()
             config.apiClient = apiClient
@@ -181,17 +258,17 @@ extension CustomerSheet_ConfirmFlowTests {
             return config
         }()
 
-        let (_, intent, paymentMethodForm) = try await _createElementAndIntent(apiClient: apiClient,
-                                                                               customerSheetConfiguration: customerSheetConfiguration,
-                                                                               merchantCountry: merchantCountry,
-                                                                               paymentMethodType: paymentMethodType,
-                                                                               customerID: customerID,
-                                                                               formCompleter: formCompleter)
+        let (clientSecret, intent, paymentMethodForm) = try await _createElementAndIntent(apiClient: apiClient,
+                                                                                          customerSheetConfiguration: customerSheetConfiguration,
+                                                                                          merchantCountry: merchantCountry,
+                                                                                          paymentMethodType: paymentMethodType,
+                                                                                          customerID: customerID,
+                                                                                          formCompleter: formCompleter)
         // Generate params from the form
         let psPaymentMethodType: PaymentSheet.PaymentMethodType = .stripe(paymentMethodType)
         guard let intentConfirmParams = paymentMethodForm.updateParams(params: IntentConfirmParams(type: psPaymentMethodType)) else {
             XCTFail("Form failed to create params. Validation state: \(paymentMethodForm.validationState)")
-            return
+            return nil
         }
         let paymentOption: PaymentSheet.PaymentOption = .new(confirmParams: intentConfirmParams)
 
@@ -201,6 +278,7 @@ extension CustomerSheet_ConfirmFlowTests {
         // Confirm the intent with the form details
         CustomerSheet.confirm(
             intent: intent,
+            elementsSession: elementsSession,
             paymentOption: paymentOption,
             configuration: customerSheetConfiguration,
             paymentHandler: paymentHandler,
@@ -216,6 +294,7 @@ extension CustomerSheet_ConfirmFlowTests {
                 expectation.fulfill()
             }
         await fulfillment(of: [expectation], timeout: 25)
+        return clientSecret
     }
 
     @MainActor
@@ -249,7 +328,7 @@ extension CustomerSheet_ConfirmFlowTests {
     @MainActor
     func _createElementAndIntent(apiClient: STPAPIClient,
                                  customerSheetConfiguration: CustomerSheet.Configuration,
-                                 merchantCountry: MerchantCountry = .US,
+                                 merchantCountry: MerchantCountry,
                                  paymentMethodType: STPPaymentMethodType,
                                  customerID: String,
                                  formCompleter: (PaymentMethodElement) -> Void) async throws -> (String, Intent, PaymentMethodElement) {
@@ -342,6 +421,35 @@ extension CustomerSheet_ConfirmFlowTests {
                                                                      merchantCountry: merchantCountry.rawValue,
                                                                      customerID: customerID)
 
+    }
+
+    func assertAllowRedisplayValue(apiClient: STPAPIClient,
+                                   confirmedPaymentIntentClientSecret clientSecret: String,
+                                   customerResponse: STPTestingAPIClient.CreateEphemeralKeyResponse,
+                                   expectedAllowRedisplay: STPPaymentMethodAllowRedisplay) async throws {
+        let updatedSetupIntent = try await apiClient.retrieveSetupIntent(clientSecret: clientSecret)
+        guard let confirmedPaymentMethodId = updatedSetupIntent.paymentMethodID else {
+            XCTFail("No payment method attached to confirmed Intent")
+            return
+        }
+
+        let expect = expectation(description: "Allow_redisplay value matches expected")
+        apiClient.listPaymentMethods(forCustomer: customerResponse.customer,
+                                     using: customerResponse.ephemeralKeySecret) { paymentMethods, error in
+            guard error == nil else {
+                XCTFail("Failed to fetch paymentMethods, error: \(String(describing: error))")
+                return
+            }
+            guard let fetchedPaymentMethod = paymentMethods?.filter({ paymentMethod in
+                paymentMethod.stripeId == confirmedPaymentMethodId
+            }).first else {
+                XCTFail("Failed to fetch paymentMethod: \(confirmedPaymentMethodId)")
+                return
+            }
+            XCTAssertEqual(fetchedPaymentMethod.allowRedisplay, expectedAllowRedisplay)
+            expect.fulfill()
+        }
+        await fulfillment(of: [expect], timeout: 10)
     }
 
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPAPIClient+PaymentSheetTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPAPIClient+PaymentSheetTest.swift
@@ -68,8 +68,8 @@ class STPAPIClient_PaymentSheetTest: XCTestCase {
         XCTAssertEqual(deferredIntent["setup_future_usage"] as? String, "off_session")
     }
 
-    func testMakeElementsSessionsParamsForCustomerSheet() throws {
-        let parameters = STPAPIClient(publishableKey: "pk_test").makeElementsSessionsParamsForCustomerSheet(
+    func testMakeDeferredElementsSessionsParamsForCustomerSheet() throws {
+        let parameters = STPAPIClient(publishableKey: "pk_test").makeDeferredElementsSessionsParamsForCustomerSheet(
             paymentMethodTypes: ["card"],
             clientDefaultPaymentMethod: "pm_12345",
             customerSessionClientSecret: CustomerSessionClientSecret(customerId: "cus_12345", clientSecret: "cuss_54321"))
@@ -84,8 +84,8 @@ class STPAPIClient_PaymentSheetTest: XCTestCase {
         XCTAssertEqual(deferredIntent["payment_method_types"] as? [String], ["card"])
 
     }
-    func testMakeElementsSessionsParamsForCustomerSheet_nilable() throws {
-        let parameters = STPAPIClient(publishableKey: "pk_test").makeElementsSessionsParamsForCustomerSheet(
+    func testMakeDeferredElementsSessionsParamsForCustomerSheet_nilable() throws {
+        let parameters = STPAPIClient(publishableKey: "pk_test").makeDeferredElementsSessionsParamsForCustomerSheet(
             paymentMethodTypes: nil,
             clientDefaultPaymentMethod: nil,
             customerSessionClientSecret: nil)
@@ -98,6 +98,32 @@ class STPAPIClient_PaymentSheetTest: XCTestCase {
         let deferredIntent = try XCTUnwrap(parameters["deferred_intent"] as?  [String: Any])
         XCTAssertEqual(deferredIntent["mode"] as? String, "setup")
         XCTAssertNil(deferredIntent["payment_method_types"])
+    }
 
+    func testMakeElementsSessionsParamsForCustomerSheet() throws {
+        let parameters = STPAPIClient(publishableKey: "pk_test").makeElementsSessionsParamsForCustomerSheet(
+            setupIntentClientSecret: "seti_123456",
+            clientDefaultPaymentMethod: "pm_12345",
+            customerSessionClientSecret: CustomerSessionClientSecret(customerId: "cus_12345", clientSecret: "cuss_54321"))
+
+        XCTAssertEqual(parameters["type"] as? String, "setup_intent")
+        XCTAssertEqual(parameters["client_secret"] as? String, "seti_123456")
+
+        XCTAssertEqual(parameters["locale"] as? String, Locale.current.toLanguageTag())
+        XCTAssertEqual(parameters["customer_session_client_secret"] as? String, "cuss_54321")
+        XCTAssertEqual(parameters["client_default_payment_method"] as? String, "pm_12345")
+    }
+    func testMakeElementsSessionsParamsForCustomerSheet_nilable() throws {
+        let parameters = STPAPIClient(publishableKey: "pk_test").makeElementsSessionsParamsForCustomerSheet(
+            setupIntentClientSecret: "seti_123456",
+            clientDefaultPaymentMethod: nil,
+            customerSessionClientSecret: nil)
+
+        XCTAssertEqual(parameters["type"] as? String, "setup_intent")
+        XCTAssertEqual(parameters["client_secret"] as? String, "seti_123456")
+
+        XCTAssertEqual(parameters["locale"] as? String, Locale.current.toLanguageTag())
+        XCTAssertNil(parameters["customer_session_client_secret"])
+        XCTAssertNil(parameters["client_default_payment_method"])
     }
 }

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testAllowRedisplaycustomerSession/0000_post_create_ephemeral_key.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testAllowRedisplaycustomerSession/0000_post_create_ephemeral_key.tail
@@ -1,0 +1,18 @@
+POST
+https:\/\/stp-mobile-ci-test-backend-e1b3\.stripedemos\.com\/create_ephemeral_key$
+200
+text/html
+Content-Type: text/html;charset=utf-8
+Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+Set-Cookie: rack.session=oJqwRVA5aseUEhIFFHQg7wYRCiNjqev%2Bg8zU0Ul%2Fod%2BX7m7%2F%2BxpmuRFceJW0Cb9Uj87Hqd3%2FPt6WSPF4ChbkDgznaxVPD4WjyVwVmmpw3hBgxS2yUIVRZUw0UxOqCNa7R1pURIkKv8GLWL0zNFgh3QU4VR9nC4w6VZTocPk94s8al54n4fGlfNCCemtYVklNT8hcjHpTCizSLSXJIeot4fcAYuJczhLqnN%2Ff1mtafJ0%3D; path=/
+Server: Google Frontend
+x-cloud-trace-context: c5524c730990a4ac3590f5200c444d75;o=1
+Via: 1.1 google
+x-xss-protection: 1; mode=block
+Date: Mon, 29 Jul 2024 23:55:42 GMT
+x-robots-tag: noindex, nofollow
+Content-Length: 149
+x-content-type-options: nosniff
+x-frame-options: SAMEORIGIN
+
+{"ephemeral_key_secret":"ek_test_YWNjdF8xRzZtMXBGWTBxeWw2WGVXLFlwekt3cDUwa0RWS2RxcVptbTBWMWxYMjVNNEFmYXg_00Clyoyrwo","customer":"cus_QZBnBzUEvZqdb2"}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testAllowRedisplaycustomerSession/0001_post_create_setup_intent.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testAllowRedisplaycustomerSession/0001_post_create_setup_intent.tail
@@ -1,0 +1,18 @@
+POST
+https:\/\/stp-mobile-ci-test-backend-e1b3\.stripedemos\.com\/create_setup_intent$
+200
+text/html
+Content-Type: text/html;charset=utf-8
+Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+Set-Cookie: rack.session=c6xy3Z23o2N8XQt%2Bz8803%2BIjZx6Qekh6IIxvYWkWwyOjMnUq9f9LQF%2BNUqoyPSTviPIRIQa380NVgY5S6iEu%2FZ9FHsmL1Bp6HLJgXAYbVQ4t4IxB0ZIY66qn2kAreUvLD0QxY2Lo%2BpHiO1L%2BqDgMsabmPwm994Y17Hobgd6INUWGKCGprL%2F7afYm7cMsgn85zijGBAK14NIpgHevRVZkC8hNmbSq2CGu6KVcmOHmzXY%3D; path=/
+Server: Google Frontend
+x-cloud-trace-context: 66b0aa747c19fc0ddebce587bdf401f8
+Via: 1.1 google
+x-xss-protection: 1; mode=block
+Date: Mon, 29 Jul 2024 23:55:43 GMT
+x-robots-tag: noindex, nofollow
+Content-Length: 157
+x-content-type-options: nosniff
+x-frame-options: SAMEORIGIN
+
+{"intent":"seti_1Pi3PnFY0qyl6XeW3EDAN7KD","secret":"seti_1Pi3PnFY0qyl6XeW3EDAN7KD_secret_QZBnSoUsh0vQuqRPPfzbr44VNEFqhuM","status":"requires_payment_method"}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testAllowRedisplaycustomerSession/0002_get_v1_setup_intents_seti_1Pi3PnFY0qyl6XeW3EDAN7KD.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testAllowRedisplaycustomerSession/0002_get_v1_setup_intents_seti_1Pi3PnFY0qyl6XeW3EDAN7KD.tail
@@ -1,0 +1,45 @@
+GET
+https:\/\/api\.stripe\.com\/v1\/setup_intents\/seti_1Pi3PnFY0qyl6XeW3EDAN7KD\?client_secret=seti_1Pi3PnFY0qyl6XeW3EDAN7KD_secret_QZBnSoUsh0vQuqRPPfzbr44VNEFqhuM$
+200
+application/json
+access-control-allow-methods: GET,HEAD,PUT,PATCH,POST,DELETE
+content-security-policy: report-uri https://q.stripe.com/csp-report?p=v1%2Fsetup_intents%2F%3Aintent; block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: coop="https://q.stripe.com/coop-report?s=payins-bapi-srv"
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+cross-origin-opener-policy-report-only: same-origin; report-to="coop"
+Access-Control-Allow-Origin: *
+x-stripe-routing-context-priority-tier: api-testmode
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=payins-bapi-srv"}],"include_subdomains":true}
+request-id: req_96Q5rTQyhVU2GH
+Content-Length: 533
+Vary: Origin
+Date: Mon, 29 Jul 2024 23:55:43 GMT
+stripe-version: 2020-08-27
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+x-content-type-options: nosniff
+
+{
+  "id" : "seti_1Pi3PnFY0qyl6XeW3EDAN7KD",
+  "description" : null,
+  "next_action" : null,
+  "livemode" : false,
+  "payment_method" : null,
+  "payment_method_configuration_details" : null,
+  "usage" : "off_session",
+  "payment_method_types" : [
+    "card"
+  ],
+  "object" : "setup_intent",
+  "last_setup_error" : null,
+  "created" : 1722297343,
+  "client_secret" : "seti_1Pi3PnFY0qyl6XeW3EDAN7KD_secret_QZBnSoUsh0vQuqRPPfzbr44VNEFqhuM",
+  "automatic_payment_methods" : null,
+  "cancellation_reason" : null,
+  "status" : "requires_payment_method"
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testAllowRedisplaycustomerSession/0003_post_v1_setup_intents_seti_1Pi3PnFY0qyl6XeW3EDAN7KD_confirm.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testAllowRedisplaycustomerSession/0003_post_v1_setup_intents_seti_1Pi3PnFY0qyl6XeW3EDAN7KD_confirm.tail
@@ -1,0 +1,94 @@
+POST
+https:\/\/api\.stripe\.com\/v1\/setup_intents\/seti_1Pi3PnFY0qyl6XeW3EDAN7KD\/confirm$
+200
+application/json
+access-control-allow-methods: GET,HEAD,PUT,PATCH,POST,DELETE
+content-security-policy: report-uri https://q.stripe.com/csp-report?p=v1%2Fsetup_intents%2F%3Aintent%2Fconfirm; block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: coop="https://q.stripe.com/coop-report?s=payins-bapi-srv"
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+cross-origin-opener-policy-report-only: same-origin; report-to="coop"
+Access-Control-Allow-Origin: *
+stripe-should-retry: false
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=payins-bapi-srv"}],"include_subdomains":true}
+request-id: req_qXxKnnKdzyTLJG
+x-stripe-routing-context-priority-tier: api-testmode
+Content-Length: 1553
+Vary: Origin
+Date: Mon, 29 Jul 2024 23:55:44 GMT
+original-request: req_qXxKnnKdzyTLJG
+stripe-version: 2020-08-27
+idempotency-key: 035cb6de-f047-4e3f-a844-444444642709
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+x-content-type-options: nosniff
+
+{
+  "id" : "seti_1Pi3PnFY0qyl6XeW3EDAN7KD",
+  "description" : null,
+  "next_action" : null,
+  "livemode" : false,
+  "payment_method" : {
+    "object" : "payment_method",
+    "id" : "pm_1Pi3PnFY0qyl6XeWJt29ad5C",
+    "billing_details" : {
+      "email" : null,
+      "phone" : null,
+      "name" : null,
+      "address" : {
+        "state" : null,
+        "country" : "US",
+        "line2" : null,
+        "city" : null,
+        "line1" : null,
+        "postal_code" : "65432"
+      }
+    },
+    "card" : {
+      "last4" : "4242",
+      "funding" : "credit",
+      "generated_from" : null,
+      "networks" : {
+        "available" : [
+          "visa"
+        ],
+        "preferred" : null
+      },
+      "brand" : "visa",
+      "checks" : {
+        "address_postal_code_check" : null,
+        "cvc_check" : null,
+        "address_line1_check" : null
+      },
+      "three_d_secure_usage" : {
+        "supported" : true
+      },
+      "wallet" : null,
+      "display_brand" : "visa",
+      "exp_month" : 12,
+      "exp_year" : 2032,
+      "country" : "US"
+    },
+    "livemode" : false,
+    "created" : 1722297344,
+    "allow_redisplay" : "always",
+    "type" : "card",
+    "customer" : "cus_QZBnBzUEvZqdb2"
+  },
+  "payment_method_configuration_details" : null,
+  "usage" : "off_session",
+  "payment_method_types" : [
+    "card"
+  ],
+  "object" : "setup_intent",
+  "last_setup_error" : null,
+  "created" : 1722297343,
+  "client_secret" : "seti_1Pi3PnFY0qyl6XeW3EDAN7KD_secret_QZBnSoUsh0vQuqRPPfzbr44VNEFqhuM",
+  "automatic_payment_methods" : null,
+  "cancellation_reason" : null,
+  "status" : "succeeded"
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testAllowRedisplaycustomerSession/0004_get_v1_setup_intents_seti_1Pi3PnFY0qyl6XeW3EDAN7KD.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testAllowRedisplaycustomerSession/0004_get_v1_setup_intents_seti_1Pi3PnFY0qyl6XeW3EDAN7KD.tail
@@ -1,0 +1,45 @@
+GET
+https:\/\/api\.stripe\.com\/v1\/setup_intents\/seti_1Pi3PnFY0qyl6XeW3EDAN7KD\?client_secret=seti_1Pi3PnFY0qyl6XeW3EDAN7KD_secret_QZBnSoUsh0vQuqRPPfzbr44VNEFqhuM$
+200
+application/json
+access-control-allow-methods: GET,HEAD,PUT,PATCH,POST,DELETE
+content-security-policy: report-uri https://q.stripe.com/csp-report?p=v1%2Fsetup_intents%2F%3Aintent; block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: coop="https://q.stripe.com/coop-report?s=payins-bapi-srv"
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+cross-origin-opener-policy-report-only: same-origin; report-to="coop"
+Access-Control-Allow-Origin: *
+x-stripe-routing-context-priority-tier: api-testmode
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=payins-bapi-srv"}],"include_subdomains":true}
+request-id: req_ndCocB3RcaUoZE
+Content-Length: 544
+Vary: Origin
+Date: Mon, 29 Jul 2024 23:55:45 GMT
+stripe-version: 2020-08-27
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+x-content-type-options: nosniff
+
+{
+  "id" : "seti_1Pi3PnFY0qyl6XeW3EDAN7KD",
+  "description" : null,
+  "next_action" : null,
+  "livemode" : false,
+  "payment_method" : "pm_1Pi3PnFY0qyl6XeWJt29ad5C",
+  "payment_method_configuration_details" : null,
+  "usage" : "off_session",
+  "payment_method_types" : [
+    "card"
+  ],
+  "object" : "setup_intent",
+  "last_setup_error" : null,
+  "created" : 1722297343,
+  "client_secret" : "seti_1Pi3PnFY0qyl6XeW3EDAN7KD_secret_QZBnSoUsh0vQuqRPPfzbr44VNEFqhuM",
+  "automatic_payment_methods" : null,
+  "cancellation_reason" : null,
+  "status" : "succeeded"
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testAllowRedisplaycustomerSession/0005_get_v1_payment_methods.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testAllowRedisplaycustomerSession/0005_get_v1_payment_methods.tail
@@ -1,0 +1,81 @@
+GET
+https:\/\/api\.stripe\.com\/v1\/payment_methods\?customer=cus_QZBnBzUEvZqdb2&type=card$
+200
+application/json
+access-control-allow-methods: GET,HEAD,PUT,PATCH,POST,DELETE
+content-security-policy: report-uri https://q.stripe.com/csp-report?p=v1%2Fpayment_methods; block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: coop="https://q.stripe.com/coop-report?s=payins-bapi-srv"
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+cross-origin-opener-policy-report-only: same-origin; report-to="coop"
+Access-Control-Allow-Origin: *
+x-stripe-routing-context-priority-tier: api-testmode
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=payins-bapi-srv"}],"include_subdomains":true}
+request-id: req_LOj4fHq1t2MdhL
+Content-Length: 1270
+Vary: Origin
+Date: Mon, 29 Jul 2024 23:55:45 GMT
+stripe-version: 2020-08-27
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+x-content-type-options: nosniff
+
+{
+  "has_more" : false,
+  "object" : "list",
+  "data" : [
+    {
+      "object" : "payment_method",
+      "id" : "pm_1Pi3PnFY0qyl6XeWJt29ad5C",
+      "billing_details" : {
+        "email" : null,
+        "phone" : null,
+        "name" : null,
+        "address" : {
+          "state" : null,
+          "country" : "US",
+          "line2" : null,
+          "city" : null,
+          "line1" : null,
+          "postal_code" : "65432"
+        }
+      },
+      "card" : {
+        "fingerprint" : "96sroMqLCHmUdUpL",
+        "last4" : "4242",
+        "funding" : "credit",
+        "generated_from" : null,
+        "networks" : {
+          "available" : [
+            "visa"
+          ],
+          "preferred" : null
+        },
+        "brand" : "visa",
+        "checks" : {
+          "address_postal_code_check" : null,
+          "cvc_check" : null,
+          "address_line1_check" : null
+        },
+        "three_d_secure_usage" : {
+          "supported" : true
+        },
+        "wallet" : null,
+        "display_brand" : "visa",
+        "exp_month" : 12,
+        "exp_year" : 2032,
+        "country" : "US"
+      },
+      "livemode" : false,
+      "created" : 1722297344,
+      "allow_redisplay" : "always",
+      "type" : "card",
+      "customer" : "cus_QZBnBzUEvZqdb2"
+    }
+  ],
+  "url" : "\/v1\/payment_methods"
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testAllowRedisplaylegacy/0000_post_create_ephemeral_key.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testAllowRedisplaylegacy/0000_post_create_ephemeral_key.tail
@@ -1,0 +1,18 @@
+POST
+https:\/\/stp-mobile-ci-test-backend-e1b3\.stripedemos\.com\/create_ephemeral_key$
+200
+text/html
+Content-Type: text/html;charset=utf-8
+Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+Set-Cookie: rack.session=qDuOGwB8E%2BSI%2FgXmONg3HHHqipDdxIg3VXwvCFqS1xbDc4oGHH6cu%2B0KSKDGZnufHg52%2B6t9cbOLBL535MkT%2B%2FFImMGektm7sWZJPl%2FQU545d%2BsAguqzRRbPO3u1k4CeQDI7WjDig1yVrHE23UId%2BMzgT3VRHMN4ipJ3wV8XCT46crUFyumfZr7zfRLL3w4boweZQpWJhLcnNS44zbKbsgJGAQzc76zrQDirn2mQA3g%3D; path=/
+Server: Google Frontend
+x-cloud-trace-context: 0d9169a0b1fa7a2fa5de5c3d8bcd6178
+Via: 1.1 google
+x-xss-protection: 1; mode=block
+Date: Mon, 29 Jul 2024 23:55:45 GMT
+x-robots-tag: noindex, nofollow
+Content-Length: 149
+x-content-type-options: nosniff
+x-frame-options: SAMEORIGIN
+
+{"ephemeral_key_secret":"ek_test_YWNjdF8xRzZtMXBGWTBxeWw2WGVXLExDekxJTnhjV1JSVnQ5RGFFN3FkUlhwM3BWQ0NKbTA_00cKYnrit5","customer":"cus_QZBnlT6uMwK2QA"}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testAllowRedisplaylegacy/0001_post_create_setup_intent.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testAllowRedisplaylegacy/0001_post_create_setup_intent.tail
@@ -1,0 +1,18 @@
+POST
+https:\/\/stp-mobile-ci-test-backend-e1b3\.stripedemos\.com\/create_setup_intent$
+200
+text/html
+Content-Type: text/html;charset=utf-8
+Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+Set-Cookie: rack.session=Wt%2FxqiMPUPHTNmiWOqE0eZ0w6nrcW%2F1ScRk3bDWfuYR4%2BQUAfhWZ%2F139qnHuhh6VT0SMe4YF6GEdp4Q%2F70vHQ2ecAW1nJ1uxNq%2B%2FPOcdiJZcwQRIRDJ2o%2BvrtT7M3sCaTo7lAF3gwZ8vVzn7etGpCweApYMKO4uH7UmRY6wQO2jTS4LAB3Vm%2FkGy9aC9jOykJnAN%2Bi72bdPVJOSsDIzmeIkQbnfuBB5JQrSFlf6%2B3nA%3D; path=/
+Server: Google Frontend
+x-cloud-trace-context: 66c54e6b89fce13fcf5040bc88171749
+Via: 1.1 google
+x-xss-protection: 1; mode=block
+Date: Mon, 29 Jul 2024 23:55:46 GMT
+x-robots-tag: noindex, nofollow
+Content-Length: 157
+x-content-type-options: nosniff
+x-frame-options: SAMEORIGIN
+
+{"intent":"seti_1Pi3PqFY0qyl6XeWgg8AgQOL","secret":"seti_1Pi3PqFY0qyl6XeWgg8AgQOL_secret_QZBnfcrTos8icQpDCoJNWpWajmGT3fS","status":"requires_payment_method"}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testAllowRedisplaylegacy/0002_get_v1_setup_intents_seti_1Pi3PqFY0qyl6XeWgg8AgQOL.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testAllowRedisplaylegacy/0002_get_v1_setup_intents_seti_1Pi3PqFY0qyl6XeWgg8AgQOL.tail
@@ -1,0 +1,45 @@
+GET
+https:\/\/api\.stripe\.com\/v1\/setup_intents\/seti_1Pi3PqFY0qyl6XeWgg8AgQOL\?client_secret=seti_1Pi3PqFY0qyl6XeWgg8AgQOL_secret_QZBnfcrTos8icQpDCoJNWpWajmGT3fS$
+200
+application/json
+access-control-allow-methods: GET,HEAD,PUT,PATCH,POST,DELETE
+content-security-policy: report-uri https://q.stripe.com/csp-report?p=v1%2Fsetup_intents%2F%3Aintent; block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: coop="https://q.stripe.com/coop-report?s=payins-bapi-srv"
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+cross-origin-opener-policy-report-only: same-origin; report-to="coop"
+Access-Control-Allow-Origin: *
+x-stripe-routing-context-priority-tier: api-testmode
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=payins-bapi-srv"}],"include_subdomains":true}
+request-id: req_5x0GUBy4FHp7d4
+Content-Length: 533
+Vary: Origin
+Date: Mon, 29 Jul 2024 23:55:46 GMT
+stripe-version: 2020-08-27
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+x-content-type-options: nosniff
+
+{
+  "id" : "seti_1Pi3PqFY0qyl6XeWgg8AgQOL",
+  "description" : null,
+  "next_action" : null,
+  "livemode" : false,
+  "payment_method" : null,
+  "payment_method_configuration_details" : null,
+  "usage" : "off_session",
+  "payment_method_types" : [
+    "card"
+  ],
+  "object" : "setup_intent",
+  "last_setup_error" : null,
+  "created" : 1722297346,
+  "client_secret" : "seti_1Pi3PqFY0qyl6XeWgg8AgQOL_secret_QZBnfcrTos8icQpDCoJNWpWajmGT3fS",
+  "automatic_payment_methods" : null,
+  "cancellation_reason" : null,
+  "status" : "requires_payment_method"
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testAllowRedisplaylegacy/0003_post_v1_setup_intents_seti_1Pi3PqFY0qyl6XeWgg8AgQOL_confirm.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testAllowRedisplaylegacy/0003_post_v1_setup_intents_seti_1Pi3PqFY0qyl6XeWgg8AgQOL_confirm.tail
@@ -1,0 +1,94 @@
+POST
+https:\/\/api\.stripe\.com\/v1\/setup_intents\/seti_1Pi3PqFY0qyl6XeWgg8AgQOL\/confirm$
+200
+application/json
+access-control-allow-methods: GET,HEAD,PUT,PATCH,POST,DELETE
+content-security-policy: report-uri https://q.stripe.com/csp-report?p=v1%2Fsetup_intents%2F%3Aintent%2Fconfirm; block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: coop="https://q.stripe.com/coop-report?s=payins-bapi-srv"
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+cross-origin-opener-policy-report-only: same-origin; report-to="coop"
+Access-Control-Allow-Origin: *
+stripe-should-retry: false
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=payins-bapi-srv"}],"include_subdomains":true}
+request-id: req_XOOi6xA48xvsjq
+x-stripe-routing-context-priority-tier: api-testmode
+Content-Length: 1558
+Vary: Origin
+Date: Mon, 29 Jul 2024 23:55:47 GMT
+original-request: req_XOOi6xA48xvsjq
+stripe-version: 2020-08-27
+idempotency-key: 2a5ed00b-8781-4331-bdd2-39c79fc7a8b1
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+x-content-type-options: nosniff
+
+{
+  "id" : "seti_1Pi3PqFY0qyl6XeWgg8AgQOL",
+  "description" : null,
+  "next_action" : null,
+  "livemode" : false,
+  "payment_method" : {
+    "object" : "payment_method",
+    "id" : "pm_1Pi3PqFY0qyl6XeWC3xrz289",
+    "billing_details" : {
+      "email" : null,
+      "phone" : null,
+      "name" : null,
+      "address" : {
+        "state" : null,
+        "country" : "US",
+        "line2" : null,
+        "city" : null,
+        "line1" : null,
+        "postal_code" : "65432"
+      }
+    },
+    "card" : {
+      "last4" : "4242",
+      "funding" : "credit",
+      "generated_from" : null,
+      "networks" : {
+        "available" : [
+          "visa"
+        ],
+        "preferred" : null
+      },
+      "brand" : "visa",
+      "checks" : {
+        "address_postal_code_check" : null,
+        "cvc_check" : null,
+        "address_line1_check" : null
+      },
+      "three_d_secure_usage" : {
+        "supported" : true
+      },
+      "wallet" : null,
+      "display_brand" : "visa",
+      "exp_month" : 12,
+      "exp_year" : 2032,
+      "country" : "US"
+    },
+    "livemode" : false,
+    "created" : 1722297347,
+    "allow_redisplay" : "unspecified",
+    "type" : "card",
+    "customer" : "cus_QZBnlT6uMwK2QA"
+  },
+  "payment_method_configuration_details" : null,
+  "usage" : "off_session",
+  "payment_method_types" : [
+    "card"
+  ],
+  "object" : "setup_intent",
+  "last_setup_error" : null,
+  "created" : 1722297346,
+  "client_secret" : "seti_1Pi3PqFY0qyl6XeWgg8AgQOL_secret_QZBnfcrTos8icQpDCoJNWpWajmGT3fS",
+  "automatic_payment_methods" : null,
+  "cancellation_reason" : null,
+  "status" : "succeeded"
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testAllowRedisplaylegacy/0004_get_v1_setup_intents_seti_1Pi3PqFY0qyl6XeWgg8AgQOL.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testAllowRedisplaylegacy/0004_get_v1_setup_intents_seti_1Pi3PqFY0qyl6XeWgg8AgQOL.tail
@@ -1,0 +1,45 @@
+GET
+https:\/\/api\.stripe\.com\/v1\/setup_intents\/seti_1Pi3PqFY0qyl6XeWgg8AgQOL\?client_secret=seti_1Pi3PqFY0qyl6XeWgg8AgQOL_secret_QZBnfcrTos8icQpDCoJNWpWajmGT3fS$
+200
+application/json
+access-control-allow-methods: GET,HEAD,PUT,PATCH,POST,DELETE
+content-security-policy: report-uri https://q.stripe.com/csp-report?p=v1%2Fsetup_intents%2F%3Aintent; block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: coop="https://q.stripe.com/coop-report?s=payins-bapi-srv"
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+cross-origin-opener-policy-report-only: same-origin; report-to="coop"
+Access-Control-Allow-Origin: *
+x-stripe-routing-context-priority-tier: api-testmode
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=payins-bapi-srv"}],"include_subdomains":true}
+request-id: req_uLIbgAzRlMINeJ
+Content-Length: 544
+Vary: Origin
+Date: Mon, 29 Jul 2024 23:55:48 GMT
+stripe-version: 2020-08-27
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+x-content-type-options: nosniff
+
+{
+  "id" : "seti_1Pi3PqFY0qyl6XeWgg8AgQOL",
+  "description" : null,
+  "next_action" : null,
+  "livemode" : false,
+  "payment_method" : "pm_1Pi3PqFY0qyl6XeWC3xrz289",
+  "payment_method_configuration_details" : null,
+  "usage" : "off_session",
+  "payment_method_types" : [
+    "card"
+  ],
+  "object" : "setup_intent",
+  "last_setup_error" : null,
+  "created" : 1722297346,
+  "client_secret" : "seti_1Pi3PqFY0qyl6XeWgg8AgQOL_secret_QZBnfcrTos8icQpDCoJNWpWajmGT3fS",
+  "automatic_payment_methods" : null,
+  "cancellation_reason" : null,
+  "status" : "succeeded"
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testAllowRedisplaylegacy/0005_get_v1_payment_methods.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testAllowRedisplaylegacy/0005_get_v1_payment_methods.tail
@@ -1,0 +1,81 @@
+GET
+https:\/\/api\.stripe\.com\/v1\/payment_methods\?customer=cus_QZBnlT6uMwK2QA&type=card$
+200
+application/json
+access-control-allow-methods: GET,HEAD,PUT,PATCH,POST,DELETE
+content-security-policy: report-uri https://q.stripe.com/csp-report?p=v1%2Fpayment_methods; block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: coop="https://q.stripe.com/coop-report?s=payins-bapi-srv"
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+cross-origin-opener-policy-report-only: same-origin; report-to="coop"
+Access-Control-Allow-Origin: *
+x-stripe-routing-context-priority-tier: api-testmode
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=payins-bapi-srv"}],"include_subdomains":true}
+request-id: req_LUPIdn2MQbqQgQ
+Content-Length: 1275
+Vary: Origin
+Date: Mon, 29 Jul 2024 23:55:48 GMT
+stripe-version: 2020-08-27
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+x-content-type-options: nosniff
+
+{
+  "has_more" : false,
+  "object" : "list",
+  "data" : [
+    {
+      "object" : "payment_method",
+      "id" : "pm_1Pi3PqFY0qyl6XeWC3xrz289",
+      "billing_details" : {
+        "email" : null,
+        "phone" : null,
+        "name" : null,
+        "address" : {
+          "state" : null,
+          "country" : "US",
+          "line2" : null,
+          "city" : null,
+          "line1" : null,
+          "postal_code" : "65432"
+        }
+      },
+      "card" : {
+        "fingerprint" : "96sroMqLCHmUdUpL",
+        "last4" : "4242",
+        "funding" : "credit",
+        "generated_from" : null,
+        "networks" : {
+          "available" : [
+            "visa"
+          ],
+          "preferred" : null
+        },
+        "brand" : "visa",
+        "checks" : {
+          "address_postal_code_check" : null,
+          "cvc_check" : null,
+          "address_line1_check" : null
+        },
+        "three_d_secure_usage" : {
+          "supported" : true
+        },
+        "wallet" : null,
+        "display_brand" : "visa",
+        "exp_month" : 12,
+        "exp_year" : 2032,
+        "country" : "US"
+      },
+      "livemode" : false,
+      "created" : 1722297347,
+      "allow_redisplay" : "unspecified",
+      "type" : "card",
+      "customer" : "cus_QZBnlT6uMwK2QA"
+    }
+  ],
+  "url" : "\/v1\/payment_methods"
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testCardConfirmation/0000_post_create_ephemeral_key.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testCardConfirmation/0000_post_create_ephemeral_key.tail
@@ -1,0 +1,18 @@
+POST
+https:\/\/stp-mobile-ci-test-backend-e1b3\.stripedemos\.com\/create_ephemeral_key$
+200
+text/html
+Content-Type: text/html;charset=utf-8
+Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+Set-Cookie: rack.session=%2BOg%2BO6WcIKnkdYft1Qb6pHMfwrmhyI6IN3LohFbBGGmlN3M5gGY%2BQKbrpqMokUocdhSr3X0C1PPyIkH3UZduiBGLtU%2F1zdWbEYZx%2Bl6%2FsUi3oKLZ1u0SkNtYFuDaHoNv7wmEO2qUUd%2F3BJ%2FJ8wZWwiFMvb6HjPWG9e3cEgARVaJYbsH%2FiFp9jWGGMukbD71BYS3zRovSPqttsr%2FJMC9oU55aMhmJxJZQI130zEJcAc4%3D; path=/
+Server: Google Frontend
+x-cloud-trace-context: b5c0f791b96418da5ffc393bbd7b8093
+Via: 1.1 google
+x-xss-protection: 1; mode=block
+Date: Mon, 29 Jul 2024 23:55:51 GMT
+x-robots-tag: noindex, nofollow
+Content-Length: 149
+x-content-type-options: nosniff
+x-frame-options: SAMEORIGIN
+
+{"ephemeral_key_secret":"ek_test_YWNjdF8xRzZtMXBGWTBxeWw2WGVXLHVvYllOYTNIMlpLblIwaG5JMGh1ZmFrb3RMeVpiak4_00e9XkIiXz","customer":"cus_QZBnfC3Axe5nOL"}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testCardConfirmation/0001_post_create_setup_intent.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testCardConfirmation/0001_post_create_setup_intent.tail
@@ -1,0 +1,18 @@
+POST
+https:\/\/stp-mobile-ci-test-backend-e1b3\.stripedemos\.com\/create_setup_intent$
+200
+text/html
+Content-Type: text/html;charset=utf-8
+Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+Set-Cookie: rack.session=vact%2FON%2FulDmgZUbhHvzCD5ruAQ4P05TNNI9XQoVeUUChfFe%2BtI%2FMuBrEyQdLbDOGu%2B3PcBDEvspmmGBXVks97asoJphMYEPKg%2FWlQO6aycbRbp%2FZh15dui8%2FXxFyAYx0PMGt5hII6uEef8CyKpYCMMLRCYQar2XbOAZzy89fFqYGVliYbi5szrUGJc1OOMoLvDHB8G6VHwxUeCUmm%2B4wuhhfHU%2BIrEibwGvSkzfKfo%3D; path=/
+Server: Google Frontend
+x-cloud-trace-context: f5572c334c3869a006b96b99d23870da
+Via: 1.1 google
+x-xss-protection: 1; mode=block
+Date: Mon, 29 Jul 2024 23:55:51 GMT
+x-robots-tag: noindex, nofollow
+Content-Length: 157
+x-content-type-options: nosniff
+x-frame-options: SAMEORIGIN
+
+{"intent":"seti_1Pi3PvFY0qyl6XeWYtYtvsok","secret":"seti_1Pi3PvFY0qyl6XeWYtYtvsok_secret_QZBn5ap3lr3UXkR8KwPLzmbALk1MY8b","status":"requires_payment_method"}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testCardConfirmation/0002_get_v1_setup_intents_seti_1Pi3PvFY0qyl6XeWYtYtvsok.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testCardConfirmation/0002_get_v1_setup_intents_seti_1Pi3PvFY0qyl6XeWYtYtvsok.tail
@@ -1,0 +1,45 @@
+GET
+https:\/\/api\.stripe\.com\/v1\/setup_intents\/seti_1Pi3PvFY0qyl6XeWYtYtvsok\?client_secret=seti_1Pi3PvFY0qyl6XeWYtYtvsok_secret_QZBn5ap3lr3UXkR8KwPLzmbALk1MY8b$
+200
+application/json
+access-control-allow-methods: GET,HEAD,PUT,PATCH,POST,DELETE
+content-security-policy: report-uri https://q.stripe.com/csp-report?p=v1%2Fsetup_intents%2F%3Aintent; block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: coop="https://q.stripe.com/coop-report?s=payins-bapi-srv"
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+cross-origin-opener-policy-report-only: same-origin; report-to="coop"
+Access-Control-Allow-Origin: *
+x-stripe-routing-context-priority-tier: api-testmode
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=payins-bapi-srv"}],"include_subdomains":true}
+request-id: req_F0BRUfyQ9OfnXf
+Content-Length: 533
+Vary: Origin
+Date: Mon, 29 Jul 2024 23:55:51 GMT
+stripe-version: 2020-08-27
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+x-content-type-options: nosniff
+
+{
+  "id" : "seti_1Pi3PvFY0qyl6XeWYtYtvsok",
+  "description" : null,
+  "next_action" : null,
+  "livemode" : false,
+  "payment_method" : null,
+  "payment_method_configuration_details" : null,
+  "usage" : "off_session",
+  "payment_method_types" : [
+    "card"
+  ],
+  "object" : "setup_intent",
+  "last_setup_error" : null,
+  "created" : 1722297351,
+  "client_secret" : "seti_1Pi3PvFY0qyl6XeWYtYtvsok_secret_QZBn5ap3lr3UXkR8KwPLzmbALk1MY8b",
+  "automatic_payment_methods" : null,
+  "cancellation_reason" : null,
+  "status" : "requires_payment_method"
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testCardConfirmation/0003_post_v1_setup_intents_seti_1Pi3PvFY0qyl6XeWYtYtvsok_confirm.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testCardConfirmation/0003_post_v1_setup_intents_seti_1Pi3PvFY0qyl6XeWYtYtvsok_confirm.tail
@@ -1,0 +1,94 @@
+POST
+https:\/\/api\.stripe\.com\/v1\/setup_intents\/seti_1Pi3PvFY0qyl6XeWYtYtvsok\/confirm$
+200
+application/json
+access-control-allow-methods: GET,HEAD,PUT,PATCH,POST,DELETE
+content-security-policy: report-uri https://q.stripe.com/csp-report?p=v1%2Fsetup_intents%2F%3Aintent%2Fconfirm; block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: coop="https://q.stripe.com/coop-report?s=payins-bapi-srv"
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+cross-origin-opener-policy-report-only: same-origin; report-to="coop"
+Access-Control-Allow-Origin: *
+stripe-should-retry: false
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=payins-bapi-srv"}],"include_subdomains":true}
+request-id: req_g4w2CvHIprr3ME
+x-stripe-routing-context-priority-tier: api-testmode
+Content-Length: 1558
+Vary: Origin
+Date: Mon, 29 Jul 2024 23:55:52 GMT
+original-request: req_g4w2CvHIprr3ME
+stripe-version: 2020-08-27
+idempotency-key: 5bbc0f47-e6fa-4401-b4eb-ecb98e9d11b5
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+x-content-type-options: nosniff
+
+{
+  "id" : "seti_1Pi3PvFY0qyl6XeWYtYtvsok",
+  "description" : null,
+  "next_action" : null,
+  "livemode" : false,
+  "payment_method" : {
+    "object" : "payment_method",
+    "id" : "pm_1Pi3PwFY0qyl6XeWeJmKbCNn",
+    "billing_details" : {
+      "email" : null,
+      "phone" : null,
+      "name" : null,
+      "address" : {
+        "state" : null,
+        "country" : "US",
+        "line2" : null,
+        "city" : null,
+        "line1" : null,
+        "postal_code" : "65432"
+      }
+    },
+    "card" : {
+      "last4" : "4242",
+      "funding" : "credit",
+      "generated_from" : null,
+      "networks" : {
+        "available" : [
+          "visa"
+        ],
+        "preferred" : null
+      },
+      "brand" : "visa",
+      "checks" : {
+        "address_postal_code_check" : null,
+        "cvc_check" : null,
+        "address_line1_check" : null
+      },
+      "three_d_secure_usage" : {
+        "supported" : true
+      },
+      "wallet" : null,
+      "display_brand" : "visa",
+      "exp_month" : 12,
+      "exp_year" : 2032,
+      "country" : "US"
+    },
+    "livemode" : false,
+    "created" : 1722297352,
+    "allow_redisplay" : "unspecified",
+    "type" : "card",
+    "customer" : "cus_QZBnfC3Axe5nOL"
+  },
+  "payment_method_configuration_details" : null,
+  "usage" : "off_session",
+  "payment_method_types" : [
+    "card"
+  ],
+  "object" : "setup_intent",
+  "last_setup_error" : null,
+  "created" : 1722297351,
+  "client_secret" : "seti_1Pi3PvFY0qyl6XeWYtYtvsok_secret_QZBn5ap3lr3UXkR8KwPLzmbALk1MY8b",
+  "automatic_payment_methods" : null,
+  "cancellation_reason" : null,
+  "status" : "succeeded"
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testCardConfirmationFR/0000_post_create_ephemeral_key.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testCardConfirmationFR/0000_post_create_ephemeral_key.tail
@@ -1,0 +1,18 @@
+POST
+https:\/\/stp-mobile-ci-test-backend-e1b3\.stripedemos\.com\/create_ephemeral_key$
+200
+text/html
+Content-Type: text/html;charset=utf-8
+Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+Set-Cookie: rack.session=cx%2BaZgtTPzl5%2B1%2FlL4RNII56UQ4dCAyspjQBhTtjWrayg8B%2B2vmUauqrCu707XTUHGXZInaOXC7jOt1mdla69duXlUEX%2FtyRN3%2B2RGXg9eJnRTIrSEm%2BvB44NMbxmTELBV4OoNIBUJaAqPvDCRNTv9isvHLiJbXHlpSc51GDHrNv3YW%2B2Iy5WIu%2F1YyNXD6PD7qZOwSaoXvpgy%2FHfVmadWr86AvIb45bEat6Fzo%2BRn0%3D; path=/
+Server: Google Frontend
+x-cloud-trace-context: a2307c32ff5f90d0463e260c43282ead
+Via: 1.1 google
+x-xss-protection: 1; mode=block
+Date: Mon, 29 Jul 2024 23:55:48 GMT
+x-robots-tag: noindex, nofollow
+Content-Length: 149
+x-content-type-options: nosniff
+x-frame-options: SAMEORIGIN
+
+{"ephemeral_key_secret":"ek_test_YWNjdF8xSnRnZlFLRzZ2YzdyN1lDLFN1OGN2QzhLenJNeXIyaUdFN2FKNk1RZkRJRWhWQzE_00Ze67dmp9","customer":"cus_QZBnLLrkDENsKB"}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testCardConfirmationFR/0001_post_create_setup_intent.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testCardConfirmationFR/0001_post_create_setup_intent.tail
@@ -1,0 +1,18 @@
+POST
+https:\/\/stp-mobile-ci-test-backend-e1b3\.stripedemos\.com\/create_setup_intent$
+200
+text/html
+Content-Type: text/html;charset=utf-8
+Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+Set-Cookie: rack.session=vZJCJfCnCq5SeAqjfcKgkDypsyVj3%2F3p1%2FvwWxP3MRicTlk9VpCLnoP9RsSKmbUPLzUfyy%2B%2FrMCPgWrzMBpnlZusYXW5zkG7Ondz56eatBWzPTTMlwSyg2MNZapATOh3geh%2BS5S4FMAnFsE0yVQ0UmrdhEr%2FPWeNeeMtJjKlzOljbyJLRhe8F6d6%2Br0vgLN41B6ffBQxC%2BuwfMHPMqvDDdQ6FY1I7p0tUFUVEODjVnQ%3D; path=/
+Server: Google Frontend
+x-cloud-trace-context: 00f42f2b277d0a091168b5cf98b2ea13
+Via: 1.1 google
+x-xss-protection: 1; mode=block
+Date: Mon, 29 Jul 2024 23:55:49 GMT
+x-robots-tag: noindex, nofollow
+Content-Length: 157
+x-content-type-options: nosniff
+x-frame-options: SAMEORIGIN
+
+{"intent":"seti_1Pi3PtKG6vc7r7YCXh0KFVRi","secret":"seti_1Pi3PtKG6vc7r7YCXh0KFVRi_secret_QZBnRscDWDGBHJmawMOZ3MR4flJjGOx","status":"requires_payment_method"}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testCardConfirmationFR/0002_get_v1_setup_intents_seti_1Pi3PtKG6vc7r7YCXh0KFVRi.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testCardConfirmationFR/0002_get_v1_setup_intents_seti_1Pi3PtKG6vc7r7YCXh0KFVRi.tail
@@ -1,0 +1,45 @@
+GET
+https:\/\/api\.stripe\.com\/v1\/setup_intents\/seti_1Pi3PtKG6vc7r7YCXh0KFVRi\?client_secret=seti_1Pi3PtKG6vc7r7YCXh0KFVRi_secret_QZBnRscDWDGBHJmawMOZ3MR4flJjGOx$
+200
+application/json
+access-control-allow-methods: GET,HEAD,PUT,PATCH,POST,DELETE
+content-security-policy: report-uri https://q.stripe.com/csp-report?p=v1%2Fsetup_intents%2F%3Aintent; block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: coop="https://q.stripe.com/coop-report?s=payins-bapi-srv"
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+cross-origin-opener-policy-report-only: same-origin; report-to="coop"
+Access-Control-Allow-Origin: *
+x-stripe-routing-context-priority-tier: api-testmode
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=payins-bapi-srv"}],"include_subdomains":true}
+request-id: req_j6vzuzypAqp2CC
+Content-Length: 533
+Vary: Origin
+Date: Mon, 29 Jul 2024 23:55:49 GMT
+stripe-version: 2020-08-27
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+x-content-type-options: nosniff
+
+{
+  "id" : "seti_1Pi3PtKG6vc7r7YCXh0KFVRi",
+  "description" : null,
+  "next_action" : null,
+  "livemode" : false,
+  "payment_method" : null,
+  "payment_method_configuration_details" : null,
+  "usage" : "off_session",
+  "payment_method_types" : [
+    "card"
+  ],
+  "object" : "setup_intent",
+  "last_setup_error" : null,
+  "created" : 1722297349,
+  "client_secret" : "seti_1Pi3PtKG6vc7r7YCXh0KFVRi_secret_QZBnRscDWDGBHJmawMOZ3MR4flJjGOx",
+  "automatic_payment_methods" : null,
+  "cancellation_reason" : null,
+  "status" : "requires_payment_method"
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testCardConfirmationFR/0003_post_v1_setup_intents_seti_1Pi3PtKG6vc7r7YCXh0KFVRi_confirm.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testCardConfirmationFR/0003_post_v1_setup_intents_seti_1Pi3PtKG6vc7r7YCXh0KFVRi_confirm.tail
@@ -1,0 +1,94 @@
+POST
+https:\/\/api\.stripe\.com\/v1\/setup_intents\/seti_1Pi3PtKG6vc7r7YCXh0KFVRi\/confirm$
+200
+application/json
+access-control-allow-methods: GET,HEAD,PUT,PATCH,POST,DELETE
+content-security-policy: report-uri https://q.stripe.com/csp-report?p=v1%2Fsetup_intents%2F%3Aintent%2Fconfirm; block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: coop="https://q.stripe.com/coop-report?s=payins-bapi-srv"
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+cross-origin-opener-policy-report-only: same-origin; report-to="coop"
+Access-Control-Allow-Origin: *
+stripe-should-retry: false
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=payins-bapi-srv"}],"include_subdomains":true}
+request-id: req_54t3jAC2BRiNgt
+x-stripe-routing-context-priority-tier: api-testmode
+Content-Length: 1558
+Vary: Origin
+Date: Mon, 29 Jul 2024 23:55:50 GMT
+original-request: req_54t3jAC2BRiNgt
+stripe-version: 2020-08-27
+idempotency-key: c6e0c825-4918-49eb-82bf-656b5cf5a950
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+x-content-type-options: nosniff
+
+{
+  "id" : "seti_1Pi3PtKG6vc7r7YCXh0KFVRi",
+  "description" : null,
+  "next_action" : null,
+  "livemode" : false,
+  "payment_method" : {
+    "object" : "payment_method",
+    "id" : "pm_1Pi3PtKG6vc7r7YCxI6Z7e9J",
+    "billing_details" : {
+      "email" : null,
+      "phone" : null,
+      "name" : null,
+      "address" : {
+        "state" : null,
+        "country" : "US",
+        "line2" : null,
+        "city" : null,
+        "line1" : null,
+        "postal_code" : "65432"
+      }
+    },
+    "card" : {
+      "last4" : "4242",
+      "funding" : "credit",
+      "generated_from" : null,
+      "networks" : {
+        "available" : [
+          "visa"
+        ],
+        "preferred" : null
+      },
+      "brand" : "visa",
+      "checks" : {
+        "address_postal_code_check" : null,
+        "cvc_check" : null,
+        "address_line1_check" : null
+      },
+      "three_d_secure_usage" : {
+        "supported" : true
+      },
+      "wallet" : null,
+      "display_brand" : "visa",
+      "exp_month" : 12,
+      "exp_year" : 2032,
+      "country" : "US"
+    },
+    "livemode" : false,
+    "created" : 1722297349,
+    "allow_redisplay" : "unspecified",
+    "type" : "card",
+    "customer" : "cus_QZBnLLrkDENsKB"
+  },
+  "payment_method_configuration_details" : null,
+  "usage" : "off_session",
+  "payment_method_types" : [
+    "card"
+  ],
+  "object" : "setup_intent",
+  "last_setup_error" : null,
+  "created" : 1722297349,
+  "client_secret" : "seti_1Pi3PtKG6vc7r7YCXh0KFVRi_secret_QZBnRscDWDGBHJmawMOZ3MR4flJjGOx",
+  "automatic_payment_methods" : null,
+  "cancellation_reason" : null,
+  "status" : "succeeded"
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testSepaConfirmation/0000_post_create_ephemeral_key.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testSepaConfirmation/0000_post_create_ephemeral_key.tail
@@ -1,0 +1,18 @@
+POST
+https:\/\/stp-mobile-ci-test-backend-e1b3\.stripedemos\.com\/create_ephemeral_key$
+200
+text/html
+Content-Type: text/html;charset=utf-8
+Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+Set-Cookie: rack.session=DXIgyQAWJ%2FC14TJWnyvjvUfbEOQxWaZPU8gYI4hibK5FWH%2F7uMd74lPRFlnL3oNboTkRFHXjxnJTTIrUkCFf%2BacWNe6BZ%2By6RwxrCB0j70eeZT1pZYW%2FcrqKo4jobngCh2WzaDsz0vA1sarxECReoi1Me2bjLiGSYuZZNnCBAcWCMdJeUndFktO5xQOBYEY595sO%2Fdm%2F0crurY2oqwzDv4WRQ1c8fPGss1Nn%2FbIDihE%3D; path=/
+Server: Google Frontend
+x-cloud-trace-context: 46dfe4a9eede8053174218b7b7ea2708;o=1
+Via: 1.1 google
+x-xss-protection: 1; mode=block
+Date: Mon, 29 Jul 2024 23:55:53 GMT
+x-robots-tag: noindex, nofollow
+Content-Length: 149
+x-content-type-options: nosniff
+x-frame-options: SAMEORIGIN
+
+{"ephemeral_key_secret":"ek_test_YWNjdF8xRzZtMXBGWTBxeWw2WGVXLFQ2SWVPS3ZIUDI1THBwMXBtd2Z2eEhqWUJsUUM5dmY_00e9d9uV99","customer":"cus_QZBnDi0wpmFwYn"}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testSepaConfirmation/0001_post_create_setup_intent.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testSepaConfirmation/0001_post_create_setup_intent.tail
@@ -1,0 +1,18 @@
+POST
+https:\/\/stp-mobile-ci-test-backend-e1b3\.stripedemos\.com\/create_setup_intent$
+200
+text/html
+Content-Type: text/html;charset=utf-8
+Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+Set-Cookie: rack.session=igmRZKjy7eSznWRWbOdrdkSKyZcBtGKpIT2dJ5sju3J6AeIRSv0Bf9t%2Fovpo2El5AXb5u7sMkqAwDAC9Bhlxk49D%2FOH6XcPRVI9pmRggJScoqpN8i%2BuPJ%2BEj2xr7bm%2FkgEKees%2B8QcUX3h%2F%2FnmC0lxMhyHcVY9oaqrfc%2BVW7f0Ilb2iZ1SI63BVCNNAmSNqF%2FbzGUd7eosmDkibPv91g5JA9Aad9qs6d4EueIZm%2BodU%3D; path=/
+Server: Google Frontend
+x-cloud-trace-context: a0dd0bbea1f5244a9235627a355159c1
+Via: 1.1 google
+x-xss-protection: 1; mode=block
+Date: Mon, 29 Jul 2024 23:55:53 GMT
+x-robots-tag: noindex, nofollow
+Content-Length: 157
+x-content-type-options: nosniff
+x-frame-options: SAMEORIGIN
+
+{"intent":"seti_1Pi3PxFY0qyl6XeWpog1ApXf","secret":"seti_1Pi3PxFY0qyl6XeWpog1ApXf_secret_QZBnULUGCLSUDxcxn7ckSBfLIEtdM0U","status":"requires_payment_method"}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testSepaConfirmation/0002_get_v1_setup_intents_seti_1Pi3PxFY0qyl6XeWpog1ApXf.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testSepaConfirmation/0002_get_v1_setup_intents_seti_1Pi3PxFY0qyl6XeWpog1ApXf.tail
@@ -1,0 +1,45 @@
+GET
+https:\/\/api\.stripe\.com\/v1\/setup_intents\/seti_1Pi3PxFY0qyl6XeWpog1ApXf\?client_secret=seti_1Pi3PxFY0qyl6XeWpog1ApXf_secret_QZBnULUGCLSUDxcxn7ckSBfLIEtdM0U$
+200
+application/json
+access-control-allow-methods: GET,HEAD,PUT,PATCH,POST,DELETE
+content-security-policy: report-uri https://q.stripe.com/csp-report?p=v1%2Fsetup_intents%2F%3Aintent; block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: coop="https://q.stripe.com/coop-report?s=payins-bapi-srv"
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+cross-origin-opener-policy-report-only: same-origin; report-to="coop"
+Access-Control-Allow-Origin: *
+x-stripe-routing-context-priority-tier: api-testmode
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=payins-bapi-srv"}],"include_subdomains":true}
+request-id: req_DRnFzNPe2Kt3sD
+Content-Length: 539
+Vary: Origin
+Date: Mon, 29 Jul 2024 23:55:54 GMT
+stripe-version: 2020-08-27
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+x-content-type-options: nosniff
+
+{
+  "id" : "seti_1Pi3PxFY0qyl6XeWpog1ApXf",
+  "description" : null,
+  "next_action" : null,
+  "livemode" : false,
+  "payment_method" : null,
+  "payment_method_configuration_details" : null,
+  "usage" : "off_session",
+  "payment_method_types" : [
+    "sepa_debit"
+  ],
+  "object" : "setup_intent",
+  "last_setup_error" : null,
+  "created" : 1722297353,
+  "client_secret" : "seti_1Pi3PxFY0qyl6XeWpog1ApXf_secret_QZBnULUGCLSUDxcxn7ckSBfLIEtdM0U",
+  "automatic_payment_methods" : null,
+  "cancellation_reason" : null,
+  "status" : "requires_payment_method"
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testSepaConfirmation/0003_post_v1_setup_intents_seti_1Pi3PxFY0qyl6XeWpog1ApXf_confirm.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testSepaConfirmation/0003_post_v1_setup_intents_seti_1Pi3PxFY0qyl6XeWpog1ApXf_confirm.tail
@@ -1,0 +1,80 @@
+POST
+https:\/\/api\.stripe\.com\/v1\/setup_intents\/seti_1Pi3PxFY0qyl6XeWpog1ApXf\/confirm$
+200
+application/json
+access-control-allow-methods: GET,HEAD,PUT,PATCH,POST,DELETE
+content-security-policy: report-uri https://q.stripe.com/csp-report?p=v1%2Fsetup_intents%2F%3Aintent%2Fconfirm; block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: coop="https://q.stripe.com/coop-report?s=payins-bapi-srv"
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+cross-origin-opener-policy-report-only: same-origin; report-to="coop"
+Access-Control-Allow-Origin: *
+stripe-should-retry: false
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=payins-bapi-srv"}],"include_subdomains":true}
+request-id: req_xkHlAB3rv4RH0E
+x-stripe-routing-context-priority-tier: api-testmode
+Content-Length: 1311
+Vary: Origin
+Date: Mon, 29 Jul 2024 23:55:54 GMT
+original-request: req_xkHlAB3rv4RH0E
+stripe-version: 2020-08-27
+idempotency-key: c2861236-80e7-4899-86ed-4101d65300ed
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+x-content-type-options: nosniff
+
+{
+  "id" : "seti_1Pi3PxFY0qyl6XeWpog1ApXf",
+  "description" : null,
+  "next_action" : null,
+  "livemode" : false,
+  "payment_method" : {
+    "object" : "payment_method",
+    "sepa_debit" : {
+      "fingerprint" : "vifs0Ho7vwRn1Miu",
+      "country" : "DE",
+      "last4" : "3000",
+      "bank_code" : "37040044",
+      "generated_from" : {
+        "setup_attempt" : null,
+        "charge" : null
+      },
+      "branch_code" : ""
+    },
+    "id" : "pm_1Pi3PyFY0qyl6XeWHn1UYkSA",
+    "billing_details" : {
+      "email" : "test@example.com",
+      "phone" : null,
+      "name" : "John Doe",
+      "address" : {
+        "state" : "AL",
+        "country" : "US",
+        "line2" : "",
+        "city" : "San Francisco",
+        "line1" : "123 Main",
+        "postal_code" : "65432"
+      }
+    },
+    "livemode" : false,
+    "created" : 1722297354,
+    "allow_redisplay" : "unspecified",
+    "type" : "sepa_debit",
+    "customer" : "cus_QZBnDi0wpmFwYn"
+  },
+  "payment_method_configuration_details" : null,
+  "usage" : "off_session",
+  "payment_method_types" : [
+    "sepa_debit"
+  ],
+  "object" : "setup_intent",
+  "last_setup_error" : null,
+  "created" : 1722297353,
+  "client_secret" : "seti_1Pi3PxFY0qyl6XeWpog1ApXf_secret_QZBnULUGCLSUDxcxn7ckSBfLIEtdM0U",
+  "automatic_payment_methods" : null,
+  "cancellation_reason" : null,
+  "status" : "succeeded"
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testUSBankAccount/0000_post_create_setup_intent.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testUSBankAccount/0000_post_create_setup_intent.tail
@@ -1,0 +1,18 @@
+POST
+https:\/\/stp-mobile-ci-test-backend-e1b3\.stripedemos\.com\/create_setup_intent$
+200
+text/html
+Content-Type: text/html;charset=utf-8
+Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+Set-Cookie: rack.session=XbFTX3Wb5AZUKYMWFCrEaDJ7w32hfpqKiJB6bDLd8XCZPW0O3M0OEPde0fU70Bu9C1KrPBAAIH7%2B7YYeFlzz9HfENuDr7EpoQFI2chAHs3zqA2PxxhU4pbiQI1OXHylxuBAgqGzJO2SRDRxXPWzW57ku1FEs4ijmCZq4oQtzuNUUJLuJpk0yrS6%2BA7ltaFd1eegN2PwPXP4dzJndlexWEXkCrDgBtlHTGBZd3KVf69A%3D; path=/
+Server: Google Frontend
+x-cloud-trace-context: 7f7117cb28f2a1c07f5cf409e9caf6ee
+Via: 1.1 google
+x-xss-protection: 1; mode=block
+Date: Mon, 29 Jul 2024 23:55:55 GMT
+x-robots-tag: noindex, nofollow
+Content-Length: 157
+x-content-type-options: nosniff
+x-frame-options: SAMEORIGIN
+
+{"intent":"seti_1Pi3PzFY0qyl6XeWtut8tn5B","secret":"seti_1Pi3PzFY0qyl6XeWtut8tn5B_secret_QZBnryLtgkHSvAQduQyCdnWiHCMsjZQ","status":"requires_payment_method"}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testUSBankAccount/0001_get_v1_setup_intents_seti_1Pi3PzFY0qyl6XeWtut8tn5B.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testUSBankAccount/0001_get_v1_setup_intents_seti_1Pi3PzFY0qyl6XeWtut8tn5B.tail
@@ -1,0 +1,50 @@
+GET
+https:\/\/api\.stripe\.com\/v1\/setup_intents\/seti_1Pi3PzFY0qyl6XeWtut8tn5B\?client_secret=seti_1Pi3PzFY0qyl6XeWtut8tn5B_secret_QZBnryLtgkHSvAQduQyCdnWiHCMsjZQ$
+200
+application/json
+access-control-allow-methods: GET,HEAD,PUT,PATCH,POST,DELETE
+content-security-policy: report-uri https://q.stripe.com/csp-report?p=v1%2Fsetup_intents%2F%3Aintent; block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: coop="https://q.stripe.com/coop-report?s=payins-bapi-srv"
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+cross-origin-opener-policy-report-only: same-origin; report-to="coop"
+Access-Control-Allow-Origin: *
+x-stripe-routing-context-priority-tier: api-testmode
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=payins-bapi-srv"}],"include_subdomains":true}
+request-id: req_ajssUxCA1vqhpD
+Content-Length: 651
+Vary: Origin
+Date: Mon, 29 Jul 2024 23:55:56 GMT
+stripe-version: 2020-08-27
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+x-content-type-options: nosniff
+
+{
+  "id" : "seti_1Pi3PzFY0qyl6XeWtut8tn5B",
+  "description" : null,
+  "next_action" : null,
+  "status" : "requires_payment_method",
+  "livemode" : false,
+  "payment_method" : null,
+  "payment_method_configuration_details" : null,
+  "usage" : "off_session",
+  "payment_method_types" : [
+    "us_bank_account"
+  ],
+  "object" : "setup_intent",
+  "last_setup_error" : null,
+  "created" : 1722297355,
+  "client_secret" : "seti_1Pi3PzFY0qyl6XeWtut8tn5B_secret_QZBnryLtgkHSvAQduQyCdnWiHCMsjZQ",
+  "automatic_payment_methods" : null,
+  "cancellation_reason" : null,
+  "payment_method_options" : {
+    "us_bank_account" : {
+      "verification_method" : "automatic"
+    }
+  }
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testUSBankAccount/0002_post_v1_setup_intents_seti_1Pi3PzFY0qyl6XeWtut8tn5B_link_account_sessions.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testUSBankAccount/0002_post_v1_setup_intents_seti_1Pi3PzFY0qyl6XeWtut8tn5B_link_account_sessions.tail
@@ -1,0 +1,57 @@
+POST
+https:\/\/api\.stripe\.com\/v1\/setup_intents\/seti_1Pi3PzFY0qyl6XeWtut8tn5B\/link_account_sessions$
+200
+application/json
+access-control-allow-methods: GET,HEAD,PUT,PATCH,POST,DELETE
+content-security-policy: report-uri https://q.stripe.com/csp-report?p=v1%2Fsetup_intents%2F%3Aintent%2Flink_account_sessions; block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: coop="https://q.stripe.com/coop-report?s=mono-bapi-srv"
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+cross-origin-opener-policy-report-only: same-origin; report-to="coop"
+Access-Control-Allow-Origin: *
+stripe-should-retry: false
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=mono-bapi-srv"}],"include_subdomains":true}
+request-id: req_PvExZYK7gTn31x
+x-stripe-routing-context-priority-tier: api-testmode
+Content-Length: 491
+Vary: Origin
+Date: Mon, 29 Jul 2024 23:55:56 GMT
+original-request: req_PvExZYK7gTn31x
+stripe-version: 2020-08-27
+idempotency-key: fa8e3bb5-b96f-44fc-80fd-c4b6e2a4929a
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+x-content-type-options: nosniff
+
+{
+  "object" : "link_account_session",
+  "filters" : {
+    "countries" : null,
+    "account_subcategories" : [
+      "checking",
+      "savings"
+    ]
+  },
+  "id" : "fcsess_1Pi3Q0FY0qyl6XeWbevA6ivO",
+  "livemode" : false,
+  "prefetch" : [
+
+  ],
+  "linked_accounts" : {
+    "has_more" : false,
+    "object" : "list",
+    "data" : [
+
+    ],
+    "total_count" : 0,
+    "url" : "\/v1\/linked_accounts"
+  },
+  "client_secret" : "fcsess_client_secret_bOhu0zVU5hFavJi00YtzHZ7X",
+  "permissions" : [
+    "payment_method"
+  ]
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testUSBankAccountAttachDefaults/0000_post_create_setup_intent.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testUSBankAccountAttachDefaults/0000_post_create_setup_intent.tail
@@ -1,0 +1,18 @@
+POST
+https:\/\/stp-mobile-ci-test-backend-e1b3\.stripedemos\.com\/create_setup_intent$
+200
+text/html
+Content-Type: text/html;charset=utf-8
+Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+Set-Cookie: rack.session=1hi55VPaPx39nASdTLrPid2nraSuZy80jpIPhv2GsPhaDkXrtshmDpS3Z8hNVNSDWPxtE62EMR7NaOXv3Omtd3vvxdPujOko9JAZhvVt%2BFd4zF%2BZaq6gZGpgfAqgeZBTa5Zq%2BAYmkJ3i3Buaoy%2F7oz1ICqhzg3wAVzyj%2FpGt2LKgece9Ls8hwSZD2GjsY%2BSqrNe7jGE6LNsvDT7Uf5sVjG%2BOuzLi1sk93S%2BHUz1dHnU%3D; path=/
+Server: Google Frontend
+x-cloud-trace-context: 0a431fbe5bfd16222cb73d84b877c33f
+Via: 1.1 google
+x-xss-protection: 1; mode=block
+Date: Mon, 29 Jul 2024 23:55:55 GMT
+x-robots-tag: noindex, nofollow
+Content-Length: 157
+x-content-type-options: nosniff
+x-frame-options: SAMEORIGIN
+
+{"intent":"seti_1Pi3PyFY0qyl6XeWbq2Ownj9","secret":"seti_1Pi3PyFY0qyl6XeWbq2Ownj9_secret_QZBnddhtehamAow4qJ9w2GqkdCwcI6S","status":"requires_payment_method"}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testUSBankAccountAttachDefaults/0001_get_v1_setup_intents_seti_1Pi3PyFY0qyl6XeWbq2Ownj9.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testUSBankAccountAttachDefaults/0001_get_v1_setup_intents_seti_1Pi3PyFY0qyl6XeWbq2Ownj9.tail
@@ -1,0 +1,50 @@
+GET
+https:\/\/api\.stripe\.com\/v1\/setup_intents\/seti_1Pi3PyFY0qyl6XeWbq2Ownj9\?client_secret=seti_1Pi3PyFY0qyl6XeWbq2Ownj9_secret_QZBnddhtehamAow4qJ9w2GqkdCwcI6S$
+200
+application/json
+access-control-allow-methods: GET,HEAD,PUT,PATCH,POST,DELETE
+content-security-policy: report-uri https://q.stripe.com/csp-report?p=v1%2Fsetup_intents%2F%3Aintent; block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: coop="https://q.stripe.com/coop-report?s=payins-bapi-srv"
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+cross-origin-opener-policy-report-only: same-origin; report-to="coop"
+Access-Control-Allow-Origin: *
+x-stripe-routing-context-priority-tier: api-testmode
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=payins-bapi-srv"}],"include_subdomains":true}
+request-id: req_cUv5Bf5LLCLM6h
+Content-Length: 651
+Vary: Origin
+Date: Mon, 29 Jul 2024 23:55:55 GMT
+stripe-version: 2020-08-27
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+x-content-type-options: nosniff
+
+{
+  "id" : "seti_1Pi3PyFY0qyl6XeWbq2Ownj9",
+  "description" : null,
+  "next_action" : null,
+  "status" : "requires_payment_method",
+  "livemode" : false,
+  "payment_method" : null,
+  "payment_method_configuration_details" : null,
+  "usage" : "off_session",
+  "payment_method_types" : [
+    "us_bank_account"
+  ],
+  "object" : "setup_intent",
+  "last_setup_error" : null,
+  "created" : 1722297354,
+  "client_secret" : "seti_1Pi3PyFY0qyl6XeWbq2Ownj9_secret_QZBnddhtehamAow4qJ9w2GqkdCwcI6S",
+  "automatic_payment_methods" : null,
+  "cancellation_reason" : null,
+  "payment_method_options" : {
+    "us_bank_account" : {
+      "verification_method" : "automatic"
+    }
+  }
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testUSBankAccountAttachDefaults/0002_post_v1_setup_intents_seti_1Pi3PyFY0qyl6XeWbq2Ownj9_link_account_sessions.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testUSBankAccountAttachDefaults/0002_post_v1_setup_intents_seti_1Pi3PyFY0qyl6XeWbq2Ownj9_link_account_sessions.tail
@@ -1,0 +1,57 @@
+POST
+https:\/\/api\.stripe\.com\/v1\/setup_intents\/seti_1Pi3PyFY0qyl6XeWbq2Ownj9\/link_account_sessions$
+200
+application/json
+access-control-allow-methods: GET,HEAD,PUT,PATCH,POST,DELETE
+content-security-policy: report-uri https://q.stripe.com/csp-report?p=v1%2Fsetup_intents%2F%3Aintent%2Flink_account_sessions; block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: coop="https://q.stripe.com/coop-report?s=mono-bapi-srv"
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+cross-origin-opener-policy-report-only: same-origin; report-to="coop"
+Access-Control-Allow-Origin: *
+stripe-should-retry: false
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=mono-bapi-srv"}],"include_subdomains":true}
+request-id: req_97uB8vbMjFzIwX
+x-stripe-routing-context-priority-tier: api-testmode
+Content-Length: 491
+Vary: Origin
+Date: Mon, 29 Jul 2024 23:55:55 GMT
+original-request: req_97uB8vbMjFzIwX
+stripe-version: 2020-08-27
+idempotency-key: 685961dd-0c77-4d17-b6bf-94fa09aca277
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+x-content-type-options: nosniff
+
+{
+  "object" : "link_account_session",
+  "filters" : {
+    "countries" : null,
+    "account_subcategories" : [
+      "checking",
+      "savings"
+    ]
+  },
+  "id" : "fcsess_1Pi3PzFY0qyl6XeWBRk6ubhD",
+  "livemode" : false,
+  "prefetch" : [
+
+  ],
+  "linked_accounts" : {
+    "has_more" : false,
+    "object" : "list",
+    "data" : [
+
+    ],
+    "total_count" : 0,
+    "url" : "\/v1\/linked_accounts"
+  },
+  "client_secret" : "fcsess_client_secret_TpwEcDErDbZuD3p1pqlJXPSX",
+  "permissions" : [
+    "payment_method"
+  ]
+}


### PR DESCRIPTION
## Summary
Moves the setting of allow_redisplay to CustomerSheet+API and adds confirmation tests to verify values are being set correctly 

## Motivation
Match the way paymentSheet is setting allow redisplay, and allow for better testability

## Testing
Manual + Added tests

## Changelog
N/A