### PR TITLE
[BANKCON-11757] Allow keeping footer above keyboard in `PaneLayoutView`

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginViewController.swift
@@ -49,6 +49,7 @@ final class LinkLoginViewController: UIViewController {
         return formView
     }()
 
+    private var paneLayoutView: PaneLayoutView?
     private var footerButton: StripeUICore.Button?
 
     init(dataSource: LinkLoginDataSource) {
@@ -98,23 +99,27 @@ final class LinkLoginViewController: UIViewController {
         )
         self.footerButton = footerView.primaryButton
 
-        let paneLayoutView = PaneLayoutView(
+        self.paneLayoutView = PaneLayoutView(
             contentView: contentView,
-            footerView: footerView.footerView
+            footerView: footerView.footerView,
+            keepFooterAboveKeyboard: true
         )
 
-        paneLayoutView.addTo(view: view)
+        paneLayoutView?.addTo(view: view)
 
         #if !canImport(CompositorServices)
         // if user drags, dismiss keyboard so the CTA buttons can be shown
-        paneLayoutView.scrollView.keyboardDismissMode = .onDrag
+        paneLayoutView?.scrollView.keyboardDismissMode = .onDrag
         #endif
 
         let emailAddress = dataSource.manifest.accountholderCustomerEmailAddress
         if let emailAddress, !emailAddress.isEmpty {
             formView.prefillEmailAddress(emailAddress)
         } else {
-            formView.beginEditingEmailAddressField()
+            // Slightly delay opening the keyboard to avoid a janky animation.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { [weak self] in
+                self?.formView.beginEditingEmailAddressField()
+            }
         }
 
         setContinueWithLinkButtonDisabledState()

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginViewController.swift
@@ -101,11 +101,10 @@ final class LinkLoginViewController: UIViewController {
 
         self.paneLayoutView = PaneLayoutView(
             contentView: contentView,
-            footerView: footerView.footerView,
-            keepFooterAboveKeyboard: true
+            footerView: footerView.footerView
         )
 
-        paneLayoutView?.addTo(view: view)
+        paneLayoutView?.addTo(view: view, keepFooterAboveKeyboard: true)
 
         #if !canImport(CompositorServices)
         // if user drags, dismiss keyboard so the CTA buttons can be shown

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/Constants.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/Constants.swift
@@ -12,5 +12,6 @@ struct Constants {
     struct Layout {
         private init() {}
         static let defaultHorizontalMargin: CGFloat = 24.0
+        static let defaultVerticalPadding: CGFloat = 16.0
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/PaneLayoutView/PaneLayoutView+Extensions.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/PaneLayoutView/PaneLayoutView+Extensions.swift
@@ -219,9 +219,9 @@ extension PaneLayoutView {
         )
         paddingStackView.isLayoutMarginsRelativeArrangement = true
         paddingStackView.directionalLayoutMargins = NSDirectionalEdgeInsets(
-            top: 16,
+            top: Constants.Layout.defaultVerticalPadding,
             leading: Constants.Layout.defaultHorizontalMargin,
-            bottom: 16,
+            bottom: Constants.Layout.defaultVerticalPadding,
             trailing: Constants.Layout.defaultHorizontalMargin
         )
         return (paddingStackView, primaryButtonReference, secondaryButtonReference)


### PR DESCRIPTION
## Summary

This tweaks the `PaneLayoutView` to support keeping the footer view always above the keyboard view. This behavior is **disabled by default** when using a PaneLayoutView, as to not alter any existing screens. This PR enables this on the `LinkLoginViewController`, which is currently gated behind an unreleased feature.

| Before | After |
|--------|--------|
| ![Simulator Screenshot - iPhone 15 - 2024-08-08 at 14 39 40](https://github.com/user-attachments/assets/d701cf6b-8c25-4255-b7ff-452a0f7989b5) | ![Simulator Screenshot - iPhone 15 - 2024-08-08 at 14 38 48](https://github.com/user-attachments/assets/c50588a1-bc72-459e-8391-109dfbd5cc9e) |

> [!NOTE]  
> We intentionally don't move the footer view when the sheet is presented on iPad, since the entire sheet is shifted above the keyboard already.

https://github.com/user-attachments/assets/a98c38c7-e193-4eb3-a0f5-565d27ab00e8

## Motivation

✨ Product quality ✨ 

## Testing

> [!IMPORTANT]  
> I've done a bunch of manual testing myself, but I encourage reviewers to think of edge cases here I might've missed.

https://github.com/user-attachments/assets/31ae77ca-0961-41d9-9921-efb802f87393

## Changelog

N/a
