### PR TITLE
Eventing framework

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -236,7 +236,7 @@ class PaymentSheetStandardUITests: PaymentSheetUITestCase {
         }
         // Make sure the appropriate events have "selected_lpm" = "card"
         for analytic in analyticsLog {
-            if ["mc_form_shown", "mc_form_interacted", "mc_confirm_button_tapped", "mc_custom_payment_newpm_success"].contains(analytic[string: "event"]) {
+            if ["mc_form_shown", "mc_form_interacted", "mc_form_completed", "mc_confirm_button_tapped", "mc_custom_payment_newpm_success"].contains(analytic[string: "event"]) {
                XCTAssertEqual(analytic[string: "selected_lpm"], "card")
             }
         }
@@ -280,6 +280,9 @@ class PaymentSheetStandardUITests: PaymentSheetUITestCase {
         confirmRemoval.tap()
 
         XCTAssertEqual(app.cells.count, 3) // Should be "Add", "Apple Pay", "Link"
+
+        // Give time for analyticsLog to receive mc_custom_paymentoption_removed
+        sleep(1)
 
         XCTAssertEqual(
             analyticsLog.suffix(1).map({ $0[string: "event"] }),

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -219,8 +219,8 @@ class PaymentSheetStandardUITests: PaymentSheetUITestCase {
 
         // Check analytics
         XCTAssertEqual(
-            analyticsLog.suffix(3).map({ $0[string: "event"] }),
-            ["mc_form_interacted", "mc_card_number_completed", "mc_confirm_button_tapped"]
+            analyticsLog.suffix(4).map({ $0[string: "event"] }),
+            ["mc_form_interacted", "mc_card_number_completed", "mc_form_completed", "mc_confirm_button_tapped"]
         )
 
         app.buttons["Confirm"].tap()
@@ -280,6 +280,11 @@ class PaymentSheetStandardUITests: PaymentSheetUITestCase {
         confirmRemoval.tap()
 
         XCTAssertEqual(app.cells.count, 3) // Should be "Add", "Apple Pay", "Link"
+
+        XCTAssertEqual(
+            analyticsLog.suffix(1).map({ $0[string: "event"] }),
+            ["mc_custom_paymentoption_removed"]
+        )
     }
 
     func testPaymentSheetSwiftUI() throws {
@@ -512,8 +517,8 @@ class PaymentSheetDeferredUITests: PaymentSheetUITestCase {
         XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
 
         XCTAssertEqual(
-            analyticsLog.suffix(8).map({ $0[string: "event"] }),
-            ["mc_form_interacted", "mc_card_number_completed", "mc_confirm_button_tapped", "stripeios.payment_method_creation", "stripeios.paymenthandler.confirm.started", "stripeios.payment_intent_confirmation", "stripeios.paymenthandler.confirm.finished", "mc_complete_payment_newpm_success"]
+            analyticsLog.suffix(9).map({ $0[string: "event"] }),
+            ["mc_form_interacted", "mc_card_number_completed", "mc_form_completed", "mc_confirm_button_tapped", "stripeios.payment_method_creation", "stripeios.paymenthandler.confirm.started", "stripeios.payment_intent_confirmation", "stripeios.paymenthandler.confirm.finished", "mc_complete_payment_newpm_success"]
         )
 
         // Make sure they all have the same session id

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetVerticalUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetVerticalUITest.swift
@@ -106,7 +106,7 @@ class PaymentSheetVerticalUITests: PaymentSheetUITestCase {
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10))
         XCTAssertEqual(
             analyticsLog.map({ $0[string: "event"]! }).filter({ $0.starts(with: "mc") }),
-            ["mc_load_started", "mc_load_succeeded", "mc_custom_init_customer_applepay", "mc_custom_sheet_newpm_show", "mc_carousel_payment_method_tapped", "mc_form_shown", "mc_form_interacted", "mc_confirm_button_tapped", "mc_custom_payment_newpm_success"]
+            ["mc_load_started", "mc_load_succeeded", "mc_custom_init_customer_applepay", "mc_custom_sheet_newpm_show", "mc_carousel_payment_method_tapped", "mc_form_shown", "mc_form_interacted", "mc_form_completed", "mc_confirm_button_tapped", "mc_custom_payment_newpm_success"]
         )
         // Reload
         reload(app, settings: settings)

--- a/StripeCore/StripeCore.xcodeproj/project.pbxproj
+++ b/StripeCore/StripeCore.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		6A05FB4B2BCF245C0001D128 /* FinancialConnectionsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A05FB4A2BCF245C0001D128 /* FinancialConnectionsEvent.swift */; };
 		6A52ABC06783A90B9E339948 /* StripeFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73CE623A81057C4063A1E0C4 /* StripeFile.swift */; };
 		6B4156FCFAEDD1C73DC6EDAD /* iOSSnapshotTestCase in Frameworks */ = {isa = PBXBuildFile; platformFilters = (ios, maccatalyst, ); productRef = 23D22B2C40BA7C182BCE50B2 /* iOSSnapshotTestCase */; };
+		6B9282392C94A99400277765 /* STPAnalyticsEventTranslatorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9282382C94A99400277765 /* STPAnalyticsEventTranslatorTest.swift */; };
 		6B987BDA2C910F5500DDFDB3 /* STPAnalyticsEventTranslator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B987BD92C910F5500DDFDB3 /* STPAnalyticsEventTranslator.swift */; };
 		6B987BDD2C9111BC00DDFDB3 /* Notification+Stripe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B987BDC2C9111BC00DDFDB3 /* Notification+Stripe.swift */; };
 		6B9C7B832BC73B1C007D5A28 /* AnalyticsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9C7B822BC73B1C007D5A28 /* AnalyticsHelper.swift */; };
@@ -247,6 +248,7 @@
 		6A05FB462BCF24370001D128 /* FinancialConnectionsLinkedBank.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsLinkedBank.swift; sourceTree = "<group>"; };
 		6A05FB482BCF244A0001D128 /* InstantDebitsLinkedBank.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstantDebitsLinkedBank.swift; sourceTree = "<group>"; };
 		6A05FB4A2BCF245C0001D128 /* FinancialConnectionsEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsEvent.swift; sourceTree = "<group>"; };
+		6B9282382C94A99400277765 /* STPAnalyticsEventTranslatorTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPAnalyticsEventTranslatorTest.swift; sourceTree = "<group>"; };
 		6B987BD92C910F5500DDFDB3 /* STPAnalyticsEventTranslator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPAnalyticsEventTranslator.swift; sourceTree = "<group>"; };
 		6B987BDC2C9111BC00DDFDB3 /* Notification+Stripe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification+Stripe.swift"; sourceTree = "<group>"; };
 		6B9C7B822BC73B1C007D5A28 /* AnalyticsHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHelper.swift; sourceTree = "<group>"; };
@@ -462,6 +464,7 @@
 				B3CA4B1855BF8D2F08F275A9 /* Error_SerializeForLoggingTest.swift */,
 				B67F2CA32BAB91860011E34A /* AnalyticLoggableErrorTest.swift */,
 				2B16FDA9232BD4FBD4B13EC2 /* STPAnalyticsClientTest.swift */,
+				6B9282382C94A99400277765 /* STPAnalyticsEventTranslatorTest.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -943,6 +946,7 @@
 				8AD68C8D00A0BCF94E5230DC /* UIImage+StripeCoreTests.swift in Sources */,
 				6D68B868938BAB15A843B33C /* TestJSONEncoder.swift in Sources */,
 				EFF90360C85642F7F2898186 /* URLEncoderTest.swift in Sources */,
+				6B9282392C94A99400277765 /* STPAnalyticsEventTranslatorTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/StripeCore/StripeCore.xcodeproj/project.pbxproj
+++ b/StripeCore/StripeCore.xcodeproj/project.pbxproj
@@ -53,6 +53,8 @@
 		6A05FB4B2BCF245C0001D128 /* FinancialConnectionsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A05FB4A2BCF245C0001D128 /* FinancialConnectionsEvent.swift */; };
 		6A52ABC06783A90B9E339948 /* StripeFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73CE623A81057C4063A1E0C4 /* StripeFile.swift */; };
 		6B4156FCFAEDD1C73DC6EDAD /* iOSSnapshotTestCase in Frameworks */ = {isa = PBXBuildFile; platformFilters = (ios, maccatalyst, ); productRef = 23D22B2C40BA7C182BCE50B2 /* iOSSnapshotTestCase */; };
+		6B987BDA2C910F5500DDFDB3 /* STPAnalyticsEventTranslator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B987BD92C910F5500DDFDB3 /* STPAnalyticsEventTranslator.swift */; };
+		6B987BDD2C9111BC00DDFDB3 /* Notification+Stripe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B987BDC2C9111BC00DDFDB3 /* Notification+Stripe.swift */; };
 		6B9C7B832BC73B1C007D5A28 /* AnalyticsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9C7B822BC73B1C007D5A28 /* AnalyticsHelper.swift */; };
 		6D68B868938BAB15A843B33C /* TestJSONEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF290DF69F5FD1004BBDECA /* TestJSONEncoder.swift */; };
 		6ED5C41DBDAB475BF1119E98 /* UnknownFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64635404BD4D5D62486A7626 /* UnknownFields.swift */; };
@@ -245,6 +247,8 @@
 		6A05FB462BCF24370001D128 /* FinancialConnectionsLinkedBank.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsLinkedBank.swift; sourceTree = "<group>"; };
 		6A05FB482BCF244A0001D128 /* InstantDebitsLinkedBank.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstantDebitsLinkedBank.swift; sourceTree = "<group>"; };
 		6A05FB4A2BCF245C0001D128 /* FinancialConnectionsEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsEvent.swift; sourceTree = "<group>"; };
+		6B987BD92C910F5500DDFDB3 /* STPAnalyticsEventTranslator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPAnalyticsEventTranslator.swift; sourceTree = "<group>"; };
+		6B987BDC2C9111BC00DDFDB3 /* Notification+Stripe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification+Stripe.swift"; sourceTree = "<group>"; };
 		6B9C7B822BC73B1C007D5A28 /* AnalyticsHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHelper.swift; sourceTree = "<group>"; };
 		6CDBCD70CB220014972B49A5 /* PluginDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginDetector.swift; sourceTree = "<group>"; };
 		6E852B53CF75A119D3810B41 /* NSBundle+Stripe_AppName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSBundle+Stripe_AppName.swift"; sourceTree = "<group>"; };
@@ -515,6 +519,7 @@
 		66BA4CFF0FEE2E4813FB4D31 /* Analytics */ = {
 			isa = PBXGroup;
 			children = (
+				6B987BDB2C91119100DDFDB3 /* Eventing */,
 				B6DBB2BE2BA8C4E300783D15 /* STPAnalyticsClient+Error.swift */,
 				ABF11F814A986AA710410FF8 /* Analytic.swift */,
 				6B9C7B822BC73B1C007D5A28 /* AnalyticsHelper.swift */,
@@ -537,6 +542,15 @@
 				8FF688F66CD047D08B3AE0CB /* String+Localized.swift */,
 			);
 			path = Localization;
+			sourceTree = "<group>";
+		};
+		6B987BDB2C91119100DDFDB3 /* Eventing */ = {
+			isa = PBXGroup;
+			children = (
+				6B987BD92C910F5500DDFDB3 /* STPAnalyticsEventTranslator.swift */,
+				6B987BDC2C9111BC00DDFDB3 /* Notification+Stripe.swift */,
+			);
+			path = Eventing;
 			sourceTree = "<group>";
 		};
 		6D488D8BF0ADC365242F73C8 /* API Bindings */ = {
@@ -947,6 +961,7 @@
 				552DA7969984C443617DBC3E /* STPMultipartFormDataPart.swift in Sources */,
 				DAD4099D03E43A0CA89464CD /* StripeAPI.swift in Sources */,
 				D22FAB2F1AE9AE43C1808747 /* StripeAPIConfiguration+Version.swift in Sources */,
+				6B987BDA2C910F5500DDFDB3 /* STPAnalyticsEventTranslator.swift in Sources */,
 				677951C643328D76E46720A5 /* StripeAPIConfiguration.swift in Sources */,
 				6A05FB4B2BCF245C0001D128 /* FinancialConnectionsEvent.swift in Sources */,
 				02A26B79617FAE660C9EB506 /* StripeError.swift in Sources */,
@@ -999,6 +1014,7 @@
 				2991461DD354A6124CCF78DA /* STPLocalizationUtils.swift in Sources */,
 				4506A7016EA7C45796D3A30D /* STPLocalizedString.swift in Sources */,
 				DFF3092E51B6C3ED81AB1448 /* String+Localized.swift in Sources */,
+				6B987BDD2C9111BC00DDFDB3 /* Notification+Stripe.swift in Sources */,
 				89DB623A200678B4E9845AF2 /* FraudDetectionData.swift in Sources */,
 				920832EE256E377572DD41EB /* STPTelemetryClient.swift in Sources */,
 				3B27DDDDC91F1599BF1469BB /* UserDefaults+PaymentsCore.swift in Sources */,

--- a/StripeCore/StripeCore/Source/Analytics/Eventing/Notification+Stripe.swift
+++ b/StripeCore/StripeCore/Source/Analytics/Eventing/Notification+Stripe.swift
@@ -6,16 +6,22 @@
 import Foundation
 
 /**
- * WARNING: These events are intended to be used for analytics purposes ONLY. This API is highly volatile and is expected to change without notice.  There are no
- * guarantees about the accuracy, correctness, or stability of when these events are fired nor the data associated with them.
+ * WARNING: These events are intended to be used for analytics purposes ONLY. This API is volatile and is expected to change.
+ * There are no guarantees about the accuracy, correctness, or stability of when these events are fired nor the data associated with them.
  */
 @_spi(MobilePaymentElementEventingBeta)
 public extension Notification.Name {
+    /// The name of the notification used to send notifications for Mobile Payment Element
     static let mobilePaymentElement = Notification.Name("MobilePaymentElement")
 }
 
 @_spi(MobilePaymentElementEventingBeta)
+/// The object type of the NSNotification's object.
 public struct MobilePaymentElementEvent {
+
+    /// The name of the event
     public let eventName: String
+
+    /// Associated metadata with the event
     public let metadata: [String: Any?]
 }

--- a/StripeCore/StripeCore/Source/Analytics/Eventing/Notification+Stripe.swift
+++ b/StripeCore/StripeCore/Source/Analytics/Eventing/Notification+Stripe.swift
@@ -14,7 +14,6 @@ public extension Notification.Name {
     static let mobilePaymentElement = Notification.Name("MobilePaymentElement")
 }
 
-
 @_spi(MobilePaymentElementEventingBeta)
 public struct MobilePaymentElementEvent {
     public let eventName: String

--- a/StripeCore/StripeCore/Source/Analytics/Eventing/Notification+Stripe.swift
+++ b/StripeCore/StripeCore/Source/Analytics/Eventing/Notification+Stripe.swift
@@ -5,13 +5,12 @@
 
 import Foundation
 
-/**
- * WARNING: These events are intended to be used for analytics purposes ONLY. This API is volatile and is expected to change.
- * There are no guarantees about the accuracy, correctness, or stability of when these events are fired nor the data associated with them.
- */
 @_spi(MobilePaymentElementEventingBeta)
 public extension Notification.Name {
-    /// The name of the notification used to send notifications for Mobile Payment Element
+    /// WARNING: These events are intended to be used for analytics purposes ONLY. This API is volatile and is expected to change.
+    /// There are no guarantees about the accuracy, correctness, or stability of when these events are fired nor the data associated with them.
+    ///
+    /// A notification posted by Mobile Payment Element for analytics purposes.
     static let mobilePaymentElement = Notification.Name("MobilePaymentElement")
 }
 
@@ -20,12 +19,12 @@ public extension Notification.Name {
 public struct MobilePaymentElementEvent {
 
     /// The name of the event
-    public let eventName: Name
+    public let eventName: EventName
 
     /// Associated metadata with the event
     public let metadata: [MetadataKey: Any?]
 
-    public enum Name {
+    public enum EventName {
         case presentedSheet
         case selectedPaymentMethodType
         case displayedPaymentMethodForm

--- a/StripeCore/StripeCore/Source/Analytics/Eventing/Notification+Stripe.swift
+++ b/StripeCore/StripeCore/Source/Analytics/Eventing/Notification+Stripe.swift
@@ -20,8 +20,25 @@ public extension Notification.Name {
 public struct MobilePaymentElementEvent {
 
     /// The name of the event
-    public let eventName: String
+    public let eventName: Name
 
     /// Associated metadata with the event
-    public let metadata: [String: Any?]
+    public let metadata: [MetadataKey: Any?]
+
+    public enum Name {
+        case presentedSheet
+        case selectedPaymentMethodType
+        case displayedPaymentMethodForm
+
+        case startedInteractionWithPaymentMethodForm
+        case completedPaymentMethodForm
+        case tappedConfirmButton
+
+        case selectedSavedPaymentMethod
+        case removedSavedPaymentMethod
+    }
+
+    public enum MetadataKey {
+        case paymentMethodType
+    }
 }

--- a/StripeCore/StripeCore/Source/Analytics/Eventing/Notification+Stripe.swift
+++ b/StripeCore/StripeCore/Source/Analytics/Eventing/Notification+Stripe.swift
@@ -1,0 +1,22 @@
+//
+//  Notification+Stripe.swift
+//  StripeCore
+//
+
+import Foundation
+
+/**
+ * WARNING: These events are intended to be used for analytics purposes ONLY. This API is highly volatile and is expected to change without notice.  There are no
+ * guarantees about the accuracy, correctness, or stability of when these events are fired nor the data associated with them.
+ */
+@_spi(MobilePaymentElementEventingBeta)
+public extension Notification.Name {
+    static let mobilePaymentElement = Notification.Name("MobilePaymentElement")
+}
+
+
+@_spi(MobilePaymentElementEventingBeta)
+public struct MobilePaymentElementEvent {
+    public let eventName: String
+    public let metadata: [String: Any?]
+}

--- a/StripeCore/StripeCore/Source/Analytics/Eventing/STPAnalyticsEventTranslator.swift
+++ b/StripeCore/StripeCore/Source/Analytics/Eventing/STPAnalyticsEventTranslator.swift
@@ -10,8 +10,8 @@ struct STPAnalyticsTranslatedEvent {
     let event: MobilePaymentElementEvent
 
     init(notificationName: Notification.Name = .mobilePaymentElement,
-         eventName: String,
-         metadata: [String: Any]) {
+         eventName: MobilePaymentElementEvent.Name,
+         metadata: [MobilePaymentElementEvent.MetadataKey: Any]) {
         self.notificationName = notificationName
         self.event = .init(eventName: eventName, metadata: metadata)
     }
@@ -25,43 +25,43 @@ struct STPAnalyticsEventTranslator {
         return .init(eventName: translatedEventName, metadata: filterPayload(payload))
     }
 
-    func translateEvent(_ analyticEvent: STPAnalyticEvent) -> String? {
+    func translateEvent(_ analyticEvent: STPAnalyticEvent) -> MobilePaymentElementEvent.Name? {
         switch analyticEvent {
         // Sheet presentation
         case .mcShowCustomNewPM, .mcShowCompleteNewPM, .mcShowCustomSavedPM, .mcShowCompleteSavedPM:
-            return "presentedSheet"
+            return .presentedSheet
 
         // Tapping on a payment method type
         case .paymentSheetCarouselPaymentMethodTapped:
-            return "selectedPaymentMethodType"
+            return .selectedPaymentMethodType
 
         // Payment Method form showed
         case .paymentSheetFormShown:
-            return "displayedPaymentMethodForm"
+            return .displayedPaymentMethodForm
 
         // Form Interaction
         case .paymentSheetFormInteracted:
-            return "startedInteractionWithPaymentMethodForm"
+            return .startedInteractionWithPaymentMethodForm
         case .paymentSheetFormCompleted:
-            return "completedPaymentMethodForm"
+            return .completedPaymentMethodForm
         case .paymentSheetConfirmButtonTapped:
-            return "tappedConfirmButton"
+            return .tappedConfirmButton
 
         // Saved Payment Methods
         case .mcOptionSelectCustomSavedPM, .mcOptionSelectCompleteSavedPM:
-            return "selectedSavedPaymentMethod"
+            return .selectedSavedPaymentMethod
         case .mcOptionRemoveCustomSavedPM, .mcOptionRemoveCompleteSavedPM:
-            return "removedSavedPaymentMethod"
+            return .removedSavedPaymentMethod
 
         default:
             return nil
         }
     }
 
-    func filterPayload(_ originalPayload: [String: Any]) -> [String: Any] {
-        var filteredPayload: [String: Any] = [:]
+    func filterPayload(_ originalPayload: [String: Any]) -> [MobilePaymentElementEvent.MetadataKey: Any] {
+        var filteredPayload: [MobilePaymentElementEvent.MetadataKey: Any] = [:]
         if let paymentMethodType = originalPayload["selected_lpm"] {
-            filteredPayload["paymentMethodType"] = paymentMethodType
+            filteredPayload[.paymentMethodType] = paymentMethodType
         }
         return filteredPayload
     }

--- a/StripeCore/StripeCore/Source/Analytics/Eventing/STPAnalyticsEventTranslator.swift
+++ b/StripeCore/StripeCore/Source/Analytics/Eventing/STPAnalyticsEventTranslator.swift
@@ -18,15 +18,15 @@ struct STPAnalyticsTranslatedEvent {
 }
 
 struct STPAnalyticsEventTranslator {
-    func translate(_ analytic: Analytic, payload: [String: Any]) -> STPAnalyticsTranslatedEvent? {
-        guard let translatedEventName = translateEvent(analytic) else {
+    func translate(_ analyticEvent: STPAnalyticEvent, payload: [String: Any]) -> STPAnalyticsTranslatedEvent? {
+        guard let translatedEventName = translateEvent(analyticEvent) else {
             return nil
         }
-        return .init(eventName: translatedEventName, metadata: translatePayload(payload))
+        return .init(eventName: translatedEventName, metadata: filterPayload(payload))
     }
 
-    func translateEvent(_ analytic: Analytic) -> String? {
-        switch analytic.event {
+    func translateEvent(_ analyticEvent: STPAnalyticEvent) -> String? {
+        switch analyticEvent {
         // Sheet presentation
         case .mcShowCustomNewPM, .mcShowCompleteNewPM, .mcShowCustomSavedPM, .mcShowCompleteSavedPM:
             return "presentedSheet"
@@ -58,11 +58,11 @@ struct STPAnalyticsEventTranslator {
         }
     }
 
-    func translatePayload(_ payload: [String: Any]) -> [String: Any] {
-        var payload: [String: Any] = [:]
-        if let paymentMethodType = payload["selected_lpm"] {
-            payload["paymentMethodType"] = paymentMethodType
+    func filterPayload(_ originalPayload: [String: Any]) -> [String: Any] {
+        var filteredPayload: [String: Any] = [:]
+        if let paymentMethodType = originalPayload["selected_lpm"] {
+            filteredPayload["paymentMethodType"] = paymentMethodType
         }
-        return payload
+        return filteredPayload
     }
 }

--- a/StripeCore/StripeCore/Source/Analytics/Eventing/STPAnalyticsEventTranslator.swift
+++ b/StripeCore/StripeCore/Source/Analytics/Eventing/STPAnalyticsEventTranslator.swift
@@ -49,7 +49,3 @@ struct STPAnalyticsEventTranslator {
         }
     }
 }
-
-
-
-

--- a/StripeCore/StripeCore/Source/Analytics/Eventing/STPAnalyticsEventTranslator.swift
+++ b/StripeCore/StripeCore/Source/Analytics/Eventing/STPAnalyticsEventTranslator.swift
@@ -1,0 +1,82 @@
+//
+//  STPAnalyticsEventTranslator.swift
+//  StripeCore
+//
+
+import Foundation
+
+struct STPAnalyticsTranslatedEvent {
+    let notificationName: Notification.Name
+    let event: MobilePaymentElementEvent
+
+    init(notificationName: Notification.Name = .mobilePaymentElement,
+         eventName: String,
+         metadata: [String: Any]) {
+        self.notificationName = notificationName
+        self.event = .init(eventName: eventName, metadata: metadata)
+    }
+}
+
+struct STPAnalyticsEventTranslator {
+    func translate(_ analytic: Analytic, payload: [String: Any]) -> STPAnalyticsTranslatedEvent? {
+        switch analytic.event {
+
+        // Sheet presentation (Custom)
+        case .mcShowCustomNewPM:
+            return .init(eventName: "didPresentCustom", metadata: payload)
+        case .mcShowCustomSavedPM:
+            return .init(eventName: "didPresentWithSavedPMCustom", metadata: payload)
+
+        // Sheet presentation (Complete)
+        case .mcShowCompleteNewPM:
+            return .init(eventName: "didPresentComplete", metadata: payload)
+        case .mcShowCompleteSavedPM:
+            return .init(eventName: "didPresentWithSavedPMComplete", metadata: payload)
+
+        // Tapping on a payment method type
+        case .paymentSheetCarouselPaymentMethodTapped:
+            return .init(eventName: "didSelectPaymentMethodType", metadata: payload)
+
+        // Payment Method form showed
+        case .paymentSheetFormShown:
+            return .init(eventName: "didShowPaymentMethodForm", metadata: payload)
+
+        // Form Interaction
+        case .paymentSheetFormInteracted:
+            return .init(eventName: "didStartInteractWithForm", metadata: payload)
+        case .paymentSheetFormCompleted:
+            return .init(eventName: "formDidComplete", metadata: payload)
+
+        // Removing Payment Method
+        case .mcSavedPaymentMethodRemoved:
+            return .init(eventName: "didRemovePaymentMethod", metadata: payload)
+
+        // Saved Payment Methods (Custom)
+        case .mcOptionSelectCustomNewPM:
+            return .init(eventName: "didSelectSavedPaymentMethodNewCustom", metadata: payload)
+        case .mcOptionSelectCustomSavedPM:
+            return .init(eventName: "didSelectSavedPaymentMethodSavedCustom", metadata: payload)
+        case .mcOptionSelectCustomApplePay:
+            return .init(eventName: "didSelectSavedPaymentMethodApplePayCustom", metadata: payload)
+        case .mcOptionSelectCustomLink:
+            return .init(eventName: "didSelectSavedPaymentMethodLinkCustom", metadata: payload)
+
+        // Saved Payment Methods (Complete)
+        case .mcOptionSelectCompleteNewPM:
+            return .init(eventName: "didSelectSavedPaymentMethodNewComplete", metadata: payload)
+        case .mcOptionSelectCompleteSavedPM:
+            return .init(eventName: "didSelectSavedPaymentMethodSavedComplete", metadata: payload)
+        case .mcOptionSelectCompleteApplePay:
+            return .init(eventName: "didSelectSavedPaymentMethodApplePayComplete", metadata: payload)
+        case .mcOptionSelectCompleteLink:
+            return .init(eventName: "didSelectSavedPaymentMethodLinkComplete", metadata: payload)
+
+        default:
+            return nil
+        }
+    }
+}
+
+
+
+

--- a/StripeCore/StripeCore/Source/Analytics/Eventing/STPAnalyticsEventTranslator.swift
+++ b/StripeCore/StripeCore/Source/Analytics/Eventing/STPAnalyticsEventTranslator.swift
@@ -10,7 +10,7 @@ struct STPAnalyticsTranslatedEvent {
     let event: MobilePaymentElementEvent
 
     init(notificationName: Notification.Name = .mobilePaymentElement,
-         eventName: MobilePaymentElementEvent.Name,
+         eventName: MobilePaymentElementEvent.EventName,
          metadata: [MobilePaymentElementEvent.MetadataKey: Any]) {
         self.notificationName = notificationName
         self.event = .init(eventName: eventName, metadata: metadata)
@@ -25,7 +25,7 @@ struct STPAnalyticsEventTranslator {
         return .init(eventName: translatedEventName, metadata: filterPayload(payload))
     }
 
-    func translateEvent(_ analyticEvent: STPAnalyticEvent) -> MobilePaymentElementEvent.Name? {
+    func translateEvent(_ analyticEvent: STPAnalyticEvent) -> MobilePaymentElementEvent.EventName? {
         switch analyticEvent {
         // Sheet presentation
         case .mcShowCustomNewPM, .mcShowCompleteNewPM, .mcShowCustomSavedPM, .mcShowCompleteSavedPM:

--- a/StripeCore/StripeCore/Source/Analytics/Eventing/STPAnalyticsEventTranslator.swift
+++ b/StripeCore/StripeCore/Source/Analytics/Eventing/STPAnalyticsEventTranslator.swift
@@ -21,17 +21,11 @@ struct STPAnalyticsEventTranslator {
     func translate(_ analytic: Analytic, payload: [String: Any]) -> STPAnalyticsTranslatedEvent? {
         switch analytic.event {
 
-        // Sheet presentation (Custom)
-        case .mcShowCustomNewPM:
-            return .init(eventName: "didPresentCustom", metadata: payload)
-        case .mcShowCustomSavedPM:
-            return .init(eventName: "didPresentWithSavedPMCustom", metadata: payload)
-
-        // Sheet presentation (Complete)
-        case .mcShowCompleteNewPM:
-            return .init(eventName: "didPresentComplete", metadata: payload)
-        case .mcShowCompleteSavedPM:
-            return .init(eventName: "didPresentWithSavedPMComplete", metadata: payload)
+        // Sheet presentation
+        case .mcShowCustomNewPM, .mcShowCompleteNewPM:
+            return .init(eventName: "didPresent", metadata: payload)
+        case .mcShowCustomSavedPM, .mcShowCompleteSavedPM:
+            return .init(eventName: "didPresentWithSavedPM", metadata: payload)
 
         // Tapping on a payment method type
         case .paymentSheetCarouselPaymentMethodTapped:
@@ -51,25 +45,15 @@ struct STPAnalyticsEventTranslator {
         case .mcSavedPaymentMethodRemoved:
             return .init(eventName: "didRemovePaymentMethod", metadata: payload)
 
-        // Saved Payment Methods (Custom)
-        case .mcOptionSelectCustomNewPM:
-            return .init(eventName: "didSelectSavedPaymentMethodNewCustom", metadata: payload)
-        case .mcOptionSelectCustomSavedPM:
-            return .init(eventName: "didSelectSavedPaymentMethodSavedCustom", metadata: payload)
-        case .mcOptionSelectCustomApplePay:
-            return .init(eventName: "didSelectSavedPaymentMethodApplePayCustom", metadata: payload)
-        case .mcOptionSelectCustomLink:
-            return .init(eventName: "didSelectSavedPaymentMethodLinkCustom", metadata: payload)
-
-        // Saved Payment Methods (Complete)
-        case .mcOptionSelectCompleteNewPM:
-            return .init(eventName: "didSelectSavedPaymentMethodNewComplete", metadata: payload)
-        case .mcOptionSelectCompleteSavedPM:
-            return .init(eventName: "didSelectSavedPaymentMethodSavedComplete", metadata: payload)
-        case .mcOptionSelectCompleteApplePay:
-            return .init(eventName: "didSelectSavedPaymentMethodApplePayComplete", metadata: payload)
-        case .mcOptionSelectCompleteLink:
-            return .init(eventName: "didSelectSavedPaymentMethodLinkComplete", metadata: payload)
+        // Saved Payment Methods
+        case .mcOptionSelectCustomNewPM, .mcOptionSelectCompleteNewPM:
+            return .init(eventName: "didSelectSavedPaymentMethodNew", metadata: payload)
+        case .mcOptionSelectCustomSavedPM, .mcOptionSelectCompleteSavedPM:
+            return .init(eventName: "didSelectSavedPaymentMethodSaved", metadata: payload)
+        case .mcOptionSelectCustomApplePay, .mcOptionSelectCompleteApplePay:
+            return .init(eventName: "didSelectSavedPaymentMethodApplePay", metadata: payload)
+        case .mcOptionSelectCustomLink, .mcOptionSelectCompleteLink:
+            return .init(eventName: "didSelectSavedPaymentMethodLink", metadata: payload)
 
         default:
             return nil

--- a/StripeCore/StripeCore/Source/Analytics/Eventing/STPAnalyticsEventTranslator.swift
+++ b/StripeCore/StripeCore/Source/Analytics/Eventing/STPAnalyticsEventTranslator.swift
@@ -42,7 +42,7 @@ struct STPAnalyticsEventTranslator {
         // Saved Payment Methods
         case .mcOptionSelectCustomSavedPM, .mcOptionSelectCompleteSavedPM:
             return .init(eventName: "selectedSavedPaymentMethod", metadata: payload)
-        case .mcSavedPaymentMethodRemoved:
+        case .mcOptionRemoveCustomSavedPM, .mcOptionRemoveCompleteSavedPM:
             return .init(eventName: "removedSavedPaymentMethod", metadata: payload)
         default:
             return nil

--- a/StripeCore/StripeCore/Source/Analytics/Eventing/STPAnalyticsEventTranslator.swift
+++ b/StripeCore/StripeCore/Source/Analytics/Eventing/STPAnalyticsEventTranslator.swift
@@ -19,33 +19,50 @@ struct STPAnalyticsTranslatedEvent {
 
 struct STPAnalyticsEventTranslator {
     func translate(_ analytic: Analytic, payload: [String: Any]) -> STPAnalyticsTranslatedEvent? {
-        switch analytic.event {
+        guard let translatedEventName = translateEvent(analytic) else {
+            return nil
+        }
+        return .init(eventName: translatedEventName, metadata: translatePayload(payload))
+    }
 
+    func translateEvent(_ analytic: Analytic) -> String? {
+        switch analytic.event {
         // Sheet presentation
         case .mcShowCustomNewPM, .mcShowCompleteNewPM, .mcShowCustomSavedPM, .mcShowCompleteSavedPM:
-            return .init(eventName: "presentedSheet", metadata: payload)
+            return "presentedSheet"
 
         // Tapping on a payment method type
         case .paymentSheetCarouselPaymentMethodTapped:
-            return .init(eventName: "selectedPaymentMethodType", metadata: payload)
+            return "selectedPaymentMethodType"
 
         // Payment Method form showed
         case .paymentSheetFormShown:
-            return .init(eventName: "displayedPaymentMethodForm", metadata: payload)
+            return "displayedPaymentMethodForm"
 
         // Form Interaction
         case .paymentSheetFormInteracted:
-            return .init(eventName: "startedInteractionWithPaymentMethodForm", metadata: payload)
+            return "startedInteractionWithPaymentMethodForm"
         case .paymentSheetFormCompleted:
-            return .init(eventName: "completedPaymentMethodForm", metadata: payload)
+            return "completedPaymentMethodForm"
+        case .paymentSheetConfirmButtonTapped:
+            return "tappedConfirmButton"
 
         // Saved Payment Methods
         case .mcOptionSelectCustomSavedPM, .mcOptionSelectCompleteSavedPM:
-            return .init(eventName: "selectedSavedPaymentMethod", metadata: payload)
+            return "selectedSavedPaymentMethod"
         case .mcOptionRemoveCustomSavedPM, .mcOptionRemoveCompleteSavedPM:
-            return .init(eventName: "removedSavedPaymentMethod", metadata: payload)
+            return "removedSavedPaymentMethod"
+
         default:
             return nil
         }
+    }
+
+    func translatePayload(_ payload: [String: Any]) -> [String: Any] {
+        var payload: [String: Any] = [:]
+        if let paymentMethodType = payload["selected_lpm"] {
+            payload["paymentMethodType"] = paymentMethodType
+        }
+        return payload
     }
 }

--- a/StripeCore/StripeCore/Source/Analytics/Eventing/STPAnalyticsEventTranslator.swift
+++ b/StripeCore/StripeCore/Source/Analytics/Eventing/STPAnalyticsEventTranslator.swift
@@ -22,39 +22,28 @@ struct STPAnalyticsEventTranslator {
         switch analytic.event {
 
         // Sheet presentation
-        case .mcShowCustomNewPM, .mcShowCompleteNewPM:
-            return .init(eventName: "didPresent", metadata: payload)
-        case .mcShowCustomSavedPM, .mcShowCompleteSavedPM:
-            return .init(eventName: "didPresentWithSavedPM", metadata: payload)
+        case .mcShowCustomNewPM, .mcShowCompleteNewPM, .mcShowCustomSavedPM, .mcShowCompleteSavedPM:
+            return .init(eventName: "presentedSheet", metadata: payload)
 
         // Tapping on a payment method type
         case .paymentSheetCarouselPaymentMethodTapped:
-            return .init(eventName: "didSelectPaymentMethodType", metadata: payload)
+            return .init(eventName: "selectedPaymentMethodType", metadata: payload)
 
         // Payment Method form showed
         case .paymentSheetFormShown:
-            return .init(eventName: "didShowPaymentMethodForm", metadata: payload)
+            return .init(eventName: "displayedPaymentMethodForm", metadata: payload)
 
         // Form Interaction
         case .paymentSheetFormInteracted:
-            return .init(eventName: "didStartInteractWithForm", metadata: payload)
+            return .init(eventName: "startedInteractionWithPaymentMethodForm", metadata: payload)
         case .paymentSheetFormCompleted:
-            return .init(eventName: "formDidComplete", metadata: payload)
-
-        // Removing Payment Method
-        case .mcSavedPaymentMethodRemoved:
-            return .init(eventName: "didRemovePaymentMethod", metadata: payload)
+            return .init(eventName: "completedPaymentMethodForm", metadata: payload)
 
         // Saved Payment Methods
-        case .mcOptionSelectCustomNewPM, .mcOptionSelectCompleteNewPM:
-            return .init(eventName: "didSelectSavedPaymentMethodNew", metadata: payload)
         case .mcOptionSelectCustomSavedPM, .mcOptionSelectCompleteSavedPM:
-            return .init(eventName: "didSelectSavedPaymentMethodSaved", metadata: payload)
-        case .mcOptionSelectCustomApplePay, .mcOptionSelectCompleteApplePay:
-            return .init(eventName: "didSelectSavedPaymentMethodApplePay", metadata: payload)
-        case .mcOptionSelectCustomLink, .mcOptionSelectCompleteLink:
-            return .init(eventName: "didSelectSavedPaymentMethodLink", metadata: payload)
-
+            return .init(eventName: "selectedSavedPaymentMethod", metadata: payload)
+        case .mcSavedPaymentMethodRemoved:
+            return .init(eventName: "removedSavedPaymentMethod", metadata: payload)
         default:
             return nil
         }

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
@@ -113,7 +113,8 @@ import Foundation
     case mcOptionSelectCompleteLink = "mc_complete_paymentoption_link_select"
 
     // MARK: - PaymentSheet Saved Payment Method Removed
-    case mcSavedPaymentMethodRemoved = "mc_savedpaymentmethod_removed"
+    case mcOptionRemoveCustomSavedPM = "mc_custom_paymentoption_removed"
+    case mcOptionRemoveCompleteSavedPM = "mc_complete_paymentoption_removed"
 
     // MARK: - Link Signup
     case linkSignupCheckboxChecked = "link.signup.checkbox_checked"

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
@@ -112,6 +112,9 @@ import Foundation
     case mcOptionSelectCompleteApplePay = "mc_complete_paymentoption_applepay_select"
     case mcOptionSelectCompleteLink = "mc_complete_paymentoption_link_select"
 
+    // MARK: - PaymentSheet Saved Payment Method Removed
+    case mcSavedPaymentMethodRemoved = "mc_savedpaymentmethod_removed"
+
     // MARK: - Link Signup
     case linkSignupCheckboxChecked = "link.signup.checkbox_checked"
     case linkSignupFlowPresented = "link.signup.flow_presented"
@@ -193,6 +196,7 @@ import Foundation
     case paymentSheetConfirmButtonTapped = "mc_confirm_button_tapped"
     case paymentSheetFormShown = "mc_form_shown"
     case paymentSheetFormInteracted = "mc_form_interacted"
+    case paymentSheetFormCompleted = "mc_form_completed"
     case paymentSheetCardNumberCompleted = "mc_card_number_completed"
 
     // MARK: - v1/elements/session

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticsClient.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticsClient.swift
@@ -119,7 +119,7 @@ import UIKit
             return
         }
 
-        if let translatedEvent = analyticsEventTranslator.translate(analytic, payload: payload) {
+        if let translatedEvent = analyticsEventTranslator.translate(analytic.event, payload: payload) {
             NotificationCenter.default.post(name: translatedEvent.notificationName,
                                             object: translatedEvent.event)
         }

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticsClient.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticsClient.swift
@@ -36,7 +36,7 @@ import UIKit
         configuration: StripeAPIConfiguration.sharedUrlSessionConfiguration
     )
     let url = URL(string: "https://q.stripe.com")!
-
+    private let analyticsEventTranslator = STPAnalyticsEventTranslator()
     @objc public class func tokenType(fromParameters parameters: [AnyHashable: Any]) -> String? {
         let parameterKeys = parameters.keys
 
@@ -117,6 +117,11 @@ import UIKit
         guard !STPAnalyticsClient.isUnitOrUITest else {
             _testLogHistory.append(payload)
             return
+        }
+
+        if let translatedEvent = analyticsEventTranslator.translate(analytic, payload: payload) {
+            NotificationCenter.default.post(name: translatedEvent.notificationName,
+                                            object: translatedEvent.event)
         }
 
         var request = URLRequest(url: url)

--- a/StripeCore/StripeCoreTests/Analytics/STPAnalyticsEventTranslatorTest.swift
+++ b/StripeCore/StripeCoreTests/Analytics/STPAnalyticsEventTranslatorTest.swift
@@ -32,17 +32,15 @@ class STPAnalyticsTranslatedEventTest: XCTestCase {
     }
     func testAnalyticNotTranslated() {
         let translator = STPAnalyticsEventTranslator()
-        let analytic = GenericAnalytic(event: .paymentSheetLoadStarted, params: [:])
 
-        let result = translator.translate(analytic, payload: [:])
+        let result = translator.translate(.paymentSheetLoadStarted, payload: [:])
 
         XCTAssertNil(result)
     }
     func _testTranslationMapping(event: STPAnalyticEvent, translatedEventName: String) {
         let translator = STPAnalyticsEventTranslator()
-        let analytic = GenericAnalytic(event: event, params: [:])
 
-        guard let result = translator.translate(analytic, payload: [:]) else {
+        guard let result = translator.translate(event, payload: [:]) else {
             XCTFail("There is no mapping for event: \"\(event)\". See: STPAnalyticsEventTranslator")
             return
         }
@@ -50,4 +48,23 @@ class STPAnalyticsTranslatedEventTest: XCTestCase {
         XCTAssertEqual(result.notificationName, Notification.Name.mobilePaymentElement)
         XCTAssertEqual(result.event.eventName, translatedEventName)
     }
+
+    func testPayloadIsFiltered() {
+        let translator = STPAnalyticsEventTranslator()
+        let payload: [String: Any] = ["selected_lpm": "card",
+                                      "otherData": "testValue"]
+
+        let result = translator.translate(.paymentSheetFormShown, payload: payload)
+
+        XCTAssertEqual(result?.event.metadata as? [String: String], ["paymentMethodType": "card"])
+    }
+
+    func testTranslatesToEmptyPayload() {
+        let translator = STPAnalyticsEventTranslator()
+        let payload: [String: Any] = ["otherData": "testValue"]
+
+        let result = translator.translate(.paymentSheetFormShown, payload: payload)
+        XCTAssertEqual(result?.event.metadata as? [String:String], [:])
+    }
+
 }

--- a/StripeCore/StripeCoreTests/Analytics/STPAnalyticsEventTranslatorTest.swift
+++ b/StripeCore/StripeCoreTests/Analytics/STPAnalyticsEventTranslatorTest.swift
@@ -37,7 +37,7 @@ class STPAnalyticsTranslatedEventTest: XCTestCase {
 
         XCTAssertNil(result)
     }
-    func _testTranslationMapping(event: STPAnalyticEvent, translatedEventName: MobilePaymentElementEvent.Name) {
+    func _testTranslationMapping(event: STPAnalyticEvent, translatedEventName: MobilePaymentElementEvent.EventName) {
         let translator = STPAnalyticsEventTranslator()
 
         guard let result = translator.translate(event, payload: [:]) else {

--- a/StripeCore/StripeCoreTests/Analytics/STPAnalyticsEventTranslatorTest.swift
+++ b/StripeCore/StripeCoreTests/Analytics/STPAnalyticsEventTranslatorTest.swift
@@ -10,25 +10,25 @@ import XCTest
 
 class STPAnalyticsTranslatedEventTest: XCTestCase {
     func testSheetPresentation() {
-        _testTranslationMapping(event: .mcShowCustomNewPM, translatedEventName: "presentedSheet")
-        _testTranslationMapping(event: .mcShowCompleteNewPM, translatedEventName: "presentedSheet")
-        _testTranslationMapping(event: .mcShowCustomSavedPM, translatedEventName: "presentedSheet")
-        _testTranslationMapping(event: .mcShowCompleteSavedPM, translatedEventName: "presentedSheet")
+        _testTranslationMapping(event: .mcShowCustomNewPM, translatedEventName: .presentedSheet)
+        _testTranslationMapping(event: .mcShowCompleteNewPM, translatedEventName: .presentedSheet)
+        _testTranslationMapping(event: .mcShowCustomSavedPM, translatedEventName: .presentedSheet)
+        _testTranslationMapping(event: .mcShowCompleteSavedPM, translatedEventName: .presentedSheet)
     }
     func testTapPaymentMethodType() {
-        _testTranslationMapping(event: .paymentSheetCarouselPaymentMethodTapped, translatedEventName: "selectedPaymentMethodType")
+        _testTranslationMapping(event: .paymentSheetCarouselPaymentMethodTapped, translatedEventName: .selectedPaymentMethodType)
     }
     func testFormInteractions() {
-        _testTranslationMapping(event: .paymentSheetFormShown, translatedEventName: "displayedPaymentMethodForm")
-        _testTranslationMapping(event: .paymentSheetFormInteracted, translatedEventName: "startedInteractionWithPaymentMethodForm")
-        _testTranslationMapping(event: .paymentSheetFormCompleted, translatedEventName: "completedPaymentMethodForm")
-        _testTranslationMapping(event: .paymentSheetConfirmButtonTapped, translatedEventName: "tappedConfirmButton")
+        _testTranslationMapping(event: .paymentSheetFormShown, translatedEventName: .displayedPaymentMethodForm)
+        _testTranslationMapping(event: .paymentSheetFormInteracted, translatedEventName: .startedInteractionWithPaymentMethodForm)
+        _testTranslationMapping(event: .paymentSheetFormCompleted, translatedEventName: .completedPaymentMethodForm)
+        _testTranslationMapping(event: .paymentSheetConfirmButtonTapped, translatedEventName: .tappedConfirmButton)
     }
     func testSavedPaymentMethods() {
-        _testTranslationMapping(event: .mcOptionSelectCustomSavedPM, translatedEventName: "selectedSavedPaymentMethod")
-        _testTranslationMapping(event: .mcOptionSelectCompleteSavedPM, translatedEventName: "selectedSavedPaymentMethod")
-        _testTranslationMapping(event: .mcOptionRemoveCustomSavedPM, translatedEventName: "removedSavedPaymentMethod")
-        _testTranslationMapping(event: .mcOptionRemoveCompleteSavedPM, translatedEventName: "removedSavedPaymentMethod")
+        _testTranslationMapping(event: .mcOptionSelectCustomSavedPM, translatedEventName: .selectedSavedPaymentMethod)
+        _testTranslationMapping(event: .mcOptionSelectCompleteSavedPM, translatedEventName: .selectedSavedPaymentMethod)
+        _testTranslationMapping(event: .mcOptionRemoveCustomSavedPM, translatedEventName: .removedSavedPaymentMethod)
+        _testTranslationMapping(event: .mcOptionRemoveCompleteSavedPM, translatedEventName: .removedSavedPaymentMethod)
     }
     func testAnalyticNotTranslated() {
         let translator = STPAnalyticsEventTranslator()
@@ -37,7 +37,7 @@ class STPAnalyticsTranslatedEventTest: XCTestCase {
 
         XCTAssertNil(result)
     }
-    func _testTranslationMapping(event: STPAnalyticEvent, translatedEventName: String) {
+    func _testTranslationMapping(event: STPAnalyticEvent, translatedEventName: MobilePaymentElementEvent.Name) {
         let translator = STPAnalyticsEventTranslator()
 
         guard let result = translator.translate(event, payload: [:]) else {
@@ -57,7 +57,7 @@ class STPAnalyticsTranslatedEventTest: XCTestCase {
 
         let result = translator.translate(.paymentSheetFormShown, payload: payload)
 
-        XCTAssertEqual(result?.event.metadata as? [String: String], ["paymentMethodType": "card"])
+        XCTAssertEqual(result?.event.metadata as? [MobilePaymentElementEvent.MetadataKey: String], [.paymentMethodType: "card"])
     }
 
     func testTranslatesToEmptyPayload() {

--- a/StripeCore/StripeCoreTests/Analytics/STPAnalyticsEventTranslatorTest.swift
+++ b/StripeCore/StripeCoreTests/Analytics/STPAnalyticsEventTranslatorTest.swift
@@ -52,7 +52,8 @@ class STPAnalyticsTranslatedEventTest: XCTestCase {
     func testPayloadIsFiltered() {
         let translator = STPAnalyticsEventTranslator()
         let payload: [String: Any] = ["selected_lpm": "card",
-                                      "otherData": "testValue"]
+                                      "otherData": "testValue",
+        ]
 
         let result = translator.translate(.paymentSheetFormShown, payload: payload)
 
@@ -64,7 +65,6 @@ class STPAnalyticsTranslatedEventTest: XCTestCase {
         let payload: [String: Any] = ["otherData": "testValue"]
 
         let result = translator.translate(.paymentSheetFormShown, payload: payload)
-        XCTAssertEqual(result?.event.metadata as? [String:String], [:])
+        XCTAssertEqual(result?.event.metadata as? [String: String], [:])
     }
-
 }

--- a/StripeCore/StripeCoreTests/Analytics/STPAnalyticsEventTranslatorTest.swift
+++ b/StripeCore/StripeCoreTests/Analytics/STPAnalyticsEventTranslatorTest.swift
@@ -22,6 +22,7 @@ class STPAnalyticsTranslatedEventTest: XCTestCase {
         _testTranslationMapping(event: .paymentSheetFormShown, translatedEventName: "displayedPaymentMethodForm")
         _testTranslationMapping(event: .paymentSheetFormInteracted, translatedEventName: "startedInteractionWithPaymentMethodForm")
         _testTranslationMapping(event: .paymentSheetFormCompleted, translatedEventName: "completedPaymentMethodForm")
+        _testTranslationMapping(event: .paymentSheetConfirmButtonTapped, translatedEventName: "tappedConfirmButton")
     }
     func testSavedPaymentMethods() {
         _testTranslationMapping(event: .mcOptionSelectCustomSavedPM, translatedEventName: "selectedSavedPaymentMethod")

--- a/StripeCore/StripeCoreTests/Analytics/STPAnalyticsEventTranslatorTest.swift
+++ b/StripeCore/StripeCoreTests/Analytics/STPAnalyticsEventTranslatorTest.swift
@@ -1,0 +1,52 @@
+//
+//  STPAnalyticsEventTranslatorTest.swift
+//  StripeCoreTests
+//
+
+import Foundation
+import XCTest
+
+@testable @_spi(STP) @_spi(MobilePaymentElementEventingBeta) import StripeCore
+
+class STPAnalyticsTranslatedEventTest: XCTestCase {
+    func testSheetPresentation() {
+        _testTranslationMapping(event: .mcShowCustomNewPM, translatedEventName: "presentedSheet")
+        _testTranslationMapping(event: .mcShowCompleteNewPM, translatedEventName: "presentedSheet")
+        _testTranslationMapping(event: .mcShowCustomSavedPM, translatedEventName: "presentedSheet")
+        _testTranslationMapping(event: .mcShowCompleteSavedPM, translatedEventName: "presentedSheet")
+    }
+    func testTapPaymentMethodType() {
+        _testTranslationMapping(event: .paymentSheetCarouselPaymentMethodTapped, translatedEventName: "selectedPaymentMethodType")
+    }
+    func testFormInteractions() {
+        _testTranslationMapping(event: .paymentSheetFormShown, translatedEventName: "displayedPaymentMethodForm")
+        _testTranslationMapping(event: .paymentSheetFormInteracted, translatedEventName: "startedInteractionWithPaymentMethodForm")
+        _testTranslationMapping(event: .paymentSheetFormCompleted, translatedEventName: "completedPaymentMethodForm")
+    }
+    func testSavedPaymentMethods() {
+        _testTranslationMapping(event: .mcOptionSelectCustomSavedPM, translatedEventName: "selectedSavedPaymentMethod")
+        _testTranslationMapping(event: .mcOptionSelectCompleteSavedPM, translatedEventName: "selectedSavedPaymentMethod")
+        _testTranslationMapping(event: .mcOptionRemoveCustomSavedPM, translatedEventName: "removedSavedPaymentMethod")
+        _testTranslationMapping(event: .mcOptionRemoveCompleteSavedPM, translatedEventName: "removedSavedPaymentMethod")
+    }
+    func testAnalyticNotTranslated() {
+        let translator = STPAnalyticsEventTranslator()
+        let analytic = GenericAnalytic(event: .paymentSheetLoadStarted, params: [:])
+
+        let result = translator.translate(analytic, payload: [:])
+
+        XCTAssertNil(result)
+    }
+    func _testTranslationMapping(event: STPAnalyticEvent, translatedEventName: String) {
+        let translator = STPAnalyticsEventTranslator()
+        let analytic = GenericAnalytic(event: event, params: [:])
+
+        guard let result = translator.translate(analytic, payload: [:]) else {
+            XCTFail("There is no mapping for event: \"\(event)\". See: STPAnalyticsEventTranslator")
+            return
+        }
+
+        XCTAssertEqual(result.notificationName, Notification.Name.mobilePaymentElement)
+        XCTAssertEqual(result.event.eventName, translatedEventName)
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/PaymentSheetAnalyticsHelper.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/PaymentSheetAnalyticsHelper.swift
@@ -186,7 +186,7 @@ final class PaymentSheetAnalyticsHelper {
     /// Used to ensure we only send one `mc_form_completed` event per `mc_form_shown` to avoid spamming.
     var didSendPaymentSheetFormCompletedEvent: Bool = false
     /// Used because it is possible for logFormCompleted to be called before logFormShown when switching payment methods
-    var lastLogFormShown: String? = nil
+    var lastLogFormShown: String?
     func logFormCompleted(paymentMethodTypeIdentifier: String) {
         if !didSendPaymentSheetFormCompletedEvent && paymentMethodTypeIdentifier == lastLogFormShown {
             didSendPaymentSheetFormCompletedEvent = true
@@ -279,7 +279,7 @@ final class PaymentSheetAnalyticsHelper {
             guard let elementsSession else { return nil }
             return PaymentSheet.isLinkEnabled(elementsSession: elementsSession, configuration: configuration)
         }()
-        
+
         var additionalParams = [:] as [String: Any]
         additionalParams["duration"] = duration
         additionalParams["link_enabled"] = linkEnabled

--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/PaymentSheetAnalyticsHelper.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/PaymentSheetAnalyticsHelper.swift
@@ -125,45 +125,39 @@ final class PaymentSheetAnalyticsHelper {
     }
 
     func logSavedPMScreenOptionSelected(option: SavedPaymentOptionsViewController.Selection) {
-        let event: STPAnalyticEvent = {
+        let (event, selectedLPM): (STPAnalyticEvent, String?) = {
             if isCustom {
                 switch option {
                 case .add:
-                    return .mcOptionSelectCustomNewPM
-                case .saved:
-                    return .mcOptionSelectCustomSavedPM
+                    return (.mcOptionSelectCustomNewPM, nil)
+                case .saved(let paymentMethod):
+                    return (.mcOptionSelectCustomSavedPM, paymentMethod.type.identifier)
                 case .applePay:
-                    return .mcOptionSelectCustomApplePay
+                    return (.mcOptionSelectCustomApplePay, nil)
                 case .link:
-                    return .mcOptionSelectCustomLink
+                    return (.mcOptionSelectCustomLink, nil)
                 }
             } else {
                 switch option {
                 case .add:
-                    return .mcOptionSelectCompleteNewPM
-                case .saved:
-                    return .mcOptionSelectCompleteSavedPM
+                    return (.mcOptionSelectCompleteNewPM, nil)
+                case .saved(let paymentMethod):
+                    return (.mcOptionSelectCompleteSavedPM, paymentMethod.type.identifier)
                 case .applePay:
-                    return .mcOptionSelectCompleteApplePay
+                    return (.mcOptionSelectCompleteApplePay, nil)
                 case .link:
-                    return .mcOptionSelectCompleteLink
+                    return (.mcOptionSelectCompleteLink, nil)
                 }
             }
         }()
-        log(event: event)
+        log(event: event, selectedLPM: selectedLPM)
     }
 
     func logNewPaymentMethodSelected(paymentMethodTypeIdentifier: String) {
         log(event: .paymentSheetCarouselPaymentMethodTapped, selectedLPM: paymentMethodTypeIdentifier)
     }
     func logSavedPaymentMethodRemoved(paymentMethod: STPPaymentMethod) {
-        var params: [String: Any] = [
-            "payment_method_type": paymentMethod.type.identifier,
-        ]
-        if let cardBrand = paymentMethod.card {
-            params["card_brand"] = cardBrand.brand
-        }
-        log(event: .mcSavedPaymentMethodRemoved, params: params)
+        log(event: .mcSavedPaymentMethodRemoved, selectedLPM: paymentMethod.type.identifier)
     }
 
     /// Used to ensure we only send one `mc_form_interacted` event per `mc_form_shown` to avoid spamming.

--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/PaymentSheetAnalyticsHelper.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/PaymentSheetAnalyticsHelper.swift
@@ -157,7 +157,8 @@ final class PaymentSheetAnalyticsHelper {
         log(event: .paymentSheetCarouselPaymentMethodTapped, selectedLPM: paymentMethodTypeIdentifier)
     }
     func logSavedPaymentMethodRemoved(paymentMethod: STPPaymentMethod) {
-        log(event: .mcSavedPaymentMethodRemoved, selectedLPM: paymentMethod.type.identifier)
+        let event: STPAnalyticEvent = isCustom ? .mcOptionRemoveCustomSavedPM : .mcOptionRemoveCompleteSavedPM
+        log(event: event, selectedLPM: paymentMethod.type.identifier)
     }
 
     /// Used to ensure we only send one `mc_form_interacted` event per `mc_form_shown` to avoid spamming.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
@@ -158,6 +158,7 @@ class SavedPaymentOptionsViewController: UIViewController {
     let configuration: Configuration
     private let intent: Intent
     private let paymentSheetConfiguration: PaymentSheet.Configuration
+    private let analyticsHelper: PaymentSheetAnalyticsHelper
 
     var selectedPaymentOption: PaymentOption? {
         guard let index = selectedViewModelIndex, viewModels.indices.contains(index) else {
@@ -311,6 +312,7 @@ class SavedPaymentOptionsViewController: UIViewController {
         intent: Intent,
         appearance: PaymentSheet.Appearance,
         cbcEligible: Bool = false,
+        analyticsHelper: PaymentSheetAnalyticsHelper,
         delegate: SavedPaymentOptionsViewControllerDelegate? = nil
     ) {
         self.savedPaymentMethods = savedPaymentMethods
@@ -320,6 +322,7 @@ class SavedPaymentOptionsViewController: UIViewController {
         self.appearance = appearance
         self.cbcEligible = cbcEligible
         self.delegate = delegate
+        self.analyticsHelper = analyticsHelper
         super.init(nibName: nil, bundle: nil)
         updateUI()
     }
@@ -632,6 +635,7 @@ extension SavedPaymentOptionsViewController: UpdateCardViewControllerDelegate {
     func didRemove(viewController: UpdateCardViewController, paymentMethod: STPPaymentMethod) {
         removePaymentMethod(paymentMethod)
         _ = viewController.bottomSheetController?.popContentViewController()
+        analyticsHelper.logSavedPaymentMethodRemoved(paymentMethod: paymentMethod)
     }
 
     func didUpdate(viewController: UpdateCardViewController,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
@@ -635,7 +635,6 @@ extension SavedPaymentOptionsViewController: UpdateCardViewControllerDelegate {
     func didRemove(viewController: UpdateCardViewController, paymentMethod: STPPaymentMethod) {
         removePaymentMethod(paymentMethod)
         _ = viewController.bottomSheetController?.popContentViewController()
-        analyticsHelper.logSavedPaymentMethodRemoved(paymentMethod: paymentMethod)
     }
 
     func didUpdate(viewController: UpdateCardViewController,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
@@ -226,6 +226,7 @@ class VerticalSavedPaymentMethodsViewController: UIViewController {
         if paymentMethodRows.isEmpty {
             completeSelection()
         }
+        analyticsHelper.logSavedPaymentMethodRemoved(paymentMethod: paymentMethod)
     }
 
     private func completeSelection(afterDelay: TimeInterval = 0.0) {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
@@ -214,6 +214,7 @@ class VerticalSavedPaymentMethodsViewController: UIViewController {
 
         // Detach the payment method from the customer
         savedPaymentMethodManager.detach(paymentMethod: paymentMethod)
+        analyticsHelper.logSavedPaymentMethodRemoved(paymentMethod: paymentMethod)
 
         // Remove the payment method row button
         paymentMethodRows.removeAll { $0.paymentMethod.stripeId == paymentMethod.stripeId }
@@ -226,7 +227,6 @@ class VerticalSavedPaymentMethodsViewController: UIViewController {
         if paymentMethodRows.isEmpty {
             completeSelection()
         }
-        analyticsHelper.logSavedPaymentMethodRemoved(paymentMethod: paymentMethod)
     }
 
     private func completeSelection(afterDelay: TimeInterval = 0.0) {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -211,7 +211,8 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
             paymentSheetConfiguration: configuration,
             intent: intent,
             appearance: configuration.appearance,
-            cbcEligible: elementsSession.isCardBrandChoiceEligible
+            cbcEligible: elementsSession.isCardBrandChoiceEligible,
+            analyticsHelper: analyticsHelper
         )
         self.addPaymentMethodViewController = AddPaymentMethodViewController(
             intent: intent,
@@ -565,6 +566,9 @@ extension PaymentSheetFlowControllerViewController: AddPaymentMethodViewControll
     func didUpdate(_ viewController: AddPaymentMethodViewController) {
         error = nil  // clear error
         updateUI()
+        if viewController.paymentOption != nil {
+            analyticsHelper.logFormCompleted(paymentMethodTypeIdentifier: viewController.selectedPaymentMethodType.identifier)
+        }
     }
 
     func updateErrorLabel(for error: Error?) {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -533,6 +533,7 @@ extension PaymentSheetFlowControllerViewController: SavedPaymentOptionsViewContr
         }
 
         savedPaymentMethodManager.detach(paymentMethod: paymentMethod)
+        analyticsHelper.logSavedPaymentMethodRemoved(paymentMethod: paymentMethod)
 
         if !savedPaymentOptionsViewController.canEditPaymentMethods {
             savedPaymentOptionsViewController.isRemovingPaymentMethods = false

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
@@ -788,6 +788,7 @@ extension PaymentSheetVerticalViewController: UpdateCardViewControllerDelegate {
     func didRemove(viewController: UpdateCardViewController, paymentMethod: STPPaymentMethod) {
         // Detach the payment method from the customer
         savedPaymentMethodManager.detach(paymentMethod: paymentMethod)
+        analyticsHelper.logSavedPaymentMethodRemoved(paymentMethod: paymentMethod)
 
         // Update savedPaymentMethods
         self.savedPaymentMethods.removeAll(where: { $0.stripeId == paymentMethod.stripeId })
@@ -795,7 +796,6 @@ extension PaymentSheetVerticalViewController: UpdateCardViewControllerDelegate {
         // Update UI
         regenerateUI()
         _ = viewController.bottomSheetController?.popContentViewController()
-        analyticsHelper.logSavedPaymentMethodRemoved(paymentMethod: paymentMethod)
     }
 
     func didUpdate(viewController: UpdateCardViewController, paymentMethod: STPPaymentMethod, updateParams: STPPaymentMethodUpdateParams) async throws {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
@@ -795,6 +795,7 @@ extension PaymentSheetVerticalViewController: UpdateCardViewControllerDelegate {
         // Update UI
         regenerateUI()
         _ = viewController.bottomSheetController?.popContentViewController()
+        analyticsHelper.logSavedPaymentMethodRemoved(paymentMethod: paymentMethod)
     }
 
     func didUpdate(viewController: UpdateCardViewController, paymentMethod: STPPaymentMethod, updateParams: STPPaymentMethodUpdateParams) async throws {
@@ -816,6 +817,9 @@ extension PaymentSheetVerticalViewController: PaymentMethodFormViewControllerDel
     func didUpdate(_ viewController: PaymentMethodFormViewController) {
         error = nil  // clear error
         updateUI()
+        if viewController.paymentOption != nil {
+            analyticsHelper.logFormCompleted(paymentMethodTypeIdentifier: viewController.paymentMethodType.identifier)
+        }
     }
 
     func updateErrorLabel(for error: Swift.Error?) {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -561,6 +561,7 @@ extension PaymentSheetViewController: SavedPaymentOptionsViewControllerDelegate 
         }
 
         savedPaymentMethodManager.detach(paymentMethod: paymentMethod)
+        analyticsHelper.logSavedPaymentMethodRemoved(paymentMethod: paymentMethod)
 
         if !savedPaymentOptionsViewController.canEditPaymentMethods {
             savedPaymentOptionsViewController.isRemovingPaymentMethods = false

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -176,7 +176,8 @@ class PaymentSheetViewController: UIViewController, PaymentSheetViewControllerPr
             paymentSheetConfiguration: configuration,
             intent: intent,
             appearance: configuration.appearance,
-            cbcEligible: elementsSession.isCardBrandChoiceEligible
+            cbcEligible: elementsSession.isCardBrandChoiceEligible,
+            analyticsHelper: analyticsHelper
         )
 
         if loadResult.savedPaymentMethods.isEmpty {
@@ -605,6 +606,9 @@ extension PaymentSheetViewController: AddPaymentMethodViewControllerDelegate {
     func didUpdate(_ viewController: AddPaymentMethodViewController) {
         error = nil  // clear error
         updateUI()
+        if viewController.paymentOption != nil {
+            analyticsHelper.logFormCompleted(paymentMethodTypeIdentifier: viewController.selectedPaymentMethodType.identifier)
+        }
     }
 
     func updateErrorLabel(for error: Error?) {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentOptionsViewControllerSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentOptionsViewControllerSnapshotTests.swift
@@ -38,7 +38,8 @@ final class SavedPaymentOptionsViewControllerSnapshotTests: STPSnapshotTestCase 
                                                     configuration: config,
                                                     paymentSheetConfiguration: PaymentSheet.Configuration(),
                                                     intent: intent,
-                                                    appearance: appearance)
+                                                    appearance: appearance,
+                                                    analyticsHelper: ._testValue())
         let testWindow = UIWindow()
         testWindow.isHidden = false
         if darkMode {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentOptionsViewControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentOptionsViewControllerTests.swift
@@ -315,6 +315,7 @@ class SavedPaymentOptionsViewControllerTests: XCTestCase {
                                                  intent: Intent._testValue(),
                                                  appearance: .default,
                                                  cbcEligible: cbcEligible,
+                                                 analyticsHelper: ._testValue(),
                                                  delegate: nil)
     }
 }


### PR DESCRIPTION
## Summary
Adds an eventing early preview of an eventing framework

## Motivation
Analytics access to some events

## Testing
Updated existing tests to accmodate for new metrics

## Example Integration
Users would need to add `@_spi`
```
+ @_spi(MobilePaymentElementEventingBeta) import StripeCore
```

Add an Observer
```
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(mobilePaymentElementNotification(notification:)),
+                                               name: .mobilePaymentElement, object: nil)
```

Define a callback function to receive notifications
```
+    @objc
+    func mobilePaymentElementNotification(notification: NSNotification) {
+        guard let mpeNotification = notification.object as? MobilePaymentElementEvent else {
+            return
+        }
+        print("Notification(eventName): \(mpeNotification.eventName)")
+        print("Notification(metadata): \(mpeNotification.metadata)")
+    }
+
```

## Changelog
Will add when it is time to announce
