### PR TITLE
Financial Connections: wrote a UI test for utilizing the reset flow

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
@@ -613,6 +613,39 @@ final class FinancialConnectionsUITests: XCTestCase {
                 .exists
         )
     }
+
+    // this tests going through "ResetFlowViewController"
+    func testNativeResetFlowWithErrorToSuccess() {
+        let app = XCUIApplication.fc_launch(
+            playgroundConfigurationString:
+"""
+{"use_case":"payment_intent","experience":"financial_connections","sdk_type":"native","test_mode":true,"merchant":"default","payment_method_permission":true}
+"""
+        )
+
+        app.fc_playgroundCell.tap()
+        app.fc_playgroundShowAuthFlowButton.tap()
+
+        app.fc_nativeConsentAgreeButton.waitForExistenceAndTap()
+
+        app.fc_scrollDown()
+
+        app.fc_nativeFeaturedInstitution(name: "Down bank (unscheduled)").waitForExistenceAndTap()
+
+        // selecting another bank will activate "reset flow"
+        app.buttons["select_another_bank_button"].waitForExistenceAndTap()
+
+        app.fc_nativeFeaturedInstitution(name: "Test Institution").waitForExistenceAndTap()
+
+        app.fc_nativeConnectAccountsButton.waitForExistenceAndTap()
+
+        app.fc_nativeSuccessDoneButton.waitForExistenceAndTap()
+
+        XCTAssert(
+            app.fc_playgroundSuccessAlertView.staticTexts.containing(NSPredicate(format: "label CONTAINS 'StripeBank'")).firstMatch
+                .exists
+        )
+    }
 }
 
 extension XCTestCase {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Error/ErrorViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Error/ErrorViewController.swift
@@ -61,6 +61,7 @@ final class ErrorViewController: UIViewController {
             institutionIconView.setImageUrl(dataSource.institution?.icon?.default)
             let primaryButtonConfiguration = PaneLayoutView.ButtonConfiguration(
                 title: String.Localized.select_another_bank,
+                accessibilityIdentifier: "select_another_bank_button",
                 action: { [weak self] in
                     guard let self else { return }
                     self.delegate?.errorViewControllerDidSelectAnotherBank(self)


### PR DESCRIPTION
## Summary

We did not have a UI test for the "reset flow" (ex. can happen if you press "Select Another Bank" from an error screen), so this PR writes a test for it.

## Testing

Run ` bitrise run financial-connections-stability-tests`:

```
FinancialConnectionsNetworkingUITests
    ✓ testNativeNetworkingTestMode (133.603 seconds)
    ✓ testNativeNetworkingTestModeSignUpWithMultiSelectAndPrefilledEmail (31.130 seconds)
    ✓ testNativeNetworkingTestModeSignUpWithPrefilledEmailAndPhone (24.739 seconds)
FinancialConnectionsUITests
    ✓ testDataLiveModeOAuthNativeAuthFlow (32.169 seconds)
    ✓ testDataLiveModeOAuthWebAuthFlow (19.843 seconds)
    ✓ testDataTestModeOAuthNativeAuthFlow (20.198 seconds)
    ✓ testNativeConnectMerchantForDataUseCase (21.713 seconds)
    ✓ testNativeConnectMerchantForPaymentManualEntryUseCase (17.415 seconds)
    ✓ testNativeConnectMerchantForPaymentUseCase (22.176 seconds)
    ✓ testNativeConnectMerchantForTokenCase (24.333 seconds)
    ✓ testNativeCustomManualEntryHandoff (15.540 seconds)
    ✓ testNativeOnEventClosureEvents (22.275 seconds)
    ✓ testNativeResetFlowWithErrorToSuccess (22.472 seconds)          <------------------------------------
    ✓ testNativeSkipSuccessPane (20.281 seconds)
    ✓ testPaymentSearchInLiveModeNativeAuthFlow (26.299 seconds)
    ✓ testPaymentTestModeLegacyNativeAuthFlow (20.620 seconds)
    ✓ testPaymentTestModeManualEntryAutofill (14.278 seconds)
    ✓ testPaymentTestModeManualEntryNativeAuthFlow (24.769 seconds)
    ✓ testWebInstantDebitsFlow (12.702 seconds)
InstantDebitsUITests
    ✓ test_accountHolder (17.767 seconds)
    ✓ test_nux (30.513 seconds)
    ✓ test_rux (18.052 seconds)
```