### PR TITLE
[BANKCON-14310] Add fallback + icon for Add Bank Account row

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerNewAccountRowView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerNewAccountRowView.swift
@@ -54,7 +54,7 @@ final class LinkAccountPickerNewAccountRowView: UIView {
 
 private func CreateIconView(imageUrl: String, theme: FinancialConnectionsTheme) -> UIView {
     RoundedIconView(
-        image: .imageUrl(imageUrl, fallback: Image.add),
+        image: .imageUrl(imageUrl, placeholder: Image.add),
         style: .rounded,
         theme: theme
     )

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerNewAccountRowView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerNewAccountRowView.swift
@@ -54,7 +54,7 @@ final class LinkAccountPickerNewAccountRowView: UIView {
 
 private func CreateIconView(imageUrl: String, theme: FinancialConnectionsTheme) -> UIView {
     RoundedIconView(
-        image: .imageUrl(imageUrl),
+        image: .imageUrl(imageUrl, fallback: Image.add),
         style: .rounded,
         theme: theme
     )

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/RoundedIconView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/RoundedIconView.swift
@@ -12,8 +12,11 @@ import UIKit
 final class RoundedIconView: UIView {
 
     enum ImageType {
+        /// A local image. Images live in `/Resources/Images`, and defined in `/Source/Helpers/Image.swift`.
         case image(Image)
-        case imageUrl(String?)
+
+        /// A remote image from a given URL, and an optional local image to fallback to
+        case imageUrl(String?, fallback: Image? = nil)
     }
 
     enum Style {
@@ -46,10 +49,10 @@ final class RoundedIconView: UIView {
         switch image {
         case .image(let image):
             iconImageView.image = image.makeImage(template: true)
-        case .imageUrl(let imageUrl):
+        case .imageUrl(let imageUrl, let fallbackImage):
             iconImageView.setImage(
                 with: imageUrl,
-                placeholder: nil,
+                placeholder: fallbackImage?.makeImage(template: true),
                 useAlwaysTemplateRenderingMode: true
             )
         }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/RoundedIconView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/RoundedIconView.swift
@@ -15,8 +15,8 @@ final class RoundedIconView: UIView {
         /// A local image. Images live in `/Resources/Images`, and defined in `/Source/Helpers/Image.swift`.
         case image(Image)
 
-        /// A remote image from a given URL, and an optional local image to fallback to
-        case imageUrl(String?, fallback: Image? = nil)
+        /// A remote image from a given URL, and an optional local image to use as a placeholder.
+        case imageUrl(String?, placeholder: Image? = nil)
     }
 
     enum Style {
@@ -49,10 +49,10 @@ final class RoundedIconView: UIView {
         switch image {
         case .image(let image):
             iconImageView.image = image.makeImage(template: true)
-        case .imageUrl(let imageUrl, let fallbackImage):
+        case .imageUrl(let imageUrl, let placeholder):
             iconImageView.setImage(
                 with: imageUrl,
-                placeholder: fallbackImage?.makeImage(template: true),
+                placeholder: placeholder?.makeImage(template: true),
                 useAlwaysTemplateRenderingMode: true
             )
         }


### PR DESCRIPTION
## Summary

Due to an issue with one of our remote icons being inaccessible, we learned that the icon for the `Add bank account` row does not have a local fallback image. This adds support for that in the `RoundedIconView` component. 

## Motivation

Resiliency

## Testing

Both of these screenshots are taken when the `imageUrl` for the icon view is inaccessible:

| Before | After |
|--------|--------|
| ![Simulator Screenshot - iPhone 15 - 2024-09-09 at 15 45 39](https://github.com/user-attachments/assets/d6f3ebb6-283a-4e93-9286-d8773550bcd7) | ![Simulator Screenshot - iPhone 15 - 2024-09-09 at 16 19 30](https://github.com/user-attachments/assets/37a5ddbf-af82-4bb4-a793-c830bcb3c68c) | 

## Changelog

N/a
