### PR TITLE
[BANKCON-14293] Update data access message for Instant Debits

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerFooterView.swift
@@ -12,6 +12,7 @@ import UIKit
 final class AccountPickerFooterView: UIView {
 
     private let singleAccount: Bool
+    private let isInstantDebits: Bool
     private let theme: FinancialConnectionsTheme
     private let didSelectLinkAccounts: () -> Void
 
@@ -31,29 +32,32 @@ final class AccountPickerFooterView: UIView {
         businessName: String?,
         permissions: [StripeAPI.FinancialConnectionsAccount.Permissions],
         singleAccount: Bool,
-        shouldShowDataAccessView: Bool,
+        isInstantDebits: Bool,
         theme: FinancialConnectionsTheme,
         didSelectLinkAccounts: @escaping () -> Void,
         didSelectMerchantDataAccessLearnMore: @escaping (URL) -> Void
     ) {
         self.singleAccount = singleAccount
+        self.isInstantDebits = isInstantDebits
         self.theme = theme
         self.didSelectLinkAccounts = didSelectLinkAccounts
         super.init(frame: .zero)
 
-        let verticalStackView = HitTestStackView()
-        if shouldShowDataAccessView {
-            verticalStackView.addArrangedSubview(MerchantDataAccessView(
-                isStripeDirect: isStripeDirect,
-                businessName: businessName,
-                permissions: permissions,
-                isNetworking: false,
-                font: .label(.small),
-                boldFont: .label(.smallEmphasized),
-                didSelectLearnMore: didSelectMerchantDataAccessLearnMore
-            ))
-        }
-        verticalStackView.addArrangedSubview(linkAccountsButton)
+        let verticalStackView = HitTestStackView(
+            arrangedSubviews: [
+                MerchantDataAccessView(
+                    isStripeDirect: isStripeDirect,
+                    businessName: businessName,
+                    permissions: permissions,
+                    isNetworking: false,
+                    isInstantDebits: isInstantDebits,
+                    font: .label(.small),
+                    boldFont: .label(.smallEmphasized),
+                    didSelectLearnMore: didSelectMerchantDataAccessLearnMore
+                ),
+                linkAccountsButton,
+            ]
+        )
 
         verticalStackView.axis = .vertical
         verticalStackView.spacing = 16

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerFooterView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerFooterView.swift
@@ -31,6 +31,7 @@ final class AccountPickerFooterView: UIView {
         businessName: String?,
         permissions: [StripeAPI.FinancialConnectionsAccount.Permissions],
         singleAccount: Bool,
+        shouldShowDataAccessView: Bool,
         theme: FinancialConnectionsTheme,
         didSelectLinkAccounts: @escaping () -> Void,
         didSelectMerchantDataAccessLearnMore: @escaping (URL) -> Void
@@ -40,20 +41,20 @@ final class AccountPickerFooterView: UIView {
         self.didSelectLinkAccounts = didSelectLinkAccounts
         super.init(frame: .zero)
 
-        let verticalStackView = HitTestStackView(
-            arrangedSubviews: [
-                MerchantDataAccessView(
-                    isStripeDirect: isStripeDirect,
-                    businessName: businessName,
-                    permissions: permissions,
-                    isNetworking: false,
-                    font: .label(.small),
-                    boldFont: .label(.smallEmphasized),
-                    didSelectLearnMore: didSelectMerchantDataAccessLearnMore
-                ),
-                linkAccountsButton,
-            ]
-        )
+        let verticalStackView = HitTestStackView()
+        if shouldShowDataAccessView {
+            verticalStackView.addArrangedSubview(MerchantDataAccessView(
+                isStripeDirect: isStripeDirect,
+                businessName: businessName,
+                permissions: permissions,
+                isNetworking: false,
+                font: .label(.small),
+                boldFont: .label(.smallEmphasized),
+                didSelectLearnMore: didSelectMerchantDataAccessLearnMore
+            ))
+        }
+        verticalStackView.addArrangedSubview(linkAccountsButton)
+
         verticalStackView.axis = .vertical
         verticalStackView.spacing = 16
         verticalStackView.isLayoutMarginsRelativeArrangement = true

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerViewController.swift
@@ -77,6 +77,7 @@ final class AccountPickerViewController: UIViewController {
             businessName: businessName,
             permissions: dataSource.manifest.permissions,
             singleAccount: dataSource.manifest.singleAccount,
+            shouldShowDataAccessView: !dataSource.manifest.isProductInstantDebits,
             theme: dataSource.manifest.theme,
             didSelectLinkAccounts: { [weak self] in
                 guard let self = self else {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerViewController.swift
@@ -77,7 +77,7 @@ final class AccountPickerViewController: UIViewController {
             businessName: businessName,
             permissions: dataSource.manifest.permissions,
             singleAccount: dataSource.manifest.singleAccount,
-            shouldShowDataAccessView: !dataSource.manifest.isProductInstantDebits,
+            isInstantDebits: dataSource.manifest.isProductInstantDebits,
             theme: dataSource.manifest.theme,
             didSelectLinkAccounts: { [weak self] in
                 guard let self = self else {


### PR DESCRIPTION
## Summary

Reported during [Instant Debits Bug Bash](https://docs.google.com/document/d/1N5aW1W5enkuxdDyAXZFL--EXWY-6rDAm5oA7QtEd_3U/edit?usp=sharing).

Since account information is not shared with the merchant for Instant Debits, this updates that disclaimer message during the ID flow.

## Motivation

Correctness and consistency between platforms

## Testing

Financial Connections

| Account picker | Learn more |
|--------|--------|
| ![Simulator Screenshot - iPhone 15 - 2024-09-09 at 10 04 20](https://github.com/user-attachments/assets/e2804d18-42ec-47fc-867a-c7a8a48c7f2e) | ![Simulator Screenshot - iPhone 15 - 2024-09-11 at 10 00 54](https://github.com/user-attachments/assets/9b413773-cba3-4bb3-a308-8faa3f6f7e05) | 

Instant Debits

| Account picker | Learn more |
|--------|--------|
| ![Simulator Screenshot - iPhone 15 - 2024-09-11 at 09 58 25](https://github.com/user-attachments/assets/95199dda-26d5-41b1-8401-c11684e7fb03) | ![Simulator Screenshot - iPhone 15 - 2024-09-11 at 09 58 30](https://github.com/user-attachments/assets/a8bf307c-2fcc-47be-9648-56bc55faddcc) |  

Reference (web):

<img width="381" alt="Screenshot 2024-09-11 at 9 42 27 AM" src="https://github.com/user-attachments/assets/f396500b-78d4-4d28-9f8b-a62c0aaba9cb">

## Changelog

N/a
