### PR TITLE
[BANKCON-14525] Configure payment sheet form for Panther

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -259,9 +259,7 @@ extension PaymentMethodFormViewController {
         switch paymentMethodType {
         case .stripe(.USBankAccount):
             handleCollectBankAccount(from: viewController)
-        case .instantDebits:
-            handleCollectInstantDebits(from: viewController)
-        case .linkCardBrand:
+        case .instantDebits, .linkCardBrand:
             handleCollectInstantDebits(from: viewController)
         default:
             return

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -220,7 +220,7 @@ extension PaymentMethodFormViewController {
             } else {
                 return true
             }
-        } else if paymentMethodType == .instantDebits {
+        } else if paymentMethodType == .instantDebits || paymentMethodType == .linkCardBrand {
             // only override buy button (show "Continue") IF we don't have a linked bank
             return instantDebitsFormElement?.getLinkedBank() == nil
         }
@@ -230,11 +230,12 @@ extension PaymentMethodFormViewController {
     var overridePrimaryButtonState: OverridePrimaryButtonState? {
         guard shouldOverridePrimaryButton else { return nil }
         let isEnabled: Bool = {
-            if paymentMethodType == .stripe(.USBankAccount) && usBankAccountFormElement?.canLinkAccount ?? false {
-                true
-            } else if paymentMethodType == .instantDebits && instantDebitsFormElement?.enableCTA ?? false {
-                true
-            } else {
+            switch paymentMethodType {
+            case .stripe(let paymentMethod):
+                paymentMethod == .USBankAccount && (usBankAccountFormElement?.canLinkAccount ?? false)
+            case .instantDebits, .linkCardBrand:
+                instantDebitsFormElement?.enableCTA ?? false
+            default:
                 false
             }
         }()
@@ -259,6 +260,8 @@ extension PaymentMethodFormViewController {
         case .stripe(.USBankAccount):
             handleCollectBankAccount(from: viewController)
         case .instantDebits:
+            handleCollectInstantDebits(from: viewController)
+        case .linkCardBrand:
             handleCollectInstantDebits(from: viewController)
         default:
             return


### PR DESCRIPTION
## Summary

This makes the necessary changes in MPE to support `linkCardBrand` as a payment method. Since this reuses the instant debits flow, we there aren't too many changes needed here.

## Motivation

BANKCON-14525

## Testing

Here's the full e2e flow: 

https://github.com/user-attachments/assets/6557bfbd-8bbf-4927-9d22-adf7a0b6c78c

## Changelog

N/a
