### PR TITLE
Financial Connections: added onEvent handler tests

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundViewModel.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundViewModel.swift
@@ -227,6 +227,7 @@ final class PlaygroundViewModel: ObservableObject {
         ) { [weak self] setupPlaygroundResponse in
             guard let self else { return }
             if let setupPlaygroundResponse = setupPlaygroundResponse {
+                var onEventEvents: [String] = []
                 PresentFinancialConnectionsSheet(
                     useCase: self.playgroundConfiguration.useCase,
                     setupPlaygroundResponseJSON: setupPlaygroundResponse,
@@ -235,6 +236,7 @@ final class PlaygroundViewModel: ObservableObject {
                             let message = "\(event.name.rawValue); \(event.metadata.dictionary)"
                             BannerHelper.shared.showBanner(with: message, for: 3.0)
                         }
+                        onEventEvents.append(event.name.rawValue)
                     },
                     completionHandler: { [weak self] result in
                         switch result {
@@ -246,11 +248,13 @@ final class PlaygroundViewModel: ObservableObject {
                             let accountNames = session.accounts.data.map({ $0.displayName ?? "N/A" })
                             let accountIds = session.accounts.data.map({ $0.id })
 
+                            // WARNING: the "events" output is used for end-to-end tests so be careful modifying it
                             let sessionInfo =
 """
 session_id=\(sessionId)
 account_names=\(accountNames)
 account_ids=\(accountIds)
+events=\(onEventEvents.joined(separator: ","))
 """
 
                             let message = "\(accountInfos)\n\n\(sessionInfo)"

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
@@ -407,6 +407,36 @@ final class FinancialConnectionsUITests: XCTestCase {
         let playgroundCancelAlert = app.alerts["Cancelled"]
         XCTAssertTrue(playgroundCancelAlert.waitForExistence(timeout: 10.0))
     }
+
+    func testNativeOnEventClosureEvents() throws {
+        let app = XCUIApplication.fc_launch(
+            playgroundConfigurationString:
+"""
+{"use_case":"payment_intent","experience":"financial_connections","sdk_type":"native","test_mode":true,"merchant":"default","payment_method_permission":true}
+"""
+        )
+
+        app.fc_playgroundCell.tap()
+        app.fc_playgroundShowAuthFlowButton.tap()
+
+        app.fc_nativeManuallyVerifyLabel.waitForExistenceAndTap()
+
+        app.fc_nativeBackButton().waitForExistenceAndTap()
+
+        app.fc_nativeConsentAgreeButton.waitForExistenceAndTap()
+
+        app.fc_nativeFeaturedInstitution(name: "Test Institution").waitForExistenceAndTap()
+
+        app.fc_nativeConnectAccountsButton.tap()
+
+        app.fc_nativeSuccessDoneButton.tap()
+
+        // ensure alert body contains "Stripe Bank" (AKA one bank is linked)
+        XCTAssert(
+            app.fc_playgroundSuccessAlertView.staticTexts.containing(NSPredicate(format: "label CONTAINS 'events=open,manual_entry_initiated,consent_acquired,institution_selected,institution_authorized,accounts_selected,success'")).firstMatch
+                .exists
+        )
+    }
 }
 
 extension XCTestCase {

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIApplication+Extensions.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIApplication+Extensions.swift
@@ -171,6 +171,10 @@ extension XCUIApplication {
         return bankAccount
     }
 
+    func fc_nativeBackButton() -> XCUIElement {
+        return navigationBars["fc_navigation_bar"].buttons["Back"]
+    }
+
     func fc_scrollDown() {
         swipeUp(velocity: .verySlow)
     }


### PR DESCRIPTION
## Summary

^ added an extra UI test that ensures the onEvent closure doesn't accidentally breal

## Testing

Ran the test locally:

<img width="550" alt="Screenshot 2024-08-29 at 1 39 45 PM" src="https://github.com/user-attachments/assets/b3ac2ad4-50a8-456a-b5b0-7a31e80ea50e">

Also ran tests:

```
FinancialConnectionsNetworkingUITests
it stat    ✓ testNativeNetworkingTestMode (131.759 seconds)
    ✓ testNativeNetworkingTestModeSignUpWithMultiSelectAndPrefilledEmail (30.878 seconds)
    ✓ testNativeNetworkingTestModeSignUpWithPrefilledEmailAndPhone (24.171 seconds)
FinancialConnectionsUITests
    ✓ testDataLiveModeOAuthNativeAuthFlow (30.291 seconds)
    ✓ testDataLiveModeOAuthWebAuthFlow (18.526 seconds)
    ✓ testDataTestModeOAuthNativeAuthFlow (20.801 seconds)
    ✓ testNativeOnEventClosureEvents (22.141 seconds)
    ✓ testPaymentSearchInLiveModeNativeAuthFlow (26.130 seconds)
    ✓ testPaymentTestModeLegacyNativeAuthFlow (20.089 seconds)
    ✓ testPaymentTestModeManualEntryAutofill (14.836 seconds)
    ✓ testPaymentTestModeManualEntryNativeAuthFlow (25.561 seconds)
    ✓ testWebInstantDebitsFlow (16.326 seconds)


	 Executed 12 tests, with 0 failures (0 unexpected) in 381.508 (381.519) seconds
```