### PR TITLE
[BANKCON-11837] Read `next_pane` and custom success content from `share_networked_account` response

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
@@ -166,7 +166,7 @@ protocol FinancialConnectionsAPI {
         selectedAccountIds: [String],
         clientSecret: String,
         consumerSessionClientSecret: String
-    ) -> Future<FinancialConnectionsInstitutionList>
+    ) -> Future<ShareNetworkedAccountsResponse>
 
     func markLinkStepUpAuthenticationVerified(
         clientSecret: String
@@ -768,7 +768,7 @@ extension FinancialConnectionsAPIClient: FinancialConnectionsAPI {
         selectedAccountIds: [String],
         clientSecret: String,
         consumerSessionClientSecret: String
-    ) -> Future<FinancialConnectionsInstitutionList> {
+    ) -> Future<ShareNetworkedAccountsResponse> {
         let parameters: [String: Any] = [
             "selected_accounts": selectedAccountIds,
             "client_secret": clientSecret,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsInstitution.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsInstitution.swift
@@ -22,3 +22,22 @@ struct FinancialConnectionsInstitution: Decodable, Hashable, Equatable {
 struct FinancialConnectionsInstitutionList: Decodable {
     let data: [FinancialConnectionsInstitution]
 }
+
+struct ShareNetworkedAccountsResponse: Decodable {
+    let data: [FinancialConnectionsInstitution]
+    let nextPane: FinancialConnectionsSessionManifest.NextPane?
+    let displayText: DisplayText?
+
+    struct DisplayText: Decodable {
+        let text: Text?
+
+        struct Text: Decodable {
+            let succcessPane: SuccessPane?
+
+            struct SuccessPane: Decodable {
+                let caption: String
+                let subCaption: String
+            }
+        }
+    }
+}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerDataSource.swift
@@ -28,7 +28,7 @@ protocol LinkAccountPickerDataSource: AnyObject {
     func fetchNetworkedAccounts() -> Future<FinancialConnectionsNetworkedAccountsResponse>
     func selectNetworkedAccounts(
         _ selectedAccounts: [FinancialConnectionsPartnerAccount]
-    ) -> Future<FinancialConnectionsInstitutionList>
+    ) -> Future<ShareNetworkedAccountsResponse>
 }
 
 final class LinkAccountPickerDataSourceImplementation: LinkAccountPickerDataSource {
@@ -81,7 +81,7 @@ final class LinkAccountPickerDataSourceImplementation: LinkAccountPickerDataSour
 
     func selectNetworkedAccounts(
         _ selectedAccounts: [FinancialConnectionsPartnerAccount]
-    ) -> Future<FinancialConnectionsInstitutionList> {
+    ) -> Future<ShareNetworkedAccountsResponse> {
         return apiClient.selectNetworkedAccounts(
             selectedAccountIds: selectedAccounts.map({ $0.id }),
             clientSecret: clientSecret,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
@@ -18,6 +18,13 @@ protocol LinkAccountPickerViewControllerDelegate: AnyObject {
 
     func linkAccountPickerViewController(
         _ viewController: LinkAccountPickerViewController,
+        didRequestNextPane nextPane: FinancialConnectionsSessionManifest.NextPane,
+        customSuccessPaneCaption: String,
+        customSuccessPaneSubCaption: String
+    )
+
+    func linkAccountPickerViewController(
+        _ viewController: LinkAccountPickerViewController,
         didSelectAccounts selectedAccounts: [FinancialConnectionsPartnerAccount]
     )
 
@@ -288,11 +295,21 @@ final class LinkAccountPickerViewController: UIViewController {
                 .observe { [weak self] result in
                     guard let self = self else { return }
                     switch result {
-                    case .success:
-                        self.delegate?.linkAccountPickerViewController(
-                            self,
-                            didRequestNextPane: .success
-                        )
+                    case .success(let response):
+                        let nextPane = response.nextPane ?? .success
+                        if let successPane = response.displayText?.text?.succcessPane {
+                            self.delegate?.linkAccountPickerViewController(
+                                self,
+                                didRequestNextPane: nextPane,
+                                customSuccessPaneCaption: successPane.caption,
+                                customSuccessPaneSubCaption: successPane.subCaption
+                            )
+                        } else {
+                            self.delegate?.linkAccountPickerViewController(
+                                self,
+                                didRequestNextPane: nextPane
+                            )
+                        }
                     case .failure(let error):
                         self.dataSource
                             .analyticsClient

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -639,7 +639,7 @@ extension NativeFlowController: AccountPickerViewControllerDelegate {
         saveToLinkWithStripeSucceeded: Bool?
     ) {
         dataManager.linkedAccounts = selectedAccounts
-        dataManager.customSuccessPaneMessage = customSuccessPaneMessage
+        dataManager.customSuccessPaneSubCaption = customSuccessPaneMessage
         if let saveToLinkWithStripeSucceeded {
             dataManager.saveToLinkWithStripeSucceeded = saveToLinkWithStripeSucceeded
         }
@@ -698,7 +698,7 @@ extension NativeFlowController: ManualEntryViewControllerDelegate {
         dataManager.accountNumberLast4 = accountNumberLast4
 
         if dataManager.manifest.manualEntryUsesMicrodeposits {
-            dataManager.customSuccessPaneMessage = String(
+            dataManager.customSuccessPaneSubCaption = String(
                 format: STPLocalizedString(
                     "You can expect micro-deposits to account ••••%@ in 1-2 days and an email with further instructions.",
                     "The subtitle/description of the success screen that appears when a user manually entered their bank account information. It informs the user that their bank account information will have to be verified."
@@ -772,7 +772,7 @@ extension NativeFlowController: NetworkingLinkSignupViewControllerDelegate {
         withError error: Error?
     ) {
         if let customSuccessPaneMessage {
-            dataManager.customSuccessPaneMessage = customSuccessPaneMessage
+            dataManager.customSuccessPaneSubCaption = customSuccessPaneMessage
         }
         if saveToLinkWithStripeSucceeded != nil {
             dataManager.saveToLinkWithStripeSucceeded = saveToLinkWithStripeSucceeded
@@ -929,6 +929,17 @@ extension NativeFlowController: LinkAccountPickerViewControllerDelegate {
 
     func linkAccountPickerViewController(
         _ viewController: LinkAccountPickerViewController,
+        didRequestNextPane nextPane: FinancialConnectionsSessionManifest.NextPane,
+        customSuccessPaneCaption: String,
+        customSuccessPaneSubCaption: String
+    ) {
+        dataManager.customSuccessPaneCaption = customSuccessPaneCaption
+        dataManager.customSuccessPaneSubCaption = customSuccessPaneSubCaption
+        pushPane(nextPane, animated: true)
+    }
+
+    func linkAccountPickerViewController(
+        _ viewController: LinkAccountPickerViewController,
         didReceiveTerminalError error: Error
     ) {
         showTerminalError(error)
@@ -953,7 +964,7 @@ extension NativeFlowController: NetworkingSaveToLinkVerificationViewControllerDe
         if saveToLinkWithStripeSucceeded != nil {
             dataManager.saveToLinkWithStripeSucceeded = saveToLinkWithStripeSucceeded
         }
-        dataManager.customSuccessPaneMessage = customSuccessPaneMessage
+        dataManager.customSuccessPaneSubCaption = customSuccessPaneMessage
         pushPane(.success, animated: true)
     }
 
@@ -971,10 +982,15 @@ extension NativeFlowController: NetworkingLinkStepUpVerificationViewControllerDe
 
     func networkingLinkStepUpVerificationViewController(
         _ viewController: NetworkingLinkStepUpVerificationViewController,
-        didCompleteVerificationWithInstitution institution: FinancialConnectionsInstitution
+        didCompleteVerificationWithInstitution institution: FinancialConnectionsInstitution,
+        nextPane: FinancialConnectionsSessionManifest.NextPane,
+        customSuccessPaneCaption: String?,
+        customSuccessPaneSubCaption: String?
     ) {
         dataManager.institution = institution
-        pushPane(.success, animated: true)
+        dataManager.customSuccessPaneCaption = customSuccessPaneCaption
+        dataManager.customSuccessPaneSubCaption = customSuccessPaneSubCaption
+        pushPane(nextPane, animated: true)
     }
 
     func networkingLinkStepUpVerificationViewController(
@@ -1291,7 +1307,8 @@ private func CreatePaneViewController(
             apiClient: dataManager.apiClient,
             clientSecret: dataManager.clientSecret,
             analyticsClient: dataManager.analyticsClient,
-            customSuccessPaneMessage: dataManager.customSuccessPaneMessage
+            customSuccessPaneCaption: dataManager.customSuccessPaneCaption,
+            customSuccessPaneSubCaption: dataManager.customSuccessPaneSubCaption
         )
         let successViewController = SuccessViewController(dataSource: successDataSource)
         successViewController.delegate = nativeFlowController

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowDataManager.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowDataManager.swift
@@ -31,7 +31,8 @@ protocol NativeFlowDataManager: AnyObject {
     var consumerPublishableKey: String? { get set }
     var saveToLinkWithStripeSucceeded: Bool? { get set }
     var lastPaneLaunched: FinancialConnectionsSessionManifest.NextPane? { get set }
-    var customSuccessPaneMessage: String? { get set }
+    var customSuccessPaneCaption: String? { get set }
+    var customSuccessPaneSubCaption: String? { get set }
 
     func resetState(withNewManifest newManifest: FinancialConnectionsSessionManifest)
     func completeFinancialConnectionsSession(terminalError: String?) -> Future<StripeAPI.FinancialConnectionsSession>
@@ -83,7 +84,8 @@ class NativeFlowAPIDataManager: NativeFlowDataManager {
     var accountNumberLast4: String?
     var saveToLinkWithStripeSucceeded: Bool?
     var lastPaneLaunched: FinancialConnectionsSessionManifest.NextPane?
-    var customSuccessPaneMessage: String?
+    var customSuccessPaneCaption: String?
+    var customSuccessPaneSubCaption: String?
 
     var consumerSession: ConsumerSessionData? {
         didSet {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationDataSource.swift
@@ -15,7 +15,7 @@ protocol NetworkingLinkStepUpVerificationDataSource: AnyObject {
     var networkingOTPDataSource: NetworkingOTPDataSource { get }
 
     func markLinkStepUpAuthenticationVerified() -> Future<FinancialConnectionsSessionManifest>
-    func selectNetworkedAccount() -> Future<FinancialConnectionsInstitutionList>
+    func selectNetworkedAccount() -> Future<ShareNetworkedAccountsResponse>
 }
 
 final class NetworkingLinkStepUpVerificationDataSourceImplementation: NetworkingLinkStepUpVerificationDataSource {
@@ -63,7 +63,7 @@ final class NetworkingLinkStepUpVerificationDataSourceImplementation: Networking
         return apiClient.markLinkStepUpAuthenticationVerified(clientSecret: clientSecret)
     }
 
-    func selectNetworkedAccount() -> Future<FinancialConnectionsInstitutionList> {
+    func selectNetworkedAccount() -> Future<ShareNetworkedAccountsResponse> {
         return apiClient.selectNetworkedAccounts(
             selectedAccountIds: selectedAccountIds,
             clientSecret: clientSecret,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationViewController.swift
@@ -13,7 +13,10 @@ import UIKit
 protocol NetworkingLinkStepUpVerificationViewControllerDelegate: AnyObject {
     func networkingLinkStepUpVerificationViewController(
         _ viewController: NetworkingLinkStepUpVerificationViewController,
-        didCompleteVerificationWithInstitution institution: FinancialConnectionsInstitution
+        didCompleteVerificationWithInstitution institution: FinancialConnectionsInstitution,
+        nextPane: FinancialConnectionsSessionManifest.NextPane,
+        customSuccessPaneCaption: String?,
+        customSuccessPaneSubCaption: String?
     )
     func networkingLinkStepUpVerificationViewController(
         _ viewController: NetworkingLinkStepUpVerificationViewController,
@@ -210,7 +213,7 @@ extension NetworkingLinkStepUpVerificationViewController: NetworkingOTPViewDeleg
                         .observe { [weak self] result in
                             guard let self = self else { return }
                             switch result {
-                            case .success(let institutionList):
+                            case .success(let response):
                                 self.dataSource
                                     .analyticsClient
                                     .log(
@@ -218,10 +221,15 @@ extension NetworkingLinkStepUpVerificationViewController: NetworkingOTPViewDeleg
                                         pane: .networkingLinkStepUpVerification
                                     )
 
-                                if let institution = institutionList.data.first {
+                                if let institution = response.data.first {
+                                    let nextPane = response.nextPane ?? .success
+                                    let successPane = response.displayText?.text?.succcessPane
                                     self.delegate?.networkingLinkStepUpVerificationViewController(
                                         self,
-                                        didCompleteVerificationWithInstitution: institution
+                                        didCompleteVerificationWithInstitution: institution,
+                                        nextPane: nextPane,
+                                        customSuccessPaneCaption: successPane?.caption,
+                                        customSuccessPaneSubCaption: successPane?.subCaption
                                     )
                                 } else {
                                     // this shouldn't happen, but in case it does, we navigate to `institutionPicker` so user

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Success/SuccessDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Success/SuccessDataSource.swift
@@ -15,7 +15,8 @@ protocol SuccessDataSource: AnyObject {
     var saveToLinkWithStripeSucceeded: Bool? { get }
     var analyticsClient: FinancialConnectionsAnalyticsClient { get }
     var showLinkMoreAccountsButton: Bool { get }
-    var customSuccessPaneMessage: String? { get }
+    var customSuccessPaneCaption: String? { get }
+    var customSuccessPaneSubCaption: String? { get }
 }
 
 final class SuccessDataSourceImplementation: SuccessDataSource {
@@ -26,7 +27,8 @@ final class SuccessDataSourceImplementation: SuccessDataSource {
     private let apiClient: FinancialConnectionsAPIClient
     private let clientSecret: String
     let analyticsClient: FinancialConnectionsAnalyticsClient
-    var customSuccessPaneMessage: String?
+    var customSuccessPaneCaption: String?
+    var customSuccessPaneSubCaption: String?
     var showLinkMoreAccountsButton: Bool {
         !manifest.singleAccount && !manifest.disableLinkMoreAccounts && !(manifest.isNetworkingUserFlow ?? false)
     }
@@ -38,7 +40,8 @@ final class SuccessDataSourceImplementation: SuccessDataSource {
         apiClient: FinancialConnectionsAPIClient,
         clientSecret: String,
         analyticsClient: FinancialConnectionsAnalyticsClient,
-        customSuccessPaneMessage: String?
+        customSuccessPaneCaption: String?,
+        customSuccessPaneSubCaption: String?
     ) {
         self.manifest = manifest
         self.linkedAccountsCount = linkedAccountsCount
@@ -46,6 +49,7 @@ final class SuccessDataSourceImplementation: SuccessDataSource {
         self.apiClient = apiClient
         self.clientSecret = clientSecret
         self.analyticsClient = analyticsClient
-        self.customSuccessPaneMessage = customSuccessPaneMessage
+        self.customSuccessPaneCaption = customSuccessPaneCaption
+        self.customSuccessPaneSubCaption = customSuccessPaneSubCaption
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Success/SuccessViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Success/SuccessViewController.swift
@@ -39,7 +39,11 @@ final class SuccessViewController: UIViewController {
         view.addSubview(contentView)
 
         let bodyView = CreateBodyView(
-            subtitle: dataSource.customSuccessPaneMessage ?? CreateSubtitleText(
+            title: dataSource.customSuccessPaneCaption ?? STPLocalizedString(
+                "Success",
+                "The title of the success screen that appears when a user is done with the process of connecting their bank account to an application. Now that the bank account is connected (or linked), the user will be able to use the bank account for payments."
+            ),
+            subtitle: dataSource.customSuccessPaneSubCaption ?? CreateSubtitleText(
                 // manual entry has "0" linked accounts count
                 isLinkingOneAccount: (dataSource.linkedAccountsCount == 0 || dataSource.linkedAccountsCount == 1),
                 showSaveToLinkFailedNotice: showSaveToLinkFailedNotice
@@ -113,17 +117,16 @@ final class SuccessViewController: UIViewController {
     }
 }
 
-private func CreateBodyView(subtitle: String?, theme: FinancialConnectionsTheme) -> UIView {
+private func CreateBodyView(
+    title: String,
+    subtitle: String?,
+    theme: FinancialConnectionsTheme
+) -> UIView {
     let titleLabel = AttributedLabel(
         font: .heading(.extraLarge),
         textColor: .textDefault
     )
-    titleLabel.setText(
-        STPLocalizedString(
-            "Success",
-            "The title of the success screen that appears when a user is done with the process of connecting their bank account to an application. Now that the bank account is connected (or linked), the user will be able to use the bank account for payments."
-        )
-    )
+    titleLabel.setText(title)
     let labelVerticalStackView = UIStackView(
         arrangedSubviews: [titleLabel]
     )


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
