### PR TITLE
[BANKCON-11768] Add E2E UI tests for Native Instant Debits flow

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnections Example.xcodeproj/project.pbxproj
+++ b/Example/FinancialConnections Example/FinancialConnections Example.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		24E793526FA832586DB7FC96 /* BannerHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE8601634DE1E43030B0D469 /* BannerHelper.swift */; };
 		2FFB7D24916B79615F334BD4 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 936C5935D51A54BE9F183ECA /* Main.storyboard */; };
 		307E63F1F0E10D8B419C3DAB /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FF678252EB811ACE4D0EC296 /* LaunchScreen.storyboard */; };
+		49B5463A2C6E54DB008DC127 /* InstantDebitsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B546392C6E54DB008DC127 /* InstantDebitsUITests.swift */; };
 		597C7552115D87218591934C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07DA32DE3842C0AD47047104 /* AppDelegate.swift */; };
 		59C21AF5DEA23997E909ACA4 /* StripeCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 03E7365D673694C8D7EDFB20 /* StripeCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5AA50D95EC1C2489AD98071E /* PlaygroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B379D3A9F9EA11716D5AEB3 /* PlaygroundView.swift */; };
@@ -95,6 +96,7 @@
 		363C5AD7E84C53FF964C6A0D /* PlaygroundViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaygroundViewModel.swift; sourceTree = "<group>"; };
 		3E18F0765C9C715F64080DD3 /* Project-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Project-Release.xcconfig"; sourceTree = "<group>"; };
 		3E1E39731621D996DDD83DAC /* StripeCoreTestUtils.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripeCoreTestUtils.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		49B546392C6E54DB008DC127 /* InstantDebitsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstantDebitsUITests.swift; sourceTree = "<group>"; };
 		4F33EDB6E5F9D5101B65E0E1 /* FinancialConnectionsNetworkingUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsNetworkingUITests.swift; sourceTree = "<group>"; };
 		5785AD2F7A6D71D9470B0DB6 /* StripeFinancialConnections.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripeFinancialConnections.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5B50C88219DC0F3F0BFC5CE4 /* FinancialConnections-Example-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "FinancialConnections-Example-Release.xcconfig"; sourceTree = "<group>"; };
@@ -249,6 +251,7 @@
 				6AC6B40C2B880EEA000A4B32 /* XCTestCase+Extensions.swift */,
 				6A6C23162BBCC6210083FF66 /* XCUIGestureVelocity+Extensions.swift */,
 				6A870D082C5308A500ED4DDC /* XCUIElementQuery+Extensions.swift */,
+				49B546392C6E54DB008DC127 /* InstantDebitsUITests.swift */,
 			);
 			path = FinancialConnectionsUITests;
 			sourceTree = "<group>";
@@ -392,6 +395,7 @@
 				09B82E32FC066FC442BD945D /* XCUIApplication+Extensions.swift in Sources */,
 				82D499E3F32FB4663D26EBA6 /* XCUIElement+Extensions.swift in Sources */,
 				6A6C23172BBCC6210083FF66 /* XCUIGestureVelocity+Extensions.swift in Sources */,
+				49B5463A2C6E54DB008DC127 /* InstantDebitsUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/InstantDebitsUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/InstantDebitsUITests.swift
@@ -1,0 +1,104 @@
+//
+//  InstantDebitsUITests.swift
+//  FinancialConnectionsUITests
+//
+//  Created by Mat Schmid on 2024-08-15.
+//
+
+import XCTest
+
+final class InstantDebitsUITests: XCTestCase {
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        continueAfterFailure = false
+    }
+
+    func test_nux() {
+        let app = XCUIApplication.fc_launch(playgroundConfigurationString:
+            """
+            {"use_case":"payment_intent","experience":"instant_debits","sdk_type":"native","test_mode":true,"merchant":"default","payment_method_permission":true}
+            """
+        )
+
+        app.fc_playgroundCell.tap()
+        app.fc_playgroundShowAuthFlowButton.tap()
+
+        app.fc_nativeConsentAgreeButton.tap()
+
+        let emailTextField = app.textFields["email_text_field"]
+        XCTAssertTrue(emailTextField.waitForExistence(timeout: 10.0), "Failed to find email text field")
+        emailTextField.typeText("\(UUID().uuidString)@uitest.com")
+
+        let phoneTextField = app.textFields["phone_text_field"]
+        XCTAssertTrue(phoneTextField.waitForExistence(timeout: 10.0), "Failed to find phone text field")
+        phoneTextField.typeText("6135555555")
+
+        let linkLoginCtaButton = app.buttons["link_login.primary_button"]
+        XCTAssertTrue(linkLoginCtaButton.waitForExistence(timeout: 10.0))
+        linkLoginCtaButton.tap()
+
+        let featuredLegacyTestInstitution = app.tables.cells.staticTexts["Test OAuth Institution"]
+        XCTAssertTrue(featuredLegacyTestInstitution.waitForExistence(timeout: 60.0))
+        featuredLegacyTestInstitution.tap()
+
+        app.fc_nativePrepaneContinueButton.tap()
+        app.fc_nativeConnectAccountsButton.tap()
+        app.fc_nativeSuccessDoneButton.tap()
+    }
+
+    func test_rux() {
+        let app = XCUIApplication.fc_launch(playgroundConfigurationString:
+            """
+            {"use_case":"payment_intent","experience":"instant_debits","sdk_type":"native","test_mode":true,"merchant":"default","payment_method_permission":true}
+            """
+        )
+
+        app.fc_playgroundCell.tap()
+        app.fc_playgroundShowAuthFlowButton.tap()
+
+        app.fc_nativeConsentAgreeButton.tap()
+
+        let emailTextField = app.textFields["email_text_field"]
+        XCTAssertTrue(emailTextField.waitForExistence(timeout: 10.0), "Failed to find email text field")
+        emailTextField.typeText("test@test.com")
+
+        let testModeAutofillButton = app.buttons["test_mode_autofill_button"]
+        XCTAssertTrue(testModeAutofillButton.waitForExistence(timeout: 10.0))
+        testModeAutofillButton.tap()
+
+        let successBankAccountRow = app.staticTexts["Success"]
+        XCTAssertTrue(successBankAccountRow.waitForExistence(timeout: 60.0))
+        successBankAccountRow.tap()
+
+        app.fc_nativeConnectAccountsButton.tap()
+        app.fc_nativeSuccessDoneButton.tap()
+    }
+
+    func test_accountHolder() {
+        let app = XCUIApplication.fc_launch(playgroundConfigurationString:
+            """
+            {"use_case":"payment_intent","experience":"instant_debits","sdk_type":"native","test_mode":true,"merchant":"default","payment_method_permission":true,"email":"test@test.com"}
+            """
+        )
+
+        app.fc_playgroundCell.tap()
+        app.fc_playgroundShowAuthFlowButton.tap()
+
+        app.fc_nativeConsentAgreeButton.tap()
+
+        let linkContinueButton = app.buttons["link_continue_button"]
+        XCTAssertTrue(linkContinueButton.waitForExistence(timeout: 60.0))
+        linkContinueButton.tap()
+
+        let testModeAutofillButton = app.buttons["test_mode_autofill_button"]
+        XCTAssertTrue(testModeAutofillButton.waitForExistence(timeout: 10.0))
+        testModeAutofillButton.tap()
+
+        let successBankAccountRow = app.staticTexts["Success"]
+        XCTAssertTrue(successBankAccountRow.waitForExistence(timeout: 60.0))
+        successBankAccountRow.tap()
+
+        app.fc_nativeConnectAccountsButton.tap()
+        app.fc_nativeSuccessDoneButton.tap()
+    }
+}

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/InstantDebitsUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/InstantDebitsUITests.swift
@@ -31,7 +31,15 @@ final class InstantDebitsUITests: XCTestCase {
 
         let phoneTextField = app.textFields["phone_text_field"]
         XCTAssertTrue(phoneTextField.waitForExistence(timeout: 10.0), "Failed to find phone text field")
-        phoneTextField.typeText("6135555555")
+
+        let countryCodeSelector = app.otherElements["phone_country_code_selector"]
+        XCTAssertTrue(countryCodeSelector.waitForExistence(timeout: 10.0), "Failed to find phone text field")
+        countryCodeSelector.tap()
+        app.pickerWheels.firstMatch.adjust(toPickerWheelValue: "🇺🇸 United States (+1)")
+        app.toolbars.buttons["Done"].tap()
+
+        phoneTextField.tap()
+        phoneTextField.typeText("4015006000")
 
         let linkLoginCtaButton = app.buttons["link_login.primary_button"]
         XCTAssertTrue(linkLoginCtaButton.waitForExistence(timeout: 10.0))

--- a/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
+++ b/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		49C911392C597EAF00589E0D /* LinkLoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C911352C597EAF00589E0D /* LinkLoginViewController.swift */; };
 		49C9113B2C59932300589E0D /* LinkSignupFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C9113A2C59932300589E0D /* LinkSignupFormView.swift */; };
 		49F047532C63B430006BAD3E /* StripeSchemeAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F047522C63B430006BAD3E /* StripeSchemeAddress.swift */; };
+		49F047552C63C2E5006BAD3E /* FinancialConnectionsPaymentDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F047542C63C2E5006BAD3E /* FinancialConnectionsPaymentDetails.swift */; };
 		4A0D015C978BD79BBFE6CE57 /* ManualEntryDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4C39F5F9AF440B13F51A81 /* ManualEntryDataSource.swift */; };
 		4A537AE0C50CAFF3889EFE28 /* UIViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7E41313B709F87B549D85F /* UIViewController+Extensions.swift */; };
 		4DC8EB63806434ABF4C9CC43 /* add@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 782A419DCF59BE6AB6439D04 /* add@3x.png */; };
@@ -332,6 +333,7 @@
 		49C911352C597EAF00589E0D /* LinkLoginViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinkLoginViewController.swift; sourceTree = "<group>"; };
 		49C9113A2C59932300589E0D /* LinkSignupFormView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LinkSignupFormView.swift; path = StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/LinkSignupFormView.swift; sourceTree = SOURCE_ROOT; };
 		49F047522C63B430006BAD3E /* StripeSchemeAddress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StripeSchemeAddress.swift; sourceTree = "<group>"; };
+		49F047542C63C2E5006BAD3E /* FinancialConnectionsPaymentDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsPaymentDetails.swift; sourceTree = "<group>"; };
 		4A7B146AA6BF44921A249DB8 /* EmptyFinancialConnectionsAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyFinancialConnectionsAPIClient.swift; sourceTree = "<group>"; };
 		4AFBF95DAE0783010A17EB58 /* FinancialConnectionsSession_only_accounts.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = FinancialConnectionsSession_only_accounts.json; sourceTree = "<group>"; };
 		4BFCD9C339634B71FC8F85E9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -772,6 +774,7 @@
 				495539ED2C484DC200543D18 /* FinancialConnectionsTheme.swift */,
 				49AC518B2C52DE2C00B712CC /* FinancialConnectionsLinkLoginPane.swift */,
 				6A384A832C24DD720044AB99 /* FinancialConnectionsGenericInfoScreen.swift */,
+				49F047542C63C2E5006BAD3E /* FinancialConnectionsPaymentDetails.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1325,6 +1328,7 @@
 				1C043C73281C0856D2C979C6 /* FinancialConnectionsSession.swift in Sources */,
 				9E0044ABEC04E2A8C50E3658 /* FinancialConnectionsSessionManifest.swift in Sources */,
 				6A6F989C2C4F1BF00035C03D /* CreatePaneParameters.swift in Sources */,
+				49F047552C63C2E5006BAD3E /* FinancialConnectionsPaymentDetails.swift in Sources */,
 				D936C8A9F6E018DB144A5B0A /* FinancialConnectionsSynchronize.swift in Sources */,
 				15EC9F36187C341800164428 /* FinancialConnectionsAnalyticsClient.swift in Sources */,
 				C61D5957D3276991795F7D16 /* FinancialConnectionsSheetAnalytics.swift in Sources */,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
@@ -213,6 +213,16 @@ protocol FinancialConnectionsAPI {
         linkAccountSession: String,
         consumerSessionClientSecret: String
     ) -> Future<AttachLinkConsumerToLinkAccountSessionResponse>
+
+    func paymentDetails(
+        consumerSessionClientSecret: String,
+        bankAccountId: String
+    ) -> Future<FinancialConnectionsPaymentDetails>
+
+    func paymentMethods(
+        consumerSessionClientSecret: String,
+        paymentDetailsId: String
+    ) -> Future<FinancialConnectionsPaymentMethod>
 }
 
 extension FinancialConnectionsAPIClient: FinancialConnectionsAPI {
@@ -912,6 +922,47 @@ extension FinancialConnectionsAPIClient: FinancialConnectionsAPI {
             useConsumerPublishableKeyIfNeeded: false
         )
     }
+
+    func paymentDetails(
+        consumerSessionClientSecret: String,
+        bankAccountId: String
+    ) -> Future<FinancialConnectionsPaymentDetails> {
+        let parameters: [String: Any] = [
+            "request_surface": requestSurface,
+            "credentials": [
+                "consumer_session_client_secret": consumerSessionClientSecret
+            ],
+            "bank_account": [
+                "account": bankAccountId
+            ],
+            "type": "bank_account",
+        ]
+        return post(
+            resource: APIEndpointPaymentDetails,
+            parameters: parameters,
+            useConsumerPublishableKeyIfNeeded: true
+        )
+    }
+
+    func paymentMethods(
+        consumerSessionClientSecret: String,
+        paymentDetailsId: String
+    ) -> Future<FinancialConnectionsPaymentMethod> {
+        let parameters: [String: Any] = [
+            "link": [
+                "credentials": [
+                    "consumer_session_client_secret": consumerSessionClientSecret
+                ],
+                "payment_details_id": paymentDetailsId,
+            ],
+            "type": "link",
+        ]
+        return post(
+            resource: APIEndpointPaymentMethods,
+            parameters: parameters,
+            useConsumerPublishableKeyIfNeeded: false
+        )
+    }
 }
 
 private let APIEndpointListAccounts = "link_account_sessions/list_accounts"
@@ -940,5 +991,8 @@ private let APIEndpointSaveAccountsToLink = "link_account_sessions/save_accounts
 private let APIEndpointShareNetworkedAccount = "link_account_sessions/share_networked_account"
 private let APIEndpointConsumerSessions = "connections/link_account_sessions/consumer_sessions"
 private let APIEndpointPollAccountNumbers = "link_account_sessions/poll_account_numbers"
+// Instant Debits
 private let APIEndpointLinkAccountsSignUp = "consumers/accounts/sign_up"
 private let APIEndpointAttachLinkConsumerToLinkAccountSession = "consumers/attach_link_consumer_to_link_account_session"
+private let APIEndpointPaymentDetails = "consumers/payment_details"
+private let APIEndpointPaymentMethods = "payment_methods"

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsPaymentDetails.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsPaymentDetails.swift
@@ -1,0 +1,26 @@
+//
+//  FinancialConnectionsPaymentDetails.swift
+//  StripeFinancialConnections
+//
+//  Created by Mat Schmid on 2024-08-07.
+//
+
+import Foundation
+
+struct FinancialConnectionsPaymentDetails: Decodable {
+    let redactedPaymentDetails: RedactedPaymentDetails
+}
+
+struct RedactedPaymentDetails: Decodable {
+    let id: String
+    let bankAccountDetails: BankAccountDetails?
+}
+
+struct BankAccountDetails: Decodable {
+    let bankName: String?
+    let last4: String?
+}
+
+struct FinancialConnectionsPaymentMethod: Decodable {
+    let id: String
+}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/FlowRouter.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/FlowRouter.swift
@@ -89,11 +89,6 @@ class FlowRouter {
     }
 
     private var shouldUseNativeInstantDebits: Bool {
-        // Show web instant debits flow while UITesting for now.
-        guard ProcessInfo.processInfo.environment["UITesting"] == nil else {
-            return false
-        }
-
         // Override all other conditions if the example app has native or web selected.
         guard case .none = exampleAppSdkOverride else {
             return exampleAppSdkOverride.shouldUseNativeFlow

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostController.swift
@@ -205,22 +205,13 @@ extension HostController: FinancialConnectionsWebFlowViewControllerDelegate {
 extension HostController: NativeFlowControllerDelegate {
     func nativeFlowController(
         _ nativeFlowController: NativeFlowController,
-        didFinish result: FinancialConnectionsSheet.Result
+        didFinish result: HostControllerResult
     ) {
         guard let viewController = navigationController.topViewController else {
             assertionFailure("Navigation stack is empty")
             return
         }
-        let hostControllerResult: HostControllerResult
-        switch result {
-        case .completed(let session):
-            hostControllerResult = .completed(.financialConnections(session))
-        case .canceled:
-            hostControllerResult = .canceled
-        case .failed(let error):
-            hostControllerResult = .failed(error: error)
-        }
-        delegate?.hostController(self, viewController: viewController, didFinish: hostControllerResult)
+        delegate?.hostController(self, viewController: viewController, didFinish: result)
     }
 
     func nativeFlowController(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginViewController.swift
@@ -96,6 +96,7 @@ final class LinkLoginViewController: UIViewController {
         let footerView = PaneLayoutView.createFooterView(
             primaryButtonConfiguration: PaneLayoutView.ButtonConfiguration(
                 title: linkLoginPane.cta,
+                accessibilityIdentifier: "link_login.primary_button",
                 action: didSelectContinueWithLink
             ),
             topText: linkLoginPane.aboveCta,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -13,7 +13,7 @@ protocol NativeFlowControllerDelegate: AnyObject {
 
     func nativeFlowController(
         _ nativeFlowController: NativeFlowController,
-        didFinish result: FinancialConnectionsSheet.Result
+        didFinish result: HostControllerResult
     )
 
     func nativeFlowController(
@@ -352,7 +352,7 @@ extension NativeFlowController {
             )
         }
 
-        let finishAuthSession: (FinancialConnectionsSheet.Result) -> Void = { [weak self] result in
+        let finishAuthSession: (HostControllerResult) -> Void = { [weak self] result in
             guard let self = self else { return }
             self.delegate?.nativeFlowController(self, didFinish: result)
         }
@@ -378,21 +378,53 @@ extension NativeFlowController {
                         if !session.accounts.data.isEmpty || session.paymentAccount != nil
                             || session.bankAccountToken != nil
                         {
-                            self.delegate?.nativeFlowController(
-                                self,
-                                didReceiveEvent: FinancialConnectionsEvent(
-                                    name: .success,
-                                    metadata: FinancialConnectionsEvent.Metadata(
-                                        manualEntry: session.paymentAccount?.isManualEntry ?? false
+                            createPaymentMethodIfNeeded(for: session) { result in
+                                if let result {
+                                    switch result {
+                                    case .success(let linkedBank):
+                                        self.delegate?.nativeFlowController(
+                                            self,
+                                            didReceiveEvent: FinancialConnectionsEvent(
+                                                name: .success,
+                                                metadata: FinancialConnectionsEvent.Metadata(
+                                                    manualEntry: session.paymentAccount?.isManualEntry ?? false
+                                                )
+                                            )
+                                        )
+                                        self.logCompleteEvent(
+                                            type: eventType,
+                                            status: "completed",
+                                            numberOfLinkedAccounts: session.accounts.data.count
+                                        )
+                                        finishAuthSession(.completed(.instantDebits(linkedBank)))
+                                    case .failure(let createPaymentError):
+                                        self.logCompleteEvent(
+                                            type: eventType,
+                                            status: "failed",
+                                            error: createPaymentError
+                                        )
+                                        finishAuthSession(.failed(error: createPaymentError))
+                                    }
+                                } else {
+                                    // This is the case where no payment method was created.
+                                    // We can still complete with the existing session details.
+                                    self.delegate?.nativeFlowController(
+                                        self,
+                                        didReceiveEvent: FinancialConnectionsEvent(
+                                            name: .success,
+                                            metadata: FinancialConnectionsEvent.Metadata(
+                                                manualEntry: session.paymentAccount?.isManualEntry ?? false
+                                            )
+                                        )
                                     )
-                                )
-                            )
-                            self.logCompleteEvent(
-                                type: eventType,
-                                status: "completed",
-                                numberOfLinkedAccounts: session.accounts.data.count
-                            )
-                            finishAuthSession(.completed(session: session))
+                                    self.logCompleteEvent(
+                                        type: eventType,
+                                        status: "completed",
+                                        numberOfLinkedAccounts: session.accounts.data.count
+                                    )
+                                    finishAuthSession(.completed(.financialConnections(session)))
+                                }
+                            }
                         } else if let closeAuthFlowError = closeAuthFlowError {
                             self.logCompleteEvent(
                                 type: eventType,
@@ -443,6 +475,59 @@ extension NativeFlowController {
                     }
                 }
             }
+    }
+
+    private func createPaymentMethodIfNeeded(
+        for session: StripeAPI.FinancialConnectionsSession,
+        completion: @escaping (Result<InstantDebitsLinkedBank, Error>?) -> Void)
+    {
+        guard dataManager.manifest.isProductInstantDebits else {
+            completion(nil)
+            return
+        }
+
+        let bankAccountId: String?
+        switch session.paymentAccount {
+        case .bankAccount(let account):
+            bankAccountId = account.id
+        case .linkedAccount(let account):
+            bankAccountId = account.id
+        default:
+            bankAccountId = nil
+        }
+
+        if let bankAccountId, let consumerSession = dataManager.consumerSession {
+            var bankAccountDetails: BankAccountDetails?
+            dataManager.createPaymentDetails(
+                consumerSessionClientSecret: consumerSession.clientSecret,
+                bankAccountId: bankAccountId
+            ).chained { [weak self] paymentDetails -> Future<FinancialConnectionsPaymentMethod> in
+                guard let self else {
+                    return Promise(error: FinancialConnectionsSheetError.unknown(debugDescription: "data source deallocated"))
+                }
+
+                bankAccountDetails = paymentDetails.redactedPaymentDetails.bankAccountDetails
+                return self.dataManager.createPaymentMethod(
+                    consumerSessionClientSecret: consumerSession.clientSecret,
+                    paymentDetailsId: paymentDetails.redactedPaymentDetails.id
+                )
+            }
+            .observe { result in
+                switch result {
+                case .success(let paymentMethod):
+                    let linkedBank = InstantDebitsLinkedBankImplementation(
+                        paymentMethodId: paymentMethod.id,
+                        bankName: bankAccountDetails?.bankName,
+                        last4: bankAccountDetails?.last4
+                    )
+                    completion(.success(linkedBank))
+                case .failure(let error):
+                    completion(.failure(error))
+                }
+            }
+        } else {
+            completion(nil)
+        }
     }
 
     private func logCompleteEvent(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowDataManager.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowDataManager.swift
@@ -34,6 +34,14 @@ protocol NativeFlowDataManager: AnyObject {
     var customSuccessPaneCaption: String? { get set }
     var customSuccessPaneSubCaption: String? { get set }
 
+    func createPaymentDetails(
+        consumerSessionClientSecret: String,
+        bankAccountId: String
+    ) -> Future<FinancialConnectionsPaymentDetails>
+    func createPaymentMethod(
+        consumerSessionClientSecret: String,
+        paymentDetailsId: String
+    ) -> Future<FinancialConnectionsPaymentMethod>
     func resetState(withNewManifest newManifest: FinancialConnectionsSessionManifest)
     func completeFinancialConnectionsSession(terminalError: String?) -> Future<StripeAPI.FinancialConnectionsSession>
 }
@@ -120,6 +128,26 @@ class NativeFlowAPIDataManager: NativeFlowDataManager {
         // If the server returns active institution use that, otherwise resort to initial institution.
         self.institution = manifest.activeInstitution ?? manifest.initialInstitution
         didUpdateManifest()
+    }
+
+    func createPaymentDetails(
+        consumerSessionClientSecret: String,
+        bankAccountId: String
+    ) -> Future<FinancialConnectionsPaymentDetails> {
+        apiClient.paymentDetails(
+            consumerSessionClientSecret: consumerSessionClientSecret,
+            bankAccountId: bankAccountId
+        )
+    }
+
+    func createPaymentMethod(
+        consumerSessionClientSecret: String,
+        paymentDetailsId: String
+    ) -> Future<FinancialConnectionsPaymentMethod> {
+        apiClient.paymentMethods(
+            consumerSessionClientSecret: consumerSessionClientSecret,
+            paymentDetailsId: paymentDetailsId
+        )
     }
 
     func completeFinancialConnectionsSession(terminalError: String?) -> Future<StripeAPI.FinancialConnectionsSession> {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/PhoneCountryCodeSelectorView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/PhoneCountryCodeSelectorView.swift
@@ -76,6 +76,7 @@ final class PhoneCountryCodeSelectorView: UIView {
         backgroundColor = .backgroundOffset
         layer.cornerRadius = 8
         clipsToBounds = true
+        accessibilityIdentifier = "phone_country_code_selector"
 
         let horizontalStackView = UIStackView(
             arrangedSubviews: [

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
@@ -211,4 +211,12 @@ class EmptyFinancialConnectionsAPIClient: FinancialConnectionsAPI {
     ) -> Future<AttachLinkConsumerToLinkAccountSessionResponse> {
         return Promise<StripeFinancialConnections.AttachLinkConsumerToLinkAccountSessionResponse>()
     }
+
+    func paymentDetails(consumerSessionClientSecret: String, bankAccountId: String) -> StripeCore.Future<StripeFinancialConnections.FinancialConnectionsPaymentDetails> {
+        Promise<StripeFinancialConnections.FinancialConnectionsPaymentDetails>()
+    }
+
+    func paymentMethods(consumerSessionClientSecret: String, paymentDetailsId: String) -> StripeCore.Future<StripeFinancialConnections.FinancialConnectionsPaymentMethod> {
+        Promise<StripeFinancialConnections.FinancialConnectionsPaymentMethod>()
+    }
 }


### PR DESCRIPTION
## Summary

This adds three simple end to end UI tests for the native instant debits flow. These test the "golden path" of these scenarios:

- New user experience
- Return user experience
- Account holder sign in experience

## Motivation

E2E test coverage!

## Testing

See code comments for videos of each test being executed!

## Changelog

N/a