### PR TITLE
Fix PS Example release builds

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/UIView+PaymentSheetDebugging.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/UIView+PaymentSheetDebugging.swift
@@ -4,7 +4,7 @@
 //
 
 import UIKit
-#if DEBUG
+
 extension UIView {
     func ambiguousView() -> UIView? {
         for subview in self.subviews {
@@ -30,4 +30,3 @@ extension UIView {
         return nil
     }
 }
-#endif


### PR DESCRIPTION
## Summary
This `#if DEBUG` was left in by mistake after I moved the code out of the framework. We always want support for this compiled into the PaymentSheet Example app.

## Testing
Rebuilt an Archive build locally.

## Changelog
None