### PR TITLE
[BANKCON-11480] Complete instant debits flow with payment method

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
+++ b/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		49C911392C597EAF00589E0D /* LinkLoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C911352C597EAF00589E0D /* LinkLoginViewController.swift */; };
 		49C9113B2C59932300589E0D /* LinkSignupFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C9113A2C59932300589E0D /* LinkSignupFormView.swift */; };
 		49F047532C63B430006BAD3E /* StripeSchemeAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F047522C63B430006BAD3E /* StripeSchemeAddress.swift */; };
+		49F047552C63C2E5006BAD3E /* FinancialConnectionsPaymentDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F047542C63C2E5006BAD3E /* FinancialConnectionsPaymentDetails.swift */; };
 		4A0D015C978BD79BBFE6CE57 /* ManualEntryDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4C39F5F9AF440B13F51A81 /* ManualEntryDataSource.swift */; };
 		4A537AE0C50CAFF3889EFE28 /* UIViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7E41313B709F87B549D85F /* UIViewController+Extensions.swift */; };
 		4DC8EB63806434ABF4C9CC43 /* add@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 782A419DCF59BE6AB6439D04 /* add@3x.png */; };
@@ -332,6 +333,7 @@
 		49C911352C597EAF00589E0D /* LinkLoginViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinkLoginViewController.swift; sourceTree = "<group>"; };
 		49C9113A2C59932300589E0D /* LinkSignupFormView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LinkSignupFormView.swift; path = StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/LinkSignupFormView.swift; sourceTree = SOURCE_ROOT; };
 		49F047522C63B430006BAD3E /* StripeSchemeAddress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StripeSchemeAddress.swift; sourceTree = "<group>"; };
+		49F047542C63C2E5006BAD3E /* FinancialConnectionsPaymentDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsPaymentDetails.swift; sourceTree = "<group>"; };
 		4A7B146AA6BF44921A249DB8 /* EmptyFinancialConnectionsAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyFinancialConnectionsAPIClient.swift; sourceTree = "<group>"; };
 		4AFBF95DAE0783010A17EB58 /* FinancialConnectionsSession_only_accounts.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = FinancialConnectionsSession_only_accounts.json; sourceTree = "<group>"; };
 		4BFCD9C339634B71FC8F85E9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -772,6 +774,7 @@
 				495539ED2C484DC200543D18 /* FinancialConnectionsTheme.swift */,
 				49AC518B2C52DE2C00B712CC /* FinancialConnectionsLinkLoginPane.swift */,
 				6A384A832C24DD720044AB99 /* FinancialConnectionsGenericInfoScreen.swift */,
+				49F047542C63C2E5006BAD3E /* FinancialConnectionsPaymentDetails.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1325,6 +1328,7 @@
 				1C043C73281C0856D2C979C6 /* FinancialConnectionsSession.swift in Sources */,
 				9E0044ABEC04E2A8C50E3658 /* FinancialConnectionsSessionManifest.swift in Sources */,
 				6A6F989C2C4F1BF00035C03D /* CreatePaneParameters.swift in Sources */,
+				49F047552C63C2E5006BAD3E /* FinancialConnectionsPaymentDetails.swift in Sources */,
 				D936C8A9F6E018DB144A5B0A /* FinancialConnectionsSynchronize.swift in Sources */,
 				15EC9F36187C341800164428 /* FinancialConnectionsAnalyticsClient.swift in Sources */,
 				C61D5957D3276991795F7D16 /* FinancialConnectionsSheetAnalytics.swift in Sources */,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
@@ -213,6 +213,16 @@ protocol FinancialConnectionsAPI {
         linkAccountSession: String,
         consumerSessionClientSecret: String
     ) -> Future<AttachLinkConsumerToLinkAccountSessionResponse>
+
+    func paymentDetails(
+        consumerSessionClientSecret: String,
+        bankAccountId: String
+    ) -> Future<FinancialConnectionsPaymentDetails>
+
+    func paymentMethods(
+        consumerSessionClientSecret: String,
+        paymentDetailsId: String
+    ) -> Future<FinancialConnectionsPaymentMethod>
 }
 
 extension FinancialConnectionsAPIClient: FinancialConnectionsAPI {
@@ -912,6 +922,47 @@ extension FinancialConnectionsAPIClient: FinancialConnectionsAPI {
             useConsumerPublishableKeyIfNeeded: false
         )
     }
+
+    func paymentDetails(
+        consumerSessionClientSecret: String,
+        bankAccountId: String
+    ) -> Future<FinancialConnectionsPaymentDetails> {
+        let parameters: [String: Any] = [
+            "request_surface": requestSurface,
+            "credentials": [
+                "consumer_session_client_secret": consumerSessionClientSecret
+            ],
+            "bank_account": [
+                "account": bankAccountId
+            ],
+            "type": "bank_account",
+        ]
+        return post(
+            resource: APIEndpointPaymentDetails,
+            parameters: parameters,
+            useConsumerPublishableKeyIfNeeded: true
+        )
+    }
+
+    func paymentMethods(
+        consumerSessionClientSecret: String,
+        paymentDetailsId: String
+    ) -> Future<FinancialConnectionsPaymentMethod> {
+        let parameters: [String: Any] = [
+            "link": [
+                "credentials": [
+                    "consumer_session_client_secret": consumerSessionClientSecret
+                ],
+                "payment_details_id": paymentDetailsId,
+            ],
+            "type": "link",
+        ]
+        return post(
+            resource: APIEndpointPaymentMethods,
+            parameters: parameters,
+            useConsumerPublishableKeyIfNeeded: false
+        )
+    }
 }
 
 private let APIEndpointListAccounts = "link_account_sessions/list_accounts"
@@ -940,5 +991,8 @@ private let APIEndpointSaveAccountsToLink = "link_account_sessions/save_accounts
 private let APIEndpointShareNetworkedAccount = "link_account_sessions/share_networked_account"
 private let APIEndpointConsumerSessions = "connections/link_account_sessions/consumer_sessions"
 private let APIEndpointPollAccountNumbers = "link_account_sessions/poll_account_numbers"
+// Instant Debits
 private let APIEndpointLinkAccountsSignUp = "consumers/accounts/sign_up"
 private let APIEndpointAttachLinkConsumerToLinkAccountSession = "consumers/attach_link_consumer_to_link_account_session"
+private let APIEndpointPaymentDetails = "consumers/payment_details"
+private let APIEndpointPaymentMethods = "payment_methods"

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsPaymentDetails.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsPaymentDetails.swift
@@ -1,0 +1,26 @@
+//
+//  FinancialConnectionsPaymentDetails.swift
+//  StripeFinancialConnections
+//
+//  Created by Mat Schmid on 2024-08-07.
+//
+
+import Foundation
+
+struct FinancialConnectionsPaymentDetails: Decodable {
+    let redactedPaymentDetails: RedactedPaymentDetails
+}
+
+struct RedactedPaymentDetails: Decodable {
+    let id: String
+    let bankAccountDetails: BankAccountDetails?
+}
+
+struct BankAccountDetails: Decodable {
+    let bankName: String?
+    let last4: String?
+}
+
+struct FinancialConnectionsPaymentMethod: Decodable {
+    let id: String
+}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostController.swift
@@ -205,22 +205,13 @@ extension HostController: FinancialConnectionsWebFlowViewControllerDelegate {
 extension HostController: NativeFlowControllerDelegate {
     func nativeFlowController(
         _ nativeFlowController: NativeFlowController,
-        didFinish result: FinancialConnectionsSheet.Result
+        didFinish result: HostControllerResult
     ) {
         guard let viewController = navigationController.topViewController else {
             assertionFailure("Navigation stack is empty")
             return
         }
-        let hostControllerResult: HostControllerResult
-        switch result {
-        case .completed(let session):
-            hostControllerResult = .completed(.financialConnections(session))
-        case .canceled:
-            hostControllerResult = .canceled
-        case .failed(let error):
-            hostControllerResult = .failed(error: error)
-        }
-        delegate?.hostController(self, viewController: viewController, didFinish: hostControllerResult)
+        delegate?.hostController(self, viewController: viewController, didFinish: result)
     }
 
     func nativeFlowController(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -13,7 +13,7 @@ protocol NativeFlowControllerDelegate: AnyObject {
 
     func nativeFlowController(
         _ nativeFlowController: NativeFlowController,
-        didFinish result: FinancialConnectionsSheet.Result
+        didFinish result: HostControllerResult
     )
 
     func nativeFlowController(
@@ -352,7 +352,7 @@ extension NativeFlowController {
             )
         }
 
-        let finishAuthSession: (FinancialConnectionsSheet.Result) -> Void = { [weak self] result in
+        let finishAuthSession: (HostControllerResult) -> Void = { [weak self] result in
             guard let self = self else { return }
             self.delegate?.nativeFlowController(self, didFinish: result)
         }
@@ -378,21 +378,53 @@ extension NativeFlowController {
                         if !session.accounts.data.isEmpty || session.paymentAccount != nil
                             || session.bankAccountToken != nil
                         {
-                            self.delegate?.nativeFlowController(
-                                self,
-                                didReceiveEvent: FinancialConnectionsEvent(
-                                    name: .success,
-                                    metadata: FinancialConnectionsEvent.Metadata(
-                                        manualEntry: session.paymentAccount?.isManualEntry ?? false
+                            createPaymentMethodIfNeeded(for: session) { result in
+                                if let result {
+                                    switch result {
+                                    case .success(let linkedBank):
+                                        self.delegate?.nativeFlowController(
+                                            self,
+                                            didReceiveEvent: FinancialConnectionsEvent(
+                                                name: .success,
+                                                metadata: FinancialConnectionsEvent.Metadata(
+                                                    manualEntry: session.paymentAccount?.isManualEntry ?? false
+                                                )
+                                            )
+                                        )
+                                        self.logCompleteEvent(
+                                            type: eventType,
+                                            status: "completed",
+                                            numberOfLinkedAccounts: session.accounts.data.count
+                                        )
+                                        finishAuthSession(.completed(.instantDebits(linkedBank)))
+                                    case .failure(let createPaymentError):
+                                        self.logCompleteEvent(
+                                            type: eventType,
+                                            status: "failed",
+                                            error: createPaymentError
+                                        )
+                                        finishAuthSession(.failed(error: createPaymentError))
+                                    }
+                                } else {
+                                    // This is the case where no payment method was created.
+                                    // We can still complete with the existing session details.
+                                    self.delegate?.nativeFlowController(
+                                        self,
+                                        didReceiveEvent: FinancialConnectionsEvent(
+                                            name: .success,
+                                            metadata: FinancialConnectionsEvent.Metadata(
+                                                manualEntry: session.paymentAccount?.isManualEntry ?? false
+                                            )
+                                        )
                                     )
-                                )
-                            )
-                            self.logCompleteEvent(
-                                type: eventType,
-                                status: "completed",
-                                numberOfLinkedAccounts: session.accounts.data.count
-                            )
-                            finishAuthSession(.completed(session: session))
+                                    self.logCompleteEvent(
+                                        type: eventType,
+                                        status: "completed",
+                                        numberOfLinkedAccounts: session.accounts.data.count
+                                    )
+                                    finishAuthSession(.completed(.financialConnections(session)))
+                                }
+                            }
                         } else if let closeAuthFlowError = closeAuthFlowError {
                             self.logCompleteEvent(
                                 type: eventType,
@@ -443,6 +475,59 @@ extension NativeFlowController {
                     }
                 }
             }
+    }
+
+    private func createPaymentMethodIfNeeded(
+        for session: StripeAPI.FinancialConnectionsSession,
+        completion: @escaping (Result<InstantDebitsLinkedBank, Error>?) -> Void)
+    {
+        guard dataManager.manifest.isProductInstantDebits else {
+            completion(nil)
+            return
+        }
+
+        let bankAccountId: String?
+        switch session.paymentAccount {
+        case .bankAccount(let account):
+            bankAccountId = account.id
+        case .linkedAccount(let account):
+            bankAccountId = account.id
+        default:
+            bankAccountId = nil
+        }
+
+        if let bankAccountId, let consumerSession = dataManager.consumerSession {
+            var bankAccountDetails: BankAccountDetails?
+            dataManager.createPaymentDetails(
+                consumerSessionClientSecret: consumerSession.clientSecret,
+                bankAccountId: bankAccountId
+            ).chained { [weak self] paymentDetails -> Future<FinancialConnectionsPaymentMethod> in
+                guard let self else {
+                    return Promise(error: FinancialConnectionsSheetError.unknown(debugDescription: "data source deallocated"))
+                }
+
+                bankAccountDetails = paymentDetails.redactedPaymentDetails.bankAccountDetails
+                return self.dataManager.createPaymentMethod(
+                    consumerSessionClientSecret: consumerSession.clientSecret,
+                    paymentDetailsId: paymentDetails.redactedPaymentDetails.id
+                )
+            }
+            .observe { result in
+                switch result {
+                case .success(let paymentMethod):
+                    let linkedBank = InstantDebitsLinkedBankImplementation(
+                        paymentMethodId: paymentMethod.id,
+                        bankName: bankAccountDetails?.bankName,
+                        last4: bankAccountDetails?.last4
+                    )
+                    completion(.success(linkedBank))
+                case .failure(let error):
+                    completion(.failure(error))
+                }
+            }
+        } else {
+            completion(nil)
+        }
     }
 
     private func logCompleteEvent(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowDataManager.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowDataManager.swift
@@ -34,6 +34,14 @@ protocol NativeFlowDataManager: AnyObject {
     var customSuccessPaneCaption: String? { get set }
     var customSuccessPaneSubCaption: String? { get set }
 
+    func createPaymentDetails(
+        consumerSessionClientSecret: String,
+        bankAccountId: String
+    ) -> Future<FinancialConnectionsPaymentDetails>
+    func createPaymentMethod(
+        consumerSessionClientSecret: String,
+        paymentDetailsId: String
+    ) -> Future<FinancialConnectionsPaymentMethod>
     func resetState(withNewManifest newManifest: FinancialConnectionsSessionManifest)
     func completeFinancialConnectionsSession(terminalError: String?) -> Future<StripeAPI.FinancialConnectionsSession>
 }
@@ -120,6 +128,26 @@ class NativeFlowAPIDataManager: NativeFlowDataManager {
         // If the server returns active institution use that, otherwise resort to initial institution.
         self.institution = manifest.activeInstitution ?? manifest.initialInstitution
         didUpdateManifest()
+    }
+
+    func createPaymentDetails(
+        consumerSessionClientSecret: String,
+        bankAccountId: String
+    ) -> Future<FinancialConnectionsPaymentDetails> {
+        apiClient.paymentDetails(
+            consumerSessionClientSecret: consumerSessionClientSecret,
+            bankAccountId: bankAccountId
+        )
+    }
+
+    func createPaymentMethod(
+        consumerSessionClientSecret: String,
+        paymentDetailsId: String
+    ) -> Future<FinancialConnectionsPaymentMethod> {
+        apiClient.paymentMethods(
+            consumerSessionClientSecret: consumerSessionClientSecret,
+            paymentDetailsId: paymentDetailsId
+        )
     }
 
     func completeFinancialConnectionsSession(terminalError: String?) -> Future<StripeAPI.FinancialConnectionsSession> {

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
@@ -211,4 +211,12 @@ class EmptyFinancialConnectionsAPIClient: FinancialConnectionsAPI {
     ) -> Future<AttachLinkConsumerToLinkAccountSessionResponse> {
         return Promise<StripeFinancialConnections.AttachLinkConsumerToLinkAccountSessionResponse>()
     }
+
+    func paymentDetails(consumerSessionClientSecret: String, bankAccountId: String) -> StripeCore.Future<StripeFinancialConnections.FinancialConnectionsPaymentDetails> {
+        Promise<StripeFinancialConnections.FinancialConnectionsPaymentDetails>()
+    }
+
+    func paymentMethods(consumerSessionClientSecret: String, paymentDetailsId: String) -> StripeCore.Future<StripeFinancialConnections.FinancialConnectionsPaymentMethod> {
+        Promise<StripeFinancialConnections.FinancialConnectionsPaymentMethod>()
+    }
 }


### PR DESCRIPTION
## Summary

Once the native instant debits flow completes, we need to create a payment method from the bank account. To do this, we first call `/consumers/payment_details` to get the bank account details, then `/payment_methods` to create the payment method from the payment details ID.

## Motivation

Part of the [Native Instant Debits project](https://home.corp.stripe.com/compass/projects/native-instant-debits-on-mobile)!

## Testing

Here's the full E2E flow from the payment sheet example app:

https://github.com/user-attachments/assets/38800f5e-e6af-4c4a-a8d7-7eabeb476acd

## Changelog

N/a