### PR TITLE
[NME] Allow pushing to `institution_picker` from the update required drawer

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
@@ -705,4 +705,5 @@ private func IsAccountUpdateRequired(
     return account.nextPaneOnSelection == .bankAuthRepair
     // supportability -- account requires re-sharing with additonal permissions
     || account.nextPaneOnSelection == .partnerAuth
+    || account.nextPaneOnSelection == .institutionPicker
 }


### PR DESCRIPTION
## Summary

Reflects https://git.corp.stripe.com/stripe-internal/pay-server/pull/875078

Allows `nextPaneOnSelection` values of `institutionPicker` as the next destination when proceeding from the drawer shown when selecting a networked account.

## Motivation

[BANKCON-11861](https://jira.corp.stripe.com/browse/BANKCON-11861)

## Testing

I wasn't able to reproduce the situaiton where `.institutionPicker` is the `nextPaneOnSelection`, but look at the testing in [BANKCON-11861](https://jira.corp.stripe.com/browse/BANKCON-11861), this PR mirrors it!

## Changelog

N/a