### PR TITLE
Add tests configuration for StripeConnect.

### DIFF
--- a/StripeConnect/StripeConnect.xcodeproj/project.pbxproj
+++ b/StripeConnect/StripeConnect.xcodeproj/project.pbxproj
@@ -8,6 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		41A2A5622C5A972A0077FC74 /* Placeholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41A2A5612C5A972A0077FC74 /* Placeholder.swift */; };
+		41A2A5642C5ABD6C0077FC74 /* StripeConnectTests.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = 41A2A5632C5ABD6C0077FC74 /* StripeConnectTests.xctestplan */; };
+		41A2A5682C5AC5120077FC74 /* StripeCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 41A2A5672C5AC5120077FC74 /* StripeCore.framework */; };
+		41D17A452C5A73A6007C6EE6 /* StripeConnect.docc in Sources */ = {isa = PBXBuildFile; fileRef = 41D17A442C5A73A6007C6EE6 /* StripeConnect.docc */; };
 		41D17A4B2C5A73A7007C6EE6 /* StripeConnect.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 41D17A402C5A73A6007C6EE6 /* StripeConnect.framework */; };
 		41D17A502C5A73A7007C6EE6 /* StripeConnectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D17A4F2C5A73A7007C6EE6 /* StripeConnectTests.swift */; };
 		41D17A512C5A73A7007C6EE6 /* StripeConnect.h in Headers */ = {isa = PBXBuildFile; fileRef = 41D17A432C5A73A6007C6EE6 /* StripeConnect.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -35,6 +38,8 @@
 
 /* Begin PBXFileReference section */
 		41A2A5612C5A972A0077FC74 /* Placeholder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Placeholder.swift; sourceTree = "<group>"; };
+		41A2A5632C5ABD6C0077FC74 /* StripeConnectTests.xctestplan */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = StripeConnectTests.xctestplan; sourceTree = "<group>"; };
+		41A2A5672C5AC5120077FC74 /* StripeCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = StripeCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		41D17A402C5A73A6007C6EE6 /* StripeConnect.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripeConnect.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		41D17A432C5A73A6007C6EE6 /* StripeConnect.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StripeConnect.h; sourceTree = "<group>"; };
 		41D17A4A2C5A73A7007C6EE6 /* StripeConnectTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StripeConnectTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -56,6 +61,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				41A2A5682C5AC5120077FC74 /* StripeCore.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -78,13 +84,23 @@
 			path = Source;
 			sourceTree = "<group>";
 		};
+		41A2A5662C5AC5110077FC74 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				41A2A5672C5AC5120077FC74 /* StripeCore.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		41D17A362C5A73A6007C6EE6 = {
 			isa = PBXGroup;
 			children = (
+				41A2A5632C5ABD6C0077FC74 /* StripeConnectTests.xctestplan */,
 				41D17A642C5A7429007C6EE6 /* BuildConfigurations */,
 				41D17A422C5A73A6007C6EE6 /* StripeConnect */,
 				41D17A4E2C5A73A7007C6EE6 /* StripeConnectTests */,
 				41D17A412C5A73A6007C6EE6 /* Products */,
+				41A2A5662C5AC5110077FC74 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -209,6 +225,9 @@
 				Base,
 			);
 			mainGroup = 41D17A362C5A73A6007C6EE6;
+			packageReferences = (
+				41A2A5652C5AC0290077FC74 /* XCRemoteSwiftPackageReference "ios-snapshot-test-case" */,
+			);
 			productRefGroup = 41D17A412C5A73A6007C6EE6 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -229,6 +248,7 @@
 				41D17A6D2C5A7429007C6EE6 /* StripeiOS-Shared.xcconfig in Resources */,
 				41D17A6A2C5A7429007C6EE6 /* StripeiOS Tests-Shared.xcconfig in Resources */,
 				41D17A6B2C5A7429007C6EE6 /* StripeiOS-Debug.xcconfig in Resources */,
+				41A2A5642C5ABD6C0077FC74 /* StripeConnectTests.xctestplan in Resources */,
 				41D17A672C5A7429007C6EE6 /* Project-Shared.xcconfig in Resources */,
 				41D17A682C5A7429007C6EE6 /* StripeiOS Tests-Debug.xcconfig in Resources */,
 				41D17A6E2C5A7429007C6EE6 /* Version.xcconfig in Resources */,
@@ -409,6 +429,17 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		41A2A5652C5AC0290077FC74 /* XCRemoteSwiftPackageReference "ios-snapshot-test-case" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/uber/ios-snapshot-test-case";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 8.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
 	};
 	rootObject = 41D17A372C5A73A6007C6EE6 /* Project object */;
 }

--- a/StripeConnect/StripeConnectTests.xctestplan
+++ b/StripeConnect/StripeConnectTests.xctestplan
@@ -1,0 +1,40 @@
+{
+  "configurations" : [
+    {
+      "id" : "E4E61B3B-0FEC-4C2A-BE82-E8558946FFBC",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false,
+    "environmentVariableEntries" : [
+      {
+        "key" : "FB_REFERENCE_IMAGE_DIR",
+        "value" : "$(SOURCE_ROOT)\/..\/Tests\/ReferenceImages"
+      }
+    ],
+    "locationScenario" : {
+      "identifier" : "San Francisco, CA, USA",
+      "referenceType" : "built-in"
+    },
+    "region" : "US",
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:..\/StripeConnect\/StripeConnect.xcodeproj",
+      "identifier" : "41D17A3F2C5A73A6007C6EE6",
+      "name" : "StripeConnect"
+    }
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:..\/StripeConnect\/StripeConnect.xcodeproj",
+        "identifier" : "41D17A492C5A73A7007C6EE6",
+        "name" : "StripeConnectTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -288,6 +288,12 @@ workflows:
         - destination: $DEFAULT_TEST_DEVICE
         - test_repetition_mode: retry_on_failure
         - maximum_test_repetitions: "2"
+        - scheme: StripeConnect
+    - xcode-test@4:
+        inputs:
+        - destination: $DEFAULT_TEST_DEVICE
+        - test_repetition_mode: retry_on_failure
+        - maximum_test_repetitions: "2"
         - scheme: StripeIdentity
     - xcode-test@4:
         inputs:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -66,6 +66,12 @@ platform :ios do
     end
   end
 
+  lane :stripeconnect_tests do
+    Dir.chdir('..') do
+      sh("./ci_scripts/test.rb --scheme StripeConnect --device '#{DEFAULT_TEST_DEVICE}' --version #{DEFAULT_TEST_VERSION} --retry-on-failure")
+    end
+  end
+
   lane :integration_all do
     Dir.chdir('..') do
       sh("./ci_scripts/test.rb --scheme 'IntegrationTester' --device '#{DEFAULT_TEST_DEVICE}' --version #{DEFAULT_TEST_VERSION} --retry-on-failure")
@@ -74,7 +80,11 @@ platform :ios do
 
   private_lane :legacy_tests do |options|
     # TODO(bmelts): would be nice to read these from modules.yaml
-    schemes = %w[StripeiOS StripePayments StripePaymentsUI StripePaymentSheet StripeCameraCore StripeCore StripeUICore StripeApplePay StripeCardScan]
+    schemes = %w[StripeiOS StripePayments StripePaymentsUI StripePaymentSheet StripeCameraCore StripeCore StripeUICore
+                 StripeApplePay StripeCardScan]
+
+    schemes << 'StripeConnect' if Gem::Version.new(options[:version]) >= Gem::Version.new('15.0')
+
     Dir.chdir('..') do
       schemes.each do |scheme|
         sh("./ci_scripts/test.rb --scheme '#{scheme}' --device '#{options[:device]}' --version #{options[:version]} --skip-snapshot-tests --retry-on-failure")

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -55,6 +55,14 @@ Generate new localized screenshots
 
 
 
+### ios stripeconnect_tests
+
+```sh
+[bundle exec] fastlane ios stripeconnect_tests
+```
+
+
+
 ### ios integration_all
 
 ```sh
@@ -75,6 +83,22 @@ Generate new localized screenshots
 
 ```sh
 [bundle exec] fastlane ios legacy_tests_14
+```
+
+
+
+### ios legacy_tests_15
+
+```sh
+[bundle exec] fastlane ios legacy_tests_15
+```
+
+
+
+### ios legacy_tests_16
+
+```sh
+[bundle exec] fastlane ios legacy_tests_16
 ```
 
 


### PR DESCRIPTION
## Summary
Follow up to #3868. This PR adds StripeCore as a dependency to StripeConnect and configures tests for StripeConnect.

https://jira.corp.stripe.com/browse/MXMOBILE-2439