### PR TITLE
Add `link_card_brand` as LinkMode and synthetic payment method

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfirmParams.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfirmParams.swift
@@ -69,6 +69,9 @@ class IntentConfirmParams {
         case .instantDebits:
             let params = STPPaymentMethodParams(type: .link)
             self.init(params: params, type: type)
+        case .linkCardBrand:
+            let params = STPPaymentMethodParams(type: .card)
+            self.init(params: params, type: type)
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -17,7 +17,8 @@ extension PaymentSheet {
         case stripe(STPPaymentMethodType)
         case external(ExternalPaymentMethod)
 
-        // Synthetic payment methods:
+        // Synthetic payment methods. These are payment methods which don't have an `STPPaymentMethodType` defined for the same name.
+        // That is, the payment method manifest for a synthetic PMT will show a PMT that doesn't match the form name.
         case instantDebits
         case linkCardBrand
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -16,7 +16,10 @@ extension PaymentSheet {
     enum PaymentMethodType: Equatable, Hashable {
         case stripe(STPPaymentMethodType)
         case external(ExternalPaymentMethod)
+
+        // Synthetic payment methods:
         case instantDebits
+        case linkCardBrand
 
         static var analyticLogForIcon: Set<PaymentMethodType> = []
         static let analyticLogForIconSemaphore = DispatchSemaphore(value: 1)
@@ -27,7 +30,7 @@ extension PaymentSheet {
                 return paymentMethodType.displayName
             case .external(let externalPaymentMethod):
                 return externalPaymentMethod.label
-            case .instantDebits:
+            case .instantDebits, .linkCardBrand:
                 return String.Localized.bank
             }
         }
@@ -42,6 +45,8 @@ extension PaymentSheet {
                 return externalPaymentMethod.type
             case .instantDebits:
                 return "instant_debits"
+            case .linkCardBrand:
+                return "link_card_brand"
             }
         }
 
@@ -103,7 +108,7 @@ extension PaymentSheet {
                     }
                     return DownloadManager.sharedManager.imagePlaceHolder()
                 }
-            case .instantDebits:
+            case .instantDebits, .linkCardBrand:
                 return Image.pm_type_us_bank.makeImage(overrideUserInterfaceStyle: forDarkBackground ? .dark : .light)
             }
         }
@@ -114,7 +119,7 @@ extension PaymentSheet {
                 return stpPaymentMethodType.iconRequiresTinting
             case .external:
                 return false
-            case .instantDebits:
+            case .instantDebits, .linkCardBrand:
                 return true
             }
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -133,7 +133,7 @@ class PaymentSheetFormFactory {
 
     func make() -> PaymentMethodElement {
         switch paymentMethod {
-        case .instantDebits:
+        case .instantDebits, .linkCardBrand:
             return makeInstantDebits()
         case .external:
             return makeExternalPaymentMethodForm()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
@@ -37,7 +37,7 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
                     return .new(confirmParams: params)
                 case .external(let type):
                     return .external(paymentMethod: type, billingDetails: params.paymentMethodParams.nonnil_billingDetails)
-                case .instantDebits:
+                case .instantDebits, .linkCardBrand:
                     return .new(confirmParams: params)
                 }
             case .saved(paymentMethod: let paymentMethod):

--- a/StripePayments/StripePayments/Source/API Bindings/Models/Shared/LinkSettings.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/Shared/LinkSettings.swift
@@ -21,10 +21,17 @@ import Foundation
         case ephemeral
     }
 
+    @_spi(STP) @frozen public enum LinkMode: String {
+        case linkPaymentMethod = "LINK_PAYMENT_METHOD"
+        case passthrough = "PASSTHROUGH"
+        case linkCardBrand = "LINK_CARD_BRAND"
+    }
+
     @_spi(STP) public let fundingSources: Set<FundingSource>
     @_spi(STP) public let popupWebviewOption: PopupWebviewOption?
     @_spi(STP) public let passthroughModeEnabled: Bool?
     @_spi(STP) public let disableSignup: Bool?
+    @_spi(STP) public let linkMode: LinkMode?
     @_spi(STP) public let linkFlags: [String: Bool]?
 
     @_spi(STP) public let allResponseFields: [AnyHashable: Any]
@@ -34,6 +41,7 @@ import Foundation
         popupWebviewOption: PopupWebviewOption?,
         passthroughModeEnabled: Bool?,
         disableSignup: Bool?,
+        linkMode: LinkMode?,
         linkFlags: [String: Bool]?,
         allResponseFields: [AnyHashable: Any]
     ) {
@@ -41,6 +49,7 @@ import Foundation
         self.popupWebviewOption = popupWebviewOption
         self.passthroughModeEnabled = passthroughModeEnabled
         self.disableSignup = disableSignup
+        self.linkMode = linkMode
         self.linkFlags = linkFlags
         self.allResponseFields = allResponseFields
     }
@@ -61,6 +70,7 @@ import Foundation
         let webviewOption = PopupWebviewOption(rawValue: response["link_popup_webview_option"] as? String ?? "")
         let passthroughModeEnabled = response["link_passthrough_mode_enabled"] as? Bool ?? false
         let disableSignup = response["link_mobile_disable_signup"] as? Bool ?? false
+        let linkMode = (response["link_mode"] as? String).flatMap { LinkMode(rawValue: $0) }
 
         // Collect the flags for the URL generator
         let linkFlags = response.reduce(into: [String: Bool]()) { partialResult, element in
@@ -74,6 +84,7 @@ import Foundation
             popupWebviewOption: webviewOption,
             passthroughModeEnabled: passthroughModeEnabled,
             disableSignup: disableSignup,
+            linkMode: linkMode,
             linkFlags: linkFlags,
             allResponseFields: response
         ) as? Self


### PR DESCRIPTION
## Summary

As part of [Panther](https://docs.google.com/document/d/1ErJVA3lLvNspPe3A8uYP9feK8Yvfq-Sw5aatNIvlGxk/edit?usp=sharing), this does two things:

- [[BANKCON-14081](https://jira.corp.stripe.com/browse/BANKCON-14081)] Add `link_mode` enum to LinkSettings model
- [[BANKCON-14083](https://jira.corp.stripe.com/browse/BANKCON-14083)] Add `linkCardBrand` as a synthetic payment type

More to come!

## Motivation

Building Panther support!

## Testing

No functional changes introduced yet, but here's the new linkMode value being set:

<img width="1010" alt="Screenshot 2024-09-16 at 9 48 33 AM" src="https://github.com/user-attachments/assets/c691008a-ee29-40f9-9c6a-6e5323e0942a">

## Changelog

N/a