### PR TITLE
Pass Elements Session context to Financial Connections SDK

### DIFF
--- a/StripeCore/StripeCore.xcodeproj/project.pbxproj
+++ b/StripeCore/StripeCore.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		45DAE581F74EF7E11C64212B /* InstallMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E64986F72C7BD8B1105A95 /* InstallMethod.swift */; };
 		48A6CCB4008A5060C2655C5F /* XCTestCase+Stripe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DE48D0086BED21F9E837D0B /* XCTestCase+Stripe.swift */; };
 		4910B9282C3D8F3F00B030D4 /* Result+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4910B9272C3D8F3F00B030D4 /* Result+Extensions.swift */; };
+		495199892C9DBE5C0033A77D /* ElementsContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49E6DE962C9DBC730000C7BE /* ElementsContextTests.swift */; };
+		497CC9662C9DB18E00F68EBD /* ElementsContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 497CC9652C9DB18E00F68EBD /* ElementsContext.swift */; };
 		4B2FAC57E03D8654A177C408 /* Dictionary+Stripe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7727AEEFD2FC880BADDA1872 /* Dictionary+Stripe.swift */; };
 		53D46A03B77577EE21F4B166 /* StripeCodableTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FCE36551600C3E53BEAF8F0 /* StripeCodableTest.swift */; };
 		552DA7969984C443617DBC3E /* STPMultipartFormDataPart.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C72BA9C44FF60A0E7BEF76 /* STPMultipartFormDataPart.swift */; };
@@ -228,6 +230,8 @@
 		4910B9272C3D8F3F00B030D4 /* Result+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+Extensions.swift"; sourceTree = "<group>"; };
 		49424775D3233411D9C2473B /* StripeCodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StripeCodable.swift; sourceTree = "<group>"; };
 		49538DBF8457D96707A2DA56 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
+		497CC9652C9DB18E00F68EBD /* ElementsContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElementsContext.swift; sourceTree = "<group>"; };
+		49E6DE962C9DBC730000C7BE /* ElementsContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElementsContextTests.swift; sourceTree = "<group>"; };
 		4A8030BF88608CA86E295F18 /* Enums+CustomStringConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Enums+CustomStringConvertible.swift"; sourceTree = "<group>"; };
 		4C51E3FA5EE3587BB7BBC634 /* STPError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPError.swift; sourceTree = "<group>"; };
 		4EC3BCEEECB3E1485B18F0C4 /* FinancialConnectionsSDKInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsSDKInterface.swift; sourceTree = "<group>"; };
@@ -428,6 +432,14 @@
 			path = Categories;
 			sourceTree = "<group>";
 		};
+		49E6DE952C9DBC640000C7BE /* Connections Bindings */ = {
+			isa = PBXGroup;
+			children = (
+				49E6DE962C9DBC730000C7BE /* ElementsContextTests.swift */,
+			);
+			path = "Connections Bindings";
+			sourceTree = "<group>";
+		};
 		4A2CD3EB30A5C54998ED92DD /* Mock Files */ = {
 			isa = PBXGroup;
 			children = (
@@ -444,6 +456,7 @@
 				6A05FB462BCF24370001D128 /* FinancialConnectionsLinkedBank.swift */,
 				6A05FB482BCF244A0001D128 /* InstantDebitsLinkedBank.swift */,
 				6A05FB4A2BCF245C0001D128 /* FinancialConnectionsEvent.swift */,
+				497CC9652C9DB18E00F68EBD /* ElementsContext.swift */,
 			);
 			path = "Connections Bindings";
 			sourceTree = "<group>";
@@ -638,6 +651,7 @@
 		9EF2F5FC20874E0DD2A5D40C /* StripeCoreTests */ = {
 			isa = PBXGroup;
 			children = (
+				49E6DE952C9DBC640000C7BE /* Connections Bindings */,
 				523A1ACB7F366E117F7FE2B4 /* Analytics */,
 				7FD20B12B83EC2F371B71C37 /* API Bindings */,
 				3A3F265C90373C3EF2F61523 /* Categories */,
@@ -935,6 +949,7 @@
 			files = (
 				B67F2CA42BAB91860011E34A /* AnalyticLoggableErrorTest.swift in Sources */,
 				A4DBBFD379C4E0120BD25C56 /* STPAPIClient+EmptyResponseTest.swift in Sources */,
+				495199892C9DBE5C0033A77D /* ElementsContextTests.swift in Sources */,
 				79DA4102C501FC2E53D946B5 /* STPAPIClient+ErrorResponseTest.swift in Sources */,
 				53D46A03B77577EE21F4B166 /* StripeCodableTest.swift in Sources */,
 				3E9FC2CD06E1D5F6B09872E9 /* AnalyticsClientV2Test.swift in Sources */,
@@ -1004,6 +1019,7 @@
 				096274D0729AA8849FAD103C /* PaymentsSDKVariant.swift in Sources */,
 				DA5A05459309B9B77ACDD736 /* STPDeviceUtils.swift in Sources */,
 				4910B9282C3D8F3F00B030D4 /* Result+Extensions.swift in Sources */,
+				497CC9662C9DB18E00F68EBD /* ElementsContext.swift in Sources */,
 				83790210FFC2DD764C042C8E /* STPDispatchFunctions.swift in Sources */,
 				72DA29CA8A750E8B00DBF3D4 /* STPError.swift in Sources */,
 				F628BBE9FDA9D3A217ACA753 /* STPNumericStringValidator.swift in Sources */,
@@ -1151,6 +1167,10 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = CB2721EE8E075E700FF3E58A /* StripeiOS-Release.xcconfig */;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = Y28TH9SHX7;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = Y28TH9SHX7;
+				"DEVELOPMENT_TEAM[sdk=xros*]" = Y28TH9SHX7;
 				INFOPLIST_FILE = StripeCore/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.stripe.stripe-core";
 				PRODUCT_NAME = StripeCore;
@@ -1183,6 +1203,10 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = C3DCE66C04A91C235972687D /* StripeiOS-Debug.xcconfig */;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = Y28TH9SHX7;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = Y28TH9SHX7;
+				"DEVELOPMENT_TEAM[sdk=xros*]" = Y28TH9SHX7;
 				INFOPLIST_FILE = StripeCore/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.stripe.stripe-core";
 				PRODUCT_NAME = StripeCore;

--- a/StripeCore/StripeCore/Source/Connections Bindings/ElementsContext.swift
+++ b/StripeCore/StripeCore/Source/Connections Bindings/ElementsContext.swift
@@ -1,0 +1,30 @@
+//
+//  ElementsContext.swift
+//  StripeCore
+//
+//  Created by Mat Schmid on 2024-09-20.
+//
+
+import Foundation
+
+@_spi(STP) public struct ElementsContext {
+    @_spi(STP) public enum HostedSurface: String {
+        case paymentsSheet = "payment_element"
+        case customerSheet = "customer_sheet"
+    }
+
+    // The presentation surface for the Financial Connections sheet.
+    @_spi(STP) public let hostedSurface: HostedSurface?
+
+    // Parses arbitrary `additionalParamters` into `ElementsContext`.
+    @_spi(STP) public init(from additionalParameters: [String: Any]) {
+        let hostedSurface: HostedSurface? = {
+            guard let hostedSurface = additionalParameters["hosted_surface"] as? String else {
+                return nil
+            }
+            return HostedSurface(rawValue: hostedSurface)
+        }()
+
+        self.hostedSurface = hostedSurface
+    }
+}

--- a/StripeCore/StripeCore/Source/Connections Bindings/ElementsContext.swift
+++ b/StripeCore/StripeCore/Source/Connections Bindings/ElementsContext.swift
@@ -8,23 +8,27 @@
 import Foundation
 
 @_spi(STP) public struct ElementsContext {
-    @_spi(STP) public enum HostedSurface: String {
-        case paymentsSheet = "payment_element"
-        case customerSheet = "customer_sheet"
+    @_spi(STP) public enum LinkMode: String {
+        case linkPaymentMethod = "LINK_PAYMENT_METHOD"
+        case passthrough = "PASSTHROUGH"
+        case linkCardBrand = "LINK_CARD_BRAND"
+        
+        @_spi(STP) public var isPantherPayment: Bool {
+            self == .linkCardBrand
+        }
     }
 
-    // The presentation surface for the Financial Connections sheet.
-    @_spi(STP) public let hostedSurface: HostedSurface?
+    @_spi(STP) public let linkMode: LinkMode?
 
-    // Parses arbitrary `additionalParamters` into `ElementsContext`.
+    /// Parses arbitrary `additionalParamters` into `ElementsContext`.
     @_spi(STP) public init(from additionalParameters: [String: Any]) {
-        let hostedSurface: HostedSurface? = {
-            guard let hostedSurface = additionalParameters["hosted_surface"] as? String else {
+        let linkMode: LinkMode? = {
+            guard let linkMode = additionalParameters["link_mode"] as? String else {
                 return nil
             }
-            return HostedSurface(rawValue: hostedSurface)
+            return LinkMode(rawValue: linkMode)
         }()
 
-        self.hostedSurface = hostedSurface
+        self.linkMode = linkMode
     }
 }

--- a/StripeCore/StripeCore/Source/Connections Bindings/FinancialConnectionsSDKInterface.swift
+++ b/StripeCore/StripeCore/Source/Connections Bindings/FinancialConnectionsSDKInterface.swift
@@ -14,6 +14,7 @@ import UIKit
         apiClient: STPAPIClient,
         clientSecret: String,
         returnURL: String?,
+        additionalParameters: [String: Any],
         onEvent: ((FinancialConnectionsEvent) -> Void)?,
         from presentingViewController: UIViewController,
         completion: @escaping (FinancialConnectionsSDKResult) -> Void

--- a/StripeCore/StripeCoreTests/Connections Bindings/ElementsContextTests.swift
+++ b/StripeCore/StripeCoreTests/Connections Bindings/ElementsContextTests.swift
@@ -15,24 +15,35 @@ final class ElementsContextTests: XCTestCase {
         let elementsContext = ElementsContext(from: additionalParameter)
 
         XCTAssertNotNil(elementsContext)
-        XCTAssertNil(elementsContext.hostedSurface)
+        XCTAssertNil(elementsContext.linkMode)
     }
 
-    func testHostedSurface() {
-        var additionalParameter = ["hosted_surface": "gibberish"]
+    func testLinkMode() {
+        let linkModeKey = "link_mode"
+
+        var additionalParameter = [linkModeKey: "gibberish"]
         let gibberishElementsContext = ElementsContext(from: additionalParameter)
 
         XCTAssertNotNil(gibberishElementsContext)
-        XCTAssertNil(gibberishElementsContext.hostedSurface)
+        XCTAssertNil(gibberishElementsContext.linkMode)
+        XCTAssertNil(gibberishElementsContext.linkMode?.isPantherPayment)
 
-        additionalParameter["hosted_surface"] = "payment_element"
-        let paymentElementElementsContext = ElementsContext(from: additionalParameter)
+        additionalParameter[linkModeKey] = "LINK_PAYMENT_METHOD"
+        let lpmElementsContext = ElementsContext(from: additionalParameter)
 
-        XCTAssertEqual(paymentElementElementsContext.hostedSurface, .paymentsSheet)
+        XCTAssertEqual(lpmElementsContext.linkMode, .linkPaymentMethod)
+        XCTAssert(lpmElementsContext.linkMode?.isPantherPayment == false)
 
-        additionalParameter["hosted_surface"] = "customer_sheet"
-        let customerSheetElementsContext = ElementsContext(from: additionalParameter)
+        additionalParameter[linkModeKey] = "PASSTHROUGH"
+        let passthroughElementsContext = ElementsContext(from: additionalParameter)
 
-        XCTAssertEqual(customerSheetElementsContext.hostedSurface, .customerSheet)
+        XCTAssertEqual(passthroughElementsContext.linkMode, .passthrough)
+        XCTAssert(passthroughElementsContext.linkMode?.isPantherPayment == false)
+
+        additionalParameter[linkModeKey] = "LINK_CARD_BRAND"
+        let linkCardBrandElementsContext = ElementsContext(from: additionalParameter)
+
+        XCTAssertEqual(linkCardBrandElementsContext.linkMode, .linkCardBrand)
+        XCTAssert(linkCardBrandElementsContext.linkMode?.isPantherPayment == true)
     }
 }

--- a/StripeCore/StripeCoreTests/Connections Bindings/ElementsContextTests.swift
+++ b/StripeCore/StripeCoreTests/Connections Bindings/ElementsContextTests.swift
@@ -1,0 +1,38 @@
+//
+//  ElementsContextTests.swift
+//  StripeCore
+//
+//  Created by Mat Schmid on 2024-09-20.
+//
+
+import XCTest
+
+@testable @_spi(STP) import StripeCore
+
+final class ElementsContextTests: XCTestCase {
+    func testEmptyParameters() {
+        let additionalParameter: [String: Any] = [:]
+        let elementsContext = ElementsContext(from: additionalParameter)
+
+        XCTAssertNotNil(elementsContext)
+        XCTAssertNil(elementsContext.hostedSurface)
+    }
+
+    func testHostedSurface() {
+        var additionalParameter = ["hosted_surface": "gibberish"]
+        let gibberishElementsContext = ElementsContext(from: additionalParameter)
+
+        XCTAssertNotNil(gibberishElementsContext)
+        XCTAssertNil(gibberishElementsContext.hostedSurface)
+
+        additionalParameter["hosted_surface"] = "payment_element"
+        let paymentElementElementsContext = ElementsContext(from: additionalParameter)
+
+        XCTAssertEqual(paymentElementElementsContext.hostedSurface, .paymentsSheet)
+
+        additionalParameter["hosted_surface"] = "customer_sheet"
+        let customerSheetElementsContext = ElementsContext(from: additionalParameter)
+
+        XCTAssertEqual(customerSheetElementsContext.hostedSurface, .customerSheet)
+    }
+}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/FinancialConnectionsSDK/FinancialConnectionsSDKImplementation.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/FinancialConnectionsSDK/FinancialConnectionsSDKImplementation.swift
@@ -20,6 +20,7 @@ public class FinancialConnectionsSDKImplementation: FinancialConnectionsSDKInter
         apiClient: STPAPIClient,
         clientSecret: String,
         returnURL: String?,
+        additionalParameters: [String: Any],
         onEvent: ((StripeCore.FinancialConnectionsEvent) -> Void)?,
         from presentingViewController: UIViewController,
         completion: @escaping (FinancialConnectionsSDKResult) -> Void
@@ -30,6 +31,7 @@ public class FinancialConnectionsSDKImplementation: FinancialConnectionsSDKInter
         )
         financialConnectionsSheet.apiClient = apiClient
         financialConnectionsSheet.onEvent = onEvent
+        financialConnectionsSheet.elementsContext = ElementsContext(from: additionalParameters)
         // Captures self explicitly until the callback is invoked
         financialConnectionsSheet.present(
             from: presentingViewController,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/FinancialConnectionsSheet.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/FinancialConnectionsSheet.swift
@@ -74,6 +74,9 @@ final public class FinancialConnectionsSheet {
 
     private var wrapperViewController: ModalPresentationWrapperViewController?
 
+    // Any additional Elements context useful for the Financial Connections SDK.
+    @_spi(STP) public var elementsContext: ElementsContext?
+
     // Analytics client to use for logging analytics
     @_spi(STP) public let analyticsClient: STPAnalyticsClientProtocol
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -207,6 +207,7 @@ extension PaymentMethodFormViewController {
 
     private var usBankAccountFormElement: USBankAccountPaymentMethodElement? { form as? USBankAccountPaymentMethodElement }
     private var instantDebitsFormElement: InstantDebitsPaymentMethodElement? { form as? InstantDebitsPaymentMethodElement }
+    private var linkMode: LinkSettings.LinkMode? { elementsSession.linkSettings?.linkMode }
 
     private var shouldOverridePrimaryButton: Bool {
         if paymentMethodType == .stripe(.USBankAccount) {
@@ -303,9 +304,14 @@ extension PaymentMethodFormViewController {
                 self.delegate?.updateErrorLabel(for: genericError)
             }
         }
-        let additionalParameters: [String: Any] = [
-            "hosted_surface": "payment_element",
+
+        var additionalParameters: [String: Any] = [
+            "hosted_surface": "payment_element"
         ]
+        if let linkMode {
+            additionalParameters["link_mode"] = linkMode.rawValue
+        }
+
         switch intent {
         case .paymentIntent(let paymentIntent):
             client.collectBankAccountForPayment(
@@ -391,11 +397,15 @@ extension PaymentMethodFormViewController {
                 self.delegate?.updateErrorLabel(for: genericError)
             }
         }
-        let additionalParameters: [String: Any] = [
+        var additionalParameters: [String: Any] = [
             "product": "instant_debits",
             "attach_required": true,
             "hosted_surface": "payment_element",
         ]
+        if let linkMode {
+            additionalParameters["link_mode"] = linkMode.rawValue
+        }
+
         switch intent {
         case .paymentIntent(let paymentIntent):
             client.collectBankAccountForPayment(

--- a/StripePayments/StripePayments/Source/Helpers/STPBankAccountCollector.swift
+++ b/StripePayments/StripePayments/Source/Helpers/STPBankAccountCollector.swift
@@ -254,6 +254,7 @@ public class STPBankAccountCollector: NSObject {
                 apiClient: self.apiClient,
                 clientSecret: linkAccountSession.clientSecret,
                 returnURL: returnURL,
+                additionalParameters: additionalParameters,
                 onEvent: onEvent,
                 from: viewController
             ) { result in
@@ -507,6 +508,7 @@ public class STPBankAccountCollector: NSObject {
                 apiClient: self.apiClient,
                 clientSecret: linkAccountSession.clientSecret,
                 returnURL: returnURL,
+                additionalParameters: additionalParameters,
                 onEvent: onEvent,
                 from: viewController
             ) { result in
@@ -596,6 +598,7 @@ public class STPBankAccountCollector: NSObject {
                 apiClient: self.apiClient,
                 clientSecret: linkAccountSession.clientSecret,
                 returnURL: returnURL,
+                additionalParameters: additionalParameters,
                 onEvent: onEvent,
                 from: viewController
             ) { result in

--- a/StripePayments/StripePayments/Source/Internal/Helpers/ConnectionsSDKAvailability.swift
+++ b/StripePayments/StripePayments/Source/Internal/Helpers/ConnectionsSDKAvailability.swift
@@ -51,6 +51,7 @@ final class StubbedConnectionsSDKInterface: FinancialConnectionsSDKInterface {
         apiClient: STPAPIClient,
         clientSecret: String,
         returnURL: String?,
+        additionalParameters: [String: Any],
         onEvent: ((FinancialConnectionsEvent) -> Void)?,
         from presentingViewController: UIViewController,
         completion: @escaping (FinancialConnectionsSDKResult) -> Void


### PR DESCRIPTION
## Summary

Per https://docs.google.com/document/d/1e3iaEKCjTgim53Aq6Q8DvXW7kxdZqzqXZqfuRjbKYEU/edit?usp=sharing

This adds support for passing elements session context to the Financial Connections SDK. Right now, this doesn't do much, but we will be using this work in the [Panther project](https://docs.google.com/document/d/1ErJVA3lLvNspPe3A8uYP9feK8Yvfq-Sw5aatNIvlGxk/edit#bookmark=id.e0msiotu3v8x) to tell the FC flow whether we're in the Panther flow. It will also be used for Financial Connections incentives down the line, where we'll pass information about the payment amount.

## Motivation

Enable new features!

## Testing

The `elementsContext.hostedSurface` is correctly set in the `FinancialConnectionsSheet`

<img width="1184" alt="Screenshot 2024-09-20 at 10 15 27 AM" src="https://github.com/user-attachments/assets/ad895fc4-88c5-4e02-8a7e-b71fbfef20a3">

## Changelog

N/a