### PR TITLE
Financial Connections: small fix for a networking manual entry edge case

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -797,6 +797,11 @@ extension NativeFlowController: ManualEntryViewControllerDelegate {
             FinancialConnectionsPaymentAccountResource,
         accountNumberLast4: String
     ) {
+        // #ir-magnesium-presser; keeping accounts selected can lead to them being passed along
+        // to the Link signup/save call later in the flow. We don't need them anymore since we know
+        // they've failed us in some way at this point.
+        dataManager.linkedAccounts = nil
+        
         dataManager.paymentAccountResource = paymentAccountResource
         dataManager.accountNumberLast4 = accountNumberLast4
 


### PR DESCRIPTION
## Summary

^ see the comment in the code

## Testing

The save API call succeeds for the edge-case:

<img width="2097" alt="Screenshot 2024-09-03 at 10 40 14 AM" src="https://github.com/user-attachments/assets/372757c9-0486-4649-aee7-3bad04302ad9">

Run tests:

```
All tests
Test Suite FinancialConnectionsUITests.xctest started
FinancialConnectionsNetworkingUITests
    ✓ testNativeNetworkingManualEntryTestMode (113.717 seconds)
    ✓ testNativeNetworkingTestMode (134.633 seconds)
    ✓ testNativeNetworkingTestModeSignUpWithMultiSelectAndPrefilledEmail (31.833 seconds)
    ✓ testNativeNetworkingTestModeSignUpWithPrefilledEmailAndPhone (23.631 seconds)
FinancialConnectionsUITests
    ✓ testDataLiveModeOAuthNativeAuthFlow (29.722 seconds)
    ✓ testDataLiveModeOAuthWebAuthFlow (21.971 seconds)
    ✓ testDataTestModeOAuthNativeAuthFlow (20.738 seconds)
    ✓ testNativeOnEventClosureEvents (23.452 seconds)
    ✓ testPaymentSearchInLiveModeNativeAuthFlow (25.480 seconds)
    ✓ testPaymentTestModeLegacyNativeAuthFlow (19.701 seconds)
    ✓ testPaymentTestModeManualEntryAutofill (13.778 seconds)
    ✓ testPaymentTestModeManualEntryNativeAuthFlow (24.716 seconds)
    ✓ testWebInstantDebitsFlow (14.644 seconds)


	 Executed 13 tests, with 0 failures (0 unexpected) in 498.017 (498.028) seconds
	 ```