### PR TITLE
[BANKCON-14297] Require valid email to enter Instant Debits flow

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/InstantDebitsPaymentMethodElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/InstantDebitsPaymentMethodElement.swift
@@ -65,7 +65,7 @@ final class InstantDebitsPaymentMethodElement: ContainerElement {
     }
 
     var enableCTA: Bool {
-        return !email.isEmpty
+        return STPEmailAddressValidator.stringIsValidEmailAddress(email)
     }
     var email: String {
         return emailElement.text


### PR DESCRIPTION
## Summary

In the Payment Sheet form for Instant Debits, we now require an email be "valid" (i.e. matches the [Regex pattern for an email](https://www.regular-expressions.info/email.html)) before allowing the user continue. Previously, we enabled the Continue button we the email field was not empty, however, if the email was not valid, and error would be shown immediately when tapped. 

Before:

| Button enabled for non-email | Error when `Continue` is tapped |
|--------|--------|
| ![Simulator Screenshot - iPhone 15 - 2024-09-09 at 14 54 32](https://github.com/user-attachments/assets/5dd4a292-2709-47dc-9f2f-038effcb233a) | ![Simulator Screenshot - iPhone 15 - 2024-09-09 at 14 54 36](https://github.com/user-attachments/assets/b711f78f-b942-40bd-9830-445a92f35f00) | 

After:

https://github.com/user-attachments/assets/a5079026-ecf8-480e-a4f7-b3a13fb1f813

## Motivation

Better UX

## Testing

See before / after above!

## Changelog

N/a