### PR TITLE
[testmode] Re-enable test

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
@@ -615,9 +615,7 @@ final class FinancialConnectionsUITests: XCTestCase {
     }
 
     // this tests going through "ResetFlowViewController"
-    func testNativeResetFlowWithErrorToSuccess() throws {
-        throw XCTSkip("Skipping this test case until we edit this institution's name")
-
+    func testNativeResetFlowWithErrorToSuccess() {
         let app = XCUIApplication.fc_launch(
             playgroundConfigurationString:
 """


### PR DESCRIPTION
## Summary
Re-enable test that I disabled in https://github.com/stripe/stripe-ios/pull/4030

## Motivation
We've now changed the bank name internally, so now we're renabling this test. See also https://github.com/stripe/stripe-android/pull/9324

## Testing
N/A

## Changelog
N/A
