### PR TITLE
Update PaymentSheet playground settings to save custom endpoint

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -430,7 +430,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
     var userOverrideCountry: UserOverrideCountry
     var customCtaLabel: String?
     var paymentMethodConfigurationId: String?
-    var checkoutEndpoint: String?
+    var checkoutEndpoint: String
     var autoreload: Autoreload
     var externalPaymentMethods: ExternalPaymentMethods
     var preferredNetworksEnabled: PreferredNetworksEnabled

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -283,10 +283,18 @@ class PlaygroundController: ObservableObject {
     var customerSessionClientSecret: String?
     var paymentMethodTypes: [String]?
     var amount: Int?
-    var checkoutEndpoint: String = PaymentSheetTestPlaygroundSettings.defaultCheckoutEndpoint
     var addressViewController: AddressViewController?
     var appearance = PaymentSheet.Appearance.default
     var currentDataTask: URLSessionDataTask?
+
+    var checkoutEndpoint: String {
+        get {
+            settings.checkoutEndpoint
+        }
+        set {
+            settings.checkoutEndpoint = newValue
+        }
+    }
 
     func makeAlertController() -> UIAlertController {
         let alertController = UIAlertController(


### PR DESCRIPTION
## Summary

This fixes an issue I noticed with the PaymentSheet example app, where a custom checkout endpoint was not being included when sharing a configuration. As in, when launching the app by scanning the QR code, any custom endpoint would not be shared. This seems to be because the `checkoutEndpoint` property on the `PlaygroundController` was not using / updating the value in the `PlaygroundSettings` model.

## Motivation

This will make it a lot easier for bug bash testers when a custom endpoint is needed for testing!

## Testing

When setting a custom checkout endpoint: 
<img width=40% src="https://github.com/user-attachments/assets/9e3c2e37-e12e-423e-b21d-52547a964dcc">

**Before:**
Generating a QR code for this configuration, the encoded settings string did not use the custom endpoint: (this is the default checkout endpoint)

```json
{
    "checkoutEndpoint": "https:\/\/stp-mobile-playground-backend-v7.stripedemos.com\/checkout"
}
```

This is a snippet of the whole encoded object, taken by putting a breakpoint in the [`base64Data` property](https://github.com/stripe/stripe-ios/blob/dce44782e444f0d8d88df9dc2bc17676caa22fe7/Example/PaymentSheet%20Example/PaymentSheet%20Example/PaymentSheetTestPlaygroundSettings.swift#L500-L503), then decoding the encoded string using [an online decoder](https://www.base64decode.org/).

**After:**

```json
{
    "checkoutEndpoint": "https:\/\/fc-instant-debits-playground.glitch.me\/checkout"
}
```

**Test it yourself!** 

1. Checkout and build this branch to a physical device.
2. Scan this QR code.
3. Verify the endpoint is set to https://fc-instant-debits-playground.glitch.me/checkout

<img width="300" alt="image" src="https://github.com/user-attachments/assets/620c59eb-cb80-412e-9e11-54cb17d71919">

## Changelog

N/a
