### PR TITLE
MOVILESDK-2317: Correct color discrepancy in iOS link signup checkbox label when disabled

### DIFF
--- a/Stripe.xcworkspace/contents.xcworkspacedata
+++ b/Stripe.xcworkspace/contents.xcworkspacedata
@@ -26,9 +26,6 @@
          location = "group:PaymentSheet Example/PaymentSheet Example.xcodeproj">
       </FileRef>
       <FileRef
-         location = "group:/Users/nschris/stripe/stripe-ios/Example/StripeConnectExample/StripeConnect Example.xcodeproj">
-      </FileRef>
-      <FileRef
          location = "group:UI Examples/UI Examples.xcodeproj">
       </FileRef>
    </Group>

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/InlineSignup/LinkInlineSignupView-CheckboxElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/InlineSignup/LinkInlineSignupView-CheckboxElement.swift
@@ -68,7 +68,7 @@ extension LinkInlineSignupView {
                 self.checkboxButton.alpha = 1.0
             }
             else {
-                self.checkboxButton.alpha = 0.5
+                self.checkboxButton.alpha = 0.6
             }
             
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/InlineSignup/LinkInlineSignupView-CheckboxElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/InlineSignup/LinkInlineSignupView-CheckboxElement.swift
@@ -61,6 +61,17 @@ extension LinkInlineSignupView {
             self.merchantName = merchantName
             self.appearance = appearance
         }
+        
+        func setUserInteraction(isUserInteractionEnabled: Bool) {
+            self.checkboxButton.isEnabled = isUserInteractionEnabled
+            if isUserInteractionEnabled {
+                self.checkboxButton.alpha = 1.0
+            }
+            else {
+                self.checkboxButton.alpha = 0.5
+            }
+            
+        }
 
         @objc func didToggleCheckbox() {
             delegate?.didUpdate(element: self)

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/InlineSignup/LinkInlineSignupView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/InlineSignup/LinkInlineSignupView.swift
@@ -271,3 +271,18 @@ extension LinkInlineSignupView: LinkLegalTermsViewDelegate {
     }
 
 }
+
+extension LinkInlineSignupView: EventHandler {
+    func handleEvent(_ event: STPEvent) {
+        UIView.animate(withDuration: PaymentSheetUI.defaultAnimationDuration) {
+            switch event {
+            case .shouldDisableUserInteraction:
+                self.checkboxElement.setUserInteraction(isUserInteractionEnabled: false)
+            case .shouldEnableUserInteraction:
+                self.checkboxElement.setUserInteraction(isUserInteractionEnabled: true)
+            default:
+                break
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
I added an event handler to LinkInlineSignupView for .shouldDisableUserInteraction and .shouldEnableUserInteraction and a function to the LinkInlineSignupView - CheckboxElement to set user interaction and correct a color discrepancy.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Before:
https://github.com/user-attachments/assets/969a61a8-651a-4eec-a3c6-29b24d987a9b
After:
https://github.com/user-attachments/assets/793bc235-c375-4ef6-8b9f-716bae66c380




## Testing
<!-- How was the code tested? Be as specific as possible. -->
Visually checked that the link signup checkbox looked disabled and did not accept user interaction when disabled

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
