### PR TITLE
Financial Connections: Added Connect merchant and UI tests

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundConfiguration.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundConfiguration.swift
@@ -113,15 +113,30 @@ final class PlaygroundConfiguration {
         let displayName: String
         /// whether on the 'backend' we provide test mode keys
         let isTestModeSupported: Bool
+        /// for connect
+        let stripeAccount: String?
 
         var id: String {
             return customId.rawValue
+        }
+
+        init(
+            customId: CustomId,
+            displayName: String,
+            isTestModeSupported: Bool,
+            stripeAccount: String? = nil
+        ) {
+            self.customId = customId
+            self.displayName = displayName
+            self.isTestModeSupported = isTestModeSupported
+            self.stripeAccount = stripeAccount
         }
 
         // The id's should use underscore as "-" is not supported in Glitch
         enum CustomId: String {
             case `default` = "default"
             case networking = "networking"
+            case connect = "connect"
             case customKeys = "custom_keys"
             case partnerD = "partner_d"
             case partnerF = "partner_f"
@@ -140,6 +155,12 @@ final class PlaygroundConfiguration {
             customId: .networking,
             displayName: "Networking",
             isTestModeSupported: true
+        ),
+        Merchant(
+            customId: .connect,
+            displayName: "Connect",
+            isTestModeSupported: true,
+            stripeAccount: "acct_1PnnD9CY58qxxwvr"
         ),
         Merchant(
             customId: .customKeys,
@@ -169,6 +190,7 @@ final class PlaygroundConfiguration {
 
     ]
     private static let merchantCustomIdKey = "merchant"
+    private static let stripeAccountKey = "stripe_account"
     var merchant: Merchant {
         get {
             if
@@ -190,6 +212,7 @@ final class PlaygroundConfiguration {
                 testMode = false
             }
             configurationStore[Self.merchantCustomIdKey] = newValue.customId.rawValue
+            configurationStore[Self.stripeAccountKey] = newValue.stripeAccount
         }
     }
 

--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundViewModel.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundViewModel.swift
@@ -230,6 +230,7 @@ final class PlaygroundViewModel: ObservableObject {
                 var onEventEvents: [String] = []
                 PresentFinancialConnectionsSheet(
                     useCase: self.playgroundConfiguration.useCase,
+                    stripeAccount: self.playgroundConfiguration.merchant.stripeAccount,
                     setupPlaygroundResponseJSON: setupPlaygroundResponse,
                     onEvent: { event in
                         if self.liveEvents.wrappedValue == true {
@@ -377,6 +378,7 @@ private func SetupPlayground(
 
 private func PresentFinancialConnectionsSheet(
     useCase: PlaygroundConfiguration.UseCase,
+    stripeAccount: String?,
     setupPlaygroundResponseJSON: [String: String],
     onEvent: @escaping (FinancialConnectionsEvent) -> Void,
     completionHandler: @escaping (FinancialConnectionsSheet.Result) -> Void
@@ -422,6 +424,7 @@ private func PresentFinancialConnectionsSheet(
         // disable app-to-app for UI tests
         returnURL: isUITest ? nil : "financial-connections-example://redirect"
     )
+    financialConnectionsSheet.apiClient.stripeAccount = stripeAccount
     financialConnectionsSheet.onEvent = onEvent
     let topMostViewController = UIViewController.topMostViewController()!
     if useCase == .token {

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
@@ -497,6 +497,122 @@ final class FinancialConnectionsUITests: XCTestCase {
                 .exists
         )
     }
+
+    func testNativeConnectMerchantForDataUseCase() {
+        let app = XCUIApplication.fc_launch(
+            playgroundConfigurationString:
+"""
+{"use_case":"data","experience":"financial_connections","sdk_type":"native","test_mode":true,"merchant":"connect","payment_method_permission":true}
+"""
+        )
+
+        app.fc_playgroundCell.tap()
+        app.fc_playgroundShowAuthFlowButton.tap()
+
+        app.fc_nativeConsentAgreeButton.tap()
+
+        app.fc_nativeFeaturedInstitution(name: "Test Institution").waitForExistenceAndTap()
+
+        app.fc_nativeConnectAccountsButton.tap()
+
+        XCTAssert(app.fc_nativeNetworkingNotNowButton.waitForExistence(timeout: 60)) // wait for networking sign up to show
+        app.fc_dismissKeyboard()
+        app.fc_nativeNetworkingNotNowButton.waitForExistenceAndTap() // skip networking sign up
+
+        app.fc_nativeSuccessDoneButton.tap()
+
+        // ensure alert body contains "Stripe Bank" (AKA one bank is linked)
+        XCTAssert(
+            app.fc_playgroundSuccessAlertView.staticTexts.containing(NSPredicate(format: "label CONTAINS 'StripeBank'")).firstMatch
+                .exists
+        )
+    }
+
+    func testNativeConnectMerchantForPaymentUseCase() {
+        let app = XCUIApplication.fc_launch(
+            playgroundConfigurationString:
+"""
+{"use_case":"payment_intent","experience":"financial_connections","sdk_type":"native","test_mode":true,"merchant":"connect","payment_method_permission":true}
+"""
+        )
+
+        app.fc_playgroundCell.tap()
+        app.fc_playgroundShowAuthFlowButton.tap()
+
+        app.fc_nativeConsentAgreeButton.tap()
+
+        app.fc_nativeFeaturedInstitution(name: "Test Institution").waitForExistenceAndTap()
+
+        app.fc_nativeConnectAccountsButton.tap()
+
+        XCTAssert(app.fc_nativeNetworkingNotNowButton.waitForExistence(timeout: 60)) // wait for networking sign up to show
+        app.fc_dismissKeyboard()
+        app.fc_nativeNetworkingNotNowButton.waitForExistenceAndTap() // skip networking sign up
+
+        app.fc_nativeSuccessDoneButton.tap()
+
+        // ensure alert body contains "Stripe Bank" (AKA one bank is linked)
+        XCTAssert(
+            app.fc_playgroundSuccessAlertView.staticTexts.containing(NSPredicate(format: "label CONTAINS 'StripeBank'")).firstMatch
+                .exists
+        )
+    }
+
+    func testNativeConnectMerchantForPaymentManualEntryUseCase() {
+        let app = XCUIApplication.fc_launch(
+            playgroundConfigurationString:
+"""
+{"use_case":"payment_intent","experience":"financial_connections","sdk_type":"native","test_mode":true,"merchant":"connect","payment_method_permission":true}
+"""
+        )
+
+        app.fc_playgroundCell.tap()
+        app.fc_playgroundShowAuthFlowButton.tap()
+
+        app.fc_nativeManuallyVerifyLabel.waitForExistenceAndTap()
+
+        app.fc_nativeTestModeAutofillButton.waitForExistenceAndTap()
+
+        // the not now button could appear if networking manual entry is enabled
+        if app.fc_nativeNetworkingNotNowButton.waitForExistence(timeout: 5) {
+            app.fc_dismissKeyboard()
+            app.fc_nativeNetworkingNotNowButton.waitForExistenceAndTap() // skip networking sign up
+        }
+
+        app.fc_nativeSuccessDoneButton.tap()
+
+        XCTAssert(app.fc_playgroundSuccessAlertView.exists)
+    }
+
+    func testNativeConnectMerchantForTokenCase() {
+        let app = XCUIApplication.fc_launch(
+            playgroundConfigurationString:
+"""
+{"use_case":"token","experience":"financial_connections","sdk_type":"native","test_mode":true,"merchant":"connect","payment_method_permission":true}
+"""
+        )
+
+        app.fc_playgroundCell.tap()
+        app.fc_playgroundShowAuthFlowButton.tap()
+
+        app.fc_nativeConsentAgreeButton.tap()
+
+        app.fc_nativeFeaturedInstitution(name: "Test Institution").waitForExistenceAndTap()
+
+        app.fc_nativeConnectAccountsButton.tap()
+
+        XCTAssert(app.fc_nativeNetworkingNotNowButton.waitForExistence(timeout: 60)) // wait for networking sign up to show
+        app.fc_dismissKeyboard()
+        app.fc_nativeNetworkingNotNowButton.waitForExistenceAndTap() // skip networking sign up
+
+        app.fc_nativeSuccessDoneButton.tap()
+
+        // ensure alert body contains "Stripe Bank" (AKA one bank is linked)
+        XCTAssert(
+            app.fc_playgroundSuccessAlertView.staticTexts.containing(NSPredicate(format: "label CONTAINS 'StripeBank'")).firstMatch
+                .exists
+        )
+    }
 }
 
 extension XCTestCase {

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIApplication+Extensions.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIApplication+Extensions.swift
@@ -139,6 +139,10 @@ extension XCUIApplication {
         return buttons["Save with Link"]
     }
 
+    var fc_nativeNetworkingNotNowButton: XCUIElement {
+        return buttons["Not now"]
+    }
+
     var fc_nativeSuccessDoneButton: XCUIElement {
         let successDoneButton = buttons["success_done_button"]
         XCTAssertTrue(successDoneButton.waitForExistence(timeout: 120.0), "Failed to open Success pane - \(#function) waiting failed")  // wait for accounts to link


### PR DESCRIPTION
## Summary

^ this pr does:
1) Adds a new "Connect" merchant
2) Utilizes this "Connect" merchant to run standard UI tests to ensure everything works as usual

## Testing

Run `bitrise run financial-connections-stability-tests`:

```
FinancialConnectionsNetworkingUITests
    ✓ testNativeNetworkingTestMode (131.115 seconds)
    ✓ testNativeNetworkingTestModeSignUpWithMultiSelectAndPrefilledEmail (31.996 seconds)
    ✓ testNativeNetworkingTestModeSignUpWithPrefilledEmailAndPhone (24.524 seconds)
FinancialConnectionsUITests
    ✓ testDataLiveModeOAuthNativeAuthFlow (30.228 seconds)
    ✓ testDataLiveModeOAuthWebAuthFlow (20.754 seconds)
    ✓ testDataTestModeOAuthNativeAuthFlow (20.754 seconds)
    ✓ testNativeConnectMerchantForDataUseCase (22.015 seconds)
    ✓ testNativeConnectMerchantForPaymentManualEntryUseCase (18.501 seconds)
    ✓ testNativeConnectMerchantForPaymentUseCase (21.977 seconds)
    ✓ testNativeConnectMerchantForTokenCase (26.302 seconds)
    ✓ testNativeCustomManualEntryHandoff (15.997 seconds)
    ✓ testNativeOnEventClosureEvents (22.763 seconds)
    ✓ testNativeSkipSuccessPane (21.795 seconds)
    ✓ testPaymentSearchInLiveModeNativeAuthFlow (25.794 seconds)
    ✓ testPaymentTestModeLegacyNativeAuthFlow (17.845 seconds)
    ✓ testPaymentTestModeManualEntryAutofill (13.547 seconds)
    ✓ testPaymentTestModeManualEntryNativeAuthFlow (24.322 seconds)
    ✓ testWebInstantDebitsFlow (13.291 seconds)
InstantDebitsUITests
    ✓ test_accountHolder (21.120 seconds)
    ✓ test_nux (30.323 seconds)
    ✓ test_rux (21.805 seconds)


	 Executed 21 tests, with 0 failures (0 unexpected) in 576.768 (576.792) seconds
```

### New Connect Merchant UI

| Playground | Consent |
| --- | --- |
| ![Simulator Screenshot - iPhone 15 - 2024-09-06 at 13 27 25](https://github.com/user-attachments/assets/49465665-1561-452d-88ef-2ea916b37a51) | ![Simulator Screenshot - iPhone 15 - 2024-09-06 at 13 27 29](https://github.com/user-attachments/assets/f2274ea0-4907-4f94-bd82-d832ecc37055) |

