### PR TITLE
[BANKCON-14297] Fix Instant Debits down bank error and other APIs

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
@@ -334,7 +334,7 @@ extension FinancialConnectionsAPIClient: FinancialConnectionsAPI {
         return self.post(
             resource: APIEndpointAuthSessionsCancel,
             parameters: body,
-            useConsumerPublishableKeyIfNeeded: false
+            useConsumerPublishableKeyIfNeeded: true
         )
     }
 
@@ -349,7 +349,7 @@ extension FinancialConnectionsAPIClient: FinancialConnectionsAPI {
         return self.post(
             resource: APIEndpointAuthSessionsRetrieve,
             parameters: body,
-            useConsumerPublishableKeyIfNeeded: false
+            useConsumerPublishableKeyIfNeeded: true
         )
     }
 
@@ -455,7 +455,7 @@ extension FinancialConnectionsAPIClient: FinancialConnectionsAPI {
         return self.post(
             resource: APIEndpointLinkMoreAccounts,
             parameters: body,
-            useConsumerPublishableKeyIfNeeded: false
+            useConsumerPublishableKeyIfNeeded: true
         )
     }
 


### PR DESCRIPTION
## Summary

This fixes some error handling when selecting a bank down for maintenance from the institution picker for Instant Debits. Before, we were incorrectly closing the flow in this scenario, and now we allow the user select another bank and continue through the flow.

This is fixed by allowing the `/link_account_sessions/link_more_accounts` endpoint to use the consumer's publishable key if needed.

This PR also updates two other endpoints to do the same, as they might be hit during the instant debits flow ([Android is doing the same](https://github.com/stripe/stripe-android/pull/9212/commits/eb2b48692b01ff9c0d5c9cc125bd4528c15da49b)):

- `/connections/auth_sessions/cancel`
- `/connections/auth_sessions/retrieve`

## Motivation

Correctness and consistency with other platforms

## Testing

Before:

https://github.com/user-attachments/assets/b91147d5-0b07-41fe-a380-f4597625ae23

After:

https://github.com/user-attachments/assets/a4e0e2ae-3e6a-42ca-a92f-c351cad08dca

## Changelog

N/a