### PR TITLE
[BANKCON-11476] FC - Use consumer publishable key once verified

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
@@ -185,7 +185,7 @@ extension STPAPIClient: FinancialConnectionsAPIClient {
         clientSecret: String,
         returnURL: String?
     ) -> Future<FinancialConnectionsSynchronize> {
-        let parameters: [String: Any] = [
+        var parameters: [String: Any] = [
             "expand": ["manifest.active_auth_session"],
             "client_secret": clientSecret,
             "mobile": {
@@ -199,6 +199,9 @@ extension STPAPIClient: FinancialConnectionsAPIClient {
             }(),
             "locale": Locale.current.toLanguageTag(),
         ]
+        if let publishableKey {
+            parameters["key"] = publishableKey
+        }
         return self.post(
             resource: "financial_connections/sessions/synchronize",
             parameters: parameters

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginDataSource.swift
@@ -82,7 +82,7 @@ final class LinkLoginDataSourceImplementation: LinkLoginDataSource {
     func attachToAccountAndSynchronize(
         with linkSignUpResponse: LinkSignUpResponse
     ) -> Future<FinancialConnectionsSynchronize> {
-        attachLinkConsumerToLinkAccountSessionResponse(
+        attachLinkConsumerToLinkAccountSession(
             linkAccountSession: clientSecret,
             consumerSessionClientSecret: linkSignUpResponse.consumerSession.clientSecret
         )
@@ -100,7 +100,7 @@ final class LinkLoginDataSourceImplementation: LinkLoginDataSource {
         }
     }
 
-    private func attachLinkConsumerToLinkAccountSessionResponse(
+    private func attachLinkConsumerToLinkAccountSession(
         linkAccountSession: String,
         consumerSessionClientSecret: String
     ) -> Future<AttachLinkConsumerToLinkAccountSessionResponse> {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowDataManager.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowDataManager.swift
@@ -31,7 +31,9 @@ protocol NativeFlowDataManager: AnyObject {
     var saveToLinkWithStripeSucceeded: Bool? { get set }
     var lastPaneLaunched: FinancialConnectionsSessionManifest.NextPane? { get set }
     var customSuccessPaneMessage: String? { get set }
+    var consumerPublishableKey: String? { get set }
 
+    func updateApiClient(with publishableKey: String)
     func resetState(withNewManifest newManifest: FinancialConnectionsSessionManifest)
     func completeFinancialConnectionsSession(terminalError: String?) -> Future<StripeAPI.FinancialConnectionsSession>
 }
@@ -68,10 +70,10 @@ class NativeFlowAPIDataManager: NativeFlowDataManager {
     }
     let returnURL: String?
     let consentPaneModel: FinancialConnectionsConsent?
-    let apiClient: FinancialConnectionsAPIClient
     let clientSecret: String
     let analyticsClient: FinancialConnectionsAnalyticsClient
 
+    var apiClient: FinancialConnectionsAPIClient
     var institution: FinancialConnectionsInstitution?
     var authSession: FinancialConnectionsAuthSession?
     var linkedAccounts: [FinancialConnectionsPartnerAccount]?
@@ -84,6 +86,7 @@ class NativeFlowAPIDataManager: NativeFlowDataManager {
     var saveToLinkWithStripeSucceeded: Bool?
     var lastPaneLaunched: FinancialConnectionsSessionManifest.NextPane?
     var customSuccessPaneMessage: String?
+    var consumerPublishableKey: String?
 
     init(
         manifest: FinancialConnectionsSessionManifest,
@@ -106,6 +109,10 @@ class NativeFlowAPIDataManager: NativeFlowDataManager {
         // If the server returns active institution use that, otherwise resort to initial institution.
         self.institution = manifest.activeInstitution ?? manifest.initialInstitution
         didUpdateManifest()
+    }
+
+    func updateApiClient(with publishableKey: String) {
+        self.apiClient = STPAPIClient(publishableKey: publishableKey)
     }
 
     func completeFinancialConnectionsSession(terminalError: String?) -> Future<StripeAPI.FinancialConnectionsSession> {


### PR DESCRIPTION
Resolves: https://jira.corp.stripe.com/browse/BANKCON-11476

## Summary

In the native instant debits flow, we now use the consumer's publishable key (**CPK**) rather than the merchant's (**MPK**) once the Link user is verified. Here are the different flows:

NUX (in the instant debits flow, from the link login pane):
1. `/sign_up`: Called using the **MPK**. From this we get the consumer's publishable key and the consumer session data.
2. `/attach_link_consumer_to_link_account_session`: Called using the **MPK**. We don't use anything from the response to this call, we just want to know if it was successful.
3. `/synchronize`: Called using the **CPK**. From this we get the next pane. Once this completes, we set the CPK to be used for all subsequent API requests.

RUX (after a valid OTP is entered, in the instant debits flow, from the network verification pane): 
1. `/confirm_verification`: Called using the **MPK**. This already happens as part of the network verification pane.
2. `/attach_link_consumer_to_link_account_session`: Called using the **MPK**. We don't use anything from the response to this call, we just want to know if it was successful.
3. `/synchronize`: Called using the **CPK**. From this we get the next pane. Once this completes, we set the CPK to be used for all subsequent API requests.

## Motivation

Part of the [Native Instant Debits project](https://docs.google.com/document/d/1k0tv4jUxL9QSxni1QEo-ZiHG_HDCX9gAMo2qKE8kqbQ/edit?usp=sharing). This fixes some of the known issues mentioned in https://github.com/stripe/stripe-ios/pull/3848.

## Testing

RUX: 

https://github.com/user-attachments/assets/1315470a-3ba7-447b-9c85-194cb341c8d4

NUX:

https://github.com/user-attachments/assets/01b77347-527e-47f3-b8aa-2a26f6c33569

## Changelog

N/a
