### PR TITLE
Financial Connections: re-enabled Networking Manual Entry tests

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
@@ -402,14 +402,13 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         )
     }
 
-    // TODO: uncomment once we release an SDK version w/ backend changes
-//    func testNativeNetworkingManualEntryTestMode() throws {
-//        let emailAddresss = "\(UUID().uuidString)@UITestForIOS.com"
-//        executeNativeNetworkingManualEntryTestModeSignUpFlowTest(emailAddress: emailAddresss)
-//        executeNativeNetworkingManualEntryTestModeSignInFlowTest(emailAddress: emailAddresss)
-//        executeNativeNetworkingManualEntryTestModeConsentWithUpdateRequiredTest(emailAddress: emailAddresss)
-//        executeNativeNetworkingManualEntryTestModeNotNowFlowTest(emailAddress: emailAddresss)
-//    }
+    func testNativeNetworkingManualEntryTestMode() throws {
+        let emailAddresss = "\(UUID().uuidString)@UITestForIOS.com"
+        executeNativeNetworkingManualEntryTestModeSignUpFlowTest(emailAddress: emailAddresss)
+        executeNativeNetworkingManualEntryTestModeSignInFlowTest(emailAddress: emailAddresss)
+        executeNativeNetworkingManualEntryTestModeConsentWithUpdateRequiredTest(emailAddress: emailAddresss)
+        executeNativeNetworkingManualEntryTestModeNotNowFlowTest(emailAddress: emailAddresss)
+    }
 
     private func executeNativeNetworkingManualEntryTestModeSignUpFlowTest(emailAddress: String) {
         let app = XCUIApplication.fc_launch(
@@ -499,7 +498,7 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
             XCTAssertTrue(app.fc_nativeConnectAccountsButton.waitForExistence(timeout: 60.0))
             app.fc_scrollDown()
             app.staticTexts["High Balance"].waitForExistenceAndTap()
-            
+
             app.fc_nativeConnectAccountsButton.tap()
 
             app.fc_nativeSuccessDoneButton.waitForExistenceAndTap()


### PR DESCRIPTION
## Summary

^ [backend PR landing where its safe to do this](https://git.corp.stripe.com/stripe-internal/pay-server/pull/888294)

## Testing

Ran tests:

```
FinancialConnectionsNetworkingUITests
    ✓ testNativeNetworkingManualEntryTestMode (168.810 seconds) <-------------------------------------------
    ✓ testNativeNetworkingTestMode (131.255 seconds)
    ✓ testNativeNetworkingTestModeSignUpWithMultiSelectAndPrefilledEmail (31.176 seconds)
    ✓ testNativeNetworkingTestModeSignUpWithPrefilledEmailAndPhone (24.044 seconds)
FinancialConnectionsUITests
    ✓ testDataLiveModeOAuthNativeAuthFlow (30.940 seconds)
    ✓ testDataLiveModeOAuthWebAuthFlow (21.929 seconds)
    ✓ testDataTestModeOAuthNativeAuthFlow (20.309 seconds)
    ✓ testNativeConnectMerchantForDataUseCase (20.162 seconds)
    ✓ testNativeConnectMerchantForPaymentManualEntryUseCase (17.042 seconds)
    ✓ testNativeConnectMerchantForPaymentUseCase (21.657 seconds)
    ✓ testNativeConnectMerchantForTokenCase (23.786 seconds)
    ✓ testNativeCustomManualEntryHandoff (15.856 seconds)
    ✓ testNativeOnEventClosureEvents (21.609 seconds)
    ✓ testNativeSkipSuccessPane (20.185 seconds)
    ✓ testPaymentSearchInLiveModeNativeAuthFlow (24.977 seconds)
    ✓ testPaymentTestModeLegacyNativeAuthFlow (19.406 seconds)
    ✓ testPaymentTestModeManualEntryAutofill (14.381 seconds)
    ✓ testPaymentTestModeManualEntryNativeAuthFlow (24.615 seconds)
    ✓ testWebInstantDebitsFlow (12.683 seconds)
InstantDebitsUITests
    ✓ test_accountHolder (17.042 seconds)
    ✓ test_nux (29.934 seconds)
    ✓ test_rux (18.098 seconds)


	 Executed 22 tests, with 0 failures (0 unexpected) in 729.897 (729.923) seconds
```