### PR TITLE
[BANKCON-11757] UI Polish from Instant Debits UX Review

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/EmailTextField.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/EmailTextField.swift
@@ -27,6 +27,7 @@ final class EmailTextField: UIView {
                 "Email address",
                 "The title of a user-input-field that appears when a user is signing up to Link (a payment service). It instructs user to type an email address."
             ),
+            showDoneToolbar: true,
             theme: theme
         )
         textField.textField.keyboardType = .emailAddress

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/PhoneCountryCodeSelectorView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/PhoneCountryCodeSelectorView.swift
@@ -48,7 +48,7 @@ final class PhoneCountryCodeSelectorView: UIView {
         var theme: ElementsUITheme = .default
         theme.colors = {
             var colors = ElementsUITheme.Color()
-            colors.primary = .brand500
+            colors.primary = self.theme.primaryColor
             colors.secondaryText = .textSubdued
             return colors
         }()
@@ -60,14 +60,16 @@ final class PhoneCountryCodeSelectorView: UIView {
         return keyboardToolbar
     }()
     private let pickerView: PhoneCountryCodePickerView
+    private let theme: FinancialConnectionsTheme
     var selectedCountryCode: String {
         return pickerView.selectedCountryCode
     }
 
     weak var delegate: PhoneCountryCodeSelectorViewDelegate?
 
-    init(defaultCountryCode: String?) {
+    init(defaultCountryCode: String?, theme: FinancialConnectionsTheme) {
         self.pickerView = PhoneCountryCodePickerView(defaultCountryCode: defaultCountryCode)
+        self.theme = theme
         super.init(frame: .zero)
         pickerView.delegate = self
 
@@ -167,7 +169,7 @@ private struct PhoneCountryCodeSelectorViewUIViewRepresentable: UIViewRepresenta
     let defaultCountryCode: String?
 
     func makeUIView(context: Context) -> PhoneCountryCodeSelectorView {
-        PhoneCountryCodeSelectorView(defaultCountryCode: defaultCountryCode)
+        PhoneCountryCodeSelectorView(defaultCountryCode: defaultCountryCode, theme: .light)
     }
 
     func updateUIView(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/PhoneTextField.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/PhoneTextField.swift
@@ -84,7 +84,8 @@ final class PhoneTextField: UIView {
             defaultCountryCode = e164PhoneNumber.countryCode
         }
         self.countryCodeSelectorView = PhoneCountryCodeSelectorView(
-            defaultCountryCode: defaultCountryCode
+            defaultCountryCode: defaultCountryCode,
+            theme: theme
         )
         self.theme = theme
         super.init(frame: .zero)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationViewController.swift
@@ -60,7 +60,7 @@ final class NetworkingLinkVerificationViewController: UIViewController {
                     "The title of a screen where users are informed that they can sign-in-to Link."
                 ),
                 subtitle: String(format: STPLocalizedString(
-                    "Enter the code sent to %@.",
+                    "Enter the code sent to %@",
                     "The subtitle/description of a screen where users are informed that they have received a One-Type-Password (OTP) to their phone. '%@' gets replaced by a redacted phone number."
                 ), AuthFlowHelpers.formatRedactedPhoneNumber(redactedPhoneNumber)),
                 contentView: otpView


### PR DESCRIPTION
## Summary

This includes a few minor UI changes that were pointed out in the Instant Debits UX review:

 - Shows a `Done` button above the keyboard when the Email textfield is selected. This just dismisses the keyboard.
 - Fixes the theming of the Done button for the Phone country code selector.
 -  Removes a `.` at the end of the OTP verification message.

## Motivation

✨ UI polish ✨ 

## Testing

Minor changes, nothing to test.

## Changelog

N/a
