### PR TITLE
Fix polling test

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/APIPollingHelperTests.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/APIPollingHelperTests.swift
@@ -209,7 +209,7 @@ final class APIPollingHelperTests: XCTestCase {
 
         // the `nil` happens after DispatchQueue.main.async, so wait a little bit
         let nilExpectation = expectation(description: "")
-        DispatchQueue.main.async {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             nilExpectation.fulfill()
         }
         wait(for: [nilExpectation], timeout: 1)


### PR DESCRIPTION
Timing difference from https://github.com/stripe/stripe-ios/pull/3869 - needs one or two more runloop cycles