### PR TITLE
Financial Connections: for networking manual entry, mid-flow consent, handled extra edge cases like step up.

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerDataSource.swift
@@ -30,7 +30,7 @@ protocol LinkAccountPickerDataSource: AnyObject {
     func selectNetworkedAccounts(
         _ selectedAccounts: [FinancialConnectionsPartnerAccount]
     ) -> Future<FinancialConnectionsInstitutionList>
-    func markConsentAcquired() -> Promise<FinancialConnectionsSessionManifest>
+    func markConsentAcquired() -> Future<FinancialConnectionsSessionManifest>
 }
 
 final class LinkAccountPickerDataSourceImplementation: LinkAccountPickerDataSource {
@@ -124,7 +124,7 @@ final class LinkAccountPickerDataSourceImplementation: LinkAccountPickerDataSour
         )
     }
 
-    func markConsentAcquired() -> Promise<FinancialConnectionsSessionManifest> {
+    func markConsentAcquired() -> Future<FinancialConnectionsSessionManifest> {
         return apiClient.markConsentAcquired(clientSecret: clientSecret)
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerDataSource.swift
@@ -23,12 +23,14 @@ protocol LinkAccountPickerDataSource: AnyObject {
     var nextPaneOnAddAccount: FinancialConnectionsSessionManifest.NextPane? { get set }
     var analyticsClient: FinancialConnectionsAnalyticsClient { get }
     var dataAccessNotice: FinancialConnectionsDataAccessNotice? { get }
+    var acquireConsentOnPrimaryCtaClick: Bool { get }
 
     func updateSelectedAccounts(_ selectedAccounts: [FinancialConnectionsAccountTuple])
     func fetchNetworkedAccounts() -> Future<FinancialConnectionsNetworkedAccountsResponse>
     func selectNetworkedAccounts(
         _ selectedAccounts: [FinancialConnectionsPartnerAccount]
     ) -> Future<FinancialConnectionsInstitutionList>
+    func markConsentAcquired() -> Promise<FinancialConnectionsSessionManifest>
 }
 
 final class LinkAccountPickerDataSourceImplementation: LinkAccountPickerDataSource {
@@ -68,6 +70,9 @@ final class LinkAccountPickerDataSourceImplementation: LinkAccountPickerDataSour
     }
     private let consentDataAccessNotice: FinancialConnectionsDataAccessNotice?
     private var networkedAccountsResponse: FinancialConnectionsNetworkedAccountsResponse?
+    var acquireConsentOnPrimaryCtaClick: Bool {
+        return networkedAccountsResponse?.acquireConsentOnPrimaryCtaClick ?? false
+    }
 
     private(set) var selectedAccounts: [FinancialConnectionsAccountTuple] = [] {
         didSet {
@@ -115,7 +120,11 @@ final class LinkAccountPickerDataSourceImplementation: LinkAccountPickerDataSour
             selectedAccountIds: selectedAccounts.map({ $0.id }),
             clientSecret: clientSecret,
             consumerSessionClientSecret: consumerSession.clientSecret,
-            consentAcquired: networkedAccountsResponse?.acquireConsentOnPrimaryCtaClick
+            consentAcquired: acquireConsentOnPrimaryCtaClick
         )
+    }
+
+    func markConsentAcquired() -> Promise<FinancialConnectionsSessionManifest> {
+        return apiClient.markConsentAcquired(clientSecret: clientSecret)
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
@@ -268,7 +268,28 @@ final class LinkAccountPickerViewController: UIViewController {
                 pane: .linkAccountPicker
             )
 
-        if nextPane == .success {
+        if
+            dataSource.acquireConsentOnPrimaryCtaClick,
+            let selectedAccount = dataSource.selectedAccounts.first(
+                // to better handle multi-select, we want to ensure that
+                // the account we pick has a `drawerOnSelection`
+                where: { $0.accountPickerAccount.drawerOnSelection != nil }
+            ),
+            let drawerOnSelection = selectedAccount.accountPickerAccount.drawerOnSelection,
+            IsAccountUpdateRequired(forAccount: selectedAccount.partnerAccount)
+        {
+            footerView?.showLoadingView(true)
+            dataSource
+                .markConsentAcquired()
+                .observe { [weak self] _ in
+                    guard let self = self else { return }
+                    footerView?.showLoadingView(false)
+                    self.presentAccountUpdateRequiredDrawer(
+                        drawerOnSelection: drawerOnSelection,
+                        partnerAccount: selectedAccount.partnerAccount
+                    )
+                }
+        } else if nextPane == .success {
             footerView?.showLoadingView(true)
             // prevent user from accidentally pressing
             // a button on the screen; this is safe because
@@ -297,44 +318,164 @@ final class LinkAccountPickerViewController: UIViewController {
                     }
                 }
         } else {
-            // we should never push here to these panes since we will present
-            // as sheet when the user selects an account that needs to be repaired
-            // or requires additional permissions (supportability)
-            if nextPane == .partnerAuth {
-                dataSource
-                    .analyticsClient
-                    .logUnexpectedError(
-                        FinancialConnectionsSheetError
-                            .unknown(
-                                debugDescription: "Connecting a supportability account, but user shouldn't be able to."
-                            ),
-                        errorName: "ConnectSupportabilityAccountError",
-                        pane: .linkAccountPicker
+
+            let pushToNextPane = { [weak self] in
+                guard let self = self else { return }
+                // we should never push here to these panes here since we will present
+                // as sheet when the user selects an account that needs to be repaired
+                // or requires additional permissions (supportability)
+                if nextPane == .partnerAuth {
+                    dataSource
+                        .analyticsClient
+                        .logUnexpectedError(
+                            FinancialConnectionsSheetError
+                                .unknown(
+                                    debugDescription: "Connecting a supportability account, but user shouldn't be able to."
+                                ),
+                            errorName: "ConnectSupportabilityAccountError",
+                            pane: .linkAccountPicker
+                        )
+                    delegate?.linkAccountPickerViewController(
+                        self,
+                        didRequestNextPane: .institutionPicker
                     )
-                delegate?.linkAccountPickerViewController(
-                    self,
-                    didRequestNextPane: .institutionPicker
-                )
-            } else if nextPane == .bankAuthRepair {
-                dataSource
-                    .analyticsClient
-                    .logUnexpectedError(
-                        FinancialConnectionsSheetError
-                            .unknown(
-                                debugDescription: "Connecting a repair account, but user shouldn't be able to."
-                            ),
-                        errorName: "ConnectRepairAccountError",
-                        pane: .linkAccountPicker
+                } else if nextPane == .bankAuthRepair {
+                    dataSource
+                        .analyticsClient
+                        .logUnexpectedError(
+                            FinancialConnectionsSheetError
+                                .unknown(
+                                    debugDescription: "Connecting a repair account, but user shouldn't be able to."
+                                ),
+                            errorName: "ConnectRepairAccountError",
+                            pane: .linkAccountPicker
+                        )
+                    delegate?.linkAccountPickerViewController(
+                        self,
+                        didRequestNextPane: .institutionPicker
                     )
-                delegate?.linkAccountPickerViewController(
-                    self,
-                    didRequestNextPane: .institutionPicker
-                )
+                } else {
+                    // non-sheet next pane -- likely step up
+                    delegate?.linkAccountPickerViewController(self, didRequestNextPane: nextPane)
+                }
+            }
+
+            if dataSource.acquireConsentOnPrimaryCtaClick {
+                footerView?.showLoadingView(true)
+                dataSource
+                    .markConsentAcquired()
+                    .observe { [weak self] _ in
+                        guard let self = self else { return }
+                        footerView?.showLoadingView(false)
+                        pushToNextPane()
+                    }
             } else {
-                // non-sheet next pane -- likely step up
-                delegate?.linkAccountPickerViewController(self, didRequestNextPane: nextPane)
+                pushToNextPane()
             }
         }
+    }
+
+    // the "account update required drawer" offers the user two choices:
+    // 1. re-link bank account by going through the bank auth flow again (partner_auth pane)
+    // 2. repair the bank account (bank_auth_repair)
+    private func presentAccountUpdateRequiredDrawer(
+        drawerOnSelection: FinancialConnectionsGenericInfoScreen,
+        partnerAccount: FinancialConnectionsPartnerAccount
+    ) {
+        let deselectPreviouslySelectedAccount = { [weak self] in
+            guard let self = self else { return }
+            self.dataSource.updateSelectedAccounts(
+                self.dataSource.selectedAccounts.filter(
+                    { $0.partnerAccount.id != partnerAccount.id }
+                )
+            )
+        }
+
+        var delayDeselectingAccounts = false
+        let willDismissSheet = {
+            if delayDeselectingAccounts {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                    deselectPreviouslySelectedAccount()
+                }
+            } else {
+                deselectPreviouslySelectedAccount()
+            }
+        }
+
+        let didSelectContinue: () -> Void = { [weak self] in
+            guard let self else { return }
+            if partnerAccount.nextPaneOnSelection == .partnerAuth {
+                if let institution = partnerAccount.institution {
+                    self.delegate?.linkAccountPickerViewController(
+                        self,
+                        requestedPartnerAuthWithInstitution: institution
+                    )
+                } else {
+                    self.delegate?.linkAccountPickerViewController(
+                        self,
+                        didRequestNextPane: .institutionPicker
+                    )
+                }
+            }
+            // nextPaneOnSelection == bankAuthRepair
+            else {
+                dataSource
+                    .analyticsClient
+                    .logUnexpectedError(
+                        FinancialConnectionsSheetError
+                            .unknown(
+                                debugDescription: "Updating a repair account, but repairs are not supported in Mobile."
+                            ),
+                        errorName: "UpdateRepairAccountError",
+                        pane: .linkAccountPicker
+                    )
+                delegate?.linkAccountPickerViewController(
+                    self,
+                    didRequestNextPane: .institutionPicker
+                )
+            }
+        }
+
+        let genericInfoViewController = GenericInfoViewController(
+            genericInfoScreen: drawerOnSelection,
+            theme: dataSource.manifest.theme,
+            panePresentationStyle: .sheet,
+            iconView: {
+                if let institutionIconUrl = partnerAccount.institution?.icon?.default {
+                    let institutionIconView = InstitutionIconView()
+                    institutionIconView.setImageUrl(institutionIconUrl)
+                    return institutionIconView
+                } else {
+                    return nil
+                }
+            }(),
+            // "did select continue"
+            didSelectPrimaryButton: { genericInfoViewController in
+                // delay deselecting accounts while we animate to the
+                // next screen to reduce "animation jank" of
+                // the account getting deselected
+                delayDeselectingAccounts = true
+                genericInfoViewController.dismiss(
+                    animated: true,
+                    completion: {
+                        didSelectContinue()
+                    }
+                )
+            },
+            // "did select cancel"
+            didSelectSecondaryButton: { genericInfoViewController in
+                delayDeselectingAccounts = false
+                genericInfoViewController.dismiss(
+                    animated: true
+                )
+            },
+            didSelectURL: { [weak self] url in
+                guard let self = self else { return }
+                self.didSelectURLInTextFromBackend(url)
+            },
+            willDismissSheet: willDismissSheet
+        )
+        genericInfoViewController.present(on: self)
     }
 
     private func didSelectURLInTextFromBackend(_ url: URL) {
@@ -357,16 +498,19 @@ extension LinkAccountPickerViewController: LinkAccountPickerBodyViewDelegate {
         FeedbackGeneratorAdapter.selectionChanged()
 
         let selectedPartnerAccount = selectedAccountTuple.partnerAccount
-        let eligibleToPresentAccountUpdateRequiredDrawer: Bool = (
-            // repair flow
-            selectedPartnerAccount.nextPaneOnSelection == .bankAuthRepair
-                // supportability -- account requires re-sharing with additonal permissions
-                || selectedPartnerAccount.nextPaneOnSelection == .partnerAuth
+        let eligibleToPresentAccountUpdateRequiredDrawer = IsAccountUpdateRequired(
+            forAccount: selectedPartnerAccount
         )
 
         if let drawerOnSelection = selectedAccountTuple.accountPickerAccount.drawerOnSelection {
+            // we need the `eligibleToPresentAccountUpdateRequiredDrawer` check here because
+            // of confusing evolution of code...`drawerOnSelection` is used for two different
+            // types of drawers, so we check `eligibleToPresentAccountUpdateRequiredDrawer`
+            // to avoid presenting a drawer here because we will present another drawer later
             if !eligibleToPresentAccountUpdateRequiredDrawer {
-                let genericInfoViewController = GenericInfoViewController(
+                // the "account selection drawer" gives user an explanation of
+                // why they can't use this bank account
+                let accountSelectionDrawerViewController = GenericInfoViewController(
                     genericInfoScreen: drawerOnSelection,
                     theme: dataSource.manifest.theme,
                     panePresentationStyle: .sheet,
@@ -378,11 +522,13 @@ extension LinkAccountPickerViewController: LinkAccountPickerBodyViewDelegate {
                         self.didSelectURLInTextFromBackend(url)
                     }
                 )
-                genericInfoViewController.present(on: self)
+                accountSelectionDrawerViewController.present(on: self)
             } else {
-                // we will likely be presenting account update required drawer later in this function
+                // we will (likely) be presenting a different drawer further down the function
             }
 
+            // this extra `allowSelection` check is necessary because we override
+            // `isDisabled` for `AccountPickerRowView` when `drawerOnSelection != nil`
             if !selectedAccountTuple.accountPickerAccount.allowSelection {
                 // if the account is not selectable, then we return early
                 return
@@ -458,100 +604,15 @@ extension LinkAccountPickerViewController: LinkAccountPickerBodyViewDelegate {
                             )
                     }
 
-                    let deselectPreviouslySelectedAccount = { [weak self] in
-                        guard let self = self else { return }
-                        self.dataSource.updateSelectedAccounts(
-                            self.dataSource.selectedAccounts.filter(
-                                { $0.partnerAccount.id != selectedPartnerAccount.id }
-                            )
+                    // if we need to acquire consent, instead of showing the drawer now,
+                    // we will show the drawer when user presses the CTA where
+                    // pressing the CTA will make a call to `markConsentAcquired`
+                    if !dataSource.acquireConsentOnPrimaryCtaClick {
+                        presentAccountUpdateRequiredDrawer(
+                            drawerOnSelection: drawerOnSelection,
+                            partnerAccount: selectedPartnerAccount
                         )
                     }
-
-                    var delayDeselectingAccounts = false
-                    let willDismissSheet = {
-                        if delayDeselectingAccounts {
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-                                deselectPreviouslySelectedAccount()
-                            }
-                        } else {
-                            deselectPreviouslySelectedAccount()
-                        }
-                    }
-
-                    let didSelectContinue: () -> Void = { [weak self] in
-                        guard let self else { return }
-                        if selectedPartnerAccount.nextPaneOnSelection == .partnerAuth {
-                            if let institution = selectedPartnerAccount.institution {
-                                self.delegate?.linkAccountPickerViewController(
-                                    self,
-                                    requestedPartnerAuthWithInstitution: institution
-                                )
-                            } else {
-                                self.delegate?.linkAccountPickerViewController(
-                                    self,
-                                    didRequestNextPane: .institutionPicker
-                                )
-                            }
-                        }
-                        // nextPaneOnSelection == bankAuthRepair
-                        else {
-                            dataSource
-                                .analyticsClient
-                                .logUnexpectedError(
-                                    FinancialConnectionsSheetError
-                                        .unknown(
-                                            debugDescription: "Updating a repair account, but repairs are not supported in Mobile."
-                                        ),
-                                    errorName: "UpdateRepairAccountError",
-                                    pane: .linkAccountPicker
-                                )
-                            delegate?.linkAccountPickerViewController(
-                                self,
-                                didRequestNextPane: .institutionPicker
-                            )
-                        }
-                    }
-
-                    let genericInfoViewController = GenericInfoViewController(
-                        genericInfoScreen: drawerOnSelection,
-                        theme: dataSource.manifest.theme,
-                        panePresentationStyle: .sheet,
-                        iconView: {
-                            if let institutionIconUrl = selectedPartnerAccount.institution?.icon?.default {
-                                let institutionIconView = InstitutionIconView()
-                                institutionIconView.setImageUrl(institutionIconUrl)
-                                return institutionIconView
-                            } else {
-                                return nil
-                            }
-                        }(),
-                        // "did select continue"
-                        didSelectPrimaryButton: { genericInfoViewController in
-                            // delay deselecting accounts while we animate to the
-                            // next screen to reduce "animation jank" of
-                            // the account getting deselected
-                            delayDeselectingAccounts = true
-                            genericInfoViewController.dismiss(
-                                animated: true,
-                                completion: {
-                                    didSelectContinue()
-                                }
-                            )
-                        },
-                        // "did select cancel"
-                        didSelectSecondaryButton: { genericInfoViewController in
-                            delayDeselectingAccounts = false
-                            genericInfoViewController.dismiss(
-                                animated: true
-                            )
-                        },
-                        didSelectURL: { [weak self] url in
-                            guard let self = self else { return }
-                            self.didSelectURLInTextFromBackend(url)
-                        },
-                        willDismissSheet: willDismissSheet
-                    )
-                    genericInfoViewController.present(on: self)
                 } else {
                     dataSource
                         .analyticsClient
@@ -614,4 +675,13 @@ private func ZipAccounts(
         }
     }
     return accountTuples
+}
+
+private func IsAccountUpdateRequired(
+    forAccount account: FinancialConnectionsPartnerAccount
+) -> Bool {
+    // repair flow
+    return account.nextPaneOnSelection == .bankAuthRepair
+    // supportability -- account requires re-sharing with additonal permissions
+    || account.nextPaneOnSelection == .partnerAuth
 }


### PR DESCRIPTION
## Summary

[Based on Stripe.js](https://git.corp.stripe.com/stripe-internal/stripe-js-v3/pull/23598)

This PR adds support for when a user in consent screen presses "manual entry" and logs into Link to see RUX/Link Account Picker.

The Link Account Picker will be modified where the button will now say "Agree and connect account" instead of "Connect account." This is because we need to get user consent (they skipped consent by clicking manual entry). 

This also causes a side-effect where the "update required" drawers, which used to be presented on tap, now need to be presented after consent.

So this PR:
1) If consent is required in RUX/Link Account Picker, a drawer will not be presented on tap
2) User consent will be acquired if `acquireConsentOnPrimaryCtaClick`
3) That same drawer will now be presented on click of agree

## Testing

### This Video Shows The Drawer Not Open On Tap (And Loading Spinner For Consent)

https://github.com/user-attachments/assets/1b55994b-7e98-4614-b3c5-c9eb8ffdf773

### This Video Shows Other Type Of Drawers Still Working

https://github.com/user-attachments/assets/3b69ce00-caaf-4fa6-bea8-f5ad4bc47c3c

### This Video Shows Step Up Verification Working (See Loading Spinner For Acquire Consent)

https://github.com/user-attachments/assets/4f70fa1f-8233-4d69-8de4-680ef1406cdf

<img width="1463" alt="image" src="https://github.com/user-attachments/assets/0e4e82c4-6395-4148-9352-d22791181f94">

### All The Existing Other Tests Pass!

```
FinancialConnectionsNetworkingUITests
    ✓ testNativeNetworkingManualEntryTestMode (107.516 seconds)
    ✓ testNativeNetworkingTestMode (133.921 seconds)
    ✓ testNativeNetworkingTestModeSignUpWithMultiSelectAndPrefilledEmail (32.324 seconds)
    ✓ testNativeNetworkingTestModeSignUpWithPrefilledEmailAndPhone (24.578 seconds)
FinancialConnectionsUITests
    ✓ testDataLiveModeOAuthNativeAuthFlow (29.810 seconds)
    ✓ testDataLiveModeOAuthWebAuthFlow (20.255 seconds)
    ✓ testDataTestModeOAuthNativeAuthFlow (20.578 seconds)
    ✓ testPaymentSearchInLiveModeNativeAuthFlow (25.280 seconds)
    ✓ testPaymentTestModeLegacyNativeAuthFlow (19.068 seconds)
    ✓ testPaymentTestModeManualEntryAutofill (13.591 seconds)
    ✓ testPaymentTestModeManualEntryNativeAuthFlow (24.333 seconds)
    ✓ testWebInstantDebitsFlow (13.146 seconds)


	 Executed 12 tests, with 0 failures (0 unexpected) in 464.400 (464.409) seconds
```