### PR TITLE
Validate IntentConfiguration amount is nonzero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## X.Y.Z 2024-xx-yy
 ### PaymentSheet
 * [Fixed] Fixed PaymentSheet.FlowController returning unlocalized labels for certain payment methods e.g. "AfterPay ClearPay" instead of "Afterpay" or "Clearpay" depending on locale.
+* [Added] `PaymentSheet.IntentConfiguration` now validates that its `amount` is non-zero.
 
 ## 23.29.0 2024-08-05
 ### PaymentSheet

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetError.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetError.swift
@@ -63,66 +63,6 @@ public enum PaymentSheetError: Error, LocalizedError {
 }
 
 extension PaymentSheetError: CustomDebugStringConvertible {
-    /// A string that can safely be logged to our analytics service that does not contain any PII
-    public var safeLoggingString: String {
-        switch self {
-        case .unknown:
-            return "unknown"
-        case .missingClientSecret:
-            return "missingClientSecret"
-        case .invalidClientSecret:
-            return "invalidClientSecret"
-        case .unexpectedResponseFromStripeAPI:
-            return "unexpectedResponseFromStripeAPI"
-        case .applePayNotSupportedOrMisconfigured:
-            return "applePayNotSupportedOrMisconfigured"
-        case .alreadyPresented:
-            return "alreadyPresented"
-        case .flowControllerConfirmFailed:
-            return "flowControllerConfirmFailed"
-        case .errorHandlingNextAction:
-            return "errorHandlingNextAction"
-        case .unrecognizedHandlerStatus:
-            return "unrecognizedHandlerStatus"
-        case .accountLinkFailure:
-            return "accountLinkFailure"
-        case .setupIntentClientSecretProviderNil:
-            return "setupIntentClientSecretProviderNil"
-        case .noPaymentMethodTypesAvailable:
-            return "noPaymentMethodTypesAvailable"
-        case .paymentIntentInTerminalState:
-            return "paymentIntentInTerminalState"
-        case .setupIntentInTerminalState:
-            return "setupIntentInTerminalState"
-        case .fetchPaymentMethodsFailure:
-            return "fetchPaymentMethodsFailure"
-        case .deferredIntentValidationFailed:
-            return "deferredIntentValidationFailed"
-        case .linkSignUpNotRequired:
-            return "linkSignUpNotRequired"
-        case .linkCallVerifyNotRequired:
-            return "linkCallVerifyNotRequired"
-        case .linkingWithoutValidSession:
-            return "linkingWithoutValidSession"
-        case .savingWithoutValidLinkSession:
-            return "savingWithoutValidLinkSession"
-        case .payingWithoutValidLinkSession:
-            return "payingWithoutValidLinkSession"
-        case .deletingWithoutValidLinkSession:
-            return "deletingWithoutValidLinkSession"
-        case .updatingWithoutValidLinkSession:
-            return "updatingWithoutValidLinkSession"
-        case .linkLookupNotFound:
-            return "linkLookupNotFound"
-        case .failedToCreateLinkSession:
-            return "failedToCreateLinkSession"
-        case .linkNotAuthorized:
-            return "linkNotAuthorized"
-        case .unexpectedNewPaymentMethod:
-            return "unexpectedNewPaymentMethod"
-        }
-    }
-
     /// A description logged to a developer for debugging
     public var debugDescription: String {
         let errorMessageSuffix = {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetError.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetError.swift
@@ -39,6 +39,7 @@ public enum PaymentSheetError: Error, LocalizedError {
     case fetchPaymentMethodsFailure
 
     // MARK: Deferred intent errors
+    case intentConfigurationValidationFailed(message: String)
     case deferredIntentValidationFailed(message: String)
 
     // MARK: - Link errors
@@ -183,6 +184,8 @@ extension PaymentSheetError: CustomDebugStringConvertible {
                 return "setupIntentClientSecretForCustomerAttach, but setupIntentClientSecretProvider is nil"
             case .unexpectedNewPaymentMethod:
                 return "New payment method should not have been created yet"
+            case .intentConfigurationValidationFailed(message: let message):
+                return message
             }
         }()
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetIntentConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetIntentConfiguration.swift
@@ -80,10 +80,13 @@ public extension PaymentSheet {
             self.paymentMethodConfigurationId = paymentMethodConfigurationId
             self.confirmHandler = confirmHandler
             self.isCVCRecollectionEnabledCallback = isCVCRecollectionEnabledCallback ?? { return false }
+            validate()
         }
 
         /// Information about the payment (PaymentIntent) or setup (SetupIntent).
-        public var mode: Mode
+        public var mode: Mode {
+            didSet { validate() }
+        }
 
         /// A list of payment method types to display to the customer. If nil, we dynamically determine the payment methods using your Stripe Dashboard settings.
         public var paymentMethodTypes: [String]?
@@ -159,6 +162,8 @@ public extension PaymentSheet {
             )
         }
 
+        // MARK: - Internal
+
         /// An async version of `ConfirmHandler`.
         typealias AsyncConfirmHandler = (
             _ paymentMethod: STPPaymentMethod,
@@ -187,6 +192,16 @@ public extension PaymentSheet {
             }
             // TODO
             self.isCVCRecollectionEnabledCallback = { return false }
+        }
+
+        @discardableResult
+        func validate() -> Error? {
+            let errorMessage: String
+            if case .payment(let amount, _, _, _) = mode, amount > 0 {
+                errorMessage = "The amount in `PaymentSheet.IntentConfiguration` must be non-zero! See https://docs.stripe.com/api/payment_intents/create#create_payment_intent-amount"
+                return PaymentSheetError.intentConfigurationValidationFailed(message: errorMessage)
+            }
+            return nil
         }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetIntentConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetIntentConfiguration.swift
@@ -197,7 +197,7 @@ public extension PaymentSheet {
         @discardableResult
         func validate() -> Error? {
             let errorMessage: String
-            if case .payment(let amount, _, _, _) = mode, amount > 0 {
+            if case .payment(let amount, _, _, _) = mode, amount <= 0 {
                 errorMessage = "The amount in `PaymentSheet.IntentConfiguration` must be non-zero! See https://docs.stripe.com/api/payment_intents/create#create_payment_intent-amount"
                 return PaymentSheetError.intentConfigurationValidationFailed(message: errorMessage)
             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -30,9 +30,14 @@ final class PaymentSheetLoader {
 
         Task { @MainActor in
             do {
+                // Validate inputs
                 if !mode.isDeferred && configuration.apiClient.publishableKeyIsUserKey {
                     // User keys can't pass payment_method_data directly to /confirm, which is what the non-deferred intent flows do
                     assertionFailure("Dashboard isn't supported in non-deferred intent flows")
+                }
+                if case .deferredIntent(let intentConfiguration) = mode,
+                   let error = intentConfiguration.validate() {
+                    throw error
                 }
 
                 // Fetch ElementsSession

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderStubbedTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderStubbedTest.swift
@@ -404,7 +404,7 @@ class PaymentSheetLoaderStubbedTest: APIStubbedTestCase {
         let confirmHandler: PaymentSheet.IntentConfiguration.ConfirmHandler = {_, _, _ in
             XCTFail("Confirm handler shouldn't be called.")
         }
-        let intentConfig = PaymentSheet.IntentConfiguration.init(mode: .payment(amount: 0, currency: "USD"), confirmHandler: confirmHandler)
+        let intentConfig = PaymentSheet.IntentConfiguration.init(mode: .payment(amount: 100, currency: "USD"), confirmHandler: confirmHandler)
         PaymentSheetLoader.load(
             mode: .deferredIntent(intentConfig),
             configuration: ._testValue_MostPermissive(),


### PR DESCRIPTION
Passing a non-zero amount is an integration error.

### Before
Fails at load time w/ a 'noPaymentMethodTypesAvailable' error because `v1/elements/sessions` returns an empty list of pm types. 

### After
In debug, we assert.

In production, we'll get a more accurate `intentConfigurationValidationFailed` error_code in the mc_load_failed analytic. Ideally we'd also get an error_message; I'll look into that in another PR.

## Testing
Manually tested.

<img src="https://github.com/user-attachments/assets/c026c239-7a5d-40e3-a582-f91c87138810" width="300">

## Changelog
See changelog
