### PR TITLE
[BANKCON-11807] Prevent back navigation from institution picker after verification

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginViewController.swift
@@ -81,6 +81,11 @@ final class LinkLoginViewController: UIViewController {
             }
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        setContinueWithLinkButtonDisabledState()
+    }
+
     private func showContent(linkLoginPane: FinancialConnectionsLinkLoginPane) {
         let contentView = PaneLayoutView.createContentView(
             iconView: nil,
@@ -134,6 +139,45 @@ final class LinkLoginViewController: UIViewController {
     }
 
     private func didSelectContinueWithLink() {
+        if formView.phoneNumber.isEmpty {
+            lookupAccount(with: formView.email)
+        } else {
+            createAccount()
+        }
+    }
+
+    private func lookupAccount(with emailAddress: String) {
+        formView.emailTextField.showLoadingView(true)
+
+        dataSource
+            .lookup(emailAddress: emailAddress)
+            .observe { [weak self, weak formView] result in
+                formView?.emailTextField.showLoadingView(false)
+                guard let self else { return }
+
+                switch result {
+                case .success(let response):
+                    if response.exists {
+                        if response.consumerSession != nil {
+                            self.delegate?.linkLoginViewController(self, foundReturningUserWith: response)
+                        } else {
+                            self.delegate?.linkLoginViewController(
+                                self,
+                                didReceiveTerminalError: FinancialConnectionsSheetError.unknown(
+                                    debugDescription: "No consumer session returned from lookupConsumerSession for emailAddress: \(emailAddress)"
+                                )
+                            )
+                        }
+                    } else {
+                        formView?.showAndEditPhoneNumberFieldIfNeeded()
+                    }
+                case .failure(let error):
+                    self.delegate?.linkLoginViewController(self, didReceiveTerminalError: error)
+                }
+            }
+    }
+
+    private func createAccount() {
         footerButton?.isLoading = true
 
         dataSource.signUp(
@@ -173,41 +217,19 @@ final class LinkLoginViewController: UIViewController {
 
     private func setContinueWithLinkButtonDisabledState() {
         let isEmailValid = formView.emailTextField.isEmailValid
-        let isPhoneNumberValid = formView.phoneTextField.isPhoneNumberValid
-        footerButton?.isEnabled = isEmailValid && isPhoneNumberValid
+
+        if formView.phoneTextField.isHidden {
+            footerButton?.isEnabled = isEmailValid
+        } else {
+            let isPhoneNumberValid = formView.phoneTextField.isPhoneNumberValid
+            footerButton?.isEnabled = isEmailValid && isPhoneNumberValid
+        }
     }
 }
 
 extension LinkLoginViewController: LinkSignupFormViewDelegate {
     func linkSignupFormView(_ view: LinkSignupFormView, didEnterValidEmailAddress emailAddress: String) {
-        formView.emailTextField.showLoadingView(true)
-
-        dataSource
-            .lookup(emailAddress: emailAddress)
-            .observe { [weak self, weak formView] result in
-                formView?.emailTextField.showLoadingView(false)
-                guard let self else { return }
-
-                switch result {
-                case .success(let response):
-                    if response.exists {
-                        if response.consumerSession != nil {
-                            self.delegate?.linkLoginViewController(self, foundReturningUserWith: response)
-                        } else {
-                            self.delegate?.linkLoginViewController(
-                                self,
-                                didReceiveTerminalError: FinancialConnectionsSheetError.unknown(
-                                    debugDescription: "No consumer session returned from lookupConsumerSession for emailAddress: \(emailAddress)"
-                                )
-                            )
-                        }
-                    } else {
-                        formView?.showAndEditPhoneNumberFieldIfNeeded()
-                    }
-                case .failure(let error):
-                    self.delegate?.linkLoginViewController(self, didReceiveTerminalError: error)
-                }
-            }
+        lookupAccount(with: emailAddress)
     }
 
     func linkSignupFormViewDidUpdateFields(_ view: LinkSignupFormView) {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -885,12 +885,11 @@ extension NativeFlowController: NetworkingLinkVerificationViewControllerDelegate
     func networkingLinkVerificationViewController(
         _ viewController: NetworkingLinkVerificationViewController,
         didRequestNextPane nextPane: FinancialConnectionsSessionManifest.NextPane,
-        consumerSession: ConsumerSessionData?
+        consumerSession: ConsumerSessionData?,
+        preventBackNavigation: Bool
     ) {
-        if let consumerSession = consumerSession {
-            dataManager.consumerSession = consumerSession
-        }
-        pushPane(nextPane, animated: true)
+        dataManager.consumerSession = consumerSession
+        pushPane(nextPane, animated: true, clearNavigationStack: preventBackNavigation)
     }
 
     func networkingLinkVerificationViewController(
@@ -1017,7 +1016,7 @@ extension NativeFlowController: LinkLoginViewControllerDelegate {
         signedUpAttachedAndSynchronized synchronizePayload: FinancialConnectionsSynchronize
     ) {
         dataManager.manifest = synchronizePayload.manifest
-        pushPane(synchronizePayload.manifest.nextPane, animated: true)
+        pushPane(synchronizePayload.manifest.nextPane, animated: true, clearNavigationStack: true)
     }
 
     func linkLoginViewController(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/LinkSignupFormView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/LinkSignupFormView.swift
@@ -119,8 +119,6 @@ extension LinkSignupFormView: EmailTextFieldDelegate {
         didChangeEmailAddress emailAddress: String,
         isValid: Bool
     ) {
-        delegate?.linkSignupFormViewDidUpdateFields(self)
-
         if isValid {
             debounceEmailTimer?.invalidate()
             debounceEmailTimer = Timer.scheduledTimer(
@@ -134,6 +132,8 @@ extension LinkSignupFormView: EmailTextFieldDelegate {
                 repeats: false
             ) { [weak self] _ in
                 guard let self = self else { return }
+                self.delegate?.linkSignupFormViewDidUpdateFields(self)
+
                 if
                     // make sure the email inputted is still valid
                     // even after the debounce
@@ -151,6 +151,7 @@ extension LinkSignupFormView: EmailTextFieldDelegate {
             }
         } else {
             // errors are displayed automatically by the component
+            delegate?.linkSignupFormViewDidUpdateFields(self)
             lastValidEmail = nil
         }
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationViewController.swift
@@ -14,7 +14,8 @@ protocol NetworkingLinkVerificationViewControllerDelegate: AnyObject {
     func networkingLinkVerificationViewController(
         _ viewController: NetworkingLinkVerificationViewController,
         didRequestNextPane nextPane: FinancialConnectionsSessionManifest.NextPane,
-        consumerSession: ConsumerSessionData?
+        consumerSession: ConsumerSessionData?,
+        preventBackNavigation: Bool
     )
     func networkingLinkVerificationViewController(
         _ viewController: NetworkingLinkVerificationViewController,
@@ -80,12 +81,13 @@ final class NetworkingLinkVerificationViewController: UIViewController {
         view.bringSubviewToFront(loadingView)  // defensive programming to avoid loadingView being hiddden
     }
 
-    private func requestNextPane(_ pane: FinancialConnectionsSessionManifest.NextPane) {
+    private func requestNextPane(_ pane: FinancialConnectionsSessionManifest.NextPane, preventBackNavigation: Bool) {
         if let consumerSession = dataSource.consumerSession {
             delegate?.networkingLinkVerificationViewController(
                 self,
                 didRequestNextPane: pane,
-                consumerSession: consumerSession
+                consumerSession: consumerSession,
+                preventBackNavigation: preventBackNavigation
             )
         } else {
             assertionFailure("logic error: did not have consumerSession")
@@ -104,7 +106,7 @@ final class NetworkingLinkVerificationViewController: UIViewController {
 
                 switch result {
                 case .success:
-                    self.requestNextPane(.linkAccountPicker)
+                    self.requestNextPane(.linkAccountPicker, preventBackNavigation: true)
                 case .failure(let error):
                     self.delegate?.networkingLinkVerificationViewController(self, didReceiveTerminalError: error)
                 }
@@ -136,7 +138,12 @@ extension NetworkingLinkVerificationViewController: NetworkingOTPViewDelegate {
             ],
             pane: .networkingLinkVerification
         )
-        delegate?.networkingLinkVerificationViewController(self, didRequestNextPane: .institutionPicker, consumerSession: nil)
+        delegate?.networkingLinkVerificationViewController(
+            self,
+            didRequestNextPane: .institutionPicker,
+            consumerSession: nil,
+            preventBackNavigation: false
+        )
         showLoadingView(false) // started in networkingOTPViewWillStartConsumerLookup
     }
 
@@ -200,11 +207,15 @@ extension NetworkingLinkVerificationViewController: NetworkingOTPViewDelegate {
                 guard let self = self else { return }
                 switch result {
                 case .success:
-                    self.dataSource.analyticsClient.log(
-                        eventName: "networking.verification.success",
-                        pane: .networkingLinkVerification
-                    )
-                    self.requestNextPane(.linkAccountPicker)
+                    if self.dataSource.manifest.isProductInstantDebits {
+                        self.attachConsumerToLinkAccountAndSynchronize(from: view)
+                    } else {
+                        self.dataSource.analyticsClient.log(
+                            eventName: "networking.verification.success",
+                            pane: .networkingLinkVerification
+                        )
+                        self.requestNextPane(.linkAccountPicker, preventBackNavigation: false)
+                    }
                 case .failure(let error):
                     self.dataSource
                         .analyticsClient
@@ -229,7 +240,7 @@ extension NetworkingLinkVerificationViewController: NetworkingOTPViewDelegate {
                     } else {
                         nextPane = .institutionPicker
                     }
-                    self.requestNextPane(nextPane)
+                    self.requestNextPane(nextPane, preventBackNavigation: false)
                 }
 
                 self.hideOTPLoadingViewAfterDelay(view)


### PR DESCRIPTION
## Summary

This updates some behavior associated with the Link Login pane to prevent users from returning to this pane after they've been verified. If this is a new user, they are verified after they enter their phone number. If this is a returning user, they are verified after they enter their OTP. You are still able to return to the Link Login pane from the OTP verification screen. 

## Motivation

Part of the [Native Instant Debits project](https://docs.google.com/document/d/1k0tv4jUxL9QSxni1QEo-ZiHG_HDCX9gAMo2qKE8kqbQ/edit?usp=sharing).

## Testing

https://github.com/user-attachments/assets/882578c7-70df-4f01-bd73-85345655fed2

## Changelog

N/a