### PR TITLE
[StripeConnect] Add appearance.

### DIFF
--- a/Example/StripeConnectExample/StripeConnect Example.xcodeproj/project.pbxproj
+++ b/Example/StripeConnectExample/StripeConnect Example.xcodeproj/project.pbxproj
@@ -24,6 +24,9 @@
 		416E9EDE2C78C0BA00A0B917 /* AppInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416E9EDD2C78C0BA00A0B917 /* AppInfo.swift */; };
 		416E9EE02C78C10800A0B917 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416E9EDF2C78C10800A0B917 /* MainViewController.swift */; };
 		416E9EE32C7B988100A0B917 /* AppSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416E9EE22C7B988100A0B917 /* AppSettings.swift */; };
+		41810D712C89F4CD00F10EB7 /* AppearanceSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41810D702C89F4CD00F10EB7 /* AppearanceSettings.swift */; };
+		41810D762C8A005D00F10EB7 /* AppearanceInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41810D752C8A005D00F10EB7 /* AppearanceInfo.swift */; };
+		41810D782C8A006F00F10EB7 /* AppSettings+AppearanceInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41810D772C8A006F00F10EB7 /* AppSettings+AppearanceInfo.swift */; };
 		41E9A1BD2C7CC85100EDE131 /* SwiftUIContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41E9A1BC2C7CC85100EDE131 /* SwiftUIContainerViewController.swift */; };
 		41E9A1BF2C7CD3C700EDE131 /* UIViewController+NavigationEmbed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41E9A1BE2C7CD3C700EDE131 /* UIViewController+NavigationEmbed.swift */; };
 		41E9A1C12C7CE30000EDE131 /* AppSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41E9A1C02C7CE30000EDE131 /* AppSettingsView.swift */; };
@@ -73,6 +76,9 @@
 		416E9EDD2C78C0BA00A0B917 /* AppInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfo.swift; sourceTree = "<group>"; };
 		416E9EDF2C78C10800A0B917 /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 		416E9EE22C7B988100A0B917 /* AppSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettings.swift; sourceTree = "<group>"; };
+		41810D702C89F4CD00F10EB7 /* AppearanceSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceSettings.swift; sourceTree = "<group>"; };
+		41810D752C8A005D00F10EB7 /* AppearanceInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceInfo.swift; sourceTree = "<group>"; };
+		41810D772C8A006F00F10EB7 /* AppSettings+AppearanceInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppSettings+AppearanceInfo.swift"; sourceTree = "<group>"; };
 		41E9A1BC2C7CC85100EDE131 /* SwiftUIContainerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIContainerViewController.swift; sourceTree = "<group>"; };
 		41E9A1BE2C7CD3C700EDE131 /* UIViewController+NavigationEmbed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+NavigationEmbed.swift"; sourceTree = "<group>"; };
 		41E9A1C02C7CE30000EDE131 /* AppSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsView.swift; sourceTree = "<group>"; };
@@ -129,6 +135,7 @@
 		416E9E952C76BD4400A0B917 /* StripeConnectExample */ = {
 			isa = PBXGroup;
 			children = (
+				41810D742C8A004F00F10EB7 /* Appearance */,
 				413D18402C7FA2FF0051AA42 /* Views */,
 				41E9A1BB2C7CC83500EDE131 /* Helpers */,
 				416E9EE12C7B987400A0B917 /* Storage */,
@@ -186,6 +193,16 @@
 				416E9EE22C7B988100A0B917 /* AppSettings.swift */,
 			);
 			path = Storage;
+			sourceTree = "<group>";
+		};
+		41810D742C8A004F00F10EB7 /* Appearance */ = {
+			isa = PBXGroup;
+			children = (
+				41810D702C89F4CD00F10EB7 /* AppearanceSettings.swift */,
+				41810D752C8A005D00F10EB7 /* AppearanceInfo.swift */,
+				41810D772C8A006F00F10EB7 /* AppSettings+AppearanceInfo.swift */,
+			);
+			path = Appearance;
 			sourceTree = "<group>";
 		};
 		41E9A1BB2C7CC83500EDE131 /* Helpers */ = {
@@ -301,6 +318,7 @@
 			files = (
 				416E9E9B2C76BD4400A0B917 /* AppStartViewController.swift in Sources */,
 				413D18442C7FAE280051AA42 /* OptionListRow.swift in Sources */,
+				41810D782C8A006F00F10EB7 /* AppSettings+AppearanceInfo.swift in Sources */,
 				416E9E972C76BD4400A0B917 /* AppDelegate.swift in Sources */,
 				41E9A1C12C7CE30000EDE131 /* AppSettingsView.swift in Sources */,
 				416E9ED62C78BD9900A0B917 /* API.swift in Sources */,
@@ -311,6 +329,8 @@
 				413D18422C7FA30A0051AA42 /* TextInput.swift in Sources */,
 				41E9A1BD2C7CC85100EDE131 /* SwiftUIContainerViewController.swift in Sources */,
 				416E9EDE2C78C0BA00A0B917 /* AppInfo.swift in Sources */,
+				41810D762C8A005D00F10EB7 /* AppearanceInfo.swift in Sources */,
+				41810D712C89F4CD00F10EB7 /* AppearanceSettings.swift in Sources */,
 				41E9A1BF2C7CD3C700EDE131 /* UIViewController+NavigationEmbed.swift in Sources */,
 				416E9EE02C78C10800A0B917 /* MainViewController.swift in Sources */,
 			);

--- a/Example/StripeConnectExample/StripeConnectExample/Appearance/AppSettings+AppearanceInfo.swift
+++ b/Example/StripeConnectExample/StripeConnectExample/Appearance/AppSettings+AppearanceInfo.swift
@@ -1,0 +1,112 @@
+//
+//  AppSettings+AppearanceInfo.swift
+//  StripeConnect Example
+//
+//  Created by Chris Mays on 9/5/24.
+//
+
+import Foundation
+@_spi(PrivateBetaConnect) import StripeConnect
+import UIKit
+
+extension AppSettings {
+    var appearanceOptions: [AppearanceInfo] {
+        [
+            .default,
+            .hotDog,
+            .link,
+            .oceanBreeze,
+            .shrek
+        ]
+    }
+    
+    var appearanceInfo: AppearanceInfo {
+        get {
+            appearanceOptions.first(where: {
+                $0.id == AppSettings.shared.appearanceId
+            }) ?? .default
+        }
+        set {
+            appearanceId = newValue.id
+        }
+    }
+}
+
+
+extension AppearanceInfo {
+    static var `default`: AppearanceInfo {
+        .init(displayName: "Default", appearance: .default)
+    }
+    
+    static var shrek: AppearanceInfo {
+        var appearance = EmbeddedComponentManager.Appearance()
+        appearance.colors.primary = UIColor(red: 90/255, green: 233/255, blue: 43/255, alpha: 1)
+        appearance.colors.background = UIColor(red: 131/255, green: 116/255, blue: 17/255, alpha: 1)
+        appearance.buttonPrimary.colorBackground = UIColor(red: 218/255, green: 185/255, blue: 185/255, alpha: 1)
+        appearance.buttonPrimary.colorBorder = UIColor(red: 240/255, green: 0/255, blue: 0/255, alpha: 1)
+        appearance.buttonPrimary.colorText = UIColor(red: 0/255, green: 0/255, blue: 0/255, alpha: 1)
+        appearance.buttonSecondary.colorBackground = UIColor(red: 2/255, green: 95/255, blue: 8/255, alpha: 1)
+        appearance.colors.text = UIColor(red: 85/255, green: 65/255, blue: 37/255, alpha: 1)
+        appearance.badgeNeutral.colorText = UIColor(red: 40/255, green: 215/255, blue: 42/255, alpha: 1)
+        appearance.badgeNeutral.colorBackground = UIColor(red: 99/255, green: 136/255, blue: 99/255, alpha: 1)
+        appearance.buttonSecondary.colorText = UIColor(red: 0/255, green: 0/255, blue: 0/255, alpha: 1)
+        return .init(displayName: "Shrek", appearance: appearance)
+    }
+    
+    static var hotDog: AppearanceInfo {
+        var appearance = EmbeddedComponentManager.Appearance()
+
+        appearance.colors.primary = UIColor(red: 255/255, green: 34/255, blue: 0/255, alpha: 1)
+        appearance.colors.background = UIColor(red: 255/255, green: 255/255, blue: 0/255, alpha: 1)
+        appearance.buttonSecondary.colorBackground = UIColor(red: 198/255, green: 198/255, blue: 198/255, alpha: 1)
+        appearance.buttonSecondary.colorBorder = UIColor(red: 31/255, green: 31/255, blue: 31/255, alpha: 1)
+        appearance.buttonPrimary.colorBorder = UIColor(red: 31/255, green: 31/255, blue: 31/255, alpha: 1)
+        appearance.buttonPrimary.colorText = UIColor(red: 31/255, green: 31/255, blue: 31/255, alpha: 1)
+        appearance.buttonPrimary.colorBackground = UIColor(red: 198/255, green: 198/255, blue: 198/255, alpha: 1)
+        appearance.colors.offsetBackground = UIColor(red: 255/255, green: 34/255, blue: 0/255, alpha: 1)
+        appearance.colors.text = UIColor(red: 0/255, green: 0/255, blue: 0/255, alpha: 1)
+        appearance.colors.secondaryText = UIColor(red: 0/255, green: 0/255, blue: 0/255, alpha: 1)
+        appearance.badgeDanger.colorText = UIColor(red: 153/255, green: 20/255, blue: 0/255, alpha: 1)
+        appearance.badgeWarning.colorBackground = UIColor(red: 249/255, green: 164/255, blue: 67/255, alpha: 1)
+
+        appearance.cornerRadius.base = 0
+        
+        return .init(displayName: "Hot Dog Stand", appearance: appearance)
+    }
+    
+    static var oceanBreeze: AppearanceInfo {
+        var appearance = EmbeddedComponentManager.Appearance()
+        appearance.colors.background = UIColor(red: 234/255, green: 246/255, blue: 251/255, alpha: 1)  // #EAF6FB
+        appearance.colors.primary = UIColor(red: 21/255, green: 96/255, blue: 158/255, alpha: 1)  // #15609E
+        appearance.badgeSuccess.colorText = UIColor(red: 42/255, green: 96/255, blue: 147/255, alpha: 1)  // #2A6093
+        appearance.badgeNeutral.colorText = UIColor(red: 90/255, green: 98/255, blue: 29/255, alpha: 1)  // #5A621D
+        appearance.buttonSecondary.colorText = UIColor(red: 44/255, green: 147/255, blue: 232/255, alpha: 1)  // #2C93E8
+        appearance.buttonSecondary.colorBorder = UIColor(red: 44/255, green: 147/255, blue: 232/255, alpha: 1)  // #2C93E8
+        appearance.cornerRadius.base = 23
+
+        return .init(displayName: "Ocean Breeze", appearance: appearance)
+    }
+    
+    static var link: AppearanceInfo {
+        var appearance = EmbeddedComponentManager.Appearance()
+
+        appearance.colors.primary = UIColor(red: 28/255, green: 57/255, blue: 68/255, alpha: 1)
+        appearance.buttonPrimary.colorBackground = UIColor(red: 51/255, green: 220/255, blue: 179/255, alpha: 1)
+        appearance.buttonPrimary.colorBorder = UIColor(red: 51/255, green: 220/255, blue: 179/255, alpha: 1)
+        appearance.buttonPrimary.colorText = UIColor(red: 28/255, green: 57/255, blue: 68/255, alpha: 1)
+        appearance.colors.secondaryText = UIColor(red: 72/255, green: 91/255, blue: 97/255, alpha: 1)
+        appearance.colors.text = UIColor(red: 28/255, green: 57/255, blue: 68/255, alpha: 1)
+        appearance.colors.actionPrimaryText = UIColor(red: 51/255, green: 220/255, blue: 179/255, alpha: 1)
+        appearance.badgeSuccess.colorBackground = UIColor(red: 180/255, green: 254/255, blue: 225/255, alpha: 1)
+        appearance.badgeSuccess.colorBorder = UIColor(red: 192/255, green: 215/255, blue: 205/255, alpha: 1)
+        appearance.badgeSuccess.colorText = UIColor(red: 28/255, green: 57/255, blue: 68/255, alpha: 1)
+        appearance.badgeNeutral.colorBackground = UIColor(red: 222/255, green: 254/255, blue: 204/255, alpha: 1)
+        appearance.badgeNeutral.colorText = UIColor(red: 28/255, green: 57/255, blue: 68/255, alpha: 1)
+
+        appearance.cornerRadius.base = 5
+
+        appearance.spacingUnit = 9
+        
+        return .init(displayName: "Link", appearance: appearance)
+    }
+}

--- a/Example/StripeConnectExample/StripeConnectExample/Appearance/AppearanceInfo.swift
+++ b/Example/StripeConnectExample/StripeConnectExample/Appearance/AppearanceInfo.swift
@@ -1,0 +1,17 @@
+//
+//  AppearanceInfo.swift
+//  StripeConnect Example
+//
+//  Created by Chris Mays on 9/5/24.
+//
+
+import Foundation
+@_spi(PrivateBetaConnect) import StripeConnect
+
+struct AppearanceInfo: Identifiable {
+    var id: String {
+        return displayName
+    }
+    let displayName: String    
+    var appearance: EmbeddedComponentManager.Appearance
+}

--- a/Example/StripeConnectExample/StripeConnectExample/Appearance/AppearanceSettings.swift
+++ b/Example/StripeConnectExample/StripeConnectExample/Appearance/AppearanceSettings.swift
@@ -1,0 +1,70 @@
+//
+//  AppearanceSettings.swift
+//  StripeConnect Example
+//
+//  Created by Chris Mays on 9/5/24.
+//
+
+@_spi(PrivateBetaConnect) import StripeConnect
+import SwiftUI
+
+struct AppearanceSettings: View {
+    @Environment(\.dismiss) var dismiss
+    @Environment(\.viewControllerPresenter) var viewControllerPresenter
+    
+    let componentManager: EmbeddedComponentManager
+    
+    var saveEnabled: Bool {
+        AppSettings.shared.appearanceInfo.id != selectedAppearance.id
+    }
+    
+    @State var selectedAppearance: AppearanceInfo
+    
+    
+    init(componentManager: EmbeddedComponentManager) {
+        self.componentManager = componentManager
+        _selectedAppearance = .init(initialValue: AppSettings.shared.appearanceInfo)
+    }
+    
+    var body: some View {
+        NavigationView {
+            List {
+                Section {
+                    ForEach(AppSettings.shared.appearanceOptions) { appearanceInfo in
+                        OptionListRow(title: appearanceInfo.displayName,
+                                      selected: selectedAppearance.id == appearanceInfo.id,
+                                      onSelected: {
+                            selectedAppearance = appearanceInfo
+                        })
+                    }
+                } header: {
+                    Text("Select a preset")
+                }
+            }
+            .listStyle(.insetGrouped)
+            .navigationTitle("Configure Appearance")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button {
+                        dismiss()
+                    } label: {
+                        Text("Cancel")
+                    }
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button {
+                        AppSettings.shared.appearanceInfo = selectedAppearance
+                        componentManager.update(appearance: selectedAppearance.appearance)
+                        dismiss()
+                    } label: {
+                        Text("Save")
+                    }
+                    .disabled(!saveEnabled)
+                }
+            }
+        }
+        .environment(\.horizontalSizeClass, .compact)
+    }
+    
+}

--- a/Example/StripeConnectExample/StripeConnectExample/MainViewController.swift
+++ b/Example/StripeConnectExample/StripeConnectExample/MainViewController.swift
@@ -61,7 +61,7 @@ class MainViewController: UITableViewController {
     }
 
     lazy var embeddedComponentManager: EmbeddedComponentManager = {
-        .init(fetchClientSecret: { [weak self, merchant] in
+        return .init(appearance: AppSettings.shared.appearanceInfo.appearance, fetchClientSecret: { [weak self, merchant] in
             do {
                 return try await API.accountSession(merchantId: merchant.id).get().clientSecret
             } catch {
@@ -75,6 +75,26 @@ class MainViewController: UITableViewController {
         super.viewDidLoad()
         title = merchant.displayName ?? merchant.merchantId
         navigationItem.titleView = navbarTitleButton
+        addChangeAppearanceButtonNavigationItem(to: self)
+    }
+    
+    func addChangeAppearanceButtonNavigationItem(to viewController: UIViewController) {
+         // Add a button to change the appearance
+         let button = UIBarButtonItem(
+             image: UIImage(systemName: "paintpalette"),
+             style: .plain,
+             target: self,
+             action: #selector(selectAppearance)
+         )
+         button.accessibilityLabel = "Change appearance"
+         var buttonItems = viewController.navigationItem.rightBarButtonItems ?? []
+         buttonItems = [button] + buttonItems
+         viewController.navigationItem.rightBarButtonItems = buttonItems
+     }
+    
+    @objc
+    func selectAppearance() {
+        self.navigationController?.present(AppearanceSettings(componentManager: embeddedComponentManager).containerViewController, animated: true)
     }
 
     /// Called when table row is selected
@@ -87,6 +107,7 @@ class MainViewController: UITableViewController {
         }
         
         viewControllerToPush.navigationItem.backButtonDisplayMode = .minimal
+        addChangeAppearanceButtonNavigationItem(to: viewControllerToPush)
         navigationController?.pushViewController(viewControllerToPush, animated: true)
     }
 

--- a/Example/StripeConnectExample/StripeConnectExample/Storage/AppSettings.swift
+++ b/Example/StripeConnectExample/StripeConnectExample/Storage/AppSettings.swift
@@ -11,7 +11,8 @@ class AppSettings {
     enum  Constants {
         static let defaultServerBaseURL = "https://stripe-connect-mobile-example-v1.glitch.me/"
         static let serverBaseURLKey = "ServerBaseURL"
-        
+        static let appearanceIdKey = "AppearanceId"
+
         static let selectedMerchantKey = "SelectedMerchant"
     }
     
@@ -24,6 +25,16 @@ class AppSettings {
         }
         set {
             UserDefaults.standard.setValue(newValue, forKey: Constants.serverBaseURLKey)
+        }
+    }
+    
+    var appearanceId: String? {
+        get {
+            UserDefaults.standard.string(forKey: Constants.appearanceIdKey) ??
+            nil
+        }
+        set {
+            UserDefaults.standard.setValue(newValue, forKey: Constants.appearanceIdKey)
         }
     }
     

--- a/Stripe.xcworkspace/contents.xcworkspacedata
+++ b/Stripe.xcworkspace/contents.xcworkspacedata
@@ -26,6 +26,9 @@
          location = "group:PaymentSheet Example/PaymentSheet Example.xcodeproj">
       </FileRef>
       <FileRef
+         location = "group:StripeConnectExample/StripeConnect Example.xcodeproj">
+      </FileRef>
+      <FileRef
          location = "group:UI Examples/UI Examples.xcodeproj">
       </FileRef>
    </Group>

--- a/StripeConnect/StripeConnect.xcodeproj/project.pbxproj
+++ b/StripeConnect/StripeConnect.xcodeproj/project.pbxproj
@@ -33,16 +33,22 @@
 		413987DD2C640A29001D375E /* FetchInitParamsMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 413987DC2C640A29001D375E /* FetchInitParamsMessageHandler.swift */; };
 		413987DF2C640C50001D375E /* OnExitMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 413987DE2C640C50001D375E /* OnExitMessageHandler.swift */; };
 		413987E12C641688001D375E /* PageDidLoadMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 413987E02C641688001D375E /* PageDidLoadMessageHandler.swift */; };
+		413D18462C7FB75B0051AA42 /* EmbeddedComponentManager+Appearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 413D18452C7FB75B0051AA42 /* EmbeddedComponentManager+Appearance.swift */; };
+		413D18482C7FBAA70051AA42 /* CSSHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 413D18472C7FBAA70051AA42 /* CSSHelpers.swift */; };
+		41542A692C88B6F2004E728E /* JSONEncoder+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41542A682C88B6F2004E728E /* JSONEncoder+extension.swift */; };
+		41542A6B2C88B79E004E728E /* JSONSerialization+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41542A6A2C88B79E004E728E /* JSONSerialization+extension.swift */; };
 		416E9E742C751A1A00A0B917 /* ConnectComponentWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416E9E732C751A1A00A0B917 /* ConnectComponentWebView.swift */; };
 		416E9E762C751B0500A0B917 /* EmbeddedComponentManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416E9E752C751B0500A0B917 /* EmbeddedComponentManager.swift */; };
 		416E9E782C753B7900A0B917 /* ConnectComponentWebViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416E9E772C753B7900A0B917 /* ConnectComponentWebViewTests.swift */; };
 		416E9E822C76994C00A0B917 /* WebView+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416E9E812C76994C00A0B917 /* WebView+Tests.swift */; };
 		416E9E842C76AE0A00A0B917 /* ComponentType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416E9E832C76AE0900A0B917 /* ComponentType.swift */; };
+		416E9E862C76B35E00A0B917 /* PayoutsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416E9E852C76B35E00A0B917 /* PayoutsViewController.swift */; };
+		416E9E892C76B36F00A0B917 /* PayoutsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416E9E872C76B36F00A0B917 /* PayoutsViewControllerTests.swift */; };
 		416E9ECF2C77EAA400A0B917 /* EmbeddedComponentError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416E9ECE2C77EAA400A0B917 /* EmbeddedComponentError.swift */; };
 		416E9ED22C77F6E000A0B917 /* Locale+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416E9ED12C77F6E000A0B917 /* Locale+extension.swift */; };
 		416E9ED42C77F90600A0B917 /* WKScriptMessage+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416E9ED32C77F90600A0B917 /* WKScriptMessage+extension.swift */; };
-		416E9E862C76B35E00A0B917 /* PayoutsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416E9E852C76B35E00A0B917 /* PayoutsViewController.swift */; };
-		416E9E892C76B36F00A0B917 /* PayoutsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416E9E872C76B36F00A0B917 /* PayoutsViewControllerTests.swift */; };
+		41810D692C88C4B100F10EB7 /* AppearanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41810D682C88C4B100F10EB7 /* AppearanceTests.swift */; };
+		41810D6B2C88E71D00F10EB7 /* Appearance+Encoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41810D6A2C88E71D00F10EB7 /* Appearance+Encoding.swift */; };
 		41814EE82C6BC8800014EB5E /* ScriptWebTestBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41814EE72C6BC8800014EB5E /* ScriptWebTestBase.swift */; };
 		41814EEB2C6BCAB30014EB5E /* DebugMessageHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41814EEA2C6BCAB30014EB5E /* DebugMessageHandlerTests.swift */; };
 		41814EED2C6BED8C0014EB5E /* FetchClientSecretMessageHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41814EEC2C6BED8C0014EB5E /* FetchClientSecretMessageHandlerTests.swift */; };
@@ -104,6 +110,10 @@
 		41A2A5FC2C5ACBDD0077FC74 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 41A2A5CA2C5ACBDD0077FC74 /* Localizable.strings */; };
 		41A2A5FE2C5ACCAA0077FC74 /* StripeConnectBundleLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41A2A5FD2C5ACCAA0077FC74 /* StripeConnectBundleLocator.swift */; };
 		41A2A6012C5ACD9F0077FC74 /* STPLocalizedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41A2A6002C5ACD9F0077FC74 /* STPLocalizedString.swift */; };
+		41BCCFEB2C8B348500797E01 /* AppearanceWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41BCCFEA2C8B348500797E01 /* AppearanceWrapper.swift */; };
+		41BCCFED2C8B34F600797E01 /* StringCodingKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41BCCFEC2C8B34F600797E01 /* StringCodingKey.swift */; };
+		41BCCFF02C8B3C8900797E01 /* AppearanceWrapper+Default.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41BCCFEF2C8B3C8900797E01 /* AppearanceWrapper+Default.swift */; };
+		41BCCFF32C8B449800797E01 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41BCCFF22C8B449800797E01 /* TestHelpers.swift */; };
 		41D17A4B2C5A73A7007C6EE6 /* StripeConnect.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 41D17A402C5A73A6007C6EE6 /* StripeConnect.framework */; };
 		41D17A512C5A73A7007C6EE6 /* StripeConnect.h in Headers */ = {isa = PBXBuildFile; fileRef = 41D17A432C5A73A6007C6EE6 /* StripeConnect.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		41D17A652C5A7429007C6EE6 /* Project-Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 41D17A5A2C5A7429007C6EE6 /* Project-Debug.xcconfig */; };
@@ -155,16 +165,22 @@
 		413987DC2C640A29001D375E /* FetchInitParamsMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchInitParamsMessageHandler.swift; sourceTree = "<group>"; };
 		413987DE2C640C50001D375E /* OnExitMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnExitMessageHandler.swift; sourceTree = "<group>"; };
 		413987E02C641688001D375E /* PageDidLoadMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageDidLoadMessageHandler.swift; sourceTree = "<group>"; };
+		413D18452C7FB75B0051AA42 /* EmbeddedComponentManager+Appearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EmbeddedComponentManager+Appearance.swift"; sourceTree = "<group>"; };
+		413D18472C7FBAA70051AA42 /* CSSHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CSSHelpers.swift; sourceTree = "<group>"; };
+		41542A682C88B6F2004E728E /* JSONEncoder+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSONEncoder+extension.swift"; sourceTree = "<group>"; };
+		41542A6A2C88B79E004E728E /* JSONSerialization+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSONSerialization+extension.swift"; sourceTree = "<group>"; };
 		416E9E732C751A1A00A0B917 /* ConnectComponentWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectComponentWebView.swift; sourceTree = "<group>"; };
 		416E9E752C751B0500A0B917 /* EmbeddedComponentManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbeddedComponentManager.swift; sourceTree = "<group>"; };
 		416E9E772C753B7900A0B917 /* ConnectComponentWebViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectComponentWebViewTests.swift; sourceTree = "<group>"; };
 		416E9E812C76994C00A0B917 /* WebView+Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebView+Tests.swift"; sourceTree = "<group>"; };
 		416E9E832C76AE0900A0B917 /* ComponentType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentType.swift; sourceTree = "<group>"; };
+		416E9E852C76B35E00A0B917 /* PayoutsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PayoutsViewController.swift; sourceTree = "<group>"; };
+		416E9E872C76B36F00A0B917 /* PayoutsViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PayoutsViewControllerTests.swift; sourceTree = "<group>"; };
 		416E9ECE2C77EAA400A0B917 /* EmbeddedComponentError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbeddedComponentError.swift; sourceTree = "<group>"; };
 		416E9ED12C77F6E000A0B917 /* Locale+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Locale+extension.swift"; sourceTree = "<group>"; };
 		416E9ED32C77F90600A0B917 /* WKScriptMessage+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WKScriptMessage+extension.swift"; sourceTree = "<group>"; };
-		416E9E852C76B35E00A0B917 /* PayoutsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PayoutsViewController.swift; sourceTree = "<group>"; };
-		416E9E872C76B36F00A0B917 /* PayoutsViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PayoutsViewControllerTests.swift; sourceTree = "<group>"; };
+		41810D682C88C4B100F10EB7 /* AppearanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceTests.swift; sourceTree = "<group>"; };
+		41810D6A2C88E71D00F10EB7 /* Appearance+Encoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Appearance+Encoding.swift"; sourceTree = "<group>"; };
 		41814EE72C6BC8800014EB5E /* ScriptWebTestBase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptWebTestBase.swift; sourceTree = "<group>"; };
 		41814EEA2C6BCAB30014EB5E /* DebugMessageHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugMessageHandlerTests.swift; sourceTree = "<group>"; };
 		41814EEC2C6BED8C0014EB5E /* FetchClientSecretMessageHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchClientSecretMessageHandlerTests.swift; sourceTree = "<group>"; };
@@ -226,6 +242,10 @@
 		41A2A5C92C5ACBDD0077FC74 /* en-IN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-IN"; path = "en-IN.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		41A2A5FD2C5ACCAA0077FC74 /* StripeConnectBundleLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StripeConnectBundleLocator.swift; sourceTree = "<group>"; };
 		41A2A6002C5ACD9F0077FC74 /* STPLocalizedString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPLocalizedString.swift; sourceTree = "<group>"; };
+		41BCCFEA2C8B348500797E01 /* AppearanceWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceWrapper.swift; sourceTree = "<group>"; };
+		41BCCFEC2C8B34F600797E01 /* StringCodingKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringCodingKey.swift; sourceTree = "<group>"; };
+		41BCCFEF2C8B3C8900797E01 /* AppearanceWrapper+Default.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppearanceWrapper+Default.swift"; sourceTree = "<group>"; };
+		41BCCFF22C8B449800797E01 /* TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
 		41D17A402C5A73A6007C6EE6 /* StripeConnect.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripeConnect.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		41D17A432C5A73A6007C6EE6 /* StripeConnect.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StripeConnect.h; sourceTree = "<group>"; };
 		41D17A4A2C5A73A7007C6EE6 /* StripeConnectTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StripeConnectTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -308,6 +328,7 @@
 				413987C02C63F34B001D375E /* MessageSenders */,
 				410D0FE02C6D31A3009B0E26 /* PopupWebViewController.swift */,
 				416E9E732C751A1A00A0B917 /* ConnectComponentWebView.swift */,
+				41BCCFEA2C8B348500797E01 /* AppearanceWrapper.swift */,
 			);
 			path = Webview;
 			sourceTree = "<group>";
@@ -342,21 +363,23 @@
 			path = Components;
 			sourceTree = "<group>";
 		};
-		416E9ED02C77F6C100A0B917 /* Extensions */ = {
-			isa = PBXGroup;
-			children = (
-				416E9ED12C77F6E000A0B917 /* Locale+extension.swift */,
-				416E9ED32C77F90600A0B917 /* WKScriptMessage+extension.swift */,
-			);
-			path = Extensions;
-      sourceTree = "<group>";
-		};
 		416E9E882C76B36F00A0B917 /* Components */ = {
 			isa = PBXGroup;
 			children = (
 				416E9E872C76B36F00A0B917 /* PayoutsViewControllerTests.swift */,
 			);
 			path = Components;
+			sourceTree = "<group>";
+		};
+		416E9ED02C77F6C100A0B917 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				416E9ED12C77F6E000A0B917 /* Locale+extension.swift */,
+				416E9ED32C77F90600A0B917 /* WKScriptMessage+extension.swift */,
+				41542A682C88B6F2004E728E /* JSONEncoder+extension.swift */,
+				41542A6A2C88B79E004E728E /* JSONSerialization+extension.swift */,
+			);
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 		41814EE52C6BC8610014EB5E /* Webview */ = {
@@ -402,6 +425,7 @@
 				413987C62C63F34B001D375E /* Internal */,
 				41A2A5FF2C5ACD3E0077FC74 /* Helpers */,
 				416E9E752C751B0500A0B917 /* EmbeddedComponentManager.swift */,
+				413D18452C7FB75B0051AA42 /* EmbeddedComponentManager+Appearance.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -484,6 +508,18 @@
 				41A2A5FD2C5ACCAA0077FC74 /* StripeConnectBundleLocator.swift */,
 				41A2A6002C5ACD9F0077FC74 /* STPLocalizedString.swift */,
 				416E9ECE2C77EAA400A0B917 /* EmbeddedComponentError.swift */,
+				413D18472C7FBAA70051AA42 /* CSSHelpers.swift */,
+				41810D6A2C88E71D00F10EB7 /* Appearance+Encoding.swift */,
+				41BCCFEC2C8B34F600797E01 /* StringCodingKey.swift */,
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
+		41BCCFEE2C8B3C7900797E01 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				41BCCFEF2C8B3C8900797E01 /* AppearanceWrapper+Default.swift */,
+				41BCCFF22C8B449800797E01 /* TestHelpers.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -522,9 +558,11 @@
 		41D17A4E2C5A73A7007C6EE6 /* StripeConnectTests */ = {
 			isa = PBXGroup;
 			children = (
+				41BCCFEE2C8B3C7900797E01 /* Helpers */,
 				416E9E882C76B36F00A0B917 /* Components */,
 				41814EE62C6BC8690014EB5E /* Internal */,
 				416E9E812C76994C00A0B917 /* WebView+Tests.swift */,
+				41810D682C88C4B100F10EB7 /* AppearanceTests.swift */,
 			);
 			path = StripeConnectTests;
 			sourceTree = "<group>";
@@ -769,9 +807,12 @@
 				413987D62C64088E001D375E /* ReturnedFromAuthenticatedWebViewSender.swift in Sources */,
 				413987DF2C640C50001D375E /* OnExitMessageHandler.swift in Sources */,
 				413987C92C63F34B001D375E /* FetchClientSecretMessageHandler.swift in Sources */,
+				41BCCFEB2C8B348500797E01 /* AppearanceWrapper.swift in Sources */,
 				413987E12C641688001D375E /* PageDidLoadMessageHandler.swift in Sources */,
+				41542A692C88B6F2004E728E /* JSONEncoder+extension.swift in Sources */,
 				416E9E842C76AE0A00A0B917 /* ComponentType.swift in Sources */,
 				410D0FCE2C6D000B009B0E26 /* OpenAuthenticatedWebViewMessageHandler.swift in Sources */,
+				413D18482C7FBAA70051AA42 /* CSSHelpers.swift in Sources */,
 				413987CD2C63F34B001D375E /* MessageSender.swift in Sources */,
 				41A2A6012C5ACD9F0077FC74 /* STPLocalizedString.swift in Sources */,
 				413987CE2C63F34B001D375E /* UpdateConnectInstanceSender.swift in Sources */,
@@ -782,13 +823,17 @@
 				413987DD2C640A29001D375E /* FetchInitParamsMessageHandler.swift in Sources */,
 				413987D42C640848001D375E /* CallSetterWithSerializableValueSender.swift in Sources */,
 				416E9E742C751A1A00A0B917 /* ConnectComponentWebView.swift in Sources */,
+				413D18462C7FB75B0051AA42 /* EmbeddedComponentManager+Appearance.swift in Sources */,
+				41810D6B2C88E71D00F10EB7 /* Appearance+Encoding.swift in Sources */,
 				410D0FE12C6D31A3009B0E26 /* PopupWebViewController.swift in Sources */,
 				413987CB2C63F34B001D375E /* ScriptMessageHandlerWithReply.swift in Sources */,
 				413987CA2C63F34B001D375E /* ScriptMessageHandler.swift in Sources */,
 				416E9E862C76B35E00A0B917 /* PayoutsViewController.swift in Sources */,
+				41542A6B2C88B79E004E728E /* JSONSerialization+extension.swift in Sources */,
 				413987C82C63F34B001D375E /* DebugMessageHandler.swift in Sources */,
 				410D0FCC2C6CFFDB009B0E26 /* AccountSessionClaimedMessageHandler.swift in Sources */,
 				416E9ED22C77F6E000A0B917 /* Locale+extension.swift in Sources */,
+				41BCCFED2C8B34F600797E01 /* StringCodingKey.swift in Sources */,
 				4186664E2C66ACB3003DB62E /* OnLoadErrorMessageHandler.swift in Sources */,
 				410D0FE52C6D32F0009B0E26 /* ApplicationURLOpener.swift in Sources */,
 				416E9E762C751B0500A0B917 /* EmbeddedComponentManager.swift in Sources */,
@@ -807,16 +852,19 @@
 				416E9E892C76B36F00A0B917 /* PayoutsViewControllerTests.swift in Sources */,
 				41814EEB2C6BCAB30014EB5E /* DebugMessageHandlerTests.swift in Sources */,
 				41814EEF2C6BEF2C0014EB5E /* FetchInitParamsMessageHandlerTests.swift in Sources */,
+				41810D692C88C4B100F10EB7 /* AppearanceTests.swift in Sources */,
 				410D0FD22C6D047A009B0E26 /* AccountSessionClaimedMessageHandlerTests.swift in Sources */,
 				41814EF12C6BF94B0014EB5E /* OnExitMessageHandlerTests.swift in Sources */,
 				416E9E782C753B7900A0B917 /* ConnectComponentWebViewTests.swift in Sources */,
 				410D0FD42C6D051B009B0E26 /* OpenAuthenticatedWebViewMessageHandlerTests.swift in Sources */,
 				410D0FCA2C6CFE27009B0E26 /* OnLoadErrorMessageHandlerTests.swift in Sources */,
+				41BCCFF32C8B449800797E01 /* TestHelpers.swift in Sources */,
 				410D0FDB2C6D21B0009B0E26 /* CallSetterWithSerializableValueSenderTests.swift in Sources */,
 				410D0FE72C6D3BBC009B0E26 /* ConnectWebViewTests.swift in Sources */,
 				410D0FD02C6D0319009B0E26 /* PageDidLoadMessageHandlerTests.swift in Sources */,
 				41814EED2C6BED8C0014EB5E /* FetchClientSecretMessageHandlerTests.swift in Sources */,
 				41814EE82C6BC8800014EB5E /* ScriptWebTestBase.swift in Sources */,
+				41BCCFF02C8B3C8900797E01 /* AppearanceWrapper+Default.swift in Sources */,
 				416E9E822C76994C00A0B917 /* WebView+Tests.swift in Sources */,
 				41814EF32C6BFA4B0014EB5E /* OnLoaderStartMessageHandlerTests.swift in Sources */,
 			);

--- a/StripeConnect/StripeConnect/Source/EmbeddedComponentManager+Appearance.swift
+++ b/StripeConnect/StripeConnect/Source/EmbeddedComponentManager+Appearance.swift
@@ -1,0 +1,237 @@
+//
+//  EmbeddedComponentManager+Appearance.swift
+//  StripeConnect
+//
+//  Created by Chris Mays on 8/28/24.
+//
+
+@_spi(STP) import StripeCore
+import UIKit
+
+@_spi(PrivateBetaConnect)
+extension EmbeddedComponentManager {
+    /// Describes the appearance of embedded components.
+    /// - seealso: https://docs.stripe.com/connect/embedded-appearance-options
+    public struct Appearance {
+        public enum TextTransform {
+            /// The text doesn’t have a transform.
+            case none
+            /// Displays the text in all uppercase characters.
+            case uppercase
+            /// Displays the text in all lowercase characters.
+            case lowercase
+            /// Displays the text with the first character capitalized.
+            case capitalize
+            
+            // Since the public API does not call for TextTransform to be a string
+            // we manually create a raw value here.
+            var rawValue: String {
+                switch self {
+                case .none:
+                    return "none"
+                case .uppercase:
+                    return "uppercase"
+                case .lowercase:
+                    return "lowercase"
+                case .capitalize:
+                    return "capitalize"
+                }
+            }
+            
+            init?(rawValue: String) {
+                switch rawValue {
+                case "none":
+                    self = .none
+                case "uppercase":
+                    self = .uppercase
+                case "lowercase":
+                    self = .lowercase
+                case "capitalize":
+                    self = .capitalize
+                default:
+                    return nil
+                }
+            }
+        }
+        
+        /// Describes the typography attributes used in embedded components
+        public struct Typography {
+            /// Describes the font attributes used for a
+            /// typography style in embedded components.
+            public struct Style {
+                /// The font size for this typography style.
+                public var fontSize: CGFloat?
+                /// The font weight for this typography style.
+                public var weight: UIFont.Weight?
+                /// The text transform for this typography style.
+                public var textTransform: TextTransform?
+
+                /// Creates a `EmbeddedComponentManager.Appearance.Typography.Stylye` with default values
+                public init() {}
+                
+            }
+            
+            /// Determines the font family value used throughout embedded components.
+            /// Only the family is used from the specified font. The size and weight can be
+            /// configured from `fontSizeBase` or `fontSize` and `fontWeight`
+            /// properties for individual typography styles.
+            ///
+            /// - Note: Custom fonts included in your app's binary must be specified using a
+            ///   `CustomFontSource` when initializing the `EmbeddedComponentManager` before
+            ///   referencing them in the appearance's `typography.font` property.
+            public var font: UIFont?
+            /// The baseline font size set on the embedded component root.
+            /// This scales the value of other font size variables.
+            public var fontSizeBase: CGFloat?
+            /// Describes the font size and weight for the medium body typography.
+            /// The `textTransform` property is ignored.
+            public var bodyMd: Style = .init()
+            /// Describes the font size and weight for the small body typography.
+            /// The `textTransform` property is ignored.
+            public var bodySm: Style = .init()
+            /// Describes the font size and weight for the extra large heading typography.
+            public var headingXl: Style = .init()
+            /// Describes the font size and weight for the large heading typography.
+            public var headingLg: Style = .init()
+            /// Describes the font size and weight for the medium heading typography.
+            public var headingMd: Style = .init()
+            /// Describes the font size and weight for the small heading typography.
+            public var headingSm: Style = .init()
+            /// Describes the font size and weight for the extra small heading typography.
+            public var headingXs: Style = .init()
+            /// Describes the font size and weight for the medium label typography.
+            public var labelMd: Style = .init()
+            /// Describes the font size and weight for the small label typography.
+            public var labelSm: Style = .init()
+            
+            /// Creates a `EmbeddedComponentManager.Appearance.Typography` with default values
+            public init() { }
+        }
+        
+        /// Describes the colors used in embedded components.
+        /// - Note: If UIColors using dynamicProviders are specified, the appearance will automatically
+        ///   update when the component's UITraitCollection is updated (e.g. dark mode)
+        /// - Seealso: https://developer.apple.com/documentation/uikit/appearance_customization/supporting_dark_mode_in_your_interface
+        public struct Colors {
+            /// The primary color used throughout embedded components.
+            /// Set this to your primary brand color.
+            /// The alpha component is ignored.
+            public var primary: UIColor?
+            /// The color used for regular text.
+            public var text: UIColor?
+            /// The color used to indicate errors or destructive actions.
+            /// The alpha component is ignored.
+            public var danger: UIColor?
+            /// The background color for embedded components, including overlays,
+            /// tooltips, and popovers. The alpha component is ignored.
+            public var background: UIColor?
+            /// The color used for secondary text.
+            public var secondaryText: UIColor?
+            /// The color used for borders throughout the component.
+            public var border: UIColor?
+            /// The color used for primary actions and links.
+            /// The alpha component is ignored.
+            public var actionPrimaryText: UIColor?
+            /// The color used for secondary actions and links.
+            /// The alpha component is ignored.
+            public var actionSecondaryText: UIColor?
+            /// The background color used when highlighting information,
+            /// like the selected row on a table or particular piece of UI.
+            /// The alpha component is ignored.
+            public var offsetBackground: UIColor?
+            /// The background color used for form items.
+            /// The alpha component is ignored.
+            public var formBackground: UIColor?
+            /// The color used to highlight form items when focused.
+            public var formHighlightBorder: UIColor?
+            /// The color used for to fill in form items like checkboxes,
+            /// radio buttons and switches. The alpha component is ignored.
+            public var formAccent: UIColor?
+            
+            /// Creates a `EmbeddedComponentManager.Appearance.Colors` with default values
+            public init() {}
+        }
+        
+        /// Describes the appearance of a button type used in embedded components
+        public struct Button {
+            /// The color used as a background for this button type.
+            /// The alpha component is ignored.
+            public var colorBackground: UIColor?
+            /// The border color used for this button type.
+            /// The alpha component is ignored.
+            public var colorBorder: UIColor?
+            /// The text color used for this button type.
+            /// The alpha component is ignored.
+            public var colorText: UIColor?
+            
+            /// Creates a `EmbeddedComponentManager.Appearance.Button` with default values
+            public init() { }
+        }
+        
+        /// Describes the appearance of a badge type usied in embedded components.
+        public struct Badge {
+            /// The background color for this badge type.
+            /// The alpha component is ignored.
+            public var colorBackground: UIColor?
+            /// The border color for this badge type.
+            public var colorBorder: UIColor?
+            /// The text color for this badge type. The alpha component is ignored.
+            public var colorText: UIColor?
+            
+            /// Creates a `EmbeddedComponentManager.Appearance.Badge` with default values
+            public init() {}
+        }
+        
+        /// Describes the corner radius used in embedded components.
+        public struct CornerRadius {
+            /// The general border radius used in embedded components.
+            /// This sets the default corner radius for all components.
+            public var base: CGFloat?
+            /// The corner radius used for form elements.
+            public var form: CGFloat?
+            /// The corner radius used for buttons.
+            public var button: CGFloat?
+            /// The corner radius used for badges.
+            public var badge: CGFloat?
+            /// The corner radius used for overlays.
+            public var overlay: CGFloat?
+            
+            /// Creates a `EmbeddedComponentManager.Appearance.CornerRadius` with default values
+            public init() {}
+        }
+        
+        /// The default appearance
+        public static let `default`: Appearance = .init()
+        
+        /// Describes the appearance of typography used in embedded components.
+        public var typography: Typography = .init()
+        /// Describes the colors used in embedded components.
+        public var colors: Colors = .init()
+        /// The base spacing unit that derives all spacing values.
+        /// Increase or decrease this value to make your layout more or less spacious.
+        public var spacingUnit: CGFloat?
+        /// Describes the appearance of the primary button
+        public var buttonPrimary: Button  = .init()
+        /// Describes the appearance of the secondary button
+        public var buttonSecondary: Button  = .init()
+        /// Describes the appearance used to represent neutral
+        /// state or lack of state in status badges.
+        public var badgeNeutral: Badge  = .init()
+        /// Describes the appearance used to reinforce a successful
+        /// outcome in status badges.
+        public var badgeSuccess: Badge  = .init()
+        /// Describes the appearance used in status badges to highlight
+        /// things that might require action, but are optional to resolve.
+        public var badgeWarning: Badge  = .init()
+        /// Describes the appearance used in status badges for high-priority,
+        /// critical situations that the user must address immediately, and to
+        /// indicate failed or unsuccessful outcomes.
+        public var badgeDanger: Badge  = .init()
+        /// Describes the corner radius used in embedded components.
+        public var cornerRadius: CornerRadius = .init()
+        
+        /// Creates a `EmbeddedComponentManager.Appearance` with default values
+        public init() {}
+    }
+}
+

--- a/StripeConnect/StripeConnect/Source/EmbeddedComponentManager.swift
+++ b/StripeConnect/StripeConnect/Source/EmbeddedComponentManager.swift
@@ -12,24 +12,50 @@ import UIKit
 @_spi(PrivateBetaConnect)
 public class EmbeddedComponentManager {
     let apiClient: STPAPIClient
+    
+    // Weakly held web views who get notified when appearance updates.
+    private(set) var childWebViews: NSHashTable<ConnectComponentWebView> = .weakObjects()
+    
     let fetchClientSecret: () async -> String?
-
+    private(set) var appearance: EmbeddedComponentManager.Appearance
     /**
      Initializes a StripeConnect instance.
 
      - Parameters:
        - apiClient: The APIClient instance used to make requests to Stripe.
-       - fetchClientSecret: Closure that fetches client secret.
+       - appearance: Customizes the look of Connect embedded components.
+       - fetchClientSecret: ​​The closure that retrieves the [client secret](https://docs.stripe.com/api/account_sessions/object#account_session_object-client_secret)
+     returned by `/v1/account_sessions`. This tells the `EmbeddedComponentManager` which account to
+     delegate access to. This function is also used to retrieve a client secret function to
+     refresh the session when it expires.
      */
     public init(apiClient: STPAPIClient = STPAPIClient.shared,
+                appearance: EmbeddedComponentManager.Appearance = .default,
                 fetchClientSecret: @escaping () async -> String?) {
         self.apiClient = apiClient
         self.fetchClientSecret = fetchClientSecret
+        self.appearance = appearance
+    }
+    
+    /// Updates the appearance of components created from this EmbeddedComponentManager
+    /// - Seealso: https://docs.stripe.com/connect/get-started-connect-embedded-components#customize-the-look-of-connect-embedded-components
+    public func update(appearance: Appearance) {
+        self.appearance = appearance
+        for item in childWebViews.allObjects {
+            item.updateAppearance(appearance: appearance)
+        }
     }
     
     /// Creates a payouts component
     /// - Seealso: https://docs.stripe.com/connect/supported-embedded-components/payouts
     public func createPayoutsViewController() -> PayoutsViewController {
         .init(componentManager: self)
+    }
+
+    /// Used to keep reference of all web views associated with this component manager.
+    /// - Parameters:
+    ///   - webView: The web view associated with this component manager
+    func registerChild(_ webView: ConnectComponentWebView) {
+        childWebViews.add(webView)
     }
 }

--- a/StripeConnect/StripeConnect/Source/Helpers/Appearance+Encoding.swift
+++ b/StripeConnect/StripeConnect/Source/Helpers/Appearance+Encoding.swift
@@ -1,0 +1,135 @@
+//
+//  Appearance+Encoding.swift
+//  StripeConnect
+//
+//  Created by Chris Mays on 9/4/24.
+//
+
+@_spi(STP) import StripeCore
+import UIKit
+
+typealias Appearance = EmbeddedComponentManager.Appearance
+
+extension Appearance {
+    func asDictionary(traitCollection: UITraitCollection) -> [String: String] {
+        var dict: [String: String] = [:]
+        
+        dict.mergeAssertingOnOverwrites(colors.asDictionary(traitCollection: traitCollection))
+        dict.mergeAssertingOnOverwrites(typography.asDictionary())
+        dict.mergeAssertingOnOverwrites(buttonPrimary.asDictionary(keyPrefix: "buttonPrimary"))
+        dict.mergeAssertingOnOverwrites(buttonSecondary.asDictionary(keyPrefix: "buttonSecondary"))
+        dict.mergeAssertingOnOverwrites(badgeNeutral.asDictionary(keyPrefix: "badgeNeutral"))
+        dict.mergeAssertingOnOverwrites(badgeSuccess.asDictionary(keyPrefix: "badgeSuccess"))
+        dict.mergeAssertingOnOverwrites(badgeWarning.asDictionary(keyPrefix: "badgeWarning"))
+        dict.mergeAssertingOnOverwrites(badgeDanger.asDictionary(keyPrefix: "badgeDanger"))
+        dict.mergeAssertingOnOverwrites(cornerRadius.asDictionary())
+        
+        dict["spacingUnit"] = spacingUnit?.pxString
+        
+        return dict
+    }
+}
+
+extension Appearance.CornerRadius {
+    private var mappings: [String: KeyPath<Self, CGFloat?>] {
+        [
+            "borderRadius": \.base,
+            "buttonBorderRadius": \.button,
+            "formBorderRadius": \.form,
+            "badgeBorderRadius": \.badge,
+            "overlayBorderRadius": \.overlay,
+        ]
+    }
+    
+    func asDictionary() -> [String: String] {
+        mappings.compactMapValues { self[keyPath: $0]?.pxString }
+    }
+}
+
+extension Appearance.Badge {
+    private func mappings(keyPrefix: String) -> [String: KeyPath<Self, UIColor?>] {
+        [
+            "\(keyPrefix)ColorBackground": \.colorBackground,
+            "\(keyPrefix)ColorText": \.colorText,
+            "\(keyPrefix)ColorBorder": \.colorBorder
+        ]
+    }
+    
+    func asDictionary(keyPrefix: String) -> [String: String] {
+        mappings(keyPrefix: keyPrefix).compactMapValues { self[keyPath: $0]?.cssValue(includeAlpha: false) }
+    }
+}
+
+extension Appearance.Button {
+    
+    private func mappings(keyPrefix: String) -> [String: KeyPath<Self, UIColor?>] {
+        [
+            "\(keyPrefix)ColorBackground": \.colorBackground,
+            "\(keyPrefix)ColorText": \.colorText,
+            "\(keyPrefix)ColorBorder": \.colorBorder
+        ]
+    }
+    
+    func asDictionary(keyPrefix: String) -> [String: String] {
+        mappings(keyPrefix: keyPrefix).compactMapValues { self[keyPath: $0]?.cssValue(includeAlpha: false) }
+    }
+}
+
+extension Appearance.Colors {
+    var mappings: [String: KeyPath<Self, UIColor?>] {
+        [
+            "formAccentColor": \.formAccent,
+            "colorPrimary": \.primary,
+            "colorBackground": \.background,
+            "colorText": \.text,
+            "colorDanger": \.danger,
+            "actionPrimaryColorText": \.actionPrimaryText,
+            "actionSecondaryColorText": \.actionSecondaryText,
+            "offsetBackgroundColor": \.offsetBackground,
+            "formBackgroundColor": \.formBackground,
+            "colorSecondaryText": \.secondaryText,
+            "colorBorder": \.border,
+            "formHighlightColorBorder": \.formHighlightBorder
+        ]
+    }
+    
+    func asDictionary(traitCollection: UITraitCollection) -> [String: String] {
+        mappings.compactMapValues { self[keyPath: $0]?.resolvedColor(with: traitCollection).cssRgbValue }
+    }
+}
+
+extension Appearance.Typography {
+    func asDictionary() -> [String: String] {
+        var dict: [String: String] = [:]
+        
+        // Default font to "-apple-system" to use the system default,
+        // otherwise the webView will use Times
+        dict["fontFamily"] = font?.familyName ?? "-apple-system"
+        
+        dict["fontSizeBase"] = fontSizeBase?.pxString
+        
+        dict.mergeAssertingOnOverwrites(bodySm.asDictionary(keyPrefix: "bodySm"))
+        dict.mergeAssertingOnOverwrites(bodyMd.asDictionary(keyPrefix: "bodyMd"))
+        
+        dict.mergeAssertingOnOverwrites(headingXs.asDictionary(keyPrefix: "headingXs"))
+        dict.mergeAssertingOnOverwrites(headingSm.asDictionary(keyPrefix: "headingSm"))
+        dict.mergeAssertingOnOverwrites(headingMd.asDictionary(keyPrefix: "headingMd"))
+        dict.mergeAssertingOnOverwrites(headingLg.asDictionary(keyPrefix: "headingLg"))
+        dict.mergeAssertingOnOverwrites(headingXl.asDictionary(keyPrefix: "headingXl"))
+        
+        dict.mergeAssertingOnOverwrites(labelMd.asDictionary(keyPrefix: "labelMd"))
+        dict.mergeAssertingOnOverwrites(labelSm.asDictionary(keyPrefix: "labelSm"))
+        
+        return dict
+    }
+}
+
+extension Appearance.Typography.Style {
+    func asDictionary(keyPrefix: String) -> [String: String] {
+        var dict: [String: String] = [:]
+        dict["\(keyPrefix)FontSize"] = fontSize?.pxString
+        dict["\(keyPrefix)FontWeight"] = weight?.cssValue
+        dict["\(keyPrefix)TextTransform"] = textTransform?.rawValue
+        return dict
+    }
+}

--- a/StripeConnect/StripeConnect/Source/Helpers/CSSHelpers.swift
+++ b/StripeConnect/StripeConnect/Source/Helpers/CSSHelpers.swift
@@ -1,0 +1,73 @@
+//
+//  CSSHelpers.swift
+//  StripeConnect
+//
+//  Created by Chris Mays on 8/28/24.
+//
+
+import UIKit
+
+extension CGFloat {
+    var pxString: String {
+        "\(Int(self))px"
+    }
+}
+
+extension UIFont.Weight {
+    
+    // https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#common_weight_name_mapping
+    static var stringMappings: [UIFont.Weight: String] {
+        [
+            .thin: "100",
+            .ultraLight: "200",
+            .light: "300",
+            .regular: "400",
+            .medium: "500",
+            .semibold: "600",
+            .bold: "700",
+            .heavy: "800",
+            .black: "900"
+        ]
+    }
+    
+    var cssValue: String? {
+        UIFont.Weight.stringMappings[self]
+    }
+}
+
+// TODO: MXMOBILE-2753 Move this to StripeCore.
+extension UIColor {
+    func cssValue(includeAlpha: Bool) -> String {
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 1
+        
+        getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        
+        if includeAlpha {
+            return String(
+                format: "rgba(%.0f, %.0f, %.0f, %f)",
+                red * 255,
+                green * 255,
+                blue * 255,
+                alpha
+            )
+        } else {
+            return String(
+                format: "rgb(%.0f, %.0f, %.0f)",
+                red * 255,
+                green * 255,
+                blue * 255
+            )
+        }
+    }
+    
+    var cssRgbaValue: String {
+        cssValue(includeAlpha: true)
+    }
+    
+    var cssRgbValue: String {
+        cssValue(includeAlpha: false)
+    }
+}

--- a/StripeConnect/StripeConnect/Source/Helpers/StringCodingKey.swift
+++ b/StripeConnect/StripeConnect/Source/Helpers/StringCodingKey.swift
@@ -1,0 +1,25 @@
+//
+//  StringCodingKey.swift
+//  StripeConnect
+//
+//  Created by Chris Mays on 9/6/24.
+//
+
+import Foundation
+
+struct StringCodingKey: CodingKey {
+    var stringValue: String
+    var intValue: Int?
+    
+    init(_ string: String) {
+        stringValue = string
+    }
+    
+    init?(stringValue: String) {
+        self.stringValue = stringValue
+    }
+    
+    init?(intValue: Int) {
+        return nil
+    }
+}

--- a/StripeConnect/StripeConnect/Source/Internal/Extensions/JSONEncoder+extension.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Extensions/JSONEncoder+extension.swift
@@ -1,0 +1,17 @@
+//
+//  JSONEncoder+extension.swift
+//  StripeConnect
+//
+//  Created by Chris Mays on 9/4/24.
+//
+
+import Foundation
+
+extension JSONEncoder {
+    static var connectEncoder: JSONEncoder {
+        let encoder = JSONEncoder()
+        // Ensure keys are sorted for test stability.
+        encoder.outputFormatting = .sortedKeys
+        return encoder
+    }
+}

--- a/StripeConnect/StripeConnect/Source/Internal/Extensions/JSONSerialization+extension.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Extensions/JSONSerialization+extension.swift
@@ -1,0 +1,15 @@
+//
+//  JSONSerialization+extension.swift
+//  StripeConnect
+//
+//  Created by Chris Mays on 9/4/24.
+//
+
+import Foundation
+
+extension JSONSerialization {
+    static func connectData(withJSONObject object: Any) throws  -> Data {
+        // Ensure keys are sorted for test stability.
+        try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys, .fragmentsAllowed])
+    }
+}

--- a/StripeConnect/StripeConnect/Source/Internal/Extensions/WKScriptMessage+extension.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Extensions/WKScriptMessage+extension.swift
@@ -12,7 +12,15 @@ extension WKScriptMessage {
         if let payload = body as? DecodableType {
             return payload
         }
-        let jsonData = try JSONSerialization.data(withJSONObject: body, options: [])
+        let jsonData = try toData()
         return try JSONDecoder().decode(DecodableType.self, from: jsonData)
+    }
+    
+    func toData() throws -> Data {
+        if let bodyString = body as? String,
+            let data = bodyString.data(using: .utf8) {
+            return data
+        }
+        return try JSONSerialization.connectData(withJSONObject: body)
     }
 }

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/AppearanceWrapper.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/AppearanceWrapper.swift
@@ -1,0 +1,18 @@
+//
+//  AppearanceWrapper.swift
+//  StripeConnect
+//
+//  Created by Chris Mays on 9/6/24.
+//
+
+import UIKit
+
+struct AppearanceWrapper: Encodable {
+    let appearance: Appearance
+    let traitCollection: UITraitCollection
+    
+    public func encode(to encoder: Encoder) throws {
+           var container = encoder.container(keyedBy: StringCodingKey.self)
+           try container.encode(appearance.asDictionary(traitCollection: traitCollection), forKey: StringCodingKey("variables"))
+    }
+}

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/FetchInitParamsMessageHandler.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/FetchInitParamsMessageHandler.swift
@@ -9,11 +9,10 @@ import Foundation
 
 // This message is emitted when the SDK is requesting initialization info.
 class FetchInitParamsMessageHandler: ScriptMessageHandlerWithReply<VoidPayload, FetchInitParamsMessageHandler.Reply> {
-    struct Reply: Codable, Equatable {
+    struct Reply: Encodable {
         let locale: String
-        var appearance: VoidPayload = .init()
+        var appearance: AppearanceWrapper
         var fonts: [VoidPayload] = []
-        // TODO: Add fonts & appearance here.
     }
     init(didReceiveMessage: @escaping (VoidPayload) async throws -> Reply) {
         super.init(name: "fetchInitParams", didReceiveMessage: didReceiveMessage)

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/Helpers/ScriptMessageHandlerWithReply.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/Helpers/ScriptMessageHandlerWithReply.swift
@@ -8,7 +8,7 @@
 import WebKit
 
 /// Convenience class that conforms to WKScriptMessageHandlerWithReply and can be instantiated with a closure
-class ScriptMessageHandlerWithReply<Payload: Decodable, Response: Codable>: NSObject, WKScriptMessageHandlerWithReply {
+class ScriptMessageHandlerWithReply<Payload: Decodable, Response: Encodable>: NSObject, WKScriptMessageHandlerWithReply {
     let name: String
     let didReceiveMessage: (Payload) async throws -> Response
     
@@ -28,7 +28,7 @@ class ScriptMessageHandlerWithReply<Payload: Decodable, Response: Codable>: NSOb
         do {
             let payload: Payload = try message.toDecodable()
             let value = try await didReceiveMessage(payload)
-            let responseData = try JSONEncoder().encode(value)
+            let responseData = try JSONEncoder.connectEncoder.encode(value)
             
             guard let response = try? JSONSerialization.jsonObject(with: responseData, options: .allowFragments) else {
                 return (nil, "Failed to encode response")

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/MessageSenders/MessageSender.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/MessageSenders/MessageSender.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// Sends a message to the webview by calling a function on `window`
 protocol MessageSender {
-    associatedtype Payload: Codable & Equatable
+    associatedtype Payload: Encodable
     /// Name of the method (e.g. `updateConnectInstance`)
     var name: String { get }
     /// Function param
@@ -18,10 +18,7 @@ protocol MessageSender {
 
 extension MessageSender {
     var javascriptMessage: String? {
-        let encoder = JSONEncoder()
-        // Ensure keys are sorted for test stability.
-        encoder.outputFormatting = .sortedKeys
-        guard let jsonData = try? encoder.encode(payload),
+        guard let jsonData = try? JSONEncoder.connectEncoder.encode(payload),
               let jsonString = String(data: jsonData, encoding: .utf8) else {
             //TODO: MXMOBILE-2491 Log failure to analytics
             return nil

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/MessageSenders/UpdateConnectInstanceSender.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/MessageSenders/UpdateConnectInstanceSender.swift
@@ -9,9 +9,9 @@ import Foundation
 
 /// Updates appearance and locale options.
 struct UpdateConnectInstanceSender: MessageSender {
-    struct Payload: Codable, Equatable {
+    struct Payload: Encodable {
         let locale: String
-        // TODO: Add appearance here.
+        private(set) var appearance: AppearanceWrapper
     }
     let name: String = "updateConnectInstance"
     let payload: Payload

--- a/StripeConnect/StripeConnectTests/AppearanceTests.swift
+++ b/StripeConnect/StripeConnectTests/AppearanceTests.swift
@@ -1,0 +1,186 @@
+//
+//  AppearanceTests.swift
+//  StripeConnectTests
+//
+//  Created by Chris Mays on 9/4/24.
+//
+
+import XCTest
+import UIKit
+@_spi(PrivateBetaConnect) @testable import StripeConnect
+
+class AppearanceTests: XCTestCase {
+    typealias Appearance = EmbeddedComponentManager.Appearance
+    
+    let testAppearance: Appearance = {
+        var appearance = EmbeddedComponentManager.Appearance()
+        appearance.typography.font = UIFont(name: "Helvetica", size: 16)
+        appearance.typography.fontSizeBase = 16
+        appearance.typography.bodyMd.fontSize = 16
+        appearance.typography.bodyMd.weight = .regular
+        appearance.typography.bodyMd.textTransform = EmbeddedComponentManager.Appearance.TextTransform.none
+        appearance.typography.bodySm.fontSize = 14
+        appearance.typography.bodySm.weight = .light
+        appearance.typography.bodySm.textTransform = .lowercase
+        appearance.typography.headingXl.fontSize = 28
+        appearance.typography.headingXl.weight = .bold
+        appearance.typography.headingXl.textTransform = .uppercase
+        appearance.typography.headingLg.fontSize = 24
+        appearance.typography.headingLg.weight = .semibold
+        appearance.typography.headingLg.textTransform = .capitalize
+        appearance.typography.headingMd.fontSize = 20
+        appearance.typography.headingMd.weight = .medium
+        appearance.typography.headingSm.fontSize = 18
+        appearance.typography.headingSm.weight = .regular
+        appearance.typography.headingXs.fontSize = 16
+        appearance.typography.headingXs.weight = .light
+        appearance.typography.labelMd.fontSize = 14
+        appearance.typography.labelMd.weight = .medium
+        appearance.typography.labelSm.fontSize = 12
+        appearance.typography.labelSm.weight = .regular
+
+        appearance.colors.primary = UIColor(red: 0.1, green: 0.2, blue: 0.3, alpha: 1.0)
+        appearance.colors.text = UIColor(red: 0.2, green: 0.3, blue: 0.4, alpha: 1.0)
+        appearance.colors.danger = UIColor(red: 0.3, green: 0.4, blue: 0.5, alpha: 1.0)
+        appearance.colors.background = UIColor(red: 0.4, green: 0.5, blue: 0.6, alpha: 1.0)
+        appearance.colors.secondaryText = UIColor(red: 0.5, green: 0.6, blue: 0.7, alpha: 1.0)
+        appearance.colors.border = UIColor(red: 0.6, green: 0.7, blue: 0.8, alpha: 1.0)
+        appearance.colors.actionPrimaryText = UIColor(red: 0.7, green: 0.8, blue: 0.9, alpha: 1.0)
+        appearance.colors.actionSecondaryText = UIColor(red: 0.8, green: 0.9, blue: 1.0, alpha: 1.0)
+        appearance.colors.offsetBackground = UIColor(red: 0.9, green: 1.0, blue: 0.1, alpha: 1.0)
+        appearance.colors.formBackground = UIColor(red: 1.0, green: 0.1, blue: 0.2, alpha: 1.0)
+        appearance.colors.formHighlightBorder = UIColor(red: 0.1, green: 0.2, blue: 0.3, alpha: 0.5)
+        appearance.colors.formAccent = UIColor(red: 0.2, green: 0.3, blue: 0.4, alpha: 1.0)
+
+        appearance.spacingUnit = 8
+
+        appearance.buttonPrimary.colorBackground = UIColor(red: 0.3, green: 0.4, blue: 0.5, alpha: 1.0)
+        appearance.buttonPrimary.colorBorder = UIColor(red: 0.4, green: 0.5, blue: 0.6, alpha: 1.0)
+        appearance.buttonPrimary.colorText = UIColor(red: 0.5, green: 0.6, blue: 0.7, alpha: 1.0)
+
+        appearance.buttonSecondary.colorBackground = UIColor(red: 0.6, green: 0.7, blue: 0.8, alpha: 1.0)
+        appearance.buttonSecondary.colorBorder = UIColor(red: 0.7, green: 0.8, blue: 0.9, alpha: 1.0)
+        appearance.buttonSecondary.colorText = UIColor(red: 0.8, green: 0.9, blue: 1.0, alpha: 1.0)
+
+        appearance.badgeNeutral.colorBackground = UIColor(red: 0.9, green: 1.0, blue: 0.1, alpha: 1.0)
+        appearance.badgeNeutral.colorText = UIColor(red: 1.0, green: 0.1, blue: 0.2, alpha: 1.0)
+        appearance.badgeNeutral.colorBorder = UIColor(red: 0.1, green: 0.2, blue: 0.3, alpha: 1.0)
+
+        appearance.badgeSuccess.colorBackground = UIColor(red: 0.2, green: 0.3, blue: 0.4, alpha: 1.0)
+        appearance.badgeSuccess.colorText = UIColor(red: 0.3, green: 0.4, blue: 0.5, alpha: 1.0)
+        appearance.badgeSuccess.colorBorder = UIColor(red: 0.4, green: 0.5, blue: 0.6, alpha: 1.0)
+
+        appearance.badgeWarning.colorBackground = UIColor(red: 0.5, green: 0.6, blue: 0.7, alpha: 1.0)
+        appearance.badgeWarning.colorText = UIColor(red: 0.6, green: 0.7, blue: 0.8, alpha: 1.0)
+        appearance.badgeWarning.colorBorder = UIColor(red: 0.7, green: 0.8, blue: 0.9, alpha: 1.0)
+
+        appearance.badgeDanger.colorBackground = UIColor(red: 0.8, green: 0.9, blue: 1.0, alpha: 1.0)
+        appearance.badgeDanger.colorText = UIColor(red: 0.9, green: 1.0, blue: 0.1, alpha: 1.0)
+        appearance.badgeDanger.colorBorder = UIColor(red: 1.0, green: 0.1, blue: 0.2, alpha: 1.0)
+
+        appearance.cornerRadius.base = 4
+        appearance.cornerRadius.form = 6
+        appearance.cornerRadius.button = 8
+        appearance.cornerRadius.badge = 10
+        appearance.cornerRadius.overlay = 12
+        return appearance
+    }()
+    
+    func testAllFieldsAreFilledWithCorrectValuesInDictionary() {
+        let actualValues = testAppearance.asDictionary(traitCollection: .init())
+        let expectedValues: [String: String] = [
+            "fontFamily": "Helvetica",
+            "fontSizeBase": "16px",
+            "bodyMdFontSize": "16px",
+            "bodyMdFontWeight": "400",
+            "bodyMdTextTransform": "none",
+            "bodySmFontSize": "14px",
+            "bodySmFontWeight": "300",
+            "bodySmTextTransform": "lowercase",
+            "headingXlFontSize": "28px",
+            "headingXlFontWeight": "700",
+            "headingXlTextTransform": "uppercase",
+            "headingLgFontSize": "24px",
+            "headingLgFontWeight": "600",
+            "headingLgTextTransform": "capitalize",
+            "headingMdFontSize": "20px",
+            "headingMdFontWeight": "500",
+            "headingSmFontSize": "18px",
+            "headingSmFontWeight": "400",
+            "headingXsFontSize": "16px",
+            "headingXsFontWeight": "300",
+            "labelMdFontSize": "14px",
+            "labelMdFontWeight": "500",
+            "labelSmFontSize": "12px",
+            "labelSmFontWeight": "400",
+            "formAccentColor": "rgb(51, 76, 102)",
+            "colorPrimary": "rgb(26, 51, 76)",
+            "colorBackground": "rgb(102, 128, 153)",
+            "colorText": "rgb(51, 76, 102)",
+            "colorDanger": "rgb(76, 102, 128)",
+            "actionPrimaryColorText": "rgb(178, 204, 230)",
+            "actionSecondaryColorText": "rgb(204, 230, 255)",
+            "offsetBackgroundColor": "rgb(230, 255, 26)",
+            "formBackgroundColor": "rgb(255, 26, 51)",
+            "colorSecondaryText": "rgb(128, 153, 178)",
+            "colorBorder": "rgb(153, 178, 204)",
+            "formHighlightColorBorder": "rgb(26, 51, 76)",
+            "spacingUnit": "8px",
+            "buttonPrimaryColorBackground": "rgb(76, 102, 128)",
+            "buttonPrimaryColorBorder": "rgb(102, 128, 153)",
+            "buttonPrimaryColorText": "rgb(128, 153, 178)",
+            "buttonSecondaryColorBackground": "rgb(153, 178, 204)",
+            "buttonSecondaryColorBorder": "rgb(178, 204, 230)",
+            "buttonSecondaryColorText": "rgb(204, 230, 255)",
+            "badgeNeutralColorBackground": "rgb(230, 255, 26)",
+            "badgeNeutralColorText": "rgb(255, 26, 51)",
+            "badgeNeutralColorBorder": "rgb(26, 51, 76)",
+            "badgeSuccessColorBackground": "rgb(51, 76, 102)",
+            "badgeSuccessColorText": "rgb(76, 102, 128)",
+            "badgeSuccessColorBorder": "rgb(102, 128, 153)",
+            "badgeWarningColorBackground": "rgb(128, 153, 178)",
+            "badgeWarningColorText": "rgb(153, 178, 204)",
+            "badgeWarningColorBorder": "rgb(178, 204, 230)",
+            "badgeDangerColorBackground": "rgb(204, 230, 255)",
+            "badgeDangerColorText": "rgb(230, 255, 26)",
+            "badgeDangerColorBorder": "rgb(255, 26, 51)",
+            "borderRadius": "4px",
+            "buttonBorderRadius": "8px",
+            "formBorderRadius": "6px",
+            "badgeBorderRadius": "10px",
+            "overlayBorderRadius": "12px"
+        ]
+
+        XCTAssertEqual(actualValues, expectedValues)
+    }
+    
+    
+    func testDefaultAppearance() {
+        let appearance: Appearance = .default
+        XCTAssertEqual(appearance.asDictionary(traitCollection: .init()), [
+            "fontFamily": "-apple-system"
+        ])
+    }
+    
+    func testColorsChangeBasedOnTraitCollection() {
+        var appearance: Appearance = .default
+        
+        appearance.colors.actionPrimaryText = UIColor { $0.userInterfaceStyle == .light ? .red : .green }
+        appearance.colors.background = UIColor { $0.userInterfaceStyle == .light ? .white : .black }
+        appearance.colors.text = UIColor { $0.userInterfaceStyle == .light ? .black : .white }
+        
+        let lightModeTraits = UITraitCollection(userInterfaceStyle: .light)
+        let darkModeTraits =  UITraitCollection(userInterfaceStyle: .dark)
+
+        XCTAssertEqual(appearance.asDictionary(traitCollection: lightModeTraits)["actionPrimaryColorText"], "rgb(255, 0, 0)")
+        XCTAssertEqual(appearance.asDictionary(traitCollection: darkModeTraits)["actionPrimaryColorText"], "rgb(0, 255, 0)")
+
+        
+        XCTAssertEqual(appearance.asDictionary(traitCollection: lightModeTraits)["colorBackground"], "rgb(255, 255, 255)")
+        XCTAssertEqual(appearance.asDictionary(traitCollection: darkModeTraits)["colorBackground"], "rgb(0, 0, 0)")
+
+        
+        XCTAssertEqual(appearance.asDictionary(traitCollection: lightModeTraits)["colorText"], "rgb(0, 0, 0)")
+        XCTAssertEqual(appearance.asDictionary(traitCollection: darkModeTraits)["colorText"], "rgb(255, 255, 255)")
+    }
+}

--- a/StripeConnect/StripeConnectTests/Components/PayoutsViewControllerTests.swift
+++ b/StripeConnect/StripeConnectTests/Components/PayoutsViewControllerTests.swift
@@ -45,6 +45,6 @@ class PayoutsViewControllerTests: XCTestCase {
         
         vc.webView.evaluateOnLoadError(type: "rate_limit_error", message: "Error message")
         
-        wait(for: [expectation], timeout: 1.0)
+        wait(for: [expectation], timeout: TestHelpers.defaultTimeout)
     }
 }

--- a/StripeConnect/StripeConnectTests/Helpers/AppearanceWrapper+Default.swift
+++ b/StripeConnect/StripeConnectTests/Helpers/AppearanceWrapper+Default.swift
@@ -1,0 +1,13 @@
+//
+//  AppearanceWrapper+Default.swift
+//  StripeConnectTests
+//
+//  Created by Chris Mays on 9/6/24.
+//
+
+import Foundation
+@_spi(PrivateBetaConnect) @testable import StripeConnect
+
+extension AppearanceWrapper {
+    public static let `default`: AppearanceWrapper = .init(appearance: .default, traitCollection: .init())
+}

--- a/StripeConnect/StripeConnectTests/Helpers/TestHelpers.swift
+++ b/StripeConnect/StripeConnectTests/Helpers/TestHelpers.swift
@@ -1,0 +1,54 @@
+//
+//  TestHelpers.swift
+//  StripeConnectTests
+//
+//  Created by Chris Mays on 9/6/24.
+//
+
+import Foundation
+import UIKit
+
+enum TestHelpers {
+    
+    // Setting the default timeout to 5 seconds to minimize flakiness because web view operations
+    // can be slow especially when running tests in parallel.
+    static let defaultTimeout = 5.0
+    
+    static func withTimeout<T>(seconds: TimeInterval = defaultTimeout, operation: @escaping () async throws -> T) async throws -> T {
+        try await withThrowingTaskGroup(of: T.self) { group in
+            group.addTask {
+                try await operation()
+            }
+            
+            group.addTask {
+                try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+                throw TestHelperError.timeout(seconds: seconds)
+            }
+            
+            let result = try await group.next()!
+            group.cancelAll()
+            return result
+        }
+    }
+}
+
+extension UIView {
+    // Overriding the user interface style alone does not trigger a trait collection change
+    // the view also needs to be added to a window.
+    func triggerTraitCollectionChange(style: UIUserInterfaceStyle) {
+        let window = UIWindow()
+        window.overrideUserInterfaceStyle = .dark
+        window.addSubview(self)
+    }
+}
+
+enum TestHelperError: Error, CustomDebugStringConvertible {
+    var debugDescription: String {
+        switch self {
+        case let .timeout(seconds):
+            return "Operation timed out after \(seconds) seconds"
+        }
+    }
+
+    case timeout(seconds: TimeInterval)
+}

--- a/StripeConnect/StripeConnectTests/Internal/Webview/ConnectWebViewTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/ConnectWebViewTests.swift
@@ -46,7 +46,7 @@ class ConnectWebViewTests: XCTestCase {
                         
             XCTAssertTrue(userAgent.hasSuffix("- stripe-ios/1.2.3"), "User agent should include the SDK identifier but value was: \(String(describing: result))")
         }
-        wait(for: [expectation], timeout: 2.0)
+        wait(for: [expectation], timeout: TestHelpers.defaultTimeout)
     }
     
     func testOpenSafariVCIfNotInAllowedHosts() {

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/AccountSessionClaimedMessageHandlerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/AccountSessionClaimedMessageHandlerTests.swift
@@ -19,6 +19,6 @@ class AccountSessionClaimedMessageHandlerTests: ScriptWebTestBase {
         }))
         
         webView.evaluateAccountSessionClaimed(merchantId: merchantId)
-        waitForExpectations(timeout: 1, handler: nil)
+        waitForExpectations(timeout: TestHelpers.defaultTimeout, handler: nil)
     }
 }

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/DebugMessageHandlerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/DebugMessageHandlerTests.swift
@@ -20,6 +20,6 @@ class DebugMessageHandlerTests: ScriptWebTestBase {
         
         webView.evaluateDebugMessage(message: debugMessage)
         
-        waitForExpectations(timeout: 1, handler: nil)
+        waitForExpectations(timeout: TestHelpers.defaultTimeout, handler: nil)
     }
 }

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/FetchClientSecretMessageHandlerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/FetchClientSecretMessageHandlerTests.swift
@@ -12,20 +12,16 @@ class FetchClientSecretMessageHandlerTests: ScriptWebTestBase {
     
     @MainActor
     func testMessageSend() async throws {
-        let expectation = self.expectation(description: "Message received")
         let key = "key_123"
         
         let messageHandler = FetchClientSecretMessageHandler(didReceiveMessage: { _ in
             return key
         })
         
-        webView.addMessageReplyHandler(messageHandler: messageHandler, verifyResult: { result in
-            XCTAssertEqual(result, key)
-            expectation.fulfill()
-        })
+        webView.addMessageReplyHandler(messageHandler: messageHandler)
         
         try await webView.evaluateMessageWithReply(name: "fetchClientSecret",
-                                           json: "{}")
-        await fulfillment(of: [expectation], timeout: 0.2)
+                                                   json: "{}",
+                                                   expectedResponse: key)
     }
 }

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/FetchInitParamsMessageHandlerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/FetchInitParamsMessageHandlerTests.swift
@@ -12,17 +12,13 @@ class FetchInitParamsMessageHandlerTests: ScriptWebTestBase {
     
     @MainActor
     func testMessageSend() async throws {
-        let expectation = self.expectation(description: "Message received")
-        let message = FetchInitParamsMessageHandler.Reply(locale: "en")
+        let message = FetchInitParamsMessageHandler.Reply(locale: "en", appearance: .default)
         webView.addMessageReplyHandler(messageHandler: FetchInitParamsMessageHandler(didReceiveMessage: { _ in
             return message
-        }), verifyResult: { result in
-            XCTAssertEqual(result, message)
-            expectation.fulfill()
-        })
+        }))
         
         try await webView.evaluateMessageWithReply(name: "fetchInitParams",
-                                           json: "{}")
-        await fulfillment(of: [expectation], timeout: 0.2)
+                                                   json: "{}",
+                                                   expectedResponse: message)
     }
 }

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/OnExitMessageHandlerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/OnExitMessageHandlerTests.swift
@@ -19,6 +19,6 @@ class OnExitMessageHandlerTests: ScriptWebTestBase {
         
         webView.evaluateSetOnExit()
         
-        waitForExpectations(timeout: 1, handler: nil)
+        waitForExpectations(timeout: TestHelpers.defaultTimeout, handler: nil)
     }
 }

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/OnLoadErrorMessageHandlerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/OnLoadErrorMessageHandlerTests.swift
@@ -18,6 +18,6 @@ class OnLoadErrorMessageHandlerTests: ScriptWebTestBase {
         
         webView.evaluateOnLoadError(type: "failed_to_load", message: "Error message")
         
-        waitForExpectations(timeout: 1, handler: nil)
+        waitForExpectations(timeout: TestHelpers.defaultTimeout, handler: nil)
     }
 }

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/OnLoaderStartMessageHandlerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/OnLoaderStartMessageHandlerTests.swift
@@ -19,6 +19,6 @@ class OnLoaderStartMessageHandlerTests: ScriptWebTestBase {
         
         webView.evaluateOnLoaderStart(elementTagName: "onboarding")
         
-        waitForExpectations(timeout: 1, handler: nil)
+        waitForExpectations(timeout: TestHelpers.defaultTimeout, handler: nil)
     }
 }

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/OpenAuthenticatedWebViewMessageHandlerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/OpenAuthenticatedWebViewMessageHandlerTests.swift
@@ -20,6 +20,6 @@ class OpenAuthenticatedWebViewMessageHandlerTests: ScriptWebTestBase {
         
         webView.evaluateOpenAuthenticatedWebView(url: url, id: id)
         
-        waitForExpectations(timeout: 1, handler: nil)
+        waitForExpectations(timeout: TestHelpers.defaultTimeout, handler: nil)
     }
 }

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/PageDidLoadMessageHandlerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/PageDidLoadMessageHandlerTests.swift
@@ -21,6 +21,6 @@ class PageDidLoadMessageHandlerTests: ScriptWebTestBase {
         
         webView.evaluatePageDidLoad(pageViewId: pageViewId)
         
-        waitForExpectations(timeout: 1, handler: nil)
+        waitForExpectations(timeout: TestHelpers.defaultTimeout, handler: nil)
     }
 }

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageSenders/UpdateConnectInstanceSenderTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageSenders/UpdateConnectInstanceSenderTests.swift
@@ -11,14 +11,14 @@ import XCTest
 
 class UpdateConnectInstanceSenderTests: ScriptWebTestBase {
     func testSendMessage() throws {
-        try validateMessageSent(sender: UpdateConnectInstanceSender(payload: .init(locale: "en")))
+        try validateMessageSent(sender: UpdateConnectInstanceSender(payload: .init(locale: "en", appearance: .default)))
     }
     
     func testSenderSignature() {
         XCTAssertEqual(
-            UpdateConnectInstanceSender(payload: .init(locale: "en")).javascriptMessage,
+            UpdateConnectInstanceSender(payload: .init(locale: "en", appearance: .default)).javascriptMessage,
             """
-            window.updateConnectInstance({"locale":"en"});
+            window.updateConnectInstance({"appearance":{"variables":{"fontFamily":"-apple-system"}},"locale":"en"});
             """
         )
     }

--- a/StripeConnect/StripeConnectTests/Internal/Webview/ScriptWebTestBase.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/ScriptWebTestBase.swift
@@ -27,6 +27,6 @@ class ScriptWebTestBase: XCTestCase {
         let expectation = try webView.expectationForMessageReceived(sender: sender)
         try webView.sendMessage(sender: sender)
         
-        wait(for: [expectation], timeout: 1.0)
+        wait(for: [expectation], timeout: TestHelpers.defaultTimeout)
     }
 }

--- a/StripeConnect/StripeConnectTests/WebView+Tests.swift
+++ b/StripeConnect/StripeConnectTests/WebView+Tests.swift
@@ -93,21 +93,23 @@ extension WKWebView {
         let expectation = XCTestExpectation(description: "JavaScript execution")
         let messageHandler = MessageHandler()
         messageHandler.messageReceived = { (payload: Any) in
-            if let jsonString = payload as? String,
-               let data = jsonString.data(using: .utf8),
-               let dict = try? JSONDecoder().decode(Sender.Payload.self, from: data) {
-                XCTAssertEqual(dict, sender.payload)
-                expectation.fulfill()
-            } else {
-                print("TEST")
+            guard let payloadData = try? JSONSerialization.connectData(withJSONObject: payload) else {
+                XCTFail("Failed to encode payload")
+                return
             }
+            guard let responseData = try? JSONEncoder.connectEncoder.encode(sender.payload) else {
+                XCTFail("Failed to encode response data")
+                return
+            }
+            XCTAssertEqual(String(data: responseData, encoding: .utf8), String(data: payloadData, encoding: .utf8))
+            expectation.fulfill()
         }
         
         // Inject the receiver function that validates the message was sent
         let receiverFunctionName = "receiver_" + sender.name
         evaluateJavaScript("""
             window.\(sender.name) = function(message) {
-                window.webkit.messageHandlers.\(receiverFunctionName).postMessage(JSON.stringify(message));
+                window.webkit.messageHandlers.\(receiverFunctionName).postMessage(message);
             };
         """)
         configuration.userContentController.add(messageHandler, name: receiverFunctionName)
@@ -132,26 +134,55 @@ extension WKWebView {
         evaluateJavaScript(script, completionHandler: completionHandler)
     }
     
-    @discardableResult
-    func evaluateMessageWithReply(name: String,
-                                  json: String,
-                                  postReply: Bool = true,
-                                  completionHandler: ((Any?, (any Error)?) -> Void)? = nil) async throws -> Any? {
-        let script = """
-                    const result = await window.webkit.messageHandlers.\(name).postMessage(\(json));
+    func evaluateMessageWithReply<Response: Encodable>(name: String,
+                                                       json: String,
+                                                       expectedResponse: Response,
+                                                       timeout: TimeInterval = TestHelpers.defaultTimeout,
+                                                       file: StaticString = #filePath,
+                                                       line: UInt = #line) async throws {
+        try await TestHelpers.withTimeout(seconds: timeout) {
+            return try await withCheckedThrowingContinuation { continuation in
+                let replyMessageHandler = DataScriptMessageHandler(name: self.replyKey(message: name)) { message in
+                    let expectedMessage: String?
+                    
+                    if let expectedResponse = expectedResponse as? String {
+                        expectedMessage = expectedResponse
+                    } else {
+                        guard let json = try? JSONEncoder.connectEncoder.encode(expectedResponse)else {
+                            XCTFail("Failed to expected response \(expectedResponse)", file: file, line: line)
+                            return
+                        }
+                        expectedMessage = String(data: json, encoding: .utf8)
+                    }
+                    
+                    guard let actualMessage = String(data: message, encoding: .utf8) else {
+                        XCTFail("Failed to get message \(message)", file: file, line: line)
+                        return
+                    }
+                    
+                    XCTAssertEqual(actualMessage, expectedMessage, file: file, line: line)
+                    continuation.resume(returning: ())
+                }
                 
-                """ + (postReply ?
+                self.configuration.userContentController.add(replyMessageHandler, name: replyMessageHandler.name)
+                
+                let script = """
+                const result = await window.webkit.messageHandlers.\(name).postMessage(\(json));
+                window.webkit.messageHandlers.\(self.replyKey(message: name)).postMessage(result);
                 """
-                    window.webkit.messageHandlers.\(replyKey(message: name)).postMessage({"result": result});
-                """ : "")
-        return try await callAsyncJavaScript(script, contentWorld: .page)
+                
+                Task {
+                    do {
+                        _ = try await self.callAsyncJavaScript(script, contentWorld: .page)
+                    } catch {
+                        continuation.resume(throwing: error)
+                    }
+                }
+            }
+        }
     }
-    
-    func addMessageReplyHandler<Payload, Response>(messageHandler: ScriptMessageHandlerWithReply<Payload, Response>, verifyResult: @escaping (Response) -> Void) {
-        addMessageHandler(messageHandler: .init(name: replyKey(message: messageHandler.name), didReceiveMessage: { (message: Reply<Response>) in
-            verifyResult(message.result)
-        }))
-        
+
+    func addMessageReplyHandler<Payload, Response>(messageHandler: ScriptMessageHandlerWithReply<Payload, Response>) {
         configuration.userContentController.addScriptMessageHandler(messageHandler, contentWorld: .page, name: messageHandler.name)
     }
     
@@ -165,5 +196,29 @@ extension WKWebView {
     
     struct Reply<R: Decodable>: Decodable {
         let result: R
+    }
+}
+
+
+private class DataScriptMessageHandler: NSObject, WKScriptMessageHandler {
+    let name: String
+    let didReceiveMessage: (Data) -> Void
+    
+    init(name: String,
+         didReceiveMessage: @escaping (Data) -> Void) {
+        self.name = name
+        self.didReceiveMessage = didReceiveMessage
+    }
+    
+    func userContentController(_ userContentController: WKUserContentController,
+                               didReceive message: WKScriptMessage) {
+        guard message.name == name else {
+            return
+        }
+        do {
+            didReceiveMessage(try message.toData())
+        } catch {
+            XCTFail("Failed to decode body for message with name: \(message.name) \(error.localizedDescription)")
+        }
     }
 }


### PR DESCRIPTION
## Summary
Adds the ability to set and update appearance for embedded components. Due to the fact that appearance cannot be made codable I also had to refactor some of the message receiving and sending code to make appearance compatible. 

## Features
- ComponentWebView uses the ComponentManager's appearance, and updates when the appearance or trait collection is updated. Colors are derived based on the webview's traitcollection.
- Example app has new theming functionality.

https://jira.corp.stripe.com/browse/MXMOBILE-2486