### PR TITLE
[StripeConnect] Add example app.

### DIFF
--- a/Example/StripeConnectExample/StripeConnect Example.xcodeproj/project.pbxproj
+++ b/Example/StripeConnectExample/StripeConnect Example.xcodeproj/project.pbxproj
@@ -1,0 +1,587 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		413D18422C7FA30A0051AA42 /* TextInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 413D18412C7FA30A0051AA42 /* TextInput.swift */; };
+		413D18442C7FAE280051AA42 /* OptionListRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 413D18432C7FAE280051AA42 /* OptionListRow.swift */; };
+		413D184A2C7FCE5E0051AA42 /* StripeConnectExample.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = 413D18492C7FCE5E0051AA42 /* StripeConnectExample.xctestplan */; };
+		416E9E972C76BD4400A0B917 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416E9E962C76BD4400A0B917 /* AppDelegate.swift */; };
+		416E9E992C76BD4400A0B917 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416E9E982C76BD4400A0B917 /* SceneDelegate.swift */; };
+		416E9E9B2C76BD4400A0B917 /* AppStartViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416E9E9A2C76BD4400A0B917 /* AppStartViewController.swift */; };
+		416E9EA02C76BD4600A0B917 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 416E9E9F2C76BD4600A0B917 /* Assets.xcassets */; };
+		416E9EA32C76BD4600A0B917 /* Base in Resources */ = {isa = PBXBuildFile; fileRef = 416E9EA22C76BD4600A0B917 /* Base */; };
+		416E9EB82C76BD4600A0B917 /* StripeConnectExampleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416E9EB72C76BD4600A0B917 /* StripeConnectExampleUITests.swift */; };
+		416E9ECB2C76BE0C00A0B917 /* StripeConnect.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 416E9EC72C76BDFE00A0B917 /* StripeConnect.framework */; };
+		416E9ECC2C76BE0C00A0B917 /* StripeConnect.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 416E9EC72C76BDFE00A0B917 /* StripeConnect.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		416E9ED62C78BD9900A0B917 /* API.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416E9ED52C78BD9900A0B917 /* API.swift */; };
+		416E9EDA2C78BDC300A0B917 /* AccountSessionResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416E9ED92C78BDC300A0B917 /* AccountSessionResponse.swift */; };
+		416E9EDC2C78BE1300A0B917 /* APIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416E9EDB2C78BE1300A0B917 /* APIError.swift */; };
+		416E9EDE2C78C0BA00A0B917 /* AppInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416E9EDD2C78C0BA00A0B917 /* AppInfo.swift */; };
+		416E9EE02C78C10800A0B917 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416E9EDF2C78C10800A0B917 /* MainViewController.swift */; };
+		416E9EE32C7B988100A0B917 /* AppSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416E9EE22C7B988100A0B917 /* AppSettings.swift */; };
+		41E9A1BD2C7CC85100EDE131 /* SwiftUIContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41E9A1BC2C7CC85100EDE131 /* SwiftUIContainerViewController.swift */; };
+		41E9A1BF2C7CD3C700EDE131 /* UIViewController+NavigationEmbed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41E9A1BE2C7CD3C700EDE131 /* UIViewController+NavigationEmbed.swift */; };
+		41E9A1C12C7CE30000EDE131 /* AppSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41E9A1C02C7CE30000EDE131 /* AppSettingsView.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		416E9EB42C76BD4600A0B917 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 416E9E8B2C76BD4400A0B917 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 416E9E922C76BD4400A0B917;
+			remoteInfo = StripeConnectExample;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		416E9ECD2C76BE0C00A0B917 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				416E9ECC2C76BE0C00A0B917 /* StripeConnect.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		413D18412C7FA30A0051AA42 /* TextInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextInput.swift; sourceTree = "<group>"; };
+		413D18432C7FAE280051AA42 /* OptionListRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionListRow.swift; sourceTree = "<group>"; };
+		413D18492C7FCE5E0051AA42 /* StripeConnectExample.xctestplan */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = StripeConnectExample.xctestplan; sourceTree = "<group>"; };
+		416E9E932C76BD4400A0B917 /* StripeConnect Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "StripeConnect Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		416E9E962C76BD4400A0B917 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		416E9E982C76BD4400A0B917 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		416E9E9A2C76BD4400A0B917 /* AppStartViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStartViewController.swift; sourceTree = "<group>"; };
+		416E9E9F2C76BD4600A0B917 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		416E9EA22C76BD4600A0B917 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		416E9EA42C76BD4600A0B917 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		416E9EB32C76BD4600A0B917 /* StripeConnect ExampleUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "StripeConnect ExampleUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		416E9EB72C76BD4600A0B917 /* StripeConnectExampleUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StripeConnectExampleUITests.swift; sourceTree = "<group>"; };
+		416E9EC72C76BDFE00A0B917 /* StripeConnect.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = StripeConnect.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		416E9ED52C78BD9900A0B917 /* API.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = API.swift; sourceTree = "<group>"; };
+		416E9ED92C78BDC300A0B917 /* AccountSessionResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSessionResponse.swift; sourceTree = "<group>"; };
+		416E9EDB2C78BE1300A0B917 /* APIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIError.swift; sourceTree = "<group>"; };
+		416E9EDD2C78C0BA00A0B917 /* AppInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfo.swift; sourceTree = "<group>"; };
+		416E9EDF2C78C10800A0B917 /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
+		416E9EE22C7B988100A0B917 /* AppSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettings.swift; sourceTree = "<group>"; };
+		41E9A1BC2C7CC85100EDE131 /* SwiftUIContainerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIContainerViewController.swift; sourceTree = "<group>"; };
+		41E9A1BE2C7CD3C700EDE131 /* UIViewController+NavigationEmbed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+NavigationEmbed.swift"; sourceTree = "<group>"; };
+		41E9A1C02C7CE30000EDE131 /* AppSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsView.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		416E9E902C76BD4400A0B917 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				416E9ECB2C76BE0C00A0B917 /* StripeConnect.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		416E9EB02C76BD4600A0B917 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		413D18402C7FA2FF0051AA42 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				413D18412C7FA30A0051AA42 /* TextInput.swift */,
+				413D18432C7FAE280051AA42 /* OptionListRow.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		416E9E8A2C76BD4400A0B917 = {
+			isa = PBXGroup;
+			children = (
+				413D18492C7FCE5E0051AA42 /* StripeConnectExample.xctestplan */,
+				416E9E952C76BD4400A0B917 /* StripeConnectExample */,
+				416E9EB62C76BD4600A0B917 /* StripeConnectExampleUITests */,
+				416E9E942C76BD4400A0B917 /* Products */,
+				416E9EC62C76BDFE00A0B917 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		416E9E942C76BD4400A0B917 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				416E9E932C76BD4400A0B917 /* StripeConnect Example.app */,
+				416E9EB32C76BD4600A0B917 /* StripeConnect ExampleUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		416E9E952C76BD4400A0B917 /* StripeConnectExample */ = {
+			isa = PBXGroup;
+			children = (
+				413D18402C7FA2FF0051AA42 /* Views */,
+				41E9A1BB2C7CC83500EDE131 /* Helpers */,
+				416E9EE12C7B987400A0B917 /* Storage */,
+				416E9ED72C78BDAC00A0B917 /* API */,
+				416E9E962C76BD4400A0B917 /* AppDelegate.swift */,
+				416E9E982C76BD4400A0B917 /* SceneDelegate.swift */,
+				416E9E9A2C76BD4400A0B917 /* AppStartViewController.swift */,
+				416E9E9F2C76BD4600A0B917 /* Assets.xcassets */,
+				416E9EA12C76BD4600A0B917 /* LaunchScreen.storyboard */,
+				416E9EA42C76BD4600A0B917 /* Info.plist */,
+				416E9EDF2C78C10800A0B917 /* MainViewController.swift */,
+				41E9A1C02C7CE30000EDE131 /* AppSettingsView.swift */,
+			);
+			path = StripeConnectExample;
+			sourceTree = "<group>";
+		};
+		416E9EB62C76BD4600A0B917 /* StripeConnectExampleUITests */ = {
+			isa = PBXGroup;
+			children = (
+				416E9EB72C76BD4600A0B917 /* StripeConnectExampleUITests.swift */,
+			);
+			path = StripeConnectExampleUITests;
+			sourceTree = "<group>";
+		};
+		416E9EC62C76BDFE00A0B917 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				416E9EC72C76BDFE00A0B917 /* StripeConnect.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		416E9ED72C78BDAC00A0B917 /* API */ = {
+			isa = PBXGroup;
+			children = (
+				416E9ED82C78BDB700A0B917 /* Models */,
+				416E9ED52C78BD9900A0B917 /* API.swift */,
+			);
+			path = API;
+			sourceTree = "<group>";
+		};
+		416E9ED82C78BDB700A0B917 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				416E9ED92C78BDC300A0B917 /* AccountSessionResponse.swift */,
+				416E9EDB2C78BE1300A0B917 /* APIError.swift */,
+				416E9EDD2C78C0BA00A0B917 /* AppInfo.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		416E9EE12C7B987400A0B917 /* Storage */ = {
+			isa = PBXGroup;
+			children = (
+				416E9EE22C7B988100A0B917 /* AppSettings.swift */,
+			);
+			path = Storage;
+			sourceTree = "<group>";
+		};
+		41E9A1BB2C7CC83500EDE131 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				41E9A1BC2C7CC85100EDE131 /* SwiftUIContainerViewController.swift */,
+				41E9A1BE2C7CD3C700EDE131 /* UIViewController+NavigationEmbed.swift */,
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		416E9E922C76BD4400A0B917 /* StripeConnect Example */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 416E9EBD2C76BD4600A0B917 /* Build configuration list for PBXNativeTarget "StripeConnect Example" */;
+			buildPhases = (
+				416E9E8F2C76BD4400A0B917 /* Sources */,
+				416E9E902C76BD4400A0B917 /* Frameworks */,
+				416E9E912C76BD4400A0B917 /* Resources */,
+				416E9ECD2C76BE0C00A0B917 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "StripeConnect Example";
+			productName = StripeConnectExample;
+			productReference = 416E9E932C76BD4400A0B917 /* StripeConnect Example.app */;
+			productType = "com.apple.product-type.application";
+		};
+		416E9EB22C76BD4600A0B917 /* StripeConnect ExampleUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 416E9EC32C76BD4600A0B917 /* Build configuration list for PBXNativeTarget "StripeConnect ExampleUITests" */;
+			buildPhases = (
+				416E9EAF2C76BD4600A0B917 /* Sources */,
+				416E9EB02C76BD4600A0B917 /* Frameworks */,
+				416E9EB12C76BD4600A0B917 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				416E9EB52C76BD4600A0B917 /* PBXTargetDependency */,
+			);
+			name = "StripeConnect ExampleUITests";
+			productName = StripeConnectExampleUITests;
+			productReference = 416E9EB32C76BD4600A0B917 /* StripeConnect ExampleUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		416E9E8B2C76BD4400A0B917 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1540;
+				LastUpgradeCheck = 1540;
+				TargetAttributes = {
+					416E9E922C76BD4400A0B917 = {
+						CreatedOnToolsVersion = 15.4;
+					};
+					416E9EB22C76BD4600A0B917 = {
+						CreatedOnToolsVersion = 15.4;
+						TestTargetID = 416E9E922C76BD4400A0B917;
+					};
+				};
+			};
+			buildConfigurationList = 416E9E8E2C76BD4400A0B917 /* Build configuration list for PBXProject "StripeConnect Example" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 416E9E8A2C76BD4400A0B917;
+			productRefGroup = 416E9E942C76BD4400A0B917 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				416E9E922C76BD4400A0B917 /* StripeConnect Example */,
+				416E9EB22C76BD4600A0B917 /* StripeConnect ExampleUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		416E9E912C76BD4400A0B917 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				413D184A2C7FCE5E0051AA42 /* StripeConnectExample.xctestplan in Resources */,
+				416E9EA02C76BD4600A0B917 /* Assets.xcassets in Resources */,
+				416E9EA32C76BD4600A0B917 /* Base in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		416E9EB12C76BD4600A0B917 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		416E9E8F2C76BD4400A0B917 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				416E9E9B2C76BD4400A0B917 /* AppStartViewController.swift in Sources */,
+				413D18442C7FAE280051AA42 /* OptionListRow.swift in Sources */,
+				416E9E972C76BD4400A0B917 /* AppDelegate.swift in Sources */,
+				41E9A1C12C7CE30000EDE131 /* AppSettingsView.swift in Sources */,
+				416E9ED62C78BD9900A0B917 /* API.swift in Sources */,
+				416E9E992C76BD4400A0B917 /* SceneDelegate.swift in Sources */,
+				416E9EDA2C78BDC300A0B917 /* AccountSessionResponse.swift in Sources */,
+				416E9EE32C7B988100A0B917 /* AppSettings.swift in Sources */,
+				416E9EDC2C78BE1300A0B917 /* APIError.swift in Sources */,
+				413D18422C7FA30A0051AA42 /* TextInput.swift in Sources */,
+				41E9A1BD2C7CC85100EDE131 /* SwiftUIContainerViewController.swift in Sources */,
+				416E9EDE2C78C0BA00A0B917 /* AppInfo.swift in Sources */,
+				41E9A1BF2C7CD3C700EDE131 /* UIViewController+NavigationEmbed.swift in Sources */,
+				416E9EE02C78C10800A0B917 /* MainViewController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		416E9EAF2C76BD4600A0B917 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				416E9EB82C76BD4600A0B917 /* StripeConnectExampleUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		416E9EB52C76BD4600A0B917 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 416E9E922C76BD4400A0B917 /* StripeConnect Example */;
+			targetProxy = 416E9EB42C76BD4600A0B917 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		416E9EA12C76BD4600A0B917 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				416E9EA22C76BD4600A0B917 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		416E9EBB2C76BD4600A0B917 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		416E9EBC2C76BD4600A0B917 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		416E9EBE2C76BD4600A0B917 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = StripeConnectExample/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.stripe.StripeConnect-Example";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		416E9EBF2C76BD4600A0B917 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = StripeConnectExample/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.stripe.StripeConnect-Example";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		416E9EC42C76BD4600A0B917 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.stripe.StripeConnectExampleUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = StripeConnectExample;
+			};
+			name = Debug;
+		};
+		416E9EC52C76BD4600A0B917 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.stripe.StripeConnectExampleUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = StripeConnectExample;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		416E9E8E2C76BD4400A0B917 /* Build configuration list for PBXProject "StripeConnect Example" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				416E9EBB2C76BD4600A0B917 /* Debug */,
+				416E9EBC2C76BD4600A0B917 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		416E9EBD2C76BD4600A0B917 /* Build configuration list for PBXNativeTarget "StripeConnect Example" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				416E9EBE2C76BD4600A0B917 /* Debug */,
+				416E9EBF2C76BD4600A0B917 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		416E9EC32C76BD4600A0B917 /* Build configuration list for PBXNativeTarget "StripeConnect ExampleUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				416E9EC42C76BD4600A0B917 /* Debug */,
+				416E9EC52C76BD4600A0B917 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 416E9E8B2C76BD4400A0B917 /* Project object */;
+}

--- a/Example/StripeConnectExample/StripeConnect Example.xcodeproj/xcshareddata/xcschemes/StripeConnect Example.xcscheme
+++ b/Example/StripeConnectExample/StripeConnect Example.xcodeproj/xcshareddata/xcschemes/StripeConnect Example.xcscheme
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1540"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "416E9E922C76BD4400A0B917"
+               BuildableName = "StripeConnect Example.app"
+               BlueprintName = "StripeConnect Example"
+               ReferencedContainer = "container:StripeConnect Example.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:StripeConnectExample.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "416E9E922C76BD4400A0B917"
+            BuildableName = "StripeConnect Example.app"
+            BlueprintName = "StripeConnect Example"
+            ReferencedContainer = "container:StripeConnect Example.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "416E9E922C76BD4400A0B917"
+            BuildableName = "StripeConnect Example.app"
+            BlueprintName = "StripeConnect Example"
+            ReferencedContainer = "container:StripeConnect Example.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Example/StripeConnectExample/StripeConnectExample.xctestplan
+++ b/Example/StripeConnectExample/StripeConnectExample.xctestplan
@@ -1,0 +1,29 @@
+{
+  "configurations" : [
+    {
+      "id" : "83961E64-C898-420A-8DB3-072746830EF8",
+      "name" : "Test Scheme Action",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false,
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:StripeConnect Example.xcodeproj",
+      "identifier" : "416E9E922C76BD4400A0B917",
+      "name" : "StripeConnect Example"
+    }
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:StripeConnect Example.xcodeproj",
+        "identifier" : "416E9EB22C76BD4600A0B917",
+        "name" : "StripeConnect ExampleUITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Example/StripeConnectExample/StripeConnectExample/API/API.swift
+++ b/Example/StripeConnectExample/StripeConnectExample/API/API.swift
@@ -1,0 +1,55 @@
+//
+//  API.swift
+//  StripeConnect Example
+//
+//  Created by Chris Mays on 8/23/24.
+//
+
+import Foundation
+
+struct API {
+    static func appInfo(baseURL: String = AppSettings.shared.selectedServerBaseURL) async -> Result<AppInfo, APIError> {
+        await apiRequest(path: "app_info", baseURL: baseURL)
+    }
+    
+    static func accountSession(merchantId: String? = nil, baseURL: String = AppSettings.shared.selectedServerBaseURL) async -> Result<AccountSessionResponse, APIError> {
+        await apiRequest(path: "account_session", 
+                         method: "POST",
+                         headers: merchantId.map { ["account": $0] } ?? [:],
+                         baseURL: baseURL)
+    }
+    
+    static func apiRequest<Response: Codable>(path: String,
+                                              method: String = "GET",
+                                              headers: [String: String] = [:],
+                                              baseURL: String = AppSettings.shared.selectedServerBaseURL) async -> Result<Response, APIError> {
+        guard let baseUrl = URL(string: baseURL) else {
+            return .failure(.invalidURL)
+        }
+        let url = baseUrl.appending(path: path)
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.allHTTPHeaderFields = headers
+        do {
+            let decoder = JSONDecoder()
+            decoder.keyDecodingStrategy = .convertFromSnakeCase
+            let (data, response)  = try await URLSession.shared.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200 else {
+                do {
+                    return .failure(.responseError(response: try decoder.decode(APIErrorResponse.self, from: data)))
+                } catch {
+                    return .failure(.failedToParse(error: error))
+                }
+            }
+            do {
+                return .success(try decoder.decode(Response.self, from: data))
+            } catch {
+                return .failure(.failedToParse(error: error))
+            }
+        }
+        catch {
+            return .failure(.networkError(error: error))
+        }
+    }
+}

--- a/Example/StripeConnectExample/StripeConnectExample/API/Models/APIError.swift
+++ b/Example/StripeConnectExample/StripeConnectExample/API/Models/APIError.swift
@@ -1,0 +1,35 @@
+//
+//  APIError.swift
+//  StripeConnect Example
+//
+//  Created by Chris Mays on 8/23/24.
+//
+
+import Foundation
+
+enum APIError: Error, CustomDebugStringConvertible {
+    case failedToParse(error: Error)
+    case invalidURL
+    case networkError(error: Error)
+    case responseError(response: APIErrorResponse)
+    case unknown(error: Error)
+    
+    var debugDescription: String {
+        switch self {
+        case let .failedToParse(error):
+            return "Failed to parse response: \(error.localizedDescription)"
+        case .invalidURL:
+            return "Invalid url"
+        case let .responseError(response):
+            return response.error
+        case let .networkError(error):
+            return "Network Error: \(error.localizedDescription)"
+        case let .unknown(error):
+            return "An unknown error occurred: \(error)"
+        }
+    }
+}
+
+struct APIErrorResponse: Codable {
+    let error: String
+}

--- a/Example/StripeConnectExample/StripeConnectExample/API/Models/AccountSessionResponse.swift
+++ b/Example/StripeConnectExample/StripeConnectExample/API/Models/AccountSessionResponse.swift
@@ -1,0 +1,12 @@
+//
+//  AccountSessionResponse.swift
+//  StripeConnect Example
+//
+//  Created by Chris Mays on 8/23/24.
+//
+
+import Foundation
+
+struct AccountSessionResponse: Codable {
+    let clientSecret: String
+}

--- a/Example/StripeConnectExample/StripeConnectExample/API/Models/AppInfo.swift
+++ b/Example/StripeConnectExample/StripeConnectExample/API/Models/AppInfo.swift
@@ -1,0 +1,21 @@
+//
+//  AppInfo.swift
+//  StripeConnect Example
+//
+//  Created by Chris Mays on 8/23/24.
+//
+
+import Foundation
+
+struct AppInfo: Codable {
+    let publishableKey: String
+    let availableMerchants: [MerchantInfo]
+}
+
+struct MerchantInfo: Codable, Identifiable, Equatable {
+    var id: String {
+        merchantId
+    }
+    let displayName: String?
+    let merchantId: String
+}

--- a/Example/StripeConnectExample/StripeConnectExample/AppDelegate.swift
+++ b/Example/StripeConnectExample/StripeConnectExample/AppDelegate.swift
@@ -1,0 +1,34 @@
+//
+//  AppDelegate.swift
+//  StripeConnectExample
+//
+//  Created by Chris Mays on 8/21/24.
+//
+
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        // Called when a new scene session is being created.
+        // Use this method to select a configuration to create the new scene with.
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        // Called when the user discards a scene session.
+        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+    }
+
+
+}
+

--- a/Example/StripeConnectExample/StripeConnectExample/AppSettingsView.swift
+++ b/Example/StripeConnectExample/StripeConnectExample/AppSettingsView.swift
@@ -1,0 +1,90 @@
+//
+//  ServerSettingsView.swift
+//  StripeConnect Example
+//
+//  Created by Chris Mays on 8/26/24.
+//
+
+import SwiftUI
+
+struct AppSettingsView: View {
+    
+    @Environment(\.dismiss) var dismiss
+    @Environment(\.viewControllerPresenter) var viewControllerPresenter
+    
+    // App info is sometimes nil, if for example it fails to load.
+    var appInfo: AppInfo?
+    
+    @State var selectedMerchant: MerchantInfo?
+    @State var serverURLString: String = AppSettings.shared.selectedServerBaseURL
+    
+    var isCustomEndpointValid: Bool {
+        guard let url = URL(string: serverURLString) else { return false }
+        return UIApplication.shared.canOpenURL(url)
+    }
+    
+    var saveEnabled: Bool {
+        isCustomEndpointValid &&
+        (AppSettings.shared.selectedMerchant(appInfo: appInfo)?.id != selectedMerchant?.id ||
+         AppSettings.shared.selectedServerBaseURL != serverURLString)
+    }
+    
+    init(appInfo: AppInfo?) {
+        self.appInfo = appInfo
+        _selectedMerchant = .init(initialValue: AppSettings.shared.selectedMerchant(appInfo: appInfo))
+    }
+    
+    var body: some View {
+        NavigationView {
+            List {
+                Section {
+                    ForEach((appInfo?.availableMerchants ?? [])) { merchant in
+                        OptionListRow(title: merchant.displayName ?? "",
+                                      subtitle: merchant.id,
+                                      selected: selectedMerchant?.id == merchant.id,
+                                      onSelected: {
+                            selectedMerchant = merchant
+                        })
+                    }
+                } header: {
+                    Text("Select a demo account")
+                }
+                Section {
+                    TextInput(label: "", placeholder: "https://example.com", text: $serverURLString, isValid: isCustomEndpointValid)
+                    Button {
+                        serverURLString = AppSettings.Constants.defaultServerBaseURL
+                    } label: {
+                        Text("Reset to default")
+                            .disabled(AppSettings.Constants.defaultServerBaseURL == serverURLString)
+                    }
+                } header: {
+                    Text("API Server Settings")
+                }
+            }
+            .listStyle(.insetGrouped)
+            .animation(.easeOut(duration: 0.2), value: selectedMerchant)
+            .navigationTitle("Configure server")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button {
+                        dismiss()
+                    } label: {
+                        Text("Cancel")
+                    }
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button {
+                        AppSettings.shared.setSelectedMerchant(merchant: selectedMerchant)
+                        AppSettings.shared.selectedServerBaseURL = serverURLString
+                        viewControllerPresenter?.setRootViewController(AppLoadingView().containerViewController)
+                    } label: {
+                        Text("Save")
+                    }
+                    .disabled(!saveEnabled)
+                }
+            }
+        }
+        .environment(\.horizontalSizeClass, .compact)
+    }
+}

--- a/Example/StripeConnectExample/StripeConnectExample/AppStartViewController.swift
+++ b/Example/StripeConnectExample/StripeConnectExample/AppStartViewController.swift
@@ -1,0 +1,95 @@
+//
+//  ViewController.swift
+//  StripeConnectExample
+//
+//  Created by Chris Mays on 8/21/24.
+//
+
+@_spi(PrivateBetaConnect) import StripeConnect
+import StripeCore
+import UIKit
+import SwiftUI
+
+struct AppLoadingView: View {
+    @Environment(\.viewControllerPresenter) var viewControllerPresenter
+    @State var loadingState: LoadingState = .loading
+    @State var displayLoadTimeReassurance: Bool = false
+    @State var loadTimeReassuranceWorkItem: DispatchWorkItem?
+
+    enum LoadingState {
+        case loading
+        case failed(reason: String)
+        case finished
+    }
+    
+    var body: some View {
+        VStack(spacing: 10) {
+            switch loadingState {
+            case .loading:
+                ProgressView()
+                Text("Warming up the server… This may take several seconds")
+                    .opacity(displayLoadTimeReassurance ? 1.0 : 0.0)
+                    .multilineTextAlignment(.center)
+            case .failed(let reason):
+                Text("Failed to start app.")
+                VStack {
+                    Button {
+                        load()
+                    } label: {
+                        Text("Reload")
+                    }
+                    Button {
+                        viewControllerPresenter?.presentViewController(AppSettingsView(appInfo: nil).containerViewController)
+                    } label: {
+                        Text("App Settings")
+                    }
+                }
+                Text("\(reason)")
+                    .padding()
+            case .finished:
+                Text("")
+            }
+        }
+        .onAppear {
+            load()
+        }
+    }
+    
+    func load() {
+        loadingState = .loading
+        let workItem = DispatchWorkItem {
+            withAnimation(.easeIn) {
+                displayLoadTimeReassurance = true
+            }
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(1), execute: workItem)
+        loadTimeReassuranceWorkItem = workItem
+        Task { @MainActor in
+            defer {         
+                loadTimeReassuranceWorkItem?.cancel()
+                loadTimeReassuranceWorkItem = nil
+                displayLoadTimeReassurance = false
+            }
+            
+            let appInfoResult = await API.appInfo()
+            guard let appInfo = try? appInfoResult.get() else {
+                var errorMessage = ""
+                if case let .failure(error) = appInfoResult {
+                    errorMessage = error.debugDescription
+                }
+                                
+                loadingState = .failed(reason: "\(errorMessage)")
+                return
+            }
+            guard let firstMerchant = appInfo.availableMerchants.first else {
+                loadingState = .failed(reason: "No merchants returned from api")
+                return
+            }
+            
+            STPAPIClient.shared.publishableKey = appInfo.publishableKey
+            let selectedMerchant = AppSettings.shared.selectedMerchant(appInfo: appInfo) ?? firstMerchant
+            viewControllerPresenter?.setRootViewController(MainViewController(appInfo: appInfo, merchant: selectedMerchant).embedInNavigationController())
+            
+        }
+    }
+}

--- a/Example/StripeConnectExample/StripeConnectExample/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Example/StripeConnectExample/StripeConnectExample/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Example/StripeConnectExample/StripeConnectExample/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Example/StripeConnectExample/StripeConnectExample/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Example/StripeConnectExample/StripeConnectExample/Assets.xcassets/Contents.json
+++ b/Example/StripeConnectExample/StripeConnectExample/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Example/StripeConnectExample/StripeConnectExample/Base.lproj/LaunchScreen.storyboard
+++ b/Example/StripeConnectExample/StripeConnectExample/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="StripeConnect Example" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tpl-NI-fTA">
+                                <rect key="frame" x="49" y="409" width="294" height="35"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="29"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Example/StripeConnectExample/StripeConnectExample/Helpers/SwiftUIContainerViewController.swift
+++ b/Example/StripeConnectExample/StripeConnectExample/Helpers/SwiftUIContainerViewController.swift
@@ -1,0 +1,74 @@
+//
+//  SwiftUIContainerViewController.swift
+//  StripeConnect Example
+//
+//  Created by Chris Mays on 8/26/24.
+//
+
+import SwiftUI
+import UIKit
+
+/// Helper SwiftUI Container VC that enables SwiftUI to present view controllers
+class SwiftUIContainerViewController<Content: View>: UIViewController {
+    let content: Content
+    
+    init(content: Content) {
+        self.content = content
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        let hostingController = UIHostingController(rootView: content.environment(\.viewControllerPresenter, .init(presentViewController: { [weak self] vc in
+            DispatchQueue.main.async {
+                self?.present(vc, animated: true)
+            }
+        }, pushViewController: { [weak self] vc in
+            DispatchQueue.main.async {
+                self?.navigationController?.pushViewController(vc, animated: true)
+            }
+        }, setRootViewController: { [weak self] vc in
+            DispatchQueue.main.async {
+                self?.dismiss(animated: true)
+                self?.view.window?.rootViewController = vc
+            }
+        })))
+        
+        self.view.addSubview(hostingController.view)
+        self.addChild(hostingController)
+        hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            hostingController.view.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+            hostingController.view.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+            hostingController.view.topAnchor.constraint(equalTo: self.view.topAnchor),
+            hostingController.view.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
+        ])
+    }
+}
+
+struct ViewControllerPresenter {
+    let presentViewController: (UIViewController) -> Void
+    let pushViewController: (UIViewController) -> Void
+    let setRootViewController: (UIViewController) -> Void
+}
+
+private struct ViewControllerPresenterKey: EnvironmentKey {
+    static let defaultValue: ViewControllerPresenter? = nil
+}
+
+extension EnvironmentValues {
+  var viewControllerPresenter: ViewControllerPresenter? {
+    get { self[ViewControllerPresenterKey.self] }
+    set { self[ViewControllerPresenterKey.self] = newValue }
+  }
+}
+
+extension View {
+    var containerViewController: SwiftUIContainerViewController<Self> {
+        .init(content: self)
+    }
+}

--- a/Example/StripeConnectExample/StripeConnectExample/Helpers/UIViewController+NavigationEmbed.swift
+++ b/Example/StripeConnectExample/StripeConnectExample/Helpers/UIViewController+NavigationEmbed.swift
@@ -1,0 +1,16 @@
+//
+//  UIViewController+NavigationEmbed.swift
+//  StripeConnect Example
+//
+//  Created by Chris Mays on 8/26/24.
+//
+
+import UIKit
+
+extension UIViewController {
+    func embedInNavigationController() -> UINavigationController {
+        let navigationController = UINavigationController(rootViewController: self)
+        self.navigationItem.largeTitleDisplayMode = .never
+        return navigationController
+    }
+}

--- a/Example/StripeConnectExample/StripeConnectExample/Info.plist
+++ b/Example/StripeConnectExample/StripeConnectExample/Info.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Example/StripeConnectExample/StripeConnectExample/MainViewController.swift
+++ b/Example/StripeConnectExample/StripeConnectExample/MainViewController.swift
@@ -1,0 +1,129 @@
+//
+//  MainViewController.swift
+//  StripeConnect Example
+//
+//  Created by Mel Ludowise on 4/30/24.
+//
+
+@_spi(PrivateBetaConnect) import StripeConnect
+import SwiftUI
+import UIKit
+
+class MainViewController: UITableViewController {
+
+    let appInfo: AppInfo
+    let merchant: MerchantInfo
+    
+    init(appInfo: AppInfo, merchant: MerchantInfo) {
+        self.appInfo = appInfo
+        self.merchant = merchant
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    /// Rows that display inside this table
+    enum Row: String, CaseIterable {
+        case payouts = "Payouts"
+
+        var label: String { rawValue }
+
+        var accessoryType: UITableViewCell.AccessoryType {
+            .disclosureIndicator
+        }
+
+        var labelColor: UIColor {
+            return .label
+        }
+    }
+
+    /// Navbar button title view
+    lazy var navbarTitleButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle(title, for: .normal)
+        button.setImage(UIImage(systemName: "chevron.down",
+                                withConfiguration: UIImage.SymbolConfiguration(pointSize: 10)),
+                        for: .normal)
+        button.semanticContentAttribute = .forceRightToLeft
+        button.tintColor = .label
+        button.addTarget(self, action: #selector(presentServerSettings), for: .touchUpInside)
+        button.titleLabel?.adjustsFontSizeToFitWidth = true
+        button.accessibilityLabel = "Configure server"
+        return button
+    }()
+
+    override var title: String? {
+        didSet {
+            navbarTitleButton.setTitle(title, for: .normal)
+        }
+    }
+
+    lazy var embeddedComponentManager: EmbeddedComponentManager = {
+        .init(fetchClientSecret: { [weak self, merchant] in
+            do {
+                return try await API.accountSession(merchantId: merchant.id).get().clientSecret
+            } catch {
+                self?.presentAlert(title: "An error occurred", message: "Failed to retrieve client secret.")
+                return nil
+            }
+        })
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = merchant.displayName ?? merchant.merchantId
+        navigationItem.titleView = navbarTitleButton
+    }
+
+    /// Called when table row is selected
+    func performAction(_ row: Row, cell: UITableViewCell) {
+        let viewControllerToPush: UIViewController
+
+        switch row {
+        case .payouts:
+            viewControllerToPush = embeddedComponentManager.createPayoutsViewController()
+        }
+        
+        viewControllerToPush.navigationItem.backButtonDisplayMode = .minimal
+        navigationController?.pushViewController(viewControllerToPush, animated: true)
+    }
+
+    // MARK: - UITableViewDataSource
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        Row.allCases.count
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let row = Row.allCases[indexPath.row]
+        let cell = UITableViewCell()
+        cell.textLabel?.text = row.label
+        cell.textLabel?.textColor = row.labelColor
+        cell.accessoryType = row.accessoryType
+        return cell
+    }
+
+    // MARK: - UITableViewDelegate
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        guard let cell = tableView.cellForRow(at: indexPath) else {
+            return
+        }
+        cell.isSelected = false
+
+        performAction(Row.allCases[indexPath.row], cell: cell)
+    }
+    
+    @objc
+    func presentServerSettings() {
+        self.present(AppSettingsView(appInfo: appInfo).containerViewController, animated: true)
+    }
+    
+    func presentAlert(title: String, message: String) {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        self.present(alert, animated: true)
+    }
+}

--- a/Example/StripeConnectExample/StripeConnectExample/SceneDelegate.swift
+++ b/Example/StripeConnectExample/StripeConnectExample/SceneDelegate.swift
@@ -1,0 +1,55 @@
+//
+//  SceneDelegate.swift
+//  StripeConnectExample
+//
+//  Created by Chris Mays on 8/21/24.
+//
+
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+    func scene(_ scene: UIScene,
+               willConnectTo session: UISceneSession,
+               options connectionOptions: UIScene.ConnectionOptions) {
+        guard let windowScene = (scene as? UIWindowScene) else { return }
+        
+        let window = UIWindow(windowScene: windowScene)
+        window.rootViewController = AppLoadingView().containerViewController
+        self.window = window
+        window.makeKeyAndVisible()
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+        // Release any resources associated with this scene that can be re-created the next time the scene connects.
+        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific state information
+        // to restore the scene back to its current state.
+    }
+
+
+}
+

--- a/Example/StripeConnectExample/StripeConnectExample/Storage/AppSettings.swift
+++ b/Example/StripeConnectExample/StripeConnectExample/Storage/AppSettings.swift
@@ -1,0 +1,40 @@
+//
+//  AppSettings.swift
+//  StripeConnect Example
+//
+//  Created by Chris Mays on 8/25/24.
+//
+
+import Foundation
+
+class AppSettings {
+    enum  Constants {
+        static let defaultServerBaseURL = "https://stripe-connect-mobile-example-v1.glitch.me/"
+        static let serverBaseURLKey = "ServerBaseURL"
+        
+        static let selectedMerchantKey = "SelectedMerchant"
+    }
+    
+    static let shared = AppSettings()
+    
+    var selectedServerBaseURL: String {
+        get {
+            UserDefaults.standard.string(forKey: Constants.serverBaseURLKey) ??
+            Constants.defaultServerBaseURL
+        }
+        set {
+            UserDefaults.standard.setValue(newValue, forKey: Constants.serverBaseURLKey)
+        }
+    }
+    
+    func selectedMerchant(appInfo: AppInfo?) -> MerchantInfo? {
+        let merchantId = UserDefaults.standard.string(forKey: Constants.selectedMerchantKey)
+        return appInfo?.availableMerchants.first(where: {
+            $0.merchantId == merchantId
+        }) ?? appInfo?.availableMerchants.first
+    }
+    
+    func setSelectedMerchant(merchant: MerchantInfo?) {
+        UserDefaults.standard.setValue(merchant?.id, forKey: Constants.selectedMerchantKey)
+    }
+}

--- a/Example/StripeConnectExample/StripeConnectExample/Views/OptionListRow.swift
+++ b/Example/StripeConnectExample/StripeConnectExample/Views/OptionListRow.swift
@@ -1,0 +1,35 @@
+//
+//  OptionListRow.swift
+//  StripeConnect Example
+//
+//  Created by Chris Mays on 8/28/24.
+//
+
+import SwiftUI
+
+struct OptionListRow: View {
+    let title: String
+    private(set) var subtitle: String?
+    var selected: Bool = false
+    var onSelected: ()-> Void
+    var body: some View {
+        Button {
+            onSelected()
+        } label: {
+            HStack {
+                VStack(alignment: .leading) {
+                    Text(title)
+                        .font(.body)
+                        .foregroundColor(.primary)
+                    subtitle.map(Text.init)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                Spacer()
+                Image(systemName: "checkmark")
+                    .foregroundColor(.accentColor)
+                    .opacity(selected ? 1.0 : 0.0)
+            }
+        }
+    }
+}

--- a/Example/StripeConnectExample/StripeConnectExample/Views/TextInput.swift
+++ b/Example/StripeConnectExample/StripeConnectExample/Views/TextInput.swift
@@ -1,0 +1,43 @@
+//
+//  TextInput.swift
+//  StripeConnect Example
+//
+//  Created by Chris Mays on 8/28/24.
+//
+
+import SwiftUI
+
+struct TextInput: View {
+    let label: Text
+    let placeholder: String
+    @Binding var text: String
+    private(set) var isValid = true
+
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            label
+            TextField(placeholder, text: $text)
+                .textFieldStyle(.roundedBorder)
+                .focused($isFocused)
+            if !text.isEmpty && !isFocused && !isValid {
+                Text("Invalid value")
+                    .foregroundColor(Color(uiColor: .systemRed))
+                    .font(.caption)
+            }
+        }
+    }
+}
+
+extension TextInput {
+    init(label: String,
+         placeholder: String,
+         text: Binding<String>,
+         isValid: Bool = true) {
+        self.init(label: Text(label),
+                  placeholder: placeholder,
+                  text: text,
+                  isValid: isValid)
+    }
+}

--- a/Example/StripeConnectExample/StripeConnectExampleUITests/StripeConnectExampleUITests.swift
+++ b/Example/StripeConnectExample/StripeConnectExampleUITests/StripeConnectExampleUITests.swift
@@ -1,0 +1,14 @@
+//
+//  StripeConnectExampleUITests.swift
+//  StripeConnectExampleUITests
+//
+//  Created by Chris Mays on 8/21/24.
+//
+
+import XCTest
+
+final class StripeConnectExampleUITests: XCTestCase {
+    func testStub() throws {
+        // Delete when tests are added
+    }
+}

--- a/Stripe.xcworkspace/contents.xcworkspacedata
+++ b/Stripe.xcworkspace/contents.xcworkspacedata
@@ -26,6 +26,9 @@
          location = "group:PaymentSheet Example/PaymentSheet Example.xcodeproj">
       </FileRef>
       <FileRef
+         location = "group:/Users/nschris/stripe/stripe-ios/Example/StripeConnectExample/StripeConnect Example.xcodeproj">
+      </FileRef>
+      <FileRef
          location = "group:UI Examples/UI Examples.xcodeproj">
       </FileRef>
    </Group>

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -664,6 +664,24 @@ workflows:
     meta:
       bitrise.io:
         stack: osx-xcode-15.0.x
+        machine_type_id: g2-m1-max.5core
+  ui-tests-5:
+    steps:
+    - xcode-test@4:
+        inputs:
+        - destination: $DEFAULT_TEST_DEVICE
+        - test_repetition_mode: retry_on_failure
+        - maximum_test_repetitions: "2"
+        - scheme: StripeConnect Example
+        - test_plan: StripeConnectExample
+        - log_formatter: xcbeautify
+        - xcodebuild_options: -maximum-concurrent-test-simulator-destinations 6 -maximum-parallel-testing-workers 6
+    - deploy-to-bitrise-io@2: {}
+    before_run:
+    - prep_all
+    meta:
+      bitrise.io:
+        stack: osx-xcode-15.0.x
         machine_type_id: g2-m1-max.5core                
   upload_logs:
     steps:


### PR DESCRIPTION
## Summary
This adds a basic example app utilizing the StripeConnect SDK.

[MXMOBILE-2480](https://jira.corp.stripe.com/browse/MXMOBILE-2480)

## App Breakdown
- On app open retrieve app_info from the API. If loading takes longer than 1 second a reassurance message appears. On success push to the main components view. On Failure show error message and option to retry or go to app settings.
-  The components list shows the Payouts option, more will be available in the future. Selecting the payouts list will push on a PayoutsViewController.
- Tapping the top nav bar takes you to app settings where you can configure the server url and which account is currently selected.

## API Description
`GET: /app_info` : This is requested on app start and will return the public key as well as the available accounts. The display name is optional, but helpful.
Example Response:
```
{
  "publishable_key": "pk_test_<key>",
  "available_merchants": [
    {
      "display_name": "Name to display in app ",
      "merchant_id": "acct_123456"
    },
  ]
}
```
`POST /account_session` The will be called in fetchSession on the SDK. If the account header is provided then it will get the session for that account otherwise it will get a session from the default account which is currently acct_1N9FIXQ26HdRlxHg.
Example Response:
```
{
   "client_secret": "<secret>"
}
```

## Demo

https://github.com/user-attachments/assets/ccaef189-8161-4670-a719-d9184cd1763e
