### PR TITLE
Add message senders and message handlers for StripeConnect.

### DIFF
--- a/StripeConnect/StripeConnect.xcodeproj/project.pbxproj
+++ b/StripeConnect/StripeConnect.xcodeproj/project.pbxproj
@@ -7,6 +7,37 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		410D0FCA2C6CFE27009B0E26 /* OnLoadErrorMessageHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 410D0FC92C6CFE27009B0E26 /* OnLoadErrorMessageHandlerTests.swift */; };
+		410D0FCC2C6CFFDB009B0E26 /* AccountSessionClaimedMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 410D0FCB2C6CFFDB009B0E26 /* AccountSessionClaimedMessageHandler.swift */; };
+		410D0FCE2C6D000B009B0E26 /* OpenAuthenticatedWebViewMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 410D0FCD2C6D000B009B0E26 /* OpenAuthenticatedWebViewMessageHandler.swift */; };
+		410D0FD02C6D0319009B0E26 /* PageDidLoadMessageHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 410D0FCF2C6D0319009B0E26 /* PageDidLoadMessageHandlerTests.swift */; };
+		410D0FD22C6D047A009B0E26 /* AccountSessionClaimedMessageHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 410D0FD12C6D047A009B0E26 /* AccountSessionClaimedMessageHandlerTests.swift */; };
+		410D0FD42C6D051B009B0E26 /* OpenAuthenticatedWebViewMessageHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 410D0FD32C6D051B009B0E26 /* OpenAuthenticatedWebViewMessageHandlerTests.swift */; };
+		410D0FD72C6D07C7009B0E26 /* MessageSenderTestBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 410D0FD62C6D07C7009B0E26 /* MessageSenderTestBase.swift */; };
+		410D0FD92C6D1F25009B0E26 /* UpdateConnectInstanceSenderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 410D0FD82C6D1F25009B0E26 /* UpdateConnectInstanceSenderTests.swift */; };
+		410D0FDB2C6D21B0009B0E26 /* CallSetterWithSerializableValueSenderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 410D0FDA2C6D21B0009B0E26 /* CallSetterWithSerializableValueSenderTests.swift */; };
+		410D0FDD2C6D23AD009B0E26 /* ReturnedFromAuthenticatedWebViewSenderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 410D0FDC2C6D23AD009B0E26 /* ReturnedFromAuthenticatedWebViewSenderTests.swift */; };
+		413987C82C63F34B001D375E /* DebugMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 413987B82C63F34B001D375E /* DebugMessageHandler.swift */; };
+		413987C92C63F34B001D375E /* FetchClientSecretMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 413987B92C63F34B001D375E /* FetchClientSecretMessageHandler.swift */; };
+		413987CA2C63F34B001D375E /* ScriptMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 413987BA2C63F34B001D375E /* ScriptMessageHandler.swift */; };
+		413987CB2C63F34B001D375E /* ScriptMessageHandlerWithReply.swift in Sources */ = {isa = PBXBuildFile; fileRef = 413987BB2C63F34B001D375E /* ScriptMessageHandlerWithReply.swift */; };
+		413987CC2C63F34B001D375E /* VoidPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 413987BC2C63F34B001D375E /* VoidPayload.swift */; };
+		413987CD2C63F34B001D375E /* MessageSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 413987BE2C63F34B001D375E /* MessageSender.swift */; };
+		413987CE2C63F34B001D375E /* UpdateConnectInstanceSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 413987BF2C63F34B001D375E /* UpdateConnectInstanceSender.swift */; };
+		413987D42C640848001D375E /* CallSetterWithSerializableValueSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 413987D32C640848001D375E /* CallSetterWithSerializableValueSender.swift */; };
+		413987D62C64088E001D375E /* ReturnedFromAuthenticatedWebViewSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 413987D52C64088E001D375E /* ReturnedFromAuthenticatedWebViewSender.swift */; };
+		413987DD2C640A29001D375E /* FetchInitParamsMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 413987DC2C640A29001D375E /* FetchInitParamsMessageHandler.swift */; };
+		413987DF2C640C50001D375E /* OnExitMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 413987DE2C640C50001D375E /* OnExitMessageHandler.swift */; };
+		413987E12C641688001D375E /* PageDidLoadMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 413987E02C641688001D375E /* PageDidLoadMessageHandler.swift */; };
+		41814EE82C6BC8800014EB5E /* WebViewMessageHandlerTestBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41814EE72C6BC8800014EB5E /* WebViewMessageHandlerTestBase.swift */; };
+		41814EEB2C6BCAB30014EB5E /* DebugMessageHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41814EEA2C6BCAB30014EB5E /* DebugMessageHandlerTests.swift */; };
+		41814EED2C6BED8C0014EB5E /* FetchClientSecretMessageHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41814EEC2C6BED8C0014EB5E /* FetchClientSecretMessageHandlerTests.swift */; };
+		41814EEF2C6BEF2C0014EB5E /* FetchInitParamsMessageHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41814EEE2C6BEF2C0014EB5E /* FetchInitParamsMessageHandlerTests.swift */; };
+		41814EF12C6BF94B0014EB5E /* OnExitMessageHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41814EF02C6BF94B0014EB5E /* OnExitMessageHandlerTests.swift */; };
+		41814EF32C6BFA4B0014EB5E /* OnLoaderStartMessageHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41814EF22C6BFA4B0014EB5E /* OnLoaderStartMessageHandlerTests.swift */; };
+		4186664A2C66AC66003DB62E /* OnSetterFunctionCalledMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 418666492C66AC66003DB62E /* OnSetterFunctionCalledMessageHandler.swift */; };
+		4186664C2C66AC8C003DB62E /* OnLoaderStartMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4186664B2C66AC8C003DB62E /* OnLoaderStartMessageHandler.swift */; };
+		4186664E2C66ACB3003DB62E /* OnLoadErrorMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4186664D2C66ACB3003DB62E /* OnLoadErrorMessageHandler.swift */; };
 		41A2A5642C5ABD6C0077FC74 /* StripeConnectTests.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = 41A2A5632C5ABD6C0077FC74 /* StripeConnectTests.xctestplan */; };
 		41A2A5682C5AC5120077FC74 /* StripeCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 41A2A5672C5AC5120077FC74 /* StripeCore.framework */; };
 		41A2A5CD2C5ACBDD0077FC74 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 41A2A56C2C5ACBDD0077FC74 /* Localizable.strings */; };
@@ -85,6 +116,37 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		410D0FC92C6CFE27009B0E26 /* OnLoadErrorMessageHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnLoadErrorMessageHandlerTests.swift; sourceTree = "<group>"; };
+		410D0FCB2C6CFFDB009B0E26 /* AccountSessionClaimedMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSessionClaimedMessageHandler.swift; sourceTree = "<group>"; };
+		410D0FCD2C6D000B009B0E26 /* OpenAuthenticatedWebViewMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAuthenticatedWebViewMessageHandler.swift; sourceTree = "<group>"; };
+		410D0FCF2C6D0319009B0E26 /* PageDidLoadMessageHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageDidLoadMessageHandlerTests.swift; sourceTree = "<group>"; };
+		410D0FD12C6D047A009B0E26 /* AccountSessionClaimedMessageHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSessionClaimedMessageHandlerTests.swift; sourceTree = "<group>"; };
+		410D0FD32C6D051B009B0E26 /* OpenAuthenticatedWebViewMessageHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAuthenticatedWebViewMessageHandlerTests.swift; sourceTree = "<group>"; };
+		410D0FD62C6D07C7009B0E26 /* MessageSenderTestBase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageSenderTestBase.swift; sourceTree = "<group>"; };
+		410D0FD82C6D1F25009B0E26 /* UpdateConnectInstanceSenderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateConnectInstanceSenderTests.swift; sourceTree = "<group>"; };
+		410D0FDA2C6D21B0009B0E26 /* CallSetterWithSerializableValueSenderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallSetterWithSerializableValueSenderTests.swift; sourceTree = "<group>"; };
+		410D0FDC2C6D23AD009B0E26 /* ReturnedFromAuthenticatedWebViewSenderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReturnedFromAuthenticatedWebViewSenderTests.swift; sourceTree = "<group>"; };
+		413987B82C63F34B001D375E /* DebugMessageHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DebugMessageHandler.swift; sourceTree = "<group>"; };
+		413987B92C63F34B001D375E /* FetchClientSecretMessageHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FetchClientSecretMessageHandler.swift; sourceTree = "<group>"; };
+		413987BA2C63F34B001D375E /* ScriptMessageHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScriptMessageHandler.swift; sourceTree = "<group>"; };
+		413987BB2C63F34B001D375E /* ScriptMessageHandlerWithReply.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScriptMessageHandlerWithReply.swift; sourceTree = "<group>"; };
+		413987BC2C63F34B001D375E /* VoidPayload.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VoidPayload.swift; sourceTree = "<group>"; };
+		413987BE2C63F34B001D375E /* MessageSender.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageSender.swift; sourceTree = "<group>"; };
+		413987BF2C63F34B001D375E /* UpdateConnectInstanceSender.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UpdateConnectInstanceSender.swift; sourceTree = "<group>"; };
+		413987D32C640848001D375E /* CallSetterWithSerializableValueSender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallSetterWithSerializableValueSender.swift; sourceTree = "<group>"; };
+		413987D52C64088E001D375E /* ReturnedFromAuthenticatedWebViewSender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReturnedFromAuthenticatedWebViewSender.swift; sourceTree = "<group>"; };
+		413987DC2C640A29001D375E /* FetchInitParamsMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchInitParamsMessageHandler.swift; sourceTree = "<group>"; };
+		413987DE2C640C50001D375E /* OnExitMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnExitMessageHandler.swift; sourceTree = "<group>"; };
+		413987E02C641688001D375E /* PageDidLoadMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageDidLoadMessageHandler.swift; sourceTree = "<group>"; };
+		41814EE72C6BC8800014EB5E /* WebViewMessageHandlerTestBase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewMessageHandlerTestBase.swift; sourceTree = "<group>"; };
+		41814EEA2C6BCAB30014EB5E /* DebugMessageHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugMessageHandlerTests.swift; sourceTree = "<group>"; };
+		41814EEC2C6BED8C0014EB5E /* FetchClientSecretMessageHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchClientSecretMessageHandlerTests.swift; sourceTree = "<group>"; };
+		41814EEE2C6BEF2C0014EB5E /* FetchInitParamsMessageHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchInitParamsMessageHandlerTests.swift; sourceTree = "<group>"; };
+		41814EF02C6BF94B0014EB5E /* OnExitMessageHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnExitMessageHandlerTests.swift; sourceTree = "<group>"; };
+		41814EF22C6BFA4B0014EB5E /* OnLoaderStartMessageHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnLoaderStartMessageHandlerTests.swift; sourceTree = "<group>"; };
+		418666492C66AC66003DB62E /* OnSetterFunctionCalledMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnSetterFunctionCalledMessageHandler.swift; sourceTree = "<group>"; };
+		4186664B2C66AC8C003DB62E /* OnLoaderStartMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnLoaderStartMessageHandler.swift; sourceTree = "<group>"; };
+		4186664D2C66ACB3003DB62E /* OnLoadErrorMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnLoadErrorMessageHandler.swift; sourceTree = "<group>"; };
 		41A2A5632C5ABD6C0077FC74 /* StripeConnectTests.xctestplan */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = StripeConnectTests.xctestplan; sourceTree = "<group>"; };
 		41A2A5672C5AC5120077FC74 /* StripeCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = StripeCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		41A2A56B2C5ACBDD0077FC74 /* lt-LT */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "lt-LT"; path = "lt-LT.lproj/Localizable.strings"; sourceTree = "<group>"; };
@@ -173,9 +235,111 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		410D0FD52C6D07B1009B0E26 /* MessageSenders */ = {
+			isa = PBXGroup;
+			children = (
+				410D0FD62C6D07C7009B0E26 /* MessageSenderTestBase.swift */,
+				410D0FD82C6D1F25009B0E26 /* UpdateConnectInstanceSenderTests.swift */,
+				410D0FDA2C6D21B0009B0E26 /* CallSetterWithSerializableValueSenderTests.swift */,
+				410D0FDC2C6D23AD009B0E26 /* ReturnedFromAuthenticatedWebViewSenderTests.swift */,
+			);
+			path = MessageSenders;
+			sourceTree = "<group>";
+		};
+		413987BD2C63F34B001D375E /* MessageHandlers */ = {
+			isa = PBXGroup;
+			children = (
+				413987D92C64093C001D375E /* Helpers */,
+				413987B82C63F34B001D375E /* DebugMessageHandler.swift */,
+				413987B92C63F34B001D375E /* FetchClientSecretMessageHandler.swift */,
+				413987DC2C640A29001D375E /* FetchInitParamsMessageHandler.swift */,
+				413987DE2C640C50001D375E /* OnExitMessageHandler.swift */,
+				4186664B2C66AC8C003DB62E /* OnLoaderStartMessageHandler.swift */,
+				4186664D2C66ACB3003DB62E /* OnLoadErrorMessageHandler.swift */,
+				413987E02C641688001D375E /* PageDidLoadMessageHandler.swift */,
+				410D0FCB2C6CFFDB009B0E26 /* AccountSessionClaimedMessageHandler.swift */,
+				410D0FCD2C6D000B009B0E26 /* OpenAuthenticatedWebViewMessageHandler.swift */,
+			);
+			path = MessageHandlers;
+			sourceTree = "<group>";
+		};
+		413987C02C63F34B001D375E /* MessageSenders */ = {
+			isa = PBXGroup;
+			children = (
+				413987BE2C63F34B001D375E /* MessageSender.swift */,
+				413987BF2C63F34B001D375E /* UpdateConnectInstanceSender.swift */,
+				413987D32C640848001D375E /* CallSetterWithSerializableValueSender.swift */,
+				413987D52C64088E001D375E /* ReturnedFromAuthenticatedWebViewSender.swift */,
+			);
+			path = MessageSenders;
+			sourceTree = "<group>";
+		};
+		413987C42C63F34B001D375E /* Webview */ = {
+			isa = PBXGroup;
+			children = (
+				413987BD2C63F34B001D375E /* MessageHandlers */,
+				413987C02C63F34B001D375E /* MessageSenders */,
+			);
+			path = Webview;
+			sourceTree = "<group>";
+		};
+		413987C62C63F34B001D375E /* Internal */ = {
+			isa = PBXGroup;
+			children = (
+				413987C42C63F34B001D375E /* Webview */,
+			);
+			path = Internal;
+			sourceTree = "<group>";
+		};
+		413987D92C64093C001D375E /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				413987BC2C63F34B001D375E /* VoidPayload.swift */,
+				413987BA2C63F34B001D375E /* ScriptMessageHandler.swift */,
+				413987BB2C63F34B001D375E /* ScriptMessageHandlerWithReply.swift */,
+				418666492C66AC66003DB62E /* OnSetterFunctionCalledMessageHandler.swift */,
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
+		41814EE52C6BC8610014EB5E /* Webview */ = {
+			isa = PBXGroup;
+			children = (
+				410D0FD52C6D07B1009B0E26 /* MessageSenders */,
+				41814EE92C6BCA970014EB5E /* MessageHandlers */,
+			);
+			path = Webview;
+			sourceTree = "<group>";
+		};
+		41814EE62C6BC8690014EB5E /* Internal */ = {
+			isa = PBXGroup;
+			children = (
+				41814EE52C6BC8610014EB5E /* Webview */,
+			);
+			path = Internal;
+			sourceTree = "<group>";
+		};
+		41814EE92C6BCA970014EB5E /* MessageHandlers */ = {
+			isa = PBXGroup;
+			children = (
+				41814EE72C6BC8800014EB5E /* WebViewMessageHandlerTestBase.swift */,
+				41814EEA2C6BCAB30014EB5E /* DebugMessageHandlerTests.swift */,
+				41814EEC2C6BED8C0014EB5E /* FetchClientSecretMessageHandlerTests.swift */,
+				41814EEE2C6BEF2C0014EB5E /* FetchInitParamsMessageHandlerTests.swift */,
+				41814EF02C6BF94B0014EB5E /* OnExitMessageHandlerTests.swift */,
+				41814EF22C6BFA4B0014EB5E /* OnLoaderStartMessageHandlerTests.swift */,
+				410D0FC92C6CFE27009B0E26 /* OnLoadErrorMessageHandlerTests.swift */,
+				410D0FCF2C6D0319009B0E26 /* PageDidLoadMessageHandlerTests.swift */,
+				410D0FD12C6D047A009B0E26 /* AccountSessionClaimedMessageHandlerTests.swift */,
+				410D0FD32C6D051B009B0E26 /* OpenAuthenticatedWebViewMessageHandlerTests.swift */,
+			);
+			path = MessageHandlers;
+			sourceTree = "<group>";
+		};
 		41A2A5602C5A97130077FC74 /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				413987C62C63F34B001D375E /* Internal */,
 				41A2A5FF2C5ACD3E0077FC74 /* Helpers */,
 			);
 			path = Source;
@@ -296,6 +460,7 @@
 		41D17A4E2C5A73A7007C6EE6 /* StripeConnectTests */ = {
 			isa = PBXGroup;
 			children = (
+				41814EE62C6BC8690014EB5E /* Internal */,
 				41D17A4F2C5A73A7007C6EE6 /* StripeConnectTests.swift */,
 			);
 			path = StripeConnectTests;
@@ -537,7 +702,24 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4186664C2C66AC8C003DB62E /* OnLoaderStartMessageHandler.swift in Sources */,
+				413987D62C64088E001D375E /* ReturnedFromAuthenticatedWebViewSender.swift in Sources */,
+				413987DF2C640C50001D375E /* OnExitMessageHandler.swift in Sources */,
+				413987C92C63F34B001D375E /* FetchClientSecretMessageHandler.swift in Sources */,
+				413987E12C641688001D375E /* PageDidLoadMessageHandler.swift in Sources */,
+				410D0FCE2C6D000B009B0E26 /* OpenAuthenticatedWebViewMessageHandler.swift in Sources */,
+				413987CD2C63F34B001D375E /* MessageSender.swift in Sources */,
 				41A2A6012C5ACD9F0077FC74 /* STPLocalizedString.swift in Sources */,
+				413987CE2C63F34B001D375E /* UpdateConnectInstanceSender.swift in Sources */,
+				4186664A2C66AC66003DB62E /* OnSetterFunctionCalledMessageHandler.swift in Sources */,
+				413987CC2C63F34B001D375E /* VoidPayload.swift in Sources */,
+				413987DD2C640A29001D375E /* FetchInitParamsMessageHandler.swift in Sources */,
+				413987D42C640848001D375E /* CallSetterWithSerializableValueSender.swift in Sources */,
+				413987CB2C63F34B001D375E /* ScriptMessageHandlerWithReply.swift in Sources */,
+				413987CA2C63F34B001D375E /* ScriptMessageHandler.swift in Sources */,
+				413987C82C63F34B001D375E /* DebugMessageHandler.swift in Sources */,
+				410D0FCC2C6CFFDB009B0E26 /* AccountSessionClaimedMessageHandler.swift in Sources */,
+				4186664E2C66ACB3003DB62E /* OnLoadErrorMessageHandler.swift in Sources */,
 				41A2A5FE2C5ACCAA0077FC74 /* StripeConnectBundleLocator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -547,6 +729,20 @@
 			buildActionMask = 2147483647;
 			files = (
 				41D17A502C5A73A7007C6EE6 /* StripeConnectTests.swift in Sources */,
+				410D0FDD2C6D23AD009B0E26 /* ReturnedFromAuthenticatedWebViewSenderTests.swift in Sources */,
+				410D0FD92C6D1F25009B0E26 /* UpdateConnectInstanceSenderTests.swift in Sources */,
+				41814EEB2C6BCAB30014EB5E /* DebugMessageHandlerTests.swift in Sources */,
+				41814EEF2C6BEF2C0014EB5E /* FetchInitParamsMessageHandlerTests.swift in Sources */,
+				410D0FD22C6D047A009B0E26 /* AccountSessionClaimedMessageHandlerTests.swift in Sources */,
+				41814EF12C6BF94B0014EB5E /* OnExitMessageHandlerTests.swift in Sources */,
+				410D0FD42C6D051B009B0E26 /* OpenAuthenticatedWebViewMessageHandlerTests.swift in Sources */,
+				410D0FCA2C6CFE27009B0E26 /* OnLoadErrorMessageHandlerTests.swift in Sources */,
+				410D0FDB2C6D21B0009B0E26 /* CallSetterWithSerializableValueSenderTests.swift in Sources */,
+				410D0FD72C6D07C7009B0E26 /* MessageSenderTestBase.swift in Sources */,
+				410D0FD02C6D0319009B0E26 /* PageDidLoadMessageHandlerTests.swift in Sources */,
+				41814EED2C6BED8C0014EB5E /* FetchClientSecretMessageHandlerTests.swift in Sources */,
+				41814EE82C6BC8800014EB5E /* WebViewMessageHandlerTestBase.swift in Sources */,
+				41814EF32C6BFA4B0014EB5E /* OnLoaderStartMessageHandlerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1030,6 +1226,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = Y28TH9SHX7;
 				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stripe.StripeConnectTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1045,6 +1242,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = Y28TH9SHX7;
 				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stripe.StripeConnectTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/AccountSessionClaimedMessageHandler.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/AccountSessionClaimedMessageHandler.swift
@@ -1,0 +1,19 @@
+//
+//  AccountSessionClaimedMessageHandler.swift
+//  StripeConnect
+//
+//  Created by Chris Mays on 8/14/24.
+//
+
+import Foundation
+
+/// Emitted when the claim response is available
+class AccountSessionClaimedMessageHandler: ScriptMessageHandler<AccountSessionClaimedMessageHandler.Payload> {
+    struct Payload: Codable, Equatable {
+        /// The connected account ID
+        let merchantId: String
+    }
+    init(didReceiveMessage: @escaping (Payload) -> Void) {
+        super.init(name: "accountSessionClaimed", didReceiveMessage: didReceiveMessage)
+    }
+}

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/DebugMessageHandler.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/DebugMessageHandler.swift
@@ -1,0 +1,15 @@
+//
+//  DebugMessage.swift
+//  StripeConnect
+//
+//  Created by Chris Mays on 8/2/24.
+//
+
+import Foundation
+
+// Emitted when the SDK should print to the console in debug mode.
+class DebugMessageHandler: ScriptMessageHandler<String> {
+    init(didReceiveMessage: @escaping (String) -> Void = { Swift.debugPrint($0) }) {
+        super.init(name: "debug", didReceiveMessage: didReceiveMessage)
+    }
+}

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/FetchClientSecretMessageHandler.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/FetchClientSecretMessageHandler.swift
@@ -1,0 +1,15 @@
+//
+//  FetchClientSecretMessageHandler.swift
+//  StripeConnect
+//
+//  Created by Chris Mays on 8/2/24.
+//
+
+import Foundation
+
+// Called when the client secret is needed for embedded components
+class FetchClientSecretMessageHandler: ScriptMessageHandlerWithReply<VoidPayload, String?> {
+    init(didReceiveMessage: @escaping (VoidPayload) async throws -> String?) {
+        super.init(name: "fetchClientSecret", didReceiveMessage: didReceiveMessage)
+    }
+}

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/FetchInitParamsMessageHandler.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/FetchInitParamsMessageHandler.swift
@@ -1,0 +1,19 @@
+//
+//  FetchInitParamsMessageHandler.swift
+//  StripeConnect
+//
+//  Created by Chris Mays on 8/7/24.
+//
+
+import Foundation
+
+// This message is emitted when the SDK is requesting initialization info.
+class FetchInitParamsMessageHandler: ScriptMessageHandlerWithReply<VoidPayload, FetchInitParamsMessageHandler.Reply> {
+    struct Reply: Codable, Equatable {
+        let locale: String
+        // TODO: Add fonts & appearance here.
+    }
+    init(didReceiveMessage: @escaping (VoidPayload) async throws -> Reply) {
+        super.init(name: "fetchInitParams", didReceiveMessage: didReceiveMessage)
+    }
+}

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/Helpers/OnSetterFunctionCalledMessageHandler.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/Helpers/OnSetterFunctionCalledMessageHandler.swift
@@ -1,0 +1,25 @@
+//
+//  OnSetterFunctionCalledMessageHandler.swift
+//  StripeConnect
+//
+//  Created by Chris Mays on 8/9/24.
+//
+
+import Foundation
+
+class OnSetterFunctionCalledMessageHandler<Values: Codable & Equatable>: ScriptMessageHandler<OnSetterFunctionCalledMessageHandler.Payload<Values>> {
+    struct Payload<Value: Codable & Equatable>: Codable {
+        /// Name of the component-specific setter function (e.g. `onExit`)
+        let setter: String
+        /// Setter specific payload
+        let value: Value?
+    }
+
+    init(setter: String, didReceiveMessage: @escaping (Values?) -> Void) {
+        super.init(name: "onSetterFunctionCalled", didReceiveMessage: { payload in
+            if payload.setter == setter {
+                didReceiveMessage(payload.value)
+            }
+        })
+    }
+}

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/Helpers/ScriptMessageHandler.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/Helpers/ScriptMessageHandler.swift
@@ -1,0 +1,37 @@
+//
+//  ScriptMessageHandler.swift
+//  StripeConnect
+//
+//  Created by Mel Ludowise on 5/1/24.
+//
+
+import WebKit
+
+/// Convenience class that conforms to WKScriptMessageHandler and can be instantiated with a closure
+class ScriptMessageHandler<Payload: Decodable>: NSObject, WKScriptMessageHandler {
+    let name: String
+    let didReceiveMessage: (Payload) -> Void
+    
+    init(name: String,
+         didReceiveMessage: @escaping (Payload) -> Void) {
+        self.name = name
+        self.didReceiveMessage = didReceiveMessage
+    }
+    
+    func userContentController(_ userContentController: WKUserContentController,
+                               didReceive message: WKScriptMessage) {
+        guard message.name == name else {
+            debugPrint("Unexpected message name: \(message.name)")
+            return
+        }
+        guard 
+            let bodyData = (message.body as? String)?.data(using: .utf8),
+            let body = try? JSONDecoder().decode(Payload.self, from: bodyData) else {
+            //TODO: MXMOBILE-2491 Log as analytics
+            debugPrint("Failed to decode body for message with name: \(message.name)")
+            return
+        }
+        
+        didReceiveMessage(body)
+    }
+}

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/Helpers/ScriptMessageHandlerWithReply.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/Helpers/ScriptMessageHandlerWithReply.swift
@@ -1,0 +1,46 @@
+//
+//  ScriptMessageHandlerWithReply.swift
+//  StripeConnect
+//
+//  Created by Mel Ludowise on 5/1/24.
+//
+
+import WebKit
+
+/// Convenience class that conforms to WKScriptMessageHandlerWithReply and can be instantiated with a closure
+class ScriptMessageHandlerWithReply<Payload: Decodable, Response: Codable>: NSObject, WKScriptMessageHandlerWithReply {
+    let name: String
+    let didReceiveMessage: (Payload) async throws -> Response
+    
+    init(name: String,
+         didReceiveMessage: @escaping (Payload) async throws -> Response) {
+        self.name = name
+        self.didReceiveMessage = didReceiveMessage
+    }
+    
+    @MainActor
+    func userContentController(_ userContentController: WKUserContentController,
+                               didReceive message: WKScriptMessage) async -> (Any?, String?) {
+        guard message.name == name else {
+            debugPrint("Unexpected message name: \(message.name)")
+            return (nil, "Unexpected message")
+        }
+        guard
+            let bodyData = (message.body as? String)?.data(using: .utf8),
+            let body = try? JSONDecoder().decode(Payload.self, from: bodyData) else {
+            //TODO: MXMOBILE-2491 Log as analytics
+            debugPrint("Failed to decode body for message with name: \(message.name)")
+            return (nil, "Failed to decode body for message")
+        }
+        do {
+            let value = try await didReceiveMessage(body)
+            let data = try JSONEncoder().encode(value)
+            guard let response = try? JSONSerialization.jsonObject(with: data, options: .allowFragments) else {
+                return (nil, "Failed to decode body")
+            }
+            return (response, nil)
+        } catch {
+            return (nil, error.localizedDescription)
+        }
+    }
+}

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/Helpers/VoidPayload.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/Helpers/VoidPayload.swift
@@ -1,0 +1,11 @@
+//
+//  VoidPayload.swift
+//  StripeConnect
+//
+//  Created by Chris Mays on 8/2/24.
+//
+
+import Foundation
+
+/// Represents an empty message payload (e.g. `{}`)
+struct VoidPayload: Codable, Equatable { }

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/OnExitMessageHandler.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/OnExitMessageHandler.swift
@@ -1,0 +1,17 @@
+//
+//  OnExitMessageHandler.swift
+//  StripeConnect
+//
+//  Created by Chris Mays on 8/7/24.
+//
+
+import Foundation
+
+// The event emitted when onboarding is exited
+class OnExitMessageHandler: OnSetterFunctionCalledMessageHandler<VoidPayload> {
+    init(didReceiveMessage: @escaping () -> Void) {
+        super.init(setter: "setOnExit", didReceiveMessage: { _ in
+            didReceiveMessage()
+        })
+    }
+}

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/OnLoadErrorMessageHandler.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/OnLoadErrorMessageHandler.swift
@@ -1,0 +1,31 @@
+//
+//  OnLoadErrorMessageHandler.swift
+//  StripeConnect
+//
+//  Created by Chris Mays on 8/9/24.
+//
+
+import Foundation
+
+// Emitted when there is an error loading connect js
+class OnLoadErrorMessageHandler: OnSetterFunctionCalledMessageHandler<OnLoadErrorMessageHandler.Values> {
+    struct Values: Codable, Equatable {
+        let error: ErrorValue
+        
+        struct ErrorValue: Codable, Equatable {
+            let type: String
+            let message: String
+        }
+    }
+    
+    init(didReceiveMessage: @escaping (Values) -> Void) {
+        super.init(setter: "setOnLoadError", didReceiveMessage: { values in
+            if let values {
+                didReceiveMessage(values)
+            } else {
+                //TODO: MXMOBILE-2491 Log as analytics
+                debugPrint("Did not receive values for onLoad")
+            }
+        })
+    }
+}

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/OnLoaderStartMessageHandler.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/OnLoaderStartMessageHandler.swift
@@ -1,0 +1,24 @@
+//
+//  OnLoaderStartMessageHandler.swift
+//  StripeConnect
+//
+//  Created by Chris Mays on 8/9/24.
+//
+
+import Foundation
+
+// Emitted when connect js has initialized and the component renders a loading state
+class OnLoaderStartMessageHandler: OnSetterFunctionCalledMessageHandler<OnLoaderStartMessageHandler.Values> {
+    struct Values: Codable, Equatable {
+        let elementTagName: String
+    }
+    init(didReceiveMessage: @escaping (OnLoaderStartMessageHandler.Values) -> Void) {
+        super.init(setter: "setOnLoaderStart", didReceiveMessage: { value in
+            if let value {
+                didReceiveMessage(value)
+            } else {
+                debugPrint("Did not receive values for setOnLoaderStart")
+            }
+        })
+    }
+}

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/OpenAuthenticatedWebViewMessageHandler.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/OpenAuthenticatedWebViewMessageHandler.swift
@@ -1,0 +1,21 @@
+//
+//  OpenAuthenticatedWebViewMessageHandler.swift
+//  StripeConnect
+//
+//  Created by Chris Mays on 8/14/24.
+//
+
+import Foundation
+
+/// Indicates to open the provided URL in an `ASWebAuthenticationSession`.
+class OpenAuthenticatedWebViewMessageHandler: ScriptMessageHandler<OpenAuthenticatedWebViewMessageHandler.Payload> {
+    struct Payload: Codable, Equatable {
+        /// URL that's opened in an `ASWebAuthenticationSession`
+        let url: URL
+        /// Unique identifier logged in analytics when the `ASWebAuthenticationSession` is opened or closed.
+        let id: String
+    }
+    init(didReceiveMessage: @escaping (Payload) -> Void) {
+        super.init(name: "openAuthenticatedWebView", didReceiveMessage: didReceiveMessage)
+    }
+}

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/PageDidLoadMessageHandler.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/PageDidLoadMessageHandler.swift
@@ -1,0 +1,19 @@
+//
+//  PageDidLoadMessageHandler.swift
+//  StripeConnect
+//
+//  Created by Chris Mays on 8/7/24.
+//
+
+import Foundation
+
+// A message that indicates components have loaded
+class PageDidLoadMessageHandler: ScriptMessageHandler<PageDidLoadMessageHandler.Payload> {
+    struct Payload: Codable, Equatable {
+        /// A unique session ID shared with web for analytics logging
+        let pageViewId: String
+    }
+    init(didReceiveMessage: @escaping (Payload) -> Void) {
+        super.init(name: "pageDidLoad", didReceiveMessage: didReceiveMessage)
+    }
+}

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/MessageSenders/CallSetterWithSerializableValueSender.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/MessageSenders/CallSetterWithSerializableValueSender.swift
@@ -1,0 +1,19 @@
+//
+//  CallSetterWithSerializableValueSender.swift
+//  StripeConnect
+//
+//  Created by Chris Mays on 8/7/24.
+//
+
+import Foundation
+
+struct CallSetterWithSerializableValueSender<Value: Codable & Equatable>: MessageSender {
+    struct Payload: Codable, Equatable {
+        /// Name of the component-specific JS setter function on the component (e.g. `setFullTermsOfService`)
+        let setter: String
+        /// Args value to pass to the setter function
+        let value: Value
+    }
+    let name: String = "callSetterWithSerializableValue"
+    let payload: Payload
+}

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/MessageSenders/MessageSender.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/MessageSenders/MessageSender.swift
@@ -1,0 +1,31 @@
+//
+//  MessageSender.swift
+//  StripeConnect
+//
+//  Created by Chris Mays on 8/2/24.
+//
+
+import Foundation
+
+/// Sends a message to the webview by calling a function on `window`
+protocol MessageSender {
+    associatedtype Payload: Codable & Equatable
+    /// Name of the method (e.g. `updateConnectInstance`)
+    var name: String { get }
+    /// Function param
+    var payload: Payload { get }
+}
+
+extension MessageSender {
+    var javascriptMessage: String? {
+        let encoder = JSONEncoder()
+        // Ensure keys are sorted for test stability.
+        encoder.outputFormatting = .sortedKeys
+        guard let jsonData = try? encoder.encode(payload),
+              let jsonString = String(data: jsonData, encoding: .utf8) else {
+            //TODO: MXMOBILE-2491 Log failure to analytics
+            return nil
+        }
+        return "window.\(name)(\(jsonString));"
+    }
+}

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/MessageSenders/ReturnedFromAuthenticatedWebViewSender.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/MessageSenders/ReturnedFromAuthenticatedWebViewSender.swift
@@ -1,0 +1,18 @@
+//
+//  ReturnedFromAuthenticatedWebViewSender.swift
+//  StripeConnect
+//
+//  Created by Chris Mays on 8/7/24.
+//
+
+import Foundation
+
+/// Notifies that the user finished the flow within the `ASWebAuthenticationSession`
+struct ReturnedFromAuthenticatedWebViewSender: MessageSender {
+    struct Payload: Codable, Equatable {
+        /// The return URL from the `ASWebAuthenticationSession` redirect. This value will be nil if the user canceled out fo the view
+        let url: String?
+    }
+    let name: String = "returnedFromAuthenticatedWebView"
+    let payload: Payload
+}

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/MessageSenders/UpdateConnectInstanceSender.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/MessageSenders/UpdateConnectInstanceSender.swift
@@ -1,0 +1,18 @@
+//
+//  UpdateConnectInstanceSender.swift
+//  StripeConnect
+//
+//  Created by Chris Mays on 8/2/24.
+//
+
+import Foundation
+
+/// Updates appearance and locale options.
+struct UpdateConnectInstanceSender: MessageSender {
+    struct Payload: Codable, Equatable {
+        let locale: String
+        // TODO: Add appearance here.
+    }
+    let name: String = "updateConnectInstance"
+    let payload: Payload
+}

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/AccountSessionClaimedMessageHandlerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/AccountSessionClaimedMessageHandlerTests.swift
@@ -1,0 +1,28 @@
+//
+//  AccountSessionClaimedMessageHandlerTests.swift
+//  StripeConnectTests
+//
+//  Created by Chris Mays on 8/14/24.
+//
+
+@testable import StripeConnect
+import XCTest
+
+class AccountSessionClaimedMessageHandlerTests: ScriptMessageHandlerTestBase {
+    func testMessageSend() {
+        let expectation = self.expectation(description: "Message received")
+        let merchantId = "acct_1234"
+        
+        addMessageHandler(messageHandler: AccountSessionClaimedMessageHandler(didReceiveMessage: { payload in
+            expectation.fulfill()
+            XCTAssertEqual(payload, .init(merchantId: merchantId))
+        }))
+        
+        evaluateMessage(name: "accountSessionClaimed",
+                        json: """
+                        {"merchantId": "\(merchantId)"}
+                        """)
+        
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+}

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/DebugMessageHandlerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/DebugMessageHandlerTests.swift
@@ -1,0 +1,28 @@
+//
+//  DebugMessageHandlerTests.swift
+//  StripeConnectTests
+//
+//  Created by Chris Mays on 8/13/24.
+//
+
+@testable import StripeConnect
+import XCTest
+
+class DebugMessageHandlerTests: ScriptMessageHandlerTestBase {
+    func testMessageSend() {
+        let expectation = self.expectation(description: "Message received")
+        let debugMessage = "test message"
+        
+        addMessageHandler(messageHandler: DebugMessageHandler(didReceiveMessage: { payload in
+            expectation.fulfill()
+            XCTAssertEqual(payload, debugMessage)
+        }))
+        
+        evaluateMessage(name: "debug",
+                        json: """
+                        "\(debugMessage)"
+                        """)
+        
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+}

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/FetchClientSecretMessageHandlerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/FetchClientSecretMessageHandlerTests.swift
@@ -1,0 +1,28 @@
+//
+//  FetchClientSecretMessageHandlerTests.swift
+//  StripeConnectTests
+//
+//  Created by Chris Mays on 8/13/24.
+//
+
+@testable import StripeConnect
+import XCTest
+
+class FetchClientSecretMessageHandlerTests: ScriptMessageHandlerTestBase {
+    
+    func testMessageSend() async throws {
+        let expectation = self.expectation(description: "Message received")
+        let key = "key_123"
+        
+        addMessageReplyHandler(messageHandler: FetchClientSecretMessageHandler(didReceiveMessage: { _ in
+            return key
+        }), verifyResult: { result in
+            XCTAssertEqual(result, key)
+            expectation.fulfill()
+        })
+        
+        try await evaluateMessageWithReply(name: "fetchClientSecret",
+                                           json: "{}")
+        await fulfillment(of: [expectation], timeout: 0.2)
+    }
+}

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/FetchInitParamsMessageHandlerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/FetchInitParamsMessageHandlerTests.swift
@@ -1,0 +1,26 @@
+//
+//  FetchInitParamsMessageHandlerTests.swift
+//  StripeConnectTests
+//
+//  Created by Chris Mays on 8/13/24.
+//
+
+@testable import StripeConnect
+import XCTest
+
+class FetchInitParamsMessageHandlerTests: ScriptMessageHandlerTestBase {
+    func testMessageSend() async throws {
+        let expectation = self.expectation(description: "Message received")
+        let message = FetchInitParamsMessageHandler.Reply(locale: "en")
+        addMessageReplyHandler(messageHandler: FetchInitParamsMessageHandler(didReceiveMessage: { _ in
+            return message
+        }), verifyResult: { result in
+            XCTAssertEqual(result, message)
+            expectation.fulfill()
+        })
+        
+        try await evaluateMessageWithReply(name: "fetchInitParams",
+                                           json: "{}")
+        await fulfillment(of: [expectation], timeout: 0.2)
+    }
+}

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/OnExitMessageHandlerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/OnExitMessageHandlerTests.swift
@@ -1,0 +1,29 @@
+//
+//  OnExitMessageHandlerTests.swift
+//  StripeConnectTests
+//
+//  Created by Chris Mays on 8/13/24.
+//
+
+
+@testable import StripeConnect
+import XCTest
+
+class OnExitMessageHandlerTests: ScriptMessageHandlerTestBase {
+    func testMessageSend() {
+        let expectation = self.expectation(description: "Message received")
+        
+        addMessageHandler(messageHandler: OnExitMessageHandler(didReceiveMessage: {
+            expectation.fulfill()
+        }))
+        
+        evaluateMessage(name: "onSetterFunctionCalled",
+                        json: """
+                        {
+                            "setter": "setOnExit"
+                        }
+                        """)
+        
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+}

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/OnLoadErrorMessageHandlerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/OnLoadErrorMessageHandlerTests.swift
@@ -1,0 +1,34 @@
+//
+//  OnLoadErrorMessageHandlerTests.swift
+//  StripeConnectTests
+//
+//  Created by Chris Mays on 8/14/24.
+//
+@testable import StripeConnect
+import XCTest
+
+class OnLoadErrorMessageHandlerTests: ScriptMessageHandlerTestBase {
+    func testMessageSend() {
+        let expectation = self.expectation(description: "Message received")
+        addMessageHandler(messageHandler: OnLoadErrorMessageHandler(didReceiveMessage: { payload in
+            expectation.fulfill()
+            
+            XCTAssertEqual(payload, OnLoadErrorMessageHandler.Values(error: .init(type: "failed_to_load", message: "Error message")))
+        }))
+        
+        evaluateMessage(name: "onSetterFunctionCalled",
+                        json: """
+                        {
+                            "setter": "setOnLoadError",
+                            "value": {
+                                "error": {
+                                    "type": "failed_to_load",
+                                    "message": "Error message"
+                                }
+                            }
+                        }
+                        """)
+        
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+}

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/OnLoaderStartMessageHandlerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/OnLoaderStartMessageHandlerTests.swift
@@ -1,0 +1,32 @@
+//
+//  OnLoaderStartMessageHandlerTests.swift
+//  StripeConnectTests
+//
+//  Created by Chris Mays on 8/13/24.
+//
+
+@testable import StripeConnect
+import XCTest
+
+class OnLoaderStartMessageHandlerTests: ScriptMessageHandlerTestBase {
+    func testMessageSend() {
+        let expectation = self.expectation(description: "Message received")
+        addMessageHandler(messageHandler: OnLoaderStartMessageHandler(didReceiveMessage: { payload in
+            expectation.fulfill()
+            
+            XCTAssertEqual(payload, OnLoaderStartMessageHandler.Values(elementTagName: "onboarding"))
+        }))
+        
+        evaluateMessage(name: "onSetterFunctionCalled",
+                        json: """
+                        {
+                            "setter": "setOnLoaderStart",
+                            "value": {
+                                "elementTagName": "onboarding"
+                            }
+                        }
+                        """)
+        
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+}

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/OpenAuthenticatedWebViewMessageHandlerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/OpenAuthenticatedWebViewMessageHandlerTests.swift
@@ -1,0 +1,28 @@
+//
+//  OpenAuthenticatedWebViewMessageHandlerTests.swift
+//  StripeConnectTests
+//
+//  Created by Chris Mays on 8/14/24.
+//
+
+@testable import StripeConnect
+import XCTest
+
+class OpenAuthenticatedWebViewMessageHandlerTests: ScriptMessageHandlerTestBase {
+    func testMessageSend() {
+        let expectation = self.expectation(description: "Message received")
+        let url = "https://dashboard.stripe.com"
+        let id = "1234"
+        addMessageHandler(messageHandler: OpenAuthenticatedWebViewMessageHandler(didReceiveMessage: { payload in
+            expectation.fulfill()
+            XCTAssertEqual(payload, .init(url: URL(string: "https://dashboard.stripe.com")!, id: id))
+        }))
+        
+        evaluateMessage(name: "openAuthenticatedWebView",
+                        json: """
+                        {"url": "\(url)", "id": "\(id)" }
+                        """)
+        
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+}

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/PageDidLoadMessageHandlerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/PageDidLoadMessageHandlerTests.swift
@@ -1,0 +1,29 @@
+//
+//  PageDidLoadMessageHandlerTests.swift
+//  StripeConnectTests
+//
+//  Created by Chris Mays on 8/14/24.
+//
+
+@testable import StripeConnect
+import XCTest
+
+class PageDidLoadMessageHandlerTests: ScriptMessageHandlerTestBase {
+    func testMessageSend() {
+        let expectation = self.expectation(description: "Message received")
+        
+        let pageViewId = "123"
+        
+        addMessageHandler(messageHandler: PageDidLoadMessageHandler(didReceiveMessage: { payload in
+            expectation.fulfill()
+            XCTAssertEqual(payload, .init(pageViewId: pageViewId))
+        }))
+        
+        evaluateMessage(name: "pageDidLoad",
+                        json: """
+                        {"pageViewId": "\(pageViewId)"}
+                        """)
+        
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+}

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/WebViewMessageHandlerTestBase.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/WebViewMessageHandlerTestBase.swift
@@ -1,0 +1,67 @@
+//
+//  WebViewMessageHandlerTestBase.swift
+//  StripeConnectTests
+//
+//  Created by Chris Mays on 8/13/24.
+//
+
+@testable import StripeConnect
+import XCTest
+import WebKit
+
+class ScriptMessageHandlerTestBase: XCTestCase {
+    
+    var webView: WKWebView!
+    
+    override func setUp() {
+        super.setUp()
+        webView = WKWebView(frame: .zero, configuration: .init())
+    }
+    
+    func addMessageHandler<T>(messageHandler: ScriptMessageHandler<T>) {
+        webView.configuration.userContentController.add(messageHandler, name: messageHandler.name)
+    }
+    
+    struct Reply<R: Decodable>: Decodable {
+        let result: R
+    }
+    
+    func addMessageReplyHandler<Payload, Response>(messageHandler: ScriptMessageHandlerWithReply<Payload, Response>, verifyResult: @escaping (Response) -> Void) {
+        addMessageHandler(messageHandler: .init(name: replyKey(message: messageHandler.name), didReceiveMessage: { (message: Reply<Response>) in
+            verifyResult(message.result)
+        }))
+        
+        webView.configuration.userContentController.addScriptMessageHandler(messageHandler, contentWorld: .page, name: messageHandler.name)
+    }
+    
+    override func tearDown() {
+        webView = nil
+        super.tearDown()
+    }
+    
+    func evaluateMessage(name: String,
+                         json: String,
+                         completionHandler: ((Any?, (any Error)?) -> Void)? = nil) {
+        let script = """
+        window.webkit.messageHandlers.\(name).postMessage(JSON.stringify(\(json)));
+        """
+        
+        webView.evaluateJavaScript(script, completionHandler: completionHandler)
+    }
+    
+    @discardableResult
+    func evaluateMessageWithReply(name: String,
+                                  json: String,
+                                  completionHandler: ((Any?, (any Error)?) -> Void)? = nil) async throws -> Any? {
+        let script = """
+                    const message = {text: "Hello, World!"};
+                    const result = await window.webkit.messageHandlers.\(name).postMessage(JSON.stringify(\(json)));
+                    window.webkit.messageHandlers.\(replyKey(message: name)).postMessage(JSON.stringify({"result": result}));
+                """
+        return try await webView.callAsyncJavaScript(script, contentWorld: .page)
+    }
+    
+    func replyKey(message: String) -> String {
+        message + "_reply"
+    }
+}

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageSenders/CallSetterWithSerializableValueSenderTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageSenders/CallSetterWithSerializableValueSenderTests.swift
@@ -1,0 +1,25 @@
+//
+//  CallSetterWithSerializableValueSenderTests.swift
+//  StripeConnectTests
+//
+//  Created by Chris Mays on 8/14/24.
+//
+
+import Foundation
+@testable import StripeConnect
+import XCTest
+
+class CallSetterWithSerializableValueSenderTests: MessageSenderTestBase {
+    func testSendMessage() throws {
+        try validateMessageSent(sender: CallSetterWithSerializableValueSender(payload: .init(setter: "setPayment", value: "pi_1234")))
+    }
+    
+    func testSenderSignature() {
+        XCTAssertEqual(
+            CallSetterWithSerializableValueSender(payload: .init(setter: "setPayment", value: "pi_1234")).javascriptMessage,
+            """
+            window.callSetterWithSerializableValue({"setter":"setPayment","value":"pi_1234"});
+            """
+        )
+    }
+}

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageSenders/MessageSenderTestBase.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageSenders/MessageSenderTestBase.swift
@@ -1,0 +1,63 @@
+//
+//  MessageSenderTestBase.swift
+//  StripeConnectTests
+//
+//  Created by Chris Mays on 8/14/24.
+//
+
+@testable import StripeConnect
+import XCTest
+import WebKit
+
+class MessageSenderTestBase: XCTestCase {
+    var webView: WKWebView!
+    
+    override func setUp() {
+        super.setUp()
+        webView = WKWebView(frame: .zero)
+    }
+    
+    override func tearDown() {
+        webView = nil
+        super.tearDown()
+    }
+    
+    private class MessageHandler: NSObject, WKScriptMessageHandler {
+        var messageReceived: ((Any) -> Void)?
+        
+        func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+            messageReceived?(message.body)
+        }
+    }
+    
+    func validateMessageSent<Sender: MessageSender>(sender: Sender) throws {
+        let jsMessage = try XCTUnwrap(sender.javascriptMessage)
+        let expectation = XCTestExpectation(description: "JavaScript execution")
+        let messageHandler = MessageHandler()
+        messageHandler.messageReceived = { (payload: Any) in
+            if let jsonString = payload as? String,
+               let data = jsonString.data(using: .utf8),
+               let dict = try? JSONDecoder().decode(Sender.Payload.self, from: data) {
+                XCTAssertEqual(dict, sender.payload)
+                expectation.fulfill()
+            }
+        }
+        
+        // Inject the receiver function that validates the message was sent
+        let receiverFunctionName = "receiver"
+        webView.evaluateJavaScript("""
+                window.\(sender.name) = function(message) {
+                    window.webkit.messageHandlers.\(receiverFunctionName).postMessage(JSON.stringify(message));
+                };
+            """)
+        webView.configuration.userContentController.add(messageHandler, name: receiverFunctionName)
+        
+        webView.evaluateJavaScript(jsMessage) { (result, error) in
+            if let error {
+                XCTFail("JavaScript execution failed: \(error)")
+            }
+        }
+        
+        wait(for: [expectation], timeout: 1.0)
+    }
+}

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageSenders/ReturnedFromAuthenticatedWebViewSenderTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageSenders/ReturnedFromAuthenticatedWebViewSenderTests.swift
@@ -1,0 +1,25 @@
+//
+//  ReturnedFromAuthenticatedWebViewSenderTests.swift
+//  StripeConnectTests
+//
+//  Created by Chris Mays on 8/14/24.
+//
+
+import Foundation
+@testable import StripeConnect
+import XCTest
+
+class ReturnedFromAuthenticatedWebViewSenderTests: MessageSenderTestBase {
+    func testSendMessage() throws {
+        try validateMessageSent(sender: ReturnedFromAuthenticatedWebViewSender(payload: .init(url: "https://dashboard.stripe.com")))
+    }
+    
+    func testSenderSignature() {
+        XCTAssertEqual(
+            ReturnedFromAuthenticatedWebViewSender(payload: .init(url: "https://dashboard.stripe.com")).javascriptMessage,
+            """
+            window.returnedFromAuthenticatedWebView({"url":"https:\\/\\/dashboard.stripe.com"});
+            """
+        )
+    }
+}

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageSenders/UpdateConnectInstanceSenderTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageSenders/UpdateConnectInstanceSenderTests.swift
@@ -1,0 +1,25 @@
+//
+//  UpdateConnectInstanceSenderTests.swift
+//  StripeConnectTests
+//
+//  Created by Chris Mays on 8/14/24.
+//
+
+import Foundation
+@testable import StripeConnect
+import XCTest
+
+class UpdateConnectInstanceSenderTests: MessageSenderTestBase {
+    func testSendMessage() throws {
+        try validateMessageSent(sender: UpdateConnectInstanceSender(payload: .init(locale: "en")))
+    }
+    
+    func testSenderSignature() {
+        XCTAssertEqual(
+            UpdateConnectInstanceSender(payload: .init(locale: "en")).javascriptMessage,
+            """
+            window.updateConnectInstance({"locale":"en"});
+            """
+        )
+    }
+}


### PR DESCRIPTION
## Summary
Add message handlers and message senders that will be used to communicate with the web view. This also adds tests to ensure the senders and receivers interact properly with the webview.


https://jira.corp.stripe.com/browse/MXMOBILE-2479