### PR TITLE
[BANKCON-14534] Add `expected_payment_method_type` to `/confirm` params

### DIFF
--- a/StripeCore/StripeCore/Source/Connections Bindings/InstantDebitsLinkedBank.swift
+++ b/StripeCore/StripeCore/Source/Connections Bindings/InstantDebitsLinkedBank.swift
@@ -11,4 +11,5 @@ import Foundation
     var paymentMethodId: String { get }
     var bankName: String? { get }
     var last4: String? { get }
+    var expectedPaymentMethodType: String? { get }
 }

--- a/StripeCore/StripeCore/Source/Connections Bindings/LinkMode.swift
+++ b/StripeCore/StripeCore/Source/Connections Bindings/LinkMode.swift
@@ -15,4 +15,8 @@ import Foundation
     @_spi(STP) public var isPantherPayment: Bool {
         self == .linkCardBrand
     }
+
+    @_spi(STP) public var expectedPaymentMethodType: String {
+        isPantherPayment ? "card" : "bank_account"
+    }
 }

--- a/StripeCore/StripeCore/Source/Helpers/Async.swift
+++ b/StripeCore/StripeCore/Source/Helpers/Async.swift
@@ -114,9 +114,10 @@ import Foundation
     }
 
     public func transformed<T>(
+        on queue: DispatchQueue = .main,
         with closure: @escaping (Value) throws -> T
     ) -> Future<T> {
-         chained { value in
+        chained(on: queue) { value in
              try Promise(value: closure(value))
         }
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
@@ -219,6 +219,12 @@ protocol FinancialConnectionsAPI {
         bankAccountId: String
     ) -> Future<FinancialConnectionsPaymentDetails>
 
+    func sharePaymentDetails(
+        consumerSessionClientSecret: String,
+        paymentDetailsId: String,
+        expectedPaymentMethodType: String
+    ) -> Future<FinancialConnectionsSharePaymentDetails>
+
     func paymentMethods(
         consumerSessionClientSecret: String,
         paymentDetailsId: String
@@ -944,6 +950,27 @@ extension FinancialConnectionsAPIClient: FinancialConnectionsAPI {
         )
     }
 
+    func sharePaymentDetails(
+        consumerSessionClientSecret: String,
+        paymentDetailsId: String,
+        expectedPaymentMethodType: String
+    ) -> Future<FinancialConnectionsSharePaymentDetails> {
+        let parameters: [String: Any] = [
+            "request_surface": requestSurface,
+            "id": paymentDetailsId,
+            "credentials": [
+                "consumer_session_client_secret": consumerSessionClientSecret
+            ],
+            "expected_payment_method_type": expectedPaymentMethodType,
+            "expand": ["payment_method"],
+        ]
+        return post(
+            resource: APIEndpointSharePaymentDetails,
+            parameters: parameters,
+            useConsumerPublishableKeyIfNeeded: false
+        )
+    }
+
     func paymentMethods(
         consumerSessionClientSecret: String,
         paymentDetailsId: String
@@ -995,4 +1022,5 @@ private let APIEndpointPollAccountNumbers = "link_account_sessions/poll_account_
 private let APIEndpointLinkAccountsSignUp = "consumers/accounts/sign_up"
 private let APIEndpointAttachLinkConsumerToLinkAccountSession = "consumers/attach_link_consumer_to_link_account_session"
 private let APIEndpointPaymentDetails = "consumers/payment_details"
+private let APIEndpointSharePaymentDetails = "consumers/payment_details/share"
 private let APIEndpointPaymentMethods = "payment_methods"

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsPaymentDetails.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsPaymentDetails.swift
@@ -7,6 +7,10 @@
 
 import Foundation
 
+protocol PaymentMethodIDProvider {
+    var id: String { get }
+}
+
 struct FinancialConnectionsPaymentDetails: Decodable {
     let redactedPaymentDetails: RedactedPaymentDetails
 }
@@ -23,4 +27,13 @@ struct BankAccountDetails: Decodable {
 
 struct FinancialConnectionsPaymentMethod: Decodable {
     let id: String
+}
+
+struct FinancialConnectionsSharePaymentDetails: Decodable {
+    let paymentMethod: FinancialConnectionsPaymentMethod
+}
+
+extension FinancialConnectionsPaymentMethod: PaymentMethodIDProvider {}
+extension FinancialConnectionsSharePaymentDetails: PaymentMethodIDProvider {
+    var id: String { paymentMethod.id }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostController.swift
@@ -175,7 +175,8 @@ private extension HostController {
             accountPickerPane: synchronizePayload.text?.accountPickerPane,
             apiClient: apiClient,
             clientSecret: clientSecret,
-            analyticsClient: analyticsClient
+            analyticsClient: analyticsClient,
+            elementsSessionContext: elementsSessionContext
         )
         nativeFlowController = NativeFlowController(
             dataManager: dataManager,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/FinancialConnectionsSDK/InstantDebitsLinkedBankImplementation.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/FinancialConnectionsSDK/InstantDebitsLinkedBankImplementation.swift
@@ -14,14 +14,17 @@ struct InstantDebitsLinkedBankImplementation: InstantDebitsLinkedBank {
     public let paymentMethodId: String
     public let bankName: String?
     public let last4: String?
+    public let expectedPaymentMethodType: String?
 
     public init(
         paymentMethodId: String,
         bankName: String?,
-        last4: String?
+        last4: String?,
+        expectedPaymentMethodType: String?
     ) {
         self.paymentMethodId = paymentMethodId
         self.bankName = bankName
         self.last4 = last4
+        self.expectedPaymentMethodType = expectedPaymentMethodType
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -508,6 +508,7 @@ extension NativeFlowController {
 
         // Bank account details extraction for the linked bank
         var bankAccountDetails: BankAccountDetails?
+        let linkMode = dataManager.elementsSessionContext?.linkMode
         dataManager.createPaymentDetails(
             consumerSessionClientSecret: consumerSession.clientSecret,
             bankAccountId: bankAccountId
@@ -520,11 +521,11 @@ extension NativeFlowController {
             bankAccountDetails = paymentDetails.redactedPaymentDetails.bankAccountDetails
 
             // Decide which API to call based on the payment mode
-            if self.dataManager.elementsSessionContext?.linkMode?.isPantherPayment == true {
+            if let linkMode, linkMode.isPantherPayment {
                 return self.dataManager.apiClient.sharePaymentDetails(
                     consumerSessionClientSecret: consumerSession.clientSecret,
                     paymentDetailsId: paymentDetails.redactedPaymentDetails.id,
-                    expectedPaymentMethodType: "card"
+                    expectedPaymentMethodType: linkMode.expectedPaymentMethodType
                 )
                 .transformed { $0 as PaymentMethodIDProvider }
             } else {
@@ -541,7 +542,8 @@ extension NativeFlowController {
                 let linkedBank = InstantDebitsLinkedBankImplementation(
                     paymentMethodId: paymentMethod.id,
                     bankName: bankAccountDetails?.bankName,
-                    last4: bankAccountDetails?.last4
+                    last4: bankAccountDetails?.last4,
+                    expectedPaymentMethodType: linkMode?.expectedPaymentMethodType
                 )
                 completion(.success(linkedBank))
             case .failure(let error):

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowDataManager.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowDataManager.swift
@@ -18,6 +18,7 @@ protocol NativeFlowDataManager: AnyObject {
     var apiClient: FinancialConnectionsAPIClient { get }
     var clientSecret: String { get }
     var analyticsClient: FinancialConnectionsAnalyticsClient { get }
+    var elementsSessionContext: ElementsSessionContext? { get }
     var reduceManualEntryProminenceInErrors: Bool { get }
 
     var institution: FinancialConnectionsInstitution? { get set }
@@ -83,6 +84,7 @@ class NativeFlowAPIDataManager: NativeFlowDataManager {
     let apiClient: FinancialConnectionsAPIClient
     let clientSecret: String
     let analyticsClient: FinancialConnectionsAnalyticsClient
+    let elementsSessionContext: ElementsSessionContext?
 
     var institution: FinancialConnectionsInstitution?
     var authSession: FinancialConnectionsAuthSession?
@@ -117,7 +119,8 @@ class NativeFlowAPIDataManager: NativeFlowDataManager {
         accountPickerPane: FinancialConnectionsAccountPickerPane?,
         apiClient: FinancialConnectionsAPIClient,
         clientSecret: String,
-        analyticsClient: FinancialConnectionsAnalyticsClient
+        analyticsClient: FinancialConnectionsAnalyticsClient,
+        elementsSessionContext: ElementsSessionContext?
     ) {
         self.manifest = manifest
         self.visualUpdate = visualUpdate
@@ -127,6 +130,7 @@ class NativeFlowAPIDataManager: NativeFlowDataManager {
         self.apiClient = apiClient
         self.clientSecret = clientSecret
         self.analyticsClient = analyticsClient
+        self.elementsSessionContext = elementsSessionContext
         // Use server provided active AuthSession.
         self.authSession = manifest.activeAuthSession
         // If the server returns active institution use that, otherwise resort to initial institution.

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsWebFlowViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsWebFlowViewController.swift
@@ -174,7 +174,8 @@ extension FinancialConnectionsWebFlowViewController {
                                 bankName: Self.extractValue(from: returnUrl, key: "bank_name")?
                                 // backend can return "+" instead of a more-common encoding of "%20" for spaces
                                     .replacingOccurrences(of: "+", with: " "),
-                                last4: Self.extractValue(from: returnUrl, key: "last4")
+                                last4: Self.extractValue(from: returnUrl, key: "last4"),
+                                expectedPaymentMethodType: Self.extractValue(from: returnUrl, key: "expected_payment_method_type")
                             )
                             self.notifyDelegateOfSuccess(result: .instantDebits(instantDebitsLinkedBank))
                         } else {

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
@@ -216,6 +216,10 @@ class EmptyFinancialConnectionsAPIClient: FinancialConnectionsAPI {
         Promise<StripeFinancialConnections.FinancialConnectionsPaymentDetails>()
     }
 
+    func sharePaymentDetails(consumerSessionClientSecret: String, paymentDetailsId: String, expectedPaymentMethodType: String) -> Future<FinancialConnectionsSharePaymentDetails> {
+        Promise<StripeFinancialConnections.FinancialConnectionsSharePaymentDetails>()
+    }
+
     func paymentMethods(consumerSessionClientSecret: String, paymentDetailsId: String) -> StripeCore.Future<StripeFinancialConnections.FinancialConnectionsPaymentMethod> {
         Promise<StripeFinancialConnections.FinancialConnectionsPaymentMethod>()
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -149,9 +149,13 @@ extension PaymentSheet {
                     configuration: configuration
                 )
                 if case .new(let confirmParams) = paymentOption {
-                    if let paymentMethodId = confirmParams.instantDebitsLinkedBank?.paymentMethodId {
-                        params.paymentMethodId = paymentMethodId
+                    if let linkedBank = confirmParams.instantDebitsLinkedBank {
+                        params.paymentMethodId = linkedBank.paymentMethodId
                         params.paymentMethodParams = nil
+
+                        if let expectedPaymentMethodType = linkedBank.expectedPaymentMethodType {
+                            params.additionalAPIParameters["expected_payment_method_type"] = expectedPaymentMethodType
+                        }
 
                         if paymentIntent.isSetupFutureUsageSet {
                             params.mandateData = STPMandateDataParams.makeWithInferredValues()


### PR DESCRIPTION
## Summary

As part of the [Panther project](https://docs.google.com/document/d/1ErJVA3lLvNspPe3A8uYP9feK8Yvfq-Sw5aatNIvlGxk/edit?usp=sharing), this passes the `expected_payment_method_type` param to the `/confirm` payment endpoint after going through the instant debits flow.

## Motivation

BANKCON-14534

## Testing

E2E tests coming soon. Verified the parameter is passed to the `/confirm` endpoint:

<img width="1108" alt="Screenshot 2024-09-30 at 9 35 14 AM" src="https://github.com/user-attachments/assets/aae91af0-b72f-4a50-b013-845f93120371">

## Changelog

N/a
