### PR TITLE
Improve STPPaymentHandler analytics by sending PaymentMethod id when …

### DIFF
--- a/Stripe/StripeiOSTests/STPPaymentHandlerFunctionalTest.swift
+++ b/Stripe/StripeiOSTests/STPPaymentHandlerFunctionalTest.swift
@@ -219,7 +219,7 @@ final class STPPaymentHandlerFunctionalSwiftTest: STPNetworkStubbingTestCase, ST
         }
         waitForExpectations(timeout: 10)
     }
-    
+
     func test_confirm_payment_intent_savedpm_sends_analytic() {
         // Confirming a hardcoded already-confirmed PI with invalid params...
         let paymentIntentParams = STPPaymentIntentParams(clientSecret: "pi_3P20wFFY0qyl6XeW0dSOQ6W7_secret_9V8GkrCOt1MEW8SBmAaGnmT6A")
@@ -233,16 +233,14 @@ final class STPPaymentHandlerFunctionalSwiftTest: STPNetworkStubbingTestCase, ST
             let firstAnalytic = analyticsClient._testLogHistory.first
             XCTAssertEqual(firstAnalytic?["event"] as? String, STPAnalyticEvent.paymentHandlerConfirmStarted.rawValue)
             XCTAssertEqual(firstAnalytic?["intent_id"] as? String, "pi_3P20wFFY0qyl6XeW0dSOQ6W7")
-            XCTAssertEqual(firstAnalytic?["payment_method_type"] as? String, "card")
             XCTAssertEqual(firstAnalytic?["payment_method_id"] as? String, "pm_123")
             let lastAnalytic = analyticsClient._testLogHistory.last
             XCTAssertEqual(lastAnalytic?["event"] as? String, STPAnalyticEvent.paymentHandlerConfirmFinished.rawValue)
             XCTAssertEqual(lastAnalytic?["payment_method_id"] as? String, "pm_123")
             XCTAssertEqual(lastAnalytic?["intent_id"] as? String, "pi_3P20wFFY0qyl6XeW0dSOQ6W7")
             XCTAssertEqual(lastAnalytic?["status"] as? String, "failed")
-            XCTAssertEqual(lastAnalytic?["payment_method_type"] as? String, "card")
             XCTAssertEqual(lastAnalytic?["error_type"] as? String, "invalid_request_error")
-            XCTAssertEqual(lastAnalytic?["error_code"] as? String, "payment_intent_unexpected_state")
+            XCTAssertEqual(lastAnalytic?["error_code"] as? String, "resource_missing")
             XCTAssertTrue((lastAnalytic?["request_id"] as? String)!.starts(with: "req_"))
             paymentHandlerExpectation.fulfill()
         }
@@ -276,11 +274,11 @@ final class STPPaymentHandlerFunctionalSwiftTest: STPNetworkStubbingTestCase, ST
         }
         waitForExpectations(timeout: 10)
     }
-    
+
     func test_confirm_setup_intent_savedpm_sends_analytic() {
-        let setupIntentParams = STPSetupIntentConfirmParams(clientSecret: "seti_1P1xLBFY0qyl6XeWc7c2LrMK_secret_PrgithiYFFPH0NVGP1BK7Oy9OU3mrDT", paymentMethodType: .card)
+        let setupIntentParams = STPSetupIntentConfirmParams(clientSecret: "seti_1P1xLBFY0qyl6XeWc7c2LrMK_secret_PrgithiYFFPH0NVGP1BK7Oy9OU3mrDT")
         // Confirming a hardcoded already-confirmed SI with invalid params...
-        setupIntentParams.paymentMethodID = "123"
+        setupIntentParams.paymentMethodID = "pm_123"
 
         let paymentHandlerExpectation = expectation(description: "paymentHandlerExpectation")
         let paymentHandler = STPPaymentHandler(apiClient: STPAPIClient(publishableKey: STPTestingDefaultPublishableKey))
@@ -291,16 +289,14 @@ final class STPPaymentHandlerFunctionalSwiftTest: STPNetworkStubbingTestCase, ST
             let firstAnalytic = analyticsClient._testLogHistory.first
             XCTAssertEqual(firstAnalytic?["event"] as? String, STPAnalyticEvent.paymentHandlerConfirmStarted.rawValue)
             XCTAssertEqual(firstAnalytic?["intent_id"] as? String, "seti_1P1xLBFY0qyl6XeWc7c2LrMK")
-            XCTAssertEqual(firstAnalytic?["payment_method_type"] as? String, "card")
             XCTAssertEqual(firstAnalytic?["payment_method_id"] as? String, "pm_123")
             let lastAnalytic = analyticsClient._testLogHistory.last
             XCTAssertEqual(lastAnalytic?["event"] as? String, STPAnalyticEvent.paymentHandlerConfirmFinished.rawValue)
             XCTAssertEqual(lastAnalytic?["intent_id"] as? String, "seti_1P1xLBFY0qyl6XeWc7c2LrMK")
             XCTAssertEqual(lastAnalytic?["payment_method_id"] as? String, "pm_123")
             XCTAssertEqual(lastAnalytic?["status"] as? String, "failed")
-            XCTAssertEqual(lastAnalytic?["payment_method_type"] as? String, "card")
             XCTAssertEqual(lastAnalytic?["error_type"] as? String, "invalid_request_error")
-            XCTAssertEqual(lastAnalytic?["error_code"] as? String, "parameter_missing")
+            XCTAssertEqual(lastAnalytic?["error_code"] as? String, "resource_missing")
             XCTAssertTrue((lastAnalytic?["request_id"] as? String)!.starts(with: "req_"))
             paymentHandlerExpectation.fulfill()
         }

--- a/Stripe/StripeiOSTests/STPPaymentHandlerFunctionalTest.swift
+++ b/Stripe/StripeiOSTests/STPPaymentHandlerFunctionalTest.swift
@@ -219,6 +219,35 @@ final class STPPaymentHandlerFunctionalSwiftTest: STPNetworkStubbingTestCase, ST
         }
         waitForExpectations(timeout: 10)
     }
+    
+    func test_confirm_payment_intent_savedpm_sends_analytic() {
+        // Confirming a hardcoded already-confirmed PI with invalid params...
+        let paymentIntentParams = STPPaymentIntentParams(clientSecret: "pi_3P20wFFY0qyl6XeW0dSOQ6W7_secret_9V8GkrCOt1MEW8SBmAaGnmT6A")
+        paymentIntentParams.paymentMethodId = "pm_123"
+        let paymentHandlerExpectation = expectation(description: "paymentHandlerExpectation")
+        let paymentHandler = STPPaymentHandler(apiClient: STPAPIClient(publishableKey: STPTestingDefaultPublishableKey))
+        let analyticsClient = STPAnalyticsClient()
+        paymentHandler.analyticsClient = analyticsClient
+        paymentHandler.confirmPayment(paymentIntentParams, with: self) { (_, _, _) in
+            // ...should send these analytics
+            let firstAnalytic = analyticsClient._testLogHistory.first
+            XCTAssertEqual(firstAnalytic?["event"] as? String, STPAnalyticEvent.paymentHandlerConfirmStarted.rawValue)
+            XCTAssertEqual(firstAnalytic?["intent_id"] as? String, "pi_3P20wFFY0qyl6XeW0dSOQ6W7")
+            XCTAssertEqual(firstAnalytic?["payment_method_type"] as? String, "card")
+            XCTAssertEqual(firstAnalytic?["payment_method_id"] as? String, "pm_123")
+            let lastAnalytic = analyticsClient._testLogHistory.last
+            XCTAssertEqual(lastAnalytic?["event"] as? String, STPAnalyticEvent.paymentHandlerConfirmFinished.rawValue)
+            XCTAssertEqual(lastAnalytic?["payment_method_id"] as? String, "pm_123")
+            XCTAssertEqual(lastAnalytic?["intent_id"] as? String, "pi_3P20wFFY0qyl6XeW0dSOQ6W7")
+            XCTAssertEqual(lastAnalytic?["status"] as? String, "failed")
+            XCTAssertEqual(lastAnalytic?["payment_method_type"] as? String, "card")
+            XCTAssertEqual(lastAnalytic?["error_type"] as? String, "invalid_request_error")
+            XCTAssertEqual(lastAnalytic?["error_code"] as? String, "payment_intent_unexpected_state")
+            XCTAssertTrue((lastAnalytic?["request_id"] as? String)!.starts(with: "req_"))
+            paymentHandlerExpectation.fulfill()
+        }
+        waitForExpectations(timeout: 10)
+    }
 
     func test_confirm_setup_intent_sends_analytic() {
         let setupIntentParams = STPSetupIntentConfirmParams(clientSecret: "seti_1P1xLBFY0qyl6XeWc7c2LrMK_secret_PrgithiYFFPH0NVGP1BK7Oy9OU3mrDT", paymentMethodType: .card)
@@ -238,6 +267,36 @@ final class STPPaymentHandlerFunctionalSwiftTest: STPNetworkStubbingTestCase, ST
             let lastAnalytic = analyticsClient._testLogHistory.last
             XCTAssertEqual(lastAnalytic?["event"] as? String, STPAnalyticEvent.paymentHandlerConfirmFinished.rawValue)
             XCTAssertEqual(lastAnalytic?["intent_id"] as? String, "seti_1P1xLBFY0qyl6XeWc7c2LrMK")
+            XCTAssertEqual(lastAnalytic?["status"] as? String, "failed")
+            XCTAssertEqual(lastAnalytic?["payment_method_type"] as? String, "card")
+            XCTAssertEqual(lastAnalytic?["error_type"] as? String, "invalid_request_error")
+            XCTAssertEqual(lastAnalytic?["error_code"] as? String, "parameter_missing")
+            XCTAssertTrue((lastAnalytic?["request_id"] as? String)!.starts(with: "req_"))
+            paymentHandlerExpectation.fulfill()
+        }
+        waitForExpectations(timeout: 10)
+    }
+    
+    func test_confirm_setup_intent_savedpm_sends_analytic() {
+        let setupIntentParams = STPSetupIntentConfirmParams(clientSecret: "seti_1P1xLBFY0qyl6XeWc7c2LrMK_secret_PrgithiYFFPH0NVGP1BK7Oy9OU3mrDT", paymentMethodType: .card)
+        // Confirming a hardcoded already-confirmed SI with invalid params...
+        setupIntentParams.paymentMethodID = "123"
+
+        let paymentHandlerExpectation = expectation(description: "paymentHandlerExpectation")
+        let paymentHandler = STPPaymentHandler(apiClient: STPAPIClient(publishableKey: STPTestingDefaultPublishableKey))
+        let analyticsClient = STPAnalyticsClient()
+        paymentHandler.analyticsClient = analyticsClient
+        paymentHandler.confirmSetupIntent(setupIntentParams, with: self) { (_, _, _) in
+            // ...should send these analytics
+            let firstAnalytic = analyticsClient._testLogHistory.first
+            XCTAssertEqual(firstAnalytic?["event"] as? String, STPAnalyticEvent.paymentHandlerConfirmStarted.rawValue)
+            XCTAssertEqual(firstAnalytic?["intent_id"] as? String, "seti_1P1xLBFY0qyl6XeWc7c2LrMK")
+            XCTAssertEqual(firstAnalytic?["payment_method_type"] as? String, "card")
+            XCTAssertEqual(firstAnalytic?["payment_method_id"] as? String, "pm_123")
+            let lastAnalytic = analyticsClient._testLogHistory.last
+            XCTAssertEqual(lastAnalytic?["event"] as? String, STPAnalyticEvent.paymentHandlerConfirmFinished.rawValue)
+            XCTAssertEqual(lastAnalytic?["intent_id"] as? String, "seti_1P1xLBFY0qyl6XeWc7c2LrMK")
+            XCTAssertEqual(lastAnalytic?["payment_method_id"] as? String, "pm_123")
             XCTAssertEqual(lastAnalytic?["status"] as? String, "failed")
             XCTAssertEqual(lastAnalytic?["payment_method_type"] as? String, "card")
             XCTAssertEqual(lastAnalytic?["error_type"] as? String, "invalid_request_error")
@@ -274,9 +333,7 @@ final class STPPaymentHandlerFunctionalSwiftTest: STPNetworkStubbingTestCase, ST
     func test_handle_next_action_2_payment_intent_sends_analytic() {
         // Calling handleNextAction(for:) with a STPPaymentIntent w/ an unknown next action...
         let paymentHandlerExpectation = expectation(description: "paymentHandlerExpectation")
-        var piJSON = STPTestUtils.jsonNamed("PaymentIntent")
-        piJSON![jsonDict: "next_action"]!["type"] = "foo"
-        let paymentIntent = STPPaymentIntent.decodedObject(fromAPIResponse: piJSON)!
+        var paymentIntent = STPFixtures.paymentIntent(paymentMethodTypes: ["card"], status: .requiresAction, paymentMethod: STPTestUtils.jsonNamed(STPTestJSONPaymentMethodCard), nextAction: .unknown)
 
         let paymentHandler = STPPaymentHandler(apiClient: STPAPIClient(publishableKey: STPTestingDefaultPublishableKey))
         let analyticsClient = STPAnalyticsClient()
@@ -285,10 +342,11 @@ final class STPPaymentHandlerFunctionalSwiftTest: STPNetworkStubbingTestCase, ST
             // ...should send these analytics
             let firstAnalytic = analyticsClient._testLogHistory.first
             XCTAssertEqual(firstAnalytic?["event"] as? String, STPAnalyticEvent.paymentHandlerHandleNextActionStarted.rawValue)
-            XCTAssertEqual(firstAnalytic?["intent_id"] as? String, "pi_1Cl15wIl4IdHmuTbCWrpJXN6")
+            XCTAssertEqual(firstAnalytic?["intent_id"] as? String, "123")
             let lastAnalytic = analyticsClient._testLogHistory.last
             XCTAssertEqual(lastAnalytic?["event"] as? String, STPAnalyticEvent.paymentHandlerHandleNextActionFinished.rawValue)
-            XCTAssertEqual(lastAnalytic?["intent_id"] as? String, "pi_1Cl15wIl4IdHmuTbCWrpJXN6")
+            XCTAssertEqual(lastAnalytic?["payment_method_id"] as? String, "pm_123456789")
+            XCTAssertEqual(lastAnalytic?["intent_id"] as? String, "123")
             XCTAssertEqual(lastAnalytic?["status"] as? String, "failed")
             XCTAssertEqual(lastAnalytic?["error_type"] as? String, "STPPaymentHandlerErrorDomain")
             XCTAssertEqual(lastAnalytic?["error_code"] as? String, "unsupportedAuthenticationErrorCode")
@@ -329,7 +387,6 @@ final class STPPaymentHandlerFunctionalSwiftTest: STPNetworkStubbingTestCase, ST
         let paymentHandlerExpectation = expectation(description: "paymentHandlerExpectation")
         var siJSON = STPTestUtils.jsonNamed("SetupIntent")!
         siJSON[jsonDict: "next_action"]!["type"] = "foo"
-        siJSON[jsonDict: "next_action"]!["type"] = "foo"
         siJSON["payment_method"] = STPTestUtils.jsonNamed("CardPaymentMethod")!
         let setupIntent = STPSetupIntent.decodedObject(fromAPIResponse: siJSON)!
 
@@ -341,8 +398,10 @@ final class STPPaymentHandlerFunctionalSwiftTest: STPNetworkStubbingTestCase, ST
             let firstAnalytic = analyticsClient._testLogHistory.first
             XCTAssertEqual(firstAnalytic?["event"] as? String, STPAnalyticEvent.paymentHandlerHandleNextActionStarted.rawValue)
             XCTAssertEqual(firstAnalytic?["intent_id"] as? String, "seti_123456789")
+            XCTAssertEqual(firstAnalytic?["payment_method_id"] as? String, "pm_123456789")
             let lastAnalytic = analyticsClient._testLogHistory.last
             XCTAssertEqual(lastAnalytic?["event"] as? String, STPAnalyticEvent.paymentHandlerHandleNextActionFinished.rawValue)
+            XCTAssertEqual(lastAnalytic?["payment_method_id"] as? String, "pm_123456789")
             XCTAssertEqual(lastAnalytic?["intent_id"] as? String, "seti_123456789")
             XCTAssertEqual(lastAnalytic?["status"] as? String, "failed")
             XCTAssertEqual(lastAnalytic?["error_type"] as? String, "STPPaymentHandlerErrorDomain")

--- a/StripePayments/StripePayments/Source/PaymentHandler/STPAnalyticsClient+STPPaymentHandler.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPAnalyticsClient+STPPaymentHandler.swift
@@ -26,6 +26,7 @@ extension STPPaymentHandler {
         let intentID: String?
         let status: STPPaymentHandlerActionStatus?
         let paymentMethodType: String?
+        let paymentMethodID: String?
         let error: Error?
 
         var params: [String: Any] {
@@ -33,6 +34,7 @@ extension STPPaymentHandler {
             params["intent_id"] = intentID
             params["status"] = status?.stringValue
             params["payment_method_type"] = paymentMethodType
+            params["payment_method_id"] = paymentMethodID
             return params
         }
     }
@@ -40,36 +42,78 @@ extension STPPaymentHandler {
     // MARK: - Confirm started
 
     func logConfirmSetupIntentStarted(setupIntentID: String?, confirmParams: STPSetupIntentConfirmParams) {
-        let analytic = Analytic(event: .paymentHandlerConfirmStarted, intentID: setupIntentID, status: nil, paymentMethodType: confirmParams.paymentMethodType?.identifier, error: nil)
+        let analytic = Analytic(
+            event: .paymentHandlerConfirmStarted,
+            intentID: setupIntentID,
+            status: nil,
+            paymentMethodType: confirmParams.paymentMethodType?.identifier,
+            paymentMethodID: confirmParams.paymentMethodID,
+            error: nil
+        )
         analyticsClient.log(analytic: analytic, apiClient: apiClient)
     }
 
     func logConfirmPaymentIntentStarted(paymentIntentID: String?, paymentParams: STPPaymentIntentParams) {
-        let analytic = Analytic(event: .paymentHandlerConfirmStarted, intentID: paymentIntentID, status: nil, paymentMethodType: paymentParams.paymentMethodType?.identifier, error: nil)
+        let analytic = Analytic(
+            event: .paymentHandlerConfirmStarted,
+            intentID: paymentIntentID,
+            status: nil,
+            paymentMethodType: paymentParams.paymentMethodType?.identifier,
+            paymentMethodID: paymentParams.paymentMethodId,
+            error: nil
+        )
         analyticsClient.log(analytic: analytic, apiClient: apiClient)
     }
 
     // MARK: - Confirm completed
 
-    func logConfirmPaymentIntentCompleted(paymentIntentID: String?, status: STPPaymentHandlerActionStatus, paymentMethodType: STPPaymentMethodType?, error: Error?) {
-        let analytic = Analytic(event: .paymentHandlerConfirmFinished, intentID: paymentIntentID, status: status, paymentMethodType: paymentMethodType?.identifier, error: error)
+    func logConfirmPaymentIntentCompleted(paymentIntentID: String?, paymentParams: STPPaymentIntentParams, status: STPPaymentHandlerActionStatus, error: Error?) {
+        let analytic = Analytic(
+            event: .paymentHandlerConfirmFinished,
+            intentID: paymentIntentID,
+            status: status,
+            paymentMethodType: paymentParams.paymentMethodType?.identifier,
+            paymentMethodID: paymentParams.paymentMethodId,
+            error: error
+        )
         analyticsClient.log(analytic: analytic, apiClient: apiClient)
     }
 
-    func logConfirmSetupIntentCompleted(setupIntentID: String?, status: STPPaymentHandlerActionStatus, paymentMethodType: STPPaymentMethodType?, error: Error?) {
-        let analytic = Analytic(event: .paymentHandlerConfirmFinished, intentID: setupIntentID, status: status, paymentMethodType: paymentMethodType?.identifier, error: error)
+    func logConfirmSetupIntentCompleted(setupIntentID: String?, confirmParams: STPSetupIntentConfirmParams, status: STPPaymentHandlerActionStatus, error: Error?) {
+        let analytic = Analytic(
+            event: .paymentHandlerConfirmFinished,
+            intentID: setupIntentID,
+            status: status,
+            paymentMethodType: confirmParams.paymentMethodType?.identifier,
+            paymentMethodID: confirmParams.paymentMethodID,
+            error: error
+        )
         analyticsClient.log(analytic: analytic, apiClient: apiClient)
     }
 
     // MARK: - Handle next action
 
-    func logHandleNextActionStarted(intentID: String?, paymentMethodType: STPPaymentMethodType?) {
-        let analytic = Analytic(event: .paymentHandlerHandleNextActionStarted, intentID: intentID, status: nil, paymentMethodType: paymentMethodType?.identifier, error: nil)
+    func logHandleNextActionStarted(intentID: String?, paymentMethod: STPPaymentMethod?) {
+        let analytic = Analytic(
+            event: .paymentHandlerHandleNextActionStarted,
+            intentID: intentID,
+            status: nil,
+            paymentMethodType: paymentMethod?.type.identifier,
+            paymentMethodID: paymentMethod?.stripeId,
+            error: nil
+        )
         analyticsClient.log(analytic: analytic, apiClient: apiClient)
     }
 
-    func logHandleNextActionFinished(intentID: String?, status: STPPaymentHandlerActionStatus, paymentMethodType: STPPaymentMethodType?, error: Error?) {
-        let analytic = Analytic(event: .paymentHandlerHandleNextActionFinished, intentID: intentID, status: status, paymentMethodType: paymentMethodType?.identifier, error: error)
+    func logHandleNextActionFinished(intentID: String?, paymentMethod: STPPaymentMethod?, status: STPPaymentHandlerActionStatus, error: Error?) {
+        let analytic = Analytic(
+            event: .paymentHandlerHandleNextActionFinished,
+            intentID: intentID,
+            status: status,
+            paymentMethodType: paymentMethod?.type.identifier,
+            paymentMethodID: paymentMethod?.stripeId,
+            error: error
+        )
         analyticsClient.log(analytic: analytic, apiClient: apiClient)
     }
 }

--- a/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
@@ -354,7 +354,7 @@ public class STPPaymentHandler: NSObject {
         let paymentIntentID = paymentIntent.stripeId
         let paymentMethod = paymentIntent.paymentMethod
         if shouldSendAnalytic {
-            logHandleNextActionStarted(intentID: paymentIntentID, paymentMethod: paymentIntent.paymentMethod)
+            logHandleNextActionStarted(intentID: paymentIntentID, paymentMethod: paymentMethod)
         }
         // Overwrite completion to send an analytic before calling the caller-supplied completion
         let completion: STPPaymentHandlerActionPaymentIntentCompletionBlock = { [weak self] status, paymentIntent, error in

--- a/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
@@ -186,7 +186,7 @@ public class STPPaymentHandler: NSObject {
         logConfirmPaymentIntentStarted(paymentIntentID: paymentIntentID, paymentParams: paymentParams)
         // Overwrite completion to send an analytic before calling the caller-supplied completion
         let completion: STPPaymentHandlerActionPaymentIntentCompletionBlock = { [weak self] status, paymentIntent, error in
-            self?.logConfirmPaymentIntentCompleted(paymentIntentID: paymentIntentID, status: status, paymentMethodType: paymentParams.paymentMethodType, error: error)
+            self?.logConfirmPaymentIntentCompleted(paymentIntentID: paymentIntentID, paymentParams: paymentParams, status: status, error: error)
             completion(status, paymentIntent, error)
         }
         if Self.inProgress {
@@ -302,7 +302,7 @@ public class STPPaymentHandler: NSObject {
     ///   - returnURL: An optional URL to redirect your customer back to after they authenticate or cancel in a webview. This should match the returnURL you specified during PaymentIntent confirmation.
     ///   - completion: The completion block. If the status returned is `STPPaymentHandlerActionStatusSucceeded`, the PaymentIntent status is not necessarily STPPaymentIntentStatusSucceeded (e.g. some bank payment methods take days before the PaymentIntent succeeds).
     @objc(handleNextActionForPayment:withAuthenticationContext:returnURL:completion:)
-            public func handleNextAction(
+    public func handleNextAction(
         forPayment paymentIntentClientSecret: String,
         with authenticationContext: STPAuthenticationContext,
         returnURL: String?,
@@ -311,10 +311,10 @@ public class STPPaymentHandler: NSObject {
         let paymentIntentID = STPPaymentIntent.id(fromClientSecret: paymentIntentClientSecret)
         // Overwrite completion to send an analytic before calling the caller-supplied completion
         let completion: STPPaymentHandlerActionPaymentIntentCompletionBlock = { [weak self] status, paymentIntent, error in
-            self?.logHandleNextActionFinished(intentID: paymentIntentID, status: status, paymentMethodType: paymentIntent?.paymentMethod?.type, error: error)
+            self?.logHandleNextActionFinished(intentID: paymentIntentID, paymentMethod: paymentIntent?.paymentMethod, status: status, error: error)
             completion(status, paymentIntent, error)
         }
-        logHandleNextActionStarted(intentID: paymentIntentID, paymentMethodType: nil)
+        logHandleNextActionStarted(intentID: paymentIntentID, paymentMethod: nil)
         if !STPPaymentIntentParams.isClientSecretValid(paymentIntentClientSecret) {
             assertionFailure("`STPPaymentHandler.handleNextAction` was called with an invalid client secret. See https://docs.stripe.com/api/payment_intents/object#payment_intent_object-client_secret")
             completion(.failed, nil, _error(for: .invalidClientSecret))
@@ -352,13 +352,14 @@ public class STPPaymentHandler: NSObject {
         completion: @escaping STPPaymentHandlerActionPaymentIntentCompletionBlock
     ) {
         let paymentIntentID = paymentIntent.stripeId
+        let paymentMethod = paymentIntent.paymentMethod
         if shouldSendAnalytic {
-            logHandleNextActionStarted(intentID: paymentIntentID, paymentMethodType: paymentIntent.paymentMethod?.type)
+            logHandleNextActionStarted(intentID: paymentIntentID, paymentMethod: paymentIntent.paymentMethod)
         }
         // Overwrite completion to send an analytic before calling the caller-supplied completion
         let completion: STPPaymentHandlerActionPaymentIntentCompletionBlock = { [weak self] status, paymentIntent, error in
             if shouldSendAnalytic {
-                self?.logHandleNextActionFinished(intentID: paymentIntentID, status: status, paymentMethodType: paymentIntent?.paymentMethod?.type, error: error)
+                self?.logHandleNextActionFinished(intentID: paymentIntentID, paymentMethod: paymentMethod, status: status, error: error)
             }
             completion(status, paymentIntent, error)
         }
@@ -453,7 +454,7 @@ public class STPPaymentHandler: NSObject {
         logConfirmSetupIntentStarted(setupIntentID: setupIntentID, confirmParams: setupIntentConfirmParams)
         // Overwrite completion to send an analytic before calling the caller-supplied completion
         let completion: STPPaymentHandlerActionSetupIntentCompletionBlock = { [weak self] status, setupIntent, error in
-            self?.logConfirmSetupIntentCompleted(setupIntentID: setupIntentID, status: status, paymentMethodType: setupIntentConfirmParams.paymentMethodType, error: error)
+            self?.logConfirmSetupIntentCompleted(setupIntentID: setupIntentID, confirmParams: setupIntentConfirmParams, status: status, error: error)
             completion(status, setupIntent, error)
         }
 
@@ -569,10 +570,10 @@ public class STPPaymentHandler: NSObject {
         let setupIntentID = STPSetupIntent.id(fromClientSecret: setupIntentClientSecret)
         // Overwrite completion to send an analytic before calling the caller-supplied completion
         let completion: STPPaymentHandlerActionSetupIntentCompletionBlock = { [weak self] status, setupIntent, error in
-            self?.logHandleNextActionFinished(intentID: setupIntentID, status: status, paymentMethodType: setupIntent?.paymentMethod?.type, error: error)
+            self?.logHandleNextActionFinished(intentID: setupIntentID, paymentMethod: setupIntent?.paymentMethod, status: status, error: error)
             completion(status, setupIntent, error)
         }
-        logHandleNextActionStarted(intentID: setupIntentID, paymentMethodType: nil)
+        logHandleNextActionStarted(intentID: setupIntentID, paymentMethod: nil)
 
         if !STPSetupIntentConfirmParams.isClientSecretValid(setupIntentClientSecret) {
             assertionFailure("`STPPaymentHandler.handleNextAction` was called with an invalid client secret. See https://docs.stripe.com/api/payment_intents/object#setup_intent_object-client_secret")
@@ -609,13 +610,14 @@ public class STPPaymentHandler: NSObject {
         completion: @escaping STPPaymentHandlerActionSetupIntentCompletionBlock
     ) {
         let setupIntentID = setupIntent.stripeID
+        let paymentMethod = setupIntent.paymentMethod
         if shouldSendAnalytic {
-            logHandleNextActionStarted(intentID: setupIntentID, paymentMethodType: nil)
+            logHandleNextActionStarted(intentID: setupIntentID, paymentMethod: paymentMethod)
         }
         // Overwrite completion to send an analytic before calling the caller-supplied completion
         let completion: STPPaymentHandlerActionSetupIntentCompletionBlock = { [weak self] status, setupIntent, error in
             if shouldSendAnalytic {
-                self?.logHandleNextActionFinished(intentID: setupIntentID, status: status, paymentMethodType: setupIntent?.paymentMethod?.type, error: error)
+                self?.logHandleNextActionFinished(intentID: setupIntentID, paymentMethod: paymentMethod, status: status, error: error)
             }
             completion(status, setupIntent, error)
         }

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPPaymentHandlerFunctionalSwiftTest/testconfirmpaymentintentsavedpmsendsanalytic/0000_post_v1_payment_intents_pi_3P20wFFY0qyl6XeW0dSOQ6W7_confirm.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPPaymentHandlerFunctionalSwiftTest/testconfirmpaymentintentsavedpmsendsanalytic/0000_post_v1_payment_intents_pi_3P20wFFY0qyl6XeW0dSOQ6W7_confirm.tail
@@ -1,0 +1,78 @@
+POST
+https:\/\/api\.stripe\.com\/v1\/payment_intents\/pi_3P20wFFY0qyl6XeW0dSOQ6W7\/confirm$
+400
+application/json
+access-control-allow-methods: GET,HEAD,PUT,PATCH,POST,DELETE
+content-security-policy: report-uri https://q.stripe.com/csp-report?p=v1%2Fpayment_intents%2F%3Aintent%2Fconfirm; block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: coop="https://q.stripe.com/coop-report?s=payins-bapi-srv"
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+cross-origin-opener-policy-report-only: same-origin; report-to="coop"
+Access-Control-Allow-Origin: *
+x-stripe-routing-context-priority-tier: api-testmode
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=payins-bapi-srv"}],"include_subdomains":true}
+request-id: req_yeaIfIqyozYY0R
+Content-Length: 1606
+Vary: Origin
+Date: Mon, 05 Aug 2024 23:34:01 GMT
+original-request: req_yeaIfIqyozYY0R
+stripe-version: 2020-08-27
+idempotency-key: ae26a620-5e8b-4fd2-a3f8-879f7eee2a77
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+Content-Language: en-us
+x-content-type-options: nosniff
+X-Stripe-Mock-Request: client_secret=pi_3P20wFFY0qyl6XeW0dSOQ6W7_secret_9V8GkrCOt1MEW8SBmAaGnmT6A&expand\[0]=payment_method&payment_method=pm_123&use_stripe_sdk=true
+
+{
+  "error" : {
+    "payment_intent" : {
+      "payment_method_configuration_details" : null,
+      "canceled_at" : null,
+      "source" : null,
+      "amount" : 100,
+      "capture_method" : "automatic",
+      "livemode" : false,
+      "shipping" : null,
+      "status" : "requires_payment_method",
+      "object" : "payment_intent",
+      "currency" : "usd",
+      "last_payment_error" : null,
+      "amount_subtotal" : 100,
+      "automatic_payment_methods" : null,
+      "cancellation_reason" : null,
+      "next_action" : null,
+      "total_details" : {
+        "amount_discount" : 0,
+        "amount_tax" : 0
+      },
+      "payment_method" : null,
+      "client_secret" : "pi_3P20wFFY0qyl6XeW0dSOQ6W7_secret_9V8GkrCOt1MEW8SBmAaGnmT6A",
+      "id" : "pi_3P20wFFY0qyl6XeW0dSOQ6W7",
+      "confirmation_method" : "automatic",
+      "amount_details" : {
+        "tip" : {
+
+        }
+      },
+      "processing" : null,
+      "receipt_email" : null,
+      "payment_method_types" : [
+        "card"
+      ],
+      "setup_future_usage" : null,
+      "created" : 1712278047,
+      "description" : null
+    },
+    "request_log_url" : "https:\/\/dashboard.stripe.com\/test\/logs\/req_yeaIfIqyozYY0R?t=1722900841",
+    "code" : "resource_missing",
+    "doc_url" : "https:\/\/stripe.com\/docs\/error-codes\/resource-missing",
+    "message" : "No such PaymentMethod: 'pm_123'; It's possible this PaymentMethod exists on one of your connected accounts, in which case you should retry this request on that connected account. Learn more at https:\/\/stripe.com\/docs\/connect\/authentication",
+    "param" : "payment_method",
+    "type" : "invalid_request_error"
+  }
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPPaymentHandlerFunctionalSwiftTest/testconfirmsetupintentsavedpmsendsanalytic/0000_post_v1_setup_intents_seti_1P1xLBFY0qyl6XeWc7c2LrMK_confirm.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPPaymentHandlerFunctionalSwiftTest/testconfirmsetupintentsavedpmsendsanalytic/0000_post_v1_setup_intents_seti_1P1xLBFY0qyl6XeWc7c2LrMK_confirm.tail
@@ -1,0 +1,59 @@
+POST
+https:\/\/api\.stripe\.com\/v1\/setup_intents\/seti_1P1xLBFY0qyl6XeWc7c2LrMK\/confirm$
+400
+application/json
+access-control-allow-methods: GET,HEAD,PUT,PATCH,POST,DELETE
+content-security-policy: report-uri https://q.stripe.com/csp-report?p=v1%2Fsetup_intents%2F%3Aintent%2Fconfirm; block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: coop="https://q.stripe.com/coop-report?s=payins-bapi-srv"
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+cross-origin-opener-policy-report-only: same-origin; report-to="coop"
+Access-Control-Allow-Origin: *
+x-stripe-routing-context-priority-tier: api-testmode
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=payins-bapi-srv"}],"include_subdomains":true}
+request-id: req_X0IW5Oejg4l8Hy
+Content-Length: 1190
+Vary: Origin
+Date: Mon, 05 Aug 2024 23:34:39 GMT
+original-request: req_X0IW5Oejg4l8Hy
+stripe-version: 2020-08-27
+idempotency-key: 068adc5a-4ff4-4bb0-b9ce-4a0861f2829e
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+Content-Language: en-us
+x-content-type-options: nosniff
+X-Stripe-Mock-Request: client_secret=seti_1P1xLBFY0qyl6XeWc7c2LrMK_secret_PrgithiYFFPH0NVGP1BK7Oy9OU3mrDT&expand\[0]=payment_method&payment_method=pm_123&use_stripe_sdk=true
+
+{
+  "error" : {
+    "request_log_url" : "https:\/\/dashboard.stripe.com\/test\/logs\/req_X0IW5Oejg4l8Hy?t=1722900879",
+    "code" : "resource_missing",
+    "doc_url" : "https:\/\/stripe.com\/docs\/error-codes\/resource-missing",
+    "message" : "No such PaymentMethod: 'pm_123'; It's possible this PaymentMethod exists on one of your connected accounts, in which case you should retry this request on that connected account. Learn more at https:\/\/stripe.com\/docs\/connect\/authentication",
+    "param" : "payment_method",
+    "type" : "invalid_request_error",
+    "setup_intent" : {
+      "id" : "seti_1P1xLBFY0qyl6XeWc7c2LrMK",
+      "description" : null,
+      "next_action" : null,
+      "livemode" : false,
+      "payment_method" : "pm_1P1xLBFY0qyl6XeW7OPeQ8jp",
+      "payment_method_configuration_details" : null,
+      "usage" : "off_session",
+      "payment_method_types" : [
+        "sepa_debit"
+      ],
+      "object" : "setup_intent",
+      "last_setup_error" : null,
+      "created" : 1712264217,
+      "client_secret" : "seti_1P1xLBFY0qyl6XeWc7c2LrMK_secret_PrgithiYFFPH0NVGP1BK7Oy9OU3mrDT",
+      "automatic_payment_methods" : null,
+      "cancellation_reason" : null,
+      "status" : "succeeded"
+    }
+  }
+}


### PR DESCRIPTION
…possible so that we can look up the corresponding type, in cases where we don't know the PM type on the client (e.g. confirming a saved PM).

## Motivation
We don't know the PM type for:
1. `confirm` calls using a saved PM
2. `handleNextAction` calls

We do however know the PM id! So let's send that. 

Originally when I wrote this I thought we could already find the PM type by cross referencing the Intent - but that doesn't work if you e.g. confirm with a saved PM, it fails, and you give up.  In that case, the PI doesn't have the PM attached. 

https://jira.corp.stripe.com/browse/RUN_MOBILESDK-3367

This still leaves one hole - `handleNextAction` where the merchant gives us a client_secret. The "stripeios.paymenthandler.handle_next_action.started" won't have any PM information and "stripeios.paymenthandler.handle_next_action.finished" also won't have any PM information in certain error cases where we didn't successfully retrieve the intent.

## Testing
See unit tests.

## Changelog
Not user facing.
