### PR TITLE
Make dictionary extension methods SPI-public

### DIFF
--- a/StripeCore/StripeCore/Source/Categories/Dictionary+Stripe.swift
+++ b/StripeCore/StripeCore/Source/Categories/Dictionary+Stripe.swift
@@ -45,14 +45,14 @@ extension Dictionary {
         return newDict
     }
 
-    public mutating func mergeAssertingOnOverwrites(_ other: [Key: Value]) {
+    @_spi(STP) public mutating func mergeAssertingOnOverwrites(_ other: [Key: Value]) {
         merge(other) { a, b in
             stpAssertionFailure("Dictionary merge is overwriting a key with values: \(a) and \(b)!")
             return a
         }
     }
 
-    public func mergingAssertingOnOverwrites<S>(_ other: S) -> [Key: Value] where S: Sequence, S.Element == (Key, Value) {
+    @_spi(STP) public func mergingAssertingOnOverwrites<S>(_ other: S) -> [Key: Value] where S: Sequence, S.Element == (Key, Value) {
         merging(other) { a, b in
             stpAssertionFailure("Dictionary merge is overwriting a key with values: \(a) and \(b)!")
             return a


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Make public Dictionary extension methods SPI-public as opposed to public – these were never meant to be exposed publicly.


## Testing
<!-- How was the code tested? Be as specific as possible. -->
CI

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
None