### PR TITLE
[Connect] Add ability to specify arbitrary demo accounts in example app

### DIFF
--- a/Example/StripeConnectExample/StripeConnectExample/MainViewController.swift
+++ b/Example/StripeConnectExample/StripeConnectExample/MainViewController.swift
@@ -12,7 +12,7 @@ import UIKit
 class MainViewController: UITableViewController {
 
     let appInfo: AppInfo
-    let merchant: MerchantInfo
+    var merchant: MerchantInfo
 
     init(appInfo: AppInfo, merchant: MerchantInfo) {
         self.appInfo = appInfo
@@ -76,9 +76,16 @@ class MainViewController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = merchant.displayName ?? merchant.merchantId
         navigationItem.titleView = navbarTitleButton
         addChangeAppearanceButtonNavigationItem(to: self)
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        if let merchant = AppSettings.shared.selectedMerchant(appInfo: appInfo) {
+            self.merchant = merchant
+        }
+        title = merchant.displayName ?? merchant.merchantId
     }
 
     func addChangeAppearanceButtonNavigationItem(to viewController: UIViewController) {

--- a/Example/StripeConnectExample/StripeConnectExample/MainViewController.swift
+++ b/Example/StripeConnectExample/StripeConnectExample/MainViewController.swift
@@ -13,17 +13,17 @@ class MainViewController: UITableViewController {
 
     let appInfo: AppInfo
     let merchant: MerchantInfo
-    
+
     init(appInfo: AppInfo, merchant: MerchantInfo) {
         self.appInfo = appInfo
         self.merchant = merchant
         super.init(nibName: nil, bundle: nil)
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     /// Rows that display inside this table
     enum Row: String, CaseIterable {
         case onboarding = "Onboarding"
@@ -80,7 +80,7 @@ class MainViewController: UITableViewController {
         navigationItem.titleView = navbarTitleButton
         addChangeAppearanceButtonNavigationItem(to: self)
     }
-    
+
     func addChangeAppearanceButtonNavigationItem(to viewController: UIViewController) {
          // Add a button to change the appearance
          let button = UIBarButtonItem(
@@ -94,7 +94,7 @@ class MainViewController: UITableViewController {
          buttonItems = [button] + buttonItems
          viewController.navigationItem.rightBarButtonItems = buttonItems
      }
-    
+
     @objc
     func selectAppearance() {
         self.navigationController?.present(AppearanceSettings(componentManager: embeddedComponentManager).containerViewController, animated: true)
@@ -116,7 +116,7 @@ class MainViewController: UITableViewController {
         case .payouts:
             viewControllerToPush = embeddedComponentManager.createPayoutsViewController()
         }
-        
+
         viewControllerToPush.navigationItem.backButtonDisplayMode = .minimal
         addChangeAppearanceButtonNavigationItem(to: viewControllerToPush)
         navigationController?.pushViewController(viewControllerToPush, animated: true)
@@ -147,28 +147,28 @@ class MainViewController: UITableViewController {
 
         performAction(Row.allCases[indexPath.row], cell: cell)
     }
-    
+
     @objc
     func presentServerSettings() {
         self.present(AppSettingsView(appInfo: appInfo).containerViewController, animated: true)
     }
-    
+
     func presentAlert(title: String, message: String) {
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "OK", style: .default))
         self.present(alert, animated: true)
     }
-    
+
     func customFonts() -> [EmbeddedComponentManager.CustomFontSource] {
         // Note: The font name does not always match the file name,
         // but it makes initialization of font source easier when it does.
         let fonts: [String] = [
             "Handjet-Regular",
-            "Handjet-Bold"
+            "Handjet-Bold",
         ]
-                
+
         let fontSources: [EmbeddedComponentManager.CustomFontSource] = fonts.map { fontName in
-            guard let fontFileURL = Bundle.main.url(forResource: fontName, withExtension: "ttf"), 
+            guard let fontFileURL = Bundle.main.url(forResource: fontName, withExtension: "ttf"),
                     let font = UIFont(name: fontName, size: UIFont.systemFontSize) else {
                 print("Failed to load font with name \(fontName)")
                 return nil
@@ -180,8 +180,8 @@ class MainViewController: UITableViewController {
                 return nil
             }
         }
-        .compactMap({ $0})
-        
+        .compactMap({ $0 })
+
         if fontSources.count != fonts.count {
             print("Failed to load some fonts. Below are the available fonts to choose from: ")
             for family in UIFont.familyNames.sorted() {
@@ -191,7 +191,7 @@ class MainViewController: UITableViewController {
                 }
             }
         }
-        
+
         return fontSources
     }
 }

--- a/Example/StripeConnectExample/StripeConnectExample/MainViewController.swift
+++ b/Example/StripeConnectExample/StripeConnectExample/MainViewController.swift
@@ -12,18 +12,18 @@ import UIKit
 class MainViewController: UITableViewController {
 
     let appInfo: AppInfo
-    var merchant: MerchantInfo
-
+    let merchant: MerchantInfo
+    
     init(appInfo: AppInfo, merchant: MerchantInfo) {
         self.appInfo = appInfo
         self.merchant = merchant
         super.init(nibName: nil, bundle: nil)
     }
-
+    
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
+    
     /// Rows that display inside this table
     enum Row: String, CaseIterable {
         case onboarding = "Onboarding"
@@ -76,18 +76,11 @@ class MainViewController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        title = merchant.displayName ?? merchant.merchantId
         navigationItem.titleView = navbarTitleButton
         addChangeAppearanceButtonNavigationItem(to: self)
     }
-
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        if let merchant = AppSettings.shared.selectedMerchant(appInfo: appInfo) {
-            self.merchant = merchant
-        }
-        title = merchant.displayName ?? merchant.merchantId
-    }
-
+    
     func addChangeAppearanceButtonNavigationItem(to viewController: UIViewController) {
          // Add a button to change the appearance
          let button = UIBarButtonItem(
@@ -101,7 +94,7 @@ class MainViewController: UITableViewController {
          buttonItems = [button] + buttonItems
          viewController.navigationItem.rightBarButtonItems = buttonItems
      }
-
+    
     @objc
     func selectAppearance() {
         self.navigationController?.present(AppearanceSettings(componentManager: embeddedComponentManager).containerViewController, animated: true)
@@ -123,7 +116,7 @@ class MainViewController: UITableViewController {
         case .payouts:
             viewControllerToPush = embeddedComponentManager.createPayoutsViewController()
         }
-
+        
         viewControllerToPush.navigationItem.backButtonDisplayMode = .minimal
         addChangeAppearanceButtonNavigationItem(to: viewControllerToPush)
         navigationController?.pushViewController(viewControllerToPush, animated: true)
@@ -154,28 +147,28 @@ class MainViewController: UITableViewController {
 
         performAction(Row.allCases[indexPath.row], cell: cell)
     }
-
+    
     @objc
     func presentServerSettings() {
         self.present(AppSettingsView(appInfo: appInfo).containerViewController, animated: true)
     }
-
+    
     func presentAlert(title: String, message: String) {
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "OK", style: .default))
         self.present(alert, animated: true)
     }
-
+    
     func customFonts() -> [EmbeddedComponentManager.CustomFontSource] {
         // Note: The font name does not always match the file name,
         // but it makes initialization of font source easier when it does.
         let fonts: [String] = [
             "Handjet-Regular",
-            "Handjet-Bold",
+            "Handjet-Bold"
         ]
-
+                
         let fontSources: [EmbeddedComponentManager.CustomFontSource] = fonts.map { fontName in
-            guard let fontFileURL = Bundle.main.url(forResource: fontName, withExtension: "ttf"),
+            guard let fontFileURL = Bundle.main.url(forResource: fontName, withExtension: "ttf"), 
                     let font = UIFont(name: fontName, size: UIFont.systemFontSize) else {
                 print("Failed to load font with name \(fontName)")
                 return nil
@@ -187,8 +180,8 @@ class MainViewController: UITableViewController {
                 return nil
             }
         }
-        .compactMap({ $0 })
-
+        .compactMap({ $0})
+        
         if fontSources.count != fonts.count {
             print("Failed to load some fonts. Below are the available fonts to choose from: ")
             for family in UIFont.familyNames.sorted() {
@@ -198,7 +191,7 @@ class MainViewController: UITableViewController {
                 }
             }
         }
-
+        
         return fontSources
     }
 }

--- a/Example/StripeConnectExample/StripeConnectExample/Storage/AppSettings.swift
+++ b/Example/StripeConnectExample/StripeConnectExample/Storage/AppSettings.swift
@@ -83,6 +83,5 @@ class AppSettings {
 
     func setSelectedMerchant(merchant: MerchantInfo?) {
         defaults.setValue(merchant?.id, forKey: Constants.selectedMerchantKey)
-        defaults.synchronize()
     }
 }

--- a/Example/StripeConnectExample/StripeConnectExample/Storage/AppSettings.swift
+++ b/Example/StripeConnectExample/StripeConnectExample/Storage/AppSettings.swift
@@ -73,12 +73,17 @@ class AppSettings {
     }
 
     func selectedMerchant(appInfo: AppInfo?) -> MerchantInfo? {
+        // Default to the first available merchant if this is the first time opening the app
         guard let merchantId = defaults.string(forKey: Constants.selectedMerchantKey) else {
             return appInfo?.availableMerchants.first
         }
-        return appInfo?.availableMerchants.first(where: {
+
+        // If the merchant is in the list of available merchants, then use its display name
+        let displayName = appInfo?.availableMerchants.first(where: {
             $0.merchantId == merchantId
-        }) ?? .init(displayName: nil, merchantId: merchantId)
+        })?.displayName
+
+        return .init(displayName: displayName, merchantId: merchantId)
     }
 
     func setSelectedMerchant(merchant: MerchantInfo?) {

--- a/Example/StripeConnectExample/StripeConnectExample/Storage/AppSettings.swift
+++ b/Example/StripeConnectExample/StripeConnectExample/Storage/AppSettings.swift
@@ -73,19 +73,16 @@ class AppSettings {
     }
 
     func selectedMerchant(appInfo: AppInfo?) -> MerchantInfo? {
-        let merchantId = defaults.string(forKey: Constants.selectedMerchantKey)
+        guard let merchantId = defaults.string(forKey: Constants.selectedMerchantKey) else {
+            return appInfo?.availableMerchants.first
+        }
         return appInfo?.availableMerchants.first(where: {
             $0.merchantId == merchantId
-        }) ?? appInfo?.availableMerchants.first
+        }) ?? .init(displayName: nil, merchantId: merchantId)
     }
 
     func setSelectedMerchant(merchant: MerchantInfo?) {
         defaults.setValue(merchant?.id, forKey: Constants.selectedMerchantKey)
-    }
-}
-
-private extension UserDefaults {
-    func string(forKey defaultName: String, defaultValue: String = "") -> String {
-        self.string(forKey: defaultName) ?? defaultValue
+        defaults.synchronize()
     }
 }

--- a/Example/StripeConnectExample/StripeConnectExample/Storage/AppSettings.swift
+++ b/Example/StripeConnectExample/StripeConnectExample/Storage/AppSettings.swift
@@ -90,3 +90,9 @@ class AppSettings {
         defaults.setValue(merchant?.id, forKey: Constants.selectedMerchantKey)
     }
 }
+
+private extension UserDefaults {
+    func string(forKey defaultName: String, defaultValue: String = "") -> String {
+        self.string(forKey: defaultName) ?? defaultValue
+    }
+}


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

Adds the ability specify arbitrary demo / test accounts in the Connect example app.

Primary use case is so we can test with different accounts internally during bug-bashing, but also useful for testing onboarding since we need to create new accounts with empty data to test it properly.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

https://jira.corp.stripe.com/browse/MXMOBILE-2793

## Testing
<!-- How was the code tested? Be as specific as possible. -->

https://github.com/user-attachments/assets/6ad28c68-dd1b-4025-90d2-798cf2d31ec4
