### PR TITLE
[BANKCON-14297] Fix Pay+SFU mode for Instant Debits

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -152,6 +152,10 @@ extension PaymentSheet {
                     if let paymentMethodId = confirmParams.instantDebitsLinkedBank?.paymentMethodId {
                         params.paymentMethodId = paymentMethodId
                         params.paymentMethodParams = nil
+
+                        if paymentIntent.isSetupFutureUsageSet {
+                            params.mandateData = STPMandateDataParams.makeWithInferredValues()
+                        }
                     }
                 }
                 paymentHandler.confirmPayment(
@@ -179,14 +183,7 @@ extension PaymentSheet {
                     if let paymentMethodId = confirmParams.instantDebitsLinkedBank?.paymentMethodId {
                         setupIntentParams.paymentMethodID = paymentMethodId
                         setupIntentParams.paymentMethodParams = nil
-
-                        let mandateCustomerAcceptanceParams = STPMandateCustomerAcceptanceParams()
-                        let onlineParams = STPMandateOnlineParams(ipAddress: "", userAgent: "")
-                        // Tell Stripe to infer mandate info from client
-                        onlineParams.inferFromClient = true
-                        mandateCustomerAcceptanceParams.onlineParams = onlineParams
-                        mandateCustomerAcceptanceParams.type = .online
-                        setupIntentParams.mandateData = STPMandateDataParams(customerAcceptance: mandateCustomerAcceptanceParams)
+                        setupIntentParams.mandateData = STPMandateDataParams.makeWithInferredValues()
                     }
                 }
                 paymentHandler.confirmSetupIntent(
@@ -482,12 +479,7 @@ extension PaymentSheet {
         var isSetupFutureUsageSet: Bool {
             switch self {
             case .paymentIntent(let paymentIntent):
-                return paymentIntent.setupFutureUsage != .none || (paymentIntent.paymentMethodOptions?.allResponseFields.values.contains(where: {
-                    if let value = $0 as? [String: Any] {
-                        return value["setup_future_usage"] != nil
-                    }
-                    return false
-                }) ?? false)
+                return paymentIntent.isSetupFutureUsageSet
             case .setupIntent:
                 return true
             }

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentIntents/STPPaymentIntent.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentIntents/STPPaymentIntent.swift
@@ -132,6 +132,18 @@ public class STPPaymentIntent: NSObject {
     /// Payment-method-specific configuration for this PaymentIntent.
     @_spi(STP) public let paymentMethodOptions: STPPaymentMethodOptions?
 
+    /// Whether the payment intent has setup for future usage set.
+    @_spi(STP) public var isSetupFutureUsageSet: Bool {
+        let setupFutureUsageInResponse = (paymentMethodOptions?.allResponseFields.values.contains(where: {
+            if let value = $0 as? [String: Any] {
+                return value["setup_future_usage"] != nil
+            }
+            return false
+        }) ?? false)
+
+        return setupFutureUsage != .none || setupFutureUsageInResponse
+    }
+
     /// :nodoc:
     @objc public override var description: String {
         let props: [String] = [


### PR DESCRIPTION
## Summary

This fixes Instant Debits to work with setup for future usage intents. We now set the `mandate_data` param in that scenario.

## Motivation

Makes Instant Debits work as intended!

## Testing

Before: 

<img width=38% src="https://github.com/user-attachments/assets/8125cb03-4811-4eee-a63a-d8902180b02b">

Each payment mode works: 

https://github.com/user-attachments/assets/97a59c7b-69c9-4438-84ff-338b95c224c8

## Changelog

N/a
