### PR TITLE
[BANKCON-11876] Select first selectable account in Link Account Picker pane

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
@@ -208,7 +208,11 @@ final class LinkAccountPickerViewController: UIViewController {
         self.footerView = footerView
         footerContainerView.addAndPinSubview(footerView)
 
-        bodyView.selectAccounts([]) // activate the logic to list all accounts
+        let firstSelectableAccount = accountTuples.first { accountTuple in
+            accountTuple.accountPickerAccount.allowSelection && accountTuple.accountPickerAccount.drawerOnSelection == nil
+        }
+        let firstAccount = [firstSelectableAccount].compactMap({ $0.self })
+        bodyView.selectAccounts(firstAccount)
     }
 
     private func didSelectConnectAccounts() {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
@@ -213,6 +213,7 @@ final class LinkAccountPickerViewController: UIViewController {
         }
         let firstAccount = [firstSelectableAccount].compactMap({ $0.self })
         bodyView.selectAccounts(firstAccount)
+        footerView.didSelectAccounts(firstAccount)
     }
 
     private func didSelectConnectAccounts() {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
@@ -212,8 +212,7 @@ final class LinkAccountPickerViewController: UIViewController {
             accountTuple.accountPickerAccount.allowSelection && accountTuple.accountPickerAccount.drawerOnSelection == nil
         }
         let firstAccount = [firstSelectableAccount].compactMap({ $0.self })
-        bodyView.selectAccounts(firstAccount)
-        footerView.didSelectAccounts(firstAccount)
+        dataSource.updateSelectedAccounts(firstAccount)
     }
 
     private func didSelectConnectAccounts() {


### PR DESCRIPTION
## Summary

Fixing issue identified in [bug bash](https://docs.google.com/document/d/1MSzE2b2_nigERMxLkxtxdI4BETpACHoQ0UwMJ0i-Reg/edit?usp=sharing).

When showing the Link Account Picker pane, we now pre-select the first selectable account in the list. 

## Motivation

Consistency between platforms.

## Testing

| Before | After |
|--------|--------|
| ![Simulator Screenshot - iPhone 15 - 2024-08-14 at 11 12 57](https://github.com/user-attachments/assets/a14e29dd-6e7f-495d-9a2a-f0a95a11fcc5) | ![Simulator Screenshot - iPhone 15 - 2024-08-14 at 11 21 11](https://github.com/user-attachments/assets/b7d9ad5e-8699-4bc8-8eaf-f04cc8c395d3) | 

## Changelog

N/a