### PR TITLE
Financial Connections: small fix for a networking manual entry edge case

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -882,6 +882,10 @@ extension NativeFlowController: AttachLinkedPaymentAccountViewControllerDelegate
     func attachLinkedPaymentAccountViewControllerDidSelectManualEntry(
         _ viewController: AttachLinkedPaymentAccountViewController
     ) {
+        // #ir-magnesium-presser; keeping accounts selected can lead to them being passed along
+        // to the Link signup/save call later in the flow. We don't need them anymore since we know
+        // they've failed us in some way at this point.
+        dataManager.linkedAccounts = nil
         pushPane(.manualEntry, animated: true)
     }
 


### PR DESCRIPTION
## Summary

^ see the comment in the code

## Testing

Video testing the edge case:

https://github.com/user-attachments/assets/82daccfe-5912-48b0-8c4d-30767bea9b31

We can see that save to link succeeds:

<img width="774" alt="Screenshot 2024-08-30 at 2 01 39 PM" src="https://github.com/user-attachments/assets/d72c8d6e-f10e-4717-b4e9-82f2b7492a9e">
