### PR TITLE
[testmode] Rename Down Bank

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
@@ -630,7 +630,7 @@ final class FinancialConnectionsUITests: XCTestCase {
 
         app.fc_scrollDown()
 
-        app.fc_nativeFeaturedInstitution(name: "Down bank (unscheduled)").waitForExistenceAndTap()
+        app.fc_nativeFeaturedInstitution(name: "Down Bank (Unscheduled)").waitForExistenceAndTap()
 
         // selecting another bank will activate "reset flow"
         app.buttons["select_another_bank_button"].waitForExistenceAndTap()

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
@@ -615,7 +615,9 @@ final class FinancialConnectionsUITests: XCTestCase {
     }
 
     // this tests going through "ResetFlowViewController"
-    func testNativeResetFlowWithErrorToSuccess() {
+    func testNativeResetFlowWithErrorToSuccess() throws {
+        throw XCTSkip("Skipping this test case until we edit this institution's name")
+
         let app = XCUIApplication.fc_launch(
             playgroundConfigurationString:
 """


### PR DESCRIPTION
## Summary
Rename Down Bank, so that its naming convention aligns with other similar institutions.

## Motivation
See above. See also https://github.com/stripe/stripe-android/pull/9299

## Testing
This is a testing-only change. The test will expectedly fail until we update the institution's name internally.

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A
