### PR TITLE
Fix some test code erroneously using background queue & race condition in Async.swift

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -625,7 +625,7 @@ extension PlaygroundController {
             return
         case .deferred_csc:
             if settings.integrationType == .deferred_csc {
-                DispatchQueue.global(qos: .background).async {
+                DispatchQueue.global(qos: .userInteractive).asyncAfter(deadline: .now() + 1) {
                     intentCreationCallback(.success(self.clientSecret!))
                 }
             }

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/SessionFetcherTests.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/SessionFetcherTests.swift
@@ -77,7 +77,7 @@ class SessionFetcherTests: XCTestCase {
             accountFetcher: accountFetcher
         )
 
-        fetcher.fetchSession().observe(on: nil) { (result) in
+        fetcher.fetchSession().observe { (result) in
             switch result {
             case .success(let session):
                 XCTAssertEqual(session.accounts.data.count, 0)
@@ -96,7 +96,7 @@ class SessionFetcherTests: XCTestCase {
             accountFetcher: accountFetcher
         )
 
-        fetcher.fetchSession().observe(on: nil) { (result) in
+        fetcher.fetchSession().observe { (result) in
             switch result {
             case .success(let session):
                 XCTAssertEqual(session.accounts.data.count, 1)

--- a/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/ViewControllers/DocumentCaptureViewControllerTest.swift
+++ b/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/ViewControllers/DocumentCaptureViewControllerTest.swift
@@ -11,7 +11,6 @@ import Foundation
 @_spi(STP) import StripeCameraCoreTestUtils
 @_spi(STP) import StripeCore
 @_spi(STP) import StripeCoreTestUtils
-import StripeCoreTestUtils
 import XCTest
 
 @testable@_spi(STP) import StripeCameraCore
@@ -38,7 +37,7 @@ final class DocumentCaptureViewControllerTest: XCTestCase {
 
     let mockError = NSError(domain: "mock_error", code: 100, userInfo: nil)
 
-    override class func setUp() {
+    override static func setUp() {
         super.setUp()
         mockSampleBuffer = CapturedImageMock.frontDriversLicense.image.convertToSampleBuffer()
         guard let mockVerificationPage = try? VerificationPageMock.response200.make() else {
@@ -329,9 +328,14 @@ final class DocumentCaptureViewControllerTest: XCTestCase {
         // Request to save data
         vc.saveOrFlipDocument(scannedImage: mockBackImage, documentSide: .back)
 
-        guard case .success = mockSheetController.backUploadedDocumentsResult else {
-            return XCTFail("Expected success result")
+        let e = expectation(description: "back upload result")
+        mockDocumentUploader.backUploadPromise.observe { _ in
+            guard case .success = self.mockSheetController.backUploadedDocumentsResult else {
+                return XCTFail("Expected success result")
+            }
+            e.fulfill()
         }
+        waitForExpectations(timeout: 1)
 
         // Verify state
         verify(

--- a/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/ViewControllers/DocumentCaptureViewControllerTest.swift
+++ b/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/ViewControllers/DocumentCaptureViewControllerTest.swift
@@ -302,10 +302,14 @@ final class DocumentCaptureViewControllerTest: XCTestCase {
 
         // Request to save data
         vc.saveOrFlipDocument(scannedImage: mockFrontImage, documentSide: .front)
-
-        guard case .success = mockSheetController.frontUploadedDocumentsResult else {
-            return XCTFail("Expected success result")
+        let e = expectation(description: "back upload result")
+        mockDocumentUploader.frontUploadPromise.observe { _ in
+            guard case .success = self.mockSheetController.frontUploadedDocumentsResult else {
+                return XCTFail("Expected success result")
+            }
+            e.fulfill()
         }
+        waitForExpectations(timeout: 1)
 
         // Verify state
         verify(

--- a/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/ViewControllers/DocumentFileUploadViewControllerTest.swift
+++ b/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/ViewControllers/DocumentFileUploadViewControllerTest.swift
@@ -151,14 +151,19 @@ final class DocumentFileUploadViewControllerTest: XCTestCase {
         // click continue button to upload back
         vc.didTapContinueButton()
         // Verify data saved and transitioned to next screen
-        guard case .success(let front) = mockSheetController.frontUploadedDocumentsResult else {
-            return XCTFail("Expected success result")
+        let e = expectation(description: "back upload result")
+        mockDocumentUploader.frontUploadPromise.observe { _ in
+            guard case .success(let front) = self.mockSheetController.frontUploadedDocumentsResult else {
+                return XCTFail("Expected success result")
+            }
+            guard case .success(let back) = self.mockSheetController.backUploadedDocumentsResult else {
+                return XCTFail("Expected success result")
+            }
+            XCTAssertEqual(front, frontFileData)
+            XCTAssertEqual(back, backFileData)
+            e.fulfill()
         }
-        guard case .success(let back) = mockSheetController.backUploadedDocumentsResult else {
-            return XCTFail("Expected success result")
-        }
-        XCTAssertEqual(front, frontFileData)
-        XCTAssertEqual(back, backFileData)
+        waitForExpectations(timeout: 1)
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheet.swift
@@ -184,21 +184,19 @@ public class CustomerSheet {
             loadSpecsPromise.resolve(with: ())
         }
 
-        loadSpecsPromise.observe { _ in
-            DispatchQueue.main.async {
-                let isApplePayEnabled = StripeAPI.deviceSupportsApplePay() && self.configuration.applePayEnabled
-                let savedPaymentSheetVC = CustomerSavedPaymentMethodsViewController(savedPaymentMethods: savedPaymentMethods,
-                                                                                    selectedPaymentMethodOption: selectedPaymentMethodOption,
-                                                                                    merchantSupportedPaymentMethodTypes: merchantSupportedPaymentMethodTypes,
-                                                                                    configuration: self.configuration,
-                                                                                    customerSheetDataSource: customerSheetDataSource,
-                                                                                    isApplePayEnabled: isApplePayEnabled,
-                                                                                    paymentMethodRemove: paymentMethodRemove,
-                                                                                    cbcEligible: cbcEligible,
-                                                                                    csCompletion: self.csCompletion,
-                                                                                    delegate: self)
-                self.bottomSheetViewController.setViewControllers([savedPaymentSheetVC])
-            }
+        loadSpecsPromise.observe(on: .main) { _ in
+            let isApplePayEnabled = StripeAPI.deviceSupportsApplePay() && self.configuration.applePayEnabled
+            let savedPaymentSheetVC = CustomerSavedPaymentMethodsViewController(savedPaymentMethods: savedPaymentMethods,
+                                                                                selectedPaymentMethodOption: selectedPaymentMethodOption,
+                                                                                merchantSupportedPaymentMethodTypes: merchantSupportedPaymentMethodTypes,
+                                                                                configuration: self.configuration,
+                                                                                customerSheetDataSource: customerSheetDataSource,
+                                                                                isApplePayEnabled: isApplePayEnabled,
+                                                                                paymentMethodRemove: paymentMethodRemove,
+                                                                                cbcEligible: cbcEligible,
+                                                                                csCompletion: self.csCompletion,
+                                                                                delegate: self)
+            self.bottomSheetViewController.setViewControllers([savedPaymentSheetVC])
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/CustomerSheetSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/CustomerSheetSnapshotTests.swift
@@ -560,32 +560,25 @@ class CustomerSheetSnapshotTests: STPSnapshotTestCase {
 
         cs.present(from: vc) { _ in }
 
-        // Payment sheet usually takes anywhere between 50ms-200ms (but once in a while 2-3 seconds).
+        // Customer sheet usually takes anywhere between 50ms-200ms (but once in a while 2-3 seconds).
         // to present with the expected content. When the sheet is presented, it initially shows a loading screen,
         // and when it is done loading, the loading screen is replaced with the expected content.
-        // Therefore, the following code polls every 50 milliseconds to check if the LoadingViewController
-        // has been removed.  If the LoadingViewController is not there (or we reach the maximum number of times to poll),
+        // Therefore, the following code polls every 0.1 seconds to check if the LoadingViewController
+        // has been removed. If the LoadingViewController is not there (or we reach the maximum number of times to poll),
         // we assume the content has been loaded and continue.
-        let presentingExpectation = XCTestExpectation(description: "Presenting payment sheet")
-        DispatchQueue.global(qos: .background).async {
-            var isLoading = true
-            while isLoading {
-                DispatchQueue.main.sync {
-                    guard
-                        (self.cs.bottomSheetViewController.contentStack.first as? LoadingViewController)
-                            != nil
-                    else {
-                        isLoading = false
-                        presentingExpectation.fulfill()
-                        return
-                    }
-                }
-                if isLoading {
-                    usleep(50000)  // 50ms
+        let loadFinishedExpectation = XCTestExpectation(description: "Load finished")
+        func pollForLoadingFinished() {
+            if !(cs.bottomSheetViewController.contentStack.first is LoadingViewController) {
+                loadFinishedExpectation.fulfill()
+            } else {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+                    guard self != nil else { return }
+                    pollForLoadingFinished()
                 }
             }
         }
-        wait(for: [presentingExpectation], timeout: 5)
+        pollForLoadingFinished()
+        wait(for: [loadFinishedExpectation], timeout: 5)
 
         cs.bottomSheetViewController.presentationController!.overrideTraitCollection = UITraitCollection(
             preferredContentSizeCategory: preferredContentSizeCategory

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetSnapshotTests.swift
@@ -1186,7 +1186,7 @@ class PaymentSheetSnapshotTests: STPSnapshotTestCase {
         DispatchQueue.main.asyncAfter(deadline: .now() + numSeconds) {
             waitExpectation.fulfill()
         }
-        wait(for: [waitExpectation], timeout: 10.0)
+        wait(for: [waitExpectation])
     }
 
     func verify(

--- a/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+Payments.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+Payments.swift
@@ -920,7 +920,7 @@ extension STPAPIClient {
         )
 
         var params = [
-            "app": String(data: appData ?? Data(), encoding: .utf8) ?? "",
+            "app": String(decoding: appData ?? Data(), as: UTF8.self),
             "source": sourceID,
         ]
         if let returnURLString = returnURLString {

--- a/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+Payments.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+Payments.swift
@@ -1145,7 +1145,8 @@ extension STPAPIClient {
                         shared_lastError = error
                     }
                     if let paymentMethods = deserializer?.paymentMethods {
-                        shared_allPaymentMethods.append(contentsOf: paymentMethods)
+                        // For unknown reasons, `append(contentsOf:` here sometimes causes an EXC_BAD_INSTRUCTION if you repeatedly run tests
+                        paymentMethods.forEach { shared_allPaymentMethods.append($0) }
                     }
                     group.leave()
                 }
@@ -1248,7 +1249,7 @@ extension STPAPIClient {
         customerId: String,
         fromCustomerUsing ephemeralKeySecret: String
     ) async throws {
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) -> Void in
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             detachPaymentMethodRemoveDuplicates(paymentMethodID,
                                                 customerId: customerId,
                                                 fromCustomerUsing: ephemeralKeySecret) { error in
@@ -1281,7 +1282,7 @@ extension STPAPIClient {
         _ paymentMethodID: String,
         fromCustomerUsing ephemeralKeySecret: String
     ) async throws {
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) -> Void in
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             detachPaymentMethod(paymentMethodID, fromCustomerUsing: ephemeralKeySecret) { error in
                 if let error = error {
                     continuation.resume(throwing: error)
@@ -1315,7 +1316,7 @@ extension STPAPIClient {
         _ paymentMethodID: String,
         customerID: String,
         ephemeralKeySecret: String) async throws {
-            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) -> Void in
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
                 attachPaymentMethod(paymentMethodID, customerID: customerID, ephemeralKeySecret: ephemeralKeySecret) { error in
                     if let error = error {
                         continuation.resume(throwing: error)

--- a/StripeUICore/StripeUICore/Source/Elements/Factories/Address/AddressSpecProvider.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Factories/Address/AddressSpecProvider.swift
@@ -58,15 +58,6 @@ let addressDataFilename = "localized_address_data"
         }
     }
 
-    /// Loads address specs with a promise
-    public func loadAddressSpecs() -> Promise<Void> {
-        let promise = Promise<Void>()
-        loadAddressSpecs {
-            promise.resolve(with: ())
-        }
-        return promise
-    }
-
     func addressSpec(for country: String) -> AddressSpec {
         guard let spec = addressSpecs[country] else {
             return AddressSpec.default


### PR DESCRIPTION
## Summary
I noticed these snapshot tests were flakey b/c they're using the background queue, which is unreliable & can take seconds (I saw up to 6 seconds!) to execute a work item. I originally just made them use `.userInteractive` but realized they could be simplified more.

I ran the CustomerSheetSnapshotTests tests 20 times in a row and realized there's still a flake - a race condition in `Async.swift` when you observe at the ~same time you set result! I put access to its two properties, `result` and `callbacks`, behind a serial queue.  The Promise's `observe` callback is now called on the main thread by default rather than the thread of the caller that set `result`.

Finally, running PayymentSheetSnapshotTests 20 times in a row showed a bizarre crash where https://github.com/stripe/stripe-ios/blob/e9b3c5bb/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift#L316 crashes accessing `paymentMethod.type` b/c `paymentMethod` is `Swift.__EmptyDictionarySingleton` instead of `STPPaymentMethodType`. I "fixed" that too, in `STPAPIClient+Payments.swift`

## Testing
Ran the snapshot tests 40 times in a row.  Before, it would consistently flake. Now it doesn't.
```
Test Suite 'CustomerSheetSnapshotTests' passed at 2024-07-31 12:13:54.387.
	 Executed 1720 tests, with 0 failures (0 unexpected) in 701.713 (702.001) seconds
```

## Changelog
This did fix a real bug but it's hard to know if it has an impact outside of tests.