### PR TITLE
[BANKCON-14851] Remove unnecessary consumer session lookup in step up verification pane

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationDataSource.swift
@@ -48,7 +48,7 @@ final class NetworkingLinkStepUpVerificationDataSourceImplementation: Networking
             customEmailType: "NETWORKED_CONNECTIONS_OTP_EMAIL",
             connectionsMerchantName: manifest.businessName,
             pane: .networkingLinkStepUpVerification,
-            consumerSession: nil,
+            consumerSession: consumerSession,
             apiClient: apiClient,
             clientSecret: clientSecret,
             analyticsClient: analyticsClient,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationViewController.swift
@@ -70,7 +70,7 @@ final class NetworkingLinkStepUpVerificationViewController: UIViewController {
         super.viewDidLoad()
         view.backgroundColor = .customBackgroundColor
 
-        otpView.lookupConsumerAndStartVerification()
+        otpView.startVerification()
     }
 
     private func handleFailure(error: Error, errorName: String) {
@@ -131,7 +131,7 @@ final class NetworkingLinkStepUpVerificationViewController: UIViewController {
     }
 
     private func didSelectResendCode() {
-        otpView.lookupConsumerAndStartVerification()
+        otpView.startVerification()
     }
 }
 


### PR DESCRIPTION
> [!IMPORTANT]  
>Web equivalent, with lots of additional context: https://git.corp.stripe.com/stripe-internal/pay-server/pull/901066

## Summary

When starting a verification from the `LinkStepUpVerification` pane, remove the consumer session lookup call that is made before starting verification. 

## Motivation

This call is extraneous because we have already done a lookup earlier in the flow.

## Testing

Before these changes, you can see a second call to `consumer_sessions` is made when the email OTP screen is shown: 

https://github.com/user-attachments/assets/6d4cc467-5884-4b1b-b154-c1bf09509f38

After these changes, you can see only one call to `consumer_sessions` is made through the flow, and it completing successfully:

https://github.com/user-attachments/assets/9b29c603-206c-4425-a136-6b4f53e06a70

## Changelog

N/a