### PR TITLE
Refactor form cache

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
@@ -75,7 +75,7 @@ class AddPaymentMethodViewController: UIViewController {
 
     // MARK: - Views
     private lazy var paymentMethodFormViewController: PaymentMethodFormViewController = {
-        let pmFormVC = PaymentMethodFormViewController(type: selectedPaymentMethodType, intent: intent, elementsSession: elementsSession, previousCustomerInput: previousCustomerInput, configuration: configuration, isLinkEnabled: isLinkEnabled, headerView: nil, delegate: self)
+        let pmFormVC = PaymentMethodFormViewController(type: selectedPaymentMethodType, intent: intent, elementsSession: elementsSession, previousCustomerInput: previousCustomerInput, formCache: .init(), configuration: configuration, isLinkEnabled: isLinkEnabled, headerView: nil, delegate: self)
         // Only use the previous customer input in the very first load, to avoid overwriting customer input
         previousCustomerInput = nil
         return pmFormVC
@@ -153,7 +153,7 @@ class AddPaymentMethodViewController: UIViewController {
 
     private func updateFormElement() {
         if selectedPaymentMethodType != paymentMethodFormViewController.paymentMethodType {
-            paymentMethodFormViewController = PaymentMethodFormViewController(type: selectedPaymentMethodType, intent: intent, elementsSession: elementsSession, previousCustomerInput: previousCustomerInput, configuration: configuration, isLinkEnabled: isLinkEnabled, headerView: nil, delegate: self)
+            paymentMethodFormViewController = PaymentMethodFormViewController(type: selectedPaymentMethodType, intent: intent, elementsSession: elementsSession, previousCustomerInput: previousCustomerInput, formCache: .init(), configuration: configuration, isLinkEnabled: isLinkEnabled, headerView: nil, delegate: self)
         }
         updateUI()
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -61,9 +61,6 @@ final class PaymentSheetLoader {
                     }
                 }
 
-                // Clear the payment method form cache
-                PaymentMethodFormViewController.clearFormCache()
-
                 // List the Customer's saved PaymentMethods
                 async let savedPaymentMethods = fetchSavedPaymentMethods(elementsSession: elementsSession, configuration: configuration)
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
@@ -74,6 +74,7 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
     let configuration: PaymentSheet.Configuration
     let intent: Intent
     let elementsSession: STPElementsSession
+    let formCache: PaymentMethodFormCache = .init()
     var error: Swift.Error?
     var isPaymentInFlight: Bool = false
     private var savedPaymentMethods: [STPPaymentMethod]
@@ -715,6 +716,7 @@ extension PaymentSheetVerticalViewController: VerticalPaymentMethodListViewContr
             intent: intent,
             elementsSession: elementsSession,
             previousCustomerInput: previousCustomerInput,
+            formCache: formCache,
             configuration: configuration,
             isLinkEnabled: loadResult.isLinkEnabled,
             headerView: headerView,
@@ -723,7 +725,15 @@ extension PaymentSheetVerticalViewController: VerticalPaymentMethodListViewContr
     }
 
     private func shouldDisplayForm(for paymentMethodType: PaymentSheet.PaymentMethodType) -> Bool {
-        return makeFormVC(paymentMethodType: paymentMethodType).form.collectsUserInput
+        return PaymentSheetFormFactory(
+            intent: intent,
+            elementsSession: elementsSession,
+            configuration: .paymentSheet(configuration),
+            paymentMethod: paymentMethodType,
+            previousCustomerInput: nil,
+            offerSaveToLinkWhenSupported: false,
+            linkAccount: LinkAccountContext.shared.account
+        ).make().collectsUserInput
     }
 
     func didCancel() {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentMethodFormViewControllerTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentMethodFormViewControllerTest.swift
@@ -16,7 +16,6 @@ final class PaymentMethodFormViewControllerTest: XCTestCase {
         let expectation = expectation(description: "Load specs")
         AddressSpecProvider.shared.loadAddressSpecs {
             FormSpecProvider.shared.load { _ in
-                PaymentMethodFormViewController.clearFormCache()
                 expectation.fulfill()
             }
         }
@@ -35,7 +34,7 @@ final class PaymentMethodFormViewControllerTest: XCTestCase {
         // ...and no default billing address...
         XCTAssertEqual(configuration.defaultBillingDetails, PaymentSheet.Configuration().defaultBillingDetails)
         // ...PaymentMethodFormVC...
-        let sut = PaymentMethodFormViewController(type: .stripe(.card), intent: ._testPaymentIntent(paymentMethodTypes: [.card]), elementsSession: ._testCardValue(), previousCustomerInput: nil, configuration: configuration, isLinkEnabled: false, headerView: nil, delegate: self)
+        let sut = PaymentMethodFormViewController(type: .stripe(.card), intent: ._testPaymentIntent(paymentMethodTypes: [.card]), elementsSession: ._testCardValue(), previousCustomerInput: nil, formCache: .init(), configuration: configuration, isLinkEnabled: false, headerView: nil, delegate: self)
 
         // ...should fill its address fields with the shipping address
         sut.beginAppearanceTransition(true, animated: false)
@@ -61,6 +60,7 @@ final class PaymentMethodFormViewControllerTest: XCTestCase {
             intent: ._testPaymentIntent(paymentMethodTypes: [.cashApp], setupFutureUsage: .offSession),
             elementsSession: ._testValue(paymentMethodTypes: ["cashapp"]),
             previousCustomerInput: nil,
+            formCache: .init(),
             configuration: ._testValue_MostPermissive(),
             isLinkEnabled: false,
             headerView: nil,
@@ -75,6 +75,35 @@ final class PaymentMethodFormViewControllerTest: XCTestCase {
         XCTAssertTrue(mandate.mandateTextView.viewDidAppear)
         // ...and notify the delegate
         XCTAssertTrue(didUpdateDelegateMethodCalled)
+    }
+
+    func testFormCache() {
+        let formCache = PaymentMethodFormCache()
+        let firstSUT = PaymentMethodFormViewController(
+            type: .stripe(.card),
+            intent: ._testPaymentIntent(paymentMethodTypes: [.card], setupFutureUsage: .offSession),
+            elementsSession: ._testValue(paymentMethodTypes: ["cashapp"]),
+            previousCustomerInput: nil,
+            formCache: formCache,
+            configuration: ._testValue_MostPermissive(),
+            isLinkEnabled: false,
+            headerView: nil,
+            delegate: self
+        )
+        firstSUT.form.getTextFieldElement("ZIP").setText("12345")
+
+        let secondSUT = PaymentMethodFormViewController(
+            type: .stripe(.card),
+            intent: ._testPaymentIntent(paymentMethodTypes: [.card], setupFutureUsage: .offSession),
+            elementsSession: ._testValue(paymentMethodTypes: ["cashapp"]),
+            previousCustomerInput: nil,
+            formCache: formCache,
+            configuration: ._testValue_MostPermissive(),
+            isLinkEnabled: false,
+            headerView: nil,
+            delegate: self
+        )
+        XCTAssertEqual(secondSUT.form.getTextFieldElement("ZIP").text, "12345")
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerViewControllerSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerViewControllerSnapshotTests.swift
@@ -100,7 +100,6 @@ final class PaymentSheetFlowControllerViewControllerSnapshotTests: STPSnapshotTe
         let expectation = expectation(description: "Load specs")
         AddressSpecProvider.shared.loadAddressSpecs {
             FormSpecProvider.shared.load { _ in
-                PaymentMethodFormViewController.clearFormCache()
                 expectation.fulfill()
             }
         }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLPMConfirmFlowTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLPMConfirmFlowTests.swift
@@ -567,13 +567,14 @@ extension PaymentSheet_LPM_ConfirmFlowTests {
 
         for (description, intent) in intents {
             // Make the form
-            PaymentMethodFormViewController.clearFormCache()
-            let formVC = PaymentMethodFormViewController(type: .stripe(paymentMethodType), intent: intent, elementsSession: ._testValue(intent: intent), previousCustomerInput: nil, configuration: configuration, isLinkEnabled: false, headerView: nil, delegate: self)
+            let formVC = PaymentMethodFormViewController(type: .stripe(paymentMethodType), intent: intent, elementsSession: ._testValue(intent: intent), previousCustomerInput: nil, formCache: .init(), configuration: configuration, isLinkEnabled: false, headerView: nil, delegate: self)
             let paymentMethodForm = formVC.form
 
             // Add to window to avoid layout errors due to zero size and presentation errors
             window.rootViewController = formVC
-            formVC.viewDidAppear(true)
+            
+            // Simulate view appearance. This makes SimpleMandateElement mark its mandate as having been displayed.
+            formVC.viewDidAppear(false)
 
             // Fill out the form
             formCompleter(paymentMethodForm)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderTest.swift
@@ -38,7 +38,6 @@ final class PaymentSheetLoaderTest: STPNetworkStubbingTestCase {
         let expectation = XCTestExpectation(description: "Load w/ PaymentIntent")
         let types = ["ideal", "card", "bancontact", "sofort"]
         let clientSecret = try await STPTestingAPIClient.shared.fetchPaymentIntent(types: types)
-        PaymentMethodFormViewController.formCache = [.stripe(.card): FormElement(elements: [])]
         // Given a PaymentIntent client secret...
         PaymentSheetLoader.load(mode: .paymentIntentClientSecret(clientSecret), configuration: self.configuration, isFlowController: false) { result in
             expectation.fulfill()
@@ -58,8 +57,6 @@ final class PaymentSheetLoaderTest: STPNetworkStubbingTestCase {
                 XCTAssertEqual(paymentIntent.clientSecret, clientSecret)
                 XCTAssertEqual(loadResult.savedPaymentMethods, [])
                 XCTAssertTrue(loadResult.isApplePayEnabled)
-                // Ensure the form cache was cleared
-                XCTAssertTrue(PaymentMethodFormViewController.formCache.isEmpty)
             case .failure(let error):
                 XCTFail(error.nonGenericDescription)
             }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetVerticalViewControllerSnapshotTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetVerticalViewControllerSnapshotTest.swift
@@ -18,7 +18,6 @@ final class PaymentSheetVerticalViewControllerSnapshotTest: STPSnapshotTestCase 
         AddressSpecProvider.shared.loadAddressSpecs {
             FormSpecProvider.shared.load { _ in
                 expectation.fulfill()
-                PaymentMethodFormViewController.clearFormCache()
             }
         }
         waitForExpectations(timeout: 1)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetVerticalViewControllerTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetVerticalViewControllerTest.swift
@@ -16,7 +16,6 @@ final class PaymentSheetVerticalViewControllerTest: XCTestCase {
         let expectation = expectation(description: "Load specs")
         AddressSpecProvider.shared.loadAddressSpecs {
             FormSpecProvider.shared.load { _ in
-                PaymentMethodFormViewController.clearFormCache()
                 expectation.fulfill()
             }
         }


### PR DESCRIPTION
## Summary
We cache forms via a singleton but that's bad. Now it's an instance properly scoped to the lifetime of the VerticalVC. 

Also reworked `shouldDisplayForm(for:)` to not create the FormVC.

## Motivation
Lets us get rid of all the static clearCache calls.
