### PR TITLE
Run unmocked tests on release

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -51,7 +51,7 @@ stages:
     - lokalise-upload: {}
   stage-releases-run-all:
     workflows:
-    - framework-tests: {}
+    - framework-tests-no-mocks: {}
     - test-builds-xcode-15: {}
     - test-builds-xcode-15-release: {}
     - test-builds-vision: {}


### PR DESCRIPTION
## Summary
Run unmocked tests on releases too

## Motivation
These tests should run nightly and before releases.

## Testing
CI

