### PR TITLE
Fix SwiftUI force dismissal of PaymentSheet not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## X.Y.Z 2024-XX-YY
 ### PaymentSheet
 * [Fixed] Avoid multiple calls to CVC Recollection callback for deferred intent integrations
+* [Fixed] Fixed an issue in SwiftUI where setting `isPresented=false` wouldn't dismiss the sheet.
+
 
 ## 23.29.1 2024-08-12
 ### PaymentSheet

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+SwiftUI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+SwiftUI.swift
@@ -239,11 +239,11 @@ extension PaymentSheet {
                         }
                         presentPaymentSheet(on: viewController)
                     case (true, false):
-                        guard let viewController = findViewController(for: view) else {
-                            parent.presented = true
+                        guard parent.paymentSheet?.bottomSheetViewController.presentingViewController != nil else {
+                            // If PS is not presented, there's nothing to do
                             return
                         }
-                        forciblyDismissPaymentSheet(from: viewController)
+                        parent.paymentSheet?.bottomSheetViewController.didTapOrSwipeToDismiss()
                     case (true, true):
                         break
                     }
@@ -261,12 +261,6 @@ extension PaymentSheet {
                 parent.paymentSheet?.present(from: presenter) { (result: PaymentSheetResult) in
                     self.parent.presented = false
                     self.parent.onCompletion(result)
-                }
-            }
-
-            func forciblyDismissPaymentSheet(from controller: UIViewController) {
-                if let bsvc = controller.presentedViewController as? BottomSheetViewController {
-                    bsvc.didTapOrSwipeToDismiss()
                 }
             }
         }
@@ -308,11 +302,11 @@ extension PaymentSheet {
                         }
                         presentPaymentSheet(on: viewController)
                     case (true, false):
-                        guard let viewController = findViewController(for: view) else {
-                            parent.presented = true
+                        guard parent.paymentSheetFlowController?.viewController.presentingViewController != nil else {
+                            // If PSFC is not presented, there's nothing to do
                             return
                         }
-                        forciblyDismissPaymentSheet(from: viewController)
+                        parent.paymentSheetFlowController?.viewController.didTapOrSwipeToDismiss()
                     case (true, true):
                         break
                     }
@@ -338,12 +332,6 @@ extension PaymentSheet {
                         self.parent.presented = false
                         self.parent.optionsCompletion?()
                     }
-                }
-            }
-
-            func forciblyDismissPaymentSheet(from controller: UIViewController) {
-                if let bsvc = controller.presentedViewController as? BottomSheetViewController {
-                    bsvc.didTapOrSwipeToDismiss()
                 }
             }
         }


### PR DESCRIPTION
## Summary
For unclear reasons, after the sheet has displayed `findViewController` can return the presented `BottomSheetViewController` and not the `SwiftUI.PresentationHostingController` that presented it. 

I don't think we need to grab the presented VC at all, though - we have the `paymentSheet` or `paymentSheetFlowController` instance already and can invoke `didTapOrSwipeToDismiss` directly on its vc.

## Motivation
https://github.com/stripe/stripe-ios/issues/3822

## Testing
Manually tested setting `isPresented = false` in the playground, observed it worked.

## Changelog
See CHANGELOG
