### PR TITLE
Support Xcode 16

### DIFF
--- a/Stripe.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Stripe.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,4 @@
 {
-  "originHash" : "c2f4a8c2436760fc0134632c1cdcb8e7f9b44493c60679a155d27d6838da7d8e",
   "pins" : [
     {
       "identity" : "capture-core-sp",
@@ -37,5 +36,5 @@
       }
     }
   ],
-  "version" : 3
+  "version" : 2
 }

--- a/Stripe.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Stripe.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2ad13697f5d60ad400147e34535361f52e72d2f7a280df77bb3c3521cc5623bc",
+  "originHash" : "c2f4a8c2436760fc0134632c1cdcb8e7f9b44493c60679a155d27d6838da7d8e",
   "pins" : [
     {
       "identity" : "capture-core-sp",
@@ -24,8 +24,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/erikdoe/ocmock",
       "state" : {
-        "branch" : "master",
-        "revision" : "05cbc9d934e84ad32530fa53fd7d29c7966d5828"
+        "revision" : "2c0bfd373289f4a7716db5d6db471640f91a6507"
       }
     },
     {
@@ -38,6 +37,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }
-

--- a/Stripe.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Stripe.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "2ad13697f5d60ad400147e34535361f52e72d2f7a280df77bb3c3521cc5623bc",
   "pins" : [
     {
       "identity" : "capture-core-sp",

--- a/Stripe.xcworkspace/xcshareddata/xcschemes/AllStripeFrameworks.xcscheme
+++ b/Stripe.xcworkspace/xcshareddata/xcschemes/AllStripeFrameworks.xcscheme
@@ -174,6 +174,34 @@
                ReferencedContainer = "container:Stripe3DS2/Stripe3DS2.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "41D17A3F2C5A73A6007C6EE6"
+               BuildableName = "StripeConnect.framework"
+               BlueprintName = "StripeConnect"
+               ReferencedContainer = "container:StripeConnect/StripeConnect.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "41D17A492C5A73A7007C6EE6"
+               BuildableName = "StripeConnectTests.xctest"
+               BlueprintName = "StripeConnectTests"
+               ReferencedContainer = "container:StripeConnect/StripeConnect.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/Stripe/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe/Stripe.xcodeproj/project.pbxproj
@@ -2264,8 +2264,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/erikdoe/ocmock";
 			requirement = {
-				branch = master;
-				kind = branch;
+				kind = revision;
+				revision = 2c0bfd373289f4a7716db5d6db471640f91a6507;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/ApplicationURLOpener.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/ApplicationURLOpener.swift
@@ -12,7 +12,7 @@ protocol ApplicationURLOpener {
     func canOpenURL(_ url: URL) -> Bool
     func open(
         _ url: URL,
-        options: [UIApplication.OpenExternalURLOptionsKey : Any],
+        options: [UIApplication.OpenExternalURLOptionsKey: Any],
         completionHandler completion: OpenCompletionHandler?
     )
 }

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/ApplicationURLOpener.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/ApplicationURLOpener.swift
@@ -10,10 +10,22 @@ import UIKit
 /// Protocol used to dependency inject `UIApplication.open` for use in tests
 protocol ApplicationURLOpener {
     func canOpenURL(_ url: URL) -> Bool
-    func open(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey: Any], completionHandler completion: ((Bool) -> Void)?)
+    func open(
+        _ url: URL,
+        options: [UIApplication.OpenExternalURLOptionsKey : Any],
+        completionHandler completion: OpenCompletionHandler?
+    )
 }
 
 extension ApplicationURLOpener {
+    // The signature of the `completionHandler` in UIApplication.open changed
+    // in Xcode 16
+    #if compiler(>=6.0)
+    typealias OpenCompletionHandler = @MainActor @Sendable (Bool) -> Void
+    #else
+    typealias OpenCompletionHandler = (Bool) -> Void
+    #endif
+
     func openIfPossible(_ url: URL) {
         guard canOpenURL(url) else {
             // TODO: MXMOBILE-2491 Log as analytics when url can't be opened.

--- a/StripeConnect/StripeConnectTests/Internal/Webview/ConnectWebViewTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/ConnectWebViewTests.swift
@@ -157,13 +157,13 @@ class MockNavigationAction: WKNavigationAction {
 
 class MockURLOpener: ApplicationURLOpener {
     var canOpenURLOverride: ((_ url: URL) -> Bool)?
-    var openURLOverride: ((_ url: URL, _ options: [UIApplication.OpenExternalURLOptionsKey: Any], _ completion: ((Bool) -> Void)?) -> Void)?
+    var openURLOverride: ((_ url: URL, _ options: [UIApplication.OpenExternalURLOptionsKey: Any], _ completion: (@MainActor @Sendable (Bool) -> Void)?) -> Void)?
 
     func canOpenURL(_ url: URL) -> Bool {
         canOpenURLOverride?(url) ?? false
     }
 
-    func open(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey: Any], completionHandler completion: ((Bool) -> Void)?) {
+    func open(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey: Any], completionHandler completion: (@MainActor @Sendable (Bool) -> Void)?) {
         openURLOverride?(url, options, completion)
     }
 }

--- a/StripeConnect/StripeConnectTests/Internal/Webview/ConnectWebViewTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/ConnectWebViewTests.swift
@@ -157,13 +157,13 @@ class MockNavigationAction: WKNavigationAction {
 
 class MockURLOpener: ApplicationURLOpener {
     var canOpenURLOverride: ((_ url: URL) -> Bool)?
-    var openURLOverride: ((_ url: URL, _ options: [UIApplication.OpenExternalURLOptionsKey: Any], _ completion: (@MainActor @Sendable (Bool) -> Void)?) -> Void)?
+    var openURLOverride: ((_ url: URL, _ options: [UIApplication.OpenExternalURLOptionsKey: Any], _ completion: OpenCompletionHandler?) -> Void)?
 
     func canOpenURL(_ url: URL) -> Bool {
         canOpenURLOverride?(url) ?? false
     }
 
-    func open(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey: Any], completionHandler completion: (@MainActor @Sendable (Bool) -> Void)?) {
+    func open(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey: Any], completionHandler completion: OpenCompletionHandler?) {
         openURLOverride?(url, options, completion)
     }
 }

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -38,6 +38,7 @@ stages:
     workflows:
     - framework-tests: {}
     - test-builds-xcode-15: {}
+    - test-builds-xcode-16: {}
     - test-builds-vision: {}
     - install-tests-non-carthage: {}
     - lint-tests: {}
@@ -53,7 +54,9 @@ stages:
     workflows:
     - framework-tests-no-mocks: {}
     - test-builds-xcode-15: {}
+    - test-builds-xcode-16: {}
     - test-builds-xcode-15-release: {}
+    - test-builds-xcode-16-release: {}
     - test-builds-vision: {}
     - deploy-docs: {}
     - install-tests-non-carthage: {}
@@ -71,6 +74,7 @@ stages:
   stage-nightly-all:
     workflows:
     - test-builds-xcode-15-release: {}
+    - test-builds-xcode-16-release: {}
     - framework-tests-no-mocks: {}
     - check-docs: {}
     - legacy-tests-15: {}
@@ -348,6 +352,21 @@ workflows:
       bitrise.io:
         stack: osx-xcode-15.0.x
         machine_type_id: g2-m1.8core
+  test-builds-xcode-16:
+    steps:
+    - xcode-build-for-test@2:
+        inputs:
+        - scheme: AllStripeFrameworks
+        - destination: generic/platform=iOS Simulator
+    - deploy-to-bitrise-io@2: {}
+    envs:
+    - DEFAULT_TEST_DEVICE: platform=iOS Simulator,name=iPhone 15,OS=18.0
+    before_run:
+    - prep_all
+    meta:
+      bitrise.io:
+        stack: osx-xcode-16.0.x
+        machine_type_id: g2-m1.8core
   test-builds-xcode-15-release:
     steps:
     - script@1:
@@ -359,6 +378,18 @@ workflows:
     meta:
       bitrise.io:
         stack: osx-xcode-15.0.x
+        machine_type_id: g2-m1.8core
+  test-builds-xcode-16-release:
+    steps:
+    - script@1:
+        inputs:
+        - content: xcodebuild build -workspace "Stripe.xcworkspace" -scheme "AllStripeFrameworks" -configuration "Release" -sdk "iphonesimulator" | xcpretty
+        title: Build release builds
+    before_run:
+    - prep_all
+    meta:
+      bitrise.io:
+        stack: osx-xcode-16.0.x
         machine_type_id: g2-m1.8core
   test-builds-vision:
     steps:


### PR DESCRIPTION
## Summary
- Fixes StripeConnect and StripeCardScan to compile on Xcode 16 
- Adds Bitrise tests for Xcode 16 to ensure it compiles
- Updates OCMock to an Xcode 16 compatible version

Note: OCMock doesn't work with SPM unless you add the dependency via commit hash as opposed to release version. We're using the commit hash that corresponds to v3.9.4:
- https://github.com/erikdoe/ocmock/releases/tag/v3.9.4
- https://github.com/erikdoe/ocmock/issues/500#issuecomment-955731638

## Motivation
https://jira.corp.stripe.com/browse/MXMOBILE-2808

## Testing
- Verified this branch passes tests
- Created a branch without the Connect fixes and verified it fails on CI: https://github.com/stripe/stripe-ios/pull/4065

Manually tested CardScan example app:

https://github.com/user-attachments/assets/cd9448d1-ca23-4396-82f4-05baa5430ffa