### PR TITLE
[Instant Debits] Finalize API request changes needed

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
@@ -278,7 +278,7 @@ extension FinancialConnectionsAPIClient: FinancialConnectionsAPI {
         return self.get(
             resource: APIEndpointFeaturedInstitutions,
             parameters: parameters,
-            useConsumerPublishableKeyIfNeeded: false
+            useConsumerPublishableKeyIfNeeded: true
         )
     }
 
@@ -306,7 +306,7 @@ extension FinancialConnectionsAPIClient: FinancialConnectionsAPI {
         return self.post(
             resource: APIEndpointAuthSessions,
             parameters: body,
-            useConsumerPublishableKeyIfNeeded: false
+            useConsumerPublishableKeyIfNeeded: true
         )
     }
 
@@ -403,7 +403,7 @@ extension FinancialConnectionsAPIClient: FinancialConnectionsAPI {
                 return self.post(
                     resource: APIEndpointAuthSessionsAccounts,
                     parameters: body,
-                    useConsumerPublishableKeyIfNeeded: false
+                    useConsumerPublishableKeyIfNeeded: true
                 )
             },
             pollTimingOptions: APIPollingHelper<FinancialConnectionsAuthSessionAccounts>.PollTimingOptions(
@@ -427,7 +427,7 @@ extension FinancialConnectionsAPIClient: FinancialConnectionsAPI {
         return self.post(
             resource: APIEndpointAuthSessionsSelectedAccounts,
             parameters: body,
-            useConsumerPublishableKeyIfNeeded: false
+            useConsumerPublishableKeyIfNeeded: true
         )
     }
 
@@ -555,7 +555,7 @@ extension FinancialConnectionsAPIClient: FinancialConnectionsAPI {
                 return self.post(
                     resource: APIEndpointAttachPaymentAccount,
                     parameters: body,
-                    useConsumerPublishableKeyIfNeeded: false
+                    useConsumerPublishableKeyIfNeeded: true
                 )
             },
             pollTimingOptions: APIPollingHelper<FinancialConnectionsPaymentAccountResource>.PollTimingOptions(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/ConsumerSession/ConsumerSessionModels.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/ConsumerSession/ConsumerSessionModels.swift
@@ -14,25 +14,27 @@ struct ConsumerSessionData: Decodable {
     let redactedFormattedPhoneNumber: String
     let verificationSessions: [VerificationSession]
 
+    /// A consumer session is considered verified if the `state == .verified` or the `type == .signUp`.
     var isVerified: Bool {
         verificationSessions.contains(where: { $0.state == .verified })
+        || verificationSessions.contains(where: { $0.type == .signUp })
     }
 }
 
 struct VerificationSession: Decodable {
     enum SessionType: String, SafeEnumDecodable, Equatable {
-        case signUp = "signup"
-        case email = "email"
-        case sms = "sms"
+        case signUp = "SIGNUP"
+        case email = "EMAIL"
+        case sms = "SMS"
         case unparsable
     }
 
     enum SessionState: String, SafeEnumDecodable, Equatable {
-        case started
-        case failed
-        case verified
-        case canceled
-        case expired
+        case started = "STARTED"
+        case failed = "FAILED"
+        case verified = "VERIFIED"
+        case canceled = "CANCELED"
+        case expired = "EXPIRED"
         case unparsable
     }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -1200,6 +1200,7 @@ private func CreatePaneViewController(
                 manifest: dataManager.manifest,
                 apiClient: dataManager.apiClient,
                 clientSecret: dataManager.clientSecret,
+                returnURL: dataManager.returnURL,
                 analyticsClient: dataManager.analyticsClient
             )
             let networkingLinkVerificationViewController = NetworkingLinkVerificationViewController(dataSource: networkingLinkVerificationDataSource)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationDataSource.swift
@@ -17,6 +17,7 @@ protocol NetworkingLinkVerificationDataSource: AnyObject {
 
     func markLinkVerified() -> Future<FinancialConnectionsSessionManifest>
     func fetchNetworkedAccounts() -> Future<FinancialConnectionsNetworkedAccountsResponse>
+    func attachConsumerToLinkAccountAndSynchronize() -> Future<FinancialConnectionsSynchronize>
 }
 
 final class NetworkingLinkVerificationDataSourceImplementation: NetworkingLinkVerificationDataSource {
@@ -25,22 +26,29 @@ final class NetworkingLinkVerificationDataSourceImplementation: NetworkingLinkVe
     let manifest: FinancialConnectionsSessionManifest
     private let apiClient: FinancialConnectionsAPIClient
     private let clientSecret: String
+    private let returnURL: String?
     let analyticsClient: FinancialConnectionsAnalyticsClient
     let networkingOTPDataSource: NetworkingOTPDataSource
 
-    private(set) var consumerSession: ConsumerSessionData?
+    private(set) var consumerSession: ConsumerSessionData? {
+        didSet {
+            apiClient.consumerSession = consumerSession
+        }
+    }
 
     init(
         accountholderCustomerEmailAddress: String,
         manifest: FinancialConnectionsSessionManifest,
         apiClient: FinancialConnectionsAPIClient,
         clientSecret: String,
+        returnURL: String?,
         analyticsClient: FinancialConnectionsAnalyticsClient
     ) {
         self.accountholderCustomerEmailAddress = accountholderCustomerEmailAddress
         self.manifest = manifest
         self.apiClient = apiClient
         self.clientSecret = clientSecret
+        self.returnURL = returnURL
         self.analyticsClient = analyticsClient
         let networkingOTPDataSource = NetworkingOTPDataSourceImplementation(
             otpType: "SMS",
@@ -71,6 +79,38 @@ final class NetworkingLinkVerificationDataSourceImplementation: NetworkingLinkVe
             clientSecret: clientSecret,
             consumerSessionClientSecret: consumerSessionClientSecret
         )
+    }
+
+    func attachConsumerToLinkAccountAndSynchronize() -> Future<FinancialConnectionsSynchronize> {
+        guard manifest.isProductInstantDebits else {
+            return Promise(error: FinancialConnectionsSheetError.unknown(
+                debugDescription: "Invalid \(#function) state: should only be used in instant debits flow"
+            ))
+        }
+
+        guard let consumerSessionClientSecret = consumerSession?.clientSecret else {
+            return Promise(error: FinancialConnectionsSheetError.unknown(
+                debugDescription: "Invalid \(#function) state: no consumerSessionClientSecret"
+            ))
+        }
+
+        return apiClient.attachLinkConsumerToLinkAccountSession(
+            requestSurface: "ios_instant_debits",
+            linkAccountSession: clientSecret,
+            consumerSessionClientSecret: consumerSessionClientSecret
+        )
+        .chained { [weak self] _ in
+            guard let self else {
+                return Promise(error: FinancialConnectionsSheetError.unknown(
+                    debugDescription: "Data source deallocated"
+                ))
+            }
+
+            return self.apiClient.synchronize(
+                clientSecret: self.clientSecret,
+                returnURL: self.returnURL
+            )
+        }
     }
 }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationViewController.swift
@@ -92,6 +92,30 @@ final class NetworkingLinkVerificationViewController: UIViewController {
             delegate?.networkingLinkVerificationViewController(self, didReceiveTerminalError: FinancialConnectionsSheetError.unknown(debugDescription: "logic error: did not have consumerSession"))
         }
     }
+
+    private func attachConsumerToLinkAccountAndSynchronize(from view: NetworkingOTPView) {
+        dataSource
+            .attachConsumerToLinkAccountAndSynchronize()
+            .observe { [weak self] result in
+                guard let self else { return }
+                self.hideOTPLoadingViewAfterDelay(view)
+
+                switch result {
+                case .success(let synchronizePayload):
+                    self.requestNextPane(synchronizePayload.manifest.nextPane)
+                case .failure(let error):
+                    self.delegate?.networkingLinkVerificationViewController(self, didReceiveTerminalError: error)
+                }
+            }
+    }
+
+    private func hideOTPLoadingViewAfterDelay(_ view: NetworkingOTPView) {
+        // only hide loading view after animation
+        // to next screen has completed
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak view] in
+            view?.showLoadingView(false)
+        }
+    }
 }
 
 // MARK: - NetworkingOTPViewDelegate
@@ -163,17 +187,24 @@ extension NetworkingLinkVerificationViewController: NetworkingOTPViewDelegate {
     }
 
     func networkingOTPViewDidConfirmVerification(_ view: NetworkingOTPView) {
+        var shouldHideLoadingView = true
+
         view.showLoadingView(true)
         dataSource.markLinkVerified()
             .observe { [weak self] result in
                 guard let self = self else { return }
                 switch result {
                 case .success:
-                    self.dataSource.analyticsClient.log(
-                        eventName: "networking.verification.success",
-                        pane: .networkingLinkVerification
-                    )
-                    self.requestNextPane(.linkAccountPicker)
+                    if self.dataSource.manifest.isProductInstantDebits {
+                        shouldHideLoadingView = false
+                        self.attachConsumerToLinkAccountAndSynchronize(from: view)
+                    } else {
+                        self.dataSource.analyticsClient.log(
+                            eventName: "networking.verification.success",
+                            pane: .networkingLinkVerification
+                        )
+                        self.requestNextPane(.linkAccountPicker)
+                    }
                 case .failure(let error):
                     self.dataSource
                         .analyticsClient
@@ -201,12 +232,8 @@ extension NetworkingLinkVerificationViewController: NetworkingOTPViewDelegate {
                     self.requestNextPane(nextPane)
                 }
 
-                // only hide loading view after animation
-                // to next screen has completed
-                DispatchQueue.main.asyncAfter(
-                    deadline: .now() + 1.0
-                ) { [weak view] in
-                    view?.showLoadingView(false)
+                if shouldHideLoadingView {
+                    self.hideOTPLoadingViewAfterDelay(view)
                 }
             }
     }


### PR DESCRIPTION
## Summary

This finalizes a few remaining changes needed to complete the Instant Debits flow in both the new user experience, and the return user experience. Here's what changes:

- Use the consumer publishable key for more requests that happen after a user is verified
- Consider a consumer session as verified if the flow is "sign up"
- Fix the raw values for the consumer session's `State` and `Type` enums to the correct capitalization.
- When in the instant debits flow, after a return Link user is verified, call the `/attach_link_consumer_to_link_account_session` and `/synchronize` endpoints before continuing.

With these changes, both the NUX and RUX flows should work from start to finish :) 

## Motivation

Part of the [Native Instant Debits project](https://docs.google.com/document/d/1k0tv4jUxL9QSxni1QEo-ZiHG_HDCX9gAMo2qKE8kqbQ/edit?usp=sharing). This fixes some of the known issues mentioned in https://github.com/stripe/stripe-ios/pull/3848.

## Testing

RUX: 

https://github.com/user-attachments/assets/1315470a-3ba7-447b-9c85-194cb341c8d4

NUX:

https://github.com/user-attachments/assets/01b77347-527e-47f3-b8aa-2a26f6c33569

## Changelog

N/a
