### PR TITLE
Financial Connections: fixed a bug where we should be expanding manifest

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
@@ -266,8 +266,9 @@ extension FinancialConnectionsAPIClient: FinancialConnectionsAPI {
     }
 
     func markConsentAcquired(clientSecret: String) -> Promise<FinancialConnectionsSessionManifest> {
-        let parameters = [
+        let parameters: [String: Any] = [
             "client_secret": clientSecret,
+            "expand": ["active_auth_session"],
         ]
         return self.post(
             resource: APIEndpointConsentAcquired,
@@ -437,8 +438,9 @@ extension FinancialConnectionsAPIClient: FinancialConnectionsAPI {
     }
 
     func markLinkingMoreAccounts(clientSecret: String) -> Promise<FinancialConnectionsSessionManifest> {
-        let body = [
+        let body: [String: Any] = [
             "client_secret": clientSecret,
+            "expand": ["active_auth_session"],
         ]
         return self.post(
             resource: APIEndpointLinkMoreAccounts,


### PR DESCRIPTION
## Summary

^ we are seeing edge-case issues [slack link](https://stripe.slack.com/archives/C07JV43GPD3/p1724887343261609)

if we don't do this, the backend can return a STRING instead of an OBJECT (what we expect) for manifest

this can seemingly happen for this edge case (for specific merchants - not our test ones): `consent -> institution picker -> partner auth -> back -> back -> consent`

[query of these errors](https://hubble.corp.stripe.com/queries/kgaidis/599e4cab?sort=-_day) - not a lot

## Testing

See other code that does this already and ensure its correct:
- https://livegrep.corp.stripe.com/search/stripe?q=%22expand%22%3A%20%5B%22active_auth_session%22%5D%2C&fold_case=auto&regex=false&context=true

Test that markConsent works correctly:

<img width="820" alt="Screenshot 2024-08-28 at 4 56 52 PM" src="https://github.com/user-attachments/assets/f86737f6-13aa-4642-a21e-6db502cbf3f4">

Test that markLinkingMoreAccounts works correctly:

<img width="815" alt="Screenshot 2024-08-28 at 4 57 36 PM" src="https://github.com/user-attachments/assets/0d8ef83d-fa96-4225-9be8-a1114fbb76e0">

Run `bitrise run financial-connections-stability-tests`:

```
FinancialConnectionsNetworkingUITests
    ✓ testNativeNetworkingTestMode (135.553 seconds)
    ✓ testNativeNetworkingTestModeSignUpWithMultiSelectAndPrefilledEmail (32.020 seconds)
    ✓ testNativeNetworkingTestModeSignUpWithPrefilledEmailAndPhone (24.605 seconds)
FinancialConnectionsUITests
    ✓ testDataLiveModeOAuthNativeAuthFlow (31.086 seconds)
    ✓ testDataLiveModeOAuthWebAuthFlow (19.286 seconds)
    ✓ testDataTestModeOAuthNativeAuthFlow (19.991 seconds)
    ✓ testPaymentSearchInLiveModeNativeAuthFlow (25.959 seconds)
    ✓ testPaymentTestModeLegacyNativeAuthFlow (19.740 seconds)
    ✓ testPaymentTestModeManualEntryAutofill (14.061 seconds)
    ✓ testPaymentTestModeManualEntryNativeAuthFlow (24.639 seconds)
    ✓ testWebInstantDebitsFlow (13.520 seconds)
```