### PR TITLE
Fix an issue where saved payment method UI wouldn't respect `PaymentS…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [Fixed] Fixed an issue where the keyboard could focus on a hidden phone number field.
 * [Added] Support for Sunbit (Private Beta) with PaymentIntents.
 * [Added] Support for Billie (Private Beta) with PaymentIntents.
+* [Fixed] Fixed an issue where saved payment method UI wouldn't respect `PaymentSheet.Configuration.style` when selected.
 
 ### Payments
 * [Added] Support for Sunbit (Private Beta) bindings.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentMethodCollectionView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentMethodCollectionView.swift
@@ -274,114 +274,116 @@ extension SavedPaymentMethodCollectionView {
         }
 
         private func update() {
-            if let viewModel = viewModel {
-                switch viewModel {
-                case .saved(let paymentMethod):
-                    if let attributedText = attributedTextForLabel(paymentMethod: paymentMethod) {
-                        label.attributedText = attributedText
-                    } else {
-                        label.text = paymentMethod.paymentSheetLabel
+            // Setting the image ends up implicitly using UITraitCollection.current, which is undefined in this context, so wrap this in `traitCollection.performAsCurrent` to ensure it uses this view's trait collection
+            traitCollection.performAsCurrent {
+                if let viewModel = viewModel {
+                    switch viewModel {
+                    case .saved(let paymentMethod):
+                        if let attributedText = attributedTextForLabel(paymentMethod: paymentMethod) {
+                            label.attributedText = attributedText
+                        } else {
+                            label.text = paymentMethod.paymentSheetLabel
+                        }
+                        accessibilityIdentifier = label.text
+                        shadowRoundedRectangle.accessibilityIdentifier = label.text
+                        shadowRoundedRectangle.accessibilityLabel = paymentMethod.paymentSheetAccessibilityLabel
+                        paymentMethodLogo.image = paymentMethod.makeSavedPaymentMethodCellImage()
+                    case .applePay:
+                        // TODO (cleanup) - get this from PaymentOptionDisplayData?
+                        label.text = String.Localized.apple_pay
+                        accessibilityIdentifier = label.text
+                        shadowRoundedRectangle.accessibilityIdentifier = label.text
+                        shadowRoundedRectangle.accessibilityLabel = label.text
+                        paymentMethodLogo.image = PaymentOption.applePay.makeSavedPaymentMethodCellImage()
+                    case .link:
+                        label.text = STPPaymentMethodType.link.displayName
+                        accessibilityIdentifier = label.text
+                        shadowRoundedRectangle.accessibilityIdentifier = label.text
+                        shadowRoundedRectangle.accessibilityLabel = label.text
+                        paymentMethodLogo.image = PaymentOption.link(option: .wallet).makeSavedPaymentMethodCellImage()
+                        paymentMethodLogo.tintColor = UIColor.linkNavLogo.resolvedContrastingColor(
+                            forBackgroundColor: appearance.colors.componentBackground
+                        )
+                    case .add:
+                        label.text = STPLocalizedString(
+                            "+ Add",
+                            "Text for a button that, when tapped, displays another screen where the customer can add payment method details"
+                        )
+                        shadowRoundedRectangle.accessibilityLabel = String.Localized.add_new_payment_method
+                        shadowRoundedRectangle.accessibilityIdentifier = "+ Add"
+                        paymentMethodLogo.isHidden = true
+                        plus.isHidden = false
+                        plus.setNeedsDisplay()
                     }
-                    accessibilityIdentifier = label.text
-                    shadowRoundedRectangle.accessibilityIdentifier = label.text
-                    shadowRoundedRectangle.accessibilityLabel = paymentMethod.paymentSheetAccessibilityLabel
-                    paymentMethodLogo.image = paymentMethod.makeSavedPaymentMethodCellImage()
-                case .applePay:
-                    // TODO (cleanup) - get this from PaymentOptionDisplayData?
-                    label.text = String.Localized.apple_pay
-                    accessibilityIdentifier = label.text
-                    shadowRoundedRectangle.accessibilityIdentifier = label.text
-                    shadowRoundedRectangle.accessibilityLabel = label.text
-                    paymentMethodLogo.image = PaymentOption.applePay.makeSavedPaymentMethodCellImage()
-                case .link:
-                    label.text = STPPaymentMethodType.link.displayName
-                    accessibilityIdentifier = label.text
-                    shadowRoundedRectangle.accessibilityIdentifier = label.text
-                    shadowRoundedRectangle.accessibilityLabel = label.text
-                    paymentMethodLogo.image = PaymentOption.link(option: .wallet).makeSavedPaymentMethodCellImage()
-                    paymentMethodLogo.tintColor = UIColor.linkNavLogo.resolvedContrastingColor(
-                        forBackgroundColor: appearance.colors.componentBackground
-                    )
-                case .add:
-                    label.text = STPLocalizedString(
-                        "+ Add",
-                        "Text for a button that, when tapped, displays another screen where the customer can add payment method details"
-                    )
-                    shadowRoundedRectangle.accessibilityLabel = String.Localized.add_new_payment_method
-                    shadowRoundedRectangle.accessibilityIdentifier = "+ Add"
-                    paymentMethodLogo.isHidden = true
-                    plus.isHidden = false
-                    plus.setNeedsDisplay()
                 }
-            }
-            let applyDefaultStyle: () -> Void = { [self] in
-                shadowRoundedRectangle.isEnabled = true
-                shadowRoundedRectangle.isSelected = false
-                label.textColor = appearance.colors.text
-                paymentMethodLogo.alpha = 1
-                plus.alpha = 1
-                selectedIcon.isHidden = true
-                layer.shadowOpacity = 0
-            }
+                let applyDefaultStyle: () -> Void = { [self] in
+                    shadowRoundedRectangle.isEnabled = true
+                    shadowRoundedRectangle.isSelected = false
+                    label.textColor = appearance.colors.text
+                    paymentMethodLogo.alpha = 1
+                    plus.alpha = 1
+                    selectedIcon.isHidden = true
+                    layer.shadowOpacity = 0
+                }
 
-            if isRemovingPaymentMethods {
-                if case .saved = viewModel {
-                    if shouldAllowEditing {
-                        accessoryButton.isHidden = false
-                        accessoryButton.set(style: .edit, with: appearance.colors.danger)
-                        accessoryButton.backgroundColor = UIColor.dynamic(
-                            light: .systemGray5, dark: appearance.colors.componentBackground.lighten(by: 0.075))
-                        accessoryButton.iconColor = appearance.colors.icon
-                    } else if allowsPaymentMethodRemoval {
-                        accessoryButton.isHidden = false
-                        accessoryButton.set(style: .remove, with: appearance.colors.danger)
-                        accessoryButton.backgroundColor = appearance.colors.danger
-                        accessoryButton.iconColor = appearance.colors.danger.contrastingColor
+                if isRemovingPaymentMethods {
+                    if case .saved = viewModel {
+                        if shouldAllowEditing {
+                            accessoryButton.isHidden = false
+                            accessoryButton.set(style: .edit, with: appearance.colors.danger)
+                            accessoryButton.backgroundColor = UIColor.dynamic(
+                                light: .systemGray5, dark: appearance.colors.componentBackground.lighten(by: 0.075))
+                            accessoryButton.iconColor = appearance.colors.icon
+                        } else if allowsPaymentMethodRemoval {
+                            accessoryButton.isHidden = false
+                            accessoryButton.set(style: .remove, with: appearance.colors.danger)
+                            accessoryButton.backgroundColor = appearance.colors.danger
+                            accessoryButton.iconColor = appearance.colors.danger.contrastingColor
+                        }
+                        contentView.bringSubviewToFront(accessoryButton)
+                        applyDefaultStyle()
+
+                    } else {
+                        accessoryButton.isHidden = true
+
+                        // apply disabled style
+                        shadowRoundedRectangle.isEnabled = false
+                        paymentMethodLogo.alpha = 0.6
+                        plus.alpha = 0.6
+                        label.textColor = appearance.colors.text.disabledColor
                     }
-                    contentView.bringSubviewToFront(accessoryButton)
-                    applyDefaultStyle()
 
+                } else if isSelected {
+                    accessoryButton.isHidden = true
+                    shadowRoundedRectangle.isEnabled = true
+                    label.textColor = appearance.colors.text
+                    paymentMethodLogo.alpha = 1
+                    plus.alpha = 1
+                    selectedIcon.isHidden = false
+                    selectedIcon.backgroundColor = appearance.colors.primary
+
+                    // Draw a border with primary color
+                    shadowRoundedRectangle.isSelected = true
                 } else {
                     accessoryButton.isHidden = true
-
-                    // apply disabled style
-                    shadowRoundedRectangle.isEnabled = false
-                    paymentMethodLogo.alpha = 0.6
-                    plus.alpha = 0.6
-                    label.textColor = appearance.colors.text.disabledColor
+                    applyDefaultStyle()
                 }
+                accessoryButton.isAccessibilityElement = !accessoryButton.isHidden
+                label.font = appearance.scaledFont(for: appearance.font.base.medium, style: .footnote, maximumPointSize: 20)
 
-            } else if isSelected {
-                accessoryButton.isHidden = true
-                shadowRoundedRectangle.isEnabled = true
-                label.textColor = appearance.colors.text
-                paymentMethodLogo.alpha = 1
-                plus.alpha = 1
-                selectedIcon.isHidden = false
-                selectedIcon.backgroundColor = appearance.colors.primary
-
-                // Draw a border with primary color
-                shadowRoundedRectangle.isSelected = true
-            } else {
-                accessoryButton.isHidden = true
-                applyDefaultStyle()
-            }
-            accessoryButton.isAccessibilityElement = !accessoryButton.isHidden
-            label.font = appearance.scaledFont(for: appearance.font.base.medium, style: .footnote, maximumPointSize: 20)
-
-            shadowRoundedRectangle.accessibilityTraits = {
-                if isRemovingPaymentMethods {
-                    return [.notEnabled]
-                } else {
-                    if isSelected {
-                        return [.button, .selected]
+                shadowRoundedRectangle.accessibilityTraits = {
+                    if isRemovingPaymentMethods {
+                        return [.notEnabled]
                     } else {
-                        return [.button]
+                        if isSelected {
+                            return [.button, .selected]
+                        } else {
+                            return [.button]
+                        }
                     }
-                }
-            }()
+                }()
+            }
         }
-
     }
 
     // A circle with an image in the middle


### PR DESCRIPTION
…heet.Configuration.style` when selected.

Per https://developer.apple.com/documentation/uikit/uitraitcollection/3238080-currenttraitcollection?language=objc
But:
> The following table lists the supported methods where UIKit sets the currentTraitCollection value:
...
> Outside these methods, you’re responsible for ensuring the currentTraitCollection property has a valid trait collection. 
> Use [performAsCurrentTraitCollection:](https://developer.apple.com/documentation/uikit/uitraitcollection/3238082-performascurrenttraitcollection?language=objc) to execute your code inside a context with a valid currentTraitCollection property. This is the preferred way to set currentTraitCollection.

## Testing
Manually tested before:
![Simulator Screen Recording -  snapshot tester  iPhone 12 mini 16 4 - 2024-08-02 at 11 06 30](https://github.com/user-attachments/assets/a8891571-749e-4367-b426-43ef614b44c6)

After:
![Simulator Screen Recording -  snapshot tester  iPhone 12 mini 16 4 - 2024-08-02 at 11 05 19](https://github.com/user-attachments/assets/dd0894a0-9ee2-4c03-802c-941828fe06e1)

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
