### PR TITLE
[BANKCON-11696] Prioritize using email from consumer session for verification

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -1194,7 +1194,7 @@ private func CreatePaneViewController(
     case .networkingLinkVerification:
         let accountholderCustomerEmailAddress = dataManager.manifest.accountholderCustomerEmailAddress
         let consumerSessionEmailAddress = dataManager.consumerSession?.emailAddress
-        if let accountholderCustomerEmailAddress = accountholderCustomerEmailAddress ?? consumerSessionEmailAddress {
+        if let accountholderCustomerEmailAddress = consumerSessionEmailAddress ?? accountholderCustomerEmailAddress {
             let networkingLinkVerificationDataSource = NetworkingLinkVerificationDataSourceImplementation(
                 accountholderCustomerEmailAddress: accountholderCustomerEmailAddress,
                 manifest: dataManager.manifest,


### PR DESCRIPTION
## Summary

This is a small change to change the priority order of which email is used for verification. We need to use the email from the consumer session first if it's available, because it will represent what was entered in the link signup pane.

Here's the scenario:

- An account holder email is passed into the flow that doesn't have a link account. This is the `manifest.accountholderCustomerEmailAddress`.
- On the Link signup pane, the email is changed to an existing Link account email. This is the `consumerSession.emailAddress`.
- 💥 

## Motivation

Fixes an edge case in the Native Instant Debits project

## Testing

Before:

https://github.com/user-attachments/assets/cdd1b2d2-4ab4-4ca4-a1ea-06b894e390c9

After:

https://github.com/user-attachments/assets/f62481f1-0960-49fb-b86f-c4365e7d767c

## Changelog

This feature isn't launched yet, so there's no need to update the changelog.
