### PR TITLE
[DRAFT] Card brand filtering for PAN and saved payment methods

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlayground.swift
@@ -70,6 +70,7 @@ struct CustomerSheetTestPlayground: View {
                         SettingView(setting: $playgroundController.settings.applePay)
                         SettingView(setting: $playgroundController.settings.defaultBillingAddress)
                         SettingView(setting: $playgroundController.settings.preferredNetworksEnabled)
+                        SettingView(setting: $playgroundController.settings.cardBrandAcceptance)
                         SettingView(setting: $playgroundController.settings.autoreload)
                         TextField("headerTextForSelectionScreen", text: headerTextForSelectionScreenBinding)
                         SettingView(setting: $playgroundController.settings.allowsRemovalOfLastSavedPaymentMethod)

--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundController.swift
@@ -4,7 +4,7 @@
 //
 
 import Combine
-@_spi(STP) @_spi(CustomerSessionBetaAccess) import StripePaymentSheet
+@_spi(STP) @_spi(CustomerSessionBetaAccess) @_spi(CardBrandFilteringBeta) import StripePaymentSheet
 import SwiftUI
 
 class CustomerSheetTestPlaygroundController: ObservableObject {
@@ -139,6 +139,16 @@ class CustomerSheetTestPlaygroundController: ObservableObject {
         configuration.billingDetailsCollectionConfiguration.attachDefaultsToPaymentMethod = settings.attachDefaults == .on
         configuration.preferredNetworks = settings.preferredNetworksEnabled == .on ? [.visa, .cartesBancaires] : nil
         configuration.applePayEnabled = self.applePayEnabled()
+        
+        switch settings.cardBrandAcceptance {
+        case .all:
+            configuration.cardBrandAcceptance = .all
+        case .blockAmEx:
+            configuration.cardBrandAcceptance = .disallowed(brands: [.amex])
+        case .allowVisa:
+            configuration.cardBrandAcceptance = .allowed(brands: [.visa])
+        }
+        
         return configuration
     }
 

--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundSettings.swift
@@ -134,6 +134,13 @@ public struct CustomerSheetTestPlaygroundSettings: Codable, Equatable {
             }
         }
     }
+    
+    enum CardBrandAcceptance: String, PickerEnum {
+        static let enumName: String = "cardBrandAcceptance"
+        case all
+        case blockAmEx
+        case allowVisa
+    }
 
     var customerMode: CustomerMode
     var customerId: String?
@@ -154,6 +161,7 @@ public struct CustomerSheetTestPlaygroundSettings: Codable, Equatable {
     var allowsRemovalOfLastSavedPaymentMethod: AllowsRemovalOfLastSavedPaymentMethod
     var paymentMethodRemove: PaymentMethodRemove
     var paymentMethodAllowRedisplayFilters: PaymentMethodAllowRedisplayFilters
+    var cardBrandAcceptance: CardBrandAcceptance
 
     static func defaultValues() -> CustomerSheetTestPlaygroundSettings {
         return CustomerSheetTestPlaygroundSettings(customerMode: .new,
@@ -173,7 +181,8 @@ public struct CustomerSheetTestPlaygroundSettings: Codable, Equatable {
                                                    preferredNetworksEnabled: .off,
                                                    allowsRemovalOfLastSavedPaymentMethod: .on,
                                                    paymentMethodRemove: .enabled,
-                                                   paymentMethodAllowRedisplayFilters: .always)
+                                                   paymentMethodAllowRedisplayFilters: .always,
+                                                   cardBrandAcceptance: .all)
     }
 
     var base64Data: String {

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -44,6 +44,7 @@ struct PaymentSheetTestPlayground: View {
             SettingView(setting: $playgroundController.settings.userOverrideCountry)
             SettingView(setting: $playgroundController.settings.externalPaymentMethods)
             SettingView(setting: $playgroundController.settings.preferredNetworksEnabled)
+            SettingView(setting: $playgroundController.settings.cardBrandAcceptance)
             SettingView(setting: $playgroundController.settings.allowsRemovalOfLastSavedPaymentMethod)
         }
         Group {

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -408,6 +408,13 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
         case on
         case off
     }
+    
+    enum CardBrandAcceptance: String, PickerEnum {
+        static let enumName: String = "cardBrandAcceptance"
+        case all
+        case blockAmEx
+        case allowVisa
+    }
 
     var uiStyle: UIStyle
     var layout: Layout
@@ -449,6 +456,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
     var collectEmail: BillingDetailsEmail
     var collectPhone: BillingDetailsPhone
     var collectAddress: BillingDetailsAddress
+    var cardBrandAcceptance: CardBrandAcceptance
 
     static func defaultValues() -> PaymentSheetTestPlaygroundSettings {
         return PaymentSheetTestPlaygroundSettings(
@@ -488,7 +496,8 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
             collectName: .automatic,
             collectEmail: .automatic,
             collectPhone: .automatic,
-            collectAddress: .automatic)
+            collectAddress: .automatic,
+            cardBrandAcceptance: .all)
     }
 
     static let nsUserDefaultsKey = "PaymentSheetTestPlaygroundSettings"

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -14,7 +14,7 @@ import Contacts
 import PassKit
 @_spi(STP) import StripeCore
 @_spi(STP) import StripePayments
-@_spi(CustomerSessionBetaAccess) @_spi(STP) @_spi(PaymentSheetSkipConfirmation) @_spi(ExperimentalAllowsRemovalOfLastSavedPaymentMethodAPI) @_spi(ExperimentalPaymentMethodLayoutAPI) import StripePaymentSheet
+@_spi(CustomerSessionBetaAccess) @_spi(STP) @_spi(PaymentSheetSkipConfirmation) @_spi(ExperimentalAllowsRemovalOfLastSavedPaymentMethodAPI) @_spi(ExperimentalPaymentMethodLayoutAPI) @_spi(CardBrandFilteringBeta) import StripePaymentSheet
 import SwiftUI
 import UIKit
 
@@ -171,6 +171,16 @@ class PlaygroundController: ObservableObject {
         case .vertical:
             configuration.paymentMethodLayout = .vertical
         }
+        
+        switch settings.cardBrandAcceptance {
+        case .all:
+            configuration.cardBrandAcceptance = .all
+        case .blockAmEx:
+            configuration.cardBrandAcceptance = .disallowed(brands: [.amex])
+        case .allowVisa:
+            configuration.cardBrandAcceptance = .allowed(brands: [.visa])
+        }
+        
         return configuration
     }
 

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -1565,6 +1565,58 @@ class PaymentSheetCustomerSessionCBCUITests: PaymentSheetUITestCase {
     }
 }
 
+class PaymentSheetCardBrandFilteringUITests: PaymentSheetUITestCase {
+    func testPaymentSheet_disallowedBrands() throws {
+        var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
+        settings.customerMode = .new
+        settings.cardBrandAcceptance = .blockAmEx
+        loadPlayground(app, settings)
+        
+        app.buttons["Present PaymentSheet"].tap()
+        
+        let numberField = app.textFields["Card number"]
+        numberField.forceTapWhenHittableInTestCase(self)
+        app.typeText("3712")
+        
+        // Text should show that we cannot process American Express
+        XCTAssertTrue(app.staticTexts["American Express is not accepted"].waitForExistence(timeout: 5.0))
+        
+        numberField.clearText()
+        
+        // Try and pay with a Visa
+        try fillCardData(app)
+        
+        app.buttons["Pay $50.99"].tap()
+        let successText = app.staticTexts["Success!"]
+        XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
+    }
+    
+    func testPaymentSheet_allowedBrands() throws {
+        var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
+        settings.customerMode = .new
+        settings.cardBrandAcceptance = .allowVisa
+        loadPlayground(app, settings)
+        
+        app.buttons["Present PaymentSheet"].tap()
+        
+        let numberField = app.textFields["Card number"]
+        numberField.forceTapWhenHittableInTestCase(self)
+        app.typeText("3712")
+        
+        // Text should show that we cannot process American Express
+        XCTAssertTrue(app.staticTexts["American Express is not accepted"].waitForExistence(timeout: 5.0))
+        
+        numberField.clearText()
+        
+        // Try and pay with a Visa
+        try fillCardData(app)
+        
+        app.buttons["Pay $50.99"].tap()
+        let successText = app.staticTexts["Success!"]
+        XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
+    }
+}
+
 class PaymentSheetCVCRecollectionUITests: PaymentSheetUITestCase {
     func testCVCRecollectionFlowController_deferredCSC() throws {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
@@ -214,6 +214,7 @@ import Foundation
     case paymentSheetUpdateCardBrand = "mc_update_card"
     case paymentSheetUpdateCardBrandFailed = "mc_update_card_failed"
     case paymentSheetClosesEditScreen = "mc_cancel_edit_screen"
+    case paymentSheetDisallowedCardBrand = "mc_disallowed_card_brand"
 
     // MARK: - CustomerSheet card brand choice
     case customerSheetDisplayCardBrandDropdownIndicator = "cs_display_cbc_dropdown"

--- a/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
+++ b/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
@@ -107,6 +107,8 @@
 		5E00512CDFBC1C93781E20AB /* PaymentSheetLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88DBDEE23A856CE8D3B49861 /* PaymentSheetLoader.swift */; };
 		6103F2BC2BE45990002D67F8 /* SavedPaymentMethodManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6103F2BB2BE45990002D67F8 /* SavedPaymentMethodManager.swift */; };
 		610EAAF02C0F5D9400124AB2 /* FormHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 610EAAEF2C0F5D9400124AB2 /* FormHeaderView.swift */; };
+		612F957D2CA4618E00A3B960 /* CardBrandFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612F957C2CA4618E00A3B960 /* CardBrandFilter.swift */; };
+		612F95802CA461B600A3B960 /* CardBrandFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612F957E2CA461AA00A3B960 /* CardBrandFilterTests.swift */; };
 		6141C5072C0A47A700E81735 /* RightAccessoryButtonTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6141C5062C0A47A700E81735 /* RightAccessoryButtonTest.swift */; };
 		614A8AE72BE53C6900E8688B /* SavedPaymentMethodManagerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6103F2BD2BE53737002D67F8 /* SavedPaymentMethodManagerTest.swift */; };
 		6151DDC02B14FDCF00ED4F7E /* UpdateCardViewControllerSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6151DDBF2B14FDCF00ED4F7E /* UpdateCardViewControllerSnapshotTests.swift */; };
@@ -455,6 +457,8 @@
 		6103F2BB2BE45990002D67F8 /* SavedPaymentMethodManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedPaymentMethodManager.swift; sourceTree = "<group>"; };
 		6103F2BD2BE53737002D67F8 /* SavedPaymentMethodManagerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedPaymentMethodManagerTest.swift; sourceTree = "<group>"; };
 		610EAAEF2C0F5D9400124AB2 /* FormHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormHeaderView.swift; sourceTree = "<group>"; };
+		612F957C2CA4618E00A3B960 /* CardBrandFilter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardBrandFilter.swift; sourceTree = "<group>"; };
+		612F957E2CA461AA00A3B960 /* CardBrandFilterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardBrandFilterTests.swift; sourceTree = "<group>"; };
 		6139AA50F07A1E2AC7E9827F /* AUBECSMandate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AUBECSMandate.swift; sourceTree = "<group>"; };
 		6141C5062C0A47A700E81735 /* RightAccessoryButtonTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightAccessoryButtonTest.swift; sourceTree = "<group>"; };
 		6151DDBF2B14FDCF00ED4F7E /* UpdateCardViewControllerSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateCardViewControllerSnapshotTests.swift; sourceTree = "<group>"; };
@@ -840,6 +844,7 @@
 				966339C092711FED8EFE98FB /* STPAnalyticsClient+PaymentSheet.swift */,
 				446E3BBF316178C04343B193 /* STPApplePayContext+PaymentSheet.swift */,
 				2C59FD8C17CA1D740BCAFA4D /* STPPaymentIntentShippingDetailsParams+PaymentSheet.swift */,
+				612F957C2CA4618E00A3B960 /* CardBrandFilter.swift */,
 			);
 			path = PaymentSheet;
 			sourceTree = "<group>";
@@ -1402,6 +1407,7 @@
 				64C8F350CDB5A29F62E86592 /* FlowControllerStateTests.swift */,
 				990304EF35A0EE37DCE20D5B /* IntentStatusPollerTest.swift */,
 				6B0E5AE62C08F4B5008AAFBE /* IntentConfirmParamsTest.swift */,
+				612F957E2CA461AA00A3B960 /* CardBrandFilterTests.swift */,
 				FCA28FF8CD5BA829A44CDCE7 /* Link */,
 				33B8F21A22FA091BC9D2924B /* LinkStubs.swift */,
 				C830FEC205E7162FF4D414BE /* PaymentMethodMessagingViewFunctionalTest.swift */,
@@ -1738,6 +1744,7 @@
 				AE8EF3966E7BABDFC3B426ED /* PaymentSheet+DashboardConfirmParamsTest.swift in Sources */,
 				B65B42972C013DED00EC565D /* PaymentMethodFormViewControllerTest.swift in Sources */,
 				6B50BCEE2C29EE1F009702FB /* SavedPaymentOptionsViewControllerTests.swift in Sources */,
+				612F95802CA461B600A3B960 /* CardBrandFilterTests.swift in Sources */,
 				C28450436BDA52BE9BE3BDC3 /* PaymentSheetConfigurationTests.swift in Sources */,
 				F1A350D67665949CF91A0C02 /* CustomerSheetConfigurationTests.swift in Sources */,
 			);
@@ -1923,6 +1930,7 @@
 				F0D8CE0D86F703C995608BFC /* RotatingCardBrandsView.swift in Sources */,
 				B6E8C7FB2C184A0300B977B2 /* PaymentSheetFormFactory+Mandates.swift in Sources */,
 				F3738B13E3A7C82543B75579 /* ShadowedRoundedRectangleView.swift in Sources */,
+				612F957D2CA4618E00A3B960 /* CardBrandFilter.swift in Sources */,
 				2A45D3B00BEE9A8D5909CCB1 /* SheetNavigationBar.swift in Sources */,
 				18A5870973D314A946B92748 /* SheetNavigationButton.swift in Sources */,
 				70FEF1703F45F8A90F687E51 /* SimpleMandateTextView.swift in Sources */,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/PaymentSheetAnalyticsHelper.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/PaymentSheetAnalyticsHelper.swift
@@ -351,6 +351,8 @@ extension PaymentSheet.Configuration {
         payload["billing_details_collection_configuration"] = billingDetailsCollectionConfiguration.analyticPayload
         payload["preferred_networks"] = preferredNetworks?.map({ STPCardBrandUtilities.apiValue(from: $0) }).joined(separator: ", ")
         payload["payment_method_layout"] = paymentMethodLayout.description
+        payload["card_brand_acceptance"] = cardBrandAcceptance != .all
+        
         return payload
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewController.swift
@@ -82,6 +82,7 @@ class CustomerSavedPaymentMethodsCollectionViewController: UIViewController {
         let allowsRemovalOfLastSavedPaymentMethod: Bool
         let paymentMethodRemove: Bool
         let isTestMode: Bool
+        let cardBrandFilter: CardBrandFilter
     }
 
     /// Whether or not you can edit save payment methods by removing or updating them.
@@ -436,7 +437,8 @@ extension CustomerSavedPaymentMethodsCollectionViewController: PaymentOptionCell
                                               appearance: appearance,
                                               hostedSurface: .customerSheet,
                                               canRemoveCard: configuration.paymentMethodRemove && (savedPaymentMethods.count > 1 || configuration.allowsRemovalOfLastSavedPaymentMethod),
-                                              isTestMode: configuration.isTestMode)
+                                              isTestMode: configuration.isTestMode,
+                                              cardBrandFilter: configuration.cardBrandFilter)
         editVc.delegate = self
         self.bottomSheetController?.pushContentViewController(editVc)
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsViewController.swift
@@ -103,7 +103,8 @@ class CustomerSavedPaymentMethodsViewController: UIViewController {
                 showApplePay: showApplePay,
                 allowsRemovalOfLastSavedPaymentMethod: configuration.allowsRemovalOfLastSavedPaymentMethod,
                 paymentMethodRemove: paymentMethodRemove,
-                isTestMode: configuration.apiClient.isTestmode
+                isTestMode: configuration.apiClient.isTestmode,
+                cardBrandFilter: .init(cardBrandAcceptance: configuration.cardBrandAcceptance)
             ),
             appearance: configuration.appearance,
             cbcEligible: cbcEligible,
@@ -654,7 +655,8 @@ class CustomerSavedPaymentMethodsViewController: UIViewController {
                 showApplePay: isApplePayEnabled,
                 allowsRemovalOfLastSavedPaymentMethod: configuration.allowsRemovalOfLastSavedPaymentMethod,
                 paymentMethodRemove: paymentMethodRemove,
-                isTestMode: configuration.apiClient.isTestmode
+                isTestMode: configuration.apiClient.isTestmode,
+                cardBrandFilter: .init(cardBrandAcceptance: configuration.cardBrandAcceptance)
             ),
             appearance: configuration.appearance,
             cbcEligible: cbcEligible,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetConfiguration.swift
@@ -68,6 +68,11 @@ extension CustomerSheet {
                        "preferredNetworks must not contain any duplicate card brands")
             }
         }
+        
+        /// By default, CustomerSheet will accept all supported cards by Stripe.
+        /// You can specify card brands PaymentSheet should block disallow or allow payment for by providing an array of those card brands.
+        /// Note: This is only a client-side solution.
+        @_spi(CardBrandFilteringBeta) public var cardBrandAcceptance: PaymentSheet.CardBrandAcceptance = .all
 
         /// This is an experimental feature that may be removed at any time.
         /// If true (the default), the customer can delete all saved payment methods.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSection/CardSectionElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSection/CardSectionElement.swift
@@ -60,6 +60,7 @@ final class CardSectionElement: ContainerElement {
     let theme: ElementsUITheme
     let preferredNetworks: [STPCardBrand]?
     let hostedSurface: HostedSurface
+    let cardBrandFilter: CardBrandFilter
 
     init(
         collectName: Bool = false,
@@ -68,11 +69,13 @@ final class CardSectionElement: ContainerElement {
         cardBrandChoiceEligible: Bool = false,
         hostedSurface: HostedSurface,
         theme: ElementsUITheme = .default,
+        cardBrandFilter: CardBrandFilter,
         analyticsHelper: PaymentSheetAnalyticsHelper
     ) {
         self.hostedSurface = hostedSurface
         self.theme = theme
         self.analyticsHelper = analyticsHelper
+        self.cardBrandFilter = cardBrandFilter
         let nameElement = collectName
             ? PaymentMethodElementWrapper(
                 TextFieldElement.NameConfiguration(
@@ -94,7 +97,7 @@ final class CardSectionElement: ContainerElement {
             }
         }
         let panElement = PaymentMethodElementWrapper(TextFieldElement.PANConfiguration(defaultValue: defaultValues.pan,
-                                                                                       cardBrandDropDown: cardBrandDropDown?.element), theme: theme) { field, params in
+                                                                                       cardBrandDropDown: cardBrandDropDown?.element, cardFilter: cardBrandFilter), theme: theme) { field, params in
             cardParams(for: params).number = field.text
             return params
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/TextField/TextFieldElement+Card.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/TextField/TextFieldElement+Card.swift
@@ -22,10 +22,23 @@ extension TextFieldElement {
         let rotatingCardBrandsView = RotatingCardBrandsView()
         let defaultValue: String?
         let cardBrandDropDown: DropdownFieldElement?
-
-        init(defaultValue: String? = nil, cardBrandDropDown: DropdownFieldElement? = nil) {
+        let cardFilter: CardBrandFilter
+        
+        init(defaultValue: String? = nil, cardBrandDropDown: DropdownFieldElement? = nil, cardFilter: CardBrandFilter = .default) {
             self.defaultValue = defaultValue
             self.cardBrandDropDown = cardBrandDropDown
+            self.cardFilter = cardFilter
+        }
+        
+        private func cardBrand(for text: String) -> STPCardBrand {
+            guard let cardBrandDropDown = cardBrandDropDown,
+                  let firstBrandString = cardBrandDropDown.nonPlacerholderItems.first?.rawData else {
+                return STPCardValidator.brand(forNumber: text)
+            }
+            
+            let cardBrandFromDropDown = STPCard.brand(from: firstBrandString)
+            let cardBrandFromBin = STPCardValidator.brand(forNumber: text)
+            return cardBrandFromDropDown == .unknown ? cardBrandFromBin : cardBrandFromDropDown
         }
 
         func accessoryView(for text: String, theme: ElementsUITheme) -> UIView? {
@@ -40,14 +53,14 @@ extension TextFieldElement {
                 }
             }
 
-            let cardBrand = STPCardValidator.brand(forNumber: text)
+            let cardBrand = cardBrand(for: text)
             if cardBrand == .unknown {
                 if case .invalid(Error.invalidBrand) = validate(text: text, isOptional: false) {
                     return DynamicImageView.makeUnknownCardImageView(theme: theme)
                 } else {
                     // display all available card brands
                     rotatingCardBrandsView.cardBrands =
-                        RotatingCardBrandsView.orderedCardBrands(from: STPCardBrand.allCases)
+                    RotatingCardBrandsView.orderedCardBrands(from: STPCardBrand.allCases.filter{ cardFilter.isAccepted(cardBrand:$0) })
                     return rotatingCardBrandsView
                 }
             } else {
@@ -73,6 +86,7 @@ extension TextFieldElement {
             case incomplete
             case invalidBrand
             case invalidLuhn
+            case disallowedBrand(brand: STPCardBrand)
 
             func shouldDisplay(isUserEditing: Bool) -> Bool {
                 switch self {
@@ -80,7 +94,7 @@ extension TextFieldElement {
                     return false
                 case .incomplete, .invalidLuhn:
                     return !isUserEditing
-                case .invalidBrand:
+                case .invalidBrand, .disallowedBrand:
                     return true
                 }
             }
@@ -93,6 +107,18 @@ extension TextFieldElement {
                     return String.Localized.your_card_number_is_incomplete
                 case .invalidBrand, .invalidLuhn:
                     return String.Localized.your_card_number_is_invalid
+                case .disallowedBrand(let brand):
+                    let cardBrandDisplayName =  STPCardBrandUtilities.stringFrom(brand) ?? "This card brand"
+                    return "\(cardBrandDisplayName) is not accepted"
+                }
+            }
+            
+            var isDisallowedBrand: Bool {
+                switch self {
+                case .empty, .incomplete, .invalidBrand, .invalidLuhn:
+                    return false
+                case .disallowedBrand:
+                    return true
                 }
             }
         }
@@ -108,6 +134,13 @@ extension TextFieldElement {
             let binRange = binController.mostSpecificBINRange(forNumber: text)
             if binRange.brand == .unknown {
                 return .invalid(Error.invalidBrand)
+            }
+            
+            
+            let cardBrand = cardBrand(for: text)
+            let shouldShowDisallowedError = cardBrandDropDown == nil || text.count > 8
+            if !cardFilter.isAccepted(cardBrand: cardBrand) && shouldShowDisallowedError {
+                return .invalid(Error.disallowedBrand(brand: cardBrand))
             }
 
             // Is the PAN the correct length?
@@ -290,14 +323,16 @@ extension TextFieldElement {
         let lastFour: String
         let isEditable = false
         let cardBrandDropDown: DropdownFieldElement
-
+        let cardFilter: CardBrandFilter
+        
         private var lastFourFormatted: String {
             "•••• •••• •••• \(lastFour)"
         }
 
-        init(lastFour: String, cardBrandDropDown: DropdownFieldElement) {
+        init(lastFour: String, cardBrandDropDown: DropdownFieldElement, cardFilter: CardBrandFilter) {
             self.lastFour = lastFour
             self.cardBrandDropDown = cardBrandDropDown
+            self.cardFilter = cardFilter
         }
 
         func makeDisplayText(for text: String) -> NSAttributedString {
@@ -306,8 +341,8 @@ extension TextFieldElement {
 
         func accessoryView(for text: String, theme: ElementsUITheme) -> UIView? {
             // Re-use same logic from PANConfiguration for accessory view
-            return TextFieldElement.PANConfiguration(cardBrandDropDown: cardBrandDropDown)
-                                            .accessoryView(for: lastFourFormatted, theme: theme)
+            return TextFieldElement.PANConfiguration(cardBrandDropDown: cardBrandDropDown,
+                                                     cardFilter: cardFilter).accessoryView(for: lastFourFormatted, theme: theme)
         }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
@@ -162,6 +162,11 @@ extension PaymentSheet {
                        "preferredNetworks must not contain any duplicate card brands")
             }
         }
+        
+        /// By default, PaymentSheet will accept all supported cards by Stripe.
+        /// You can specify card brands PaymentSheet should block disallow or allow payment for by providing an array of those card brands.
+        /// Note: This is only a client-side solution.
+        @_spi(CardBrandFilteringBeta) public var cardBrandAcceptance: CardBrandAcceptance = .all
 
         /// Initializes a Configuration with default values
         public init() {}
@@ -525,5 +530,30 @@ extension PaymentSheet.CustomerConfiguration {
         case .customerSession:
             return elementsSession?.customer?.customerSession.apiKey
         }
+    }
+}
+
+@_spi(CardBrandFilteringBeta) extension PaymentSheet {
+    /// Options to block certain card brands on the client
+    public enum CardBrandAcceptance: Equatable {
+        
+        /// Card brand categories that can be allowed or disallowed
+        public enum BrandCategory: Equatable  {
+            /// Visa branded cards
+            case visa
+            /// Mastercard branded cards
+            case mastercard
+            /// Amex branded cards
+            case amex
+            /// Encompasses all of Discover Global Network (Discover, Diners, JCB, UnionPay, Elo)
+            case discoverGlobalNetwork
+        }
+        
+        /// Accept all card brands supported by Stripe
+        case all
+        /// Accept only the card brands specified in the associated value
+        case allowed(brands: [BrandCategory])
+        /// Accept all card brands supported by Stripe except for those specified in the associated value
+        case disallowed(brands: [BrandCategory])
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
@@ -58,6 +58,7 @@ extension PaymentSheetFormFactory {
             cardBrandChoiceEligible: cardBrandChoiceEligible,
             hostedSurface: .init(config: configuration),
             theme: theme,
+            cardBrandFilter: .init(cardBrandAcceptance: configuration.cardBrandAcceptance),
             analyticsHelper: analyticsHelper
         )
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactoryConfig.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactoryConfig.swift
@@ -93,4 +93,13 @@ enum PaymentSheetFormFactoryConfig {
             return config.isUsingBillingAddressCollection()
         }
     }
+    
+    var cardBrandAcceptance: PaymentSheet.CardBrandAcceptance {
+        switch self {
+        case .paymentSheet(let configuration):
+            return configuration.cardBrandAcceptance
+        case .customerSheet(let configuration):
+            return configuration.cardBrandAcceptance
+        }
+    }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -271,7 +271,10 @@ final class PaymentSheetLoader {
             }
         }
 
-        return savedPaymentMethods
+        return savedPaymentMethods.filter {
+            guard let cardBrand = $0.card?.brand else { return true }
+            return CardBrandFilter(cardBrandAcceptance: configuration.cardBrandAcceptance).isAccepted(cardBrand: cardBrand)
+        }
     }
 
     static func fetchSavedPaymentMethodsUsingApiClient(configuration: PaymentSheet.Configuration) async throws -> [STPPaymentMethod] {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
@@ -103,6 +103,7 @@ class SavedPaymentOptionsViewController: UIViewController {
         let isTestMode: Bool
         let allowsRemovalOfLastSavedPaymentMethod: Bool
         let allowsRemovalOfPaymentMethods: Bool
+        let cardBrandFilter: CardBrandFilter
     }
 
     // MARK: - Internal Properties
@@ -560,7 +561,8 @@ extension SavedPaymentOptionsViewController: PaymentOptionCellDelegate {
                                               appearance: appearance,
                                               hostedSurface: .paymentSheet,
                                               canRemoveCard: configuration.allowsRemovalOfPaymentMethods && (savedPaymentMethods.count > 1 || configuration.allowsRemovalOfLastSavedPaymentMethod),
-                                              isTestMode: configuration.isTestMode)
+                                              isTestMode: configuration.isTestMode,
+                                              cardBrandFilter: configuration.cardBrandFilter)
         editVc.delegate = self
         self.bottomSheetController?.pushContentViewController(editVc)
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
@@ -310,7 +310,8 @@ extension VerticalSavedPaymentMethodsViewController: SavedPaymentMethodRowButton
                                                             appearance: configuration.appearance,
                                                             hostedSurface: .paymentSheet,
                                                             canRemoveCard: canRemovePaymentMethods,
-                                                            isTestMode: configuration.apiClient.isTestmode)
+                                                            isTestMode: configuration.apiClient.isTestmode,
+                                                            cardBrandFilter: .init(cardBrandAcceptance: configuration.cardBrandAcceptance))
 
         updateViewController.delegate = self
         self.updateViewController = updateViewController

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -206,7 +206,8 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
                 isCVCRecollectionEnabled: false,
                 isTestMode: configuration.apiClient.isTestmode,
                 allowsRemovalOfLastSavedPaymentMethod: configuration.allowsRemovalOfLastSavedPaymentMethod,
-                allowsRemovalOfPaymentMethods: elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet()
+                allowsRemovalOfPaymentMethods: elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet(),
+                cardBrandFilter: .init(cardBrandAcceptance: configuration.cardBrandAcceptance)
             ),
             paymentSheetConfiguration: configuration,
             intent: intent,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
@@ -594,7 +594,8 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
                                                                 appearance: configuration.appearance,
                                                                 hostedSurface: .paymentSheet,
                                                                 canRemoveCard: configuration.allowsRemovalOfLastSavedPaymentMethod && elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet(),
-                                                                isTestMode: configuration.apiClient.isTestmode)
+                                                                isTestMode: configuration.apiClient.isTestmode,
+                                                                cardBrandFilter: .init(cardBrandAcceptance: configuration.cardBrandAcceptance))
             updateViewController.delegate = self
             bottomSheetController?.pushContentViewController(updateViewController)
             return

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -171,7 +171,8 @@ class PaymentSheetViewController: UIViewController, PaymentSheetViewControllerPr
                 isCVCRecollectionEnabled: isCVCRecollectionEnabled,
                 isTestMode: configuration.apiClient.isTestmode,
                 allowsRemovalOfLastSavedPaymentMethod: configuration.allowsRemovalOfLastSavedPaymentMethod,
-                allowsRemovalOfPaymentMethods: loadResult.elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet()
+                allowsRemovalOfPaymentMethods: loadResult.elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet(),
+                cardBrandFilter: .init(cardBrandAcceptance: configuration.cardBrandAcceptance)
             ),
             paymentSheetConfiguration: configuration,
             intent: intent,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/UpdateCardViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/UpdateCardViewController.swift
@@ -27,6 +27,7 @@ final class UpdateCardViewController: UIViewController {
     private let isTestMode: Bool
     private let hostedSurface: HostedSurface
     private let canRemoveCard: Bool
+    private let cardBrandFilter: CardBrandFilter
 
     private var latestError: Error? {
         didSet {
@@ -91,7 +92,7 @@ final class UpdateCardViewController: UIViewController {
 
     // MARK: Elements
     private lazy var panElement: TextFieldElement = {
-        return TextFieldElement.LastFourConfiguration(lastFour: paymentMethod.card?.last4 ?? "", cardBrandDropDown: cardBrandDropDown).makeElement(theme: appearance.asElementsTheme)
+        return TextFieldElement.LastFourConfiguration(lastFour: paymentMethod.card?.last4 ?? "", cardBrandDropDown: cardBrandDropDown, cardFilter: cardBrandFilter).makeElement(theme: appearance.asElementsTheme)
     }()
 
     private lazy var cardBrandDropDown: DropdownFieldElement = {
@@ -136,14 +137,15 @@ final class UpdateCardViewController: UIViewController {
          appearance: PaymentSheet.Appearance,
          hostedSurface: HostedSurface,
          canRemoveCard: Bool,
-         isTestMode: Bool) {
+         isTestMode: Bool,
+         cardBrandFilter: CardBrandFilter) {
         self.paymentMethod = paymentMethod
         self.removeSavedPaymentMethodMessage = removeSavedPaymentMethodMessage
         self.appearance = appearance
         self.hostedSurface = hostedSurface
         self.isTestMode = isTestMode
         self.canRemoveCard = canRemoveCard
-
+        self.cardBrandFilter = cardBrandFilter
         super.init(nibName: nil, bundle: nil)
     }
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/CardBrandFilterTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/CardBrandFilterTests.swift
@@ -1,0 +1,89 @@
+//
+//  CardBrandFilterTests.swift
+//  StripePaymentSheetTests
+//
+//  Created by Nick Porter on 9/18/24.
+//
+
+import XCTest
+@testable @_spi(CardBrandFilteringBeta) import StripePaymentSheet
+@_spi(STP) import StripeCore
+
+class CardBrandFilterTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        STPAnalyticsClient.sharedClient._testLogHistory = []
+    }
+
+    func testIsAccepted_allBrandsAccepted() {
+        let filter = CardBrandFilter(cardBrandAcceptance: .all)
+        
+        for brand in STPCardBrand.allCases {
+            XCTAssertTrue(filter.isAccepted(cardBrand: brand), "Brand \(brand) should be accepted when all brands are accepted.")
+        }
+    }
+
+    func testIsAccepted_allowedBrands() {
+        let allowedBrands: [PaymentSheet.CardBrandAcceptance.BrandCategory] = [.visa, .mastercard]
+        let filter = CardBrandFilter(cardBrandAcceptance: .allowed(brands: allowedBrands))
+
+        for brand in STPCardBrand.allCases {
+            let isExpectedToBeAccepted: Bool
+            if let brandCategory = brand.asBrandCategory {
+                isExpectedToBeAccepted = allowedBrands.contains(brandCategory)
+            } else {
+                // Brands without a category should not be accepted
+                isExpectedToBeAccepted = false
+            }
+            let isAccepted = filter.isAccepted(cardBrand: brand)
+            XCTAssertEqual(isAccepted, isExpectedToBeAccepted, "Brand \(brand) acceptance mismatch. Expected \(isExpectedToBeAccepted), got \(isAccepted).")
+        }
+    }
+
+    func testIsAccepted_disallowedBrands() {
+        let disallowedBrands: [PaymentSheet.CardBrandAcceptance.BrandCategory] = [.amex, .discoverGlobalNetwork]
+        let filter = CardBrandFilter(cardBrandAcceptance: .disallowed(brands: disallowedBrands))
+
+        for brand in STPCardBrand.allCases {
+            let isExpectedToBeAccepted: Bool
+            if let brandCategory = brand.asBrandCategory {
+                isExpectedToBeAccepted = !disallowedBrands.contains(brandCategory)
+            } else {
+                // Brands without a category should be accepted
+                isExpectedToBeAccepted = true
+            }
+            let isAccepted = filter.isAccepted(cardBrand: brand)
+            XCTAssertEqual(isAccepted, isExpectedToBeAccepted, "Brand \(brand) acceptance mismatch. Expected \(isExpectedToBeAccepted), got \(isAccepted).")
+        }
+    }
+
+    func testIsAccepted_unknownBrandCategory() {
+        let allowedBrands: [PaymentSheet.CardBrandAcceptance.BrandCategory] = [.visa]
+        let filter = CardBrandFilter(cardBrandAcceptance: .allowed(brands: allowedBrands))
+
+        for brand in STPCardBrand.allCases where brand.asBrandCategory == nil {
+            XCTAssertFalse(filter.isAccepted(cardBrand: brand), "Brand \(brand) without category should be accepted.")
+        }
+    }
+
+    func testIsAccepted_allowsBrandWithNilCategory_whenDisallowed() {
+        let disallowedBrands: [PaymentSheet.CardBrandAcceptance.BrandCategory] = [.visa]
+        let filter = CardBrandFilter(cardBrandAcceptance: .disallowed(brands: disallowedBrands))
+
+        for brand in STPCardBrand.allCases where brand.asBrandCategory == nil {
+            XCTAssertTrue(filter.isAccepted(cardBrand: brand), "Brand \(brand) without category should be accepted.")
+        }
+    }
+    
+    func testIsAccepted_disallowedBrandsAnalytic() {
+        let disallowedBrands: [PaymentSheet.CardBrandAcceptance.BrandCategory] = [.amex]
+        let filter = CardBrandFilter(cardBrandAcceptance: .disallowed(brands: disallowedBrands))
+        
+        XCTAssertFalse(filter.isAccepted(cardBrand: .amex))
+        
+        XCTAssertEqual(STPAnalyticsClient.sharedClient._testLogHistory.count, 1)
+        XCTAssertEqual(STPAnalyticsClient.sharedClient._testLogHistory.first?["event"] as? String, "mc_disallowed_card_brand")
+        XCTAssertEqual(STPAnalyticsClient.sharedClient._testLogHistory.first?["brand"] as? String, "american_express")
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewControllerTests.swift
@@ -296,7 +296,8 @@ class CustomerSavedPaymentMethodsCollectionViewControllerTests: XCTestCase {
         return CustomerSavedPaymentMethodsCollectionViewController.Configuration(showApplePay: false,
                                                                                  allowsRemovalOfLastSavedPaymentMethod: allowsRemovalOfLastSavedPaymentMethod,
                                                                                  paymentMethodRemove: paymentMethodRemove,
-                                                                                 isTestMode: true)
+                                                                                 isTestMode: true,
+                                                                                 cardBrandFilter: .default)
     }
     func customerSavedPaymentMethods(_ configuration: CustomerSavedPaymentMethodsCollectionViewController.Configuration,
                                      savedPaymentMethods: [STPPaymentMethod],

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentOptionsViewControllerSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentOptionsViewControllerSnapshotTests.swift
@@ -32,7 +32,7 @@ final class SavedPaymentOptionsViewControllerSnapshotTests: STPSnapshotTestCase 
             STPPaymentMethod._testUSBankAccount(),
             STPPaymentMethod._testSEPA(),
         ]
-        let config = SavedPaymentOptionsViewController.Configuration(customerID: "cus_123", showApplePay: true, showLink: true, removeSavedPaymentMethodMessage: nil, merchantDisplayName: "Test Merchant", isCVCRecollectionEnabled: false, isTestMode: false, allowsRemovalOfLastSavedPaymentMethod: false, allowsRemovalOfPaymentMethods: true)
+        let config = SavedPaymentOptionsViewController.Configuration(customerID: "cus_123", showApplePay: true, showLink: true, removeSavedPaymentMethodMessage: nil, merchantDisplayName: "Test Merchant", isCVCRecollectionEnabled: false, isTestMode: false, allowsRemovalOfLastSavedPaymentMethod: false, allowsRemovalOfPaymentMethods: true, cardBrandFilter: .default)
         let intent = Intent.deferredIntent(intentConfig: .init(mode: .payment(amount: 0, currency: "USD", setupFutureUsage: nil, captureMethod: .automatic), confirmHandler: { _, _, _ in }))
         let sut = SavedPaymentOptionsViewController(savedPaymentMethods: paymentMethods,
                                                     configuration: config,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentOptionsViewControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentOptionsViewControllerTests.swift
@@ -303,7 +303,8 @@ class SavedPaymentOptionsViewControllerTests: XCTestCase {
                                                                isCVCRecollectionEnabled: true,
                                                                isTestMode: true,
                                                                allowsRemovalOfLastSavedPaymentMethod: allowsRemovalOfLastSavedPaymentMethod,
-                                                               allowsRemovalOfPaymentMethods: allowsRemovalOfPaymentMethods)
+                                                               allowsRemovalOfPaymentMethods: allowsRemovalOfPaymentMethods,
+                                                               cardBrandFilter: .default)
     }
 
     func savedPaymentOptionsController(_ configuration: SavedPaymentOptionsViewController.Configuration,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/UpdateCardViewControllerSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/UpdateCardViewControllerSnapshotTests.swift
@@ -30,7 +30,8 @@ final class UpdateCardViewControllerSnapshotTests: STPSnapshotTestCase {
                                            appearance: appearance,
                                            hostedSurface: .paymentSheet,
                                            canRemoveCard: true,
-                                           isTestMode: false)
+                                           isTestMode: false,
+                                           cardBrandFilter: .default)
         sut.view.autosizeHeight(width: 375)
         let testWindow = UIWindow(frame: CGRect(x: 0, y: 0, width: 375, height: sut.view.frame.size.height))
         testWindow.isHidden = false

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadFiltersCardBrandAcceptance/0000_post_create_ephemeral_key.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadFiltersCardBrandAcceptance/0000_post_create_ephemeral_key.tail
@@ -1,0 +1,18 @@
+POST
+https:\/\/stp-mobile-ci-test-backend-e1b3\.stripedemos\.com\/create_ephemeral_key$
+200
+text/html
+Content-Type: text/html;charset=utf-8
+Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+Set-Cookie: rack.session=5YvpcxsXJZ%2Fhj7jw%2Fkb7TeFaUAd8aAwJ%2FgXmrj4DXmUKnwgpTQS4T0iyKQgeClXZIWmNzZVAPBRyY8SL%2BIbsjs16UNf336nWIib4AyOsyRGwbahizO2%2F%2B5wOnfeaNYkoenS6djKpVZvSo3wHCnunVyjpFMDSUUr86vlXMKr28vTO763yv5i6vVvuHoV%2Bshi6lZLAPFsmCV61US7CJsoJdwjztQ7yGil1i%2BRgq1mGdAc%3D; path=/
+Server: Google Frontend
+x-cloud-trace-context: 99ce3801992dd6351355d26d0ccb18b0;o=1
+Via: 1.1 google
+x-xss-protection: 1; mode=block
+Date: Wed, 25 Sep 2024 16:18:58 GMT
+x-robots-tag: noindex, nofollow
+Content-Length: 149
+x-content-type-options: nosniff
+x-frame-options: SAMEORIGIN
+
+{"ephemeral_key_secret":"ek_test_YWNjdF8xTnBJWVJJcTJMbXB5SUNvLG5GWFZ0TERGNE1XT3J4ZVJGbXJEM2Mycmg5dURkUnk_003SMwqR0H","customer":"cus_OtOGvD0ZVacBoj"}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadFiltersCardBrandAcceptance/0001_get_v1_payment_methods.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadFiltersCardBrandAcceptance/0001_get_v1_payment_methods.tail
@@ -1,0 +1,135 @@
+GET
+https:\/\/api\.stripe\.com\/v1\/payment_methods\?customer=cus_OtOGvD0ZVacBoj&type=card$
+200
+application/json
+access-control-allow-methods: GET,HEAD,PUT,PATCH,POST,DELETE
+content-security-policy: report-uri https://q.stripe.com/csp-report?p=v1%2Fpayment_methods; block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: coop="https://q.stripe.com/coop-report?s=payins-bapi-srv"
+x-wc: A
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+cross-origin-opener-policy-report-only: same-origin; report-to="coop"
+Access-Control-Allow-Origin: *
+x-stripe-routing-context-priority-tier: api-testmode
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=payins-bapi-srv"}],"include_subdomains":true}
+request-id: req_1TQ81SCqk79I0Y
+Content-Length: 2583
+Vary: Origin
+Date: Wed, 25 Sep 2024 16:18:58 GMT
+stripe-version: 2020-08-27
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+x-content-type-options: nosniff
+
+{
+  "has_more" : false,
+  "object" : "list",
+  "data" : [
+    {
+      "object" : "payment_method",
+      "id" : "pm_1O5bTlIq2LmpyICoB8eZH4BJ",
+      "billing_details" : {
+        "email" : null,
+        "phone" : null,
+        "name" : "Apple Pay",
+        "address" : {
+          "state" : "CA",
+          "country" : "US",
+          "line2" : null,
+          "city" : "Oyster Point",
+          "line1" : "1",
+          "postal_code" : null
+        }
+      },
+      "card" : {
+        "fingerprint" : "H5ytsQoN2pwNyAbE",
+        "last4" : "4242",
+        "funding" : "credit",
+        "generated_from" : null,
+        "networks" : {
+          "available" : [
+            "visa"
+          ],
+          "preferred" : null
+        },
+        "brand" : "visa",
+        "checks" : {
+          "address_postal_code_check" : null,
+          "cvc_check" : null,
+          "address_line1_check" : null
+        },
+        "three_d_secure_usage" : {
+          "supported" : true
+        },
+        "wallet" : {
+          "type" : "apple_pay",
+          "apple_pay" : {
+            "type" : "apple_pay"
+          },
+          "dynamic_last4" : "4242"
+        },
+        "display_brand" : "visa",
+        "exp_month" : 12,
+        "exp_year" : 2042,
+        "country" : "US"
+      },
+      "livemode" : false,
+      "created" : 1698357158,
+      "allow_redisplay" : "unspecified",
+      "type" : "card",
+      "customer" : "cus_OtOGvD0ZVacBoj"
+    },
+    {
+      "object" : "payment_method",
+      "id" : "card_1O5upWIq2LmpyICo9tQmU9xY",
+      "billing_details" : {
+        "email" : null,
+        "phone" : null,
+        "name" : "Not Apple Pay",
+        "address" : {
+          "state" : null,
+          "country" : null,
+          "line2" : null,
+          "city" : null,
+          "line1" : null,
+          "postal_code" : null
+        }
+      },
+      "card" : {
+        "fingerprint" : "H5ytsQoN2pwNyAbE",
+        "last4" : "4242",
+        "funding" : "credit",
+        "generated_from" : null,
+        "networks" : {
+          "available" : [
+            "visa"
+          ],
+          "preferred" : null
+        },
+        "brand" : "visa",
+        "checks" : {
+          "address_postal_code_check" : null,
+          "cvc_check" : null,
+          "address_line1_check" : null
+        },
+        "three_d_secure_usage" : {
+          "supported" : true
+        },
+        "wallet" : null,
+        "display_brand" : "visa",
+        "exp_month" : 4,
+        "exp_year" : 2042,
+        "country" : "US"
+      },
+      "livemode" : false,
+      "created" : 1698431542,
+      "type" : "card",
+      "customer" : "cus_OtOGvD0ZVacBoj"
+    }
+  ],
+  "url" : "\/v1\/payment_methods"
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadFiltersCardBrandAcceptance/0002_get_v1_elements_sessions.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadFiltersCardBrandAcceptance/0002_get_v1_elements_sessions.tail
@@ -1,0 +1,337 @@
+GET
+https:\/\/api\.stripe\.com\/v1\/elements\/sessions\?deferred_intent%5Bamount%5D=1000&deferred_intent%5Bcapture_method%5D=automatic&deferred_intent%5Bcurrency%5D=JPY&deferred_intent%5Bmode%5D=payment&key=pk_test_51NpIYRIq2LmpyICoBLPaTxfWFW4I34pnWuBjKXf8CgOlVih7Ni6oDfPRHGTzBEnpsrHiPvqP2UyydilqY66BWp8N00mQCJ1PU5&locale=en-US&type=deferred_intent$
+200
+application/json
+access-control-allow-methods: GET,HEAD,PUT,PATCH,POST,DELETE
+content-security-policy: report-uri https://q.stripe.com/csp-report?p=v1%2Felements%2Fsessions; block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: coop="https://q.stripe.com/coop-report?s=ocs-bapi-srv"
+x-wc: A
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+cross-origin-opener-policy-report-only: same-origin; report-to="coop"
+Access-Control-Allow-Origin: *
+x-stripe-routing-context-priority-tier: api-testmode
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=ocs-bapi-srv"}],"include_subdomains":true}
+request-id: req_ysy5tt8vd5DwqA
+Content-Length: 13381
+Vary: Origin
+Date: Wed, 25 Sep 2024 16:18:58 GMT
+stripe-version: 2020-08-27
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+x-content-type-options: nosniff
+
+{
+  "payment_method_preference" : {
+    "country_code" : "US",
+    "object" : "payment_method_preference",
+    "type" : "deferred_intent",
+    "ordered_payment_method_types" : [
+      "card",
+      "link",
+      "konbini"
+    ]
+  },
+  "capability_enabled_card_networks" : [
+    "cartes_bancaires"
+  ],
+  "flags" : {
+    "elements_enable_external_payment_method_wallets_india" : false,
+    "elements_enable_external_payment_method_check" : false,
+    "elements_enable_external_payment_method_fonix" : false,
+    "elements_enable_external_payment_method_au_pay" : false,
+    "elements_enable_invalid_country_for_pm_error" : false,
+    "elements_enable_external_payment_method_ebt_snap" : false,
+    "elements_enable_external_payment_method_v_pay" : false,
+    "elements_enable_link_in_passthrough_ece" : true,
+    "elements_enable_passive_hcaptcha_in_payment_method_creation" : true,
+    "legacy_confirmation_tokens" : false,
+    "elements_enable_external_payment_method_swish" : false,
+    "elements_enable_external_payment_method_online_banking_poland" : false,
+    "elements_enable_read_allow_redisplay" : true,
+    "elements_enable_card_brand_choice_payment_element_spm" : true,
+    "elements_enable_external_payment_method_divido" : false,
+    "elements_enable_external_payment_method_tng" : false,
+    "elements_enable_express_checkout_button_demo_pay" : false,
+    "elements_enable_external_payment_method_tabby" : false,
+    "elements_enable_mx_card_installments" : false,
+    "link_payment_method_nicknames" : true,
+    "elements_enable_external_payment_method_bpay" : false,
+    "elements_enable_external_payment_method_laybuy" : false,
+    "elements_enable_external_payment_method_bluecode" : false,
+    "elements_enable_external_payment_method_grabpay_later" : false,
+    "elements_disable_klarna_ece_crossborder_validation" : false,
+    "elements_disable_payment_element_card_country_zip_validations" : false,
+    "elements_enable_external_payment_method_billie" : false,
+    "elements_enable_external_payment_method_postfinance" : false,
+    "elements_enable_external_payment_method_scalapay" : false,
+    "elements_enable_external_payment_method_famipay" : false,
+    "link_doi_optional_experiment_rollout" : true,
+    "elements_enable_save_for_future_payments_pre_check" : false,
+    "show_swish_redirect_and_qr_code_auth_flows" : true,
+    "elements_enable_external_payment_method_online_banking_finland" : false,
+    "elements_enable_external_payment_method_nexi_pay" : false,
+    "elements_enable_external_payment_method_pay_easy" : false,
+    "elements_enable_external_payment_method_sequra" : false,
+    "elements_spm_set_as_default" : false,
+    "payment_element_link_modal_preload_killswitch" : false,
+    "elements_enable_external_payment_method_paidy" : false,
+    "elements_enable_write_allow_redisplay" : true,
+    "elements_enable_external_payment_method_online_banking_thailand" : false,
+    "elements_enable_external_payment_method_momo" : false,
+    "elements_enable_external_payment_method_payrexx" : false,
+    "elements_appearance_payment_accordion_overrides" : false,
+    "elements_enable_cb_apple_pay_for_connect_platforms" : false,
+    "link_purchase_protections_rollout" : true,
+    "elements_enable_external_payment_method_walley" : false,
+    "elements_enable_external_payment_method_mb_way" : false,
+    "elements_enable_external_payment_method_rabbitline_pay" : false,
+    "disable_cbc_in_link_popup" : false,
+    "elements_enable_external_payment_method_gopay" : false,
+    "elements_enable_mobilepay" : false,
+    "elements_enable_external_payment_method_knet" : false,
+    "elements_enable_external_payment_method_pledg" : false,
+    "elements_enable_klarna_unified_offer" : true,
+    "elements_enable_external_payment_method_postepay" : false,
+    "elements_enable_19_digit_pans" : false,
+    "elements_enable_external_payment_method_aplazo" : false,
+    "elements_enable_external_payment_method_dapp" : false,
+    "elements_enable_external_payment_method_atone" : false,
+    "elements_enable_external_payment_method_dankort" : false,
+    "elements_enable_external_payment_method_fawry" : false,
+    "elements_enable_external_payment_method_payconiq" : false,
+    "elements_enable_external_payment_method_vipps" : false,
+    "elements_enable_external_payment_method_paysafecard" : false,
+    "elements_enable_external_payment_method_eftpos_australia" : false,
+    "elements_enable_external_payment_method_wechat_mobile" : false,
+    "elements_spm_messages" : false,
+    "elements_enable_external_payment_method_azupay" : false,
+    "ece_apple_pay_payment_request_passthrough" : false,
+    "elements_enable_external_payment_method_online_banking_czech_republic" : false,
+    "elements_enable_external_payment_method_aplazame" : false,
+    "elements_enable_external_payment_method_rakuten_pay" : false,
+    "paypal_express_checkout_recurring_support" : false,
+    "elements_enable_external_payment_method_paypo" : false,
+    "elements_enable_external_payment_method_netbanking" : false,
+    "elements_enable_external_payment_method_pix_international" : false,
+    "elements_enable_external_payment_method_poli" : false,
+    "elements_enable_external_payment_method_kriya" : false,
+    "financial_connections_enable_deferred_intent_flow" : true,
+    "elements_enable_external_payment_method_hands_in" : false,
+    "elements_enable_external_payment_method_younitedpay" : false,
+    "elements_enable_br_card_installments" : false,
+    "elements_enable_external_payment_method_atome" : false,
+    "elements_enable_external_payment_method_mercado_pago" : false,
+    "elements_enable_external_payment_method_amazon_pay" : false,
+    "elements_enable_external_payment_method_line_pay" : false,
+    "elements_enable_external_payment_method_paytm" : false,
+    "elements_enable_external_payment_method_catch" : false,
+    "elements_enable_external_payment_method_skrill" : false,
+    "elements_enable_external_payment_method_paypay" : false,
+    "elements_enable_klarna_express_checkout" : false,
+    "elements_enable_external_payment_method_ratepay" : false,
+    "elements_enable_external_payment_method_sezzle" : false,
+    "elements_enable_external_payment_method_bankaxept" : false,
+    "elements_enable_external_payment_method_satispay" : false,
+    "elements_enable_external_payment_method_dbarai" : false,
+    "elements_enable_external_payment_method_titres_restaurant" : false,
+    "elements_enable_external_payment_method_coinbase_pay" : false,
+    "elements_enable_external_payment_method_trustly" : false,
+    "elements_enable_external_payment_method_kbc" : false,
+    "elements_enable_external_payment_method_bizum" : false,
+    "elements_enable_external_payment_method_gcash" : false,
+    "elements_enable_card_brand_choice_payment_element_link" : true,
+    "elements_enable_external_payment_method_payit" : false,
+    "link_doi_ungated_behavior_rollout" : true,
+    "elements_enable_blik" : true,
+    "elements_enable_south_korea_market_underlying_pms" : false,
+    "elements_enable_external_payment_method_girocard" : false,
+    "elements_enable_external_payment_method_oney" : false,
+    "elements_enable_external_payment_method_humm" : false,
+    "elements_enable_external_payment_method_iwocapay" : false,
+    "elements_enable_external_payment_method_benefit" : false,
+    "elements_enable_external_payment_method_twint" : false,
+    "link_enable_card_brand_choice" : true,
+    "elements_enable_external_payment_method_paybright" : false,
+    "elements_enable_link_spm" : true,
+    "elements_spm_max_visible_payment_methods" : false,
+    "elements_disable_link_email_otp" : false,
+    "cbc_in_link_popup" : true,
+    "elements_enable_external_payment_method_picpay" : false,
+    "elements_enable_external_payment_method_planpay" : false,
+    "elements_enable_external_payment_method_samsung_pay" : false,
+    "elements_enable_external_payment_method_truelayer" : false,
+    "elements_enable_link_in_ece_personalization" : false,
+    "elements_enable_passive_captcha" : true,
+    "elements_disable_paypal_express" : false,
+    "elements_disable_recurring_express_checkout_button_amazon_pay" : false,
+    "elements_enable_external_payment_method_alipay_mobile" : false,
+    "elements_enable_external_payment_method_merpay" : false,
+    "elements_enable_external_payment_method_payu" : false,
+    "elements_disable_express_checkout_button_amazon_pay" : false,
+    "elements_enable_external_payment_method_venmo" : false,
+    "link_set_active_field_true" : false,
+    "elements_enable_external_payment_method_mondu" : false,
+    "elements_enable_external_payment_method_paydirekt" : false,
+    "elements_stop_move_focus_to_first_errored_field" : true,
+    "elements_enable_external_payment_method_online_banking_slovakia" : false,
+    "elements_enable_external_payment_method_interac" : false,
+    "link_new_learn_more_modal_enabled" : true,
+    "use_link_views" : false,
+    "elements_enable_external_payment_method_mybank" : false
+  },
+  "merchant_logo_url" : null,
+  "session_id" : "elements_session_1baHfC7AlFZ",
+  "account_id" : "acct_1NpIYRIq2LmpyICo",
+  "merchant_id" : "acct_1NpIYRIq2LmpyICo",
+  "merchant_currency" : "jpy",
+  "card_brand_choice" : {
+    "eligible" : false,
+    "preferred_networks" : [
+      "cartes_bancaires"
+    ],
+    "supported_cobranded_networks" : {
+      "cartes_bancaires" : false
+    }
+  },
+  "shipping_address_settings" : {
+    "autocomplete_allowed" : true
+  },
+  "external_payment_method_data" : null,
+  "meta_pay_signed_container_context" : null,
+  "apple_pay_preference" : "enabled",
+  "lpm_promotions" : null,
+  "merchant_country" : "JP",
+  "google_pay_preference" : "enabled",
+  "paypal_express_config" : {
+    "client_id" : null,
+    "paypal_merchant_id" : null
+  },
+  "experiments_data" : {
+    "arb_id" : "e89a500d-e51c-49d0-849f-7cf36b8b87f1",
+    "experiment_assignments" : {
+      "default_values_prefill_holdback" : "control",
+      "ocs_buyer_xp_elements_lpm_holdback" : "control",
+      "optional_doi_aa" : "control",
+      "optional_doi_ab" : "control",
+      "link_popup_webview_option_ios" : "control",
+      "elements_merchant_ui_api_srv" : "control"
+    }
+  },
+  "legacy_customer" : null,
+  "link_settings" : {
+    "link_enable_webauthn_for_link_popup" : true,
+    "link_no_code_default_values_recall" : true,
+    "link_payment_session_context" : {
+      "bank_account_permissions" : [
+
+      ],
+      "bank_account_verification_method" : null
+    },
+    "link_consumer_incentive" : null,
+    "link_default_opt_in" : "FULL",
+    "link_elements_pageload_sign_up_disabled" : false,
+    "link_funding_sources_onboarding_unavailable_from_holdback" : [
+
+    ],
+    "link_crypto_onramp_bank_upsell" : false,
+    "link_funding_sources" : [
+      "CARD"
+    ],
+    "link_disabled_reasons" : {
+      "payment_element_payment_method_mode" : [
+
+      ],
+      "payment_element_passthrough_mode" : [
+        "automatic_payment_methods_enabled",
+        "includes_link_in_payment_method_types"
+      ]
+    },
+    "link_elements_is_crypto_onramp" : false,
+    "link_payment_element_disabled_by_targeting" : false,
+    "link_popup_webview_option" : "shared",
+    "link_targeting_results" : {
+      "payment_element_passthrough_mode" : null
+    },
+    "link_disable_email_otp" : false,
+    "link_local_storage_login_enabled" : true,
+    "link_in_optional_default_opt_in_experiment" : false,
+    "link_enable_instant_debits_in_testmode" : false,
+    "link_global_holdback_on" : false,
+    "link_session_storage_login_enabled" : true,
+    "link_payment_element_enable_webauthn_login" : true,
+    "link_payment_method_nicknames" : true,
+    "link_authenticated_change_event_enabled" : false,
+    "link_bank_onboarding_enabled" : false,
+    "link_hcaptcha_rqdata" : null,
+    "link_m2_default_integration_enabled" : true,
+    "link_financial_incentives_experiment_enabled" : false,
+    "link_passthrough_mode_enabled" : false,
+    "link_no_code_default_values_identification" : true,
+    "link_enable_email_otp_for_link_popup" : true,
+    "link_pay_button_element_enabled" : true,
+    "link_crypto_onramp_elements_logout_disabled" : false,
+    "link_mode" : "LINK_PAYMENT_METHOD",
+    "link_no_code_default_values_usage" : true,
+    "link_hcaptcha_site_key" : "20000000-ffff-ffff-ffff-000000000002",
+    "link_crypto_onramp_force_cvc_reverification" : false,
+    "link_email_verification_login_enabled" : false,
+    "link_only_for_payment_method_types_enabled" : false,
+    "link_bank_incentives_enabled" : false,
+    "link_funding_sources_onboarding_enabled" : [
+      "CARD"
+    ],
+    "link_pm_killswitch_on_in_elements" : false
+  },
+  "passive_captcha" : {
+    "site_key" : "20000000-ffff-ffff-ffff-000000000002",
+    "rqdata" : null
+  },
+  "payment_method_specs" : [
+    {
+      "async" : false,
+      "type" : "card",
+      "fields" : [
+
+      ]
+    }
+  ],
+  "prefill_selectors" : {
+    "default_values" : {
+      "email" : [
+
+      ],
+      "merchant_provides_default_values_on_update" : true
+    }
+  },
+  "unactivated_payment_method_types" : [
+    "link",
+    "konbini"
+  ],
+  "unverified_payment_methods_on_domain" : [
+    "apple_pay"
+  ],
+  "order" : null,
+  "link_purchase_protections_data" : {
+    "type" : null,
+    "is_eligible" : false
+  },
+  "apple_pay_merchant_token_webhook_url" : "https:\/\/pm-hooks.stripe.com\/apple_pay\/merchant_token\/pDq7tf9uieoQWMVJixFwuOve\/acct_1NpIYRIq2LmpyICo\/",
+  "customer" : null,
+  "klarna_express_config" : {
+    "klarna_mid" : null
+  },
+  "business_name" : "Mobile Japan Test Merchant",
+  "ordered_payment_method_types_and_wallets" : [
+    "card",
+    "link",
+    "apple_pay",
+    "konbini",
+    "google_pay"
+  ],
+  "customer_error" : null
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadFiltersCardBrandAcceptance/0003_get_v1_customers_cus_OtOGvD0ZVacBoj.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadFiltersCardBrandAcceptance/0003_get_v1_customers_cus_OtOGvD0ZVacBoj.tail
@@ -1,0 +1,37 @@
+GET
+https:\/\/api\.stripe\.com\/v1\/customers\/cus_OtOGvD0ZVacBoj\?$
+200
+application/json
+access-control-allow-methods: GET,HEAD,PUT,PATCH,POST,DELETE
+content-security-policy: report-uri https://q.stripe.com/csp-report?p=v1%2Fcustomers%2F%3Acustomer; block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: coop="https://q.stripe.com/coop-report?s=accounts-bapi-srv"
+x-wc: A
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+cross-origin-opener-policy-report-only: same-origin; report-to="coop"
+Access-Control-Allow-Origin: *
+x-stripe-routing-context-priority-tier: api-testmode
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=accounts-bapi-srv"}],"include_subdomains":true}
+request-id: req_39Z1310qbspTrf
+Content-Length: 215
+Vary: Origin
+Date: Wed, 25 Sep 2024 16:18:59 GMT
+stripe-version: 2020-08-27
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+x-content-type-options: nosniff
+
+{
+  "object" : "customer",
+  "id" : "cus_OtOGvD0ZVacBoj",
+  "livemode" : false,
+  "created" : 1698357141,
+  "email" : null,
+  "default_source" : "card_1O5upWIq2LmpyICo9tQmU9xY",
+  "description" : null,
+  "shipping" : null
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadFiltersCardBrandAcceptance/0004_get_v1_payment_methods.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadFiltersCardBrandAcceptance/0004_get_v1_payment_methods.tail
@@ -1,0 +1,35 @@
+GET
+https:\/\/api\.stripe\.com\/v1\/payment_methods\?customer=cus_OtOGvD0ZVacBoj&limit=100&type=sepa_debit$
+200
+application/json
+access-control-allow-methods: GET,HEAD,PUT,PATCH,POST,DELETE
+content-security-policy: report-uri https://q.stripe.com/csp-report?p=v1%2Fpayment_methods; block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: coop="https://q.stripe.com/coop-report?s=payins-bapi-srv"
+x-wc: A
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+cross-origin-opener-policy-report-only: same-origin; report-to="coop"
+Access-Control-Allow-Origin: *
+x-stripe-routing-context-priority-tier: api-testmode
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=payins-bapi-srv"}],"include_subdomains":true}
+request-id: req_STUxcaoyt8MBp8
+Content-Length: 89
+Vary: Origin
+Date: Wed, 25 Sep 2024 16:18:59 GMT
+stripe-version: 2020-08-27
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+x-content-type-options: nosniff
+
+{
+  "has_more" : false,
+  "object" : "list",
+  "data" : [
+
+  ],
+  "url" : "\/v1\/payment_methods"
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadFiltersCardBrandAcceptance/0005_get_v1_payment_methods.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadFiltersCardBrandAcceptance/0005_get_v1_payment_methods.tail
@@ -1,0 +1,35 @@
+GET
+https:\/\/api\.stripe\.com\/v1\/payment_methods\?customer=cus_OtOGvD0ZVacBoj&limit=100&type=us_bank_account$
+200
+application/json
+access-control-allow-methods: GET,HEAD,PUT,PATCH,POST,DELETE
+content-security-policy: report-uri https://q.stripe.com/csp-report?p=v1%2Fpayment_methods; block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: coop="https://q.stripe.com/coop-report?s=payins-bapi-srv"
+x-wc: A
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+cross-origin-opener-policy-report-only: same-origin; report-to="coop"
+Access-Control-Allow-Origin: *
+x-stripe-routing-context-priority-tier: api-testmode
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=payins-bapi-srv"}],"include_subdomains":true}
+request-id: req_FEt7w0DmtBR5Sj
+Content-Length: 89
+Vary: Origin
+Date: Wed, 25 Sep 2024 16:18:59 GMT
+stripe-version: 2020-08-27
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+x-content-type-options: nosniff
+
+{
+  "has_more" : false,
+  "object" : "list",
+  "data" : [
+
+  ],
+  "url" : "\/v1\/payment_methods"
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadFiltersCardBrandAcceptance/0006_get_v1_payment_methods.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadFiltersCardBrandAcceptance/0006_get_v1_payment_methods.tail
@@ -1,0 +1,135 @@
+GET
+https:\/\/api\.stripe\.com\/v1\/payment_methods\?customer=cus_OtOGvD0ZVacBoj&limit=100&type=card$
+200
+application/json
+access-control-allow-methods: GET,HEAD,PUT,PATCH,POST,DELETE
+content-security-policy: report-uri https://q.stripe.com/csp-report?p=v1%2Fpayment_methods; block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: coop="https://q.stripe.com/coop-report?s=payins-bapi-srv"
+x-wc: A
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+cross-origin-opener-policy-report-only: same-origin; report-to="coop"
+Access-Control-Allow-Origin: *
+x-stripe-routing-context-priority-tier: api-testmode
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=payins-bapi-srv"}],"include_subdomains":true}
+request-id: req_CZbvEKLpda05l3
+Content-Length: 2583
+Vary: Origin
+Date: Wed, 25 Sep 2024 16:18:59 GMT
+stripe-version: 2020-08-27
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+x-content-type-options: nosniff
+
+{
+  "has_more" : false,
+  "object" : "list",
+  "data" : [
+    {
+      "object" : "payment_method",
+      "id" : "pm_1O5bTlIq2LmpyICoB8eZH4BJ",
+      "billing_details" : {
+        "email" : null,
+        "phone" : null,
+        "name" : "Apple Pay",
+        "address" : {
+          "state" : "CA",
+          "country" : "US",
+          "line2" : null,
+          "city" : "Oyster Point",
+          "line1" : "1",
+          "postal_code" : null
+        }
+      },
+      "card" : {
+        "fingerprint" : "H5ytsQoN2pwNyAbE",
+        "last4" : "4242",
+        "funding" : "credit",
+        "generated_from" : null,
+        "networks" : {
+          "available" : [
+            "visa"
+          ],
+          "preferred" : null
+        },
+        "brand" : "visa",
+        "checks" : {
+          "address_postal_code_check" : null,
+          "cvc_check" : null,
+          "address_line1_check" : null
+        },
+        "three_d_secure_usage" : {
+          "supported" : true
+        },
+        "wallet" : {
+          "type" : "apple_pay",
+          "apple_pay" : {
+            "type" : "apple_pay"
+          },
+          "dynamic_last4" : "4242"
+        },
+        "display_brand" : "visa",
+        "exp_month" : 12,
+        "exp_year" : 2042,
+        "country" : "US"
+      },
+      "livemode" : false,
+      "created" : 1698357158,
+      "allow_redisplay" : "unspecified",
+      "type" : "card",
+      "customer" : "cus_OtOGvD0ZVacBoj"
+    },
+    {
+      "object" : "payment_method",
+      "id" : "card_1O5upWIq2LmpyICo9tQmU9xY",
+      "billing_details" : {
+        "email" : null,
+        "phone" : null,
+        "name" : "Not Apple Pay",
+        "address" : {
+          "state" : null,
+          "country" : null,
+          "line2" : null,
+          "city" : null,
+          "line1" : null,
+          "postal_code" : null
+        }
+      },
+      "card" : {
+        "fingerprint" : "H5ytsQoN2pwNyAbE",
+        "last4" : "4242",
+        "funding" : "credit",
+        "generated_from" : null,
+        "networks" : {
+          "available" : [
+            "visa"
+          ],
+          "preferred" : null
+        },
+        "brand" : "visa",
+        "checks" : {
+          "address_postal_code_check" : null,
+          "cvc_check" : null,
+          "address_line1_check" : null
+        },
+        "three_d_secure_usage" : {
+          "supported" : true
+        },
+        "wallet" : null,
+        "display_brand" : "visa",
+        "exp_month" : 4,
+        "exp_year" : 2042,
+        "country" : "US"
+      },
+      "livemode" : false,
+      "created" : 1698431542,
+      "type" : "card",
+      "customer" : "cus_OtOGvD0ZVacBoj"
+    }
+  ],
+  "url" : "\/v1\/payment_methods"
+}


### PR DESCRIPTION
## Summary
- Adds the CBF public API to PaymentSheet and CustomerSheet under SPI
- Adds unit and UI tests
- Updates playground with a CBF toggle
- Filters cards in the card text field based on brand
- Hides saved payment methods of cards with disallowed brands

## Motivation
https://docs.google.com/document/d/1DD7mncHsHbMtU_jqr_TnaLL8ltjO61pPmdOAlJXxYHY/edit

## Testing
- Manual
- Unit tests
- UI tests

## Changelog
N/A for now