### PR TITLE
[NME] Add demo merchants for NMW bug bash

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundConfiguration.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundConfiguration.swift
@@ -127,6 +127,8 @@ final class PlaygroundConfiguration {
             case partnerF = "partner_f"
             case partnerC = "partner_c"
             case bugBash = "bug_bash"
+            case abavVerification = "abav_verification"
+            case skipVerification = "skip_verification"
         }
     }
 
@@ -159,6 +161,16 @@ final class PlaygroundConfiguration {
         Merchant(
             customId: .bugBash,
             displayName: "Bug Bash",
+            isTestModeSupported: true
+        ),
+        Merchant(
+            customId: .abavVerification,
+            displayName: "ABAV Verification",
+            isTestModeSupported: true
+        ),
+        Merchant(
+            customId: .skipVerification,
+            displayName: "Skip Verification",
             isTestModeSupported: true
         ),
 


### PR DESCRIPTION
## Summary

This adds 2 new demo merchants to the Financial Connections example app for the Networking Manual Entry bug bash! The keys to these merchants have already been added to the glitch server 👍 

## Motivation

Make it easy to bug bash with these merchant accounts!

## Testing

<img width=50% src="https://github.com/user-attachments/assets/706a2344-f0cd-4906-8de2-05914022d08a">


## Changelog

N/a
