### PR TITLE
Enable ultrawide lens when scanning cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## X.Y.Z 2024-XX-YY
 ### PaymentSheet
 * [Fixed] PaymentSheet now uses a border width of 1.5 instead of 0 when `PaymentSheet.Appearance.borderWidth' is 0.
-
+* [Fixed] The 0.5x lens is now when scanning cards, if available. (Thanks [@akhmedovgg](https://github.com/akhmedovgg)!)
 
 ## 23.29.2 2024-08-19
 ### PaymentSheet


### PR DESCRIPTION
## Summary
Use the ultrawide lens, if available, when scanning cards.

## Motivation
Improves close-up focusing during card scanning.

## Testing
Tested on iPad M1 (`dualWideCamera`) + iPhone 15 Pro (`tripleCamera`)

## Changelog
Added entry
