### PR TITLE
Fix `AccountPickerHelpersTests.testCurrencyStrings` for non-US locales

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerHelpers.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerHelpers.swift
@@ -64,10 +64,15 @@ final class AccountPickerHelpers {
     }
 
     // exposed for testing purposes
-    static func currencyString(currency: String, balanceAmount: Int) -> String? {
+    static func currencyString(
+        currency: String,
+        balanceAmount: Int,
+        locale: Locale = .current
+    ) -> String? {
         let numberFormatter = NumberFormatter()
         numberFormatter.currencyCode = currency
         numberFormatter.numberStyle = .currency
+        numberFormatter.locale = locale
         return numberFormatter.string(
             for: NSDecimalNumber.stp_fn_decimalNumber(withAmount: balanceAmount, currency: currency)
         )

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/AccountPickerHelpersTests.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/AccountPickerHelpersTests.swift
@@ -9,17 +9,33 @@
 import XCTest
 
 class AccountPickerHelpersTests: XCTestCase {
+    func testCurrencyStringsFromUsd() {
+        XCTAssertEqual(currencyString(currency: "usd", balanceAmount: 1000000), "$10,000.00")
+        XCTAssertEqual(currencyString(currency: "usd", balanceAmount: 1000), "$10.00")
+        XCTAssertEqual(currencyString(currency: "eur", balanceAmount: 10), "€0.10")
+        XCTAssertEqual(currencyString(currency: "gbp", balanceAmount: 999), "£9.99")
+        XCTAssertEqual(currencyString(currency: "jpy", balanceAmount: 543), "¥543")
+        XCTAssertEqual(currencyString(currency: "krw", balanceAmount: 123456), "₩123,456")
+        XCTAssertEqual(currencyString(currency: "usd", balanceAmount: 0), "$0.00")
+        XCTAssertEqual(currencyString(currency: "usd", balanceAmount: -1000), "-$10.00")
+        XCTAssertEqual(currencyString(currency: "usd", balanceAmount: -1000000), "-$10,000.00")
+    }
 
-    func testCurrencyStrings() throws {
-        XCTAssert(AccountPickerHelpers.currencyString(currency: "usd", balanceAmount: 1000000) == "$10,000.00")
-        XCTAssert(AccountPickerHelpers.currencyString(currency: "usd", balanceAmount: 1000) == "$10.00")
-        XCTAssert(AccountPickerHelpers.currencyString(currency: "eur", balanceAmount: 10) == "€0.10")
-        XCTAssert(AccountPickerHelpers.currencyString(currency: "gbp", balanceAmount: 999) == "£9.99")
-        XCTAssert(AccountPickerHelpers.currencyString(currency: "jpy", balanceAmount: 543) == "¥543")
-        XCTAssert(AccountPickerHelpers.currencyString(currency: "krw", balanceAmount: 123456) == "₩123,456")
-        XCTAssert(AccountPickerHelpers.currencyString(currency: "usd", balanceAmount: 0) == "$0.00")
-        XCTAssert(AccountPickerHelpers.currencyString(currency: "usd", balanceAmount: -1000) == "-$10.00")
-        XCTAssert(AccountPickerHelpers.currencyString(currency: "usd", balanceAmount: -1000000) == "-$10,000.00")
+    func testCurrencyStringsFromCadToUsd() {
+        let currencyString = AccountPickerHelpers.currencyString(
+            currency: "usd",
+            balanceAmount: 1000,
+            locale: Locale(identifier: "en_CA")
+        )
+        XCTAssertEqual(currencyString, "US$10.00")
+    }
 
+    // Helper function to hard-code a USD locale.
+    private func currencyString(currency: String, balanceAmount: Int) -> String? {
+        AccountPickerHelpers.currencyString(
+            currency: currency,
+            balanceAmount: balanceAmount,
+            locale: Locale(identifier: "en_US")
+        )
     }
 }


### PR DESCRIPTION
## Summary

This is a small fix to some unit tests we have, which were failing outside of the US. Before these changes, most of the assertions were failing due to assumptions of the locale being US. 

<img width="1322" alt="Screenshot 2024-08-21 at 9 50 16 AM" src="https://github.com/user-attachments/assets/afb38c44-0c9b-4ad8-81c9-197c01602a65">

Now we hard-code a US locale, and these tests cases pass!

## Motivation

Passing tests!

## Testing

Trust CI ✅ 

## Changelog

N/a