### PR TITLE
Dynamically set `request_surface` in FC API requests

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
@@ -15,6 +15,10 @@ final class FinancialConnectionsAPIClient {
     var consumerPublishableKey: String?
     var consumerSession: ConsumerSessionData?
 
+    var requestSurface: String {
+        isLinkWithStripe ? "ios_instant_debits" : "ios_connections"
+    }
+
     init(apiClient: STPAPIClient) {
         self.backingAPIClient = apiClient
     }
@@ -197,14 +201,12 @@ protocol FinancialConnectionsAPI {
     ) -> Future<FinancialConnectionsSessionManifest>
 
     func linkAccountSignUp(
-        requestSurface: String,
         emailAddress: String,
         phoneNumber: String,
         country: String
     ) -> Future<LinkSignUpResponse>
 
     func attachLinkConsumerToLinkAccountSession(
-        requestSurface: String,
         linkAccountSession: String,
         consumerSessionClientSecret: String
     ) -> Future<AttachLinkConsumerToLinkAccountSessionResponse>
@@ -822,7 +824,7 @@ extension FinancialConnectionsAPIClient: FinancialConnectionsAPI {
         consumerSessionClientSecret: String
     ) -> Future<ConsumerSessionResponse> {
         var parameters: [String: Any] = [
-            "request_surface": "ios_connections",
+            "request_surface": requestSurface,
             "type": otpType,
             "credentials": [
                 "consumer_session_client_secret": consumerSessionClientSecret,
@@ -849,7 +851,7 @@ extension FinancialConnectionsAPIClient: FinancialConnectionsAPI {
             "credentials": [
                 "consumer_session_client_secret": consumerSessionClientSecret,
             ],
-            "request_surface": "ios_connections",
+            "request_surface": requestSurface,
         ]
         return post(
             resource: "consumers/sessions/confirm_verification",
@@ -859,7 +861,6 @@ extension FinancialConnectionsAPIClient: FinancialConnectionsAPI {
     }
 
     func linkAccountSignUp(
-        requestSurface: String, // "ios_instant_debits"
         emailAddress: String,
         phoneNumber: String,
         country: String
@@ -883,7 +884,6 @@ extension FinancialConnectionsAPIClient: FinancialConnectionsAPI {
     }
 
     func attachLinkConsumerToLinkAccountSession(
-        requestSurface: String,
         linkAccountSession: String,
         consumerSessionClientSecret: String
     ) -> Future<AttachLinkConsumerToLinkAccountSessionResponse> {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginDataSource.swift
@@ -72,7 +72,6 @@ final class LinkLoginDataSourceImplementation: LinkLoginDataSource {
         country: String
     ) -> Future<LinkSignUpResponse> {
         apiClient.linkAccountSignUp(
-            requestSurface: "ios_instant_debits",
             emailAddress: emailAddress,
             phoneNumber: phoneNumber,
             country: country
@@ -103,7 +102,6 @@ final class LinkLoginDataSourceImplementation: LinkLoginDataSource {
         consumerSessionClientSecret: String
     ) -> Future<AttachLinkConsumerToLinkAccountSessionResponse> {
         apiClient.attachLinkConsumerToLinkAccountSession(
-            requestSurface: "ios_instant_debits",
             linkAccountSession: linkAccountSession,
             consumerSessionClientSecret: consumerSessionClientSecret
         )

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationDataSource.swift
@@ -95,7 +95,6 @@ final class NetworkingLinkVerificationDataSourceImplementation: NetworkingLinkVe
         }
 
         return apiClient.attachLinkConsumerToLinkAccountSession(
-            requestSurface: "ios_instant_debits",
             linkAccountSession: clientSecret,
             consumerSessionClientSecret: consumerSessionClientSecret
         )


### PR DESCRIPTION
## Summary

For all API requests to the `/consumers/...` path, we need to provide the `request_surface` body parameter. This is either `ios_instant_debits` if we're in the Native Instant Debits flow or `ios_connections` otherwise. This PR now dynamically sets that value according to the manifest's `isLinkWithStripe` field (set [here](https://stripe.sourcegraphcloud.com/github.com/stripe/stripe-ios/-/blob/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowDataManager.swift?L140)).

## Motivation

Consistency and correctness ✨ 

## Testing

N/a

## Changelog

N/a