### PR TITLE
Financial Connections: for networking manual entry, RUX/Link Account Picker consent acquiring, added error handling

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
@@ -281,13 +281,23 @@ final class LinkAccountPickerViewController: UIViewController {
             footerView?.showLoadingView(true)
             dataSource
                 .markConsentAcquired()
-                .observe { [weak self] _ in
+                .observe { [weak self] result in
                     guard let self = self else { return }
                     footerView?.showLoadingView(false)
-                    self.presentAccountUpdateRequiredDrawer(
-                        drawerOnSelection: drawerOnSelection,
-                        partnerAccount: selectedAccount.partnerAccount
-                    )
+                    switch result {
+                    case .success:
+                        self.presentAccountUpdateRequiredDrawer(
+                            drawerOnSelection: drawerOnSelection,
+                            partnerAccount: selectedAccount.partnerAccount
+                        )
+                    case .failure(let error):
+                        self.dataSource.analyticsClient.logUnexpectedError(
+                            error,
+                            errorName: "ConsentAcquiredError",
+                            pane: .linkAccountPicker
+                        )
+                        self.delegate?.linkAccountPickerViewController(self, didReceiveTerminalError: error)
+                    }
                 }
         } else if nextPane == .success {
             footerView?.showLoadingView(true)
@@ -364,10 +374,21 @@ final class LinkAccountPickerViewController: UIViewController {
                 footerView?.showLoadingView(true)
                 dataSource
                     .markConsentAcquired()
-                    .observe { [weak self] _ in
+                    .observe { [weak self] result in
                         guard let self = self else { return }
                         footerView?.showLoadingView(false)
-                        pushToNextPane()
+                        switch result {
+                        case .success:
+                            pushToNextPane()
+                        case .failure(let error):
+                            self.dataSource.analyticsClient.logUnexpectedError(
+                                error,
+                                errorName: "ConsentAcquiredError",
+                                pane: .linkAccountPicker
+                            )
+                            self.delegate?.linkAccountPickerViewController(self, didReceiveTerminalError: error)
+                        }
+
                     }
             } else {
                 pushToNextPane()


### PR DESCRIPTION
## Summary

We were missing error handling 

## Testing

### Test Consent Acquired on An "Account Update Required" Account

https://github.com/user-attachments/assets/1be3c015-f287-4bd3-9079-9e54ed81eff5

###  Test Step Up Mark Consent

https://github.com/user-attachments/assets/3c1fa80b-5732-4f75-92f0-7e3e51115b00

Run UI tests:

```
FinancialConnectionsNetworkingUITests
    ✓ testNativeNetworkingManualEntryTestMode (109.116 seconds)
    ✓ testNativeNetworkingTestMode (134.830 seconds)
    ✓ testNativeNetworkingTestModeSignUpWithMultiSelectAndPrefilledEmail (32.589 seconds)
    ✓ testNativeNetworkingTestModeSignUpWithPrefilledEmailAndPhone (25.353 seconds)
FinancialConnectionsUITests
    ✓ testDataLiveModeOAuthNativeAuthFlow (30.022 seconds)
    ✓ testDataLiveModeOAuthWebAuthFlow (20.694 seconds)
    ✓ testDataTestModeOAuthNativeAuthFlow (20.349 seconds)
    ✓ testPaymentSearchInLiveModeNativeAuthFlow (25.506 seconds)
    ✓ testPaymentTestModeLegacyNativeAuthFlow (19.781 seconds)
    ✓ testPaymentTestModeManualEntryAutofill (13.884 seconds)
    ✓ testPaymentTestModeManualEntryNativeAuthFlow (24.318 seconds)
    ✓ testWebInstantDebitsFlow (14.332 seconds)

```