### PR TITLE
Pass through correct value of elementsSession

### DIFF
--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetGDPRConfirmFlowTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetGDPRConfirmFlowTests.swift
@@ -302,7 +302,6 @@ final class PaymentSheet_GDPR_ConfirmFlowTests: STPNetworkStubbingTestCase {
         let clientSecretResolved = expectation(description: "clientSecretResolved")
         var clientSecret: String!
         let intent = try await intentCreation(intentKind: intentKind,
-                                              elementsSession: elementsSession,
                                               apiClient: apiClient,
                                               customerID: newCustomer.customer,
                                               paymentMethodTypes: paymentMethodTypes,
@@ -395,7 +394,7 @@ final class PaymentSheet_GDPR_ConfirmFlowTests: STPNetworkStubbingTestCase {
             configuration: configuration,
             authenticationContext: self,
             intent: intent,
-            elementsSession: ._testValue(intent: intent),
+            elementsSession: elementsSession,
             paymentOption: .new(confirmParams: intentConfirmParams),
             paymentHandler: paymentHandler
         ) { result, _  in
@@ -484,7 +483,6 @@ extension PaymentSheet_GDPR_ConfirmFlowTests {
     }
 
     func intentCreation(intentKind: IntentKind,
-                        elementsSession: STPElementsSession,
                         apiClient: STPAPIClient,
                         customerID: String,
                         paymentMethodTypes: [String],

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetGDPRConfirmFlowTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetGDPRConfirmFlowTests.swift
@@ -301,12 +301,12 @@ final class PaymentSheet_GDPR_ConfirmFlowTests: STPNetworkStubbingTestCase {
                                                                                               merchantCountry: merchantCountry.rawValue.lowercased())
         let clientSecretResolved = expectation(description: "clientSecretResolved")
         var clientSecret: String!
-        let intent = try await intentCreation(intentKind: intentKind,
-                                              apiClient: apiClient,
-                                              customerID: newCustomer.customer,
-                                              paymentMethodTypes: paymentMethodTypes,
-                                              currency: currency,
-                                              merchantCountry: merchantCountry) { cs in
+        let intent = try await createIntent(intentKind: intentKind,
+                                            apiClient: apiClient,
+                                            customerID: newCustomer.customer,
+                                            paymentMethodTypes: paymentMethodTypes,
+                                            currency: currency,
+                                            merchantCountry: merchantCountry) { cs in
             clientSecret = cs
             clientSecretResolved.fulfill()
         }
@@ -482,13 +482,13 @@ extension PaymentSheet_GDPR_ConfirmFlowTests {
                                              ])
     }
 
-    func intentCreation(intentKind: IntentKind,
-                        apiClient: STPAPIClient,
-                        customerID: String,
-                        paymentMethodTypes: [String],
-                        currency: String,
-                        merchantCountry: MerchantCountry,
-                        clientSecretCallback: @escaping (String) -> Void ) async throws -> Intent {
+    func createIntent(intentKind: IntentKind,
+                      apiClient: STPAPIClient,
+                      customerID: String,
+                      paymentMethodTypes: [String],
+                      currency: String,
+                      merchantCountry: MerchantCountry,
+                      clientSecretCallback: @escaping (String) -> Void ) async throws -> Intent {
         switch intentKind {
         // MARK: - Payment Intent
         case .paymentIntent_intentFirst_csc:


### PR DESCRIPTION
## Summary
In these test cases, we weren't passing in the correct instance of elements/sessions. Introduced here:
https://github.com/stripe/stripe-ios/pull/3851/files#r1697340803

## Motivation
Nightly non-stubbed tests were failing

## Testing
Manually ran tests on my box

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
