### PR TITLE
[BANKCON-14531] Update Instant Debits flow to call `/share` endpoint for Panther payments

### DIFF
--- a/StripeCore/StripeCore/Source/Helpers/Async.swift
+++ b/StripeCore/StripeCore/Source/Helpers/Async.swift
@@ -114,9 +114,10 @@ import Foundation
     }
 
     public func transformed<T>(
+        on queue: DispatchQueue = .main,
         with closure: @escaping (Value) throws -> T
     ) -> Future<T> {
-         chained { value in
+        chained(on: queue) { value in
              try Promise(value: closure(value))
         }
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
@@ -219,6 +219,12 @@ protocol FinancialConnectionsAPI {
         bankAccountId: String
     ) -> Future<FinancialConnectionsPaymentDetails>
 
+    func sharePaymentDetails(
+        consumerSessionClientSecret: String,
+        paymentDetailsId: String,
+        expectedPaymentMethodType: String
+    ) -> Future<FinancialConnectionsSharePaymentDetails>
+
     func paymentMethods(
         consumerSessionClientSecret: String,
         paymentDetailsId: String
@@ -944,6 +950,27 @@ extension FinancialConnectionsAPIClient: FinancialConnectionsAPI {
         )
     }
 
+    func sharePaymentDetails(
+        consumerSessionClientSecret: String,
+        paymentDetailsId: String,
+        expectedPaymentMethodType: String
+    ) -> Future<FinancialConnectionsSharePaymentDetails> {
+        let parameters: [String: Any] = [
+            "request_surface": requestSurface,
+            "id": paymentDetailsId,
+            "credentials": [
+                "consumer_session_client_secret": consumerSessionClientSecret
+            ],
+            "expected_payment_method_type": expectedPaymentMethodType,
+            "expand": ["payment_method"],
+        ]
+        return post(
+            resource: APIEndpointSharePaymentDetails,
+            parameters: parameters,
+            useConsumerPublishableKeyIfNeeded: false
+        )
+    }
+
     func paymentMethods(
         consumerSessionClientSecret: String,
         paymentDetailsId: String
@@ -995,4 +1022,5 @@ private let APIEndpointPollAccountNumbers = "link_account_sessions/poll_account_
 private let APIEndpointLinkAccountsSignUp = "consumers/accounts/sign_up"
 private let APIEndpointAttachLinkConsumerToLinkAccountSession = "consumers/attach_link_consumer_to_link_account_session"
 private let APIEndpointPaymentDetails = "consumers/payment_details"
+private let APIEndpointSharePaymentDetails = "consumers/payment_details/share"
 private let APIEndpointPaymentMethods = "payment_methods"

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsPaymentDetails.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsPaymentDetails.swift
@@ -7,6 +7,10 @@
 
 import Foundation
 
+protocol PaymentMethodIDProvider {
+    var id: String { get }
+}
+
 struct FinancialConnectionsPaymentDetails: Decodable {
     let redactedPaymentDetails: RedactedPaymentDetails
 }
@@ -23,4 +27,13 @@ struct BankAccountDetails: Decodable {
 
 struct FinancialConnectionsPaymentMethod: Decodable {
     let id: String
+}
+
+struct FinancialConnectionsSharePaymentDetails: Decodable {
+    let paymentMethod: FinancialConnectionsPaymentMethod
+}
+
+extension FinancialConnectionsPaymentMethod: PaymentMethodIDProvider {}
+extension FinancialConnectionsSharePaymentDetails: PaymentMethodIDProvider {
+    var id: String { paymentMethod.id }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostController.swift
@@ -175,7 +175,8 @@ private extension HostController {
             accountPickerPane: synchronizePayload.text?.accountPickerPane,
             apiClient: apiClient,
             clientSecret: clientSecret,
-            analyticsClient: analyticsClient
+            analyticsClient: analyticsClient,
+            elementsSessionContext: elementsSessionContext
         )
         nativeFlowController = NativeFlowController(
             dataManager: dataManager,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowDataManager.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowDataManager.swift
@@ -18,6 +18,7 @@ protocol NativeFlowDataManager: AnyObject {
     var apiClient: FinancialConnectionsAPIClient { get }
     var clientSecret: String { get }
     var analyticsClient: FinancialConnectionsAnalyticsClient { get }
+    var elementsSessionContext: ElementsSessionContext? { get }
     var reduceManualEntryProminenceInErrors: Bool { get }
 
     var institution: FinancialConnectionsInstitution? { get set }
@@ -83,6 +84,7 @@ class NativeFlowAPIDataManager: NativeFlowDataManager {
     let apiClient: FinancialConnectionsAPIClient
     let clientSecret: String
     let analyticsClient: FinancialConnectionsAnalyticsClient
+    let elementsSessionContext: ElementsSessionContext?
 
     var institution: FinancialConnectionsInstitution?
     var authSession: FinancialConnectionsAuthSession?
@@ -117,7 +119,8 @@ class NativeFlowAPIDataManager: NativeFlowDataManager {
         accountPickerPane: FinancialConnectionsAccountPickerPane?,
         apiClient: FinancialConnectionsAPIClient,
         clientSecret: String,
-        analyticsClient: FinancialConnectionsAnalyticsClient
+        analyticsClient: FinancialConnectionsAnalyticsClient,
+        elementsSessionContext: ElementsSessionContext?
     ) {
         self.manifest = manifest
         self.visualUpdate = visualUpdate
@@ -127,6 +130,7 @@ class NativeFlowAPIDataManager: NativeFlowDataManager {
         self.apiClient = apiClient
         self.clientSecret = clientSecret
         self.analyticsClient = analyticsClient
+        self.elementsSessionContext = elementsSessionContext
         // Use server provided active AuthSession.
         self.authSession = manifest.activeAuthSession
         // If the server returns active institution use that, otherwise resort to initial institution.

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
@@ -216,6 +216,10 @@ class EmptyFinancialConnectionsAPIClient: FinancialConnectionsAPI {
         Promise<StripeFinancialConnections.FinancialConnectionsPaymentDetails>()
     }
 
+    func sharePaymentDetails(consumerSessionClientSecret: String, paymentDetailsId: String, expectedPaymentMethodType: String) -> Future<FinancialConnectionsSharePaymentDetails> {
+        Promise<StripeFinancialConnections.FinancialConnectionsSharePaymentDetails>()
+    }
+
     func paymentMethods(consumerSessionClientSecret: String, paymentDetailsId: String) -> StripeCore.Future<StripeFinancialConnections.FinancialConnectionsPaymentMethod> {
         Promise<StripeFinancialConnections.FinancialConnectionsPaymentMethod>()
     }


### PR DESCRIPTION
Android equivalent: https://github.com/stripe/stripe-android/pull/9308

## Summary

This updates the Instant Debits flow to call the `/consumers/payment_details/share` endpoint instead of the `/payment_methods` endpoint for Panther payments. This endpoint, along with the `expected_payment_method_type: "card"` parameter will indicate whether or not we should "Panther-ize" the payment method response. Lots more details in the [Panther eng plan](https://docs.google.com/document/d/1ErJVA3lLvNspPe3A8uYP9feK8Yvfq-Sw5aatNIvlGxk/edit?usp=sharing)!

## Motivation

BANKCON-14531

## Testing

With some minor changes to the mobile payment elements (PR coming next!) we can now see the full e2e flow in action!

https://github.com/user-attachments/assets/426fee87-7c93-4f0f-9f93-ad29f1d762bd

## Changelog

N/a
