### PR TITLE
Fix FinancialConnectionsNetworkingUITests

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
@@ -63,7 +63,7 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         XCTAssertTrue(phoneTextFieldToolbarDoneButton.waitForExistence(timeout: 60.0))
         phoneTextFieldToolbarDoneButton.tap()
 
-        let saveToLinkButon = app.buttons["Save to Link"]
+        let saveToLinkButon = app.buttons["Save with Link"]
         XCTAssertTrue(saveToLinkButon.waitForExistence(timeout: 120.0))  // glitch app can take time to lload
         saveToLinkButon.tap()
 
@@ -327,7 +327,7 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         XCTAssertTrue(phoneTextFieldToolbarDoneButton.waitForExistence(timeout: 60.0))
         phoneTextFieldToolbarDoneButton.tap()
 
-        let saveToLinkButon = app.buttons["Save to Link"]
+        let saveToLinkButon = app.buttons["Save with Link"]
         XCTAssertTrue(saveToLinkButon.waitForExistence(timeout: 120.0))  // glitch app can take time to lload
         saveToLinkButon.tap()
 
@@ -383,7 +383,7 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
 
         // both, email and phone, will already be pre-filled
 
-        let saveToLinkButon = app.buttons["Save to Link"]
+        let saveToLinkButon = app.buttons["Save with Link"]
         XCTAssertTrue(saveToLinkButon.waitForExistence(timeout: 120.0))  // glitch app can take time to lload
         saveToLinkButon.tap()
 

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
@@ -63,7 +63,7 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         XCTAssertTrue(phoneTextFieldToolbarDoneButton.waitForExistence(timeout: 60.0))
         phoneTextFieldToolbarDoneButton.tap()
 
-        let saveToLinkButon = app.buttons["Save with Link"]
+        let saveToLinkButon = app.buttons["networking_link_signup_footer_view.save_to_link_button"]
         XCTAssertTrue(saveToLinkButon.waitForExistence(timeout: 120.0))  // glitch app can take time to lload
         saveToLinkButon.tap()
 
@@ -327,7 +327,7 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         XCTAssertTrue(phoneTextFieldToolbarDoneButton.waitForExistence(timeout: 60.0))
         phoneTextFieldToolbarDoneButton.tap()
 
-        let saveToLinkButon = app.buttons["Save with Link"]
+        let saveToLinkButon = app.buttons["networking_link_signup_footer_view.save_to_link_button"]
         XCTAssertTrue(saveToLinkButon.waitForExistence(timeout: 120.0))  // glitch app can take time to lload
         saveToLinkButon.tap()
 
@@ -383,7 +383,7 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
 
         // both, email and phone, will already be pre-filled
 
-        let saveToLinkButon = app.buttons["Save with Link"]
+        let saveToLinkButon = app.buttons["networking_link_signup_footer_view.save_to_link_button"]
         XCTAssertTrue(saveToLinkButon.waitForExistence(timeout: 120.0))  // glitch app can take time to lload
         saveToLinkButon.tap()
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupFooterView.swift
@@ -63,6 +63,7 @@ class NetworkingLinkSignupFooterView: HitTestView {
     private lazy var saveToLinkButton: StripeUICore.Button = {
         let saveToLinkButton = Button.primary(theme: theme)
         saveToLinkButton.title = saveToLinkButtonText
+        saveToLinkButton.accessibilityIdentifier = "networking_link_signup_footer_view.save_to_link_button"
         saveToLinkButton.addTarget(self, action: #selector(didSelectSaveToLinkButton), for: .touchUpInside)
         saveToLinkButton.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([


### PR DESCRIPTION
## Summary

This fixes some [failing `FinancialConnectionsNetworkingUITests` tests](https://app.bitrise.io/build/cd602d84-6b3c-4df7-bc42-01101db3254c). The tests were looking for a button by text, but the text [comes from the server](https://github.com/stripe/stripe-ios/blob/23d48c98621e2dda405a6c3809bc98f462883976/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift#L113), which was recently updated from `Save to Link` to `Save with Link`.

## Motivation

Fix `master` :)

## Testing

Trust CI ✅ 

## Changelog

N/a