### PR TITLE
[BANKCON-11478] FC - Tweak warmup sheet for returning users

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -798,6 +798,12 @@ extension NativeFlowController: NetworkingLinkLoginWarmupViewControllerDelegate 
         pushPane(.networkingLinkVerification, animated: true)
     }
 
+    func networkingLinkLoginWarmupViewControllerDidSelectCancel(
+        _ viewController: NetworkingLinkLoginWarmupViewController
+    ) {
+        viewController.dismiss(animated: true)
+    }
+
     func networkingLinkLoginWarmupViewController(
         _ viewController: NetworkingLinkLoginWarmupViewController,
         didSelectSkipWithManifest manifest: FinancialConnectionsSessionManifest

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupViewController.swift
@@ -13,6 +13,9 @@ protocol NetworkingLinkLoginWarmupViewControllerDelegate: AnyObject {
     func networkingLinkLoginWarmupViewControllerDidSelectContinue(
         _ viewController: NetworkingLinkLoginWarmupViewController
     )
+    func networkingLinkLoginWarmupViewControllerDidSelectCancel(
+        _ viewController: NetworkingLinkLoginWarmupViewController
+    )
     func networkingLinkLoginWarmupViewController(
         _ viewController: NetworkingLinkLoginWarmupViewController,
         didSelectSkipWithManifest manifest: FinancialConnectionsSessionManifest
@@ -39,6 +42,18 @@ final class NetworkingLinkLoginWarmupViewController: SheetViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        let footerSecondaryButtonTitle: String
+        if dataSource.manifest.isProductInstantDebits {
+            footerSecondaryButtonTitle = STPLocalizedString(
+                "Cancel",
+                "A button title. This button, when pressed, will simply dismiss the warmup pane, as it is required to continue with Link in the Instant Debits flow."
+            )
+        } else {
+            footerSecondaryButtonTitle = STPLocalizedString(
+                "Not now",
+                "A button title. This button, when pressed, will skip logging in the user with their e-mail to Link (one-click checkout provider)."
+            )
+        }
         setup(
             withContentView: PaneLayoutView.createContentView(
                 iconView: RoundedIconView(
@@ -73,10 +88,7 @@ final class NetworkingLinkLoginWarmupViewController: SheetViewController {
                     }
                 ),
                 secondaryButtonConfiguration: PaneLayoutView.ButtonConfiguration(
-                    title: STPLocalizedString(
-                        "Not now",
-                        "A button title. This button, when pressed, will skip logging in the user with their e-mail to Link (one-click checkout provider)."
-                    ),
+                    title: footerSecondaryButtonTitle,
                     action: { [weak self] in
                         self?.didSelectSkip()
                     }
@@ -95,29 +107,33 @@ final class NetworkingLinkLoginWarmupViewController: SheetViewController {
     }
 
     private func didSelectSkip() {
-        dataSource.analyticsClient.log(
-            eventName: "click.skip_sign_in",
-            pane: .networkingLinkLoginWarmup
-        )
-        dataSource.disableNetworking()
-            .observe { [weak self] result in
-                guard let self = self else { return }
-                switch result {
-                case .success(let manifest):
-                    self.delegate?.networkingLinkLoginWarmupViewController(
-                        self,
-                        didSelectSkipWithManifest: manifest
-                    )
-                case .failure(let error):
-                    self.dataSource
-                        .analyticsClient
-                        .logUnexpectedError(
-                            error,
-                            errorName: "DisableNetworkingError",
-                            pane: .networkingLinkLoginWarmup
+        if dataSource.manifest.isProductInstantDebits {
+            delegate?.networkingLinkLoginWarmupViewControllerDidSelectCancel(self)
+        } else {
+            dataSource.analyticsClient.log(
+                eventName: "click.skip_sign_in",
+                pane: .networkingLinkLoginWarmup
+            )
+            dataSource.disableNetworking()
+                .observe { [weak self] result in
+                    guard let self = self else { return }
+                    switch result {
+                    case .success(let manifest):
+                        self.delegate?.networkingLinkLoginWarmupViewController(
+                            self,
+                            didSelectSkipWithManifest: manifest
                         )
-                    self.delegate?.networkingLinkLoginWarmupViewController(self, didReceiveTerminalError: error)
+                    case .failure(let error):
+                        self.dataSource
+                            .analyticsClient
+                            .logUnexpectedError(
+                                error,
+                                errorName: "DisableNetworkingError",
+                                pane: .networkingLinkLoginWarmup
+                            )
+                        self.delegate?.networkingLinkLoginWarmupViewController(self, didReceiveTerminalError: error)
+                    }
                 }
-            }
+        }
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupViewController.swift
@@ -108,7 +108,19 @@ final class NetworkingLinkLoginWarmupViewController: SheetViewController {
 
     private func didSelectSkip() {
         if dataSource.manifest.isProductInstantDebits {
-            delegate?.networkingLinkLoginWarmupViewControllerDidSelectCancel(self)
+            guard let delegate else {
+                dataSource
+                    .analyticsClient
+                    .logUnexpectedError(
+                        FinancialConnectionsSheetError.unknown(
+                            debugDescription: "Unexpected nil delegate in the NetworkLinkLoginWarmup pane when selecting Cancel."
+                        ),
+                        errorName: "InstantDebitsCancelError",
+                        pane: .networkingLinkLoginWarmup
+                    )
+                return
+            }
+            delegate.networkingLinkLoginWarmupViewControllerDidSelectCancel(self)
         } else {
             dataSource.analyticsClient.log(
                 eventName: "click.skip_sign_in",


### PR DESCRIPTION
## Summary

This updates the Networking Link login warmup pane with the following change for the Instant Debits flow:

- Change secondary button text from `Not now` to `Cancel`.
- On tap of this button, dismiss the warmup pane rather than continuing without networking.

## Motivation

Part of the [Native Instant Debits project](https://docs.google.com/document/d/1k0tv4jUxL9QSxni1QEo-ZiHG_HDCX9gAMo2qKE8kqbQ/edit?usp=sharing).

## Testing

Before:

https://github.com/user-attachments/assets/a3982abc-2980-4157-b99e-8afcfd3bbf33

After:

https://github.com/user-attachments/assets/60c1ffba-9454-4504-9b97-e475900720c2

## Changelog

N/a
