### PR TITLE
Send fraudDetectionApiFailure when logging to m.stripe.com fails

### DIFF
--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
@@ -266,4 +266,7 @@ import Foundation
     case refreshSetupIntentSuccess = "stripeios.refresh_setup_intent_success"
     case refreshPaymentIntentFailed = "stripeios.refresh_payment_intent_failed"
     case refreshSetupIntentFailed = "stripeios.refresh_setup_intent_failed"
+
+    // MARK: - Telemetry Client
+    case fraudDetectionApiFailure = "fraud_detection_data_repository.api_failure"
 }

--- a/StripeCore/StripeCore/Source/Telemetry/STPTelemetryClient.swift
+++ b/StripeCore/StripeCore/Source/Telemetry/STPTelemetryClient.swift
@@ -43,11 +43,24 @@ private let TelemetryURL = URL(string: "https://m.stripe.com/6")!
         forceSend: Bool = false,
         completion: ((Result<[String: Any], Error>) -> Void)? = nil
     ) {
+
+        let wrappedCompletion: ((Result<[String: Any], Error>) -> Void) = { result in
+            switch result {
+            case .success:
+                break
+            case .failure(let error):
+                let errorAnalytic = ErrorAnalytic(event: .fraudDetectionApiFailure, error: error)
+                STPAnalyticsClient.sharedClient.log(analytic: errorAnalytic)
+            }
+
+            completion?(result)
+        }
+
         guard forceSend || STPTelemetryClient.shouldSendTelemetry() else {
-            completion?(.failure(NSError.stp_genericConnectionError()))
+            wrappedCompletion(.failure(NSError.stp_genericConnectionError()))
             return
         }
-        sendTelemetryRequest(jsonPayload: payload, completion: completion)
+        sendTelemetryRequest(jsonPayload: payload, completion: wrappedCompletion)
     }
 
     @_spi(STP) public func updateFraudDetectionIfNecessary(

--- a/StripeCore/StripeCore/Source/Telemetry/STPTelemetryClient.swift
+++ b/StripeCore/StripeCore/Source/Telemetry/STPTelemetryClient.swift
@@ -43,16 +43,11 @@ private let TelemetryURL = URL(string: "https://m.stripe.com/6")!
         forceSend: Bool = false,
         completion: ((Result<[String: Any], Error>) -> Void)? = nil
     ) {
-
         let wrappedCompletion: ((Result<[String: Any], Error>) -> Void) = { result in
-            switch result {
-            case .success:
-                break
-            case .failure(let error):
+            if case .failure(let error) = result {
                 let errorAnalytic = ErrorAnalytic(event: .fraudDetectionApiFailure, error: error)
                 STPAnalyticsClient.sharedClient.log(analytic: errorAnalytic)
             }
-
             completion?(result)
         }
 


### PR DESCRIPTION
## Summary
- Sends a failure/error analytic when logging to m.stripe.com occurs
- Android PR: https://github.com/stripe/stripe-android/pull/8374/

## Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-2148

## Testing
- Manual

## Changelog
N/A
