### PR TITLE
[BANKCON-14297] Fix institution search in instant debits

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
@@ -307,7 +307,7 @@ extension FinancialConnectionsAPIClient: FinancialConnectionsAPI {
         return self.get(
             resource: APIEndpointSearchInstitutions,
             parameters: parameters,
-            useConsumerPublishableKeyIfNeeded: false
+            useConsumerPublishableKeyIfNeeded: true
         )
     }
 


### PR DESCRIPTION
## Summary

This fixes the institution search endpoint to use the consumer's publishable key when needed (i.e. instant debits). Without this, the search endpoint will never return any results.

## Motivation

✨

## Testing

| Before | After |
|--------|--------|
| ![Simulator Screenshot - iPhone 15 - 2024-09-10 at 17 11 07](https://github.com/user-attachments/assets/fb72c678-583d-413a-9d82-ccd880e81047) | ![Simulator Screenshot - iPhone 15 - 2024-09-10 at 17 10 35](https://github.com/user-attachments/assets/db6f601c-9557-4aaf-82aa-2def844e689e) | 

## Changelog

N/a
