### PR TITLE
[BANKCON-11476] Refactor FinancialConnectionsAPIClient to support using consumer pub key

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
+++ b/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		495539EE2C484DC200543D18 /* FinancialConnectionsTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495539ED2C484DC200543D18 /* FinancialConnectionsTheme.swift */; };
 		496A6AE72C29E0BB00D34F8E /* testmode@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 496A6AE62C29E0BB00D34F8E /* testmode@3x.png */; };
 		497142BC2C514B08000DFA64 /* FlowRouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 497142BB2C514B08000DFA64 /* FlowRouterTests.swift */; };
+		49A0B5862C5D2F3C00D697D9 /* FinancialConnectionsAPIClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49A0B5852C5D2F3C00D697D9 /* FinancialConnectionsAPIClientTests.swift */; };
 		49AC518C2C52DE2C00B712CC /* FinancialConnectionsLinkLoginPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49AC518B2C52DE2C00B712CC /* FinancialConnectionsLinkLoginPane.swift */; };
 		49C911372C597EAF00589E0D /* LinkLoginDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C911332C597EAF00589E0D /* LinkLoginDataSource.swift */; };
 		49C911392C597EAF00589E0D /* LinkLoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C911352C597EAF00589E0D /* LinkLoginViewController.swift */; };
@@ -320,6 +321,7 @@
 		495539ED2C484DC200543D18 /* FinancialConnectionsTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsTheme.swift; sourceTree = "<group>"; };
 		496A6AE62C29E0BB00D34F8E /* testmode@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testmode@3x.png"; sourceTree = "<group>"; };
 		497142BB2C514B08000DFA64 /* FlowRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowRouterTests.swift; sourceTree = "<group>"; };
+		49A0B5852C5D2F3C00D697D9 /* FinancialConnectionsAPIClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsAPIClientTests.swift; sourceTree = "<group>"; };
 		49AC518B2C52DE2C00B712CC /* FinancialConnectionsLinkLoginPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsLinkLoginPane.swift; sourceTree = "<group>"; };
 		49C911332C597EAF00589E0D /* LinkLoginDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinkLoginDataSource.swift; sourceTree = "<group>"; };
 		49C911352C597EAF00589E0D /* LinkLoginViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinkLoginViewController.swift; sourceTree = "<group>"; };
@@ -1053,6 +1055,7 @@
 				73AB8A480620B5C3567F453C /* FinancialConnectionsAnalyticsTest.swift */,
 				E05C2C5CDAA55CE700662040 /* FinancialConnectionsSessionTests.swift */,
 				20E7725EF317C3BD62ADF845 /* FinancialConnectionsSheetTests.swift */,
+				49A0B5852C5D2F3C00D697D9 /* FinancialConnectionsAPIClientTests.swift */,
 				4BFCD9C339634B71FC8F85E9 /* Info.plist */,
 				F8C7FDF59D906EA5C6B7A514 /* ManualEntryValidatorTests.swift */,
 				4E7D318EE807701AB3FCA17D /* MarkdownBoldAttributedStringTests.swift */,
@@ -1451,6 +1454,7 @@
 				846D1D7429B9E414744DEC99 /* FinancialConnectionsSheetTests.swift in Sources */,
 				C19996D0AC7E046DA87B6B32 /* ManualEntryValidatorTests.swift in Sources */,
 				779C729BB49FD4B99DCD517B /* MarkdownBoldAttributedStringTests.swift in Sources */,
+				49A0B5862C5D2F3C00D697D9 /* FinancialConnectionsAPIClientTests.swift in Sources */,
 				BF5F964E1CA6312755D4161E /* SessionFetcherTests.swift in Sources */,
 				ED818E10F37230678B9B73CC /* SoftLinkTests.swift in Sources */,
 				D9F35B3B31CA2E52055D6B1D /* StringExtensionsTests.swift in Sources */,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
@@ -22,8 +22,8 @@ final class FinancialConnectionsAPIClient {
     /// Returns the `consumerPublishableKey` for scenarios where it is valid to do so. That is;
     /// - `canUseConsumerKey` must be `true`. This is a flag passed in by each API request.
     /// - `isLinkWithStripe` must be `true`. This represents whether we're in the Instant Debits flow.
-    /// - `consumerSession` must be verfied. This represents whether we have a verified Link user.
-    private func consumerPublishableKeyProvider(canUseConsumerKey: Bool) -> String? {
+    /// - `consumerSession` must be verified. This represents whether we have a verified Link user.
+    func consumerPublishableKeyProvider(canUseConsumerKey: Bool) -> String? {
         guard canUseConsumerKey, isLinkWithStripe, consumerSession?.isVerified == true else {
             return nil
         }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/ConsumerSession/ConsumerSessionModels.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/ConsumerSession/ConsumerSessionModels.swift
@@ -6,11 +6,38 @@
 //
 
 import Foundation
+@_spi(STP) import StripeCore
 
 struct ConsumerSessionData: Decodable {
     let clientSecret: String
     let emailAddress: String
     let redactedFormattedPhoneNumber: String
+    let verificationSessions: [VerificationSession]
+
+    var isVerified: Bool {
+        verificationSessions.contains(where: { $0.state == .verified })
+    }
+}
+
+struct VerificationSession: Decodable {
+    enum SessionType: String, SafeEnumDecodable, Equatable {
+        case signUp = "signup"
+        case email = "email"
+        case sms = "sms"
+        case unparsable
+    }
+
+    enum SessionState: String, SafeEnumDecodable, Equatable {
+        case started
+        case failed
+        case verified
+        case canceled
+        case expired
+        case unparsable
+    }
+
+    let type: SessionType
+    let state: SessionState
 }
 
 struct LookupConsumerSessionResponse: Decodable {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostController.swift
@@ -60,14 +60,14 @@ class HostController {
     // MARK: - Init
 
     init(
-        apiClient: STPAPIClient,
+        apiClient: FinancialConnectionsAPIClient,
         analyticsClientV1: STPAnalyticsClientProtocol,
         clientSecret: String,
         returnURL: String?,
         publishableKey: String?,
         stripeAccount: String?
     ) {
-        self.apiClient = FinancialConnectionsAPIClient(apiClient: apiClient)
+        self.apiClient = apiClient
         self.analyticsClientV1 = analyticsClientV1
         self.clientSecret = clientSecret
         self.returnURL = returnURL

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostController.swift
@@ -39,7 +39,7 @@ class HostController {
 
     // MARK: - Properties
 
-    private let apiClient: STPAPIClient
+    private let apiClient: FinancialConnectionsAPIClient
     private let clientSecret: String
     private let returnURL: String?
     private let analyticsClient: FinancialConnectionsAnalyticsClient
@@ -67,7 +67,7 @@ class HostController {
         publishableKey: String?,
         stripeAccount: String?
     ) {
-        self.apiClient = apiClient
+        self.apiClient = FinancialConnectionsAPIClient(apiClient: apiClient)
         self.analyticsClientV1 = analyticsClientV1
         self.clientSecret = clientSecret
         self.returnURL = returnURL
@@ -112,7 +112,7 @@ extension HostController: HostViewControllerDelegate {
                 flow: flow,
                 killswitchActive: flowRouter.killswitchActive
             ),
-            apiClient: apiClient
+            apiClient: apiClient.backingAPIClient
         )
 
         switch flow {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostViewController.swift
@@ -52,7 +52,7 @@ final class HostViewController: UIViewController {
 
     private let analyticsClientV1: STPAnalyticsClientProtocol
     private let clientSecret: String
-    private let apiClient: STPAPIClient
+    private let apiClient: FinancialConnectionsAPIClient
     private let returnURL: String?
 
     private var lastError: Error?
@@ -63,7 +63,7 @@ final class HostViewController: UIViewController {
         analyticsClientV1: STPAnalyticsClientProtocol,
         clientSecret: String,
         returnURL: String?,
-        apiClient: STPAPIClient,
+        apiClient: FinancialConnectionsAPIClient,
         delegate: HostViewControllerDelegate?
     ) {
         self.analyticsClientV1 = analyticsClientV1
@@ -106,7 +106,7 @@ extension HostViewController {
 
         analyticsClientV1.log(
             analytic: FinancialConnectionsSheetInitialSynchronizeStarted(clientSecret: clientSecret),
-            apiClient: apiClient
+            apiClient: apiClient.backingAPIClient
         )
 
         apiClient
@@ -123,7 +123,7 @@ extension HostViewController {
                         success: result.success,
                         possibleError: result.error
                     ),
-                    apiClient: apiClient
+                    apiClient: apiClient.backingAPIClient
                 )
 
                 switch result {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/FinancialConnectionsSheet.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/FinancialConnectionsSheet.swift
@@ -211,8 +211,9 @@ final public class FinancialConnectionsSheet {
             }
         }
 
+        let financialConnectionsApiClient = FinancialConnectionsAPIClient(apiClient: apiClient)
         hostController = HostController(
-            apiClient: apiClient,
+            apiClient: financialConnectionsApiClient,
             analyticsClientV1: analyticsClient,
             clientSecret: financialConnectionsSessionClientSecret,
             returnURL: returnURL,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginDataSource.swift
@@ -91,9 +91,7 @@ final class LinkLoginDataSourceImplementation: LinkLoginDataSource {
                 return Promise(error: Self.deallocatedError)
             }
 
-            let consumerPublishableKey = linkSignUpResponse.publishableKey
-            let consumerApiClient = STPAPIClient(publishableKey: consumerPublishableKey)
-            return consumerApiClient.synchronize(
+            return apiClient.synchronize(
                 clientSecret: self.clientSecret,
                 returnURL: self.returnURL
             )

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -992,7 +992,7 @@ extension NativeFlowController: LinkLoginViewControllerDelegate {
         _ viewController: LinkLoginViewController,
         foundReturningUserWith lookupConsumerSessionResponse: LookupConsumerSessionResponse
     ) {
-        // TODO(BANKCON-11476): Save consumer publishable key for future use.
+        dataManager.consumerPublishableKey = lookupConsumerSessionResponse.publishableKey
         dataManager.consumerSession = lookupConsumerSessionResponse.consumerSession
         pushPane(.networkingLinkVerification, animated: true)
     }
@@ -1001,7 +1001,7 @@ extension NativeFlowController: LinkLoginViewControllerDelegate {
         _ viewController: LinkLoginViewController,
         receivedLinkSignUpResponse linkSignUpResponse: LinkSignUpResponse
     ) {
-        // TODO(BANKCON-11476): Update apiClient to use new publishable key.
+        dataManager.consumerPublishableKey = linkSignUpResponse.publishableKey
         dataManager.consumerSession = linkSignUpResponse.consumerSession
     }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowDataManager.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowDataManager.swift
@@ -28,6 +28,7 @@ protocol NativeFlowDataManager: AnyObject {
     var paymentAccountResource: FinancialConnectionsPaymentAccountResource? { get set }
     var accountNumberLast4: String? { get set }
     var consumerSession: ConsumerSessionData? { get set }
+    var consumerPublishableKey: String? { get set }
     var saveToLinkWithStripeSucceeded: Bool? { get set }
     var lastPaneLaunched: FinancialConnectionsSessionManifest.NextPane? { get set }
     var customSuccessPaneMessage: String? { get set }
@@ -80,10 +81,21 @@ class NativeFlowAPIDataManager: NativeFlowDataManager {
     var errorPaneReferrerPane: FinancialConnectionsSessionManifest.NextPane?
     var paymentAccountResource: FinancialConnectionsPaymentAccountResource?
     var accountNumberLast4: String?
-    var consumerSession: ConsumerSessionData?
     var saveToLinkWithStripeSucceeded: Bool?
     var lastPaneLaunched: FinancialConnectionsSessionManifest.NextPane?
     var customSuccessPaneMessage: String?
+
+    var consumerSession: ConsumerSessionData? {
+        didSet {
+            apiClient.consumerSession = consumerSession
+        }
+    }
+
+    var consumerPublishableKey: String? {
+        didSet {
+            apiClient.consumerPublishableKey = consumerPublishableKey
+        }
+    }
 
     init(
         manifest: FinancialConnectionsSessionManifest,
@@ -125,6 +137,7 @@ class NativeFlowAPIDataManager: NativeFlowDataManager {
     }
 
     private func didUpdateManifest() {
+        apiClient.isLinkWithStripe = manifest.isLinkWithStripe == true
         analyticsClient.setAdditionalParameters(fromManifest: manifest)
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
@@ -257,7 +257,7 @@ private struct NetowrkingOTPViewRepresentable: UIViewRepresentable {
             connectionsMerchantName: nil,
             pane: .networkingLinkVerification,
             consumerSession: nil,
-            apiClient: STPAPIClient.shared,
+            apiClient: FinancialConnectionsAPIClient.shared,
             clientSecret: "",
             analyticsClient: FinancialConnectionsAnalyticsClient(),
             isTestMode: false,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
@@ -257,7 +257,7 @@ private struct NetowrkingOTPViewRepresentable: UIViewRepresentable {
             connectionsMerchantName: nil,
             pane: .networkingLinkVerification,
             consumerSession: nil,
-            apiClient: FinancialConnectionsAPIClient.shared,
+            apiClient: FinancialConnectionsAPIClient(apiClient: .shared),
             clientSecret: "",
             analyticsClient: FinancialConnectionsAnalyticsClient(),
             isTestMode: false,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsAccountFetcher.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsAccountFetcher.swift
@@ -18,12 +18,12 @@ class FinancialConnectionsAccountAPIFetcher: FinancialConnectionsAccountFetcher 
 
     // MARK: - Properties
 
-    private let api: FinancialConnectionsAPIClient
+    private let api: FinancialConnectionsAPI
     private let clientSecret: String
 
     // MARK: - Init
 
-    init(api: FinancialConnectionsAPIClient, clientSecret: String) {
+    init(api: FinancialConnectionsAPI, clientSecret: String) {
         self.api = api
         self.clientSecret = clientSecret
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsSessionFetcher.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsSessionFetcher.swift
@@ -16,14 +16,14 @@ class FinancialConnectionsSessionAPIFetcher: FinancialConnectionsSessionFetcher 
 
     // MARK: - Properties
 
-    private let api: FinancialConnectionsAPIClient
+    private let api: FinancialConnectionsAPI
     private let clientSecret: String
     private let accountFetcher: FinancialConnectionsAccountFetcher
 
     // MARK: - Init
 
     init(
-        api: FinancialConnectionsAPIClient,
+        api: FinancialConnectionsAPI,
         clientSecret: String,
         accountFetcher: FinancialConnectionsAccountFetcher
     ) {

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
@@ -10,7 +10,7 @@ import Foundation
 @_spi(STP) import StripeCoreTestUtils
 @testable import StripeFinancialConnections
 
-class EmptyFinancialConnectionsAPIClient: FinancialConnectionsAPIClient {
+class EmptyFinancialConnectionsAPIClient: FinancialConnectionsAPI {
 
     func fetchFinancialConnectionsAccounts(clientSecret: String, startingAfterAccountId: String?) -> Promise<
         StripeAPI.FinancialConnectionsSession.AccountList

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsAPIClientTests.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsAPIClientTests.swift
@@ -1,0 +1,55 @@
+//
+//  FinancialConnectionsAPIClientTests.swift
+//  StripeFinancialConnectionsTests
+//
+//  Created by Mat Schmid on 2024-08-02.
+//
+
+import OHHTTPStubs
+import OHHTTPStubsSwift
+import XCTest
+
+@_spi(STP) import StripeCore
+@_spi(STP) import StripeCoreTestUtils
+@testable @_spi(STP) import StripeFinancialConnections
+
+class FinancialConnectionsAPIClientTests: XCTestCase {
+    private let mockApiClient = APIStubbedTestCase.stubbedAPIClient()
+
+    func testConusmerPublishableKeyProvider() {
+        let apiClient = FinancialConnectionsAPIClient(apiClient: mockApiClient)
+        XCTAssertNil(apiClient.consumerPublishableKeyProvider(canUseConsumerKey: true))
+
+        let consumerPublishableKey = "consumerPublishableKey"
+        apiClient.consumerPublishableKey = consumerPublishableKey
+        XCTAssertNil(apiClient.consumerPublishableKeyProvider(canUseConsumerKey: true))
+
+        apiClient.isLinkWithStripe = true
+        XCTAssertNil(apiClient.consumerPublishableKeyProvider(canUseConsumerKey: true))
+
+        let unverifiedConsumerSession = ConsumerSessionData(
+            clientSecret: "clientSecret",
+            emailAddress: "emailAddress",
+            redactedFormattedPhoneNumber: "redactedFormattedPhoneNumber",
+            verificationSessions: []
+        )
+        apiClient.consumerSession = unverifiedConsumerSession
+        XCTAssertNil(apiClient.consumerPublishableKeyProvider(canUseConsumerKey: true))
+
+        let verifiedConsumerSession = ConsumerSessionData(
+            clientSecret: "clientSecret",
+            emailAddress: "emailAddress",
+            redactedFormattedPhoneNumber: "redactedFormattedPhoneNumber",
+            verificationSessions: [
+                VerificationSession(
+                    type: .sms,
+                    state: .verified
+                ),
+            ]
+        )
+        apiClient.consumerSession = verifiedConsumerSession
+        XCTAssertEqual(apiClient.consumerPublishableKeyProvider(canUseConsumerKey: true), consumerPublishableKey)
+
+        XCTAssertNil(apiClient.consumerPublishableKeyProvider(canUseConsumerKey: false))
+    }
+}

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsSheetTests.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsSheetTests.swift
@@ -20,7 +20,7 @@ class FinancialConnectionsSheetTests: XCTestCase {
     private let mockViewController = UIViewController()
     private let mockClientSecret = "las_123345"
     private let mockAnalyticsClient = MockAnalyticsClient()
-    private let mockApiClient = APIStubbedTestCase.stubbedAPIClient()
+    private let mockApiClient = FinancialConnectionsAPIClient(apiClient: APIStubbedTestCase.stubbedAPIClient())
 
     override func setUpWithError() throws {
         try super.setUpWithError()


### PR DESCRIPTION
Resolves: https://jira.corp.stripe.com/browse/BANKCON-11476
Part of the [Native Instant Debits project](https://docs.google.com/document/d/1k0tv4jUxL9QSxni1QEo-ZiHG_HDCX9gAMo2qKE8kqbQ/edit?usp=sharing).

## Summary

This is a refactor of our `FinancialConnectionsAPIClient` from a protocol to a class such that it can switch between using the merchant's publishable key and the consumer's publishable key. The conditions for using the consumer's publishable key are: 

```swift
/// Returns the `consumerPublishableKey` for scenarios where it is valid to do so. That is;
/// - `canUseConsumerKey` must be `true`. This is a flag passed in by each API request.
/// - `isLinkWithStripe` must be `true`. This represents whether we're in the Instant Debits flow.
/// - `consumerSession` must be verified. This represents whether we have a verified Link user.
func consumerPublishableKeyProvider(canUseConsumerKey: Bool) -> String? {
    guard canUseConsumerKey, isLinkWithStripe, consumerSession?.isVerified == true else {
        return nil
    }
    return consumerPublishableKey
}
```

As a rule of thumb, `useConsumerPublishableKeyIfNeeded` should be `true` for requests that can happen after the user is verified. However, there are some exceptions to this rules (such as the create payment method request).

## Motivation

Once a Link user is verified, we must use their publishable key for some requests. This enables that

## Testing

Unit tests added + `bitrise run financial-connections-stability-tests` passes!

## Changelog

N/a