### PR TITLE
Fix STPPaymentCardTextField cbc not calling didchange delegate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ### PaymentSheet
 * [Fixed] Fixed PaymentSheet.FlowController returning unlocalized labels for certain payment methods e.g. "AfterPay ClearPay" instead of "Afterpay" or "Clearpay" depending on locale.
 
+### PaymentsUI
+* [Fixed] Fixed an issue where STPPaymentCardTextField wouldn't call its delegate `paymentCardTextFieldDidChange` method when the preferred card network changed. 
+
 ## 23.29.0 2024-08-05
 ### PaymentSheet
 * [Fixed] Fixed a scroll issue with native 3DS2 authentication screen when the keyboard appears.

--- a/StripePaymentsUI/StripePaymentsUI/Source/Helpers/STPCBCController.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/Helpers/STPCBCController.swift
@@ -146,11 +146,10 @@ class STPCBCController {
 
     var contextMenuConfiguration: UIContextMenuConfiguration {
         return UIContextMenuConfiguration(actionProvider: { _ in
-            let action = { (action: UIAction) -> Void in
+            let action = { (action: UIAction) in
                 let brand = STPCard.brand(from: action.identifier.rawValue)
                 // Set the selected brand if a brand is selected
                 self.selectedBrand = brand != .unknown ? brand : nil
-                self.updateHandler?()
             }
             let placeholderAction = UIAction(title: String.Localized.card_brand_dropdown_placeholder, attributes: .disabled, handler: action)
             let menu = UIMenu(children:

--- a/StripePaymentsUI/StripePaymentsUI/Source/UI Components/STPPaymentCardTextField.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/UI Components/STPPaymentCardTextField.swift
@@ -601,7 +601,9 @@ open class STPPaymentCardTextField: UIControl, UIKeyInput, STPFormTextFieldDeleg
         }
         let postalCodeRequested = viewModel.postalCodeRequested
         viewModel = STPPaymentCardTextFieldViewModel(brandUpdateHandler: { [weak self] in
-            self?.updateImage(for: .number)
+            guard let self else { return }
+            self.updateImage(for: .number)
+            self.delegate?.paymentCardTextFieldDidChange?(self)
         })
         viewModel.postalCodeRequested = postalCodeRequested
         onChange()
@@ -727,7 +729,9 @@ open class STPPaymentCardTextField: UIControl, UIKeyInput, STPFormTextFieldDeleg
 
     @objc internal lazy var viewModel: STPPaymentCardTextFieldViewModel = {
         STPPaymentCardTextFieldViewModel(brandUpdateHandler: { [weak self] in
-            self?.updateImage(for: .number)
+            guard let self else { return }
+            self.updateImage(for: .number)
+            self.delegate?.paymentCardTextFieldDidChange?(self)
         })
     }()
 

--- a/StripePaymentsUI/StripePaymentsUI/Source/UI Components/STPPaymentCardTextField.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/UI Components/STPPaymentCardTextField.swift
@@ -603,7 +603,7 @@ open class STPPaymentCardTextField: UIControl, UIKeyInput, STPFormTextFieldDeleg
         viewModel = STPPaymentCardTextFieldViewModel(brandUpdateHandler: { [weak self] in
             guard let self else { return }
             self.updateImage(for: .number)
-            self.delegate?.paymentCardTextFieldDidChange?(self)
+            self.onChange()
         })
         viewModel.postalCodeRequested = postalCodeRequested
         onChange()
@@ -731,7 +731,7 @@ open class STPPaymentCardTextField: UIControl, UIKeyInput, STPFormTextFieldDeleg
         STPPaymentCardTextFieldViewModel(brandUpdateHandler: { [weak self] in
             guard let self else { return }
             self.updateImage(for: .number)
-            self.delegate?.paymentCardTextFieldDidChange?(self)
+            onChange()
         })
     }()
 


### PR DESCRIPTION
## Summary
STPPaymentCardTextField didn't call its didChange delegate when you select a card brand.  I think it reasonably should, and for unclear reasons the RN SDK depends on didChange being called whenever the params changes. 

## Motivation
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-3417

## Testing
Manually tested. 

## Changelog
See changelog