### PR TITLE
Financial Connections: wrote UI tests for custom manual entry and skip success pane

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundConfiguration.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundConfiguration.swift
@@ -125,7 +125,7 @@ final class PlaygroundConfiguration {
             case customKeys = "custom_keys"
             case partnerD = "partner_d"
             case partnerF = "partner_f"
-            case partnerC = "partner_c"
+            case platformC = "platform_c"
             case bugBash = "bug_bash"
         }
     }
@@ -155,6 +155,11 @@ final class PlaygroundConfiguration {
             customId: .partnerF,
             displayName: "Partner F",
             isTestModeSupported: false
+        ),
+        Merchant(
+            customId: .platformC,
+            displayName: "Platform C",
+            isTestModeSupported: true
         ),
         Merchant(
             customId: .bugBash,


### PR DESCRIPTION
## Summary

Wrote UI tests for custom manual entry and skip success pane.

The purpose is that as we change the code in the future, that we are less likely to break things.

## Testing

```
FinancialConnectionsNetworkingUITests
    ✓ testNativeNetworkingTestMode (133.710 seconds)
    ✓ testNativeNetworkingTestModeSignUpWithMultiSelectAndPrefilledEmail (31.500 seconds)
    ✓ testNativeNetworkingTestModeSignUpWithPrefilledEmailAndPhone (24.726 seconds)
FinancialConnectionsUITests
    ✓ testDataLiveModeOAuthNativeAuthFlow (29.240 seconds)
    ✓ testDataLiveModeOAuthWebAuthFlow (20.662 seconds)
    ✓ testDataTestModeOAuthNativeAuthFlow (20.582 seconds)
    ✓ testNativeCustomManualEntryHandoff (15.694 seconds)
    ✓ testNativeOnEventClosureEvents (23.063 seconds)
    ✓ testNativeSkipSuccessPane (21.184 seconds)
    ✓ testPaymentSearchInLiveModeNativeAuthFlow (25.250 seconds)
    ✓ testPaymentTestModeLegacyNativeAuthFlow (19.331 seconds)
    ✓ testPaymentTestModeManualEntryAutofill (13.872 seconds)
    ✓ testPaymentTestModeManualEntryNativeAuthFlow (25.165 seconds)
    ✓ testWebInstantDebitsFlow (13.399 seconds)


	 Executed 14 tests, with 0 failures (0 unexpected) in 417.378 (417.388) seconds
```