### PR TITLE
Add `device_id` to common V2 analytics payload

### DIFF
--- a/StripeCore/StripeCore/Source/Analytics/AnalyticsClientV2.swift
+++ b/StripeCore/StripeCore/Source/Analytics/AnalyticsClientV2.swift
@@ -134,6 +134,9 @@ extension AnalyticsClientV2Protocol {
             "install": InstallMethod.current.rawValue,
             "app_bundle_id": Bundle.stp_applicationBundleId() ?? "",
         ]
+        if let deviceId = UIDevice.current.identifierForVendor?.uuidString {
+            payload["device_id"] = deviceId
+        }
 
         return payload
     }

--- a/StripeCore/StripeCoreTests/Analytics/AnalyticsClientV2Test.swift
+++ b/StripeCore/StripeCoreTests/Analytics/AnalyticsClientV2Test.swift
@@ -58,9 +58,13 @@ final class AnalyticsClientV2Test: XCTestCase {
         XCTAssertNotNil(commonPayload["app_name"] as? String)
         XCTAssertNotNil(commonPayload["app_version"] as? String)
 
+        // Verify this is a valid UUID
+        XCTAssertNotNil((commonPayload["device_id"] as? String).map(UUID.init))
+
         let platformInfo = commonPayload["platform_info"] as? [String: Any]
         XCTAssertNotNil(platformInfo?["install"] as? String)
         XCTAssertNotNil(platformInfo?["app_bundle_id"] as? String)
+
     }
 
     func testPayloadFromAnalytic() {


### PR DESCRIPTION
## Summary
Adds a `device_id` param to the analytics payload which contains the device's vendor ID. The vendor ID is unique per app install and can enable us to dedupe analytic events by device/user in situations we otherwise might not be able to.

Practical examples:
- Identity: Allows us to determine if multiple verifications are created for a single user rather than reusing the same verification
- Connect: Allows us to understand how many users are actively using embedded components on the same connected account
- Connect: Logs a unique ID before the component has loaded, enabling us to track if the same user is repeatedly encountering errors preventing the component to load vs. spread across multiple users

Note: Because `device_id` is getting added to the common V2 analytics payload, this means that the Identity and FinancialConnections SDKs will also send `device_id` to r.stripe.com, however additional work will be needed to consume this value from the request in the analytics table.

## Motivation
https://jira.corp.stripe.com/browse/MXMOBILE-2490

## Testing
Unit tests