### PR TITLE
Financial Connections: for networking manual entry, added support for mid-flow consent params

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIElementQuery+Extensions.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIElementQuery+Extensions.swift
@@ -9,7 +9,7 @@ import Foundation
 import XCTest
 
 extension XCUIElementQuery {
-    
+
     var lastMatch: XCUIElement {
         guard count > 0 else {
             return firstMatch

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
@@ -115,7 +115,8 @@ protocol FinancialConnectionsAPIClient {
     func selectNetworkedAccounts(
         selectedAccountIds: [String],
         clientSecret: String,
-        consumerSessionClientSecret: String
+        consumerSessionClientSecret: String,
+        consentAcquired: Bool?
     ) -> Future<FinancialConnectionsInstitutionList>
 
     func markLinkStepUpAuthenticationVerified(
@@ -659,13 +660,15 @@ extension STPAPIClient: FinancialConnectionsAPIClient {
     func selectNetworkedAccounts(
         selectedAccountIds: [String],
         clientSecret: String,
-        consumerSessionClientSecret: String
+        consumerSessionClientSecret: String,
+        consentAcquired: Bool?
     ) -> Future<FinancialConnectionsInstitutionList> {
-        let parameters: [String: Any] = [
+        var parameters: [String: Any] = [
             "selected_accounts": selectedAccountIds,
             "client_secret": clientSecret,
             "consumer_session_client_secret": consumerSessionClientSecret,
         ]
+        parameters["consent_acquired"] = consentAcquired
         return post(resource: APIEndpointShareNetworkedAccount, parameters: parameters)
     }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsNetworkedAccountsResponse.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsNetworkedAccountsResponse.swift
@@ -11,6 +11,7 @@ struct FinancialConnectionsNetworkedAccountsResponse: Decodable {
     let data: [FinancialConnectionsPartnerAccount]
     let display: Display?
     let nextPaneOnAddAccount: FinancialConnectionsSessionManifest.NextPane?
+    let acquireConsentOnPrimaryCtaClick: Bool?
 
     struct Display: Decodable {
         let text: Text?

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerDataSource.swift
@@ -114,7 +114,8 @@ final class LinkAccountPickerDataSourceImplementation: LinkAccountPickerDataSour
         return apiClient.selectNetworkedAccounts(
             selectedAccountIds: selectedAccounts.map({ $0.id }),
             clientSecret: clientSecret,
-            consumerSessionClientSecret: consumerSession.clientSecret
+            consumerSessionClientSecret: consumerSession.clientSecret,
+            consentAcquired: networkedAccountsResponse?.acquireConsentOnPrimaryCtaClick
         )
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationDataSource.swift
@@ -67,7 +67,8 @@ final class NetworkingLinkStepUpVerificationDataSourceImplementation: Networking
         return apiClient.selectNetworkedAccounts(
             selectedAccountIds: selectedAccountIds,
             clientSecret: clientSecret,
-            consumerSessionClientSecret: consumerSession.clientSecret
+            consumerSessionClientSecret: consumerSession.clientSecret,
+            consentAcquired: nil
         )
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
@@ -96,7 +96,8 @@ class EmptyFinancialConnectionsAPIClient: FinancialConnectionsAPIClient {
     func attachBankAccountToLinkAccountSession(
         clientSecret: String,
         accountNumber: String,
-        routingNumber: String
+        routingNumber: String,
+        consumerSessionClientSecret: String?
     ) -> Future<FinancialConnectionsPaymentAccountResource> {
         return Promise<FinancialConnectionsPaymentAccountResource>()
     }
@@ -138,6 +139,7 @@ class EmptyFinancialConnectionsAPIClient: FinancialConnectionsAPIClient {
 
     func disableNetworking(
         disabledReason: String?,
+        clientSuggestedNextPaneOnDisableNetworking: String?,
         clientSecret: String
     ) -> Future<FinancialConnectionsSessionManifest> {
         Promise<StripeFinancialConnections.FinancialConnectionsSessionManifest>()
@@ -159,7 +161,8 @@ class EmptyFinancialConnectionsAPIClient: FinancialConnectionsAPIClient {
     func selectNetworkedAccounts(
         selectedAccountIds: [String],
         clientSecret: String,
-        consumerSessionClientSecret: String
+        consumerSessionClientSecret: String,
+        consentAcquired: Bool?
     ) -> StripeCore.Future<StripeFinancialConnections.FinancialConnectionsInstitutionList> {
         return Promise<StripeFinancialConnections.FinancialConnectionsInstitutionList>()
     }


### PR DESCRIPTION
## Summary

This PR:
- This PR adds support for "mid flow consent." IF a user goes through the "Return User Experience [RUX]" by tapping "manual entry" in consent, then we will show an "Agree and continue" button in RUX/Link Account Picker.
- The visual changes are run by the backend.
- This PR specifically passes on some parameters from API calls: it gets `acquireConsentOnPrimaryCtaClick`, and uses it to pass into `selectNetworkedAccounts`.
- We are replicating [this Stripe.js PR](https://git.corp.stripe.com/stripe-internal/stripe-js-v3/pull/23488)

Context:
- Financial Connections is implementing support for "networking manual entry." This feature allows a user to enter their manually entered account _once_, and then we will allow them to reuse it later through Link. 
- This is just one PR of many where each PR will be merged to a feature branch `fc-networkingmanualentry`.
- It's expected that this PR may have some gaps or TODO's because its going to a feature branch. That being said, we still want to make sure there's no glaring logic issues/bugs. 

## Testing

API param is returned from response:
<img width="1698" alt="acquireConsentOnClick" src="https://github.com/user-attachments/assets/e0620102-a3e4-414e-a477-c294e0bed3d0">

API param is passed into response:
<img width="1021" alt="consent_acquired_passed_in" src="https://github.com/user-attachments/assets/4ac28259-7ebb-45ea-a2e7-60df098741be">

Video of the experience:

https://github.com/user-attachments/assets/b99c847b-d5de-43b3-820e-493b7e6fa38b
